### PR TITLE
script: JSContextify fetch, elementinteral/servointernal and webrtc

### DIFF
--- a/components/script/dom/customstateset.rs
+++ b/components/script/dom/customstateset.rs
@@ -4,12 +4,12 @@
 
 use dom_struct::dom_struct;
 use indexmap::IndexSet;
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::ElementInternalsBinding::CustomStateSetMethods;
 use script_bindings::like::Setlike;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use script_bindings::root::{Dom, DomRoot};
-use script_bindings::script_runtime::CanGc;
 use script_bindings::str::DOMString;
 use script_bindings::trace::CustomTraceable;
 
@@ -35,8 +35,8 @@ impl CustomStateSet {
         }
     }
 
-    pub(crate) fn new(window: &Window, element: &HTMLElement, can_gc: CanGc) -> DomRoot<Self> {
-        reflect_dom_object(Box::new(Self::new_inherited(element)), window, can_gc)
+    pub(crate) fn new(cx: &mut JSContext, window: &Window, element: &HTMLElement) -> DomRoot<Self> {
+        reflect_dom_object_with_cx(Box::new(Self::new_inherited(element)), window, cx)
     }
 
     /// Returns a borrowed version of the set without the usual Ref wrapper.

--- a/components/script/dom/elementinternals.rs
+++ b/components/script/dom/elementinternals.rs
@@ -395,12 +395,12 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-elementinternals-states>
-    fn States(&self, can_gc: CanGc) -> DomRoot<CustomStateSet> {
+    fn States(&self, cx: &mut JSContext) -> DomRoot<CustomStateSet> {
         self.states.or_init(|| {
             CustomStateSet::new(
+                cx,
                 &self.target_element.owner_window(),
                 &self.target_element,
-                can_gc,
             )
         })
     }

--- a/components/script/dom/fetch/fetchlaterresult.rs
+++ b/components/script/dom/fetch/fetchlaterresult.rs
@@ -3,14 +3,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use js::context::JSContext;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
 use crate::dom::bindings::codegen::Bindings::FetchLaterResultBinding::FetchLaterResultMethods;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::window::Window;
 use crate::fetch::DeferredFetchRecordId;
-use crate::script_runtime::CanGc;
 
 /// <https://fetch.spec.whatwg.org/#fetchlaterresult>
 #[dom_struct]
@@ -31,14 +31,14 @@ impl FetchLaterResult {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         deferred_record_id: DeferredFetchRecordId,
-        can_gc: CanGc,
     ) -> DomRoot<FetchLaterResult> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(FetchLaterResult::new_inherited(deferred_record_id)),
             window,
-            can_gc,
+            cx,
         )
     }
 }

--- a/components/script/dom/fetch/headers.rs
+++ b/components/script/dom/fetch/headers.rs
@@ -17,7 +17,7 @@ use net_traits::request::is_cors_safelisted_request_header;
 use net_traits::trim_http_whitespace;
 use script_bindings::cell::DomRefCell;
 use script_bindings::cformat;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 
 use crate::dom::bindings::codegen::Bindings::HeadersBinding::{HeadersInit, HeadersMethods};
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
@@ -25,7 +25,6 @@ use crate::dom::bindings::iterable::Iterable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::{ByteString, is_token};
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct Headers {
@@ -54,16 +53,16 @@ impl Headers {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<Headers> {
-        Self::new_with_proto(global, None, can_gc)
+    pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<Headers> {
+        Self::new_with_proto(cx, global, None)
     }
 
     fn new_with_proto(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<Headers> {
-        reflect_dom_object_with_proto(Box::new(Headers::new_inherited()), global, proto, can_gc)
+        reflect_dom_object_with_proto_and_cx(Box::new(Headers::new_inherited()), global, proto, cx)
     }
 }
 
@@ -75,7 +74,7 @@ impl HeadersMethods<crate::DomTypeHolder> for Headers {
         proto: Option<HandleObject>,
         init: Option<HeadersInit>,
     ) -> Fallible<DomRoot<Headers>> {
-        let dom_headers_new = Headers::new_with_proto(global, proto, CanGc::from_cx(cx));
+        let dom_headers_new = Headers::new_with_proto(cx, global, proto);
         dom_headers_new.fill(init)?;
         Ok(dom_headers_new)
     }
@@ -287,14 +286,14 @@ impl Headers {
         }
     }
 
-    pub(crate) fn for_request(global: &GlobalScope, can_gc: CanGc) -> DomRoot<Headers> {
-        let headers_for_request = Headers::new(global, can_gc);
+    pub(crate) fn for_request(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<Headers> {
+        let headers_for_request = Headers::new(cx, global);
         headers_for_request.guard.set(Guard::Request);
         headers_for_request
     }
 
-    pub(crate) fn for_response(global: &GlobalScope, can_gc: CanGc) -> DomRoot<Headers> {
-        let headers_for_response = Headers::new(global, can_gc);
+    pub(crate) fn for_response(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<Headers> {
+        let headers_for_response = Headers::new(cx, global);
         headers_for_response.guard.set(Guard::Response);
         headers_for_response
     }

--- a/components/script/dom/fetch/request.rs
+++ b/components/script/dom/fetch/request.rs
@@ -10,6 +10,7 @@ use dom_struct::dom_struct;
 use http::Method as HttpMethod;
 use http::header::{HeaderName, HeaderValue};
 use http::method::InvalidMethod;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use net_traits::ReferrerPolicy as MsgReferrerPolicy;
 use net_traits::fetch::headers::is_forbidden_method;
@@ -20,7 +21,7 @@ use net_traits::request::{
 };
 use script_bindings::cell::DomRefCell;
 use script_bindings::cformat;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 use servo_url::ServoUrl;
 
 use crate::body::{
@@ -44,7 +45,6 @@ use crate::dom::headers::{Guard, Headers};
 use crate::dom::promise::Promise;
 use crate::dom::stream::readablestream::ReadableStream;
 use crate::fetch::RequestWithGlobalScope;
-use crate::script_runtime::CanGc;
 use crate::url::ensure_blob_referenced_by_url_is_kept_alive;
 
 #[dom_struct]
@@ -73,26 +73,26 @@ impl Request {
     }
 
     fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         url: ServoUrl,
-        can_gc: CanGc,
     ) -> DomRoot<Request> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(Request::new_inherited(global, url)),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 
     fn from_net_request(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         net_request: NetTraitsRequest,
-        can_gc: CanGc,
     ) -> DomRoot<Request> {
-        let r = Request::new(global, proto, net_request.current_url(), can_gc);
+        let r = Request::new(cx, global, proto, net_request.current_url());
         *r.request.borrow_mut() = net_request;
         r
     }
@@ -349,7 +349,7 @@ impl Request {
         // TODO
 
         // Step 28. Set this’s request to request.
-        let r = Request::from_net_request(global, proto, request, CanGc::from_cx(cx));
+        let r = Request::from_net_request(cx, global, proto, request);
 
         // Step 29. Let signals be « signal » if signal is non-null; otherwise « ».
         let signals = signal.map_or(vec![], |s| vec![s]);
@@ -365,8 +365,7 @@ impl Request {
         //
         // "or_init" looks unclear here, but it always enters the block since r
         // hasn't had any other way to initialize its headers
-        r.headers
-            .or_init(|| Headers::for_request(&r.global(), CanGc::from_cx(cx)));
+        r.headers.or_init(|| Headers::for_request(cx, &r.global()));
 
         // Step 33. If init is not empty, then:
         //
@@ -551,7 +550,7 @@ impl Request {
         let mut new_req_inner = req.clone();
         let body = new_req_inner.body.take();
 
-        let r_clone = Request::new(&r.global(), None, url, CanGc::from_cx(cx));
+        let r_clone = Request::new(cx, &r.global(), None, url);
         *r_clone.request.borrow_mut() = new_req_inner;
 
         // Step 2. If request’s body is non-null, set newRequest’s body
@@ -637,8 +636,7 @@ impl RequestMethods<crate::DomTypeHolder> for Request {
 
     /// <https://fetch.spec.whatwg.org/#dom-request-headers>
     fn Headers(&self, cx: &mut js::context::JSContext) -> DomRoot<Headers> {
-        self.headers
-            .or_init(|| Headers::new(&self.global(), CanGc::from_cx(cx)))
+        self.headers.or_init(|| Headers::new(cx, &self.global()))
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-request-destination>

--- a/components/script/dom/fetch/response.rs
+++ b/components/script/dom/fetch/response.rs
@@ -36,7 +36,7 @@ use crate::dom::headers::{Guard, Headers, is_obs_text, is_vchar};
 use crate::dom::promise::Promise;
 use crate::dom::stream::readablestream::ReadableStream;
 use crate::dom::stream::underlyingsourcecontainer::UnderlyingSourceType;
-use crate::script_runtime::{CanGc, StreamConsumer};
+use crate::script_runtime::StreamConsumer;
 
 #[dom_struct]
 pub(crate) struct Response {
@@ -316,7 +316,7 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
     /// <https://fetch.spec.whatwg.org/#dom-response-headers>
     fn Headers(&self, cx: &mut js::context::JSContext) -> DomRoot<Headers> {
         self.headers_reflector
-            .or_init(|| Headers::for_response(&self.global(), CanGc::from_cx(cx)))
+            .or_init(|| Headers::for_response(cx, &self.global()))
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-response-clone>

--- a/components/script/dom/navigator/navigator.rs
+++ b/components/script/dom/navigator/navigator.rs
@@ -519,7 +519,7 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
     /// <https://storage.spec.whatwg.org/#api>
     fn Storage(&self, cx: &mut js::context::JSContext) -> DomRoot<StorageManager> {
         self.storage
-            .or_init(|| StorageManager::new(&self.global(), CanGc::from_cx(cx)))
+            .or_init(|| StorageManager::new(cx, &self.global()))
     }
 
     /// <https://w3c.github.io/beacon/#sec-processing-model>
@@ -614,9 +614,9 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
     }
 
     /// <https://servo.org/internal-no-spec>
-    fn Servo(&self) -> DomRoot<ServoInternals> {
+    fn Servo(&self, cx: &mut js::context::JSContext) -> DomRoot<ServoInternals> {
         self.servo_internals
-            .or_init(|| ServoInternals::new(&self.global(), CanGc::deprecated_note()))
+            .or_init(|| ServoInternals::new(cx, &self.global()))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-registerprotocolhandler>

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -5,6 +5,7 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::gc::MutableHandleValue;
 use js::jsapi::Heap;
 use js::jsval::UndefinedValue;
@@ -14,7 +15,7 @@ use profile_traits::mem::MemoryReportResult;
 use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::error::{Error, Fallible};
 use script_bindings::interfaces::ServoInternalsHelpers;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use script_bindings::str::USVString;
 use servo_config::prefs::{self, PrefValue, Preferences};
 use servo_constellation_traits::ScriptToConstellationMessage;
@@ -25,7 +26,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::routed_promise::{RoutedPromiseListener, callback_promise};
-use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
 fn pref_to_jsval(cx: &mut js::context::JSContext, pref: &PrefValue, rval: MutableHandleValue) {
@@ -59,8 +59,8 @@ impl ServoInternals {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<ServoInternals> {
-        reflect_dom_object(Box::new(ServoInternals::new_inherited()), global, can_gc)
+    pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<ServoInternals> {
+        reflect_dom_object_with_cx(Box::new(ServoInternals::new_inherited()), global, cx)
     }
 }
 
@@ -112,7 +112,7 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
     /// <https://servo.org/internal-no-spec>
     fn DefaultPreferenceValue(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         name: USVString,
         rval: MutableHandleValue,
     ) -> Fallible<()> {
@@ -127,7 +127,7 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
     /// <https://servo.org/internal-no-spec>
     fn GetPreference(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         name: USVString,
         rval: MutableHandleValue,
     ) -> Fallible<()> {
@@ -197,7 +197,7 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
 impl RoutedPromiseListener<MemoryReportResult> for ServoInternals {
     fn handle_response(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         response: MemoryReportResult,
         promise: &Rc<Promise>,
     ) {
@@ -210,7 +210,7 @@ impl RoutedPromiseListener<MemoryReportResult> for ServoInternals {
 impl ServoInternalsHelpers for ServoInternals {
     /// The navigator.servo api is exposed to about: pages except about:blank, as
     /// well as any URLs provided by embedders that register new protocol handlers.
-    fn is_servo_internal(cx: &mut js::context::JSContext, _global: HandleObject) -> bool {
+    fn is_servo_internal(cx: &mut JSContext, _global: HandleObject) -> bool {
         let realm = CurrentRealm::assert(cx);
         let global_scope = GlobalScope::from_current_realm(&realm);
         let url = global_scope.get_url();

--- a/components/script/dom/storage/storagemanager.rs
+++ b/components/script/dom/storage/storagemanager.rs
@@ -5,8 +5,9 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::realm::CurrentRealm;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::generic_channel::GenericCallback;
 
 use crate::dom::bindings::codegen::Bindings::PermissionStatusBinding::{
@@ -22,7 +23,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::permissions::request_permission_to_use;
 use crate::dom::promise::Promise;
-use crate::script_runtime::CanGc;
 use crate::task_source::SendableTaskSource;
 
 #[dom_struct]
@@ -37,8 +37,8 @@ impl StorageManager {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<StorageManager> {
-        reflect_dom_object(Box::new(StorageManager::new_inherited()), global, can_gc)
+    pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<StorageManager> {
+        reflect_dom_object_with_cx(Box::new(StorageManager::new_inherited()), global, cx)
     }
 
     fn origin_cannot_obtain_local_storage_shelf(&self) -> bool {

--- a/components/script/dom/webrtc/rtcdatachannel.rs
+++ b/components/script/dom/webrtc/rtcdatachannel.rs
@@ -15,7 +15,7 @@ use js::rust::CustomAutoRooterGuard;
 use js::typedarray::{ArrayBuffer, ArrayBufferView, CreateWith};
 use script_bindings::cell::DomRefCell;
 use script_bindings::match_domstring_ascii;
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use script_bindings::weakref::WeakRef;
 use servo_constellation_traits::BlobImpl;
 use servo_media::webrtc::{
@@ -40,7 +40,6 @@ use crate::dom::messageevent::MessageEvent;
 use crate::dom::rtcerror::RTCError;
 use crate::dom::rtcerrorevent::RTCErrorEvent;
 use crate::dom::rtcpeerconnection::RTCPeerConnection;
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableRTCDataChannel {
@@ -122,14 +121,14 @@ impl RTCDataChannel {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         peer_connection: &RTCPeerConnection,
         label: USVString,
         options: &RTCDataChannelInit,
         servo_media_id: Option<DataChannelId>,
-        can_gc: CanGc,
     ) -> DomRoot<RTCDataChannel> {
-        let rtc_data_channel = reflect_dom_object(
+        let rtc_data_channel = reflect_dom_object_with_cx(
             Box::new(RTCDataChannel::new_inherited(
                 peer_connection,
                 label,
@@ -137,7 +136,7 @@ impl RTCDataChannel {
                 servo_media_id,
             )),
             global,
-            can_gc,
+            cx,
         );
 
         peer_connection

--- a/components/script/dom/webrtc/rtcpeerconnection.rs
+++ b/components/script/dom/webrtc/rtcpeerconnection.rs
@@ -53,7 +53,6 @@ use crate::dom::rtcsessiondescription::RTCSessionDescription;
 use crate::dom::rtctrackevent::RTCTrackEvent;
 use crate::dom::window::Window;
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::CanGc;
 use crate::task_source::SendableTaskSource;
 
 #[dom_struct]
@@ -293,12 +292,12 @@ impl RTCPeerConnection {
         match event {
             DataChannelEvent::NewChannel => {
                 let channel = RTCDataChannel::new(
+                    cx,
                     &self.global(),
                     self,
                     USVString::from("".to_owned()),
                     &RTCDataChannelInit::empty(),
                     Some(channel_id),
-                    CanGc::from_cx(cx),
                 );
 
                 let event = RTCDataChannelEvent::new(
@@ -779,26 +778,21 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
     /// <https://www.w3.org/TR/webrtc/#dom-peerconnection-createdatachannel>
     fn CreateDataChannel(
         &self,
+        cx: &mut JSContext,
         label: USVString,
         init: &RTCDataChannelInit,
     ) -> DomRoot<RTCDataChannel> {
-        RTCDataChannel::new(
-            &self.global(),
-            self,
-            label,
-            init,
-            None,
-            CanGc::deprecated_note(),
-        )
+        RTCDataChannel::new(cx, &self.global(), self, label, init, None)
     }
 
     /// <https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-addtransceiver>
     fn AddTransceiver(
         &self,
+        cx: &mut JSContext,
         _track_or_kind: MediaStreamTrackOrString,
         init: &RTCRtpTransceiverInit,
     ) -> DomRoot<RTCRtpTransceiver> {
-        RTCRtpTransceiver::new(&self.global(), init.direction, CanGc::deprecated_note())
+        RTCRtpTransceiver::new(cx, &self.global(), init.direction)
     }
 }
 

--- a/components/script/dom/webrtc/rtcrtpsender.rs
+++ b/components/script/dom/webrtc/rtcrtpsender.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
 use crate::dom::bindings::codegen::Bindings::RTCRtpSenderBinding::{
     RTCRtcpParameters, RTCRtpParameters, RTCRtpSendParameters, RTCRtpSenderMethods,
@@ -16,7 +16,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct RTCRtpSender {
@@ -30,8 +29,8 @@ impl RTCRtpSender {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<Self> {
-        reflect_dom_object(Box::new(Self::new_inherited()), global, can_gc)
+    pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<Self> {
+        reflect_dom_object_with_cx(Box::new(Self::new_inherited()), global, cx)
     }
 }
 

--- a/components/script/dom/webrtc/rtcrtptransceiver.rs
+++ b/components/script/dom/webrtc/rtcrtptransceiver.rs
@@ -5,7 +5,8 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use js::context::JSContext;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
 use crate::dom::bindings::codegen::Bindings::RTCRtpTransceiverBinding::{
     RTCRtpTransceiverDirection, RTCRtpTransceiverMethods,
@@ -13,7 +14,6 @@ use crate::dom::bindings::codegen::Bindings::RTCRtpTransceiverBinding::{
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::rtcrtpsender::RTCRtpSender;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct RTCRtpTransceiver {
@@ -24,11 +24,11 @@ pub(crate) struct RTCRtpTransceiver {
 
 impl RTCRtpTransceiver {
     fn new_inherited(
+        cx: &mut JSContext,
         global: &GlobalScope,
         direction: RTCRtpTransceiverDirection,
-        can_gc: CanGc,
     ) -> Self {
-        let sender = RTCRtpSender::new(global, can_gc);
+        let sender = RTCRtpSender::new(cx, global);
         Self {
             reflector_: Reflector::new(),
             direction: Cell::new(direction),
@@ -37,14 +37,14 @@ impl RTCRtpTransceiver {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         direction: RTCRtpTransceiverDirection,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
-            Box::new(Self::new_inherited(global, direction, can_gc)),
+        reflect_dom_object_with_cx(
+            Box::new(Self::new_inherited(cx, global, direction)),
             global,
-            can_gc,
+            cx,
         )
     }
 }

--- a/components/script/dom/workers/workernavigator.rs
+++ b/components/script/dom/workers/workernavigator.rs
@@ -123,7 +123,7 @@ impl WorkerNavigatorMethods<crate::DomTypeHolder> for WorkerNavigator {
     /// <https://storage.spec.whatwg.org/#api>
     fn Storage(&self, cx: &mut JSContext) -> DomRoot<StorageManager> {
         self.storage
-            .or_init(|| StorageManager::new(&self.global(), CanGc::from_cx(cx)))
+            .or_init(|| StorageManager::new(cx, &self.global()))
     }
 
     // https://gpuweb.github.io/gpuweb/#dom-navigator-gpu

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -60,7 +60,6 @@ use crate::network_listener::{
     self, FetchResponseListener, NetworkListener, ResourceTimingListener, submit_timing_data,
 };
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::CanGc;
 
 /// Fetch canceller object. By default initialized to having a
 /// request associated with it, which can be aborted or terminated.

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -418,11 +418,7 @@ pub(crate) fn FetchLater(
     // Step 14. Add the following abort steps to requestObject’s signal: Set deferredRecord’s invoke state to "aborted".
     signal.add(&AbortAlgorithm::FetchLater(deferred_record_id));
     // Step 15. Return a new FetchLaterResult whose activated getter steps are to return activated.
-    Ok(FetchLaterResult::new(
-        window,
-        deferred_record_id,
-        CanGc::from_cx(cx),
-    ))
+    Ok(FetchLaterResult::new(cx, window, deferred_record_id))
 }
 
 /// <https://fetch.spec.whatwg.org/#deferred-fetch-record-invoke-state>

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1077,7 +1077,7 @@ DOMInterfaces = {
 
 'RTCPeerConnection': {
     'realm': ['AddIceCandidate', 'CreateAnswer', 'CreateOffer', 'SetLocalDescription', 'SetRemoteDescription'],
-    'cx': ['Close'],
+    'cx': ['AddTransceiver', 'Close', 'CreateDataChannel',],
     'weakReferenceable': True,
 },
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -456,8 +456,8 @@ DOMInterfaces = {
 },
 
 'ElementInternals': {
-    'canGc': ['GetLabels', 'States'],
-    'cx': ['CheckValidity', 'GetValidity', 'ReportValidity', 'SetValidity'],
+    'canGc': ['GetLabels'],
+    'cx': ['CheckValidity', 'GetValidity', 'ReportValidity', 'SetValidity', 'States'],
 },
 
 'EventSource': {
@@ -990,7 +990,7 @@ DOMInterfaces = {
 },
 
 'Navigator': {
-    'cx': ['Bluetooth', 'Clipboard', 'Geolocation', 'Gpu', 'Languages', 'SendBeacon', 'ServiceWorker', 'Storage', 'UserActivation', 'WakeLock', 'Xr', 'MediaDevices', 'MediaSession'],
+    'cx': ['Bluetooth', 'Clipboard', 'Geolocation', 'Gpu', 'Languages', 'SendBeacon', 'ServiceWorker', 'Servo', 'Storage', 'UserActivation', 'WakeLock', 'Xr', 'MediaDevices', 'MediaSession'],
 },
 
 'CredentialsContainer': {


### PR DESCRIPTION
This JSContextifies the missing parts of dom/fetch, elementinternal, servointernal and dom/webrtc.

Can be reviewed per commit.

Testing: Compilation is the test.
