### PR TITLE
layout: Do not create widgets for elements with the `content` property

### DIFF
--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -187,9 +187,10 @@ impl IndependentFormattingContext {
 
                 // Some replaced elements can have inner widgets, e.g. `<video controls>`.
                 let node = node_and_style_info.node;
-                let widget = (node.pseudo_element_chain().is_empty() &&
-                    node.is_root_of_user_agent_widget())
-                .then(|| {
+                let should_make_widget = node.pseudo_element_chain().is_empty() &&
+                    node.is_root_of_user_agent_widget() &&
+                    !contents.is_content_replacement;
+                let widget = should_make_widget.then(|| {
                     let widget_info = node_and_style_info
                         .with_pseudo_element(context, PseudoElement::ServoAnonymousBox)
                         .expect("Should always be able to construct info for anonymous boxes.");

--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -49,6 +49,9 @@ use crate::{ConstraintSpace, ContainingBlock};
 #[derive(Debug, MallocSizeOf)]
 pub(crate) struct ReplacedContents {
     pub kind: ReplacedContentKind,
+    /// Whether or not this [`ReplacedContents`] is due to content replacement, i.e.
+    /// `content: <image>` in style.
+    pub is_content_replacement: bool,
     natural_size: NaturalSizes,
     base_fragment_info: BaseFragmentInfo,
 }
@@ -214,6 +217,7 @@ impl ReplacedContents {
 
         Some(Self {
             kind,
+            is_content_replacement: false,
             natural_size,
             base_fragment_info: node.into(),
         })
@@ -320,10 +324,11 @@ impl ReplacedContents {
             let [GenericContentItem::Image(image)] = items.as_slice()
         {
             // Invalid images are treated as zero-sized.
-            return Some(
-                Self::from_image(node, context, image)
-                    .unwrap_or_else(|| Self::zero_sized_invalid_image(node)),
-            );
+            let mut replaced_contents = Self::from_image(node, context, image)
+                .unwrap_or_else(|| Self::zero_sized_invalid_image(node));
+
+            replaced_contents.is_content_replacement = true;
+            return Some(replaced_contents);
         }
         None
     }
@@ -364,6 +369,7 @@ impl ReplacedContents {
                 showing_broken_image_icon: false,
                 url: Some(image_url.clone().into()),
             }),
+            is_content_replacement: false,
             natural_size: NaturalSizes::from_width_and_height(width, height),
             base_fragment_info: node.into(),
         })
@@ -387,6 +393,7 @@ impl ReplacedContents {
                 showing_broken_image_icon: false,
                 url: None,
             }),
+            is_content_replacement: false,
             natural_size: NaturalSizes::from_width_and_height(0., 0.),
             base_fragment_info: node.into(),
         }

--- a/tests/wpt/tests/css/css-content/element-replacement-gradient-details-crash.html
+++ b/tests/wpt/tests/css/css-content/element-replacement-gradient-details-crash.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/46196" />
+<style>
+  details { content: linear-gradient(blue, red); }
+  summary { display: inline-table; }
+</style>
+<details open=""><summary>


### PR DESCRIPTION
Widgets are created for replaced elements, but these should not be
created for replaced elements created due to the application of the
`content` property on normal elements. These kind of elements have their
entire contents replaced. Creating a widget here can cause an unexpected
shape of the `FragmentTree` because anonymous boxes in Servo currently
have `display: inline`.

Testing: This change includes a new WPT crash test.
Fixes: #46196.
