### PR TITLE
script: Use `safe_to_jsval` where possible

### DIFF
--- a/components/script/dom/encoding/textdecoderstream.rs
+++ b/components/script/dom/encoding/textdecoderstream.rs
@@ -24,7 +24,6 @@ use crate::dom::stream::transformstreamdefaultcontroller::TransformerType;
 use crate::dom::types::{TransformStream, TransformStreamDefaultController};
 
 /// <https://encoding.spec.whatwg.org/#decode-and-enqueue-a-chunk>
-#[expect(unsafe_code)]
 pub(crate) fn decode_and_enqueue_a_chunk(
     cx: &mut js::context::JSContext,
     global: &GlobalScope,
@@ -59,12 +58,11 @@ pub(crate) fn decode_and_enqueue_a_chunk(
         return Ok(());
     }
     rooted!(&in(cx) let mut rval = UndefinedValue());
-    unsafe { output_chunk.to_jsval(cx.raw_cx(), rval.handle_mut()) };
+    output_chunk.safe_to_jsval(cx, rval.handle_mut());
     controller.enqueue(cx, global, rval.handle())
 }
 
 /// <https://encoding.spec.whatwg.org/#flush-and-enqueue>
-#[expect(unsafe_code)]
 pub(crate) fn flush_and_enqueue(
     cx: &mut js::context::JSContext,
     global: &GlobalScope,
@@ -89,7 +87,7 @@ pub(crate) fn flush_and_enqueue(
         return Ok(());
     }
     rooted!(&in(cx) let mut rval = UndefinedValue());
-    unsafe { output_chunk.to_jsval(cx.raw_cx(), rval.handle_mut()) };
+    output_chunk.safe_to_jsval(cx, rval.handle_mut());
     controller.enqueue(cx, global, rval.handle())
 }
 

--- a/components/script/dom/window/windowproxy.rs
+++ b/components/script/dom/window/windowproxy.rs
@@ -1026,7 +1026,7 @@ unsafe extern "C" fn get_own_property_descriptor(
     let desc = unsafe { MutableHandle::from_raw(desc) };
     if let Some((window, attrs)) = window {
         rooted!(&in(cx) let mut val = UndefinedValue());
-        unsafe { window.to_jsval(cx.raw_cx(), val.handle_mut()) };
+        window.safe_to_jsval(cx, val.handle_mut());
         set_property_descriptor(desc, val.handle(), attrs, unsafe { &mut *is_none });
         return true;
     }
@@ -1110,7 +1110,7 @@ unsafe extern "C" fn get(
     let window = unsafe { GetSubframeWindowProxy(cx, proxy, id) };
     let vp = unsafe { MutableHandle::from_raw(vp) };
     if let Some((window, _attrs)) = window {
-        unsafe { window.to_jsval(cx.raw_cx(), vp) };
+        window.safe_to_jsval(cx, vp);
         return true;
     }
 

--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -710,11 +710,7 @@ pub(crate) fn cross_origin_get<D: DomTypes>(
     }
 
     rooted!(&in(cx) let mut getter_jsval = UndefinedValue());
-    unsafe {
-        getter
-            .get()
-            .to_jsval(cx.raw_cx(), getter_jsval.handle_mut());
-    }
+    getter.get().safe_to_jsval(cx, getter_jsval.handle_mut());
 
     // > 7. Return `? Call(getter, Receiver)`.
     unsafe {
@@ -773,9 +769,7 @@ unsafe fn cross_origin_set<D: DomTypes>(
     }
 
     rooted!(&in(cx) let mut setter_jsval = UndefinedValue());
-    setter
-        .get()
-        .to_jsval(cx.raw_cx(), setter_jsval.handle_mut());
+    setter.get().safe_to_jsval(cx, setter_jsval.handle_mut());
 
     // > 3.1. Perform ? Call(setter, Receiver, «V»).
     // >


### PR DESCRIPTION
This migrates the last usages of `cx.raw_cx()` where an equivalent API exists that takes a `&mut JSContext` as well.

Part of #40600

Testing: it compiles