### PR TITLE
script: Switch GetClientRect and dirty_all_nodes to use unrooted iterators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "aead-stream"
-version = "0.6.0"
+version = "0.6.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a901e5bcd15b4a9555a8f17a608d28ef92cf77bc4aa3b4a0c1a3fce1a9cc0bac"
+checksum = "4cc2d8c7d80cce546b635811cc9371c1db8794d36fcc160a08cb1e6824a5eab2"
 dependencies = [
  "aead",
 ]
@@ -367,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app_units"
@@ -3093,9 +3093,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gio-sys"
-version = "0.22.8"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353fdc7da7cd16da916104b1e0e4e7de380ec9c8aaa20d4d742d66310ab4b0d5"
+checksum = "64729ba2772c080448f9f966dba8f4456beeb100d8c28a865ef8a0f2ef4987e1"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -3126,9 +3126,9 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.22.8"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddbcf514bd1881fc1b960e4e52b4e82873f4da3bceddbd58d42827b508888100"
+checksum = "02856b71413e175be50eff37fe0aefa53e227054ee3d96196faee8a0823cac80"
 dependencies = [
  "bitflags 2.13.0",
  "futures-channel",
@@ -3147,9 +3147,9 @@ dependencies = [
 
 [[package]]
 name = "glib-macros"
-version = "0.22.6"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "506d23499707c7142898429757e8d9a3871d965239a2cb66dfa05052be6d6f19"
+checksum = "bda575994e3689b1bc12f89c3df621ead46ff292623b76b4710a3a5b79be54bb"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3159,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "glib-sys"
-version = "0.22.8"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030967459f9f676851872c6304adea7825c6d462ec9b72554c733cf0c5952233"
+checksum = "1eb23a616a3dbc7fc15bbd26f58756ff0b04c8a894df3f0680cd21011db6a642"
 dependencies = [
  "libc",
  "system-deps",
@@ -3222,9 +3222,9 @@ dependencies = [
 
 [[package]]
 name = "gobject-sys"
-version = "0.22.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a861859b887a79cf461359c192c97a57d8fb0229dd291232e57aa11f6fa72c"
+checksum = "18eda93f09d3778f38255b231b17ef67195013a592c91624a4daf8bead875565"
 dependencies = [
  "glib-sys",
  "libc",
@@ -3284,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer"
-version = "0.25.3"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4527e1b9bae8d29ce137bde5b8eec8ae8f78f13ad00fc6e70cbe227d6ad027"
+checksum = "ad8d6d77fae07708536f86a34ac15fc36c7e958ef7930b75119dba0242936f08"
 dependencies = [
  "cfg-if",
  "futures-channel",
@@ -3294,7 +3294,7 @@ dependencies = [
  "futures-util",
  "glib",
  "gstreamer-sys",
- "itertools 0.15.0",
+ "itertools 0.14.0",
  "kstring",
  "libc",
  "muldiv",
@@ -3309,9 +3309,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-app"
-version = "0.25.2"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f8ae9238c2352398dcc084de28df3f7099af216ac6c160b52318d23f25c010"
+checksum = "714874829f75e805192ddc2bd130b9d7669ebc3ed0e8b106039dd3416cb82916"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3337,9 +3337,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-audio"
-version = "0.25.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f97532c3e21287a6e94563a328cce89367324acf8a4489291b40ede2e39163a0"
+checksum = "46e64660e1963ff3b6a4a5175f917524254a6ae36ac7b83e29b760d879a33073"
 dependencies = [
  "cfg-if",
  "glib",
@@ -3352,9 +3352,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-audio-sys"
-version = "0.25.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2abfb81a073c5c8fb115a3639f47b6430f669ee9fa29123bb0116c9ef59d7d16"
+checksum = "b5111bd07d0e22cc66ec9b4b4ef5408beefb148af19944fbe4602983a043f34c"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -3366,9 +3366,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-base"
-version = "0.25.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91c94a4d3047d05dd6e1f6d91c74f61f56384c7ea1c9d0c1051572eeeb0138d"
+checksum = "c08353a8a382be9a49b15fb9c46b3abd6f8a6e6439e1eaedc87d08f1abdcfad1"
 dependencies = [
  "atomic_refcell",
  "cfg-if",
@@ -3380,9 +3380,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-base-sys"
-version = "0.25.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709fbbc623dc066908ba10c43d629c21096508dea04796592a206c4edd864e37"
+checksum = "6569606feeb89cfcf95a6476a64a0f0aec83fadcef0e91c24e576f7851ceac3a"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -3393,9 +3393,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-gl"
-version = "0.25.2"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d452d542cee699b747f3b5ab54096fcdf1d9b6f22b890d9d86a9d9f9258f49"
+checksum = "94f83397da547ce27d7b912980ecb21c99c6aedee4015765355fe66cdf0bd9b9"
 dependencies = [
  "glib",
  "gstreamer",
@@ -3524,9 +3524,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-sdp"
-version = "0.25.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7859290ba340f1bd45d4bc0ada958700e9d3b1a522b456fd7ee88da468cd13"
+checksum = "11650b5fbc5994877bc525519c554cb66166f155f9cc3119b0fe88a33dc5176e"
 dependencies = [
  "glib",
  "gstreamer",
@@ -3547,9 +3547,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-sys"
-version = "0.25.2"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533fa8d28fc830eafccbcfcfddb390563ea5d3a351af2c3aab99e197e5f5b1ba"
+checksum = "85d09343b4c23d64b3ef35f1f644598860cc9a4617e7ccded141de97cd528608"
 dependencies = [
  "cfg-if",
  "glib-sys",
@@ -3560,9 +3560,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-video"
-version = "0.25.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7907cb8a73edc98cf279e5de7370bb2c245b7bedf623ba8c7e59648cd4739133"
+checksum = "51809937ed7f6fa3974b2730a39623d59fd7415ede882d08d5ecef5de39d758d"
 dependencies = [
  "cfg-if",
  "futures-channel",
@@ -3576,9 +3576,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-video-sys"
-version = "0.25.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6753d53c9a5e274f33441bee2c7dabef82edefb39605b75c834d24af89e7e"
+checksum = "458f82631a5063057c10583a57ba0fbce689e67122cfdb5eddbeaa43eb812e75"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -3590,9 +3590,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-webrtc"
-version = "0.25.2"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb47b71d463547b50ec8d0c69e175cb3f5cfc28f55c4cfd6735c9d368202a74"
+checksum = "7def31f08759da6f658462d7def7138e00346e5345958ba291926e9511e97d16"
 dependencies = [
  "glib",
  "gstreamer",
@@ -4650,9 +4650,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.31"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -4664,9 +4664,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.31"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7280,9 +7280,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
@@ -11504,9 +11504,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-naga-bridge"
-version = "29.0.4"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95226013f547544b223281cd16a4fb549aa9dcb562adbda0faae4c73ffbbc161"
+checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
 dependencies = [
  "naga",
  "wgpu-types",
@@ -12347,9 +12347,9 @@ dependencies = [
 
 [[package]]
 name = "zeitstempel"
-version = "0.2.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7082d20989e6410d2d1c304c8b73fb66aa2c8f68a169b94bf31d340e85b3a4f"
+checksum = "3347afac8523417112bc46e087add86d639eb76c84a16209d34aa5c6e8d16edd"
 dependencies = [
  "cfg-if",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "aead-stream"
-version = "0.6.0-rc.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cc2d8c7d80cce546b635811cc9371c1db8794d36fcc160a08cb1e6824a5eab2"
+checksum = "a901e5bcd15b4a9555a8f17a608d28ef92cf77bc4aa3b4a0c1a3fce1a9cc0bac"
 dependencies = [
  "aead",
 ]
@@ -367,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "app_units"
@@ -3093,9 +3093,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gio-sys"
-version = "0.22.0"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64729ba2772c080448f9f966dba8f4456beeb100d8c28a865ef8a0f2ef4987e1"
+checksum = "353fdc7da7cd16da916104b1e0e4e7de380ec9c8aaa20d4d742d66310ab4b0d5"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -3126,9 +3126,9 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.22.4"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02856b71413e175be50eff37fe0aefa53e227054ee3d96196faee8a0823cac80"
+checksum = "ddbcf514bd1881fc1b960e4e52b4e82873f4da3bceddbd58d42827b508888100"
 dependencies = [
  "bitflags 2.13.0",
  "futures-channel",
@@ -3147,9 +3147,9 @@ dependencies = [
 
 [[package]]
 name = "glib-macros"
-version = "0.22.2"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda575994e3689b1bc12f89c3df621ead46ff292623b76b4710a3a5b79be54bb"
+checksum = "506d23499707c7142898429757e8d9a3871d965239a2cb66dfa05052be6d6f19"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3159,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "glib-sys"
-version = "0.22.3"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eb23a616a3dbc7fc15bbd26f58756ff0b04c8a894df3f0680cd21011db6a642"
+checksum = "030967459f9f676851872c6304adea7825c6d462ec9b72554c733cf0c5952233"
 dependencies = [
  "libc",
  "system-deps",
@@ -3222,9 +3222,9 @@ dependencies = [
 
 [[package]]
 name = "gobject-sys"
-version = "0.22.0"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18eda93f09d3778f38255b231b17ef67195013a592c91624a4daf8bead875565"
+checksum = "22a861859b887a79cf461359c192c97a57d8fb0229dd291232e57aa11f6fa72c"
 dependencies = [
  "glib-sys",
  "libc",
@@ -3284,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer"
-version = "0.25.1"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8d6d77fae07708536f86a34ac15fc36c7e958ef7930b75119dba0242936f08"
+checksum = "ab4527e1b9bae8d29ce137bde5b8eec8ae8f78f13ad00fc6e70cbe227d6ad027"
 dependencies = [
  "cfg-if",
  "futures-channel",
@@ -3294,7 +3294,7 @@ dependencies = [
  "futures-util",
  "glib",
  "gstreamer-sys",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "kstring",
  "libc",
  "muldiv",
@@ -3309,9 +3309,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-app"
-version = "0.25.0"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714874829f75e805192ddc2bd130b9d7669ebc3ed0e8b106039dd3416cb82916"
+checksum = "97f8ae9238c2352398dcc084de28df3f7099af216ac6c160b52318d23f25c010"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3337,9 +3337,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-audio"
-version = "0.25.0"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e64660e1963ff3b6a4a5175f917524254a6ae36ac7b83e29b760d879a33073"
+checksum = "f97532c3e21287a6e94563a328cce89367324acf8a4489291b40ede2e39163a0"
 dependencies = [
  "cfg-if",
  "glib",
@@ -3352,9 +3352,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-audio-sys"
-version = "0.25.0"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5111bd07d0e22cc66ec9b4b4ef5408beefb148af19944fbe4602983a043f34c"
+checksum = "2abfb81a073c5c8fb115a3639f47b6430f669ee9fa29123bb0116c9ef59d7d16"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -3366,9 +3366,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-base"
-version = "0.25.0"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08353a8a382be9a49b15fb9c46b3abd6f8a6e6439e1eaedc87d08f1abdcfad1"
+checksum = "c91c94a4d3047d05dd6e1f6d91c74f61f56384c7ea1c9d0c1051572eeeb0138d"
 dependencies = [
  "atomic_refcell",
  "cfg-if",
@@ -3380,9 +3380,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-base-sys"
-version = "0.25.0"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569606feeb89cfcf95a6476a64a0f0aec83fadcef0e91c24e576f7851ceac3a"
+checksum = "709fbbc623dc066908ba10c43d629c21096508dea04796592a206c4edd864e37"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -3393,9 +3393,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-gl"
-version = "0.25.0"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f83397da547ce27d7b912980ecb21c99c6aedee4015765355fe66cdf0bd9b9"
+checksum = "91d452d542cee699b747f3b5ab54096fcdf1d9b6f22b890d9d86a9d9f9258f49"
 dependencies = [
  "glib",
  "gstreamer",
@@ -3524,9 +3524,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-sdp"
-version = "0.25.0"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11650b5fbc5994877bc525519c554cb66166f155f9cc3119b0fe88a33dc5176e"
+checksum = "5a7859290ba340f1bd45d4bc0ada958700e9d3b1a522b456fd7ee88da468cd13"
 dependencies = [
  "glib",
  "gstreamer",
@@ -3547,9 +3547,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-sys"
-version = "0.25.0"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85d09343b4c23d64b3ef35f1f644598860cc9a4617e7ccded141de97cd528608"
+checksum = "533fa8d28fc830eafccbcfcfddb390563ea5d3a351af2c3aab99e197e5f5b1ba"
 dependencies = [
  "cfg-if",
  "glib-sys",
@@ -3560,9 +3560,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-video"
-version = "0.25.0"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51809937ed7f6fa3974b2730a39623d59fd7415ede882d08d5ecef5de39d758d"
+checksum = "7907cb8a73edc98cf279e5de7370bb2c245b7bedf623ba8c7e59648cd4739133"
 dependencies = [
  "cfg-if",
  "futures-channel",
@@ -3576,9 +3576,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-video-sys"
-version = "0.25.0"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f82631a5063057c10583a57ba0fbce689e67122cfdb5eddbeaa43eb812e75"
+checksum = "94f6753d53c9a5e274f33441bee2c7dabef82edefb39605b75c834d24af89e7e"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -3590,9 +3590,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-webrtc"
-version = "0.25.0"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7def31f08759da6f658462d7def7138e00346e5345958ba291926e9511e97d16"
+checksum = "0eb47b71d463547b50ec8d0c69e175cb3f5cfc28f55c4cfd6735c9d368202a74"
 dependencies = [
  "glib",
  "gstreamer",
@@ -4650,9 +4650,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.29"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
+checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -4664,9 +4664,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.29"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
+checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7280,9 +7280,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "zeroize",
 ]
@@ -11504,9 +11504,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-naga-bridge"
-version = "29.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
+checksum = "95226013f547544b223281cd16a4fb549aa9dcb562adbda0faae4c73ffbbc161"
 dependencies = [
  "naga",
  "wgpu-types",
@@ -12347,9 +12347,9 @@ dependencies = [
 
 [[package]]
 name = "zeitstempel"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3347afac8523417112bc46e087add86d639eb76c84a16209d34aa5c6e8d16edd"
+checksum = "d7082d20989e6410d2d1c304c8b73fb66aa2c8f68a169b94bf31d340e85b3a4f"
 dependencies = [
  "cfg-if",
  "libc",

--- a/components/script/dom/css/fontfaceset.rs
+++ b/components/script/dom/css/fontfaceset.rs
@@ -84,7 +84,7 @@ impl FontFaceSet {
                 window
                     .font_context()
                     .add_template_to_font_context(family_name, template);
-                window.Document().dirty_all_nodes();
+                window.Document().dirty_all_nodes(cx.no_gc());
             },
             _ => {},
         }

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -969,7 +969,7 @@ impl Document {
 
         self.title_changed();
         self.notify_embedder_favicon();
-        self.dirty_all_nodes();
+        self.dirty_all_nodes(cx.no_gc());
         self.window().resume(cx);
         media.resume(&client_context_id);
 
@@ -1088,7 +1088,7 @@ impl Document {
         self.stylesheets.borrow().has_changed()
     }
 
-    pub(crate) fn restyle_reason(&self) -> RestyleReason {
+    pub(crate) fn restyle_reason(&self, no_gc: &NoGC) -> RestyleReason {
         let mut condition = self.needs_restyle.get();
         if self.stylesheets_changed_since_last_reflow() {
             condition.insert(RestyleReason::StylesheetsChanged);
@@ -1097,7 +1097,7 @@ impl Document {
         // FIXME: This should check the dirty bit on the document,
         // not the document element. Needs some layout changes to make
         // that workable.
-        if let Some(root) = self.GetDocumentElement() &&
+        if let Some(root) = self.get_document_element_unrooted(no_gc) &&
             root.upcast::<Node>().has_dirty_descendants()
         {
             condition.insert(RestyleReason::DOMChanged);
@@ -1453,14 +1453,14 @@ impl Document {
         window.send_to_embedder(msg);
     }
 
-    pub(crate) fn dirty_all_nodes(&self) {
+    pub(crate) fn dirty_all_nodes(&self, no_gc: &NoGC) {
         let root = match self.GetDocumentElement() {
             Some(root) => root,
             None => return,
         };
         for node in root
             .upcast::<Node>()
-            .traverse_preorder(ShadowIncluding::Yes)
+            .traverse_preorder_non_rooting(no_gc, ShadowIncluding::Yes)
         {
             node.dirty(NodeDamage::Other)
         }
@@ -3049,12 +3049,12 @@ impl Document {
     /// Whether or not this [`Document`] needs a rendering update, due to changed
     /// contents or pending events. This is used to decide whether or not to schedule
     /// a call to the "update the rendering" algorithm.
-    pub(crate) fn needs_rendering_update(&self) -> bool {
+    pub(crate) fn needs_rendering_update(&self, no_gc: &NoGC) -> bool {
         if !self.is_fully_active() {
             return false;
         }
         if !self.window().layout_blocked() &&
-            (!self.restyle_reason().is_empty() ||
+            (!self.restyle_reason(no_gc).is_empty() ||
                 self.window().layout().needs_new_display_list() ||
                 self.window().layout().needs_accessibility_update())
         {
@@ -3175,7 +3175,7 @@ impl Document {
         if self.ReadyState() != DocumentReadyState::Complete {
             return false;
         }
-        if !self.restyle_reason().is_empty() {
+        if !self.restyle_reason(cx.no_gc()).is_empty() {
             return false;
         }
         if !self.rendering_update_reasons.get().is_empty() {
@@ -3567,6 +3567,13 @@ impl Document {
 
         accessibility_data.unroot_all_removed_nodes();
         None
+    }
+
+    pub(crate) fn get_document_element_unrooted<'a>(
+        &self,
+        no_gc: &'a NoGC,
+    ) -> Option<UnrootedDom<'a, Element>> {
+        self.upcast::<Node>().child_elements_unrooted(no_gc).next()
     }
 }
 

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -994,7 +994,7 @@ impl DocumentEventHandler {
                     // See documentation for [`Node::find_click_focusable_area`].
                     document
                         .focus_handler()
-                        .focus(cx, node.find_click_focusable_area());
+                        .focus(cx, node.find_click_focusable_area(cx.no_gc()));
                 }
 
                 // Step 9. If mbutton is the secondary mouse button, then
@@ -2230,7 +2230,7 @@ impl DocumentEventHandler {
                 document.viewport_scrolling_box(ScrollContainerQueryFlags::Inclusive)
             });
 
-        while !scrolling_box.can_keyboard_scroll_in_axis(scroll_axis) {
+        while !scrolling_box.can_keyboard_scroll_in_axis(cx.no_gc(), scroll_axis) {
             // Always fall back to trying to scroll the entire document.
             if scrolling_box.is_viewport() {
                 break;
@@ -2253,14 +2253,16 @@ impl DocumentEventHandler {
                     KeyboardScroll::End => Vector2D::new(
                         0.0,
                         -current_scroll_offset.y + scrolling_box.content_size().height -
-                            scrolling_box.size().height,
+                            scrolling_box.size(cx.no_gc()).height,
                     ),
-                    KeyboardScroll::PageDown => {
-                        Vector2D::new(0.0, scrolling_box.size().height - 2.0 * LINE_HEIGHT)
-                    },
-                    KeyboardScroll::PageUp => {
-                        Vector2D::new(0.0, 2.0 * LINE_HEIGHT - scrolling_box.size().height)
-                    },
+                    KeyboardScroll::PageDown => Vector2D::new(
+                        0.0,
+                        scrolling_box.size(cx.no_gc()).height - 2.0 * LINE_HEIGHT,
+                    ),
+                    KeyboardScroll::PageUp => Vector2D::new(
+                        0.0,
+                        2.0 * LINE_HEIGHT - scrolling_box.size(cx.no_gc()).height,
+                    ),
                     KeyboardScroll::Up => Vector2D::new(0.0, -LINE_HEIGHT),
                     KeyboardScroll::Down => Vector2D::new(0.0, LINE_HEIGHT),
                     KeyboardScroll::Left => Vector2D::new(-LINE_WIDTH, 0.0),
@@ -2282,7 +2284,7 @@ impl DocumentEventHandler {
 
         // If this is the viewport and we cannot scroll, try to ask a parent viewport to scroll,
         // if we are inside an `<iframe>`.
-        if !scrolling_box.can_keyboard_scroll_in_axis(scroll_axis) {
+        if !scrolling_box.can_keyboard_scroll_in_axis(cx.no_gc(), scroll_axis) {
             assert!(scrolling_box.is_viewport());
 
             let window_proxy = document.window().window_proxy();

--- a/components/script/dom/document/documentfragment.rs
+++ b/components/script/dom/document/documentfragment.rs
@@ -129,7 +129,7 @@ impl DocumentFragmentMethods<crate::DomTypeHolder> for DocumentFragment {
 
     /// <https://dom.spec.whatwg.org/#dom-parentnode-childelementcount>
     fn ChildElementCount(&self) -> u32 {
-        self.upcast::<Node>().child_elements().count() as u32
+        self.upcast::<Node>().children_count()
     }
 
     /// <https://dom.spec.whatwg.org/#dom-parentnode-prepend>

--- a/components/script/dom/document/documentfragment.rs
+++ b/components/script/dom/document/documentfragment.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::rust::HandleObject;
 use stylo_atoms::Atom;
 
@@ -128,8 +128,8 @@ impl DocumentFragmentMethods<crate::DomTypeHolder> for DocumentFragment {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-parentnode-childelementcount>
-    fn ChildElementCount(&self) -> u32 {
-        self.upcast::<Node>().children_count()
+    fn ChildElementCount(&self, no_gc: &NoGC) -> u32 {
+        self.upcast::<Node>().child_elements_unrooted(no_gc).count() as u32
     }
 
     /// <https://dom.spec.whatwg.org/#dom-parentnode-prepend>

--- a/components/script/dom/document/focus.rs
+++ b/components/script/dom/document/focus.rs
@@ -7,7 +7,7 @@ use std::cmp::Ordering;
 
 use bitflags::bitflags;
 use embedder_traits::FocusSequenceNumber;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use keyboard_types::Modifiers;
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::HTMLIFrameElementBinding::HTMLIFrameElementMethods;
@@ -518,7 +518,7 @@ impl DocumentFocusHandler {
             .focused_area
             .borrow()
             .element()
-            .is_none_or(|focused| focused.is_focusable_area())
+            .is_none_or(|focused| focused.is_focusable_area(cx.no_gc()))
         {
             return;
         }
@@ -612,7 +612,7 @@ impl DocumentFocusHandler {
         let selection_mechanism = starting_point
             .as_ref()
             .and_then(|node| node.downcast::<Element>())
-            .filter(|element| element.is_sequentially_focusable())
+            .filter(|element| element.is_sequentially_focusable(cx.no_gc()))
             .map(|element| {
                 SequentialFocusNavigationMechanism::Sequential(
                     element.explicitly_set_tab_index().unwrap_or_default(),
@@ -637,7 +637,7 @@ impl DocumentFocusHandler {
             selection_mechanism,
             starting_point,
         )
-        .search();
+        .search(cx.no_gc());
 
         // > 6. If candidate is not null, then run the focusing steps for candidate and return.
         if let Some(candidate) = candidate {
@@ -862,9 +862,9 @@ impl SequentialFocusNavigationSearch {
         }
     }
 
-    pub(crate) fn search(mut self) -> Option<DomRoot<Element>> {
+    pub(crate) fn search(mut self, no_gc: &NoGC) -> Option<DomRoot<Element>> {
         for node in self.focus_navigation_scope_owner.iterator() {
-            if self.process_node(&node) == Continue::No {
+            if self.process_node(no_gc, &node) == Continue::No {
                 break;
             }
         }
@@ -876,13 +876,16 @@ impl SequentialFocusNavigationSearch {
         // If searching a nested focus navigation scope, never try to search the containing
         // scope, as that will lead to an endless cycle.
         if self.search_context != SequentialFocusNavigationSearchContext::Nested {
-            return self.maybe_search_in_containing_focus_navigation_scope();
+            return self.maybe_search_in_containing_focus_navigation_scope(no_gc);
         }
 
         None
     }
 
-    fn maybe_search_in_containing_focus_navigation_scope(&self) -> Option<DomRoot<Element>> {
+    fn maybe_search_in_containing_focus_navigation_scope(
+        &self,
+        no_gc: &NoGC,
+    ) -> Option<DomRoot<Element>> {
         let containing_node = self.focus_navigation_scope_owner.node();
         let containing_focus_navigation_scope_owner =
             containing_node.containing_focus_navigation_scope_owner()?;
@@ -907,7 +910,7 @@ impl SequentialFocusNavigationSearch {
 
         if self.direction == SequentialFocusDirection::Backward &&
             let Some(containing_element) = containing_node.downcast::<Element>() &&
-            containing_element.is_sequentially_focusable()
+            containing_element.is_sequentially_focusable(no_gc)
         {
             return Some(DomRoot::from_ref(containing_element));
         }
@@ -921,26 +924,30 @@ impl SequentialFocusNavigationSearch {
             passed_starting_point: false,
             search_context: SequentialFocusNavigationSearchContext::Containing,
         }
-        .search()
+        .search(no_gc)
     }
 
-    fn process_node(&mut self, node: &Node) -> Continue {
+    fn process_node(&mut self, no_gc: &NoGC, node: &Node) -> Continue {
         if Some(node) == self.starting_point.as_deref() {
             self.passed_starting_point = true;
-        } else if self.process_node_as_sequentially_focusable_node(node) == Continue::No {
+        } else if self.process_node_as_sequentially_focusable_node(no_gc, node) == Continue::No {
             return Continue::No;
         }
 
-        self.process_node_as_focus_scope_owner(node)
+        self.process_node_as_focus_scope_owner(no_gc, node)
     }
 
     /// If this node is sequentially focusable, consider whether or not to accept it
     /// as the new winner.
-    fn process_node_as_sequentially_focusable_node(&mut self, node: &Node) -> Continue {
+    fn process_node_as_sequentially_focusable_node(
+        &mut self,
+        no_gc: &NoGC,
+        node: &Node,
+    ) -> Continue {
         let Some(element) = node.downcast::<Element>() else {
             return Continue::Yes;
         };
-        if !element.is_sequentially_focusable() {
+        if !element.is_sequentially_focusable(no_gc) {
             return Continue::Yes;
         }
 
@@ -954,7 +961,7 @@ impl SequentialFocusNavigationSearch {
 
     /// If this node itself forms a nested sequential focus scope, decide whether or
     /// not to descend and consider its contained focusable areas as candidates.
-    fn process_node_as_focus_scope_owner(&mut self, node: &Node) -> Continue {
+    fn process_node_as_focus_scope_owner(&mut self, no_gc: &NoGC, node: &Node) -> Continue {
         // Never try to recurse into the same focus scope that we are in. This path
         // might be reached if we are in the root focus scope where the document is
         // one of the nodes processed.
@@ -1005,7 +1012,7 @@ impl SequentialFocusNavigationSearch {
             passed_starting_point: self.passed_starting_point,
             search_context: SequentialFocusNavigationSearchContext::Nested,
         }
-        .search();
+        .search(no_gc);
 
         let Some(element) = element else {
             return Continue::Yes;

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -20,7 +20,7 @@ use euclid::Rect;
 use html5ever::serialize::TraversalScope;
 use html5ever::serialize::TraversalScope::{ChildrenOnly, IncludeNode};
 use html5ever::{LocalName, Namespace, Prefix, QualName, local_name, namespace_prefix, ns};
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::jsapi::{Heap, JSObject};
 use js::jsval::JSVal;
 use js::realm::CurrentRealm;
@@ -586,8 +586,9 @@ impl Element {
             .is_some_and(|overflow| overflow.establishes_scroll_container())
     }
 
-    pub(crate) fn has_overflow(&self) -> bool {
-        self.ScrollHeight() > self.ClientHeight() || self.ScrollWidth() > self.ClientWidth()
+    pub(crate) fn has_overflow(&self, no_gc: &NoGC) -> bool {
+        self.ScrollHeight() > self.ClientHeight(no_gc) ||
+            self.ScrollWidth() > self.ClientWidth(no_gc)
     }
 
     /// Whether or not this element has a scrolling box according to
@@ -597,8 +598,8 @@ impl Element {
     ///  1. The element has a layout box.
     ///  2. The style specifies that overflow should be scrollable (`auto`, `hidden` or `scroll`).
     ///  3. The fragment actually has content that overflows the box.
-    fn has_scrolling_box(&self) -> bool {
-        self.has_css_layout_box() && self.establishes_scroll_container() && self.has_overflow()
+    fn has_scrolling_box(&self, no_gc: &NoGC) -> bool {
+        self.has_css_layout_box() && self.establishes_scroll_container() && self.has_overflow(no_gc)
     }
 
     pub(crate) fn shadow_root(&self) -> Option<DomRoot<ShadowRoot>> {
@@ -919,8 +920,12 @@ impl Element {
             // determine the scroll-into-view position of `target` with `behavior` as the scroll
             // behavior, `block` as the block flow position, `inline` as the inline base direction
             // position and `scrolling box` as the scrolling box.
-            let position =
-                scrolling_box.determine_scroll_into_view_position(block, inline, get_target_rect());
+            let position = scrolling_box.determine_scroll_into_view_position(
+                cx.no_gc(),
+                block,
+                inline,
+                get_target_rect(),
+            );
 
             // Step 1.3: If `position` is not the same as `scrolling box`’s current scroll position, or
             // `scrolling box` has an ongoing smooth scroll,
@@ -2620,7 +2625,7 @@ impl Element {
         }
 
         // Step 10
-        if !self.has_scrolling_box() {
+        if !self.has_scrolling_box(cx.no_gc()) {
             return;
         }
 
@@ -3362,7 +3367,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         }
 
         // Step 10
-        if !self.has_scrolling_box() {
+        if !self.has_scrolling_box(cx.no_gc()) {
             return;
         }
 
@@ -3459,7 +3464,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         }
 
         // Step 10
-        if !self.has_scrolling_box() {
+        if !self.has_scrolling_box(cx.no_gc()) {
             return;
         }
 
@@ -3531,23 +3536,23 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-element-clienttop>
-    fn ClientTop(&self) -> i32 {
-        self.client_rect().origin.y
+    fn ClientTop(&self, no_gc: &NoGC) -> i32 {
+        self.client_rect(no_gc).origin.y
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-element-clientleft>
-    fn ClientLeft(&self) -> i32 {
-        self.client_rect().origin.x
+    fn ClientLeft(&self, no_gc: &NoGC) -> i32 {
+        self.client_rect(no_gc).origin.x
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-element-clientwidth>
-    fn ClientWidth(&self) -> i32 {
-        self.client_rect().size.width
+    fn ClientWidth(&self, no_gc: &NoGC) -> i32 {
+        self.client_rect(no_gc).size.width
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-element-clientheight>
-    fn ClientHeight(&self) -> i32 {
-        self.client_rect().size.height
+    fn ClientHeight(&self, no_gc: &NoGC) -> i32 {
+        self.client_rect(no_gc).size.height
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-currentcsszoom
@@ -4868,7 +4873,7 @@ impl VirtualMethods for Element {
     }
 }
 impl Element {
-    pub(crate) fn client_rect(&self) -> Rect<i32, CSSPixel> {
+    pub(crate) fn client_rect(&self, no_gc: &NoGC) -> Rect<i32, CSSPixel> {
         let doc = self.node.owner_doc();
 
         if let Some(rect) = self
@@ -4876,7 +4881,7 @@ impl Element {
             .as_ref()
             .and_then(|data| data.client_rect.as_ref())
             .and_then(|rect| rect.get().ok()) &&
-            doc.restyle_reason().is_empty()
+            doc.restyle_reason(no_gc).is_empty()
         {
             return rect;
         }

--- a/components/script/dom/element/focus.rs
+++ b/components/script/dom/element/focus.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use js::context::NoGC;
 use script_bindings::codegen::GenericBindings::ElementBinding::ElementMethods;
 use script_bindings::codegen::GenericBindings::ShadowRootBinding::ShadowRootMethods;
 use script_bindings::codegen::InheritTypes::{ElementTypeId, HTMLElementTypeId, NodeTypeId};
@@ -25,7 +26,7 @@ impl Element {
     /// different types of focusable areas ahead of time so that the logic is useful for answering
     /// both "Is this element a focusable area?" and "Is this element click (or sequentially)
     /// focusable."
-    pub(crate) fn focusable_area_kind(&self) -> FocusableAreaKind {
+    pub(crate) fn focusable_area_kind(&self, no_gc: &NoGC) -> FocusableAreaKind {
         // Do not allow unrendered, disconnected, or disabled nodes to be focusable areas ever.
         let node: &Node = self.upcast();
         if !node.is_connected() || !self.has_css_layout_box() || self.is_actually_disabled() {
@@ -129,9 +130,9 @@ impl Element {
                 // This is checking whether there is an input event scrollable overflow value in
                 // a given axis and also overflow in that same axis.
                 (matches!(axes_overflow.x, Overflow::Auto | Overflow::Scroll) &&
-                    self.ScrollWidth() > self.ClientWidth()) ||
+                    self.ScrollWidth() > self.ClientWidth(no_gc)) ||
                     (matches!(axes_overflow.y, Overflow::Auto | Overflow::Scroll) &&
-                        self.ScrollHeight() > self.ClientHeight())
+                        self.ScrollHeight() > self.ClientHeight(no_gc))
             })
         {
             return FocusableAreaKind::Sequential;
@@ -148,13 +149,13 @@ impl Element {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#sequentially-focusable>.
-    pub(crate) fn is_sequentially_focusable(&self) -> bool {
-        self.focusable_area_kind()
+    pub(crate) fn is_sequentially_focusable(&self, no_gc: &NoGC) -> bool {
+        self.focusable_area_kind(no_gc)
             .contains(FocusableAreaKind::Sequential)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#focusable-area>
-    pub(crate) fn is_focusable_area(&self) -> bool {
-        !self.focusable_area_kind().is_empty()
+    pub(crate) fn is_focusable_area(&self, no_gc: &NoGC) -> bool {
+        !self.focusable_area_kind(no_gc).is_empty()
     }
 }

--- a/components/script/dom/html/htmldialogelement.rs
+++ b/components/script/dom/html/htmldialogelement.rs
@@ -313,17 +313,17 @@ impl HTMLDialogElement {
 
         // Step 3. If subject has the autofocus attribute, then set control to subject.
         if self.upcast::<HTMLElement>().Autofocus() {
-            control = self.upcast::<Node>().get_the_focusable_area();
+            control = self.upcast::<Node>().get_the_focusable_area(cx.no_gc());
         }
 
         // Step 4. If control is null, then set control to the focus delegate of subject.
         if control.is_none() {
-            control = self.upcast::<Node>().focus_delegate();
+            control = self.upcast::<Node>().focus_delegate(cx.no_gc());
         }
 
         // Step 5. If control is null, then set control to subject.
         if control.is_none() {
-            control = self.upcast::<Node>().get_the_focusable_area();
+            control = self.upcast::<Node>().get_the_focusable_area(cx.no_gc());
         }
 
         // Step 6. Run the focusing steps for control.

--- a/components/script/dom/node/focus.rs
+++ b/components/script/dom/node/focus.rs
@@ -4,7 +4,7 @@
 
 use std::collections::VecDeque;
 
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::codegen::GenericBindings::ShadowRootBinding::ShadowRootMethods;
 use script_bindings::inheritance::Castable;
 use script_bindings::root::DomRoot;
@@ -104,10 +104,10 @@ impl Node {
     /// the node from the hit test. This isn't exactly how browsers work though, as they seem
     /// to look for the first inclusive ancestor node that has a focusable area associated with it.
     /// Note also that this may return [`FocusableArea::Viewport`].
-    pub(crate) fn find_click_focusable_area(&self) -> FocusableArea {
+    pub(crate) fn find_click_focusable_area(&self, no_gc: &NoGC) -> FocusableArea {
         self.inclusive_ancestors(ShadowIncluding::Yes)
             .find_map(|node| {
-                node.get_the_focusable_area().filter(|focusable_area| {
+                node.get_the_focusable_area(no_gc).filter(|focusable_area| {
                     focusable_area.kind().contains(FocusableAreaKind::Click)
                 })
             })
@@ -121,10 +121,10 @@ impl Node {
     /// this for a focus target that actually *is* a focusable area. The obvious thing is to
     /// just return the focus target, but it's still odd that this isn't mentioned in the
     /// specification.
-    pub(crate) fn get_the_focusable_area(&self) -> Option<FocusableArea> {
+    pub(crate) fn get_the_focusable_area(&self, no_gc: &NoGC) -> Option<FocusableArea> {
         let kind = self
             .downcast::<Element>()
-            .map(Element::focusable_area_kind)
+            .map(|element| Element::focusable_area_kind(element, no_gc))
             .unwrap_or_default();
         if !kind.is_empty() {
             if let Some(iframe_element) = self.downcast::<HTMLIFrameElement>() {
@@ -139,7 +139,7 @@ impl Node {
                 kind,
             });
         }
-        self.get_the_focusable_area_if_not_a_focusable_area()
+        self.get_the_focusable_area_if_not_a_focusable_area(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#get-the-focusable-area>
@@ -150,7 +150,10 @@ impl Node {
     /// is the `Document`'s viewport.
     ///
     /// TODO: It might be better to distinguish these two cases in the future.
-    fn get_the_focusable_area_if_not_a_focusable_area(&self) -> Option<FocusableArea> {
+    fn get_the_focusable_area_if_not_a_focusable_area(
+        &self,
+        no_gc: &NoGC,
+    ) -> Option<FocusableArea> {
         // > To get the focusable area for a focus target that is either an element that is not a
         // > focusable area, or is a navigable, given an optional string focus trigger (default
         // > "other"), run the first matching set of steps from the following list:
@@ -203,7 +206,7 @@ impl Node {
             }
 
             // >   Step 3. Return the focus delegate for focus target given focus trigger.
-            return self.focus_delegate();
+            return self.focus_delegate(no_gc);
         }
 
         None
@@ -213,7 +216,7 @@ impl Node {
     ///
     /// In addition to returning the focus delegate for this [`Node`], this method also returns
     /// the [`FocusableAreaKind`] for efficiency reasons.
-    pub(crate) fn focus_delegate(&self) -> Option<FocusableArea> {
+    pub(crate) fn focus_delegate(&self, no_gc: &NoGC) -> Option<FocusableArea> {
         // > 1. If focusTarget is a shadow host and its shadow root's delegates focus is false, then
         // >    return null.
         let shadow_root = self.downcast::<Element>().and_then(Element::shadow_root);
@@ -248,7 +251,7 @@ impl Node {
             // >      set focusableArea to descendant.
             let kind = descendant
                 .downcast::<Element>()
-                .map(Element::focusable_area_kind)
+                .map(|node| Element::focusable_area_kind(node, no_gc))
                 .unwrap_or_default();
             if is_dialog_element && kind.contains(FocusableAreaKind::Sequential) {
                 return Some(FocusableArea::Node {
@@ -269,7 +272,7 @@ impl Node {
             // > 6.4. Otherwise, set focusableArea to the result of getting the focusable area for
             //        descendant given focusTrigger.
             if let Some(focusable_area) =
-                descendant.get_the_focusable_area_if_not_a_focusable_area()
+                descendant.get_the_focusable_area_if_not_a_focusable_area(no_gc)
             {
                 // > 6.5. If focusableArea is not null, then return focusableArea.
                 return Some(focusable_area);
@@ -299,7 +302,8 @@ impl Node {
         // > 2. If new focus target is null, then:
         // > 2.1 If no fallback target was specified, then return.
         // > 2.2 Otherwise, set new focus target to the fallback target.
-        let Some(focusable_area) = self.get_the_focusable_area().or(fallback_target) else {
+        let Some(focusable_area) = self.get_the_focusable_area(cx.no_gc()).or(fallback_target)
+        else {
             return false;
         };
 

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -1731,7 +1731,7 @@ impl Node {
         SimpleNodeIterator::new(self.GetLastChild(), |n| n.GetPreviousSibling())
     }
 
-    /// Returns the children as Elements
+    /// Returns the children that are Elements
     pub(crate) fn child_elements(&self) -> impl Iterator<Item = DomRoot<Element>> + use<> {
         self.children()
             .filter_map(DomRoot::downcast as fn(_) -> _)

--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -346,9 +346,6 @@ impl Range {
     fn client_rects<'a>(&self, no_gc: &'a NoGC) -> impl Iterator<Item = Rect<Au, CSSPixel>> + 'a {
         // FIXME: For text nodes that are only partially selected, this should return the client
         // rect of the selected part, not the whole text node.
-
-        // FIXME: For text nodes that are only partially selected, this should return the client
-        // rect of the selected part, not the whole text node.
         let start = self.start_container();
         let end = self.end_container();
         let document = start.owner_doc();

--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -343,16 +343,19 @@ impl Range {
         self.abstract_range().Collapsed()
     }
 
-    fn client_rects(&self) -> impl Iterator<Item = Rect<Au, CSSPixel>> {
+    fn client_rects<'a>(&self, no_gc: &'a NoGC) -> impl Iterator<Item = Rect<Au, CSSPixel>> + 'a {
+        // FIXME: For text nodes that are only partially selected, this should return the client
+        // rect of the selected part, not the whole text node.
+
         // FIXME: For text nodes that are only partially selected, this should return the client
         // rect of the selected part, not the whole text node.
         let start = self.start_container();
         let end = self.end_container();
         let document = start.owner_doc();
-        let end_clone = end.clone();
+        let end_clone = UnrootedDom::from_dom(Dom::from_ref(&*end), no_gc);
         start
-            .following_nodes(document.upcast::<Node>(), ShadowIncluding::No)
-            .take_while(move |node| node != &end)
+            .following_nodes_unrooted(no_gc, document.upcast::<Node>(), ShadowIncluding::No)
+            .take_while(move |node| *node != *end)
             .chain(iter::once(end_clone))
             .flat_map(move |node| node.border_boxes())
     }
@@ -1228,8 +1231,9 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         let start = self.start_container();
         let window = start.owner_window();
 
-        let client_rects = self
-            .client_rects()
+        let client_rects: Vec<_> = self.client_rects(cx.no_gc()).collect();
+        let client_rects = client_rects
+            .iter()
             .map(|rect| {
                 DOMRect::new(
                     cx,
@@ -1250,7 +1254,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         let window = self.start_container().owner_window();
 
         // Step 1. Let list be the result of invoking getClientRects() on the same range this method was invoked on.
-        let list = self.client_rects();
+        let list = self.client_rects(cx.no_gc());
 
         // Step 2. If list is empty return a DOMRect object whose x, y, width and height members are zero.
         // Step 3. If all rectangles in list have zero width or height, return the first rectangle in list.

--- a/components/script/dom/scrolling_box.rs
+++ b/components/script/dom/scrolling_box.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 
 use app_units::Au;
 use euclid::{Rect, Vector2D};
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use layout_api::{AxesOverflow, ScrollContainerQueryFlags};
 use script_bindings::codegen::GenericBindings::WindowBinding::ScrollBehavior;
 use script_bindings::inheritance::Castable;
@@ -128,13 +128,15 @@ impl ScrollingBox {
         content_size
     }
 
-    pub(crate) fn size(&self) -> LayoutSize {
+    pub(crate) fn size(&self, no_gc: &NoGC) -> LayoutSize {
         if let Some(size) = self.cached_size.get() {
             return size;
         }
 
         let size = match &self.target {
-            ScrollingBoxSource::Element(element) => element.client_rect().size.to_f32().cast_unit(),
+            ScrollingBoxSource::Element(element) => {
+                element.client_rect(no_gc).size.to_f32().cast_unit()
+            },
             ScrollingBoxSource::Viewport(document) => {
                 document.window().viewport_details().size.cast_unit()
             },
@@ -179,7 +181,7 @@ impl ScrollingBox {
         }
     }
 
-    pub(crate) fn can_keyboard_scroll_in_axis(&self, axis: ScrollingBoxAxis) -> bool {
+    pub(crate) fn can_keyboard_scroll_in_axis(&self, no_gc: &NoGC, axis: ScrollingBoxAxis) -> bool {
         let overflow = match axis {
             ScrollingBoxAxis::X => self.overflow.x,
             ScrollingBoxAxis::Y => self.overflow.y,
@@ -188,14 +190,15 @@ impl ScrollingBox {
             return false;
         }
         match axis {
-            ScrollingBoxAxis::X => self.content_size().width > self.size().width,
-            ScrollingBoxAxis::Y => self.content_size().height > self.size().height,
+            ScrollingBoxAxis::X => self.content_size().width > self.size(no_gc).width,
+            ScrollingBoxAxis::Y => self.content_size().height > self.size(no_gc).height,
         }
     }
 
     /// <https://drafts.csswg.org/cssom-view/#determine-the-scroll-into-view-position>
     pub(crate) fn determine_scroll_into_view_position(
         &self,
+        no_gc: &NoGC,
         block: ScrollAxisState,
         inline: ScrollAxisState,
         target_rect: Rect<Au, CSSPixel>,
@@ -230,7 +233,7 @@ impl ScrollingBox {
             },
         };
 
-        let size = self.size();
+        let size = self.size(no_gc);
         let current_scroll_position = self.scroll_position();
         Vector2D::new(
             Self::calculate_scroll_position_one_axis(

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -2623,7 +2623,7 @@ impl Window {
             None
         };
 
-        let restyle_reason = document.restyle_reason();
+        let restyle_reason = document.restyle_reason(cx.no_gc());
         document.clear_restyle_reasons();
         let restyle = if restyle_reason.needs_restyle() {
             debug!("Invalidating layout cache due to reflow condition {restyle_reason:?}",);
@@ -2758,7 +2758,7 @@ impl Window {
         }
 
         let document = self.Document();
-        if document.needs_rendering_update() {
+        if document.needs_rendering_update(cx.no_gc()) {
             return;
         }
 
@@ -3433,7 +3433,7 @@ impl Window {
         // If viewport units were used, all nodes need to be restyled, because
         // we currently do not track which ones rely on viewport units.
         if self.layout().device().used_viewport_size() {
-            self.Document().dirty_all_nodes();
+            self.Document().dirty_all_nodes(cx.no_gc());
         }
 
         // http://dev.w3.org/csswg/cssom-view/#resizing-viewports

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -51,7 +51,7 @@ use headers::{HeaderMapExt, LastModified, ReferrerPolicy as ReferrerPolicyHeader
 use http::header::REFRESH;
 use hyper_serde::Serde;
 use ipc_channel::router::ROUTER;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::glue::GetWindowProxyClass;
 use js::jsapi::{GCReason, JSContext as UnsafeJSContext};
 use js::jsval::UndefinedValue;
@@ -1317,13 +1317,14 @@ impl ScriptThread {
     /// responsible for scheduling animation ticks.
     fn maybe_schedule_rendering_opportunity_after_ipc_message(
         &self,
+        no_gc: &NoGC,
         built_any_display_lists: bool,
     ) {
         let needs_rendering_update = self
             .documents
             .borrow()
             .iter()
-            .any(|(_, document)| document.needs_rendering_update());
+            .any(|(_, document)| document.needs_rendering_update(no_gc));
         let running_animations = self.documents.borrow().iter().any(|(_, document)| {
             document.is_fully_active() &&
                 !document.window().throttled() &&
@@ -1571,7 +1572,10 @@ impl ScriptThread {
         self.maybe_resolve_pending_screenshot_readiness_requests(cx);
 
         // This must happen last to detect if any change above makes a rendering update necessary.
-        self.maybe_schedule_rendering_opportunity_after_ipc_message(built_any_display_lists);
+        self.maybe_schedule_rendering_opportunity_after_ipc_message(
+            cx.no_gc(),
+            built_any_display_lists,
+        );
 
         true
     }
@@ -1891,7 +1895,7 @@ impl ScriptThread {
                 self.handle_webdriver_msg(pipeline_id, msg, cx)
             },
             ScriptThreadMessage::WebFontLoaded(pipeline_id) => {
-                self.handle_web_font_loaded(pipeline_id)
+                self.handle_web_font_loaded(cx.no_gc(), pipeline_id)
             },
             ScriptThreadMessage::DispatchIFrameLoadEvent {
                 target: browsing_context_id,
@@ -2928,7 +2932,9 @@ impl ScriptThread {
         });
         let focusable_area = iframe_element
             .map(|iframe_element| {
-                let kind = iframe_element.upcast::<Element>().focusable_area_kind();
+                let kind = iframe_element
+                    .upcast::<Element>()
+                    .focusable_area_kind(cx.no_gc());
                 FocusableArea::IFrameViewport {
                     iframe_element,
                     kind,
@@ -3327,14 +3333,14 @@ impl ScriptThread {
     }
 
     /// Handles a Web font being loaded. Does nothing if the page no longer exists.
-    fn handle_web_font_loaded(&self, pipeline_id: PipelineId) {
+    fn handle_web_font_loaded(&self, no_gc: &NoGC, pipeline_id: PipelineId) {
         let Some(document) = self.documents.borrow().find_document(pipeline_id) else {
             warn!("Web font loaded in closed pipeline {}.", pipeline_id);
             return;
         };
 
         // TODO: This should only dirty nodes that are waiting for a web font to finish loading!
-        document.dirty_all_nodes();
+        document.dirty_all_nodes(no_gc);
     }
 
     /// Handles a worklet being loaded by triggering a relayout of the page. Does nothing if the

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -14,7 +14,7 @@ use embedder_traits::{
 };
 use euclid::default::{Point2D, Rect, Size2D};
 use hyper_serde::Serde;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::conversions::{FromJSValConvertible, jsstr_to_string};
 use js::jsapi::{HandleValueArray, JSITER_OWNONLY, JSType, PropertyDescriptor};
 use js::jsval::UndefinedValue;
@@ -1139,8 +1139,8 @@ pub(crate) fn handle_get_element_shadow_root(
 
 impl Element {
     /// <https://w3c.github.io/webdriver/#dfn-keyboard-interactable>
-    fn is_keyboard_interactable(&self) -> bool {
-        self.is_focusable_area() || self.is::<HTMLBodyElement>() || self.is_document_element()
+    fn is_keyboard_interactable(&self, no_gc: &NoGC) -> bool {
+        self.is_focusable_area(no_gc) || self.is::<HTMLBodyElement>() || self.is_document_element()
     }
 }
 
@@ -1269,7 +1269,7 @@ pub(crate) fn handle_will_send_keys(
 
         // Step 7.6. If element is not keyboard-interactable,
         // return ErrorStatus::ElementNotInteractable.
-        if !element.is_keyboard_interactable() {
+        if !element.is_keyboard_interactable(cx.no_gc()) {
             let _ = reply.send(Err(ErrorStatus::ElementNotInteractable));
             return;
         }
@@ -1877,7 +1877,7 @@ pub(crate) fn handle_element_clear(
 
                 // Step 10. If element is not keyboard-interactable or not pointer-interactable,
                 // return error with error code element not interactable.
-                if !element.is_keyboard_interactable() {
+                if !element.is_keyboard_interactable(cx.no_gc()) {
                     return Err(ErrorStatus::ElementNotInteractable);
                 }
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -403,6 +403,7 @@ DOMInterfaces = {
     ],
     'realm': ['RequestFullscreen'],
     'cx_no_gc': ['GetAssignedSlot'],
+    'no_gc': ['ClientTop', 'ClientLeft', 'ClientWidth', 'ClientHeight'],
 },
 
 'ElementInternals': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -301,6 +301,7 @@ DOMInterfaces = {
         'ReplaceChildren'
     ],
     'cx_no_gc': ['GetElementById'],
+    'no_gc': ['ChildElementCount']
 },
 
 'DocumentType': {


### PR DESCRIPTION
Both of these methods can be called a lot on some websites.
This uses the unrooted iterators variety for their loop.

Includes https://github.com/servo/servo/pull/46143

Testing: NoGC only needs compilation to be tested and DocumentFragment::ChildElementCount is hopefully tested by WPT.
