### PR TITLE
LTS: Prepare 0.1.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1830,7 +1830,7 @@ dependencies = [
 
 [[package]]
 name = "deny_public_fields_tests"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "servo-deny-public-fields",
 ]
@@ -4903,7 +4903,7 @@ dependencies = [
 
 [[package]]
 name = "malloc_size_of_tests"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "servo-malloc-size-of",
  "servo_arc",
@@ -6484,7 +6484,7 @@ dependencies = [
 
 [[package]]
 name = "profile_tests"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "ipc-channel",
  "servo-config",
@@ -7182,7 +7182,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script_tests"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "encoding_rs",
  "euclid",
@@ -7412,7 +7412,7 @@ dependencies = [
 
 [[package]]
 name = "servo"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -7487,7 +7487,7 @@ dependencies = [
 
 [[package]]
 name = "servo-allocator"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "backtrace",
  "libc",
@@ -7500,7 +7500,7 @@ dependencies = [
 
 [[package]]
 name = "servo-background-hang-monitor"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "backtrace",
  "crossbeam-channel",
@@ -7517,7 +7517,7 @@ dependencies = [
 
 [[package]]
 name = "servo-background-hang-monitor-api"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "serde",
  "servo-base",
@@ -7525,7 +7525,7 @@ dependencies = [
 
 [[package]]
 name = "servo-base"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "accesskit",
  "crossbeam-channel",
@@ -7549,7 +7549,7 @@ dependencies = [
 
 [[package]]
 name = "servo-bluetooth"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "bitflags 2.11.0",
  "blurmock",
@@ -7567,7 +7567,7 @@ dependencies = [
 
 [[package]]
 name = "servo-bluetooth-traits"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "regex",
  "serde",
@@ -7577,7 +7577,7 @@ dependencies = [
 
 [[package]]
 name = "servo-canvas"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "bytemuck",
  "crossbeam-channel",
@@ -7605,7 +7605,7 @@ dependencies = [
 
 [[package]]
 name = "servo-canvas-traits"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -7625,7 +7625,7 @@ dependencies = [
 
 [[package]]
 name = "servo-config"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -7635,7 +7635,7 @@ dependencies = [
 
 [[package]]
 name = "servo-config-macro"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7645,7 +7645,7 @@ dependencies = [
 
 [[package]]
 name = "servo-constellation"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "accesskit",
  "backtrace",
@@ -7691,7 +7691,7 @@ dependencies = [
 
 [[package]]
 name = "servo-constellation-traits"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "content-security-policy",
  "encoding_rs",
@@ -7725,14 +7725,14 @@ dependencies = [
 
 [[package]]
 name = "servo-default-resources"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "servo-embedder-traits",
 ]
 
 [[package]]
 name = "servo-deny-public-fields"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "syn",
  "synstructure",
@@ -7740,7 +7740,7 @@ dependencies = [
 
 [[package]]
 name = "servo-devtools"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "atomic_refcell",
  "base64 0.22.1",
@@ -7768,7 +7768,7 @@ dependencies = [
 
 [[package]]
 name = "servo-devtools-traits"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "http 1.4.0",
  "malloc_size_of_derive",
@@ -7784,7 +7784,7 @@ dependencies = [
 
 [[package]]
 name = "servo-dom-struct"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7793,7 +7793,7 @@ dependencies = [
 
 [[package]]
 name = "servo-embedder-traits"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "accesskit",
  "bitflags 2.11.0",
@@ -7825,7 +7825,7 @@ dependencies = [
 
 [[package]]
 name = "servo-fonts"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "app_units",
  "bitflags 2.11.0",
@@ -7880,7 +7880,7 @@ dependencies = [
 
 [[package]]
 name = "servo-fonts-traits"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "atomic_refcell",
  "dwrote",
@@ -7903,7 +7903,7 @@ dependencies = [
 
 [[package]]
 name = "servo-geometry"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "app_units",
  "euclid",
@@ -7915,7 +7915,7 @@ dependencies = [
 
 [[package]]
 name = "servo-hyper-serde"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "cookie 0.18.1",
  "headers 0.4.1",
@@ -7930,7 +7930,7 @@ dependencies = [
 
 [[package]]
 name = "servo-jstraceable-derive"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -7939,7 +7939,7 @@ dependencies = [
 
 [[package]]
 name = "servo-layout"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -7993,7 +7993,7 @@ dependencies = [
 
 [[package]]
 name = "servo-layout-api"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -8025,7 +8025,7 @@ dependencies = [
 
 [[package]]
 name = "servo-malloc-size-of"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "accountable-refcell",
  "app_units",
@@ -8065,7 +8065,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "once_cell",
  "servo-media-audio",
@@ -8077,7 +8077,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-audio"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "byte-slice-cast",
  "euclid",
@@ -8099,7 +8099,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-auto"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "servo-media-dummy",
  "servo-media-gstreamer",
@@ -8107,7 +8107,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-derive"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8116,7 +8116,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-dummy"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "ipc-channel",
  "servo-media",
@@ -8129,7 +8129,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-examples"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "euclid",
  "rand 0.9.2",
@@ -8141,7 +8141,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "byte-slice-cast",
  "glib",
@@ -8173,7 +8173,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "gstreamer",
  "gstreamer-video",
@@ -8182,7 +8182,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render-android"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8195,7 +8195,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render-unix"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8210,7 +8210,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-player"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "ipc-channel",
  "malloc_size_of_derive",
@@ -8223,7 +8223,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-streams"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "malloc_size_of_derive",
  "servo-malloc-size-of",
@@ -8232,7 +8232,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-thread"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "euclid",
  "ipc-channel",
@@ -8249,7 +8249,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-traits"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "malloc_size_of_derive",
  "servo-malloc-size-of",
@@ -8257,7 +8257,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-webrtc"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "log",
  "servo-media-streams",
@@ -8266,7 +8266,7 @@ dependencies = [
 
 [[package]]
 name = "servo-metrics"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "malloc_size_of_derive",
  "servo-base",
@@ -8280,7 +8280,7 @@ dependencies = [
 
 [[package]]
 name = "servo-net"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "async-compression",
  "async-recursion",
@@ -8351,7 +8351,7 @@ dependencies = [
 
 [[package]]
 name = "servo-net-traits"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "content-security-policy",
  "cookie 0.18.1",
@@ -8391,7 +8391,7 @@ dependencies = [
 
 [[package]]
 name = "servo-paint"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "bitflags 2.11.0",
  "crossbeam-channel",
@@ -8431,7 +8431,7 @@ dependencies = [
 
 [[package]]
 name = "servo-paint-api"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "bitflags 2.11.0",
  "crossbeam-channel",
@@ -8466,7 +8466,7 @@ dependencies = [
 
 [[package]]
 name = "servo-pixels"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "criterion",
  "euclid",
@@ -8481,7 +8481,7 @@ dependencies = [
 
 [[package]]
 name = "servo-profile"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "libc",
  "log",
@@ -8499,7 +8499,7 @@ dependencies = [
 
 [[package]]
 name = "servo-profile-traits"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "crossbeam-channel",
  "ipc-channel",
@@ -8515,7 +8515,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "accountable-refcell",
  "aes",
@@ -8654,7 +8654,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script-bindings"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "bitflags 2.11.0",
  "crossbeam-channel",
@@ -8693,7 +8693,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script-traits"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "accesskit",
  "crossbeam-channel",
@@ -8728,7 +8728,7 @@ dependencies = [
 
 [[package]]
 name = "servo-storage"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "libc",
  "log",
@@ -8755,7 +8755,7 @@ dependencies = [
 
 [[package]]
 name = "servo-storage-traits"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "malloc_size_of_derive",
  "serde",
@@ -8768,7 +8768,7 @@ dependencies = [
 
 [[package]]
 name = "servo-timers"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "crossbeam-channel",
  "malloc_size_of_derive",
@@ -8777,7 +8777,7 @@ dependencies = [
 
 [[package]]
 name = "servo-tracing"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -8787,7 +8787,7 @@ dependencies = [
 
 [[package]]
 name = "servo-url"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "encoding_rs",
  "malloc_size_of_derive",
@@ -8800,7 +8800,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webdriver-server"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "base64 0.22.1",
  "cookie 0.18.1",
@@ -8826,7 +8826,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgl"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -8850,7 +8850,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgpu"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "arrayvec",
  "euclid",
@@ -8868,7 +8868,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgpu-traits"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "arrayvec",
  "malloc_size_of_derive",
@@ -8883,7 +8883,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webxr"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -8901,7 +8901,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webxr-api"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "euclid",
  "ipc-channel",
@@ -8916,7 +8916,7 @@ dependencies = [
 
 [[package]]
 name = "servo-xpath"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "log",
  "malloc_size_of_derive",
@@ -8936,7 +8936,7 @@ dependencies = [
 
 [[package]]
 name = "servoshell"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "accesskit",
  "android_logger",
@@ -9329,7 +9329,7 @@ dependencies = [
 
 [[package]]
 name = "style_tests"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "app_units",
  "cssparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ default-members = ["ports/servoshell"]
 exclude = [".cargo", "support/crown"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.2"
 authors = ["The Servo Project Developers"]
 repository = "https://github.com/servo/servo"
 # A generic description for packages that don't have a meaningful description yet.
@@ -230,70 +230,70 @@ xml5ever = "0.39"
 # be listed here, between the `Begin` and `End` comments, so that we can easily find and
 # update the version requirements when bumping the workspace version.
 # Begin workspace-version dependencies - Don't change this comment, we grep for it in scripts!
-deny_public_fields = { package = "servo-deny-public-fields", version = "=0.1.0", path = "components/deny_public_fields" }
-devtools = { package = "servo-devtools", version = "=0.1.0", path = "components/devtools" }
-devtools_traits = { package = "servo-devtools-traits", version = "=0.1.0", path = "components/shared/devtools" }
-dom_struct = { package = "servo-dom-struct", version = "=0.1.0", path = "components/dom_struct" }
-embedder_traits = { package = "servo-embedder-traits", version = "=0.1.0", path = "components/shared/embedder" }
-fonts = { package = "servo-fonts", version = "=0.1.0", path = "components/fonts" }
-fonts_traits = { package = "servo-fonts-traits", version = "=0.1.0", path = "components/shared/fonts" }
-hyper_serde = { package = "servo-hyper-serde", version = "=0.1.0", path = "components/hyper_serde" }
-jstraceable_derive = { package = "servo-jstraceable-derive", version = "=0.1.0", path = "components/jstraceable_derive" }
-layout = { package = "servo-layout", version = "=0.1.0", path = "components/layout" }
-layout_api = { package = "servo-layout-api", version = "=0.1.0", path = "components/shared/layout" }
-malloc_size_of = { package = "servo-malloc-size-of", version = "=0.1.0", path = "components/malloc_size_of" }
-media = { package = "servo-media-thread", version = "=0.1.0", path = "components/media/media-thread" }
-metrics = { package = "servo-metrics", version = "=0.1.0", path = "components/metrics" }
-net = { package = "servo-net", version = "=0.1.0", path = "components/net" }
-net_traits = { package = "servo-net-traits", version = "=0.1.0", path = "components/shared/net" }
-paint = { package = "servo-paint", version = "=0.1.0", path = "components/paint" }
-paint_api = { package = "servo-paint-api", version = "=0.1.0", path = "components/shared/paint" }
-pixels = { package = "servo-pixels", version = "=0.1.0", path = "components/pixels" }
-profile = { package = "servo-profile", version = "=0.1.0", path = "components/profile" }
-profile_traits = { package = "servo-profile-traits", version = "=0.1.0", path = "components/shared/profile" }
-script = { package = "servo-script", version = "=0.1.0", path = "components/script" }
-script_bindings = { package = "servo-script-bindings", version = "=0.1.0", path = "components/script_bindings" }
-script_traits = { package = "servo-script-traits", version = "=0.1.0", path = "components/shared/script" }
-servo = { version = "=0.1.1", path = "components/servo", default-features = false }
-servo-allocator = { version = "=0.1.0", path = "components/allocator" }
-servo-background-hang-monitor = { version = "=0.1.0", path = "components/background_hang_monitor" }
-servo-background-hang-monitor-api = { version = "=0.1.0", path = "components/shared/background_hang_monitor" }
-servo-base = { version = "=0.1.0", path = "components/shared/base" }
-servo-bluetooth = { version = "=0.1.0", path = "components/bluetooth" }
-servo-bluetooth-traits = { version = "=0.1.0", path = "components/shared/bluetooth" }
-servo-canvas = { version = "=0.1.0", path = "components/canvas" }
-servo-canvas-traits = { version = "=0.1.0", path = "components/shared/canvas" }
-servo-config = { version = "=0.1.0", path = "components/config" }
-servo-config-macro = { version = "=0.1.0", path = "components/config/macro" }
-servo-constellation = { version = "=0.1.0", path = "components/constellation" }
-servo-constellation-traits = { version = "=0.1.0", path = "components/shared/constellation" }
-servo-default-resources = { version = "=0.1.0", path = "components/default-resources" }
-servo-geometry = { version = "=0.1.0", path = "components/geometry" }
-servo-media = { version = "=0.1.0", path = "components/media/servo-media" }
-servo-media-audio = { version = "=0.1.0", path = "components/media/audio" }
-servo-media-auto = { version = "=0.1.0", path = "components/media/backends/auto" }
-servo-media-derive = { version = "=0.1.0", path = "components/media/servo-media-derive" }
-servo-media-dummy = { version = "=0.1.0", path = "components/media/backends/dummy" }
-servo-media-gstreamer = { version = "=0.1.0", path = "components/media/backends/gstreamer" }
-servo-media-gstreamer-render = { version = "=0.1.0", path = "components/media/backends/gstreamer/render" }
-servo-media-gstreamer-render-android = { version = "=0.1.0", path = "components/media/backends/gstreamer/render-android" }
-servo-media-gstreamer-render-unix = { version = "=0.1.0", path = "components/media/backends/gstreamer/render-unix" }
-servo-media-player = { version = "=0.1.0", path = "components/media/player" }
-servo-media-streams = { version = "=0.1.0", path = "components/media/streams" }
-servo-media-traits = { version = "=0.1.0", path = "components/media/traits" }
-servo-media-webrtc = { version = "=0.1.0", path = "components/media/webrtc" }
-servo-tracing = { version = "=0.1.0", path = "components/servo_tracing" }
-servo-url = { version = "=0.1.0", path = "components/url" }
-storage = { package = "servo-storage", version = "=0.1.0", path = "components/storage" }
-storage_traits = { package = "servo-storage-traits", version = "=0.1.0", path = "components/shared/storage" }
-timers = { package = "servo-timers", version = "=0.1.0", path = "components/timers" }
-webdriver_server = { package = "servo-webdriver-server", version = "=0.1.0", path = "components/webdriver_server" }
-webgl = { package = "servo-webgl", version = "=0.1.0", path = "components/webgl", default-features = false }
-webgpu = { package = "servo-webgpu", version = "=0.1.0", path = "components/webgpu" }
-webgpu_traits = { package = "servo-webgpu-traits", version = "=0.1.0", path = "components/shared/webgpu" }
-webxr = { package = "servo-webxr", version = "=0.1.0", path = "components/webxr" }
-webxr-api = { package = "servo-webxr-api", version = "=0.1.0", path = "components/shared/webxr" }
-xpath = { package = "servo-xpath", version = "=0.1.0", path = "components/xpath" }
+deny_public_fields = { package = "servo-deny-public-fields", version = "=0.1.2", path = "components/deny_public_fields" }
+devtools = { package = "servo-devtools", version = "=0.1.2", path = "components/devtools" }
+devtools_traits = { package = "servo-devtools-traits", version = "=0.1.2", path = "components/shared/devtools" }
+dom_struct = { package = "servo-dom-struct", version = "=0.1.2", path = "components/dom_struct" }
+embedder_traits = { package = "servo-embedder-traits", version = "=0.1.2", path = "components/shared/embedder" }
+fonts = { package = "servo-fonts", version = "=0.1.2", path = "components/fonts" }
+fonts_traits = { package = "servo-fonts-traits", version = "=0.1.2", path = "components/shared/fonts" }
+hyper_serde = { package = "servo-hyper-serde", version = "=0.1.2", path = "components/hyper_serde" }
+jstraceable_derive = { package = "servo-jstraceable-derive", version = "=0.1.2", path = "components/jstraceable_derive" }
+layout = { package = "servo-layout", version = "=0.1.2", path = "components/layout" }
+layout_api = { package = "servo-layout-api", version = "=0.1.2", path = "components/shared/layout" }
+malloc_size_of = { package = "servo-malloc-size-of", version = "=0.1.2", path = "components/malloc_size_of" }
+media = { package = "servo-media-thread", version = "=0.1.2", path = "components/media/media-thread" }
+metrics = { package = "servo-metrics", version = "=0.1.2", path = "components/metrics" }
+net = { package = "servo-net", version = "=0.1.2", path = "components/net" }
+net_traits = { package = "servo-net-traits", version = "=0.1.2", path = "components/shared/net" }
+paint = { package = "servo-paint", version = "=0.1.2", path = "components/paint" }
+paint_api = { package = "servo-paint-api", version = "=0.1.2", path = "components/shared/paint" }
+pixels = { package = "servo-pixels", version = "=0.1.2", path = "components/pixels" }
+profile = { package = "servo-profile", version = "=0.1.2", path = "components/profile" }
+profile_traits = { package = "servo-profile-traits", version = "=0.1.2", path = "components/shared/profile" }
+script = { package = "servo-script", version = "=0.1.2", path = "components/script" }
+script_bindings = { package = "servo-script-bindings", version = "=0.1.2", path = "components/script_bindings" }
+script_traits = { package = "servo-script-traits", version = "=0.1.2", path = "components/shared/script" }
+servo = { version = "=0.1.2", path = "components/servo", default-features = false }
+servo-allocator = { version = "=0.1.2", path = "components/allocator" }
+servo-background-hang-monitor = { version = "=0.1.2", path = "components/background_hang_monitor" }
+servo-background-hang-monitor-api = { version = "=0.1.2", path = "components/shared/background_hang_monitor" }
+servo-base = { version = "=0.1.2", path = "components/shared/base" }
+servo-bluetooth = { version = "=0.1.2", path = "components/bluetooth" }
+servo-bluetooth-traits = { version = "=0.1.2", path = "components/shared/bluetooth" }
+servo-canvas = { version = "=0.1.2", path = "components/canvas" }
+servo-canvas-traits = { version = "=0.1.2", path = "components/shared/canvas" }
+servo-config = { version = "=0.1.2", path = "components/config" }
+servo-config-macro = { version = "=0.1.2", path = "components/config/macro" }
+servo-constellation = { version = "=0.1.2", path = "components/constellation" }
+servo-constellation-traits = { version = "=0.1.2", path = "components/shared/constellation" }
+servo-default-resources = { version = "=0.1.2", path = "components/default-resources" }
+servo-geometry = { version = "=0.1.2", path = "components/geometry" }
+servo-media = { version = "=0.1.2", path = "components/media/servo-media" }
+servo-media-audio = { version = "=0.1.2", path = "components/media/audio" }
+servo-media-auto = { version = "=0.1.2", path = "components/media/backends/auto" }
+servo-media-derive = { version = "=0.1.2", path = "components/media/servo-media-derive" }
+servo-media-dummy = { version = "=0.1.2", path = "components/media/backends/dummy" }
+servo-media-gstreamer = { version = "=0.1.2", path = "components/media/backends/gstreamer" }
+servo-media-gstreamer-render = { version = "=0.1.2", path = "components/media/backends/gstreamer/render" }
+servo-media-gstreamer-render-android = { version = "=0.1.2", path = "components/media/backends/gstreamer/render-android" }
+servo-media-gstreamer-render-unix = { version = "=0.1.2", path = "components/media/backends/gstreamer/render-unix" }
+servo-media-player = { version = "=0.1.2", path = "components/media/player" }
+servo-media-streams = { version = "=0.1.2", path = "components/media/streams" }
+servo-media-traits = { version = "=0.1.2", path = "components/media/traits" }
+servo-media-webrtc = { version = "=0.1.2", path = "components/media/webrtc" }
+servo-tracing = { version = "=0.1.2", path = "components/servo_tracing" }
+servo-url = { version = "=0.1.2", path = "components/url" }
+storage = { package = "servo-storage", version = "=0.1.2", path = "components/storage" }
+storage_traits = { package = "servo-storage-traits", version = "=0.1.2", path = "components/shared/storage" }
+timers = { package = "servo-timers", version = "=0.1.2", path = "components/timers" }
+webdriver_server = { package = "servo-webdriver-server", version = "=0.1.2", path = "components/webdriver_server" }
+webgl = { package = "servo-webgl", version = "=0.1.2", path = "components/webgl", default-features = false }
+webgpu = { package = "servo-webgpu", version = "=0.1.2", path = "components/webgpu" }
+webgpu_traits = { package = "servo-webgpu-traits", version = "=0.1.2", path = "components/shared/webgpu" }
+webxr = { package = "servo-webxr", version = "=0.1.2", path = "components/webxr" }
+webxr-api = { package = "servo-webxr-api", version = "=0.1.2", path = "components/shared/webxr" }
+xpath = { package = "servo-xpath", version = "=0.1.2", path = "components/xpath" }
 # End workspace-version dependencies - Don't change this comment, we grep for it in scripts!
 
 # RSA key generation could be very slow without compilation

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo"
-version = "0.1.1"
+version.workspace = true
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -39,6 +39,10 @@ ignore = [
     # We can't upgrade yet due to MSRV. However, we do not use the vulnerable API at all.
     # As per <https://github.com/advisories/GHSA-r6v5-fh4h-64xc> this can be verified with clippy.
     "RUSTSEC-2026-0009",
+    # The crate `ttf-parser` is unmaintained.
+    # This is a dependency of `usvg`, `rustybuzz`, `fontdb`.
+    # We will need to wait for upstream actions.
+    "RUSTSEC-2026-0192",
 ]
 
 # This section is considered when running `cargo deny check licenses`

--- a/ports/servoshell/platform/macos/Info.plist
+++ b/ports/servoshell/platform/macos/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
+	<string>0.1.2</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSPrincipalClass</key>

--- a/ports/servoshell/platform/windows/servoshell.exe.manifest
+++ b/ports/servoshell/platform/windows/servoshell.exe.manifest
@@ -4,7 +4,7 @@
           xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <assemblyIdentity type="win32"
                     name="servo.ServoShell"
-                    version="0.1.0.0"/>
+                    version="0.1.2.0"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>

--- a/resources/resource_protocol/license.html
+++ b/resources/resource_protocol/license.html
@@ -7542,9 +7542,7 @@ limitations under the License.</pre>
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/servo/stylo ">servo_arc 0.4.3</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_malloc_size_of 0.14.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-malloc-size-of 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-malloc-size-of 0.1.2</a></li>
                         <li><a href=" https://github.com/gimli-rs/addr2line ">addr2line 0.25.1</a></li>
                         <li><a href=" https://github.com/tkaitchuck/ahash ">ahash 0.8.12</a></li>
                         <li><a href=" https://github.com/rust-fuzz/arbitrary/ ">arbitrary 1.4.2</a></li>
@@ -7703,6 +7701,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/bluss/scopeguard ">scopeguard 1.2.0</a></li>
                         <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys 2.17.0</a></li>
                         <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework 3.7.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">servo_arc 0.4.3</a></li>
                         <li><a href=" https://github.com/adjivas/sig ">sig 1.0.0</a></li>
                         <li><a href=" https://github.com/vorner/signal-hook ">signal-hook-registry 1.4.8</a></li>
                         <li><a href=" https://github.com/linebender/simplecss ">simplecss 0.2.2</a></li>
@@ -7714,6 +7713,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/storyyeller/stable_deref_trait ">stable_deref_trait 1.2.1</a></li>
                         <li><a href=" https://github.com/servo/string-cache ">string_cache 0.9.0</a></li>
                         <li><a href=" https://github.com/servo/string-cache ">string_cache_codegen 0.6.1</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_malloc_size_of 0.15.0</a></li>
                         <li><a href=" https://github.com/servo/surfman ">surfman 0.11.0</a></li>
                         <li><a href=" https://github.com/linebender/svgtypes ">svgtypes 0.15.3</a></li>
                         <li><a href=" https://github.com/gdesmott/system-deps ">system-deps 6.2.2</a></li>
@@ -12366,7 +12366,7 @@ limitations under the License.
                         <li><a href=" https://github.com/emilk/egui/tree/main/crates/emath ">emath 0.33.3</a></li>
                         <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint ">epaint 0.33.3</a></li>
                         <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.33.3</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-hyper-serde 0.13.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-hyper-serde 0.1.2</a></li>
                         <li><a href=" https://github.com/alexheretic/ab-glyph ">ab_glyph 0.2.32</a></li>
                         <li><a href=" https://github.com/alexheretic/ab-glyph ">ab_glyph_rasterizer 0.1.10</a></li>
                         <li><a href=" https://github.com/AccessKit/accesskit ">accesskit 0.24.0</a></li>
@@ -12384,7 +12384,7 @@ limitations under the License.
                         <li><a href=" https://github.com/1Password/arboard ">arboard 3.6.1</a></li>
                         <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.41</a></li>
                         <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.89</a></li>
-                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.39.1</a></li>
+                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.40.0</a></li>
                         <li><a href=" https://github.com/jrmuizel/build-parallel ">build-parallel 0.1.2</a></li>
                         <li><a href=" https://github.com/emk/cesu8-rs ">cesu8 1.1.0</a></li>
                         <li><a href=" https://github.com/linebender/color ">color 0.3.2</a></li>
@@ -12495,7 +12495,7 @@ limitations under the License.
                         <li><a href=" https://github.com/nical/rust_debug ">svg_fmt 0.4.5</a></li>
                         <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.117</a></li>
                         <li><a href=" https://github.com/Actyx/sync_wrapper ">sync_wrapper 1.0.2</a></li>
-                        <li><a href=" https://github.com/gankra/thin-vec ">thin-vec 0.2.14</a></li>
+                        <li><a href=" https://github.com/mozilla/thin-vec ">thin-vec 0.2.16</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 1.0.69</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 2.0.18</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 1.0.69</a></li>
@@ -13345,9 +13345,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/servo/servo ">servo-script-bindings 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script-bindings 0.1.2</a></li>
                         <li><a href=" https://github.com/dropbox/rust-alloc-no-stdlib ">alloc-stdlib 0.2.2</a></li>
-                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.39.1</a></li>
+                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.40.0</a></li>
                         <li><a href=" https://github.com/dropbox/rust-brotli ">brotli 8.0.2</a></li>
                         <li><a href=" https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek ">curve25519-dalek 4.1.3</a></li>
                         <li><a href=" https://github.com/mitsuhiko/sha1-smol ">sha1_smol 1.0.1</a></li>
@@ -13621,8 +13621,8 @@ express Statement of Purpose.
                 <h3 id="CDLA-Permissive-2.0">Community Data License Agreement Permissive 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-root-certs 1.0.6</a></li>
-                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-roots 1.0.6</a></li>
+                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-root-certs 1.0.7</a></li>
+                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-roots 1.0.7</a></li>
                     </ul>
                 <pre class="license-text"># Community Data License Agreement - Permissive - Version 2.0
 
@@ -13774,7 +13774,7 @@ THIS SOFTWARE.
                 <h3 id="ISC">ISC License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.10</a>
+                            <a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.13</a>
                     </p>
                 <pre class="license-text">Except as otherwise noted, this project is licensed under the following
 (ISC-style) terms:
@@ -13801,8 +13801,8 @@ third-party/chromium/LICENSE.
                 <h3 id="ISC">ISC License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.16.2</a></li>
-                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.39.1</a></li>
+                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.16.3</a></li>
+                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.40.0</a></li>
                     </ul>
                 <pre class="license-text">ISC License:
 
@@ -16442,7 +16442,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.39.1</a>
+                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.40.0</a>
                     </p>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -18862,88 +18862,88 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/servo/stylo ">stylo 0.14.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">selectors 0.36.1</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_atoms 0.14.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_derive 0.14.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_dom 0.14.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_static_prefs 0.14.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_traits 0.14.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">to_shmem 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">to_shmem_derive 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-allocator 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-background-hang-monitor 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-bluetooth 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-canvas 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-config 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-config-macro 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-constellation 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-default-resources 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-deny-public-fields 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-devtools 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-dom-struct 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-fonts 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-geometry 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-jstraceable-derive 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-layout 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-audio 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-auto 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-dummy 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render-android 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render-unix 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-examples 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-thread 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-player 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-derive 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-streams 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-webrtc 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-metrics 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-net 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-paint 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-pixels 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-profile 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-script 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-script-bindings 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-tracing 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-background-hang-monitor-api 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-base 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-bluetooth-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-canvas-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-constellation-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-devtools-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-embedder-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-fonts-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-layout-api 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-net-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-paint-api 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-profile-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-script-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-storage-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webgpu-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webxr-api 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-storage 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-timers 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-url 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webdriver-server 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webgl 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webgpu 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webxr 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-xpath 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servoshell 0.1.0</a></li>
-                        <li><a href=" https://crates.io/crates/deny_public_fields_tests ">deny_public_fields_tests 0.1.0</a></li>
-                        <li><a href=" https://crates.io/crates/malloc_size_of_tests ">malloc_size_of_tests 0.1.0</a></li>
-                        <li><a href=" https://crates.io/crates/profile_tests ">profile_tests 0.1.0</a></li>
-                        <li><a href=" https://crates.io/crates/script_tests ">script_tests 0.1.0</a></li>
-                        <li><a href=" https://crates.io/crates/style_tests ">style_tests 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-allocator 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-background-hang-monitor 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-bluetooth 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-canvas 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-config 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-config-macro 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-constellation 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-default-resources 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-deny-public-fields 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-devtools 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-dom-struct 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-fonts 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-geometry 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-jstraceable-derive 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-layout 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-audio 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-auto 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-dummy 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render-android 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render-unix 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-examples 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-thread 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-player 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-derive 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-streams 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-traits 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-webrtc 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-metrics 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-net 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-paint 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-pixels 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-profile 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script-bindings 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-tracing 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-background-hang-monitor-api 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-base 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-bluetooth-traits 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-canvas-traits 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-constellation-traits 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-devtools-traits 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-embedder-traits 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-fonts-traits 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-layout-api 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-net-traits 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-paint-api 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-profile-traits 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script-traits 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-storage-traits 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webgpu-traits 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webxr-api 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-storage 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-timers 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-url 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webdriver-server 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webgl 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webgpu 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webxr 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-xpath 0.1.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servoshell 0.1.2</a></li>
+                        <li><a href=" https://crates.io/crates/deny_public_fields_tests ">deny_public_fields_tests 0.1.2</a></li>
+                        <li><a href=" https://crates.io/crates/malloc_size_of_tests ">malloc_size_of_tests 0.1.2</a></li>
+                        <li><a href=" https://crates.io/crates/profile_tests ">profile_tests 0.1.2</a></li>
+                        <li><a href=" https://crates.io/crates/script_tests ">script_tests 0.1.2</a></li>
+                        <li><a href=" https://crates.io/crates/style_tests ">style_tests 0.1.2</a></li>
                         <li><a href=" https://github.com/servo/app_units ">app_units 0.7.8</a></li>
                         <li><a href=" https://github.com/servo/dwrote-rs ">dwrote 0.11.5</a></li>
-                        <li><a href=" https://github.com/servo/mozjs/ ">mozjs_sys 0.140.8-2</a></li>
+                        <li><a href=" https://github.com/servo/mozjs/ ">mozjs_sys 140.12.0-0-lts</a></li>
                         <li><a href=" https://github.com/soc/option-ext.git ">option-ext 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">selectors 0.36.1</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo 0.15.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_atoms 0.15.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_derive 0.15.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_dom 0.15.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_static_prefs 0.15.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_traits 0.15.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">to_shmem 0.3.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">to_shmem_derive 0.1.0</a></li>
                         <li><a href=" https://hg.mozilla.org/mozilla-central/file/tip/testing/webdriver ">webdriver 0.53.0</a></li>
                         <li><a href=" https://github.com/servo/webrender ">webrender 0.68.0</a></li>
                         <li><a href=" https://github.com/servo/webrender ">webrender_api 0.68.0</a></li>
@@ -19329,7 +19329,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/servo/mozjs/ ">mozjs 0.15.7</a>
+                            <a href=" https://github.com/servo/mozjs/ ">mozjs 0.15.15</a>
                     </p>
                 <pre class="license-text">Mozilla Public License Version 2.0
 &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -17,7 +17,7 @@ android {
         minSdk = 30
         targetSdk = 33
         versionCode = generatedVersionCode
-        versionName = "0.1.0"
+        versionName = "0.1.2"
     }
 
     compileOptions {

--- a/support/openharmony/entry/oh-package.json5
+++ b/support/openharmony/entry/oh-package.json5
@@ -5,7 +5,7 @@
   "name": "servoshell",
   "description": "Please describe the basic information.",
   "main": "",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "dependencies": {
     "libservoshell.so": "file:./src/main/cpp/types/libentry"
   }

--- a/support/openharmony/oh-package.json5
+++ b/support/openharmony/oh-package.json5
@@ -8,6 +8,6 @@
   "name": "servoshell",
   "description": "Servo browser shell",
   "main": "",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "dependencies": {}
 }

--- a/support/windows/servoshell.wxs.mako
+++ b/support/windows/servoshell.wxs.mako
@@ -6,7 +6,7 @@
            UpgradeCode="060cd15d-eab1-4614-b438-3988e3efdcf1"
            Language="1033"
            Codepage="1252"
-           Version="0.1.0">
+           Version="0.1.2">
     <Package Id="*"
              Keywords="Installer"
              Description="Servo Tech Demo Installer"


### PR DESCRIPTION
This PR targets the LTS branch

- Bump the workspace version to 0.1.2
- We had changes through multiple servo components this time, so republish everything instead of just `servo` like in 0.1.1.

Changes in 0.1.2:
1e574d4210513eb89b02f97ccced31a6c9f37d1a..67f08f45a13d13b0209d61e62a7038edda8f7d85

- Updates Spidermonkey from ESR 140.10 to 140.12, pulling in security fixes from [MFSA 2026-48] and [MFSA 2026-58], including CVE-2026-8388, CVE-2026-8391 and CVE-2026-12299
- Backport 24 security related changes to the LTS  

[MFSA 2026-48]: https://www.mozilla.org/en-US/security/advisories/mfsa2026-48/
[MFSA 2026-58]: https://www.mozilla.org/en-US/security/advisories/mfsa2026-58/

Testing: This is a regular version bump, no specific testing required.
