### PR TITLE
script: Do not crash with delete command when cursor is at start of the editing host

### DIFF
--- a/components/script/dom/execcommand/basecommand.rs
+++ b/components/script/dom/execcommand/basecommand.rs
@@ -42,6 +42,7 @@ use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmlfontelement::HTMLFontElement;
 use crate::dom::iterators::ShadowIncluding;
 use crate::dom::node::{Node, NodeTraits};
+use crate::dom::range::Range;
 use crate::dom::selection::Selection;
 
 #[derive(Default, Clone, Copy, MallocSizeOf)]
@@ -626,6 +627,46 @@ impl CommandName {
                 CommandName::ForeColor |
                 CommandName::HiliteColor
         )
+    }
+
+    pub(crate) fn is_enabled(&self, cx: &JSContext, range: &Range, editing_host: &Node) -> bool {
+        match self {
+            // The delete command is not enabled in the situation that the cursor is inside the
+            // editing host at the start, where a backspace would do nothing. However, if the
+            // editing host itself is selected then it is enabled.
+            //
+            // Therefore, start at the start_container and traverse its ancestors up to editing
+            // host. If the index remains 0, then there is no effective character to delete and
+            // the command is disabled.
+            CommandName::Delete => {
+                if !range.collapsed() {
+                    return true;
+                }
+                let start_container = range.start_container();
+                if *start_container == *editing_host {
+                    // TODO: This should return true. However, that crashes deletes at the start
+                    // of the editing host. There currently is no way to distinguish between a
+                    // range that is collapsed to a full node and set to before a node. Chromium
+                    // tracks this with a concept of "anchor position before/after node":
+                    // https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/editing/position.h;l=39;drc=a5c6d7b223bfc6028ecae4b1f17d711374238c0d
+                    return false;
+                }
+                let mut current_offset = range.start_offset();
+                for current_ancestor in
+                    start_container.inclusive_ancestors_unrooted(cx, ShadowIncluding::Yes)
+                {
+                    if current_offset != 0 {
+                        return true;
+                    }
+                    if *current_ancestor == editing_host {
+                        return false;
+                    }
+                    current_offset = current_ancestor.index();
+                }
+                false
+            },
+            _ => true,
+        }
     }
 
     pub(crate) fn is_enabled_in_plaintext_only_state(&self) -> bool {

--- a/components/script/dom/execcommand/execcommands.rs
+++ b/components/script/dom/execcommand/execcommands.rs
@@ -100,6 +100,10 @@ impl Document {
         // > and there is some editing host that is an inclusive ancestor of both its start node and its end node.
         // TODO
 
+        if !command_name.is_enabled(cx, &range, &start_container_editing_host) {
+            return None;
+        }
+
         // Some commands are only enabled if the editing host is *not* in plaintext-only state.
         if !command_name.is_enabled_in_plaintext_only_state() &&
             (start_container_editing_host.is_in_plaintext_only_state() ||

--- a/tests/wpt/meta/custom-elements/reactions/Document.html.ini
+++ b/tests/wpt/meta/custom-elements/reactions/Document.html.ini
@@ -1,0 +1,3 @@
+[Document.html]
+  [execCommand on Document must enqueue a disconnected reaction when deleting a custom element from a contenteditable element]
+    expected: FAIL

--- a/tests/wpt/meta/editing/other/delete-editing-host.html.ini
+++ b/tests/wpt/meta/editing/other/delete-editing-host.html.ini
@@ -1,0 +1,6 @@
+[delete-editing-host.html]
+  [Should not do anything when deleting full editing host]
+    expected: FAIL
+
+  [Should retain all children when deleting full editing host]
+    expected: FAIL

--- a/tests/wpt/meta/editing/other/exec-command-with-text-editor.tentative.html.ini
+++ b/tests/wpt/meta/editing/other/exec-command-with-text-editor.tentative.html.ini
@@ -305,12 +305,6 @@
   [In <input type="password">, execCommand("defaultParagraphSeparator", false, div), a[b\]c): execCommand() should return false]
     expected: FAIL
 
-  [In <input type="password"> in contenteditable, execCommand("delete", false, null), ab[\]c): should not fire beforeinput event]
-    expected: FAIL
-
-  [In <input type="password"> in contenteditable, execCommand("delete", false, null), a[b\]c): should not fire beforeinput event]
-    expected: FAIL
-
   [In <input type="password"> in contenteditable, execCommand("fontsize", false, 5), a[b\]c): The command should not be enabled]
     expected: FAIL
 
@@ -519,6 +513,24 @@
     expected: FAIL
 
   [In <input type="password"> in contenteditable, execCommand("insertparagraph", false, null), a[b\]c): input.target should be undefined]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("delete", false, null), ab[\]c): The command should be enabled]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("delete", false, null), ab[\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("delete", false, null), ab[\]c): input.inputType should be deleteContentBackward]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("delete", false, null), a[b\]c): The command should be enabled]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("delete", false, null), a[b\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("delete", false, null), a[b\]c): input.inputType should be deleteContentBackward]
     expected: FAIL
 
 
@@ -829,12 +841,6 @@
   [In <input type="text">, execCommand("defaultParagraphSeparator", false, div), a[b\]c): execCommand() should return false]
     expected: FAIL
 
-  [In <input type="text"> in contenteditable, execCommand("delete", false, null), ab[\]c): should not fire beforeinput event]
-    expected: FAIL
-
-  [In <input type="text"> in contenteditable, execCommand("delete", false, null), a[b\]c): should not fire beforeinput event]
-    expected: FAIL
-
   [In <input type="text"> in contenteditable, execCommand("fontsize", false, 5), a[b\]c): The command should not be enabled]
     expected: FAIL
 
@@ -1043,6 +1049,24 @@
     expected: FAIL
 
   [In <input type="text"> in contenteditable, execCommand("insertparagraph", false, null), a[b\]c): input.target should be undefined]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("delete", false, null), ab[\]c): The command should be enabled]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("delete", false, null), ab[\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("delete", false, null), ab[\]c): input.inputType should be deleteContentBackward]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("delete", false, null), a[b\]c): The command should be enabled]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("delete", false, null), a[b\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("delete", false, null), a[b\]c): input.inputType should be deleteContentBackward]
     expected: FAIL
 
 
@@ -1362,12 +1386,6 @@
   [In <textarea>, execCommand("defaultParagraphSeparator", false, div), a[b\]c): execCommand() should return false]
     expected: FAIL
 
-  [In <textarea> in contenteditable, execCommand("delete", false, null), ab[\]c): should not fire beforeinput event]
-    expected: FAIL
-
-  [In <textarea> in contenteditable, execCommand("delete", false, null), a[b\]c): should not fire beforeinput event]
-    expected: FAIL
-
   [In <textarea> in contenteditable, execCommand("fontsize", false, 5), a[b\]c): The command should not be enabled]
     expected: FAIL
 
@@ -1582,4 +1600,22 @@
     expected: FAIL
 
   [In <textarea> in contenteditable, execCommand("insertparagraph", false, null), a[b\]c): input.target should be [object HTMLTextAreaElement\]]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("delete", false, null), ab[\]c): The command should be enabled]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("delete", false, null), ab[\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("delete", false, null), ab[\]c): input.inputType should be deleteContentBackward]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("delete", false, null), a[b\]c): The command should be enabled]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("delete", false, null), a[b\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("delete", false, null), a[b\]c): input.inputType should be deleteContentBackward]
     expected: FAIL

--- a/tests/wpt/meta/editing/other/inline-editing-host-has-placeholder-with-after-pseudo-element.html.ini
+++ b/tests/wpt/meta/editing/other/inline-editing-host-has-placeholder-with-after-pseudo-element.html.ini
@@ -1,2 +1,3 @@
 [inline-editing-host-has-placeholder-with-after-pseudo-element.html]
-  expected: TIMEOUT
+  [The editing host should have inserted text]
+    expected: FAIL

--- a/tests/wpt/meta/editing/other/inline-editing-host-has-placeholder-with-before-pseudo-element.html.ini
+++ b/tests/wpt/meta/editing/other/inline-editing-host-has-placeholder-with-before-pseudo-element.html.ini
@@ -1,2 +1,3 @@
 [inline-editing-host-has-placeholder-with-before-pseudo-element.html]
-  expected: TIMEOUT
+  [The editing host should have inserted text]
+    expected: FAIL

--- a/tests/wpt/meta/editing/run/delete-list-items-in-table-cell.html.ini
+++ b/tests/wpt/meta/editing/run/delete-list-items-in-table-cell.html.ini
@@ -4,3 +4,9 @@
 
   [[["delete",""\]\] "<div contenteditable=\\"true\\"><table><tr><td><ul><li>{}</li></ul></td></tr></table></div></table></div>" compare innerHTML]
     expected: FAIL
+
+  [[["delete",""\]\] "<div contenteditable=\\"true\\"><table><tr><td><ol><li>{}</li></ol></td></tr></table></div></table></div>": execCommand("delete", false, "") return value]
+    expected: FAIL
+
+  [[["delete",""\]\] "<div contenteditable=\\"true\\"><table><tr><td><ul><li>{}</li></ul></td></tr></table></div></table></div>": execCommand("delete", false, "") return value]
+    expected: FAIL

--- a/tests/wpt/meta/editing/run/delete.html.ini
+++ b/tests/wpt/meta/editing/run/delete.html.ini
@@ -185,6 +185,30 @@
   [[["stylewithcss","true"\],["delete",""\]\] "<span style=display:block>fo[o</span><span style=display:block>b\]ar</span>" queryCommandState("stylewithcss") before]
     expected: FAIL
 
+  [[["delete",""\]\] "<ol><li>foo</ol>{}<br><ol><li>bar</ol>": execCommand("delete", false, "") return value]
+    expected: FAIL
+
+  [[["delete",""\]\] "<ol id=a><li>foo</ol>{}<br><ol><li>bar</ol>": execCommand("delete", false, "") return value]
+    expected: FAIL
+
+  [[["delete",""\]\] "<ol><li>foo</ol>{}<br><ol id=b><li>bar</ol>": execCommand("delete", false, "") return value]
+    expected: FAIL
+
+  [[["delete",""\]\] "<ol id=a><li>foo</ol>{}<br><ol id=b><li>bar</ol>": execCommand("delete", false, "") return value]
+    expected: FAIL
+
+  [[["delete",""\]\] "<ol class=a><li>foo</ol>{}<br><ol class=b><li>bar</ol>": execCommand("delete", false, "") return value]
+    expected: FAIL
+
+  [[["delete",""\]\] "<ul><li>foo</ul>{}<br><ul><li>bar</ul>": execCommand("delete", false, "") return value]
+    expected: FAIL
+
+  [[["delete",""\]\] "<ol><li>foo</ol>{}<br><ul><li>bar</ul>": execCommand("delete", false, "") return value]
+    expected: FAIL
+
+  [[["delete",""\]\] "<ul><li>foo</ul>{}<br><ol><li>bar</ol>": execCommand("delete", false, "") return value]
+    expected: FAIL
+
 
 [delete.html?4001-5000]
   [[["stylewithcss","false"\],["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo<p style=text-decoration:line-through>[\]bar" queryCommandValue("defaultparagraphseparator") before]
@@ -595,6 +619,12 @@
   [[["delete",""\]\] "<p>foo</p><br><p>[\]bar</p>" compare innerHTML]
     expected: FAIL
 
+  [[["delete",""\]\] "<span>foo</span>{}<span>bar</span>": execCommand("delete", false, "") return value]
+    expected: FAIL
+
+  [[["delete",""\]\] "<span>foo</span>{}<span>bar</span>" compare innerHTML]
+    expected: FAIL
+
 
 [delete.html?1001-2000]
   [[["delete",""\]\] "<div style=white-space:pre-line>foo  [\]bar</div>" compare innerHTML]
@@ -745,6 +775,21 @@
     expected: FAIL
 
   [[["delete",""\]\] "<table><tr><td>foo<br><br><tr><td>[\]bar</table>" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "<ol><li>foo</ol>{}<br>": execCommand("delete", false, "") return value]
+    expected: FAIL
+
+  [[["delete",""\]\] "<ol><li>foo<br></ol>{}<br>": execCommand("delete", false, "") return value]
+    expected: FAIL
+
+  [[["delete",""\]\] "<ol><li>foo<br><br></ol>{}<br>": execCommand("delete", false, "") return value]
+    expected: FAIL
+
+  [[["delete",""\]\] "<ol><li><br></ol>{}<br>": execCommand("delete", false, "") return value]
+    expected: FAIL
+
+  [[["delete",""\]\] "<ol><li>foo<li><br></ol>{}<br>": execCommand("delete", false, "") return value]
     expected: FAIL
 
 
@@ -1053,6 +1098,36 @@
     expected: FAIL
 
   [[["styleWithCSS","false"\],["defaultparagraphseparator","p"\],["delete",""\]\] "<p><font size=5>foo</font><p><font color=blue>[\]bar</font>" queryCommandValue("foreColor") before]
+    expected: FAIL
+
+  [[["delete",""\]\] "<div><div>{}<br></div></div>": execCommand("delete", false, "") return value]
+    expected: FAIL
+
+  [[["delete",""\]\] "<div><div contenteditable=false><div contenteditable><div>{}<br></div></div></div></div>": execCommand("delete", false, "") return value]
+    expected: FAIL
+
+  [[["delete",""\]\] "<div><div contenteditable=false><span contenteditable>{}<br></span></div></div></div>": execCommand("delete", false, "") return value]
+    expected: FAIL
+
+  [[["delete",""\]\] "<p>{}<span contenteditable=false>ab</span></p>": execCommand("delete", false, "") return value]
+    expected: FAIL
+
+  [[["delete",""\]\] "<div>abc</div><br>{}<br><div>def</div>": execCommand("delete", false, "") return value]
+    expected: FAIL
+
+  [[["delete",""\]\] "<div>abc</div><br>{}<br><div>def</div>" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "<div style=display:flex><span>{}<br></span></div><div>abc</div>": execCommand("delete", false, "") return value]
+    expected: FAIL
+
+  [[["delete",""\]\] "<div style=display:inline-flex><span>{}<br></span></div><div>abc</div>": execCommand("delete", false, "") return value]
+    expected: FAIL
+
+  [[["delete",""\]\] "<div style=display:grid><span>{}<br></span></div><div>abc</div>": execCommand("delete", false, "") return value]
+    expected: FAIL
+
+  [[["delete",""\]\] "<div style=display:inline-grid><span>{}<br></span></div><div>abc</div>": execCommand("delete", false, "") return value]
     expected: FAIL
 
 

--- a/tests/wpt/tests/editing/crashtests/delete-before-first-child-of-editing-host.html
+++ b/tests/wpt/tests/editing/crashtests/delete-before-first-child-of-editing-host.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+<head>
+<link rel="help" href="https://github.com/servo/servo/issues/46235" />
+<meta charset="utf-8">
+<body>
+<!-- For this test it is important that there are no text nodes in the inner div -->
+<div id="outer" contenteditable="true">
+    <div contenteditable="true"><span></span></div>
+</div>
+
+<script>
+"use strict";
+
+const span = document.querySelector('span');
+document.getElementById('outer').textContent = "Text";
+
+const range = document.createRange();
+getSelection().addRange(range);
+range.setEndBefore(span);
+
+document.execCommand("delete");
+</script>
+</body>
+</html>


### PR DESCRIPTION
It currently is not possible to distinguish between the two scenarios:

1. We select the full editing host with `selection.collapse(editingHost)`
2. We set the cursor to just before the first child of the editing host

In both cases, the start container is the editing host and the index is zero. Other browsers do not enable the delete command in the second case, but keep it enabled (and do nothing) in the first case.

For now, to avoid crashes, we mimic browser behavior for determining whether the command is enabled by traversing the indices and check if we are at the start of the editing host. Unfortunately this regresses the WPT test that checks if the full empty editing host can be deleted, but that requires the non-standard concept of anchor position type that Chromium has.

Testing: adds a new crashtest
Fixes #46235
