### PR TITLE
webgpu: Split GPUAdapterInfo into separate crate

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -30,7 +30,7 @@ linker = "lld-link.exe"
 
 [env]
 MACOSX_DEPLOYMENT_TARGET = "13.0"
-RUSTC_BOOTSTRAP = "crown,script,script_bindings,style_tests,mozjs,mozjs_sys"
+RUSTC_BOOTSTRAP = "crown,script,script_webgpu,script_bindings,style_tests,mozjs,mozjs_sys"
 
 [build]
 rustdocflags = ["--document-private-items"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,7 +823,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -9005,6 +9005,7 @@ dependencies = [
  "servo-profile-traits",
  "servo-script-bindings",
  "servo-script-traits",
+ "servo-script-webgpu",
  "servo-storage-traits",
  "servo-timers",
  "servo-tracing",
@@ -9118,6 +9119,19 @@ dependencies = [
  "stylo_atoms",
  "stylo_traits",
  "webrender_api",
+]
+
+[[package]]
+name = "servo-script-webgpu"
+version = "0.4.0"
+dependencies = [
+ "malloc_size_of_derive",
+ "mozjs",
+ "servo-deny-public-fields",
+ "servo-dom-struct",
+ "servo-jstraceable-derive",
+ "servo-malloc-size-of",
+ "servo-script-bindings",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -322,6 +322,7 @@ profile = { package = "servo-profile", version = "=0.4.0", path = "components/pr
 profile_traits = { package = "servo-profile-traits", version = "=0.4.0", path = "components/shared/profile" }
 script = { package = "servo-script", version = "=0.4.0", path = "components/script" }
 script_bindings = { package = "servo-script-bindings", version = "=0.4.0", path = "components/script_bindings" }
+script_webgpu = { package = "servo-script-webgpu", version = "=0.4.0", path = "components/script_webgpu" }
 script_traits = { package = "servo-script-traits", version = "=0.4.0", path = "components/shared/script" }
 servo = { version = "=0.4.0", path = "components/servo", default-features = false }
 servo-allocator = { version = "=0.4.0", path = "components/allocator" }

--- a/components/dom_struct/lib.rs
+++ b/components/dom_struct/lib.rs
@@ -23,8 +23,9 @@ fn dom_struct_impl(
     input: proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
     let associated_memory = args.to_string().contains("associated_memory");
-    if !associated_memory && !args.is_empty() {
-        panic!("#[dom_struct] only takes 'associated_memory' as an argument");
+    let no_has_parent = args.to_string().contains("no_has_parent");
+    if !associated_memory && !no_has_parent && !args.is_empty() {
+        panic!("#[dom_struct] only takes 'associated_memory' or 'no_has_parent' as an argument");
     }
     let attributes = quote! {
         #[derive(deny_public_fields::DenyPublicFields, JSTraceable, MallocSizeOf)]
@@ -42,7 +43,7 @@ fn dom_struct_impl(
     if let Item::Struct(s) = item {
         let expanded_dom_object = expand_dom_object(s.clone(), associated_memory);
         let s2 = quote! { #s #expanded_dom_object };
-        if !s.generics.params.is_empty() {
+        if no_has_parent {
             return s2;
         }
         if let Fields::Named(ref f) = s.fields {
@@ -51,18 +52,32 @@ fn dom_struct_impl(
             let name = &s.ident;
             let ty = &f.ty;
 
-            quote! (
-                #s2
+            if !s.generics.params.is_empty() {
+                quote! (
+                    #s2
 
-                impl crate::HasParent for #name {
-                    type Parent = #ty;
-                    /// This is used in a type assertion to ensure that
+                    impl<D: DomTypes> crate::HasParent for #name<D> {
+                        type Parent = #ty;
+                        /// This is used in a type assertion to ensure that
                     /// the source and webidls agree as to what the parent type is
                     fn as_parent(&self) -> &#ty {
                         &self.#ident
                     }
-                }
-            )
+                })
+            } else {
+                quote! (
+                    #s2
+
+                    impl crate::HasParent for #name {
+                        type Parent = #ty;
+                        /// This is used in a type assertion to ensure that
+                        /// the source and webidls agree as to what the parent type is
+                        fn as_parent(&self) -> &#ty {
+                            &self.#ident
+                        }
+                    }
+                )
+            }
         } else {
             panic!("#[dom_struct] only applies to structs with named fields");
         }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -27,6 +27,7 @@ testbinding = ["script_bindings/testbinding"]
 tracing = ["dep:tracing", "script_bindings/tracing"]
 webgl_backtrace = ["servo-canvas-traits/webgl_backtrace"]
 webgpu = [
+    "dep:script_webgpu",
     "dep:webgpu_traits",
     "dep:wgpu-core",
     "dep:wgpu-types",
@@ -128,6 +129,7 @@ resvg = { workspace = true }
 rsa = { workspace = true }
 rustc-hash = { workspace = true }
 script_bindings = { workspace = true }
+script_webgpu = { workspace = true, optional = true }
 script_traits = { workspace = true }
 selectors = { workspace = true }
 seq-macro = { workspace = true }

--- a/components/script/dom/bindings/mod.rs
+++ b/components/script/dom/bindings/mod.rs
@@ -162,12 +162,15 @@ pub(crate) use script_bindings::{callback, iterable, num};
 
 /// Generated JS-Rust bindings.
 #[allow(missing_docs, non_snake_case)]
+#[expect(unused)]
 pub(crate) mod codegen {
     pub(crate) mod DomTypeHolder {
         include!(concat!(env!("OUT_DIR"), "/DomTypeHolder.rs"));
     }
     pub(crate) use script_bindings::codegen::GenericBindings;
     #[expect(dead_code)]
+    #[allow(non_camel_case_types)]
+    #[allow(clippy::upper_case_acronyms)]
     pub(crate) mod Bindings {
         include!(concat!(env!("OUT_DIR"), "/ConcreteBindings/mod.rs"));
     }

--- a/components/script/dom/webgpu/mod.rs
+++ b/components/script/dom/webgpu/mod.rs
@@ -4,7 +4,10 @@
 
 pub(crate) mod gpu;
 pub(crate) mod gpuadapter;
-pub(crate) mod gpuadapterinfo;
+pub(crate) mod gpuadapterinfo {
+    pub(crate) type GPUAdapterInfo =
+        script_webgpu::gpuadapterinfo::GPUAdapterInfo<crate::DomTypeHolder>;
+}
 pub(crate) mod gpubindgroup;
 pub(crate) mod gpubindgrouplayout;
 pub(crate) mod gpubuffer;

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1689,3 +1689,7 @@ Unions = {
     'derives': ['Clone'],
 },
 }
+
+SubCrates = {
+    'script_webgpu': ['GPUAdapterInfo'],
+}

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -2696,9 +2696,10 @@ class CGAssertInheritance(CGThing):
     """
     Generate a type assertion for inheritance
     """
-    def __init__(self, descriptor: Descriptor) -> None:
+    def __init__(self, descriptor: Descriptor, generic: bool = False) -> None:
         CGThing.__init__(self)
         self.descriptor = descriptor
+        self.generic = generic
 
     def define(self) -> str:
         parent = self.descriptor.interface.parent
@@ -2723,16 +2724,18 @@ class CGAssertInheritance(CGThing):
             "selfName": selfName,
         }
 
+        genericsDecl = "<D: DomTypes>" if self.generic else ""
+        generics = "<D>" if self.generic else ""
         return f"""
-impl {args['selfName']} {{
-    fn __assert_parent_type(&self) {{
-        use crate::dom::bindings::inheritance::HasParent;
-        // If this type assertion fails, make sure the first field of your
-        // DOM struct is of the correct type -- it must be the parent class.
-        let _: &{args['parentName']} = self.as_parent();
+    impl{genericsDecl} {args['selfName']}{generics} {{
+        fn __assert_parent_type(&self) {{
+            use crate::dom::bindings::inheritance::HasParent;
+            // If this type assertion fails, make sure the first field of your
+            // DOM struct is of the correct type -- it must be the parent class.
+            let _: &{args['parentName']} = self.as_parent();
+        }}
     }}
-}}
-"""
+    """
 
 
 def str_to_cstr(s: str) -> str:
@@ -3479,9 +3482,10 @@ class CGIDLInterface(CGThing):
     """
     Class for codegen of an implementation of the IDLInterface trait.
     """
-    def __init__(self, descriptor: Descriptor) -> None:
+    def __init__(self, descriptor: Descriptor, generic: bool = False) -> None:
         CGThing.__init__(self)
         self.descriptor = descriptor
+        self.generic = generic
 
     def define(self) -> str:
         interface = self.descriptor.interface
@@ -3497,7 +3501,20 @@ class CGIDLInterface(CGThing):
             check = f"ptr::eq(class, unsafe {{ &{bindingModule}::Class.get().dom_class }})"
         # Get DFS-ordered ID range for this interface (set by PrototypeList generation).
         proto_first, proto_last = _proto_ranges.get(name, (0, 65535))
-        return f"""
+
+        if self.generic:
+            return f"""
+    impl<D: DomTypes> IDLInterface for {name}<D> {{
+        #[inline]
+        fn derives(class: &'static DOMClass) -> bool {{
+            {check}
+        }}
+        const PROTO_FIRST: u16 = {proto_first};
+        const PROTO_LAST: u16 = {proto_last};
+    }}
+    """
+        else:
+            return f"""
 impl IDLInterface for {name} {{
     #[inline]
     fn derives(class: &'static DOMClass) -> bool {{
@@ -3536,14 +3553,27 @@ class CGDomObjectWrap(CGThing):
     """
     Class for codegen of an implementation of the DomObjectWrap trait.
     """
-    def __init__(self, descriptor: Descriptor) -> None:
+    def __init__(self, descriptor: Descriptor, generic: bool = False) -> None:
         CGThing.__init__(self)
         self.descriptor = descriptor
+        self.generic = generic
 
     def define(self) -> str:
         ifaceName = self.descriptor.interface.identifier.name
         bindingModule = f"crate::dom::bindings::codegen::GenericBindings::{toBindingPath(self.descriptor)}"
-        return f"""
+        if self.generic:
+            return f"""
+    impl<D: DomTypes> DomObjectWrap<D> for {firstCap(ifaceName)}<D> {{
+        const WRAP: unsafe fn(
+            &mut JSContext,
+            &D::GlobalScope,
+            Option<HandleObject>,
+            Box<Self>,
+        ) -> Root<Dom<Self>> = {bindingModule}::Wrap::<D>;
+    }}
+    """
+        else:
+            return f"""
 impl DomObjectWrap<crate::DomTypeHolder> for {firstCap(ifaceName)} {{
     const WRAP: unsafe fn(
         &mut JSContext,
@@ -3559,14 +3589,28 @@ class CGWeakReferenceableDomObjectWrap(CGThing):
     """
     Class for codegen of an implementation of the WeakReferenceableDomObjectWrap trait.
     """
-    def __init__(self, descriptor: Descriptor) -> None:
+    def __init__(self, descriptor: Descriptor, generic: bool = False) -> None:
         CGThing.__init__(self)
         self.descriptor = descriptor
+        self.generic = generic
 
     def define(self) -> str:
         ifaceName = self.descriptor.interface.identifier.name
         bindingModule = f"crate::dom::bindings::codegen::GenericBindings::{toBindingPath(self.descriptor)}"
-        return f"""
+
+        if self.generic:
+            return f"""
+impl<D: DomTypes> WeakReferenceableDomObjectWrap<D> for {firstCap(ifaceName)}<D> {{
+    const WRAP: unsafe fn(
+        &mut JSContext,
+        &GlobalScope,
+        Option<HandleObject>,
+        Rc<Self>,
+    ) -> Root<Dom<Self>> = {bindingModule}::Wrap::<crate::DomTypeHolder>;
+}}
+"""
+        else:
+            return f"""
 impl WeakReferenceableDomObjectWrap<crate::DomTypeHolder> for {firstCap(ifaceName)} {{
     const WRAP: unsafe fn(
         &mut JSContext,
@@ -7209,10 +7253,18 @@ class CGWeakReferenceableTrait(CGThing):
 
 
 class CGForbidDrop(CGThing):
-    def __init__(self, descriptor: Descriptor) -> None:
+    def __init__(self, descriptor: Descriptor, generic: bool = False) -> None:
         CGThing.__init__(self)
         assert not descriptor.allowDropImpl
-        self.code = f"""
+        if generic:
+            self.code = f"""
+    impl<D: DomTypes> Drop for {firstCap(descriptor.interface.identifier.name)}<D> {{
+        fn drop(&mut self) {{
+        }}
+    }}
+    """
+        else:
+            self.code = f"""
 impl Drop for {firstCap(descriptor.interface.identifier.name)} {{
     fn drop(&mut self) {{
     }}
@@ -8003,7 +8055,7 @@ class CGConcreteBindingRoot(CGThing):
     the generic bindings with type specialization applied.
     """
     root: CGThing | None
-    def __init__(self, config: Configuration, prefix: str, webIDLFile: str) -> None:
+    def __init__(self, config: Configuration, prefix: str, webIDLFile: str, only_interfaces: set[str], generic: bool = False) -> None:
         descriptors = config.getDescriptors(webIDLFile=webIDLFile,
                                             hasInterfaceObject=True)
         # We also want descriptors that have an interface prototype object
@@ -8031,38 +8083,55 @@ class CGConcreteBindingRoot(CGThing):
         originalBinding = f"crate::dom::bindings::codegen::{prefix.replace('/', '::').replace('Concrete', 'Generic')}"
 
         cgthings = []
-        for e in enums:
-            enumName = e.identifier.name
-            cgthings += [
-                CGGeneric(f"pub(crate) use {originalBinding}::{enumName} as {enumName};"),
-                CGGeneric(f"pub(crate) use {originalBinding}::{enumName}Values as {enumName}Values;"),
-            ]
+        if not generic:
+            for e in enums:
+                enumName = e.identifier.name
+                cgthings += [
+                    CGGeneric(f"pub(crate) use {originalBinding}::{enumName} as {enumName};"),
+                    CGGeneric(f"pub(crate) use {originalBinding}::{enumName}Values as {enumName}Values;"),
+                ]
 
-        cgthings += [CGGeneric(
-            f"pub(crate) type {t.identifier.name} = "
-            f"{originalBinding}::{t.identifier.name}"
-            f"{'::<crate::DomTypeHolder>' if containsDomInterface(t.innerType) else ''};"
-        ) for t in typedefs]
+            cgthings += [CGGeneric(
+                f"pub(crate) type {t.identifier.name} = "
+                f"{originalBinding}::{t.identifier.name}"
+                f"{'::<crate::DomTypeHolder>' if containsDomInterface(t.innerType) else ''};"
+            ) for t in typedefs]
 
-        cgthings += [CGGeneric(
-            f"pub(crate) type {d.identifier.name} = "
-            f"{originalBinding}::{d.identifier.name}"
-            f"{'::<crate::DomTypeHolder>' if containsDomInterface(d) else ''};"
-        ) for d in dictionaries]
+            cgthings += [CGGeneric(
+                f"pub(crate) type {d.identifier.name} = "
+                f"{originalBinding}::{d.identifier.name}"
+                f"{'::<crate::DomTypeHolder>' if containsDomInterface(d) else ''};"
+            ) for d in dictionaries]
 
-        cgthings += [CGGeneric(
-            f"pub(crate) type {c.identifier.name} = "
-            f"{originalBinding}::{c.identifier.name}<crate::DomTypeHolder>;"
-        ) for c in mainCallbacks]
+            cgthings += [CGGeneric(
+                f"pub(crate) type {c.identifier.name} = "
+                f"{originalBinding}::{c.identifier.name}<crate::DomTypeHolder>;"
+            ) for c in mainCallbacks]
 
         cgthings += [CGGeneric(f"pub(crate) use {originalBinding} as GenericBindings;")]
+
+
         for d in descriptors:
             ifaceName = d.interface.identifier.name
+            should_skip = ifaceName not in only_interfaces
+
+
             cgthings += [
-                CGGeneric(
-                    f"pub(crate) use {originalBinding}::{firstCap(ifaceName)}_Binding as {firstCap(ifaceName)}_Binding;"
-                ),
+                    CGGeneric(
+                        f"pub(crate) use {originalBinding}::{firstCap(ifaceName)}_Binding as {firstCap(ifaceName)}_Binding;"
+                    ),
             ]
+
+            if should_skip:
+                if not generic:
+                    if d.interface.isIteratorInterface():
+                        cgthings.append(CGDomObjectIteratorWrap(d))
+                    elif d.concrete and not d.isGlobal():
+                        if d.weakReferenceable:
+                            cgthings.append(CGWeakReferenceableDomObjectWrap(d, generic=generic))
+                        else:
+                            cgthings.append(CGDomObjectWrap(d, generic=generic))
+                continue
 
             for marker in ["Serializable", "Transferable"]:
                 if d.interface.getExtendedAttribute(marker):
@@ -8070,23 +8139,27 @@ class CGConcreteBindingRoot(CGThing):
 
             if d.concrete:
                 if not d.interface.isIteratorInterface():
-                    cgthings.append(CGAssertInheritance(d))
+                    cgthings.append(CGAssertInheritance(d, generic =generic))
                 else:
                     cgthings.append(CGIteratorDerives(d))
+
+
 
             if (
                 (d.concrete or d.hasDescendants())
                 and not d.interface.isIteratorInterface()
             ):
-                cgthings.append(CGIDLInterface(d))
+                cgthings.append(CGIDLInterface(d, generic=generic))
 
-            if d.interface.isIteratorInterface():
-                cgthings.append(CGDomObjectIteratorWrap(d))
-            elif d.concrete and not d.isGlobal():
-                if d.weakReferenceable:
-                    cgthings.append(CGWeakReferenceableDomObjectWrap(d))
-                else:
-                    cgthings.append(CGDomObjectWrap(d))
+            if not generic:
+                if d.interface.isIteratorInterface():
+                    cgthings.append(CGDomObjectIteratorWrap(d))
+                elif d.concrete and not d.isGlobal():
+                    if d.weakReferenceable:
+                        cgthings.append(CGWeakReferenceableDomObjectWrap(d))
+                    else:
+                        cgthings.append(CGDomObjectWrap(d, generic = generic))
+
 
             if d.weakReferenceable:
                 cgthings.append(CGWeakReferenceableTrait(d))
@@ -8096,7 +8169,7 @@ class CGConcreteBindingRoot(CGThing):
                 not d.interface.isCallback() and
                 not d.allowDropImpl
             ):
-                cgthings.append(CGForbidDrop(d))
+                cgthings.append(CGForbidDrop(d, generic=generic))
 
             if not d.interface.isCallback():
                 traitName = f"{ifaceName}Methods"
@@ -8104,7 +8177,8 @@ class CGConcreteBindingRoot(CGThing):
                     CGGeneric(f"pub(crate) use self::{firstCap(ifaceName)}_Binding::{traitName} as {traitName};"),
                 ]
                 if len(descriptors) == 1 and d.concrete:
-                    cgthings += [CGGeneric(f"pub(crate) use self::{firstCap(ifaceName)}_Binding::Wrap;")]
+                    if not generic:
+                        cgthings += [CGGeneric(f"pub(crate) use self::{firstCap(ifaceName)}_Binding::Wrap;")]
                     if d.interface.hasInterfaceObject() and d.shouldHaveGetConstructorObjectMethod():
                         cgthings += [CGGeneric(f"""
 pub(crate) fn GetConstructorObject(
@@ -8119,26 +8193,27 @@ pub(crate) fn GetConstructorObject(
                 constants = f"{ifaceName}Constants"
                 cgthings += [CGGeneric(f"pub(crate) use {originalBinding}::{constants} as {constants};")]
 
-        for c in callbackDescriptors:
-            ifaceName = c.interface.identifier.name
-            cgthings += [CGGeneric(
-                f"pub(crate) type {ifaceName} = {originalBinding}::{ifaceName}<crate::DomTypeHolder>;"
-            )]
+        if not generic:
+            for c in callbackDescriptors:
+                ifaceName = c.interface.identifier.name
+                cgthings += [CGGeneric(
+                    f"pub(crate) type {ifaceName} = {originalBinding}::{ifaceName}<crate::DomTypeHolder>;"
+                )]
 
         # And make sure we have the right number of newlines at the end
         curr = CGWrapper(CGList(cgthings, "\n\n"), post="\n\n")
 
         # Add imports
         # These are the global imports (outside of the generated module)
-        curr = CGImports(curr, descriptors=[], callbacks=[],
+        if not generic:
+            curr = CGImports(curr, descriptors=[], callbacks=[],
                          dictionaries=[], enums=[], typedefs=[],
                          imports=[
                              'crate::dom::bindings::import::module::*',
                              'crate::dom::types::*'],
                          config=config)
-
         # Add the auto-generated comment.
-        curr = CGWrapper(curr, pre=f"{AUTOGENERATED_WARNING_COMMENT}{ALLOWED_WARNINGS}")
+        curr = CGWrapper(curr, pre=f"{AUTOGENERATED_WARNING_COMMENT}")
 
         # Store the final result.
         self.root = curr

--- a/components/script_bindings/codegen/configuration.py
+++ b/components/script_bindings/codegen/configuration.py
@@ -49,6 +49,7 @@ class Configuration:
     typedefs: list[IDLTypedef]
     dictionaries: list[IDLDictionary]
     callbacks: list[IDLCallback]
+    sub_crates: dict[str,list[str]]
 
     def __init__(self, filename: str, parseData: list[IDLObjectWithIdentifier]) -> None:
         # Read the configuration file.
@@ -58,6 +59,7 @@ class Configuration:
         self.enumConfig = glbl['Enums']
         self.dictConfig = glbl['Dictionaries']
         self.unionConfig = glbl['Unions']
+        self.sub_crates = glbl['SubCrates']
 
         # Build descriptors for all the interfaces we have in the parse data.
         # This allows callers to specify a subset of interfaces by filtering

--- a/components/script_bindings/codegen/run.py
+++ b/components/script_bindings/codegen/run.py
@@ -6,12 +6,12 @@
 
 from __future__ import annotations
 
-import os
-import sys
 import json
+import os
 import re
-from typing import TYPE_CHECKING
+import sys
 from collections.abc import Iterator
+from typing import TYPE_CHECKING
 
 SCRIPT_PATH = os.path.abspath(os.path.dirname(__file__))
 SCRIPT_BINDINGS_ROOT = os.path.abspath(os.path.join(SCRIPT_PATH, ".."))
@@ -36,8 +36,8 @@ def main() -> None:
     config_file = "Bindings.conf"
 
     import WebIDL
-    from configuration import Configuration
     from codegen import CGBindingRoot, CGConcreteBindingRoot
+    from configuration import Configuration
 
     parser = WebIDL.Parser(make_dir(os.path.join(out_dir, "cache")))
     webidls = [name for name in os.listdir(webidls_dir) if name.endswith(".webidl")]
@@ -58,6 +58,7 @@ def main() -> None:
     config = Configuration(config_file, parser_results)
     make_dir(os.path.join(out_dir, "Bindings"))
     make_dir(os.path.join(out_dir, "ConcreteBindings"))
+    make_dir(os.path.join(out_dir, "WebGPUConcreteBindings"))
 
     for name, filename in [
         ("PrototypeList", "PrototypeList.rs"),
@@ -70,6 +71,7 @@ def main() -> None:
         ("ConcreteInheritTypes", "ConcreteInheritTypes.rs"),
         ("Bindings", "Bindings/mod.rs"),
         ("Bindings", "ConcreteBindings/mod.rs"),
+        ("Bindings", "WebGPUConcreteBindings/mod.rs"),
         ("UnionTypes", "GenericUnionTypes.rs"),
         ("ConcreteUnionTypes", "UnionTypes.rs"),
         ("DomTypes", "DomTypes.rs"),
@@ -80,6 +82,8 @@ def main() -> None:
     make_dir(doc_servo)
     generate(config, "SupportedDomApis", os.path.join(doc_servo, "apis.html"))
 
+    all_interface_descriptors = set(d.interface.identifier.name.replace('\'','') for d in config.descriptors)
+    s = set(item for item in config.sub_crates["script_webgpu"])
     for webidl in webidls:
         filename = os.path.join(webidls_dir, webidl)
         prefix = "Bindings/%sBinding" % webidl[:-len(".webidl")]
@@ -88,7 +92,16 @@ def main() -> None:
             with open(os.path.join(out_dir, prefix + ".rs"), "wb") as f:
                 f.write(module.encode("utf-8"))
         prefix = "ConcreteBindings/%sBinding" % webidl[:-len(".webidl")]
-        module = CGConcreteBindingRoot(config, prefix, filename).define()
+        module = CGConcreteBindingRoot(config, prefix, filename, only_interfaces = all_interface_descriptors -s).define()
+        if module:
+            with open(os.path.join(out_dir, prefix + ".rs"), "wb") as f:
+                f.write(module.encode("utf-8"))
+
+    for webidl in webidls:
+        filename = os.path.join(webidls_dir, webidl)
+        prefix = "ConcreteBindings/%sBinding" % webidl[:-len(".webidl")]
+        module = CGConcreteBindingRoot(config, prefix, filename, only_interfaces = s, generic=True).define()
+        prefix = "WebGPUConcreteBindings/%sBinding" % webidl[:-len(".webidl")]
         if module:
             with open(os.path.join(out_dir, prefix + ".rs"), "wb") as f:
                 f.write(module.encode("utf-8"))

--- a/components/script_bindings/iterable.rs
+++ b/components/script_bindings/iterable.rs
@@ -64,7 +64,7 @@ pub trait IteratorDerives {
 }
 
 /// An iterator over the iterable entries of a given DOM interface.
-#[dom_struct]
+#[dom_struct(no_has_parent)]
 pub struct IterableIterator<
     D: DomTypes,
     T: DomObjectIteratorWrap<D> + JSTraceable + Iterable + DomGlobalGeneric<D>,

--- a/components/script_bindings/reflector.rs
+++ b/components/script_bindings/reflector.rs
@@ -359,3 +359,55 @@ where
     let global_scope = global.upcast();
     unsafe { T::WRAP(cx, global_scope, proto, obj) }
 }
+
+type WrapFn<D, AbstractType> = unsafe fn(
+    &mut js::context::JSContext,
+    &<D as DomTypes>::GlobalScope,
+    Option<HandleObject>,
+    Box<AbstractType>,
+) -> DomRoot<AbstractType>;
+
+/// Create the reflector for a new DOM object and yield ownership to the
+/// reflector.
+pub fn reflect_dom_object_with_cx_and_wrap<D, AbstractType, GlobalType>(
+    obj: Box<AbstractType>,
+    global: &GlobalType,
+    cx: &mut js::context::JSContext,
+    wrap: WrapFn<D, AbstractType>,
+) -> DomRoot<AbstractType>
+where
+    D: DomTypes,
+    AbstractType: DomObject,
+    GlobalType: DerivedFrom<D::GlobalScope>,
+    Box<AbstractType>: From<Box<AbstractType>>,
+    DomRoot<AbstractType>: From<DomRoot<AbstractType>>,
+{
+    let global_scope = global.upcast();
+    unsafe { wrap(cx, global_scope, None, obj) }
+}
+
+type WrapFnRc<D, AbstractType> = unsafe fn(
+    &mut js::context::JSContext,
+    &<D as DomTypes>::GlobalScope,
+    Option<HandleObject>,
+    Rc<AbstractType>,
+) -> DomRoot<AbstractType>;
+
+/// Create the reflector for a new DOM object and yield ownership to the
+/// reflector.
+pub fn reflect_weak_referenceable_dom_object_with_cx_and_wrap<D, AbstractType, GlobalType>(
+    cx: &mut JSContext,
+    obj: Rc<AbstractType>,
+    global: &GlobalType,
+    wrap: WrapFnRc<D, AbstractType>,
+) -> DomRoot<AbstractType>
+where
+    D: DomTypes,
+    AbstractType: DomObject,
+    GlobalType: DerivedFrom<D::GlobalScope>,
+    Rc<AbstractType>: From<Rc<AbstractType>>,
+    DomRoot<AbstractType>: From<DomRoot<AbstractType>>,
+{
+    let global_scope = global.upcast();
+    unsafe { wrap(cx, global_scope, None, obj) }
+}

--- a/components/script_webgpu/Cargo.toml
+++ b/components/script_webgpu/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "servo-script-webgpu"
+build = "build.rs"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
+
+[lib]
+name = "script_webgpu"
+path = "lib.rs"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(crown)'] }
+
+[dependencies]
+deny_public_fields = { workspace = true }
+dom_struct = { workspace = true }
+js = { workspace = true }
+jstraceable_derive = { workspace = true }
+script_bindings = { workspace = true }
+malloc_size_of = { workspace = true }
+malloc_size_of_derive = { workspace = true }

--- a/components/script_webgpu/build.rs
+++ b/components/script_webgpu/build.rs
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    // copy include! files from script_bindings's OUT_DIR, to script's OUT_DIR
+    // this is done to bypass limitation of Rust Analyzer: https://github.com/rust-lang/rust-analyzer/issues/17040
+    let script_bindings_out_dir =
+        PathBuf::from(env::var_os("DEP_SCRIPT_BINDINGS_CRATE_OUT_DIR").unwrap());
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    // copy ConcreteBindings folder
+    let _ = std::fs::create_dir(out_dir.join("ConcreteBindings"));
+    let script_concrete_bindings_out_dir = script_bindings_out_dir.join("WebGPUConcreteBindings");
+    println!(
+        "cargo::rerun-if-changed={}",
+        script_concrete_bindings_out_dir.display()
+    );
+    std::fs::read_dir(script_concrete_bindings_out_dir)
+        .unwrap()
+        .filter_map(|res| res.map(|e| e.path()).ok())
+        .filter(|path| path.is_file())
+        .for_each(|file| {
+            std::fs::copy(
+                &file,
+                out_dir
+                    .join("ConcreteBindings")
+                    .join(file.file_name().unwrap()),
+            )
+            .unwrap();
+        });
+}

--- a/components/script_webgpu/gpuadapterinfo.rs
+++ b/components/script_webgpu/gpuadapterinfo.rs
@@ -2,17 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::marker::PhantomData;
+
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use jstraceable_derive::JSTraceable;
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{
+    GPUAdapterInfoMethods, GPUAdapterInfoWrap,
+};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx_and_wrap};
 
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUAdapterInfoMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
-use crate::dom::globalscope::GlobalScope;
 
 #[dom_struct]
-pub(crate) struct GPUAdapterInfo {
+pub struct GPUAdapterInfo<D: DomTypes> {
     reflector_: Reflector,
     vendor: DOMString,
     architecture: DOMString,
@@ -21,9 +27,14 @@ pub(crate) struct GPUAdapterInfo {
     subgroup_min_size: u32,
     subgroup_max_size: u32,
     is_fallback_adapter: bool,
+    #[no_trace = "Phantom data is not real"]
+    phantom: PhantomData<D>,
 }
 
-impl GPUAdapterInfo {
+impl<D> GPUAdapterInfo<D>
+where
+    D: DomTypes<GPUAdapterInfo = GPUAdapterInfo<D>>,
+{
     fn new_inherited(
         vendor: DOMString,
         architecture: DOMString,
@@ -42,13 +53,14 @@ impl GPUAdapterInfo {
             subgroup_min_size,
             subgroup_max_size,
             is_fallback_adapter,
+            phantom: PhantomData,
         }
     }
 
     #[expect(clippy::too_many_arguments)]
-    pub(crate) fn new(
+    pub fn new(
         cx: &mut JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         vendor: DOMString,
         architecture: DOMString,
         device: DOMString,
@@ -57,7 +69,7 @@ impl GPUAdapterInfo {
         subgroup_max_size: u32,
         is_fallback_adapter: bool,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object_with_cx_and_wrap::<D, _, _>(
             Box::new(Self::new_inherited(
                 vendor,
                 architecture,
@@ -69,13 +81,14 @@ impl GPUAdapterInfo {
             )),
             global,
             cx,
+            GPUAdapterInfoWrap::<D>,
         )
     }
 
-    pub(crate) fn clone_from(
+    pub fn clone_from(
         cx: &mut JSContext,
-        global: &GlobalScope,
-        info: &GPUAdapterInfo,
+        global: &D::GlobalScope,
+        info: &GPUAdapterInfo<D>,
     ) -> DomRoot<Self> {
         Self::new(
             cx,
@@ -91,7 +104,7 @@ impl GPUAdapterInfo {
     }
 }
 
-impl GPUAdapterInfoMethods<crate::DomTypeHolder> for GPUAdapterInfo {
+impl<D: DomTypes> GPUAdapterInfoMethods<D> for GPUAdapterInfo<D> {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapterinfo-vendor>
     fn Vendor(&self) -> DOMString {
         self.vendor.clone()

--- a/components/script_webgpu/lib.rs
+++ b/components/script_webgpu/lib.rs
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#![cfg_attr(crown, feature(register_tool))]
+// Register the linter `crown`, which is the Servo-specific linter for the script crate.
+#![cfg_attr(crown, register_tool(crown))]
+
+pub mod gpuadapterinfo;
+pub(crate) use js::gc::Traceable as JSTraceable;
+pub(crate) use jstraceable_derive::JSTraceable;
+pub(crate) use script_bindings::reflector::{DomObject, MutDomObject, Reflector};
+
+pub(crate) use crate::dom::bindings::inheritance::HasParent;
+
+// Reexports
+pub(crate) mod dom {
+    pub(crate) mod types {}
+    pub(crate) mod bindings {
+        pub(crate) use script_bindings::*;
+    }
+}
+
+/// Generated JS-Rust bindings.
+#[allow(missing_docs, non_snake_case)]
+pub(crate) mod codegen {
+    #[expect(unused)]
+    pub(crate) mod Bindings {
+        use std::ptr;
+
+        use js::context::JSContext;
+        use js::gc::HandleObject;
+        pub(crate) use script_bindings::DomTypes;
+        use script_bindings::conversions::IDLInterface;
+        use script_bindings::reflector::DomObjectWrap;
+        pub(crate) use script_bindings::reflector::Reflector;
+        use script_bindings::root::{Dom, DomRoot, Root};
+        use script_bindings::utils::DOMClass;
+
+        pub(crate) use crate::gpuadapterinfo::GPUAdapterInfo;
+        include!(concat!(
+            env!("OUT_DIR"),
+            "/ConcreteBindings/WebGPUBinding.rs"
+        ));
+    }
+}


### PR DESCRIPTION
This is part of splitting WebGPU into a separate crate starting with only one file.
The important changes are:
- Changes to codegen for ConcreteBindingRoot which now takes optionally a set of interfaces it will generate the bindings for and skip others.
- Allow generating with a wrap function.

Caveats:
- Implementing of the Wrap trait is currently manual for GPUAdapterInfo.
- The Binding Generation is generating a lot of files which end up being unused.

More files are planned but starting with one will allow us to get all the kinks out.


Testing: *Describe the new automated tests that cover this change or explain why it doesn't require tests.*
Fixes: *Link to an issue this pull request fixes or remove this line if there is no issue.*
