### PR TITLE
android: Replace `ConstraintLayout` with `LinearLayout`

### DIFF
--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -148,6 +148,5 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.13.0")
     implementation("androidx.compose.material3:material3:1.4.0")
-    implementation("androidx.constraintlayout:constraintlayout:2.1.3")
     implementation("androidx.preference:preference-ktx:1.2.0")
 }

--- a/support/android/apk/servoapp/src/main/res/layout-w600dp/activity_main.xml
+++ b/support/android/apk/servoapp/src/main/res/layout-w600dp/activity_main.xml
@@ -13,15 +13,15 @@
         android:layout_height="wrap_content"
         >
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:gravity="center">
 
             <androidx.compose.ui.platform.ComposeView
                 android:id="@+id/toolbarButtons"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
-                app:layout_constraintStart_toStartOf="parent"
                 />
 
             <EditText
@@ -29,48 +29,37 @@
                 style="@android:style/Widget.Material.EditText"
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
+                android:layout_weight="1"
                 android:autofillHints="url"
                 android:hint="@string/url_or_search"
                 android:imeOptions="actionDone"
                 android:inputType="textUri"
                 android:selectAllOnFocus="true"
                 android:singleLine="true"
-                android:layout_marginEnd="10dp"
-                app:layout_constraintStart_toEndOf="@id/toolbarButtons"
-                app:layout_constraintEnd_toStartOf="@+id/progressbar"
-                app:layout_constraintHorizontal_bias="0.0"
-                tools:layout_editor_absoluteY="0dp" />
+                android:layout_marginEnd="10dp" />
 
             <com.google.android.material.progressindicator.CircularProgressIndicator
                 android:id="@+id/progressbar"
                 android:layout_width="0dp"
-                android:layout_height="22dp"
-                android:layout_marginTop="8dp"
+                android:layout_height="wrap_content"
                 android:layout_marginEnd="10dp"
-                android:layout_weight="0"
                 android:indeterminate="true"
                 android:visibility="gone"
-                app:indicatorSize="20dp"
-                app:layout_constraintEnd_toStartOf="@+id/settings_menu_item"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:indicatorSize="20dp" />
 
             <androidx.compose.ui.platform.ComposeView
                 android:id="@+id/settings_menu_item"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                app:layout_constraintEnd_toStartOf="@id/history_menu_item"
-                app:layout_constraintTop_toTopOf="parent"
                 />
 
             <androidx.compose.ui.platform.ComposeView
                 android:id="@+id/history_menu_item"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
                 />
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
+        </LinearLayout>
     </com.google.android.material.appbar.MaterialToolbar>
 
     <org.servo.servoview.ServoView

--- a/support/android/apk/servoapp/src/main/res/layout/activity_main.xml
+++ b/support/android/apk/servoapp/src/main/res/layout/activity_main.xml
@@ -12,41 +12,35 @@
         android:layout_height="wrap_content"
         >
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="match_parent"
+            android:gravity="center">
 
             <EditText
                 android:id="@+id/urlfield"
                 style="@android:style/Widget.Material.EditText"
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
+                android:layout_weight="1"
                 android:autofillHints="url"
                 android:hint="@string/url_or_search"
                 android:imeOptions="actionDone"
                 android:inputType="textUri"
                 android:selectAllOnFocus="true"
                 android:singleLine="true"
-                android:layout_marginEnd="10dp"
-                app:layout_constraintEnd_toStartOf="@+id/progressbar"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="parent"
-                tools:layout_editor_absoluteY="0dp" />
+                android:layout_marginEnd="10dp" />
 
             <com.google.android.material.progressindicator.CircularProgressIndicator
                 android:id="@+id/progressbar"
                 android:layout_width="0dp"
-                android:layout_height="22dp"
-                android:layout_marginTop="8dp"
+                android:layout_height="match_parent"
                 android:layout_marginEnd="10dp"
-                android:layout_weight="0"
                 android:indeterminate="true"
                 android:visibility="gone"
-                app:indicatorSize="20dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:indicatorSize="20dp" />
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
+        </LinearLayout>
     </com.google.android.material.appbar.MaterialToolbar>
 
     <org.servo.servoview.ServoView


### PR DESCRIPTION
`ConstraintLayout` is great for complex layouts, but in these cases, we're just recreating what a `LinearLayout` does, albeit with a lot more code. Even though we'll be migrating these layouts to Compose UI soon (#45715), it'll be a lot easier to grok what the layouts are trying to do if they are just plain `LinearLayout`s.

Testing: There are no automated tests for Android.