### PR TITLE
CI: Install shellcheck dependency for test-scripts

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -172,7 +172,7 @@ jobs:
         run: |
           sudo apt update
           echo "wireshark-common wireshark-common/install-setuid boolean true" | sudo debconf-set-selections
-          sudo apt install -qy tshark
+          sudo apt install -qy tshark shellcheck
           ./mach bootstrap --yes --skip-lints --skip-nextest
 
       # Always install crown, even on self-hosted runners, because it is tightly

--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -31,9 +31,9 @@ on:
         default: false
         type: boolean
       force-github-hosted-runner:
-          required: false
-          type: boolean
-          default: false
+        required: false
+        type: boolean
+        default: false
       bencher:
         required: false
         default: false
@@ -65,9 +65,9 @@ on:
         default: false
         type: boolean
       force-github-hosted-runner:
-          required: false
-          type: boolean
-          default: false
+        required: false
+        type: boolean
+        default: false
       bencher:
         required: false
         default: false
@@ -145,7 +145,7 @@ jobs:
         name: Bootstrap
         run: |
           ./mach bootstrap --yes --skip-lints --skip-nextest
-          brew install gnu-tar
+          brew install gnu-tar shellcheck
       - name: Build (${{ inputs.profile }})
         env:
           RUSTFLAGS: ${{ inputs.profile == 'checked-release' && '-D warnings' || '' }}
@@ -231,7 +231,7 @@ jobs:
     if: ${{ inputs.bencher && inputs.profile != 'debug' && github.event_name != 'workflow_dispatch' && github.event_name != 'merge_group' }}
     uses: ./.github/workflows/bencher.yml
     with:
-      target: 'macos-arm64'
+      target: "macos-arm64"
       profile: ${{ inputs.profile }}
       compressed-file-path: ${{ inputs.profile }}-binary-macos-arm64/target.tar.gz
       binary-path: target/${{ inputs.profile }}/servoshell

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -31,9 +31,9 @@ on:
         default: false
         type: boolean
       force-github-hosted-runner:
-          required: false
-          type: boolean
-          default: false
+        required: false
+        type: boolean
+        default: false
       bencher:
         required: false
         default: false
@@ -65,9 +65,9 @@ on:
         default: false
         type: boolean
       force-github-hosted-runner:
-          required: false
-          type: boolean
-          default: false
+        required: false
+        type: boolean
+        default: false
       bencher:
         required: false
         default: false
@@ -144,7 +144,7 @@ jobs:
         name: Bootstrap
         run: |
           ./mach bootstrap --yes --skip-lints --skip-nextest
-          brew install gnu-tar
+          brew install gnu-tar shellcheck
       - name: Build (${{ inputs.profile }})
         env:
           RUSTFLAGS: ${{ inputs.profile == 'checked-release' && '-D warnings' || '' }}
@@ -230,7 +230,7 @@ jobs:
     if: ${{ inputs.bencher && inputs.profile != 'debug' && github.event_name != 'workflow_dispatch' && github.event_name != 'merge_group' }}
     uses: ./.github/workflows/bencher.yml
     with:
-      target: 'macos'
+      target: "macos"
       profile: ${{ inputs.profile }}
       compressed-file-path: ${{ inputs.profile }}-binary-macos/target.tar.gz
       binary-path: target/${{ inputs.profile }}/servoshell


### PR DESCRIPTION
In systems that are not self hosted, automatically install `shellcheck` dependency which is required by recent `./mach test-scripts`

Testing: The github CI actions skipped many tests including Bootstrap dependencies (probably because it ran in self hosted system?). So I tested it on a forked repo and shellcheck warning does not exist

Fixes: #46236 