### PR TITLE
script: Remove some unnecessary JSContext arguments.

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -3428,7 +3428,7 @@ impl Document {
                 );
                 metrics.set_performance_paint_metric(metric_value, first_reflow, metric_type);
                 let entry = binding.upcast::<PerformanceEntry>();
-                self.window.Performance(cx).queue_entry(cx, entry);
+                self.window.Performance(cx).queue_entry(entry);
             },
             ProgressiveWebMetricType::LargestContentfulPaint { area, url } => {
                 let binding = LargestContentfulPaint::new(
@@ -3440,7 +3440,7 @@ impl Document {
                 );
                 metrics.set_largest_contentful_paint(metric_value, area);
                 let entry = binding.upcast::<PerformanceEntry>();
-                self.window.Performance(cx).queue_entry(cx, entry);
+                self.window.Performance(cx).queue_entry(entry);
             },
             ProgressiveWebMetricType::TimeToInteractive => {
                 unreachable!("Unexpected non-paint metric.")
@@ -4812,7 +4812,7 @@ impl Document {
         );
         self.window
             .Performance(cx)
-            .queue_entry(cx, entry.upcast::<PerformanceEntry>());
+            .queue_entry(entry.upcast::<PerformanceEntry>());
 
         // Step 4 Run the screen orientation change steps with document.
         // TODO ScreenOrientation hasn't implemented yet

--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -217,7 +217,6 @@ impl Performance {
 
     pub(crate) fn add_single_type_observer(
         &self,
-        cx: &mut JSContext,
         observer: &DOMPerformanceObserver,
         entry_type: EntryType,
         buffered: bool,
@@ -232,8 +231,7 @@ impl Performance {
 
             if !self.pending_notification_observers_task.get() {
                 self.pending_notification_observers_task.set(true);
-                let global = &self.global();
-                let owner = Trusted::new(&*global.performance(cx));
+                let owner = Trusted::new(self);
                 self.global()
                     .task_manager()
                     .performance_timeline_task_source()
@@ -279,11 +277,7 @@ impl Performance {
     /// <https://w3c.github.io/performance-timeline/#queue-a-performanceentry>
     /// Also this algorithm has been extented according to :
     /// <https://w3c.github.io/resource-timing/#sec-extensions-performance-interface>
-    pub(crate) fn queue_entry(
-        &self,
-        cx: &mut JSContext,
-        entry: &PerformanceEntry,
-    ) -> Option<usize> {
+    pub(crate) fn queue_entry(&self, entry: &PerformanceEntry) -> Option<usize> {
         // https://w3c.github.io/performance-timeline/#dfn-determine-eligibility-for-adding-a-performance-entry
         if entry.entry_type() == EntryType::Resource && !self.should_queue_resource_entry(entry) {
             return None;
@@ -318,8 +312,7 @@ impl Performance {
         // Queue a new notification task.
         self.pending_notification_observers_task.set(true);
 
-        let global = &self.global();
-        let owner = Trusted::new(&*global.performance(cx));
+        let owner = Trusted::new(self);
         self.global()
             .task_manager()
             .performance_timeline_task_source()
@@ -606,7 +599,7 @@ impl PerformanceMethods<crate::DomTypeHolder> for Performance {
 
         // Step 2. Queue a PerformanceEntry entry.
         // Step 3. Add entry to the performance entry buffer. (This is done in queue_entry itself)
-        self.queue_entry(cx, entry.upcast::<PerformanceEntry>());
+        self.queue_entry(entry.upcast::<PerformanceEntry>());
 
         // Step 4. Return entry.
         Ok(entry)
@@ -776,7 +769,7 @@ impl PerformanceMethods<crate::DomTypeHolder> for Performance {
 
         // Step 10. Queue a PerformanceEntry entry.
         // Step 11. Add entry to the performance entry buffer. (This is done in queue_entry itself)
-        self.queue_entry(cx, entry.upcast::<PerformanceEntry>());
+        self.queue_entry(entry.upcast::<PerformanceEntry>());
 
         // Step 12. Return entry.
         Ok(entry)

--- a/components/script/dom/performance/performanceobserver.rs
+++ b/components/script/dom/performance/performanceobserver.rs
@@ -189,7 +189,6 @@ impl PerformanceObserverMethods<crate::DomTypeHolder> for PerformanceObserver {
             // This may pre-fill buffered entries, and
             // existing types are appended to.
             self.global().performance(cx).add_single_type_observer(
-                cx,
                 self,
                 entry_type,
                 options.buffered.unwrap_or(false),

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1260,7 +1260,7 @@ impl ParserContext {
         self.pushed_entry_index = document
             .global()
             .performance(cx)
-            .queue_entry(cx, performance_entry.upcast::<PerformanceEntry>());
+            .queue_entry(performance_entry.upcast::<PerformanceEntry>());
     }
 }
 

--- a/components/script/network_listener.rs
+++ b/components/script/network_listener.rs
@@ -89,7 +89,7 @@ pub(crate) fn submit_timing_data(
         PerformanceResourceTiming::new(cx, global, url, initiator_type, resource_timing);
     global
         .performance(cx)
-        .queue_entry(cx, performance_entry.upcast::<PerformanceEntry>());
+        .queue_entry(performance_entry.upcast::<PerformanceEntry>());
 }
 
 pub(crate) trait FetchResponseListener: Send + 'static {


### PR DESCRIPTION
In Performance methods, we don't need to obtain a new Performance reference when we already have `&self` available.

Testing: Existing tests suffice.