### PR TITLE
net: Fix CSP trailing-dot host WPT resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,8 +1481,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 [[package]]
 name = "content-security-policy"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d348c3856ad6a6b957d69dc8cf93e66fe9be5a7657fdd7028b1a56d2775e3fce"
+source = "git+https://github.com/Taym95/rust-content-security-policy?branch=fix-csp-trailing-dot-host-source#97e13eeac10be0e24213e66dd0f95416989cfa86"
 dependencies = [
  "base64",
  "bitflags 2.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,8 +1480,9 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "content-security-policy"
-version = "0.8.0"
-source = "git+https://github.com/Taym95/rust-content-security-policy?branch=fix-csp-trailing-dot-host-source#97e13eeac10be0e24213e66dd0f95416989cfa86"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6813ceff986382cd86f67722f308177253e8fab1954a2d51c5e386ffdb3e2d03"
 dependencies = [
  "base64",
  "bitflags 2.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -422,6 +422,8 @@ lto = "thin"
 codegen-units = 1
 
 [patch.crates-io]
+content-security-policy = { git = "https://github.com/Taym95/rust-content-security-policy", branch = "fix-csp-trailing-dot-host-source" }
+
 # If you need to temporarily test Servo with a local fork of some upstream
 # crate, add that here. Use the form:
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ cfg-if = "1.0.4"
 chacha20poly1305 = { version = "0.11", features = ["rand_core", "zeroize"] }
 chardetng = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
-content-security-policy = { version = "0.8.0", features = ["serde"] }
+content-security-policy = { version = "0.8.1", features = ["serde"] }
 cookie = { package = "cookie", version = "0.18" }
 criterion = "0.8"
 crossbeam-channel = "0.5"
@@ -422,8 +422,6 @@ lto = "thin"
 codegen-units = 1
 
 [patch.crates-io]
-content-security-policy = { git = "https://github.com/Taym95/rust-content-security-policy", branch = "fix-csp-trailing-dot-host-source" }
-
 # If you need to temporarily test Servo with a local fork of some upstream
 # crate, add that here. Use the form:
 #

--- a/components/net/hosts.rs
+++ b/components/net/hosts.rs
@@ -56,11 +56,21 @@ pub fn parse_hostsfile(hostsfile_content: &str) -> HashMap<String, IpAddr> {
         .collect()
 }
 
+fn lookup_host_replacement(table: &HashMap<String, IpAddr>, host: &str) -> Option<IpAddr> {
+    table.get(host).copied().or_else(|| {
+        // <https://www.w3.org/TR/CSP/#grammardef-host-part>
+        // host-part   = "*" / [ "*." ] 1*host-char *( "." 1*host-char ) [ "." ]
+        host.strip_suffix('.')
+            .filter(|host_without_trailing_dot| !host_without_trailing_dot.is_empty())
+            .and_then(|host_without_trailing_dot| table.get(host_without_trailing_dot).copied())
+    })
+}
+
 pub fn replace_host(host: &str) -> Cow<'_, str> {
     HOST_TABLE
         .lock()
         .as_ref()
-        .and_then(|table| table.get(host))
+        .and_then(|table| lookup_host_replacement(table, host))
         .map_or(host.into(), |replaced_host| {
             replaced_host.to_string().into()
         })

--- a/tests/wpt/meta/content-security-policy/generic/src-trailing-dot.sub.any.js.ini
+++ b/tests/wpt/meta/content-security-policy/generic/src-trailing-dot.sub.any.js.ini
@@ -1,2 +1,0 @@
-[src-trailing-dot.sub.any.serviceworker.html]
-  expected: ERROR

--- a/tests/wpt/meta/content-security-policy/generic/src-trailing-dot.sub.any.js.ini
+++ b/tests/wpt/meta/content-security-policy/generic/src-trailing-dot.sub.any.js.ini
@@ -1,18 +1,2 @@
 [src-trailing-dot.sub.any.serviceworker.html]
-  [Fetch from host with trailing dot should be allowed by CSP.]
-    expected: FAIL
-
-
-[src-trailing-dot.sub.any.sharedworker.html]
-  [Fetch from host with trailing dot should be allowed by CSP.]
-    expected: FAIL
-
-
-[src-trailing-dot.sub.any.html]
-  [Fetch from host with trailing dot should be allowed by CSP.]
-    expected: FAIL
-
-
-[src-trailing-dot.sub.any.worker.html]
-  [Fetch from host with trailing dot should be allowed by CSP.]
-    expected: FAIL
+  expected: ERROR

--- a/tests/wpt/meta/fetch/metadata/trailing-dot.https.sub.any.js.ini
+++ b/tests/wpt/meta/fetch/metadata/trailing-dot.https.sub.any.js.ini
@@ -1,34 +1,3 @@
 [trailing-dot.https.sub.any.serviceworker.html]
   expected: ERROR
 
-[trailing-dot.https.sub.any.sharedworker.html]
-  [Fetching a resource from the same origin, but spelled with a trailing dot.]
-    expected: FAIL
-
-  [Fetching a resource from the same site, but spelled with a trailing dot.]
-    expected: FAIL
-
-  [Fetching a resource from a cross-site host, spelled with a trailing dot.]
-    expected: FAIL
-
-
-[trailing-dot.https.sub.any.worker.html]
-  [Fetching a resource from the same origin, but spelled with a trailing dot.]
-    expected: FAIL
-
-  [Fetching a resource from the same site, but spelled with a trailing dot.]
-    expected: FAIL
-
-  [Fetching a resource from a cross-site host, spelled with a trailing dot.]
-    expected: FAIL
-
-
-[trailing-dot.https.sub.any.html]
-  [Fetching a resource from the same origin, but spelled with a trailing dot.]
-    expected: FAIL
-
-  [Fetching a resource from the same site, but spelled with a trailing dot.]
-    expected: FAIL
-
-  [Fetching a resource from a cross-site host, spelled with a trailing dot.]
-    expected: FAIL


### PR DESCRIPTION
While working on Shared-worker I noticed this test failing and found out also need fix in content-security-policy.

Depends on : https://github.com/rust-ammonia/rust-content-security-policy/pull/72
Testing: tests/wpt/meta/content-security-policy/generic/src-trailing-dot.sub.any.js.ini test passing.