### PR TITLE
script: Make `IframeCollection::set_viewport_details` resilient to missing `<iframe>`s

### DIFF
--- a/components/script/iframe_collection.rs
+++ b/components/script/iframe_collection.rs
@@ -101,15 +101,15 @@ impl IFrameCollection {
 
     /// Set the size of an `<iframe>` in the collection given its `BrowsingContextId` and
     /// the new size. Returns the old size.
-    pub(crate) fn set_viewport_details(
+    fn set_viewport_details(
         &mut self,
         browsing_context_id: BrowsingContextId,
         new_size: ViewportDetails,
     ) -> Option<ViewportDetails> {
+        // Top-level document destruction can destroy an entire tree of frames, which
+        // means that the the `<iframe>` we are targeting at this moment might not exist.
         self.get_mut(browsing_context_id)
-            .expect("Tried to set a size for an unknown <iframe>")
-            .size
-            .replace(new_size)
+            .and_then(|iframe| iframe.size.replace(new_size))
     }
 
     /// Update the recorded iframe sizes of the contents of layout. Return a


### PR DESCRIPTION
Destroying a `Document` also destroys all of its descendent `<iframe>`s
in the `IFrameCollection` which can mean a subsequent layout tries to
target a now missing `<iframe>`. This change makes the code resilient to
this happening.

This can be triggered by calling `window.close()` on a top-level window
with `<iframe>`s.

Testing: This fixes an issue that is very timing dependent, so it is difficult
to make a test for this.
Fixes: #46146.
