### PR TITLE
script: Remove `SafeJSContext` from codegen

### DIFF
--- a/components/script/dom/globalscope/origin.rs
+++ b/components/script/dom/globalscope/origin.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::{HandleObject, HandleValue};
 use net_traits::pub_domains::is_same_site;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
@@ -21,7 +22,6 @@ use crate::dom::html::htmlareaelement::HTMLAreaElement;
 use crate::dom::html::htmlhyperlinkelementutils::{HyperlinkElement, HyperlinkElementTraits};
 use crate::dom::url::URL;
 use crate::dom::window::Window;
-use crate::script_runtime::JSContext;
 
 /// <https://html.spec.whatwg.org/multipage/#the-origin-interface>
 #[dom_struct]
@@ -40,7 +40,7 @@ impl Origin {
     }
 
     fn new(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         origin: ImmutableOrigin,
@@ -55,22 +55,22 @@ impl Origin {
 
     /// <https://html.spec.whatwg.org/multipage/#extract-an-origin>
     fn extract_an_origin_from_platform_object(
+        cx: &mut JSContext,
         value: HandleValue,
-        cx: JSContext,
         current_global: &GlobalScope,
     ) -> Option<ImmutableOrigin> {
         // <https://html.spec.whatwg.org/multipage/#the-origin-interface:extract-an-origin>
-        if let Ok(origin_obj) = root_from_handlevalue::<Origin>(value, cx) {
+        if let Ok(origin_obj) = root_from_handlevalue::<Origin>(cx, value) {
             return Some(origin_obj.origin.clone());
         }
 
         // <https://url.spec.whatwg.org/#concept-url-origin>
-        if let Ok(url_obj) = root_from_handlevalue::<URL>(value, cx) {
+        if let Ok(url_obj) = root_from_handlevalue::<URL>(cx, value) {
             return Some(url_obj.origin());
         }
 
         // <https://html.spec.whatwg.org/multipage/#window:extract-an-origin>
-        if let Ok(window_obj) = root_from_handlevalue::<Window>(value, cx) {
+        if let Ok(window_obj) = root_from_handlevalue::<Window>(cx, value) {
             let window_origin = window_obj.origin();
             if !current_global.origin().same_origin_domain(&window_origin) {
                 return None;
@@ -79,7 +79,7 @@ impl Origin {
         }
 
         // <https://html.spec.whatwg.org/multipage/#api-for-a-and-area-elements:extract-an-origin>
-        if let Ok(anchor_obj) = root_from_handlevalue::<HTMLAnchorElement>(value, cx) {
+        if let Ok(anchor_obj) = root_from_handlevalue::<HTMLAnchorElement>(cx, value) {
             anchor_obj.reinitialize_url();
             if let Some(ref url) = *anchor_obj.get_url().borrow() {
                 return Some(url.origin());
@@ -88,7 +88,7 @@ impl Origin {
         }
 
         // <https://html.spec.whatwg.org/multipage/#api-for-a-and-area-elements:extract-an-origin>
-        if let Ok(area_obj) = root_from_handlevalue::<HTMLAreaElement>(value, cx) {
+        if let Ok(area_obj) = root_from_handlevalue::<HTMLAreaElement>(cx, value) {
             area_obj.reinitialize_url();
             if let Some(ref url) = *area_obj.get_url().borrow() {
                 return Some(url.origin());
@@ -103,7 +103,7 @@ impl Origin {
 impl OriginMethods<crate::DomTypeHolder> for Origin {
     /// <https://html.spec.whatwg.org/multipage/#dom-origin-constructor>
     fn Constructor(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<Origin> {
@@ -112,16 +112,14 @@ impl OriginMethods<crate::DomTypeHolder> for Origin {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-origin-from>
     fn From(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         value: HandleValue,
     ) -> Fallible<DomRoot<Origin>> {
         // Step 1. If value is a platform object:
         //   1. Let origin be the result of executing value's extract an origin operation.
         //   2. If origin is not null, then return a new Origin object whose origin is origin.
-        if let Some(origin) =
-            Origin::extract_an_origin_from_platform_object(value, cx.into(), global)
-        {
+        if let Some(origin) = Origin::extract_an_origin_from_platform_object(cx, value, global) {
             return Ok(Origin::new(cx, global, None, origin));
         }
 

--- a/components/script/dom/trustedtypes/trustedtypepolicyfactory.rs
+++ b/components/script/dom/trustedtypes/trustedtypepolicyfactory.rs
@@ -352,7 +352,7 @@ impl TrustedTypePolicyFactory {
         cx: &mut JSContext,
         value: HandleValue,
     ) -> Result<DomRoot<TrustedScript>, ()> {
-        root_from_handlevalue::<TrustedScript>(value, cx.into())
+        root_from_handlevalue::<TrustedScript>(cx, value)
     }
 }
 
@@ -368,7 +368,7 @@ impl TrustedTypePolicyFactoryMethods<crate::DomTypeHolder> for TrustedTypePolicy
     }
     /// <https://www.w3.org/TR/trusted-types/#dom-trustedtypepolicyfactory-ishtml>
     fn IsHTML(&self, cx: &mut JSContext, value: HandleValue) -> bool {
-        root_from_handlevalue::<TrustedHTML>(value, cx.into()).is_ok()
+        root_from_handlevalue::<TrustedHTML>(cx, value).is_ok()
     }
     /// <https://www.w3.org/TR/trusted-types/#dom-trustedtypepolicyfactory-isscript>
     fn IsScript(&self, cx: &mut JSContext, value: HandleValue) -> bool {
@@ -376,7 +376,7 @@ impl TrustedTypePolicyFactoryMethods<crate::DomTypeHolder> for TrustedTypePolicy
     }
     /// <https://www.w3.org/TR/trusted-types/#dom-trustedtypepolicyfactory-isscripturl>
     fn IsScriptURL(&self, cx: &mut JSContext, value: HandleValue) -> bool {
-        root_from_handlevalue::<TrustedScriptURL>(value, cx.into()).is_ok()
+        root_from_handlevalue::<TrustedScriptURL>(cx, value).is_ok()
     }
     /// <https://www.w3.org/TR/trusted-types/#dom-trustedtypepolicyfactory-emptyhtml>
     fn EmptyHTML(&self, cx: &mut JSContext) -> DomRoot<TrustedHTML> {

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -1116,7 +1116,7 @@ impl WorkerGlobalScope {
             DevtoolScriptControlMsg::Eval(code, id, frame_actor_id, reply) => {
                 let debugger_global_handle = rooted_heap_handle(self, |this| &this.debugger_global);
                 let debugger_global =
-                    root_from_handlevalue::<DebuggerGlobalScope>(debugger_global_handle, cx.into())
+                    root_from_handlevalue::<DebuggerGlobalScope>(cx, debugger_global_handle)
                         .expect("must be a debugger global scope");
 
                 debugger_global.fire_eval(

--- a/components/script/indexeddb.rs
+++ b/components/script/indexeddb.rs
@@ -544,8 +544,7 @@ pub(crate) fn evaluate_key_path_on_value(
 
                 // If value is a Blob and identifier is "size"
                 if identifier == "size" &&
-                    let Ok(blob) =
-                        root_from_handlevalue::<Blob>(current_value.handle(), cx.into())
+                    let Ok(blob) = root_from_handlevalue::<Blob>(cx, current_value.handle())
                 {
                     // Let value be a Number equal to value’s size.
                     blob.Size().safe_to_jsval(cx, current_value.handle_mut());
@@ -555,8 +554,7 @@ pub(crate) fn evaluate_key_path_on_value(
 
                 // If value is a Blob and identifier is "type"
                 if identifier == "type" &&
-                    let Ok(blob) =
-                        root_from_handlevalue::<Blob>(current_value.handle(), cx.into())
+                    let Ok(blob) = root_from_handlevalue::<Blob>(cx, current_value.handle())
                 {
                     // Let value be a String equal to value’s type.
                     blob.Type().safe_to_jsval(cx, current_value.handle_mut());
@@ -566,8 +564,7 @@ pub(crate) fn evaluate_key_path_on_value(
 
                 // If value is a File and identifier is "name"
                 if identifier == "name" &&
-                    let Ok(file) =
-                        root_from_handlevalue::<File>(current_value.handle(), cx.into())
+                    let Ok(file) = root_from_handlevalue::<File>(cx, current_value.handle())
                 {
                     // Let value be a String equal to value’s name.
                     file.name().safe_to_jsval(cx, current_value.handle_mut());
@@ -577,8 +574,7 @@ pub(crate) fn evaluate_key_path_on_value(
 
                 // If value is a File and identifier is "lastModified"
                 if identifier == "lastModified" &&
-                    let Ok(file) =
-                        root_from_handlevalue::<File>(current_value.handle(), cx.into())
+                    let Ok(file) = root_from_handlevalue::<File>(cx, current_value.handle())
                 {
                     // Let value be a Number equal to value’s lastModified.
                     file.LastModified()
@@ -589,8 +585,7 @@ pub(crate) fn evaluate_key_path_on_value(
 
                 // If value is a File and identifier is "lastModifiedDate"
                 if identifier == "lastModifiedDate" &&
-                    let Ok(file) =
-                        root_from_handlevalue::<File>(current_value.handle(), cx.into())
+                    let Ok(file) = root_from_handlevalue::<File>(cx, current_value.handle())
                 {
                     // Let value be a new Date object with [[DateValue]] internal slot equal to value’s lastModified.
                     let time = ClippedTime {

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -1012,7 +1012,7 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
             return handleOptional(template, declType, handleDefault("None"))
 
         conversionFunction = "root_from_handlevalue"
-        maybeCx = ", SafeJSContext::from_ptr(cx.raw_cx())"
+        maybeCx = "cx, "
         descriptorType = descriptor.returnType
         if isMember == "Variadic":
             conversionFunction = "native_from_handlevalue"
@@ -1033,7 +1033,7 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
 
         templateBody = fill(
             """
-            match ${function}($${val}${maybeCx}) {
+            match ${function}(${maybeCx}$${val}) {
                 Ok(val) => val,
                 Err(()) => {
                     $*{failureCode}
@@ -8490,7 +8490,7 @@ class CGCallback(CGClass):
         args = list(method.args)
         # Strip out the JSContext*/JSObject* args
         # that got added.
-        assert args[0].name == "cx" and args[0].argType == "SafeJSContext"
+        assert args[0].name == "cx" and args[0].argType == "&mut JSContext"
         assert args[1].name == "aThisObj" and args[1].argType == "HandleValue"
         args = args[2:]
         # Record the names of all the arguments, so we can use them when we call
@@ -8772,7 +8772,7 @@ class CallbackMember(CGNativeMember):
             return args
         # We want to allow the caller to pass in a "this" object, as
         # well as a JSContext.
-        return [Argument("SafeJSContext", "cx"),
+        return [Argument("&mut JSContext", "cx"),
                 Argument("HandleValue", "aThisObj")] + args
 
     def getCallSetup(self) -> str:

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -32,7 +32,6 @@ use crate::inheritance::Castable;
 use crate::num::Finite;
 use crate::reflector::{DomObject, Reflector};
 use crate::root::DomRoot;
-use crate::script_runtime::JSContext as SafeJSContext;
 use crate::str::{ByteString, DOMString, USVString};
 use crate::trace::RootedTraceableBox;
 use crate::utils::{DOMClass, DOMJSClass};
@@ -232,7 +231,7 @@ impl<T: DomObject + IDLInterface> FromJSValConvertible for DomRoot<T> {
         value: HandleValue,
         _config: Self::Config,
     ) -> Result<ConversionResult<DomRoot<T>>, ()> {
-        Ok(match root_from_handlevalue(value, cx.into()) {
+        Ok(match root_from_handlevalue(cx, value) {
             Ok(result) => ConversionResult::Success(result),
             Err(()) => ConversionResult::Failure(c"value is not an object".into()),
         })
@@ -401,7 +400,10 @@ where
 /// # Safety
 /// cx must point to a valid, non-null JS context.
 #[allow(clippy::result_unit_err)]
-pub fn root_from_handlevalue<T>(v: HandleValue, cx: SafeJSContext) -> Result<DomRoot<T>, ()>
+pub fn root_from_handlevalue<T>(
+    cx: &mut js::context::JSContext,
+    v: HandleValue,
+) -> Result<DomRoot<T>, ()>
 where
     T: DomObject + IDLInterface,
 {
@@ -410,7 +412,7 @@ where
     }
     #[expect(unsafe_code)]
     unsafe {
-        root_from_object(v.get().to_object(), *cx)
+        root_from_object(v.get().to_object(), cx.raw_cx())
     }
 }
 
@@ -521,7 +523,10 @@ where
 /// # Safety
 /// `cx` must point to a valid, non-null JSContext.
 #[allow(clippy::result_unit_err)]
-pub fn native_from_handlevalue<T>(v: HandleValue, cx: SafeJSContext) -> Result<*const T, ()>
+pub fn native_from_handlevalue<T>(
+    cx: &mut js::context::JSContext,
+    v: HandleValue,
+) -> Result<*const T, ()>
 where
     T: DomObject + IDLInterface,
 {
@@ -531,7 +536,7 @@ where
 
     #[expect(unsafe_code)]
     unsafe {
-        native_from_object(v.get().to_object(), *cx)
+        native_from_object(v.get().to_object(), cx.raw_cx())
     }
 }
 

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -45,7 +45,6 @@ pub(crate) mod base {
     pub(crate) use crate::proxyhandler::{CrossOriginProperties, is_platform_object_same_origin};
     pub(crate) use crate::reflector::DomObject;
     pub(crate) use crate::root::DomRoot;
-    pub(crate) use crate::script_runtime::JSContext as SafeJSContext;
     pub(crate) use crate::str::{ByteString, DOMString, USVString};
     pub(crate) use crate::trace::RootedTraceableBox;
     pub(crate) use crate::utils::{get_dictionary_property, set_dictionary_property};


### PR DESCRIPTION
Remove the last two places where it was used. Converted all those to take `&mut JSContext` instead.

Part of #40600

Testing: it compiles