### PR TITLE
script: Migrate `dom/debugger` to `&mut JSContext`

### DIFF
--- a/components/script/dom/debugger/debuggerblackboxevent.rs
+++ b/components/script/dom/debugger/debuggerblackboxevent.rs
@@ -5,15 +5,15 @@
 use devtools_traits::BlackboxCoverage;
 use devtools_traits::BlackboxCoverage::{Full, Partial};
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::codegen::GenericBindings::DebuggerBlackboxEventBinding::DebuggerBlackboxEventMethods;
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 
 use crate::dom::bindings::codegen::Bindings::DebuggerGlobalScopeBinding::DebuggerSourceLocation;
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::event::Event;
 use crate::dom::types::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 /// Event for Rust → JS calls in [`crate::dom::debugger::DebuggerGlobalScope`].
@@ -31,10 +31,10 @@ pub(crate) struct DebuggerBlackboxEvent {
 
 impl DebuggerBlackboxEvent {
     pub(crate) fn new(
+        cx: &mut JSContext,
         debugger_global: &GlobalScope,
         spidermonkey_id: u32,
         coverage: BlackboxCoverage,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
         let result = Box::new(match coverage {
             Partial((start_line, start_column), (end_line, end_column)) => Self {
@@ -57,7 +57,7 @@ impl DebuggerBlackboxEvent {
             },
         });
 
-        let result = reflect_dom_object(result, debugger_global, can_gc);
+        let result = reflect_dom_object_with_cx(result, debugger_global, cx);
         result.event.init_event("blackbox".into(), false, false);
 
         result

--- a/components/script/dom/debugger/debuggerclearbreakpointevent.rs
+++ b/components/script/dom/debugger/debuggerclearbreakpointevent.rs
@@ -5,14 +5,14 @@
 use std::fmt::Debug;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::codegen::GenericBindings::DebuggerClearBreakpointEventBinding::DebuggerClearBreakpointEventMethods;
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::event::Event;
 use crate::dom::types::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 /// Event for Rust → JS calls in [`crate::dom::debugger::DebuggerGlobalScope`].
@@ -25,11 +25,11 @@ pub(crate) struct DebuggerClearBreakpointEvent {
 
 impl DebuggerClearBreakpointEvent {
     pub(crate) fn new(
+        cx: &mut JSContext,
         debugger_global: &GlobalScope,
         spidermonkey_id: u32,
         script_id: u32,
         offset: u32,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
         let result = Box::new(Self {
             event: Event::new_inherited(),
@@ -37,7 +37,7 @@ impl DebuggerClearBreakpointEvent {
             script_id,
             offset,
         });
-        let result = reflect_dom_object(result, debugger_global, can_gc);
+        let result = reflect_dom_object_with_cx(result, debugger_global, cx);
         result
             .event
             .init_event("clearBreakpoint".into(), false, false);

--- a/components/script/dom/debugger/debuggerevalevent.rs
+++ b/components/script/dom/debugger/debuggerevalevent.rs
@@ -3,7 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::reflect_dom_object;
+use js::context::JSContext;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use script_bindings::str::DOMString;
 
 use crate::dom::bindings::codegen::Bindings::DebuggerEvalEventBinding::DebuggerEvalEventMethods;
@@ -11,7 +12,6 @@ use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventM
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::event::Event;
 use crate::dom::types::{GlobalScope, PipelineId};
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 /// Event for Rust → JS calls in [`crate::dom::debugger::DebuggerGlobalScope`].
@@ -25,12 +25,12 @@ pub(crate) struct DebuggerEvalEvent {
 
 impl DebuggerEvalEvent {
     pub(crate) fn new(
+        cx: &mut JSContext,
         debugger_global: &GlobalScope,
         code: DOMString,
         pipeline_id: &PipelineId,
         worker_id: Option<DOMString>,
         frame_actor_id: Option<DOMString>,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
         let result = Box::new(Self {
             event: Event::new_inherited(),
@@ -39,7 +39,7 @@ impl DebuggerEvalEvent {
             worker_id,
             frame_actor_id,
         });
-        let result = reflect_dom_object(result, debugger_global, can_gc);
+        let result = reflect_dom_object_with_cx(result, debugger_global, cx);
         result.event.init_event("eval".into(), false, false);
 
         result

--- a/components/script/dom/debugger/debuggerframeevent.rs
+++ b/components/script/dom/debugger/debuggerframeevent.rs
@@ -5,14 +5,14 @@
 use std::fmt::Debug;
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::reflect_dom_object;
+use js::context::JSContext;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 
 use crate::dom::bindings::codegen::Bindings::DebuggerFrameEventBinding::DebuggerFrameEventMethods;
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::event::Event;
 use crate::dom::types::{GlobalScope, PipelineId};
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 /// Event for Rust → JS calls in [`crate::dom::debugger::DebuggerGlobalScope`].
@@ -25,11 +25,11 @@ pub(crate) struct DebuggerFrameEvent {
 
 impl DebuggerFrameEvent {
     pub(crate) fn new(
+        cx: &mut JSContext,
         debugger_global: &GlobalScope,
         pipeline_id: &PipelineId,
         start: u32,
         count: u32,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
         let result = Box::new(Self {
             event: Event::new_inherited(),
@@ -37,7 +37,7 @@ impl DebuggerFrameEvent {
             start,
             count,
         });
-        let result = reflect_dom_object(result, debugger_global, can_gc);
+        let result = reflect_dom_object_with_cx(result, debugger_global, cx);
         result.event.init_event("frames".into(), false, false);
 
         result

--- a/components/script/dom/debugger/debuggergetenvironmentevent.rs
+++ b/components/script/dom/debugger/debuggergetenvironmentevent.rs
@@ -5,7 +5,8 @@
 use std::fmt::Debug;
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::reflect_dom_object;
+use js::context::JSContext;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use script_bindings::str::DOMString;
 
 use crate::dom::bindings::codegen::Bindings::DebuggerGetEnvironmentEventBinding::DebuggerGetEnvironmentEventMethods;
@@ -13,7 +14,6 @@ use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventM
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::event::Event;
 use crate::dom::types::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 /// Event for Rust → JS calls in [`crate::dom::debugger::DebuggerGlobalScope`].
@@ -24,15 +24,15 @@ pub(crate) struct DebuggerGetEnvironmentEvent {
 
 impl DebuggerGetEnvironmentEvent {
     pub(crate) fn new(
+        cx: &mut JSContext,
         debugger_global: &GlobalScope,
         frame_actor_id: DOMString,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
         let result = Box::new(Self {
             event: Event::new_inherited(),
             frame_actor_id,
         });
-        let result = reflect_dom_object(result, debugger_global, can_gc);
+        let result = reflect_dom_object_with_cx(result, debugger_global, cx);
         result
             .event
             .init_event("getEnvironment".into(), false, false);

--- a/components/script/dom/debugger/debuggergetpossiblebreakpointsevent.rs
+++ b/components/script/dom/debugger/debuggergetpossiblebreakpointsevent.rs
@@ -5,14 +5,14 @@
 use std::fmt::Debug;
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::reflect_dom_object;
+use js::context::JSContext;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 
 use crate::dom::bindings::codegen::Bindings::DebuggerGetPossibleBreakpointsEventBinding::DebuggerGetPossibleBreakpointsEventMethods;
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::event::Event;
 use crate::dom::types::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 /// Event for Rust → JS calls in [`crate::dom::debugger::DebuggerGlobalScope`].
@@ -23,15 +23,15 @@ pub(crate) struct DebuggerGetPossibleBreakpointsEvent {
 
 impl DebuggerGetPossibleBreakpointsEvent {
     pub(crate) fn new(
+        cx: &mut JSContext,
         debugger_global: &GlobalScope,
         spidermonkey_id: u32,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
         let result = Box::new(Self {
             event: Event::new_inherited(),
             spidermonkey_id,
         });
-        let result = reflect_dom_object(result, debugger_global, can_gc);
+        let result = reflect_dom_object_with_cx(result, debugger_global, cx);
         result
             .event
             .init_event("getPossibleBreakpoints".into(), false, false);

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -52,7 +52,7 @@ use crate::dom::types::{
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::identityhub::IdentityHub;
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::{CanGc, IntroductionType};
+use crate::script_runtime::IntroductionType;
 use crate::script_thread::with_script_thread;
 
 #[dom_struct]
@@ -171,9 +171,9 @@ impl DebuggerGlobalScope {
         let mut realm = enter_auto_realm(cx, self);
         let cx = &mut realm;
         let debuggee_pipeline_id = crate::dom::pipelineid::PipelineId::new(
+            cx,
             self.upcast(),
             debuggee_pipeline_id,
-            CanGc::from_cx(cx),
         );
         let event = DomRoot::upcast::<Event>(DebuggerAddDebuggeeEvent::new(
             cx,
@@ -205,17 +205,17 @@ impl DebuggerGlobalScope {
         let mut realm = enter_auto_realm(cx, self);
         let cx = &mut realm;
         let debuggee_pipeline_id = crate::dom::pipelineid::PipelineId::new(
+            cx,
             self.upcast(),
             debuggee_pipeline_id,
-            CanGc::from_cx(cx),
         );
         let event = DomRoot::upcast::<Event>(DebuggerEvalEvent::new(
+            cx,
             self.upcast(),
             code,
             &debuggee_pipeline_id,
             debuggee_worker_id.map(|id| id.to_string().into()),
             frame_actor_id.map(|id| id.into()),
-            CanGc::from_cx(cx),
         ));
         assert!(
             event.fire(cx, self.upcast()),
@@ -237,9 +237,9 @@ impl DebuggerGlobalScope {
         let mut realm = enter_auto_realm(cx, self);
         let cx = &mut realm.current_realm();
         let event = DomRoot::upcast::<Event>(DebuggerGetPossibleBreakpointsEvent::new(
+            cx,
             self.upcast(),
             spidermonkey_id,
-            CanGc::from_cx(cx),
         ));
         assert!(
             event.fire(cx, self.upcast()),
@@ -255,11 +255,11 @@ impl DebuggerGlobalScope {
         offset: u32,
     ) {
         let event = DomRoot::upcast::<Event>(DebuggerSetBreakpointEvent::new(
+            cx,
             self.upcast(),
             spidermonkey_id,
             script_id,
             offset,
-            CanGc::from_cx(cx),
         ));
         assert!(
             event.fire(cx, self.upcast()),
@@ -269,8 +269,8 @@ impl DebuggerGlobalScope {
 
     pub(crate) fn fire_interrupt(&self, cx: &mut js::context::JSContext) {
         let event = DomRoot::upcast::<Event>(DebuggerInterruptEvent::new(
+            cx,
             self.upcast(),
-            CanGc::from_cx(cx),
         ));
         assert!(
             event.fire(cx, self.upcast()),
@@ -294,13 +294,13 @@ impl DebuggerGlobalScope {
         let mut realm = enter_auto_realm(cx, self);
         let cx = &mut realm.current_realm();
         let pipeline_id =
-            crate::dom::pipelineid::PipelineId::new(self.upcast(), pipeline_id, CanGc::from_cx(cx));
+            crate::dom::pipelineid::PipelineId::new(cx, self.upcast(), pipeline_id);
         let event = DomRoot::upcast::<Event>(DebuggerFrameEvent::new(
+            cx,
             self.upcast(),
             &pipeline_id,
             start,
             count,
-            CanGc::from_cx(cx),
         ));
         assert!(
             event.fire(cx, self.upcast()),
@@ -322,9 +322,9 @@ impl DebuggerGlobalScope {
         let mut realm = enter_auto_realm(cx, self);
         let cx = &mut realm.current_realm();
         let event = DomRoot::upcast::<Event>(DebuggerGetEnvironmentEvent::new(
+            cx,
             self.upcast(),
             frame_actor_id.into(),
-            CanGc::from_cx(cx),
         ));
         assert!(
             event.fire(cx, self.upcast()),
@@ -339,10 +339,10 @@ impl DebuggerGlobalScope {
         frame_actor_id: Option<String>,
     ) {
         let event = DomRoot::upcast::<Event>(DebuggerResumeEvent::new(
+            cx,
             self.upcast(),
             resume_limit_type.map(DOMString::from),
             frame_actor_id.map(DOMString::from),
-            CanGc::from_cx(cx),
         ));
         assert!(
             event.fire(cx, self.upcast()),
@@ -358,11 +358,11 @@ impl DebuggerGlobalScope {
         offset: u32,
     ) {
         let event = DomRoot::upcast::<Event>(DebuggerClearBreakpointEvent::new(
+            cx,
             self.upcast(),
             spidermonkey_id,
             script_id,
             offset,
-            CanGc::from_cx(cx),
         ));
         assert!(
             event.fire(cx, self.upcast()),
@@ -377,10 +377,10 @@ impl DebuggerGlobalScope {
         coverage: BlackboxCoverage,
     ) {
         let event = DomRoot::upcast::<Event>(DebuggerBlackboxEvent::new(
+            cx,
             self.upcast(),
             spidermonkey_id,
             coverage,
-            CanGc::from_cx(cx),
         ));
         assert!(
             event.fire(cx, self.upcast()),
@@ -395,10 +395,10 @@ impl DebuggerGlobalScope {
         coverage: BlackboxCoverage,
     ) {
         let event = DomRoot::upcast::<Event>(DebuggerUnblackboxEvent::new(
+            cx,
             self.upcast(),
             spidermonkey_id,
             coverage,
-            CanGc::from_cx(cx),
         ));
         assert!(
             event.fire(cx, self.upcast()),

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -170,11 +170,8 @@ impl DebuggerGlobalScope {
     ) {
         let mut realm = enter_auto_realm(cx, self);
         let cx = &mut realm;
-        let debuggee_pipeline_id = crate::dom::pipelineid::PipelineId::new(
-            cx,
-            self.upcast(),
-            debuggee_pipeline_id,
-        );
+        let debuggee_pipeline_id =
+            crate::dom::pipelineid::PipelineId::new(cx, self.upcast(), debuggee_pipeline_id);
         let event = DomRoot::upcast::<Event>(DebuggerAddDebuggeeEvent::new(
             cx,
             self.upcast(),
@@ -204,11 +201,8 @@ impl DebuggerGlobalScope {
         );
         let mut realm = enter_auto_realm(cx, self);
         let cx = &mut realm;
-        let debuggee_pipeline_id = crate::dom::pipelineid::PipelineId::new(
-            cx,
-            self.upcast(),
-            debuggee_pipeline_id,
-        );
+        let debuggee_pipeline_id =
+            crate::dom::pipelineid::PipelineId::new(cx, self.upcast(), debuggee_pipeline_id);
         let event = DomRoot::upcast::<Event>(DebuggerEvalEvent::new(
             cx,
             self.upcast(),
@@ -268,10 +262,7 @@ impl DebuggerGlobalScope {
     }
 
     pub(crate) fn fire_interrupt(&self, cx: &mut js::context::JSContext) {
-        let event = DomRoot::upcast::<Event>(DebuggerInterruptEvent::new(
-            cx,
-            self.upcast(),
-        ));
+        let event = DomRoot::upcast::<Event>(DebuggerInterruptEvent::new(cx, self.upcast()));
         assert!(
             event.fire(cx, self.upcast()),
             "Guaranteed by DebuggerInterruptEvent::new"
@@ -293,8 +284,7 @@ impl DebuggerGlobalScope {
         );
         let mut realm = enter_auto_realm(cx, self);
         let cx = &mut realm.current_realm();
-        let pipeline_id =
-            crate::dom::pipelineid::PipelineId::new(cx, self.upcast(), pipeline_id);
+        let pipeline_id = crate::dom::pipelineid::PipelineId::new(cx, self.upcast(), pipeline_id);
         let event = DomRoot::upcast::<Event>(DebuggerFrameEvent::new(
             cx,
             self.upcast(),

--- a/components/script/dom/debugger/debuggerinterruptevent.rs
+++ b/components/script/dom/debugger/debuggerinterruptevent.rs
@@ -5,14 +5,14 @@
 use std::fmt::Debug;
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::reflect_dom_object;
+use js::context::JSContext;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 
 use crate::dom::bindings::codegen::Bindings::DebuggerInterruptEventBinding::DebuggerInterruptEventMethods;
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::event::Event;
 use crate::dom::types::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 /// Event for Rust → JS calls in [`crate::dom::debugger::DebuggerGlobalScope`].
@@ -21,11 +21,11 @@ pub(crate) struct DebuggerInterruptEvent {
 }
 
 impl DebuggerInterruptEvent {
-    pub(crate) fn new(debugger_global: &GlobalScope, can_gc: CanGc) -> DomRoot<Self> {
+    pub(crate) fn new(cx: &mut JSContext, debugger_global: &GlobalScope) -> DomRoot<Self> {
         let result = Box::new(Self {
             event: Event::new_inherited(),
         });
-        let result = reflect_dom_object(result, debugger_global, can_gc);
+        let result = reflect_dom_object_with_cx(result, debugger_global, cx);
         result.event.init_event("interrupt".into(), false, false);
 
         result

--- a/components/script/dom/debugger/debuggerresumeevent.rs
+++ b/components/script/dom/debugger/debuggerresumeevent.rs
@@ -5,7 +5,8 @@
 use std::fmt::Debug;
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::reflect_dom_object;
+use js::context::JSContext;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use script_bindings::str::DOMString;
 
 use crate::dom::bindings::codegen::Bindings::DebuggerResumeEventBinding::DebuggerResumeEventMethods;
@@ -13,7 +14,6 @@ use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventM
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::event::Event;
 use crate::dom::types::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 /// Event for Rust → JS calls in [`crate::dom::debugger::DebuggerGlobalScope`].
@@ -25,17 +25,17 @@ pub(crate) struct DebuggerResumeEvent {
 
 impl DebuggerResumeEvent {
     pub(crate) fn new(
+        cx: &mut JSContext,
         debugger_global: &GlobalScope,
         resume_limit_type: Option<DOMString>,
         frame_actor_id: Option<DOMString>,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
         let result = Box::new(Self {
             event: Event::new_inherited(),
             resume_limit_type,
             frame_actor_id,
         });
-        let result = reflect_dom_object(result, debugger_global, can_gc);
+        let result = reflect_dom_object_with_cx(result, debugger_global, cx);
         result.event.init_event("resume".into(), false, false);
 
         result

--- a/components/script/dom/debugger/debuggersetbreakpointevent.rs
+++ b/components/script/dom/debugger/debuggersetbreakpointevent.rs
@@ -5,14 +5,14 @@
 use std::fmt::Debug;
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::reflect_dom_object;
+use js::context::JSContext;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 
 use crate::dom::bindings::codegen::Bindings::DebuggerSetBreakpointEventBinding::DebuggerSetBreakpointEventMethods;
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::event::Event;
 use crate::dom::types::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 /// Event for Rust → JS calls in [`crate::dom::debugger::DebuggerGlobalScope`].
@@ -25,11 +25,11 @@ pub(crate) struct DebuggerSetBreakpointEvent {
 
 impl DebuggerSetBreakpointEvent {
     pub(crate) fn new(
+        cx: &mut JSContext,
         debugger_global: &GlobalScope,
         spidermonkey_id: u32,
         script_id: u32,
         offset: u32,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
         let result = Box::new(Self {
             event: Event::new_inherited(),
@@ -37,7 +37,7 @@ impl DebuggerSetBreakpointEvent {
             script_id,
             offset,
         });
-        let result = reflect_dom_object(result, debugger_global, can_gc);
+        let result = reflect_dom_object_with_cx(result, debugger_global, cx);
         result
             .event
             .init_event("setBreakpoint".into(), false, false);

--- a/components/script/dom/debugger/debuggerunblackboxevent.rs
+++ b/components/script/dom/debugger/debuggerunblackboxevent.rs
@@ -5,15 +5,15 @@
 use devtools_traits::BlackboxCoverage;
 use devtools_traits::BlackboxCoverage::{Full, Partial};
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::codegen::GenericBindings::DebuggerUnblackboxEventBinding::DebuggerUnblackboxEventMethods;
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 
 use crate::dom::bindings::codegen::Bindings::DebuggerGlobalScopeBinding::DebuggerSourceLocation;
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::event::Event;
 use crate::dom::types::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 /// Event for Rust → JS calls in [`crate::dom::debugger::DebuggerGlobalScope`].
@@ -31,10 +31,10 @@ pub(crate) struct DebuggerUnblackboxEvent {
 
 impl DebuggerUnblackboxEvent {
     pub(crate) fn new(
+        cx: &mut JSContext,
         debugger_global: &GlobalScope,
         spidermonkey_id: u32,
         coverage: BlackboxCoverage,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
         let result = Box::new(match coverage {
             Partial((start_line, start_column), (end_line, end_column)) => Self {
@@ -57,7 +57,7 @@ impl DebuggerUnblackboxEvent {
             },
         });
 
-        let result = reflect_dom_object(result, debugger_global, can_gc);
+        let result = reflect_dom_object_with_cx(result, debugger_global, cx);
         result.event.init_event("unblackbox".into(), false, false);
 
         result

--- a/components/script/dom/debugger/pipelineid.rs
+++ b/components/script/dom/debugger/pipelineid.rs
@@ -3,12 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use js::context::JSContext;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
 use crate::dom::bindings::codegen::Bindings::DebuggerAddDebuggeeEventBinding::PipelineIdMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct PipelineId {
@@ -19,17 +19,17 @@ pub(crate) struct PipelineId {
 
 impl PipelineId {
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         pipeline_id: servo_base::id::PipelineId,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(Self {
                 reflector_: Reflector::new(),
                 inner: pipeline_id,
             }),
             global,
-            can_gc,
+            cx,
         )
     }
 }


### PR DESCRIPTION
Trivial thanks to prior work - just migrating constructors.

Testing: Compilation.
Fixes: Part of #40600.