### PR TITLE
ci: Remove unneeded install step

### DIFF
--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -114,9 +114,6 @@ jobs:
         uses: KyleMayes/install-llvm-action@v2
         with:
           version: "17"
-      - name: Install llvm-strip dependency
-        if: ${{ inputs.file-size == true && inputs.profile == 'production' }}
-        run: sudo apt install libncurses5
       - name: File size (llvm stripped)
         if: ${{ inputs.file-size == true && inputs.profile == 'production' }}
         run: |


### PR DESCRIPTION
This fixes a CI failure on main, due to the missing `apt update`. It's unclear why ncurses was installed in the first place,
given the name of the job is install llvm-strip. Removing it seems to work just fine (based on [`./mach try linux-production-bencher`](https://github.com/jschwe/servo/actions/runs/28861232938/job/85606028788))

Testing: Fixes a CI failure, that only occurs on main.
Fixes: #46340
