### PR TITLE
script: Don't store `DomRoot` inside `Performance` interfaces

### DIFF
--- a/components/script/dom/performance/largestcontentfulpaint.rs
+++ b/components/script/dom/performance/largestcontentfulpaint.rs
@@ -13,7 +13,7 @@ use super::performanceentry::{EntryType, PerformanceEntry};
 use crate::dom::bindings::codegen::Bindings::LargestContentfulPaintBinding::LargestContentfulPaintMethods;
 use crate::dom::bindings::codegen::Bindings::PerformanceBinding::DOMHighResTimeStamp;
 use crate::dom::bindings::reflector::DomGlobal;
-use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::element::Element;
 use crate::dom::globalscope::GlobalScope;
@@ -27,7 +27,7 @@ pub(crate) struct LargestContentfulPaint {
     render_time: CrossProcessInstant,
     size: usize,
     url: DOMString,
-    element: Option<DomRoot<Element>>,
+    element: Option<Dom<Element>>,
 }
 
 impl LargestContentfulPaint {
@@ -51,7 +51,6 @@ impl LargestContentfulPaint {
         }
     }
 
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new(
         cx: &mut JSContext,
         global: &GlobalScope,
@@ -59,8 +58,15 @@ impl LargestContentfulPaint {
         size: usize,
         url: Option<ServoUrl>,
     ) -> DomRoot<LargestContentfulPaint> {
-        let entry = LargestContentfulPaint::new_inherited(render_time, size, url);
-        reflect_dom_object_with_cx(Box::new(entry), global, cx)
+        reflect_dom_object_with_cx(
+            Box::new(LargestContentfulPaint::new_inherited(
+                render_time,
+                size,
+                url,
+            )),
+            global,
+            cx,
+        )
     }
 }
 
@@ -91,6 +97,6 @@ impl LargestContentfulPaintMethods<crate::DomTypeHolder> for LargestContentfulPa
 
     /// <https://www.w3.org/TR/largest-contentful-paint/#dom-largestcontentfulpaint-element>
     fn GetElement(&self) -> Option<DomRoot<Element>> {
-        self.element.clone()
+        self.element.as_ref().map(|element| element.as_rooted())
     }
 }

--- a/components/script/dom/performance/mod.rs
+++ b/components/script/dom/performance/mod.rs
@@ -11,7 +11,6 @@ pub(crate) mod performancemark;
 pub(crate) mod performancemeasure;
 pub(crate) mod performancenavigation;
 pub(crate) mod performancenavigationtiming;
-#[expect(dead_code)]
 pub(crate) mod performanceobserver;
 pub(crate) mod performanceobserverentrylist;
 pub(crate) mod performancepainttiming;

--- a/components/script/dom/performance/mod.rs
+++ b/components/script/dom/performance/mod.rs
@@ -5,7 +5,6 @@
 pub(crate) mod largestcontentfulpaint;
 #[allow(clippy::module_inception, reason = "The interface name is Performance")]
 pub(crate) mod performance;
-#[expect(dead_code)]
 pub(crate) mod performanceentry;
 pub(crate) mod performancemark;
 pub(crate) mod performancemeasure;

--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -122,8 +122,9 @@ impl IntoIterator for PerformanceEntryList {
 }
 
 #[derive(JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 struct PerformanceObserver {
-    observer: DomRoot<DOMPerformanceObserver>,
+    observer: Dom<DOMPerformanceObserver>,
     entry_types: Vec<EntryType>,
 }
 
@@ -218,7 +219,7 @@ impl Performance {
             Some(p) => observers[p].entry_types = entry_types,
             // Otherwise, we create and insert the new PerformanceObserver.
             None => observers.push(PerformanceObserver {
-                observer: DomRoot::from_ref(observer),
+                observer: Dom::from_ref(observer),
                 entry_types,
             }),
         };
@@ -262,7 +263,7 @@ impl Performance {
             },
             // Otherwise, we create and insert the new PerformanceObserver.
             None => observers.push(PerformanceObserver {
-                observer: DomRoot::from_ref(observer),
+                observer: Dom::from_ref(observer),
                 entry_types: vec![entry_type],
             }),
         };

--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -112,15 +112,6 @@ impl PerformanceEntryList {
     }
 }
 
-impl IntoIterator for PerformanceEntryList {
-    type Item = Dom<PerformanceEntry>;
-    type IntoIter = ::std::vec::IntoIter<Dom<PerformanceEntry>>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.entries.into_iter()
-    }
-}
-
 #[derive(JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 struct PerformanceObserver {

--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -27,7 +27,7 @@ use super::performancenavigationtiming::PerformanceNavigationTiming;
 use super::performanceobserver::PerformanceObserver as DOMPerformanceObserver;
 use crate::dom::PERFORMANCE_TIMING_ATTRIBUTES;
 use crate::dom::bindings::codegen::Bindings::PerformanceBinding::{
-    DOMHighResTimeStamp, PerformanceEntryList as DOMPerformanceEntryList, PerformanceMethods,
+    DOMHighResTimeStamp, PerformanceMethods,
 };
 use crate::dom::bindings::codegen::UnionTypes::StringOrDouble;
 use crate::dom::bindings::error::{Error, Fallible};
@@ -35,7 +35,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
-use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::structuredclone;
 use crate::dom::bindings::trace::RootedTraceableBox;
@@ -47,14 +47,17 @@ use crate::script_runtime::CanGc;
 /// Implementation of a list of PerformanceEntry items shared by the
 /// Performance and PerformanceObserverEntryList interfaces implementations.
 #[derive(JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct PerformanceEntryList {
     /// <https://w3c.github.io/performance-timeline/#dfn-performance-entry-buffer>
-    entries: DOMPerformanceEntryList,
+    entries: Vec<Dom<PerformanceEntry>>,
 }
 
 impl PerformanceEntryList {
-    pub(crate) fn new(entries: DOMPerformanceEntryList) -> Self {
-        PerformanceEntryList { entries }
+    pub(crate) fn new(entries: Vec<DomRoot<PerformanceEntry>>) -> Self {
+        PerformanceEntryList {
+            entries: entries.into_iter().map(|entry| entry.as_traced()).collect(),
+        }
     }
 
     /// <https://www.w3.org/TR/performance-timeline/#dfn-filter-buffer-map-by-name-and-type>
@@ -72,7 +75,7 @@ impl PerformanceEntryList {
                         .as_ref()
                         .is_none_or(|type_| e.entry_type() == *type_)
             })
-            .cloned()
+            .map(|entry| entry.as_rooted())
             .collect::<Vec<DomRoot<PerformanceEntry>>>();
 
         // Step 6. Sort results's entries in chronological order with respect to startTime
@@ -110,8 +113,8 @@ impl PerformanceEntryList {
 }
 
 impl IntoIterator for PerformanceEntryList {
-    type Item = DomRoot<PerformanceEntry>;
-    type IntoIter = ::std::vec::IntoIter<DomRoot<PerformanceEntry>>;
+    type Item = Dom<PerformanceEntry>;
+    type IntoIter = ::std::vec::IntoIter<Dom<PerformanceEntry>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.entries.into_iter()
@@ -143,7 +146,7 @@ pub(crate) struct Performance {
     /// <https://w3c.github.io/resource-timing/#performance-resource-timing-buffer-full-event-pending-flag>
     resource_timing_buffer_pending_full_event: Cell<bool>,
     /// <https://w3c.github.io/resource-timing/#performance-resource-timing-secondary-buffer>
-    resource_timing_secondary_entries: DomRefCell<VecDeque<DomRoot<PerformanceEntry>>>,
+    resource_timing_secondary_entries: DomRefCell<VecDeque<Dom<PerformanceEntry>>>,
 }
 
 impl Performance {
@@ -229,11 +232,10 @@ impl Performance {
     ) {
         if buffered {
             let buffer = self.buffer.borrow();
-            let mut new_entries = buffer.get_entries_by_name_and_type(None, Some(entry_type));
+            let new_entries = buffer.get_entries_by_name_and_type(None, Some(entry_type));
             if !new_entries.is_empty() {
-                let mut obs_entries = observer.entries();
-                obs_entries.append(&mut new_entries);
-                observer.set_entries(obs_entries);
+                let new_entries = new_entries.into_iter().map(|entry| entry.as_traced());
+                observer.entries_mut().extend(new_entries);
             }
 
             if !self.pending_notification_observers_task.get() {
@@ -306,10 +308,7 @@ impl Performance {
 
         // Step 4.
         // add the new entry to the buffer.
-        self.buffer
-            .borrow_mut()
-            .entries
-            .push(DomRoot::from_ref(entry));
+        self.buffer.borrow_mut().entries.push(Dom::from_ref(entry));
 
         let entry_last_index = self.buffer.borrow_mut().entries.len() - 1;
 
@@ -374,16 +373,13 @@ impl Performance {
         // Step 1. While resource timing secondary buffer is not empty and can add resource timing entry returns true, run the following substeps:
         while self.can_add_resource_timing_entry() {
             // Step 1.1. Let entry be the oldest PerformanceResourceTiming in resource timing secondary buffer.
-            let entry = self
+            if let Some(ref entry) = self
                 .resource_timing_secondary_entries
                 .borrow_mut()
-                .pop_front();
-            if let Some(ref entry) = entry {
+                .pop_front()
+            {
                 // Step 1.2. Add entry to the end of performance entry buffer.
-                self.buffer
-                    .borrow_mut()
-                    .entries
-                    .push(DomRoot::from_ref(entry));
+                self.buffer.borrow_mut().entries.push(Dom::from_ref(entry));
                 // Step 1.3. Increment resource timing buffer current size by 1.
                 self.resource_timing_buffer_current_size
                     .set(self.resource_timing_buffer_current_size.get() + 1);
@@ -444,7 +440,7 @@ impl Performance {
         // Step 3. Add new entry to the resource timing secondary buffer.
         self.resource_timing_secondary_entries
             .borrow_mut()
-            .push_back(DomRoot::from_ref(entry));
+            .push_back(Dom::from_ref(entry));
 
         // Step 4. Increase resource timing secondary buffer current size by 1.
         //   This is tracked automatically via `.len()`.
@@ -453,7 +449,7 @@ impl Performance {
 
     pub(crate) fn update_entry(&self, index: usize, entry: &PerformanceEntry) {
         if let Some(e) = self.buffer.borrow_mut().entries.get_mut(index) {
-            *e = DomRoot::from_ref(entry);
+            *e = Dom::from_ref(entry);
         }
     }
 

--- a/components/script/dom/performance/performanceentry.rs
+++ b/components/script/dom/performance/performanceentry.rs
@@ -111,11 +111,6 @@ impl PerformanceEntry {
     pub(crate) fn start_time(&self) -> Option<CrossProcessInstant> {
         self.start_time
     }
-
-    /// <https://www.w3.org/TR/performance-timeline/#dom-performanceentry-duration>
-    pub(crate) fn duration(&self) -> Duration {
-        self.duration
-    }
 }
 
 impl PerformanceEntryMethods<crate::DomTypeHolder> for PerformanceEntry {

--- a/components/script/dom/performance/performanceobserver.rs
+++ b/components/script/dom/performance/performanceobserver.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::Cell;
+use std::cell::{Cell, RefMut};
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
@@ -11,17 +11,15 @@ use js::rust::{HandleObject, MutableHandleValue};
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 
-use super::performance::PerformanceEntryList;
 use super::performanceentry::{EntryType, PerformanceEntry};
 use super::performanceobserverentrylist::PerformanceObserverEntryList;
 use crate::dom::bindings::callback::ExceptionHandling;
-use crate::dom::bindings::codegen::Bindings::PerformanceBinding::PerformanceEntryList as DOMPerformanceEntryList;
 use crate::dom::bindings::codegen::Bindings::PerformanceObserverBinding::{
     PerformanceObserverCallback, PerformanceObserverInit, PerformanceObserverMethods,
 };
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::DomGlobal;
-use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::console::Console;
 use crate::dom::globalscope::GlobalScope;
 
@@ -37,47 +35,37 @@ pub(crate) struct PerformanceObserver {
     reflector_: Reflector,
     #[conditional_malloc_size_of]
     callback: Rc<PerformanceObserverCallback>,
-    entries: DomRefCell<DOMPerformanceEntryList>,
+    entries: DomRefCell<Vec<Dom<PerformanceEntry>>>,
     observer_type: Cell<ObserverType>,
 }
 
 impl PerformanceObserver {
-    fn new_inherited(
-        callback: Rc<PerformanceObserverCallback>,
-        entries: DomRefCell<DOMPerformanceEntryList>,
-    ) -> PerformanceObserver {
+    fn new_inherited(callback: Rc<PerformanceObserverCallback>) -> PerformanceObserver {
         PerformanceObserver {
             reflector_: Reflector::new(),
             callback,
-            entries,
+            entries: Default::default(),
             observer_type: Cell::new(ObserverType::Undefined),
         }
     }
 
-    pub(crate) fn new(
-        cx: &mut JSContext,
-        global: &GlobalScope,
-        callback: Rc<PerformanceObserverCallback>,
-        entries: DOMPerformanceEntryList,
-    ) -> DomRoot<PerformanceObserver> {
-        Self::new_with_proto(cx, global, None, callback, entries)
-    }
-
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_with_proto(
         cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         callback: Rc<PerformanceObserverCallback>,
-        entries: DOMPerformanceEntryList,
     ) -> DomRoot<PerformanceObserver> {
-        let observer = PerformanceObserver::new_inherited(callback, DomRefCell::new(entries));
-        reflect_dom_object_with_proto_and_cx(Box::new(observer), global, proto, cx)
+        reflect_dom_object_with_proto_and_cx(
+            Box::new(PerformanceObserver::new_inherited(callback)),
+            global,
+            proto,
+            cx,
+        )
     }
 
     /// Buffer a new performance entry.
     pub(crate) fn queue_entry(&self, entry: &PerformanceEntry) {
-        self.entries.borrow_mut().push(DomRoot::from_ref(entry));
+        self.entries.borrow_mut().push(Dom::from_ref(entry));
     }
 
     /// Trigger performance observer callback with the list of performance entries
@@ -86,8 +74,13 @@ impl PerformanceObserver {
         if self.entries.borrow().is_empty() {
             return;
         }
-        let entry_list = PerformanceEntryList::new(self.entries.borrow_mut().drain(..).collect());
-        let observer_entry_list = PerformanceObserverEntryList::new(cx, &self.global(), entry_list);
+        let entries = self
+            .entries
+            .borrow_mut()
+            .drain(..)
+            .map(|entry| entry.as_rooted())
+            .collect();
+        let observer_entry_list = PerformanceObserverEntryList::new(cx, &self.global(), entries);
         // using self both as thisArg and as the second formal argument
         let _ = self.callback.Call_(
             cx,
@@ -98,16 +91,8 @@ impl PerformanceObserver {
         );
     }
 
-    pub(crate) fn callback(&self) -> Rc<PerformanceObserverCallback> {
-        self.callback.clone()
-    }
-
-    pub(crate) fn entries(&self) -> DOMPerformanceEntryList {
-        self.entries.borrow().clone()
-    }
-
-    pub(crate) fn set_entries(&self, entries: DOMPerformanceEntryList) {
-        *self.entries.borrow_mut() = entries;
+    pub(crate) fn entries_mut(&self) -> RefMut<'_, Vec<Dom<PerformanceEntry>>> {
+        self.entries.borrow_mut()
     }
 }
 
@@ -120,11 +105,7 @@ impl PerformanceObserverMethods<crate::DomTypeHolder> for PerformanceObserver {
         callback: Rc<PerformanceObserverCallback>,
     ) -> Fallible<DomRoot<PerformanceObserver>> {
         Ok(PerformanceObserver::new_with_proto(
-            cx,
-            global,
-            proto,
-            callback,
-            Vec::new(),
+            cx, global, proto, callback,
         ))
     }
 
@@ -228,10 +209,7 @@ impl PerformanceObserverMethods<crate::DomTypeHolder> for PerformanceObserver {
     /// <https://w3c.github.io/performance-timeline/#takerecords-method>
     fn TakeRecords(&self) -> Vec<DomRoot<PerformanceEntry>> {
         let mut entries = self.entries.borrow_mut();
-        let taken = entries
-            .iter()
-            .map(|entry| DomRoot::from_ref(&**entry))
-            .collect();
+        let taken = entries.iter().map(|entry| entry.as_rooted()).collect();
         entries.clear();
         taken
     }

--- a/components/script/dom/performance/performanceobserverentrylist.rs
+++ b/components/script/dom/performance/performanceobserverentrylist.rs
@@ -21,21 +21,23 @@ pub(crate) struct PerformanceObserverEntryList {
 }
 
 impl PerformanceObserverEntryList {
-    fn new_inherited(entries: PerformanceEntryList) -> PerformanceObserverEntryList {
+    fn new_inherited(entries: Vec<DomRoot<PerformanceEntry>>) -> PerformanceObserverEntryList {
         PerformanceObserverEntryList {
             reflector_: Reflector::new(),
-            entries: DomRefCell::new(entries),
+            entries: DomRefCell::new(PerformanceEntryList::new(entries)),
         }
     }
 
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new(
         cx: &mut JSContext,
         global: &GlobalScope,
-        entries: PerformanceEntryList,
+        entries: Vec<DomRoot<PerformanceEntry>>,
     ) -> DomRoot<PerformanceObserverEntryList> {
-        let observer_entry_list = PerformanceObserverEntryList::new_inherited(entries);
-        reflect_dom_object_with_cx(Box::new(observer_entry_list), global, cx)
+        reflect_dom_object_with_cx(
+            Box::new(PerformanceObserverEntryList::new_inherited(entries)),
+            global,
+            cx,
+        )
     }
 }
 


### PR DESCRIPTION
Extracted from main PR since it required more changes, unused code was also removed.

Testing: It compiles, there shouldn't be any behaviour changes
Part of #39139
