### PR TITLE
webgpu: Support `GPUTextureUsage::TRANSIENT_ATTACHMENT` and `GPUCanvasContext::getConfiguration`

### DIFF
--- a/components/script/dom/webgpu/gpucanvascontext.rs
+++ b/components/script/dom/webgpu/gpucanvascontext.rs
@@ -394,6 +394,11 @@ impl GPUCanvasContextMethods<crate::DomTypeHolder> for GPUCanvasContext {
         self.replace_drawing_buffer();
     }
 
+    /// <https://www.w3.org/TR/webgpu/#dom-gpucanvascontext-getconfiguration>
+    fn GetConfiguration(&self) -> Option<GPUCanvasConfiguration> {
+        self.configuration.borrow().clone()
+    }
+
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-getcurrenttexture>
     fn GetCurrentTexture(&self, cx: &mut JSContext) -> Fallible<DomRoot<GPUTexture>> {
         // 1. If this.[[configuration]] is null, throw an InvalidStateError and return.

--- a/components/script/dom/webgpu/gpucanvascontext.rs
+++ b/components/script/dom/webgpu/gpucanvascontext.rs
@@ -334,7 +334,7 @@ impl GPUCanvasContextMethods<crate::DomTypeHolder> for GPUCanvasContext {
         // 1. Let device be configuration.device
         let device = &configuration.device;
 
-        // 5. Let descriptor be the GPUTextureDescriptor for the canvas and configuration.
+        // 6. Let descriptor be the GPUTextureDescriptor for the canvas and configuration.
         let descriptor = self.texture_descriptor_for_canvas_and_configuration(configuration);
 
         // 2. Validate texture format required features of configuration.format with device.[[device]].
@@ -352,16 +352,24 @@ impl GPUCanvasContextMethods<crate::DomTypeHolder> for GPUCanvasContext {
             )));
         }
 
-        // 6. Let this.[[configuration]] to configuration.
+        // 5. If configuration.usage includes the TRANSIENT_ATTACHMENT bit, throw a TypeError.
+        if configuration.usage & GPUTextureUsageConstants::TRANSIENT_ATTACHMENT != 0 {
+            return Err(Error::Type(
+                c"configuration.usage includes the TRANSIENT_ATTACHMENT bit".into(),
+            ));
+        }
+
+        // 7. Let this.[[configuration]] to configuration.
         self.configuration.replace(Some(configuration.clone()));
 
-        // 7. Set this.[[textureDescriptor]] to descriptor.
+        // 8. Set this.[[textureDescriptor]] to descriptor.
         self.texture_descriptor.replace(Some(descriptor));
 
-        // 8. Replace the drawing buffer of this.
+        // 9. Replace the drawing buffer of this.
         self.replace_drawing_buffer();
 
-        // 9. Validate texture descriptor
+        // 10. Issue the subsequent steps on the Device timeline of device.
+        // 10.1. Validate texture descriptor
         let texture_id = self.global().wgpu_id_hub().create_texture_id();
         self.droppable
             .channel

--- a/components/script_bindings/webidls/WebGPU.webidl
+++ b/components/script_bindings/webidls/WebGPU.webidl
@@ -269,7 +269,7 @@ namespace GPUTextureUsage {
     const GPUFlagsConstant TEXTURE_BINDING      = 0x04;
     const GPUFlagsConstant STORAGE_BINDING      = 0x08;
     const GPUFlagsConstant RENDER_ATTACHMENT    = 0x10;
-    //const GPUFlagsConstant TRANSIENT_ATTACHMENT = 0x20;
+    const GPUFlagsConstant TRANSIENT_ATTACHMENT = 0x20;
 };
 
 [Exposed=(Window, Worker), SecureContext, Pref="dom_webgpu_enabled"]

--- a/components/script_bindings/webidls/WebGPU.webidl
+++ b/components/script_bindings/webidls/WebGPU.webidl
@@ -1224,6 +1224,9 @@ partial interface GPUCanvasContext {
     [Throws, Pref="dom_webgpu_enabled"]
     undefined configure(GPUCanvasConfiguration descriptor);
     [Pref="dom_webgpu_enabled"] undefined unconfigure();
+
+    [Pref="dom_webgpu_enabled"]
+    GPUCanvasConfiguration? getConfiguration();
     [Throws, Pref="dom_webgpu_enabled"]
     GPUTexture getCurrentTexture();
 };


### PR DESCRIPTION
Just some small WebIDL changes with simple corresponding servo changes.

Testing: WebGPU CTS run