### PR TITLE
script: Remove `ScriptThread::get_cx()`

### DIFF
--- a/components/script/dom/characterdata/characterdata.rs
+++ b/components/script/dom/characterdata/characterdata.rs
@@ -74,7 +74,7 @@ impl CharacterData {
 
     #[inline]
     pub(crate) fn append_data(&self, cx: &mut JSContext, data: &str) {
-        self.queue_mutation_record();
+        self.queue_mutation_record(cx);
         self.data.borrow_mut().push_str(data);
         self.content_changed(cx);
     }
@@ -95,11 +95,11 @@ impl CharacterData {
     }
 
     // Queue a MutationObserver record before changing the content.
-    fn queue_mutation_record(&self) {
+    fn queue_mutation_record(&self, cx: &JSContext) {
         let mutation = LazyCell::new(|| Mutation::CharacterData {
             old_value: self.data.borrow().clone(),
         });
-        MutationObserver::queue_a_mutation_record(self.upcast::<Node>(), mutation);
+        MutationObserver::queue_a_mutation_record(cx, self.upcast::<Node>(), mutation);
     }
 }
 
@@ -111,7 +111,7 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
 
     /// <https://dom.spec.whatwg.org/#dom-characterdata-data>
     fn SetData(&self, cx: &mut JSContext, data: DOMString) {
-        self.queue_mutation_record();
+        self.queue_mutation_record(cx);
         let old_length = self.Length();
         let new_length = data.str().encode_utf16().count() as u32;
         *self.data.borrow_mut() = String::from(data.str());
@@ -224,7 +224,7 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
                 },
             };
             // Step 4: Mutation observers.
-            self.queue_mutation_record();
+            self.queue_mutation_record(cx);
 
             // Step 5 to 7.
             new_data = String::with_capacity(

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -11,7 +11,7 @@ use std::{mem, ptr};
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Namespace, Prefix, ns};
-use js::context::{JSContext, NoGC};
+use js::context::JSContext;
 use js::conversions::FromJSValConvertible;
 use js::glue::UnwrapObjectStatic;
 use js::jsapi::{HandleValueArray, Heap, IsCallable, IsConstructor, JSObject};
@@ -270,7 +270,7 @@ impl CustomElementRegistry {
     /// <https://html.spec.whatwg.org/multipage/#upgrade-particular-elements-within-a-document>
     fn upgrade_particular_elements_within_a_document(
         &self,
-        no_gc: &NoGC,
+        cx: &JSContext,
         document: &Document,
         definition: &Rc<CustomElementDefinition>,
         local_name: &LocalName,
@@ -283,7 +283,7 @@ impl CustomElementRegistry {
         // only include elements whose is value is equal to name.
         for candidate in document
             .upcast::<Node>()
-            .traverse_preorder_non_rooting(no_gc, ShadowIncluding::Yes)
+            .traverse_preorder_non_rooting(cx, ShadowIncluding::Yes)
             .filter_map(UnrootedDom::downcast::<Element>)
         {
             // Note: If the registry is scoped, only include elements whose custom
@@ -306,7 +306,7 @@ impl CustomElementRegistry {
             {
                 // Step 2. For each element element of upgradeCandidates: enqueue a
                 // custom element upgrade reaction given element and definition.
-                ScriptThread::enqueue_upgrade_reaction(&candidate, definition.clone());
+                ScriptThread::enqueue_upgrade_reaction(cx, &candidate, definition.clone());
             }
         }
     }
@@ -582,7 +582,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         if self.is_scoped.get() {
             for document in self.scoped_document_set.borrow().iter() {
                 self.upgrade_particular_elements_within_a_document(
-                    cx.no_gc(),
+                    cx,
                     document,
                     &definition,
                     &local_name,
@@ -594,7 +594,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
             // this, this's relevant global object's associated Document, definition,
             // localName, and name.
             self.upgrade_particular_elements_within_a_document(
-                cx.no_gc(),
+                cx,
                 &self.window.Document(),
                 &definition,
                 &local_name,
@@ -671,10 +671,10 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-upgrade>
-    fn Upgrade(&self, no_gc: &NoGC, node: &Node) {
+    fn Upgrade(&self, cx: &JSContext, node: &Node) {
         // Step 1. For each shadow-including inclusive descendant candidate of
         // root, in shadow-including tree order:
-        for node in node.traverse_preorder_non_rooting(no_gc, ShadowIncluding::Yes) {
+        for node in node.traverse_preorder_non_rooting(cx, ShadowIncluding::Yes) {
             // Step 1.1. If candidate is not an Element node, then continue.
             let Some(element) = node.downcast::<Element>() else {
                 continue;
@@ -688,12 +688,12 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
                 continue;
             }
             // Step 1.3. Try to upgrade candidate.
-            try_upgrade_element(element);
+            try_upgrade_element(cx, element);
         }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-initialize>
-    fn Initialize(&self, root: &Node) -> ErrorResult {
+    fn Initialize(&self, cx: &JSContext, root: &Node) -> ErrorResult {
         // Step 1. If this's is scoped is false and either root is a Document node
         // or root's node document's custom element registry is not this, then
         // throw a "NotSupportedError" DOMException.
@@ -754,7 +754,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
             }
 
             // Step 4.4. Try to upgrade inclusiveDescendant.
-            try_upgrade_element(element);
+            try_upgrade_element(cx, element);
         }
         Ok(())
     }
@@ -1136,7 +1136,7 @@ fn run_upgrade_constructor(
 }
 
 /// <https://html.spec.whatwg.org/multipage/#concept-try-upgrade>
-pub(crate) fn try_upgrade_element(element: &Element) {
+pub(crate) fn try_upgrade_element(cx: &JSContext, element: &Element) {
     // Step 1. Let definition be the result of looking up a custom element definition given element's node document,
     // element's namespace, element's local name, and element's is value.
     let document = element.owner_document();
@@ -1148,7 +1148,7 @@ pub(crate) fn try_upgrade_element(element: &Element) {
     {
         // Step 2. If definition is not null, then enqueue a custom element upgrade reaction given
         // element and definition.
-        ScriptThread::enqueue_upgrade_reaction(element, definition);
+        ScriptThread::enqueue_upgrade_reaction(cx, element, definition);
     }
 }
 
@@ -1260,7 +1260,7 @@ impl CustomElementReactionStack {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#enqueue-an-element-on-the-appropriate-element-queue>
-    pub(crate) fn enqueue_element(&self, element: &Element) {
+    pub(crate) fn enqueue_element(&self, cx: &JSContext, element: &Element) {
         if let Some(current_queue) = self.stack.borrow().last() {
             // Step 2
             current_queue.append_element(element);
@@ -1278,7 +1278,7 @@ impl CustomElementReactionStack {
                 .set(BackupElementQueueFlag::Processing);
 
             // Step 4
-            ScriptThread::enqueue_microtask(Microtask::CustomElementReaction);
+            ScriptThread::enqueue_microtask(cx, Microtask::CustomElementReaction);
         }
     }
 
@@ -1413,7 +1413,7 @@ impl CustomElementReactionStack {
                         element.push_callback_reaction(connected_callback, Box::new([]));
                     }
 
-                    self.enqueue_element(element);
+                    self.enqueue_element(cx, element);
                     return;
                 }
 
@@ -1432,12 +1432,13 @@ impl CustomElementReactionStack {
         element.push_callback_reaction(callback, args.into_boxed_slice());
 
         // Step 7. Enqueue an element on the appropriate element queue given element.
-        self.enqueue_element(element);
+        self.enqueue_element(cx, element);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#enqueue-a-custom-element-upgrade-reaction>
     pub(crate) fn enqueue_upgrade_reaction(
         &self,
+        cx: &JSContext,
         element: &Element,
         definition: Rc<CustomElementDefinition>,
     ) {
@@ -1446,7 +1447,7 @@ impl CustomElementReactionStack {
         element.push_upgrade_reaction(definition);
 
         // Step 2. Enqueue an element on the appropriate element queue given element.
-        self.enqueue_element(element);
+        self.enqueue_element(cx, element);
     }
 }
 

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -2992,9 +2992,9 @@ impl Document {
             .set(counter - 1);
     }
 
-    pub(crate) fn react_to_environment_changes(&self) {
+    pub(crate) fn react_to_environment_changes(&self, cx: &JSContext) {
         for image in self.responsive_images.borrow().iter() {
-            image.react_to_environment_changes();
+            image.react_to_environment_changes(cx);
         }
     }
 

--- a/components/script/dom/element/create.rs
+++ b/components/script/dom/element/create.rs
@@ -160,7 +160,7 @@ fn create_html_element(
                 },
                 // Step 4.4. Otherwise, enqueue a custom element upgrade reaction given result and definition.
                 CustomElementCreationMode::Asynchronous => {
-                    ScriptThread::enqueue_upgrade_reaction(&element, definition)
+                    ScriptThread::enqueue_upgrade_reaction(cx, &element, definition)
                 },
             }
             return element;
@@ -220,7 +220,7 @@ fn create_html_element(
                     result.set_custom_element_state(CustomElementState::Undefined);
                     result.set_custom_element_registry(registry.as_deref());
                     // Step 4.2.2. Enqueue a custom element upgrade reaction given result and definition.
-                    ScriptThread::enqueue_upgrade_reaction(&result, definition);
+                    ScriptThread::enqueue_upgrade_reaction(cx, &result, definition);
                     return result;
                 },
             }

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -1988,7 +1988,7 @@ impl Element {
             namespace: namespace.clone(),
             old_value: old_value.map(|old_value| DOMString::from(&**old_value)),
         });
-        MutationObserver::queue_a_mutation_record(&self.node, mutation);
+        MutationObserver::queue_a_mutation_record(cx, &self.node, mutation);
 
         // Avoid double borrow
         let has_new_value = new_value.is_some();

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -3084,9 +3084,9 @@ impl GlobalScope {
     }
 
     /// Enqueue a microtask for subsequent execution.
-    pub(crate) fn enqueue_microtask(&self, cx: &mut js::context::JSContext, job: Microtask) {
+    pub(crate) fn enqueue_microtask(&self, cx: &js::context::JSContext, job: Microtask) {
         if self.is::<Window>() {
-            ScriptThread::enqueue_microtask(job);
+            ScriptThread::enqueue_microtask(cx, job);
         } else if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
             worker.enqueue_microtask(cx, job);
         }

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -1212,18 +1212,18 @@ impl HTMLImageElement {
             generation: self.generation.get(),
         };
 
-        ScriptThread::await_stable_state(Microtask::ImageElement(task));
+        ScriptThread::await_stable_state(cx, Microtask::ImageElement(task));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#img-environment-changes>
-    pub(crate) fn react_to_environment_changes(&self) {
+    pub(crate) fn react_to_environment_changes(&self, cx: &JSContext) {
         // Step 1. Await a stable state.
         let task = ImageElementMicrotask::EnvironmentChanges {
             elem: DomRoot::from_ref(self),
             generation: self.generation.get(),
         };
 
-        ScriptThread::await_stable_state(Microtask::ImageElement(task));
+        ScriptThread::await_stable_state(cx, Microtask::ImageElement(task));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#img-environment-changes>
@@ -1938,7 +1938,7 @@ impl HTMLImageElementMethods<crate::DomTypeHolder> for HTMLImageElement {
             promise: promise.clone(),
         };
 
-        ScriptThread::await_stable_state(Microtask::ImageElement(task));
+        ScriptThread::await_stable_state(cx, Microtask::ImageElement(task));
 
         // Step 3. Return promise.
         promise

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -1084,7 +1084,7 @@ impl HTMLMediaElement {
         // method from below, if microtasks were trait objects, we would be able
         // to put the code directly in this method, without the boilerplate
         // indirections.
-        ScriptThread::await_stable_state(Microtask::MediaElement(task));
+        ScriptThread::await_stable_state(cx, Microtask::MediaElement(task));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-media-load-algorithm>
@@ -1148,21 +1148,21 @@ impl HTMLMediaElement {
         match mode {
             Mode::Object => {
                 // => "If mode is object"
-                self.load_from_src_object();
+                self.load_from_src_object(cx);
             },
             Mode::Attribute(src) => {
                 // => "If mode is attribute"
-                self.load_from_src_attribute(base_url, &src);
+                self.load_from_src_attribute(cx, base_url, &src);
             },
             Mode::Children(source) => {
                 // => "Otherwise (mode is children)""
-                self.load_from_source_child(&source);
+                self.load_from_source_child(cx, &source);
             },
         }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-media-load-algorithm>
-    fn load_from_src_object(&self) {
+    fn load_from_src_object(&self, cx: &JSContext) {
         self.load_state.set(LoadState::LoadingFromSrcObject);
 
         // Step 9.object.1. Set the currentSrc attribute to the empty string.
@@ -1173,11 +1173,11 @@ impl HTMLMediaElement {
         // load failed.
         // Note that the resource fetch algorithm itself takes care of the cleanup in case
         // of failure itself.
-        self.resource_fetch_algorithm(Resource::Object);
+        self.resource_fetch_algorithm(cx, Resource::Object);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-media-load-algorithm>
-    fn load_from_src_attribute(&self, base_url: ServoUrl, src: &str) {
+    fn load_from_src_attribute(&self, cx: &JSContext, base_url: ServoUrl, src: &str) {
         self.load_state.set(LoadState::LoadingFromSrcAttribute);
 
         // Step 9.attribute.1. If the src attribute's value is the empty string, then end
@@ -1204,11 +1204,11 @@ impl HTMLMediaElement {
         // then the load failed.
         // Note that the resource fetch algorithm itself takes care
         // of the cleanup in case of failure itself.
-        self.resource_fetch_algorithm(Resource::Url(url_record));
+        self.resource_fetch_algorithm(cx, Resource::Url(url_record));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-media-load-algorithm>
-    fn load_from_source_child(&self, source: &HTMLSourceElement) {
+    fn load_from_source_child(&self, cx: &JSContext, source: &HTMLSourceElement) {
         self.load_state.set(LoadState::LoadingFromSourceChild);
 
         // Step 9.children.1. Let pointer be a position defined by two adjacent nodes in the media
@@ -1229,7 +1229,7 @@ impl HTMLMediaElement {
             .get_attribute_string_value(&local_name!("src"))
             .filter(|value| !value.is_empty())
         else {
-            self.load_from_source_child_failure_steps(source);
+            self.load_from_source_child_failure_steps(cx, source);
             return;
         };
 
@@ -1239,7 +1239,7 @@ impl HTMLMediaElement {
         if let Some(media) = element.get_attribute_string_value(&local_name!("media")) &&
             !MediaList::matches_environment(&element.owner_document(), &media)
         {
-            self.load_from_source_child_failure_steps(source);
+            self.load_from_source_child_failure_steps(cx, source);
             return;
         }
 
@@ -1249,7 +1249,7 @@ impl HTMLMediaElement {
         let Ok(url_record) = source.owner_document().base_url().join(&src) else {
             // Step 9.children.5. If urlRecord is failure, then end the synchronous section,
             // and jump down to the failed with elements step below.
-            self.load_from_source_child_failure_steps(source);
+            self.load_from_source_child_failure_steps(cx, source);
             return;
         };
 
@@ -1260,7 +1260,7 @@ impl HTMLMediaElement {
         if let Some(type_) = element.get_attribute_string_value(&local_name!("type")) &&
             ServoMedia::get().can_play_type(&type_) == SupportsMediaType::No
         {
-            self.load_from_source_child_failure_steps(source);
+            self.load_from_source_child_failure_steps(cx, source);
             return;
         }
 
@@ -1277,11 +1277,11 @@ impl HTMLMediaElement {
         // algorithm returns without aborting this one, then the load failed.
         // Note that the resource fetch algorithm itself takes care
         // of the cleanup in case of failure itself.
-        self.resource_fetch_algorithm(Resource::Url(url_record));
+        self.resource_fetch_algorithm(cx, Resource::Url(url_record));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-media-load-algorithm>
-    fn load_from_source_child_failure_steps(&self, source: &HTMLSourceElement) {
+    fn load_from_source_child_failure_steps(&self, cx: &JSContext, source: &HTMLSourceElement) {
         // Step 9.children.10. Failed with elements: Queue a media element task given the media
         // element to fire an event named error at candidate.
         let trusted_this = Trusted::new(self);
@@ -1307,7 +1307,7 @@ impl HTMLMediaElement {
             generation_id: self.generation_id.get(),
         };
 
-        ScriptThread::await_stable_state(Microtask::MediaElement(task));
+        ScriptThread::await_stable_state(cx, Microtask::MediaElement(task));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-media-load-algorithm>
@@ -1360,7 +1360,7 @@ impl HTMLMediaElement {
         // Step 9.children.17. If candidate is null, jump back to the search loop step. Otherwise,
         // jump back to the process candidate step.
         if let Some(source_candidate) = source_candidate {
-            self.load_from_source_child(&source_candidate);
+            self.load_from_source_child(cx, &source_candidate);
             return;
         }
 
@@ -1397,7 +1397,7 @@ impl HTMLMediaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-media-load-algorithm>
-    fn resource_selection_algorithm_failure_steps(&self) {
+    fn resource_selection_algorithm_failure_steps(&self, cx: &JSContext) {
         match self.load_state.get() {
             LoadState::LoadingFromSrcObject => {
                 // Step 9.object.4. Failed with media provider: Reaching this step indicates that
@@ -1417,20 +1417,20 @@ impl HTMLMediaElement {
                 // Step 9.children.10. Failed with elements: Queue a media element task given the
                 // media element to fire an event named error at candidate.
                 if let Some(source) = self.current_source_child.take() {
-                    self.load_from_source_child_failure_steps(&source);
+                    self.load_from_source_child_failure_steps(cx, &source);
                 }
             },
             _ => {},
         }
     }
 
-    fn fetch_request(&self, offset: Option<u64>, seek_lock: Option<SeekLock>) {
+    fn fetch_request(&self, cx: &JSContext, offset: Option<u64>, seek_lock: Option<SeekLock>) {
         if self.resource_url.borrow().is_none() && self.blob_url.borrow().is_none() {
             error!("Missing request url");
             if let Some(seek_lock) = seek_lock {
                 seek_lock.unlock(/* successful seek */ false);
             }
-            self.resource_selection_algorithm_failure_steps();
+            self.resource_selection_algorithm_failure_steps(cx);
             return;
         }
 
@@ -1513,10 +1513,10 @@ impl HTMLMediaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-media-load-resource>
-    fn resource_fetch_algorithm(&self, resource: Resource) {
+    fn resource_fetch_algorithm(&self, cx: &JSContext, resource: Resource) {
         if let Err(e) = self.create_media_player(&resource) {
             error!("Create media player error {:?}", e);
-            self.resource_selection_algorithm_failure_steps();
+            self.resource_selection_algorithm_failure_steps(cx);
             return;
         }
 
@@ -1574,7 +1574,7 @@ impl HTMLMediaElement {
                 *self.resource_url.borrow_mut() = Some(url);
 
                 // Steps 5.remote.2-5.remote.8
-                self.fetch_request(None, None);
+                self.fetch_request(cx, None, None);
             },
             Resource::Object => {
                 if let Some(ref src_object) = *self.src_object.borrow() {
@@ -1583,7 +1583,7 @@ impl HTMLMediaElement {
                             let blob_url = URL::CreateObjectURL(&self.global(), blob);
                             *self.blob_url.borrow_mut() =
                                 Some(ServoUrl::parse(&blob_url.str()).expect("infallible"));
-                            self.fetch_request(None, None);
+                            self.fetch_request(cx, None, None);
                         },
                         SrcObject::MediaStream(stream) => {
                             let tracks = &*stream.get_tracks();
@@ -1598,7 +1598,7 @@ impl HTMLMediaElement {
                                     .set_stream(&track.id(), pos == tracks.len() - 1)
                                     .is_err()
                                 {
-                                    self.resource_selection_algorithm_failure_steps();
+                                    self.resource_selection_algorithm_failure_steps(cx);
                                 }
                             }
                         },
@@ -1909,7 +1909,7 @@ impl HTMLMediaElement {
             generation_id: self.generation_id.get(),
         };
 
-        ScriptThread::await_stable_state(Microtask::MediaElement(task));
+        ScriptThread::await_stable_state(cx, Microtask::MediaElement(task));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-media-load-algorithm>
@@ -1929,14 +1929,14 @@ impl HTMLMediaElement {
     /// => "If the media data cannot be fetched at all, due to network errors..."
     /// => "If the media data can be fetched but is found by inspection to be in an unsupported
     /// format, or can otherwise not be rendered at all"
-    fn media_data_processing_failure_steps(&self) {
+    fn media_data_processing_failure_steps(&self, cx: &JSContext) {
         // Step 1. The user agent should cancel the fetching process.
         if let Some(ref mut current_fetch_context) = *self.current_fetch_context.borrow_mut() {
             current_fetch_context.cancel(CancelReason::Error);
         }
 
         // Step 2. Abort this subalgorithm, returning to the resource selection algorithm.
-        self.resource_selection_algorithm_failure_steps();
+        self.resource_selection_algorithm_failure_steps(cx);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#media-data-processing-steps-list>
@@ -2387,7 +2387,7 @@ impl HTMLMediaElement {
         if self.ready_state.get() == ReadyState::HaveNothing {
             // => "If the media data can be fetched but is found by inspection to be in an
             // unsupported format, or can otherwise not be rendered at all"
-            self.media_data_processing_failure_steps();
+            self.media_data_processing_failure_steps(cx);
         } else {
             // => "If the media data is corrupted"
             self.media_data_processing_fatal_steps(MEDIA_ERR_DECODE, cx);
@@ -2761,7 +2761,7 @@ impl HTMLMediaElement {
         self.send_media_session_event(MediaSessionEvent::SetPositionState(media_position_state));
     }
 
-    fn playback_seek_done(&self, position: f64) {
+    fn playback_seek_done(&self, cx: &JSContext, position: f64) {
         // If the seek was initiated by script or by the user agent itself continue with the
         // following steps, otherwise abort.
         let delta = (position - self.current_seek_position.get()).abs();
@@ -2776,7 +2776,7 @@ impl HTMLMediaElement {
             generation_id: self.generation_id.get(),
         };
 
-        ScriptThread::await_stable_state(Microtask::MediaElement(task));
+        ScriptThread::await_stable_state(cx, Microtask::MediaElement(task));
     }
 
     fn playback_state_changed(&self, state: &PlaybackState) {
@@ -3447,7 +3447,7 @@ impl VirtualMethods for HTMLMediaElement {
             let task = MediaElementMicrotask::PauseIfNotInDocument {
                 elem: DomRoot::from_ref(self),
             };
-            ScriptThread::await_stable_state(Microtask::MediaElement(task));
+            ScriptThread::await_stable_state(cx, Microtask::MediaElement(task));
         }
     }
 
@@ -3772,7 +3772,7 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
         if !status_is_success {
             if element.ready_state.get() == ReadyState::HaveNothing {
                 // => "If the media data cannot be fetched at all, due to network errors..."
-                element.media_data_processing_failure_steps();
+                element.media_data_processing_failure_steps(cx);
             } else {
                 // => "If the connection is interrupted after some media data has been received..."
                 element.media_data_processing_fatal_steps(MEDIA_ERR_NETWORK, cx);
@@ -3949,7 +3949,7 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
         } else {
             // => "If the media data can be fetched but is found by inspection to be in an
             // unsupported format, or can otherwise not be rendered at all"
-            element.media_data_processing_failure_steps();
+            element.media_data_processing_failure_steps(cx);
         }
 
         network_listener::submit_timing(cx, &self, &status, &timing);
@@ -4064,9 +4064,9 @@ impl HTMLMediaElementEventHandler {
             PlayerEvent::NeedData => element.playback_need_data(),
             PlayerEvent::PositionChanged(position) => element.playback_position_changed(position),
             PlayerEvent::SeekData(offset, seek_lock) => {
-                element.fetch_request(Some(offset), Some(seek_lock))
+                element.fetch_request(cx, Some(offset), Some(seek_lock))
             },
-            PlayerEvent::SeekDone(position) => element.playback_seek_done(position),
+            PlayerEvent::SeekDone(position) => element.playback_seek_done(cx, position),
             PlayerEvent::StateChanged(ref state) => element.playback_state_changed(state),
             PlayerEvent::VideoFrameUpdated => element.playback_video_frame_updated(),
         }

--- a/components/script/dom/html/htmlslotelement.rs
+++ b/components/script/dom/html/htmlslotelement.rs
@@ -332,7 +332,7 @@ impl HTMLSlotElement {
             slottable.node().dirty(NodeDamage::Other);
         }
 
-        self.signal_a_slot_change();
+        self.signal_a_slot_change(cx);
 
         // If we don't disconnect the old slottables from this slot then they'll stay implicitily
         // connected, which causes problems later on. Only do this for slottables that have not
@@ -368,7 +368,7 @@ impl HTMLSlotElement {
     }
 
     /// <https://dom.spec.whatwg.org/#signal-a-slot-change>
-    pub(crate) fn signal_a_slot_change(&self) {
+    pub(crate) fn signal_a_slot_change(&self, cx: &JSContext) {
         self.upcast::<Node>().dirty(NodeDamage::ContentOrHeritage);
 
         if self.is_in_agents_signal_slots.get() {
@@ -381,7 +381,7 @@ impl HTMLSlotElement {
         mutation_observers.add_signal_slot(self);
 
         // Step 2. Queue a mutation observer microtask.
-        mutation_observers.queue_mutation_observer_microtask(ScriptThread::microtask_queue());
+        mutation_observers.queue_mutation_observer_microtask(cx, ScriptThread::microtask_queue());
     }
 
     pub(crate) fn remove_from_signal_slots(&self) {

--- a/components/script/dom/mutationobserver/mutationobserver.rs
+++ b/components/script/dom/mutationobserver/mutationobserver.rs
@@ -102,6 +102,7 @@ impl MutationObserver {
 
     /// <https://dom.spec.whatwg.org/#queueing-a-mutation-record>
     pub(crate) fn queue_a_mutation_record<'a, F>(
+        cx: &JSContext,
         target: &Node,
         attr_type: LazyCell<Mutation<'a>, F>,
     ) where
@@ -250,7 +251,7 @@ impl MutationObserver {
 
         // Step 5 Queue a mutation observer microtask.
         let mutation_observers = ScriptThread::mutation_observers();
-        mutation_observers.queue_mutation_observer_microtask(ScriptThread::microtask_queue());
+        mutation_observers.queue_mutation_observer_microtask(cx, ScriptThread::microtask_queue());
     }
 }
 

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -1484,7 +1484,7 @@ impl Node {
             let Some(slot_element) = old_parent.downcast::<HTMLSlotElement>() &&
             !slot_element.has_assigned_nodes()
         {
-            slot_element.signal_a_slot_change();
+            slot_element.signal_a_slot_change(cx);
         }
 
         // Step 16. If node has an inclusive descendant that is a slot:
@@ -1541,7 +1541,7 @@ impl Node {
             let Some(slot_element) = new_parent.downcast::<HTMLSlotElement>() &&
             !slot_element.has_assigned_nodes()
         {
-            slot_element.signal_a_slot_change();
+            slot_element.signal_a_slot_change(cx);
         }
 
         // Step 23. Run assign slottables for a tree with node’s root.
@@ -1587,7 +1587,7 @@ impl Node {
             prev: old_previous_sibling.as_deref(),
             next: old_next_sibling.as_deref(),
         });
-        MutationObserver::queue_a_mutation_record(&old_parent, mutation);
+        MutationObserver::queue_a_mutation_record(cx, &old_parent, mutation);
 
         // Step 26. Queue a tree mutation record for newParent with « node », « »,
         // newPreviousSibling, and child.
@@ -1597,7 +1597,7 @@ impl Node {
             prev: new_previous_sibling.as_deref(),
             next: child,
         });
-        MutationObserver::queue_a_mutation_record(new_parent, mutation);
+        MutationObserver::queue_a_mutation_record(cx, new_parent, mutation);
 
         Ok(())
     }
@@ -2540,7 +2540,7 @@ impl Node {
                 prev: None,
                 next: None,
             });
-            MutationObserver::queue_a_mutation_record(node, mutation);
+            MutationObserver::queue_a_mutation_record(cx, node, mutation);
         }
 
         // Step 5. If child is non-null:
@@ -2599,7 +2599,7 @@ impl Node {
                 let Some(slot_element) = parent_as_slot &&
                 !slot_element.has_assigned_nodes()
             {
-                slot_element.signal_a_slot_change();
+                slot_element.signal_a_slot_change(cx);
             }
 
             // Step 7.6 Run assign slottables for a tree with node’s root.
@@ -2631,7 +2631,7 @@ impl Node {
                             );
                         }
                     } else {
-                        try_upgrade_element(&descendant);
+                        try_upgrade_element(cx, &descendant);
                     }
                 }
             }
@@ -2653,7 +2653,7 @@ impl Node {
                 prev: previous_sibling.as_deref(),
                 next: child,
             });
-            MutationObserver::queue_a_mutation_record(parent, mutation);
+            MutationObserver::queue_a_mutation_record(cx, parent, mutation);
         }
 
         // We use a delayed task for this step to work around an awkward interaction between
@@ -2726,7 +2726,7 @@ impl Node {
                 prev: None,
                 next: None,
             });
-            MutationObserver::queue_a_mutation_record(parent, mutation);
+            MutationObserver::queue_a_mutation_record(cx, parent, mutation);
         }
         parent.owner_doc().remove_script_and_layout_blocker(cx);
     }
@@ -2805,7 +2805,7 @@ impl Node {
             let Some(slot_element) = parent.downcast::<HTMLSlotElement>() &&
             !slot_element.has_assigned_nodes()
         {
-            slot_element.signal_a_slot_change();
+            slot_element.signal_a_slot_change(cx);
         }
 
         // Step 10. If node has an inclusive descendant that is a slot:
@@ -2843,7 +2843,7 @@ impl Node {
                 prev: old_previous_sibling.as_deref(),
                 next: old_next_sibling.as_deref(),
             });
-            MutationObserver::queue_a_mutation_record(parent, mutation);
+            MutationObserver::queue_a_mutation_record(cx, parent, mutation);
         }
         parent.owner_doc().remove_script_and_layout_blocker(cx);
     }
@@ -3766,7 +3766,7 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
             next: reference_child,
         });
 
-        MutationObserver::queue_a_mutation_record(self, mutation);
+        MutationObserver::queue_a_mutation_record(cx, self, mutation);
 
         // Step 15. Return child.
         Ok(DomRoot::from_ref(child))

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -1625,11 +1625,14 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-queuemicrotask>
-    fn QueueMicrotask(&self, callback: Rc<VoidFunction>) {
-        ScriptThread::enqueue_microtask(Microtask::User(UserMicrotask {
-            callback,
-            pipeline: self.pipeline_id(),
-        }));
+    fn QueueMicrotask(&self, cx: &JSContext, callback: Rc<VoidFunction>) {
+        ScriptThread::enqueue_microtask(
+            cx,
+            Microtask::User(UserMicrotask {
+                callback,
+                pipeline: self.pipeline_id(),
+            }),
+        );
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-createimagebitmap>

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -426,8 +426,8 @@ impl WorkerGlobalScope {
             .get_or_init(|| OneshotTimers::new(self.upcast()))
     }
 
-    pub(crate) fn enqueue_microtask(&self, cx: &mut JSContext, job: Microtask) {
-        self.microtask_queue.enqueue(job, cx.into());
+    pub(crate) fn enqueue_microtask(&self, cx: &JSContext, job: Microtask) {
+        self.microtask_queue.enqueue(cx, job);
     }
 
     /// Perform a microtask checkpoint.

--- a/components/script/microtask.rs
+++ b/components/script/microtask.rs
@@ -10,8 +10,9 @@ use std::cell::Cell;
 use std::mem;
 use std::rc::Rc;
 
-use js::jsapi::JobQueueMayNotBeEmpty;
+use js::context::JSContext;
 use js::realm::AutoRealm;
+use js::rust::wrappers2::JobQueueMayNotBeEmpty;
 use script_bindings::cell::DomRefCell;
 use servo_base::id::PipelineId;
 
@@ -27,7 +28,7 @@ use crate::dom::stream::byteteereadintorequest::ByteTeeReadIntoRequestMicrotask;
 use crate::dom::stream::byteteereadrequest::ByteTeeReadRequestMicrotask;
 use crate::dom::stream::defaultteereadrequest::DefaultTeeReadRequestMicrotask;
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::{JSContext, notify_about_rejected_promises};
+use crate::script_runtime::notify_about_rejected_promises;
 use crate::script_thread::ScriptThread;
 
 /// A collection of microtasks in FIFO order.
@@ -54,8 +55,8 @@ pub(crate) enum Microtask {
 }
 
 pub(crate) trait MicrotaskRunnable {
-    fn handler(&self, _cx: &mut js::context::JSContext) {}
-    fn enter_realm<'cx>(&self, cx: &'cx mut js::context::JSContext) -> AutoRealm<'cx>;
+    fn handler(&self, _cx: &mut JSContext) {}
+    fn enter_realm<'cx>(&self, cx: &'cx mut JSContext) -> AutoRealm<'cx>;
 }
 
 /// A promise callback scheduled to run during the next microtask checkpoint (#4283).
@@ -82,9 +83,9 @@ impl MicrotaskQueue {
     /// Add a new microtask to this queue. It will be invoked as part of the next
     /// microtask checkpoint.
     #[expect(unsafe_code)]
-    pub(crate) fn enqueue(&self, job: Microtask, cx: JSContext) {
+    pub(crate) fn enqueue(&self, cx: &JSContext, job: Microtask) {
         self.microtask_queue.borrow_mut().push(job);
-        unsafe { JobQueueMayNotBeEmpty(*cx) };
+        unsafe { JobQueueMayNotBeEmpty(cx) };
     }
 
     /// <https://html.spec.whatwg.org/multipage/#perform-a-microtask-checkpoint>
@@ -92,7 +93,7 @@ impl MicrotaskQueue {
     #[expect(unsafe_code)]
     pub(crate) fn checkpoint<F>(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         target_provider: F,
         globalscopes: Vec<DomRoot<GlobalScope>>,
     ) where

--- a/components/script/script_mutation_observers.rs
+++ b/components/script/script_mutation_observers.rs
@@ -85,7 +85,11 @@ impl ScriptMutationObservers {
     }
 
     /// <https://dom.spec.whatwg.org/#queue-a-mutation-observer-compound-microtask>
-    pub(crate) fn queue_mutation_observer_microtask(&self, microtask_queue: Rc<MicrotaskQueue>) {
+    pub(crate) fn queue_mutation_observer_microtask(
+        &self,
+        cx: &JSContext,
+        microtask_queue: Rc<MicrotaskQueue>,
+    ) {
         // Step 1. If the surrounding agent’s mutation observer microtask queued is true, then return.
         if self.mutation_observer_microtask_queued.get() {
             return;
@@ -95,9 +99,7 @@ impl ScriptMutationObservers {
         self.mutation_observer_microtask_queued.set(true);
 
         // Step 3. Queue a microtask to notify mutation observers.
-        crate::script_thread::with_script_thread(|script_thread| {
-            microtask_queue.enqueue(Microtask::NotifyMutationObservers, script_thread.get_cx());
-        });
+        microtask_queue.enqueue(cx, Microtask::NotifyMutationObservers);
     }
 
     pub(crate) fn add_signal_slot(&self, observer: &HTMLSlotElement) {

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -420,12 +420,12 @@ unsafe extern "C" fn enqueue_promise_job(
         let is_user_interacting =
             interaction == PromiseUserInputEventHandlingState::HadUserInteractionAtCreation;
         microtask_queue.enqueue(
+            cx,
             Microtask::Promise(EnqueuedPromiseCallback {
                 callback: unsafe { PromiseJobCallback::new(cx, job.get()) },
                 pipeline,
                 is_user_interacting,
             }),
-            cx.into(),
         );
         result = true
     });

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -51,6 +51,7 @@ use headers::{HeaderMapExt, LastModified, ReferrerPolicy as ReferrerPolicyHeader
 use http::header::REFRESH;
 use hyper_serde::Serde;
 use ipc_channel::router::ROUTER;
+use js::context::JSContext;
 use js::glue::GetWindowProxyClass;
 use js::jsapi::{GCReason, JSContext as UnsafeJSContext};
 use js::jsval::UndefinedValue;
@@ -73,7 +74,6 @@ use profile_traits::time::ProfilerCategory;
 use profile_traits::time_profile;
 use rustc_hash::{FxHashMap, FxHashSet};
 use script_bindings::cell::DomRefCell;
-use script_bindings::script_runtime::JSContext;
 use script_traits::{
     ConstellationInputEvent, DiscardBrowsingContext, DocumentActivity, InitialScriptState,
     NewPipelineInfo, Painter, ProgressiveWebMetricType, ScriptThreadMessage,
@@ -604,11 +604,9 @@ impl ScriptThread {
     }
 
     // https://html.spec.whatwg.org/multipage/#await-a-stable-state
-    pub(crate) fn await_stable_state(task: Microtask) {
+    pub(crate) fn await_stable_state(cx: &JSContext, task: Microtask) {
         with_script_thread(|script_thread| {
-            script_thread
-                .microtask_queue
-                .enqueue(task, script_thread.get_cx());
+            script_thread.microtask_queue.enqueue(cx, task);
         });
     }
 
@@ -849,13 +847,14 @@ impl ScriptThread {
     }
 
     pub(crate) fn enqueue_upgrade_reaction(
+        cx: &js::context::JSContext,
         element: &Element,
         definition: Rc<CustomElementDefinition>,
     ) {
         with_script_thread(|script_thread| {
             script_thread
                 .custom_element_reaction_stack
-                .enqueue_upgrade_reaction(element, definition);
+                .enqueue_upgrade_reaction(cx, element, definition);
         })
     }
 
@@ -1050,11 +1049,6 @@ impl ScriptThread {
         )
     }
 
-    #[expect(unsafe_code)]
-    pub(crate) fn get_cx(&self) -> JSContext {
-        unsafe { JSContext::from_ptr(js::rust::Runtime::get().unwrap().as_ptr()) }
-    }
-
     /// Check if we are closing.
     fn can_continue_running_inner(&self) -> bool {
         if self.closing.load(Ordering::SeqCst) {
@@ -1238,7 +1232,7 @@ impl ScriptThread {
             if resized {
                 // https://html.spec.whatwg.org/multipage/#img-environment-changes
                 // As per the spec, this can be run at any time.
-                document.react_to_environment_changes();
+                document.react_to_environment_changes(cx);
             }
 
             let mut realm = enter_auto_realm(cx, &*document);
@@ -4303,11 +4297,9 @@ impl ScriptThread {
         };
     }
 
-    pub(crate) fn enqueue_microtask(job: Microtask) {
+    pub(crate) fn enqueue_microtask(cx: &js::context::JSContext, job: Microtask) {
         with_script_thread(|script_thread| {
-            script_thread
-                .microtask_queue
-                .enqueue(job, script_thread.get_cx());
+            script_thread.microtask_queue.enqueue(cx, job);
         });
     }
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -191,7 +191,7 @@ DOMInterfaces = {
 'CustomElementRegistry': {
     'cx': ['Define', 'Get'],
     'realm': ['WhenDefined'],
-    'no_gc': ['Upgrade']
+    'cx_no_gc': ['Initialize', 'Upgrade']
 },
 
 'DataTransfer': {
@@ -1388,6 +1388,7 @@ DOMInterfaces = {
         'WebdriverException',
         'IndexedDB',
     ],
+    'cx_no_gc': ['QueueMicrotask'],
 },
 
 'WindowProxy' : {


### PR DESCRIPTION
Instead we now pass `&JSContext` all the way down to enqueue a microtask. That does not incure GC, which is why we can keep the performance optimizations for (among others) slot changes.

Part of #40600

Testing: it compiles