### PR TITLE
script: Migrate `dom/webvtt` to `&mut JSContext`

### DIFF
--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -104,7 +104,6 @@ use crate::fetch::{FetchCanceller, RequestWithGlobalScope, create_a_potential_co
 use crate::microtask::{Microtask, MicrotaskRunnable};
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 use crate::task_source::SendableTaskSource;
 
@@ -3317,7 +3316,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
     fn TextTracks(&self, cx: &mut JSContext) -> DomRoot<TextTrackList> {
         let window = self.owner_window();
         self.text_tracks_list
-            .or_init(|| TextTrackList::new(&window, &[], CanGc::from_cx(cx)))
+            .or_init(|| TextTrackList::new(cx, &window, &[]))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-media-addtexttrack>
@@ -3332,6 +3331,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
         // Step 1 & 2
         // FIXME(#22314, dlrobertson) set the ready state to Loaded
         let track = TextTrack::new(
+            cx,
             &window,
             "".into(),
             kind,
@@ -3339,7 +3339,6 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
             language,
             TextTrackMode::Hidden,
             None,
-            CanGc::from_cx(cx),
         );
         // Step 3 & 4
         self.TextTracks(cx).add(&track);

--- a/components/script/dom/html/htmltrackelement.rs
+++ b/components/script/dom/html/htmltrackelement.rs
@@ -17,7 +17,6 @@ use crate::dom::element::Element;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
 use crate::dom::texttrack::TextTrack;
-use crate::script_runtime::CanGc;
 
 #[derive(Clone, Copy, JSTraceable, MallocSizeOf, PartialEq)]
 #[repr(u16)]
@@ -58,6 +57,7 @@ impl HTMLTrackElement {
         proto: Option<HandleObject>,
     ) -> DomRoot<HTMLTrackElement> {
         let track = TextTrack::new(
+            cx,
             document.window(),
             Default::default(),
             Default::default(),
@@ -65,7 +65,6 @@ impl HTMLTrackElement {
             Default::default(),
             Default::default(),
             None,
-            CanGc::from_cx(cx),
         );
         Node::reflect_node_with_proto(
             cx,

--- a/components/script/dom/webvtt/texttrack.rs
+++ b/components/script/dom/webvtt/texttrack.rs
@@ -75,10 +75,9 @@ impl TextTrack {
         )
     }
 
-    pub(crate) fn get_cues(&self) -> DomRoot<TextTrackCueList> {
-        self.cue_list.or_init(|| {
-            TextTrackCueList::new(self.global().as_window(), &[], CanGc::deprecated_note())
-        })
+    pub(crate) fn get_cues(&self, cx: &mut JSContext) -> DomRoot<TextTrackCueList> {
+        self.cue_list
+            .or_init(|| TextTrackCueList::new(cx, self.global().as_window(), &[]))
     }
 
     pub(crate) fn id(&self) -> &str {
@@ -126,45 +125,41 @@ impl TextTrackMethods<crate::DomTypeHolder> for TextTrack {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-texttrack-cues>
-    fn GetCues(&self) -> Option<DomRoot<TextTrackCueList>> {
+    fn GetCues(&self, cx: &mut JSContext) -> Option<DomRoot<TextTrackCueList>> {
         match self.Mode() {
             TextTrackMode::Disabled => None,
-            _ => Some(self.get_cues()),
+            _ => Some(self.get_cues(cx)),
         }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-texttrack-activecues>
-    fn GetActiveCues(&self) -> Option<DomRoot<TextTrackCueList>> {
+    fn GetActiveCues(&self, cx: &mut JSContext) -> Option<DomRoot<TextTrackCueList>> {
         // XXX implement active cues logic
         //      https://github.com/servo/servo/issues/22314
-        Some(TextTrackCueList::new(
-            self.global().as_window(),
-            &[],
-            CanGc::deprecated_note(),
-        ))
+        Some(TextTrackCueList::new(cx, self.global().as_window(), &[]))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-texttrack-addcue>
-    fn AddCue(&self, cue: &TextTrackCue) -> ErrorResult {
+    fn AddCue(&self, cx: &mut JSContext, cue: &TextTrackCue) -> ErrorResult {
         // FIXME(#22314, dlrobertson) add Step 1 & 2
         // Step 3
         if let Some(old_track) = cue.get_track() {
             // gecko calls RemoveCue when the given cue
             // has an associated track, but doesn't return
             // the error from it, so we wont either.
-            if old_track.RemoveCue(cue).is_err() {
+            if old_track.RemoveCue(cx, cue).is_err() {
                 warn!("Failed to remove cues for the added cue's text track");
             }
         }
         // Step 4
-        self.get_cues().add(cue);
+        self.get_cues(cx).add(cue);
         Ok(())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-texttrack-removecue>
-    fn RemoveCue(&self, cue: &TextTrackCue) -> ErrorResult {
+    fn RemoveCue(&self, cx: &mut JSContext, cue: &TextTrackCue) -> ErrorResult {
         // Step 1
-        let cues = self.get_cues();
+        let cues = self.get_cues(cx);
         let index = match cues.find(cue) {
             Some(i) => Ok(i),
             None => Err(Error::NotFound(None)),

--- a/components/script/dom/webvtt/texttrack.rs
+++ b/components/script/dom/webvtt/texttrack.rs
@@ -5,8 +5,9 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 
 use crate::dom::bindings::codegen::Bindings::TextTrackBinding::{
     TextTrackKind, TextTrackMethods, TextTrackMode,
@@ -20,7 +21,6 @@ use crate::dom::texttrackcue::TextTrackCue;
 use crate::dom::texttrackcuelist::TextTrackCueList;
 use crate::dom::texttracklist::TextTrackList;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct TextTrack {
@@ -57,6 +57,7 @@ impl TextTrack {
 
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         id: DOMString,
         kind: TextTrackKind,
@@ -64,14 +65,13 @@ impl TextTrack {
         language: DOMString,
         mode: TextTrackMode,
         track_list: Option<&TextTrackList>,
-        can_gc: CanGc,
     ) -> DomRoot<TextTrack> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(TextTrack::new_inherited(
                 id, kind, label, language, mode, track_list,
             )),
             window,
-            can_gc,
+            cx,
         )
     }
 

--- a/components/script/dom/webvtt/texttrackcue.rs
+++ b/components/script/dom/webvtt/texttrackcue.rs
@@ -5,8 +5,9 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 
 use crate::dom::bindings::codegen::Bindings::TextTrackCueBinding::TextTrackCueMethods;
 use crate::dom::bindings::num::Finite;
@@ -15,7 +16,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::texttrack::TextTrack;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct TextTrackCue {
@@ -46,17 +46,17 @@ impl TextTrackCue {
 
     #[expect(dead_code)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         id: DOMString,
         start_time: f64,
         end_time: f64,
         track: Option<&TextTrack>,
-        can_gc: CanGc,
     ) -> DomRoot<TextTrackCue> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(TextTrackCue::new_inherited(id, start_time, end_time, track)),
             window,
-            can_gc,
+            cx,
         )
     }
 

--- a/components/script/dom/webvtt/texttrackcuelist.rs
+++ b/components/script/dom/webvtt/texttrackcuelist.rs
@@ -3,15 +3,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
 use crate::dom::bindings::codegen::Bindings::TextTrackCueListBinding::TextTrackCueListMethods;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::texttrackcue::TextTrackCue;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct TextTrackCueList {
@@ -28,15 +28,11 @@ impl TextTrackCueList {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         cues: &[&TextTrackCue],
-        can_gc: CanGc,
     ) -> DomRoot<TextTrackCueList> {
-        reflect_dom_object(
-            Box::new(TextTrackCueList::new_inherited(cues)),
-            window,
-            can_gc,
-        )
+        reflect_dom_object_with_cx(Box::new(TextTrackCueList::new_inherited(cues)), window, cx)
     }
 
     pub(crate) fn item(&self, idx: usize) -> Option<DomRoot<TextTrackCue>> {

--- a/components/script/dom/webvtt/texttracklist.rs
+++ b/components/script/dom/webvtt/texttracklist.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 
 use crate::dom::bindings::codegen::Bindings::TextTrackListBinding::TextTrackListMethods;
 use crate::dom::bindings::codegen::UnionTypes::VideoTrackOrAudioTrackOrTextTrack;
@@ -18,7 +19,6 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::texttrack::TextTrack;
 use crate::dom::trackevent::TrackEvent;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct TextTrackList {
@@ -35,15 +35,11 @@ impl TextTrackList {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         tracks: &[&TextTrack],
-        can_gc: CanGc,
     ) -> DomRoot<TextTrackList> {
-        reflect_dom_object(
-            Box::new(TextTrackList::new_inherited(tracks)),
-            window,
-            can_gc,
-        )
+        reflect_dom_object_with_cx(Box::new(TextTrackList::new_inherited(tracks)), window, cx)
     }
 
     pub(crate) fn item(&self, idx: usize) -> Option<DomRoot<TextTrack>> {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1204,6 +1204,10 @@ DOMInterfaces = {
     'cx': ['Encode']
 },
 
+'TextTrack': {
+    'cx': ['GetCues', 'GetActiveCues', 'AddCue', 'RemoveCue']
+},
+
 'TreeWalker': {
     'cx': ['ParentNode', 'PreviousNode', 'NextNode', 'FirstChild', 'LastChild', 'PreviousSibling', 'NextSibling']
 },


### PR DESCRIPTION
Spotted these while working on `dom/media`. Comes with the nice bonus of cleaning up the rest of the media element!

Testing: If it compiles, it works.
Fixes: Part of #40600.
