### PR TITLE
script: Finish JSContextify, remove CanGc and CanGc reflect methods

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -52,7 +52,6 @@ use crate::dom::readablestream::{
 use crate::dom::urlsearchparams::URLSearchParams;
 use crate::mime_multipart::{Node, read_multipart_body};
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::CanGc;
 use crate::task_source::SendableTaskSource;
 
 /// <https://fetch.spec.whatwg.org/#concept-body-clone>
@@ -1064,7 +1063,7 @@ fn run_form_data_algorithm(
             let closing_boundary = format!("--{}--", boundary.as_str()).into_bytes();
             let trimmed_bytes = bytes.strip_suffix(b"\r\n").unwrap_or(&bytes);
             if trimmed_bytes == closing_boundary {
-                let formdata = FormData::new(None, root, CanGc::from_cx(cx));
+                let formdata = FormData::new(cx, None, root);
                 return Ok(FetchedData::FormData(formdata));
             }
         }
@@ -1077,7 +1076,7 @@ fn run_form_data_algorithm(
         // a more detailed parsing specification is to be written. Volunteers welcome.
 
         // Return a new FormData object, appending each entry, resulting from the parsing operation, to its entry list.
-        let formdata = FormData::new(None, root, CanGc::from_cx(cx));
+        let formdata = FormData::new(cx, None, root);
 
         append_multipart_nodes(cx, root, &formdata, nodes)?;
 
@@ -1090,7 +1089,7 @@ fn run_form_data_algorithm(
         //
         // Return a new FormData object whose entry list is entries.
         let entries = form_urlencoded::parse(&bytes);
-        let formdata = FormData::new(None, root, CanGc::from_cx(cx));
+        let formdata = FormData::new(cx, None, root);
         for (k, e) in entries {
             formdata.Append(cx, USVString(k.into_owned()), USVString(e.into_owned()));
         }

--- a/components/script/dom/bluetooth/bluetoothpermissionresult.rs
+++ b/components/script/dom/bluetooth/bluetoothpermissionresult.rs
@@ -59,7 +59,7 @@ impl BluetoothPermissionResult {
     }
 
     pub(crate) fn get_bluetooth(&self, cx: &mut JSContext) -> DomRoot<Bluetooth> {
-        self.global().as_window().Navigator().Bluetooth(cx)
+        self.global().as_window().Navigator(cx).Bluetooth(cx)
     }
 
     pub(crate) fn get_bluetooth_thread(&self) -> GenericSender<BluetoothRequest> {

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -2394,7 +2394,7 @@ impl Document {
         // https://github.com/immersive-web/navigation/issues/10
         #[cfg(feature = "webxr")]
         if pref!(dom_webxr_sessionavailable) && self.window.is_top_level() {
-            self.window.Navigator().Xr(cx).dispatch_sessionavailable();
+            self.window.Navigator(cx).Xr(cx).dispatch_sessionavailable();
         }
     }
 
@@ -4827,7 +4827,7 @@ impl Document {
         #[cfg(feature = "gamepad")]
         if visibility_state == DocumentVisibilityState::Hidden {
             self.window
-                .Navigator()
+                .Navigator(cx)
                 .GetGamepads(cx)
                 .unwrap_or_default()
                 .iter_mut()
@@ -5749,11 +5749,12 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     /// <https://dom.spec.whatwg.org/#dom-document-createtreewalker>
     fn CreateTreeWalker(
         &self,
+        cx: &mut JSContext,
         root: &Node,
         what_to_show: u32,
         filter: Option<Rc<NodeFilter>>,
     ) -> DomRoot<TreeWalker> {
-        TreeWalker::new(self, root, what_to_show, filter)
+        TreeWalker::new(cx, self, root, what_to_show, filter)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#document.title>
@@ -6450,7 +6451,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         let resource_threads = self.window.as_global_scope().resource_threads().clone();
         *self.loader.borrow_mut() =
             DocumentLoader::new_with_threads(resource_threads, Some(self.url()));
-        ServoParser::parse_html_script_input(self, self.url());
+        ServoParser::parse_html_script_input(cx, self, self.url());
 
         // Step 17. Set the insertion point to point at just before the end of the input stream
         // (which at this point will be empty).

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -1730,7 +1730,7 @@ impl DocumentEventHandler {
 
                 // Step 3.1. Let gamepad be a new Gamepad representing the gamepad.
                 // Step 3.2. Let navigator be gamepad's relevant global object's Navigator object.
-                let navigator = window.Navigator();
+                let navigator = window.Navigator(cx);
                 let selected_index = navigator.select_gamepad_index();
                 let gamepad = Gamepad::new(
                     cx,
@@ -1775,7 +1775,7 @@ impl DocumentEventHandler {
             .gamepad_task_source()
             .queue(task!(gamepad_disconnected: move |cx| {
                 let window = trusted_window.root();
-                let navigator = window.Navigator();
+                let navigator = window.Navigator(cx);
 
                 if let Some(gamepad) = navigator.get_gamepad(index) {
                     // Step 2.1. Set gamepad.[[connected]] to false.
@@ -1837,7 +1837,7 @@ impl DocumentEventHandler {
 
         // Step 6. Let navigator be gamepad's relevant global object's
         //         Navigator object.
-        let navigator = self.window.Navigator();
+        let navigator = self.window.Navigator(cx);
 
         if let Some(gamepad) = navigator.get_gamepad(gamepad_index) {
             // Step 2. Set gamepad.[[timestamp]] to now.

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -177,7 +177,6 @@ use crate::dom::validation::Validatable;
 use crate::dom::validitystate::ValidationFlags;
 use crate::layout_dom::ServoDangerousStyleElement;
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 use crate::stylesheet_loader::StylesheetOwner;
 
@@ -698,13 +697,13 @@ impl Element {
         //
         // Step 10. Set shadow’s clonable to clonable
         let shadow_root = ShadowRoot::new(
+            cx,
             self,
             &self.node.owner_doc(),
             mode,
             slot_assignment_mode,
             clonable,
             is_ua_widget,
-            CanGc::from_cx(cx),
         );
 
         // This is not in the specification, but this is where we ensure that the
@@ -2820,7 +2819,7 @@ impl Element {
     pub(crate) fn register_current_id_and_name_attribute(&self, cx: &mut JSContext) {
         if let Some(shadow_root) = self.containing_shadow_root() {
             if let Some(ref id) = *self.id_attribute.borrow() {
-                shadow_root.register_element_id(self, id, CanGc::from_cx(cx));
+                shadow_root.register_element_id(self, id);
             }
         } else {
             let document = self.owner_document();
@@ -2924,9 +2923,9 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     make_setter!(SetSlot, "slot");
 
     /// <https://dom.spec.whatwg.org/#dom-element-attributes>
-    fn Attributes(&self, can_gc: CanGc) -> DomRoot<NamedNodeMap> {
+    fn Attributes(&self, cx: &mut JSContext) -> DomRoot<NamedNodeMap> {
         self.attr_list
-            .or_init(|| NamedNodeMap::new(&self.owner_window(), self, can_gc))
+            .or_init(|| NamedNodeMap::new(cx, &self.owner_window(), self))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-hasattributes>
@@ -4640,11 +4639,7 @@ impl VirtualMethods for Element {
                             }
                             if value != atom!("") {
                                 if let Some(ref shadow_root) = containing_shadow_root {
-                                    shadow_root.register_element_id(
-                                        self,
-                                        &value,
-                                        CanGc::from_cx(cx),
-                                    );
+                                    shadow_root.register_element_id(self, &value);
                                 } else {
                                     doc.register_element_id(cx, self, &value);
                                 }

--- a/components/script/dom/element/namednodemap.rs
+++ b/components/script/dom/element/namednodemap.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use html5ever::LocalName;
 use js::context::{JSContext, NoGC};
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
 use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
@@ -16,7 +16,6 @@ use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::element::Element;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct NamedNodeMap {
@@ -32,8 +31,12 @@ impl NamedNodeMap {
         }
     }
 
-    pub(crate) fn new(window: &Window, elem: &Element, can_gc: CanGc) -> DomRoot<NamedNodeMap> {
-        reflect_dom_object(Box::new(NamedNodeMap::new_inherited(elem)), window, can_gc)
+    pub(crate) fn new(
+        cx: &mut JSContext,
+        window: &Window,
+        elem: &Element,
+    ) -> DomRoot<NamedNodeMap> {
+        reflect_dom_object_with_cx(Box::new(NamedNodeMap::new_inherited(elem)), window, cx)
     }
 }
 

--- a/components/script/dom/form/formdata.rs
+++ b/components/script/dom/form/formdata.rs
@@ -7,7 +7,7 @@ use html5ever::LocalName;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 use servo_constellation_traits::BlobImpl;
 
 use crate::dom::bindings::codegen::Bindings::FormDataBinding::FormDataMethods;
@@ -28,7 +28,6 @@ use crate::dom::html::htmlformelement::{
     FormDatum, FormDatumValue, FormSubmitterElement, HTMLFormElement,
 };
 use crate::dom::html::input_element::HTMLInputElement;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct FormData {
@@ -53,24 +52,24 @@ impl FormData {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         form_datums: Option<Vec<FormDatum>>,
         global: &GlobalScope,
-        can_gc: CanGc,
     ) -> DomRoot<FormData> {
-        Self::new_with_proto(form_datums, global, None, can_gc)
+        Self::new_with_proto(cx, form_datums, global, None)
     }
 
     fn new_with_proto(
+        cx: &mut JSContext,
         form_datums: Option<Vec<FormDatum>>,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<FormData> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(FormData::new_inherited(form_datums)),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 }
@@ -125,22 +124,17 @@ impl FormDataMethods<crate::DomTypeHolder> for FormData {
             // Step 1.2. Let list be the result of constructing the entry list for form and submitter.
             return match opt_form.get_form_dataset(cx, submitter_element, None) {
                 Some(form_datums) => Ok(FormData::new_with_proto(
+                    cx,
                     Some(form_datums),
                     global,
                     proto,
-                    CanGc::from_cx(cx),
                 )),
                 // Step 1.3. If list is null, then throw an "InvalidStateError" DOMException.
                 None => Err(Error::InvalidState(None)),
             };
         }
 
-        Ok(FormData::new_with_proto(
-            None,
-            global,
-            proto,
-            CanGc::from_cx(cx),
-        ))
+        Ok(FormData::new_with_proto(cx, None, global, proto))
     }
 
     /// <https://xhr.spec.whatwg.org/#dom-formdata-append>

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -84,7 +84,6 @@ use crate::dom::types::{DocumentFragment, HTMLIFrameElement};
 use crate::dom::window::Window;
 use crate::links::{LinkRelations, get_element_target, valid_navigable_target_name_or_keyword};
 use crate::navigation::navigate;
-use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
 /// <https://html.spec.whatwg.org/multipage/#the-form-element>
@@ -1343,7 +1342,7 @@ impl HTMLFormElement {
         let window = self.owner_window();
 
         // Step 6
-        let form_data = FormData::new(Some(ret), &window.global(), CanGc::from_cx(cx));
+        let form_data = FormData::new(cx, Some(ret), &window.global());
 
         // Step 7
         let event = FormDataEvent::new(

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -2623,7 +2623,7 @@ impl HTMLMediaElement {
         let window = global.as_window();
 
         // Update the media session metadata title with the obtained metadata.
-        window.Navigator().MediaSession(cx).update_title(
+        window.Navigator(cx).MediaSession(cx).update_title(
             metadata
                 .title
                 .clone()
@@ -2955,7 +2955,7 @@ impl HTMLMediaElement {
 
     fn send_media_session_event(&self, cx: &mut JSContext, event: MediaSessionEvent) {
         let global = self.global();
-        let media_session = global.as_window().Navigator().MediaSession(cx);
+        let media_session = global.as_window().Navigator(cx).MediaSession(cx);
 
         media_session.register_media_instance(self);
 

--- a/components/script/dom/html/htmloptionscollection.rs
+++ b/components/script/dom/html/htmloptionscollection.rs
@@ -7,7 +7,7 @@ use std::cmp::Ordering;
 use dom_struct::dom_struct;
 use html5ever::{QualName, local_name, ns};
 use js::context::{JSContext, NoGC};
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 
 use crate::dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLCollectionBinding::HTMLCollectionMethods;
@@ -27,7 +27,6 @@ use crate::dom::html::htmloptionelement::HTMLOptionElement;
 use crate::dom::html::htmlselectelement::HTMLSelectElement;
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLOptionsCollection {
@@ -45,15 +44,15 @@ impl HTMLOptionsCollection {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         select: &HTMLSelectElement,
         filter: Box<dyn CollectionFilter + 'static>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLOptionsCollection> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(HTMLOptionsCollection::new_inherited(select, filter)),
             window,
-            can_gc,
+            cx,
         )
     }
 

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -48,7 +48,6 @@ use crate::dom::types::FocusEvent;
 use crate::dom::validation::{is_barred_by_datalist_ancestor, Validatable};
 use crate::dom::validitystate::{ValidationFlags, ValidityState};
 use crate::dom::node::virtualmethods::VirtualMethods;
-use crate::script_runtime::CanGc;
 use dom_struct::dom_struct;
 use embedder_traits::{EmbedderControlRequest, SelectElementRequest};
 use embedder_traits::{SelectElementOption, SelectElementOptionOrOptgroup};
@@ -595,7 +594,7 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
         element: HTMLOptionElementOrHTMLOptGroupElement,
         before: Option<HTMLElementOrLong>,
     ) -> ErrorResult {
-        self.Options().Add(cx, element, before)
+        self.Options(cx).Add(cx, element, before)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-fe-disabled
@@ -646,15 +645,10 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     make_labels_getter!(Labels, labels_node_list);
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-options>
-    fn Options(&self) -> DomRoot<HTMLOptionsCollection> {
+    fn Options(&self, cx: &mut JSContext) -> DomRoot<HTMLOptionsCollection> {
         self.options.or_init(|| {
             let window = self.owner_window();
-            HTMLOptionsCollection::new(
-                &window,
-                self,
-                Box::new(OptionsFilter),
-                CanGc::deprecated_note(),
-            )
+            HTMLOptionsCollection::new(cx, &window, self, Box::new(OptionsFilter))
         })
     }
 
@@ -672,23 +666,23 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-length>
-    fn Length(&self, cx: &JSContext) -> u32 {
-        self.Options().Length(cx)
+    fn Length(&self, cx: &mut JSContext) -> u32 {
+        self.Options(cx).Length(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-length>
     fn SetLength(&self, cx: &mut JSContext, length: u32) {
-        self.Options().SetLength(cx, length)
+        self.Options(cx).SetLength(cx, length)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-item>
-    fn Item(&self, cx: &JSContext, index: u32) -> Option<DomRoot<Element>> {
-        self.Options().upcast().Item(cx, index)
+    fn Item(&self, cx: &mut JSContext, index: u32) -> Option<DomRoot<Element>> {
+        self.Options(cx).upcast().Item(cx, index)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-item>
-    fn IndexedGetter(&self, cx: &JSContext, index: u32) -> Option<DomRoot<Element>> {
-        self.Options().IndexedGetter(cx, index)
+    fn IndexedGetter(&self, cx: &mut JSContext, index: u32) -> Option<DomRoot<Element>> {
+        self.Options(cx).IndexedGetter(cx, index)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-setter>
@@ -698,19 +692,19 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
         index: u32,
         value: Option<&HTMLOptionElement>,
     ) -> ErrorResult {
-        self.Options().IndexedSetter(cx, index, value)
+        self.Options(cx).IndexedSetter(cx, index, value)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-nameditem>
-    fn NamedItem(&self, cx: &JSContext, name: DOMString) -> Option<DomRoot<HTMLOptionElement>> {
-        self.Options()
+    fn NamedItem(&self, cx: &mut JSContext, name: DOMString) -> Option<DomRoot<HTMLOptionElement>> {
+        self.Options(cx)
             .NamedGetter(cx, name)
             .and_then(DomRoot::downcast::<HTMLOptionElement>)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-remove>
     fn Remove_(&self, cx: &mut JSContext, index: i32) {
-        self.Options().Remove(cx, index)
+        self.Options(cx).Remove(cx, index)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-remove>

--- a/components/script/dom/navigator/navigator.rs
+++ b/components/script/dom/navigator/navigator.rs
@@ -23,7 +23,7 @@ use net_traits::{FetchMetadata, NetworkError, ResourceFetchTiming};
 use regex::Regex;
 #[cfg(feature = "gamepad")]
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::generic_channel;
 use servo_config::pref;
 use servo_url::ServoUrl;
@@ -68,7 +68,6 @@ use crate::dom::window::Window;
 use crate::dom::xrsystem::XRSystem;
 use crate::fetch::RequestWithGlobalScope;
 use crate::network_listener::{FetchResponseListener, ResourceTimingListener, submit_timing};
-use crate::script_runtime::CanGc;
 
 pub(crate) fn hardware_concurrency() -> u64 {
     static CPUS: LazyLock<u64> = LazyLock::new(|| num_cpus::get().try_into().unwrap_or(1));
@@ -170,8 +169,8 @@ impl Navigator {
         }
     }
 
-    pub(crate) fn new(window: &Window, can_gc: CanGc) -> DomRoot<Navigator> {
-        reflect_dom_object(Box::new(Navigator::new_inherited()), window, can_gc)
+    pub(crate) fn new(cx: &mut JSContext, window: &Window) -> DomRoot<Navigator> {
+        reflect_dom_object_with_cx(Box::new(Navigator::new_inherited()), window, cx)
     }
 
     #[cfg(feature = "webxr")]

--- a/components/script/dom/node/treewalker.rs
+++ b/components/script/dom/node/treewalker.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use script_bindings::script_runtime::temp_cx;
 
 use crate::dom::bindings::callback::ExceptionHandling::Rethrow;
@@ -18,7 +18,6 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::root::{Dom, DomRoot, MutDom};
 use crate::dom::document::Document;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 // https://dom.spec.whatwg.org/#interface-treewalker
 #[dom_struct]
@@ -45,20 +44,21 @@ impl TreeWalker {
     }
 
     pub(crate) fn new_with_filter(
+        cx: &mut JSContext,
         document: &Document,
         root_node: &Node,
         what_to_show: u32,
         filter: Filter,
-        can_gc: CanGc,
     ) -> DomRoot<TreeWalker> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(TreeWalker::new_inherited(root_node, what_to_show, filter)),
             document.window(),
-            can_gc,
+            cx,
         )
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         document: &Document,
         root_node: &Node,
         what_to_show: u32,
@@ -68,13 +68,7 @@ impl TreeWalker {
             None => Filter::None,
             Some(jsfilter) => Filter::Dom(jsfilter),
         };
-        TreeWalker::new_with_filter(
-            document,
-            root_node,
-            what_to_show,
-            filter,
-            CanGc::deprecated_note(),
-        )
+        TreeWalker::new_with_filter(cx, document, root_node, what_to_show, filter)
     }
 }
 

--- a/components/script/dom/screen.rs
+++ b/components/script/dom/screen.rs
@@ -4,14 +4,14 @@
 
 use dom_struct::dom_struct;
 use embedder_traits::{EmbedderMsg, ScreenMetrics};
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use js::context::JSContext;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::generic_channel;
 
 use crate::dom::bindings::codegen::Bindings::ScreenBinding::ScreenMethods;
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct Screen {
@@ -27,8 +27,8 @@ impl Screen {
         }
     }
 
-    pub(crate) fn new(window: &Window, can_gc: CanGc) -> DomRoot<Screen> {
-        reflect_dom_object(Box::new(Screen::new_inherited(window)), window, can_gc)
+    pub(crate) fn new(cx: &mut JSContext, window: &Window) -> DomRoot<Screen> {
+        reflect_dom_object_with_cx(Box::new(Screen::new_inherited(window)), window, cx)
     }
 
     /// Retrives [`ScreenMetrics`] from the embedder.

--- a/components/script/dom/serviceworker/serviceworkerregistration.rs
+++ b/components/script/dom/serviceworker/serviceworkerregistration.rs
@@ -206,7 +206,7 @@ impl ServiceWorkerRegistrationMethods<crate::DomTypeHolder> for ServiceWorkerReg
             promise.resolve_native(cx, &false);
             return promise;
         };
-        let service_worker_container = window.Navigator().ServiceWorker(cx);
+        let service_worker_container = window.Navigator(cx).ServiceWorker(cx);
 
         // Step 3: Let job be the result of running Create Job with unregister,
         // registration’s storage key, registration’s scope url, null, promise,

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -33,7 +33,7 @@ use profile_traits::time::{
 };
 use profile_traits::time_profile;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use script_bindings::script_runtime::temp_cx;
 use script_traits::DocumentActivity;
 use servo_base::id::{PipelineId, WebViewId};
@@ -93,7 +93,7 @@ use crate::dom::types::{HTMLElement, HTMLMediaElement, HTMLOptionElement};
 use crate::navigation::determine_the_origin;
 use crate::network_listener::FetchResponseListener;
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::{CanGc, IntroductionType};
+use crate::script_runtime::IntroductionType;
 use crate::script_thread::ScriptThread;
 
 mod async_html;
@@ -198,6 +198,7 @@ impl ServoParser {
 
         // Step 2. Create an HTML parser parser, associated with document.
         let parser = ServoParser::new(
+            cx,
             document,
             if pref!(dom_servoparser_async_html_tokenizer_enabled) {
                 Tokenizer::AsyncHtml(self::async_html::Tokenizer::new(document, url, None))
@@ -212,7 +213,6 @@ impl ServoParser {
             ParserKind::Normal,
             encoding_hint_from_content_type,
             encoding_of_container_document,
-            CanGc::from_cx(cx),
         );
 
         // Step 3. Place html into the input stream for parser. The encoding confidence is irrelevant.
@@ -292,6 +292,7 @@ impl ServoParser {
         };
 
         let parser = ServoParser::new(
+            cx,
             &document,
             Tokenizer::Html(self::html::Tokenizer::new(
                 &document,
@@ -302,7 +303,6 @@ impl ServoParser {
             ParserKind::Normal,
             None,
             None,
-            CanGc::from_cx(cx),
         );
         parser.parse_complete_string_chunk(cx, String::from(input));
 
@@ -313,8 +313,9 @@ impl ServoParser {
         }
     }
 
-    pub(crate) fn parse_html_script_input(document: &Document, url: ServoUrl) {
+    pub(crate) fn parse_html_script_input(cx: &mut JSContext, document: &Document, url: ServoUrl) {
         let parser = ServoParser::new(
+            cx,
             document,
             if pref!(dom_servoparser_async_html_tokenizer_enabled) {
                 Tokenizer::AsyncHtml(self::async_html::Tokenizer::new(document, url, None))
@@ -329,7 +330,6 @@ impl ServoParser {
             ParserKind::ScriptCreated,
             None,
             None,
-            CanGc::deprecated_note(),
         );
         document.set_current_parser(Some(&parser));
     }
@@ -342,12 +342,12 @@ impl ServoParser {
         encoding_hint_from_content_type: Option<&'static Encoding>,
     ) {
         let parser = ServoParser::new(
+            cx,
             document,
             Tokenizer::Xml(self::xml::Tokenizer::new(document, url)),
             ParserKind::Normal,
             encoding_hint_from_content_type,
             None,
-            CanGc::from_cx(cx),
         );
 
         // Set as the document's current parser and initialize with `input`, if given.
@@ -544,14 +544,14 @@ impl ServoParser {
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new(
+        cx: &mut JSContext,
         document: &Document,
         tokenizer: Tokenizer,
         kind: ParserKind,
         encoding_hint_from_content_type: Option<&'static Encoding>,
         encoding_of_container_document: Option<&'static Encoding>,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(ServoParser::new_inherited(
                 document,
                 tokenizer,
@@ -560,7 +560,7 @@ impl ServoParser {
                 encoding_of_container_document,
             )),
             document.window(),
-            can_gc,
+            cx,
         )
     }
 

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -12,7 +12,7 @@ use js::context::JSContext;
 use js::rust::{HandleValue, MutableHandleValue};
 use script_bindings::cell::{DomRefCell, RefMut};
 use script_bindings::error::{ErrorResult, Fallible};
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use servo_arc::Arc;
 use style::author_styles::AuthorStyles;
 use style::invalidation::element::restyle_hints::RestyleHint;
@@ -60,7 +60,6 @@ use crate::dom::sanitizer::Sanitizer;
 use crate::dom::trustedtypes::trustedhtml::TrustedHTML;
 use crate::dom::types::EventTarget;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 use crate::stylesheet_set::StylesheetSetRef;
 
 /// Whether a shadow root hosts an User Agent widget.
@@ -160,15 +159,15 @@ impl ShadowRoot {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         host: &Element,
         document: &Document,
         mode: ShadowRootMode,
         slot_assignment_mode: SlotAssignmentMode,
         clonable: bool,
         is_user_agent_widget: IsUserAgentWidget,
-        can_gc: CanGc,
     ) -> DomRoot<ShadowRoot> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(ShadowRoot::new_inherited(
                 host,
                 document,
@@ -178,7 +177,7 @@ impl ShadowRoot {
                 is_user_agent_widget,
             )),
             document.window(),
-            can_gc,
+            cx,
         )
     }
 
@@ -300,7 +299,7 @@ impl ShadowRoot {
     }
 
     /// Associate an element present in this shadow tree with the provided id.
-    pub(crate) fn register_element_id(&self, element: &Element, id: &Atom, _can_gc: CanGc) {
+    pub(crate) fn register_element_id(&self, element: &Element, id: &Atom) {
         self.document_fragment.id_map().add(id, element)
     }
 

--- a/components/script/dom/testing/layoutresult.rs
+++ b/components/script/dom/testing/layoutresult.rs
@@ -5,13 +5,12 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::gc::MutableHandleValue;
 use script_bindings::domstring::DOMString;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
 use crate::dom::bindings::codegen::Bindings::ServoTestUtilsBinding::LayoutResultMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::utils::to_frozen_array;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct LayoutResult {
@@ -39,14 +38,14 @@ impl LayoutResult {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         phases: Vec<DOMString>,
         rebuilt_fragment_count: u32,
         restyle_fragment_count: u32,
         only_descendants_changed_count: u32,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(Self::new_inherited(
                 phases,
                 rebuilt_fragment_count,
@@ -54,7 +53,7 @@ impl LayoutResult {
                 only_descendants_changed_count,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 }

--- a/components/script/dom/testing/servotestutils.rs
+++ b/components/script/dom/testing/servotestutils.rs
@@ -12,7 +12,6 @@ use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::domstring::DOMString;
 use script_bindings::reflector::Reflector;
 use script_bindings::root::DomRoot;
-use script_bindings::script_runtime::CanGc;
 use time::Duration;
 
 use crate::dom::bindings::codegen::Bindings::ServoTestUtilsBinding::ServoTestUtilsMethods;
@@ -57,12 +56,12 @@ impl ServoTestUtilsMethods<crate::DomTypeHolder> for ServoTestUtils {
         }
 
         LayoutResult::new(
+            cx,
             global,
             phases,
             statistics.rebuilt_fragment_count,
             statistics.restyle_fragment_count,
             statistics.only_descendants_changed_count,
-            CanGc::from_cx(cx),
         )
     }
 

--- a/components/script/dom/webxr/xrsession.rs
+++ b/components/script/dom/webxr/xrsession.rs
@@ -280,7 +280,7 @@ impl XRSession {
                 // Step 3-4
                 self.global()
                     .as_window()
-                    .Navigator()
+                    .Navigator(cx)
                     .Xr(cx)
                     .end_session(self);
                 // Step 5: We currently do not have any such promises
@@ -916,7 +916,7 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
         self.ended.set(true);
         self.global()
             .as_window()
-            .Navigator()
+            .Navigator(cx)
             .Xr(cx)
             .end_session(self);
         self.session.borrow_mut().end_session();

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -189,7 +189,7 @@ use crate::messaging::{MainThreadScriptMsg, ScriptEventLoopReceiver, ScriptEvent
 use crate::microtask::{Microtask, UserMicrotask};
 use crate::network_listener::{ResourceTimingListener, submit_timing};
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::{CanGc, Runtime};
+use crate::script_runtime::Runtime;
 use crate::script_thread::ScriptThread;
 use crate::script_window_proxies::ScriptWindowProxies;
 use crate::task_manager::TaskManager;
@@ -1550,14 +1550,13 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator>
-    fn Navigator(&self) -> DomRoot<Navigator> {
-        self.navigator
-            .or_init(|| Navigator::new(self, CanGc::deprecated_note()))
+    fn Navigator(&self, cx: &mut JSContext) -> DomRoot<Navigator> {
+        self.navigator.or_init(|| Navigator::new(cx, self))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-clientinformation>
-    fn ClientInformation(&self) -> DomRoot<Navigator> {
-        self.Navigator()
+    fn ClientInformation(&self, cx: &mut JSContext) -> DomRoot<Navigator> {
+        self.Navigator(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-settimeout>
@@ -1731,8 +1730,8 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     window_event_handlers!();
 
     /// <https://developer.mozilla.org/en-US/docs/Web/API/Window/screen>
-    fn Screen(&self, can_gc: CanGc) -> DomRoot<Screen> {
-        self.screen.or_init(|| Screen::new(self, can_gc))
+    fn Screen(&self, cx: &mut JSContext) -> DomRoot<Screen> {
+        self.screen.or_init(|| Screen::new(cx, self))
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-window-visualviewport>

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -1477,8 +1477,6 @@ impl Runnable {
     }
 }
 
-pub(crate) use script_bindings::script_runtime::CanGc;
-
 /// `introductionType` values in SpiderMonkey TransitiveCompileOptions.
 ///
 /// Value definitions are based on the SpiderMonkey Debugger API docs:

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -4290,7 +4290,7 @@ impl ScriptThread {
         action: MediaSessionActionType,
     ) {
         if let Some(window) = self.documents.borrow().find_window(pipeline_id) {
-            let media_session = window.Navigator().MediaSession(cx);
+            let media_session = window.Navigator(cx).MediaSession(cx);
             media_session.handle_action(cx, action);
         } else {
             warn!("No MediaSession for this pipeline ID");

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -239,6 +239,7 @@ DOMInterfaces = {
         'CreateNodeIterator',
         'CreateProcessingInstruction',
         'CreateRange',
+        'CreateTreeWalker',
         'CreateTextNode',
         'Embeds',
         'Evaluate',
@@ -354,6 +355,7 @@ DOMInterfaces = {
         'Animate',
         'Append',
         'AttachShadow',
+        'Attributes',
         'Before',
         'Children',
         'ClassList',
@@ -451,7 +453,6 @@ DOMInterfaces = {
         'ToggleAttribute',
     ],
     'realm': ['RequestFullscreen'],
-    'canGc': ['Attributes'],
     'cx_no_gc': ['GetAssignedSlot'],
 },
 
@@ -826,8 +827,8 @@ DOMInterfaces = {
 },
 
 'HTMLSelectElement': {
-    'cx': ['Add', 'CheckValidity', 'IndexedSetter', 'Remove', 'Remove_', 'ReportValidity', 'SelectedOptions',  'SetCustomValidity', 'SetLength', 'SetSelectedIndex', 'SetValue','Validity', 'ValidationMessage', 'Labels'],
-    'cx_no_gc': ['Length', 'Item', 'NamedItem', 'IndexedGetter', 'SelectedIndex', 'Value'],
+    'cx': ['Add', 'CheckValidity', 'Item', 'IndexedGetter', 'Length', 'IndexedSetter', 'NamedItem', 'Options', 'Remove', 'Remove_', 'ReportValidity', 'SelectedOptions',  'SetCustomValidity', 'SetLength', 'SetSelectedIndex', 'SetValue','Validity', 'ValidationMessage', 'Labels'],
+    'cx_no_gc': [ 'SelectedIndex', 'Value'],
 },
 
 'HTMLSlotElement': {
@@ -926,6 +927,11 @@ DOMInterfaces = {
 'IntersectionObserver': {
     'cx': ['Thresholds']
 },
+
+'LargestContentfulPaint': {
+    'cx': ['LoadTime', 'RenderTime'],
+},
+
 'KeyframeEffect': {
     'cx': ['SetKeyframes']
 },
@@ -1006,7 +1012,8 @@ DOMInterfaces = {
 },
 
 'Navigator': {
-    'cx': ['Bluetooth', 'Credentials', 'Clipboard', 'Geolocation', 'Gpu', 'MimeTypes', 'Languages', 'SendBeacon', 'ServiceWorker', 'Servo', 'Storage', 'Plugins', 'UserActivation', 'WakeLock', 'Xr', 'MediaDevices', 'MediaSession', 'Permissions', 'GetGamepads'],
+    'cx': ['Bluetooth', 'Credentials', 'Clipboard', 'Geolocation', 'Gpu', 'MimeTypes', 'Languages', 'SendBeacon', 'ServiceWorker', 'Servo',
+        'Storage', 'Plugins', 'UserActivation', 'WakeLock', 'Xr', 'MediaDevices', 'MediaSession', 'Permissions', 'GetGamepads'],
 },
 
 'CredentialsContainer': {
@@ -1390,10 +1397,10 @@ DOMInterfaces = {
 },
 
 'Window': {
-    'canGc': ['Screen'],
     'additionalTraits': ['crate::interfaces::WindowHelpers', 'crate::interfaces::HasOrigin'],
     'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'WebdriverCallback', 'GetOpener', 'Fetch'],
     'cx': [
+        'ClientInformation',
         'Close',
         'CookieStore',
         'CustomElements',
@@ -1410,11 +1417,13 @@ DOMInterfaces = {
         'Location',
         'MatchMedia',
         'NamedGetter',
+        'Navigator',
         'Open',
         'Performance',
         'PostMessage',
         'PostMessage_',
         'ReportError',
+        'Screen',
         'Scroll',
         'Scroll_',
         'ScrollBy',
@@ -1567,6 +1576,10 @@ DOMInterfaces = {
 
 'ResizeObserverEntry': {
     'cx': ['BorderBoxSize', 'ContentBoxSize', 'DevicePixelContentBoxSize'],
+},
+
+'VisibilityStateEntry': {
+    'cx': ['StartTime'],
 },
 
 'WebSocket': {

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -123,7 +123,6 @@ pub(crate) mod module {
     #[cfg(feature = "testbinding")]
     pub(crate) use crate::root::{Dom, DomSlice};
     pub(crate) use crate::root::{MaybeUnreflectedDom, Root};
-    pub(crate) use crate::script_runtime::CanGc;
     pub(crate) use crate::utils::{
         DOM_PROTO_UNFORGEABLE_HOLDER_SLOT, DOMClass, DOMJSClass, JSCLASS_DOM_GLOBAL,
         ProtoOrIfaceArray, call_policies, enumerate_global, enumerate_window, exception_to_promise,

--- a/components/script_bindings/reflector.rs
+++ b/components/script_bindings/reflector.rs
@@ -13,7 +13,6 @@ use crate::conversions::DerivedFrom;
 use crate::interfaces::GlobalScopeHelpers;
 use crate::iterable::{Iterable, IterableIterator};
 use crate::root::{Dom, DomRoot, Root};
-use crate::script_runtime::{CanGc, temp_cx};
 use crate::{DomTypes, JSTraceable};
 
 pub trait AssociatedMemorySize: Default {
@@ -255,24 +254,21 @@ pub trait DomObjectIteratorWrap<D: DomTypes>: DomObjectWrap<D> + JSTraceable + I
 
 /// Create the reflector for a new DOM object and yield ownership to the
 /// reflector.
-#[deprecated(note = "Use reflect_dom_object_with_cx")]
-pub fn reflect_dom_object<D, T, U>(obj: Box<T>, global: &U, _can_gc: CanGc) -> DomRoot<T>
+pub fn reflect_dom_object<D, T, U>(cx: &mut JSContext, obj: Box<T>, global: &U) -> DomRoot<T>
 where
     D: DomTypes,
     T: DomObject + DomObjectWrap<D>,
     U: DerivedFrom<D::GlobalScope>,
 {
     let global_scope = global.upcast();
-    let mut cx = unsafe { temp_cx() };
-    unsafe { T::WRAP(&mut cx, global_scope, None, obj) }
+    unsafe { T::WRAP(cx, global_scope, None, obj) }
 }
 
-#[deprecated(note = "Use reflect_dom_object_with_proto_and_cx")]
 pub fn reflect_dom_object_with_proto<D, T, U>(
+    cx: &mut JSContext,
     obj: Box<T>,
     global: &U,
     proto: Option<HandleObject>,
-    _can_gc: CanGc,
 ) -> DomRoot<T>
 where
     D: DomTypes,
@@ -280,12 +276,12 @@ where
     U: DerivedFrom<D::GlobalScope>,
 {
     let global_scope = global.upcast();
-    let mut cx = unsafe { temp_cx() };
-    unsafe { T::WRAP(&mut cx, global_scope, proto, obj) }
+    unsafe { T::WRAP(cx, global_scope, proto, obj) }
 }
 
 /// Create the reflector for a new DOM object and yield ownership to the
 /// reflector.
+/// Deprecated, use `reflect_dom_object` instead.
 pub fn reflect_dom_object_with_cx<D, T, U>(
     obj: Box<T>,
     global: &U,
@@ -302,6 +298,7 @@ where
 
 /// Create the reflector for a new DOM object and yield ownership to the
 /// reflector.
+/// Deprecated, use `reflect_dom_object_with_proto` instead.
 pub fn reflect_dom_object_with_proto_and_cx<D, T, U>(
     obj: Box<T>,
     global: &U,

--- a/components/script_bindings/reflector.rs
+++ b/components/script_bindings/reflector.rs
@@ -255,6 +255,7 @@ pub trait DomObjectIteratorWrap<D: DomTypes>: DomObjectWrap<D> + JSTraceable + I
 
 /// Create the reflector for a new DOM object and yield ownership to the
 /// reflector.
+#[deprecated(note = "Use reflect_dom_object_with_cx")]
 pub fn reflect_dom_object<D, T, U>(obj: Box<T>, global: &U, _can_gc: CanGc) -> DomRoot<T>
 where
     D: DomTypes,
@@ -266,6 +267,7 @@ where
     unsafe { T::WRAP(&mut cx, global_scope, None, obj) }
 }
 
+#[deprecated(note = "Use reflect_dom_object_with_proto_and_cx")]
 pub fn reflect_dom_object_with_proto<D, T, U>(
     obj: Box<T>,
     global: &U,

--- a/components/script_bindings/script_runtime.rs
+++ b/components/script_bindings/script_runtime.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::Cell;
-use std::marker::PhantomData;
 
 use js::context::JSContext;
 use js::jsapi::JS::{HeapState, RuntimeHeapState};
@@ -40,28 +39,4 @@ pub fn mark_runtime_dead() {
 /// As such all it's usages will need to be eventually replaced with proper &mut SafeJSContext references.
 pub unsafe fn temp_cx() -> JSContext {
     unsafe { JSContext::from_ptr(js::rust::Runtime::get().unwrap()) }
-}
-
-#[derive(Clone, Copy, Debug)]
-/// A compile-time marker that there are operations that could trigger a JS garbage collection
-/// operation within the current stack frame. It is trivially copyable, so it should be passed
-/// as a function argument and reused when calling other functions whenever possible. Since it
-/// is only meaningful within the current stack frame, it is impossible to move it to a different
-/// thread or into a task that will execute asynchronously.
-pub struct CanGc(PhantomData<*mut ()>);
-
-impl CanGc {
-    /// Create a new CanGc value, representing that a GC operation is possible within the
-    /// current stack frame.
-    ///
-    /// Deprecrated: do not use. Instead, use [`CanGc::from_cx(cx)`] with a `cx` from a task
-    /// callback or by declaring it in Bindings.conf.
-    pub fn deprecated_note() -> CanGc {
-        CanGc(PhantomData)
-    }
-
-    /// &mut SafeJSContext is always an indication that GC is possible.
-    pub fn from_cx(_cx: &mut JSContext) -> CanGc {
-        CanGc::deprecated_note()
-    }
 }


### PR DESCRIPTION
This is the final part of the work to move to JSContext instead of CanGc. With this we deprecate all remaining usages of CanGc and remove CanGc and the reflect method using CanGc from the codebase.

Notice that ShadowRoot::register_element_id had previously a CanGc argument which seems unnecessary and was removed.

Part of https://github.com/servo/servo/issues/40600

Testing: Compilation is the test.
