### PR TITLE
tests: Enable ServiceWorker in compression tests

### DIFF
--- a/tests/wpt/meta/compression/__dir__.ini
+++ b/tests/wpt/meta/compression/__dir__.ini
@@ -1,0 +1,3 @@
+prefs: [
+  "dom_serviceworker_enabled:true",
+]

--- a/tests/wpt/meta/compression/compression-bad-chunks.any.js.ini
+++ b/tests/wpt/meta/compression/compression-bad-chunks.any.js.ini
@@ -86,7 +86,30 @@
 
 
 [compression-bad-chunks.any.serviceworker.html]
-  expected: ERROR
+  [chunk of type SharedArrayBuffer should error the stream for deflate]
+    expected: FAIL
+
+  [chunk of type shared Uint8Array should error the stream for deflate]
+    expected: FAIL
+
+  [chunk of type SharedArrayBuffer should error the stream for deflate-raw]
+    expected: FAIL
+
+  [chunk of type shared Uint8Array should error the stream for deflate-raw]
+    expected: FAIL
+
+  [chunk of type SharedArrayBuffer should error the stream for gzip]
+    expected: FAIL
+
+  [chunk of type shared Uint8Array should error the stream for gzip]
+    expected: FAIL
+
+  [chunk of type SharedArrayBuffer should error the stream for brotli]
+    expected: FAIL
+
+  [chunk of type shared Uint8Array should error the stream for brotli]
+    expected: FAIL
+
 
 [compression-bad-chunks.any.shadowrealm-in-window.html]
   expected: ERROR

--- a/tests/wpt/meta/compression/compression-constructor-error.any.js.ini
+++ b/tests/wpt/meta/compression/compression-constructor-error.any.js.ini
@@ -1,5 +1,4 @@
 [compression-constructor-error.any.serviceworker.html]
-  expected: ERROR
 
 [compression-constructor-error.any.shadowrealm-in-shadowrealm.html]
   expected: ERROR
@@ -18,3 +17,9 @@
 
 [compression-constructor-error.any.shadowrealm-in-sharedworker.html]
   expected: ERROR
+
+[compression-constructor-error.any.worker.html]
+
+[compression-constructor-error.any.html]
+
+[compression-constructor-error.any.sharedworker.html]

--- a/tests/wpt/meta/compression/compression-constructor-error.any.js.ini
+++ b/tests/wpt/meta/compression/compression-constructor-error.any.js.ini
@@ -1,4 +1,3 @@
-[compression-constructor-error.any.serviceworker.html]
 
 [compression-constructor-error.any.shadowrealm-in-shadowrealm.html]
   expected: ERROR
@@ -18,8 +17,3 @@
 [compression-constructor-error.any.shadowrealm-in-sharedworker.html]
   expected: ERROR
 
-[compression-constructor-error.any.worker.html]
-
-[compression-constructor-error.any.html]
-
-[compression-constructor-error.any.sharedworker.html]

--- a/tests/wpt/meta/compression/compression-including-empty-chunk.any.js.ini
+++ b/tests/wpt/meta/compression/compression-including-empty-chunk.any.js.ini
@@ -24,7 +24,15 @@
 
 
 [compression-including-empty-chunk.any.serviceworker.html]
-  expected: ERROR
+  [the result of compressing [,Hello,Hello\] with brotli should be 'HelloHello']
+    expected: FAIL
+
+  [the result of compressing [Hello,,Hello\] with brotli should be 'HelloHello']
+    expected: FAIL
+
+  [the result of compressing [Hello,Hello,\] with brotli should be 'HelloHello']
+    expected: FAIL
+
 
 [compression-including-empty-chunk.https.any.shadowrealm-in-audioworklet.html]
   expected: ERROR

--- a/tests/wpt/meta/compression/compression-large-flush-output.any.js.ini
+++ b/tests/wpt/meta/compression/compression-large-flush-output.any.js.ini
@@ -5,7 +5,9 @@
   expected: ERROR
 
 [compression-large-flush-output.any.serviceworker.html]
-  expected: ERROR
+  [brotli compression with large flush output]
+    expected: FAIL
+
 
 [compression-large-flush-output.any.shadowrealm-in-dedicatedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/compression/compression-multiple-chunks.any.js.ini
+++ b/tests/wpt/meta/compression/compression-multiple-chunks.any.js.ini
@@ -2,7 +2,51 @@
   expected: ERROR
 
 [compression-multiple-chunks.any.serviceworker.html]
-  expected: ERROR
+  [compressing 2 chunks with brotli should work]
+    expected: FAIL
+
+  [compressing 3 chunks with brotli should work]
+    expected: FAIL
+
+  [compressing 4 chunks with brotli should work]
+    expected: FAIL
+
+  [compressing 5 chunks with brotli should work]
+    expected: FAIL
+
+  [compressing 6 chunks with brotli should work]
+    expected: FAIL
+
+  [compressing 7 chunks with brotli should work]
+    expected: FAIL
+
+  [compressing 8 chunks with brotli should work]
+    expected: FAIL
+
+  [compressing 9 chunks with brotli should work]
+    expected: FAIL
+
+  [compressing 10 chunks with brotli should work]
+    expected: FAIL
+
+  [compressing 11 chunks with brotli should work]
+    expected: FAIL
+
+  [compressing 12 chunks with brotli should work]
+    expected: FAIL
+
+  [compressing 13 chunks with brotli should work]
+    expected: FAIL
+
+  [compressing 14 chunks with brotli should work]
+    expected: FAIL
+
+  [compressing 15 chunks with brotli should work]
+    expected: FAIL
+
+  [compressing 16 chunks with brotli should work]
+    expected: FAIL
+
 
 [compression-multiple-chunks.any.html]
   [compressing 2 chunks with brotli should work]

--- a/tests/wpt/meta/compression/compression-output-length.any.js.ini
+++ b/tests/wpt/meta/compression/compression-output-length.any.js.ini
@@ -5,7 +5,6 @@
   expected: ERROR
 
 [compression-output-length.any.serviceworker.html]
-  expected: ERROR
 
 [compression-output-length.any.shadowrealm-in-dedicatedworker.html]
   expected: ERROR
@@ -18,3 +17,9 @@
 
 [compression-output-length.any.shadowrealm-in-shadowrealm.html]
   expected: ERROR
+
+[compression-output-length.any.sharedworker.html]
+
+[compression-output-length.any.html]
+
+[compression-output-length.any.worker.html]

--- a/tests/wpt/meta/compression/compression-output-length.any.js.ini
+++ b/tests/wpt/meta/compression/compression-output-length.any.js.ini
@@ -18,8 +18,3 @@
 [compression-output-length.any.shadowrealm-in-shadowrealm.html]
   expected: ERROR
 
-[compression-output-length.any.sharedworker.html]
-
-[compression-output-length.any.html]
-
-[compression-output-length.any.worker.html]

--- a/tests/wpt/meta/compression/compression-stream.any.js.ini
+++ b/tests/wpt/meta/compression/compression-stream.any.js.ini
@@ -32,7 +32,12 @@
   expected: ERROR
 
 [compression-stream.any.serviceworker.html]
-  expected: ERROR
+  [brotli small amount data should be reinflated back to its origin]
+    expected: FAIL
+
+  [brotli large amount data should be reinflated back to its origin]
+    expected: FAIL
+
 
 [compression-stream.https.any.shadowrealm-in-serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/compression/compression-with-detach.any.js.ini
+++ b/tests/wpt/meta/compression/compression-with-detach.any.js.ini
@@ -1,2 +1,0 @@
-[compression-with-detach.any.serviceworker.html]
-  expected: ERROR

--- a/tests/wpt/meta/compression/decompression-bad-chunks.any.js.ini
+++ b/tests/wpt/meta/compression/decompression-bad-chunks.any.js.ini
@@ -1,5 +1,28 @@
 [decompression-bad-chunks.any.serviceworker.html]
-  expected: ERROR
+  [chunk of type SharedArrayBuffer should error the stream for deflate]
+    expected: FAIL
+
+  [chunk of type shared Uint8Array should error the stream for deflate]
+    expected: FAIL
+
+  [chunk of type SharedArrayBuffer should error the stream for deflate-raw]
+    expected: FAIL
+
+  [chunk of type shared Uint8Array should error the stream for deflate-raw]
+    expected: FAIL
+
+  [chunk of type SharedArrayBuffer should error the stream for gzip]
+    expected: FAIL
+
+  [chunk of type shared Uint8Array should error the stream for gzip]
+    expected: FAIL
+
+  [chunk of type SharedArrayBuffer should error the stream for brotli]
+    expected: FAIL
+
+  [chunk of type shared Uint8Array should error the stream for brotli]
+    expected: FAIL
+
 
 [decompression-bad-chunks.any.shadowrealm-in-sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/compression/decompression-buffersource.any.js.ini
+++ b/tests/wpt/meta/compression/decompression-buffersource.any.js.ini
@@ -7,8 +7,6 @@
 [decompression-buffersource.https.any.shadowrealm-in-serviceworker.html]
   expected: ERROR
 
-[decompression-buffersource.any.serviceworker.html]
-
 [decompression-buffersource.any.shadowrealm-in-dedicatedworker.html]
   expected: ERROR
 
@@ -18,8 +16,3 @@
 [decompression-buffersource.https.any.shadowrealm-in-audioworklet.html]
   expected: ERROR
 
-[decompression-buffersource.any.worker.html]
-
-[decompression-buffersource.any.sharedworker.html]
-
-[decompression-buffersource.any.html]

--- a/tests/wpt/meta/compression/decompression-buffersource.any.js.ini
+++ b/tests/wpt/meta/compression/decompression-buffersource.any.js.ini
@@ -8,7 +8,6 @@
   expected: ERROR
 
 [decompression-buffersource.any.serviceworker.html]
-  expected: ERROR
 
 [decompression-buffersource.any.shadowrealm-in-dedicatedworker.html]
   expected: ERROR
@@ -18,3 +17,9 @@
 
 [decompression-buffersource.https.any.shadowrealm-in-audioworklet.html]
   expected: ERROR
+
+[decompression-buffersource.any.worker.html]
+
+[decompression-buffersource.any.sharedworker.html]
+
+[decompression-buffersource.any.html]

--- a/tests/wpt/meta/compression/decompression-constructor-error.any.js.ini
+++ b/tests/wpt/meta/compression/decompression-constructor-error.any.js.ini
@@ -10,16 +10,9 @@
 [decompression-constructor-error.any.shadowrealm-in-sharedworker.html]
   expected: ERROR
 
-[decompression-constructor-error.any.serviceworker.html]
-
 [decompression-constructor-error.any.shadowrealm-in-window.html]
   expected: ERROR
 
 [decompression-constructor-error.any.shadowrealm-in-shadowrealm.html]
   expected: ERROR
 
-[decompression-constructor-error.any.html]
-
-[decompression-constructor-error.any.worker.html]
-
-[decompression-constructor-error.any.sharedworker.html]

--- a/tests/wpt/meta/compression/decompression-constructor-error.any.js.ini
+++ b/tests/wpt/meta/compression/decompression-constructor-error.any.js.ini
@@ -4,7 +4,6 @@
 [decompression-constructor-error.any.shadowrealm-in-dedicatedworker.html]
   expected: ERROR
 
-
 [decompression-constructor-error.https.any.shadowrealm-in-audioworklet.html]
   expected: ERROR
 
@@ -12,10 +11,15 @@
   expected: ERROR
 
 [decompression-constructor-error.any.serviceworker.html]
-  expected: ERROR
 
 [decompression-constructor-error.any.shadowrealm-in-window.html]
   expected: ERROR
 
 [decompression-constructor-error.any.shadowrealm-in-shadowrealm.html]
   expected: ERROR
+
+[decompression-constructor-error.any.html]
+
+[decompression-constructor-error.any.worker.html]
+
+[decompression-constructor-error.any.sharedworker.html]

--- a/tests/wpt/meta/compression/decompression-correct-input.any.js.ini
+++ b/tests/wpt/meta/compression/decompression-correct-input.any.js.ini
@@ -1,5 +1,3 @@
-[decompression-correct-input.any.serviceworker.html]
-
 [decompression-correct-input.any.shadowrealm-in-window.html]
   expected: ERROR
 
@@ -18,8 +16,3 @@
 [decompression-correct-input.https.any.shadowrealm-in-audioworklet.html]
   expected: ERROR
 
-[decompression-correct-input.any.worker.html]
-
-[decompression-correct-input.any.sharedworker.html]
-
-[decompression-correct-input.any.html]

--- a/tests/wpt/meta/compression/decompression-correct-input.any.js.ini
+++ b/tests/wpt/meta/compression/decompression-correct-input.any.js.ini
@@ -1,5 +1,4 @@
 [decompression-correct-input.any.serviceworker.html]
-  expected: ERROR
 
 [decompression-correct-input.any.shadowrealm-in-window.html]
   expected: ERROR
@@ -18,3 +17,9 @@
 
 [decompression-correct-input.https.any.shadowrealm-in-audioworklet.html]
   expected: ERROR
+
+[decompression-correct-input.any.worker.html]
+
+[decompression-correct-input.any.sharedworker.html]
+
+[decompression-correct-input.any.html]

--- a/tests/wpt/meta/compression/decompression-corrupt-input.any.js.ini
+++ b/tests/wpt/meta/compression/decompression-corrupt-input.any.js.ini
@@ -14,7 +14,12 @@
   expected: ERROR
 
 [decompression-corrupt-input.any.serviceworker.html]
-  expected: ERROR
 
 [decompression-corrupt-input.https.any.shadowrealm-in-audioworklet.html]
   expected: ERROR
+
+[decompression-corrupt-input.any.html]
+
+[decompression-corrupt-input.any.worker.html]
+
+[decompression-corrupt-input.any.sharedworker.html]

--- a/tests/wpt/meta/compression/decompression-corrupt-input.any.js.ini
+++ b/tests/wpt/meta/compression/decompression-corrupt-input.any.js.ini
@@ -13,13 +13,6 @@
 [decompression-corrupt-input.https.any.shadowrealm-in-serviceworker.html]
   expected: ERROR
 
-[decompression-corrupt-input.any.serviceworker.html]
-
 [decompression-corrupt-input.https.any.shadowrealm-in-audioworklet.html]
   expected: ERROR
 
-[decompression-corrupt-input.any.html]
-
-[decompression-corrupt-input.any.worker.html]
-
-[decompression-corrupt-input.any.sharedworker.html]

--- a/tests/wpt/meta/compression/decompression-empty-input.any.js.ini
+++ b/tests/wpt/meta/compression/decompression-empty-input.any.js.ini
@@ -1,9 +1,6 @@
 [decompression-empty-input.any.shadowrealm-in-dedicatedworker.html]
   expected: ERROR
 
-[decompression-empty-input.any.serviceworker.html]
-  expected: ERROR
-
 [decompression-empty-input.https.any.shadowrealm-in-audioworklet.html]
   expected: ERROR
 
@@ -18,3 +15,5 @@
 
 [decompression-empty-input.any.shadowrealm-in-window.html]
   expected: ERROR
+
+

--- a/tests/wpt/meta/compression/decompression-extra-input.any.js.ini
+++ b/tests/wpt/meta/compression/decompression-extra-input.any.js.ini
@@ -13,13 +13,6 @@
 [decompression-extra-input.any.shadowrealm-in-window.html]
   expected: ERROR
 
-[decompression-extra-input.any.serviceworker.html]
-
 [decompression-extra-input.any.shadowrealm-in-shadowrealm.html]
   expected: ERROR
 
-[decompression-extra-input.any.worker.html]
-
-[decompression-extra-input.any.sharedworker.html]
-
-[decompression-extra-input.any.html]

--- a/tests/wpt/meta/compression/decompression-extra-input.any.js.ini
+++ b/tests/wpt/meta/compression/decompression-extra-input.any.js.ini
@@ -14,7 +14,12 @@
   expected: ERROR
 
 [decompression-extra-input.any.serviceworker.html]
-  expected: ERROR
 
 [decompression-extra-input.any.shadowrealm-in-shadowrealm.html]
   expected: ERROR
+
+[decompression-extra-input.any.worker.html]
+
+[decompression-extra-input.any.sharedworker.html]
+
+[decompression-extra-input.any.html]

--- a/tests/wpt/meta/compression/decompression-split-chunk.any.js.ini
+++ b/tests/wpt/meta/compression/decompression-split-chunk.any.js.ini
@@ -10,16 +10,9 @@
 [decompression-split-chunk.https.any.shadowrealm-in-serviceworker.html]
   expected: ERROR
 
-[decompression-split-chunk.any.serviceworker.html]
-
 [decompression-split-chunk.https.any.shadowrealm-in-audioworklet.html]
   expected: ERROR
 
 [decompression-split-chunk.any.shadowrealm-in-window.html]
   expected: ERROR
 
-[decompression-split-chunk.any.html]
-
-[decompression-split-chunk.any.sharedworker.html]
-
-[decompression-split-chunk.any.worker.html]

--- a/tests/wpt/meta/compression/decompression-split-chunk.any.js.ini
+++ b/tests/wpt/meta/compression/decompression-split-chunk.any.js.ini
@@ -11,10 +11,15 @@
   expected: ERROR
 
 [decompression-split-chunk.any.serviceworker.html]
-  expected: ERROR
 
 [decompression-split-chunk.https.any.shadowrealm-in-audioworklet.html]
   expected: ERROR
 
 [decompression-split-chunk.any.shadowrealm-in-window.html]
   expected: ERROR
+
+[decompression-split-chunk.any.html]
+
+[decompression-split-chunk.any.sharedworker.html]
+
+[decompression-split-chunk.any.worker.html]

--- a/tests/wpt/meta/compression/decompression-uint8array-output.any.js.ini
+++ b/tests/wpt/meta/compression/decompression-uint8array-output.any.js.ini
@@ -10,16 +10,9 @@
 [decompression-uint8array-output.https.any.shadowrealm-in-audioworklet.html]
   expected: ERROR
 
-[decompression-uint8array-output.any.serviceworker.html]
-
 [decompression-uint8array-output.https.any.shadowrealm-in-serviceworker.html]
   expected: ERROR
 
 [decompression-uint8array-output.any.shadowrealm-in-shadowrealm.html]
   expected: ERROR
 
-[decompression-uint8array-output.any.worker.html]
-
-[decompression-uint8array-output.any.html]
-
-[decompression-uint8array-output.any.sharedworker.html]

--- a/tests/wpt/meta/compression/decompression-uint8array-output.any.js.ini
+++ b/tests/wpt/meta/compression/decompression-uint8array-output.any.js.ini
@@ -11,10 +11,15 @@
   expected: ERROR
 
 [decompression-uint8array-output.any.serviceworker.html]
-  expected: ERROR
 
 [decompression-uint8array-output.https.any.shadowrealm-in-serviceworker.html]
   expected: ERROR
 
 [decompression-uint8array-output.any.shadowrealm-in-shadowrealm.html]
   expected: ERROR
+
+[decompression-uint8array-output.any.worker.html]
+
+[decompression-uint8array-output.any.html]
+
+[decompression-uint8array-output.any.sharedworker.html]

--- a/tests/wpt/meta/compression/decompression-with-detach.any.js.ini
+++ b/tests/wpt/meta/compression/decompression-with-detach.any.js.ini
@@ -1,2 +1,0 @@
-[decompression-with-detach.any.serviceworker.html]
-  expected: ERROR


### PR DESCRIPTION
Enabled the `dom_serviceworker_enabled` pref for the `compression` test suite. Ran the test suite locally and all tests passed consistently.

Testing: Just enabling the pref, WPT will cover this.
Fixes: Part of #45331