### PR TITLE
script: Align `lookup_custom_element_definition` according to specs

### DIFF
--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -1165,8 +1165,21 @@ pub(crate) fn try_upgrade_element(cx: &JSContext, element: &Element) {
     // Step 1. Let definition be the result of looking up a custom element
     // definition given element's custom element registry, element's namespace,
     // element's local name, and element's is value.
+    let lookup_registry = {
+        // TODO: Remove this fallback when Node::adopt is aligned according to specs.
+        //       Currently elements carry stale global registry from another document.
+        let registry = element.custom_element_registry();
+        if registry
+            .as_ref()
+            .is_some_and(|registry| registry.is_scoped())
+        {
+            registry
+        } else {
+            element.owner_document().custom_element_registry()
+        }
+    };
     if let Some(definition) = CustomElementRegistry::lookup_custom_element_definition(
-        element.custom_element_registry().as_deref(),
+        lookup_registry.as_deref(),
         element.namespace(),
         element.local_name(),
         element.get_is().as_ref(),

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -138,24 +138,9 @@ impl CustomElementRegistry {
         self.when_defined.borrow_mut().0.clear()
     }
 
-    /// <https://html.spec.whatwg.org/multipage/#look-up-a-custom-element-definition>
-    pub(crate) fn lookup_definition(
-        &self,
-        local_name: &LocalName,
-        is: Option<&LocalName>,
-    ) -> Option<Rc<CustomElementDefinition>> {
-        self.definitions
-            .borrow()
-            .0
-            .values()
-            .find(|definition| {
-                // Step 4-5
-                definition.local_name == *local_name &&
-                    (definition.name == *local_name || Some(&definition.name) == is)
-            })
-            .cloned()
-    }
-
+    /// <https://html.spec.whatwg.org/multipage/#htmlconstructor>
+    /// Step 5. Let definition be the item in registry's custom element
+    /// definition set with constructor equal to NewTarget.
     pub(crate) fn lookup_definition_by_constructor(
         &self,
         constructor: HandleObject,
@@ -191,6 +176,40 @@ impl CustomElementRegistry {
             // Step 4. Return null.
             _ => None,
         }
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#look-up-a-custom-element-definition>
+    pub(crate) fn lookup_custom_element_definition(
+        registry: Option<&CustomElementRegistry>,
+        namespace: &Namespace,
+        local_name: &LocalName,
+        is: Option<&LocalName>,
+    ) -> Option<Rc<CustomElementDefinition>> {
+        // Step 1. If registry is null, then return null.
+        let registry = registry?;
+
+        // Step 2. If namespace is not the HTML namespace, then return null.
+        if *namespace != ns!(html) {
+            return None;
+        }
+
+        // Step 3. If registry's custom element definition set contains an item
+        // with name and local name both equal to localName, then return that
+        // item.
+        // Step 4. If registry's custom element definition set contains an item
+        // with name equal to is and local name equal to localName, then return
+        // that item.
+        // Step 5. Return null.
+        registry
+            .definitions
+            .borrow()
+            .0
+            .values()
+            .find(|definition| {
+                definition.local_name == *local_name &&
+                    (definition.name == *local_name || Some(&definition.name) == is)
+            })
+            .cloned()
     }
 
     /// <https://dom.spec.whatwg.org/#is-a-global-custom-element-registry>
@@ -1143,17 +1162,17 @@ fn run_upgrade_constructor(
 
 /// <https://html.spec.whatwg.org/multipage/#concept-try-upgrade>
 pub(crate) fn try_upgrade_element(cx: &JSContext, element: &Element) {
-    // Step 1. Let definition be the result of looking up a custom element definition given element's node document,
-    // element's namespace, element's local name, and element's is value.
-    let document = element.owner_document();
-    let namespace = element.namespace();
-    let local_name = element.local_name();
-    let is = element.get_is();
-    if let Some(definition) =
-        document.lookup_custom_element_definition(namespace, local_name, is.as_ref())
-    {
-        // Step 2. If definition is not null, then enqueue a custom element upgrade reaction given
-        // element and definition.
+    // Step 1. Let definition be the result of looking up a custom element
+    // definition given element's custom element registry, element's namespace,
+    // element's local name, and element's is value.
+    if let Some(definition) = CustomElementRegistry::lookup_custom_element_definition(
+        element.custom_element_registry().as_deref(),
+        element.namespace(),
+        element.local_name(),
+        element.get_is().as_ref(),
+    ) {
+        // Step 2. If definition is not null, then enqueue a custom element
+        // upgrade reaction given element and definition.
         ScriptThread::enqueue_upgrade_reaction(cx, element, definition);
     }
 }

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -25,7 +25,7 @@ use embedder_traits::{
     AllowOrDeny, AnimationState, CustomHandlersAutomationMode, EmbedderMsg, Image, LoadStatus,
 };
 use encoding_rs::{Encoding, UTF_8};
-use html5ever::{LocalName, Namespace, QualName, local_name, ns};
+use html5ever::{LocalName, QualName, local_name, ns};
 use hyper_serde::Serde;
 use indexmap::IndexSet;
 use js::context::{JSContext, NoGC};
@@ -129,9 +129,7 @@ use crate::dom::compositionevent::CompositionEvent;
 use crate::dom::css::cssstylesheet::CSSStyleSheet;
 use crate::dom::css::fontfaceset::FontFaceSet;
 use crate::dom::css::stylesheetlist::{StyleSheetList, StyleSheetListOwner};
-use crate::dom::customelementregistry::{
-    CustomElementDefinition, CustomElementReactionStack, CustomElementRegistry,
-};
+use crate::dom::customelementregistry::{CustomElementReactionStack, CustomElementRegistry};
 use crate::dom::customevent::CustomEvent;
 use crate::dom::document::accessibility_data::AccessibilityData;
 use crate::dom::document::focus::{DocumentFocusHandler, FocusableArea};
@@ -2940,29 +2938,6 @@ impl Document {
     /// <https://html.spec.whatwg.org/multipage/#cookie-averse-document-object>
     pub(crate) fn is_cookie_averse(&self) -> bool {
         !self.has_browsing_context || !url_has_network_scheme(&self.url())
-    }
-
-    /// <https://html.spec.whatwg.org/multipage/#look-up-a-custom-element-definition>
-    pub(crate) fn lookup_custom_element_definition(
-        &self,
-        namespace: &Namespace,
-        local_name: &LocalName,
-        is: Option<&LocalName>,
-    ) -> Option<Rc<CustomElementDefinition>> {
-        // Step 1
-        if *namespace != ns!(html) {
-            return None;
-        }
-
-        // Step 2
-        if !self.has_browsing_context {
-            return None;
-        }
-
-        // Step 3
-        let registry = self.custom_element_registry()?;
-
-        registry.lookup_definition(local_name, is)
     }
 
     pub(crate) fn custom_element_registry(&self) -> Option<DomRoot<CustomElementRegistry>> {

--- a/components/script/dom/element/create.rs
+++ b/components/script/dom/element/create.rs
@@ -135,8 +135,13 @@ fn create_html_element(
     let registry = CustomElementRegistry::lookup_a_custom_element_registry(document.upcast());
 
     // Step 3. Let definition be the result of looking up a custom element
-    // definition given document, namespace, localName, and is.
-    let definition = document.lookup_custom_element_definition(&name.ns, &name.local, is.as_ref());
+    // definition given registry, namespace, localName, and is.
+    let definition = CustomElementRegistry::lookup_custom_element_definition(
+        registry.as_deref(),
+        &name.ns,
+        &name.local,
+        is.as_ref(),
+    );
 
     // Step 4. If definition is non-null...
     if let Some(definition) = definition {

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -721,11 +721,21 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         }
 
         // Step 2: Let definition be the result of looking up a custom element definition
-        // Note: the element can pass this check without yet being a custom
-        // element, as long as there is a registered definition
-        // that could upgrade it to one later.
+        let lookup_registry = {
+            // TODO: Remove this fallback when Node::adopt is aligned according to specs.
+            //       Currently elements carry stale global registry from another document.
+            let registry = self.as_element().custom_element_registry();
+            if registry
+                .as_ref()
+                .is_some_and(|registry| registry.is_scoped())
+            {
+                registry
+            } else {
+                self.upcast::<Node>().owner_doc().custom_element_registry()
+            }
+        };
         let definition = CustomElementRegistry::lookup_custom_element_definition(
-            self.as_element().custom_element_registry().as_deref(),
+            lookup_registry.as_deref(),
             self.upcast::<Element>().namespace(),
             self.as_element().local_name(),
             None,

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -36,7 +36,9 @@ use crate::dom::characterdata::CharacterData;
 use crate::dom::css::cssstyledeclaration::{
     CSSModificationAccess, CSSStyleDeclaration, CSSStyleOwner,
 };
-use crate::dom::customelementregistry::{CallbackReaction, CustomElementState};
+use crate::dom::customelementregistry::{
+    CallbackReaction, CustomElementRegistry, CustomElementState,
+};
 use crate::dom::document::Document;
 use crate::dom::document::focus::FocusableArea;
 use crate::dom::document_event_handler::character_to_code;
@@ -722,8 +724,12 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         // Note: the element can pass this check without yet being a custom
         // element, as long as there is a registered definition
         // that could upgrade it to one later.
-        let registry = self.owner_window().CustomElements(cx);
-        let definition = registry.lookup_definition(self.as_element().local_name(), None);
+        let definition = CustomElementRegistry::lookup_custom_element_definition(
+            self.as_element().custom_element_registry().as_deref(),
+            self.upcast::<Element>().namespace(),
+            self.as_element().local_name(),
+            None,
+        );
 
         // Step 3: If definition is null, then throw an "NotSupportedError" DOMException
         let definition = match definition {

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -65,7 +65,7 @@ use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::characterdata::CharacterData;
 use crate::dom::comment::Comment;
 use crate::dom::csp::{Violation, parse_csp_list_from_metadata};
-use crate::dom::customelementregistry::CustomElementReactionStack;
+use crate::dom::customelementregistry::{CustomElementReactionStack, CustomElementRegistry};
 use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLDocument};
 use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::documenttype::DocumentType;
@@ -2079,7 +2079,12 @@ fn create_element_for_token(
 
     // Step 7. Let definition be the result of looking up a custom element definition
     // given registry, namespace, localName, and is.
-    let definition = document.lookup_custom_element_definition(&name.ns, &name.local, is.as_ref());
+    let definition = CustomElementRegistry::lookup_custom_element_definition(
+        document.custom_element_registry().as_deref(),
+        &name.ns,
+        &name.local,
+        is.as_ref(),
+    );
 
     // Step 8. Let willExecuteScript be true if definition is non-null and the parser was
     // not created as part of the HTML fragment parsing algorithm; otherwise false.

--- a/tests/wpt/meta/custom-elements/registries/pseudo-class-defined.window.js.ini
+++ b/tests/wpt/meta/custom-elements/registries/pseudo-class-defined.window.js.ini
@@ -1,4 +1,5 @@
 [pseudo-class-defined.window.html]
+  expected: ERROR
   ["uncustomized" :defined doesn't care about your registry']
     expected: FAIL
 


### PR DESCRIPTION
Align `lookup_custom_element_definition` according to specs

Testing: 
Fixes: Part of https://github.com/servo/servo/issues/45603
