### PR TITLE
script: Remove `GlobalScope::get_cx()`

### DIFF
--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -45,8 +45,6 @@ use js::typedarray::{
 
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::trace::RootedTraceableBox;
-#[cfg(feature = "webgpu")]
-use crate::dom::globalscope::GlobalScope;
 
 pub(crate) type RootedTypedArray<T> = RootedTraceableBox<TypedArray<T, Box<Heap<*mut JSObject>>>>;
 
@@ -1035,9 +1033,13 @@ impl DataView {
 impl Drop for DataView {
     #[expect(unsafe_code)]
     fn drop(&mut self) {
-        let cx = GlobalScope::get_cx();
+        // TODO: https://github.com/servo/servo/issues/44640
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
         assert!(unsafe {
-            js::jsapi::DetachArrayBuffer(*cx, self.buffer.underlying_object().handle())
+            DetachArrayBuffer(
+                &mut cx,
+                Handle::from_raw(self.buffer.underlying_object().handle()),
+            )
         })
     }
 }

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -153,7 +153,7 @@ use crate::realms::enter_auto_realm;
 use crate::script_module::{
     ImportMap, ModuleRequest, ModuleStatus, ResolvedModule, ScriptFetchOptions,
 };
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext, ThreadSafeJSContext};
+use crate::script_runtime::{CanGc, ThreadSafeJSContext};
 use crate::script_thread::{ScriptThread, with_script_thread};
 use crate::task_manager::TaskManager;
 use crate::task_source::SendableTaskSource;
@@ -2421,14 +2421,6 @@ impl GlobalScope {
 
     pub(crate) fn get_module_map_entry(&self, request: &ModuleRequest) -> Option<ModuleStatus> {
         self.module_map.borrow().get(request).cloned()
-    }
-
-    #[expect(unsafe_code)]
-    pub(crate) fn get_cx() -> SafeJSContext {
-        let cx = Runtime::get()
-            .expect("Can't obtain context after runtime shutdown")
-            .as_ptr();
-        unsafe { SafeJSContext::from_ptr(cx) }
     }
 
     pub(crate) fn time(&self, label: DOMString) -> Result<(), ()> {

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -2122,7 +2122,10 @@ pub(crate) fn capture_webgl_backtrace() -> WebGLCommandBacktrace {
 pub(crate) fn capture_webgl_backtrace() -> WebGLCommandBacktrace {
     let bt = Backtrace::new();
     unsafe {
-        capture_stack!(in(*GlobalScope::get_cx()) let stack);
+        // TODO: https://github.com/servo/servo/issues/40600
+        #[expect(unsafe_code)]
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        capture_stack!(&in(cx) let stack);
         WebGLCommandBacktrace {
             backtrace: format!("{:?}", bt),
             js_backtrace: stack.and_then(|s| s.as_string(None, js::jsapi::StackFormat::Default)),


### PR DESCRIPTION
All of its usages are migrated to `&mut JSContext`.

Part of #40600

Testing: it compiles