### PR TITLE
script: Update `<select>` shadow tree after call to setValue

### DIFF
--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -745,6 +745,8 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
 
         self.validity_state(cx)
             .perform_validation_and_update(cx, ValidationFlags::VALUE_MISSING);
+
+        self.update_shadow_tree(cx);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-selectedindex>

--- a/tests/wpt/tests/html/semantics/forms/the-select-element/select-setting-value-from-js-updates-visible-state-ref.html
+++ b/tests/wpt/tests/html/semantics/forms/the-select-element/select-setting-value-from-js-updates-visible-state-ref.html
@@ -1,0 +1,4 @@
+<select id="select">
+    <option value="20">20</option>
+    <option value="10">10</option>
+</select>

--- a/tests/wpt/tests/html/semantics/forms/the-select-element/select-setting-value-from-js-updates-visible-state.html
+++ b/tests/wpt/tests/html/semantics/forms/the-select-element/select-setting-value-from-js-updates-visible-state.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Modifying the value of a select element from JS should update the shadow tree</title>
+        <link rel="author" title="Simon Wülker" href="simon.wuelker@arcor.de">
+        <link rel="help" href="https://github.com/servo/servo/issues/46212">
+        <link rel="match" href="select-setting-value-from-js-updates-visible-state-ref.html">
+    </head>
+    <body>
+        <select id="select">
+            <option value="10">10</option>
+            <option value="20">20</option>
+        </select>
+        <script>
+            document.getElementById("select").value = "20";
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
Testing: This change adds a test
Fixes https://github.com/servo/servo/issues/46212