### PR TITLE
script: Disable incremental garbage collection

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -279,6 +279,11 @@ pub struct Preferences {
     pub js_mem_gc_high_frequency_high_limit_mb: i64,
     pub js_mem_gc_high_frequency_low_limit_mb: i64,
     pub js_mem_gc_high_frequency_time_limit_ms: i64,
+    /// Whether or not incremental garbage collection is turned on. This is currently
+    /// turned off by default as pre-barriers are not implemented yet. If turned on, it
+    /// will likely lead to memory corruption.
+    ///
+    /// See <https://github.com/servo/servo/issues/7621>.
     pub js_mem_gc_incremental_enabled: bool,
     pub js_mem_gc_incremental_slice_ms: i64,
     pub js_mem_gc_low_frequency_heap_growth: i64,
@@ -517,7 +522,7 @@ impl Preferences {
             js_mem_gc_high_frequency_high_limit_mb: 500,
             js_mem_gc_high_frequency_low_limit_mb: 100,
             js_mem_gc_high_frequency_time_limit_ms: 1000,
-            js_mem_gc_incremental_enabled: true,
+            js_mem_gc_incremental_enabled: false,
             js_mem_gc_incremental_slice_ms: 10,
             js_mem_gc_low_frequency_heap_growth: 150,
             js_mem_gc_per_zone_enabled: false,

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -827,8 +827,6 @@ impl Runtime {
                 Some(empty_wrapper_callback),
                 Some(empty_has_released_callback),
             );
-            // Pre barriers aren't working correctly at the moment
-            JS_SetGCParameter(cx, JSGCParamKey::JSGC_INCREMENTAL_GC_ENABLED, 0);
         }
 
         unsafe extern "C" fn dispatch_to_event_loop(
@@ -980,12 +978,15 @@ impl Runtime {
                     .map(|val| (val * 1024 * 1024) as u32)
                     .unwrap_or(u32::MAX),
             );
-            // NOTE: This is disabled above, so enabling it here will do nothing for now.
+
+            // Pre-barriers aren't implemented correctly at the moment, so this preference
+            // defaults to false.
             JS_SetGCParameter(
                 cx,
                 JSGCParamKey::JSGC_INCREMENTAL_GC_ENABLED,
                 pref!(js_mem_gc_incremental_enabled) as u32,
             );
+
             JS_SetGCParameter(
                 cx,
                 JSGCParamKey::JSGC_PER_ZONE_GC_ENABLED,


### PR DESCRIPTION
The SpiderMonkey 137 upgrade inadvertently enabled incremental garbage
collection. Previously it was preffed on, but disabled via the
`DisableIncrementalGC()` API which unconditionally disabled it no matter what
`JSGCParamKey::JSGC_INCREMENTAL_GC_ENABLED` was set to. The upgrade replaced
`DisableIncrementalGC()` with setting `JSGCParamKey::JSGC_INCREMENTAL_GC_ENABLED`
to 0, but a later call set it to the value of the preference (`true`). This
change removes the duplicate call and sets the default value fo the preference
to `false`.

Testing: This leads to *very* timing specific memory corruption errors, so
making a reliable test for it is very difficult. Regardless, we should see
improvements in fuzzing results.
