### PR TITLE
script: Fix clash of NoGC and CanGc in node::query_selector_all

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -6053,8 +6053,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         cx: &mut JSContext,
         selectors: DOMString,
     ) -> Fallible<DomRoot<NodeList>> {
-        self.upcast::<Node>()
-            .query_selector_all(cx.no_gc(), selectors)
+        self.upcast::<Node>().query_selector_all(cx, selectors)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-document-readystate>

--- a/components/script/dom/document/documentfragment.rs
+++ b/components/script/dom/document/documentfragment.rs
@@ -167,8 +167,7 @@ impl DocumentFragmentMethods<crate::DomTypeHolder> for DocumentFragment {
         cx: &mut JSContext,
         selectors: DOMString,
     ) -> Fallible<DomRoot<NodeList>> {
-        self.upcast::<Node>()
-            .query_selector_all(cx.no_gc(), selectors)
+        self.upcast::<Node>().query_selector_all(cx, selectors)
     }
 }
 

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -3827,7 +3827,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         selectors: DOMString,
     ) -> Fallible<DomRoot<NodeList>> {
         let root = self.upcast::<Node>();
-        root.query_selector_all(cx.no_gc(), selectors)
+        root.query_selector_all(cx, selectors)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-childnode-before>

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -1637,7 +1637,7 @@ impl Node {
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     pub(crate) fn query_selector_all(
         &self,
-        no_gc: &NoGC,
+        cx: &mut JSContext,
         selectors: DOMString,
     ) -> Fallible<DomRoot<NodeList>> {
         // > The querySelectorAll(selectors) method steps are to return the static result of running scope-match
@@ -1648,10 +1648,9 @@ impl Node {
         // layout runs, so that the map can gather their elements in DOM order.
         self.owner_document()
             .id_map()
-            .resolve_all(no_gc, self.owner_doc().upcast());
+            .resolve_all(cx.no_gc(), self.owner_doc().upcast());
 
-        // SAFETY: traced_node is unrooted, but we have a reference to "self" so it won't be freed.
-        let traced_node = Dom::from_ref(self);
+        let traced_node = UnrootedDom::from_dom(Dom::from_ref(self), cx.no_gc());
         let matching_elements = with_layout_state(|| {
             let layout_node: LayoutDom<'_, _> = unsafe { traced_node.to_layout() };
             ServoDangerousStyleNode::from(layout_node)
@@ -1667,7 +1666,7 @@ impl Node {
         Ok(NodeList::new_simple_list(
             &self.owner_window(),
             iter,
-            CanGc::deprecated_note(),
+            CanGc::from_cx(cx),
         ))
     }
 

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -317,7 +317,7 @@ fn all_matching_links(
     // Step 7.2. If a DOMException, SyntaxError, XPathException, or other error occurs
     // during the execution of the element location strategy, return error invalid selector.
     root_node
-        .query_selector_all(cx.no_gc(), DOMString::from("a"))
+        .query_selector_all(cx, DOMString::from("a"))
         .map_err(|_| ErrorStatus::InvalidSelector)
         .map(|nodes| matching_links(&nodes, link_text, partial).collect())
 }
@@ -943,7 +943,7 @@ pub(crate) fn handle_find_element_elements_css_selector(
             get_known_element(documents, pipeline, element_id).and_then(|element| {
                 element
                     .upcast::<Node>()
-                    .query_selector_all(cx.no_gc(), DOMString::from(selector))
+                    .query_selector_all(cx, DOMString::from(selector))
                     .map_err(|_| ErrorStatus::InvalidSelector)
                     .map(|nodes| {
                         nodes
@@ -1034,7 +1034,7 @@ pub(crate) fn handle_find_shadow_elements_css_selector(
             get_known_shadow_root(documents, pipeline, shadow_root_id).and_then(|shadow_root| {
                 shadow_root
                     .upcast::<Node>()
-                    .query_selector_all(cx.no_gc(), DOMString::from(selector))
+                    .query_selector_all(cx, DOMString::from(selector))
                     .map_err(|_| ErrorStatus::InvalidSelector)
                     .map(|nodes| {
                         nodes
@@ -1083,7 +1083,7 @@ pub(crate) fn handle_find_shadow_elements_tag_name(
             get_known_shadow_root(documents, pipeline, shadow_root_id).map(|shadow_root| {
                 shadow_root
                     .upcast::<Node>()
-                    .query_selector_all(cx.no_gc(), DOMString::from(selector))
+                    .query_selector_all(cx, DOMString::from(selector))
                     .map(|nodes| {
                         nodes
                             .iter()


### PR DESCRIPTION
Previously in query_selector_all, we got a NoGC token from the caller but handed at the end a CanGc::deprecated_note() to NodeList::new_simple_list.
In practice this did not lead to problems as all callers where only using cx.no_gc(), hence, did not keep unrooted references alive after this call.

This PR now correctly requires a &mut JSContext (and uses CanGc::from_cx for the NodeList). Additionally, with the UnrootedDom struct we can remove the safety comment as this is now statically guaranteed.
Additionally, I am convinced the comment was wrong as while &self could have moved and then the stack variable `traced_node` being a dangling reference.

Testing: This does not change functionality so a simple compile is enough.
