### PR TITLE
mach: Fix flaky fail in test-scripts

### DIFF
--- a/python/wpt/test.py
+++ b/python/wpt/test.py
@@ -624,6 +624,9 @@ def setUpModule() -> None:
     def setup_mock_repo(repo_name: str, local_repo: LocalGitRepo, default_branch: str) -> None:
         subprocess.check_output(["cp", "-R", "-p", os.path.join(TESTS_DIR, repo_name), local_repo.path])
         local_repo.run("init", "-b", default_branch)
+        # Prevent git from doing auto maintenance in the background.
+        local_repo.run("config", "gc.auto", "0")
+        local_repo.run("config", "maintenance.auto", "false")
         local_repo.run("add", ".")
         local_repo.run("commit", "-a", "-m", "Initial commit")
 
@@ -636,7 +639,7 @@ def setUpModule() -> None:
 
 def tearDownModule() -> None:
     # pylint: disable=invalid-name
-    shutil.rmtree(TMP_DIR)
+    shutil.rmtree(TMP_DIR, ignore_errors=True)
 
 
 def run_tests() -> bool:

--- a/python/wpt/test.py
+++ b/python/wpt/test.py
@@ -624,7 +624,8 @@ def setUpModule() -> None:
     def setup_mock_repo(repo_name: str, local_repo: LocalGitRepo, default_branch: str) -> None:
         subprocess.check_output(["cp", "-R", "-p", os.path.join(TESTS_DIR, repo_name), local_repo.path])
         local_repo.run("init", "-b", default_branch)
-        # Prevent git from doing auto maintenance in the background.
+        # Prevent git from doing auto maintenance in the background, which can interfere
+        # with file operations.
         local_repo.run("config", "gc.auto", "0")
         local_repo.run("config", "maintenance.auto", "false")
         local_repo.run("add", ".")


### PR DESCRIPTION
During tearDownModule, the `shutil.rmtree()` could fail, since it apparently internally does a scan over all files, and the then deletes those files individually.
`git` may do maintenance (and this may be more aggressive in the recent 2.55 release, since we didn't see this before), and has a lockfile that it creates and removes. If `shutil.rmtree` sees that lockfile, but git finishes its background maintenance, before rmtree, then the delete operation by rmtree can fail.

We fix that by both ignoring errors during `rmtree` and also disabling git from doing mainenance in the test repo.

Testing: This fixes a flaky test
Fixes: #46300
