### PR TITLE
mach: Fix confusing servo_binary arg on android / ohos

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -602,10 +602,19 @@ class CommandBase(object):
 
                 if binary_selection:
                     if "servo_binary" not in kwargs:
-                        kwargs["servo_binary"] = kwargs.get("bin") or self.get_binary_path(
-                            cast(BuildType, kwargs.get("build_type")),
-                            sanitizer=cast(SanitizerKind, kwargs.get("sanitizer")),
-                        )
+                        # For packaged targets (Android, OpenHarmony) the binary is not important,
+                        # since we can't run it directly. We could return the shared library object,
+                        # but that doesn't seem very useful.
+                        if self.target.needs_packaging():
+                            if kwargs.get("bin") is not None:
+                                print(f"`--bin` cannot be used with the '{self.target.triple()}' target.")
+                                sys.exit(1)
+                            kwargs["servo_binary"] = None
+                        else:
+                            kwargs["servo_binary"] = kwargs.get("bin") or self.get_binary_path(
+                                cast(BuildType, kwargs.get("build_type")),
+                                sanitizer=cast(SanitizerKind, kwargs.get("sanitizer")),
+                            )
                     kwargs.pop("bin")
                     kwargs.pop("nightly")
                     if not build_type:
@@ -624,6 +633,7 @@ class CommandBase(object):
 
     @staticmethod
     def allow_target_configuration(original_function: Callable) -> Callable:
+        @functools.wraps(original_function)
         def target_configuration_decorator(self: CommandBase, *args: Any, **kwargs: Any) -> Callable:
             self.configure_build_target(kwargs, suppress_log=True)
             kwargs.pop("target", False)

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -73,7 +73,7 @@ class PostBuildCommands(CommandBase):
     @CommandArgument("--headless", "-z", action="store_true", help="Launch in headless mode")
     @CommandArgument("--software", "-s", action="store_true", help="Launch with software rendering")
     @CommandArgument("params", nargs="...", help="Command-line arguments to be passed through to Servo")
-    # Keep `allow_target_configuration` above `common_command_arguments - binary_selection requires the target
+    # Keep `allow_target_configuration` above `common_command_arguments` - `binary_selection` requires the target
     # to be configured already!
     @CommandBase.allow_target_configuration
     @CommandBase.common_command_arguments(binary_selection=True)

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -73,11 +73,13 @@ class PostBuildCommands(CommandBase):
     @CommandArgument("--headless", "-z", action="store_true", help="Launch in headless mode")
     @CommandArgument("--software", "-s", action="store_true", help="Launch with software rendering")
     @CommandArgument("params", nargs="...", help="Command-line arguments to be passed through to Servo")
-    @CommandBase.common_command_arguments(binary_selection=True)
+    # Keep `allow_target_configuration` above `common_command_arguments - binary_selection requires the target
+    # to be configured already!
     @CommandBase.allow_target_configuration
+    @CommandBase.common_command_arguments(binary_selection=True)
     def run(
         self,
-        servo_binary: str,
+        servo_binary: Optional[str],
         params: list[str],
         debugger: bool = False,
         debugger_cmd: str | None = None,
@@ -90,7 +92,7 @@ class PostBuildCommands(CommandBase):
 
     def _run(
         self,
-        servo_binary: str,
+        servo_binary: Optional[str],
         params: list[str],
         debugger: bool = False,
         debugger_cmd: str | None = None,
@@ -148,6 +150,8 @@ class PostBuildCommands(CommandBase):
             shell.communicate(("\n".join(script) + "\n").encode())
             return shell.wait()
 
+        # `servo_binary` is only `None` for packaged targets, which are handled above.
+        assert servo_binary is not None
         args = [servo_binary]
 
         if headless:

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -36,6 +36,7 @@ from mach.decorators import (
 import servo.devtools_tests
 import servo.try_parser
 from servo.command_base import BuildType, CommandBase, call, check_call
+from servo.platform.build_target import CrossBuildTarget
 from servo.post_build_commands import PostBuildCommands
 from servo.util import delete
 
@@ -465,8 +466,13 @@ class MachCommands(CommandBase):
         action="store_true",
         help="Update test expectations after test run",
     )
+    # Keep `allow_target_configuration` above `common_command_arguments`: binary_selection requires the
+    # target to be configured already.
+    @CommandBase.allow_target_configuration
     @CommandBase.common_command_arguments(binary_selection=True)
-    def test_wpt(self, servo_binary: str, multiprocess: bool, update_expectations: bool, **kwargs: Any) -> int:
+    def test_wpt(
+        self, servo_binary: Optional[str], multiprocess: bool, update_expectations: bool, **kwargs: Any
+    ) -> int:
         if update_expectations:
             if kwargs["log_raw"]:
                 print("Do not specify --log-raw when updating tests directly")
@@ -474,7 +480,12 @@ class MachCommands(CommandBase):
             with tempfile.TemporaryDirectory() as temp_dir:
                 kwargs["log_raw"] = [os.path.join(temp_dir, "wpt.log")]
 
-        test_return_value = self._test_wpt(servo_binary, multiprocess, **kwargs)
+        if isinstance(self.target, CrossBuildTarget):
+            print("test-wpt doesn't support any cross build targets (yet).")
+            return 1
+        else:
+            assert servo_binary is not None, "servo_binary should only be none on Android / OpenHarmony"
+            test_return_value = self._test_wpt(servo_binary, multiprocess, **kwargs)
 
         # We should only update when the tests actually failed. In any other case
         # such as incorrect command parameters, we shouldn't run the update command.
@@ -488,7 +499,6 @@ class MachCommands(CommandBase):
 
     @CommandBase.allow_target_configuration
     def _test_wpt(self, servo_binary: str, multiprocess: bool, **kwargs: Any) -> int:
-        # TODO(mrobinson): Why do we pass the wrong binary path in when running WPT on Android?
         return_value = wpt.run.run_tests(servo_binary, multiprocess, **kwargs)
         return return_value if not kwargs["always_succeed"] else 0
 

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -480,7 +480,7 @@ class MachCommands(CommandBase):
             with tempfile.TemporaryDirectory() as temp_dir:
                 kwargs["log_raw"] = [os.path.join(temp_dir, "wpt.log")]
 
-        if isinstance(self.target, CrossBuildTarget):
+        if self.target.is_cross_build():
             print("test-wpt doesn't support any cross build targets (yet).")
             return 1
         else:

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -36,7 +36,6 @@ from mach.decorators import (
 import servo.devtools_tests
 import servo.try_parser
 from servo.command_base import BuildType, CommandBase, call, check_call
-from servo.platform.build_target import CrossBuildTarget
 from servo.post_build_commands import PostBuildCommands
 from servo.util import delete
 


### PR DESCRIPTION
In commands which support both `binary_selection` and cross target selection (--target, --android, --ohos), previously `binary_selection` would run before the target could be configured, meaning it would select a host binary and cause an error if no host binary is found. 
That mainly affects the `run` command, but in follow-ups `smoketest` for android will be fixed and test-wpt for ohos is also i progress, so it makes sense to fix this interaction. 

The binary itself isn't really useful, and the actual work done in run, smoketest or test-wpt is quite different, due to the "install package and then run" model. Hence we set the binary to `None` on such cross targets. I also considered renaming to `binary_or_package`, but on ohos the package path depends on `--flavor` and then things start getting complicated in the decorator. Since the actual implementation will anyway branch based on android / ohos, this seems like the most straight forward way, and fixes the error that the `./mach run --android` can exit 1 if no host binary in the matching profile was built.

Testing: mach itself is not covered by automated tests 
Fixes: #35316
