### PR TITLE
mach: Add necessary space between command-line arguments `windows.py` and handle GStreamer failed installation

### DIFF
--- a/python/servo/platform/windows.py
+++ b/python/servo/platform/windows.py
@@ -166,8 +166,8 @@ class Windows(Base):
         root = self.gstreamer_root(target)
         if root is None:
             return False
-        # The runtime may be present without the development files, so also make
-        # sure that the pkg-config files have been installed.
+        # In the case of a failed installation, the runtime may be present without the development
+        # files, so also make sure that the pkg-config files have been installed.
         return os.path.exists(os.path.join(root, "lib", "pkgconfig", "gobject-2.0.pc"))
 
     def _platform_bootstrap_gstreamer(self, target: BuildTarget, force: bool, yes: bool) -> bool:

--- a/python/servo/platform/windows.py
+++ b/python/servo/platform/windows.py
@@ -163,7 +163,12 @@ class Windows(Base):
         return None
 
     def is_gstreamer_installed(self, target: BuildTarget) -> bool:
-        return self.gstreamer_root(target) is not None
+        root = self.gstreamer_root(target)
+        if root is None:
+            return False
+        # The runtime may be present without the development files, so also make
+        # sure that the pkg-config files have been installed.
+        return os.path.exists(os.path.join(root, "lib", "pkgconfig", "gobject-2.0.pc"))
 
     def _platform_bootstrap_gstreamer(self, target: BuildTarget, force: bool, yes: bool) -> bool:
         if not force and self.is_gstreamer_installed(target):
@@ -186,7 +191,7 @@ class Windows(Base):
             for installer in [libs_msi, devel_msi]:
                 arguments = [
                     "/a",
-                    f'"{installer}"TARGETDIR="{DEPENDENCIES_DIR}"',  # Install destination
+                    f'"{installer} "TARGETDIR="{DEPENDENCIES_DIR}"',  # Install destination
                     "/qn",  # Quiet mode
                 ]
                 quoted_arguments = ",".join((f"'{arg}'" for arg in arguments))


### PR DESCRIPTION
In `windows.py` there was no space between `....msi"` and `TARGETDIR`; and instead they were joined into a single string. `msiexec` treats this entire string as the path to the MSI file and attempts to open it. At the same time, the issue where the "is gstreamer installed" check only looked for `ffi-7.dll` (the runtime), preventing the installation of the devel package if the runtime package was already present—has been fixed.

Testing: This part of the Servo bootstrap does not really have testing coverage.
Fixes: None
