### PR TITLE
script: JSContextify `get_cssom_stylesheet`

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -233,6 +233,7 @@ pub(crate) fn handle_get_document_element(
 }
 
 pub(crate) fn handle_get_stylesheets(
+    cx: &mut JSContext,
     documents: &DocumentCollection,
     pipeline: PipelineId,
     reply: GenericSender<Vec<StyleSheetInfo>>,
@@ -241,7 +242,7 @@ pub(crate) fn handle_get_stylesheets(
     if let Some(document) = documents.find_document(pipeline) {
         let node = document.upcast::<Node>();
         for i in 0..node.stylesheet_list_owner().stylesheet_count() {
-            if let Some(s) = node.stylesheet_list_owner().stylesheet_at(i) {
+            if let Some(s) = node.stylesheet_list_owner().stylesheet_at(cx, i) {
                 stylesheets.push(StyleSheetInfo {
                     href: s.href().map(String::from),
                     disabled: s.disabled(),
@@ -268,7 +269,7 @@ pub(crate) fn handle_get_stylesheet_text(
         let stylesheet = document
             .upcast::<Node>()
             .stylesheet_list_owner()
-            .stylesheet_at(index as usize)?;
+            .stylesheet_at(cx, index as usize)?;
 
         // For inline, Prefer the original "authored" source from the owner node (e.g., <style> tag).
         if let Some(node) = stylesheet.owner_node() {
@@ -476,7 +477,7 @@ pub(crate) fn handle_get_selectors(
 
         let mut decl_map = HashMap::new();
         for i in 0..owner.stylesheet_count() {
-            let Some(stylesheet) = owner.stylesheet_at(i) else {
+            let Some(stylesheet) = owner.stylesheet_at(cx, i) else {
                 continue;
             };
             let Ok(list) = stylesheet.GetCssRules(cx) else {
@@ -524,7 +525,7 @@ pub(crate) fn handle_get_stylesheet_style(
         let cx = &mut realm.current_realm();
         let owner = node.stylesheet_list_owner();
 
-        let stylesheet = owner.stylesheet_at(matched_rule.stylesheet_index)?;
+        let stylesheet = owner.stylesheet_at(cx, matched_rule.stylesheet_index)?;
         let list = stylesheet.GetCssRules(cx).ok()?;
 
         let style_rule = find_rule_by_block_id(cx, &list, matched_rule.block_id)?;

--- a/components/script/dom/css/cssstylesheet.rs
+++ b/components/script/dom/css/cssstylesheet.rs
@@ -12,7 +12,9 @@ use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::StyleSheetBinding::StyleSheetMethods;
 use script_bindings::inheritance::Castable;
-use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{
+    reflect_dom_object_with_cx, reflect_dom_object_with_proto_and_cx,
+};
 use script_bindings::root::Dom;
 use servo_arc::Arc;
 use style::media_queries::MediaList as StyleMediaList;
@@ -43,7 +45,6 @@ use crate::dom::medialist::MediaList;
 use crate::dom::node::NodeTraits;
 use crate::dom::types::Promise;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 use crate::test::TrustedPromise;
 
 #[dom_struct]
@@ -106,6 +107,7 @@ impl CSSStyleSheet {
 
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         owner: Option<&Element>,
         type_: DOMString,
@@ -113,9 +115,8 @@ impl CSSStyleSheet {
         title: Option<DOMString>,
         stylesheet: Arc<StyleStyleSheet>,
         constructor_document: Option<&Document>,
-        can_gc: CanGc,
     ) -> DomRoot<CSSStyleSheet> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(CSSStyleSheet::new_inherited(
                 owner,
                 type_,
@@ -125,7 +126,7 @@ impl CSSStyleSheet {
                 constructor_document,
             )),
             window,
-            can_gc,
+            cx,
         )
     }
 

--- a/components/script/dom/css/stylesheetlist.rs
+++ b/components/script/dom/css/stylesheetlist.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_arc::Arc;
 use style::stylesheets::Stylesheet;
@@ -32,10 +33,16 @@ impl StyleSheetListOwner {
         }
     }
 
-    pub(crate) fn stylesheet_at(&self, index: usize) -> Option<DomRoot<CSSStyleSheet>> {
+    pub(crate) fn stylesheet_at(
+        &self,
+        cx: &mut JSContext,
+        index: usize,
+    ) -> Option<DomRoot<CSSStyleSheet>> {
         match *self {
-            StyleSheetListOwner::Document(ref doc) => doc.stylesheet_at(index),
-            StyleSheetListOwner::ShadowRoot(ref shadow_root) => shadow_root.stylesheet_at(index),
+            StyleSheetListOwner::Document(ref doc) => doc.stylesheet_at(cx, index),
+            StyleSheetListOwner::ShadowRoot(ref shadow_root) => {
+                shadow_root.stylesheet_at(cx, index)
+            },
         }
     }
 
@@ -126,16 +133,16 @@ impl StyleSheetListMethods<crate::DomTypeHolder> for StyleSheetList {
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-stylesheetlist-item>
-    fn Item(&self, index: u32) -> Option<DomRoot<StyleSheet>> {
+    fn Item(&self, cx: &mut JSContext, index: u32) -> Option<DomRoot<StyleSheet>> {
         // XXXManishearth this  doesn't handle the origin clean flag and is a
         // cors vulnerability
         self.document_or_shadow_root
-            .stylesheet_at(index as usize)
+            .stylesheet_at(cx, index as usize)
             .map(DomRoot::upcast)
     }
 
     // check-tidy: no specs after this line
-    fn IndexedGetter(&self, index: u32) -> Option<DomRoot<StyleSheet>> {
-        self.Item(index)
+    fn IndexedGetter(&self, cx: &mut JSContext, index: u32) -> Option<DomRoot<StyleSheet>> {
+        self.Item(cx, index)
     }
 }

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -4442,12 +4442,16 @@ impl Document {
         self.stylesheets.borrow().len()
     }
 
-    pub(crate) fn stylesheet_at(&self, index: usize) -> Option<DomRoot<CSSStyleSheet>> {
+    pub(crate) fn stylesheet_at(
+        &self,
+        cx: &mut JSContext,
+        index: usize,
+    ) -> Option<DomRoot<CSSStyleSheet>> {
         let stylesheets = self.stylesheets.borrow();
 
         stylesheets
             .get(Origin::Author, index)
-            .and_then(|s| s.owner.get_cssom_object())
+            .and_then(|s| s.owner.get_cssom_object(cx))
     }
 
     /// Add a stylesheet owned by `owner_node` to the list of document sheets, in the

--- a/components/script/dom/document/documentorshadowroot.rs
+++ b/components/script/dom/document/documentorshadowroot.rs
@@ -47,9 +47,9 @@ pub(crate) enum StylesheetSource {
 }
 
 impl StylesheetSource {
-    pub(crate) fn get_cssom_object(&self) -> Option<DomRoot<CSSStyleSheet>> {
+    pub(crate) fn get_cssom_object(&self, cx: &mut JSContext) -> Option<DomRoot<CSSStyleSheet>> {
         match self {
-            StylesheetSource::Element(el) => el.upcast::<Node>().get_cssom_stylesheet(),
+            StylesheetSource::Element(el) => el.upcast::<Node>().get_cssom_stylesheet(cx),
             StylesheetSource::Constructed(ss) => Some(ss.as_rooted()),
         }
     }

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -62,7 +62,6 @@ use crate::dom::types::{EventTarget, GlobalScope};
 use crate::links::LinkRelations;
 use crate::network_listener::{FetchResponseListener, ResourceTimingListener, submit_timing};
 use crate::script_module::{ScriptFetchOptions, fetch_a_modulepreload_module};
-use crate::script_runtime::CanGc;
 use crate::stylesheet_loader::{ElementStylesheetLoader, StylesheetContextSource, StylesheetOwner};
 
 #[derive(Clone, Copy, JSTraceable, MallocSizeOf, PartialEq)]
@@ -196,10 +195,14 @@ impl HTMLLinkElement {
         self.stylesheet.borrow().clone()
     }
 
-    pub(crate) fn get_cssom_stylesheet(&self, can_gc: CanGc) -> Option<DomRoot<CSSStyleSheet>> {
+    pub(crate) fn get_cssom_stylesheet(
+        &self,
+        cx: &mut JSContext,
+    ) -> Option<DomRoot<CSSStyleSheet>> {
         self.get_stylesheet().map(|sheet| {
             self.cssom_stylesheet.or_init(|| {
                 CSSStyleSheet::new(
+                    cx,
                     &self.owner_window(),
                     Some(self.upcast::<Element>()),
                     "text/css".into(),
@@ -207,7 +210,6 @@ impl HTMLLinkElement {
                     None, // todo handle title
                     sheet,
                     None, // constructor_document
-                    can_gc,
                 )
             })
         })
@@ -1094,8 +1096,8 @@ impl StylesheetOwner for HTMLLinkElement {
         ReferrerPolicy::EmptyString
     }
 
-    fn set_origin_clean(&self, origin_clean: bool) {
-        if let Some(stylesheet) = self.get_cssom_stylesheet(CanGc::deprecated_note()) {
+    fn set_origin_clean(&self, cx: &mut js::context::JSContext, origin_clean: bool) {
+        if let Some(stylesheet) = self.get_cssom_stylesheet(cx) {
             stylesheet.set_origin_clean(origin_clean);
         }
     }
@@ -1240,8 +1242,7 @@ impl HTMLLinkElementMethods<crate::DomTypeHolder> for HTMLLinkElement {
 
     /// <https://drafts.csswg.org/cssom/#dom-linkstyle-sheet>
     fn GetSheet(&self, cx: &mut JSContext) -> Option<DomRoot<DOMStyleSheet>> {
-        self.get_cssom_stylesheet(CanGc::from_cx(cx))
-            .map(DomRoot::upcast)
+        self.get_cssom_stylesheet(cx).map(DomRoot::upcast)
     }
 }
 

--- a/components/script/dom/html/htmlstyleelement.rs
+++ b/components/script/dom/html/htmlstyleelement.rs
@@ -38,7 +38,6 @@ use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::medialist::MediaList;
 use crate::dom::node::virtualmethods::VirtualMethods;
 use crate::dom::node::{BindContext, ChildrenMutation, Node, NodeTraits, UnbindContext};
-use crate::script_runtime::CanGc;
 use crate::stylesheet_loader::StylesheetOwner;
 
 #[dom_struct]
@@ -245,10 +244,14 @@ impl HTMLStyleElement {
         self.stylesheet.borrow().clone()
     }
 
-    pub(crate) fn get_cssom_stylesheet(&self) -> Option<DomRoot<CSSStyleSheet>> {
+    pub(crate) fn get_cssom_stylesheet(
+        &self,
+        cx: &mut JSContext,
+    ) -> Option<DomRoot<CSSStyleSheet>> {
         self.get_stylesheet().map(|sheet| {
             self.cssom_stylesheet.or_init(|| {
                 CSSStyleSheet::new(
+                    cx,
                     &self.owner_window(),
                     Some(self.upcast::<Element>()),
                     "text/css".into(),
@@ -256,7 +259,6 @@ impl HTMLStyleElement {
                     None, // todo handle title
                     sheet,
                     None, // constructor_document
-                    CanGc::deprecated_note(),
                 )
             })
         })
@@ -440,12 +442,12 @@ impl StylesheetOwner for HTMLStyleElement {
                 .is_some_and(|list| list.Contains("render".into()))
     }
 
-    fn referrer_policy(&self, _cx: &mut js::context::JSContext) -> ReferrerPolicy {
+    fn referrer_policy(&self, _cx: &mut JSContext) -> ReferrerPolicy {
         ReferrerPolicy::EmptyString
     }
 
-    fn set_origin_clean(&self, origin_clean: bool) {
-        if let Some(stylesheet) = self.get_cssom_stylesheet() {
+    fn set_origin_clean(&self, cx: &mut JSContext, origin_clean: bool) {
+        if let Some(stylesheet) = self.get_cssom_stylesheet(cx) {
             stylesheet.set_origin_clean(origin_clean);
         }
     }
@@ -453,19 +455,19 @@ impl StylesheetOwner for HTMLStyleElement {
 
 impl HTMLStyleElementMethods<crate::DomTypeHolder> for HTMLStyleElement {
     /// <https://drafts.csswg.org/cssom/#dom-linkstyle-sheet>
-    fn GetSheet(&self) -> Option<DomRoot<DOMStyleSheet>> {
-        self.get_cssom_stylesheet().map(DomRoot::upcast)
+    fn GetSheet(&self, cx: &mut JSContext) -> Option<DomRoot<DOMStyleSheet>> {
+        self.get_cssom_stylesheet(cx).map(DomRoot::upcast)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-style-disabled>
-    fn Disabled(&self) -> bool {
-        self.get_cssom_stylesheet()
+    fn Disabled(&self, cx: &mut JSContext) -> bool {
+        self.get_cssom_stylesheet(cx)
             .is_some_and(|sheet| sheet.disabled())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-style-disabled>
-    fn SetDisabled(&self, _cx: &mut js::context::JSContext, value: bool) {
-        if let Some(sheet) = self.get_cssom_stylesheet() {
+    fn SetDisabled(&self, cx: &mut js::context::JSContext, value: bool) {
+        if let Some(sheet) = self.get_cssom_stylesheet(cx) {
             sheet.set_disabled(value);
         }
     }

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -1927,11 +1927,14 @@ impl Node {
         Ok(())
     }
 
-    pub(crate) fn get_cssom_stylesheet(&self) -> Option<DomRoot<CSSStyleSheet>> {
+    pub(crate) fn get_cssom_stylesheet(
+        &self,
+        cx: &mut JSContext,
+    ) -> Option<DomRoot<CSSStyleSheet>> {
         if let Some(node) = self.downcast::<HTMLStyleElement>() {
-            node.get_cssom_stylesheet()
+            node.get_cssom_stylesheet(cx)
         } else if let Some(node) = self.downcast::<HTMLLinkElement>() {
-            node.get_cssom_stylesheet(CanGc::deprecated_note())
+            node.get_cssom_stylesheet(cx)
         } else {
             None
         }

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -190,12 +190,16 @@ impl ShadowRoot {
         self.author_styles.borrow().stylesheets.len()
     }
 
-    pub(crate) fn stylesheet_at(&self, index: usize) -> Option<DomRoot<CSSStyleSheet>> {
+    pub(crate) fn stylesheet_at(
+        &self,
+        cx: &mut JSContext,
+        index: usize,
+    ) -> Option<DomRoot<CSSStyleSheet>> {
         let stylesheets = &self.author_styles.borrow().stylesheets;
 
         stylesheets
             .get(index)
-            .and_then(|s| s.owner.get_cssom_object())
+            .and_then(|s| s.owner.get_cssom_object(cx))
     }
 
     /// Add a stylesheet owned by `owner_node` to the list of shadow root sheets, in the

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2166,7 +2166,7 @@ impl ScriptThread {
                 )
             },
             DevtoolScriptControlMsg::GetStyleSheets(id, reply) => {
-                devtools::handle_get_stylesheets(&documents, id, reply);
+                devtools::handle_get_stylesheets(cx, &documents, id, reply);
             },
             DevtoolScriptControlMsg::GetStyleSheetText(id, index, reply) => {
                 devtools::handle_get_stylesheet_text(cx, &documents, id, index, reply);

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -85,7 +85,7 @@ pub(crate) trait StylesheetOwner {
     fn load_finished(&self, successful: bool) -> Option<bool>;
 
     /// Sets origin_clean flag.
-    fn set_origin_clean(&self, origin_clean: bool);
+    fn set_origin_clean(&self, cx: &mut JSContext, origin_clean: bool);
 }
 
 pub(crate) enum StylesheetContextSource {
@@ -317,7 +317,7 @@ impl StylesheetContext {
         } else {
             document.invalidate_stylesheets();
         }
-        owner.set_origin_clean(self.origin_clean);
+        owner.set_origin_clean(cx, self.origin_clean);
 
         // Remaining steps are a combination of
         // https://html.spec.whatwg.org/multipage/#link-type-stylesheet%3Aprocess-the-linked-resource

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -828,7 +828,7 @@ DOMInterfaces = {
 },
 
 'HTMLStyleElement': {
-    'cx': ['Blocking'],
+    'cx': ['GetSheet', 'Disabled', 'SetDisabled', 'Blocking'],
 },
 
 'HTMLTableElement': {
@@ -1144,6 +1144,10 @@ DOMInterfaces = {
 
 'StyleSheet': {
     'cx': ['Media'],
+},
+
+'StyleSheetList': {
+    'cx': ['Item', 'IndexedGetter'],
 },
 
 'SubtleCrypto': {


### PR DESCRIPTION
Started out as cleaning up HTMLLinkElement and HTMLStyleElement, but propagated waaay further than I was expecting. Let me know if I should try to split this further.

Testing: Compilation.
Fixes: Part of #40600.
