### PR TITLE
android: Set AR and RANLIB

### DIFF
--- a/python/servo/platform/build_target.py
+++ b/python/servo/platform/build_target.py
@@ -224,6 +224,11 @@ class AndroidTarget(CrossBuildTarget):
 
         env["TARGET_AR"] = to_ndk_bin("llvm-ar")
         env["TARGET_RANLIB"] = to_ndk_bin("llvm-ranlib")
+        # Needed for tikv-jemalloc, which doesn't respect TARGET_AR and co.
+        # On macos this lead to it falling back to `ar` and missing jemalloc
+        # symbols in libservoshell.so.
+        env["AR"] = to_ndk_bin("llvm-ar")
+        env["RANLIB"] = to_ndk_bin("llvm-ranlib")
         env["TARGET_OBJCOPY"] = to_ndk_bin("llvm-objcopy")
         env["TARGET_YASM"] = to_ndk_bin("yasm")
         env["TARGET_STRIP"] = to_ndk_bin("llvm-strip")

--- a/python/servo/platform/build_target.py
+++ b/python/servo/platform/build_target.py
@@ -224,15 +224,16 @@ class AndroidTarget(CrossBuildTarget):
 
         env["TARGET_AR"] = to_ndk_bin("llvm-ar")
         env["TARGET_RANLIB"] = to_ndk_bin("llvm-ranlib")
+        env["TARGET_OBJCOPY"] = to_ndk_bin("llvm-objcopy")
+        env["TARGET_YASM"] = to_ndk_bin("yasm")
+        env["TARGET_STRIP"] = to_ndk_bin("llvm-strip")
+        env["RUST_FONTCONFIG_DLOPEN"] = "on"
+
         # Needed for tikv-jemalloc, which doesn't respect TARGET_AR and co.
         # On macos this lead to it falling back to `ar` and missing jemalloc
         # symbols in libservoshell.so.
         env["AR"] = to_ndk_bin("llvm-ar")
         env["RANLIB"] = to_ndk_bin("llvm-ranlib")
-        env["TARGET_OBJCOPY"] = to_ndk_bin("llvm-objcopy")
-        env["TARGET_YASM"] = to_ndk_bin("yasm")
-        env["TARGET_STRIP"] = to_ndk_bin("llvm-strip")
-        env["RUST_FONTCONFIG_DLOPEN"] = "on"
 
         env["LIBCLANG_PATH"] = path.join(llvm_toolchain, "lib")
         env["CLANG_PATH"] = to_ndk_bin("clang")


### PR DESCRIPTION
This fixes missing jemalloc symbols when building for android on macos.
I'm not sure when this regressed, since building on macos used to work before. 
It's also interesting that this didn't cause a build error, but using the macos `ar` simply caused the jemalloc symbols to be missing (`U`) and failure at runtime (`dlopen`) due to missing `_rjem_` symbols.

Testing: We don't build android on macos hosts in CI. But at least this shouldn't regress the linux build.
Part of investigating #46115
