### PR TITLE
script: Implement `KeyframeEffect::{getKeyframes/setKeyframes}`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7486,7 +7486,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.39.0"
-source = "git+https://github.com/servo/stylo?rev=0151ab3bf0183dd2f802d32e4f7fb2140ccb3475#0151ab3bf0183dd2f802d32e4f7fb2140ccb3475"
+source = "git+https://github.com/servo/stylo?rev=e90bb16403de93f469ae71665e0f047ddb00f9ed#e90bb16403de93f469ae71665e0f047ddb00f9ed"
 dependencies = [
  "bitflags 2.13.0",
  "cssparser",
@@ -9239,7 +9239,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=0151ab3bf0183dd2f802d32e4f7fb2140ccb3475#0151ab3bf0183dd2f802d32e4f7fb2140ccb3475"
+source = "git+https://github.com/servo/stylo?rev=e90bb16403de93f469ae71665e0f047ddb00f9ed#e90bb16403de93f469ae71665e0f047ddb00f9ed"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9726,7 +9726,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.19.0"
-source = "git+https://github.com/servo/stylo?rev=0151ab3bf0183dd2f802d32e4f7fb2140ccb3475#0151ab3bf0183dd2f802d32e4f7fb2140ccb3475"
+source = "git+https://github.com/servo/stylo?rev=e90bb16403de93f469ae71665e0f047ddb00f9ed#e90bb16403de93f469ae71665e0f047ddb00f9ed"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9782,7 +9782,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.19.0"
-source = "git+https://github.com/servo/stylo?rev=0151ab3bf0183dd2f802d32e4f7fb2140ccb3475#0151ab3bf0183dd2f802d32e4f7fb2140ccb3475"
+source = "git+https://github.com/servo/stylo?rev=e90bb16403de93f469ae71665e0f047ddb00f9ed#e90bb16403de93f469ae71665e0f047ddb00f9ed"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9791,7 +9791,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.19.0"
-source = "git+https://github.com/servo/stylo?rev=0151ab3bf0183dd2f802d32e4f7fb2140ccb3475#0151ab3bf0183dd2f802d32e4f7fb2140ccb3475"
+source = "git+https://github.com/servo/stylo?rev=e90bb16403de93f469ae71665e0f047ddb00f9ed#e90bb16403de93f469ae71665e0f047ddb00f9ed"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9803,7 +9803,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.19.0"
-source = "git+https://github.com/servo/stylo?rev=0151ab3bf0183dd2f802d32e4f7fb2140ccb3475#0151ab3bf0183dd2f802d32e4f7fb2140ccb3475"
+source = "git+https://github.com/servo/stylo?rev=e90bb16403de93f469ae71665e0f047ddb00f9ed#e90bb16403de93f469ae71665e0f047ddb00f9ed"
 dependencies = [
  "bitflags 2.13.0",
  "stylo_malloc_size_of",
@@ -9812,7 +9812,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.19.0"
-source = "git+https://github.com/servo/stylo?rev=0151ab3bf0183dd2f802d32e4f7fb2140ccb3475#0151ab3bf0183dd2f802d32e4f7fb2140ccb3475"
+source = "git+https://github.com/servo/stylo?rev=e90bb16403de93f469ae71665e0f047ddb00f9ed#e90bb16403de93f469ae71665e0f047ddb00f9ed"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9829,7 +9829,7 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.19.0"
-source = "git+https://github.com/servo/stylo?rev=0151ab3bf0183dd2f802d32e4f7fb2140ccb3475#0151ab3bf0183dd2f802d32e4f7fb2140ccb3475"
+source = "git+https://github.com/servo/stylo?rev=e90bb16403de93f469ae71665e0f047ddb00f9ed#e90bb16403de93f469ae71665e0f047ddb00f9ed"
 dependencies = [
  "toml",
 ]
@@ -9837,7 +9837,7 @@ dependencies = [
 [[package]]
 name = "stylo_traits"
 version = "0.19.0"
-source = "git+https://github.com/servo/stylo?rev=0151ab3bf0183dd2f802d32e4f7fb2140ccb3475#0151ab3bf0183dd2f802d32e4f7fb2140ccb3475"
+source = "git+https://github.com/servo/stylo?rev=e90bb16403de93f469ae71665e0f047ddb00f9ed#e90bb16403de93f469ae71665e0f047ddb00f9ed"
 dependencies = [
  "app_units",
  "bitflags 2.13.0",
@@ -10256,7 +10256,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?rev=0151ab3bf0183dd2f802d32e4f7fb2140ccb3475#0151ab3bf0183dd2f802d32e4f7fb2140ccb3475"
+source = "git+https://github.com/servo/stylo?rev=e90bb16403de93f469ae71665e0f047ddb00f9ed#e90bb16403de93f469ae71665e0f047ddb00f9ed"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -10269,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=0151ab3bf0183dd2f802d32e4f7fb2140ccb3475#0151ab3bf0183dd2f802d32e4f7fb2140ccb3475"
+source = "git+https://github.com/servo/stylo?rev=e90bb16403de93f469ae71665e0f047ddb00f9ed#e90bb16403de93f469ae71665e0f047ddb00f9ed"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,14 +216,14 @@ rustls-pki-types = "1.14"
 rustls-platform-verifier = "0.7.0"
 sea-query = { version = "=1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = "=0.8.0-rc.15"
-selectors = { git = "https://github.com/servo/stylo", rev = "0151ab3bf0183dd2f802d32e4f7fb2140ccb3475" }
+selectors = { git = "https://github.com/servo/stylo", rev = "e90bb16403de93f469ae71665e0f047ddb00f9ed" }
 seq-macro = "0.3.6"
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
 serde_test = "1.0"
-servo_arc = { git = "https://github.com/servo/stylo", rev = "0151ab3bf0183dd2f802d32e4f7fb2140ccb3475" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "e90bb16403de93f469ae71665e0f047ddb00f9ed" }
 sha1 = "0.11"
 sha2 = "0.11"
 sha3 = "0.12"
@@ -233,12 +233,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 speexdsp-resampler = "0.1.0"
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "0151ab3bf0183dd2f802d32e4f7fb2140ccb3475" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "0151ab3bf0183dd2f802d32e4f7fb2140ccb3475" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "0151ab3bf0183dd2f802d32e4f7fb2140ccb3475" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "0151ab3bf0183dd2f802d32e4f7fb2140ccb3475" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "0151ab3bf0183dd2f802d32e4f7fb2140ccb3475" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "0151ab3bf0183dd2f802d32e4f7fb2140ccb3475" }
+stylo = { git = "https://github.com/servo/stylo", rev = "e90bb16403de93f469ae71665e0f047ddb00f9ed" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "e90bb16403de93f469ae71665e0f047ddb00f9ed" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "e90bb16403de93f469ae71665e0f047ddb00f9ed" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "e90bb16403de93f469ae71665e0f047ddb00f9ed" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "e90bb16403de93f469ae71665e0f047ddb00f9ed" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "e90bb16403de93f469ae71665e0f047ddb00f9ed" }
 surfman = { version = "0.13.0", features = ["chains"] }
 swapper = "0.1"
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -1320,6 +1320,7 @@ impl<T: stylo_malloc_size_of::MallocSizeOf, const FRACTION_BITS: u16> MallocSize
     }
 }
 
+malloc_size_of_is_stylo_malloc_size_of!(style::properties::PropertyId);
 malloc_size_of_is_stylo_malloc_size_of!(style::animation::DocumentAnimationSet);
 malloc_size_of_is_stylo_malloc_size_of!(style::attr::AttrIdentifier);
 malloc_size_of_is_stylo_malloc_size_of!(style::attr::AttrValue);

--- a/components/script/dom/animations/keyframeeffect.rs
+++ b/components/script/dom/animations/keyframeeffect.rs
@@ -2,16 +2,52 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::ffi::CString;
+use std::ops::ControlFlow;
+use std::ptr::{self, NonNull};
+use std::sync::LazyLock;
+
+use cssparser::{Parser, ParserInput};
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use js::jsapi::JSObject;
-use js::rust::HandleObject;
+use js::conversions::{
+    ConversionResult, FromJSValConvertible, ToJSValConvertible, jsstr_to_string,
+};
+use js::gc::{HandleValue, RootedVec};
+use js::jsapi::{HandleId, Heap, JS_GetPropertyById, JSITER_OWNONLY, JSObject, JSPROP_ENUMERATE};
+use js::jsval::{ObjectValue, UndefinedValue};
+use js::rust::wrappers2::{GetPropertyKeys, JS_DefineProperty, JS_IdToValue, JS_NewObject};
+use js::rust::{
+    ForOfIterationFailure, HandleObject, IdVector, IntoHandle, IntoMutableHandle, for_of,
+};
+use rustc_hash::FxHashMap;
+use script_bindings::cell::DomRefCell;
+use script_bindings::codegen::GenericBindings::KeyframeEffectBinding::{
+    BaseKeyframe, CompositeOperationOrAuto,
+};
+use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::codegen::GenericUnionTypes::UnrestrictedDoubleOrKeyframeEffectOptions;
+use script_bindings::conversions::StringificationBehavior;
+use script_bindings::error::{Error, Fallible};
+use script_bindings::num::Finite;
 use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use script_bindings::root::{Dom, DomRoot};
+use script_bindings::str::DOMString;
+use style::parser::ParserContext;
+use style::properties::generated::PropertyDeclaration;
+use style::properties::{
+    Importance, LonghandId, NonCustomPropertyId, PropertyDeclarationBlock, PropertyId,
+    SourcePropertyDeclaration,
+};
+use style::stylesheets::CssRuleType;
+use style_traits::{CssWriter, ParsingMode, ToCss};
 
+use crate::css::parser_context_for_document;
+use crate::dom::Document;
 use crate::dom::animationeffect::AnimationEffect;
-use crate::dom::bindings::codegen::Bindings::KeyframeEffectBinding::KeyframeEffectMethods;
+use crate::dom::bindings::codegen::Bindings::KeyframeEffectBinding::{
+    BaseComputedKeyframe, KeyframeEffectMethods,
+};
 use crate::dom::bindings::root::MutNullableDom;
 use crate::dom::element::Element;
 use crate::dom::window::Window;
@@ -31,6 +67,9 @@ pub(crate) struct KeyframeEffect {
     // https://drafts.csswg.org/web-animations-1/#effect-target-target-pseudo-selector
     // https://drafts.csswg.org/web-animations-1/#keyframe-effect-effect-target.
     target_element: MutNullableDom<Element>,
+
+    /// <https://drafts.csswg.org/web-animations-1/#keyframe>
+    keyframes: DomRefCell<Vec<Keyframe>>,
 }
 
 impl KeyframeEffect {
@@ -39,6 +78,7 @@ impl KeyframeEffect {
             window: Dom::from_ref(window),
             animationeffect: AnimationEffect::new_inherited(),
             target_element: Default::default(),
+            keyframes: Default::default(),
         }
     }
 
@@ -100,11 +140,468 @@ impl KeyframeEffectMethods<crate::DomTypeHolder> for KeyframeEffect {
         effect
     }
 
+    /// <https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-getkeyframes>
+    #[expect(unsafe_code)]
+    fn GetKeyframes(
+        &self,
+        cx: &mut JSContext,
+        result: &mut RootedVec<'_, Box<Heap<*mut JSObject>>>,
+    ) -> Fallible<()> {
+        let mut layout = self.window.layout_mut();
+        let stylist = layout.stylist_mut();
+
+        // Step 1. Let result be an empty sequence of objects.
+        debug_assert!(result.is_empty());
+
+        // Step 2. Let keyframes be one of the following:
+        // If this keyframe effect is associated with a CSSAnimation, and its keyframes have not been replaced
+        // by a successful call to setKeyframes(),
+        // the computed keyframes for this keyframe effect.
+        // Otherwise,
+        // the result of applying the procedure compute missing keyframe offsets to the keyframes for this keyframe effect.
+        // TODO: We don't compute missing keyframe offsets yet. But that will likely happen in stylo, not here.
+        let keyframes = self.keyframes.borrow();
+
+        // Step 3. For each keyframe in keyframes perform the following steps:
+        for keyframe in keyframes.iter() {
+            // Step 3.1 Initialize a dictionary object, output keyframe, using the following definition:
+            // TODO Step 3.2 Set the offset, computedOffset, easing, and composite members of output keyframe
+            // to the respective keyframe offset, computed keyframe offset, keyframe-specific easing function,
+            // and keyframe-specific composite operation values of keyframe.
+            let base_keyframe = BaseComputedKeyframe {
+                composite: keyframe.composite,
+                offset: keyframe.offset,
+                // FIXME: We don't post-process the offset of keyframes to find suitable offset values for null
+                // keyframe offsets yet, so we just use the offset as-is.
+                computedOffset: keyframe.offset,
+                easing: keyframe.easing_function.clone(),
+            };
+            rooted!(&in(cx) let mut output_keyframe = unsafe { JS_NewObject(cx, ptr::null()) });
+            base_keyframe.to_jsobject(cx, output_keyframe.handle_mut());
+
+            // Step 3.3 For each animation property-value pair declaration in keyframe, perform the following steps:
+            for property_value_pair in &keyframe.declarations {
+                debug_assert!(property_value_pair.property_id.is_animatable());
+
+                // Step 3.3.1 Let property name be the result of applying the animation property name to IDL attribute
+                // name algorithm to the property name of declaration.
+                let mut property_name = String::new();
+                let mut writer = CssWriter::new(&mut property_name);
+                if property_value_pair.property_id.to_css(&mut writer).is_err() {
+                    continue;
+                }
+                let property_name = animation_property_name_to_idl_attribute_name(&property_name);
+
+                // Step 3.3.2 Let IDL value be the result of serializing the property value of declaration
+                // by passing declaration to the algorithm to serialize a CSS value [CSSOM].
+                let mut value_string = String::new();
+                if property_value_pair
+                    .block
+                    .single_value_to_css(
+                        &property_value_pair.property_id,
+                        &mut value_string,
+                        None,
+                        stylist,
+                    )
+                    .is_err()
+                {
+                    continue;
+                }
+
+                // Step 3.3.3 Let value be the result of converting IDL value to an ECMAScript String value.
+                rooted!(&in(cx) let mut value = UndefinedValue());
+                value_string.safe_to_jsval(cx, value.handle_mut());
+
+                // Step 3.3.4 Call the [[DefineOwnProperty]] internal method on output keyframe with property
+                // name property name, Property Descriptor { [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]:
+                // true, [[Value]]: value } and Boolean flag false.
+                let Ok(property_name) = CString::new(property_name) else {
+                    continue;
+                };
+
+                let success = unsafe {
+                    JS_DefineProperty(
+                        cx,
+                        output_keyframe.handle(),
+                        property_name.as_ptr(),
+                        value.handle(),
+                        JSPROP_ENUMERATE as u32,
+                    )
+                };
+                if !success {
+                    if cfg!(debug_assertions) {
+                        unreachable!("Setting a property on output_keyframe should never fail");
+                    }
+                    return Err(Error::Operation(None));
+                }
+            }
+
+            // Step 3.4 Append output keyframe to result.
+            result.push(Heap::boxed(output_keyframe.get()))
+        }
+
+        // Step 4. Return result.
+        Ok(())
+    }
+
     /// <https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-setkeyframes>
-    fn SetKeyframes(&self, _cx: &mut JSContext, _keyframes: *mut JSObject) {
+    fn SetKeyframes(&self, cx: &mut JSContext, keyframes: *mut JSObject) {
         // > This effect’s set of keyframes is replaced with the result of performing the procedure to
         // > process a keyframes argument. If that procedure throws an exception, this effect’s
         // > keyframes are not modified.
-        // FIXME: Implement this.
+        let document = self.window.Document();
+        let Ok(keyframes) = process_a_keyframes_argument(cx, &document, keyframes) else {
+            return;
+        };
+        *self.keyframes.borrow_mut() = keyframes;
     }
+}
+
+/// <https://drafts.csswg.org/web-animations-1/#process-a-keyframes-argument>
+#[expect(unsafe_code)]
+fn process_a_keyframes_argument(
+    cx: &mut JSContext,
+    document: &Document,
+    keyframes: *mut JSObject,
+) -> Fallible<Vec<Keyframe>> {
+    // Step 1. If object is null, return an empty sequence of keyframes.
+    if keyframes.is_null() {
+        return Ok(Vec::new());
+    }
+
+    // Step 2. Let processed keyframes be an empty sequence of keyframes.
+
+    // Step 3. Let method be the result of GetMethod(object, @@iterator).
+    // Step 4. Check the completion record of method.
+    // Step 5. Perform the steps corresponding to the first matching condition below:
+    rooted!(&in(cx) let iterable = ObjectValue(keyframes));
+    let mut keyframes = Vec::new();
+    let result = for_of(
+        unsafe { cx.raw_cx() },
+        iterable.handle(),
+        |iterator_element| {
+            // Step 5.3.6 If Type(nextItem) is not Undefined, Null or Object, then throw a TypeError
+            // and abort these steps.
+            //
+            // Note: nextItem is later passed to "process a keyframe like object" which cannot handle undefined
+            // or null values. This seems to be a bug in the specification which is tracked by
+            // https://github.com/w3c/csswg-drafts/issues/14113
+            if !iterator_element.is_object() {
+                return Err(ForOfIterationFailure::Other(Error::Type(
+                    c"Keyframe must be an object".to_owned(),
+                )));
+            }
+
+            // Step 5.3.7 Append to processed keyframes the result of running the procedure to process a
+            // keyframe-like object passing nextItem as the keyframe input with the allow lists flag set to false.
+            keyframes.push(keyframe_from_value(cx, document, iterator_element)?);
+
+            Ok(ControlFlow::Continue(()))
+        },
+    );
+    match result {
+        Ok(()) => Ok(keyframes),
+        Err(ForOfIterationFailure::ValueIsNotIterable) => {
+            // TODO: Step 5, Otherwise:
+            Err(Error::Operation(None))
+        },
+        Err(ForOfIterationFailure::JSFailed) => Err(Error::JSFailed),
+        Err(ForOfIterationFailure::Other(error)) => Err(error),
+    }
+}
+
+/// <https://drafts.csswg.org/web-animations-1/#keyframe>
+#[derive(JSTraceable, MallocSizeOf)]
+struct Keyframe {
+    offset: Option<Finite<f64>>,
+    easing_function: DOMString,
+    composite: CompositeOperationOrAuto,
+    declarations: Vec<KeyframePropertyDeclaration>,
+}
+
+#[derive(JSTraceable, MallocSizeOf)]
+struct KeyframePropertyDeclaration {
+    #[no_trace]
+    property_id: PropertyId,
+    /// The block is known to only contain declarations for `property_id`. There might
+    /// be more than one value if `property_id` is a shorthand.
+    #[no_trace]
+    block: PropertyDeclarationBlock,
+}
+
+/// Step 5 (for iterable keyframes) of <https://drafts.csswg.org/web-animations-1/#process-a-keyframes-argument>.
+fn keyframe_from_value(
+    cx: &mut JSContext,
+    document: &Document,
+    value: HandleValue<'_>,
+) -> Fallible<Keyframe> {
+    // Step 3.4 Let nextItem be IteratorValue(next).
+    // NOTE: This is "current_value"
+    // Step 3.5 Check the completion record of nextItem.
+
+    // Step 3.6 If Type(nextItem) is not Undefined, Null or Object,
+    // then throw a TypeError and abort these steps.
+    if !value.is_null_or_undefined() && !value.is_object() {
+        return Err(Error::Type(c"Invalid keyframe value".to_owned()));
+    }
+
+    // Step 3.7 Append to processed keyframes the result of running the procedure to process
+    // a keyframe-like object passing nextItem as the keyframe input with the allow lists
+    // flag set to false.
+    process_a_keyframe_like_object(cx, document, value)
+}
+
+/// <https://drafts.csswg.org/web-animations-1/#process-a-keyframe-like-object>
+fn process_a_keyframe_like_object(
+    cx: &mut JSContext,
+    document: &Document,
+    value: HandleValue,
+) -> Fallible<Keyframe> {
+    // Step 1. Run the procedure to convert an ECMAScript value to a dictionary type [WEBIDL] with keyframe input
+    // as the ECMAScript value, and the dictionary type depending on the value of the allow lists flag as follows:
+    // If allow lists is true,
+    // Use the following dictionary type:
+    //
+    // dictionary BasePropertyIndexedKeyframe {
+    //   (double? or sequence<double?>)                         offset = [];
+    //   (DOMString or sequence<DOMString>)                     easing = [];
+    //   (CompositeOperationOrAuto or sequence<CompositeOperationOrAuto>) composite = [];
+    // };
+    //
+    // Otherwise,
+    //     Use the following dictionary type:
+    //
+    //     dictionary BaseKeyframe {
+    //       double?                  offset = null;
+    //       DOMString                easing = "linear";
+    //       CompositeOperationOrAuto composite = "auto";
+    //     };
+    //
+    // Store the result of this procedure as keyframe output.
+    //
+    // Note: 'allow lists' is currently never true.
+    // Use the following dictionary type:
+    let Ok(keyframe_output) = BaseKeyframe::safe_from_jsval(cx, value, ()) else {
+        return Err(Error::JSFailed);
+    };
+    let ConversionResult::Success(keyframe_output) = keyframe_output else {
+        return Err(Error::Operation(None));
+    };
+
+    // From Step 2 onwards our implementation diverges from the specification. The spec
+    // wants us to build a list of animatable CSS properties and a list of properties on
+    // the object, then compute the union between the two.
+    //
+    // Instead, we iterate over all properties on the object and then check if they correspond
+    // to an animatable property.
+    let urlextradata = document.url().into_url().into();
+    let parser_context = parser_context_for_document(
+        document,
+        CssRuleType::Style,
+        ParsingMode::DEFAULT,
+        &urlextradata,
+    );
+    rooted!(&in(cx) let object = value.to_object());
+
+    // Steps 2 - 6 are in get_property_declarations
+    let declarations = get_property_declarations(cx, object.handle(), &parser_context)?;
+
+    // Step 7. Return keyframe output.
+    Ok(Keyframe {
+        offset: keyframe_output.offset,
+        easing_function: keyframe_output.easing,
+        composite: keyframe_output.composite,
+        declarations,
+    })
+}
+
+/// Implements Step 2-6 of  <https://drafts.csswg.org/web-animations-1/#process-a-keyframe-like-object>.
+#[expect(unsafe_code)]
+fn get_property_declarations(
+    cx: &mut JSContext,
+    object: HandleObject,
+    parser_context: &ParserContext<'_>,
+) -> Fallible<Vec<KeyframePropertyDeclaration>> {
+    // The spec tells us to iterate over all animatable properties and see if they're defined
+    // on the object. Instead we can iterate over the own properties of the object and see
+    // if they're animated properties, that's easier.
+    let mut ids = unsafe { IdVector::new(cx.raw_cx()) };
+    if !unsafe { GetPropertyKeys(cx, object, JSITER_OWNONLY, ids.handle_mut()) } {
+        return Ok(Vec::new());
+    }
+
+    let mut declarations = Vec::with_capacity(ids.len());
+    for id in ids.iter() {
+        rooted!(&in(cx) let id = *id);
+
+        // See if the id for the current property on the object represents a animatable CSS property.
+        if !id.is_string() {
+            continue;
+        }
+        rooted!(&in(cx) let mut key_value = UndefinedValue());
+        let raw_id: HandleId = id.handle().into();
+        if !unsafe { JS_IdToValue(cx, *raw_id.ptr, key_value.handle_mut()) } {
+            continue;
+        }
+        rooted!(&in(cx) let js_string = key_value.to_string());
+        let Some(js_string) = NonNull::new(js_string.get()) else {
+            continue;
+        };
+        let property_name = unsafe { jsstr_to_string(cx, js_string) };
+
+        let Some(property_id) = lookup_css_property_by_idl_attribute_name(&property_name) else {
+            continue;
+        };
+        debug_assert!(property_id.is_animatable());
+
+        // Step 6.1 Let raw value be the result of calling the [[Get]] internal method on keyframe input,
+        // with property name as the property key and keyframe input as the receiver.
+        // Step 6.2 Check the completion record of raw value.
+        rooted!(&in(cx) let mut property_value = UndefinedValue());
+        if !unsafe {
+            JS_GetPropertyById(
+                cx.raw_cx(),
+                object.into_handle(),
+                id.handle().into_handle(),
+                property_value.handle_mut().into_handle_mut(),
+            )
+        } {
+            continue;
+        }
+
+        // Step 6.3 Convert raw value to a DOMString or to a sequence of DOMStrings property values as follows:
+        // If allow lists is true, [..] (Note: We don't implement "allow lists")
+        // Otherwise,
+        // Let property values be the result of converting raw value to a DOMString using the procedure
+        // for converting an ECMAScript value to a DOMString [WEBIDL].
+        let property_value = match DOMString::safe_from_jsval(
+            cx,
+            property_value.handle(),
+            StringificationBehavior::Default,
+        ) {
+            Ok(ConversionResult::Success(property_value)) => property_value,
+            Ok(ConversionResult::Failure(error_message)) => {
+                return Err(Error::Operation(
+                    error_message
+                        .to_str()
+                        .ok()
+                        .map(|message| message.to_owned()),
+                ));
+            },
+            Err(_) => return Err(Error::JSFailed),
+        };
+
+        // Step 6.4 Calculate the normalized property name as the result of applying the IDL attribute name
+        // to animation property name algorithm to property name.
+        // Note: Due to the way our implementation differs from the spec (refer to the comment at
+        // the top of this function), we already have the normalized property name.
+
+        // Parse the property value as a value for the given animatable CSS property.
+        // The specification continues to treat the value as a plain string, but there's not much point.
+        let Some(declaration) =
+            parse_single_property_declaration(property_id, &property_value.str(), parser_context)
+        else {
+            continue;
+        };
+
+        // Step 6.5 Add a property to keyframe output with normalized property name as the property name,
+        // and property values as the property value.
+        declarations.push(declaration);
+    }
+
+    Ok(declarations)
+}
+
+/// Parses `input` as a value for `property`, returning `None` on failure.
+fn parse_single_property_declaration(
+    property: NonCustomPropertyId,
+    input: &str,
+    parser_context: &ParserContext<'_>,
+) -> Option<KeyframePropertyDeclaration> {
+    let mut declaration = SourcePropertyDeclaration::default();
+    let mut input = ParserInput::new(input);
+    let mut parser = Parser::new(&mut input);
+
+    // TODO: Consider reporting parse errors somewhere useful, like the devtools console.
+    parser
+        .parse_entirely(|parser| {
+            PropertyDeclaration::parse_into(
+                &mut declaration,
+                PropertyId::NonCustom(property),
+                parser_context,
+                parser,
+            )
+        })
+        .ok()?;
+
+    let mut block = PropertyDeclarationBlock::new();
+    block.extend(declaration.drain(), Importance::Normal);
+
+    Some(KeyframePropertyDeclaration {
+        property_id: PropertyId::NonCustom(property),
+        block,
+    })
+}
+
+/// This is the inverse of <https://drafts.csswg.org/web-animations-1/#animation-property-name-to-idl-attribute-name>.
+fn lookup_css_property_by_idl_attribute_name(attribute_name: &str) -> Option<NonCustomPropertyId> {
+    // TODO: Step 1. If property follows the <custom-property-name> production, return property.
+
+    // Step 2. If property refers to the CSS float property, return the string "cssFloat".
+    if attribute_name == "cssFloat" {
+        return Some(LonghandId::Float.into());
+    }
+
+    // Step 3. If property refers to the CSS offset property, return the string "cssOffset".
+    // NOTE: "offset" is not supported yet.
+
+    // Step 4. Otherwise, return the result of applying the CSS property to IDL attribute algorithm
+    // [CSSOM] to property.
+    static IDL_ATTRIBUTE_TO_ANIMATED_PROPERTY_LOOKUP_TABLE: LazyLock<
+        FxHashMap<String, NonCustomPropertyId>,
+    > = LazyLock::new(|| {
+        log::debug!("Initializing map from IDL attribute names to CSS properties");
+
+        NonCustomPropertyId::iter()
+            .filter(|non_custom_property| non_custom_property.is_animatable())
+            .filter(|non_custom_property| {
+                non_custom_property
+                    .to_property_id()
+                    .enabled_for_all_content()
+            })
+            .map(|non_custom_property| {
+                let idl_attribute_name =
+                    animation_property_name_to_idl_attribute_name(non_custom_property.name());
+                (idl_attribute_name, non_custom_property)
+            })
+            .collect()
+    });
+    IDL_ATTRIBUTE_TO_ANIMATED_PROPERTY_LOOKUP_TABLE
+        .get(attribute_name)
+        .copied()
+}
+
+/// <https://drafts.csswg.org/web-animations-1/#animation-property-name-to-idl-attribute-name>
+///
+/// # Panics
+/// Panics when the property name is empty or consists only of `-` characters.
+/// In general it is assumed that `property_name` is a CSS property.
+fn animation_property_name_to_idl_attribute_name(property_name: &str) -> String {
+    let mut idl_attribute_name = String::with_capacity(property_name.len());
+
+    let mut chunks = property_name.split('-');
+    let Some(first_chunk) = chunks.next() else {
+        unreachable!("CSS property name should not consist only of dashes");
+    };
+    idl_attribute_name.push_str(first_chunk);
+    for chunk in chunks {
+        let mut characters = chunk.chars();
+        let Some(to_capitalize) = characters.next() else {
+            continue;
+        };
+        idl_attribute_name.push(to_capitalize.to_ascii_uppercase());
+        idl_attribute_name.push_str(characters.as_str());
+    }
+
+    idl_attribute_name
 }

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -29,6 +29,8 @@ use layout_api::{LayoutDamage, QueryMsg, ScrollContainerQueryFlags, StyleData, w
 use net_traits::ReferrerPolicy;
 use net_traits::request::{CorsSettings, CredentialsMode};
 use script_bindings::cell::{DomRefCell, Ref, RefMut};
+use script_bindings::codegen::GenericBindings::AnimationBinding::AnimationMethods;
+use script_bindings::codegen::GenericBindings::KeyframeEffectBinding::KeyframeEffectMethods;
 use script_bindings::reflector::DomObject;
 use selectors::attr::CaseSensitivity;
 use selectors::matching::ElementSelectorFlags;
@@ -68,7 +70,6 @@ use crate::dom::activation::Activatable;
 use crate::dom::animation::Animation;
 use crate::dom::animations::keyframeeffect::KeyframeEffect;
 use crate::dom::attr::{Attr, is_relevant_attribute};
-use crate::dom::bindings::codegen::Bindings::AnimationBinding::AnimationMethods;
 use crate::dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use crate::dom::bindings::codegen::Bindings::ElementBinding::{
@@ -78,7 +79,6 @@ use crate::dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNo
 use crate::dom::bindings::codegen::Bindings::FunctionBinding::Function;
 use crate::dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLTemplateElementBinding::HTMLTemplateElementMethods;
-use crate::dom::bindings::codegen::Bindings::KeyframeEffectBinding::KeyframeEffectMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use crate::dom::bindings::codegen::Bindings::SanitizerBinding::{
     SetHTMLOptions, SetHTMLUnsafeOptions,

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -834,7 +834,7 @@ DOMInterfaces = {
 },
 
 'KeyframeEffect': {
-    'cx': ['SetKeyframes']
+    'cx': ['GetKeyframes', 'SetKeyframes']
 },
 
 'LargestContentfulPaint': {

--- a/components/script_bindings/webidls/KeyframeEffect.webidl
+++ b/components/script_bindings/webidls/KeyframeEffect.webidl
@@ -12,7 +12,7 @@ interface KeyframeEffect : AnimationEffect {
 //   attribute Element?           target;
 //   attribute CSSOMString?       pseudoElement;
 //   attribute CompositeOperation composite;
-//   sequence<object> getKeyframes();
+   [Throws] sequence<object> getKeyframes();
    undefined        setKeyframes(object? keyframes);
 };
 
@@ -33,7 +33,15 @@ dictionary BasePropertyIndexedKeyframe {
 //   (CompositeOperationOrAuto or sequence<CompositeOperationOrAuto>) composite = [];
 };
 dictionary BaseKeyframe {
-//   double?                  offset = null;
-//   DOMString                easing = "linear";
-//   CompositeOperationOrAuto composite = "auto";
+   double?                  offset = null;
+   DOMString                easing = "linear";
+   CompositeOperationOrAuto composite = "auto";
+};
+
+// Part of https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-getkeyframes
+dictionary BaseComputedKeyframe {
+     double?                  offset = null;
+     double                   computedOffset;
+     DOMString                easing = "linear";
+     CompositeOperationOrAuto composite = "auto";
 };

--- a/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/constructor.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/constructor.html.ini
@@ -1,7 +1,4 @@
 [constructor.html]
-  [A KeyframeEffect can be constructed with no frames]
-    expected: FAIL
-
   [easing values are parsed correctly when passed to the KeyframeEffect constructor in KeyframeEffectOptions]
     expected: FAIL
 
@@ -20,379 +17,151 @@
   [A KeyframeEffect can be constructed with a one property two value property-indexed keyframes specification]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a one property two value property-indexed keyframes specification roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a one shorthand property two value property-indexed keyframes specification]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a one shorthand property two value property-indexed keyframes specification roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a two property (one shorthand and one of its longhand components) two value property-indexed keyframes specification]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a two property (one shorthand and one of its longhand components) two value property-indexed keyframes specification roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a two property (one shorthand and one of its shorthand components) two value property-indexed keyframes specification]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a two property (one shorthand and one of its shorthand components) two value property-indexed keyframes specification roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a two property two value property-indexed keyframes specification]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a two property two value property-indexed keyframes specification roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a two property property-indexed keyframes specification with different numbers of values]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a two property property-indexed keyframes specification with different numbers of values roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a property-indexed keyframes specification with an invalid value]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a property-indexed keyframes specification with an invalid value roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a one property two value property-indexed keyframes specification that needs to stringify its values]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a one property two value property-indexed keyframes specification that needs to stringify its values roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a property-indexed keyframes specification with a CSS variable reference]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a property-indexed keyframes specification with a CSS variable reference roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a property-indexed keyframes specification with a CSS variable reference in a shorthand property]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a property-indexed keyframes specification with a CSS variable reference in a shorthand property roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a one property one value property-indexed keyframes specification]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a one property one value property-indexed keyframes specification roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a one property one non-array value property-indexed keyframes specification]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a one property one non-array value property-indexed keyframes specification roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a one property two value property-indexed keyframes specification where the first value is invalid]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a one property two value property-indexed keyframes specification where the first value is invalid roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a one property two value property-indexed keyframes specification where the second value is invalid]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a one property two value property-indexed keyframes specification where the second value is invalid roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a property-indexed keyframes specification with a CSS variable as the property]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a property-indexed keyframes specification with a CSS variable as the property roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a property-indexed keyframe with a single offset]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a property-indexed keyframe with a single offset roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of offsets]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a property-indexed keyframe with an array of offsets roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of offsets that is too short]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a property-indexed keyframe with an array of offsets that is too short roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of offsets that is too long]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a property-indexed keyframe with an array of offsets that is too long roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a property-indexed keyframe with an empty array of offsets]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a property-indexed keyframe with an empty array of offsets roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of offsets with an embedded null value]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a property-indexed keyframe with an array of offsets with an embedded null value roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of offsets with a trailing null value]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a property-indexed keyframe with an array of offsets with a trailing null value roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of offsets with leading and trailing null values]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a property-indexed keyframe with an array of offsets with leading and trailing null values roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of offsets with adjacent null values]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a property-indexed keyframe with an array of offsets with adjacent null values roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of offsets with all null values (and too many at that)]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a property-indexed keyframe with an array of offsets with all null values (and too many at that) roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a property-indexed keyframe with a single null offset]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a property-indexed keyframe with a single null offset roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of offsets that is not strictly ascending in the unused part of the array]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a property-indexed keyframe with an array of offsets that is not strictly ascending in the unused part of the array roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a property-indexed keyframe without any specified easing]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a property-indexed keyframe without any specified easing roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a property-indexed keyframe with a single easing]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a property-indexed keyframe with a single easing roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of easings]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a property-indexed keyframe with an array of easings roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of easings that is too short]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a property-indexed keyframe with an array of easings that is too short roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a property-indexed keyframe with a single-element array of easings]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a property-indexed keyframe with a single-element array of easings roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a property-indexed keyframe with an empty array of easings]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a property-indexed keyframe with an empty array of easings roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a property-indexed keyframe with an array of easings that is too long]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a property-indexed keyframe with an array of easings that is too long roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a property-indexed keyframe with a single composite operation]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a property-indexed keyframe with a single composite operation roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a property-indexed keyframe with a composite array]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a property-indexed keyframe with a composite array roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a property-indexed keyframe with a composite array that is too short]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a property-indexed keyframe with a composite array that is too short roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a property-indexed keyframe with a composite array that is too long]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a property-indexed keyframe with a composite array that is too long roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a property-indexed keyframe with a single-element composite array]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a property-indexed keyframe with a single-element composite array roundtrips]
-    expected: FAIL
-
-  [A KeyframeEffect can be constructed with a one property one keyframe sequence]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a one property one keyframe sequence roundtrips]
-    expected: FAIL
-
-  [A KeyframeEffect can be constructed with a one property two keyframe sequence]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a one property two keyframe sequence roundtrips]
-    expected: FAIL
-
-  [A KeyframeEffect can be constructed with a two property two keyframe sequence]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a two property two keyframe sequence roundtrips]
-    expected: FAIL
-
-  [A KeyframeEffect can be constructed with a one shorthand property two keyframe sequence]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a one shorthand property two keyframe sequence roundtrips]
-    expected: FAIL
-
-  [A KeyframeEffect can be constructed with a two property (a shorthand and one of its component longhands) two keyframe sequence]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a two property (a shorthand and one of its component longhands) two keyframe sequence roundtrips]
-    expected: FAIL
-
-  [A KeyframeEffect can be constructed with a two property keyframe sequence where one property is missing from the first keyframe]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a two property keyframe sequence where one property is missing from the first keyframe roundtrips]
-    expected: FAIL
-
-  [A KeyframeEffect can be constructed with a two property keyframe sequence where one property is missing from the last keyframe]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a two property keyframe sequence where one property is missing from the last keyframe roundtrips]
-    expected: FAIL
-
-  [A KeyframeEffect can be constructed with a one property two keyframe sequence that needs to stringify its values]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a one property two keyframe sequence that needs to stringify its values roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a keyframe sequence with a CSS variable reference]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a keyframe sequence with a CSS variable reference roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a keyframe sequence with a CSS variable reference in a shorthand property]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a keyframe sequence with a CSS variable reference in a shorthand property roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a keyframe sequence with a CSS variable as its property]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a keyframe sequence with a CSS variable as its property roundtrips]
-    expected: FAIL
-
-  [A KeyframeEffect can be constructed with a keyframe sequence with duplicate values for a given interior offset]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a keyframe sequence with duplicate values for a given interior offset roundtrips]
-    expected: FAIL
-
-  [A KeyframeEffect can be constructed with a keyframe sequence with duplicate values for offsets 0 and 1]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a keyframe sequence with duplicate values for offsets 0 and 1 roundtrips]
-    expected: FAIL
-
-  [A KeyframeEffect can be constructed with a two property four keyframe sequence]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a two property four keyframe sequence roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a single keyframe sequence with omitted offset]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a single keyframe sequence with omitted offset roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a single keyframe sequence with null offset]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a single keyframe sequence with null offset roundtrips]
-    expected: FAIL
-
-  [A KeyframeEffect can be constructed with a single keyframe sequence with string offset]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a single keyframe sequence with string offset roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a single keyframe sequence with a single calc() offset]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a single keyframe sequence with a single calc() offset roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a one property keyframe sequence with some omitted offsets]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a one property keyframe sequence with some omitted offsets roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a one property keyframe sequence with some null offsets]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a one property keyframe sequence with some null offsets roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a two property keyframe sequence with some omitted offsets]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a two property keyframe sequence with some omitted offsets roundtrips]
     expected: FAIL
 
   [A KeyframeEffect can be constructed with a one property keyframe sequence with all omitted offsets]
     expected: FAIL
 
-  [A KeyframeEffect constructed with a one property keyframe sequence with all omitted offsets roundtrips]
-    expected: FAIL
-
   [A KeyframeEffect can be constructed with a keyframe sequence with different easing values, but the same easing value for a given offset]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a keyframe sequence with different easing values, but the same easing value for a given offset roundtrips]
-    expected: FAIL
-
-  [A KeyframeEffect can be constructed with a keyframe sequence with different composite values, but the same composite value for a given offset]
-    expected: FAIL
-
-  [A KeyframeEffect constructed with a keyframe sequence with different composite values, but the same composite value for a given offset roundtrips]
     expected: FAIL
 
   [KeyframeEffect constructor throws with keyframes with an out-of-bounded positive offset]

--- a/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/getKeyframes.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/getKeyframes.html.ini
@@ -1,3 +1,0 @@
-[getKeyframes.html]
-  [getKeyframes() should serialize its css values with a on keyframe sequence which requires value serilaization of its values]
-    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html.ini
@@ -73,3 +73,6 @@
 
   [Properties are read in ascending order by Unicode codepoint]
     expected: FAIL
+
+  [non-animatable property 'float' is not accessed when using a keyframe sequence]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/setKeyframes.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/setKeyframes.html.ini
@@ -1,7 +1,4 @@
 [setKeyframes.html]
-  [Keyframes can be replaced with an empty keyframe]
-    expected: FAIL
-
   [Keyframes can be replaced with a one property two value property-indexed keyframes specification]
     expected: FAIL
 
@@ -119,30 +116,6 @@
   [Keyframes can be replaced with a property-indexed keyframe with a single-element composite array]
     expected: FAIL
 
-  [Keyframes can be replaced with a one property one keyframe sequence]
-    expected: FAIL
-
-  [Keyframes can be replaced with a one property two keyframe sequence]
-    expected: FAIL
-
-  [Keyframes can be replaced with a two property two keyframe sequence]
-    expected: FAIL
-
-  [Keyframes can be replaced with a one shorthand property two keyframe sequence]
-    expected: FAIL
-
-  [Keyframes can be replaced with a two property (a shorthand and one of its component longhands) two keyframe sequence]
-    expected: FAIL
-
-  [Keyframes can be replaced with a two property keyframe sequence where one property is missing from the first keyframe]
-    expected: FAIL
-
-  [Keyframes can be replaced with a two property keyframe sequence where one property is missing from the last keyframe]
-    expected: FAIL
-
-  [Keyframes can be replaced with a one property two keyframe sequence that needs to stringify its values]
-    expected: FAIL
-
   [Keyframes can be replaced with a keyframe sequence with a CSS variable reference]
     expected: FAIL
 
@@ -152,22 +125,10 @@
   [Keyframes can be replaced with a keyframe sequence with a CSS variable as its property]
     expected: FAIL
 
-  [Keyframes can be replaced with a keyframe sequence with duplicate values for a given interior offset]
-    expected: FAIL
-
-  [Keyframes can be replaced with a keyframe sequence with duplicate values for offsets 0 and 1]
-    expected: FAIL
-
-  [Keyframes can be replaced with a two property four keyframe sequence]
-    expected: FAIL
-
   [Keyframes can be replaced with a single keyframe sequence with omitted offset]
     expected: FAIL
 
   [Keyframes can be replaced with a single keyframe sequence with null offset]
-    expected: FAIL
-
-  [Keyframes can be replaced with a single keyframe sequence with string offset]
     expected: FAIL
 
   [Keyframes can be replaced with a single keyframe sequence with a single calc() offset]
@@ -186,9 +147,6 @@
     expected: FAIL
 
   [Keyframes can be replaced with a keyframe sequence with different easing values, but the same easing value for a given offset]
-    expected: FAIL
-
-  [Keyframes can be replaced with a keyframe sequence with different composite values, but the same composite value for a given offset]
     expected: FAIL
 
   [KeyframeEffect constructor throws with keyframes with an out-of-bounded positive offset]

--- a/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/style-change-events.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/style-change-events.html.ini
@@ -10,3 +10,6 @@
 
   [KeyframeEffect.KeyframeEffect copy constructor does NOT trigger a style change event]
     expected: FAIL
+
+  [KeyframeEffect.getKeyframes does NOT trigger a style change event]
+    expected: FAIL


### PR DESCRIPTION
Implementing these two methods at the same time allows us to actually run tests on them. For now we only support passing iterable objects as keyframe containers to `setKeyframes`.

Depends on https://github.com/servo/stylo/pull/406
Testing: New tests start to pass
Part of https://github.com/servo/servo/issues/36950