### PR TITLE
deny: Allow unused-allowed-org

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -222,3 +222,8 @@ skip = [
 github = [
     "servo",
 ]
+
+# On our releases we switch to crates.io dependencies,
+# so explicitly allow unused allow-org entries to avoid errors.
+[sources]
+unused-allowed-org = "allow"

--- a/deny.toml
+++ b/deny.toml
@@ -248,3 +248,8 @@ skip = [
 github = [
     "servo",
 ]
+
+# On our releases we switch to crates.io dependencies,
+# so explicitly allow unused allow-org entries to avoid errors.
+[sources]
+unused-allowed-org = "allow"


### PR DESCRIPTION
On crates.io releases we don't use git sources anymore, which required us to remove the field allow-org entry before publishing. To avoid that, let's just allow unused-allowed-org entries.

Testing: The failure mode is only visible on release branches, with crates.io stylo releases.

