### PR TITLE
LTS: backport #46277 to unblock macos CI on LTS

### DIFF
--- a/python/wpt/exporter/step.py
+++ b/python/wpt/exporter/step.py
@@ -111,10 +111,10 @@ class CreateOrUpdateBranchForPRStep(Step):
             # TODO: If we could cleverly parse and manipulate the full commit diff
             # we could avoid cloning the servo repository altogether and only
             # have to fetch the commit diffs from GitHub.
-            # NB: The output of git show might include binary files or non-UTF8 text,
+            # NB: The output of git might include binary files or non-UTF8 text,
             # so store the content of the diff as a `bytes`.
             diff = local_servo_repo.run_without_encoding(
-                "show", "--binary", "--format=%b", sha, "--", UPSTREAMABLE_PATH
+                "diff-tree", "--binary", "--no-commit-id", "-p", sha, "--", UPSTREAMABLE_PATH
             )
 
             # Retrieve the diff of any changes to files that are relevant


### PR DESCRIPTION
Backports #46227

---------

Git 2.55.0 apparently changed `git show` behavior and empty commits are no longer filtered out

`git diff-tree` is a plumbing command instead, so the output should be more stable.

https://git-scm.com/docs/git-diff-tree

Running the previous git show command, on a commit with no wpt changes:
```
git show --binary --format=%b 4fd54c062666f19aee3ad6233dbe4612a24836de tests/wpt/tests
```

With git 2.54: no output.
With git 2.55 it contains the commit message:
```
Bumps [aws-lc-rs](https://github.com/aws/aws-lc-rs) from 1.17.0 to
1.17.1.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a
href="https://github.com/aws/aws-lc-rs/releases">aws-lc-rs's
releases</a>.</em></p>
<blockquote>
<h2>aws-lc-rs v1.17.1</h2>
<p>🎉 AWS-LC FIPS v3 Module Has Been Validated</p>
<p>The AWS-LC FIPS v3 module has been awarded FIPS 140-3 validation by
NIST's CMVP:</p>
<ul>
...
```

Testing: Fixes the test-scripts test when using `git` 2.55.0
Fixes: #46214.


(cherry picked from commit 7b19e1bf0e64be563c04764a42f1b368c2db7f0f)

Testing: Macos job now passes (test-scripts failed before) [mach try](https://github.com/jschwe/servo/actions/runs/28702861831)

