### PR TITLE
layout: Avoid extra tree walks when removing accessibility nodes.

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -371,12 +371,12 @@ impl AccessibilityTree {
 
     /// Consume the [`AccessibilityUpdate`] by deleting all nodes it detected as being removed from
     /// the tree.
-    fn remove_stale_nodes(&mut self, mut update: AccessibilityUpdate) {
+    fn drop_removed_nodes(&mut self, mut update: AccessibilityUpdate) {
         if let Some(rooted_nodes) = std::mem::take(&mut update.rooted_nodes) {
             self.assert_removed_nodes_were_rooted(&update, rooted_nodes);
         }
 
-        for id in update
+        let mut ids_to_remove: Vec<NodeId> = update
             .tree_changes
             .drain()
             .filter_map(|(id, change)| match change {
@@ -386,18 +386,32 @@ impl AccessibilityTree {
                     );
                 },
                 TreeChange::Removed => Some(id),
-                _ => None,
+                TreeChange::New => None,
+                TreeChange::Moved => None,
             })
-        {
-            let _node = self.nodes.remove(&id);
-            {
-                #[cfg(debug_assertions)]
-                assert!(_node.is_some(), "Node for id {id:?} was already removed");
-            }
+            .collect();
+
+        while let Some(id) = ids_to_remove.pop() {
+            update.unresolved_local_damage.remove(&id);
+            let Some(node) = self.nodes.remove(&id) else {
+                panic!("Node for id {id:?} was already removed");
+            };
             if let Some(opaque_node) = self.id_to_opaque_node.remove(&id) {
                 self.opaque_node_to_id.remove(&opaque_node);
             }
+            for child in node.borrow().children() {
+                let child_id = child.borrow().id;
+                if !update.tree_changes.contains_key(&child_id) {
+                    ids_to_remove.push(child_id);
+                }
+            }
         }
+
+        debug_assert!(
+            update.unresolved_local_damage.is_empty(),
+            "Damage not empty: {:?}",
+            update.unresolved_local_damage
+        );
 
         if self
             .debug
@@ -576,31 +590,6 @@ impl AccessibilityNode {
         local_damage
     }
 
-    /// Recursively mark this subtree as having the given `TreeChange`.
-    ///
-    /// This is used when a node is `Moved` or `Removed`, since its entire subtree will also need to
-    /// be marked accordingly. When a node is `New`, it's marked as such when it is created. We
-    /// shouldn't call this method in that case, since it may have descendants which are not being
-    /// created in this update and shouldn't have a `New` state. Any descendants which are new will
-    /// already have their `New` state set when they are created.
-    ///
-    /// Note: if a node is moved, the requested `change` must always be `Moved(Pending)`: the logic
-    /// in this method will determine whether the move is `Complete` and set the stored value
-    /// accordingly.
-    fn set_subtree_state_change(&self, change: TreeChange, update: &mut AccessibilityUpdate) {
-        assert!(
-            change != TreeChange::New,
-            "New shouldn't be set recursively"
-        );
-
-        update.set_tree_state_change(self.id, change);
-
-        for child in self.children().iter() {
-            // `new_change` might be different per node, if only some nodes were moved elsewhere.
-            child.borrow().set_subtree_state_change(change, update);
-        }
-    }
-
     /// Update this node's properties from its corresponding DOM node.
     fn update_node_from_dom_node(
         &mut self,
@@ -714,7 +703,7 @@ impl AccessibilityNode {
         for (old_id, old_child) in old_child_ids.iter().zip(self.children().iter()) {
             if !new_child_ids.contains(old_id) {
                 let mut removed_child = old_child.borrow_mut();
-                removed_child.set_subtree_state_change(TreeChange::Removed, update);
+                update.set_tree_state_change(*old_id, TreeChange::Removed);
                 if let Some(parent_node) = removed_child.parent_node.clone() &&
                     parent_node.ptr_eq(&weak_self)
                 {
@@ -728,7 +717,7 @@ impl AccessibilityNode {
                 let mut new_child = new_child.borrow_mut();
                 new_child.parent_node = Some(weak_self.clone());
                 if !update.is_new(new_id) {
-                    new_child.set_subtree_state_change(TreeChange::PendingMove, update);
+                    update.set_tree_state_change(*new_id, TreeChange::PendingMove);
                 }
             }
         }
@@ -897,30 +886,25 @@ impl AccessibilityUpdate {
             .borrow()
             .id;
 
-        debug_assert!(self.unresolved_local_damage.is_empty());
-
         if self.changed_nodes.is_empty() {
             assert!(self.tree_changes.is_empty());
             return None;
         }
 
+        let changed_nodes = std::mem::take(&mut self.changed_nodes);
+        tree.drop_removed_nodes(self);
+
         let accesskit_tree = accesskit::Tree::new(root_node_id);
         let tree_update = accesskit::TreeUpdate {
-            nodes: std::mem::take(&mut self.changed_nodes)
+            // Filter out any nodes which were both changed and removed.
+            nodes: changed_nodes
                 .into_iter()
-                .map(|id| {
-                    (
-                        id,
-                        tree.assert_node_for_id(&id).borrow().accesskit_node.clone(),
-                    )
-                })
+                .filter_map(|id| Some((id, tree.node_for_id(id)?.borrow().accesskit_node.clone())))
                 .collect(),
             tree: Some(accesskit_tree),
             focus: NodeId(1),
             tree_id: tree.tree_id,
         };
-
-        tree.remove_stale_nodes(self);
 
         Some(tree_update)
     }

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -376,7 +376,7 @@ impl AccessibilityTree {
             self.assert_removed_nodes_were_rooted(&update, rooted_nodes);
         }
 
-        let mut ids_to_remove: Vec<NodeId> = update
+        let mut ids_to_remove: Vec<_> = update
             .tree_changes
             .drain()
             .filter_map(|(id, change)| match change {
@@ -403,7 +403,7 @@ impl AccessibilityTree {
         }
 
         // We should have resolved all damage in nodes still in the tree by this point, and any
-        // nodes not in the tree should have been removed from this map in the loop  above.
+        // nodes not in the tree should have been removed from this map in the loop above.
         assert!(
             update.unresolved_local_damage.is_empty(),
             "Damage not empty: {:?}",

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -399,15 +399,12 @@ impl AccessibilityTree {
             if let Some(opaque_node) = self.id_to_opaque_node.remove(&id) {
                 self.opaque_node_to_id.remove(&opaque_node);
             }
-            for child in node.borrow().children() {
-                let child_id = child.borrow().id;
-                if !update.tree_changes.contains_key(&child_id) {
-                    ids_to_remove.push(child_id);
-                }
-            }
+            ids_to_remove.extend(node.borrow().child_ids());
         }
 
-        debug_assert!(
+        // We should have resolved all damage in nodes still in the tree by this point, and any
+        // nodes not in the tree should have been removed from this map in the loop  above.
+        assert!(
             update.unresolved_local_damage.is_empty(),
             "Damage not empty: {:?}",
             update.unresolved_local_damage
@@ -888,6 +885,7 @@ impl AccessibilityUpdate {
 
         if self.changed_nodes.is_empty() {
             assert!(self.tree_changes.is_empty());
+            assert!(self.unresolved_local_damage.is_empty());
             return None;
         }
 

--- a/components/script/dom/document/accessibility_data.rs
+++ b/components/script/dom/document/accessibility_data.rs
@@ -16,7 +16,7 @@ use crate::dom::bindings::trace::NoTrace;
 #[derive(Clone, Default, JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct AccessibilityData {
-    /// Nodes which have been unbound from the DOM but may not yet have been removed from the
+    /// Nodes which have been removed from the DOM but may not yet have been removed from the
     /// accessibility tree. This is cleared after each reflow.
     rooted_nodes: FxHashSet<Dom<Node>>,
 
@@ -44,6 +44,9 @@ impl AccessibilityData {
     ///   it's kept alive by strong references in its parent, child and/or sibling [`Node`]s (and in
     ///   the case of the document itself, by a strong reference in the [`Window`]). See
     ///   [`Node::first_child`], [`Node::next_sibling`], etc.
+    ///    - Note that this means we only need to root nodes which are removed from the document,
+    ///      and not their descendants, as descendant nodes will still be rooted via these
+    ///      properties as long as the subtree root is stored here.
     /// - After a node is removed from the tree, those strong references are removed, and it _may_
     ///   become a candidate for GC if its DOM object isn't held (directly or indirectly) in script
     ///   and it isn't immediately inserted elsewhere in the DOM.

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -452,6 +452,14 @@ impl Node {
                 }
             }
         }
+
+        // Make sure the node and its subtree aren't GCed until the accessibility tree has had a
+        // chance to remove them.
+        if root.owner_document().accessibility_active() {
+            root.owner_document()
+                .accessibility_data_mut()
+                .root_removed_node(cx.no_gc(), root);
+        }
     }
 
     pub(crate) fn complete_move_subtree(cx: &mut JSContext, root: &Node) {
@@ -4264,12 +4272,6 @@ impl VirtualMethods for Node {
             !weak_ranges.is_empty()
         {
             weak_ranges.drain_to_parent(context.parent, context.index(), self);
-        }
-
-        if self.owner_document().accessibility_active() {
-            self.owner_document()
-                .accessibility_data_mut()
-                .root_removed_node(cx.no_gc(), self);
         }
     }
 

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -395,6 +395,64 @@ fn test_accessibility_text_change() {
     );
 }
 
+#[test]
+fn test_accessibility_partial_subtree_move_and_delete() {
+    let url = "data:text/html,<!DOCTYPE html>\
+               <div id='div1'>\
+                 <div id='div2'>\
+                   <h1 id='h1'>This is an h1</h1>\
+                   <p id='p'>This is a paragraph</p>\
+                 </div>\
+               </div>\
+               <div id='div3'><h2 id='h2'>This is an h2</h2></div>";
+    let (servo_test, delegate, webview, mut tree) = build_webview_and_tree(url);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let children: Vec<accesskit_consumer::Node> = root.children().collect();
+    assert_eq!(children.len(), 2);
+    let div1 = children[0];
+    assert_eq!(div1.role(), Role::GenericContainer);
+    let h1 = find_all_matching_nodes(div1, |node| node.role() == Role::Heading)[0];
+    assert_eq!(h1.label(), Some("This is an h1".to_owned()));
+    let _p = find_all_matching_nodes(div1, |node| node.role() == Role::Paragraph)
+        .pop()
+        .expect("Should be exactly one Paragraph node");
+
+    let div2 = children[1];
+    assert_eq!(div2.role(), Role::GenericContainer);
+    let h2 = find_all_matching_nodes(div2, |node| node.role() == Role::Heading)[0];
+    assert_eq!(h2.label(), Some("This is an h2".to_owned()));
+
+    let _ = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "div3.moveBefore(div2, h2);\
+         div3.moveBefore(h1, div2);\
+         p.remove();\
+         div1.remove();\
+         window.ServoTestUtils.forceAccessibilityUpdate();",
+    );
+    let mut updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
+    assert_eq!(updates.len(), 1);
+    let update = updates.pop().expect("Guaranteed by assert above");
+    tree.update_and_process_changes(update, &mut NoOpChangeHandler);
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let children: Vec<accesskit_consumer::Node> = root.children().collect();
+    assert_eq!(children.len(), 1);
+    let div2 = children[0];
+    assert_eq!(div2.role(), Role::GenericContainer);
+    let children: Vec<accesskit_consumer::Node> = div2.children().collect();
+    assert_eq!(children.len(), 3);
+    let h1 = children[0];
+    assert_eq!(h1.role(), Role::Heading);
+    assert_eq!(h1.label(), Some("This is an h1".to_owned()));
+    let div2 = children[1];
+    assert_eq!(div2.role(), Role::GenericContainer);
+    let h2 = children[2];
+    assert_eq!(h2.role(), Role::Heading);
+    assert_eq!(h2.label(), Some("This is an h2".to_owned()));
+}
+
 fn build_test() -> ServoTest {
     let servo_test = ServoTest::new_with_builder(|builder| {
         let mut preferences = Preferences::default();


### PR DESCRIPTION
Instead of setting the TreeChange for each node in a removed subtree, just set the TreeChange for the subtree root.

Also only root the subtree root in AccessibilityData.

Testing: Adds a new test with more involved sequences of moving and removing nodes.
Fixes: #46347