### PR TITLE
net: Send proxy credentials on the CONNECT tunnel

### DIFF
--- a/components/net/connector.rs
+++ b/components/net/connector.rs
@@ -645,11 +645,20 @@ impl Service<Destination> for ProxyConnector {
 
     fn call(&mut self, req: Destination) -> Self::Future {
         match self.matcher.intercept(&req) {
-            Some(intercept) => Box::pin(
-                Tunnel::new(intercept.uri().clone(), self.client.clone())
-                    .call(req)
-                    .map_err(|e| ConnectionError::ProxyError(format!("{e}"))),
-            ),
+            Some(intercept) => {
+                let mut tunnel = Tunnel::new(intercept.uri().clone(), self.client.clone());
+                // Forward proxy credentials (user:pass in the proxy URI) as a
+                // Proxy-Authorization header on the CONNECT request; without
+                // this an authenticated proxy rejects the tunnel.
+                if let Some(auth) = intercept.basic_auth() {
+                    tunnel = tunnel.with_auth(auth.clone());
+                }
+                Box::pin(
+                    tunnel
+                        .call(req)
+                        .map_err(|e| ConnectionError::ProxyError(format!("{e}"))),
+                )
+            },
             None => Box::pin(
                 self.client
                     .call(req)


### PR DESCRIPTION
### Problem

When an HTTP/HTTPS proxy is configured with credentials in its URI (`http://user:pass@host:port`), HTTPS requests failed with:

```
hyper_util::client::legacy::Error(Connect, ProxyError("tunnel error: unsuccessful"))
```

The `CONNECT` tunnel for HTTPS was created via `Tunnel::new(uri, ...)` but never sent a `Proxy-Authorization` header, so an authenticated proxy rejected the tunnel and the page did not load. Plain HTTP through the same proxy worked because those requests are not tunneled.

### Fix

The proxy matcher already derives the basic-auth header from the proxy URI (`Intercept::basic_auth()`). Forward it to the `Tunnel` via `with_auth()`, so the `CONNECT` request carries credentials — matching `curl -x` and other HTTP clients.

### Testing

Verified manually against an authenticated upstream HTTP proxy: before the change HTTPS navigation failed with the tunnel error above; after it, HTTPS pages load through the proxy. `curl -x http://user:pass@host:port https://…` succeeds against the same proxy, confirming the proxy itself is healthy and the missing header was the cause.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)