### PR TITLE
layout: Replace some usage of borrow_for_layout and borrow_for_layout_mut with safe alternatives

### DIFF
--- a/components/script/dom/customstateset.rs
+++ b/components/script/dom/customstateset.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::cell::Ref;
+
 use dom_struct::dom_struct;
 use indexmap::IndexSet;
 use script_bindings::cell::DomRefCell;
@@ -43,8 +45,8 @@ impl CustomStateSet {
     /// Mutating the underlying refcell while this value is active is
     /// undefined behaviour.
     #[expect(unsafe_code)]
-    pub(crate) unsafe fn set_for_layout(&self) -> &IndexSet<DOMString> {
-        unsafe { self.internal.borrow_for_layout() }
+    pub(crate) unsafe fn set_for_layout(&self) -> Ref<'_, IndexSet<DOMString>> {
+        self.internal.borrow_for_layout_safe()
     }
 
     fn states_did_change(&self) {

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -4445,7 +4445,7 @@ impl Document {
         }
         #[expect(unsafe_code)]
         unsafe {
-            for shadow_root in self.shadow_roots.borrow_for_layout().iter() {
+            for shadow_root in self.shadow_roots.borrow_for_layout_safe().iter() {
                 let layout: LayoutDom<'_, _> = shadow_root.to_layout();
                 layout.flush_stylesheets_for_layout(stylist, guard);
             }

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -1162,7 +1162,7 @@ impl<'dom> LayoutDom<'dom, Element> {
     #[inline]
     #[expect(unsafe_code)]
     pub(crate) unsafe fn initialize_style_data(self) {
-        let data = unsafe { self.unsafe_get().style_data.borrow_mut_for_layout() };
+        let mut data = unsafe { self.unsafe_get().style_data.borrow_mut_for_layout() };
         debug_assert!(data.is_none());
         *data = Some(Box::default());
     }
@@ -1651,7 +1651,7 @@ impl<'dom> LayoutDom<'dom, Element> {
 
     #[expect(unsafe_code)]
     pub(crate) fn each_custom_state_for_layout(self, mut callback: impl FnMut(&AtomIdent)) {
-        let rare_data = unsafe { self.unsafe_get().rare_data.borrow_for_layout() };
+        let rare_data = self.unsafe_get().rare_data.borrow_for_layout_safe();
         let Some(rare_data) = rare_data.as_ref() else {
             return;
         };
@@ -1661,7 +1661,8 @@ impl<'dom> LayoutDom<'dom, Element> {
 
         let element_internals: LayoutDom<'_, _> = unsafe { element_internals.to_layout() };
         if let Some(states) = element_internals.unsafe_get().custom_states_for_layout() {
-            for state in unsafe { states.unsafe_get().set_for_layout().iter() } {
+            let states_for_layout = unsafe { states.unsafe_get().set_for_layout() };
+            for state in states_for_layout.iter() {
                 // FIXME: This creates new atoms whenever it is called, which is not optimal.
                 callback(&AtomIdent::from(&*state.str()));
             }

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -1162,7 +1162,7 @@ impl<'dom> LayoutDom<'dom, Element> {
     #[inline]
     #[expect(unsafe_code)]
     pub(crate) unsafe fn initialize_style_data(self) {
-        let mut data = unsafe { self.unsafe_get().style_data.borrow_mut_for_layout() };
+        let mut data = self.unsafe_get().style_data.borrow_mut_for_layout();
         debug_assert!(data.is_none());
         *data = Some(Box::default());
     }
@@ -1170,9 +1170,7 @@ impl<'dom> LayoutDom<'dom, Element> {
     #[inline]
     #[expect(unsafe_code)]
     pub(crate) unsafe fn clear_style_data(self) {
-        unsafe {
-            self.unsafe_get().style_data.borrow_mut_for_layout().take();
-        }
+        self.unsafe_get().style_data.borrow_mut_for_layout().take();
     }
 
     pub(crate) fn synthesize_presentational_hints_for_legacy_attributes<V>(self, hints: &mut V)

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::Cell;
+use std::cell::{Cell, Ref};
 use std::default::Default;
 use std::rc::Rc;
 use std::sync::{Arc, LazyLock};
@@ -1676,9 +1676,8 @@ impl MicrotaskRunnable for ImageElementMicrotask {
 }
 
 impl<'dom> LayoutDom<'dom, HTMLImageElement> {
-    #[expect(unsafe_code)]
-    fn current_request(self) -> &'dom ImageRequest {
-        unsafe { self.unsafe_get().current_request.borrow_for_layout() }
+    fn current_request(self) -> Ref<'dom, ImageRequest> {
+        self.unsafe_get().current_request.borrow_for_layout_safe()
     }
 
     #[expect(unsafe_code)]

--- a/components/script/dom/node/layout_dom.rs
+++ b/components/script/dom/node/layout_dom.rs
@@ -193,7 +193,7 @@ impl<'dom> LayoutDom<'dom, Node> {
     #[inline]
     #[expect(unsafe_code)]
     pub(crate) unsafe fn initialize_layout_data(self, new_data: Box<GenericLayoutData>) {
-        let mut data = unsafe { self.unsafe_get().layout_data().borrow_mut_for_layout() };
+        let mut data = self.unsafe_get().layout_data().borrow_mut_for_layout();
         debug_assert!(data.is_none());
         *data = Some(new_data);
     }
@@ -208,12 +208,10 @@ impl<'dom> LayoutDom<'dom, Node> {
     #[inline]
     #[expect(unsafe_code)]
     pub(crate) unsafe fn clear_layout_data(self) {
-        unsafe {
-            self.unsafe_get()
-                .layout_data()
-                .borrow_mut_for_layout()
-                .take();
-        }
+        self.unsafe_get()
+            .layout_data()
+            .borrow_mut_for_layout()
+            .take();
     }
 
     /// Whether this element serve as a container of editable text for a text input

--- a/components/script/dom/node/layout_dom.rs
+++ b/components/script/dom/node/layout_dom.rs
@@ -193,7 +193,7 @@ impl<'dom> LayoutDom<'dom, Node> {
     #[inline]
     #[expect(unsafe_code)]
     pub(crate) unsafe fn initialize_layout_data(self, new_data: Box<GenericLayoutData>) {
-        let data = unsafe { self.unsafe_get().layout_data().borrow_mut_for_layout() };
+        let mut data = unsafe { self.unsafe_get().layout_data().borrow_mut_for_layout() };
         debug_assert!(data.is_none());
         *data = Some(new_data);
     }

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -701,7 +701,7 @@ impl<'dom> LayoutDom<'dom, ShadowRoot> {
         unsafe {
             debug_assert!(self.upcast::<Node>().get_flag(NodeFlags::IS_CONNECTED));
         };
-        let mut author_styles = unsafe { self.unsafe_get().author_styles.borrow_mut_for_layout() };
+        let mut author_styles = self.unsafe_get().author_styles.borrow_mut_for_layout();
         if author_styles.stylesheets.dirty() {
             author_styles.flush(stylist, guard);
         }

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -701,7 +701,7 @@ impl<'dom> LayoutDom<'dom, ShadowRoot> {
         unsafe {
             debug_assert!(self.upcast::<Node>().get_flag(NodeFlags::IS_CONNECTED));
         };
-        let author_styles = unsafe { self.unsafe_get().author_styles.borrow_mut_for_layout() };
+        let mut author_styles = unsafe { self.unsafe_get().author_styles.borrow_mut_for_layout() };
         if author_styles.stylesheets.dirty() {
             author_styles.flush(stylist, guard);
         }

--- a/components/script/dom/svg/svgsvgelement.rs
+++ b/components/script/dom/svg/svgsvgelement.rs
@@ -175,7 +175,6 @@ impl SVGSVGElement {
 }
 
 impl<'dom> LayoutDom<'dom, SVGSVGElement> {
-    #[expect(unsafe_code)]
     pub(crate) fn data(self) -> SVGElementData<'dom> {
         let svg_id = self.unsafe_get().uuid.clone();
         let element = self.upcast::<Element>();
@@ -183,12 +182,11 @@ impl<'dom> LayoutDom<'dom, SVGSVGElement> {
         let height = element.get_attr_for_layout(&ns!(), &local_name!("height"));
         let view_box = element.get_attr_for_layout(&ns!(), &local_name!("viewBox"));
         SVGElementData {
-            source: unsafe {
-                self.unsafe_get()
-                    .cached_serialized_data_url
-                    .borrow_for_layout()
-                    .clone()
-            },
+            source: self
+                .unsafe_get()
+                .cached_serialized_data_url
+                .borrow_for_layout_safe()
+                .clone(),
             width,
             height,
             view_box,

--- a/components/script_bindings/cell.rs
+++ b/components/script_bindings/cell.rs
@@ -43,13 +43,11 @@ impl<T> DomRefCell<T> {
     ///
     /// # Panics
     ///
-    /// Panics if this is called from anywhere other than the layout thread
-    ///
-    /// Panics if the value is currently mutably borrowed.
+    /// Panics if this is called from anywhere other than the layout thread or
+    /// if the value is currently mutably borrowed.
     #[expect(unsafe_code)]
     pub unsafe fn borrow_for_layout(&self) -> &T {
         assert_in_layout();
-
         unsafe {
             self.value
                 .try_borrow_unguarded()
@@ -58,6 +56,7 @@ impl<T> DomRefCell<T> {
     }
 
     /// Returns a reference to the contents. For use in layout only.
+    ///
     /// # Panics
     ///
     /// Panics if this is called from anywhere other than the layout thread or if the cell is already mutable borrowed.
@@ -86,6 +85,7 @@ impl<T> DomRefCell<T> {
 
     /// Mutably borrow a cell for layout. Ideally this would use
     /// `RefCell::try_borrow_mut_unguarded` but that doesn't exist yet.
+    ///
     /// # Panics
     ///
     /// Panics if this is called from anywhere other than the layout thread.

--- a/components/script_bindings/cell.rs
+++ b/components/script_bindings/cell.rs
@@ -57,6 +57,10 @@ impl<T> DomRefCell<T> {
         }
     }
 
+    /// Returns a reference to the contents. For use in layout only.
+    /// # Panics
+    ///
+    /// Panics if this is called from anywhere other than the layout thread or if the cell is already mutable borrowed.
     pub fn borrow_for_layout_safe(&self) -> Ref<'_, T> {
         assert_in_layout();
         self.value.borrow()
@@ -82,29 +86,12 @@ impl<T> DomRefCell<T> {
 
     /// Mutably borrow a cell for layout. Ideally this would use
     /// `RefCell::try_borrow_mut_unguarded` but that doesn't exist yet.
-    ///
-    /// # Safety
-    ///
-    /// Unlike RefCell::borrow, this method is unsafe because it does not return a Ref, thus leaving
-    /// the borrow flag untouched. Mutably borrowing the RefCell while the reference returned by
-    /// this method is alive is undefined behaviour.
-    ///
     /// # Panics
     ///
     /// Panics if this is called from anywhere other than the layout thread.
-    #[expect(unsafe_code)]
-    #[allow(clippy::mut_from_ref)]
-    pub unsafe fn borrow_mut_for_layout(&self) -> RefMut<'_, T> {
+    pub fn borrow_mut_for_layout(&self) -> RefMut<'_, T> {
         assert_in_layout();
         self.value.borrow_mut()
-
-        /*
-        debug_assert!(
-            self.value.try_borrow_mut().is_ok(),
-            "Mutably borrowed for layout when we are not allowed to"
-        );
-         */
-        //unsafe { &mut *self.value.as_ptr() }
     }
 
     /// Mutably borrows the wrapped value.

--- a/components/script_bindings/cell.rs
+++ b/components/script_bindings/cell.rs
@@ -49,11 +49,17 @@ impl<T> DomRefCell<T> {
     #[expect(unsafe_code)]
     pub unsafe fn borrow_for_layout(&self) -> &T {
         assert_in_layout();
+
         unsafe {
             self.value
                 .try_borrow_unguarded()
                 .expect("cell is mutably borrowed")
         }
+    }
+
+    pub fn borrow_for_layout_safe(&self) -> Ref<'_, T> {
+        assert_in_layout();
+        self.value.borrow()
     }
 
     /// Borrow the contents for the purpose of script deallocation.
@@ -88,9 +94,17 @@ impl<T> DomRefCell<T> {
     /// Panics if this is called from anywhere other than the layout thread.
     #[expect(unsafe_code)]
     #[allow(clippy::mut_from_ref)]
-    pub unsafe fn borrow_mut_for_layout(&self) -> &mut T {
+    pub unsafe fn borrow_mut_for_layout(&self) -> RefMut<'_, T> {
         assert_in_layout();
-        unsafe { &mut *self.value.as_ptr() }
+        self.value.borrow_mut()
+
+        /*
+        debug_assert!(
+            self.value.try_borrow_mut().is_ok(),
+            "Mutably borrowed for layout when we are not allowed to"
+        );
+         */
+        //unsafe { &mut *self.value.as_ptr() }
     }
 
     /// Mutably borrows the wrapped value.


### PR DESCRIPTION
This replaces borrow_mut_for_layout with it's safe alternative (a normal borrow_mut) and introduces borrow_for_layout_safe (a normal borrow) and uses the new method for someusages.

Testing: This was tested with a WPT run here: https://github.com/Narfinger/servo/actions/runs/28651538806. As most of them seem to be flaky and this would only add new crashes which are rare in the log so this looks safe to me.
