### PR TITLE
script: Move MutationObserver and VisualViewport to JSContext

### DIFF
--- a/components/script/dom/html/htmlmetaelement.rs
+++ b/components/script/dom/html/htmlmetaelement.rs
@@ -26,7 +26,6 @@ use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmlheadelement::HTMLHeadElement;
 use crate::dom::node::virtualmethods::VirtualMethods;
 use crate::dom::node::{BindContext, Node, NodeTraits, UnbindContext};
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLMetaElement {
@@ -148,7 +147,7 @@ impl HTMLMetaElement {
             let window = self.owner_window();
             window.paint_api().viewport(window.webview_id(), viewport);
             window
-                .get_or_init_visual_viewport(CanGc::from_cx(cx))
+                .get_or_init_visual_viewport(cx)
                 .update_scale(initial_scale);
         }
     }

--- a/components/script/dom/mutationobserver/mutationobserver.rs
+++ b/components/script/dom/mutationobserver/mutationobserver.rs
@@ -25,7 +25,6 @@ use crate::dom::iterators::ShadowIncluding;
 use crate::dom::mutationrecord::MutationRecord;
 use crate::dom::node::Node;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
 #[dom_struct]
@@ -213,19 +212,11 @@ impl MutationObserver {
                     } else {
                         None
                     };
-                    MutationRecord::attribute_mutated(
-                        target,
-                        name,
-                        namespace,
-                        mapped_old_value,
-                        CanGc::deprecated_note(),
-                    )
+                    MutationRecord::attribute_mutated(cx, target, name, namespace, mapped_old_value)
                 },
-                Mutation::CharacterData { .. } => MutationRecord::character_data_mutated(
-                    target,
-                    mapped_old_value,
-                    CanGc::deprecated_note(),
-                ),
+                Mutation::CharacterData { .. } => {
+                    MutationRecord::character_data_mutated(cx, target, mapped_old_value)
+                },
                 Mutation::ChildList {
                     ref added,
                     ref removed,

--- a/components/script/dom/mutationobserver/mutationrecord.rs
+++ b/components/script/dom/mutationobserver/mutationrecord.rs
@@ -5,14 +5,13 @@
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Namespace};
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
 use crate::dom::bindings::codegen::Bindings::MutationRecordBinding::MutationRecord_Binding::MutationRecordMethods;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::nodelist::NodeList;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct MutationRecord {
@@ -31,11 +30,11 @@ pub(crate) struct MutationRecord {
 impl MutationRecord {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn attribute_mutated(
+        cx: &mut JSContext,
         target: &Node,
         attribute_name: &LocalName,
         attribute_namespace: Option<&Namespace>,
         old_value: Option<DOMString>,
-        can_gc: CanGc,
     ) -> DomRoot<MutationRecord> {
         let record = Box::new(MutationRecord::new_inherited(
             "attributes",
@@ -48,15 +47,15 @@ impl MutationRecord {
             None,
             None,
         ));
-        reflect_dom_object(record, &*target.owner_window(), can_gc)
+        reflect_dom_object_with_cx(record, &*target.owner_window(), cx)
     }
 
     pub(crate) fn character_data_mutated(
+        cx: &mut JSContext,
         target: &Node,
         old_value: Option<DOMString>,
-        can_gc: CanGc,
     ) -> DomRoot<MutationRecord> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(MutationRecord::new_inherited(
                 "characterData",
                 target,
@@ -69,7 +68,7 @@ impl MutationRecord {
                 None,
             )),
             &*target.owner_window(),
-            can_gc,
+            cx,
         )
     }
 

--- a/components/script/dom/navigator/navigator.rs
+++ b/components/script/dom/navigator/navigator.rs
@@ -381,9 +381,9 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-plugins>
-    fn Plugins(&self) -> DomRoot<PluginArray> {
+    fn Plugins(&self, cx: &mut JSContext) -> DomRoot<PluginArray> {
         self.plugins
-            .or_init(|| PluginArray::new(&self.global(), CanGc::deprecated_note()))
+            .or_init(|| PluginArray::new(cx, &self.global()))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-mimetypes>

--- a/components/script/dom/navigator/pluginarray.rs
+++ b/components/script/dom/navigator/pluginarray.rs
@@ -3,15 +3,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::NoGC;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use js::context::{JSContext, NoGC};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
 use crate::dom::bindings::codegen::Bindings::PluginArrayBinding::PluginArrayMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::plugin::Plugin;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct PluginArray {
@@ -25,8 +24,8 @@ impl PluginArray {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<PluginArray> {
-        reflect_dom_object(Box::new(PluginArray::new_inherited()), global, can_gc)
+    pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<PluginArray> {
+        reflect_dom_object_with_cx(Box::new(PluginArray::new_inherited()), global, cx)
     }
 }
 

--- a/components/script/dom/visualviewport.rs
+++ b/components/script/dom/visualviewport.rs
@@ -7,14 +7,14 @@ use std::cell::Cell;
 use bitflags::bitflags;
 use dom_struct::dom_struct;
 use euclid::{Rect, Scale, Size2D};
+use js::context::JSContext;
 use paint_api::PinchZoomInfos;
 use script_bindings::codegen::GenericBindings::VisualViewportBinding::VisualViewportMethods;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::inheritance::Castable;
 use script_bindings::num::Finite;
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use script_bindings::root::{Dom, DomRoot};
-use script_bindings::script_runtime::CanGc;
 use style_traits::CSSPixel;
 use webrender_api::units::DevicePixel;
 
@@ -67,18 +67,18 @@ impl VisualViewport {
     /// The initial visual viewport based on a layout viewport relative to the initial containing block, where
     /// the dimension would be the same as layout viewport leaving the offset and the scale to its default value.
     pub(crate) fn new_from_layout_viewport(
+        cx: &mut JSContext,
         window: &Window,
         viewport_size: Size2D<f32, CSSPixel>,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(Self::new_inherited(
                 window,
                 Rect::from_size(viewport_size),
                 Scale::identity(),
             )),
             window,
-            can_gc,
+            cx,
         )
     }
 

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -2656,7 +2656,7 @@ impl Window {
         if let Some(iframe_sizes) = reflow_result.iframe_sizes {
             document
                 .iframes_mut()
-                .handle_new_iframe_sizes_after_layout(self, iframe_sizes);
+                .handle_new_iframe_sizes_after_layout(cx, self, iframe_sizes);
         }
 
         document.update_animations_post_reflow();

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -1736,7 +1736,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-window-visualviewport>
-    fn GetVisualViewport(&self, can_gc: CanGc) -> Option<DomRoot<VisualViewport>> {
+    fn GetVisualViewport(&self, cx: &mut JSContext) -> Option<DomRoot<VisualViewport>> {
         // > If the associated document is fully active, the visualViewport attribute must return the
         // > VisualViewport object associated with the Window object’s associated document. Otherwise,
         // > it must return null.
@@ -1744,7 +1744,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             return None;
         }
 
-        Some(self.get_or_init_visual_viewport(can_gc))
+        Some(self.get_or_init_visual_viewport(cx))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-windowbase64-btoa>
@@ -3187,17 +3187,20 @@ impl Window {
         self.viewport_details.get()
     }
 
-    pub(crate) fn get_or_init_visual_viewport(&self, can_gc: CanGc) -> DomRoot<VisualViewport> {
+    pub(crate) fn get_or_init_visual_viewport(
+        &self,
+        cx: &mut JSContext,
+    ) -> DomRoot<VisualViewport> {
         self.visual_viewport.or_init(|| {
-            VisualViewport::new_from_layout_viewport(self, self.viewport_details().size, can_gc)
+            VisualViewport::new_from_layout_viewport(cx, self, self.viewport_details().size)
         })
     }
 
     /// Update the [`VisualViewport`] of this [`Window`] if necessary and note the changes to be processed in the event loop.
     pub(crate) fn maybe_update_visual_viewport(
         &self,
+        cx: &mut JSContext,
         pinch_zoom_infos: PinchZoomInfos,
-        can_gc: CanGc,
     ) {
         // We doesn't need to do anything if the following condition is fulfilled. Since there are no JS listener
         // to fire and we could reconstruct visual viewport from layout viewport in case JS access it.
@@ -3207,7 +3210,7 @@ impl Window {
             return;
         }
 
-        let visual_viewport = self.get_or_init_visual_viewport(can_gc);
+        let visual_viewport = self.get_or_init_visual_viewport(cx);
         let changes = visual_viewport.update_from_pinch_zoom_infos(pinch_zoom_infos);
 
         if changes.intersects(VisualViewportChanges::DimensionChanged) {
@@ -3413,7 +3416,7 @@ impl Window {
         let layout_viewport_resized = self.run_resize_steps_for_layout_viewport(cx);
 
         if self.has_changed_visual_viewport_dimension.get() {
-            let visual_viewport = self.get_or_init_visual_viewport(CanGc::from_cx(cx));
+            let visual_viewport = self.get_or_init_visual_viewport(cx);
 
             let uievent = UIEvent::new(
                 cx,

--- a/components/script/dom/worklet/paintsize.rs
+++ b/components/script/dom/worklet/paintsize.rs
@@ -4,14 +4,14 @@
 
 use dom_struct::dom_struct;
 use euclid::Size2D;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use js::context::JSContext;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use style_traits::CSSPixel;
 
 use crate::dom::bindings::codegen::Bindings::PaintSizeBinding::PaintSizeMethods;
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::paintworkletglobalscope::PaintWorkletGlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct PaintSize {
@@ -30,11 +30,11 @@ impl PaintSize {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &PaintWorkletGlobalScope,
         size: Size2D<f32, CSSPixel>,
-        can_gc: CanGc,
     ) -> DomRoot<PaintSize> {
-        reflect_dom_object(Box::new(PaintSize::new_inherited(size)), global, can_gc)
+        reflect_dom_object_with_cx(Box::new(PaintSize::new_inherited(size)), global, cx)
     }
 }
 

--- a/components/script/dom/worklet/paintworkletglobalscope.rs
+++ b/components/script/dom/worklet/paintworkletglobalscope.rs
@@ -50,7 +50,6 @@ use crate::dom::paintrenderingcontext2d::PaintRenderingContext2D;
 use crate::dom::paintsize::PaintSize;
 use crate::dom::worklet::WorkletExecutor;
 use crate::dom::workletglobalscope::{WorkletGlobalScope, WorkletGlobalScopeInit, WorkletTask};
-use crate::script_runtime::CanGc;
 
 /// <https://drafts.css-houdini.org/css-paint-api/#paintworkletglobalscope>
 #[dom_struct]
@@ -324,7 +323,7 @@ impl PaintWorkletGlobalScope {
         rendering_context.set_bitmap_dimensions(size_in_px, device_pixel_ratio);
 
         // Step 9
-        let paint_size = PaintSize::new(self, size_in_px, CanGc::from_cx(cx));
+        let paint_size = PaintSize::new(cx, self, size_in_px);
 
         // TODO: Step 10
         // Steps 11-12

--- a/components/script/iframe_collection.rs
+++ b/components/script/iframe_collection.rs
@@ -7,7 +7,7 @@ use std::default::Default;
 use embedder_traits::ViewportDetails;
 use layout_api::IFrameSizes;
 use paint_api::PinchZoomInfos;
-use script_bindings::script_runtime::CanGc;
+use script_bindings::script_runtime::temp_cx;
 use servo_base::id::BrowsingContextId;
 use servo_constellation_traits::{IFrameSizeMsg, ScriptToConstellationMessage, WindowSizeType};
 
@@ -115,6 +115,7 @@ impl IFrameCollection {
     /// Update the recorded iframe sizes of the contents of layout. Return a
     /// [`Vec<IFrameSizeMsg>`] containing the messages to send to the `Constellation`. A
     /// message is only sent when the size actually changes.
+    #[expect(unsafe_code)]
     pub(crate) fn handle_new_iframe_sizes_after_layout(
         &mut self,
         window: &Window,
@@ -137,15 +138,15 @@ impl IFrameCollection {
                         viewport_details,
                         WindowSizeType::Resize,
                     );
+
+                    let mut cx = unsafe { temp_cx() };
                     // Additionally, update the `VisualViewport` of the `Iframe`. This allows us
                     // to process the resize for `VisualViewport` in the corrent timing. Note that
                     // `VisualViewport` for iframes would practically follow layout viewport.
                     script_thread.handle_update_pinch_zoom_infos(
+                        &mut cx,
                         iframe_size.pipeline_id,
                         PinchZoomInfos::new_from_viewport_size(viewport_details.size),
-                        // Theoritically it wouldn't do GC since it is impossible to initialize
-                        // the `VisualViewport` interface here.
-                        CanGc::deprecated_note(),
                     )
                 });
 

--- a/components/script/iframe_collection.rs
+++ b/components/script/iframe_collection.rs
@@ -5,9 +5,9 @@
 use std::default::Default;
 
 use embedder_traits::ViewportDetails;
+use js::context::JSContext;
 use layout_api::IFrameSizes;
 use paint_api::PinchZoomInfos;
-use script_bindings::script_runtime::temp_cx;
 use servo_base::id::BrowsingContextId;
 use servo_constellation_traits::{IFrameSizeMsg, ScriptToConstellationMessage, WindowSizeType};
 
@@ -115,9 +115,9 @@ impl IFrameCollection {
     /// Update the recorded iframe sizes of the contents of layout. Return a
     /// [`Vec<IFrameSizeMsg>`] containing the messages to send to the `Constellation`. A
     /// message is only sent when the size actually changes.
-    #[expect(unsafe_code)]
     pub(crate) fn handle_new_iframe_sizes_after_layout(
         &mut self,
+        cx: &mut JSContext,
         window: &Window,
         new_iframe_sizes: IFrameSizes,
     ) {
@@ -139,12 +139,11 @@ impl IFrameCollection {
                         WindowSizeType::Resize,
                     );
 
-                    let mut cx = unsafe { temp_cx() };
                     // Additionally, update the `VisualViewport` of the `Iframe`. This allows us
                     // to process the resize for `VisualViewport` in the corrent timing. Note that
                     // `VisualViewport` for iframes would practically follow layout viewport.
                     script_thread.handle_update_pinch_zoom_infos(
-                        &mut cx,
+                        cx,
                         iframe_size.pipeline_id,
                         PinchZoomInfos::new_from_viewport_size(viewport_details.size),
                     )

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -157,7 +157,7 @@ use crate::network_listener::{FetchResponseListener, submit_timing};
 use crate::realms::enter_auto_realm;
 use crate::script_mutation_observers::ScriptMutationObservers;
 use crate::script_runtime::{
-    CanGc, IntroductionType, Runtime, ScriptThreadEventCategory, ThreadSafeJSContext, get_reports,
+    IntroductionType, Runtime, ScriptThreadEventCategory, ThreadSafeJSContext, get_reports,
 };
 use crate::script_window_proxies::ScriptWindowProxies;
 use crate::task_queue::TaskQueue;
@@ -2005,7 +2005,7 @@ impl ScriptThread {
                     .remove(&user_content_manager_id);
             },
             ScriptThreadMessage::UpdatePinchZoomInfos(id, pinch_zoom_infos) => {
-                self.handle_update_pinch_zoom_infos(id, pinch_zoom_infos, CanGc::from_cx(cx));
+                self.handle_update_pinch_zoom_infos(cx, id, pinch_zoom_infos);
             },
             ScriptThreadMessage::SetAccessibilityActive(pipeline_id, active, epoch) => {
                 self.set_accessibility_active(pipeline_id, active, epoch);
@@ -4415,16 +4415,16 @@ impl ScriptThread {
 
     pub(crate) fn handle_update_pinch_zoom_infos(
         &self,
+        cx: &mut JSContext,
         pipeline_id: PipelineId,
         pinch_zoom_infos: PinchZoomInfos,
-        can_gc: CanGc,
     ) {
         let Some(window) = self.documents.borrow().find_window(pipeline_id) else {
             warn!("Visual viewport update for closed pipeline {pipeline_id}.");
             return;
         };
 
-        window.maybe_update_visual_viewport(pinch_zoom_infos, can_gc);
+        window.maybe_update_visual_viewport(cx, pinch_zoom_infos);
     }
 
     pub(crate) fn devtools_want_updates_for_node(pipeline: PipelineId, node: &Node) -> bool {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1006,7 +1006,7 @@ DOMInterfaces = {
 },
 
 'Navigator': {
-    'cx': ['Bluetooth', 'Credentials', 'Clipboard', 'Geolocation', 'Gpu', 'MimeTypes', 'Languages', 'SendBeacon', 'ServiceWorker', 'Servo', 'Storage', 'UserActivation', 'WakeLock', 'Xr', 'MediaDevices', 'MediaSession', 'Permissions', 'GetGamepads'],
+    'cx': ['Bluetooth', 'Credentials', 'Clipboard', 'Geolocation', 'Gpu', 'MimeTypes', 'Languages', 'SendBeacon', 'ServiceWorker', 'Servo', 'Storage', 'Plugins', 'UserActivation', 'WakeLock', 'Xr', 'MediaDevices', 'MediaSession', 'Permissions', 'GetGamepads'],
 },
 
 'CredentialsContainer': {
@@ -1390,7 +1390,7 @@ DOMInterfaces = {
 },
 
 'Window': {
-    'canGc': ['GetVisualViewport', 'Screen'],
+    'canGc': ['Screen'],
     'additionalTraits': ['crate::interfaces::WindowHelpers', 'crate::interfaces::HasOrigin'],
     'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'WebdriverCallback', 'GetOpener', 'Fetch'],
     'cx': [
@@ -1405,6 +1405,7 @@ DOMInterfaces = {
         'GetLocalStorage',
         'GetSelection',
         'GetSessionStorage',
+        'GetVisualViewport',
         'History',
         'Location',
         'MatchMedia',


### PR DESCRIPTION
This moves VisualViewport and MutationObservers to JSContext.

Testing: Compilation is the test.
