### PR TITLE
android: Determine default config dir and lower minSdk

### DIFF
--- a/ports/servoshell/egl/android/mod.rs
+++ b/ports/servoshell/egl/android/mod.rs
@@ -6,6 +6,7 @@
 
 use std::cell::RefCell;
 use std::os::raw::{c_char, c_int, c_void};
+use std::path::PathBuf;
 use std::ptr::NonNull;
 use std::rc::Rc;
 use std::sync::{Arc, OnceLock};
@@ -97,7 +98,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_version<'local>(
 pub extern "C" fn Java_org_servo_servoview_JNIServo_init<'local>(
     mut env: EnvUnowned<'local>,
     _: JClass<'local>,
-    _activity: JObject<'local>,
+    activity: JObject<'local>,
     opts: JObject<'local>,
     callbacks_obj: JObject<'local>,
     surface: JObject<'local>,
@@ -161,6 +162,10 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_init<'local>(
         let host = Rc::new(HostCallbacks::new(jvm));
 
         crate::init_crypto();
+
+        if let Err(error) = set_default_config_dir(env, &activity) {
+            error!("Failed to determine Android config directory: {error:?}");
+        }
 
         let (opts, mut preferences, servoshell_preferences) =
             match parse_command_line_arguments(init_opts.args.as_slice()) {
@@ -908,6 +913,39 @@ fn get_field_as_string<'local>(
         .get_field(obj, field, jni_sig!("Ljava/lang/String;"))?
         .l()?;
     JString::cast_local(env, string_value)?.try_to_string(env)
+}
+
+fn set_default_config_dir<'local>(
+    env: &mut Env<'local>,
+    activity: &JObject<'local>,
+) -> Result<(), Error> {
+    let files_dir = env
+        .call_method(
+            activity,
+            jni_str!("getFilesDir"),
+            jni_sig!("()Ljava/io/File;"),
+            &[],
+        )?
+        .l()?;
+    let path = env
+        .call_method(
+            &files_dir,
+            jni_str!("getAbsolutePath"),
+            jni_sig!("()Ljava/lang/String;"),
+            &[],
+        )?
+        .l()?;
+    let path = JString::cast_local(env, path)?.try_to_string(env)?;
+
+    let config_dir = PathBuf::from(path).join("servo");
+    if let Err(error) = std::fs::create_dir_all(&config_dir) {
+        error!("Failed to create config directory at {config_dir:?}: {error:?}");
+    }
+    debug!("Default config dir: {config_dir:?}");
+    let _ = crate::prefs::DEFAULT_CONFIG_DIR
+        .set(config_dir)
+        .inspect_err(|path| warn!("Default config dir was already set to {path:?}"));
+    Ok(())
 }
 
 fn get_options<'local>(

--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         applicationId = "org.servo.servoshell"
-        minSdk = 33
+        minSdk = 30
         targetSdk = 34
         versionCode = generatedVersionCode
         versionName = "0.3.0"


### PR DESCRIPTION
Android 33+ sets the TMPDIR environment variable, but on older versions it's unset. This leads to a crash on older android versions where the fallback is outside the app sandbox (/data/local/tmp). 
This allows us to lower the minSdk version and probably the default config directory should never have been TMPDIR in the first place, since that's not persistent.
I tested with a Pixel 4 emulator API-29, and servoshell seems to work fine. However, our current build system uses API-30 NDK, so for now we just restore API-30 support. A follow-up PR could choose a lower NDK version, and thus lower our minSDK version further. But ideally we add CI testing first.

This PR effectively reverts #46104 and fixes the crash on older devices.

Testing: We don't have automatic tests for android in CI. 
Fixes: #46115
