### PR TITLE
Update stylo (enable scrollbar-color/scrollbar-width behind a pref for the servo engine)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7488,7 +7488,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.39.0"
-source = "git+https://github.com/servo/stylo?rev=bc25ec938fa224410eebf21a8963074bc8d8126d#bc25ec938fa224410eebf21a8963074bc8d8126d"
+source = "git+https://github.com/servo/stylo?rev=5b71023cc809a1ac0147ca88f02f2a774dd8f9d6#5b71023cc809a1ac0147ca88f02f2a774dd8f9d6"
 dependencies = [
  "bitflags 2.13.0",
  "cssparser",
@@ -9240,7 +9240,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=bc25ec938fa224410eebf21a8963074bc8d8126d#bc25ec938fa224410eebf21a8963074bc8d8126d"
+source = "git+https://github.com/servo/stylo?rev=5b71023cc809a1ac0147ca88f02f2a774dd8f9d6#5b71023cc809a1ac0147ca88f02f2a774dd8f9d6"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9711,7 +9711,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.19.0"
-source = "git+https://github.com/servo/stylo?rev=bc25ec938fa224410eebf21a8963074bc8d8126d#bc25ec938fa224410eebf21a8963074bc8d8126d"
+source = "git+https://github.com/servo/stylo?rev=5b71023cc809a1ac0147ca88f02f2a774dd8f9d6#5b71023cc809a1ac0147ca88f02f2a774dd8f9d6"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9767,7 +9767,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.19.0"
-source = "git+https://github.com/servo/stylo?rev=bc25ec938fa224410eebf21a8963074bc8d8126d#bc25ec938fa224410eebf21a8963074bc8d8126d"
+source = "git+https://github.com/servo/stylo?rev=5b71023cc809a1ac0147ca88f02f2a774dd8f9d6#5b71023cc809a1ac0147ca88f02f2a774dd8f9d6"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9776,7 +9776,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.19.0"
-source = "git+https://github.com/servo/stylo?rev=bc25ec938fa224410eebf21a8963074bc8d8126d#bc25ec938fa224410eebf21a8963074bc8d8126d"
+source = "git+https://github.com/servo/stylo?rev=5b71023cc809a1ac0147ca88f02f2a774dd8f9d6#5b71023cc809a1ac0147ca88f02f2a774dd8f9d6"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9788,7 +9788,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.19.0"
-source = "git+https://github.com/servo/stylo?rev=bc25ec938fa224410eebf21a8963074bc8d8126d#bc25ec938fa224410eebf21a8963074bc8d8126d"
+source = "git+https://github.com/servo/stylo?rev=5b71023cc809a1ac0147ca88f02f2a774dd8f9d6#5b71023cc809a1ac0147ca88f02f2a774dd8f9d6"
 dependencies = [
  "bitflags 2.13.0",
  "stylo_malloc_size_of",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.19.0"
-source = "git+https://github.com/servo/stylo?rev=bc25ec938fa224410eebf21a8963074bc8d8126d#bc25ec938fa224410eebf21a8963074bc8d8126d"
+source = "git+https://github.com/servo/stylo?rev=5b71023cc809a1ac0147ca88f02f2a774dd8f9d6#5b71023cc809a1ac0147ca88f02f2a774dd8f9d6"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9814,7 +9814,7 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.19.0"
-source = "git+https://github.com/servo/stylo?rev=bc25ec938fa224410eebf21a8963074bc8d8126d#bc25ec938fa224410eebf21a8963074bc8d8126d"
+source = "git+https://github.com/servo/stylo?rev=5b71023cc809a1ac0147ca88f02f2a774dd8f9d6#5b71023cc809a1ac0147ca88f02f2a774dd8f9d6"
 dependencies = [
  "toml",
 ]
@@ -9822,7 +9822,7 @@ dependencies = [
 [[package]]
 name = "stylo_traits"
 version = "0.19.0"
-source = "git+https://github.com/servo/stylo?rev=bc25ec938fa224410eebf21a8963074bc8d8126d#bc25ec938fa224410eebf21a8963074bc8d8126d"
+source = "git+https://github.com/servo/stylo?rev=5b71023cc809a1ac0147ca88f02f2a774dd8f9d6#5b71023cc809a1ac0147ca88f02f2a774dd8f9d6"
 dependencies = [
  "app_units",
  "bitflags 2.13.0",
@@ -10242,7 +10242,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?rev=bc25ec938fa224410eebf21a8963074bc8d8126d#bc25ec938fa224410eebf21a8963074bc8d8126d"
+source = "git+https://github.com/servo/stylo?rev=5b71023cc809a1ac0147ca88f02f2a774dd8f9d6#5b71023cc809a1ac0147ca88f02f2a774dd8f9d6"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -10255,7 +10255,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=bc25ec938fa224410eebf21a8963074bc8d8126d#bc25ec938fa224410eebf21a8963074bc8d8126d"
+source = "git+https://github.com/servo/stylo?rev=5b71023cc809a1ac0147ca88f02f2a774dd8f9d6#5b71023cc809a1ac0147ca88f02f2a774dd8f9d6"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,14 +216,14 @@ rustls-pki-types = "1.14"
 rustls-platform-verifier = "0.7.0"
 sea-query = { version = "=1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = "=0.8.0-rc.15"
-selectors = { git = "https://github.com/servo/stylo", rev = "bc25ec938fa224410eebf21a8963074bc8d8126d" }
+selectors = { git = "https://github.com/servo/stylo", rev = "5b71023cc809a1ac0147ca88f02f2a774dd8f9d6" }
 seq-macro = "0.3.6"
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
 serde_test = "1.0"
-servo_arc = { git = "https://github.com/servo/stylo", rev = "bc25ec938fa224410eebf21a8963074bc8d8126d" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "5b71023cc809a1ac0147ca88f02f2a774dd8f9d6" }
 sha1 = "0.11"
 sha2 = "0.11"
 sha3 = "0.12"
@@ -233,12 +233,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 speexdsp-resampler = "0.1.0"
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "bc25ec938fa224410eebf21a8963074bc8d8126d" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "bc25ec938fa224410eebf21a8963074bc8d8126d" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "bc25ec938fa224410eebf21a8963074bc8d8126d" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "bc25ec938fa224410eebf21a8963074bc8d8126d" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "bc25ec938fa224410eebf21a8963074bc8d8126d" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "bc25ec938fa224410eebf21a8963074bc8d8126d" }
+stylo = { git = "https://github.com/servo/stylo", rev = "5b71023cc809a1ac0147ca88f02f2a774dd8f9d6" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "5b71023cc809a1ac0147ca88f02f2a774dd8f9d6" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "5b71023cc809a1ac0147ca88f02f2a774dd8f9d6" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "5b71023cc809a1ac0147ca88f02f2a774dd8f9d6" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "5b71023cc809a1ac0147ca88f02f2a774dd8f9d6" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "5b71023cc809a1ac0147ca88f02f2a774dd8f9d6" }
 surfman = { version = "0.13.0", features = ["chains"] }
 swapper = "0.1"
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }


### PR DESCRIPTION
Points the stylo dependency at servo/stylo#413, which gates `scrollbar-color` and `scrollbar-width` behind the `layout.unimplemented` pref for the servo engine. The pref is disabled in Servo, so no behavior change is expected. This PR exists to let CI validate the stylo change; it will be repointed to stylo main once servo/stylo#413 merges.

Testing: No behavior change expected (the pref is disabled in Servo); existing CI/WPT coverage validates that.