### PR TITLE
script: Migrate `dom/document` to `&mut JSContext`

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -211,7 +211,6 @@ use crate::image_animation::ImageAnimationManager;
 use crate::mime::{APPLICATION, CHARSET};
 use crate::navigation::navigate;
 use crate::network_listener::{FetchResponseListener, NetworkListener};
-use crate::script_runtime::CanGc;
 use crate::script_thread::{ScriptThread, SharedRwLocks};
 use crate::stylesheet_loader::StylesheetContextId;
 use crate::stylesheet_set::StylesheetSetRef;
@@ -3433,11 +3432,11 @@ impl Document {
             },
             ProgressiveWebMetricType::LargestContentfulPaint { area, url } => {
                 let binding = LargestContentfulPaint::new(
+                    cx,
                     self.window.as_global_scope(),
                     metric_value,
                     area,
                     url,
-                    CanGc::from_cx(cx),
                 );
                 metrics.set_largest_contentful_paint(metric_value, area);
                 let entry = binding.upcast::<PerformanceEntry>();
@@ -4806,10 +4805,10 @@ impl Document {
         // Step 3 Queue a new VisibilityStateEntry whose visibility state is visibilityState and whose timestamp is
         // the current high resolution time given document's relevant global object.
         let entry = VisibilityStateEntry::new(
+            cx,
             &self.global(),
             visibility_state,
             CrossProcessInstant::now(),
-            CanGc::from_cx(cx),
         );
         self.window
             .Performance()

--- a/components/script/dom/document/visibilitystateentry.rs
+++ b/components/script/dom/document/visibilitystateentry.rs
@@ -5,7 +5,8 @@
 use std::ops::Deref;
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::reflect_dom_object;
+use js::context::JSContext;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use time::Duration;
 
@@ -17,7 +18,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::performance::performanceentry::{EntryType, PerformanceEntry};
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct VisibilityStateEntry {
@@ -44,15 +44,15 @@ impl VisibilityStateEntry {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         state: DocumentVisibilityState,
         timestamp: CrossProcessInstant,
-        can_gc: CanGc,
     ) -> DomRoot<VisibilityStateEntry> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(VisibilityStateEntry::new_inherited(state, timestamp)),
             global,
-            can_gc,
+            cx,
         )
     }
 }

--- a/components/script/dom/performance/largestcontentfulpaint.rs
+++ b/components/script/dom/performance/largestcontentfulpaint.rs
@@ -3,7 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::reflect_dom_object;
+use js::context::JSContext;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_url::ServoUrl;
 use time::Duration;
@@ -16,7 +17,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::element::Element;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct LargestContentfulPaint {
@@ -53,14 +53,14 @@ impl LargestContentfulPaint {
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         render_time: CrossProcessInstant,
         size: usize,
         url: Option<ServoUrl>,
-        can_gc: CanGc,
     ) -> DomRoot<LargestContentfulPaint> {
         let entry = LargestContentfulPaint::new_inherited(render_time, size, url);
-        reflect_dom_object(Box::new(entry), global, can_gc)
+        reflect_dom_object_with_cx(Box::new(entry), global, cx)
     }
 }
 


### PR DESCRIPTION
Fairly simple thanks to prior work yet again.

Testing: Compilation.
Fixes: Part of #40600.