### PR TITLE
android: Support Android 10 and unify API-level definition

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -119,8 +119,9 @@ jobs:
         if: ${{ matrix.target == 'x86_64-linux-android' }}
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          # This should be kept in sync with the `minSdk` version in the servoshell android app (and servoview).
-          api-level: 30
+          # This should be kept in sync with the `minSdk` version in `servo.properties`.
+          # DO NOT INCREASE THIS without prior discussion on zulip!
+          api-level: 29
           arch: x86_64
           target: default
           script: ./mach smoketest --target ${{ matrix.target }} --profile ${{ inputs.profile }}

--- a/python/servo/platform/build_target.py
+++ b/python/servo/platform/build_target.py
@@ -88,38 +88,56 @@ class CrossBuildTarget(BuildTarget):
 class AndroidTarget(CrossBuildTarget):
     DEFAULT_TRIPLE = "aarch64-linux-android"
 
+    @staticmethod
+    def min_sdk() -> str:
+        """Minimum supported Android API level"""
+        properties_file = path.join(util.SERVO_ROOT, "support", "android", "apk", "servo.properties")
+        with open(properties_file, encoding="utf8") as properties:
+            for line in properties:
+                line = line.strip()
+                if line.startswith("#") or line.strip() == "":
+                    continue
+                key, value = line.split("=", 1)
+                if key.strip() == "android.minSdk":
+                    assert value.strip().isdigit(), (
+                        f"android.minSdk must be an integer but was {value}. Check {properties_file}."
+                    )
+                    return value.strip()
+        raise Exception(f"`android.minSdk` is missing from {properties_file}")
+
     def ndk_configuration(self) -> dict[str, str]:
         target = self.triple()
+        api = self.min_sdk()
         config = {}
         if target == "armv7-linux-androideabi":
-            config["platform"] = "android-30"
+            config["platform"] = f"android-{api}"
             config["target"] = target
             config["toolchain_prefix"] = "arm-linux-androideabi"
             config["arch"] = "arm"
             config["lib"] = "armeabi-v7a"
-            config["toolchain_name"] = "armv7a-linux-androideabi30"
+            config["toolchain_name"] = f"armv7a-linux-androideabi{api}"
         elif target == "aarch64-linux-android":
-            config["platform"] = "android-30"
+            config["platform"] = f"android-{api}"
             config["target"] = target
             config["toolchain_prefix"] = target
             config["arch"] = "arm64"
             config["lib"] = "arm64-v8a"
-            config["toolchain_name"] = "aarch64-linux-androideabi30"
+            config["toolchain_name"] = f"aarch64-linux-androideabi{api}"
         elif target == "i686-linux-android":
             # https://github.com/jemalloc/jemalloc/issues/1279
-            config["platform"] = "android-30"
+            config["platform"] = f"android-{api}"
             config["target"] = target
             config["toolchain_prefix"] = target
             config["arch"] = "x86"
             config["lib"] = "x86"
-            config["toolchain_name"] = "i686-linux-android30"
+            config["toolchain_name"] = f"i686-linux-android{api}"
         elif target == "x86_64-linux-android":
-            config["platform"] = "android-30"
+            config["platform"] = f"android-{api}"
             config["target"] = target
             config["toolchain_prefix"] = target
             config["arch"] = "x86_64"
             config["lib"] = "x86_64"
-            config["toolchain_name"] = "x86_64-linux-android30"
+            config["toolchain_name"] = f"x86_64-linux-android{api}"
         else:
             raise Exception(f"Unknown android target {target}")
 

--- a/support/android/apk/buildSrc/src/main/kotlin/Interop.kt
+++ b/support/android/apk/buildSrc/src/main/kotlin/Interop.kt
@@ -52,6 +52,17 @@ fun getNDKAbi(arch: String): String {
     }
 }
 
+fun Project.getServoMinSdk(): Int {
+    val propertiesFile = File(project.rootDir, "servo.properties")
+    val properties = Properties()
+    propertiesFile.inputStream().use { instr ->
+        properties.load(instr)
+    }
+    val minSdk = properties.getProperty("android.minSdk")
+        ?: throw GradleException("`android.minSdk` is missing from ${propertiesFile.absolutePath}")
+    return minSdk.trim().toInt()
+}
+
 fun Project.getNdkDir(): String {
     // Read environment variable used in rust build system
     var ndkRoot = System.getenv("ANDROID_NDK_ROOT")

--- a/support/android/apk/jni/Application.mk
+++ b/support/android/apk/jni/Application.mk
@@ -1,6 +1,6 @@
 NDK_TOOLCHAIN_VERSION := clang
 APP_MODULES := servojni
-APP_PLATFORM := android-30
+# APP_PLATFORM is provided by gradle (see servoview/build.gradle.kts)
 APP_STL := c++_shared
 APP_ABI := armeabi-v7a x86 x86_64
 ifeq ($(NDK_DEBUG),1)

--- a/support/android/apk/servo.properties
+++ b/support/android/apk/servo.properties
@@ -1,0 +1,7 @@
+# The `minSdk` configuration affects both the `NDK` version we require,
+# and the `minSdk` version for the gradle build.
+# This value should only be bumped if necessary, and after discussion
+# on zulip, since it directly affects the amount of people able to use
+# servo on android.
+# ATTENTION - READ THE COMMENT ABOVE, if the minSdk value below is changed.
+android.minSdk=29

--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         applicationId = "org.servo.servoshell"
-        minSdk = 30
+        minSdk = getServoMinSdk()
         targetSdk = 34
         versionCode = generatedVersionCode
         versionName = "0.4.0"

--- a/support/android/apk/servoview/build.gradle.kts
+++ b/support/android/apk/servoview/build.gradle.kts
@@ -13,7 +13,7 @@ android {
     ndkPath = getNdkDir()
 
     defaultConfig {
-        minSdk = 30
+        minSdk = getServoMinSdk()
     }
 
     lint {
@@ -145,6 +145,7 @@ project.afterEvaluate {
                 "NDK_LIBS_OUT=" + getJniLibsPath(debug, arch),
                 "NDK_DEBUG=" + if (debug) "1" else "0",
                 "APP_ABI=" + getNDKAbi(arch),
+                "APP_PLATFORM=android-" + getServoMinSdk(),
                 "NDK_LOG=1",
                 "SERVO_TARGET_DIR=" + getNativeTargetDir(debug, arch)
             )


### PR DESCRIPTION
Unify the minimum supported API-level definition, by defining it in a new servo.properties file that is read by both gradle and mach, so that we only need to change the value in one place. Downgrade the value to `29` (android 10), which was released in 2019 and covers 91% of devices according to https://apilevels.com/ (vs. 87% for android 11).

Android 9 would also be possible for arm64, however the emulator smoketest crashes on x86_64 due to usage of the `open` syscall, which that emulator apparently doesn't like.

Testing: Covered by `./mach smoketest` ([mach try android](https://github.com/jschwe/servo/actions/runs/28788146604))
