### PR TITLE
net: Avoid creating empty cookie map entries on cookie deletion

### DIFF
--- a/components/net/cookie_storage.rs
+++ b/components/net/cookie_storage.rs
@@ -128,11 +128,10 @@ impl CookieStorage {
     pub fn clear_storage(&mut self, url: Option<&ServoUrl>) {
         if let Some(url) = url {
             let domain = reg_host(url.host_str().unwrap_or(""));
-            // TODO: This creates an empty cookie list if none existed? Should
-            // we just use `get_mut` here?
-            let cookies = self.cookies_map.entry(domain).or_default();
-            for cookie in cookies.iter_mut() {
-                cookie.set_expiry_time_in_past();
+            if let Some(cookies) = self.cookies_map.get_mut(&domain) {
+                for cookie in cookies.iter_mut() {
+                    cookie.set_expiry_time_in_past();
+                }
             }
         } else {
             self.cookies_map.clear();
@@ -141,12 +140,11 @@ impl CookieStorage {
 
     pub fn delete_cookie_with_name(&mut self, url: &ServoUrl, name: String) {
         let domain = reg_host(url.host_str().unwrap_or(""));
-        // TODO: This creates an empty cookie list if none existed? Should we
-        // just use `get_mut` here?
-        let cookies = self.cookies_map.entry(domain).or_default();
-        for cookie in cookies.iter_mut() {
-            if cookie.cookie.name() == name {
-                cookie.set_expiry_time_in_past();
+        if let Some(cookies) = self.cookies_map.get_mut(&domain) {
+            for cookie in cookies.iter_mut() {
+                if cookie.cookie.name() == name {
+                    cookie.set_expiry_time_in_past();
+                }
             }
         }
     }

--- a/components/net/tests/cookie.rs
+++ b/components/net/tests/cookie.rs
@@ -538,3 +538,76 @@ fn test_parse_date() {
         Some(datetime!(2024-06-26 15:35:10).assume_utc())
     );
 }
+
+#[test]
+fn test_clear_storage_for_url_expires_matching_cookies() {
+    let mut storage = CookieStorage::new(5);
+    let source = CookieSource::HTTP;
+    let url = ServoUrl::parse("http://example.com/").unwrap();
+
+    add_cookie_to_storage(&mut storage, &url, "foo=bar");
+    assert_eq!(
+        storage.cookies_for_url(&url, source).as_deref(),
+        Some("foo=bar")
+    );
+
+    storage.clear_storage(Some(&url));
+
+    storage.remove_expired_cookies_for_url(&url);
+    assert_eq!(storage.cookies_for_url(&url, source), None);
+}
+
+#[test]
+fn test_clear_storage_without_url_clears_everything() {
+    let mut storage = CookieStorage::new(5);
+    let source = CookieSource::HTTP;
+    let url = ServoUrl::parse("http://example.com/").unwrap();
+    let other_url = ServoUrl::parse("http://example.org/").unwrap();
+
+    add_cookie_to_storage(&mut storage, &url, "foo=bar");
+    add_cookie_to_storage(&mut storage, &other_url, "baz=qux");
+
+    storage.clear_storage(None);
+
+    assert!(storage.cookie_site_descriptors().is_empty());
+    assert_eq!(storage.cookies_for_url(&url, source), None);
+    assert_eq!(storage.cookies_for_url(&other_url, source), None);
+}
+
+#[test]
+fn test_delete_cookie_with_name_expires_only_matching_cookie() {
+    let mut storage = CookieStorage::new(5);
+    let source = CookieSource::HTTP;
+    let url = ServoUrl::parse("http://example.com/").unwrap();
+
+    add_cookie_to_storage(&mut storage, &url, "foo=bar");
+    add_cookie_to_storage(&mut storage, &url, "baz=qux");
+
+    storage.delete_cookie_with_name(&url, "foo".to_owned());
+
+    storage.remove_expired_cookies_for_url(&url);
+    assert_eq!(
+        storage.cookies_for_url(&url, source).as_deref(),
+        Some("baz=qux")
+    );
+}
+
+#[test]
+fn test_delete_cookie_with_name_does_not_affect_other_domains() {
+    let mut storage = CookieStorage::new(5);
+    let source = CookieSource::HTTP;
+    let url = ServoUrl::parse("http://example.com/").unwrap();
+    let other_url = ServoUrl::parse("http://example.org/").unwrap();
+
+    add_cookie_to_storage(&mut storage, &url, "foo=bar");
+    add_cookie_to_storage(&mut storage, &other_url, "foo=bar");
+
+    storage.delete_cookie_with_name(&url, "foo".to_owned());
+
+    storage.remove_all_expired_cookies();
+    assert_eq!(storage.cookies_for_url(&url, source), None);
+    assert_eq!(
+        storage.cookies_for_url(&other_url, source).as_deref(),
+        Some("foo=bar")
+    );
+}


### PR DESCRIPTION
This change addresses several granular TODO comments regarding minor performance issues caused by the creation of unnecessary empty Vecs. Test utilities such as WebDriver clients delete all cookies from sites. Using `get_mut()` avoids unnecessary heap usage.

Testing:  added unit tests before the refactoring: 593b2b6546ff1b94198da5c922d9b2715403ef8b
