### PR TITLE
script: Remove dead code from `HTMLCanvasElement` & `CanvasRenderingContext2D`

### DIFF
--- a/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
@@ -9,7 +9,6 @@ use pixels::Snapshot;
 use script_bindings::reflector::{AssociatedMemory, Reflector, reflect_dom_object_with_cx};
 use servo_base::{Epoch, generic_channel};
 use servo_canvas_traits::canvas::{CanvasCommand, CanvasId};
-use servo_url::ServoUrl;
 use webrender_api::ImageKey;
 
 use super::canvas_state::CanvasState;

--- a/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
@@ -97,18 +97,6 @@ impl CanvasRenderingContext2D {
         })
     }
 
-    pub(crate) fn take_missing_image_urls(&self) -> Vec<ServoUrl> {
-        std::mem::take(&mut self.canvas_state.get_missing_image_urls().borrow_mut())
-    }
-
-    pub(crate) fn get_canvas_id(&self) -> CanvasId {
-        self.canvas_state.get_canvas_id()
-    }
-
-    pub(crate) fn send_canvas_command(&self, msg: CanvasCommand) {
-        self.canvas_state.send_canvas_command(msg)
-    }
-
     pub(crate) fn send_canvas_command_immediate(&self, msg: CanvasCommand) {
         self.canvas_state.send_canvas_command_immediate(msg)
     }

--- a/components/script/dom/canvas/2d/mod.rs
+++ b/components/script/dom/canvas/2d/mod.rs
@@ -5,7 +5,6 @@
 mod canvas_state;
 pub(crate) mod canvasgradient;
 pub(crate) mod canvaspattern;
-#[expect(dead_code)]
 pub(crate) mod canvasrenderingcontext2d;
 pub(crate) mod offscreencanvasrenderingcontext2d;
 pub(crate) mod paintrenderingcontext2d;

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -337,15 +337,6 @@ impl HTMLCanvasElement {
             })
     }
 
-    /// Gets the base WebGLRenderingContext for WebGL or WebGL 2, if exists.
-    pub(crate) fn get_base_webgl_context(&self) -> Option<DomRoot<WebGLRenderingContext>> {
-        match *self.context_mode.borrow() {
-            Some(RenderingContext::WebGL(ref context)) => Some(DomRoot::from_ref(context)),
-            Some(RenderingContext::WebGL2(ref context)) => Some(context.base_context()),
-            _ => None,
-        }
-    }
-
     #[expect(unsafe_code)]
     fn get_gl_attributes(
         cx: &mut js::context::JSContext,

--- a/components/script/dom/html/mod.rs
+++ b/components/script/dom/html/mod.rs
@@ -9,7 +9,6 @@ pub(crate) mod htmlbaseelement;
 pub(crate) mod htmlbodyelement;
 pub(crate) mod htmlbrelement;
 pub(crate) mod htmlbuttonelement;
-#[expect(dead_code)]
 pub(crate) mod htmlcanvaselement;
 pub(crate) mod htmlcollection;
 pub(crate) mod htmldataelement;


### PR DESCRIPTION
I found one piece of dead code, but those should be caught by rustc. They didn't as we expect dead_code at upper scope. Removing it exposes more. Changes made w.r.t. #40383 should probably be checked again.

Testing: No behavior change, so existing tests should suffice.