### PR TITLE
script: Clean up and fully migrate `dom/geometry` to `&mut JSContext`

### DIFF
--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -2206,7 +2206,7 @@ impl CanvasState {
         cx: &mut JSContext,
     ) -> DomRoot<DOMMatrix> {
         let transform = self.state.borrow_mut().transform;
-        DOMMatrix::new(global, true, transform.to_3d(), cx)
+        DOMMatrix::new(cx, global, true, transform.to_3d())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-settransform>

--- a/components/script/dom/geometry/dommatrix.rs
+++ b/components/script/dom/geometry/dommatrix.rs
@@ -8,7 +8,7 @@ use js::context::JSContext;
 use js::rust::{CustomAutoRooterGuard, HandleObject};
 use js::typedarray::{Float32Array, Float64Array};
 use rustc_hash::FxHashMap;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use script_bindings::str::DOMString;
 use servo_base::id::{DomMatrixId, DomMatrixIndex};
 use servo_constellation_traits::DomMatrix;
@@ -27,7 +27,6 @@ use crate::dom::dommatrixreadonly::{
 };
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct DOMMatrix {
@@ -37,24 +36,24 @@ pub(crate) struct DOMMatrix {
 #[expect(non_snake_case)]
 impl DOMMatrix {
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         is2D: bool,
         matrix: Transform3D<f64>,
-        cx: &mut JSContext,
     ) -> DomRoot<Self> {
-        Self::new_with_proto(global, None, is2D, matrix, cx)
+        Self::new_with_proto(cx, global, None, is2D, matrix)
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_with_proto(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         is2D: bool,
         matrix: Transform3D<f64>,
-        cx: &mut JSContext,
     ) -> DomRoot<Self> {
         let dommatrix = Self::new_inherited(is2D, matrix);
-        reflect_dom_object_with_proto(Box::new(dommatrix), global, proto, CanGc::from_cx(cx))
+        reflect_dom_object_with_proto_and_cx(Box::new(dommatrix), global, proto, cx)
     }
 
     pub(crate) fn new_inherited(is2D: bool, matrix: Transform3D<f64>) -> Self {
@@ -68,7 +67,7 @@ impl DOMMatrix {
         ro: &DOMMatrixReadOnly,
         cx: &mut JSContext,
     ) -> DomRoot<Self> {
-        Self::new(global, ro.is2D(), *ro.matrix(), cx)
+        Self::new(cx, global, ro.is2D(), *ro.matrix())
     }
 }
 
@@ -83,11 +82,11 @@ impl DOMMatrixMethods<crate::DomTypeHolder> for DOMMatrix {
     ) -> Fallible<DomRoot<Self>> {
         if init.is_none() {
             return Ok(Self::new_with_proto(
+                cx,
                 global,
                 proto,
                 true,
                 Transform3D::identity(),
-                cx,
             ));
         }
         match init.unwrap() {
@@ -98,14 +97,14 @@ impl DOMMatrixMethods<crate::DomTypeHolder> for DOMMatrix {
                     ));
                 }
                 if s.is_empty() {
-                    return Ok(Self::new(global, true, Transform3D::identity(), cx));
+                    return Ok(Self::new(cx, global, true, Transform3D::identity()));
                 }
                 transform_to_matrix(&s.str())
-                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix, cx))
+                    .map(|(is2D, matrix)| Self::new_with_proto(cx, global, proto, is2D, matrix))
             },
             StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(ref entries) => {
                 entries_to_matrix(&entries[..])
-                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix, cx))
+                    .map(|(is2D, matrix)| Self::new_with_proto(cx, global, proto, is2D, matrix))
             },
         }
     }
@@ -116,7 +115,7 @@ impl DOMMatrixMethods<crate::DomTypeHolder> for DOMMatrix {
         global: &GlobalScope,
         other: &DOMMatrixInit,
     ) -> Fallible<DomRoot<Self>> {
-        dommatrixinit_to_matrix(other).map(|(is2D, matrix)| Self::new(global, is2D, matrix, cx))
+        dommatrixinit_to_matrix(other).map(|(is2D, matrix)| Self::new(cx, global, is2D, matrix))
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrix-fromfloat32array>
@@ -545,6 +544,7 @@ impl Serializable for DOMMatrix {
     {
         if serialized.is_2d {
             Ok(Self::new(
+                cx,
                 owner,
                 true,
                 Transform3D::new(
@@ -565,10 +565,9 @@ impl Serializable for DOMMatrix {
                     0.0,
                     1.0,
                 ),
-                cx,
             ))
         } else {
-            Ok(Self::new(owner, false, serialized.matrix, cx))
+            Ok(Self::new(cx, owner, false, serialized.matrix))
         }
     }
 

--- a/components/script/dom/geometry/dommatrixreadonly.rs
+++ b/components/script/dom/geometry/dommatrixreadonly.rs
@@ -17,7 +17,7 @@ use js::typedarray::{Float32Array, Float64Array, HeapFloat32Array, HeapFloat64Ar
 use rustc_hash::FxHashMap;
 use script_bindings::cell::{DomRefCell, Ref};
 use script_bindings::cformat;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 use script_bindings::trace::RootedTraceableBox;
 use servo_base::id::{DomMatrixId, DomMatrixIndex};
 use servo_constellation_traits::DomMatrix;
@@ -45,7 +45,6 @@ use crate::dom::dommatrix::DOMMatrix;
 use crate::dom::dompoint::DOMPoint;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 #[expect(non_snake_case)]
@@ -59,24 +58,24 @@ pub(crate) struct DOMMatrixReadOnly {
 #[expect(non_snake_case)]
 impl DOMMatrixReadOnly {
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         is2D: bool,
         matrix: Transform3D<f64>,
-        cx: &mut js::context::JSContext,
     ) -> DomRoot<Self> {
-        Self::new_with_proto(global, None, is2D, matrix, cx)
+        Self::new_with_proto(cx, global, None, is2D, matrix)
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_with_proto(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         is2D: bool,
         matrix: Transform3D<f64>,
-        cx: &mut js::context::JSContext,
     ) -> DomRoot<Self> {
         let dommatrix = Self::new_inherited(is2D, matrix);
-        reflect_dom_object_with_proto(Box::new(dommatrix), global, proto, CanGc::from_cx(cx))
+        reflect_dom_object_with_proto_and_cx(Box::new(dommatrix), global, proto, cx)
     }
 
     pub(crate) fn new_inherited(is2D: bool, matrix: Transform3D<f64>) -> Self {
@@ -484,11 +483,11 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
     ) -> Fallible<DomRoot<Self>> {
         if init.is_none() {
             return Ok(Self::new_with_proto(
+                cx,
                 global,
                 proto,
                 true,
                 Transform3D::identity(),
-                cx,
             ));
         }
         match init.unwrap() {
@@ -499,14 +498,14 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
                     ));
                 }
                 if s.is_empty() {
-                    return Ok(Self::new(global, true, Transform3D::identity(), cx));
+                    return Ok(Self::new(cx, global, true, Transform3D::identity()));
                 }
                 transform_to_matrix(&s.str())
-                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix, cx))
+                    .map(|(is2D, matrix)| Self::new_with_proto(cx, global, proto, is2D, matrix))
             },
             StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(ref entries) => {
                 entries_to_matrix(&entries[..])
-                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix, cx))
+                    .map(|(is2D, matrix)| Self::new_with_proto(cx, global, proto, is2D, matrix))
             },
         }
     }
@@ -517,7 +516,7 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
         global: &GlobalScope,
         other: &DOMMatrixInit,
     ) -> Fallible<DomRoot<Self>> {
-        dommatrixinit_to_matrix(other).map(|(is2D, matrix)| Self::new(global, is2D, matrix, cx))
+        dommatrixinit_to_matrix(other).map(|(is2D, matrix)| Self::new(cx, global, is2D, matrix))
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-fromfloat32array>
@@ -801,7 +800,7 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
             -1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
         );
         let matrix = flip.then(&self.matrix.borrow());
-        DOMMatrix::new(&self.global(), is2D, matrix, cx)
+        DOMMatrix::new(cx, &self.global(), is2D, matrix)
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-flipy>
@@ -811,7 +810,7 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
             1.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
         );
         let matrix = flip.then(&self.matrix.borrow());
-        DOMMatrix::new(&self.global(), is2D, matrix, cx)
+        DOMMatrix::new(cx, &self.global(), is2D, matrix)
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-inverse>
@@ -1030,6 +1029,7 @@ impl Serializable for DOMMatrixReadOnly {
     {
         if serialized.is_2d {
             Ok(Self::new(
+                cx,
                 owner,
                 true,
                 Transform3D::new(
@@ -1050,10 +1050,9 @@ impl Serializable for DOMMatrixReadOnly {
                     0.0,
                     1.0,
                 ),
-                cx,
             ))
         } else {
-            Ok(Self::new(owner, false, serialized.matrix, cx))
+            Ok(Self::new(cx, owner, false, serialized.matrix))
         }
     }
 


### PR DESCRIPTION
This was already mostly done. `cx` is also moved to the start of the function signature for code style compliance, which is 90% of this PR...

Testing: Compilation.
Fixes: Part of #40600.