### PR TITLE
layout: Clear fragments and caches under layout roots after failed layout root layout

### DIFF
--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -341,6 +341,15 @@ pub(crate) trait NodeExt<'dom> {
     /// Remove boxes for the element itself, and all of its pseudo-element boxes.
     fn unset_all_boxes(&self);
 
+    /// Clear laid out `Fragment`s and dirty `Fragment` caches for all of this node's boxes,
+    /// ensuring that the next `FragmentTree` layout that happens at this node is complete.
+    fn clear_fragments_and_dirty_fragment_caches(&self);
+
+    /// Clear laid out `Fragment`s and dirty `Fragment` caches for all this node's boxes and
+    /// descendant's boxes, ensuring that the next `FragmentTree` layout that happens at and
+    /// below this node is complete.
+    fn clear_fragments_and_dirty_fragment_caches_recursively(&self);
+
     /// Returns the [`NodeRenderingType`] for this [`LayoutNode`] which describes whether
     /// the node is being rendered, delegating rendering, or not being rendered at all
     /// based on whether it has a [`LayoutBox`] and what kind.
@@ -531,6 +540,19 @@ impl<'dom> NodeExt<'dom> for ServoLayoutNode<'dom> {
 
         // Stylo already takes care of removing all layout data
         // for DOM descendants of elements with `display: none`.
+    }
+
+    fn clear_fragments_and_dirty_fragment_caches_recursively(&self) {
+        self.clear_fragments_and_dirty_fragment_caches();
+        for child in self.flat_tree_children() {
+            child.clear_fragments_and_dirty_fragment_caches_recursively();
+        }
+    }
+
+    fn clear_fragments_and_dirty_fragment_caches(&self) {
+        self.with_layout_box_base_including_pseudos(|base| {
+            base.clear_fragments_and_dirty_fragment_cache()
+        });
     }
 
     fn rendering_type(&self) -> NodeRenderingType {

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1299,13 +1299,21 @@ impl LayoutThread {
 
             debug_assert!(!layout_roots.is_empty());
             if layout_roots
-                .into_iter()
+                .iter()
                 .all(|layout_root| layout_root.try_layout(&layout_context))
             {
                 return (
                     ReflowPhasesRun::RanLayout,
                     std::mem::take(&mut *layout_context.iframe_sizes.lock()),
                 );
+            }
+
+            // LayoutRoot layout has failed and now the layout root and descendants may have
+            // been only partially laid out. As the next step is to do a full `FragmentTree`
+            // layout, we need to ensure that none of the partial layout results corrupt
+            // the upcoming full layout.
+            for layout_root in layout_roots {
+                layout_root.handle_failed_layout_root_layout();
             }
         }
 

--- a/components/layout/layout_root.rs
+++ b/components/layout/layout_root.rs
@@ -120,4 +120,9 @@ impl LayoutRoot<'_> {
             )
             .is_ok()
     }
+
+    pub(crate) fn handle_failed_layout_root_layout(&self) {
+        self.node
+            .clear_fragments_and_dirty_fragment_caches_recursively();
+    }
 }

--- a/tests/wpt/tests/css/css-position/crashtests/dynamic-fixed-in-nested-absolutes-crash.html
+++ b/tests/wpt/tests/css/css-position/crashtests/dynamic-fixed-in-nested-absolutes-crash.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/46109">
+<style>
+  html, #parent_abs, #child_abs { position: absolute; }
+  #fixed { position: fixed; }
+</style>
+<script>
+  onload = _ => {
+    parent_abs.appendChild(document.createElement("div"));
+    document.body.scrollHeight;
+    select.appendChild(document.createElement("div"));
+    document.body.scrollHeight;
+    fixed_child.style.width = "200px";
+  }
+</script>
+
+<select id="select">text</select>
+
+<div id="parent_abs">
+    <div id="child_abs">
+        <div id="fixed">
+            <div id="fixed_child"></div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
When layout root layout fails, for instance because a new fixed position
element has started escaping the layout root, a full layout must be
done. This change ensures that partial layout results (such as new,
orphaned hoisted absolute cells) are cleared before doing that full
layout. If this doesn't happen, layout caches will be used during the
full layout and hoisted absolutes may not be hoisted properly out of the
layout root.

Testing: This change adds a WPT crashtest.
Fixes: #46109.
