### PR TITLE
deps: Update freetype and harfbuzz

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -500,6 +500,10 @@ jobs:
           jackd -d dummy &
           pulseaudio --start
           gst-inspect-1.0 | grep Total
+      - name: Set LIBCLANG_PATH env # needed for bindgen
+        shell: bash
+        if: ${{ runner.environment != 'self-hosted' }}
+        run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV
       - name: Run Examples
         run: |
           ls components/media/examples/examples/*.rs | xargs -I{} basename  {} .rs  | grep -v params_connect | RUST_BACKTRACE=1 GST_DEBUG=3 xargs -I{} cargo run -p servo-media-examples --example {}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3666,8 +3666,8 @@ dependencies = [
 
 [[package]]
 name = "harfbuzz-sys"
-version = "0.6.1"
-source = "git+https://github.com/servo/rust-harfbuzz?rev=cd527bf7633ba3e0f06246aab07678541e080f68#cd527bf7633ba3e0f06246aab07678541e080f68"
+version = "0.7.0"
+source = "git+https://github.com/jschwe/rust-harfbuzz?branch=bump-harfbuzz-0.7#9c2a6075df7bddb5e613667d47a5ba1613a1c71b"
 dependencies = [
  "cc",
  "core-graphics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3667,13 +3667,12 @@ dependencies = [
 [[package]]
 name = "harfbuzz-sys"
 version = "0.7.0"
-source = "git+https://github.com/jschwe/rust-harfbuzz?branch=bump-harfbuzz-0.7#d41827bf01dfc701577cc3b3509281decfb2c172"
+source = "git+https://github.com/servo/rust-harfbuzz?branch=main#cd0e5b64d070c6e34e08c23e013b43d99ced6c07"
 dependencies = [
  "cc",
- "core-graphics",
- "core-text",
- "foreign-types",
  "freetype-sys",
+ "objc2-core-graphics",
+ "objc2-core-text",
  "pkg-config",
  "windows 0.62.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3667,7 +3667,8 @@ dependencies = [
 [[package]]
 name = "harfbuzz-sys"
 version = "0.7.0"
-source = "git+https://github.com/servo/rust-harfbuzz?branch=main#cd0e5b64d070c6e34e08c23e013b43d99ced6c07"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "975b6181d2b2d16236036ae09f51cc2b1cdc1506cadd1958d9c6d88a06f8a1a4"
 dependencies = [
  "cc",
  "freetype-sys",
@@ -6331,7 +6332,8 @@ checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 [[package]]
 name = "peek-poke"
 version = "0.3.0"
-source = "git+https://github.com/servo/webrender?rev=7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f#7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef60922033e31835f6cf98b9b81b58368037b71d2a81928985cd9d0b3b3171fb"
 dependencies = [
  "euclid",
  "peek-poke-derive",
@@ -6340,7 +6342,8 @@ dependencies = [
 [[package]]
 name = "peek-poke-derive"
 version = "0.3.0"
-source = "git+https://github.com/servo/webrender?rev=7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f#7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271f78bae1e699b58c180a384a2e8d78ccbb60b853e15db92339725f3a2764d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11333,8 +11336,9 @@ dependencies = [
 
 [[package]]
 name = "webrender"
-version = "0.69.0"
-source = "git+https://github.com/servo/webrender?rev=7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f#7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ede9dbc3cfb3e2c073a68e20f8fd54d9f6be8587be1c7c948e1ac51112421ef6"
 dependencies = [
  "allocator-api2",
  "bincode",
@@ -11369,8 +11373,9 @@ dependencies = [
 
 [[package]]
 name = "webrender_api"
-version = "0.69.0"
-source = "git+https://github.com/servo/webrender?rev=7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f#7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fa15766536df782680147d2ed7a2d2cebd2dc9f0f48e89c56ca39f11259d76"
 dependencies = [
  "app_units",
  "bitflags 2.13.0",
@@ -11388,8 +11393,9 @@ dependencies = [
 
 [[package]]
 name = "webrender_build"
-version = "0.69.0"
-source = "git+https://github.com/servo/webrender?rev=7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f#7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "674538885dba825ee1ddda72ade941fef81364cb843bbb0452fe7d134068ed89"
 dependencies = [
  "bitflags 2.13.0",
  "lazy_static",
@@ -12204,8 +12210,9 @@ dependencies = [
 
 [[package]]
 name = "wr_glyph_rasterizer"
-version = "0.69.0"
-source = "git+https://github.com/servo/webrender?rev=7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f#7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcda26d8788ba57a04cd75ae4a2c6da3aa8e5ab16ed1cfd5db09d0fbc04df2fb"
 dependencies = [
  "core-foundation 0.9.4",
  "core-graphics",
@@ -12230,7 +12237,8 @@ dependencies = [
 [[package]]
 name = "wr_malloc_size_of"
 version = "0.2.2"
-source = "git+https://github.com/servo/webrender?rev=7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f#7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482308b684f11723b200a32808094bb460b5ac4840903ccbcb78ad92a6354a1f"
 dependencies = [
  "app_units",
  "euclid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2831,9 +2831,9 @@ dependencies = [
 
 [[package]]
 name = "freetype"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a440748e063798e4893ceb877151e84acef9bea9a8c6800645cf3f1b3a7806e"
+checksum = "db318d6e5b1c90dd29eb4256666b3eeb5f38caf0a68f12d13d2d0793a50d0c77"
 dependencies = [
  "freetype-sys",
  "libc",
@@ -2841,12 +2841,12 @@ dependencies = [
 
 [[package]]
 name = "freetype-sys"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7edc5b9669349acfda99533e9e0bcf26a51862ab43b08ee7745c55d28eb134"
+checksum = "eab537ce43cab850c64b4cdc390ce7e4f47f877485ddc323208e268280c308ae"
 dependencies = [
  "cc",
- "libc",
+ "libz-sys",
  "pkg-config",
 ]
 
@@ -3667,8 +3667,7 @@ dependencies = [
 [[package]]
 name = "harfbuzz-sys"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb86e2fef3ba40cebffb8fa2cba811f06aa5c5fd296a4e469473e5398d166594"
+source = "git+https://github.com/servo/rust-harfbuzz?rev=cd527bf7633ba3e0f06246aab07678541e080f68#cd527bf7633ba3e0f06246aab07678541e080f68"
 dependencies = [
  "cc",
  "core-graphics",
@@ -3676,7 +3675,7 @@ dependencies = [
  "foreign-types",
  "freetype-sys",
  "pkg-config",
- "winapi",
+ "windows 0.59.0",
 ]
 
 [[package]]
@@ -6333,8 +6332,7 @@ checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 [[package]]
 name = "peek-poke"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef60922033e31835f6cf98b9b81b58368037b71d2a81928985cd9d0b3b3171fb"
+source = "git+https://github.com/servo/webrender?rev=7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f#7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f"
 dependencies = [
  "euclid",
  "peek-poke-derive",
@@ -6343,8 +6341,7 @@ dependencies = [
 [[package]]
 name = "peek-poke-derive"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271f78bae1e699b58c180a384a2e8d78ccbb60b853e15db92339725f3a2764d5"
+source = "git+https://github.com/servo/webrender?rev=7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f#7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11337,8 +11334,7 @@ dependencies = [
 [[package]]
 name = "webrender"
 version = "0.69.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384e260b5f94dd5459e58e37a4a336141ce1b91da3c3c403d579688922515731"
+source = "git+https://github.com/servo/webrender?rev=7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f#7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f"
 dependencies = [
  "allocator-api2",
  "bincode",
@@ -11374,8 +11370,7 @@ dependencies = [
 [[package]]
 name = "webrender_api"
 version = "0.69.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c9f6c3b8ea958f6c34c3eb82f46ac42dacd94e3c18c710bcd27879ade71492"
+source = "git+https://github.com/servo/webrender?rev=7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f#7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f"
 dependencies = [
  "app_units",
  "bitflags 2.13.0",
@@ -11394,8 +11389,7 @@ dependencies = [
 [[package]]
 name = "webrender_build"
 version = "0.69.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5476f637aa37fc5753921fb324cc9114cc158bfd7602382afefcd6afda4bad04"
+source = "git+https://github.com/servo/webrender?rev=7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f#7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f"
 dependencies = [
  "bitflags 2.13.0",
  "lazy_static",
@@ -11750,6 +11744,16 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
+dependencies = [
+ "windows-core 0.59.0",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -11793,11 +11797,24 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
+dependencies = [
+ "windows-implement 0.59.0",
+ "windows-interface",
+ "windows-result 0.3.4",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
+ "windows-implement 0.60.2",
  "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
@@ -11810,7 +11827,7 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
+ "windows-implement 0.60.2",
  "windows-interface",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -11837,6 +11854,17 @@ dependencies = [
  "windows-core 0.62.2",
  "windows-link 0.2.1",
  "windows-threading 0.2.1",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -11913,6 +11941,15 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
@@ -11935,7 +11972,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -11953,14 +11990,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -11988,10 +12042,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -12000,10 +12066,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -12012,10 +12090,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -12024,10 +12114,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"
@@ -12211,8 +12313,7 @@ dependencies = [
 [[package]]
 name = "wr_glyph_rasterizer"
 version = "0.69.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f35fd5520f25d3a02acc20464e53e48bb68e22ac78960f10a6fd76820e3bde2"
+source = "git+https://github.com/servo/webrender?rev=7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f#7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f"
 dependencies = [
  "core-foundation 0.9.4",
  "core-graphics",
@@ -12237,8 +12338,7 @@ dependencies = [
 [[package]]
 name = "wr_malloc_size_of"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "482308b684f11723b200a32808094bb460b5ac4840903ccbcb78ad92a6354a1f"
+source = "git+https://github.com/servo/webrender?rev=7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f#7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f"
 dependencies = [
  "app_units",
  "euclid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8452,6 +8452,7 @@ dependencies = [
  "euclid",
  "rand 0.10.2",
  "serde",
+ "servo",
  "servo-media",
  "servo-media-auto",
  "servo-media-dummy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3667,7 +3667,7 @@ dependencies = [
 [[package]]
 name = "harfbuzz-sys"
 version = "0.7.0"
-source = "git+https://github.com/jschwe/rust-harfbuzz?branch=bump-harfbuzz-0.7#9c2a6075df7bddb5e613667d47a5ba1613a1c71b"
+source = "git+https://github.com/jschwe/rust-harfbuzz?branch=bump-harfbuzz-0.7#d41827bf01dfc701577cc3b3509281decfb2c172"
 dependencies = [
  "cc",
  "core-graphics",
@@ -3675,7 +3675,7 @@ dependencies = [
  "foreign-types",
  "freetype-sys",
  "pkg-config",
- "windows 0.59.0",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -11745,16 +11745,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
-dependencies = [
- "windows-core 0.59.0",
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -11798,24 +11788,11 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
-dependencies = [
- "windows-implement 0.59.0",
- "windows-interface",
- "windows-result 0.3.4",
- "windows-strings 0.3.1",
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.2",
+ "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
@@ -11828,7 +11805,7 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
+ "windows-implement",
  "windows-interface",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -11855,17 +11832,6 @@ dependencies = [
  "windows-core 0.62.2",
  "windows-link 0.2.1",
  "windows-threading 0.2.1",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -11942,15 +11908,6 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
@@ -11973,7 +11930,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -11991,31 +11948,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -12043,22 +11983,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -12067,22 +11995,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -12091,22 +12007,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -12115,22 +12019,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ gstreamer-sys = "0.25"
 gstreamer-video = "0.25"
 gstreamer-webrtc = { version = "0.25", features = ["v1_18"] }
 half = "2"
-harfbuzz-sys = "0.7"
+harfbuzz-sys = { version = "0.7", default-features = false }
 headers = "0.4"
 hilog = "0.2.2"
 hitrace = { version = "0.2.0", features = ["api-19", "tracing-rs"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ gstreamer-sys = "0.25"
 gstreamer-video = "0.25"
 gstreamer-webrtc = { version = "0.25", features = ["v1_18"] }
 half = "2"
-harfbuzz-sys = "0.6.1"
+harfbuzz-sys = "0.7"
 headers = "0.4"
 hilog = "0.2.2"
 hitrace = { version = "0.2.0", features = ["api-19", "tracing-rs"] }
@@ -423,7 +423,7 @@ codegen-units = 1
 
 [patch.crates-io]
 # Pending crates.io releases of rust-harfbuzz and webrender with the patches
-harfbuzz-sys = { git = "https://github.com/servo/rust-harfbuzz", rev = "cd527bf7633ba3e0f06246aab07678541e080f68" }
+harfbuzz-sys = { git = "https://github.com/jschwe/rust-harfbuzz", branch = "bump-harfbuzz-0.7" }
 webrender = { git = "https://github.com/servo/webrender", rev = "7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f" }
 webrender_api = { git = "https://github.com/servo/webrender", rev = "7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f" }
 wr_malloc_size_of = { git = "https://github.com/servo/webrender", rev = "7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ euclid = "0.22"
 flate2 = "1.1"
 fontconfig_sys = { package = "yeslogic-fontconfig-sys", version = "6" }
 fontsan = "0.6.1"
-freetype-sys = "0.20"
+freetype-sys = "0.23"
 fst = "0.4"
 futures = { version = "0.3", default-features = false }
 futures-core = { version = "0.3", default-features = false }
@@ -422,6 +422,12 @@ lto = "thin"
 codegen-units = 1
 
 [patch.crates-io]
+# Pending crates.io releases of rust-harfbuzz and webrender with the patches
+harfbuzz-sys = { git = "https://github.com/servo/rust-harfbuzz", rev = "cd527bf7633ba3e0f06246aab07678541e080f68" }
+webrender = { git = "https://github.com/servo/webrender", rev = "7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f" }
+webrender_api = { git = "https://github.com/servo/webrender", rev = "7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f" }
+wr_malloc_size_of = { git = "https://github.com/servo/webrender", rev = "7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f" }
+
 # If you need to temporarily test Servo with a local fork of some upstream
 # crate, add that here. Use the form:
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -274,8 +274,8 @@ warp = "0.4.2"
 web_atoms = "0.2.4"
 webdriver = { version = "0.53.0", default-features = false }
 webpki-roots = "1.0"
-webrender = { version = "0.69", features = ["capture"] }
-webrender_api = "0.69"
+webrender = { version = "0.70", features = ["capture"] }
+webrender_api = "0.70"
 wgpu-core = "30"
 wgpu-types = "30"
 winapi = "0.3"
@@ -422,12 +422,6 @@ lto = "thin"
 codegen-units = 1
 
 [patch.crates-io]
-# Pending crates.io releases of rust-harfbuzz and webrender with the patches
-harfbuzz-sys = { git = "https://github.com/servo/rust-harfbuzz", branch = "main" }
-webrender = { git = "https://github.com/servo/webrender", rev = "7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f" }
-webrender_api = { git = "https://github.com/servo/webrender", rev = "7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f" }
-wr_malloc_size_of = { git = "https://github.com/servo/webrender", rev = "7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f" }
-
 # If you need to temporarily test Servo with a local fork of some upstream
 # crate, add that here. Use the form:
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -423,7 +423,7 @@ codegen-units = 1
 
 [patch.crates-io]
 # Pending crates.io releases of rust-harfbuzz and webrender with the patches
-harfbuzz-sys = { git = "https://github.com/jschwe/rust-harfbuzz", branch = "bump-harfbuzz-0.7" }
+harfbuzz-sys = { git = "https://github.com/servo/rust-harfbuzz", branch = "main" }
 webrender = { git = "https://github.com/servo/webrender", rev = "7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f" }
 webrender_api = { git = "https://github.com/servo/webrender", rev = "7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f" }
 wr_malloc_size_of = { git = "https://github.com/servo/webrender", rev = "7463c8fdd5e58179cbe16a2c7fd9a23c6cc17c1f" }

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -68,6 +68,7 @@ webrender_api = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 byteorder = { workspace = true }
+harfbuzz-sys = { workspace = true, features = ["coretext"] }
 objc2 = { workspace = true }
 objc2-core-foundation = { workspace = true }
 objc2-core-graphics = { workspace = true }
@@ -75,6 +76,7 @@ objc2-core-text = { workspace = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))'.dependencies]
 freetype-sys = { workspace = true }
+harfbuzz-sys = { workspace = true, features = ["freetype"] }
 servo-allocator = { workspace = true }
 
 [target.'cfg(all(any(target_os = "linux", target_os = "freebsd"), not(target_env = "ohos")))'.dependencies]
@@ -85,6 +87,7 @@ xml = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 dwrote = { workspace = true }
+harfbuzz-sys = { workspace = true, features = ["directwrite"] }
 winapi = { workspace = true }
 
 [lints.rust]

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -31,7 +31,7 @@ euclid = { workspace = true }
 fonts_traits = { workspace = true }
 fontsan = { workspace = true }
 # FIXME (#34517): macOS only needs this when building servo without `--features media-gstreamer`
-harfbuzz-sys = { workspace = true, features = ["bundled"] }
+harfbuzz-sys = { workspace = true, default-features = false, features = ["bundled"] }
 icu_locid = { workspace = true }
 icu_properties = { workspace = true, features = ["compiled_data"] }
 itertools = { workspace = true }

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -16,6 +16,11 @@ test = true
 doctest = false
 
 [features]
+# Compile FreeType from source (freetype-sys/bundled) instead of searching
+# via pkg-config. If this feature is disabled, and pkg-config fails to find a
+# suitable freetype version, the build will fail!
+# Only affects targets where freetype-sys is a dependency (Linux/Android/OHOS)
+bundled_freetype = ["freetype-sys/bundled"]
 tracing = ["dep:tracing"]
 
 [dependencies]

--- a/components/fonts/platform/freetype/freetype_face.rs
+++ b/components/fonts/platform/freetype/freetype_face.rs
@@ -187,7 +187,7 @@ impl FreeTypeFace {
         variations: &[FontVariation],
         library: &FreeTypeLibraryHandle,
     ) -> Result<Vec<FontVariation>, &'static str> {
-        if !FT_HAS_MULTIPLE_MASTERS(self.as_ptr()) ||
+        if !unsafe { FT_HAS_MULTIPLE_MASTERS(self.as_ptr()) } ||
             variations.is_empty() ||
             !servo_config::pref!(layout_variable_fonts_enabled)
         {

--- a/components/media/examples/Cargo.toml
+++ b/components/media/examples/Cargo.toml
@@ -13,6 +13,7 @@ description.workspace = true
 euclid = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
+servo = { workspace = true, features = ["bundled_freetype"]}
 servo-media = { workspace = true }
 servo-media-auto = { workspace = true }
 servo-media-dummy = { workspace = true }

--- a/components/media/examples/Cargo.toml
+++ b/components/media/examples/Cargo.toml
@@ -13,7 +13,7 @@ description.workspace = true
 euclid = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
-servo = { workspace = true, features = ["bundled_freetype"]}
+servo = { workspace = true, default-features = true }
 servo-media = { workspace = true }
 servo-media-auto = { workspace = true }
 servo-media-dummy = { workspace = true }

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["rlib"]
 [features]
 # Note: Servoshell does not use the default features of servo, so you also
 # need to add features that should be default to ports/servoshell/Cargo.toml
-default = ["baked-in-resources", "clipboard", "js_jit"]
+default = ["baked-in-resources", "bundled_freetype", "clipboard", "js_jit"]
 background_hang_monitor = ["servo-background-hang-monitor/sampler"]
 # This is slightly magical, but this will also work on ohos, where `servo-default-resource` is not added,
 # which makes `baked-in-resources a no-op (as intended) on ohos (and perhaps other platforms in the future).
@@ -31,6 +31,7 @@ bluetooth = [
     "script/bluetooth",
     "script_traits/bluetooth",
 ]
+bundled_freetype = ["fonts/bundled_freetype"]
 clipboard = ["dep:arboard"]
 crown = ["script/crown"]
 debugmozjs = ["script/debugmozjs"]

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -25,7 +25,7 @@ libc = { workspace = true }
 log = { workspace = true }
 # TODO: We need 'baked-in-resources' as the `inventory` based `ResourceReader`
 # doesn't work when libservo is a cdylib.
-servo = { workspace = true, features = ["js_jit", "baked-in-resources"] }
+servo = { workspace = true, features = ["js_jit", "baked-in-resources", "bundled_freetype"] }
 url = { workspace = true }
 
 # TODO: ANGLE is needed on Windows to provide libEGL.dll and libGLESv2.dll

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -41,8 +41,9 @@ OriginalFilename = "servoshell.exe"
 ProductName = "ServoShell"
 
 [features]
-default = ["baked-in-resources", "gamepad", "servo/clipboard", "js_jit", "max_log_level", "webgpu", "webxr"]
+default = ["baked-in-resources", "bundled_freetype", "gamepad", "servo/clipboard", "js_jit", "max_log_level", "webgpu", "webxr"]
 baked-in-resources = ["servo/baked-in-resources"]
+bundled_freetype = ["servo/bundled_freetype"]
 crown = ["servo/crown"]
 debugmozjs = ["servo/debugmozjs"]
 gamepad = ["servo/gamepad"]

--- a/tests/wpt/meta/css/css-fonts/font-variant-emoji-005.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-variant-emoji-005.html.ini
@@ -1,0 +1,2 @@
+[font-variant-emoji-005.html]
+  expected: FAIL


### PR DESCRIPTION
Updates freetype-sys to 0.23, and harfbuzz-sys to 0.7 (which bumps harfbuzz from 8.4 to 11.2.0).
We need to add a new `bundled_freetype` feature, due to https://github.com/PistonDevelopers/freetype-sys/pull/128, which
removed the automatic fallback to compiling from source.
For harfbuzz-sys, we now only enable the platform specific required features per platform. Previously e.g. the windows port would still compile freetype, since the feature was selected, even though its not required.

We have one new fail (/css/css-fonts/font-variant-emoji-005.html), but we don't support that feature yet, so we can ignore it.

Testing: Covered by existing tests. 
Fixes: #39245