### PR TITLE
script: Do not trigger restyles on light tree children not in the flat tree

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -80,6 +80,7 @@ use url::{Host, Position};
 
 use crate::animations::Animations;
 use crate::document_loader::{DocumentLoader, LoadType};
+use crate::dom::FlatTreeParent;
 use crate::dom::animationtimeline::AnimationTimeline;
 use crate::dom::attr::Attr;
 use crate::dom::beforeunloadevent::BeforeUnloadEvent;
@@ -779,8 +780,9 @@ impl Document {
         }
 
         let parent = match node.parent_in_flat_tree() {
-            Some(parent) => parent,
-            None => {
+            FlatTreeParent::Parent(parent) => parent,
+            FlatTreeParent::NotInFlatTree => return,
+            FlatTreeParent::RootNode => {
                 // There is no parent so this is the Document node, so we
                 // behave as if we were called with the document element.
                 let Some(document_element) = self.GetDocumentElement() else {

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -867,10 +867,13 @@ impl Document {
             }
         }
 
+        // Find the new dirty root. If `Node::common_ancestors_in_flat_tree` returns `None`, this
+        // means that the old dirty root is no longer part of the flat tree and `element` is the new
+        // dirty root.
         let new_dirty_root = element
             .upcast::<Node>()
             .common_ancestor_in_flat_tree(dirty_root.upcast())
-            .expect("Couldn't find common ancestor");
+            .unwrap_or_else(|| DomRoot::from_ref(element.upcast()));
 
         let mut has_dirty_descendants = true;
         for ancestor in dirty_root

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -524,20 +524,15 @@ impl DocumentEventHandler {
 
         // We need to create a target chain in case the event target shares
         // its boundaries with its ancestors.
-        let mut targets = vec![];
-        let mut current = Some(event_target);
-        while let Some(node) = current {
-            if node == common_ancestor {
-                break;
-            }
-            current = node.parent_in_flat_tree();
-            targets.push(node);
-        }
+        let mut targets: Vec<_> = event_target
+            .inclusive_ancestors_in_flat_tree()
+            .take_while(|node| *node != common_ancestor)
+            .collect();
 
         // The order for dispatching mouseenter/pointerenter events starts from the topmost
         // common ancestor of the event target and the related target.
         if event_type == FireMouseEventType::Enter {
-            targets = targets.into_iter().rev().collect();
+            targets.reverse();
         }
 
         let pointer_event_name = match event_type {
@@ -2359,13 +2354,10 @@ impl DocumentEventHandler {
         input_event: &ConstellationInputEvent,
         hit_test_result: &HitTestResult,
     ) {
-        // Collect ancestors from target to root
-        let mut targets: Vec<DomRoot<Node>> = vec![];
-        let mut current: Option<DomRoot<Node>> = Some(DomRoot::from_ref(target_element.upcast()));
-        while let Some(node) = current {
-            targets.push(DomRoot::from_ref(&*node));
-            current = node.parent_in_flat_tree();
-        }
+        let mut targets: Vec<_> = target_element
+            .upcast::<Node>()
+            .inclusive_ancestors_in_flat_tree()
+            .collect();
 
         // Reverse to dispatch from topmost ancestor to target
         if event_name == "pointerenter" {

--- a/components/script/dom/html/htmlbuttonelement.rs
+++ b/components/script/dom/html/htmlbuttonelement.rs
@@ -15,6 +15,7 @@ use script_bindings::codegen::GenericBindings::NodeBinding::NodeMethods;
 use style::selector_parser::PseudoElement;
 use stylo_dom::ElementState;
 
+use crate::dom::FlatTreeParent;
 use crate::dom::activation::Activatable;
 use crate::dom::bindings::codegen::Bindings::HTMLButtonElementBinding::HTMLButtonElementMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::GetRootNodeOptions;
@@ -524,7 +525,8 @@ impl Activatable for HTMLButtonElement {
         // Adhoc, this step is needed so that file inputs button activates the input.
         if let Some(pseudo_element) = self.upcast::<Node>().implemented_pseudo_element() {
             if pseudo_element == PseudoElement::FileSelectorButton {
-                let Some(parent) = self.upcast::<Node>().parent_in_flat_tree() else {
+                let FlatTreeParent::Parent(parent) = self.upcast::<Node>().parent_in_flat_tree()
+                else {
                     return;
                 };
 

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -2067,29 +2067,52 @@ impl Node {
 
     /// Gets the parent of this node from the perspective of layout and style.
     ///
-    /// The returned node is the node's assigned slot, if any, or the
-    /// shadow host if it's a shadow root. Otherwise, it is the node's
-    /// parent.
-    pub(crate) fn parent_in_flat_tree(&self) -> Option<DomRoot<Node>> {
+    /// If the node and its parent have a flat tree relationship, this returns:
+    ///  - The node's assigned slot.
+    ///  - The parent node's shadow host if it's a shadow root.
+    ///  - Or the node's parent.
+    ///
+    /// The parent might not have a flat tree relationship with the node if
+    ///  - It's a light tree child of a shadow host.
+    ///  - It's fallback content for an assigned slot.
+    pub(crate) fn parent_in_flat_tree(&self) -> FlatTreeParent {
         if let Some(assigned_slot) = self.assigned_slot() {
-            return Some(DomRoot::upcast(assigned_slot));
+            return FlatTreeParent::Parent(DomRoot::upcast(assigned_slot));
         }
 
-        let parent_or_none = self.GetParentNode();
-        if let Some(parent) = parent_or_none.as_deref() &&
-            let Some(shadow_root) = parent.downcast::<ShadowRoot>()
+        let Some(parent) = self.GetParentNode() else {
+            return FlatTreeParent::RootNode;
+        };
+
+        if let Some(shadow_root) = parent.downcast::<ShadowRoot>() {
+            return FlatTreeParent::Parent(DomRoot::from_ref(shadow_root.Host().upcast::<Node>()));
+        }
+
+        if parent
+            .downcast::<Element>()
+            .is_some_and(|element| element.is_shadow_host())
         {
-            return Some(DomRoot::from_ref(shadow_root.Host().upcast::<Node>()));
+            return FlatTreeParent::NotInFlatTree;
         }
 
-        parent_or_none
+        if parent
+            .downcast::<HTMLSlotElement>()
+            .is_some_and(|slot| slot.has_assigned_nodes())
+        {
+            return FlatTreeParent::NotInFlatTree;
+        }
+
+        FlatTreeParent::Parent(parent)
     }
 
     pub(crate) fn inclusive_ancestors_in_flat_tree(
         &self,
     ) -> impl Iterator<Item = DomRoot<Node>> + use<> {
-        SimpleNodeIterator::new(Some(DomRoot::from_ref(self)), move |n| {
-            n.parent_in_flat_tree()
+        SimpleNodeIterator::new(Some(DomRoot::from_ref(self)), move |node| {
+            match node.parent_in_flat_tree() {
+                FlatTreeParent::Parent(parent) => Some(parent),
+                FlatTreeParent::NotInFlatTree | FlatTreeParent::RootNode => None,
+            }
         })
     }
 
@@ -4344,4 +4367,15 @@ where
 
         self.insert(insertion_index, Dom::from_ref(node));
     }
+}
+
+/// The return value of [`Node::parent_in_flat_tree`].
+pub(crate) enum FlatTreeParent {
+    /// The parent in the flat tree.
+    Parent(DomRoot<Node>),
+    /// This node has a parent (it's not the root), but it does not share a flat tree
+    /// relationship with its parent.
+    NotInFlatTree,
+    /// This node is in the flat tree, but has no parent node.
+    RootNode,
 }

--- a/tests/wpt/tests/shadow-dom/shadow-host-child-restyle-crash.html
+++ b/tests/wpt/tests/shadow-dom/shadow-host-child-restyle-crash.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/46149">
+<script>
+function main() {
+  option.dir = "rtl";
+  window.pageYOffset;
+  dialog.close();
+  window.pageYOffset;
+  host.attachShadow({mode: "open"});
+}
+</script>
+
+<body onload="main()">
+<dialog id="dialog" open="">
+    <select>
+        <option id="option" style="display: contents">
+            <div id="host">
+        </option>
+    </select>
+</dialog>


### PR DESCRIPTION
A light child may not be in the flat tree if its parent node is a shadow
host with an attached shadow DOM or if its parent is a `<slot>` element
with a slotted node (fallback slot content). In that case,
`parent_in_flat_tree` should not return a node as the node itself is not
actually in the flat tree.

This change makes it so that the return value of `parent_in_flat_tree`
can distinguish that case from the success case and also from the case
that the input `Node` is the root node.

This prevents the script thread from recording a restyle on a node
that is not in the flat tree when it's style changes. This was causing
Stylo to look at this node and try to restyle it.

Testing: This change adds a WPT crash test.
Fixes:  #46149.
Fixes: #46024.
