### PR TITLE
script/net: Drop `ModuleFetchClient` in favour of `RequestClient`

### DIFF
--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -133,7 +133,6 @@ pub struct WebFontDocumentContext {
     pub policy_container: PolicyContainer,
     pub request_client: RequestClient,
     pub document_url: ServoUrl,
-    pub has_trustworthy_ancestor_origin: bool,
     pub insecure_requests_policy: InsecureRequestsPolicy,
     pub csp_handler: Box<dyn CspViolationHandler>,
     pub network_timing_handler: Box<dyn NetworkTimingHandler>,
@@ -145,7 +144,6 @@ impl Clone for WebFontDocumentContext {
             policy_container: self.policy_container.clone(),
             request_client: self.request_client.clone(),
             document_url: self.document_url.clone(),
-            has_trustworthy_ancestor_origin: self.has_trustworthy_ancestor_origin,
             insecure_requests_policy: self.insecure_requests_policy,
             csp_handler: self.csp_handler.clone(),
             network_timing_handler: self.network_timing_handler.clone(),
@@ -1083,8 +1081,7 @@ impl RemoteWebFontDownloader {
         .service_workers_mode(ServiceWorkersMode::All)
         .policy_container(document_context.policy_container.clone())
         .client(document_context.request_client.clone())
-        .insecure_requests_policy(document_context.insecure_requests_policy)
-        .has_trustworthy_ancestor_origin(document_context.has_trustworthy_ancestor_origin);
+        .insecure_requests_policy(document_context.insecure_requests_policy);
 
         let core_resource_thread_clone = font_context.resource_threads.lock().clone();
 

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -20,8 +20,8 @@ use malloc_size_of_derive::MallocSizeOf;
 use net_traits::blob_url_store::UrlWithBlobClaim;
 use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{
-    CredentialsMode, Destination, InsecureRequestsPolicy, Referrer, RequestBuilder, RequestClient,
-    RequestMode, ServiceWorkersMode,
+    CredentialsMode, Destination, Referrer, RequestBuilder, RequestClient, RequestMode,
+    ServiceWorkersMode,
 };
 use net_traits::{
     CoreResourceThread, FetchResponseMsg, ResourceFetchTiming, ResourceThreads, fetch_async,
@@ -133,7 +133,6 @@ pub struct WebFontDocumentContext {
     pub policy_container: PolicyContainer,
     pub request_client: RequestClient,
     pub document_url: ServoUrl,
-    pub insecure_requests_policy: InsecureRequestsPolicy,
     pub csp_handler: Box<dyn CspViolationHandler>,
     pub network_timing_handler: Box<dyn NetworkTimingHandler>,
 }
@@ -144,7 +143,6 @@ impl Clone for WebFontDocumentContext {
             policy_container: self.policy_container.clone(),
             request_client: self.request_client.clone(),
             document_url: self.document_url.clone(),
-            insecure_requests_policy: self.insecure_requests_policy,
             csp_handler: self.csp_handler.clone(),
             network_timing_handler: self.network_timing_handler.clone(),
         }
@@ -1080,8 +1078,7 @@ impl RemoteWebFontDownloader {
         .credentials_mode(CredentialsMode::CredentialsSameOrigin)
         .service_workers_mode(ServiceWorkersMode::All)
         .policy_container(document_context.policy_container.clone())
-        .client(document_context.request_client.clone())
-        .insecure_requests_policy(document_context.insecure_requests_policy);
+        .client(document_context.request_client.clone());
 
         let core_resource_thread_clone = font_context.resource_threads.lock().clone();
 

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -26,8 +26,8 @@ use net_traits::policy_container::{PolicyContainer, RequestPolicyContainer};
 use net_traits::request::{
     BodyChunkRequest, BodyChunkResponse, CredentialsMode, Destination, Initiator,
     InsecureRequestsPolicy, InternalRequest, Origin, ParserMetadata, RedirectMode, Referrer,
-    Request, RequestBody, RequestClient, RequestId, RequestMode, ResponseTainting,
-    is_cors_safelisted_method, is_cors_safelisted_request_header,
+    Request, RequestBody, RequestId, RequestMode, ResponseTainting, is_cors_safelisted_method,
+    is_cors_safelisted_request_header,
 };
 use net_traits::response::{Response, ResponseBody, ResponseType, TerminationReason};
 use net_traits::{
@@ -1225,10 +1225,9 @@ pub fn should_request_be_blocked_as_mixed_content(
     // Step 1. Return allowed if one or more of the following conditions are met:
     // 1.1. Does settings prohibit mixed security contexts?
     // returns "Does Not Restrict Mixed Security Contexts" when applied to request’s client.
-    if request.client.as_ref().is_some_and(|client| {
-        do_settings_prohibit_mixed_security_contexts(client) ==
-            MixedSecurityProhibited::NotProhibited
-    }) {
+    if do_settings_prohibit_mixed_security_contexts(request) ==
+        MixedSecurityProhibited::NotProhibited
+    {
         return false;
     }
 
@@ -1258,10 +1257,9 @@ pub fn should_response_be_blocked_as_mixed_content(
     // Step 1. Return allowed if one or more of the following conditions are met:
     // 1.1. Does settings prohibit mixed security contexts? returns Does Not Restrict Mixed Content
     // when applied to request’s client.
-    if request.client.as_ref().is_some_and(|client| {
-        do_settings_prohibit_mixed_security_contexts(client) ==
-            MixedSecurityProhibited::NotProhibited
-    }) {
+    if do_settings_prohibit_mixed_security_contexts(request) ==
+        MixedSecurityProhibited::NotProhibited
+    {
         return false;
     }
 
@@ -1375,14 +1373,20 @@ pub enum MixedSecurityProhibited {
 }
 
 /// <https://w3c.github.io/webappsec-mixed-content/#categorize-settings-object>
-fn do_settings_prohibit_mixed_security_contexts(client: &RequestClient) -> MixedSecurityProhibited {
-    if let Origin::Origin(ref origin) = client.origin {
-        // Step 1. If settings’ origin is a potentially trustworthy origin,
-        // then return "Prohibits Mixed Security Contexts".
-        // NOTE: Workers created from a data: url are secure if they were created from secure contexts
-        if origin.is_potentially_trustworthy() || origin.is_for_data_worker_from_secure_context() {
-            return MixedSecurityProhibited::Prohibited;
-        }
+fn do_settings_prohibit_mixed_security_contexts(request: &Request) -> MixedSecurityProhibited {
+    let Some(ref client) = request.client else {
+        return MixedSecurityProhibited::NotProhibited;
+    };
+
+    let Origin::Origin(ref origin) = client.origin else {
+        unreachable!("Settings' origin is never a \"client\"");
+    };
+
+    // Step 1. If settings’ origin is a potentially trustworthy origin,
+    // then return "Prohibits Mixed Security Contexts".
+    // NOTE: Workers created from a data: url are secure if they were created from secure contexts
+    if origin.is_potentially_trustworthy() || origin.is_for_data_worker_from_secure_context() {
+        return MixedSecurityProhibited::Prohibited;
     }
 
     // Step 2.2. For each navigable navigable in document’s ancestor navigables:
@@ -1413,10 +1417,9 @@ fn should_upgrade_mixed_content_request(
     }
 
     // Step 1.3
-    if request.client.as_ref().is_some_and(|client| {
-        do_settings_prohibit_mixed_security_contexts(client) ==
-            MixedSecurityProhibited::NotProhibited
-    }) {
+    if do_settings_prohibit_mixed_security_contexts(request) ==
+        MixedSecurityProhibited::NotProhibited
+    {
         return false;
     }
 

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -26,8 +26,8 @@ use net_traits::policy_container::{PolicyContainer, RequestPolicyContainer};
 use net_traits::request::{
     BodyChunkRequest, BodyChunkResponse, CredentialsMode, Destination, Initiator,
     InsecureRequestsPolicy, InternalRequest, Origin, ParserMetadata, RedirectMode, Referrer,
-    Request, RequestBody, RequestId, RequestMode, ResponseTainting, is_cors_safelisted_method,
-    is_cors_safelisted_request_header,
+    Request, RequestBody, RequestClient, RequestId, RequestMode, ResponseTainting,
+    is_cors_safelisted_method, is_cors_safelisted_request_header,
 };
 use net_traits::response::{Response, ResponseBody, ResponseType, TerminationReason};
 use net_traits::{
@@ -1221,9 +1221,10 @@ pub fn should_request_be_blocked_as_mixed_content(
     // Step 1. Return allowed if one or more of the following conditions are met:
     // 1.1. Does settings prohibit mixed security contexts?
     // returns "Does Not Restrict Mixed Security Contexts" when applied to request’s client.
-    if do_settings_prohibit_mixed_security_contexts(request) ==
-        MixedSecurityProhibited::NotProhibited
-    {
+    if request.client.as_ref().is_some_and(|client| {
+        do_settings_prohibit_mixed_security_contexts(client) ==
+            MixedSecurityProhibited::NotProhibited
+    }) {
         return false;
     }
 
@@ -1253,9 +1254,10 @@ pub fn should_response_be_blocked_as_mixed_content(
     // Step 1. Return allowed if one or more of the following conditions are met:
     // 1.1. Does settings prohibit mixed security contexts? returns Does Not Restrict Mixed Content
     // when applied to request’s client.
-    if do_settings_prohibit_mixed_security_contexts(request) ==
-        MixedSecurityProhibited::NotProhibited
-    {
+    if request.client.as_ref().is_some_and(|client| {
+        do_settings_prohibit_mixed_security_contexts(client) ==
+            MixedSecurityProhibited::NotProhibited
+    }) {
         return false;
     }
 
@@ -1369,8 +1371,8 @@ pub enum MixedSecurityProhibited {
 }
 
 /// <https://w3c.github.io/webappsec-mixed-content/#categorize-settings-object>
-fn do_settings_prohibit_mixed_security_contexts(request: &Request) -> MixedSecurityProhibited {
-    if let Origin::Origin(ref origin) = request.origin {
+fn do_settings_prohibit_mixed_security_contexts(client: &RequestClient) -> MixedSecurityProhibited {
+    if let Origin::Origin(ref origin) = client.origin {
         // Step 1. If settings’ origin is a potentially trustworthy origin,
         // then return "Prohibits Mixed Security Contexts".
         // NOTE: Workers created from a data: url are secure if they were created from secure contexts
@@ -1382,7 +1384,7 @@ fn do_settings_prohibit_mixed_security_contexts(request: &Request) -> MixedSecur
     // Step 2.2. For each navigable navigable in document’s ancestor navigables:
     // Step 2.2.1. If navigable’s active document's origin is a potentially trustworthy origin,
     // then return "Prohibits Mixed Security Contexts".
-    if request.has_trustworthy_ancestor_origin {
+    if client.has_trustworthy_ancestor_origin {
         return MixedSecurityProhibited::Prohibited;
     }
 
@@ -1407,9 +1409,10 @@ fn should_upgrade_mixed_content_request(
     }
 
     // Step 1.3
-    if do_settings_prohibit_mixed_security_contexts(request) ==
-        MixedSecurityProhibited::NotProhibited
-    {
+    if request.client.as_ref().is_some_and(|client| {
+        do_settings_prohibit_mixed_security_contexts(client) ==
+            MixedSecurityProhibited::NotProhibited
+    }) {
         return false;
     }
 

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -467,11 +467,15 @@ pub async fn main_fetch(
                 .unwrap();
         }
     } else {
+        let insecure_requests_policy = request
+            .client
+            .as_ref()
+            .map(|client| client.insecure_requests_policy);
         trace!(
             "not upgrading {} targeting {:?} with {:?}",
             request.current_url(),
             request.destination,
-            request.insecure_requests_policy
+            insecure_requests_policy
         );
     }
     if let Some(csp_request) = csp_request.as_ref() {

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1893,13 +1893,7 @@ fn cross_origin_resource_policy_check(
     // That's the default value of the enum
 
     // Step 2. Let embedderPolicy be settingsObject’s policy container’s embedder policy.
-    let RequestPolicyContainer::PolicyContainer(ref policy_container) =
-        request_client.policy_container
-    else {
-        return CrossOriginResourcePolicy::Blocked;
-    };
-
-    let embedder_policy = &policy_container.embedder_policy;
+    let embedder_policy = &request_client.policy_container.embedder_policy;
 
     // Step 3. If the cross-origin resource policy internal check with origin, "unsafe-none",
     // response, and forNavigation returns blocked, then return blocked.

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -1822,10 +1822,9 @@ impl Document {
     pub(crate) fn fetch<Listener: FetchResponseListener>(
         &self,
         load: LoadType,
-        mut request: RequestBuilder,
+        request: RequestBuilder,
         listener: Listener,
     ) {
-        request = request.insecure_requests_policy(self.insecure_requests_policy());
         let callback = NetworkListener {
             context: std::sync::Arc::new(Mutex::new(Some(listener))),
             task_source: self
@@ -1841,10 +1840,9 @@ impl Document {
 
     pub(crate) fn fetch_background<Listener: FetchResponseListener>(
         &self,
-        mut request: RequestBuilder,
+        request: RequestBuilder,
         listener: Listener,
     ) {
-        request = request.insecure_requests_policy(self.insecure_requests_policy());
         let callback = NetworkListener {
             context: std::sync::Arc::new(Mutex::new(Some(listener))),
             task_source: self

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -1825,9 +1825,7 @@ impl Document {
         mut request: RequestBuilder,
         listener: Listener,
     ) {
-        request = request
-            .insecure_requests_policy(self.insecure_requests_policy())
-            .has_trustworthy_ancestor_origin(self.has_trustworthy_ancestor_or_current_origin());
+        request = request.insecure_requests_policy(self.insecure_requests_policy());
         let callback = NetworkListener {
             context: std::sync::Arc::new(Mutex::new(Some(listener))),
             task_source: self
@@ -1846,9 +1844,7 @@ impl Document {
         mut request: RequestBuilder,
         listener: Listener,
     ) {
-        request = request
-            .insecure_requests_policy(self.insecure_requests_policy())
-            .has_trustworthy_ancestor_origin(self.has_trustworthy_ancestor_or_current_origin());
+        request = request.insecure_requests_policy(self.insecure_requests_policy());
         let callback = NetworkListener {
             context: std::sync::Arc::new(Mutex::new(Some(listener))),
             task_source: self

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -2653,6 +2653,7 @@ impl GlobalScope {
             origin: RequestOrigin::Origin(self.origin().immutable().clone()),
             is_nested_browsing_context,
             insecure_requests_policy: self.insecure_requests_policy(),
+            has_trustworthy_ancestor_origin: self.has_trustworthy_ancestor_or_current_origin(),
         }
     }
 

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -44,7 +44,7 @@ use net_traits::filemanager_thread::{
     FileManagerResult, FileManagerThreadMsg, ReadFileProgress, RelativePos,
 };
 use net_traits::image_cache::ImageCache;
-use net_traits::policy_container::{PolicyContainer, RequestPolicyContainer};
+use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{
     InsecureRequestsPolicy, Origin as RequestOrigin, Referrer, RequestBuilder, RequestClient,
 };
@@ -2649,7 +2649,7 @@ impl GlobalScope {
         let is_nested_browsing_context = window.is_some_and(|window| !window.is_top_level());
         RequestClient {
             preloaded_resources,
-            policy_container: RequestPolicyContainer::PolicyContainer(self.policy_container()),
+            policy_container: self.policy_container(),
             origin: RequestOrigin::Origin(self.origin().immutable().clone()),
             is_nested_browsing_context,
             insecure_requests_policy: self.insecure_requests_policy(),

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -518,7 +518,6 @@ impl HTMLLinkElement {
             source_set: None, // FIXME
             origin: document.borrow().origin().immutable().to_owned(),
             base_url: document.borrow().base_url(),
-            insecure_requests_policy: document.insecure_requests_policy(),
             request_client: global.request_client(None),
             referrer: global.get_referrer(),
         };

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -519,7 +519,6 @@ impl HTMLLinkElement {
             origin: document.borrow().origin().immutable().to_owned(),
             base_url: document.borrow().base_url(),
             insecure_requests_policy: document.insecure_requests_policy(),
-            has_trustworthy_ancestor_origin: document.has_trustworthy_ancestor_or_current_origin(),
             request_client: global.request_client(None),
             referrer: global.get_referrer(),
         };

--- a/components/script/dom/processingoptions.rs
+++ b/components/script/dom/processingoptions.rs
@@ -12,8 +12,8 @@ use net_traits::fetch::headers::get_decode_and_split_header_name;
 use net_traits::mime_classifier::{MediaType, MimeClassifier};
 use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{
-    CorsSettings, Destination, Initiator, InsecureRequestsPolicy, PreloadId, PreloadKey, Referrer,
-    RequestBuilder, RequestClient, RequestId,
+    CorsSettings, Destination, Initiator, PreloadId, PreloadKey, Referrer, RequestBuilder,
+    RequestClient, RequestId,
 };
 use net_traits::response::{Response, ResponseBody};
 use net_traits::{
@@ -84,7 +84,6 @@ pub(crate) struct LinkProcessingOptions {
     pub(crate) base_url: ServoUrl,
     /// <https://html.spec.whatwg.org/multipage/#link-options-origin>
     pub(crate) origin: ImmutableOrigin,
-    pub(crate) insecure_requests_policy: InsecureRequestsPolicy,
     pub(crate) referrer: Referrer,
     // https://html.spec.whatwg.org/multipage/#link-options-environment
     pub(crate) request_client: RequestClient,
@@ -206,7 +205,6 @@ impl LinkProcessingOptions {
             None,
             self.referrer,
         )
-        .insecure_requests_policy(self.insecure_requests_policy)
         .policy_container(self.policy_container)
         .client(self.request_client)
         .initiator(Initiator::Link)
@@ -409,7 +407,6 @@ pub(crate) fn process_link_headers(
             source_set: None,
             origin: document.origin().immutable().to_owned(),
             base_url: document.base_url(),
-            insecure_requests_policy: document.insecure_requests_policy(),
             request_client: global.request_client(None),
             referrer: global.get_referrer(),
         };

--- a/components/script/dom/processingoptions.rs
+++ b/components/script/dom/processingoptions.rs
@@ -85,7 +85,6 @@ pub(crate) struct LinkProcessingOptions {
     /// <https://html.spec.whatwg.org/multipage/#link-options-origin>
     pub(crate) origin: ImmutableOrigin,
     pub(crate) insecure_requests_policy: InsecureRequestsPolicy,
-    pub(crate) has_trustworthy_ancestor_origin: bool,
     pub(crate) referrer: Referrer,
     // https://html.spec.whatwg.org/multipage/#link-options-environment
     pub(crate) request_client: RequestClient,
@@ -208,7 +207,6 @@ impl LinkProcessingOptions {
             self.referrer,
         )
         .insecure_requests_policy(self.insecure_requests_policy)
-        .has_trustworthy_ancestor_origin(self.has_trustworthy_ancestor_origin)
         .policy_container(self.policy_container)
         .client(self.request_client)
         .initiator(Initiator::Link)
@@ -412,7 +410,6 @@ pub(crate) fn process_link_headers(
             origin: document.origin().immutable().to_owned(),
             base_url: document.base_url(),
             insecure_requests_policy: document.insecure_requests_policy(),
-            has_trustworthy_ancestor_origin: document.has_trustworthy_ancestor_or_current_origin(),
             request_client: global.request_client(None),
             referrer: global.get_referrer(),
         };

--- a/components/script/dom/serviceworker/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworker/serviceworkerglobalscope.rs
@@ -435,7 +435,6 @@ impl ServiceWorkerGlobalScope {
                 .use_url_credentials(true)
                 .pipeline_id(Some(pipeline_id))
                 .referrer_policy(referrer_policy)
-                .insecure_requests_policy(worker_scope.insecure_requests_policy())
                 // TODO: Use policy container from ScopeThings
                 .policy_container(global_scope.policy_container())
                 .origin(origin);

--- a/components/script/dom/servoparser/prefetch.rs
+++ b/components/script/dom/servoparser/prefetch.rs
@@ -13,14 +13,13 @@ use html5ever::tokenizer::{
 use html5ever::{Attribute, LocalName, local_name};
 use js::jsapi::JSTracer;
 use markup5ever::TokenizerResult;
-use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{
     CorsSettings, CredentialsMode, Destination, ParserMetadata, Referrer, RequestClient,
 };
 use net_traits::{CoreResourceMsg, FetchChannels, ReferrerPolicy, ResourceThreads};
 use servo_base::generic_channel::GenericSend;
 use servo_base::id::{PipelineId, WebViewId};
-use servo_url::{ImmutableOrigin, ServoUrl};
+use servo_url::ServoUrl;
 
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::trace::{CustomTraceable, JSTraceable};
@@ -64,7 +63,6 @@ impl Tokenizer {
     pub(crate) fn new(document: &Document) -> Self {
         let global = document.global();
         let sink = PrefetchSink {
-            origin: document.origin().immutable().clone(),
             pipeline_id: global.pipeline_id(),
             webview_id: document.webview_id(),
             base_url: RefCell::new(None),
@@ -76,7 +74,6 @@ impl Tokenizer {
             // true after the first script tag, since that is what will
             // block the main parser.
             prefetching: Cell::new(false),
-            policy_container: global.policy_container(),
             request_client: global.request_client(None),
         };
         let options = Default::default();
@@ -92,8 +89,6 @@ impl Tokenizer {
 #[derive(JSTraceable)]
 struct PrefetchSink {
     #[no_trace]
-    origin: ImmutableOrigin,
-    #[no_trace]
     pipeline_id: PipelineId,
     #[no_trace]
     webview_id: WebViewId,
@@ -108,8 +103,6 @@ struct PrefetchSink {
     #[no_trace]
     resource_threads: ResourceThreads,
     prefetching: Cell<bool>,
-    #[no_trace]
-    policy_container: PolicyContainer,
     #[no_trace]
     request_client: RequestClient,
 }
@@ -152,9 +145,7 @@ impl TokenSink for PrefetchSink {
                         },
                         self.referrer.clone(),
                     )
-                    .policy_container(self.policy_container.clone())
                     .client(self.request_client.clone())
-                    .origin(self.origin.clone())
                     .pipeline_id(Some(self.pipeline_id));
                     let _ = self
                         .resource_threads
@@ -173,9 +164,7 @@ impl TokenSink for PrefetchSink {
                         None,
                         self.referrer.clone(),
                     )
-                    .policy_container(self.policy_container.clone())
                     .client(self.request_client.clone())
-                    .origin(self.origin.clone())
                     .pipeline_id(Some(self.pipeline_id))
                     .referrer_policy(self.get_referrer_policy(tag, local_name!("referrerpolicy")));
 
@@ -208,9 +197,7 @@ impl TokenSink for PrefetchSink {
                         None,
                         self.referrer.clone(),
                     )
-                    .policy_container(self.policy_container.clone())
                     .client(self.request_client.clone())
-                    .origin(self.origin.clone())
                     .pipeline_id(Some(self.pipeline_id))
                     .referrer_policy(referrer_policy)
                     .integrity_metadata(integrity_metadata);

--- a/components/script/dom/servoparser/prefetch.rs
+++ b/components/script/dom/servoparser/prefetch.rs
@@ -15,8 +15,7 @@ use js::jsapi::JSTracer;
 use markup5ever::TokenizerResult;
 use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{
-    CorsSettings, CredentialsMode, Destination, InsecureRequestsPolicy, ParserMetadata, Referrer,
-    RequestClient,
+    CorsSettings, CredentialsMode, Destination, ParserMetadata, Referrer, RequestClient,
 };
 use net_traits::{CoreResourceMsg, FetchChannels, ReferrerPolicy, ResourceThreads};
 use servo_base::generic_channel::GenericSend;
@@ -77,7 +76,6 @@ impl Tokenizer {
             // true after the first script tag, since that is what will
             // block the main parser.
             prefetching: Cell::new(false),
-            insecure_requests_policy: document.insecure_requests_policy(),
             policy_container: global.policy_container(),
             request_client: global.request_client(None),
         };
@@ -110,8 +108,6 @@ struct PrefetchSink {
     #[no_trace]
     resource_threads: ResourceThreads,
     prefetching: Cell<bool>,
-    #[no_trace]
-    insecure_requests_policy: InsecureRequestsPolicy,
     #[no_trace]
     policy_container: PolicyContainer,
     #[no_trace]
@@ -156,7 +152,6 @@ impl TokenSink for PrefetchSink {
                         },
                         self.referrer.clone(),
                     )
-                    .insecure_requests_policy(self.insecure_requests_policy)
                     .policy_container(self.policy_container.clone())
                     .client(self.request_client.clone())
                     .origin(self.origin.clone())
@@ -178,7 +173,6 @@ impl TokenSink for PrefetchSink {
                         None,
                         self.referrer.clone(),
                     )
-                    .insecure_requests_policy(self.insecure_requests_policy)
                     .policy_container(self.policy_container.clone())
                     .client(self.request_client.clone())
                     .origin(self.origin.clone())
@@ -214,7 +208,6 @@ impl TokenSink for PrefetchSink {
                         None,
                         self.referrer.clone(),
                     )
-                    .insecure_requests_policy(self.insecure_requests_policy)
                     .policy_container(self.policy_container.clone())
                     .client(self.request_client.clone())
                     .origin(self.origin.clone())

--- a/components/script/dom/servoparser/prefetch.rs
+++ b/components/script/dom/servoparser/prefetch.rs
@@ -78,7 +78,6 @@ impl Tokenizer {
             // block the main parser.
             prefetching: Cell::new(false),
             insecure_requests_policy: document.insecure_requests_policy(),
-            has_trustworthy_ancestor_origin: document.has_trustworthy_ancestor_or_current_origin(),
             policy_container: global.policy_container(),
             request_client: global.request_client(None),
         };
@@ -113,7 +112,6 @@ struct PrefetchSink {
     prefetching: Cell<bool>,
     #[no_trace]
     insecure_requests_policy: InsecureRequestsPolicy,
-    has_trustworthy_ancestor_origin: bool,
     #[no_trace]
     policy_container: PolicyContainer,
     #[no_trace]
@@ -159,7 +157,6 @@ impl TokenSink for PrefetchSink {
                         self.referrer.clone(),
                     )
                     .insecure_requests_policy(self.insecure_requests_policy)
-                    .has_trustworthy_ancestor_origin(self.has_trustworthy_ancestor_origin)
                     .policy_container(self.policy_container.clone())
                     .client(self.request_client.clone())
                     .origin(self.origin.clone())
@@ -182,7 +179,6 @@ impl TokenSink for PrefetchSink {
                         self.referrer.clone(),
                     )
                     .insecure_requests_policy(self.insecure_requests_policy)
-                    .has_trustworthy_ancestor_origin(self.has_trustworthy_ancestor_origin)
                     .policy_container(self.policy_container.clone())
                     .client(self.request_client.clone())
                     .origin(self.origin.clone())
@@ -219,7 +215,6 @@ impl TokenSink for PrefetchSink {
                         self.referrer.clone(),
                     )
                     .insecure_requests_policy(self.insecure_requests_policy)
-                    .has_trustworthy_ancestor_origin(self.has_trustworthy_ancestor_origin)
                     .policy_container(self.policy_container.clone())
                     .client(self.request_client.clone())
                     .origin(self.origin.clone())

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -921,7 +921,6 @@ impl Window {
             policy_container: global.policy_container(),
             request_client: global.request_client(Some(no_gc)),
             document_url: global.api_base_url(),
-            insecure_requests_policy: global.insecure_requests_policy(),
             csp_handler: Box::new(FontCspHandler {
                 global: Trusted::new(global),
                 task_source: global

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -921,7 +921,6 @@ impl Window {
             policy_container: global.policy_container(),
             request_client: global.request_client(Some(no_gc)),
             document_url: global.api_base_url(),
-            has_trustworthy_ancestor_origin: global.has_trustworthy_ancestor_origin(),
             insecure_requests_policy: global.insecure_requests_policy(),
             csp_handler: Box::new(FontCspHandler {
                 global: Trusted::new(global),

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -58,7 +58,7 @@ use crate::dom::worker::{TrustedWorkerAddress, Worker};
 use crate::dom::workerglobalscope::{ScriptFetchContext, WorkerGlobalScope};
 use crate::messaging::{CommonScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::realms::enter_auto_realm;
-use crate::script_module::{ModuleFetchClient, fetch_a_module_worker_script_graph};
+use crate::script_module::fetch_a_module_worker_script_graph;
 use crate::script_runtime::ScriptThreadEventCategory::WorkerEvent;
 use crate::script_runtime::{Runtime, ThreadSafeJSContext};
 use crate::task_queue::{QueuedTask, QueuedTaskConversion, TaskQueue};
@@ -416,7 +416,7 @@ impl DedicatedWorkerGlobalScope {
 
                 let request_client = RequestClient {
                     preloaded_resources: PreloadedResources::default(),
-                    policy_container: policy_container.clone(),
+                    policy_container,
                     origin: Origin::Origin(origin.clone()),
                     is_nested_browsing_context,
                     insecure_requests_policy,
@@ -510,13 +510,6 @@ impl DedicatedWorkerGlobalScope {
                 let scope = global.upcast::<WorkerGlobalScope>();
                 let global_scope = global.upcast::<GlobalScope>();
 
-                let fetch_client = ModuleFetchClient {
-                    policy_container,
-                    client: request_client,
-                    pipeline_id,
-                    origin,
-                };
-
                 // Step 12. Obtain script by switching on options["type"]:
                 {
                     let _ar = AutoWorkerReset::new(&global, worker.clone());
@@ -525,7 +518,7 @@ impl DedicatedWorkerGlobalScope {
                             fetch_a_classic_worker_script(
                                 scope,
                                 worker_url,
-                                fetch_client,
+                                request_client,
                                 Destination::Worker,
                                 Some(webview_id),
                                 referrer,
@@ -537,7 +530,7 @@ impl DedicatedWorkerGlobalScope {
                                 cx,
                                 global_scope,
                                 worker_url.url(),
-                                fetch_client,
+                                request_client,
                                 Destination::Worker,
                                 referrer,
                                 credentials,
@@ -791,18 +784,18 @@ impl DedicatedWorkerGlobalScope {
 pub(crate) fn fetch_a_classic_worker_script(
     workerscope: &WorkerGlobalScope,
     url_with_blob_lock: UrlWithBlobClaim,
-    fetch_client: ModuleFetchClient,
+    fetch_client: RequestClient,
     destination: Destination,
     webview_id: Option<WebViewId>,
     referrer: Referrer,
 ) {
+    let policy_container = fetch_client.policy_container.clone();
+
     // Step 1. Let request be a new request whose URL is url,
     let request = RequestBuilder::new(webview_id, url_with_blob_lock.clone(), referrer)
         // client is fetchClient,
-        .policy_container(fetch_client.policy_container.clone())
-        .client(fetch_client.client)
-        .pipeline_id(Some(fetch_client.pipeline_id))
-        .origin(fetch_client.origin)
+        .client(fetch_client)
+        .pipeline_id(Some(workerscope.pipeline_id()))
         // destination is destination,
         .destination(destination)
         // TODO initiator type is "other",
@@ -818,7 +811,7 @@ pub(crate) fn fetch_a_classic_worker_script(
     let context = ScriptFetchContext::new(
         Trusted::new(workerscope),
         url_with_blob_lock.url(),
-        fetch_client.policy_container,
+        policy_container,
     );
     let global = workerscope.upcast::<GlobalScope>();
     let task_source = global.task_manager().networking_task_source().to_sendable();

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -420,6 +420,7 @@ impl DedicatedWorkerGlobalScope {
                     origin: Origin::Origin(origin.clone()),
                     is_nested_browsing_context,
                     insecure_requests_policy,
+                    has_trustworthy_ancestor_origin: current_global_ancestor_trustworthy,
                 };
 
                 let event_loop_sender = ScriptEventLoopSender::DedicatedWorker {
@@ -511,7 +512,6 @@ impl DedicatedWorkerGlobalScope {
 
                 let fetch_client = ModuleFetchClient {
                     insecure_requests_policy,
-                    has_trustworthy_ancestor_origin: current_global_ancestor_trustworthy,
                     policy_container,
                     client: request_client,
                     pipeline_id,
@@ -801,7 +801,6 @@ pub(crate) fn fetch_a_classic_worker_script(
     let request = RequestBuilder::new(webview_id, url_with_blob_lock.clone(), referrer)
         // client is fetchClient,
         .insecure_requests_policy(fetch_client.insecure_requests_policy)
-        .has_trustworthy_ancestor_origin(fetch_client.has_trustworthy_ancestor_origin)
         .policy_container(fetch_client.policy_container.clone())
         .client(fetch_client.client)
         .pipeline_id(Some(fetch_client.pipeline_id))

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -511,7 +511,6 @@ impl DedicatedWorkerGlobalScope {
                 let global_scope = global.upcast::<GlobalScope>();
 
                 let fetch_client = ModuleFetchClient {
-                    insecure_requests_policy,
                     policy_container,
                     client: request_client,
                     pipeline_id,
@@ -800,7 +799,6 @@ pub(crate) fn fetch_a_classic_worker_script(
     // Step 1. Let request be a new request whose URL is url,
     let request = RequestBuilder::new(webview_id, url_with_blob_lock.clone(), referrer)
         // client is fetchClient,
-        .insecure_requests_policy(fetch_client.insecure_requests_policy)
         .policy_container(fetch_client.policy_container.clone())
         .client(fetch_client.client)
         .pipeline_id(Some(fetch_client.pipeline_id))

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -16,7 +16,7 @@ use js::jsval::UndefinedValue;
 use js::rust::{CustomAutoRooter, CustomAutoRooterGuard, HandleValue};
 use net_traits::blob_url_store::UrlWithBlobClaim;
 use net_traits::image_cache::ImageCache;
-use net_traits::policy_container::{PolicyContainer, RequestPolicyContainer};
+use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{
     CredentialsMode, Destination, InsecureRequestsPolicy, Origin, ParserMetadata,
     PreloadedResources, Referrer, RequestBuilder, RequestClient, RequestMode,
@@ -416,9 +416,7 @@ impl DedicatedWorkerGlobalScope {
 
                 let request_client = RequestClient {
                     preloaded_resources: PreloadedResources::default(),
-                    policy_container: RequestPolicyContainer::PolicyContainer(
-                        policy_container.clone(),
-                    ),
+                    policy_container: policy_container.clone(),
                     origin: Origin::Origin(origin.clone()),
                     is_nested_browsing_context,
                     insecure_requests_policy,

--- a/components/script/dom/workers/sharedworkerglobalscope.rs
+++ b/components/script/dom/workers/sharedworkerglobalscope.rs
@@ -521,7 +521,6 @@ impl SharedWorkerGlobalScope {
                 let _registration_cleanup = SharedWorkerRegistrationCleanup { registration_id };
 
                 let fetch_client = ModuleFetchClient {
-                    insecure_requests_policy,
                     policy_container,
                     client: request_client,
                     pipeline_id,

--- a/components/script/dom/workers/sharedworkerglobalscope.rs
+++ b/components/script/dom/workers/sharedworkerglobalscope.rs
@@ -17,7 +17,7 @@ use js::context::JSContext;
 use js::jsval::UndefinedValue;
 use net_traits::blob_url_store::UrlWithBlobClaim;
 use net_traits::image_cache::ImageCache;
-use net_traits::policy_container::{PolicyContainer, RequestPolicyContainer};
+use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{
     CredentialsMode, Destination, InsecureRequestsPolicy, Origin, PreloadedResources, Referrer,
     RequestClient,
@@ -415,9 +415,7 @@ impl SharedWorkerGlobalScope {
 
                 let request_client = RequestClient {
                     preloaded_resources: PreloadedResources::default(),
-                    policy_container: RequestPolicyContainer::PolicyContainer(
-                        policy_container.clone(),
-                    ),
+                    policy_container: policy_container.clone(),
                     origin: Origin::Origin(origin.clone()),
                     is_nested_browsing_context,
                     insecure_requests_policy,

--- a/components/script/dom/workers/sharedworkerglobalscope.rs
+++ b/components/script/dom/workers/sharedworkerglobalscope.rs
@@ -57,7 +57,7 @@ use crate::dom::types::DebuggerGlobalScope;
 use crate::dom::webgpu::identityhub::IdentityHub;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::messaging::{CommonScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
-use crate::script_module::{ModuleFetchClient, fetch_a_module_worker_script_graph};
+use crate::script_module::fetch_a_module_worker_script_graph;
 use crate::script_runtime::ScriptThreadEventCategory::WorkerEvent;
 use crate::script_runtime::{CanGc, Runtime};
 use crate::task_queue::{QueuedTask, QueuedTaskConversion, TaskQueue};
@@ -520,13 +520,6 @@ impl SharedWorkerGlobalScope {
                 // It is intentionally unused because its Drop unregisters the worker.
                 let _registration_cleanup = SharedWorkerRegistrationCleanup { registration_id };
 
-                let fetch_client = ModuleFetchClient {
-                    policy_container,
-                    client: request_client,
-                    pipeline_id,
-                    origin,
-                };
-
                 // Step 11. Let destination be "sharedworker" if is shared is true, and
                 // "worker" otherwise.
                 // Step 12. Obtain script by switching on options["type"]:
@@ -535,7 +528,7 @@ impl SharedWorkerGlobalScope {
                         fetch_a_classic_worker_script(
                             scope,
                             worker_url,
-                            fetch_client,
+                            request_client,
                             Destination::SharedWorker,
                             Some(webview_id),
                             referrer,
@@ -547,7 +540,7 @@ impl SharedWorkerGlobalScope {
                             cx,
                             global_scope,
                             worker_url.url(),
-                            fetch_client,
+                            request_client,
                             Destination::SharedWorker,
                             referrer,
                             credentials,

--- a/components/script/dom/workers/sharedworkerglobalscope.rs
+++ b/components/script/dom/workers/sharedworkerglobalscope.rs
@@ -419,6 +419,7 @@ impl SharedWorkerGlobalScope {
                     origin: Origin::Origin(origin.clone()),
                     is_nested_browsing_context,
                     insecure_requests_policy,
+                    has_trustworthy_ancestor_origin: current_global_ancestor_trustworthy,
                 };
 
                 let event_loop_sender = ScriptEventLoopSender::SharedWorker(own_sender.clone());
@@ -521,7 +522,6 @@ impl SharedWorkerGlobalScope {
 
                 let fetch_client = ModuleFetchClient {
                     insecure_requests_policy,
-                    has_trustworthy_ancestor_origin: current_global_ancestor_trustworthy,
                     policy_container,
                     client: request_client,
                     pipeline_id,

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -169,7 +169,6 @@ fn request_init_from_request(request: NetTraitsRequest, global: &GlobalScope) ->
     .parser_metadata(request.parser_metadata)
     .initiator(request.initiator)
     .client(global.request_client(None))
-    .insecure_requests_policy(request.insecure_requests_policy)
     .response_tainting(request.response_tainting);
     builder.id = request.id;
     builder
@@ -770,8 +769,7 @@ pub(crate) trait RequestWithGlobalScope {
 
 impl RequestWithGlobalScope for RequestBuilder {
     fn with_global_scope(self, global: &GlobalScope) -> Self {
-        self.insecure_requests_policy(global.insecure_requests_policy())
-            .policy_container(global.policy_container())
+        self.policy_container(global.policy_container())
             .client(global.request_client(None))
             .pipeline_id(Some(global.pipeline_id()))
             .origin(global.origin().immutable().clone())

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -769,10 +769,8 @@ pub(crate) trait RequestWithGlobalScope {
 
 impl RequestWithGlobalScope for RequestBuilder {
     fn with_global_scope(self, global: &GlobalScope) -> Self {
-        self.policy_container(global.policy_container())
-            .client(global.request_client(None))
+        self.client(global.request_client(None))
             .pipeline_id(Some(global.pipeline_id()))
-            .origin(global.origin().immutable().clone())
     }
 }
 

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -170,7 +170,6 @@ fn request_init_from_request(request: NetTraitsRequest, global: &GlobalScope) ->
     .initiator(request.initiator)
     .client(global.request_client(None))
     .insecure_requests_policy(request.insecure_requests_policy)
-    .has_trustworthy_ancestor_origin(request.has_trustworthy_ancestor_origin)
     .response_tainting(request.response_tainting);
     builder.id = request.id;
     builder
@@ -772,7 +771,6 @@ pub(crate) trait RequestWithGlobalScope {
 impl RequestWithGlobalScope for RequestBuilder {
     fn with_global_scope(self, global: &GlobalScope) -> Self {
         self.insecure_requests_policy(global.insecure_requests_policy())
-            .has_trustworthy_ancestor_origin(global.has_trustworthy_ancestor_or_current_origin())
             .policy_container(global.policy_container())
             .client(global.request_client(None))
             .pipeline_id(Some(global.pipeline_id()))

--- a/components/script/module_loading.rs
+++ b/components/script/module_loading.rs
@@ -22,7 +22,7 @@ use js::rust::wrappers2::{
     GetRequestedModulesCount, JS_GetModulePrivate, ModuleEvaluate, ModuleLink,
 };
 use js::rust::{HandleValue, IntoHandle};
-use net_traits::request::{Destination, Referrer};
+use net_traits::request::{Destination, Referrer, RequestClient};
 use script_bindings::reflector::DomObject;
 use script_bindings::settings_stack::run_a_callback;
 use servo_url::ServoUrl;
@@ -35,7 +35,7 @@ use crate::dom::promise::Promise;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::realms::enter_auto_realm;
 use crate::script_module::{
-    ModuleFetchClient, ModuleHandler, ModuleObject, ModuleTree, RethrowError, ScriptFetchOptions,
+    ModuleHandler, ModuleObject, ModuleTree, RethrowError, ScriptFetchOptions,
     fetch_a_single_module_script, gen_type_error, module_script_from_reference_private,
 };
 use crate::script_runtime::IntroductionType;
@@ -64,7 +64,7 @@ pub(crate) struct LoadState {
     #[no_trace]
     pub(crate) destination: Destination,
     #[no_trace]
-    pub(crate) fetch_client: ModuleFetchClient,
+    pub(crate) fetch_client: RequestClient,
 }
 
 /// <https://tc39.es/ecma262/#graphloadingstate-record>
@@ -496,7 +496,7 @@ pub(crate) fn host_load_imported_module(
             // Step 11. Let destination be "script".
             Destination::Script,
             // Step 12. Let fetchClient be settingsObject.
-            ModuleFetchClient::from_global_scope(&global_scope),
+            global_scope.request_client(Some(cx.no_gc())),
         ),
     };
 
@@ -561,7 +561,7 @@ pub(crate) fn host_load_imported_module(
 fn fetch_a_single_imported_module_script(
     cx: &mut JSContext,
     url: ServoUrl,
-    fetch_client: ModuleFetchClient,
+    fetch_client: RequestClient,
     global: &GlobalScope,
     destination: Destination,
     options: ScriptFetchOptions,

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -15,7 +15,6 @@ use embedder_traits::{Theme, ViewportDetails, WebDriverLoadStatus};
 use http::header;
 use js::context::JSContext;
 use net_traits::blob_url_store::UrlWithBlobClaim;
-use net_traits::policy_container::RequestPolicyContainer;
 use net_traits::request::{
     CredentialsMode, InsecureRequestsPolicy, Origin, PreloadedResources, RedirectMode,
     RequestBuilder, RequestClient, RequestMode,
@@ -226,9 +225,7 @@ impl InProgressLoad {
 
         let request_client = RequestClient {
             preloaded_resources: PreloadedResources::default(),
-            policy_container: RequestPolicyContainer::PolicyContainer(
-                self.load_data.policy_container.clone().unwrap_or_default(),
-            ),
+            policy_container: self.load_data.policy_container.clone().unwrap_or_default(),
             origin: Origin::Origin(client_origin),
             is_nested_browsing_context: self.parent_info.is_some(),
             insecure_requests_policy,

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -229,6 +229,7 @@ impl InProgressLoad {
             origin: Origin::Origin(client_origin),
             is_nested_browsing_context: self.parent_info.is_some(),
             insecure_requests_policy,
+            has_trustworthy_ancestor_origin: self.load_data.has_trustworthy_ancestor_origin,
         };
 
         let mut request_builder = RequestBuilder::new(
@@ -245,7 +246,6 @@ impl InProgressLoad {
         .referrer_policy(self.load_data.referrer_policy)
         .policy_container(self.load_data.policy_container.clone().unwrap_or_default())
         .insecure_requests_policy(insecure_requests_policy)
-        .has_trustworthy_ancestor_origin(self.load_data.has_trustworthy_ancestor_origin)
         .headers(self.load_data.headers.clone())
         .body(self.load_data.data.clone())
         .redirect_mode(RedirectMode::Manual)

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -245,7 +245,6 @@ impl InProgressLoad {
         .pipeline_id(Some(id))
         .referrer_policy(self.load_data.referrer_policy)
         .policy_container(self.load_data.policy_container.clone().unwrap_or_default())
-        .insecure_requests_policy(insecure_requests_policy)
         .headers(self.load_data.headers.clone())
         .body(self.load_data.data.clone())
         .redirect_mode(RedirectMode::Manual)

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -52,9 +52,8 @@ use script_bindings::reflector::DomObject;
 use script_bindings::settings_stack::run_a_callback;
 use script_bindings::trace::CustomTraceable;
 use serde_json::{Map as JsonMap, Value as JsonValue};
-use servo_base::id::PipelineId;
 use servo_config::pref;
-use servo_url::{ImmutableOrigin, ServoUrl};
+use servo_url::ServoUrl;
 
 use crate::DomTypeHolder;
 use crate::dom::bindings::conversions::SafeToJSValConvertible;
@@ -645,25 +644,6 @@ impl Callback for QueueTaskHandler {
     }
 }
 
-#[derive(Clone)]
-pub(crate) struct ModuleFetchClient {
-    pub policy_container: PolicyContainer,
-    pub client: RequestClient,
-    pub pipeline_id: PipelineId,
-    pub origin: ImmutableOrigin,
-}
-
-impl ModuleFetchClient {
-    pub(crate) fn from_global_scope(global: &GlobalScope) -> Self {
-        Self {
-            policy_container: global.policy_container(),
-            client: global.request_client(None),
-            pipeline_id: global.pipeline_id(),
-            origin: global.origin().immutable().clone(),
-        }
-    }
-}
-
 /// The context required for asynchronously loading an external module script source.
 struct ModuleContext {
     /// The owner of the module that initiated the request.
@@ -1184,7 +1164,7 @@ pub(crate) fn fetch_a_module_worker_script_graph(
     cx: &mut JSContext,
     global: &GlobalScope,
     url: ServoUrl,
-    fetch_client: ModuleFetchClient,
+    fetch_client: RequestClient,
     destination: Destination,
     referrer: Referrer,
     credentials_mode: CredentialsMode,
@@ -1247,7 +1227,7 @@ pub(crate) fn fetch_an_external_module_script(
     on_complete: impl FnOnce(&mut JSContext, Option<Rc<ModuleTree>>) + Clone + 'static,
 ) {
     let referrer = global.get_referrer();
-    let fetch_client = ModuleFetchClient::from_global_scope(global);
+    let fetch_client = global.request_client(Some(cx.no_gc()));
     let global_scope = DomRoot::from_ref(global);
 
     // Step 1. Fetch a single module script given url, settingsObject, "script", options, settingsObject, "client", true,
@@ -1292,7 +1272,7 @@ pub(crate) fn fetch_a_modulepreload_module(
     on_complete: impl FnOnce(&mut JSContext, bool) + 'static,
 ) {
     let referrer = global.get_referrer();
-    let fetch_client = ModuleFetchClient::from_global_scope(global);
+    let fetch_client = global.request_client(Some(cx.no_gc()));
     let global_scope = DomRoot::from_ref(global);
 
     // Note: There is a specification inconsistency, `fetch_a_single_module_script` doesn't allow
@@ -1364,7 +1344,7 @@ pub(crate) fn fetch_inline_module_script(
         line_number,
         introduction_type,
     ));
-    let fetch_client = ModuleFetchClient::from_global_scope(global);
+    let fetch_client = global.request_client(Some(cx.no_gc()));
 
     // Step 2. Fetch the descendants of and link script, given settingsObject, "script", and onComplete.
     fetch_the_descendants_and_link_module_script(
@@ -1383,7 +1363,7 @@ fn fetch_the_descendants_and_link_module_script(
     cx: &mut JSContext,
     global: &GlobalScope,
     module_script: Rc<ModuleTree>,
-    fetch_client: ModuleFetchClient,
+    fetch_client: RequestClient,
     destination: Destination,
     on_complete: impl FnOnce(&mut JSContext, Option<Rc<ModuleTree>>) + Clone + 'static,
 ) {
@@ -1478,7 +1458,7 @@ fn fetch_the_descendants_and_link_module_script(
 pub(crate) fn fetch_a_single_module_script(
     cx: &mut JSContext,
     url: ServoUrl,
-    fetch_client: ModuleFetchClient,
+    fetch_client: RequestClient,
     global: &GlobalScope,
     destination: Destination,
     options: ScriptFetchOptions,
@@ -1568,8 +1548,6 @@ pub(crate) fn fetch_a_single_module_script(
         let policy_container = (is_top_level && global.is::<WorkerGlobalScope>())
             .then(|| fetch_client.policy_container.clone());
 
-        let webview_id = global.webview_id();
-
         // Step 8. Let request be a new request whose URL is url, mode is "cors", referrer is referrer, and client is fetchClient.
 
         // Step 10. If destination is "worker", "sharedworker", or "serviceworker", and isTopLevel is true,
@@ -1592,7 +1570,7 @@ pub(crate) fn fetch_a_single_module_script(
 
         // Step 12. Set up the module script request given request and options.
         let request = RequestBuilder::new(
-            webview_id,
+            global.webview_id(),
             ensure_blob_referenced_by_url_is_kept_alive(global, url.clone()),
             referrer,
         )
@@ -1603,10 +1581,8 @@ pub(crate) fn fetch_a_single_module_script(
         .referrer_policy(options.referrer_policy)
         .mode(mode)
         .cryptographic_nonce_metadata(options.cryptographic_nonce.clone())
-        .policy_container(fetch_client.policy_container)
-        .client(fetch_client.client)
-        .pipeline_id(Some(fetch_client.pipeline_id))
-        .origin(fetch_client.origin);
+        .client(fetch_client)
+        .pipeline_id(Some(global.pipeline_id()));
 
         let context = ModuleContext {
             owner: Trusted::new(global),

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -648,7 +648,6 @@ impl Callback for QueueTaskHandler {
 #[derive(Clone)]
 pub(crate) struct ModuleFetchClient {
     pub insecure_requests_policy: InsecureRequestsPolicy,
-    pub has_trustworthy_ancestor_origin: bool,
     pub policy_container: PolicyContainer,
     pub client: RequestClient,
     pub pipeline_id: PipelineId,
@@ -659,7 +658,6 @@ impl ModuleFetchClient {
     pub(crate) fn from_global_scope(global: &GlobalScope) -> Self {
         Self {
             insecure_requests_policy: global.insecure_requests_policy(),
-            has_trustworthy_ancestor_origin: global.has_trustworthy_ancestor_or_current_origin(),
             policy_container: global.policy_container(),
             client: global.request_client(None),
             pipeline_id: global.pipeline_id(),
@@ -1608,7 +1606,6 @@ pub(crate) fn fetch_a_single_module_script(
         .mode(mode)
         .cryptographic_nonce_metadata(options.cryptographic_nonce.clone())
         .insecure_requests_policy(fetch_client.insecure_requests_policy)
-        .has_trustworthy_ancestor_origin(fetch_client.has_trustworthy_ancestor_origin)
         .policy_container(fetch_client.policy_container)
         .client(fetch_client.client)
         .pipeline_id(Some(fetch_client.pipeline_id))

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -41,8 +41,8 @@ use net_traits::http_status::HttpStatus;
 use net_traits::mime_classifier::MimeClassifier;
 use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{
-    CredentialsMode, Destination, InsecureRequestsPolicy, ParserMetadata, Referrer, RequestBuilder,
-    RequestClient, RequestId, RequestMode,
+    CredentialsMode, Destination, ParserMetadata, Referrer, RequestBuilder, RequestClient,
+    RequestId, RequestMode,
 };
 use net_traits::{FetchMetadata, Metadata, NetworkError, ReferrerPolicy, ResourceFetchTiming};
 use script_bindings::cell::DomRefCell;
@@ -647,7 +647,6 @@ impl Callback for QueueTaskHandler {
 
 #[derive(Clone)]
 pub(crate) struct ModuleFetchClient {
-    pub insecure_requests_policy: InsecureRequestsPolicy,
     pub policy_container: PolicyContainer,
     pub client: RequestClient,
     pub pipeline_id: PipelineId,
@@ -657,7 +656,6 @@ pub(crate) struct ModuleFetchClient {
 impl ModuleFetchClient {
     pub(crate) fn from_global_scope(global: &GlobalScope) -> Self {
         Self {
-            insecure_requests_policy: global.insecure_requests_policy(),
             policy_container: global.policy_container(),
             client: global.request_client(None),
             pipeline_id: global.pipeline_id(),
@@ -1605,7 +1603,6 @@ pub(crate) fn fetch_a_single_module_script(
         .referrer_policy(options.referrer_policy)
         .mode(mode)
         .cryptographic_nonce_metadata(options.cryptographic_nonce.clone())
-        .insecure_requests_policy(fetch_client.insecure_requests_policy)
         .policy_container(fetch_client.policy_container)
         .client(fetch_client.client)
         .pipeline_id(Some(fetch_client.pipeline_id))

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -223,6 +223,8 @@ pub struct RequestClient {
     pub is_nested_browsing_context: bool,
     /// <https://w3c.github.io/webappsec-upgrade-insecure-requests/#insecure-requests-policy>
     pub insecure_requests_policy: InsecureRequestsPolicy,
+    /// <https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin>
+    pub has_trustworthy_ancestor_origin: bool,
 }
 
 /// <https://html.spec.whatwg.org/multipage/#system-visibility-state>
@@ -481,7 +483,6 @@ pub struct RequestBuilder {
     /// <https://fetch.spec.whatwg.org/#concept-request-policy-container>
     pub policy_container: RequestPolicyContainer,
     pub insecure_requests_policy: InsecureRequestsPolicy,
-    pub has_trustworthy_ancestor_origin: bool,
 
     /// <https://fetch.spec.whatwg.org/#concept-request-referrer>
     pub referrer: Referrer,
@@ -542,7 +543,6 @@ impl RequestBuilder {
             client: None,
             policy_container: RequestPolicyContainer::default(),
             insecure_requests_policy: InsecureRequestsPolicy::DoNotUpgrade,
-            has_trustworthy_ancestor_origin: false,
             referrer,
             referrer_policy: ReferrerPolicy::EmptyString,
             pipeline_id: None,
@@ -710,14 +710,6 @@ impl RequestBuilder {
         self
     }
 
-    pub fn has_trustworthy_ancestor_origin(
-        mut self,
-        has_trustworthy_ancestor_origin: bool,
-    ) -> RequestBuilder {
-        self.has_trustworthy_ancestor_origin = has_trustworthy_ancestor_origin;
-        self
-    }
-
     /// <https://fetch.spec.whatwg.org/#request-service-workers-mode>
     pub fn service_workers_mode(
         mut self,
@@ -782,7 +774,6 @@ impl RequestBuilder {
         request.client = self.client;
         request.policy_container = self.policy_container;
         request.insecure_requests_policy = self.insecure_requests_policy;
-        request.has_trustworthy_ancestor_origin = self.has_trustworthy_ancestor_origin;
         request.is_internal_request = self.is_internal_request;
         request
     }
@@ -864,7 +855,6 @@ pub struct Request {
     pub policy_container: RequestPolicyContainer,
     /// <https://w3c.github.io/webappsec-upgrade-insecure-requests/#insecure-requests-policy>
     pub insecure_requests_policy: InsecureRequestsPolicy,
-    pub has_trustworthy_ancestor_origin: bool,
     /// Servo internal: if crash details are present, trigger a crash error page with these details.
     pub crash: Option<String>,
     /// Servo internal: whether this request originates from Servo internal implementation
@@ -914,7 +904,6 @@ impl Request {
             response_tainting: ResponseTainting::Basic,
             policy_container: RequestPolicyContainer::Client,
             insecure_requests_policy: InsecureRequestsPolicy::DoNotUpgrade,
-            has_trustworthy_ancestor_origin: false,
             is_internal_request: Default::default(),
             crash: None,
         }

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -482,7 +482,6 @@ pub struct RequestBuilder {
 
     /// <https://fetch.spec.whatwg.org/#concept-request-policy-container>
     pub policy_container: RequestPolicyContainer,
-    pub insecure_requests_policy: InsecureRequestsPolicy,
 
     /// <https://fetch.spec.whatwg.org/#concept-request-referrer>
     pub referrer: Referrer,
@@ -542,7 +541,6 @@ impl RequestBuilder {
             origin: Origin::Client,
             client: None,
             policy_container: RequestPolicyContainer::default(),
-            insecure_requests_policy: InsecureRequestsPolicy::DoNotUpgrade,
             referrer,
             referrer_policy: ReferrerPolicy::EmptyString,
             pipeline_id: None,
@@ -702,14 +700,6 @@ impl RequestBuilder {
         self
     }
 
-    pub fn insecure_requests_policy(
-        mut self,
-        insecure_requests_policy: InsecureRequestsPolicy,
-    ) -> RequestBuilder {
-        self.insecure_requests_policy = insecure_requests_policy;
-        self
-    }
-
     /// <https://fetch.spec.whatwg.org/#request-service-workers-mode>
     pub fn service_workers_mode(
         mut self,
@@ -773,7 +763,6 @@ impl RequestBuilder {
         request.crash = self.crash;
         request.client = self.client;
         request.policy_container = self.policy_container;
-        request.insecure_requests_policy = self.insecure_requests_policy;
         request.is_internal_request = self.is_internal_request;
         request
     }
@@ -853,8 +842,6 @@ pub struct Request {
     pub parser_metadata: ParserMetadata,
     /// <https://fetch.spec.whatwg.org/#concept-request-policy-container>
     pub policy_container: RequestPolicyContainer,
-    /// <https://w3c.github.io/webappsec-upgrade-insecure-requests/#insecure-requests-policy>
-    pub insecure_requests_policy: InsecureRequestsPolicy,
     /// Servo internal: if crash details are present, trigger a crash error page with these details.
     pub crash: Option<String>,
     /// Servo internal: whether this request originates from Servo internal implementation
@@ -903,7 +890,6 @@ impl Request {
             redirect_count: 0,
             response_tainting: ResponseTainting::Basic,
             policy_container: RequestPolicyContainer::Client,
-            insecure_requests_policy: InsecureRequestsPolicy::DoNotUpgrade,
             is_internal_request: Default::default(),
             crash: None,
         }

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -216,7 +216,7 @@ pub struct RequestClient {
     /// <https://html.spec.whatwg.org/multipage/#map-of-preloaded-resources>
     pub preloaded_resources: PreloadedResources,
     /// <https://html.spec.whatwg.org/multipage/#concept-settings-object-policy-container>
-    pub policy_container: RequestPolicyContainer,
+    pub policy_container: PolicyContainer,
     /// <https://html.spec.whatwg.org/multipage/#concept-settings-object-origin>
     pub origin: Origin,
     /// <https://html.spec.whatwg.org/multipage/#nested-browsing-context>
@@ -1021,7 +1021,8 @@ impl Request {
             // Step 3.1. If request’s client is non-null, then set request’s
             // policy container to a clone of request’s client’s policy container. [HTML]
             if let Some(client) = self.client.as_ref() {
-                self.policy_container = client.policy_container.clone();
+                self.policy_container =
+                    RequestPolicyContainer::PolicyContainer(client.policy_container.clone());
             } else {
                 // Step 3.2. Otherwise, set request’s policy container to a new policy container.
                 self.policy_container =


### PR DESCRIPTION
To replace `ModuleFetchClient` (introduced in #43585) with `RequestClient` these changes have been made:
- Update client's policy_container type from `RequestPolicyContainer` to `PolicyContainer`. Only requests needs to distinguish between `Client` and `PolicyContainer`, and since `RequestClient` is a snapshot of an environment settings object using `RequestPolicyContainer` does not make sense
- Move `has_trustworthy_ancestor_origin` to `RequestClient`
- Remove `insecure_requests_policy` from `Request`, we were already using the one from client, the only remaining usage was used for logging
- We actually don't need to pass a `PolicyContainer` and an `Origin` to `RequestBuilder`, it's already handled by `populate_request_from_client`

Testing: Covered by existing tests
