### PR TITLE
script: Avoid creating a `Trusted<Document>` during GC

### DIFF
--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -9,7 +9,7 @@
 use net_traits::request::RequestBuilder;
 use net_traits::{BoxedFetchCallback, ResourceThreads, fetch_async};
 use script_bindings::cell::DomRefCell;
-use script_bindings::script_runtime::runtime_is_alive;
+use script_bindings::script_runtime::{during_gc_collection, runtime_is_alive};
 use servo_url::ServoUrl;
 
 use crate::dom::bindings::root::Dom;
@@ -77,7 +77,11 @@ impl Drop for LoadBlocker {
         // a dropped runtime. Therefore, we should only run the drop logic
         // in case this element is dropped, but its containing document
         // is still alive.
+        //
+        // This destructor can also run from during GC (see #46207), which can lead to
+        // accessing already freed memory if we run `finish_load_for_dropped_blocker`.
         if runtime_is_alive() &&
+            !during_gc_collection() &&
             let Some(load) = self.load.take()
         {
             self.doc.finish_load_for_dropped_blocker(load);

--- a/components/script_bindings/script_runtime.rs
+++ b/components/script_bindings/script_runtime.rs
@@ -6,6 +6,7 @@ use std::cell::Cell;
 use std::marker::PhantomData;
 
 use js::context::JSContext;
+use js::jsapi::JS::{HeapState, RuntimeHeapState};
 
 thread_local!(
     static THREAD_ACTIVE: Cell<bool> = const { Cell::new(true) };
@@ -13,6 +14,16 @@ thread_local!(
 
 pub fn runtime_is_alive() -> bool {
     THREAD_ACTIVE.with(|t| t.get())
+}
+
+/// Whether a GC collection is in progress.
+/// Mainly useful for (debug) assertions.
+pub fn during_gc_collection() -> bool {
+    // SAFETY: `RuntimeHeapState` only reads thread-local runtime state and has no preconditions.
+    matches!(
+        unsafe { RuntimeHeapState() },
+        HeapState::MajorCollecting | HeapState::MinorCollecting
+    )
 }
 
 pub fn mark_runtime_dead() {

--- a/tests/wpt/tests/html/semantics/embedded-content/media-elements/crashtests/no-blocking-loads-gc-crash.html
+++ b/tests/wpt/tests/html/semantics/embedded-content/media-elements/crashtests/no-blocking-loads-gc-crash.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<meta charset="utf-8">
+<link rel="help" href="https://github.com/servo/servo/issues/46207">
+<meta name="assert" content="No crash during GC tracing after a media element's load blocker is dropped during GC">
+<script src="/common/gc.js"></script>
+<script>
+function createAndDropBlockingMediaElement() {
+  const container = document.getElementById("container");
+  container.innerHTML = '<audio autoplay src="data:audio/mp3;base64,AAAA"></audio>';
+  container.innerHTML = "";
+  garbageCollect();
+}
+async function main() {
+  for (let round = 0; round < 200; round++) {
+    createAndDropBlockingMediaElement();
+    await garbageCollect();
+    await new Promise(r => setTimeout(r, 0));
+  }
+  document.documentElement.classList.remove("test-wait");
+}
+</script>
+<body onload="main()">
+<div id="container"></div>

--- a/tests/wpt/tests/lint.ignore
+++ b/tests/wpt/tests/lint.ignore
@@ -226,6 +226,7 @@ SET TIMEOUT: html/canvas/element/manual/draw-element-image/onpaint-css-animation
 SET TIMEOUT: html/canvas/element/manual/draw-element-image/requestPaint.tentative.html
 SET TIMEOUT: html/cross-origin-opener-policy/resources/fully-loaded.js
 SET TIMEOUT: html/editing/dnd/*
+SET TIMEOUT: html/semantics/embedded-content/media-elements/crashtests/no-blocking-loads-gc-crash.html
 SET TIMEOUT: html/semantics/embedded-content/media-elements/track/track-element/crashtests/*
 SET TIMEOUT: html/semantics/embedded-content/the-iframe-element/*
 SET TIMEOUT: html/semantics/embedded-content/the-img-element/*


### PR DESCRIPTION
`Document::finish_load_for_dropped_blocker`, creates a `Trusted<Document>` , which is problematic if the drop happens during (because of) an ongoing GC. If the owning `Document` is being collected in the same GC, we have a problem that can manifest as a segfault during the next GC.

Presumably we might still want to handle the dropped loadblocker somehow, but that can be investigated in a follow-up issue, after fixing the segfault, since this also unblocks adding a reproducible test for #46155.

Testing: Adds a crashtest that reproduces the use-after-free.
Fixes: #46207