### PR TITLE
script: Implement fetching request for track elements

### DIFF
--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -58,7 +58,9 @@ use crate::dom::bindings::codegen::Bindings::MediaErrorBinding::MediaErrorConsta
 use crate::dom::bindings::codegen::Bindings::MediaErrorBinding::MediaErrorMethods;
 use crate::dom::bindings::codegen::Bindings::NavigatorBinding::Navigator_Binding::NavigatorMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::Node_Binding::NodeMethods;
-use crate::dom::bindings::codegen::Bindings::TextTrackBinding::{TextTrackKind, TextTrackMode};
+use crate::dom::bindings::codegen::Bindings::TextTrackBinding::{
+    TextTrackKind, TextTrackMethods, TextTrackMode,
+};
 use crate::dom::bindings::codegen::Bindings::URLBinding::URLMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
 use crate::dom::bindings::codegen::UnionTypes::{
@@ -93,6 +95,7 @@ use crate::dom::node::virtualmethods::VirtualMethods;
 use crate::dom::node::{Node, NodeDamage, NodeTraits, UnbindContext};
 use crate::dom::performance::performanceresourcetiming::InitiatorType;
 use crate::dom::promise::Promise;
+use crate::dom::referrer_policy_for_element;
 use crate::dom::texttrack::TextTrack;
 use crate::dom::texttracklist::TextTrackList;
 use crate::dom::timeranges::{TimeRanges, TimeRangesContainer};
@@ -594,7 +597,7 @@ pub(crate) struct HTMLMediaElement {
     audio_tracks_list: MutNullableDom<AudioTrackList>,
     // https://html.spec.whatwg.org/multipage/#dom-media-videotracks
     video_tracks_list: MutNullableDom<VideoTrackList>,
-    /// <https://html.spec.whatwg.org/multipage/#dom-media-texttracks>
+    /// <https://html.spec.whatwg.org/multipage/#list-of-text-tracks>
     text_tracks_list: MutNullableDom<TextTrackList>,
     /// Time of last timeupdate notification.
     #[ignore_malloc_size_of = "Defined in std::time"]
@@ -606,6 +609,8 @@ pub(crate) struct HTMLMediaElement {
     /// the access to the "privileged" document.servoGetMediaControls(id) API by
     /// keeping a whitelist of media controls identifiers.
     media_controls_id: DomRefCell<Option<String>>,
+    /// <https://html.spec.whatwg.org/multipage/#did-perform-automatic-track-selection>
+    did_perform_automatic_track_selection: Cell<bool>,
 }
 
 /// <https://html.spec.whatwg.org/multipage/#dom-media-networkstate>
@@ -689,6 +694,7 @@ impl HTMLMediaElement {
             next_timeupdate_event: Cell::new(Instant::now() + Duration::from_millis(250)),
             current_fetch_context: RefCell::new(None),
             media_controls_id: DomRefCell::new(None),
+            did_perform_automatic_track_selection: Default::default(),
         }
     }
 
@@ -1461,7 +1467,7 @@ impl HTMLMediaElement {
         )
         .with_global_scope(&global)
         .headers(headers)
-        .referrer_policy(document.get_referrer_policy());
+        .referrer_policy(referrer_policy_for_element(self.upcast()));
 
         let mut current_fetch_context = self.current_fetch_context.borrow_mut();
         if let Some(ref mut current_fetch_context) = *current_fetch_context {
@@ -2983,6 +2989,87 @@ impl HTMLMediaElement {
 
         true
     }
+
+    pub(crate) fn was_added_to_list_of_text_tracks(&self) {
+        // https://html.spec.whatwg.org/multipage/#sourcing-out-of-band-text-tracks
+        // > When a text track corresponding to a track element is added to a media element's list of text tracks,
+        // > the user agent must queue a media element task given the media element to
+        // > run the following steps for the media element:
+        let this = Trusted::new(self);
+        self.global()
+            .task_manager()
+            .media_element_task_source()
+            .queue(task!(track_event_queue: move |cx| {
+                let element = this.root();
+                // Step 1. If the element's blocked-on-parser flag is true, then return.
+                // TODO
+                // Step 2. If the element's did-perform-automatic-track-selection flag is true, then return.
+                if element.did_perform_automatic_track_selection.get() {
+                    return;
+                }
+                // Step 3. Honor user preferences for automatic text track selection for this element.
+                element.honor_user_preferences_for_automatic_text_track_selection(cx);
+            }));
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#honor-user-preferences-for-automatic-text-track-selection>
+    fn honor_user_preferences_for_automatic_text_track_selection(&self, cx: &mut JSContext) {
+        // Step 1. Perform automatic text track selection for subtitles and captions.
+        self.perform_automatic_text_track_selection(
+            cx,
+            vec![TextTrackKind::Subtitles, TextTrackKind::Captions],
+        );
+        // Step 2. Perform automatic text track selection for descriptions.
+        self.perform_automatic_text_track_selection(cx, vec![TextTrackKind::Descriptions]);
+        // Step 3. If there are any text tracks in the media element's list of
+        // text tracks whose text track kind is chapters or metadata that correspond to
+        // track elements with a default attribute set whose text track mode is set to disabled,
+        // then set the text track mode of all such tracks to hidden.
+        // TODO
+        // Step 4. Set the element's did-perform-automatic-track-selection flag to true.
+        self.did_perform_automatic_track_selection.set(true);
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#perform-automatic-text-track-selection>
+    fn perform_automatic_text_track_selection(
+        &self,
+        cx: &mut JSContext,
+        text_track_kinds: Vec<TextTrackKind>,
+    ) {
+        // Step 1. Let candidates be a list consisting of the text tracks in the media element's
+        // list of text tracks whose text track kind is one of the kinds that were passed to the algorithm,
+        // if any, in the order given in the list of text tracks.
+        let Some(text_tracks_list) = self.text_tracks_list.get() else {
+            return;
+        };
+        let candidates = text_tracks_list.tracks_for_kinds(text_track_kinds);
+        // Step 2. If candidates is empty, then return.
+        if candidates.is_empty() {
+            return;
+        }
+        // Step 3. If any of the text tracks in candidates have a text track mode set to showing, return.
+        if candidates
+            .iter()
+            .any(|candidate| candidate.Mode() == TextTrackMode::Showing)
+        {
+            return;
+        }
+        // Step 4. If the user has expressed an interest in having a track from candidates enabled
+        // based on its text track kind, text track language, and text track label,
+        // then set its text track mode to showing.
+        // Otherwise, if there are any text tracks in candidates that correspond to track elements with
+        // a default attribute set whose text track mode is set to disabled,
+        // then set the text track mode of the first such track to showing.
+        if let Some(default_candidate) = candidates.iter().find(|candidate| {
+            candidate.associated_track().is_some_and(|track| {
+                track
+                    .upcast::<Element>()
+                    .has_attribute(&local_name!("default"))
+            }) && candidate.Mode() == TextTrackMode::Disabled
+        }) {
+            default_candidate.set_text_track_mode(cx, TextTrackMode::Showing);
+        }
+    }
 }
 
 impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
@@ -3314,6 +3401,10 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-media-texttracks>
     fn TextTracks(&self, cx: &mut JSContext) -> DomRoot<TextTrackList> {
+        // > The textTracks attribute of media elements must return a
+        // > TextTrackList object representing the TextTrack objects of
+        // > the text tracks in the media element's list of text tracks,
+        // > in the same order as in the list of text tracks.
         let window = self.owner_window();
         self.text_tracks_list
             .or_init(|| TextTrackList::new(cx, &window, &[]))
@@ -3328,8 +3419,12 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
         language: DOMString,
     ) -> DomRoot<TextTrack> {
         let window = self.owner_window();
-        // Step 1 & 2
-        // FIXME(#22314, dlrobertson) set the ready state to Loaded
+        // Step 1. Create a new TextTrack object.
+        // Step 2. Create a new text track corresponding to the new object,
+        // and set its text track kind to kind, its text track label to label,
+        // its text track language to language, its text track readiness state
+        // to the text track loaded state, its text track mode to the text
+        // track hidden mode, and its text track list of cues to an empty list.
         let track = TextTrack::new(
             cx,
             &window,
@@ -3340,9 +3435,13 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
             TextTrackMode::Hidden,
             None,
         );
-        // Step 3 & 4
-        self.TextTracks(cx).add(&track);
-        // Step 5
+        // Step 3. Add the new text track to the media element's list of text tracks.
+        // Step 4. Queue a media element task given the media element to fire an event
+        // named addtrack at the media element's textTracks attribute's TextTrackList object,
+        // using TrackEvent, with the track attribute initialized to
+        // the new text track's TextTrack object.
+        self.TextTracks(cx).add(self, &track);
+        // Step 5. Return the new TextTrack object.
         DomRoot::from_ref(&track)
     }
 

--- a/components/script/dom/html/htmltrackelement.rs
+++ b/components/script/dom/html/htmltrackelement.rs
@@ -2,37 +2,80 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::cell::Cell;
+
+use content_security_policy::Destination;
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name};
+use js::context::JSContext;
+use js::realm::AutoRealm;
 use js::rust::HandleObject;
+use net_traits::request::{CorsSettings, RequestId};
+use net_traits::{FetchMetadata, NetworkError, ResourceFetchTiming};
+use script_bindings::cell::DomRefCell;
+use servo_url::ServoUrl;
 
+use crate::dom::bindings::codegen::Bindings::HTMLMediaElementBinding::HTMLMediaElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLTrackElementBinding::{
     HTMLTrackElementConstants, HTMLTrackElementMethods,
 };
+use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
+use crate::dom::bindings::codegen::Bindings::TextTrackBinding::{TextTrackMethods, TextTrackMode};
 use crate::dom::bindings::inheritance::Castable;
+use crate::dom::bindings::refcounted::Trusted;
+use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::{DOMString, USVString};
+use crate::dom::csp::Violation;
 use crate::dom::document::Document;
 use crate::dom::element::Element;
+use crate::dom::element::storage::AttrRef;
+use crate::dom::eventtarget::EventTarget;
+use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlelement::HTMLElement;
-use crate::dom::node::Node;
+use crate::dom::html::htmlmediaelement::HTMLMediaElement;
+use crate::dom::node::node::NodeTraits;
+use crate::dom::node::{BindContext, MoveContext, Node, UnbindContext};
+use crate::dom::performanceresourcetiming::InitiatorType;
+use crate::dom::security::csp::GlobalCspReporting;
 use crate::dom::texttrack::TextTrack;
+use crate::dom::virtualmethods::VirtualMethods;
+use crate::dom::{AttributeMutation, cors_setting_for_element};
+use crate::fetch::{RequestWithGlobalScope, create_a_potential_cors_request};
+use crate::microtask::{Microtask, MicrotaskRunnable};
+use crate::network_listener::{FetchResponseListener, ResourceTimingListener};
+use crate::realms::enter_auto_realm;
+use crate::{ScriptThread, network_listener};
 
-#[derive(Clone, Copy, JSTraceable, MallocSizeOf, PartialEq)]
+#[derive(Clone, Copy, Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[repr(u16)]
-#[expect(unused)]
-pub(crate) enum ReadyState {
+/// <https://html.spec.whatwg.org/multipage/#text-track-readiness-state>
+pub(crate) enum TextTrackReadinessState {
+    /// <https://html.spec.whatwg.org/multipage/#text-track-not-loaded>
+    #[default]
     None = HTMLTrackElementConstants::NONE,
+    /// <https://html.spec.whatwg.org/multipage/#text-track-loading>
     Loading = HTMLTrackElementConstants::LOADING,
+    /// <https://html.spec.whatwg.org/multipage/#text-track-loaded>
     Loaded = HTMLTrackElementConstants::LOADED,
-    Error = HTMLTrackElementConstants::ERROR,
+    /// <https://html.spec.whatwg.org/multipage/#text-track-failed-to-load>
+    FailedToLoad = HTMLTrackElementConstants::ERROR,
 }
 
 #[dom_struct]
 pub(crate) struct HTMLTrackElement {
     htmlelement: HTMLElement,
-    ready_state: ReadyState,
+    /// <https://html.spec.whatwg.org/multipage/#text-track-readiness-state>
+    readiness_state: Cell<TextTrackReadinessState>,
+    /// <https://html.spec.whatwg.org/multipage/#text-track>
     track: Dom<TextTrack>,
+    /// <https://html.spec.whatwg.org/multipage/#track-url>
+    #[no_trace]
+    track_url: DomRefCell<Option<ServoUrl>>,
+    /// Used as part of
+    /// <https://html.spec.whatwg.org/multipage/#start-the-track-processing-model>
+    /// whether the algorithm is running or not.
+    is_running_processing_model_algorithm: Cell<bool>,
 }
 
 impl HTMLTrackElement {
@@ -44,13 +87,15 @@ impl HTMLTrackElement {
     ) -> HTMLTrackElement {
         HTMLTrackElement {
             htmlelement: HTMLElement::new_inherited(local_name, prefix, document),
-            ready_state: ReadyState::None,
+            readiness_state: Default::default(),
             track: Dom::from_ref(track),
+            track_url: Default::default(),
+            is_running_processing_model_algorithm: Default::default(),
         }
     }
 
     pub(crate) fn new(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
@@ -66,14 +111,81 @@ impl HTMLTrackElement {
             Default::default(),
             None,
         );
-        Node::reflect_node_with_proto(
+        let track_element = Node::reflect_node_with_proto(
             cx,
             Box::new(HTMLTrackElement::new_inherited(
                 local_name, prefix, document, &track,
             )),
             document,
             proto,
-        )
+        );
+        track.set_associated_track(&track_element);
+        track_element
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#start-the-track-processing-model>
+    pub(crate) fn start_the_track_processing_model(&self, cx: &mut JSContext) {
+        // Step 1. If another occurrence of this algorithm is already running
+        // for this text track and its track element, return,
+        // letting that other algorithm take care of this element.
+        if self.is_running_processing_model_algorithm.get() {
+            return;
+        }
+        // Step 2. If the text track's text track mode is not set to one of hidden or showing, then return.
+        if !matches!(
+            self.track.Mode(),
+            TextTrackMode::Hidden | TextTrackMode::Showing
+        ) {
+            return;
+        }
+        // Step 3. If the text track's track element does not have a media element as a parent, return.
+        let Some(parent) = self
+            .upcast::<Node>()
+            .GetParentElement()
+            .filter(|parent| parent.is::<HTMLMediaElement>())
+        else {
+            return;
+        };
+        // Step 4. Run the remainder of these steps in parallel, allowing whatever caused these steps to run to continue.
+        // Step 5. Top: Await a stable state. The synchronous section consists of the following steps.
+        // (The steps in the synchronous section are marked with ⌛.)
+        // Step 6. ⌛ Set the text track readiness state to loading.
+        self.readiness_state.set(TextTrackReadinessState::Loading);
+        // Step 7. ⌛ Let URL be the track URL of the track element.
+        let url = self.track_url.borrow().clone();
+        // Step 8. ⌛ If the track element's parent is a media element,
+        // then let corsAttributeState be the state of the parent media element's
+        // crossorigin content attribute. Otherwise, let corsAttributeState be No CORS.
+        let cors_attribute_state = cors_setting_for_element(&parent);
+        let task = TrackElementMicrotask::ProcessingModel {
+            elem: DomRoot::from_ref(self),
+            cors_attribute_state,
+            url,
+        };
+        self.is_running_processing_model_algorithm.set(true);
+
+        ScriptThread::await_stable_state(cx, Microtask::TrackElement(task));
+    }
+
+    fn check_if_track_parent_element_changed(&self, cx: &mut JSContext) {
+        if let Some(parent) = self
+            .upcast::<Node>()
+            .GetParentNode()
+            .and_then(DomRoot::downcast::<HTMLMediaElement>)
+        {
+            // https://html.spec.whatwg.org/multipage/#sourcing-out-of-band-text-tracks
+            // > When a track element's parent element changes and the new parent is a media element,
+            // > then the user agent must add the track element's corresponding text track to
+            // > the media element's list of text tracks, and then queue a media element task
+            // > given the media element to fire an event named addtrack at the media element's
+            // > textTracks attribute's TextTrackList object, using TrackEvent,
+            // > with the track attribute initialized to the text track's TextTrack object.
+            parent.TextTracks(cx).add(&parent, &self.track);
+
+            // https://html.spec.whatwg.org/multipage/#sourcing-out-of-band-text-tracks:start-the-track-processing-model
+            // > The track element's parent element changes and the new parent is a media element.
+            self.start_the_track_processing_model(cx);
+        }
     }
 }
 
@@ -132,11 +244,262 @@ impl HTMLTrackElementMethods<crate::DomTypeHolder> for HTMLTrackElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-track-readystate>
     fn ReadyState(&self) -> u16 {
-        self.ready_state as u16
+        self.readiness_state.get() as u16
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-track-track>
     fn Track(&self) -> DomRoot<TextTrack> {
         DomRoot::from_ref(&*self.track)
+    }
+}
+
+impl VirtualMethods for HTMLTrackElement {
+    fn super_type(&self) -> Option<&dyn VirtualMethods> {
+        Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
+    }
+
+    fn attribute_mutated(
+        &self,
+        cx: &mut JSContext,
+        attr: AttrRef<'_>,
+        mutation: AttributeMutation,
+    ) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(cx, attr, mutation);
+        match *attr.local_name() {
+            local_name!("src") => {
+                // https://html.spec.whatwg.org/multipage/#attr-track-src
+                // > When the element's src attribute is set, run these steps:
+                if matches!(mutation, AttributeMutation::Set(..)) {
+                    // Step 2. Let value be the element's src attribute value.
+                    let value = &**attr.value();
+                    // Step 1. Let trackURL be failure.
+                    // Step 3. If value is not the empty string,
+                    // then set trackURL to the result of encoding-parsing-and-serializing
+                    // a URL given value, relative to the element's node document.
+                    // Step 4. Set the element's track URL to trackURL if it is not failure;
+                    // otherwise to the empty string.
+                    *self.track_url.borrow_mut() = if !value.is_empty() {
+                        self.owner_document().base_url().join(value).ok()
+                    } else {
+                        None
+                    };
+                }
+                // https://html.spec.whatwg.org/multipage/#sourcing-out-of-band-text-tracks
+                // > Whenever a track element has its src attribute set, changed, or removed,
+                // > the user agent must immediately empty the element's text track's text track list of cues.
+                // > (This also causes the algorithm above to stop adding cues from the resource
+                // > being obtained using the previously given URL, if any.)
+                self.track.empty_cue_list();
+            },
+            _ => {},
+        }
+    }
+
+    fn moving_steps(&self, cx: &mut JSContext, context: &MoveContext) {
+        if let Some(super_type) = self.super_type() {
+            super_type.moving_steps(cx, context);
+        }
+
+        if let Some(parent) = context
+            .old_parent
+            .and_then(|node| node.downcast::<HTMLMediaElement>())
+        {
+            // https://html.spec.whatwg.org/multipage/#sourcing-out-of-band-text-tracks
+            // > When a track element's parent element changes and the old parent was a media element,
+            // > then the user agent must remove the track element's corresponding text track from
+            // > the media element's list of text tracks, and then queue a media element task
+            // > given the media element to fire an event named removetrack at the media element's
+            // > textTracks attribute's TextTrackList object, using TrackEvent,
+            // > with the track attribute initialized to the text track's TextTrack object.
+            parent.TextTracks(cx).remove(&self.track);
+        }
+
+        self.check_if_track_parent_element_changed(cx);
+    }
+
+    fn bind_to_tree(&self, cx: &mut JSContext, context: &BindContext) {
+        if let Some(super_type) = self.super_type() {
+            super_type.bind_to_tree(cx, context);
+        }
+
+        self.check_if_track_parent_element_changed(cx);
+    }
+
+    fn unbind_from_tree(&self, cx: &mut JSContext, context: &UnbindContext) {
+        if let Some(s) = self.super_type() {
+            s.unbind_from_tree(cx, context);
+        }
+
+        if let Some(parent) = context.parent.downcast::<HTMLMediaElement>() {
+            // https://html.spec.whatwg.org/multipage/#sourcing-out-of-band-text-tracks
+            // > When a track element's parent element changes and the old parent was a media element,
+            // > then the user agent must remove the track element's corresponding text track from
+            // > the media element's list of text tracks, and then queue a media element task
+            // > given the media element to fire an event named removetrack at the media element's
+            // > textTracks attribute's TextTrackList object, using TrackEvent,
+            // > with the track attribute initialized to the text track's TextTrack object.
+            parent.TextTracks(cx).remove(&self.track);
+        }
+    }
+}
+
+#[derive(JSTraceable, MallocSizeOf)]
+pub(crate) enum TrackElementMicrotask {
+    ProcessingModel {
+        elem: DomRoot<HTMLTrackElement>,
+        #[no_trace]
+        cors_attribute_state: Option<CorsSettings>,
+        #[no_trace]
+        url: Option<ServoUrl>,
+    },
+}
+
+impl MicrotaskRunnable for TrackElementMicrotask {
+    fn handler(&self, _cx: &mut JSContext) {
+        match self {
+            // https://html.spec.whatwg.org/multipage/#start-the-track-processing-model
+            TrackElementMicrotask::ProcessingModel {
+                elem,
+                cors_attribute_state,
+                url,
+            } => {
+                // Step 9. End the synchronous section, continuing the remaining steps in parallel.
+                // TODO
+                // Step 10. If URL is not the empty string:
+                if let Some(url) = url {
+                    // Step 10.1. Let request be the result of creating a potential-CORS request given URL,
+                    // "track", and corsAttributeState, and with the same-origin fallback flag set.
+                    let global = elem.global();
+                    let document = elem.owner_document();
+                    let request = create_a_potential_cors_request(
+                        Some(document.webview_id()),
+                        url.clone(),
+                        Destination::Track,
+                        *cors_attribute_state,
+                        None,
+                        global.get_referrer(),
+                    )
+                    // Step 10.2. Set request's client to the track element's node document's relevant
+                    // settings object.
+                    .with_global_scope(&global);
+                    // Step 10.3. Set request's initiator type to "track".
+                    //
+                    // Set in listener
+
+                    // Step 10.4. Fetch request.
+                    let listener = HTMLTrackElementFetchListener {
+                        element: Trusted::new(elem),
+                        url: url.clone(),
+                    };
+                    document.fetch_background(request, listener);
+                } else {
+                    elem.is_running_processing_model_algorithm.set(false);
+                }
+                // Step 11. Wait until the text track readiness state is no longer set to loading.
+                // TODO
+                // Step 12. Wait until the track URL is no longer equal to URL,
+                // at the same time as the text track mode is set to hidden or showing.
+                // TODO
+                // Step 13. Jump to the step labeled top.
+                // TODO
+            },
+        }
+    }
+
+    fn enter_realm<'cx>(&self, cx: &'cx mut JSContext) -> AutoRealm<'cx> {
+        match self {
+            TrackElementMicrotask::ProcessingModel { elem, .. } => enter_auto_realm(cx, &**elem),
+        }
+    }
+}
+
+struct HTMLTrackElementFetchListener {
+    /// The element that initiated the request.
+    element: Trusted<HTMLTrackElement>,
+    /// URL for the resource.
+    url: ServoUrl,
+}
+
+impl FetchResponseListener for HTMLTrackElementFetchListener {
+    fn process_request_body(&mut self, _: RequestId) {}
+
+    fn process_response(
+        &mut self,
+        _: &mut JSContext,
+        _: RequestId,
+        _: Result<FetchMetadata, NetworkError>,
+    ) {
+    }
+
+    fn process_response_chunk(&mut self, _: &mut JSContext, _: RequestId, _: Vec<u8>) {}
+
+    fn process_response_eof(
+        self,
+        cx: &mut JSContext,
+        _: RequestId,
+        status: Result<(), NetworkError>,
+        timing: ResourceFetchTiming,
+    ) {
+        // https://html.spec.whatwg.org/multipage/#start-the-track-processing-model
+        // > If fetching fails for any reason (network error, the server returns an error code, CORS fails, etc.),
+        // > or if URL is the empty string, then queue an element task on the DOM manipulation task source
+        // > given the media element to first change the text track readiness state to failed to load
+        // > and then fire an event named error at the track element.
+        let track = self.element.clone();
+        let element = self.element.root();
+        if status.is_err() {
+            element
+                .global()
+                .task_manager()
+                .dom_manipulation_task_source()
+                .queue(task!(failed_to_load: move |cx| {
+                        let track = track.root();
+                        track.readiness_state.set(TextTrackReadinessState::FailedToLoad);
+                        track.upcast::<EventTarget>().fire_event(cx, atom!("error"));
+                }));
+        } else {
+            // > If fetching does not fail, and the file was successfully processed,
+            // > then the final task that is queued by the networking task source,
+            // > after it has finished parsing the data, must change the text track readiness state to loaded,
+            // > and fire an event named load at the track element.
+            element
+                .global()
+                .task_manager()
+                .networking_task_source()
+                .queue(task!(succesfully_loaded: move |cx| {
+                        let track = track.root();
+                        track.readiness_state.set(TextTrackReadinessState::Loaded);
+                        track.upcast::<EventTarget>().fire_event(cx, atom!("load"));
+                }));
+        }
+        element.is_running_processing_model_algorithm.set(false);
+        network_listener::submit_timing(cx, &self, &status, &timing);
+    }
+
+    fn process_csp_violations(
+        &mut self,
+        cx: &mut JSContext,
+        _: RequestId,
+        violations: Vec<Violation>,
+    ) {
+        let global = &self.resource_timing_global();
+        global.report_csp_violations(cx, violations, None, None);
+    }
+
+    fn should_invoke(&self) -> bool {
+        true
+    }
+}
+
+impl ResourceTimingListener for HTMLTrackElementFetchListener {
+    /// Step 10.3. of <https://html.spec.whatwg.org/multipage/#start-the-track-processing-model>
+    fn resource_timing_information(&self) -> (InitiatorType, ServoUrl) {
+        (InitiatorType::Track, self.url.clone())
+    }
+
+    fn resource_timing_global(&self) -> DomRoot<GlobalScope> {
+        self.element.root().owner_document().global()
     }
 }

--- a/components/script/dom/node/virtualmethods.rs
+++ b/components/script/dom/node/virtualmethods.rs
@@ -57,6 +57,7 @@ use crate::dom::html::htmltablesectionelement::HTMLTableSectionElement;
 use crate::dom::html::htmltemplateelement::HTMLTemplateElement;
 use crate::dom::html::htmltextareaelement::HTMLTextAreaElement;
 use crate::dom::html::htmltitleelement::HTMLTitleElement;
+use crate::dom::html::htmltrackelement::HTMLTrackElement;
 use crate::dom::html::htmlvideoelement::HTMLVideoElement;
 use crate::dom::html::input_element::HTMLInputElement;
 use crate::dom::htmlbuttonelement::CommandState;
@@ -333,6 +334,9 @@ pub(crate) fn vtable_for(node: &Node) -> &dyn VirtualMethods {
         },
         NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLTitleElement)) => {
             node.downcast::<HTMLTitleElement>().unwrap() as &dyn VirtualMethods
+        },
+        NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLTrackElement)) => {
+            node.downcast::<HTMLTrackElement>().unwrap() as &dyn VirtualMethods
         },
         NodeTypeId::Element(ElementTypeId::SVGElement(SVGElementTypeId::SVGGraphicsElement(
             SVGGraphicsElementTypeId::SVGImageElement,

--- a/components/script/dom/performance/performanceresourcetiming.rs
+++ b/components/script/dom/performance/performanceresourcetiming.rs
@@ -33,6 +33,7 @@ pub(crate) enum InitiatorType {
     Navigation,
     XMLHttpRequest,
     Fetch,
+    Track,
     Other,
 }
 
@@ -157,6 +158,7 @@ impl PerformanceResourceTimingMethods<crate::DomTypeHolder> for PerformanceResou
             InitiatorType::Navigation => DOMString::from("navigation"),
             InitiatorType::XMLHttpRequest => DOMString::from("xmlhttprequest"),
             InitiatorType::Fetch => DOMString::from("fetch"),
+            InitiatorType::Track => DOMString::from("track"),
             InitiatorType::Other => DOMString::from("other"),
         }
     }

--- a/components/script/dom/webvtt/texttrack.rs
+++ b/components/script/dom/webvtt/texttrack.rs
@@ -17,6 +17,7 @@ use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::eventtarget::EventTarget;
+use crate::dom::html::htmltrackelement::HTMLTrackElement;
 use crate::dom::texttrackcue::TextTrackCue;
 use crate::dom::texttrackcuelist::TextTrackCueList;
 use crate::dom::texttracklist::TextTrackList;
@@ -25,13 +26,19 @@ use crate::dom::window::Window;
 #[dom_struct]
 pub(crate) struct TextTrack {
     eventtarget: EventTarget,
+    /// <https://html.spec.whatwg.org/multipage/#text-track-kind>
     kind: TextTrackKind,
+    /// <https://html.spec.whatwg.org/multipage/#text-track-label>
     label: String,
+    /// <https://html.spec.whatwg.org/multipage/#text-track-language>
     language: String,
     id: String,
+    /// <https://html.spec.whatwg.org/multipage/#text-track-mode>
     mode: Cell<TextTrackMode>,
+    /// <https://html.spec.whatwg.org/multipage/#text-track-list-of-cues>
     cue_list: MutNullableDom<TextTrackCueList>,
     track_list: DomRefCell<Option<Dom<TextTrackList>>>,
+    associated_track: DomRefCell<Option<Dom<HTMLTrackElement>>>,
 }
 
 impl TextTrack {
@@ -52,6 +59,7 @@ impl TextTrack {
             mode: Cell::new(mode),
             cue_list: Default::default(),
             track_list: DomRefCell::new(track_list.map(Dom::from_ref)),
+            associated_track: Default::default(),
         }
     }
 
@@ -91,6 +99,35 @@ impl TextTrack {
     pub(crate) fn remove_track_list(&self) {
         *self.track_list.borrow_mut() = None;
     }
+
+    pub(crate) fn associated_track(&self) -> Option<DomRoot<HTMLTrackElement>> {
+        self.associated_track
+            .borrow()
+            .as_ref()
+            .map(|track| DomRoot::from_ref(&**track))
+    }
+
+    pub(crate) fn set_associated_track(&self, track_element: &HTMLTrackElement) {
+        *self.associated_track.borrow_mut() = Some(Dom::from_ref(track_element));
+    }
+
+    pub(crate) fn empty_cue_list(&self) {
+        if let Some(cue_list) = self.cue_list.get() {
+            cue_list.empty();
+        }
+    }
+
+    pub(crate) fn set_text_track_mode(&self, cx: &mut JSContext, value: TextTrackMode) {
+        if self.mode.get() == value {
+            return;
+        }
+        self.mode.set(value);
+        // https://html.spec.whatwg.org/multipage/#sourcing-out-of-band-text-tracks:start-the-track-processing-model
+        // > The text track has its text track mode changed.
+        if let Some(track_element) = self.associated_track.borrow().as_ref() {
+            track_element.start_the_track_processing_model(cx);
+        }
+    }
 }
 
 impl TextTrackMethods<crate::DomTypeHolder> for TextTrack {
@@ -120,8 +157,8 @@ impl TextTrackMethods<crate::DomTypeHolder> for TextTrack {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-texttrack-mode>
-    fn SetMode(&self, value: TextTrackMode) {
-        self.mode.set(value)
+    fn SetMode(&self, cx: &mut JSContext, value: TextTrackMode) {
+        self.set_text_track_mode(cx, value)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-texttrack-cues>

--- a/components/script/dom/webvtt/texttrackcuelist.rs
+++ b/components/script/dom/webvtt/texttrackcuelist.rs
@@ -61,6 +61,10 @@ impl TextTrackCueList {
     pub(crate) fn remove(&self, idx: usize) {
         self.dom_cues.borrow_mut().remove(idx);
     }
+
+    pub(crate) fn empty(&self) {
+        self.dom_cues.borrow_mut().clear();
+    }
 }
 
 impl TextTrackCueListMethods<crate::DomTypeHolder> for TextTrackCueList {

--- a/components/script/dom/webvtt/texttracklist.rs
+++ b/components/script/dom/webvtt/texttracklist.rs
@@ -7,6 +7,7 @@ use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::reflect_dom_object_with_cx;
 
+use crate::dom::bindings::codegen::Bindings::TextTrackBinding::{TextTrackKind, TextTrackMethods};
 use crate::dom::bindings::codegen::Bindings::TextTrackListBinding::TextTrackListMethods;
 use crate::dom::bindings::codegen::UnionTypes::VideoTrackOrAudioTrackOrTextTrack;
 use crate::dom::bindings::inheritance::Castable;
@@ -16,6 +17,7 @@ use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
+use crate::dom::html::htmlmediaelement::HTMLMediaElement;
 use crate::dom::texttrack::TextTrack;
 use crate::dom::trackevent::TrackEvent;
 use crate::dom::window::Window;
@@ -58,50 +60,81 @@ impl TextTrackList {
             .map(|(i, _)| i)
     }
 
-    pub(crate) fn add(&self, track: &TextTrack) {
-        // Only add a track if it does not exist in the list
-        if self.find(track).is_none() {
-            self.dom_tracks.borrow_mut().push(Dom::from_ref(track));
-
-            let Some(idx) = self.find(track) else {
-                return;
-            };
-
-            let this = Trusted::new(self);
-            self.global()
-                .task_manager()
-                .media_element_task_source()
-                .queue(task!(track_event_queue: move |cx| {
-                    let this = this.root();
-
-                    if let Some(track) = this.item(idx) {
-                        let event = TrackEvent::new(cx,
-                            this.global().as_window(),
-                            atom!("addtrack"),
-                            false,
-                            false,
-                            &Some(VideoTrackOrAudioTrackOrTextTrack::TextTrack(
-                                DomRoot::from_ref(&track)
-                            )),
-                        );
-
-                        event.upcast::<Event>().fire(cx, this.upcast::<EventTarget>());
-                    }
-                }));
-            track.add_track_list(self);
-        }
+    pub(crate) fn tracks_for_kinds(
+        &self,
+        text_track_kinds: Vec<TextTrackKind>,
+    ) -> Vec<DomRoot<TextTrack>> {
+        self.dom_tracks
+            .borrow()
+            .iter()
+            .filter(|track| text_track_kinds.contains(&track.Kind()))
+            .map(|track| DomRoot::from_ref(&**track))
+            .collect()
     }
 
-    // FIXME(#22314, dlrobertson) allow TextTracks to be
-    // removed from the TextTrackList.
-    #[expect(dead_code)]
-    pub(crate) fn remove(&self, cx: &mut js::context::JSContext, idx: usize) {
-        if let Some(track) = self.dom_tracks.borrow().get(idx) {
-            track.remove_track_list();
+    pub(crate) fn add(&self, media_element: &HTMLMediaElement, track: &TextTrack) {
+        // Only add a track if it does not exist in the list
+        if self.find(track).is_some() {
+            return;
         }
+        self.dom_tracks.borrow_mut().push(Dom::from_ref(track));
+
+        track.add_track_list(self);
+        media_element.was_added_to_list_of_text_tracks();
+
+        let this = Trusted::new(self);
+        let track = Trusted::new(track);
+        self.global()
+            .task_manager()
+            .media_element_task_source()
+            .queue(task!(track_event_queue: move |cx| {
+                let this = this.root();
+                let track = track.root();
+
+                let event = TrackEvent::new(
+                    cx,
+                    this.global().as_window(),
+                    atom!("addtrack"),
+                    false,
+                    false,
+                    &Some(VideoTrackOrAudioTrackOrTextTrack::TextTrack(
+                        DomRoot::from_ref(&track)
+                    )),
+                );
+
+                event.upcast::<Event>().fire(cx, this.upcast::<EventTarget>());
+            }));
+    }
+
+    pub(crate) fn remove(&self, track: &TextTrack) {
+        let Some(idx) = self.find(track) else {
+            return;
+        };
         self.dom_tracks.borrow_mut().remove(idx);
-        self.upcast::<EventTarget>()
-            .fire_event(cx, atom!("removetrack"));
+        track.remove_track_list();
+
+        let this = Trusted::new(self);
+        let track = Trusted::new(track);
+        self.global()
+            .task_manager()
+            .media_element_task_source()
+            .queue(task!(track_event_queue: move |cx| {
+                let this = this.root();
+                let track = track.root();
+
+                let event = TrackEvent::new(
+                    cx,
+                    this.global().as_window(),
+                    atom!("removetrack"),
+                    false,
+                    false,
+                    &Some(VideoTrackOrAudioTrackOrTextTrack::TextTrack(
+                        DomRoot::from_ref(&track)
+                    )),
+                );
+
+                event.upcast::<Event>().fire(cx, this.upcast::<EventTarget>());
+            }));
     }
 }
 

--- a/components/script/microtask.rs
+++ b/components/script/microtask.rs
@@ -23,6 +23,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlimageelement::ImageElementMicrotask;
 use crate::dom::html::htmlmediaelement::MediaElementMicrotask;
+use crate::dom::html::htmltrackelement::TrackElementMicrotask;
 use crate::dom::promise::WaitForAllSuccessStepsMicrotask;
 use crate::dom::stream::byteteereadintorequest::ByteTeeReadIntoRequestMicrotask;
 use crate::dom::stream::byteteereadrequest::ByteTeeReadRequestMicrotask;
@@ -46,6 +47,7 @@ pub(crate) enum Microtask {
     User(UserMicrotask),
     MediaElement(MediaElementMicrotask),
     ImageElement(ImageElementMicrotask),
+    TrackElement(TrackElementMicrotask),
     ReadableStreamTeeReadRequest(DefaultTeeReadRequestMicrotask),
     WaitForAllSuccessSteps(WaitForAllSuccessStepsMicrotask),
     ReadableStreamByteTeeReadRequest(ByteTeeReadRequestMicrotask),
@@ -141,6 +143,11 @@ impl MicrotaskQueue {
                         task.handler(cx);
                     },
                     Microtask::ImageElement(ref task) => {
+                        let mut realm = task.enter_realm(cx);
+                        let cx = &mut realm;
+                        task.handler(cx);
+                    },
+                    Microtask::TrackElement(ref task) => {
                         let mut realm = task.enter_realm(cx);
                         let cx = &mut realm;
                         task.handler(cx);

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1212,7 +1212,7 @@ DOMInterfaces = {
 },
 
 'TextTrack': {
-    'cx': ['GetCues', 'GetActiveCues', 'AddCue', 'RemoveCue']
+    'cx': ['GetCues', 'GetActiveCues', 'AddCue', 'RemoveCue', 'SetMode']
 },
 
 'TreeWalker': {

--- a/tests/wpt/meta/content-security-policy/media-src/media-src-7_3_2.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/media-src/media-src-7_3_2.sub.html.ini
@@ -1,7 +1,0 @@
-[media-src-7_3_2.sub.html]
-  expected: TIMEOUT
-  [Disallowed track element onerror handler fires.]
-    expected: FAIL
-
-  [Test that securitypolicyviolation events are fired]
-    expected: NOTRUN

--- a/tests/wpt/meta/fetch/metadata/track.https.sub.html.ini
+++ b/tests/wpt/meta/fetch/metadata/track.https.sub.html.ini
@@ -1,13 +1,3 @@
 [track.https.sub.html]
-  expected: TIMEOUT
-  [Same-Origin track]
-    expected: TIMEOUT
-
-  [Same-Site track]
-    expected: NOTRUN
-
-  [Cross-Site track]
-    expected: NOTRUN
-
-  [Same-Origin, CORS track]
-    expected: NOTRUN
+  [Same-Origin, CORS track: sec-fetch-mode]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/interfaces/TextTrack/addCue.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/interfaces/TextTrack/addCue.html.ini
@@ -1,10 +1,9 @@
 [addCue.html]
-  expected: TIMEOUT
   [TextTrack.addCue(), adding a cue to two different tracks]
     expected: FAIL
 
   [TextTrack.addCue(), adding a cue associated with a track element to other track]
-    expected: TIMEOUT
+    expected: FAIL
 
   [TextTrack.addCue(), adding a removed cue to a different track]
     expected: FAIL
@@ -14,4 +13,3 @@
 
   [TextTrack.addCue(), adding a cue to a track twice]
     expected: FAIL
-

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/interfaces/TextTrack/cues.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/interfaces/TextTrack/cues.html.ini
@@ -5,9 +5,5 @@
   [TextTrack.cues, different modes]
     expected: FAIL
 
-  [TextTrack.cues, default attribute]
-    expected: FAIL
-
   [TextTrack.cues, changing order]
     expected: FAIL
-

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/interfaces/TextTrack/removeCue.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/interfaces/TextTrack/removeCue.html.ini
@@ -1,8 +1,6 @@
 [removeCue.html]
-  expected: TIMEOUT
   [TextTrack.removeCue(), cue from track element]
-    expected: TIMEOUT
+    expected: FAIL
 
   [TextTrack.removeCue(), two elementless tracks]
     expected: FAIL
-

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/interfaces/TextTrackCue/endTime.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/interfaces/TextTrackCue/endTime.html.ini
@@ -1,8 +1,6 @@
 [endTime.html]
-  expected: TIMEOUT
   [TextTrackCue.endTime, script-created cue]
     expected: FAIL
 
   [TextTrackCue.endTime, parsed cue]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/interfaces/TextTrackCue/id.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/interfaces/TextTrackCue/id.html.ini
@@ -1,8 +1,6 @@
 [id.html]
-  expected: TIMEOUT
   [TextTrackCue.id, script-created cue]
     expected: FAIL
 
   [TextTrackCue.id, parsed cue]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/interfaces/TextTrackCue/pauseOnExit.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/interfaces/TextTrackCue/pauseOnExit.html.ini
@@ -1,8 +1,6 @@
 [pauseOnExit.html]
-  expected: TIMEOUT
   [TextTrackCue.pauseOnExit, parsed cue]
-    expected: TIMEOUT
+    expected: FAIL
 
   [TextTrackCue.pauseOnExit, script-created cue]
     expected: FAIL
-

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/interfaces/TextTrackCue/startTime.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/interfaces/TextTrackCue/startTime.html.ini
@@ -1,8 +1,6 @@
 [startTime.html]
-  expected: TIMEOUT
   [TextTrackCue.startTime, parsed cue]
-    expected: TIMEOUT
+    expected: FAIL
 
   [TextTrackCue.startTime, script-created cue]
     expected: FAIL
-

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/interfaces/TextTrackCue/track.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/interfaces/TextTrackCue/track.html.ini
@@ -1,8 +1,6 @@
 [track.html]
-  expected: TIMEOUT
   [TextTrackCue.track, script-created cue]
     expected: FAIL
 
   [TextTrackCue.track, parsed cue]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/interfaces/TextTrackList/length.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/interfaces/TextTrackList/length.html.ini
@@ -1,4 +1,0 @@
-[length.html]
-  [TextTrackList.length]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/cloneNode.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/cloneNode.html.ini
@@ -7,5 +7,4 @@
     expected: TIMEOUT
 
   [track element cloneNode, loaded]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/no-cuechange-before-play.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/no-cuechange-before-play.html.ini
@@ -1,4 +1,0 @@
-[no-cuechange-before-play.html]
-  expected: TIMEOUT
-  [Ensure that the 'cuechange' event is not fired before video playback has begun.]
-    expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-add-remove-cue.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-add-remove-cue.html.ini
@@ -1,5 +1,3 @@
 [track-add-remove-cue.html]
-  expected: TIMEOUT
   [TextTrack's addCue and removeCue]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-api-texttracks.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-api-texttracks.html.ini
@@ -1,4 +1,0 @@
-[track-api-texttracks.html]
-  [Count track list]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cue-mutable-fragment.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cue-mutable-fragment.html.ini
@@ -1,5 +1,3 @@
 [track-cue-mutable-fragment.html]
-  expected: TIMEOUT
   [Cue fragment is mutable]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cue-mutable.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cue-mutable.html.ini
@@ -1,5 +1,3 @@
 [track-cue-mutable.html]
-  expected: TIMEOUT
   [Modifying attributes of a VTTCue]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cue-negative-timestamp.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cue-negative-timestamp.html.ini
@@ -1,5 +1,3 @@
 [track-cue-negative-timestamp.html]
-  expected: TIMEOUT
   [Negative timestamps]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-missed.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-missed.html.ini
@@ -1,5 +1,3 @@
 [track-cues-missed.html]
-  expected: TIMEOUT
   [Events are triggered for missed (skipped) cues during normal playback]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-pause-on-exit.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-pause-on-exit.html.ini
@@ -1,5 +1,3 @@
 [track-cues-pause-on-exit.html]
-  expected: TIMEOUT
   [Video is paused after cues having pause-on-exit flag are processed]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-seeking.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-seeking.html.ini
@@ -1,5 +1,3 @@
 [track-cues-seeking.html]
-  expected: TIMEOUT
   [TextTrack's activeCues are indexed and updated during video playback]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-sorted-before-dispatch.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-sorted-before-dispatch.html.ini
@@ -1,4 +1,3 @@
 [track-cues-sorted-before-dispatch.html]
-  expected: TIMEOUT
   [All events are triggered in chronological order]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-data-url.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-data-url.html.ini
@@ -1,11 +1,9 @@
 [track-data-url.html]
-  expected: TIMEOUT
   [track element data: URL No CORS]
-    expected: TIMEOUT
+    expected: FAIL
 
   [track element data: URL anonymous]
-    expected: TIMEOUT
+    expected: FAIL
 
   [track element data: URL use-credentials]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-default-attribute.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-default-attribute.html.ini
@@ -1,5 +1,0 @@
-[track-default-attribute.html]
-  expected: TIMEOUT
-  [A track with the "default" attribute loads automatically]
-    expected: TIMEOUT
-

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-delete-during-setup.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-delete-during-setup.html.ini
@@ -1,5 +1,0 @@
-[track-delete-during-setup.html]
-  expected: TIMEOUT
-  [Track deletion during setup]
-    expected: TIMEOUT
-

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-disabled.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-disabled.html.ini
@@ -1,4 +1,0 @@
-[track-disabled.html]
-  [Disabling a track]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-element-src-change-error.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-element-src-change-error.html.ini
@@ -1,5 +1,3 @@
 [track-element-src-change-error.html]
-  expected: TIMEOUT
   [HTMLTrackElement 'src' attribute mutations]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-element-src-change.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-element-src-change.html.ini
@@ -1,5 +1,3 @@
 [track-element-src-change.html]
-  expected: TIMEOUT
   [HTMLTrackElement 'src' attribute mutations]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-large-timestamp.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-large-timestamp.html.ini
@@ -1,5 +1,3 @@
 [track-large-timestamp.html]
-  expected: TIMEOUT
   [Very large timestamp is parsed correctly]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-load-from-element-readyState.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-load-from-element-readyState.html.ini
@@ -1,5 +1,0 @@
-[track-load-from-element-readyState.html]
-  expected: TIMEOUT
-  [Load event on HTMLTrackElement and LOADED readyState on TextTrack when src is set on the element]
-    expected: TIMEOUT
-

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-load-from-src-readyState.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-load-from-src-readyState.html.ini
@@ -1,5 +1,0 @@
-[track-load-from-src-readyState.html]
-  expected: TIMEOUT
-  [Load event on HTMLTrackElement and LOADED readyState on TextTrack when src is set from JavaScript]
-    expected: TIMEOUT
-

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-mode-not-changed-by-new-track.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-mode-not-changed-by-new-track.html.ini
@@ -1,5 +1,3 @@
 [track-mode-not-changed-by-new-track.html]
-  expected: TIMEOUT
   [A track appended after the initial track configuration does not change other tracks]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-node-add-remove.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-node-add-remove.html.ini
@@ -1,4 +1,0 @@
-[track-node-add-remove.html]
-  [Add and remove track node]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-remove-track-inband.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-remove-track-inband.html.ini
@@ -1,4 +1,4 @@
 [track-remove-track-inband.html]
+  expected: TIMEOUT
   [Tests that the 'removetrack' event is NOT fired for inband TextTrack on a failed load.]
-    expected: FAIL
-
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-remove-track.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-remove-track.html.ini
@@ -1,4 +1,0 @@
-[track-remove-track.html]
-  [Tests that the 'removetrack' event is fired when an out-of-band TextTrack is removed.]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-text-track-cue-list.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-text-track-cue-list.html.ini
@@ -1,5 +1,3 @@
 [track-text-track-cue-list.html]
-  expected: TIMEOUT
   [TextTrackCueList functionality: length, operator[\], and getCueById()]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-alignment.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-alignment.html.ini
@@ -1,11 +1,9 @@
 [track-webvtt-alignment.html]
-  expected: TIMEOUT
   [Check cues from resources/alignment-bad.vtt]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Check cues from resources/alignment.vtt]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Check cues from resources/alignment-ltr.vtt]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-blank-lines.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-blank-lines.html.ini
@@ -1,8 +1,6 @@
 [track-webvtt-blank-lines.html]
-  expected: TIMEOUT
   [Check cues from resources/cues-no-separation.vtt]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Check cues from resources/cues.vtt]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-bom.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-bom.html.ini
@@ -1,5 +1,3 @@
 [track-webvtt-bom.html]
-  expected: TIMEOUT
   [Parser properly ignores a UTF-8 BOM character at the beginning of a file and all other cues are properly parsed]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-class-markup.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-class-markup.html.ini
@@ -1,8 +1,6 @@
 [track-webvtt-class-markup.html]
-  expected: TIMEOUT
   [Check cues from resources/class.vtt]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Check cues from resources/class-bad.vtt]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-cue-identifiers.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-cue-identifiers.html.ini
@@ -1,8 +1,6 @@
 [track-webvtt-cue-identifiers.html]
-  expected: TIMEOUT
   [Check cues from resources/cue-id-error.vtt]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Check cues from resources/cue-id.vtt]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-cue-no-id.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-cue-no-id.html.ini
@@ -1,8 +1,6 @@
 [track-webvtt-cue-no-id.html]
-  expected: TIMEOUT
   [Check cues from resources/cue-no-id-error.vtt]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Check cues from resources/cue-no-id.vtt]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-cue-recovery.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-cue-recovery.html.ini
@@ -1,11 +1,9 @@
 [track-webvtt-cue-recovery.html]
-  expected: TIMEOUT
   [Check cues from resources/cue-recovery-header.vtt]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Check cues from resources/cue-recovery-note.vtt]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Check cues from resources/cue-recovery-cuetext.vtt]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-cue-size-align.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-cue-size-align.html.ini
@@ -1,8 +1,6 @@
 [track-webvtt-cue-size-align.html]
-  expected: TIMEOUT
   [Check cues from resources/cue-size-align-bad.vtt]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Check cues from resources/cue-size-align.vtt]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-cue-size.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-cue-size.html.ini
@@ -1,8 +1,6 @@
 [track-webvtt-cue-size.html]
-  expected: TIMEOUT
   [Check cues from resources/cue-size.vtt]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Check cues from resources/cue-size-bad.vtt]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-degenerate-cues.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-degenerate-cues.html.ini
@@ -1,5 +1,3 @@
 [track-webvtt-degenerate-cues.html]
-  expected: TIMEOUT
   [Check cues from resources/degenerate-cues.vtt]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-empty-cue.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-empty-cue.html.ini
@@ -1,5 +1,3 @@
 [track-webvtt-empty-cue.html]
-  expected: TIMEOUT
   [Check cues from resources/empty-cue.vtt]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-entities.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-entities.html.ini
@@ -1,8 +1,6 @@
 [track-webvtt-entities.html]
-  expected: TIMEOUT
   [Check cues from resources/entities.vtt]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Check cues from resources/entities-wrong.vtt]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-header-comment.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-header-comment.html.ini
@@ -1,5 +1,3 @@
 [track-webvtt-header-comment.html]
-  expected: TIMEOUT
   [Optional comment area under the "WEBVTT" file header is properly ignored and also, default settings and styling are currently ignored (treated as faulty cues)]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-interspersed-non-cue.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-interspersed-non-cue.html.ini
@@ -1,5 +1,3 @@
 [track-webvtt-interspersed-non-cue.html]
-  expected: TIMEOUT
   [Check cues from resources/interspersed-non-cue.vtt]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-markup.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-markup.html.ini
@@ -1,8 +1,6 @@
 [track-webvtt-markup.html]
-  expected: TIMEOUT
   [Check cues from resources/markup-bad.vtt]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Check cues from resources/markup.vtt]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-newlines.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-newlines.html.ini
@@ -1,5 +1,3 @@
 [track-webvtt-newlines.html]
-  expected: TIMEOUT
   [A cue with no newline at eof is parsed properly]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-no-timings.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-no-timings.html.ini
@@ -1,5 +1,0 @@
-[track-webvtt-no-timings.html]
-  expected: TIMEOUT
-  [Cue without timings are ignored]
-    expected: TIMEOUT
-

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-positioning.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-positioning.html.ini
@@ -1,11 +1,9 @@
 [track-webvtt-positioning.html]
-  expected: TIMEOUT
   [Check cues from resources/positioning.vtt]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Check cues from resources/positioning-ltr.vtt]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Check cues from resources/positioning-bad.vtt]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-settings.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-settings.html.ini
@@ -1,8 +1,6 @@
 [track-webvtt-settings.html]
-  expected: TIMEOUT
   [Check cues from resources/settings-bad-separation.vtt]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Check cues from resources/settings.vtt]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-timestamp.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-timestamp.html.ini
@@ -1,8 +1,6 @@
 [track-webvtt-timestamp.html]
-  expected: TIMEOUT
   [Check cues from resources/timestamp.vtt]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Check cues from resources/timestamp-bad.vtt]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-timings-hour.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-timings-hour.html.ini
@@ -1,5 +1,3 @@
 [track-webvtt-timings-hour.html]
-  expected: TIMEOUT
   [Cue timings and various syntax errors in timings, with hours]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-timings-no-hours.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-timings-no-hours.html.ini
@@ -1,5 +1,3 @@
 [track-webvtt-timings-no-hours.html]
-  expected: TIMEOUT
   [Cue timings and various syntax errors in timings, without hours]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-timings-whitespace.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-timings-whitespace.html.ini
@@ -1,5 +1,3 @@
 [track-webvtt-timings-whitespace.html]
-  expected: TIMEOUT
   [Check cues from resources/timings-whitespace.vtt]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-unsupported-markup.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-unsupported-markup.html.ini
@@ -1,5 +1,3 @@
 [track-webvtt-unsupported-markup.html]
-  expected: TIMEOUT
   [Check cues from resources/unsupported-markup.vtt]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-utf8.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-utf8.html.ini
@@ -1,5 +1,3 @@
 [track-webvtt-utf8.html]
-  expected: TIMEOUT
   [UTF-8 encoded characters are recognized properly and different encodings (iconv) are not recognized as a WebVTT file]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-valign.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-valign.html.ini
@@ -1,11 +1,9 @@
 [track-webvtt-valign.html]
-  expected: TIMEOUT
   [Check cues from resources/valign-bad.vtt]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Check cues from resources/valign.vtt]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Check cues from resources/valign-ltr.vtt]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-voice.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-voice.html.ini
@@ -1,8 +1,6 @@
 [track-webvtt-voice.html]
-  expected: TIMEOUT
   [Check cues from resources/voice-bad.vtt]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Check cues from resources/voice.vtt]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/resource-timing/initiator-type/video.html.ini
+++ b/tests/wpt/meta/resource-timing/initiator-type/video.html.ini
@@ -1,6 +1,3 @@
 [video.html]
-  [The initiator type for <track src> must be 'track']
-    expected: FAIL
-
   [The initiator type for <source src> with type="video/mp4" must be 'video']
     expected: FAIL

--- a/tests/wpt/meta/webvtt/api/VTTCue/align.html.ini
+++ b/tests/wpt/meta/webvtt/api/VTTCue/align.html.ini
@@ -1,4 +1,3 @@
 [align.html]
-  expected: TIMEOUT
   [VTTCue.align, parsed cue]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/webvtt/api/VTTCue/line.html.ini
+++ b/tests/wpt/meta/webvtt/api/VTTCue/line.html.ini
@@ -1,4 +1,3 @@
 [line.html]
-  expected: TIMEOUT
   [VTTCue.line, parsed cue]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/webvtt/api/VTTCue/snapToLines.html.ini
+++ b/tests/wpt/meta/webvtt/api/VTTCue/snapToLines.html.ini
@@ -1,4 +1,3 @@
 [snapToLines.html]
-  expected: TIMEOUT
   [VTTCue.snapToLines, parsed cue]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/webvtt/api/VTTCue/text.html.ini
+++ b/tests/wpt/meta/webvtt/api/VTTCue/text.html.ini
@@ -1,4 +1,3 @@
 [text.html]
-  expected: TIMEOUT
   [VTTCue.text, parsed cue]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/webvtt/api/VTTCue/vertical.html.ini
+++ b/tests/wpt/meta/webvtt/api/VTTCue/vertical.html.ini
@@ -1,4 +1,3 @@
 [vertical.html]
-  expected: TIMEOUT
   [VTTCue.vertical, parsed cue]
-    expected: TIMEOUT
+    expected: FAIL


### PR DESCRIPTION
This is the first step of support for track elements. Now, at the appropriate times, a request is sent out. The result of the request is ignored for now, since this PR is already big enough of its own.

To do so, a text track needs to keep track of whether it is part of a track element. Then, at the various decision points, it starts the processing model. This is mostly implemented in terms of machinery, but not all of its parallel steps. That's because I have yet to figure out what they actually mean with "wait until X", whether that just means to reboot the algorithm or not.

Part of #46288

Testing: new WPT tests passing/running.