### PR TITLE
Upgrade to WiX 7

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -142,6 +142,19 @@ jobs:
           # to the GITHUB_PATH so that it is available in subsequent steps.
           $wixBin = [System.Environment]::GetEnvironmentVariable("WIX7", "Machine")
           $wixBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Configure NuGet source for WiX
+        shell: powershell
+        run: |
+          $config = @(
+            '<?xml version="1.0" encoding="utf-8"?>'
+            '<configuration>'
+            '  <packageSources>'
+            '    <clear />'
+            '    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />'
+            '  </packageSources>'
+            '</configuration>'
+          )
+          Set-Content -Path "NuGet.config" -Value $config -Encoding ascii
       - name: Setup Python
         if: ${{ runner.environment != 'self-hosted' }}
         uses: ./.github/actions/setup-python

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -125,14 +125,14 @@ jobs:
       - name: Install Winget
         # TODO: Re-enable this condition once WiX 7 is pre-installed on the self-hosted runners.
         # if: ${{ runner.environment != 'self-hosted' }}
-        shell: pwsh
+        shell: powershell
         run: |
           Install-Module -Name Microsoft.WinGet.Client -Repository PSGallery -Force
           Repair-WinGetPackageManager -Latest -Force -AllUsers
       - name: Install WiX
         # TODO: Re-enable this condition once WiX 7 is pre-installed on the self-hosted runners.
         # if: ${{ runner.environment != 'self-hosted' }}
-        shell: pwsh
+        shell: powershell
         run: |
           winget install --silent --exact WiXToolset.WiXCLI --version 7.0.0.0 --accept-source-agreements
           # The WiX installer sets the WIX7 environment variable to the install directory, so add it

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -122,6 +122,23 @@ jobs:
           echo CCACHE=ccache >> $GITHUB_ENV
 
       # Install missing tools in a GitHub-hosted runner.
+      - name: Install Winget
+        # TODO: Re-enable this condition once WiX 7 is pre-installed on the self-hosted runners.
+        # if: ${{ runner.environment != 'self-hosted' }}
+        shell: pwsh
+        run: |
+          Install-Module -Name Microsoft.WinGet.Client -Repository PSGallery -Force
+          Repair-WinGetPackageManager -Latest -Force -AllUsers
+      - name: Install WiX
+        # TODO: Re-enable this condition once WiX 7 is pre-installed on the self-hosted runners.
+        # if: ${{ runner.environment != 'self-hosted' }}
+        shell: pwsh
+        run: |
+          winget install --silent --exact WiXToolset.WiXCLI --accept-source-agreements
+          # The WiX installer sets the WIX7 environment variable to the install directory, so add it
+          # to the GITHUB_PATH so that it is available in subsequent steps.
+          $wixBin = [System.Environment]::GetEnvironmentVariable("WIX7", "Machine")
+          $wixBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Setup Python
         if: ${{ runner.environment != 'self-hosted' }}
         uses: ./.github/actions/setup-python

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -134,7 +134,7 @@ jobs:
         # if: ${{ runner.environment != 'self-hosted' }}
         shell: pwsh
         run: |
-          winget install --silent --exact WiXToolset.WiXCLI --accept-source-agreements
+          winget install --silent --exact WiXToolset.WiXCLI --version 7.0.0.0 --accept-source-agreements
           # The WiX installer sets the WIX7 environment variable to the install directory, so add it
           # to the GITHUB_PATH so that it is available in subsequent steps.
           $wixBin = [System.Environment]::GetEnvironmentVariable("WIX7", "Machine")

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -129,6 +129,9 @@ jobs:
         run: |
           Install-Module -Name Microsoft.WinGet.Client -Repository PSGallery -Force
           Repair-WinGetPackageManager -Latest -Force -AllUsers
+        env:
+          # Authenticated requests have a higher rate limit.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install WiX
         # TODO: Re-enable this condition once WiX 7 is pre-installed on the self-hosted runners.
         # if: ${{ runner.environment != 'self-hosted' }}

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -367,28 +367,41 @@ class PackageCommands(CommandBase):
                 template.render(exe_path=target_dir, dir_to_temp=dir_to_temp, resources_path=dir_to_resources)
             )
 
-            # If the WiX installer set the WIX env var, then add it to PATH.
-            # TODO: When WIX is upgraded to v6, this won't be needed any more.
-            if "WIX" in env:
-                append_paths_to_env(env, "PATH", path.join(env["WIX"], "bin"))
+            # NOTE: `-acceptEula` below is accepting the conditions of WiX's
+            # Open Source Maintenance Fee. Servo is exempt per this clause in
+            # version 1.1 of the text, see https://github.com/wixtoolset/wix/blob/c5b1c40cd44145a24cb82349d988e7abdd0b94d5/OSMFEULA.txt
+            # > The Fee applies only to Users that use the Software as part of
+            # > revenue-generating activities and have an annual gross revenue
+            # > greater than or equal to US$10,000.
 
-            # run candle and light
+            # Create the MSI installer.
             print("Creating MSI")
             try:
                 with cd(dir_to_msi):
-                    subprocess.check_call(["candle", wxs_path])
+                    subprocess.check_call(["wix", "build", "-acceptEula", "wix7", wxs_path])
             except subprocess.CalledProcessError as e:
-                print("WiX candle exited with return value %d" % e.returncode)
-                return e.returncode
-            try:
-                wxsobj_path = "{}.wixobj".format(path.splitext(wxs_path)[0])
-                with cd(dir_to_msi):
-                    subprocess.check_call(["light", wxsobj_path])
-            except subprocess.CalledProcessError as e:
-                print("WiX light exited with return value %d" % e.returncode)
+                print("WiX build exited with return value %d" % e.returncode)
                 return e.returncode
             dir_to_installer = path.join(dir_to_msi, "Installer.msi")
             print("Packaged Servo into " + dir_to_installer)
+
+            # Register the WiX extension used by the bundle below.
+            print("Registering WiX extensions")
+            try:
+                subprocess.check_call(
+                    [
+                        "wix",
+                        "extension",
+                        "add",
+                        "-acceptEula",
+                        "wix7",
+                        "-g",
+                        "WixToolset.BootstrapperApplications.wixext",
+                    ]
+                )
+            except subprocess.CalledProcessError as e:
+                print("WiX extension add exited with return value %d" % e.returncode)
+                return e.returncode
 
             # Generate bundle with Servo installer.
             print("Creating bundle")
@@ -396,16 +409,19 @@ class PackageCommands(CommandBase):
             bundle_wxs_path = path.join(dir_to_msi, "ServoShell.wxs")
             try:
                 with cd(dir_to_msi):
-                    subprocess.check_call(["candle", bundle_wxs_path, "-ext", "WixBalExtension"])
+                    subprocess.check_call(
+                        [
+                            "wix",
+                            "build",
+                            "-acceptEula",
+                            "wix7",
+                            "-ext",
+                            "WixToolset.BootstrapperApplications.wixext",
+                            bundle_wxs_path,
+                        ]
+                    )
             except subprocess.CalledProcessError as e:
-                print("WiX candle exited with return value %d" % e.returncode)
-                return e.returncode
-            try:
-                wxsobj_path = "{}.wixobj".format(path.splitext(bundle_wxs_path)[0])
-                with cd(dir_to_msi):
-                    subprocess.check_call(["light", wxsobj_path, "-ext", "WixBalExtension"])
-            except subprocess.CalledProcessError as e:
-                print("WiX light exited with return value %d" % e.returncode)
+                print("WiX build exited with return value %d" % e.returncode)
                 return e.returncode
             print("Packaged Servo into " + path.join(dir_to_msi, "ServoShell.exe"))
 
@@ -550,7 +566,7 @@ class PackageCommands(CommandBase):
 
         replacements = {
             "ports/servoshell/platform/windows/servoshell.exe.manifest": r'assemblyIdentity[^\/>]+version="(?P<version>.*?).0\"[^\/>]*\/>',
-            "support/windows/ServoShell.wxs.mako": r'<Product(.|\n)*Version="(?P<version>.*?)".*>',
+            "support/windows/ServoShell.wxs.mako": r'<Package(.|\n)*Version="(?P<version>.*?)".*>',
             "ports/servoshell/platform/macos/Info.plist": r"<key>CFBundleShortVersionString</key>\n\s*<string>(?P<version>.*?)</string>",
             "support/android/apk/servoapp/build.gradle.kts": r'versionName\s*=\s*"(?P<version>.*?)"',
             "support/openharmony/oh-package.json5": r'"version"\s*:\s*"(?P<version>.*?)"',

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -385,23 +385,28 @@ class PackageCommands(CommandBase):
             dir_to_installer = path.join(dir_to_msi, "Installer.msi")
             print("Packaged Servo into " + dir_to_installer)
 
-            # Register the WiX extension used by the bundle below.
+            # Register the WiX extension used by the bundle below. The extension is fetched
+            # from NuGet and cached under %USERPROFILE%\.wix\extensions. Pin the version to
+            # match the WiX toolset so the cache can be pre-populated on offline runners.
             print("Registering WiX extensions")
-            try:
-                subprocess.check_call(
-                    [
-                        "wix",
-                        "extension",
-                        "add",
-                        "-acceptEula",
-                        "wix7",
-                        "-g",
-                        "WixToolset.BootstrapperApplications.wixext",
-                    ]
+            extension = "WixToolset.BootstrapperApplications.wixext/7.0.0"
+            result = subprocess.run(
+                ["wix", "extension", "add", "-acceptEula", "wix7", "-g", extension],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                # `wix extension add` fails silently (exit code 2 with no output) when the
+                # extension cannot be resolved from NuGet.
+                print(result.stdout)
+                print(result.stderr)
+                print(
+                    f"WiX extension add exited with return value {result.returncode}. "
+                    f"The extension '{extension}' could not be added to the cache, most likely "
+                    "because it could not be downloaded from NuGet. Ensure the runner can reach "
+                    "nuget.org, or pre-populate the WiX extension cache (%USERPROFILE%\\.wix\\extensions)."
                 )
-            except subprocess.CalledProcessError as e:
-                print("WiX extension add exited with return value %d" % e.returncode)
-                return e.returncode
+                return result.returncode
 
             # Generate bundle with Servo installer.
             print("Creating bundle")

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -378,7 +378,7 @@ class PackageCommands(CommandBase):
             print("Creating MSI")
             try:
                 with cd(dir_to_msi):
-                    subprocess.check_call(["wix", "build", "-acceptEula", "wix7", wxs_path])
+                    subprocess.check_call(["wix", "build", "-arch", "x64", "-acceptEula", "wix7", wxs_path])
             except subprocess.CalledProcessError as e:
                 print("WiX build exited with return value %d" % e.returncode)
                 return e.returncode

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -35,7 +35,7 @@ from servo.command_base import (
     CommandBase,
     is_windows,
 )
-from servo.util import delete, append_paths_to_env
+from servo.util import delete
 
 from python.servo.platform.build_target import SanitizerKind
 from servo.platform.build_target import is_android, is_openharmony

--- a/python/servo/platform/windows/winget.json
+++ b/python/servo/platform/windows/winget.json
@@ -13,7 +13,8 @@
                     "PackageIdentifier": "Ninja-build.Ninja"
                 },
                 {
-                    "PackageIdentifier": "WiXToolset.WiXCLI"
+                    "PackageIdentifier": "WiXToolset.WiXCLI",
+                    "Version": "7.0.0.0"
                 }
             ],
             "SourceDetails": {

--- a/python/servo/platform/windows/winget.json
+++ b/python/servo/platform/windows/winget.json
@@ -13,7 +13,7 @@
                     "PackageIdentifier": "Ninja-build.Ninja"
                 },
                 {
-                    "PackageIdentifier": "WiXToolset.WiXToolset"
+                    "PackageIdentifier": "WiXToolset.WiXCLI"
                 }
             ],
             "SourceDetails": {

--- a/support/windows/servoshell.wxs
+++ b/support/windows/servoshell.wxs
@@ -1,26 +1,26 @@
-<?xml version="1.0"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:bal="http://wixtoolset.org/schemas/v4/wxs/bal">
   <Bundle Name="ServoShell"
           Version="1.0"
           UpgradeCode="91b09c7e-6c0d-4166-b806-1dc724acf728">
 
-    <Variable Name="InstallFolder" 
-          Type="string" 
-          Value="[ProgramFiles64Folder]Servo\Servo Tech Demo" 
+    <Variable Name="InstallFolder"
+          Type="formatted"
+          Value="[ProgramFiles64Folder]Servo\Servo Tech Demo"
           bal:Overridable="yes" />
 
-    <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.HyperlinkLicense">
+    <BootstrapperApplication>
       <bal:WixStandardBootstrapperApplication
         LicenseUrl="https://www.mozilla.org/en-US/MPL/2.0/"
+        Theme="hyperlinkLicense"
         />
-    </BootstrapperApplicationRef>
+    </BootstrapperApplication>
     <Chain>
       <MsiPackage
           SourceFile="Installer.msi"
           Compressed="yes"
           DisplayName="ServoShell"
           ForcePerMachine="yes">
-          <MsiProperty Name="INSTALLDIR" Value="[InstallFolder]" />
+        <MsiProperty Name="INSTALLDIR" Value="[InstallFolder]" />
       </MsiPackage>
     </Chain>
   </Bundle>

--- a/support/windows/servoshell.wxs.mako
+++ b/support/windows/servoshell.wxs.mako
@@ -1,32 +1,24 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*"
-           Name="Servo Tech Demo"
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="Servo Tech Demo"
            Manufacturer="The Servo Authors"
            UpgradeCode="060cd15d-eab1-4614-b438-3988e3efdcf1"
            Language="1033"
            Codepage="1252"
-           Version="0.4.0">
-    <Package Id="*"
-             Keywords="Installer"
-             Description="Servo Tech Demo Installer"
-             Manufacturer="The Servo Authors"
-             InstallerVersion="200"
-             Platform="x64"
-             Languages="1033"
-             SummaryCodepage="1252"
-             Compressed="yes"/>
+           Version="0.4.0"
+           InstallerVersion="200">
+    <SummaryInformation Keywords="Installer"
+                        Description="Servo Tech Demo Installer"
+                        Manufacturer="The Servo Authors"/>
     <MajorUpgrade AllowDowngrades="yes"/>
     <Media Id="1"
            Cabinet="Servo.cab"
            EmbedCab="yes"/>
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFiles64Folder" Name="PFiles">
-        <Directory Id="Servo" Name="Servo">
-          <Directory Id="INSTALLDIR" Name="Servo Tech Demo">
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="Servo" Name="Servo">
+        <Directory Id="INSTALLDIR" Name="Servo Tech Demo">
             <Component Id="Servo"
                        Guid="95bcea71-78bb-4ec8-9766-44bc01443840"
-                       Win64="yes">
+                       Bitness="always64">
               <File Id="ServoEXE"
                     Name="servoshell.exe"
                     DiskId="1"
@@ -39,9 +31,9 @@
             ${include_directory(resources_path, "resources")}
           </Directory>
         </Directory>
-      </Directory>
+      </StandardDirectory>
 
-      <Directory Id="ProgramMenuFolder" Name="Programs">
+      <StandardDirectory Id="ProgramMenuFolder">
         <Directory Id="ProgramMenuDir" Name="Servo Tech Demo">
           <Component Id="ProgramMenuDir" Guid="e04737ce-16eb-4977-9b4c-ed2db8a5a77d">
             <RemoveFolder Id="ProgramMenuDir" On="both"/>
@@ -58,19 +50,18 @@
               Icon="servoshell.exe"/>
           </Component>
         </Directory>
-      </Directory>
-    </Directory>
+      </StandardDirectory>
 
-    <Feature Id="Complete" Level="1">
-      <ComponentRef Id="Servo"/>
-      % for c in components:
-      <ComponentRef Id="${c}"/>
-      % endfor
-      <ComponentRef Id="ProgramMenuDir"/>
-    </Feature>
+      <Feature Id="Complete" Level="1">
+        <ComponentRef Id="Servo"/>
+         % for c in components:
+         <ComponentRef Id="${c}"/>
+         % endfor
+        <ComponentRef Id="ProgramMenuDir"/>
+      </Feature>
 
-    <Icon Id="servoshell.exe" SourceFile="${windowize(exe_path)}\servoshell.exe"/>
-  </Product>
+      <Icon Id="servoshell.exe" SourceFile="${windowize(exe_path)}\servoshell.exe"/>
+    </Package>
 </Wix>
 <%!
 import os
@@ -115,7 +106,7 @@ components = []
 <Directory Id="${make_id(path.basename(d))}" Name="${n}">
   <Component Id="${make_id(path.basename(d))}"
              Guid="${uuid.uuid4()}"
-             Win64="yes">
+             Bitness="always64">
     <CreateFolder/>
     <% components.append(make_id(path.basename(d))) %>
     % for f in listfiles(d):


### PR DESCRIPTION
[WiX v3 is out of support](https://www.firegiant.com/blog/2025/2/6/wix-v3-and-wix-v4-are-no-longer-in-community-support/), so we need to update the version used to generate Servo's installer.

This change builds off the changes from #40320:
* Upgrade the wxs and mako files to the WiX v4 schema.
* Fix the packaging commands to use `wix build` instead of `candle` and `light`.

Additional changes:
* Update bootstrap and CI to install the new WiX tools (NOTE: `choco` doesn't have a package for newer WiX tools, my suggestion is to drop support for choco: #42372).
* Add the new `-acceptEula` flag (see below and comments in the code for notes about this).
* Fix the version-bump regex.

Licensing:
WiX v6+ now requires [an Open Source Maintenance Fee](https://docs.firegiant.com/wix/whatsnew/#open-source-maintenance-fee). Servo is exempt per this clause in [version 1.1 of the text](https://github.com/wixtoolset/wix/blob/c5b1c40cd44145a24cb82349d988e7abdd0b94d5/OSMFEULA.txt): 
> The Fee applies only to Users that use the Software as part of revenue-generating activities and have an annual gross revenue greater than or equal to US$10,000.

Future possibilities: 
Improvements in v5 like the [File harvesting](https://docs.firegiant.com/wix/whatsnew/#file-harvesting) addition should allow us to reduce or maybe even eliminate the mako templating and use wix builtins. 

Testing: Manual testing with `./mach package` on windows and installing the generated installer.