### PR TITLE
script: Pass &mut JSContext to get_in_memory_bytes

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -11,6 +11,7 @@ use http::HeaderMap;
 use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
+use js::context::JSContext;
 use js::jsapi::{Heap, JSObject, Value as JSValue};
 use js::jsval::{JSVal, UndefinedValue};
 use js::realm::CurrentRealm;
@@ -406,7 +407,10 @@ impl ExtractedBody {
     ///
     /// Transmitting a body over fetch, and consuming it in script,
     /// are mutually exclusive operations, since each will lock the stream to a reader.
-    pub(crate) fn into_net_request_body(self) -> (RequestBody, DomRoot<ReadableStream>) {
+    pub(crate) fn into_net_request_body(
+        self,
+        cx: &mut JSContext,
+    ) -> (RequestBody, DomRoot<ReadableStream>) {
         let ExtractedBody {
             stream,
             total_bytes,
@@ -426,7 +430,7 @@ impl ExtractedBody {
 
         // In case of the data being in-memory, send everything in one chunk, by-passing SM.
         // Empty extracted bodies are always representable as an in-memory empty payload.
-        let in_memory = stream.get_in_memory_bytes().or_else(|| {
+        let in_memory = stream.get_in_memory_bytes(cx).or_else(|| {
             if total_bytes == Some(0) {
                 Some(GenericSharedMemory::from_bytes(&[]))
             } else {

--- a/components/script/dom/fetch/request.rs
+++ b/components/script/dom/fetch/request.rs
@@ -492,7 +492,7 @@ impl Request {
             }
 
             // Step 37.2. Set initBody to bodyWithType’s body.
-            let (net_body, stream) = body_with_type.into_net_request_body();
+            let (net_body, stream) = body_with_type.into_net_request_body(cx);
             r.body_stream.set(Some(&*stream));
             init_body = Some(net_body);
         }

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -1023,7 +1023,7 @@ impl HTMLFormElement {
         let request_body = bytes
             .extract(cx, &global, false)
             .expect("Couldn't extract body.")
-            .into_net_request_body()
+            .into_net_request_body(cx)
             .0;
         load_data.data = Some(request_body);
 

--- a/components/script/dom/navigator/navigator.rs
+++ b/components/script/dom/navigator/navigator.rs
@@ -584,7 +584,7 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
                     HeaderValue::from_str(&content_type.str()).unwrap(),
                 );
             }
-            request_body = Some(extracted_body.into_net_request_body().0);
+            request_body = Some(extracted_body.into_net_request_body(cx).0);
         }
         // Step 7.1. Let req be a new request, initialized as follows:
         let request = RequestBuilder::new(

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -1482,15 +1482,12 @@ impl ReadableByteStreamController {
         underlying_source.in_memory()
     }
 
-    pub(crate) fn get_in_memory_bytes(&self) -> Option<Vec<u8>> {
+    pub(crate) fn get_in_memory_bytes(&self, cx: &mut JSContext) -> Option<Vec<u8>> {
         let underlying_source = self.underlying_source.get()?;
         if !underlying_source.in_memory() {
             return None;
         }
 
-        // TODO: https://github.com/servo/servo/issues/45963
-        #[expect(unsafe_code)]
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
         self.queue.borrow().iter().try_fold(
             Vec::with_capacity(self.queue_total_size.get() as usize),
             |mut bytes, entry| {
@@ -1498,7 +1495,7 @@ impl ReadableByteStreamController {
                 entry
                     .buffer
                     .copy_data_to(
-                        &mut cx,
+                        cx,
                         &mut chunk,
                         entry.byte_offset,
                         entry.byte_offset + entry.byte_length,

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -7,9 +7,6 @@ use std::collections::VecDeque;
 use std::ptr::{self};
 use std::rc::Rc;
 
-use servo_base::generic_channel::GenericSharedMemory;
-use servo_base::id::{MessagePortId, MessagePortIndex};
-use servo_constellation_traits::MessagePortImpl;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::conversions::{FromJSValConvertible, ToJSValConvertible};
@@ -22,6 +19,9 @@ use js::rust::{
 };
 use js::typedarray::{ArrayBufferViewU8, Uint8};
 use rustc_hash::FxHashMap;
+use servo_base::generic_channel::GenericSharedMemory;
+use servo_base::id::{MessagePortId, MessagePortIndex};
+use servo_constellation_traits::MessagePortImpl;
 
 use crate::dom::bindings::codegen::Bindings::QueuingStrategyBinding::QueuingStrategy;
 use crate::dom::bindings::codegen::Bindings::ReadableStreamBinding::{
@@ -68,8 +68,8 @@ use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::bindings::transferable::Transferable;
 use crate::dom::bindings::structuredclone::StructuredData;
 
-use crate::dom::bindings::buffer_source::{BufferSource, HeapBufferSource, create_buffer_source};
 use super::readablestreambyobreader::ReadIntoRequest;
+use crate::dom::bindings::buffer_source::{BufferSource, HeapBufferSource, create_buffer_source};
 
 /// State Machine for `PipeTo`.
 #[derive(Clone, Debug, Default, MallocSizeOf, PartialEq)]
@@ -1265,7 +1265,7 @@ impl ReadableStream {
 
     /// Return bytes for synchronous use, if the stream has all data in memory.
     /// Useful for native source integration only.
-    pub(crate) fn get_in_memory_bytes(&self) -> Option<GenericSharedMemory> {
+    pub(crate) fn get_in_memory_bytes(&self, cx: &mut JSContext) -> Option<GenericSharedMemory> {
         match self.controller.borrow().as_ref() {
             Some(ControllerType::Default(controller)) => controller
                 .get()
@@ -1275,7 +1275,7 @@ impl ReadableStream {
             Some(ControllerType::Byte(controller)) => controller
                 .get()
                 .expect("Stream should have controller.")
-                .get_in_memory_bytes()
+                .get_in_memory_bytes(cx)
                 .map(GenericSharedMemory::from_vec),
             _ => unreachable!("Getting in-memory bytes for a stream without a controller"),
         }

--- a/components/script/dom/xmlhttprequest/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest/xmlhttprequest.rs
@@ -714,7 +714,7 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
         .headers((*self.request_headers.borrow()).clone())
         .unsafe_request(true)
         // XXXManishearth figure out how to avoid this clone
-        .body(extracted_or_serialized.map(|e| e.into_net_request_body().0))
+        .body(extracted_or_serialized.map(|e| e.into_net_request_body(cx).0))
         .synchronous(self.sync.get())
         .mode(RequestMode::CorsMode)
         .use_cors_preflight(self.upload_listener.get())


### PR DESCRIPTION
As the title says. This removes a section of unsafe code from the mentioned function.

Testing: Existing tests should cover this functionality
Fixes: #45963 
