### PR TITLE
layout: Clear laid out fragments of descendants when `content` is replaced

### DIFF
--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -350,6 +350,10 @@ pub(crate) trait NodeExt<'dom> {
     /// below this node is complete.
     fn clear_fragments_and_dirty_fragment_caches_recursively(&self);
 
+    /// Clear laid out `Fragment`s and dirty `Fragment` caches for all this node's descendant's
+    /// boxes.
+    fn clear_fragments_and_dirty_fragment_caches_of_descendants(&self);
+
     /// Returns the [`NodeRenderingType`] for this [`LayoutNode`] which describes whether
     /// the node is being rendered, delegating rendering, or not being rendered at all
     /// based on whether it has a [`LayoutBox`] and what kind.
@@ -544,15 +548,19 @@ impl<'dom> NodeExt<'dom> for ServoLayoutNode<'dom> {
 
     fn clear_fragments_and_dirty_fragment_caches_recursively(&self) {
         self.clear_fragments_and_dirty_fragment_caches();
-        for child in self.flat_tree_children() {
-            child.clear_fragments_and_dirty_fragment_caches_recursively();
-        }
+        self.clear_fragments_and_dirty_fragment_caches_of_descendants();
     }
 
     fn clear_fragments_and_dirty_fragment_caches(&self) {
         self.with_layout_box_base_including_pseudos(|base| {
             base.clear_fragments_and_dirty_fragment_cache()
         });
+    }
+
+    fn clear_fragments_and_dirty_fragment_caches_of_descendants(&self) {
+        for child in self.flat_tree_children() {
+            child.clear_fragments_and_dirty_fragment_caches_recursively();
+        }
     }
 
     fn rendering_type(&self) -> NodeRenderingType {

--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -328,6 +328,7 @@ impl ReplacedContents {
                 .unwrap_or_else(|| Self::zero_sized_invalid_image(node));
 
             replaced_contents.is_content_replacement = true;
+            node.clear_fragments_and_dirty_fragment_caches_of_descendants();
             return Some(replaced_contents);
         }
         None

--- a/tests/wpt/tests/css/css-content/element-replacement-dynamic-002.html
+++ b/tests/wpt/tests/css/css-content/element-replacement-dynamic-002.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title>The content CSS attribute can replace an element's contents dynamically</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-content-3/#content-property">
+<meta name="assert" content="
+  Descendants of an element that is replaced because of the content property
+  shouldn't be laid out. Therefore, the resolved height in getComputedStyle
+  should be the computed value (`auto`), not the used amount of pixels from
+  the previous layout.
+">
+
+<div id="wrapper">
+  <div style="display: flow-root">
+    <div id="target">Text</div>
+  </div>
+</div>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/interpolation-testcommon.js"></script>
+<script>
+test(function() {
+  // Force layout
+  document.body.offsetWidth;
+
+  wrapper.style.content = "linear-gradient(blue)";
+  assert_equals(getComputedStyle(target).height, "auto");
+}, "getComputedStyle().height after ancestor becomes replaced");
+</script>

--- a/tests/wpt/tests/css/css-content/element-replacement-gradient-scale-root-crash.html
+++ b/tests/wpt/tests/css/css-content/element-replacement-gradient-scale-root-crash.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/46023">
+
+<style>
+html { scale: 1; }
+div { display: flow-root; }
+</style>
+<div><img id="img"></div>
+<script>
+onload = _ => {
+  document.documentElement.style.cssText = "content: linear-gradient(blue); scale: 0";
+  img.height;
+}
+</script>


### PR DESCRIPTION
A dynamic change of the `content` property can turn a non-replaced element into replaced. In that case, it's possible that the contents were laid out previously, and now they will be skipped.

The problem was that we were still caching the results from the previous layout in some cases. Thus, script queries like `getComputedStyle` could return the wrong value, or Servo could crash.

Testing: Adding a crashtest and a testharness one
Fixes: #46023
