### PR TITLE
Upgrade num-bigint from v0.4.7 (yanked) to v0.4.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5466,9 +5466,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",


### PR DESCRIPTION
Testing: The CI stops complaining about the usage of a yanked crate
Fixes: #46274