### PR TITLE
net: Fix heuristic cache behavior to require revalidation by default

### DIFF
--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -239,7 +239,9 @@ fn get_response_expiry(response: &Response) -> Duration {
                 max_heuristic
             }
         } else {
-            max_heuristic
+            // fail-safe:
+            // do not use a heuristic freshness lifetime without the Last-Modified header field.
+            Duration::ZERO
         };
         if is_cacheable_by_default(*code) {
             // Status codes that are cacheable by default can use heuristics to determine freshness.
@@ -685,10 +687,14 @@ pub fn refresh(
 
     // Update cached Resource with response and constructed response.
     if let Some(constructed_response) = constructed_response.as_mut() {
+        {
+            let mut stored_headers = cached_resource.metadata.headers.lock();
+            stored_headers.extend(response.headers);
+            constructed_response.headers = stored_headers.clone();
+        }
+        // We need to compute the expiry from the constructed response that
+        // may have new `expires` or `cache-control`, not the stale one.
         cached_resource.expires = get_response_expiry(constructed_response);
-        let mut stored_headers = cached_resource.metadata.headers.lock();
-        stored_headers.extend(response.headers);
-        constructed_response.headers = stored_headers.clone();
     }
 
     constructed_response

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -239,8 +239,7 @@ fn get_response_expiry(response: &Response) -> Duration {
                 max_heuristic
             }
         } else {
-            // fail-safe:
-            // do not use a heuristic freshness lifetime without the Last-Modified header field.
+            // Compatible with other browsers.
             Duration::ZERO
         };
         if is_cacheable_by_default(*code) {
@@ -687,13 +686,12 @@ pub fn refresh(
 
     // Update cached Resource with response and constructed response.
     if let Some(constructed_response) = constructed_response.as_mut() {
+        // Bracket is to minimize lock duration.
         {
             let mut stored_headers = cached_resource.metadata.headers.lock();
             stored_headers.extend(response.headers);
             constructed_response.headers = stored_headers.clone();
         }
-        // We need to compute the expiry from the constructed response that
-        // may have new `expires` or `cache-control`, not the stale one.
         cached_resource.expires = get_response_expiry(constructed_response);
     }
 

--- a/tests/wpt/meta/fetch/api/basic/conditional-get.any.js.ini
+++ b/tests/wpt/meta/fetch/api/basic/conditional-get.any.js.ini
@@ -1,16 +1,2 @@
-[conditional-get.any.sharedworker.html]
-  [Testing conditional GET with ETags]
-    expected: FAIL
-
-
-[conditional-get.any.worker.html]
-  [Testing conditional GET with ETags]
-    expected: FAIL
-
-
 [conditional-get.any.serviceworker.html]
   expected: ERROR
-
-[conditional-get.any.html]
-  [Testing conditional GET with ETags]
-    expected: FAIL

--- a/tests/wpt/meta/fetch/api/basic/conditional-get.any.js.ini
+++ b/tests/wpt/meta/fetch/api/basic/conditional-get.any.js.ini
@@ -1,2 +1,3 @@
 [conditional-get.any.serviceworker.html]
   expected: ERROR
+


### PR DESCRIPTION
This change introduces a fail-safe guard for heuristic cache behavior to ensure browsers compatibility, and fixes a bug in computing freshness lifetime.

When no `last-modified` is present, mark the cache as `stale` immediately.
- chromium: https://source.chromium.org/chromium/chromium/src/+/refs/tags/152.0.7934.1:net/http/http_response_headers.cc;l=1346-1348
- firefox: https://searchfox.org/firefox-main/rev/609faad611b33bee94f2fcb455a6b840093bab89/netwerk/protocol/http/nsHttpResponseHead.cpp#665-699

The stored expiry was recomputed from the cached response *before* the 304's headers were merged in, so an updated `expires`/`cache-control` returned by the validation was ignored. Merge the headers first, then recompute the expiry.

Testing: updated tests/wpt/meta/fetch/api/basic/conditional-get.any.js.ini and `./mach test-wpt tests/wpt/tests/fetch/api/basic/` is passed.