### PR TITLE
LTS: Update mozjs to fix windows-2022 build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5078,9 +5078,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.15.15"
+version = "0.15.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8db6d571d4113e3995670789e56338a957409e9c10be9e88e96c34814f7daca7"
+checksum = "99f453559a827f30c1a60db68d95e0149d141031f2483334682a4ffd47ebf2f1"
 dependencies = [
  "bindgen",
  "cc",
@@ -5093,9 +5093,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "140.12.0-0-lts"
+version = "140.12.0-1-lts"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea960ac2bb2b162810aa36f1f1b7fb8e27cd92a3fe9d0458b48940f24b13c19e"
+checksum = "3ad338ebb43b9faa0d8268d88d662eeda8774812c5401c1a26a50b56ab5f5a9c"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ indexmap = { version = "2.11.4", features = ["std"] }
 inventory = { version = "0.3.24" }
 ipc-channel = "0.21"
 itertools = "0.14"
-js = { package = "mozjs", version = "=0.15.15", default-features = false, features = ["libz-sys", "intl"] }
+js = { package = "mozjs", version = "=0.15.16", default-features = false, features = ["libz-sys", "intl"] }
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.12", features = ["euclid"] }
 libc = "0.2"

--- a/deny.toml
+++ b/deny.toml
@@ -43,6 +43,16 @@ ignore = [
     # This is a dependency of `usvg`, `rustybuzz`, `fontdb`.
     # We will need to wait for upstream actions.
     "RUSTSEC-2026-0192",
+    # Vulnerability in `quick-xml`: Quadratic run time when checking a start
+    # tag for duplicate attribute names.
+    #
+    # We must use this version of quick-xml until `winit` upgrades `sctk`.
+    "RUSTSEC-2026-0194",
+    # Vulnerability in `quick-xml`: Unbounded namespace-declaration allocation
+    # in `NsReader` enables memory-exhaustion denial of service.
+    #
+    # We must use this version of quick-xml until `winit` upgrades `sctk`.
+    "RUSTSEC-2026-0195",
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
This updates mozjs on the LTS branch to a version that backported the CI fix, to build the prebuilt archive on a VS-2022 runner, since the default VS version changed to VS-2026 on windows-latest, which breaks linking if you use the prebuilt archive with older VS versions.

Testing: Covered by windows CI build [mach try windows](https://github.com/jschwe/servo/actions/runs/28653056754)

