### PR TITLE
script: Remove dead code in document module

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -3203,11 +3203,6 @@ impl Document {
             .push(Dom::from_ref(resize_observer));
     }
 
-    /// Whether or not this [`Document`] has any active [`ResizeObserver`].
-    pub(crate) fn has_resize_observers(&self) -> bool {
-        !self.resize_observers.borrow().is_empty()
-    }
-
     /// <https://drafts.csswg.org/resize-observer/#gather-active-observations-h>
     /// <https://drafts.csswg.org/resize-observer/#has-active-resize-observations>
     pub(crate) fn gather_active_resize_observations_at_depth(
@@ -3602,11 +3597,6 @@ impl<'dom> LayoutDom<'dom, Document> {
         guard: &SharedRwLockReadGuard,
     ) {
         (*self.unsafe_get()).flush_shadow_root_stylesheets_if_necessary_for_layout(stylist, guard)
-    }
-
-    #[inline]
-    pub(crate) fn shadow_roots_styles_changed(self) -> bool {
-        self.unsafe_get().shadow_roots_styles_changed.get()
     }
 
     pub(crate) fn elements_with_id(self, id: &Atom) -> &[LayoutDom<'dom, Element>] {
@@ -4429,10 +4419,6 @@ impl Document {
 
     pub(crate) fn invalidate_shadow_roots_stylesheets(&self) {
         self.shadow_roots_styles_changed.set(true);
-    }
-
-    pub(crate) fn shadow_roots_styles_changed(&self) -> bool {
-        self.shadow_roots_styles_changed.get()
     }
 
     pub(crate) fn flush_shadow_root_stylesheets_if_necessary_for_layout(

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -2523,14 +2523,6 @@ impl DocumentEventHandler {
             .remove(&pointer_id);
     }
 
-    /// Get the pending pointer capture target override for a pointer.
-    pub(crate) fn get_pending_pointer_capture(&self, pointer_id: i32) -> Option<DomRoot<Element>> {
-        self.pending_pointer_capture
-            .borrow()
-            .get(&pointer_id)
-            .map(|el| DomRoot::from_ref(&**el))
-    }
-
     /// Check if an element has pointer capture for a given pointer ID.
     /// <https://w3c.github.io/pointerevents/#dom-element-haspointercapture>
     pub(crate) fn has_pointer_capture(&self, pointer_id: i32, element: &Element) -> bool {

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -240,7 +240,6 @@ pub(crate) mod datatransfer;
 pub(crate) use self::datatransfer::*;
 pub(crate) mod debugger;
 pub(crate) use self::debugger::*;
-#[expect(dead_code)]
 pub(crate) mod document;
 pub(crate) use self::document::*;
 pub(crate) mod domexception;


### PR DESCRIPTION
Follow up to #46225.
Reviewed case by case to ensure they are really dead for no reason.
Can probably do all removal for project in one sweep if preferred.

Testing: Removing dead code, covered by existing tests unless they are used in certain untested features only.
So it is eventually back to human checking.