### PR TITLE
script: Migrate `dom/performance` to `&mut JSContext`

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -1765,7 +1765,7 @@ impl Document {
     /// <https://html.spec.whatwg.org/multipage/#run-the-animation-frame-callbacks>
     pub(crate) fn run_the_animation_frame_callbacks(&self, cx: &mut CurrentRealm) {
         self.running_animation_callbacks.set(true);
-        let timing = self.global().performance().Now();
+        let timing = self.global().performance(cx).Now();
 
         let num_callbacks = self.animation_frame_list.borrow().len();
         for _ in 0..num_callbacks {
@@ -3428,7 +3428,7 @@ impl Document {
                 );
                 metrics.set_performance_paint_metric(metric_value, first_reflow, metric_type);
                 let entry = binding.upcast::<PerformanceEntry>();
-                self.window.Performance().queue_entry(entry);
+                self.window.Performance(cx).queue_entry(cx, entry);
             },
             ProgressiveWebMetricType::LargestContentfulPaint { area, url } => {
                 let binding = LargestContentfulPaint::new(
@@ -3440,7 +3440,7 @@ impl Document {
                 );
                 metrics.set_largest_contentful_paint(metric_value, area);
                 let entry = binding.upcast::<PerformanceEntry>();
-                self.window.Performance().queue_entry(entry);
+                self.window.Performance(cx).queue_entry(cx, entry);
             },
             ProgressiveWebMetricType::TimeToInteractive => {
                 unreachable!("Unexpected non-paint metric.")
@@ -4811,8 +4811,8 @@ impl Document {
             CrossProcessInstant::now(),
         );
         self.window
-            .Performance()
-            .queue_entry(entry.upcast::<PerformanceEntry>());
+            .Performance(cx)
+            .queue_entry(cx, entry.upcast::<PerformanceEntry>());
 
         // Step 4 Run the screen orientation change steps with document.
         // TODO ScreenOrientation hasn't implemented yet
@@ -4828,7 +4828,7 @@ impl Document {
         if visibility_state == DocumentVisibilityState::Hidden {
             self.window
                 .Navigator()
-                .GetGamepads()
+                .GetGamepads(cx)
                 .unwrap_or_default()
                 .iter_mut()
                 .for_each(|gamepad| {

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -1815,20 +1815,25 @@ impl DocumentEventHandler {
             .upcast::<GlobalScope>()
             .task_manager()
             .gamepad_task_source()
-            .queue(task!(update_gamepad_state: move || {
+            .queue(task!(update_gamepad_state: move |cx| {
                 let window = trusted_window.root();
                 let document = window.Document();
-                document.event_handler().update_gamepad_state(index, update_type);
+                document.event_handler().update_gamepad_state(cx, index, update_type);
             }));
     }
 
     /// <https://w3c.github.io/gamepad/#dfn-update-gamepad-state>
     #[cfg(feature = "gamepad")]
-    fn update_gamepad_state(&self, gamepad_index: usize, update_type: GamepadUpdateType) {
+    fn update_gamepad_state(
+        &self,
+        cx: &mut JSContext,
+        gamepad_index: usize,
+        update_type: GamepadUpdateType,
+    ) {
         use script_bindings::codegen::GenericBindings::PerformanceBinding::PerformanceMethods;
         // Step 1. Let now be the current high resolution time given
         //         gamepad's relevant global object.
-        let now = *self.window.Performance().Now();
+        let now = *self.window.Performance(cx).Now();
 
         // Step 6. Let navigator be gamepad's relevant global object's
         //         Navigator object.

--- a/components/script/dom/document/visibilitystateentry.rs
+++ b/components/script/dom/document/visibilitystateentry.rs
@@ -69,8 +69,8 @@ impl VisibilityStateEntryMethods<crate::DomTypeHolder> for VisibilityStateEntry 
     }
 
     /// <https://html.spec.whatwg.org/multipage/#visibilitystateentry-starttime>
-    fn StartTime(&self) -> Finite<f64> {
-        self.entry.StartTime()
+    fn StartTime(&self, cx: &mut JSContext) -> Finite<f64> {
+        self.entry.StartTime(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#visibilitystateentry-duration>

--- a/components/script/dom/event/event.rs
+++ b/components/script/dom/event/event.rs
@@ -1066,9 +1066,9 @@ impl EventMethods<crate::DomTypeHolder> for Event {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-event-timestamp>
-    fn TimeStamp(&self) -> DOMHighResTimeStamp {
+    fn TimeStamp(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
         self.global()
-            .performance()
+            .performance(cx)
             .to_dom_high_res_time_stamp(self.time_stamp)
     }
 

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -3161,12 +3161,12 @@ impl GlobalScope {
         incumbent_global()
     }
 
-    pub(crate) fn performance(&self) -> DomRoot<Performance> {
+    pub(crate) fn performance(&self, cx: &mut JSContext) -> DomRoot<Performance> {
         if let Some(window) = self.downcast::<Window>() {
-            return window.Performance();
+            return window.Performance(cx);
         }
         if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
-            return worker.Performance();
+            return worker.Performance(cx);
         }
         unreachable!();
     }

--- a/components/script/dom/intersectionobserver/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver/intersectionobserver.rs
@@ -338,14 +338,15 @@ impl IntersectionObserver {
 
         // Step 1. Construct an IntersectionObserverEntry, passing in time, rootBounds,
         // >    boundingClientRect, intersectionRect, isIntersecting, and target.
+        let time = document
+            .owner_global()
+            .performance(cx)
+            .to_dom_high_res_time_stamp(time);
         let entry = IntersectionObserverEntry::new(
             cx,
             self.owner_doc.window(),
             None,
-            document
-                .owner_global()
-                .performance()
-                .to_dom_high_res_time_stamp(time),
+            time,
             Some(&root_bounds),
             &bounding_client_rect,
             &intersection_rect,

--- a/components/script/dom/navigator/navigator.rs
+++ b/components/script/dom/navigator/navigator.rs
@@ -415,7 +415,7 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
 
     /// <https://www.w3.org/TR/gamepad/#dom-navigator-getgamepads>
     #[cfg(feature = "gamepad")]
-    fn GetGamepads(&self) -> Fallible<Vec<Option<DomRoot<Gamepad>>>> {
+    fn GetGamepads(&self, cx: &mut JSContext) -> Fallible<Vec<Option<DomRoot<Gamepad>>>> {
         use script_bindings::codegen::GenericBindings::PerformanceBinding::PerformanceMethods;
 
         // Step 1. Let doc be the current global object's associated Document.
@@ -442,7 +442,7 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
         }
 
         // Step 5. Let now be the current high resolution time given the current global object.
-        let now = *window.Performance().Now();
+        let now = *window.Performance(cx).Now();
 
         // Step 6. Let gamepads be an empty list.
         // Step 7. For each gamepad of this.[[gamepads]]:

--- a/components/script/dom/performance/largestcontentfulpaint.rs
+++ b/components/script/dom/performance/largestcontentfulpaint.rs
@@ -72,16 +72,16 @@ impl LargestContentfulPaint {
 
 impl LargestContentfulPaintMethods<crate::DomTypeHolder> for LargestContentfulPaint {
     /// <https://www.w3.org/TR/largest-contentful-paint/#dom-largestcontentfulpaint-loadtime>
-    fn LoadTime(&self) -> DOMHighResTimeStamp {
+    fn LoadTime(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
         self.global()
-            .performance()
+            .performance(cx)
             .to_dom_high_res_time_stamp(self.load_time)
     }
 
     /// <https://www.w3.org/TR/largest-contentful-paint/#dom-largestcontentfulpaint-rendertime>
-    fn RenderTime(&self) -> DOMHighResTimeStamp {
+    fn RenderTime(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
         self.global()
-            .performance()
+            .performance(cx)
             .to_dom_high_res_time_stamp(self.render_time)
     }
 

--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -217,6 +217,7 @@ impl Performance {
 
     pub(crate) fn add_single_type_observer(
         &self,
+        cx: &mut JSContext,
         observer: &DOMPerformanceObserver,
         entry_type: EntryType,
         buffered: bool,
@@ -232,7 +233,7 @@ impl Performance {
             if !self.pending_notification_observers_task.get() {
                 self.pending_notification_observers_task.set(true);
                 let global = &self.global();
-                let owner = Trusted::new(&*global.performance());
+                let owner = Trusted::new(&*global.performance(cx));
                 self.global()
                     .task_manager()
                     .performance_timeline_task_source()
@@ -278,7 +279,11 @@ impl Performance {
     /// <https://w3c.github.io/performance-timeline/#queue-a-performanceentry>
     /// Also this algorithm has been extented according to :
     /// <https://w3c.github.io/resource-timing/#sec-extensions-performance-interface>
-    pub(crate) fn queue_entry(&self, entry: &PerformanceEntry) -> Option<usize> {
+    pub(crate) fn queue_entry(
+        &self,
+        cx: &mut JSContext,
+        entry: &PerformanceEntry,
+    ) -> Option<usize> {
         // https://w3c.github.io/performance-timeline/#dfn-determine-eligibility-for-adding-a-performance-entry
         if entry.entry_type() == EntryType::Resource && !self.should_queue_resource_entry(entry) {
             return None;
@@ -314,7 +319,7 @@ impl Performance {
         self.pending_notification_observers_task.set(true);
 
         let global = &self.global();
-        let owner = Trusted::new(&*global.performance());
+        let owner = Trusted::new(&*global.performance(cx));
         self.global()
             .task_manager()
             .performance_timeline_task_source()
@@ -601,7 +606,7 @@ impl PerformanceMethods<crate::DomTypeHolder> for Performance {
 
         // Step 2. Queue a PerformanceEntry entry.
         // Step 3. Add entry to the performance entry buffer. (This is done in queue_entry itself)
-        self.queue_entry(entry.upcast::<PerformanceEntry>());
+        self.queue_entry(cx, entry.upcast::<PerformanceEntry>());
 
         // Step 4. Return entry.
         Ok(entry)
@@ -771,7 +776,7 @@ impl PerformanceMethods<crate::DomTypeHolder> for Performance {
 
         // Step 10. Queue a PerformanceEntry entry.
         // Step 11. Add entry to the performance entry buffer. (This is done in queue_entry itself)
-        self.queue_entry(entry.upcast::<PerformanceEntry>());
+        self.queue_entry(cx, entry.upcast::<PerformanceEntry>());
 
         // Step 12. Return entry.
         Ok(entry)

--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -15,7 +15,7 @@ use script_bindings::codegen::GenericBindings::PerformanceBinding::PerformanceMa
 use script_bindings::codegen::GenericBindings::PerformanceMarkBinding::PerformanceMarkMethods;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::codegen::GenericUnionTypes::StringOrPerformanceMeasureOptions;
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use time::Duration;
 
@@ -42,7 +42,6 @@ use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 /// Implementation of a list of PerformanceEntry items shared by the
 /// Performance and PerformanceObserverEntryList interfaces implementations.
@@ -157,14 +156,14 @@ impl Performance {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         navigation_start: CrossProcessInstant,
-        can_gc: CanGc,
     ) -> DomRoot<Performance> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(Performance::new_inherited(navigation_start)),
             global,
-            can_gc,
+            cx,
         )
     }
 
@@ -536,8 +535,8 @@ impl PerformanceMethods<crate::DomTypeHolder> for Performance {
     }
 
     /// <https://w3c.github.io/navigation-timing/#dom-performance-navigation>
-    fn Navigation(&self) -> DomRoot<PerformanceNavigation> {
-        PerformanceNavigation::new(&self.global(), CanGc::deprecated_note())
+    fn Navigation(&self, cx: &mut JSContext) -> DomRoot<PerformanceNavigation> {
+        PerformanceNavigation::new(cx, &self.global())
     }
 
     /// <https://w3c.github.io/hr-time/#dom-performance-now>
@@ -744,6 +743,7 @@ impl PerformanceMethods<crate::DomTypeHolder> for Performance {
         // The resulting duration value MAY be negative.
 
         let entry = PerformanceMeasure::new(
+            cx,
             &self.global(),
             measure_name,
             start_time,

--- a/components/script/dom/performance/performanceentry.rs
+++ b/components/script/dom/performance/performanceentry.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::reflector::Reflector;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use strum::VariantArray;
@@ -125,9 +126,9 @@ impl PerformanceEntryMethods<crate::DomTypeHolder> for PerformanceEntry {
     }
 
     /// <https://w3c.github.io/performance-timeline/#dom-performanceentry-starttime>
-    fn StartTime(&self) -> DOMHighResTimeStamp {
+    fn StartTime(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
         self.global()
-            .performance()
+            .performance(cx)
             .maybe_to_dom_high_res_time_stamp(self.start_time)
     }
 

--- a/components/script/dom/performance/performancemark.rs
+++ b/components/script/dom/performance/performancemark.rs
@@ -103,7 +103,7 @@ impl PerformanceMarkMethods<crate::DomTypeHolder> for PerformanceMark {
                     return Err(Error::Type(c"startTime must not be negative".to_owned()));
                 }
                 // Step 5.1.2. Otherwise, set entry’s startTime to the value of markOptions’s startTime.
-                global.performance().time_origin() +
+                global.performance(cx).time_origin() +
                     Duration::microseconds(start_time.mul_add(1000.0, 0.0) as i64)
             },
             // Step 5.2. Otherwise, set it to the value that would be returned by the Performance object’s now() method.

--- a/components/script/dom/performance/performancemeasure.rs
+++ b/components/script/dom/performance/performancemeasure.rs
@@ -3,11 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::gc::HandleValue;
 use js::jsapi::Heap;
 use js::jsval::JSVal;
 use js::rust::MutableHandleValue;
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use time::Duration;
 
@@ -16,7 +17,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::performance::performanceentry::{EntryType, PerformanceEntry};
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct PerformanceMeasure {
@@ -43,17 +43,18 @@ impl PerformanceMeasure {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         name: DOMString,
         start_time: CrossProcessInstant,
         duration: Duration,
     ) -> DomRoot<PerformanceMeasure> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(PerformanceMeasure::new_inherited(
                 name, start_time, duration,
             )),
             global,
-            CanGc::deprecated_note(),
+            cx,
         )
     }
 

--- a/components/script/dom/performance/performancenavigation.rs
+++ b/components/script/dom/performance/performancenavigation.rs
@@ -3,7 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use js::context::JSContext;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
 use crate::dom::bindings::codegen::Bindings::PerformanceNavigationBinding::{
     PerformanceNavigationConstants, PerformanceNavigationMethods,
@@ -12,7 +13,6 @@ use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::Wind
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct PerformanceNavigation {
@@ -26,12 +26,8 @@ impl PerformanceNavigation {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<PerformanceNavigation> {
-        reflect_dom_object(
-            Box::new(PerformanceNavigation::new_inherited()),
-            global,
-            can_gc,
-        )
+    pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<PerformanceNavigation> {
+        reflect_dom_object_with_cx(Box::new(PerformanceNavigation::new_inherited()), global, cx)
     }
 }
 

--- a/components/script/dom/performance/performancenavigationtiming.rs
+++ b/components/script/dom/performance/performancenavigationtiming.rs
@@ -60,27 +60,34 @@ impl PerformanceNavigationTiming {
 // https://w3c.github.io/navigation-timing/
 impl PerformanceNavigationTimingMethods<crate::DomTypeHolder> for PerformanceNavigationTiming {
     /// <https://w3c.github.io/navigation-timing/#dom-performancenavigationtiming-unloadeventstart>
-    fn UnloadEventStart(&self) -> DOMHighResTimeStamp {
+    fn UnloadEventStart(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
         self.upcast::<PerformanceResourceTiming>()
-            .to_dom_high_res_time_stamp(self.document.navigation_timing().unload_event_start.get())
+            .to_dom_high_res_time_stamp(
+                cx,
+                self.document.navigation_timing().unload_event_start.get(),
+            )
     }
 
     /// <https://w3c.github.io/navigation-timing/#dom-performancenavigationtiming-unloadeventend>
-    fn UnloadEventEnd(&self) -> DOMHighResTimeStamp {
+    fn UnloadEventEnd(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
         self.upcast::<PerformanceResourceTiming>()
-            .to_dom_high_res_time_stamp(self.document.navigation_timing().unload_event_end.get())
+            .to_dom_high_res_time_stamp(
+                cx,
+                self.document.navigation_timing().unload_event_end.get(),
+            )
     }
 
     /// <https://w3c.github.io/navigation-timing/#dom-performancenavigationtiming-dominteractive>
-    fn DomInteractive(&self) -> DOMHighResTimeStamp {
+    fn DomInteractive(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
         self.upcast::<PerformanceResourceTiming>()
-            .to_dom_high_res_time_stamp(self.document.navigation_timing().dom_interactive.get())
+            .to_dom_high_res_time_stamp(cx, self.document.navigation_timing().dom_interactive.get())
     }
 
     /// <https://w3c.github.io/navigation-timing/#dom-performancenavigationtiming-domcontentloadedeventstart>
-    fn DomContentLoadedEventStart(&self) -> DOMHighResTimeStamp {
+    fn DomContentLoadedEventStart(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
         self.upcast::<PerformanceResourceTiming>()
             .to_dom_high_res_time_stamp(
+                cx,
                 self.document
                     .navigation_timing()
                     .dom_content_loaded_event_start
@@ -89,9 +96,10 @@ impl PerformanceNavigationTimingMethods<crate::DomTypeHolder> for PerformanceNav
     }
 
     /// <https://w3c.github.io/navigation-timing/#dom-performancenavigationtiming-domcontentloadedeventend>
-    fn DomContentLoadedEventEnd(&self) -> DOMHighResTimeStamp {
+    fn DomContentLoadedEventEnd(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
         self.upcast::<PerformanceResourceTiming>()
             .to_dom_high_res_time_stamp(
+                cx,
                 self.document
                     .navigation_timing()
                     .dom_content_loaded_event_end
@@ -100,21 +108,24 @@ impl PerformanceNavigationTimingMethods<crate::DomTypeHolder> for PerformanceNav
     }
 
     /// <https://w3c.github.io/navigation-timing/#dom-performancenavigationtiming-domcomplete>
-    fn DomComplete(&self) -> DOMHighResTimeStamp {
+    fn DomComplete(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
         self.upcast::<PerformanceResourceTiming>()
-            .to_dom_high_res_time_stamp(self.document.navigation_timing().dom_complete.get())
+            .to_dom_high_res_time_stamp(cx, self.document.navigation_timing().dom_complete.get())
     }
 
     /// <https://w3c.github.io/navigation-timing/#dom-performancenavigationtiming-loadeventstart>
-    fn LoadEventStart(&self) -> DOMHighResTimeStamp {
+    fn LoadEventStart(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
         self.upcast::<PerformanceResourceTiming>()
-            .to_dom_high_res_time_stamp(self.document.navigation_timing().load_event_start.get())
+            .to_dom_high_res_time_stamp(
+                cx,
+                self.document.navigation_timing().load_event_start.get(),
+            )
     }
 
     /// <https://w3c.github.io/navigation-timing/#dom-performancenavigationtiming-loadeventend>
-    fn LoadEventEnd(&self) -> DOMHighResTimeStamp {
+    fn LoadEventEnd(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
         self.upcast::<PerformanceResourceTiming>()
-            .to_dom_high_res_time_stamp(self.document.navigation_timing().load_event_end.get())
+            .to_dom_high_res_time_stamp(cx, self.document.navigation_timing().load_event_end.get())
     }
 
     /// <https://w3c.github.io/navigation-timing/#dom-performancenavigationtiming-type>
@@ -129,9 +140,10 @@ impl PerformanceNavigationTimingMethods<crate::DomTypeHolder> for PerformanceNav
 
     // check-tidy: no specs after this line
     // Servo-only timing for when top-level content (not iframes) is complete
-    fn TopLevelDomComplete(&self) -> DOMHighResTimeStamp {
+    fn TopLevelDomComplete(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
         self.upcast::<PerformanceResourceTiming>()
             .to_dom_high_res_time_stamp(
+                cx,
                 self.document
                     .navigation_timing()
                     .top_level_dom_complete

--- a/components/script/dom/performance/performanceobserver.rs
+++ b/components/script/dom/performance/performanceobserver.rs
@@ -175,7 +175,7 @@ impl PerformanceObserverMethods<crate::DomTypeHolder> for PerformanceObserver {
             // This never pre-fills buffered entries, and
             // any existing types are replaced.
             self.global()
-                .performance()
+                .performance(cx)
                 .add_multiple_type_observer(self, entry_types);
             Ok(())
         } else if let Some(entry_type) = &options.type_ {
@@ -188,7 +188,8 @@ impl PerformanceObserverMethods<crate::DomTypeHolder> for PerformanceObserver {
             // Steps 7.3-7.5
             // This may pre-fill buffered entries, and
             // existing types are appended to.
-            self.global().performance().add_single_type_observer(
+            self.global().performance(cx).add_single_type_observer(
+                cx,
                 self,
                 entry_type,
                 options.buffered.unwrap_or(false),
@@ -201,8 +202,8 @@ impl PerformanceObserverMethods<crate::DomTypeHolder> for PerformanceObserver {
     }
 
     /// <https://w3c.github.io/performance-timeline/#dom-performanceobserver-disconnect>
-    fn Disconnect(&self) {
-        self.global().performance().remove_observer(self);
+    fn Disconnect(&self, cx: &mut JSContext) {
+        self.global().performance(cx).remove_observer(self);
         self.entries.borrow_mut().clear();
     }
 

--- a/components/script/dom/performance/performanceresourcetiming.rs
+++ b/components/script/dom/performance/performanceresourcetiming.rs
@@ -138,10 +138,11 @@ impl PerformanceResourceTiming {
     /// always after that time.
     pub(crate) fn to_dom_high_res_time_stamp(
         &self,
+        cx: &mut JSContext,
         instant: Option<CrossProcessInstant>,
     ) -> DOMHighResTimeStamp {
         self.global()
-            .performance()
+            .performance(cx)
             .maybe_to_dom_high_res_time_stamp(instant)
     }
 }
@@ -172,18 +173,18 @@ impl PerformanceResourceTimingMethods<crate::DomTypeHolder> for PerformanceResou
     }
 
     /// <https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-domainlookupstart>
-    fn DomainLookupStart(&self) -> DOMHighResTimeStamp {
-        self.to_dom_high_res_time_stamp(self.domain_lookup_start)
+    fn DomainLookupStart(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
+        self.to_dom_high_res_time_stamp(cx, self.domain_lookup_start)
     }
 
     /// <https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-domainlookupend>
-    fn DomainLookupEnd(&self) -> DOMHighResTimeStamp {
-        self.to_dom_high_res_time_stamp(self.domain_lookup_end)
+    fn DomainLookupEnd(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
+        self.to_dom_high_res_time_stamp(cx, self.domain_lookup_end)
     }
 
     /// <https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-secureconnectionstart>
-    fn SecureConnectionStart(&self) -> DOMHighResTimeStamp {
-        self.to_dom_high_res_time_stamp(self.secure_connection_start)
+    fn SecureConnectionStart(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
+        self.to_dom_high_res_time_stamp(cx, self.secure_connection_start)
     }
 
     /// <https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-transfersize>
@@ -202,42 +203,42 @@ impl PerformanceResourceTimingMethods<crate::DomTypeHolder> for PerformanceResou
     }
 
     /// <https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-requeststart>
-    fn RequestStart(&self) -> DOMHighResTimeStamp {
-        self.to_dom_high_res_time_stamp(self.request_start)
+    fn RequestStart(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
+        self.to_dom_high_res_time_stamp(cx, self.request_start)
     }
 
     /// <https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-redirectstart>
-    fn RedirectStart(&self) -> DOMHighResTimeStamp {
-        self.to_dom_high_res_time_stamp(self.redirect_start)
+    fn RedirectStart(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
+        self.to_dom_high_res_time_stamp(cx, self.redirect_start)
     }
 
     /// <https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-redirectend>
-    fn RedirectEnd(&self) -> DOMHighResTimeStamp {
-        self.to_dom_high_res_time_stamp(self.redirect_end)
+    fn RedirectEnd(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
+        self.to_dom_high_res_time_stamp(cx, self.redirect_end)
     }
 
     /// <https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-responsestart>
-    fn ResponseStart(&self) -> DOMHighResTimeStamp {
-        self.to_dom_high_res_time_stamp(self.response_start)
+    fn ResponseStart(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
+        self.to_dom_high_res_time_stamp(cx, self.response_start)
     }
 
     /// <https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-fetchstart>
-    fn FetchStart(&self) -> DOMHighResTimeStamp {
-        self.to_dom_high_res_time_stamp(self.fetch_start)
+    fn FetchStart(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
+        self.to_dom_high_res_time_stamp(cx, self.fetch_start)
     }
 
     /// <https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-connectstart>
-    fn ConnectStart(&self) -> DOMHighResTimeStamp {
-        self.to_dom_high_res_time_stamp(self.connect_start)
+    fn ConnectStart(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
+        self.to_dom_high_res_time_stamp(cx, self.connect_start)
     }
 
     /// <https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-connectend>
-    fn ConnectEnd(&self) -> DOMHighResTimeStamp {
-        self.to_dom_high_res_time_stamp(self.connect_end)
+    fn ConnectEnd(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
+        self.to_dom_high_res_time_stamp(cx, self.connect_end)
     }
 
     /// <https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-responseend>
-    fn ResponseEnd(&self) -> DOMHighResTimeStamp {
-        self.to_dom_high_res_time_stamp(self.response_end)
+    fn ResponseEnd(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
+        self.to_dom_high_res_time_stamp(cx, self.response_end)
     }
 }

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1259,8 +1259,8 @@ impl ParserContext {
         let performance_entry = PerformanceNavigationTiming::new(cx, &document.global(), document);
         self.pushed_entry_index = document
             .global()
-            .performance()
-            .queue_entry(performance_entry.upcast::<PerformanceEntry>());
+            .performance(cx)
+            .queue_entry(cx, performance_entry.upcast::<PerformanceEntry>());
     }
 }
 
@@ -1558,7 +1558,7 @@ impl FetchResponseListener for ParserContext {
                 PerformanceNavigationTiming::new(cx, &document.global(), document);
             document
                 .global()
-                .performance()
+                .performance(cx)
                 .update_entry(pushed_index, performance_entry.upcast::<PerformanceEntry>());
         }
     }

--- a/components/script/dom/webxr/xrsession.rs
+++ b/components/script/dom/webxr/xrsession.rs
@@ -469,7 +469,10 @@ impl XRSession {
             mem::swap(&mut *self.raf_callback_list.borrow_mut(), &mut current);
         }
 
-        let time = self.global().performance().to_dom_high_res_time_stamp(time);
+        let time = self
+            .global()
+            .performance(cx)
+            .to_dom_high_res_time_stamp(time);
         let frame = XRFrame::new(cx, self.global().as_window(), self, frame);
 
         // Step 8-9

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -1719,14 +1719,9 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     // https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/
     // NavigationTiming/Overview.html#sec-window.performance-attribute
-    fn Performance(&self) -> DomRoot<Performance> {
-        self.performance.or_init(|| {
-            Performance::new(
-                self.as_global_scope(),
-                self.navigation_start.get(),
-                CanGc::deprecated_note(),
-            )
-        })
+    fn Performance(&self, cx: &mut JSContext) -> DomRoot<Performance> {
+        self.performance
+            .or_init(|| Performance::new(cx, self.as_global_scope(), self.navigation_start.get()))
     }
 
     // https://html.spec.whatwg.org/multipage/#globaleventhandlers

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -90,7 +90,7 @@ use crate::microtask::{Microtask, MicrotaskQueue, UserMicrotask};
 use crate::network_listener::{FetchResponseListener, ResourceTimingListener, submit_timing};
 use crate::realms::enter_auto_realm;
 use crate::script_module::ScriptFetchOptions;
-use crate::script_runtime::{CanGc, IntroductionType, Runtime, get_reports};
+use crate::script_runtime::{IntroductionType, Runtime, get_reports};
 use crate::task::TaskCanceller;
 use crate::task_manager::TaskManager;
 use crate::timers::{IsInterval, OneshotTimers, TimerCallback};
@@ -999,14 +999,10 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
     }
 
     /// <https://w3c.github.io/hr-time/#the-performance-attribute>
-    fn Performance(&self) -> DomRoot<Performance> {
+    fn Performance(&self, cx: &mut JSContext) -> DomRoot<Performance> {
         self.performance.or_init(|| {
             let global_scope = self.upcast::<GlobalScope>();
-            Performance::new(
-                global_scope,
-                self.navigation_start,
-                CanGc::deprecated_note(),
-            )
+            Performance::new(cx, global_scope, self.navigation_start)
         })
     }
 

--- a/components/script/network_listener.rs
+++ b/components/script/network_listener.rs
@@ -88,8 +88,8 @@ pub(crate) fn submit_timing_data(
     let performance_entry =
         PerformanceResourceTiming::new(cx, global, url, initiator_type, resource_timing);
     global
-        .performance()
-        .queue_entry(performance_entry.upcast::<PerformanceEntry>());
+        .performance(cx)
+        .queue_entry(cx, performance_entry.upcast::<PerformanceEntry>());
 }
 
 pub(crate) trait FetchResponseListener: Send + 'static {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1047,7 +1047,7 @@ DOMInterfaces = {
 },
 
 'Performance': {
-    'cx': ['Mark', 'Measure'],
+    'cx': ['Mark', 'Measure', 'Navigation'],
 },
 
 'PerformanceObserver': {
@@ -1386,6 +1386,7 @@ DOMInterfaces = {
         'MatchMedia',
         'NamedGetter',
         'Open',
+        'Performance',
         'PostMessage',
         'PostMessage_',
         'ReportError',
@@ -1422,7 +1423,7 @@ DOMInterfaces = {
 },
 
 'WorkerGlobalScope': {
-    'cx': ['Crypto', 'ImportScripts', 'ReportError', 'SetInterval', 'SetTimeout', 'TrustedTypes', 'StructuredClone', 'IndexedDB', 'QueueMicrotask', 'Location', 'Navigator'],
+    'cx': ['Crypto', 'ImportScripts', 'ReportError', 'SetInterval', 'SetTimeout', 'TrustedTypes', 'StructuredClone', 'IndexedDB', 'QueueMicrotask', 'Location', 'Navigator', 'Performance'],
     'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'Fetch'],
 },
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -459,6 +459,10 @@ DOMInterfaces = {
     'cx': ['CheckValidity', 'GetValidity', 'GetLabels', 'ReportValidity', 'SetValidity', 'States'],
 },
 
+'Event': {
+    'cx': ['TimeStamp'],
+},
+
 'EventSource': {
     'weakReferenceable': True,
 },
@@ -926,6 +930,10 @@ DOMInterfaces = {
     'cx': ['SetKeyframes']
 },
 
+'LargestContentfulPaint': {
+    'cx': ['LoadTime', 'RenderTime'],
+},
+
 'LayoutResult': {
     'cx': ['Phases']
 },
@@ -998,7 +1006,7 @@ DOMInterfaces = {
 },
 
 'Navigator': {
-    'cx': ['Bluetooth', 'Credentials', 'Clipboard', 'Geolocation', 'Gpu', 'MimeTypes', 'Languages', 'SendBeacon', 'ServiceWorker', 'Servo', 'Storage', 'UserActivation', 'WakeLock', 'Xr', 'MediaDevices', 'MediaSession', 'Permissions'],
+    'cx': ['Bluetooth', 'Credentials', 'Clipboard', 'Geolocation', 'Gpu', 'MimeTypes', 'Languages', 'SendBeacon', 'ServiceWorker', 'Servo', 'Storage', 'UserActivation', 'WakeLock', 'Xr', 'MediaDevices', 'MediaSession', 'Permissions', 'GetGamepads'],
 },
 
 'CredentialsContainer': {
@@ -1050,8 +1058,20 @@ DOMInterfaces = {
     'cx': ['Mark', 'Measure', 'Navigation'],
 },
 
+'PerformanceEntry': {
+    'cx': ['StartTime'],
+},
+
+'PerformanceNavigationTiming': {
+    'cx': ['UnloadEventStart', 'UnloadEventEnd', 'DomInteractive', 'DomContentLoadedEventStart', 'DomContentLoadedEventEnd', 'DomComplete', 'LoadEventStart', 'LoadEventEnd', 'TopLevelDomComplete'],
+},
+
 'PerformanceObserver': {
-    'cx': ['Observe', 'SupportedEntryTypes'],
+    'cx': ['Observe', 'SupportedEntryTypes', 'Disconnect'],
+},
+
+'PerformanceResourceTiming': {
+    'cx': ['DomainLookupStart', 'DomainLookupEnd', 'SecureConnectionStart', 'RequestStart', 'RedirectStart', 'RedirectEnd', 'ResponseStart', 'FetchStart', 'ConnectStart', 'ConnectEnd', 'ResponseEnd'],
 },
 
 'Permissions': {
@@ -1234,6 +1254,10 @@ DOMInterfaces = {
 'URL': {
     'weakReferenceable': True,
     'cx': ['Parse', 'SearchParams'],
+},
+
+'VisibilityStateEntry': {
+    'cx': ['StartTime'],
 },
 
 'WebGLRenderingContext': {


### PR DESCRIPTION
Looks like my hunch about this one ballooning out of control was correct. Very correct. Ouch.

Testing: Compilation.
Fixes: Part of #40600.