### PR TITLE
deny: Allow some `quick-xml` advistories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -35,6 +35,16 @@ ignore = [
     # This is a dependency of `usvg`, `rustybuzz`, `fontdb`.
     # We will need to wait for upstream actions.
     "RUSTSEC-2026-0192",
+    # Vulnerability in `quick-xml`: Quadratic run time when checking a start
+    # tag for duplicate attribute names.
+    #
+    # We must use this version of quick-xml until `winit` upgrades `sctk`.
+    "RUSTSEC-2026-0194",
+    # Vulnerability in `quick-xml`: Unbounded namespace-declaration allocation
+    # in `NsReader` enables memory-exhaustion denial of service.
+    #
+    # We must use this version of quick-xml until `winit` upgrades `sctk`.
+    "RUSTSEC-2026-0195",
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
We are unfortunately stuck with the version of `quick-xml` that we are
using until we can upgrade the version of `winit` that we are using.

Testing: This change unblocks the CI, which is a kind of test.
