### PR TITLE
script: Immediately root permissions descriptor objects

### DIFF
--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use js::gc::HandleValue;
 use script_bindings::reflector::{DomObject, reflect_dom_object_with_cx};
 use servo_base::generic_channel::{GenericCallback, GenericSender};
 use servo_bluetooth_traits::{BluetoothError, BluetoothRequest, GATTType};
@@ -38,8 +39,6 @@ use crate::dom::promise::Promise;
 use crate::task::TaskOnce;
 use dom_struct::dom_struct;
 use js::conversions::ConversionResult;
-use js::jsapi::JSObject;
-use js::jsval::{ObjectValue, UndefinedValue};
 use profile_traits::{generic_channel};
 use std::collections::HashMap;
 use std::ffi::CStr;
@@ -621,13 +620,9 @@ impl PermissionAlgorithm for Bluetooth {
 
     fn create_descriptor(
         cx: &mut JSContext,
-        permission_descriptor_obj: *mut JSObject,
+        permission_descriptor_obj: HandleValue,
     ) -> Result<BluetoothPermissionDescriptor, Error> {
-        rooted!(&in(cx) let mut property = UndefinedValue());
-        property
-            .handle_mut()
-            .set(ObjectValue(permission_descriptor_obj));
-        match BluetoothPermissionDescriptor::new(cx, property.handle()) {
+        match BluetoothPermissionDescriptor::new(cx, permission_descriptor_obj) {
             Ok(ConversionResult::Success(descriptor)) => Ok(descriptor),
             Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
             Err(_) => Err(Error::Type(BT_DESC_CONVERSION_ERROR.into())),

--- a/components/script/dom/permission/permissions.rs
+++ b/components/script/dom/permission/permissions.rs
@@ -41,7 +41,7 @@ pub(crate) trait PermissionAlgorithm {
     type Status;
     fn create_descriptor(
         cx: &mut JSContext,
-        permission_descriptor_obj: *mut JSObject,
+        permission_descriptor_obj: js::gc::HandleValue,
     ) -> Result<Self::Descriptor, Error>;
     fn permission_query(
         cx: &mut JSContext,
@@ -91,6 +91,11 @@ impl Permissions {
         permission_desc: *mut JSObject,
         promise: Option<Rc<Promise>>,
     ) -> Rc<Promise> {
+        rooted!(&in(cx) let mut permission_desc_value = UndefinedValue());
+        permission_desc_value
+            .handle_mut()
+            .set(ObjectValue(permission_desc));
+
         // (Query, Request) Step 3.
         let p = match promise {
             Some(promise) => promise,
@@ -98,7 +103,7 @@ impl Permissions {
         };
 
         // (Query, Request, Revoke) Step 1.
-        let root_desc = match Permissions::create_descriptor(cx, permission_desc) {
+        let root_desc = match Permissions::create_descriptor(cx, permission_desc_value.handle()) {
             Ok(descriptor) => descriptor,
             Err(error) => {
                 p.reject_error(cx, error);
@@ -113,13 +118,14 @@ impl Permissions {
         match root_desc.name {
             #[cfg(feature = "bluetooth")]
             PermissionName::Bluetooth => {
-                let bluetooth_desc = match Bluetooth::create_descriptor(cx, permission_desc) {
-                    Ok(descriptor) => descriptor,
-                    Err(error) => {
-                        p.reject_error(cx, error);
-                        return p;
-                    },
-                };
+                let bluetooth_desc =
+                    match Bluetooth::create_descriptor(cx, permission_desc_value.handle()) {
+                        Ok(descriptor) => descriptor,
+                        Err(error) => {
+                            p.reject_error(cx, error);
+                            return p;
+                        },
+                    };
 
                 // (Query, Request) Step 5.
                 let result = BluetoothPermissionResult::new(cx, &self.global(), &status);
@@ -191,6 +197,7 @@ impl Permissions {
     }
 }
 
+// Currently these methods use Raw *mut JSObject which is potentially dangerous. We root this object immediately in `self.manipulate`.
 impl PermissionsMethods<crate::DomTypeHolder> for Permissions {
     /// <https://w3c.github.io/permissions/#dom-permissions-query>
     fn Query(&self, cx: &mut CurrentRealm, permission_desc: *mut JSObject) -> Rc<Promise> {
@@ -214,13 +221,9 @@ impl PermissionAlgorithm for Permissions {
 
     fn create_descriptor(
         cx: &mut JSContext,
-        permission_descriptor_obj: *mut JSObject,
+        property: js::gc::HandleValue,
     ) -> Result<PermissionDescriptor, Error> {
-        rooted!(&in(cx) let mut property = UndefinedValue());
-        property
-            .handle_mut()
-            .set(ObjectValue(permission_descriptor_obj));
-        match PermissionDescriptor::new(cx, property.handle()) {
+        match PermissionDescriptor::new(cx, property) {
             Ok(ConversionResult::Success(descriptor)) => Ok(descriptor),
             Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
             Err(_) => Err(Error::JSFailed),


### PR DESCRIPTION
We immediately root the object before doing any other work and to hopefully prevent the crashes. While this is technically a workaround, it does not add any major technical debt as anybody changes the argument from the codegen will see the rooted handle and can modify it.

This fixes the crash in #45933, but not the underlying issue in #46019.

Testing: Rooting does not change behavior so additional tests are not necessary.
Fixes: #45933
