### PR TITLE
android: Remove setting to show if screen is redrawing

### DIFF
--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
@@ -17,7 +17,6 @@ import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
-import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.Icon
@@ -43,7 +42,6 @@ class MainActivity : AppCompatActivity(), Servo.Client {
     private var urlFieldIsFocused = false
 
     private lateinit var progressBar: CircularProgressIndicator
-    private lateinit var idleText: TextView
     private var canGoBackState = mutableStateOf(false)
     private var canGoForwardState = mutableStateOf(false)
     private var isRefreshingState = mutableStateOf(false)
@@ -53,7 +51,6 @@ class MainActivity : AppCompatActivity(), Servo.Client {
     private var currentTitle = ""
 
     private class Settings(preferences: SharedPreferences) {
-        var showAnimatingIndicator = preferences.getBoolean("animating_indicator", false)
         var experimental = preferences.getBoolean("experimental", false)
     }
 
@@ -66,7 +63,6 @@ class MainActivity : AppCompatActivity(), Servo.Client {
         servoView = findViewById(R.id.servoview)
         urlField = findViewById(R.id.urlfield)
         progressBar = findViewById(R.id.progressbar)
-        idleText = findViewById(R.id.redrawing)
 
         historyManager = HistoryManager(this)
 
@@ -320,7 +316,6 @@ class MainActivity : AppCompatActivity(), Servo.Client {
     }
 
     override fun onRedrawing(redrawing: Boolean) {
-        idleText.setText(if (redrawing) R.string.loop else R.string.idle)
     }
 
     public override fun onPause() {
@@ -382,10 +377,6 @@ class MainActivity : AppCompatActivity(), Servo.Client {
         Log.d("onMediaSessionSetPositionState", "$duration $position $playbackRate")
     }
 
-    private fun onAnimatingIndicatorPrefChanged(value: Boolean) {
-        idleText.isVisible = value
-    }
-
     private fun onExperimentalPrefChanged(value: Boolean) {
         servoView.setExperimentalMode(value)
     }
@@ -393,10 +384,6 @@ class MainActivity : AppCompatActivity(), Servo.Client {
     private fun updateSettingsIfNecessary(force: Boolean) {
         val preferences = PreferenceManager.getDefaultSharedPreferences(applicationContext)
         val updated = Settings(preferences)
-
-        if (force || updated.showAnimatingIndicator != settings.showAnimatingIndicator) {
-            onAnimatingIndicatorPrefChanged(updated.showAnimatingIndicator)
-        }
 
         if (force || updated.experimental != settings.experimental) {
             onExperimentalPrefChanged(updated.experimental)

--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/SettingsFragment.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/SettingsFragment.kt
@@ -53,11 +53,6 @@ class SettingsFragment : Fragment() {
                         summary = stringResource(R.string.settings_experimental_summary),
                         preferenceKey = "experimental",
                     )
-                    SettingsItem(
-                        title = stringResource(R.string.settings_animating_title),
-                        summary = stringResource(R.string.settings_animating_summary),
-                        preferenceKey = "animating_indicator",
-                    )
                 }
             }
         }

--- a/support/android/apk/servoapp/src/main/res/layout-w600dp/activity_main.xml
+++ b/support/android/apk/servoapp/src/main/res/layout-w600dp/activity_main.xml
@@ -51,24 +51,8 @@
                 android:indeterminate="true"
                 android:visibility="gone"
                 app:indicatorSize="20dp"
-                app:layout_constraintEnd_toStartOf="@+id/redrawing"
+                app:layout_constraintEnd_toStartOf="@+id/settings_menu_item"
                 app:layout_constraintTop_toTopOf="parent" />
-
-            <TextView
-                android:id="@+id/redrawing"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:fontFamily="monospace"
-                android:gravity="center"
-                android:text="@string/idle"
-                android:textAlignment="center"
-                android:textSize="12sp"
-                android:layout_marginEnd="10dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toStartOf="@id/settings_menu_item"
-                app:layout_constraintTop_toTopOf="parent"
-                android:visibility="visible" />
 
             <androidx.compose.ui.platform.ComposeView
                 android:id="@+id/settings_menu_item"

--- a/support/android/apk/servoapp/src/main/res/layout/activity_main.xml
+++ b/support/android/apk/servoapp/src/main/res/layout/activity_main.xml
@@ -43,24 +43,8 @@
                 android:indeterminate="true"
                 android:visibility="gone"
                 app:indicatorSize="20dp"
-                app:layout_constraintEnd_toStartOf="@+id/redrawing"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <TextView
-                android:id="@+id/redrawing"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:fontFamily="monospace"
-                android:gravity="center"
-                android:text="@string/idle"
-                android:textAlignment="center"
-                android:textSize="12sp"
-                android:layout_marginEnd="10dp"
-                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                android:visibility="visible" />
+                app:layout_constraintTop_toTopOf="parent" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </com.google.android.material.appbar.MaterialToolbar>

--- a/support/android/apk/servoapp/src/main/res/values/strings.xml
+++ b/support/android/apk/servoapp/src/main/res/values/strings.xml
@@ -7,16 +7,12 @@
   <string name="options">Options</string>
   <string name="url_or_search">URL or Search</string>
   <string name="refresh">Refresh</string>
-  <string name="idle">idle</string>
   <string name="cancel">Cancel</string>
   
   <!-- Settings -->
   <string name="settings_title">Settings</string>
   <string name="settings_experimental_title">Experimental features</string>
   <string name="settings_experimental_summary">Enable experimental web platform features</string>
-  <string name="settings_animating_title">Idle/animating indicator</string>
-  <string name="settings_animating_summary">Show visual indicator for rendering state</string>
-  <string name="loop">LOOP</string>
   
   <!-- History -->
   <string name="history_title">History</string>


### PR DESCRIPTION
It's unclear who the audience for this settings item is.

1. If one is an end user (i.e., non Servo developer), then they really won't care about whether Servo considers itself to be redrawing or not. 
2. If one is a Servo developer, then they have the whole suite of debugging tools available to them in their environment. They'll probably set up logs or breakpoints to log whether it's redrawing (if that's what they happen to care about), alongside a bunch of other relevant information.

For these reasons, I think it's worth just deleting the setting.

Testing: There are no automated tests for Android.