### PR TITLE
script: Do not clone nodes into a live document for SVG's `<use>`

### DIFF
--- a/components/script/dom/svg/svgsvgelement.rs
+++ b/components/script/dom/svg/svgsvgelement.rs
@@ -75,62 +75,83 @@ impl SVGSVGElement {
     }
 
     pub(crate) fn serialize_and_cache_subtree(&self, cx: &mut js::context::JSContext) {
-        let cloned_nodes = self.process_use_elements(cx);
-
-        let serialize_result = self
+        let document_fragment = self.owner_document().CreateDocumentFragment(cx);
+        let cloned_node = Node::clone(
+            cx,
+            self.upcast(),
+            None,
+            CloneChildrenFlag::CloneChildren,
+            None,
+        );
+        if document_fragment
             .upcast::<Node>()
-            .xml_serialize(TraversalScope::IncludeNode);
+            .AppendChild(cx, &cloned_node)
+            .is_err()
+        {
+            error!("Unable to clone SVG tree");
+            *self.cached_serialized_data_url.borrow_mut() = Some(Err(()));
+            return;
+        }
 
-        self.cleanup_cloned_nodes(cx, &cloned_nodes);
+        self.process_use_elements(cx, &cloned_node);
 
-        let Ok(xml_source) = serialize_result else {
+        let Ok(xml_source) = cloned_node.xml_serialize(TraversalScope::IncludeNode) else {
             *self.cached_serialized_data_url.borrow_mut() = Some(Err(()));
             return;
         };
 
         let xml_source: String = xml_source.into();
         let base64_encoded_source = base64::engine::general_purpose::STANDARD.encode(xml_source);
-        let data_url = format!("data:image/svg+xml;base64,{}", base64_encoded_source);
+        let data_url = format!("data:image/svg+xml;base64,{base64_encoded_source}");
         match ServoUrl::parse(&data_url) {
             Ok(url) => *self.cached_serialized_data_url.borrow_mut() = Some(Ok(url)),
             Err(error) => error!("Unable to parse serialized SVG data url: {error}"),
         };
     }
 
-    fn process_use_elements(&self, cx: &mut JSContext) -> Vec<DomRoot<Node>> {
-        let mut cloned_nodes = Vec::new();
-        let root_node = self.upcast::<Node>();
-
+    fn process_use_elements(&self, cx: &mut JSContext, root_node: &Node) {
         for node in root_node.traverse_preorder(ShadowIncluding::No) {
             if let Some(element) = node.downcast::<Element>() &&
-                element.local_name() == &local_name!("use") &&
-                let Some(cloned) = self.process_single_use_element(cx, element)
+                element.local_name() == &local_name!("use")
             {
-                cloned_nodes.push(cloned);
+                self.process_single_use_element(cx, element, root_node)
             }
         }
-
-        cloned_nodes
     }
 
     fn process_single_use_element(
         &self,
         cx: &mut JSContext,
         use_element: &Element,
-    ) -> Option<DomRoot<Node>> {
+        root_node: &Node,
+    ) {
         let href = use_element.get_string_attribute(&local_name!("href"));
-        let href_view = href.str();
-        let id_str = href_view.strip_prefix("#")?;
-        let id = DOMString::from(id_str);
+        let Some(id_string) = href.str().strip_prefix("#").map(DOMString::from) else {
+            return;
+        };
+
         let document = self.upcast::<Node>().owner_doc();
-        let referenced_element = document.GetElementById(cx, id)?;
+        let Some(referenced_element) = document.GetElementById(cx, id_string) else {
+            return;
+        };
         let referenced_node = referenced_element.upcast::<Node>();
-        let has_svg_ancestor = referenced_node
-            .inclusive_ancestors(ShadowIncluding::No)
-            .any(|ancestor| ancestor.is::<SVGSVGElement>());
-        if !has_svg_ancestor {
-            return None;
-        }
+
+        // Don't use this node if it doesn't have an `<svg>` ancestor.
+        if !referenced_node
+            .inclusive_ancestors_unrooted(cx.no_gc(), ShadowIncluding::No)
+            .any(|ancestor| ancestor.is::<SVGSVGElement>())
+        {
+            return;
+        };
+
+        // Don't use this node if it already exists within the same `<svg>` element.
+        if referenced_node
+            .inclusive_ancestors_unrooted(cx.no_gc(), ShadowIncluding::No)
+            .any(|ancestor| *ancestor == self.upcast())
+        {
+            return;
+        };
+
         let cloned_node = Node::clone(
             cx,
             referenced_node,
@@ -138,21 +159,7 @@ impl SVGSVGElement {
             CloneChildrenFlag::CloneChildren,
             None,
         );
-        let root_node = self.upcast::<Node>();
         let _ = root_node.AppendChild(cx, &cloned_node);
-
-        Some(cloned_node)
-    }
-
-    fn cleanup_cloned_nodes(&self, cx: &mut JSContext, cloned_nodes: &[DomRoot<Node>]) {
-        if cloned_nodes.is_empty() {
-            return;
-        }
-        let root_node = self.upcast::<Node>();
-
-        for cloned_node in cloned_nodes {
-            let _ = root_node.RemoveChild(cx, cloned_node);
-        }
     }
 
     fn invalidate_cached_serialized_subtree_and_rasterization_result(&self) {

--- a/tests/wpt/tests/svg/linking/scripted/use-iframe-crash.html
+++ b/tests/wpt/tests/svg/linking/scripted/use-iframe-crash.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/46250" />
+
+<svg>
+  <foreignObject>
+    <iframe id="iframe"></iframe>
+  </foreignObject>
+  <use href="#iframe">
+</svg>


### PR DESCRIPTION
Cloning nodes into a live document fires their connection steps, which
can do things like load `<iframe>` contents. This is not good. Instead
of doing this, clone the entire SVG tree into a `DocumentFragment` so
that all nodes are essentially inert. This prevents infinite recursion
when combining `<use>` with `<iframe>` as `<iframe>` attachment steps
trigger synchronous layouts, which in turn trigger SVG cloning and
rasterization again.

This change also avoids cloning a node for `<use>` when it already exits
inside the same `<svg>` element as that would create duplicate ids.

Testing: This change adds a WPT crash test. 
Fixes: #46250.
