### PR TITLE
devtools: keep object actor identity stable across grips

### DIFF
--- a/components/default-resources/resources/debugger.js
+++ b/components/default-resources/resources/debugger.js
@@ -7,6 +7,7 @@ const debuggeesToPipelineIds = new Map;
 const debuggeesToWorkerIds = new Map;
 const sourceIdsToScripts = new Map;
 const frameActorsToFrames = new Map;
+const objectActorsToObjects = new Map;
 const environmentActorsToEnvironments = new Map;
 const environmentsToEnvironmentActors = new Map;
 const blackboxing = new Map;
@@ -112,6 +113,7 @@ function createValueGrip(value, depth) {
             }
             // TODO: handle typed arrays and storage independently
             const ownPropertyLength = value.getOwnPropertyNamesLength();
+            let objectActorId = findKeyByValue(objectActorsToObjects, value);
             const objectValue = {
                 class: value.class,
                 ownPropertyLength: Number.isFinite(ownPropertyLength) ? ownPropertyLength : undefined,
@@ -119,9 +121,21 @@ function createValueGrip(value, depth) {
             // Debugger.Object - get preview using registered previewers
             // <https://firefox-source-docs.mozilla.org/devtools-user/debugger-api/debugger.object/index.html>
             const preview = getPreview(value, depth + 1);
-            if (preview) {
-                objectValue.preview = preview;
+            if (!preview) {
+                // Reusing an actor with a stored preview can cause recursion, we should handle it properly at some point.
+                return { ObjectValue: objectValue };
             }
+            objectValue.preview = preview;
+
+            if (!objectActorId) {
+                objectActorId = registerObjectActor(JSON.stringify({ ObjectValue: objectValue }));
+                if (!objectActorId) {
+                    console.error("[debugger] Couldn't create object actor");
+                    return { ObjectValue: objectValue };
+                }
+                objectActorsToObjects.set(objectActorId, value);
+            }
+            objectValue.actor = objectActorId;
             return { ObjectValue: objectValue };
         default:
             return { StringValue: String(value) };

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -4,6 +4,7 @@
 
 use std::collections::HashMap;
 
+use atomic_refcell::AtomicRefCell;
 use devtools_traits::{DebuggerValue, PropertyDescriptor};
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
@@ -124,13 +125,17 @@ impl ObjectPropertyDescriptor {
     }
 }
 
-#[derive(MallocSizeOf)]
-pub(crate) struct ObjectActor {
-    name: String,
-    _uuid: Option<String>,
+#[derive(Clone, MallocSizeOf)]
+struct ObjectActorData {
     class: String,
     own_property_length: Option<u32>,
     preview: Option<devtools_traits::ObjectPreview>,
+}
+
+#[derive(MallocSizeOf)]
+pub(crate) struct ObjectActor {
+    name: String,
+    data: AtomicRefCell<ObjectActorData>,
 }
 
 impl Actor for ObjectActor {
@@ -149,7 +154,8 @@ impl Actor for ObjectActor {
     ) -> Result<(), ActorError> {
         match msg_type {
             "enumProperties" => {
-                let properties = self.preview.as_ref().map_or_else(Vec::new, |preview| {
+                let preview = self.data.borrow().preview.clone();
+                let properties = preview.as_ref().map_or_else(Vec::new, |preview| {
                     if preview.kind == "ArrayLike" {
                         // For arrays, convert items to indexed properties
                         // <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor#description>
@@ -197,11 +203,12 @@ impl Actor for ObjectActor {
 
             "enumEntries" => {
                 let mut entries = Vec::new();
-                if let Some(preview) = &self.preview &&
-                    let Some(map_entries) = &preview.entries
+                let preview = self.data.borrow().preview.clone();
+                if let Some(preview) = preview &&
+                    let Some(map_entries) = preview.entries
                 {
                     for (key, value) in map_entries {
-                        entries.push(PropertyIteratorEntry::MapEntry(key.clone(), value.clone()));
+                        entries.push(PropertyIteratorEntry::MapEntry(key, value));
                     }
                 }
                 self.reply_property_iterator(request, registry, entries)?
@@ -255,60 +262,57 @@ impl ObjectActor {
 
     pub fn register(
         registry: &ActorRegistry,
-        uuid: Option<String>,
+        actor_name: Option<String>,
         class: String,
         own_property_length: Option<u32>,
         preview: Option<devtools_traits::ObjectPreview>,
     ) -> String {
-        let Some(uuid) = uuid else {
-            let name = new_actor_name::<Self>();
-            let actor = ObjectActor {
-                name: name.clone(),
-                _uuid: None,
-                class,
-                own_property_length,
-                preview,
-            };
-            registry.register(actor);
+        if let Some(name) = actor_name {
+            let actor = registry.find::<Self>(&name);
+            let mut data = actor.data.borrow_mut();
+
+            data.class = class;
+            data.own_property_length = own_property_length;
+
+            if preview.is_some() || data.preview.is_none() {
+                data.preview = preview;
+            }
+
             return name;
-        };
-        if !registry.script_actor_registered(&uuid) {
-            let name = new_actor_name::<Self>();
-            let actor = ObjectActor {
-                name: name.clone(),
-                _uuid: Some(uuid.clone()),
+        }
+
+        let name = new_actor_name::<Self>();
+        let actor = ObjectActor {
+            name: name.clone(),
+            data: AtomicRefCell::new(ObjectActorData {
                 class,
                 own_property_length,
                 preview,
-            };
-
-            registry.register_script_actor(uuid, name.clone());
-            registry.register(actor);
-
-            name
-        } else {
-            registry.script_to_actor(&uuid)
-        }
+            }),
+        };
+        registry.register(actor);
+        name
     }
 }
 
 impl ActorEncode<ObjectActorMsg> for ObjectActor {
     fn encode(&self, registry: &ActorRegistry) -> ObjectActorMsg {
+        let data = self.data.borrow().clone();
         let mut msg = ObjectActorMsg {
             actor: self.name().into(),
             type_: "object".into(),
-            class: self.class.clone(),
+            class: data.class.clone(),
             extensible: true,
             frozen: false,
             sealed: false,
             function: None,
             preview: None,
-            own_property_length: self.own_property_length,
+            own_property_length: data.own_property_length,
         };
 
         // Build preview
         // <https://searchfox.org/firefox-main/source/devtools/server/actors/object/previewers.js#849>
-        let Some(preview) = self.preview.clone() else {
+        let Some(preview) = data.preview.clone() else {
             return msg;
         };
 
@@ -320,7 +324,7 @@ impl ActorEncode<ObjectActorMsg> for ObjectActor {
             is_generator: function.is_generator,
         });
 
-        if self.class == "Function" {
+        if data.class == "Function" {
             msg.function = function.clone();
         }
 

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -377,6 +377,10 @@ impl DevtoolsInstance {
                     pipeline_id,
                     frame_info,
                 )) => self.handle_create_frame_actor(result_sender, pipeline_id, frame_info),
+                DevtoolsControlMsg::FromScript(ScriptToDevtoolsControlMsg::CreateObjectActor(
+                    result_sender,
+                    value,
+                )) => self.handle_create_object_actor(result_sender, value),
                 DevtoolsControlMsg::FromScript(
                     ScriptToDevtoolsControlMsg::CreateEnvironmentActor(
                         result_sender,
@@ -890,6 +894,31 @@ impl DevtoolsInstance {
         let _ = result_sender.send(frame_actor.name().into());
     }
 
+    fn handle_create_object_actor(
+        &mut self,
+        result_sender: GenericSender<String>,
+        value: DebuggerValue,
+    ) {
+        let DebuggerValue::ObjectValue {
+            actor,
+            class,
+            own_property_length,
+            preview,
+        } = value
+        else {
+            return;
+        };
+
+        let object_actor = ObjectActor::register(
+            &self.registry,
+            actor,
+            class,
+            own_property_length,
+            preview.map(|preview| *preview),
+        );
+        let _ = result_sender.send(object_actor);
+    }
+
     fn handle_create_environment_actor(
         &mut self,
         result_sender: GenericSender<String>,
@@ -1015,14 +1044,14 @@ pub(crate) fn debugger_value_to_json(registry: &ActorRegistry, value: DebuggerVa
         },
         DebuggerValue::StringValue(str) => Value::String(str),
         DebuggerValue::ObjectValue {
-            uuid,
+            actor,
             class,
             own_property_length,
             preview,
         } => {
             let object_name = ObjectActor::register(
                 registry,
-                Some(uuid),
+                actor,
                 class,
                 own_property_length,
                 preview.map(|preview| *preview),

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -211,7 +211,7 @@ fn console_argument_from_handle_value(
 
             if let Some((class, preview)) = console_object {
                 return Ok(DebuggerValue::ObjectValue {
-                    uuid: uuid::Uuid::new_v4().to_string(),
+                    actor: None,
                     class,
                     own_property_length: preview.own_properties_length,
                     preview: Some(Box::new(preview)),

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -568,6 +568,25 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
         let _ = sender.send(reply);
     }
 
+    fn RegisterObjectActor(&self, serialized_value: DOMString) -> Option<DOMString> {
+        let chan = self.upcast::<GlobalScope>().devtools_chan()?;
+        let (tx, rx) = channel::<String>().unwrap();
+
+        let value =
+            match serde_json::from_str::<devtools_traits::DebuggerValue>(&serialized_value.str()) {
+                Ok(value) => value,
+                Err(error) => {
+                    warn!("Failed to parse serialized debugger object value: {error}");
+                    return None;
+                },
+            };
+
+        let msg = ScriptToDevtoolsControlMsg::CreateObjectActor(tx, value);
+        let _ = chan.send(msg);
+
+        rx.recv().ok().map(DOMString::from)
+    }
+
     fn PauseAndRespond(
         &self,
         pipeline_id: &PipelineIdInit,

--- a/components/script_bindings/webidls/DebuggerGlobalScope.webidl
+++ b/components/script_bindings/webidls/DebuggerGlobalScope.webidl
@@ -7,6 +7,7 @@
 [Global=DebuggerGlobalScope, Exposed=DebuggerGlobalScope]
 interface DebuggerGlobalScope: GlobalScope {
     undefined notifyNewSource(NotifyNewSource args);
+    DOMString? registerObjectActor(DOMString serializedValue);
 };
 
 dictionary NotifyNewSource {

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -140,6 +140,9 @@ pub enum ScriptToDevtoolsControlMsg {
     /// Get frame information from script
     CreateFrameActor(GenericSender<String>, PipelineId, FrameInfo),
 
+    /// Get object information from script
+    CreateObjectActor(GenericSender<String>, DebuggerValue),
+
     /// Get environment information from script
     CreateEnvironmentActor(
         GenericSender<String>,
@@ -179,10 +182,6 @@ pub struct FunctionPreview {
     pub parameter_names: Vec<String>,
     pub is_async: Option<bool>,
     pub is_generator: Option<bool>,
-}
-
-fn debugger_value_uuid() -> String {
-    Uuid::new_v4().to_string()
 }
 
 struct DebuggerNumberVisitor;
@@ -235,8 +234,7 @@ pub enum DebuggerValue {
     NumberValue(#[serde(deserialize_with = "deserialize_debugger_number")] f64),
     StringValue(String),
     ObjectValue {
-        #[serde(default = "debugger_value_uuid")]
-        uuid: String,
+        actor: Option<String>,
         class: String,
         own_property_length: Option<u32>,
         preview: Option<Box<ObjectPreview>>,

--- a/python/servo/devtools_tests/test_debugger_tab.py
+++ b/python/servo/devtools_tests/test_debugger_tab.py
@@ -186,6 +186,35 @@ class TestDebuggerTab:
             assert preview["size"] == 2
             assert preview["entries"] == [["a", 1], ["b", True]]
 
+    def test_eval_reuses_object_actor(self, run_servoshell, web_server_urls):
+        run_servoshell(url=f"{web_server_urls[0]}/debugger/frame_scoped.html")
+        with Devtools.connect() as devtools:
+            console = WebConsoleActor(devtools.client, devtools.targets[0]["consoleActor"])
+            evaluation_result = Future()
+
+            def on_evaluation_result(data):
+                if not evaluation_result.done():
+                    evaluation_result.set_result(data)
+
+            devtools.client.add_event_listener(
+                console.actor_id, Events.WebConsole.EVALUATION_RESULT, on_evaluation_result
+            )
+
+            # Evaluating the same live object twice should reuse the same object actor.
+            first_result = Future()
+            evaluation_result = first_result
+            console.evaluate_js_async("testFunc")
+            first = first_result.result(2)["result"]
+
+            second_result = Future()
+            evaluation_result = second_result
+            console.evaluate_js_async("testFunc")
+            second = second_result.result(2)["result"]
+
+            assert first["type"] == "object"
+            assert first["class"] == "Function"
+            assert first["actor"] == second["actor"]
+
     def test_manual_pause(self, run_servoshell, web_server_urls):
         run_servoshell(url=f"{web_server_urls[0]}/debugger/loop.html")
         with Devtools.connect() as devtools:


### PR DESCRIPTION
Before this, each object grip had its own uuid and could create a new ObjectActor on devTools side. With this change, grips for the same live object reuse the same actor id. We also handle preview-less properties better now. Before this, it could use an existing object actor with an old preview, which was wrong and could recurse. Nested-preview needs proper handling though, but not in this change.

Testing: Added a new test
Fixes: part of #36027 
