### PR TITLE
script: Remove dead code in module `node`

### DIFF
--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -288,7 +288,6 @@ pub(crate) mod mutationobserver;
 pub(crate) use self::mutationobserver::*;
 pub(crate) mod navigator;
 pub(crate) use self::navigator::*;
-#[expect(dead_code)]
 pub(crate) mod node;
 pub(crate) use self::node::*;
 pub(crate) mod notification;

--- a/components/script/dom/node/children_mutation.rs
+++ b/components/script/dom/node/children_mutation.rs
@@ -12,14 +12,12 @@ use crate::dom::element::Element;
 pub(crate) enum ChildrenMutation<'a> {
     Append {
         prev: &'a Node,
-        added: &'a [&'a Node],
     },
     Insert {
         prev: &'a Node,
         next: &'a Node,
     },
     Prepend {
-        added: &'a [&'a Node],
         next: &'a Node,
     },
     Replace {
@@ -37,13 +35,12 @@ pub(crate) enum ChildrenMutation<'a> {
 impl<'a> ChildrenMutation<'a> {
     pub(super) fn insert(
         prev: Option<&'a Node>,
-        added: &'a [&'a Node],
         next: Option<&'a Node>,
     ) -> ChildrenMutation<'a> {
         match (prev, next) {
             (None, None) => ChildrenMutation::ReplaceAll,
-            (Some(prev), None) => ChildrenMutation::Append { prev, added },
-            (None, Some(next)) => ChildrenMutation::Prepend { added, next },
+            (Some(prev), None) => ChildrenMutation::Append { prev },
+            (None, Some(next)) => ChildrenMutation::Prepend { next },
             (Some(prev), Some(next)) => ChildrenMutation::Insert { prev, next },
         }
     }
@@ -61,7 +58,7 @@ impl<'a> ChildrenMutation<'a> {
                 ChildrenMutation::Replace { prev, next }
             }
         } else {
-            ChildrenMutation::insert(prev, added, next)
+            ChildrenMutation::insert(prev, next)
         }
     }
 
@@ -99,7 +96,7 @@ impl<'a> ChildrenMutation<'a> {
                 .find(|node| node.is::<Element>())
                 .map(|node| node.as_rooted()),
             // Add/remove at end of container: Return the last preceding element.
-            ChildrenMutation::Append { prev, .. } |
+            ChildrenMutation::Append { prev } |
             ChildrenMutation::Replace {
                 prev: Some(prev),
                 next: None,

--- a/components/script/dom/node/children_mutation.rs
+++ b/components/script/dom/node/children_mutation.rs
@@ -18,7 +18,6 @@ pub(crate) enum ChildrenMutation<'a> {
     },
     Insert {
         prev: &'a Node,
-        added: &'a [&'a Node],
         next: &'a Node,
     },
     Prepend {
@@ -27,8 +26,6 @@ pub(crate) enum ChildrenMutation<'a> {
     },
     Replace {
         prev: Option<&'a Node>,
-        removed: &'a Node,
-        added: &'a [&'a Node],
         next: Option<&'a Node>,
     },
     ReplaceAll {
@@ -55,7 +52,7 @@ impl<'a> ChildrenMutation<'a> {
             },
             (Some(prev), None) => ChildrenMutation::Append { prev, added },
             (None, Some(next)) => ChildrenMutation::Prepend { added, next },
-            (Some(prev), Some(next)) => ChildrenMutation::Insert { prev, added, next },
+            (Some(prev), Some(next)) => ChildrenMutation::Insert { prev, next },
         }
     }
 
@@ -72,12 +69,7 @@ impl<'a> ChildrenMutation<'a> {
                     added,
                 }
             } else {
-                ChildrenMutation::Replace {
-                    prev,
-                    removed,
-                    added,
-                    next,
-                }
+                ChildrenMutation::Replace { prev, next }
             }
         } else {
             ChildrenMutation::insert(prev, added, next)

--- a/components/script/dom/node/children_mutation.rs
+++ b/components/script/dom/node/children_mutation.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::slice;
-
 use js::context::NoGC;
 
 use crate::dom::Node;
@@ -28,10 +26,7 @@ pub(crate) enum ChildrenMutation<'a> {
         prev: Option<&'a Node>,
         next: Option<&'a Node>,
     },
-    ReplaceAll {
-        removed: &'a [&'a Node],
-        added: &'a [&'a Node],
-    },
+    ReplaceAll,
     /// Mutation for when a Text node's data is modified.
     /// This doesn't change the structure of the list, which is what the other
     /// variants' fields are stored for at the moment, so this can just have no
@@ -46,10 +41,7 @@ impl<'a> ChildrenMutation<'a> {
         next: Option<&'a Node>,
     ) -> ChildrenMutation<'a> {
         match (prev, next) {
-            (None, None) => ChildrenMutation::ReplaceAll {
-                removed: &[],
-                added,
-            },
+            (None, None) => ChildrenMutation::ReplaceAll,
             (Some(prev), None) => ChildrenMutation::Append { prev, added },
             (None, Some(next)) => ChildrenMutation::Prepend { added, next },
             (Some(prev), Some(next)) => ChildrenMutation::Insert { prev, next },
@@ -62,25 +54,15 @@ impl<'a> ChildrenMutation<'a> {
         added: &'a [&'a Node],
         next: Option<&'a Node>,
     ) -> ChildrenMutation<'a> {
-        if let Some(ref removed) = *removed {
+        if removed.is_some() {
             if let (None, None) = (prev, next) {
-                ChildrenMutation::ReplaceAll {
-                    removed: slice::from_ref(removed),
-                    added,
-                }
+                ChildrenMutation::ReplaceAll
             } else {
                 ChildrenMutation::Replace { prev, next }
             }
         } else {
             ChildrenMutation::insert(prev, added, next)
         }
-    }
-
-    pub(super) fn replace_all(
-        removed: &'a [&'a Node],
-        added: &'a [&'a Node],
-    ) -> ChildrenMutation<'a> {
-        ChildrenMutation::ReplaceAll { removed, added }
     }
 
     /// Get the child that follows the added or removed children.
@@ -93,7 +75,7 @@ impl<'a> ChildrenMutation<'a> {
             ChildrenMutation::Insert { next, .. } => Some(next),
             ChildrenMutation::Prepend { next, .. } => Some(next),
             ChildrenMutation::Replace { next, .. } => next,
-            ChildrenMutation::ReplaceAll { .. } => None,
+            ChildrenMutation::ReplaceAll => None,
             ChildrenMutation::ChangeText => None,
         }
     }
@@ -159,7 +141,7 @@ impl<'a> ChildrenMutation<'a> {
                 next: None,
                 ..
             } => unreachable!(),
-            ChildrenMutation::ReplaceAll { .. } => None,
+            ChildrenMutation::ReplaceAll => None,
             ChildrenMutation::ChangeText => None,
         }
     }

--- a/components/script/dom/node/children_mutation.rs
+++ b/components/script/dom/node/children_mutation.rs
@@ -33,10 +33,7 @@ pub(crate) enum ChildrenMutation<'a> {
 }
 
 impl<'a> ChildrenMutation<'a> {
-    pub(super) fn insert(
-        prev: Option<&'a Node>,
-        next: Option<&'a Node>,
-    ) -> ChildrenMutation<'a> {
+    pub(super) fn insert(prev: Option<&'a Node>, next: Option<&'a Node>) -> ChildrenMutation<'a> {
         match (prev, next) {
             (None, None) => ChildrenMutation::ReplaceAll,
             (Some(prev), None) => ChildrenMutation::Append { prev },
@@ -48,7 +45,6 @@ impl<'a> ChildrenMutation<'a> {
     pub(super) fn replace(
         prev: Option<&'a Node>,
         removed: &'a Option<&'a Node>,
-        added: &'a [&'a Node],
         next: Option<&'a Node>,
     ) -> ChildrenMutation<'a> {
         if removed.is_some() {

--- a/components/script/dom/node/context.rs
+++ b/components/script/dom/node/context.rs
@@ -120,8 +120,6 @@ pub(crate) struct MoveContext<'a> {
     pub(crate) old_parent: Option<&'a Node>,
     /// The previous sibling of the inclusive ancestor that was moved.
     prev_sibling: Option<&'a Node>,
-    /// The next sibling of the inclusive ancestor that was moved.
-    pub(crate) next_sibling: Option<&'a Node>,
 }
 
 impl<'a> MoveContext<'a> {
@@ -129,14 +127,12 @@ impl<'a> MoveContext<'a> {
     pub(crate) fn new(
         old_parent: Option<&'a Node>,
         prev_sibling: Option<&'a Node>,
-        next_sibling: Option<&'a Node>,
         cached_index: Option<u32>,
     ) -> Self {
         MoveContext {
             index: Cell::new(cached_index),
             old_parent,
             prev_sibling,
-            next_sibling,
         }
     }
 

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -29,7 +29,7 @@ use layout_api::{
     AxesOverflow, BoxAreaType, CSSPixelRectVec, GenericLayoutData, NodeRenderingType,
     PhysicalSides, TrustedNodeAddress, with_layout_state,
 };
-use libc::{self, c_void, uintptr_t};
+use libc::{self, uintptr_t};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use script_bindings::cell::{DomRefCell, Ref, RefMut};
 use script_bindings::codegen::GenericBindings::ElementBinding::ElementMethods;
@@ -38,7 +38,6 @@ use script_bindings::codegen::GenericBindings::ProcessingInstructionBinding::Pro
 use script_bindings::codegen::InheritTypes::{DocumentFragmentTypeId, TextTypeId};
 use script_bindings::reflector::{DomObject, DomObjectWrap, reflect_dom_object_with_proto_and_cx};
 use script_traits::DocumentActivity;
-use servo_arc::Arc as ServoArc;
 use servo_base::id::PipelineId;
 use servo_config::pref;
 use smallvec::SmallVec;
@@ -47,7 +46,6 @@ use style::context::QuirksMode;
 use style::dom::OpaqueNode;
 use style::dom_apis::{QueryAll, QueryFirst};
 use style::selector_parser::PseudoElement;
-use style::stylesheets::Stylesheet;
 use style_traits::CSSPixel;
 use uuid::Uuid;
 use xml5ever::{local_name, serialize as xml_serialize};
@@ -551,10 +549,6 @@ impl Node {
         Self::complete_move_subtree(cx, child)
     }
 
-    pub(crate) fn to_untrusted_node_address(&self) -> UntrustedNodeAddress {
-        UntrustedNodeAddress(self.reflector().get_jsobject().get() as *const c_void)
-    }
-
     pub(crate) fn to_opaque(&self) -> OpaqueNode {
         OpaqueNode(self.reflector().get_jsobject().get() as usize)
     }
@@ -721,27 +715,6 @@ impl Node {
         self.ensure_rare_data()
             .mutation_observers
             .retain(|reg_obs| &*reg_obs.observer != observer)
-    }
-
-    /// Dumps the subtree rooted at this node, for debugging.
-    pub(crate) fn dump(&self) {
-        self.dump_indent(0);
-    }
-
-    /// Dumps the node tree, for debugging, with indentation.
-    pub(crate) fn dump_indent(&self, indent: u32) {
-        let mut s = String::new();
-        for _ in 0..indent {
-            s.push_str("    ");
-        }
-
-        s.push_str(&self.debug_str());
-        debug!("{:?}", s);
-
-        // FIXME: this should have a pure version?
-        for kid in self.children() {
-            kid.dump_indent(indent + 1)
-        }
     }
 
     /// Returns a string that describes this node.
@@ -950,12 +923,6 @@ impl Node {
             |n, no_gc| n.get_next_sibling_unrooted(no_gc),
             no_gc,
         )
-    }
-
-    pub(crate) fn inclusively_preceding_siblings(
-        &self,
-    ) -> impl Iterator<Item = DomRoot<Node>> + use<> {
-        SimpleNodeIterator::new(Some(DomRoot::from_ref(self)), |n| n.GetPreviousSibling())
     }
 
     pub(crate) fn inclusively_preceding_siblings_unrooted<'b>(
@@ -1962,16 +1929,6 @@ impl Node {
 
         element.upcast::<Node>().remove_self(cx);
         Ok(())
-    }
-
-    pub(crate) fn get_stylesheet(&self) -> Option<ServoArc<Stylesheet>> {
-        if let Some(node) = self.downcast::<HTMLStyleElement>() {
-            node.get_stylesheet()
-        } else if let Some(node) = self.downcast::<HTMLLinkElement>() {
-            node.get_stylesheet()
-        } else {
-            None
-        }
     }
 
     pub(crate) fn get_cssom_stylesheet(&self) -> Option<DomRoot<CSSStyleSheet>> {

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -2595,7 +2595,7 @@ impl Node {
             // TODO(xiaochengh): If we follow the spec and move it out of the if block, some WPT fail. Investigate.
             vtable_for(parent).children_changed(
                 cx,
-                &ChildrenMutation::insert(previous_sibling.as_deref(), new_nodes, child),
+                &ChildrenMutation::insert(previous_sibling.as_deref(), child),
             );
 
             // Step 8. If suppress observers flag is unset, then queue a tree mutation record for parent
@@ -2781,7 +2781,6 @@ impl Node {
                 &ChildrenMutation::replace(
                     old_previous_sibling.as_deref(),
                     &Some(node),
-                    &[],
                     old_next_sibling.as_deref(),
                 ),
             );
@@ -3701,7 +3700,6 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
             &ChildrenMutation::replace(
                 previous_sibling.as_deref(),
                 &removed_child,
-                nodes,
                 reference_child,
             ),
         );

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -2484,7 +2484,7 @@ impl Node {
             for kid in new_nodes {
                 Node::remove(cx, kid, node, SuppressObserver::Suppressed);
             }
-            vtable_for(node).children_changed(cx, &ChildrenMutation::replace_all(new_nodes, &[]));
+            vtable_for(node).children_changed(cx, &ChildrenMutation::ReplaceAll);
 
             // Step 4.2. Queue a tree mutation record for node with « », nodes, null, and null.
             let mutation = LazyCell::new(|| Mutation::ChildList {
@@ -2665,10 +2665,7 @@ impl Node {
             Node::insert(cx, node, parent, None, SuppressObserver::Suppressed);
         }
 
-        vtable_for(parent).children_changed(
-            cx,
-            &ChildrenMutation::replace_all(removed_nodes.r(), added_nodes),
-        );
+        vtable_for(parent).children_changed(cx, &ChildrenMutation::ReplaceAll);
 
         // Step 7. If either addedNodes or removedNodes is not empty, then queue a tree mutation record
         // for parent with addedNodes, removedNodes, null, and null.

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -1430,12 +1430,8 @@ impl Node {
             },
         }
 
-        let mut context = MoveContext::new(
-            Some(&old_parent),
-            prev_sibling.as_deref(),
-            next_sibling.as_deref(),
-            cached_index,
-        );
+        let mut context =
+            MoveContext::new(Some(&old_parent), prev_sibling.as_deref(), cached_index);
 
         // Step 13. Remove node from oldParent’s children.
         old_parent.move_child(cx, node);

--- a/components/script/dom/node/nodelist.rs
+++ b/components/script/dom/node/nodelist.rs
@@ -155,14 +155,6 @@ impl NodeList {
         }
     }
 
-    pub(crate) fn as_radio_list(&self) -> &RadioList {
-        if let NodeListType::Radio(ref list) = self.list_type {
-            list
-        } else {
-            panic!("called as_radio_list() on a non-radio node list")
-        }
-    }
-
     pub(crate) fn iter(&self) -> impl Iterator<Item = DomRoot<Node>> + '_ {
         let len = self.Length();
         // There is room for optimization here in non-simple cases,


### PR DESCRIPTION
Most of these are 10 years old, despite recently moved in #45583.
Notably, We remove a fair amount of unused fields in `ChildrenMutation` leading to simplification of several fn and lighter struct, which requires more careful look.

Testing: Ideally nothing should change, so covered by existing tests.