### PR TITLE
layout: Use the `Stylist` to get list of `@font-face` rules

### DIFF
--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -500,7 +500,6 @@ impl FontContext {
         url: ServoUrl,
         state: WebFontDownloadState,
     ) {
-        println!("did start load for  {:?}", url.as_str());
         self.currently_downloading_fonts
             .lock()
             .entry(url)
@@ -696,30 +695,29 @@ impl FontContextWebFontMethods for Arc<FontContext> {
         callback: StylesheetWebFontLoadFinishedCallback,
         document_context: &WebFontDocumentContext,
     ) {
-        println!("== Update font state ==");
         let mut removed_any = false;
 
-        self.active_font_face_rules.lock().diff_font_face_rules(
-            stylist,
-            guards,
-            |new_rule| {
-                println!("Loading new font face: {:?}", new_rule.descriptors.font_family);
-                self.load_single_font_face_rule(
-                    new_rule,
-                    webview_id,
-                    callback.clone(),
-                    document_context,
-                );
-            },
-            |stale_rule| {
-                println!("Unloading old font face: {:?}", stale_rule.descriptors.font_family);
-                self.remove_single_font_face_rule(
-                    &stale_rule.descriptors,
-                    &mut self.web_fonts.write(),
-                );
-                removed_any = true;
-            },
-        );
+        self.active_font_face_rules
+            .lock()
+            .diff_old_and_new_font_face_rules(
+                stylist,
+                guards,
+                |new_rule| {
+                    self.load_single_font_face_rule(
+                        new_rule,
+                        webview_id,
+                        callback.clone(),
+                        document_context,
+                    );
+                },
+                |stale_rule| {
+                    self.remove_single_font_face_rule(
+                        &stale_rule.descriptors,
+                        &mut self.web_fonts.write(),
+                    );
+                    removed_any = true;
+                },
+            );
 
         if removed_any {
             // We modified the list of available fonts, so invalidate resolved font groups.
@@ -972,7 +970,6 @@ impl FontContext {
         let web_font_family_name = state.css_font_face_descriptors.family_name.clone();
         match source {
             Source::Url(url_source) => {
-                println!("Will download from {:?}", url_source.url.as_str());
                 RemoteWebFontDownloader::download(url_source, this, web_font_family_name, state)
             },
             Source::Local(ref local_family_name) => {
@@ -1090,11 +1087,9 @@ impl RemoteWebFontDownloader {
                 match downloader.handle_web_font_fetch_message(response_message) {
                     DownloaderResponseResult::InProcess => {},
                     DownloaderResponseResult::Finished => {
-                        println!("Did download successfully: {:?}", downloader.url.as_str());
                         downloader.process_downloaded_font_and_signal_completion()
                     },
                     DownloaderResponseResult::Failure => {
-                        println!("Did download failed: {:?}", downloader.url.as_str());
                         font_context.handle_web_font_request_failed(downloader.url.clone().into());
                     },
                 }
@@ -1250,7 +1245,7 @@ impl ActiveFontFaceRules {
     /// Computes the difference between the `@font-face `rules that are currently in effect
     /// and the ones that the `Stylist` knows about. The caller is notified about new or removed rules
     /// with callbacks.
-    fn diff_font_face_rules<NewRuleCallback, StaleRuleCallback>(
+    fn diff_old_and_new_font_face_rules<NewRuleCallback, StaleRuleCallback>(
         &mut self,
         stylist: &Stylist,
         guards: &StylesheetGuards<'_>,

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -5,6 +5,7 @@
 use std::collections::{HashMap, HashSet};
 use std::default::Default;
 use std::hash::{Hash, Hasher};
+use std::iter;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -35,16 +36,14 @@ use servo_config::pref;
 use servo_url::ServoUrl;
 use style::Atom;
 use style::computed_values::font_variant_caps::T as FontVariantCaps;
-use style::device::Device;
 use style::font_face::{
     FontFaceSourceFormat, FontFaceSourceFormatKeyword, Source, SourceList, UrlSource,
 };
 use style::properties::generated::font_face::Descriptors as FontFaceRuleDescriptors;
 use style::properties::style_structs::Font as FontStyleStruct;
-use style::shared_lock::SharedRwLockReadGuard;
-use style::stylesheets::{
-    CssRule, CustomMediaMap, DocumentStyleSheet, FontFaceRule, StylesheetInDocument,
-};
+use style::shared_lock::{Locked, StylesheetGuards};
+use style::stylesheets::{FontFaceRule, Origin};
+use style::stylist::Stylist;
 use style::values::computed::font::{FamilyName, FontFamilyNameSyntax, SingleFontFamily};
 use url::Url;
 use uuid::Uuid;
@@ -110,6 +109,8 @@ pub struct FontContext {
     /// Maps from a URL to all the `@font-face` rules that are currently waiting for the load to
     /// finish.
     currently_downloading_fonts: Mutex<HashMap<ServoUrl, Vec<WebFontDownloadState>>>,
+
+    active_font_face_rules: Mutex<ActiveFontFaceRules>,
 }
 
 /// A callback that will be invoked on the Fetch thread if a web font download
@@ -167,6 +168,7 @@ impl FontContext {
             have_removed_web_fonts: AtomicBool::new(false),
             font_data: RwLock::default(),
             currently_downloading_fonts: Default::default(),
+            active_font_face_rules: Default::default(),
         }
     }
 
@@ -498,6 +500,7 @@ impl FontContext {
         url: ServoUrl,
         state: WebFontDownloadState,
     ) {
+        println!("did start load for  {:?}", url.as_str());
         self.currently_downloading_fonts
             .lock()
             .entry(url)
@@ -632,15 +635,21 @@ impl WebFontDownloadState {
 }
 
 pub trait FontContextWebFontMethods {
-    fn add_all_web_fonts_from_stylesheet(
+    fn rebuild_font_face_set(
         &self,
         webview_id: WebViewId,
-        stylesheet: &DocumentStyleSheet,
-        guard: &SharedRwLockReadGuard,
-        device: &Device,
-        finished_callback: StylesheetWebFontLoadFinishedCallback,
+        stylist: &Stylist,
+        guards: &StylesheetGuards<'_>,
+        callback: StylesheetWebFontLoadFinishedCallback,
         document_context: &WebFontDocumentContext,
-    ) -> usize;
+    );
+    fn load_single_font_face_rule(
+        &self,
+        font_face_rule: &FontFaceRule,
+        webview_id: WebViewId,
+        callback: StylesheetWebFontLoadFinishedCallback,
+        document_context: &WebFontDocumentContext,
+    );
     fn load_web_font_for_script(
         &self,
         webview_id: Option<WebViewId>,
@@ -653,56 +662,72 @@ pub trait FontContextWebFontMethods {
 }
 
 impl FontContextWebFontMethods for Arc<FontContext> {
-    fn add_all_web_fonts_from_stylesheet(
+    fn load_single_font_face_rule(
+        &self,
+        font_face_rule: &FontFaceRule,
+        webview_id: WebViewId,
+        callback: StylesheetWebFontLoadFinishedCallback,
+        document_context: &WebFontDocumentContext,
+    ) {
+        let Some(ref sources) = font_face_rule.descriptors.src else {
+            return;
+        };
+
+        let css_font_face_descriptors = font_face_rule.into();
+
+        let initiator = FontFaceRuleInitiator {
+            font_face_rule: font_face_rule.descriptors.clone(),
+            callback: callback.clone(),
+        };
+
+        self.start_loading_one_web_font(
+            Some(webview_id),
+            sources,
+            css_font_face_descriptors,
+            WebFontLoadInitiator::Stylesheet(Box::new(initiator)),
+            document_context,
+        );
+    }
+    fn rebuild_font_face_set(
         &self,
         webview_id: WebViewId,
-        stylesheet: &DocumentStyleSheet,
-        guard: &SharedRwLockReadGuard,
-        device: &Device,
-        finished_callback: StylesheetWebFontLoadFinishedCallback,
+        stylist: &Stylist,
+        guards: &StylesheetGuards<'_>,
+        callback: StylesheetWebFontLoadFinishedCallback,
         document_context: &WebFontDocumentContext,
-    ) -> usize {
-        let mut number_loading = 0;
-        let custom_media = &CustomMediaMap::default();
-        for rule in stylesheet
-            .contents(guard)
-            .effective_rules(device, custom_media, guard)
-        {
-            let CssRule::FontFace(ref lock) = *rule else {
-                continue;
-            };
+    ) {
+        println!("== Update font state ==");
+        let mut removed_any = false;
 
-            let rule: &FontFaceRule = lock.read_with(guard);
+        self.active_font_face_rules.lock().diff_font_face_rules(
+            stylist,
+            guards,
+            |new_rule| {
+                println!("Loading new font face: {:?}", new_rule.descriptors.font_family);
+                self.load_single_font_face_rule(
+                    new_rule,
+                    webview_id,
+                    callback.clone(),
+                    document_context,
+                );
+            },
+            |stale_rule| {
+                println!("Unloading old font face: {:?}", stale_rule.descriptors.font_family);
+                self.remove_single_font_face_rule(
+                    &stale_rule.descriptors,
+                    &mut self.web_fonts.write(),
+                );
+                removed_any = true;
+            },
+        );
 
-            // Per https://github.com/w3c/csswg-drafts/issues/1133 an @font-face rule
-            // is valid as far as the CSS parser is concerned even if it doesn’t have
-            // a font-family or src declaration.
-            // However, both are required for the rule to represent an actual font face.
-            if rule.descriptors.font_family.is_none() {
-                continue;
-            }
-            let Some(ref sources) = rule.descriptors.src else {
-                continue;
-            };
+        if removed_any {
+            // We modified the list of available fonts, so invalidate resolved font groups.
+            self.resolved_font_groups.write().clear();
 
-            let css_font_face_descriptors = rule.into();
-
-            let initiator = FontFaceRuleInitiator {
-                font_face_rule: rule.descriptors.clone(),
-                callback: finished_callback.clone(),
-            };
-
-            number_loading += 1;
-            self.start_loading_one_web_font(
-                Some(webview_id),
-                sources,
-                css_font_face_descriptors,
-                WebFontLoadInitiator::Stylesheet(Box::new(initiator)),
-                document_context,
-            );
+            // Ensure that we clean up any WebRender resources on the next display list update.
+            self.have_removed_web_fonts.store(true, Ordering::Relaxed);
         }
-
-        number_loading
     }
 
     fn load_web_font_for_script(
@@ -842,43 +867,6 @@ impl FontContext {
         true
     }
 
-    pub fn remove_all_web_fonts_from_stylesheet(
-        &self,
-        stylesheet: &DocumentStyleSheet,
-        device: &Device,
-        guard: &SharedRwLockReadGuard,
-    ) {
-        let mut web_fonts = self.web_fonts.write();
-
-        // TODO: Walking the stylesheet should not be necessary here. Instead, we can diff
-        // the results from Stylist.iter_extra_data() and find out which font face rules were
-        // removed.
-        let mut removed_any = false;
-        let custom_media = &CustomMediaMap::default();
-        for rule in stylesheet
-            .contents(guard)
-            .effective_rules(device, custom_media, guard)
-        {
-            let CssRule::FontFace(ref lock) = *rule else {
-                continue;
-            };
-            let rule: &FontFaceRule = lock.read_with(guard);
-
-            removed_any |= self.remove_single_font_face_rule(&rule.descriptors, &mut web_fonts);
-        }
-
-        if !removed_any {
-            return;
-        };
-
-        // Removing this stylesheet modified the available fonts, so invalidate the cache
-        // of resolved font groups.
-        self.resolved_font_groups.write().clear();
-
-        // Ensure that we clean up any WebRender resources on the next display list update.
-        self.have_removed_web_fonts.store(true, Ordering::Relaxed);
-    }
-
     pub fn add_template_to_font_context(
         &self,
         family_name: LowercaseFontFamilyName,
@@ -984,6 +972,7 @@ impl FontContext {
         let web_font_family_name = state.css_font_face_descriptors.family_name.clone();
         match source {
             Source::Url(url_source) => {
+                println!("Will download from {:?}", url_source.url.as_str());
                 RemoteWebFontDownloader::download(url_source, this, web_font_family_name, state)
             },
             Source::Local(ref local_family_name) => {
@@ -1101,9 +1090,11 @@ impl RemoteWebFontDownloader {
                 match downloader.handle_web_font_fetch_message(response_message) {
                     DownloaderResponseResult::InProcess => {},
                     DownloaderResponseResult::Finished => {
+                        println!("Did download successfully: {:?}", downloader.url.as_str());
                         downloader.process_downloaded_font_and_signal_completion()
                     },
                     DownloaderResponseResult::Failure => {
+                        println!("Did download failed: {:?}", downloader.url.as_str());
                         font_context.handle_web_font_request_failed(downloader.url.clone().into());
                     },
                 }
@@ -1223,5 +1214,119 @@ impl Hash for FontGroupCacheKey {
         H: Hasher,
     {
         self.style.hash.hash(hasher)
+    }
+}
+
+#[derive(Default, MallocSizeOf)]
+struct ActiveFontFaceRules {
+    /// Used to distinguish new, incoming `@font-face` rules from existing ones.
+    generation: bool,
+    contents: HashMap<Atom, Vec<ActiveFontFaceRule>>,
+}
+
+#[derive(MallocSizeOf)]
+struct ActiveFontFaceRule {
+    rule_with_origin: FontFaceRuleWithOrigin,
+    generation: bool,
+}
+
+#[derive(MallocSizeOf)]
+struct FontFaceRuleWithOrigin {
+    #[ignore_malloc_size_of = "FIXME"]
+    rule: ServoArc<Locked<FontFaceRule>>,
+    origin: Origin,
+}
+
+impl FontFaceRuleWithOrigin {
+    fn read_with<'a>(&'a self, guards: &'a StylesheetGuards) -> &'a FontFaceRule {
+        match self.origin {
+            Origin::Author => self.rule.read_with(guards.author),
+            Origin::UserAgent | Origin::User => self.rule.read_with(guards.ua_or_user),
+        }
+    }
+}
+
+impl ActiveFontFaceRules {
+    /// Computes the difference between the `@font-face `rules that are currently in effect
+    /// and the ones that the `Stylist` knows about. The caller is notified about new or removed rules
+    /// with callbacks.
+    fn diff_font_face_rules<NewRuleCallback, StaleRuleCallback>(
+        &mut self,
+        stylist: &Stylist,
+        guards: &StylesheetGuards<'_>,
+        mut new_rule_callback: NewRuleCallback,
+        mut stale_rule_callback: StaleRuleCallback,
+    ) where
+        NewRuleCallback: FnMut(&FontFaceRule),
+        StaleRuleCallback: FnMut(&FontFaceRule),
+    {
+        self.generation = !self.generation;
+
+        let font_face_rules_in_cascade_order = stylist
+            .iter_extra_data_origins()
+            .flat_map(|(extra_data, origin)| extra_data.font_faces.iter().zip(iter::repeat(origin)))
+            .map(|((rule, _layer), origin)| FontFaceRuleWithOrigin {
+                rule: rule.clone(),
+                origin,
+            });
+
+        // First, find any *new* font families that were not defined previously
+        let mut number_of_unchanged_rules = 0;
+        let number_of_previously_known_rules = self.contents.len();
+        for rule_with_origin in font_face_rules_in_cascade_order {
+            let borrowed_rule = rule_with_origin.read_with(guards);
+
+            let Some(font_family) = borrowed_rule.descriptors.font_family.as_ref() else {
+                // Per https://github.com/w3c/csswg-drafts/issues/1133 an @font-face rule
+                // is valid as far as the CSS parser is concerned even if it doesn’t have
+                // a font-family or src declaration.
+                // However, both are required for the rule to represent an actual font face.
+                continue;
+            };
+            if borrowed_rule.descriptors.src.is_none() {
+                // @font-face rules without a src don't constitute usable font faces.
+                continue;
+            }
+
+            let known_font_faces_for_family =
+                self.contents.entry(font_family.name.clone()).or_default();
+            if let Some(previous_definition) =
+                known_font_faces_for_family
+                    .iter_mut()
+                    .find(|known_font_face| {
+                        ServoArc::ptr_eq(
+                            &known_font_face.rule_with_origin.rule,
+                            &rule_with_origin.rule,
+                        )
+                    })
+            {
+                number_of_unchanged_rules += 1;
+                previous_definition.generation = self.generation;
+            } else {
+                new_rule_callback(borrowed_rule);
+                known_font_faces_for_family.push(ActiveFontFaceRule {
+                    rule_with_origin,
+                    generation: self.generation,
+                });
+            }
+        }
+
+        if number_of_unchanged_rules == number_of_previously_known_rules {
+            // This is the common case, where the new set of known @font-face rules is a superset of
+            // the old one after applying the cascade. In this case there is nothing more to do,
+            // because all old @font-face rules are still present.
+            return;
+        }
+
+        // Remove all `@font-face` rules that were not updated - those no longer exist on the stylist.
+        self.contents.retain(|_, known_font_faces_for_family| {
+            known_font_faces_for_family
+                .extract_if(.., |rule| rule.generation != self.generation)
+                .for_each(|removed_rule| {
+                    stale_rule_callback(removed_rule.rule_with_origin.read_with(guards))
+                });
+
+            !known_font_faces_for_family.is_empty()
+        });
     }
 }

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -110,7 +110,10 @@ pub struct FontContext {
     /// finish.
     currently_downloading_fonts: Mutex<HashMap<ServoUrl, Vec<WebFontDownloadState>>>,
 
-    active_font_face_rules: Mutex<ActiveFontFaceRules>,
+    /// The set of `@font-face` rules that are currently present in the CSS cascade. This is not necessarily
+    /// equivalent to the rules that actually apply to the page, because rules that are invalid or not
+    /// yet downloaded are also included.
+    known_font_face_rules: Mutex<KnownFontFaceRules>,
 }
 
 /// A callback that will be invoked on the Fetch thread if a web font download
@@ -168,7 +171,7 @@ impl FontContext {
             have_removed_web_fonts: AtomicBool::new(false),
             font_data: RwLock::default(),
             currently_downloading_fonts: Default::default(),
-            active_font_face_rules: Default::default(),
+            known_font_face_rules: Default::default(),
         }
     }
 
@@ -697,7 +700,7 @@ impl FontContextWebFontMethods for Arc<FontContext> {
     ) {
         let mut removed_any = false;
 
-        self.active_font_face_rules
+        self.known_font_face_rules
             .lock()
             .diff_old_and_new_font_face_rules(
                 stylist,
@@ -1213,21 +1216,26 @@ impl Hash for FontGroupCacheKey {
 }
 
 #[derive(Default, MallocSizeOf)]
-struct ActiveFontFaceRules {
+struct KnownFontFaceRules {
     /// Used to distinguish new, incoming `@font-face` rules from existing ones.
+    ///
+    /// Generations alternate between true and false, which is enough to tell one generation apart from
+    /// the next.
     generation: bool,
-    contents: HashMap<Atom, Vec<ActiveFontFaceRule>>,
+    /// Maps from a font family name to a list of `@font-face` rules declaring fonts
+    /// that belong to said family.
+    contents: HashMap<Atom, Vec<KnownFontFaceRule>>,
 }
 
 #[derive(MallocSizeOf)]
-struct ActiveFontFaceRule {
+struct KnownFontFaceRule {
     rule_with_origin: FontFaceRuleWithOrigin,
     generation: bool,
 }
 
 #[derive(MallocSizeOf)]
 struct FontFaceRuleWithOrigin {
-    #[ignore_malloc_size_of = "FIXME"]
+    #[conditional_malloc_size_of]
     rule: ServoArc<Locked<FontFaceRule>>,
     origin: Origin,
 }
@@ -1241,7 +1249,7 @@ impl FontFaceRuleWithOrigin {
     }
 }
 
-impl ActiveFontFaceRules {
+impl KnownFontFaceRules {
     /// Computes the difference between the `@font-face `rules that are currently in effect
     /// and the ones that the `Stylist` knows about. The caller is notified about new or removed rules
     /// with callbacks.
@@ -1267,7 +1275,11 @@ impl ActiveFontFaceRules {
 
         // First, find any *new* font families that were not defined previously
         let mut number_of_unchanged_rules = 0;
-        let number_of_previously_known_rules = self.contents.len();
+        let number_of_previously_known_rules: usize = self
+            .contents
+            .values()
+            .map(|fonts_from_family| fonts_from_family.len())
+            .sum();
         for rule_with_origin in font_face_rules_in_cascade_order {
             let borrowed_rule = rule_with_origin.read_with(guards);
 
@@ -1299,7 +1311,7 @@ impl ActiveFontFaceRules {
                 previous_definition.generation = self.generation;
             } else {
                 new_rule_callback(borrowed_rule);
-                known_font_faces_for_family.push(ActiveFontFaceRule {
+                known_font_faces_for_family.push(KnownFontFaceRule {
                     rule_with_origin,
                     generation: self.generation,
                 });

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -16,7 +16,7 @@ use embedder_traits::{
     EmbedderMsg, ScriptToEmbedderChan, Theme, UntrustedNodeAddress, ViewportDetails,
 };
 use euclid::{Point2D, Rect, Scale, Size2D};
-use fonts::{FontContext, FontContextWebFontMethods, WebFontDocumentContext};
+use fonts::{FontContext, FontContextWebFontMethods};
 use fonts_traits::StylesheetWebFontLoadFinishedCallback;
 use icu_locid::subtags::Language;
 use layout_api::{
@@ -44,7 +44,6 @@ use script::layout_dom::{
 use script_traits::{DrawAPaintImageResult, PaintWorkletError, Painter, ScriptThreadMessage};
 use servo_arc::Arc as ServoArc;
 use servo_base::Epoch;
-use servo_base::generic_channel::GenericSender;
 use servo_base::id::{PipelineId, WebViewId};
 use servo_config::opts::{self, DiagnosticsLogging, DiagnosticsLoggingOption};
 use servo_config::pref;
@@ -66,10 +65,8 @@ use style::properties::{ComputedValues, LonghandId, NonCustomPropertyId, Propert
 use style::queries::values::PrefersColorScheme;
 use style::selector_parser::{PseudoElement, SnapshotMap};
 use style::servo::media_features::PointerCapabilities;
-use style::shared_lock::{SharedRwLock, SharedRwLockReadGuard, StylesheetGuards};
-use style::stylesheets::{
-    CustomMediaMap, DocumentStyleSheet, Origin, Stylesheet, StylesheetInDocument,
-};
+use style::shared_lock::{SharedRwLock, StylesheetGuards};
+use style::stylesheets::{DocumentStyleSheet, Origin, Stylesheet};
 use style::stylist::Stylist;
 use style::traversal::DomTraversal;
 use style::traversal_flags::TraversalFlags;
@@ -138,9 +135,6 @@ pub struct LayoutThread {
 
     /// Is the current reflow of an iframe, as opposed to a root window?
     is_iframe: bool,
-
-    /// The channel on which messages can be sent to the script thread.
-    script_chan: GenericSender<ScriptThreadMessage>,
 
     /// The channel on which messages can be sent to the time profiler.
     time_profiler_chan: profile_time::ProfilerChan,
@@ -232,6 +226,9 @@ pub struct LayoutThread {
 
     /// See [Layout::needs_accessibility_update()].
     needs_accessibility_update: Cell<bool>,
+
+    /// A callback to run whenever a web font from a `@font-face` rule finishes loading.
+    web_font_finished_loading_callback: StylesheetWebFontLoadFinishedCallback,
 }
 
 pub struct LayoutFactoryImpl();
@@ -287,29 +284,14 @@ impl Layout for LayoutThread {
         true
     }
 
-    fn load_web_fonts_from_stylesheet(
-        &self,
-        stylesheet: &ServoArc<Stylesheet>,
-        document_context: &WebFontDocumentContext,
-    ) {
-        let guard = stylesheet.shared_lock.read();
-        self.load_all_web_fonts_from_stylesheet_with_guard(
-            &DocumentStyleSheet(stylesheet.clone()),
-            &guard,
-            document_context,
-        );
-    }
-
     #[servo_tracing::instrument(skip_all)]
     fn add_stylesheet(
         &mut self,
         stylesheet: ServoArc<Stylesheet>,
         before_stylesheet: Option<ServoArc<Stylesheet>>,
-        document_context: &WebFontDocumentContext,
     ) {
         let guard = stylesheet.shared_lock.read();
         let stylesheet = DocumentStyleSheet(stylesheet.clone());
-        self.load_all_web_fonts_from_stylesheet_with_guard(&stylesheet, &guard, document_context);
 
         match before_stylesheet {
             Some(insertion_point) => self.stylist.insert_stylesheet_before(
@@ -325,12 +307,7 @@ impl Layout for LayoutThread {
     fn remove_stylesheet(&mut self, stylesheet: ServoArc<Stylesheet>) {
         let guard = stylesheet.shared_lock.read();
         let stylesheet = DocumentStyleSheet(stylesheet.clone());
-        self.stylist.remove_stylesheet(stylesheet.clone(), &guard);
-        self.font_context.remove_all_web_fonts_from_stylesheet(
-            &stylesheet,
-            self.stylist.device(),
-            &guard,
-        );
+        self.stylist.remove_stylesheet(stylesheet, &guard);
     }
 
     #[servo_tracing::instrument(skip_all)]
@@ -807,12 +784,21 @@ impl LayoutThread {
             PointerCapabilities::default(),
         );
 
+        let locked_script_channel = Mutex::new(config.script_chan.clone());
+        let pipeline_id = config.id;
+        let web_font_finished_loading_callback = move |succeeded: bool| {
+            if succeeded {
+                let _ = locked_script_channel
+                    .lock()
+                    .send(ScriptThreadMessage::WebFontLoaded(pipeline_id));
+            }
+        };
+
         LayoutThread {
             id: config.id,
             webview_id: config.webview_id,
             url: config.url,
             is_iframe: config.is_iframe,
-            script_chan: config.script_chan.clone(),
             time_profiler_chan: config.time_profiler_chan,
             embedder_chan: config.embedder_chan.clone(),
             registered_painters: RegisteredPaintersImpl(Default::default()),
@@ -838,6 +824,8 @@ impl LayoutThread {
             accessibility_active: Cell::new(false),
             accessibility_tree: Default::default(),
             needs_accessibility_update: Cell::new(false),
+            web_font_finished_loading_callback: Arc::new(web_font_finished_loading_callback)
+                as StylesheetWebFontLoadFinishedCallback,
         }
     }
 
@@ -860,37 +848,6 @@ impl LayoutThread {
             traversal_flags,
             snapshot_map,
         }
-    }
-
-    fn load_all_web_fonts_from_stylesheet_with_guard(
-        &self,
-        stylesheet: &DocumentStyleSheet,
-        guard: &SharedRwLockReadGuard,
-        document_context: &WebFontDocumentContext,
-    ) {
-        let custom_media = &CustomMediaMap::default();
-        if !stylesheet.is_effective_for_device(self.stylist.device(), custom_media, guard) {
-            return;
-        }
-
-        let locked_script_channel = Mutex::new(self.script_chan.clone());
-        let pipeline_id = self.id;
-        let web_font_finished_loading_callback = move |succeeded: bool| {
-            if succeeded {
-                let _ = locked_script_channel
-                    .lock()
-                    .send(ScriptThreadMessage::WebFontLoaded(pipeline_id));
-            }
-        };
-
-        self.font_context.add_all_web_fonts_from_stylesheet(
-            self.webview_id,
-            stylesheet,
-            guard,
-            self.stylist.device(),
-            Arc::new(web_font_finished_loading_callback) as StylesheetWebFontLoadFinishedCallback,
-            document_context,
-        );
     }
 
     /// In some cases, if a restyle isn't necessary we can skip doing any work for layout
@@ -1100,11 +1057,6 @@ impl LayoutThread {
             for stylesheet in &ua_stylesheets.user_agent_stylesheets {
                 self.stylist
                     .append_stylesheet(stylesheet.clone(), guards.ua_or_user);
-                self.load_all_web_fonts_from_stylesheet_with_guard(
-                    stylesheet,
-                    guards.ua_or_user,
-                    &reflow_request.document_context,
-                );
             }
 
             if document.is_html_document() {
@@ -1112,21 +1064,11 @@ impl LayoutThread {
                     ua_stylesheets.html_mode_stylesheet.clone(),
                     guards.ua_or_user,
                 );
-                self.load_all_web_fonts_from_stylesheet_with_guard(
-                    &ua_stylesheets.html_mode_stylesheet,
-                    guards.ua_or_user,
-                    &reflow_request.document_context,
-                );
             }
 
             for user_stylesheet in self.user_stylesheets.iter() {
                 self.stylist
                     .append_stylesheet(user_stylesheet.clone(), guards.ua_or_user);
-                self.load_all_web_fonts_from_stylesheet_with_guard(
-                    user_stylesheet,
-                    guards.ua_or_user,
-                    &reflow_request.document_context,
-                );
             }
 
             if self.stylist.quirks_mode() == QuirksMode::Quirks {
@@ -1134,13 +1076,16 @@ impl LayoutThread {
                     ua_stylesheets.quirks_mode_stylesheet.clone(),
                     guards.ua_or_user,
                 );
-                self.load_all_web_fonts_from_stylesheet_with_guard(
-                    &ua_stylesheets.quirks_mode_stylesheet,
-                    guards.ua_or_user,
-                    &reflow_request.document_context,
-                );
             }
             self.have_added_user_agent_stylesheets = true;
+
+            self.font_context.rebuild_font_face_set(
+                self.webview_id,
+                &self.stylist,
+                guards,
+                self.web_font_finished_loading_callback.clone(),
+                &reflow_request.document_context,
+            );
         }
 
         if reflow_request.stylesheets_changed() {
@@ -1150,7 +1095,21 @@ impl LayoutThread {
 
         document.flush_shadow_root_stylesheets_if_necessary(&mut self.stylist, guards.author);
 
-        self.stylist.flush(guards)
+        let invalidation_set = self.stylist.flush(guards);
+
+        // Load new @font-face rules and remove old ones if necessary.
+        // TODO: Can we make the invalidation set tell us whether any @font-face rules changed?
+        if reflow_request.stylesheets_changed() {
+            self.font_context.rebuild_font_face_set(
+                self.webview_id,
+                &self.stylist,
+                guards,
+                self.web_font_finished_loading_callback.clone(),
+                &reflow_request.document_context,
+            );
+        }
+
+        invalidation_set
     }
 
     #[servo_tracing::instrument(skip_all)]

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1053,7 +1053,8 @@ impl LayoutThread {
         guards: &StylesheetGuards,
         ua_stylesheets: &UserAgentStylesheets,
     ) -> StylesheetInvalidationSet {
-        if !self.have_added_user_agent_stylesheets {
+        let need_user_agent_stylesheet_addition = !self.have_added_user_agent_stylesheets;
+        if need_user_agent_stylesheet_addition {
             for stylesheet in &ua_stylesheets.user_agent_stylesheets {
                 self.stylist
                     .append_stylesheet(stylesheet.clone(), guards.ua_or_user);
@@ -1078,14 +1079,6 @@ impl LayoutThread {
                 );
             }
             self.have_added_user_agent_stylesheets = true;
-
-            self.font_context.rebuild_font_face_set(
-                self.webview_id,
-                &self.stylist,
-                guards,
-                self.web_font_finished_loading_callback.clone(),
-                &reflow_request.document_context,
-            );
         }
 
         if reflow_request.stylesheets_changed() {
@@ -1099,7 +1092,7 @@ impl LayoutThread {
 
         // Load new @font-face rules and remove old ones if necessary.
         // TODO: Can we make the invalidation set tell us whether any @font-face rules changed?
-        if reflow_request.stylesheets_changed() {
+        if need_user_agent_stylesheet_addition || reflow_request.stylesheets_changed() {
             self.font_context.rebuild_font_face_set(
                 self.webview_id,
                 &self.stylist,

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -1350,6 +1350,7 @@ malloc_size_of_is_stylo_malloc_size_of!(style::selector_parser::RestyleDamage);
 malloc_size_of_is_stylo_malloc_size_of!(style::selector_parser::Snapshot);
 malloc_size_of_is_stylo_malloc_size_of!(style::shared_lock::SharedRwLock);
 malloc_size_of_is_stylo_malloc_size_of!(style::stylesheets::DocumentStyleSheet);
+malloc_size_of_is_stylo_malloc_size_of!(style::stylesheets::Origin);
 malloc_size_of_is_stylo_malloc_size_of!(style::stylist::Stylist);
 malloc_size_of_is_stylo_malloc_size_of!(style::values::computed::BorderStyle);
 malloc_size_of_is_stylo_malloc_size_of!(style::values::computed::ContentDistribution);

--- a/components/script/dom/css/fontfaceset.rs
+++ b/components/script/dom/css/fontfaceset.rs
@@ -142,6 +142,11 @@ impl FontFaceSet {
 impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
     /// <https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-ready>
     fn Ready(&self) -> Rc<Promise> {
+        if self.stylesheets.borrow().has_changed() {
+            self.window().flush_user_font_set();
+            self.switch
+        }
+        println!("Get ready promise which is fulfilled: {:?}", self.promise.borrow().is_fulfilled());
         self.promise.borrow().clone()
     }
 

--- a/components/script/dom/css/fontfaceset.rs
+++ b/components/script/dom/css/fontfaceset.rs
@@ -11,6 +11,7 @@ use js::gc::Handle;
 use js::jsapi::Value;
 use js::realm::CurrentRealm;
 use js::rust::HandleObject;
+use layout_api::{QueryMsg, ReflowGoal};
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::FontFaceBinding::{
     FontFaceLoadStatus, FontFaceMethods,
@@ -20,7 +21,7 @@ use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 
 use crate::dom::bindings::codegen::Bindings::FontFaceSetBinding::FontFaceSetMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
-use crate::dom::bindings::refcounted::TrustedPromise;
+use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
@@ -141,12 +142,20 @@ impl FontFaceSet {
 
 impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
     /// <https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-ready>
-    fn Ready(&self) -> Rc<Promise> {
-        if self.stylesheets.borrow().has_changed() {
-            self.window().flush_user_font_set();
-            self.switch
+    fn Ready(&self, cx: &mut JSContext) -> Rc<Promise> {
+        // FIXME: Figure out what to do for worker scopes.
+        if let Some(window) = DomRoot::downcast::<Window>(self.global()) {
+            // There may be pending style changes that cause new web fonts to start loading,
+            // FIXME: Use a new sort of ReflowGoal that only runs the CSS cascade without
+            //        building a new box tree or running any sort of layout really.
+            //        We query for the box area here, which is a lie.
+            let document = window.Document();
+            if document.stylesheets_changed_since_last_reflow() {
+                window.reflow(cx, ReflowGoal::LayoutQuery(QueryMsg::BoxArea));
+                document.switch_font_face_set_to_loading_if_needed(cx);
+            }
         }
-        println!("Get ready promise which is fulfilled: {:?}", self.promise.borrow().is_fulfilled());
+
         self.promise.borrow().clone()
     }
 
@@ -222,14 +231,14 @@ impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
         }
 
         // Step 4. Queue a task to run the following steps synchronously:
-        let trusted_ready_promise = TrustedPromise::new(self.promise.borrow().clone());
+        let trusted_this = Trusted::new(self);
         let trusted_load_promise = TrustedPromise::new(load_promise.clone());
         self.global()
             .task_manager()
             .font_loading_task_source()
             .queue(task!(resolve_font_face_set_load_task: move |cx| {
-                let ready_promise = trusted_ready_promise.root();
                 let load_promise = trusted_load_promise.root();
+                let this = trusted_this.root();
 
                 // Step 4.1. For all of the font faces in the font face list, call their load()
                 // method.
@@ -242,7 +251,7 @@ impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
                 // be correct, but any code that waits on the promise will have
                 // conservatively consistent behavior. This is important for preventing
                 // intermittent results in WPT tests.
-                let global = ready_promise.global();
+                let global = this.global();
                 let handler = PromiseNativeHandler::new(
                     cx,
                     &global,
@@ -252,6 +261,7 @@ impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
                     None,
                 );
 
+                let ready_promise = this.Ready(cx);
                 let mut realm = enter_auto_realm(cx, &*global);
                 ready_promise.append_native_handler(&mut realm.current_realm(), &handler);
             }));

--- a/components/script/dom/css/fontfaceset.rs
+++ b/components/script/dom/css/fontfaceset.rs
@@ -143,16 +143,19 @@ impl FontFaceSet {
 impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
     /// <https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-ready>
     fn Ready(&self, cx: &mut JSContext) -> Rc<Promise> {
-        // FIXME: Figure out what to do for worker scopes.
-        if let Some(window) = DomRoot::downcast::<Window>(self.global()) {
+        if self.promise.borrow().is_fulfilled() {
             // There may be pending style changes that cause new web fonts to start loading,
+            // re-initializing document.fonts.ready.
             // FIXME: Use a new sort of ReflowGoal that only runs the CSS cascade without
             //        building a new box tree or running any sort of layout really.
-            //        We query for the box area here, which is a lie.
-            let document = window.Document();
-            if document.stylesheets_changed_since_last_reflow() {
-                window.reflow(cx, ReflowGoal::LayoutQuery(QueryMsg::BoxArea));
-                document.switch_font_face_set_to_loading_if_needed(cx);
+            //        We query for the box area here, but we're not interested in the result.
+            // FIXME: Figure out what to do for worker scopes.
+            if let Some(window) = DomRoot::downcast::<Window>(self.global()) {
+                let document = window.Document();
+                if document.stylesheets_changed_since_last_reflow() {
+                    window.reflow(cx, ReflowGoal::LayoutQuery(QueryMsg::BoxArea));
+                    document.switch_font_face_set_to_loading_if_needed(cx);
+                }
             }
         }
 

--- a/components/script/dom/css/fontfaceset.rs
+++ b/components/script/dom/css/fontfaceset.rs
@@ -154,7 +154,6 @@ impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
                 let document = window.Document();
                 if document.stylesheets_changed_since_last_reflow() {
                     window.reflow(cx, ReflowGoal::LayoutQuery(QueryMsg::BoxArea));
-                    document.switch_font_face_set_to_loading_if_needed(cx);
                 }
             }
         }

--- a/components/script/dom/css/stylesheetlist.rs
+++ b/components/script/dom/css/stylesheetlist.rs
@@ -57,7 +57,7 @@ impl StyleSheetListOwner {
                 doc.add_owned_stylesheet(cx, owner_node, sheet)
             },
             StyleSheetListOwner::ShadowRoot(ref shadow_root) => {
-                shadow_root.add_owned_stylesheet(cx, owner_node, sheet)
+                shadow_root.add_owned_stylesheet(owner_node, sheet)
             },
         }
     }
@@ -72,7 +72,7 @@ impl StyleSheetListOwner {
                 doc.append_constructed_stylesheet(cx, cssom_stylesheet)
             },
             StyleSheetListOwner::ShadowRoot(ref shadow_root) => {
-                shadow_root.append_constructed_stylesheet(cx, cssom_stylesheet)
+                shadow_root.append_constructed_stylesheet(cssom_stylesheet)
             },
         }
     }

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -4550,11 +4550,6 @@ impl Document {
         }
     }
 
-    /// Given a stylesheet, load all web fonts from it in Layout.
-    pub(crate) fn load_web_fonts_from_stylesheet(&self, cx: &mut JSContext) {
-        self.switch_font_face_set_to_loading_if_needed(cx);
-    }
-
     pub(crate) fn add_stylesheet_to_stylist(
         &self,
         cx: &mut JSContext,

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -3165,7 +3165,7 @@ impl Document {
         if !fonts.waiting_to_fullfill_promise() {
             return false;
         }
-        if self.window().font_context().web_fonts_still_loading() != 0 {
+        if dbg!(self.window().font_context().web_fonts_still_loading()) != 0 {
             return false;
         }
         if self.ReadyState() != DocumentReadyState::Complete {
@@ -3178,6 +3178,7 @@ impl Document {
             return false;
         }
 
+        println!("will fulfill font ready promise");
         let result = fonts.fulfill_ready_promise_if_needed(cx);
 
         // Add a rendering update after the `fonts.ready` promise is fulfilled just for
@@ -4538,23 +4539,18 @@ impl Document {
         );
     }
 
-    fn switch_font_face_set_to_loading_if_needed(&self, cx: &mut JSContext) {
+    pub(crate) fn switch_font_face_set_to_loading_if_needed(&self, cx: &mut JSContext) {
+        println!("switch to loading if needed");
         if self.window.font_context().web_fonts_still_loading() != 0 &&
             let Some(font_face_set) = self.fonts.get()
         {
+            println!("load now");
             font_face_set.switch_to_loading(cx);
         }
     }
 
     /// Given a stylesheet, load all web fonts from it in Layout.
-    pub(crate) fn load_web_fonts_from_stylesheet(
-        &self,
-        cx: &mut JSContext,
-        stylesheet: &Arc<Stylesheet>,
-    ) {
-        self.window
-            .layout()
-            .load_web_fonts_from_stylesheet(stylesheet, &self.window.web_font_context(cx.no_gc()));
+    pub(crate) fn load_web_fonts_from_stylesheet(&self, cx: &mut JSContext) {
         self.switch_font_face_set_to_loading_if_needed(cx);
     }
 
@@ -4564,11 +4560,9 @@ impl Document {
         stylesheet: Arc<Stylesheet>,
         before_stylesheet: Option<Arc<Stylesheet>>,
     ) {
-        self.window.layout_mut().add_stylesheet(
-            stylesheet,
-            before_stylesheet,
-            &self.window.web_font_context(cx.no_gc()),
-        );
+        self.window
+            .layout_mut()
+            .add_stylesheet(stylesheet, before_stylesheet);
         self.switch_font_face_set_to_loading_if_needed(cx);
     }
 

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -1084,9 +1084,13 @@ impl Document {
         self.needs_restyle.set(RestyleReason::empty());
     }
 
+    pub(crate) fn stylesheets_changed_since_last_reflow(&self) -> bool {
+        self.stylesheets.borrow().has_changed()
+    }
+
     pub(crate) fn restyle_reason(&self) -> RestyleReason {
         let mut condition = self.needs_restyle.get();
-        if self.stylesheets.borrow().has_changed() {
+        if self.stylesheets_changed_since_last_reflow() {
             condition.insert(RestyleReason::StylesheetsChanged);
         }
 
@@ -3165,7 +3169,7 @@ impl Document {
         if !fonts.waiting_to_fullfill_promise() {
             return false;
         }
-        if dbg!(self.window().font_context().web_fonts_still_loading()) != 0 {
+        if self.window().font_context().web_fonts_still_loading() != 0 {
             return false;
         }
         if self.ReadyState() != DocumentReadyState::Complete {
@@ -3178,7 +3182,6 @@ impl Document {
             return false;
         }
 
-        println!("will fulfill font ready promise");
         let result = fonts.fulfill_ready_promise_if_needed(cx);
 
         // Add a rendering update after the `fonts.ready` promise is fulfilled just for
@@ -4540,11 +4543,9 @@ impl Document {
     }
 
     pub(crate) fn switch_font_face_set_to_loading_if_needed(&self, cx: &mut JSContext) {
-        println!("switch to loading if needed");
         if self.window.font_context().web_fonts_still_loading() != 0 &&
             let Some(font_face_set) = self.fonts.get()
         {
-            println!("load now");
             font_face_set.switch_to_loading(cx);
         }
     }

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -3608,7 +3608,6 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
 
     /// <https://dom.spec.whatwg.org/#dom-node-appendchild>
     fn AppendChild(&self, cx: &mut JSContext, node: &Node) -> Fallible<DomRoot<Node>> {
-        println!("Appendchild");
         Node::pre_insert(cx, node, self, None)
     }
 

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -3608,6 +3608,7 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
 
     /// <https://dom.spec.whatwg.org/#dom-node-appendchild>
     fn AppendChild(&self, cx: &mut JSContext, node: &Node) -> Fallible<DomRoot<Node>> {
+        println!("Appendchild");
         Node::pre_insert(cx, node, self, None)
     }
 

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -207,12 +207,7 @@ impl ShadowRoot {
     ///
     /// <https://drafts.csswg.org/cssom/#documentorshadowroot-final-css-style-sheets>
     #[cfg_attr(crown, expect(crown::unrooted_must_root))] // Owner needs to be rooted already necessarily.
-    pub(crate) fn add_owned_stylesheet(
-        &self,
-        cx: &mut JSContext,
-        owner_node: &Element,
-        sheet: Arc<Stylesheet>,
-    ) {
+    pub(crate) fn add_owned_stylesheet(&self, owner_node: &Element, sheet: Arc<Stylesheet>) {
         let stylesheets = &mut self.author_styles.borrow_mut().stylesheets;
 
         // FIXME(stevennovaryo): This is almost identical with the one in Document::add_stylesheet.
@@ -230,10 +225,6 @@ impl ShadowRoot {
             })
             .cloned();
 
-        if self.document.has_browsing_context() {
-            self.document.load_web_fonts_from_stylesheet(cx, &sheet);
-        }
-
         DocumentOrShadowRoot::add_stylesheet(
             StylesheetSource::Element(Dom::from_ref(owner_node)),
             StylesheetSetRef::Author(stylesheets),
@@ -245,21 +236,13 @@ impl ShadowRoot {
 
     /// Append a constructed stylesheet to the back of shadow root stylesheet set.
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-    pub(crate) fn append_constructed_stylesheet(
-        &self,
-        cx: &mut JSContext,
-        cssom_stylesheet: &CSSStyleSheet,
-    ) {
+    pub(crate) fn append_constructed_stylesheet(&self, cssom_stylesheet: &CSSStyleSheet) {
         debug_assert!(cssom_stylesheet.is_constructed());
 
         let stylesheets = &mut self.author_styles.borrow_mut().stylesheets;
         let sheet = cssom_stylesheet.style_stylesheet().clone();
 
         let insertion_point = stylesheets.iter().last().cloned();
-
-        if self.document.has_browsing_context() {
-            self.document.load_web_fonts_from_stylesheet(cx, &sheet);
-        }
 
         DocumentOrShadowRoot::add_stylesheet(
             StylesheetSource::Constructed(Dom::from_ref(cssom_stylesheet)),

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -2666,6 +2666,8 @@ impl Window {
 
         document.update_animations_post_reflow();
 
+        document.switch_font_face_set_to_loading_if_needed(cx);
+
         (
             reflow_result.reflow_phases_run,
             reflow_result.reflow_statistics,

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -303,10 +303,6 @@ impl StylesheetContext {
                 link.set_stylesheet(cx, stylesheet);
             },
             StylesheetContextSource::Import(import_rule) => {
-                // Layout knows about this stylesheet, because Stylo added it to the Stylist,
-                // but Layout doesn't know about any new web fonts that it contains.
-                document.load_web_fonts_from_stylesheet(cx, &stylesheet);
-
                 let mut guard = document.style_shared_author_lock().write();
                 import_rule.write_with(&mut guard).stylesheet = ImportSheet::Sheet(stylesheet);
             },

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -498,7 +498,7 @@ DOMInterfaces = {
 },
 
 'FontFaceSet': {
-    'cx': ['Add', 'Load'],
+    'cx': ['Add', 'Load', 'Ready'],
 },
 
 'FormData': {

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -282,14 +282,6 @@ pub trait Layout {
     /// if the [`ViewportDetails`] actually changed or `false` otherwise.
     fn set_viewport_details(&mut self, viewport_details: ViewportDetails) -> bool;
 
-    /// Load all fonts from the given stylesheet, returning the number of fonts that
-    /// need to be loaded.
-    fn load_web_fonts_from_stylesheet(
-        &self,
-        stylesheet: &ServoArc<Stylesheet>,
-        font_context: &WebFontDocumentContext,
-    );
-
     /// Add a stylesheet to this Layout. This will add it to the Layout's `Stylist` as well as
     /// loading all web fonts defined in the stylesheet. The second stylesheet is the insertion
     /// point (if it exists, the sheet needs to be inserted before it).
@@ -297,7 +289,6 @@ pub trait Layout {
         &mut self,
         stylesheet: ServoArc<Stylesheet>,
         before_stylsheet: Option<ServoArc<Stylesheet>>,
-        font_context: &WebFontDocumentContext,
     );
 
     /// Inform the layout that its ScriptThread is about to exit.

--- a/tests/wpt/meta/css/css-shadow/font-face-007.html.ini
+++ b/tests/wpt/meta/css/css-shadow/font-face-007.html.ini
@@ -1,0 +1,3 @@
+[font-face-007.html]
+  [@font-face from shadow applies to :host]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-shadow/font-face-008.html.ini
+++ b/tests/wpt/meta/css/css-shadow/font-face-008.html.ini
@@ -1,0 +1,3 @@
+[font-face-008.html]
+  [@font-face from shadow applies to a slotted element]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-shadow/font-face-009.html.ini
+++ b/tests/wpt/meta/css/css-shadow/font-face-009.html.ini
@@ -1,0 +1,3 @@
+[font-face-009.html]
+  [@font-face from shadow applies to to :host::before/::after.]
+    expected: FAIL


### PR DESCRIPTION
Instead of processing every font face rule as stylesheets are modified, process
all rules, properly cascaded by Stylo, right before layout. This fixes an issues with
flakiness around font loading and layers and  avoids searching the stylesheet for
font face rules in `O(n)`.

Fixes: #45975
Fixes: #36094.
Fixes: #35935.