### PR TITLE
script: Pass `&mut JSContext` to conversions

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -846,8 +846,8 @@ fn run_package_data_algorithm(
     mime_type: Vec<u8>,
 ) -> Fallible<FetchedData> {
     let mime = &*mime_type;
-    let realm = CurrentRealm::assert(cx);
-    let global = GlobalScope::from_current_realm(&realm);
+    let mut realm = CurrentRealm::assert(cx);
+    let global = GlobalScope::from_current_realm(&mut realm);
     match body_type {
         BodyType::Text => run_text_data_algorithm(bytes),
         BodyType::Json => run_json_data_algorithm(cx, bytes),

--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -38,7 +38,7 @@ use js::context::JSContext;
 pub(crate) use js::conversions::{
     ConversionBehavior, ConversionResult, FromJSValConvertible, ToJSValConvertible,
 };
-use js::jsapi::{JSContext as RawJSContext, JSObject};
+use js::jsapi::JSObject;
 use js::jsval::UndefinedValue;
 use js::rust::wrappers2::JS_GetProperty;
 use js::rust::{HandleObject, MutableHandleValue};
@@ -63,13 +63,13 @@ where
 
 /// Get a `DomRoot<T>` for a DOM object accessible from a `HandleObject`.
 pub(crate) fn root_from_handleobject<T>(
+    cx: &mut JSContext,
     obj: HandleObject,
-    cx: *mut RawJSContext,
 ) -> Result<DomRoot<T>, ()>
 where
     T: DomObject + IDLInterface,
 {
-    unsafe { root_from_object(obj.get(), cx) }
+    unsafe { root_from_object(cx, obj.get()) }
 }
 
 /// Get a property from a JS object.

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -33,7 +33,9 @@ pub(crate) use script_bindings::error::*;
 use script_bindings::root::DomRoot;
 use script_bindings::str::DOMString;
 
-use crate::dom::bindings::conversions::{ConversionResult, FromJSValConvertible, root_from_object};
+use crate::dom::bindings::conversions::{
+    ConversionResult, FromJSValConvertible, root_from_handleobject,
+};
 use crate::dom::bindings::str::USVString;
 use crate::dom::domexception::{DOMErrorName, DOMException};
 use crate::dom::globalscope::GlobalScope;
@@ -293,8 +295,7 @@ impl ErrorInfo {
     }
 
     fn from_dom_exception(cx: &mut JSContext, object: HandleObject) -> Option<ErrorInfo> {
-        let exception =
-            unsafe { root_from_object::<DOMException>(object.get(), cx.raw_cx()).ok()? };
+        let exception = root_from_handleobject::<DOMException>(cx, object).ok()?;
         let scripted_caller = unsafe { describe_scripted_caller(cx.raw_cx()) }.unwrap_or_default();
         Some(ErrorInfo {
             message: exception.stringifier().into(),

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -255,8 +255,8 @@ unsafe extern "C" fn read_callback(
 
     let sc_reader = unsafe { &mut *(closure as *mut StructuredDataReader<'_>) };
 
-    let realm = CurrentRealm::assert(cx);
-    let global = GlobalScope::from_current_realm(&realm);
+    let mut realm = CurrentRealm::assert(cx);
+    let global = GlobalScope::from_current_realm(&mut realm);
 
     for serializable in SerializableInterface::iter() {
         if tag == StructuredCloneTags::from(serializable) as u32 {
@@ -281,7 +281,7 @@ unsafe fn try_serialize<T: Serializable + IDLInterface>(
     w: *mut JSStructuredCloneWriter,
     writer: &mut StructuredDataWriter,
 ) -> Result<bool, OperationError> {
-    let object = unsafe { root_from_object::<T>(*object, cx.raw_cx()) };
+    let object = unsafe { root_from_object::<T>(cx, *object) };
     if let Ok(obj) = object {
         return unsafe { Ok(write_object(val, global, &*obj, w, writer)) };
     }
@@ -330,8 +330,8 @@ unsafe extern "C" fn write_callback(
 
     let sc_writer = unsafe { &mut *(closure as *mut StructuredDataWriter) };
 
-    let realm = CurrentRealm::assert(cx);
-    let global = GlobalScope::from_current_realm(&realm);
+    let mut realm = CurrentRealm::assert(cx);
+    let global = GlobalScope::from_current_realm(&mut realm);
 
     for serializable in SerializableInterface::iter() {
         let serializer = serialize_for_type(serializable);
@@ -425,13 +425,13 @@ unsafe extern "C" fn read_transfer_callback(
             NonNull::new(cx).expect("JSContext pointer should not be null in SM hook"),
         )
     };
-    let mut cx = CurrentRealm::assert(&mut cx);
-    let owner = GlobalScope::from_current_realm(&cx);
+    let mut realm = CurrentRealm::assert(&mut cx);
+    let owner = GlobalScope::from_current_realm(&mut realm);
 
     for transferrable in TransferrableInterface::iter() {
         if tag == StructuredCloneTags::from(transferrable) as u32 {
             let transfer_receiver = receiver_for_type(transferrable);
-            if transfer_receiver(&mut cx, &owner, sc_reader, extra_data, return_object).is_ok() {
+            if transfer_receiver(&mut realm, &owner, sc_reader, extra_data, return_object).is_ok() {
                 return true;
             }
         }
@@ -448,7 +448,7 @@ unsafe fn try_transfer<T: Transferable + IDLInterface>(
     ownership: *mut TransferableOwnership,
     extra_data: *mut u64,
 ) -> Result<(), OperationError> {
-    let object = unsafe { root_from_object::<T>(*obj, cx.raw_cx()) };
+    let object = unsafe { root_from_object::<T>(cx, *obj) };
     let Ok(object) = object else {
         return Err(OperationError::InterfaceDoesNotMatch);
     };
@@ -563,7 +563,7 @@ unsafe fn can_transfer_for_type(
         cx: &mut JSContext,
         obj: RawHandleObject,
     ) -> Result<bool, ()> {
-        unsafe { root_from_object::<T>(*obj, cx.raw_cx()).map(|o| Transferable::can_transfer(&*o)) }
+        unsafe { root_from_object::<T>(cx, *obj).map(|o| Transferable::can_transfer(&*o)) }
     }
 
     unsafe {
@@ -871,8 +871,7 @@ pub(crate) fn read(
 
         let mut message_ports = vec![];
         for reflector in sc_reader.roots.iter() {
-            let Ok(message_port) = root_from_object::<MessagePort>(reflector.get(), cx.raw_cx())
-            else {
+            let Ok(message_port) = root_from_object::<MessagePort>(cx, reflector.get()) else {
                 continue;
             };
             message_ports.push(message_port);

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -26,17 +26,15 @@ use embedder_traits::{
 use fonts::FontContext;
 use indexmap::IndexSet;
 use ipc_channel::router::ROUTER;
-use js::context::NoGC;
-use js::jsapi::{
-    CurrentGlobalOrNull, GetNonCCWObjectGlobal, HandleObject, Heap, JSContext, JSObject,
-};
+use js::context::{JSContext, NoGC};
+use js::jsapi::{GetNonCCWObjectGlobal, HandleObject, Heap, JSObject};
 use js::jsval::UndefinedValue;
 use js::panic::maybe_resume_unwind;
 use js::realm::CurrentRealm;
-use js::rust::wrappers2::Compile1;
+use js::rust::wrappers2::{Compile1, CurrentGlobalOrNull};
 use js::rust::{
     CustomAutoRooter, CustomAutoRooterGuard, HandleValue, MutableHandleValue, ParentRuntime,
-    Runtime, get_object_class, transform_str_to_source_text,
+    get_object_class, transform_str_to_source_text,
 };
 use js::{JSCLASS_IS_DOMJSCLASS, JSCLASS_IS_GLOBAL};
 use net_traits::blob_url_store::BlobBuf;
@@ -2361,9 +2359,9 @@ impl GlobalScope {
     ///
     /// Eventually we could return Handle here as global is already rooted by realm.
     #[expect(unsafe_code)]
-    pub(crate) fn from_current_realm(realm: &'_ CurrentRealm) -> DomRoot<Self> {
-        let global = realm.global();
-        unsafe { global_scope_from_global(global.get(), realm.raw_cx_no_gc()) }
+    pub(crate) fn from_current_realm(realm: &'_ mut CurrentRealm) -> DomRoot<Self> {
+        let global = realm.global().get();
+        unsafe { global_scope_from_global(realm, global) }
     }
 
     pub(crate) fn add_uncaught_rejection(&self, rejection: HandleObject) {
@@ -3138,13 +3136,13 @@ impl GlobalScope {
     /// ["current"]: https://html.spec.whatwg.org/multipage/#current
     #[expect(unsafe_code)]
     pub(crate) fn current() -> Option<DomRoot<Self>> {
-        let cx = Runtime::get()?;
+        let mut cx = unsafe { JSContext::get_from_thread()? };
         unsafe {
-            let global = CurrentGlobalOrNull(cx.as_ptr());
+            let global = CurrentGlobalOrNull(&cx);
             if global.is_null() {
                 None
             } else {
-                Some(global_scope_from_global(global, cx.as_ptr()))
+                Some(global_scope_from_global(&mut cx, global))
             }
         }
     }
@@ -3568,8 +3566,8 @@ impl GlobalScope {
 /// Returns the Rust global scope from a JS global object.
 #[expect(unsafe_code)]
 unsafe fn global_scope_from_global(
+    cx: &mut js::context::JSContext,
     global: *mut JSObject,
-    cx: *mut JSContext,
 ) -> DomRoot<GlobalScope> {
     unsafe {
         assert!(!global.is_null());
@@ -3578,7 +3576,7 @@ unsafe fn global_scope_from_global(
             ((*clasp).flags & (JSCLASS_IS_DOMJSCLASS | JSCLASS_IS_GLOBAL)),
             0
         );
-        root_from_object(global, cx).unwrap()
+        root_from_object(cx, global).unwrap()
     }
 }
 
@@ -3600,7 +3598,7 @@ unsafe fn global_scope_from_global_static(global: *mut JSObject) -> DomRoot<Glob
 
 #[expect(unsafe_code)]
 impl GlobalScopeHelpers<crate::DomTypeHolder> for GlobalScope {
-    fn from_current_realm(realm: &'_ CurrentRealm) -> DomRoot<Self> {
+    fn from_current_realm(realm: &'_ mut CurrentRealm) -> DomRoot<Self> {
         GlobalScope::from_current_realm(realm)
     }
 

--- a/components/script/dom/globalscope/messageport.rs
+++ b/components/script/dom/globalscope/messageport.rs
@@ -131,7 +131,7 @@ impl MessagePort {
 
         let ports = transfer
             .iter()
-            .filter_map(|&obj| unsafe { root_from_object::<MessagePort>(obj, cx.raw_cx()).ok() });
+            .filter_map(|&obj| unsafe { root_from_object::<MessagePort>(cx, obj).ok() });
         for port in ports {
             // Step 2
             if port.message_port_id() == self.message_port_id() {

--- a/components/script/dom/promise/promise.rs
+++ b/components/script/dom/promise/promise.rs
@@ -269,7 +269,8 @@ impl Promise {
         cx: &mut CurrentRealm,
         handler: &PromiseNativeHandler,
     ) {
-        run_a_script::<DomTypeHolder, _, _>(cx, &GlobalScope::from_current_realm(cx), |cx| {
+        let global = GlobalScope::from_current_realm(cx);
+        run_a_script::<DomTypeHolder, _, _>(cx, &global, |cx| {
             rooted!(&in(cx) let resolve_func =
                 create_native_handler_function(cx,
                                                handler.reflector().get_jsobject(),
@@ -340,10 +341,9 @@ unsafe extern "C" fn native_handler_callback(
     rooted!(&in(cx) let native_handler_value = native_handler_value);
     assert!(native_handler_value.get().is_object());
 
-    let handler = unsafe {
-        root_from_object::<PromiseNativeHandler>(native_handler_value.to_object(), cx.raw_cx())
-    }
-    .expect("unexpected value for native handler in promise native handler callback");
+    let handler =
+        unsafe { root_from_object::<PromiseNativeHandler>(cx, native_handler_value.to_object()) }
+            .expect("unexpected value for native handler in promise native handler callback");
 
     let native_handler_task_value =
         unsafe { *GetFunctionNativeReserved(args.callee(), SLOT_NATIVEHANDLER_TASK) };
@@ -392,8 +392,8 @@ impl FromJSValConvertibleRc for Promise {
             return Ok(ConversionResult::Failure(c"null not allowed".into()));
         }
 
-        let realm = CurrentRealm::assert(cx);
-        let global_scope = GlobalScope::from_current_realm(&realm);
+        let mut realm = CurrentRealm::assert(cx);
+        let global_scope = GlobalScope::from_current_realm(&mut realm);
 
         let promise = Promise::new_resolved(cx, &global_scope, value);
         Ok(ConversionResult::Success(promise))

--- a/components/script/dom/serviceworker/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworker/serviceworkerglobalscope.rs
@@ -587,9 +587,9 @@ impl ServiceWorkerGlobalScope {
 unsafe extern "C" fn interrupt_callback(cx: *mut RawJSContext) -> bool {
     // SAFETY: it is safe to construct a JSContext from engine hook.
     let mut cx = unsafe { JSContext::from_ptr(std::ptr::NonNull::new(cx).unwrap()) };
-    let realm = CurrentRealm::assert(&mut cx);
+    let mut realm = CurrentRealm::assert(&mut cx);
 
-    let global = GlobalScope::from_current_realm(&realm);
+    let global = GlobalScope::from_current_realm(&mut realm);
     let worker =
         DomRoot::downcast::<WorkerGlobalScope>(global).expect("global is not a worker scope");
     assert!(worker.is::<ServiceWorkerGlobalScope>());

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -211,8 +211,8 @@ impl ServoInternalsHelpers for ServoInternals {
     /// The navigator.servo api is exposed to about: pages except about:blank, as
     /// well as any URLs provided by embedders that register new protocol handlers.
     fn is_servo_internal(cx: &mut JSContext, _global: HandleObject) -> bool {
-        let realm = CurrentRealm::assert(cx);
-        let global_scope = GlobalScope::from_current_realm(&realm);
+        let mut realm = CurrentRealm::assert(cx);
+        let global_scope = GlobalScope::from_current_realm(&mut realm);
         let url = global_scope.get_url();
         (url.scheme() == "about" && url.as_str() != "about:blank") ||
             ScriptThread::is_servo_privileged(url) ||

--- a/components/script/dom/window/windowproxy.rs
+++ b/components/script/dom/window/windowproxy.rs
@@ -18,8 +18,7 @@ use js::glue::{
 };
 use js::jsapi::{
     GCContext, Handle as RawHandle, HandleId as RawHandleId, HandleObject as RawHandleObject,
-    HandleValue as RawHandleValue, JS_DefinePropertyById, JS_ForwardGetPropertyTo,
-    JS_ForwardSetPropertyTo, JS_GetOwnPropertyDescriptorById, JS_HasPropertyById,
+    HandleValue as RawHandleValue, JS_DefinePropertyById, JS_ForwardSetPropertyTo,
     JSContext as RawJSContext, JSErrNum, JSObject, JSPROP_ENUMERATE, JSPROP_READONLY, JSTracer,
     MutableHandle as RawMutableHandle, MutableHandleObject as RawMutableHandleObject,
     MutableHandleValue as RawMutableHandleValue, ObjectOpResult, PropertyDescriptor,
@@ -27,8 +26,8 @@ use js::jsapi::{
 use js::jsval::{NullValue, PrivateValue, UndefinedValue};
 use js::realm::{AutoRealm, CurrentRealm};
 use js::rust::wrappers2::{
-    JS_HasOwnPropertyById, JS_IsExceptionPending, JS_TransplantObject, NewWindowProxy,
-    SetWindowProxy,
+    JS_ForwardGetPropertyTo, JS_GetOwnPropertyDescriptorById, JS_HasOwnPropertyById,
+    JS_HasPropertyById, JS_IsExceptionPending, JS_TransplantObject, NewWindowProxy, SetWindowProxy,
 };
 use js::rust::{Handle, MutableHandle, MutableHandleValue, get_object_class};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
@@ -958,7 +957,7 @@ fn parse_open_feature_boolean(tokenized_features: &IndexMap<String, String>, nam
 #[expect(unsafe_code)]
 #[expect(non_snake_case)]
 unsafe fn GetSubframeWindowProxy(
-    cx: *mut RawJSContext,
+    cx: &mut JSContext,
     proxy: RawHandleObject,
     id: RawHandleId,
 ) -> Option<(DomRoot<WindowProxy>, u32)> {
@@ -966,9 +965,9 @@ unsafe fn GetSubframeWindowProxy(
     if let Some(index) = index {
         let mut slot = UndefinedValue();
         unsafe { GetProxyPrivate(*proxy, &mut slot) };
-        rooted!(in(cx) let target = slot.to_object());
+        rooted!(&in(cx) let target = slot.to_object());
         let script_window_proxies = ScriptThread::window_proxies();
-        if let Ok(win) = root_from_handleobject::<Window>(target.handle(), cx) {
+        if let Ok(win) = root_from_handleobject::<Window>(cx, target.handle()) {
             let browsing_context_id = win.window_proxy().browsing_context_id();
             let (result_sender, result_receiver) = generic_channel::channel().unwrap();
 
@@ -986,7 +985,7 @@ unsafe fn GetSubframeWindowProxy(
                 .and_then(|id| script_window_proxies.find_window_proxy(id))
                 .map(|proxy| (proxy, (JSPROP_ENUMERATE | JSPROP_READONLY) as u32));
         } else if let Ok(win) =
-            root_from_handleobject::<DissimilarOriginWindow>(target.handle(), cx)
+            root_from_handleobject::<DissimilarOriginWindow>(cx, target.handle())
         {
             let browsing_context_id = win.window_proxy().browsing_context_id();
             let (result_sender, result_receiver) = generic_channel::channel().unwrap();
@@ -1018,23 +1017,26 @@ unsafe extern "C" fn get_own_property_descriptor(
     desc: RawMutableHandle<PropertyDescriptor>,
     is_none: *mut bool,
 ) -> bool {
+    let mut cx = unsafe {
+        // SAFETY: We are in SM hook
+        JSContext::from_ptr(NonNull::new(cx).expect("JSContext should not be null in SM hook"))
+    };
+    let cx = &mut cx;
     let window = unsafe { GetSubframeWindowProxy(cx, proxy, id) };
+    let desc = unsafe { MutableHandle::from_raw(desc) };
     if let Some((window, attrs)) = window {
-        rooted!(in(cx) let mut val = UndefinedValue());
-        unsafe { window.to_jsval(cx, val.handle_mut()) };
-        set_property_descriptor(
-            unsafe { MutableHandle::from_raw(desc) },
-            val.handle(),
-            attrs,
-            unsafe { &mut *is_none },
-        );
+        rooted!(&in(cx) let mut val = UndefinedValue());
+        unsafe { window.to_jsval(cx.raw_cx(), val.handle_mut()) };
+        set_property_descriptor(desc, val.handle(), attrs, unsafe { &mut *is_none });
         return true;
     }
 
     let mut slot = UndefinedValue();
     unsafe { GetProxyPrivate(proxy.get(), &mut slot) };
-    rooted!(in(cx) let target = slot.to_object());
-    unsafe { JS_GetOwnPropertyDescriptorById(cx, target.handle().into(), id, desc, is_none) }
+    rooted!(&in(cx) let target = slot.to_object());
+    unsafe {
+        JS_GetOwnPropertyDescriptorById(cx, target.handle(), Handle::from_raw(id), desc, is_none)
+    }
 }
 
 #[expect(unsafe_code)]
@@ -1069,6 +1071,11 @@ unsafe extern "C" fn has(
     id: RawHandleId,
     bp: *mut bool,
 ) -> bool {
+    let mut cx = unsafe {
+        // SAFETY: We are in SM hook
+        JSContext::from_ptr(NonNull::new(cx).expect("JSContext should not be null in SM hook"))
+    };
+    let cx = &mut cx;
     let window = unsafe { GetSubframeWindowProxy(cx, proxy, id) };
     if window.is_some() {
         unsafe { *bp = true };
@@ -1077,9 +1084,9 @@ unsafe extern "C" fn has(
 
     let mut slot = UndefinedValue();
     unsafe { GetProxyPrivate(*proxy.ptr, &mut slot) };
-    rooted!(in(cx) let target = slot.to_object());
+    rooted!(&in(cx) let target = slot.to_object());
     let mut found = false;
-    if !unsafe { JS_HasPropertyById(cx, target.handle().into(), id, &mut found) } {
+    if !unsafe { JS_HasPropertyById(cx, target.handle(), Handle::from_raw(id), &mut found) } {
         return false;
     }
 
@@ -1095,16 +1102,30 @@ unsafe extern "C" fn get(
     id: RawHandleId,
     vp: RawMutableHandleValue,
 ) -> bool {
+    let mut cx = unsafe {
+        // SAFETY: We are in SM hook
+        JSContext::from_ptr(NonNull::new(cx).expect("JSContext should not be null in SM hook"))
+    };
+    let cx = &mut cx;
     let window = unsafe { GetSubframeWindowProxy(cx, proxy, id) };
+    let vp = unsafe { MutableHandle::from_raw(vp) };
     if let Some((window, _attrs)) = window {
-        unsafe { window.to_jsval(cx, MutableHandle::from_raw(vp)) };
+        unsafe { window.to_jsval(cx.raw_cx(), vp) };
         return true;
     }
 
     let mut slot = UndefinedValue();
     unsafe { GetProxyPrivate(*proxy.ptr, &mut slot) };
-    rooted!(in(cx) let target = slot.to_object());
-    unsafe { JS_ForwardGetPropertyTo(cx, target.handle().into(), id, receiver, vp) }
+    rooted!(&in(cx) let target = slot.to_object());
+    unsafe {
+        JS_ForwardGetPropertyTo(
+            cx,
+            target.handle(),
+            Handle::from_raw(id),
+            Handle::from_raw(receiver),
+            vp,
+        )
+    }
 }
 
 #[expect(unsafe_code)]

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -1141,9 +1141,9 @@ impl WorkerGlobalScope {
 unsafe extern "C" fn interrupt_callback(cx: *mut RawJSContext) -> bool {
     // SAFETY: it is safe to construct a JSContext from engine hook.
     let mut cx = unsafe { JSContext::from_ptr(std::ptr::NonNull::new(cx).unwrap()) };
-    let realm = CurrentRealm::assert(&mut cx);
+    let mut realm = CurrentRealm::assert(&mut cx);
 
-    let global = GlobalScope::from_current_realm(&realm);
+    let global = GlobalScope::from_current_realm(&mut realm);
 
     // If we are running the debugger script, just exit immediately.
     let Some(worker) = global.downcast::<WorkerGlobalScope>() else {

--- a/components/script/indexeddb.rs
+++ b/components/script/indexeddb.rs
@@ -399,7 +399,7 @@ pub fn convert_value_to_key_range(
     if input.is_object() {
         rooted!(&in(cx) let object = input.to_object());
         unsafe {
-            if let Ok(obj) = root_from_object::<IDBKeyRange>(object.get(), cx.raw_cx()) {
+            if let Ok(obj) = root_from_object::<IDBKeyRange>(cx, object.get()) {
                 let obj = obj.inner().clone();
                 return Ok(obj);
             }

--- a/components/script/module_loading.rs
+++ b/components/script/module_loading.rs
@@ -168,8 +168,8 @@ fn inner_module_loading(
                     unsafe { jsstr_to_string(cx, std::ptr::NonNull::new(jsstr).unwrap()) };
                 let module_type = unsafe { GetRequestedModuleType(cx, module_handle, index) };
 
-                let realm = CurrentRealm::assert(cx);
-                let global = GlobalScope::from_current_realm(&realm);
+                let mut realm = CurrentRealm::assert(cx);
+                let global = GlobalScope::from_current_realm(&mut realm);
 
                 // ii. Else if module.[[LoadedModules]] contains a LoadedModuleRequest Record record
                 // such that ModuleRequestsEqual(record, request) is true, then
@@ -290,28 +290,26 @@ fn finish_loading_imported_module(
 
 /// <https://tc39.es/ecma262/#sec-ContinueDynamicImport>
 fn continue_dynamic_import(
-    cx: &mut CurrentRealm,
+    realm: &mut CurrentRealm,
     promise: Rc<Promise>,
     module_completion: Result<Rc<ModuleTree>, RethrowError>,
 ) {
     // Step 1. If moduleCompletion is an abrupt completion, then
     if let Err(exception) = module_completion {
         // a. Perform ! Call(promiseCapability.[[Reject]], undefined, « moduleCompletion.[[Value]] »).
-        promise.reject(cx, exception.handle());
+        promise.reject(realm, exception.handle());
 
         // b. Return unused.
         return;
     }
-
-    let realm = CurrentRealm::assert(cx);
-    let global = GlobalScope::from_current_realm(&realm);
+    let global = GlobalScope::from_current_realm(realm);
 
     // Step 2. Let module be moduleCompletion.[[Value]].
     let module = module_completion.unwrap();
     let record = ModuleObject::new(module.get_record().map(|module| module.handle()).unwrap());
 
     // Step 3. Let loadPromise be module.LoadRequestedModules().
-    let load_promise = load_requested_modules(cx, module, None);
+    let load_promise = load_requested_modules(realm, module, None);
 
     // Step 4. Let rejectedClosure be a new Abstract Closure with parameters (reason)
     // that captures promiseCapability and performs the following steps when called:
@@ -384,7 +382,7 @@ fn continue_dynamic_import(
         }),
     ));
 
-    let mut realm = enter_auto_realm(cx, &*global);
+    let mut realm = enter_auto_realm(realm, &*global);
     let cx = &mut realm.current_realm();
     run_a_callback::<DomTypeHolder, _>(&*global, || {
         // Step 8. Perform PerformPromiseThen(loadPromise, linkAndEvaluate, onRejected).
@@ -410,8 +408,8 @@ pub(crate) fn host_load_imported_module(
     payload: Payload,
 ) {
     // Step 1. Let settingsObject be the current settings object.
-    let realm = CurrentRealm::assert(cx);
-    let mut global_scope = GlobalScope::from_current_realm(&realm);
+    let mut realm = CurrentRealm::assert(cx);
+    let mut global_scope = GlobalScope::from_current_realm(&mut realm);
 
     // TODO Step 2. If settingsObject's global object implements WorkletGlobalScope or ServiceWorkerGlobalScope and loadState is undefined, then:
 

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -995,7 +995,7 @@ unsafe extern "C" fn HostResolveImportedModule(
     // SAFETY: it is safe to construct a JSContext from engine hook.
     let mut cx = unsafe { JSContext::from_ptr(NonNull::new(cx).unwrap()) };
     let mut realm = CurrentRealm::assert(&mut cx);
-    let global_scope = GlobalScope::from_current_realm(&realm);
+    let global_scope = GlobalScope::from_current_realm(&mut realm);
 
     let cx = &mut realm;
 
@@ -1055,8 +1055,8 @@ unsafe extern "C" fn HostPopulateImportMeta(
 ) -> bool {
     // SAFETY: it is safe to construct a JSContext from engine hook.
     let mut cx = unsafe { JSContext::from_ptr(NonNull::new(cx).unwrap()) };
-    let realm = CurrentRealm::assert(&mut cx);
-    let global_scope = GlobalScope::from_current_realm(&realm);
+    let mut realm = CurrentRealm::assert(&mut cx);
+    let global_scope = GlobalScope::from_current_realm(&mut realm);
 
     // Step 2.
     let base_url = match unsafe { module_script_from_reference_private(&reference_private) } {
@@ -1110,7 +1110,7 @@ unsafe extern "C" fn import_meta_resolve(cx: *mut RawJSContext, argc: u32, vp: *
     // SAFETY: it is safe to construct a JSContext from engine hook.
     let mut cx = unsafe { JSContext::from_ptr(ptr::NonNull::new(cx).unwrap()) };
     let mut realm = CurrentRealm::assert(&mut cx);
-    let global_scope = GlobalScope::from_current_realm(&realm);
+    let global_scope = GlobalScope::from_current_realm(&mut realm);
 
     let cx = &mut realm;
 

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -405,8 +405,8 @@ unsafe extern "C" fn enqueue_promise_job(
                 GlobalScope::from_object(incumbent_global.to_object())
             }
         } else {
-            let realm = CurrentRealm::assert(cx);
-            GlobalScope::from_current_realm(&realm)
+            let mut realm = CurrentRealm::assert(cx);
+            GlobalScope::from_current_realm(&mut realm)
         };
         let pipeline = global.pipeline_id();
         let interaction = if promise.get().is_null() {
@@ -449,7 +449,7 @@ unsafe extern "C" fn promise_rejection_tracker(
     let mut cx = unsafe { JSContext::from_ptr(NonNull::new(cx).unwrap()) };
     let mut realm = CurrentRealm::assert(&mut cx);
 
-    let global = GlobalScope::from_current_realm(&realm);
+    let global = GlobalScope::from_current_realm(&mut realm);
     let cx = &mut realm;
 
     wrap_panic(&mut || {
@@ -533,9 +533,7 @@ unsafe extern "C" fn code_for_eval_gets(
     // SAFETY: We are in SM hook
     let mut cx = unsafe { JSContext::from_ptr(NonNull::new(cx).unwrap()) };
     let cx = &mut cx;
-    if let Ok(trusted_script) =
-        unsafe { root_from_object::<TrustedScript>(code.get(), cx.raw_cx()) }
-    {
+    if let Ok(trusted_script) = unsafe { root_from_object::<TrustedScript>(cx, code.get()) } {
         let script_str = trusted_script.data().str();
         let s = js::conversions::Utf8Chars::from(&*script_str);
         let new_string = unsafe { JS_NewStringCopyUTF8N(cx, &*s as *const _) };
@@ -562,8 +560,8 @@ unsafe extern "C" fn content_security_policy_allows(
     let cx = &mut cx;
     wrap_panic(&mut || {
         // SpiderMonkey provides null pointer when executing webassembly.
-        let realm = CurrentRealm::assert(cx);
-        let global = GlobalScope::from_current_realm(&realm);
+        let mut realm = CurrentRealm::assert(cx);
+        let global = GlobalScope::from_current_realm(&mut realm);
         let csp_list = global.get_csp_list();
 
         // If we don't have any CSP checks to run, short-circuit all logic here
@@ -592,9 +590,9 @@ unsafe extern "C" fn content_security_policy_allows(
                         };
                         let value = arg.into_handle().get();
                         if value.is_object() {
-                            if let Ok(trusted_script) = unsafe {
-                                root_from_object::<TrustedScript>(value.to_object(), cx.raw_cx())
-                            } {
+                            if let Ok(trusted_script) =
+                                unsafe { root_from_object::<TrustedScript>(cx, value.to_object()) }
+                            {
                                 parameter_args_vec
                                     .push(TrustedScriptOrString::TrustedScript(trusted_script));
                             } else {
@@ -1362,12 +1360,12 @@ unsafe extern "C" fn consume_stream(
         JSContext::from_ptr(NonNull::new(cx).expect("JSContext should not be null in SM hook"))
     };
     let cx = &mut cx;
-    let realm = CurrentRealm::assert(cx);
-    let global = GlobalScope::from_current_realm(&realm);
+    let mut realm = CurrentRealm::assert(cx);
+    let global = GlobalScope::from_current_realm(&mut realm);
 
     // Step 2.1 Upon fulfillment of source, store the Response with value unwrappedSource.
     if let Ok(unwrapped_source) =
-        unsafe { root_from_handleobject::<Response>(RustHandleObject::from_raw(obj), cx.raw_cx()) }
+        unsafe { root_from_handleobject::<Response>(cx, RustHandleObject::from_raw(obj)) }
     {
         // Step 2.2 Let mimeType be the result of extracting a MIME type from response’s header list.
         let mimetype = unwrapped_source.Headers(cx).extract_mime_type();

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -410,7 +410,7 @@ fn jsval_to_webdriver_inner(
             _ => unreachable!(),
         });
 
-        if let Ok(element) = unsafe { root_from_object::<Element>(*object, cx.raw_cx()) } {
+        if let Ok(element) = unsafe { root_from_object::<Element>(cx, *object) } {
             // If the element is stale, return error with error code stale element reference.
             if is_stale(&element) {
                 Err(JavaScriptEvaluationError::SerializationError(
@@ -423,9 +423,7 @@ fn jsval_to_webdriver_inner(
                         .unique_id(element.owner_window().pipeline_id()),
                 ))
             }
-        } else if let Ok(shadow_root) =
-            unsafe { root_from_object::<ShadowRoot>(*object, cx.raw_cx()) }
-        {
+        } else if let Ok(shadow_root) = unsafe { root_from_object::<ShadowRoot>(cx, *object) } {
             // If the shadow root is detached, return error with error code detached shadow root.
             if is_detached(&shadow_root) {
                 Err(JavaScriptEvaluationError::SerializationError(
@@ -438,7 +436,7 @@ fn jsval_to_webdriver_inner(
                         .unique_id(shadow_root.owner_window().pipeline_id()),
                 ))
             }
-        } else if let Ok(window) = unsafe { root_from_object::<Window>(*object, cx.raw_cx()) } {
+        } else if let Ok(window) = unsafe { root_from_object::<Window>(cx, *object) } {
             let window_proxy = window.window_proxy();
             if window_proxy.is_browsing_context_discarded() {
                 Err(JavaScriptEvaluationError::SerializationError(

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -3283,8 +3283,8 @@ class CGConstructorEnabled(CGAbstractMethod):
         if secure:
             conditions.append("""
 {
-let realm = CurrentRealm::assert(cx);
-D::GlobalScope::from_current_realm(&realm).is_secure_context()
+let mut realm = CurrentRealm::assert(cx);
+D::GlobalScope::from_current_realm(&mut realm).is_secure_context()
 }
 """)
 
@@ -4274,7 +4274,7 @@ class CGCallGenerator(CGThing):
             if static:
                 glob = "global.upcast::<D::GlobalScope>()"
             else:
-                glob = "&D::GlobalScope::from_current_realm(&CurrentRealm::assert(cx))"
+                glob = "&D::GlobalScope::from_current_realm(&mut CurrentRealm::assert(cx))"
 
             self.cgRoot.append(CGGeneric(
                 "let result = match result {\n"

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -9,8 +9,7 @@ use js::conversions::{
 };
 use js::error::throw_type_error;
 use js::glue::{
-    GetProxyHandlerExtra, GetProxyReservedSlot, IsProxyHandlerFamily, IsWrapper,
-    JS_GetReservedSlot, UnwrapObjectDynamic,
+    GetProxyHandlerExtra, GetProxyReservedSlot, IsProxyHandlerFamily, IsWrapper, JS_GetReservedSlot,
 };
 use js::jsapi::{
     Heap, IsWindowProxy, JS_DeprecatedStringHasLatin1Chars, JS_NewStringCopyN, JSContext, JSObject,
@@ -18,6 +17,7 @@ use js::jsapi::{
 use js::jsval::{ObjectValue, StringValue, UndefinedValue};
 use js::rust::wrappers2::{
     IsArrayObject, JS_GetLatin1StringCharsAndLength, JS_GetTwoByteStringCharsAndLength,
+    UnwrapObjectDynamic,
 };
 use js::rust::{
     HandleId, HandleValue, MutableHandleValue, ToString, get_object_class, is_dom_class,
@@ -285,8 +285,8 @@ pub enum PrototypeCheck {
 #[inline]
 #[allow(clippy::result_unit_err)]
 pub unsafe fn private_from_proto_check(
+    cx: &mut js::context::JSContext,
     mut obj: *mut JSObject,
-    cx: *mut JSContext,
     proto_check: PrototypeCheck,
 ) -> Result<*const libc::c_void, ()> {
     let dom_class = get_dom_class(obj).or_else(|_| {
@@ -329,12 +329,15 @@ pub unsafe fn private_from_proto_check(
 /// obj must point to a valid, non-null JS object.
 /// cx must point to a valid, non-null JS context.
 #[allow(clippy::result_unit_err)]
-pub unsafe fn native_from_object<T>(obj: *mut JSObject, cx: *mut JSContext) -> Result<*const T, ()>
+pub unsafe fn native_from_object<T>(
+    cx: &mut js::context::JSContext,
+    obj: *mut JSObject,
+) -> Result<*const T, ()>
 where
     T: DomObject + IDLInterface,
 {
     unsafe {
-        private_from_proto_check(obj, cx, PrototypeCheck::Derive(T::derives))
+        private_from_proto_check(cx, obj, PrototypeCheck::Derive(T::derives))
             .map(|ptr| ptr as *const T)
     }
 }
@@ -350,11 +353,14 @@ where
 /// obj must point to a valid, non-null JS object.
 /// cx must point to a valid, non-null JS context.
 #[allow(clippy::result_unit_err)]
-pub unsafe fn root_from_object<T>(obj: *mut JSObject, cx: *mut JSContext) -> Result<DomRoot<T>, ()>
+pub unsafe fn root_from_object<T>(
+    cx: &mut js::context::JSContext,
+    obj: *mut JSObject,
+) -> Result<DomRoot<T>, ()>
 where
     T: DomObject + IDLInterface,
 {
-    native_from_object(obj, cx).map(|ptr| unsafe { DomRoot::from_ref(&*ptr) })
+    native_from_object(cx, obj).map(|ptr| unsafe { DomRoot::from_ref(&*ptr) })
 }
 
 /// Get a `DomRoot<T>` for a DOM object accessible from a `HandleValue`.
@@ -375,7 +381,7 @@ where
     }
     #[expect(unsafe_code)]
     unsafe {
-        root_from_object(v.get().to_object(), cx.raw_cx())
+        root_from_object(cx, v.get().to_object())
     }
 }
 
@@ -489,7 +495,7 @@ where
 
     #[expect(unsafe_code)]
     unsafe {
-        native_from_object(v.get().to_object(), cx.raw_cx())
+        native_from_object(cx, v.get().to_object())
     }
 }
 
@@ -543,22 +549,22 @@ pub fn is_array_like<D: crate::DomTypes>(
 
     unsafe {
         // TODO: HTMLAllCollection
-        if root_from_object::<D::DOMTokenList>(object, cx.raw_cx()).is_ok() {
+        if root_from_object::<D::DOMTokenList>(cx, object).is_ok() {
             return true;
         }
-        if root_from_object::<D::FileList>(object, cx.raw_cx()).is_ok() {
+        if root_from_object::<D::FileList>(cx, object).is_ok() {
             return true;
         }
-        if root_from_object::<D::HTMLCollection>(object, cx.raw_cx()).is_ok() {
+        if root_from_object::<D::HTMLCollection>(cx, object).is_ok() {
             return true;
         }
-        if root_from_object::<D::HTMLFormControlsCollection>(object, cx.raw_cx()).is_ok() {
+        if root_from_object::<D::HTMLFormControlsCollection>(cx, object).is_ok() {
             return true;
         }
-        if root_from_object::<D::HTMLOptionsCollection>(object, cx.raw_cx()).is_ok() {
+        if root_from_object::<D::HTMLOptionsCollection>(cx, object).is_ok() {
             return true;
         }
-        if root_from_object::<D::NodeList>(object, cx.raw_cx()).is_ok() {
+        if root_from_object::<D::NodeList>(cx, object).is_ok() {
             return true;
         }
     }

--- a/components/script_bindings/guard.rs
+++ b/components/script_bindings/guard.rs
@@ -72,8 +72,8 @@ pub(crate) enum Condition {
 }
 
 fn is_secure_context<D: DomTypes>(cx: &mut JSContext) -> bool {
-    let realm = CurrentRealm::assert(cx);
-    D::GlobalScope::from_current_realm(&realm).is_secure_context()
+    let mut realm = CurrentRealm::assert(cx);
+    D::GlobalScope::from_current_realm(&mut realm).is_secure_context()
 }
 
 impl Condition {

--- a/components/script_bindings/interfaces.rs
+++ b/components/script_bindings/interfaces.rs
@@ -64,7 +64,7 @@ pub trait DomHelpers<D: DomTypes> {
 /// Operations that must be invoked from the generated bindings.
 #[expect(unsafe_code)]
 pub trait GlobalScopeHelpers<D: DomTypes> {
-    fn from_current_realm(realm: &'_ CurrentRealm) -> DomRoot<D::GlobalScope>;
+    fn from_current_realm(realm: &'_ mut CurrentRealm) -> DomRoot<D::GlobalScope>;
 
     /// # Safety
     /// `obj` must point to a valid, non-null JSObject.

--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -534,8 +534,8 @@ fn ensure_cross_origin_property_holder(
 pub(crate) fn is_cross_origin_object<D: DomTypes>(cx: &mut JSContext, obj: HandleObject) -> bool {
     unsafe {
         IsWindowProxy(*obj) ||
-            native_from_object::<D::Location>(*obj, cx.raw_cx()).is_ok() ||
-            native_from_object::<D::DissimilarOriginLocation>(*obj, cx.raw_cx()).is_ok()
+            native_from_object::<D::Location>(cx, *obj).is_ok() ||
+            native_from_object::<D::DissimilarOriginLocation>(cx, *obj).is_ok()
     }
 }
 
@@ -640,7 +640,7 @@ pub(crate) fn maybe_cross_origin_get_prototype<D: DomTypes>(
     if is_platform_object_same_origin(cx, proxy) {
         let mut realm = AutoRealm::new_from_handle(cx, proxy);
         let mut realm = realm.current_realm();
-        let global = D::GlobalScope::from_current_realm(&realm);
+        let global = D::GlobalScope::from_current_realm(&mut realm);
         get_proto_object(
             &mut realm,
             global.reflector().get_jsobject(),

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -535,7 +535,7 @@ unsafe fn generic_call<D: DomTypes, const EXCEPTION_TO_REJECTION: bool>(
     });
     let depth = (*info).__bindgen_anon_3.depth as usize;
     let proto_check = PrototypeCheck::Depth { depth, proto_id };
-    let this = match private_from_proto_check(obj.get(), cx.raw_cx_no_gc(), proto_check) {
+    let this = match private_from_proto_check(cx, obj.get(), proto_check) {
         Ok(val) => val,
         Err(()) => {
             // [this_implements_operation == false]


### PR DESCRIPTION
These conversions were first taking the raw context. Now they take the mutable context, so that we can call the wrappers2 variants of the SM functions.

This uncovered an issue in the following callchain:

```
global_scope_from_global -> root_from_object -> native_from_object -> private_from_proto_check -> UnwrapObjectDynamic
```

The last one is a SM function that takes a `&mut JSContext` [1]. Hence the immutable reference used in `GlobalScope::from_current_realm` is incorrect. It turns out it does require a mutable context after all.

That's why all of the callsides of `GlobalScope::from_current_realm` now pass in the realm as mutable.

Additionally, the `Runtime.get()` is replaced in `GlobalScope::current` to `JSContext::get_from_thread`.

Part of #40600

Testing: it compiles

[1]: https://docs.rs/mozjs/latest/mozjs/rust/wrappers2/fn.UnwrapObjectDynamic.html