### PR TITLE
tests: Enable `web-animations/interfaces`

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -330,6 +330,10 @@ skip: true
     skip: true
 [wasm]
   skip: false
+[web-animations]
+  skip: true
+  [interfaces]
+    skip: false
 [webaudio]
   skip: false
 [WebCryptoAPI]

--- a/tests/wpt/meta/web-animations/__dir__.ini
+++ b/tests/wpt/meta/web-animations/__dir__.ini
@@ -1,0 +1,3 @@
+prefs: [
+  "dom_web_animations_enabled:true",
+]

--- a/tests/wpt/meta/web-animations/interfaces/Animatable/animate-no-browsing-context.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animatable/animate-no-browsing-context.html.ini
@@ -1,0 +1,12 @@
+[animate-no-browsing-context.html]
+  [Element.animate() creates an animation with the correct timeline when called on an element in a document without a browsing context]
+    expected: FAIL
+
+  [The timeline associated with an animation trigger on an element in a document without a browsing context is inactive]
+    expected: FAIL
+
+  [Replacing the timeline of an animation targetting an element in a document without a browsing context leaves it in the pending state]
+    expected: FAIL
+
+  [Replacing the timeline of an animation targetting an element in a document without a browsing context and then adopting that element causes it to start updating style]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/Animatable/animate.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animatable/animate.html.ini
@@ -1,0 +1,411 @@
+[animate.html]
+  [Element.animate() creates an Animation object with a KeyframeEffect]
+    expected: FAIL
+
+  [Element.animate() creates an Animation object with a KeyframeEffect that is created in the relevant realm of the target element]
+    expected: FAIL
+
+  [Element.animate() accepts a one property two value property-indexed keyframes specification]
+    expected: FAIL
+
+  [Element.animate() accepts a one shorthand property two value property-indexed keyframes specification]
+    expected: FAIL
+
+  [Element.animate() accepts a two property (one shorthand and one of its longhand components) two value property-indexed keyframes specification]
+    expected: FAIL
+
+  [Element.animate() accepts a two property (one shorthand and one of its shorthand components) two value property-indexed keyframes specification]
+    expected: FAIL
+
+  [Element.animate() accepts a two property two value property-indexed keyframes specification]
+    expected: FAIL
+
+  [Element.animate() accepts a two property property-indexed keyframes specification with different numbers of values]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframes specification with an invalid value]
+    expected: FAIL
+
+  [Element.animate() accepts a one property two value property-indexed keyframes specification that needs to stringify its values]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframes specification with a CSS variable reference]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframes specification with a CSS variable reference in a shorthand property]
+    expected: FAIL
+
+  [Element.animate() accepts a one property one value property-indexed keyframes specification]
+    expected: FAIL
+
+  [Element.animate() accepts a one property one non-array value property-indexed keyframes specification]
+    expected: FAIL
+
+  [Element.animate() accepts a one property two value property-indexed keyframes specification where the first value is invalid]
+    expected: FAIL
+
+  [Element.animate() accepts a one property two value property-indexed keyframes specification where the second value is invalid]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframes specification with a CSS variable as the property]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe with a single offset]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe with an array of offsets]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe with an array of offsets that is too short]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe with an array of offsets that is too long]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe with an empty array of offsets]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe with an array of offsets with an embedded null value]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe with an array of offsets with a trailing null value]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe with an array of offsets with leading and trailing null values]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe with an array of offsets with adjacent null values]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe with an array of offsets with all null values (and too many at that)]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe with a single null offset]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe with an array of offsets that is not strictly ascending in the unused part of the array]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe without any specified easing]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe with a single easing]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe with an array of easings]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe with an array of easings that is too short]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe with a single-element array of easings]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe with an empty array of easings]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe with an array of easings that is too long]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe with a single composite operation]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe with a composite array]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe with a composite array that is too short]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe with a composite array that is too long]
+    expected: FAIL
+
+  [Element.animate() accepts a property-indexed keyframe with a single-element composite array]
+    expected: FAIL
+
+  [Element.animate() accepts a one property one keyframe sequence]
+    expected: FAIL
+
+  [Element.animate() accepts a one property two keyframe sequence]
+    expected: FAIL
+
+  [Element.animate() accepts a two property two keyframe sequence]
+    expected: FAIL
+
+  [Element.animate() accepts a one shorthand property two keyframe sequence]
+    expected: FAIL
+
+  [Element.animate() accepts a two property (a shorthand and one of its component longhands) two keyframe sequence]
+    expected: FAIL
+
+  [Element.animate() accepts a two property keyframe sequence where one property is missing from the first keyframe]
+    expected: FAIL
+
+  [Element.animate() accepts a two property keyframe sequence where one property is missing from the last keyframe]
+    expected: FAIL
+
+  [Element.animate() accepts a one property two keyframe sequence that needs to stringify its values]
+    expected: FAIL
+
+  [Element.animate() accepts a keyframe sequence with a CSS variable reference]
+    expected: FAIL
+
+  [Element.animate() accepts a keyframe sequence with a CSS variable reference in a shorthand property]
+    expected: FAIL
+
+  [Element.animate() accepts a keyframe sequence with a CSS variable as its property]
+    expected: FAIL
+
+  [Element.animate() accepts a keyframe sequence with duplicate values for a given interior offset]
+    expected: FAIL
+
+  [Element.animate() accepts a keyframe sequence with duplicate values for offsets 0 and 1]
+    expected: FAIL
+
+  [Element.animate() accepts a two property four keyframe sequence]
+    expected: FAIL
+
+  [Element.animate() accepts a single keyframe sequence with omitted offset]
+    expected: FAIL
+
+  [Element.animate() accepts a single keyframe sequence with null offset]
+    expected: FAIL
+
+  [Element.animate() accepts a single keyframe sequence with string offset]
+    expected: FAIL
+
+  [Element.animate() accepts a single keyframe sequence with a single calc() offset]
+    expected: FAIL
+
+  [Element.animate() accepts a one property keyframe sequence with some omitted offsets]
+    expected: FAIL
+
+  [Element.animate() accepts a one property keyframe sequence with some null offsets]
+    expected: FAIL
+
+  [Element.animate() accepts a two property keyframe sequence with some omitted offsets]
+    expected: FAIL
+
+  [Element.animate() accepts a one property keyframe sequence with all omitted offsets]
+    expected: FAIL
+
+  [Element.animate() accepts a keyframe sequence with different easing values, but the same easing value for a given offset]
+    expected: FAIL
+
+  [Element.animate() accepts a keyframe sequence with different composite values, but the same composite value for a given offset]
+    expected: FAIL
+
+  [Element.animate() does not accept keyframes with an out-of-bounded positive offset]
+    expected: FAIL
+
+  [Element.animate() does not accept keyframes with an out-of-bounded negative offset]
+    expected: FAIL
+
+  [Element.animate() does not accept property-indexed keyframes not loosely sorted by offset]
+    expected: FAIL
+
+  [Element.animate() does not accept property-indexed keyframes not loosely sorted by offset even though not all offsets are specified]
+    expected: FAIL
+
+  [Element.animate() does not accept property-indexed keyframes with offsets out of range]
+    expected: FAIL
+
+  [Element.animate() does not accept keyframes not loosely sorted by offset]
+    expected: FAIL
+
+  [Element.animate() does not accept property-indexed keyframes with an invalid easing value]
+    expected: FAIL
+
+  [Element.animate() does not accept property-indexed keyframes with an invalid easing value as one of the array values]
+    expected: FAIL
+
+  [Element.animate() does not accept property-indexed keyframe with an invalid easing in the unused part of the array of easings]
+    expected: FAIL
+
+  [Element.animate() does not accept empty property-indexed keyframe with an invalid easing]
+    expected: FAIL
+
+  [Element.animate() does not accept empty property-indexed keyframe with an invalid easings array]
+    expected: FAIL
+
+  [Element.animate() does not accept a keyframe sequence with an invalid easing value]
+    expected: FAIL
+
+  [Element.animate() does not accept property-indexed keyframes with an invalid composite value]
+    expected: FAIL
+
+  [Element.animate() does not accept property-indexed keyframes with an invalid composite value as one of the array values]
+    expected: FAIL
+
+  [Element.animate() does not accept keyframes with an invalid composite value]
+    expected: FAIL
+
+  [Element.animate() accepts a double as an options argument]
+    expected: FAIL
+
+  [Element.animate() accepts a KeyframeAnimationOptions argument]
+    expected: FAIL
+
+  [Element.animate() accepts an absent options argument]
+    expected: FAIL
+
+  [Element.animate() accepts a duration of 'auto' using a dictionary object]
+    expected: FAIL
+
+  [Element.animate() does not accept invalid duration value: -1]
+    expected: FAIL
+
+  [Element.animate() does not accept invalid duration value: NaN]
+    expected: FAIL
+
+  [Element.animate() does not accept invalid duration value: -Infinity]
+    expected: FAIL
+
+  [Element.animate() does not accept invalid duration value: "abc"]
+    expected: FAIL
+
+  [Element.animate() does not accept invalid duration value: -1 using a dictionary object]
+    expected: FAIL
+
+  [Element.animate() does not accept invalid duration value: NaN using a dictionary object]
+    expected: FAIL
+
+  [Element.animate() does not accept invalid duration value: -Infinity using a dictionary object]
+    expected: FAIL
+
+  [Element.animate() does not accept invalid duration value: "abc" using a dictionary object]
+    expected: FAIL
+
+  [Element.animate() does not accept invalid duration value: "100" using a dictionary object]
+    expected: FAIL
+
+  [Element.animate() does not accept invalid easing: '']
+    expected: FAIL
+
+  [Element.animate() does not accept invalid easing: '7']
+    expected: FAIL
+
+  [Element.animate() does not accept invalid easing: 'test']
+    expected: FAIL
+
+  [Element.animate() does not accept invalid easing: 'initial']
+    expected: FAIL
+
+  [Element.animate() does not accept invalid easing: 'inherit']
+    expected: FAIL
+
+  [Element.animate() does not accept invalid easing: 'unset']
+    expected: FAIL
+
+  [Element.animate() does not accept invalid easing: 'unrecognized']
+    expected: FAIL
+
+  [Element.animate() does not accept invalid easing: 'var(--x)']
+    expected: FAIL
+
+  [Element.animate() does not accept invalid easing: 'ease-in-out, ease-out']
+    expected: FAIL
+
+  [Element.animate() does not accept invalid easing: 'cubic-bezier(1.1, 0, 1, 1)']
+    expected: FAIL
+
+  [Element.animate() does not accept invalid easing: 'cubic-bezier(0, 0, 1.1, 1)']
+    expected: FAIL
+
+  [Element.animate() does not accept invalid easing: 'cubic-bezier(-0.1, 0, 1, 1)']
+    expected: FAIL
+
+  [Element.animate() does not accept invalid easing: 'cubic-bezier(0, 0, -0.1, 1)']
+    expected: FAIL
+
+  [Element.animate() does not accept invalid easing: 'cubic-bezier(0.1, 0, 4, 0.4)']
+    expected: FAIL
+
+  [Element.animate() does not accept invalid easing: 'steps(-1, start)']
+    expected: FAIL
+
+  [Element.animate() does not accept invalid easing: 'steps(0.1, start)']
+    expected: FAIL
+
+  [Element.animate() does not accept invalid easing: 'steps(3, nowhere)']
+    expected: FAIL
+
+  [Element.animate() does not accept invalid easing: 'steps(-3, end)']
+    expected: FAIL
+
+  [Element.animate() does not accept invalid easing: 'function (a){return a}']
+    expected: FAIL
+
+  [Element.animate() does not accept invalid easing: 'function (x){return x}']
+    expected: FAIL
+
+  [Element.animate() does not accept invalid easing: 'function(x, y){return 0.3}']
+    expected: FAIL
+
+  [Element.animate() does not accept invalid iterationStart value: -1]
+    expected: FAIL
+
+  [Element.animate() does not accept invalid iterations value: -1]
+    expected: FAIL
+
+  [Element.animate() does not accept invalid iterations value: -Infinity]
+    expected: FAIL
+
+  [Element.animate() does not accept invalid iterations value: NaN]
+    expected: FAIL
+
+  [Element.animate() correctly sets the id attribute when no id is specified]
+    expected: FAIL
+
+  [Element.animate() correctly sets the id attribute]
+    expected: FAIL
+
+  [Element.animate() correctly sets the Animation's timeline]
+    expected: FAIL
+
+  [Element.animate() correctly sets the Animation's timeline when triggered on an element in a different document]
+    expected: FAIL
+
+  [Element.animate() correctly sets the Animation's timeline with no timeline parameter in KeyframeAnimationOptions.]
+    expected: FAIL
+
+  [Element.animate() correctly sets the Animation's timeline with undefined timeline in KeyframeAnimationOptions.]
+    expected: FAIL
+
+  [Element.animate() correctly sets the Animation's timeline with null timeline in KeyframeAnimationOptions.]
+    expected: FAIL
+
+  [Element.animate() correctly sets the Animation's timeline with DocumentTimeline in KeyframeAnimationOptions.]
+    expected: FAIL
+
+  [Element.animate() calls play on the Animation]
+    expected: FAIL
+
+  [Element.animate() does NOT trigger a style change event]
+    expected: FAIL
+
+  [animate() with pseudoElement an Animation object targeting the correct pseudo-element]
+    expected: FAIL
+
+  [animate() with pseudoElement without content creates an Animation object targeting the correct pseudo-element]
+    expected: FAIL
+
+  [animate() with pseudoElement an Animation object targeting the correct pseudo-element for ::marker]
+    expected: FAIL
+
+  [animate() with pseudoElement an Animation object targeting the correct pseudo-element for ::first-line]
+    expected: FAIL
+
+  [animate() with a non-null invalid pseudoElement '' throws a SyntaxError]
+    expected: FAIL
+
+  [animate() with a non-null invalid pseudoElement 'before' throws a SyntaxError]
+    expected: FAIL
+
+  [animate() with a non-null invalid pseudoElement ':abc' throws a SyntaxError]
+    expected: FAIL
+
+  [animate() with a non-null invalid pseudoElement '::abc' throws a SyntaxError]
+    expected: FAIL
+
+  [Finished fill animation doesn't replace animation on a different pseudoElement]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/Animatable/getAnimations-iframe.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animatable/getAnimations-iframe.html.ini
@@ -1,0 +1,6 @@
+[getAnimations-iframe.html]
+  [Calling Element.getAnimations updates layout of parent frame if needed]
+    expected: FAIL
+
+  [Calling Document.getAnimations updates layout of parent frame if needed]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/Animatable/getAnimations-pseudoElement-option-on-view-transition.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animatable/getAnimations-pseudoElement-option-on-view-transition.html.ini
@@ -1,0 +1,3 @@
+[getAnimations-pseudoElement-option-on-view-transition.html]
+  [Returns view transition animations with pseudoElement option]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/Animatable/getAnimations.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animatable/getAnimations.html.ini
@@ -1,0 +1,102 @@
+[getAnimations.html]
+  [Returns an empty array for an element with no animations]
+    expected: FAIL
+
+  [Returns both animations for an element with two animations]
+    expected: FAIL
+
+  [Returns only the animations specific to each sibling element]
+    expected: FAIL
+
+  [Returns only the animations specific to each parent/child element]
+    expected: FAIL
+
+  [Returns animations on descendants when subtree: true is specified]
+    expected: FAIL
+
+  [Returns animations on pseudo-elements when subtree: true is specified]
+    expected: FAIL
+
+  [Returns animations on pseudo-element when it is specified]
+    expected: FAIL
+
+  [Returns animations on pseudo-element when it is specified with subtree: true]
+    expected: FAIL
+
+  [Returns animations on functional pseudo-element when it is specified]
+    expected: FAIL
+
+  [Returns no animation when non-animatable pseudo-element is specified]
+    expected: FAIL
+
+  [The legacy Selectors Level 2 single-colon selectors can be used]
+    expected: FAIL
+
+  [Throws SyntaxError for an invalid pseudo-element selector]
+    expected: FAIL
+
+  [Throws SyntaxError for an empty selector]
+    expected: FAIL
+
+  [Does NOT cross shadow-tree boundaries when subtree: true is specified]
+    expected: FAIL
+
+  [Returns animations for a foreign element]
+    expected: FAIL
+
+  [Does not return finished animations that do not fill forwards]
+    expected: FAIL
+
+  [Returns finished animations that fill forwards]
+    expected: FAIL
+
+  [Returns animations yet to reach their active phase]
+    expected: FAIL
+
+  [Does not return reversed finished animations that do not fill backwards]
+    expected: FAIL
+
+  [Returns reversed finished animations that fill backwards]
+    expected: FAIL
+
+  [Returns reversed animations yet to reach their active phase]
+    expected: FAIL
+
+  [Does not return animations with zero playback rate in before phase]
+    expected: FAIL
+
+  [Does not return animations with zero playback rate in after phase]
+    expected: FAIL
+
+  [Does not return an animation that has recently been made not current by setting the playback rate]
+    expected: FAIL
+
+  [Returns animations based on dynamic changes to individual animations' duration]
+    expected: FAIL
+
+  [Returns animations based on dynamic changes to individual animations' end delay]
+    expected: FAIL
+
+  [Returns animations based on dynamic changes to individual animations' iteration count]
+    expected: FAIL
+
+  [Returns animations based on dynamic changes to individual animations' current time]
+    expected: FAIL
+
+  [Does not return an animation that has been removed]
+    expected: FAIL
+
+  [Returns an animation that has been persisted]
+    expected: FAIL
+
+  [Triggers a style change event]
+    expected: FAIL
+
+  [Finished animation with fill: both is not lost after yielding to event loop]
+    expected: FAIL
+
+  [Finished animation with fill: none is not returned]
+    expected: FAIL
+
+  [Finished animation with fill: both on disconnected element is not lost after yielding to event loop]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/Animation/cancel.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animation/cancel.html.ini
@@ -1,0 +1,12 @@
+[cancel.html]
+  [Animated style is cleared after calling Animation.cancel()]
+    expected: FAIL
+
+  [After cancelling an animation, it can still be seeked]
+    expected: FAIL
+
+  [After cancelling an animation, it can still be re-used]
+    expected: FAIL
+
+  [Animation.finished promise should not be rejected by cancel method once it is resolved with inside finish method]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/Animation/commitStyles-svg-crash.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animation/commitStyles-svg-crash.html.ini
@@ -1,0 +1,2 @@
+[commitStyles-svg-crash.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/web-animations/interfaces/Animation/commitStyles.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animation/commitStyles.html.ini
@@ -1,0 +1,96 @@
+[commitStyles.html]
+  [Throws if the target element is not something with a style attribute]
+    expected: FAIL
+
+  [Throws if the target element is a pseudo element]
+    expected: FAIL
+
+  [Checks the pseudo element condition before the not rendered condition]
+    expected: FAIL
+
+  [Throws if the target effect is disconnected]
+    expected: FAIL
+
+  [Throws if the target effect is display:none]
+    expected: FAIL
+
+  [Throws if the target effect's ancestor is display:none]
+    expected: FAIL
+
+  [Treats display:contents as rendered]
+    expected: FAIL
+
+  [Treats display:contents in a display:none subtree as not rendered]
+    expected: FAIL
+
+  [Commits styles]
+    expected: FAIL
+
+  [Commits styles for backwards animation]
+    expected: FAIL
+
+  [Commits values calculated mid-interval]
+    expected: FAIL
+
+  [Commits values during the start delay]
+    expected: FAIL
+
+  [Commits value after the active interval]
+    expected: FAIL
+
+  [Commits the intermediate value of an animation in the middle of stack]
+    expected: FAIL
+
+  [Commits the intermediate value of an animation up to the middle of the stack]
+    expected: FAIL
+
+  [Commits styles for an animation that has been removed]
+    expected: FAIL
+
+  [Commit composites on top of the underlying value]
+    expected: FAIL
+
+  [Commit styles of an animation when another animation runs with a different prop]
+    expected: FAIL
+
+  [Commits logical properties]
+    expected: FAIL
+
+  [Commits logical properties as physical properties]
+    expected: FAIL
+
+  [Commits em units as pixel values]
+    expected: FAIL
+
+  [Commits custom variables]
+    expected: FAIL
+
+  [Commits variable references as their computed values]
+    expected: FAIL
+
+  [Commits relative line-height]
+    expected: FAIL
+
+  [Commits transforms]
+    expected: FAIL
+
+  [Commits styles for individual transform properties]
+    expected: FAIL
+
+  [Commits transforms as a transform list]
+    expected: FAIL
+
+  [Commits matrix-interpolated relative transforms]
+    expected: FAIL
+
+  [Commits 'none' transform]
+    expected: FAIL
+
+  [Commits shorthand styles]
+    expected: FAIL
+
+  [Triggers mutation observers when updating style]
+    expected: FAIL
+
+  [Does NOT trigger mutation observers when the change to style is redundant]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/Animation/constructor.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animation/constructor.html.ini
@@ -1,0 +1,27 @@
+[constructor.html]
+  [Animation can be constructed with null effect and null timeline]
+    expected: FAIL
+
+  [Animation can be constructed with null effect and non-null timeline]
+    expected: FAIL
+
+  [Animation can be constructed with null effect and no timeline parameter]
+    expected: FAIL
+
+  [Animation can be constructed with non-null effect and null timeline]
+    expected: FAIL
+
+  [Animation can be constructed with non-null effect and non-null timeline]
+    expected: FAIL
+
+  [Animation can be constructed with non-null effect and no timeline parameter]
+    expected: FAIL
+
+  [Animation constructed by an effect with null target runs normally]
+    expected: FAIL
+
+  [Animation constructed with a keyframe that target element is in iframe]
+    expected: FAIL
+
+  [Animation created with an affect associated with another animation.]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/Animation/effect.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animation/effect.html.ini
@@ -1,0 +1,6 @@
+[effect.html]
+  [effect is set correctly.]
+    expected: FAIL
+
+  [Clearing and setting Animation.effect should update the computed style of the target element]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/Animation/finished.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animation/finished.html.ini
@@ -1,0 +1,63 @@
+[finished.html]
+  [Test pausing then playing does not change the finished promise]
+    expected: FAIL
+
+  [Test restarting a finished animation]
+    expected: FAIL
+
+  [Test restarting a reversed finished animation]
+    expected: FAIL
+
+  [Test redundant finishing of animation]
+    expected: FAIL
+
+  [Finished promise does not resolve when paused]
+    expected: FAIL
+
+  [Finished promise does not resolve when pause-pending]
+    expected: FAIL
+
+  [The finished promise is fulfilled with its Animation]
+    expected: FAIL
+
+  [finished promise is rejected when an animation is canceled by calling cancel()]
+    expected: FAIL
+
+  [canceling an already-finished animation replaces the finished promise]
+    expected: FAIL
+
+  [Test finished promise changes for animation duration changes]
+    expected: FAIL
+
+  [Test finished promise changes when playbackRate == 0]
+    expected: FAIL
+
+  [Test finished promise resolves when reaching to the natural boundary.]
+    expected: FAIL
+
+  [Test finished promise changes when a prior finished promise resolved and the animation falls out finished state]
+    expected: FAIL
+
+  [Test new finished promise generated when finished state is checked synchronously]
+    expected: FAIL
+
+  [Test synchronous finished promise resolved even if finished state is changed soon]
+    expected: FAIL
+
+  [Test synchronous finished promise resolved even if asynchronous finished promise happens just before synchronous promise]
+    expected: FAIL
+
+  [Test finished promise is not resolved when the animation falls out finished state immediately]
+    expected: FAIL
+
+  [Test finished promise is not resolved once the animation falls out finished state even though the current finished promise is generated soon after animation state became finished]
+    expected: FAIL
+
+  [Finished promise should be resolved after the ready promise is resolved]
+    expected: FAIL
+
+  [Finished promise should be rejected after the ready promise is rejected]
+    expected: FAIL
+
+  [Finished promise does not report an unhandledrejection when rejected]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/Animation/id.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animation/id.html.ini
@@ -1,0 +1,3 @@
+[id.html]
+  [Animation.id initial value]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/Animation/oncancel.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animation/oncancel.html.ini
@@ -1,0 +1,3 @@
+[oncancel.html]
+  [oncancel event is fired when animation.cancel() is called.]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/Animation/onfinish.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animation/onfinish.html.ini
@@ -1,0 +1,16 @@
+[onfinish.html]
+  expected: ERROR
+  [onfinish event is fired when the currentTime < 0 and the playbackRate < 0]
+    expected: FAIL
+
+  [onfinish event is fired when the currentTime > 0 and the playbackRate > 0]
+    expected: FAIL
+
+  [onfinish event is fired when animation.finish() is called]
+    expected: FAIL
+
+  [onfinish event is not fired when paused]
+    expected: FAIL
+
+  [Animation can be restarted from the onfinish event]
+    expected: TIMEOUT

--- a/tests/wpt/meta/web-animations/interfaces/Animation/onremove.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animation/onremove.html.ini
@@ -1,0 +1,7 @@
+[onremove.html]
+  expected: TIMEOUT
+  [onremove event is fired when replaced animation is removed.]
+    expected: TIMEOUT
+
+  [onremove events are fired in the correct order]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/Animation/overallProgress.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animation/overallProgress.html.ini
@@ -1,0 +1,18 @@
+[overallProgress.html]
+  [overallProgress of a newly created animation without an effect is unresolved]
+    expected: FAIL
+
+  [overallProgress of an animation whose currentTime is unresolved is unresolved.]
+    expected: FAIL
+
+  [overallProgress of an animation whose effect's endTime is zero is zero if its currentTime is negative.]
+    expected: FAIL
+
+  [overallProgress of an animation whose effect's endTime is zero is one if its currentTime is non-negative.]
+    expected: FAIL
+
+  [overallProgress of an animation whose effect's endTime is infinity is zero.]
+    expected: FAIL
+
+  [overallProgress of an animation is calculated by currentTime / effect endTime.]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/Animation/pause.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animation/pause.html.ini
@@ -1,0 +1,15 @@
+[pause.html]
+  [pause() a running animation]
+    expected: FAIL
+
+  [pause() from idle]
+    expected: FAIL
+
+  [pause() from idle with a negative playbackRate]
+    expected: FAIL
+
+  [pause() from idle with a negative playbackRate and endless effect]
+    expected: FAIL
+
+  [pause() on a finished animation]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/Animation/pending.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animation/pending.html.ini
@@ -1,0 +1,12 @@
+[pending.html]
+  [reports true -> false when initially played]
+    expected: FAIL
+
+  [reports true -> false when paused]
+    expected: FAIL
+
+  [reports true -> true when played without a timeline]
+    expected: FAIL
+
+  [reports true -> true when paused without a timeline]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/Animation/persist.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animation/persist.html.ini
@@ -1,0 +1,7 @@
+[persist.html]
+  expected: TIMEOUT
+  [Allows an animation to be persisted after being removed]
+    expected: TIMEOUT
+
+  [Allows an animation to be persisted before being removed]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/Animation/play.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animation/play.html.ini
@@ -1,0 +1,3 @@
+[play.html]
+  [play() throws when seeking an infinite-duration animation played in reverse]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/Animation/ready.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animation/ready.html.ini
@@ -1,0 +1,12 @@
+[ready.html]
+  [A new ready promise is created when play()/pause() is called]
+    expected: FAIL
+
+  [Redundant calls to play() do not generate new ready promise objects]
+    expected: FAIL
+
+  [The ready promise is fulfilled with its Animation]
+    expected: FAIL
+
+  [The ready promise does not report an unhandledrejection when rejected]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/Animation/scroll-timeline-overallProgress.tentative.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animation/scroll-timeline-overallProgress.tentative.html.ini
@@ -1,0 +1,12 @@
+[scroll-timeline-overallProgress.tentative.html]
+  [animation.overallProgress reflects the progress of a scroll animation as a number between 0 and 1]
+    expected: FAIL
+
+  [animation.overallProgress reflects the overall progress of a scroll with multiple iterations.]
+    expected: FAIL
+
+  [animation.overallProgress reflects the overall progress of a scroll that uses a view-timeline.]
+    expected: FAIL
+
+  [overallProgress of a view-timeline is bounded between 0 and 1.]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/Animation/startTime.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animation/startTime.html.ini
@@ -1,0 +1,18 @@
+[startTime.html]
+  [startTime of a newly created (idle) animation is unresolved]
+    expected: FAIL
+
+  [startTime of a play-pending animation is unresolved]
+    expected: FAIL
+
+  [startTime of a pause-pending animation is unresolved]
+    expected: FAIL
+
+  [startTime of a play-pending animation created using Element.animate shortcut is unresolved]
+    expected: FAIL
+
+  [startTime is resolved when running]
+    expected: FAIL
+
+  [startTime and currentTime are unresolved when animation is cancelled]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/Animation/style-change-events.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animation/style-change-events.html.ini
@@ -1,0 +1,6 @@
+[style-change-events.html]
+  [All property keys are recognized]
+    expected: FAIL
+
+  [Animation.Animation constructor produces expected style change events]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/AnimationEffect/getComputedTiming.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/AnimationEffect/getComputedTiming.html.ini
@@ -1,0 +1,108 @@
+[getComputedTiming.html]
+  [values of getComputedTiming() when a KeyframeEffect is constructed without any KeyframeEffectOptions object]
+    expected: FAIL
+
+  [values of getComputedTiming() when a KeyframeEffect is constructed by an empty KeyframeEffectOptions object]
+    expected: FAIL
+
+  [values of getComputedTiming() when a KeyframeEffect is constructed by a normal KeyframeEffectOptions object]
+    expected: FAIL
+
+  [values of getComputedTiming() when a KeyframeEffect is constructed by a double value]
+    expected: FAIL
+
+  [values of getComputedTiming() when a KeyframeEffect is constructed by +Infinity]
+    expected: FAIL
+
+  [values of getComputedTiming() when a KeyframeEffect is constructed by an Infinity duration]
+    expected: FAIL
+
+  [values of getComputedTiming() when a KeyframeEffect is constructed by an auto duration]
+    expected: FAIL
+
+  [values of getComputedTiming() when a KeyframeEffect is constructed by an Infinity iterations]
+    expected: FAIL
+
+  [values of getComputedTiming() when a KeyframeEffect is constructed by an auto fill]
+    expected: FAIL
+
+  [values of getComputedTiming() when a KeyframeEffect is constructed by a forwards fill]
+    expected: FAIL
+
+  [getComputedTiming().activeDuration for an empty KeyframeEffectOptions object]
+    expected: FAIL
+
+  [getComputedTiming().activeDuration for a non-zero duration and default iteration count]
+    expected: FAIL
+
+  [getComputedTiming().activeDuration for a non-zero duration and integral iteration count]
+    expected: FAIL
+
+  [getComputedTiming().activeDuration for a non-zero duration and fractional iteration count]
+    expected: FAIL
+
+  [getComputedTiming().activeDuration for an non-zero duration and infinite iteration count]
+    expected: FAIL
+
+  [getComputedTiming().activeDuration for an non-zero duration and zero iteration count]
+    expected: FAIL
+
+  [getComputedTiming().activeDuration for a zero duration and default iteration count]
+    expected: FAIL
+
+  [getComputedTiming().activeDuration for a zero duration and fractional iteration count]
+    expected: FAIL
+
+  [getComputedTiming().activeDuration for a zero duration and infinite iteration count]
+    expected: FAIL
+
+  [getComputedTiming().activeDuration for a zero duration and zero iteration count]
+    expected: FAIL
+
+  [getComputedTiming().activeDuration for an infinite duration and default iteration count]
+    expected: FAIL
+
+  [getComputedTiming().activeDuration for an infinite duration and zero iteration count]
+    expected: FAIL
+
+  [getComputedTiming().activeDuration for an infinite duration and fractional iteration count]
+    expected: FAIL
+
+  [getComputedTiming().activeDuration for an infinite duration and infinite iteration count]
+    expected: FAIL
+
+  [getComputedTiming().endTime for an empty KeyframeEffectOptions object]
+    expected: FAIL
+
+  [getComputedTiming().endTime for a non-zero duration and default iteration count]
+    expected: FAIL
+
+  [getComputedTiming().endTime for a non-zero duration and non-default iteration count]
+    expected: FAIL
+
+  [getComputedTiming().endTime for a non-zero duration and non-zero delay]
+    expected: FAIL
+
+  [getComputedTiming().endTime for a non-zero duration, non-zero delay and non-default iteration]
+    expected: FAIL
+
+  [getComputedTiming().endTime for an infinite iteration count]
+    expected: FAIL
+
+  [getComputedTiming().endTime for an infinite duration]
+    expected: FAIL
+
+  [getComputedTiming().endTime for an infinite duration and delay]
+    expected: FAIL
+
+  [getComputedTiming().endTime for an infinite duration and negative delay]
+    expected: FAIL
+
+  [getComputedTiming().endTime for an non-zero duration and negative delay]
+    expected: FAIL
+
+  [getComputedTiming().endTime for an non-zero duration and negative delay greater than active duration]
+    expected: FAIL
+
+  [getComputedTiming().endTime for a zero duration and negative delay]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/AnimationEffect/updateTiming.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/AnimationEffect/updateTiming.html.ini
@@ -1,0 +1,168 @@
+[updateTiming.html]
+  [Allows setting the delay to a positive number]
+    expected: FAIL
+
+  [Allows setting the delay to a negative number]
+    expected: FAIL
+
+  [Allows setting the delay of an animation in progress: positive delay that causes the animation to be no longer in-effect]
+    expected: FAIL
+
+  [Allows setting the delay of an animation in progress: negative delay that seeks into the active interval]
+    expected: FAIL
+
+  [Allows setting the delay of an animation in progress: large negative delay that causes the animation to be finished]
+    expected: FAIL
+
+  [Allows setting the endDelay to a positive number]
+    expected: FAIL
+
+  [Allows setting the endDelay to a negative number]
+    expected: FAIL
+
+  [Allows setting the fill to 'none']
+    expected: FAIL
+
+  [Allows setting the fill to 'forwards']
+    expected: FAIL
+
+  [Allows setting the fill to 'backwards']
+    expected: FAIL
+
+  [Allows setting the fill to 'both']
+    expected: FAIL
+
+  [Allows setting the iterationStart of an animation in progress: backwards-filling]
+    expected: FAIL
+
+  [Allows setting the iterationStart of an animation in progress: active phase]
+    expected: FAIL
+
+  [Allows setting the iterationStart of an animation in progress: forwards-filling]
+    expected: FAIL
+
+  [Allows setting iterations to a double value]
+    expected: FAIL
+
+  [Allows setting iterations to infinity]
+    expected: FAIL
+
+  [Allows setting the iterations of an animation in progress]
+    expected: FAIL
+
+  [Allows setting the duration to 123.45]
+    expected: FAIL
+
+  [Allows setting the duration to auto]
+    expected: FAIL
+
+  [Allows setting the duration to Infinity]
+    expected: FAIL
+
+  [Throws when setting invalid duration: -1]
+    expected: FAIL
+
+  [Throws when setting invalid duration: NaN]
+    expected: FAIL
+
+  [Throws when setting invalid duration: -Infinity]
+    expected: FAIL
+
+  [Throws when setting invalid duration: "abc"]
+    expected: FAIL
+
+  [Throws when setting invalid duration: "100"]
+    expected: FAIL
+
+  [Allows setting the duration of an animation in progress]
+    expected: FAIL
+
+  [Allows setting the duration of an animation in progress such that the the start and current time do not change]
+    expected: FAIL
+
+  [Allows setting the direction to each of the possible keywords]
+    expected: FAIL
+
+  [Allows setting the direction of an animation in progress from 'normal' to 'reverse']
+    expected: FAIL
+
+  [Allows setting the direction of an animation in progress from 'normal' to 'reverse' while at start of active interval]
+    expected: FAIL
+
+  [Allows setting the direction of an animation in progress from 'normal' to 'reverse' while filling backwards]
+    expected: FAIL
+
+  [Allows setting the direction of an animation in progress from 'normal' to 'alternate']
+    expected: FAIL
+
+  [Allows setting the direction of an animation in progress from 'alternate' to 'alternate-reverse']
+    expected: FAIL
+
+  [Allows setting the easing to a step-start function]
+    expected: FAIL
+
+  [Allows setting the easing to a steps(1, start) function]
+    expected: FAIL
+
+  [Allows setting the easing to a steps(2, start) function]
+    expected: FAIL
+
+  [Allows setting the easing to a step-end function]
+    expected: FAIL
+
+  [Allows setting the easing to a steps(1) function]
+    expected: FAIL
+
+  [Allows setting the easing to a steps(1, end) function]
+    expected: FAIL
+
+  [Allows setting the easing to a steps(2, end) function]
+    expected: FAIL
+
+  [Allows setting the easing to a linear function]
+    expected: FAIL
+
+  [Allows setting the easing to a ease function]
+    expected: FAIL
+
+  [Allows setting the easing to a ease-in function]
+    expected: FAIL
+
+  [Allows setting the easing to a ease-in-out function]
+    expected: FAIL
+
+  [Allows setting the easing to a ease-out function]
+    expected: FAIL
+
+  [Allows setting the easing to a easing function which produces values greater than 1]
+    expected: FAIL
+
+  [Allows setting the easing to a easing function which produces values less than 1]
+    expected: FAIL
+
+  [Updates the specified value when setting the easing to 'ease']
+    expected: FAIL
+
+  [Updates the specified value when setting the easing to 'linear']
+    expected: FAIL
+
+  [Updates the specified value when setting the easing to 'ease-in']
+    expected: FAIL
+
+  [Updates the specified value when setting the easing to 'ease-out']
+    expected: FAIL
+
+  [Updates the specified value when setting the easing to 'ease-in-out']
+    expected: FAIL
+
+  [Updates the specified value when setting the easing to 'cubic-bezier(0.1, 5, 0.23, 0)']
+    expected: FAIL
+
+  [Updates the specified value when setting the easing to 'steps(3, start)']
+    expected: FAIL
+
+  [Updates the specified value when setting the easing to 'steps(3)']
+    expected: FAIL
+
+  [Allows setting the easing of an animation in progress]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/AnimationPlaybackEvent/constructor.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/AnimationPlaybackEvent/constructor.html.ini
@@ -1,0 +1,6 @@
+[constructor.html]
+  [Event created without an event parameter has null time values]
+    expected: FAIL
+
+  [Created event reflects times specified in constructor]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/DocumentOrShadowRoot/getAnimations.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/DocumentOrShadowRoot/getAnimations.html.ini
@@ -1,0 +1,33 @@
+[getAnimations.html]
+  [Document.getAnimations() returns an empty sequence for non-animated content]
+    expected: FAIL
+
+  [Document.getAnimations() returns script-generated animations]
+    expected: FAIL
+
+  [Document.getAnimations() returns script-generated animations in the order they were created]
+    expected: FAIL
+
+  [Document.getAnimations() does not return a disconnected node]
+    expected: FAIL
+
+  [Document.getAnimations() does not return an animation with a null target]
+    expected: FAIL
+
+  [Document.getAnimations() returns animations on elements inside same-origin iframes]
+    expected: FAIL
+
+  [iframe.contentDocument.getAnimations() returns animations on elements inside same-origin Document]
+    expected: FAIL
+
+  [ShadowRoot.getAnimations() return all animations in the shadow tree]
+    expected: FAIL
+
+  [Document.getAnimations() does NOT return animations in shadow trees]
+    expected: FAIL
+
+  [ShadowRoot.getAnimations() does NOT return animations in parent document]
+    expected: FAIL
+
+  [Document.getAnimations() triggers a style change event]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/DocumentTimeline/constructor.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/DocumentTimeline/constructor.html.ini
@@ -1,0 +1,12 @@
+[constructor.html]
+  [An origin time of zero is used when none is supplied]
+    expected: FAIL
+
+  [A zero origin time produces a document timeline with a current time identical to the default document timeline]
+    expected: FAIL
+
+  [A positive origin time makes the document timeline's current time lag behind the default document timeline]
+    expected: FAIL
+
+  [A negative origin time makes the document timeline's current time run ahead of the default document timeline]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/DocumentTimeline/duration.tentative.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/DocumentTimeline/duration.tentative.html.ini
@@ -1,0 +1,3 @@
+[duration.tentative.html]
+  [A document timeline does not have a duration]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/DocumentTimeline/style-change-events.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/DocumentTimeline/style-change-events.html.ini
@@ -1,0 +1,6 @@
+[style-change-events.html]
+  [DocumentTimeline.currentTime does NOT trigger a style change event]
+    expected: FAIL
+
+  [DocumentTimeline constructor does NOT trigger a style change event]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/composite.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/composite.html.ini
@@ -1,0 +1,12 @@
+[composite.html]
+  [Default value]
+    expected: FAIL
+
+  [Change composite value]
+    expected: FAIL
+
+  [Unspecified keyframe composite value when setting effect composite]
+    expected: FAIL
+
+  [Specified keyframe composite value when setting effect composite]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/constructor.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/constructor.html.ini
@@ -1,0 +1,525 @@
+[constructor.html]
+  [A KeyframeEffect can be constructed with no frames]
+    expected: FAIL
+
+  [easing values are parsed correctly when passed to the KeyframeEffect constructor in KeyframeEffectOptions]
+    expected: FAIL
+
+  [Invalid easing values are correctly rejected when passed to the KeyframeEffect constructor in KeyframeEffectOptions]
+    expected: FAIL
+
+  [composite values are parsed correctly when passed to the KeyframeEffect constructor in property-indexed keyframes]
+    expected: FAIL
+
+  [composite values are parsed correctly when passed to the KeyframeEffect constructor in regular keyframes]
+    expected: FAIL
+
+  [composite value is auto if the composite operation specified on the keyframe effect is being used]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a one property two value property-indexed keyframes specification]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a one property two value property-indexed keyframes specification roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a one shorthand property two value property-indexed keyframes specification]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a one shorthand property two value property-indexed keyframes specification roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a two property (one shorthand and one of its longhand components) two value property-indexed keyframes specification]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a two property (one shorthand and one of its longhand components) two value property-indexed keyframes specification roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a two property (one shorthand and one of its shorthand components) two value property-indexed keyframes specification]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a two property (one shorthand and one of its shorthand components) two value property-indexed keyframes specification roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a two property two value property-indexed keyframes specification]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a two property two value property-indexed keyframes specification roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a two property property-indexed keyframes specification with different numbers of values]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a two property property-indexed keyframes specification with different numbers of values roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframes specification with an invalid value]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframes specification with an invalid value roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a one property two value property-indexed keyframes specification that needs to stringify its values]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a one property two value property-indexed keyframes specification that needs to stringify its values roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframes specification with a CSS variable reference]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframes specification with a CSS variable reference roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframes specification with a CSS variable reference in a shorthand property]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframes specification with a CSS variable reference in a shorthand property roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a one property one value property-indexed keyframes specification]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a one property one value property-indexed keyframes specification roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a one property one non-array value property-indexed keyframes specification]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a one property one non-array value property-indexed keyframes specification roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a one property two value property-indexed keyframes specification where the first value is invalid]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a one property two value property-indexed keyframes specification where the first value is invalid roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a one property two value property-indexed keyframes specification where the second value is invalid]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a one property two value property-indexed keyframes specification where the second value is invalid roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframes specification with a CSS variable as the property]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframes specification with a CSS variable as the property roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe with a single offset]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe with a single offset roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of offsets]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe with an array of offsets roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of offsets that is too short]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe with an array of offsets that is too short roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of offsets that is too long]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe with an array of offsets that is too long roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe with an empty array of offsets]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe with an empty array of offsets roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of offsets with an embedded null value]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe with an array of offsets with an embedded null value roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of offsets with a trailing null value]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe with an array of offsets with a trailing null value roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of offsets with leading and trailing null values]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe with an array of offsets with leading and trailing null values roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of offsets with adjacent null values]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe with an array of offsets with adjacent null values roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of offsets with all null values (and too many at that)]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe with an array of offsets with all null values (and too many at that) roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe with a single null offset]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe with a single null offset roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of offsets that is not strictly ascending in the unused part of the array]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe with an array of offsets that is not strictly ascending in the unused part of the array roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe without any specified easing]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe without any specified easing roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe with a single easing]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe with a single easing roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of easings]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe with an array of easings roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of easings that is too short]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe with an array of easings that is too short roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe with a single-element array of easings]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe with a single-element array of easings roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe with an empty array of easings]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe with an empty array of easings roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of easings that is too long]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe with an array of easings that is too long roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe with a single composite operation]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe with a single composite operation roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe with a composite array]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe with a composite array roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe with a composite array that is too short]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe with a composite array that is too short roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe with a composite array that is too long]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe with a composite array that is too long roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a property-indexed keyframe with a single-element composite array]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a property-indexed keyframe with a single-element composite array roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a one property one keyframe sequence]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a one property one keyframe sequence roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a one property two keyframe sequence]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a one property two keyframe sequence roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a two property two keyframe sequence]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a two property two keyframe sequence roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a one shorthand property two keyframe sequence]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a one shorthand property two keyframe sequence roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a two property (a shorthand and one of its component longhands) two keyframe sequence]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a two property (a shorthand and one of its component longhands) two keyframe sequence roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a two property keyframe sequence where one property is missing from the first keyframe]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a two property keyframe sequence where one property is missing from the first keyframe roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a two property keyframe sequence where one property is missing from the last keyframe]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a two property keyframe sequence where one property is missing from the last keyframe roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a one property two keyframe sequence that needs to stringify its values]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a one property two keyframe sequence that needs to stringify its values roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a keyframe sequence with a CSS variable reference]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a keyframe sequence with a CSS variable reference roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a keyframe sequence with a CSS variable reference in a shorthand property]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a keyframe sequence with a CSS variable reference in a shorthand property roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a keyframe sequence with a CSS variable as its property]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a keyframe sequence with a CSS variable as its property roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a keyframe sequence with duplicate values for a given interior offset]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a keyframe sequence with duplicate values for a given interior offset roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a keyframe sequence with duplicate values for offsets 0 and 1]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a keyframe sequence with duplicate values for offsets 0 and 1 roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a two property four keyframe sequence]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a two property four keyframe sequence roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a single keyframe sequence with omitted offset]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a single keyframe sequence with omitted offset roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a single keyframe sequence with null offset]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a single keyframe sequence with null offset roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a single keyframe sequence with string offset]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a single keyframe sequence with string offset roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a single keyframe sequence with a single calc() offset]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a single keyframe sequence with a single calc() offset roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a one property keyframe sequence with some omitted offsets]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a one property keyframe sequence with some omitted offsets roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a one property keyframe sequence with some null offsets]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a one property keyframe sequence with some null offsets roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a two property keyframe sequence with some omitted offsets]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a two property keyframe sequence with some omitted offsets roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a one property keyframe sequence with all omitted offsets]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a one property keyframe sequence with all omitted offsets roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a keyframe sequence with different easing values, but the same easing value for a given offset]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a keyframe sequence with different easing values, but the same easing value for a given offset roundtrips]
+    expected: FAIL
+
+  [A KeyframeEffect can be constructed with a keyframe sequence with different composite values, but the same composite value for a given offset]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with a keyframe sequence with different composite values, but the same composite value for a given offset roundtrips]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with keyframes with an out-of-bounded positive offset]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with keyframes with an out-of-bounded negative offset]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with property-indexed keyframes not loosely sorted by offset]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with property-indexed keyframes not loosely sorted by offset even though not all offsets are specified]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with property-indexed keyframes with offsets out of range]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with keyframes not loosely sorted by offset]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with property-indexed keyframes with an invalid easing value]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with property-indexed keyframes with an invalid easing value as one of the array values]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with property-indexed keyframe with an invalid easing in the unused part of the array of easings]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with empty property-indexed keyframe with an invalid easing]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with empty property-indexed keyframe with an invalid easings array]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with a keyframe sequence with an invalid easing value]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with property-indexed keyframes with an invalid composite value]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with property-indexed keyframes with an invalid composite value as one of the array values]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with keyframes with an invalid composite value]
+    expected: FAIL
+
+  [A KeyframeEffect constructed without any KeyframeEffectOptions object]
+    expected: FAIL
+
+  [A KeyframeEffect constructed by an empty KeyframeEffectOptions object]
+    expected: FAIL
+
+  [A KeyframeEffect constructed by a normal KeyframeEffectOptions object]
+    expected: FAIL
+
+  [A KeyframeEffect constructed by a double value]
+    expected: FAIL
+
+  [A KeyframeEffect constructed by +Infinity]
+    expected: FAIL
+
+  [A KeyframeEffect constructed by an Infinity duration]
+    expected: FAIL
+
+  [A KeyframeEffect constructed by an auto duration]
+    expected: FAIL
+
+  [A KeyframeEffect constructed by an Infinity iterations]
+    expected: FAIL
+
+  [A KeyframeEffect constructed by an auto fill]
+    expected: FAIL
+
+  [A KeyframeEffect constructed by a forwards fill]
+    expected: FAIL
+
+  [Invalid KeyframeEffect option by -Infinity]
+    expected: FAIL
+
+  [Invalid KeyframeEffect option by NaN]
+    expected: FAIL
+
+  [Invalid KeyframeEffect option by a negative value]
+    expected: FAIL
+
+  [Invalid KeyframeEffect option by a negative Infinity duration]
+    expected: FAIL
+
+  [Invalid KeyframeEffect option by a NaN duration]
+    expected: FAIL
+
+  [Invalid KeyframeEffect option by a negative duration]
+    expected: FAIL
+
+  [Invalid KeyframeEffect option by a string duration]
+    expected: FAIL
+
+  [Invalid KeyframeEffect option by a negative Infinity iterations]
+    expected: FAIL
+
+  [Invalid KeyframeEffect option by a NaN iterations]
+    expected: FAIL
+
+  [Invalid KeyframeEffect option by a negative iterations]
+    expected: FAIL
+
+  [Invalid KeyframeEffect option by a blank easing]
+    expected: FAIL
+
+  [Invalid KeyframeEffect option by an unrecognized easing]
+    expected: FAIL
+
+  [Invalid KeyframeEffect option by an 'initial' easing]
+    expected: FAIL
+
+  [Invalid KeyframeEffect option by an 'inherit' easing]
+    expected: FAIL
+
+  [Invalid KeyframeEffect option by a variable easing]
+    expected: FAIL
+
+  [Invalid KeyframeEffect option by a multi-value easing]
+    expected: FAIL
+
+  [A KeyframeEffect constructed with null target]
+    expected: FAIL
+
+  [KeyframeEffect constructor propagates exceptions generated by accessing the options object]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/copy-constructor.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/copy-constructor.html.ini
@@ -1,0 +1,15 @@
+[copy-constructor.html]
+  [Copied KeyframeEffect has the same target]
+    expected: FAIL
+
+  [Copied KeyframeEffect does not expose UA-shadow DOM]
+    expected: FAIL
+
+  [Copied KeyframeEffect has the same keyframes]
+    expected: FAIL
+
+  [Copied KeyframeEffect has the same KeyframeEffectOptions]
+    expected: FAIL
+
+  [Copied KeyframeEffect has the same timing content]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/getKeyframes.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/getKeyframes.html.ini
@@ -1,0 +1,3 @@
+[getKeyframes.html]
+  [getKeyframes() should serialize its css values with a on keyframe sequence which requires value serilaization of its values]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/iterationComposite.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/iterationComposite.html.ini
@@ -1,0 +1,3 @@
+[iterationComposite.html]
+  [iterationComposite can be updated while an animation is in progress]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html.ini
@@ -1,0 +1,75 @@
+[processing-a-keyframes-argument-001.html]
+  [Equivalent property-indexed and sequenced keyframes: two properties with one value]
+    expected: FAIL
+
+  [Equivalent property-indexed and sequenced keyframes: two properties with three values]
+    expected: FAIL
+
+  [Equivalent property-indexed and sequenced keyframes: two properties with different numbers of values]
+    expected: FAIL
+
+  [Equivalent property-indexed and sequenced keyframes: same easing applied to all keyframes]
+    expected: FAIL
+
+  [Equivalent property-indexed and sequenced keyframes: same composite applied to all keyframes]
+    expected: FAIL
+
+  [Keyframes are read from a custom iterator]
+    expected: FAIL
+
+  ['easing' and 'offset' are ignored on iterable objects]
+    expected: FAIL
+
+  [Keyframes are read from a custom iterator with multiple properties specified]
+    expected: FAIL
+
+  [Keyframes are read from a custom iterator with where an offset is specified]
+    expected: FAIL
+
+  [If a keyframe throws for an animatable property, that exception should be propagated]
+    expected: FAIL
+
+  [Reading from a custom iterator that returns a non-object keyframe should throw]
+    expected: FAIL
+
+  [Reading from a custom iterator that returns a non-object keyframe and an invalid easing should throw]
+    expected: FAIL
+
+  [Reading from a custom iterator that returns a keyframe with a non finite floating-point offset value should throw]
+    expected: FAIL
+
+  [Reading from a custom iterator that returns a keyframe with a non finite floating-point offset value and an invalid easing should throw]
+    expected: FAIL
+
+  [An undefined keyframe returned from a custom iterator should be treated as a default keyframe]
+    expected: FAIL
+
+  [A null keyframe returned from a custom iterator should be treated as a default keyframe]
+    expected: FAIL
+
+  [A list of values returned from a custom iterator should be ignored]
+    expected: FAIL
+
+  [If a custom iterator throws from next(), the exception should be rethrown]
+    expected: FAIL
+
+  [Accessing a Symbol.iterator property that throws should rethrow]
+    expected: FAIL
+
+  [A non-object returned from the Symbol.iterator property should cause a TypeError to be thrown]
+    expected: FAIL
+
+  [Only enumerable properties on keyframes are read]
+    expected: FAIL
+
+  [Only properties defined directly on keyframes are read]
+    expected: FAIL
+
+  [Only enumerable properties on property-indexed keyframes are read]
+    expected: FAIL
+
+  [Only properties defined directly on property-indexed keyframes are read]
+    expected: FAIL
+
+  [Properties are read in ascending order by Unicode codepoint]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-002.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-002.html.ini
@@ -1,0 +1,21 @@
+[processing-a-keyframes-argument-002.html]
+  [easing values are parsed correctly when set on a property-indexed keyframe]
+    expected: FAIL
+
+  [easing values are parsed correctly when using a keyframe sequence]
+    expected: FAIL
+
+  [Invalid easing values are correctly rejected when set on a property-indexed keyframe]
+    expected: FAIL
+
+  [Invalid easing values are correctly rejected when using a keyframe sequence]
+    expected: FAIL
+
+  [Invalid easing values are correctly rejected after doing all the iterating]
+    expected: FAIL
+
+  [Errors from invalid easings on a property-indexed keyframe are thrown after reading all properties]
+    expected: FAIL
+
+  [Errors from invalid easings on a keyframe sequence are thrown after reading all properties]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/setKeyframes.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/setKeyframes.html.ini
@@ -1,0 +1,240 @@
+[setKeyframes.html]
+  [Keyframes can be replaced with an empty keyframe]
+    expected: FAIL
+
+  [Keyframes can be replaced with a one property two value property-indexed keyframes specification]
+    expected: FAIL
+
+  [Keyframes can be replaced with a one shorthand property two value property-indexed keyframes specification]
+    expected: FAIL
+
+  [Keyframes can be replaced with a two property (one shorthand and one of its longhand components) two value property-indexed keyframes specification]
+    expected: FAIL
+
+  [Keyframes can be replaced with a two property (one shorthand and one of its shorthand components) two value property-indexed keyframes specification]
+    expected: FAIL
+
+  [Keyframes can be replaced with a two property two value property-indexed keyframes specification]
+    expected: FAIL
+
+  [Keyframes can be replaced with a two property property-indexed keyframes specification with different numbers of values]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframes specification with an invalid value]
+    expected: FAIL
+
+  [Keyframes can be replaced with a one property two value property-indexed keyframes specification that needs to stringify its values]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframes specification with a CSS variable reference]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframes specification with a CSS variable reference in a shorthand property]
+    expected: FAIL
+
+  [Keyframes can be replaced with a one property one value property-indexed keyframes specification]
+    expected: FAIL
+
+  [Keyframes can be replaced with a one property one non-array value property-indexed keyframes specification]
+    expected: FAIL
+
+  [Keyframes can be replaced with a one property two value property-indexed keyframes specification where the first value is invalid]
+    expected: FAIL
+
+  [Keyframes can be replaced with a one property two value property-indexed keyframes specification where the second value is invalid]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframes specification with a CSS variable as the property]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe with a single offset]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe with an array of offsets]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe with an array of offsets that is too short]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe with an array of offsets that is too long]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe with an empty array of offsets]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe with an array of offsets with an embedded null value]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe with an array of offsets with a trailing null value]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe with an array of offsets with leading and trailing null values]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe with an array of offsets with adjacent null values]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe with an array of offsets with all null values (and too many at that)]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe with a single null offset]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe with an array of offsets that is not strictly ascending in the unused part of the array]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe without any specified easing]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe with a single easing]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe with an array of easings]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe with an array of easings that is too short]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe with a single-element array of easings]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe with an empty array of easings]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe with an array of easings that is too long]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe with a single composite operation]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe with a composite array]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe with a composite array that is too short]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe with a composite array that is too long]
+    expected: FAIL
+
+  [Keyframes can be replaced with a property-indexed keyframe with a single-element composite array]
+    expected: FAIL
+
+  [Keyframes can be replaced with a one property one keyframe sequence]
+    expected: FAIL
+
+  [Keyframes can be replaced with a one property two keyframe sequence]
+    expected: FAIL
+
+  [Keyframes can be replaced with a two property two keyframe sequence]
+    expected: FAIL
+
+  [Keyframes can be replaced with a one shorthand property two keyframe sequence]
+    expected: FAIL
+
+  [Keyframes can be replaced with a two property (a shorthand and one of its component longhands) two keyframe sequence]
+    expected: FAIL
+
+  [Keyframes can be replaced with a two property keyframe sequence where one property is missing from the first keyframe]
+    expected: FAIL
+
+  [Keyframes can be replaced with a two property keyframe sequence where one property is missing from the last keyframe]
+    expected: FAIL
+
+  [Keyframes can be replaced with a one property two keyframe sequence that needs to stringify its values]
+    expected: FAIL
+
+  [Keyframes can be replaced with a keyframe sequence with a CSS variable reference]
+    expected: FAIL
+
+  [Keyframes can be replaced with a keyframe sequence with a CSS variable reference in a shorthand property]
+    expected: FAIL
+
+  [Keyframes can be replaced with a keyframe sequence with a CSS variable as its property]
+    expected: FAIL
+
+  [Keyframes can be replaced with a keyframe sequence with duplicate values for a given interior offset]
+    expected: FAIL
+
+  [Keyframes can be replaced with a keyframe sequence with duplicate values for offsets 0 and 1]
+    expected: FAIL
+
+  [Keyframes can be replaced with a two property four keyframe sequence]
+    expected: FAIL
+
+  [Keyframes can be replaced with a single keyframe sequence with omitted offset]
+    expected: FAIL
+
+  [Keyframes can be replaced with a single keyframe sequence with null offset]
+    expected: FAIL
+
+  [Keyframes can be replaced with a single keyframe sequence with string offset]
+    expected: FAIL
+
+  [Keyframes can be replaced with a single keyframe sequence with a single calc() offset]
+    expected: FAIL
+
+  [Keyframes can be replaced with a one property keyframe sequence with some omitted offsets]
+    expected: FAIL
+
+  [Keyframes can be replaced with a one property keyframe sequence with some null offsets]
+    expected: FAIL
+
+  [Keyframes can be replaced with a two property keyframe sequence with some omitted offsets]
+    expected: FAIL
+
+  [Keyframes can be replaced with a one property keyframe sequence with all omitted offsets]
+    expected: FAIL
+
+  [Keyframes can be replaced with a keyframe sequence with different easing values, but the same easing value for a given offset]
+    expected: FAIL
+
+  [Keyframes can be replaced with a keyframe sequence with different composite values, but the same composite value for a given offset]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with keyframes with an out-of-bounded positive offset]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with keyframes with an out-of-bounded negative offset]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with property-indexed keyframes not loosely sorted by offset]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with property-indexed keyframes not loosely sorted by offset even though not all offsets are specified]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with property-indexed keyframes with offsets out of range]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with keyframes not loosely sorted by offset]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with property-indexed keyframes with an invalid easing value]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with property-indexed keyframes with an invalid easing value as one of the array values]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with property-indexed keyframe with an invalid easing in the unused part of the array of easings]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with empty property-indexed keyframe with an invalid easing]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with empty property-indexed keyframe with an invalid easings array]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with a keyframe sequence with an invalid easing value]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with property-indexed keyframes with an invalid composite value]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with property-indexed keyframes with an invalid composite value as one of the array values]
+    expected: FAIL
+
+  [KeyframeEffect constructor throws with keyframes with an invalid composite value]
+    expected: FAIL
+
+  [Changes made via setKeyframes should be immediately visible in style]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/style-change-events.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/style-change-events.html.ini
@@ -1,0 +1,12 @@
+[style-change-events.html]
+  [All property keys are recognized]
+    expected: FAIL
+
+  [KeyframeEffect.setKeyframes does NOT trigger a style change event]
+    expected: FAIL
+
+  [KeyframeEffect.KeyframeEffect constructor does NOT trigger a style change event]
+    expected: FAIL
+
+  [KeyframeEffect.KeyframeEffect copy constructor does NOT trigger a style change event]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/target.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/target.html.ini
@@ -1,0 +1,72 @@
+[target.html]
+  [Test setting target before constructing the associated animation]
+    expected: FAIL
+
+  [Test setting target from null to a valid target]
+    expected: FAIL
+
+  [Test setting target from a valid target to null]
+    expected: FAIL
+
+  [Test setting target from a valid target to another target]
+    expected: FAIL
+
+  [Target element can be set to a foreign element]
+    expected: FAIL
+
+  [Change target from null to an existing pseudoElement setting target first.]
+    expected: FAIL
+
+  [Change target from null to an existing pseudoElement setting pseudoElement first.]
+    expected: FAIL
+
+  [Change target from an existing pseudo-element to the originating element.]
+    expected: FAIL
+
+  [Change target from an existing to a different existing pseudo-element by setting target.]
+    expected: FAIL
+
+  [Change target from an existing to a different existing pseudo-element by setting pseudoElement.]
+    expected: FAIL
+
+  [Change target from a non-existing to a different existing pseudo-element by setting target.]
+    expected: FAIL
+
+  [Change target from a non-existing to a different existing pseudo-element by setting pseudoElement.]
+    expected: FAIL
+
+  [Change target from null to a non-existing pseudoElement setting target first.]
+    expected: FAIL
+
+  [Change target from null to a non-existing pseudoElement setting pseudoElement first.]
+    expected: FAIL
+
+  [Change target from a non-existing pseudo-element to the originating element.]
+    expected: FAIL
+
+  [Change target from an existing to a different non-existing pseudo-element by setting target.]
+    expected: FAIL
+
+  [Change target from an existing to a different non-existing pseudo-element by setting pseudoElement.]
+    expected: FAIL
+
+  [Change target from a non-existing to a different non-existing pseudo-element by setting target.]
+    expected: FAIL
+
+  [Change target from a non-existing to a different non-existing pseudo-element by setting pseudoElement.]
+    expected: FAIL
+
+  [Changing pseudoElement to a non-null invalid pseudo-selector '' throws a SyntaxError]
+    expected: FAIL
+
+  [Changing pseudoElement to a non-null invalid pseudo-selector 'before' throws a SyntaxError]
+    expected: FAIL
+
+  [Changing pseudoElement to a non-null invalid pseudo-selector ':abc' throws a SyntaxError]
+    expected: FAIL
+
+  [Changing pseudoElement to a non-null invalid pseudo-selector '::abc' throws a SyntaxError]
+    expected: FAIL
+
+  [Changing pseudoElement to ::placeHOLDER works]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/TimelineTrigger/constructor.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/TimelineTrigger/constructor.html.ini
@@ -1,0 +1,27 @@
+[constructor.html]
+  [Empty ranges when no list is supplied.]
+    expected: FAIL
+
+  [Empty ranges when empty list is supplied.]
+    expected: FAIL
+
+  [Default values when an empty property bag is supplied.]
+    expected: FAIL
+
+  [All values supplied (scroll timeline).]
+    expected: FAIL
+
+  [All values supplied (view timeline).]
+    expected: FAIL
+
+  [Entry range supplied; active copied from entry]
+    expected: FAIL
+
+  [Active range supplied; entry copied from active]
+    expected: FAIL
+
+  [Multiple (empty) timelines not supported]
+    expected: FAIL
+
+  [Multiple timelines not supported]
+    expected: FAIL


### PR DESCRIPTION
I haven't enabled the whole testsuite because I want to avoid any potential intermittency. The `interface` subtests should be stable and the first couple of pull requests will only involve the js side (parsing keyframes from js objects etc) anyways.

Part of https://github.com/servo/servo/issues/36950
