### PR TITLE
script: Don't store rooted values inside `ElementInternals` and `FormData`

### DIFF
--- a/components/script/dom/elementinternals.rs
+++ b/components/script/dom/elementinternals.rs
@@ -30,8 +30,9 @@ use crate::dom::validation::{Validatable, is_barred_by_datalist_ancestor};
 use crate::dom::validitystate::{ValidationFlags, ValidityState};
 
 #[derive(Clone, JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, expect(crown::unrooted_must_root))]
 enum SubmissionValue {
-    File(DomRoot<File>),
+    File(Dom<File>),
     FormData(Vec<FormDatum>),
     USVString(USVString),
     None,
@@ -42,7 +43,7 @@ impl From<Option<&FileOrUSVStringOrFormData>> for SubmissionValue {
         match value {
             None => SubmissionValue::None,
             Some(FileOrUSVStringOrFormData::File(file)) => {
-                SubmissionValue::File(DomRoot::from_ref(file))
+                SubmissionValue::File(Dom::from_ref(file))
             },
             Some(FileOrUSVStringOrFormData::USVString(usv_string)) => {
                 SubmissionValue::USVString(usv_string.clone())

--- a/components/script/dom/elementinternals.rs
+++ b/components/script/dom/elementinternals.rs
@@ -22,18 +22,20 @@ use crate::dom::customstateset::CustomStateSet;
 use crate::dom::element::Element;
 use crate::dom::file::File;
 use crate::dom::html::htmlelement::HTMLElement;
-use crate::dom::html::htmlformelement::{FormDatum, FormDatumValue, HTMLFormElement};
+use crate::dom::html::htmlformelement::{
+    FormDatum, FormDatumUnrooted, FormDatumValue, HTMLFormElement,
+};
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::nodelist::NodeList;
 use crate::dom::shadowroot::ShadowRoot;
 use crate::dom::validation::{Validatable, is_barred_by_datalist_ancestor};
 use crate::dom::validitystate::{ValidationFlags, ValidityState};
 
-#[derive(Clone, JSTraceable, MallocSizeOf)]
-#[cfg_attr(crown, expect(crown::unrooted_must_root))]
+#[derive(JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 enum SubmissionValue {
     File(Dom<File>),
-    FormData(Vec<FormDatum>),
+    FormData(Vec<FormDatumUnrooted>),
     USVString(USVString),
     None,
 }
@@ -48,9 +50,13 @@ impl From<Option<&FileOrUSVStringOrFormData>> for SubmissionValue {
             Some(FileOrUSVStringOrFormData::USVString(usv_string)) => {
                 SubmissionValue::USVString(usv_string.clone())
             },
-            Some(FileOrUSVStringOrFormData::FormData(form_data)) => {
-                SubmissionValue::FormData(form_data.datums())
-            },
+            Some(FileOrUSVStringOrFormData::FormData(form_data)) => SubmissionValue::FormData(
+                form_data
+                    .datums()
+                    .into_iter()
+                    .map(|data| data.into())
+                    .collect(),
+            ),
         }
     }
 }
@@ -115,14 +121,6 @@ impl ElementInternals {
         *self.custom_validity_error_message.borrow_mut() = message;
     }
 
-    fn set_submission_value(&self, value: SubmissionValue) {
-        *self.submission_value.borrow_mut() = value;
-    }
-
-    fn set_state(&self, value: SubmissionValue) {
-        *self.state.borrow_mut() = value;
-    }
-
     pub(crate) fn set_form_owner(&self, form: Option<&HTMLFormElement>) {
         self.form_owner.set(form);
     }
@@ -155,7 +153,7 @@ impl ElementInternals {
         }
 
         if let SubmissionValue::FormData(datums) = &*self.submission_value.borrow() {
-            entry_list.extend(datums.iter().cloned());
+            entry_list.extend(datums.iter().map(|data| data.root()));
             return;
         }
         let name = self
@@ -232,13 +230,13 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
         }
 
         // Step 3: Set target element's submission value
-        self.set_submission_value(value.as_ref().into());
+        *self.submission_value.borrow_mut() = value.as_ref().into();
 
         match maybe_state {
             // Step 4: If the state argument of the function is omitted, set element's state to its submission value
-            None => self.set_state(value.as_ref().into()),
+            None => *self.state.borrow_mut() = value.as_ref().into(),
             // Steps 5-6: Otherwise, set element's state to state
-            Some(state) => self.set_state(state.as_ref().into()),
+            Some(state) => *self.state.borrow_mut() = state.as_ref().into(),
         }
         Ok(())
     }

--- a/components/script/dom/form/formdata.rs
+++ b/components/script/dom/form/formdata.rs
@@ -25,29 +25,27 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlbuttonelement::HTMLButtonElement;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmlformelement::{
-    FormDatum, FormDatumValue, FormSubmitterElement, HTMLFormElement,
+    FormDatum, FormDatumUnrooted, FormDatumValueUnrooted, FormSubmitterElement, HTMLFormElement,
 };
 use crate::dom::html::input_element::HTMLInputElement;
 
 #[dom_struct]
 pub(crate) struct FormData {
     reflector_: Reflector,
-    data: DomRefCell<Vec<(NoTrace<LocalName>, FormDatum)>>,
+    data: DomRefCell<Vec<(NoTrace<LocalName>, FormDatumUnrooted)>>,
 }
 
 impl FormData {
     fn new_inherited(form_datums: Option<Vec<FormDatum>>) -> FormData {
-        let data = match form_datums {
-            Some(data) => data
-                .iter()
-                .map(|datum| (NoTrace(LocalName::from(&datum.name)), datum.clone()))
-                .collect::<Vec<(NoTrace<LocalName>, FormDatum)>>(),
-            None => Vec::new(),
-        };
-
         FormData {
             reflector_: Reflector::new(),
-            data: DomRefCell::new(data),
+            data: DomRefCell::new(
+                form_datums
+                    .into_iter()
+                    .flatten()
+                    .map(|datum| (NoTrace(LocalName::from(&datum.name)), datum.into()))
+                    .collect::<Vec<(NoTrace<LocalName>, FormDatumUnrooted)>>(),
+            ),
         }
     }
 
@@ -140,15 +138,14 @@ impl FormDataMethods<crate::DomTypeHolder> for FormData {
     /// <https://xhr.spec.whatwg.org/#dom-formdata-append>
     // As [`Append_`] needs &mut JSContext, we also need to have it for [`Append`]
     fn Append(&self, _cx: &mut JSContext, name: USVString, str_value: USVString) {
-        let datum = FormDatum {
-            ty: DOMString::from("string"),
-            name: DOMString::from(name.0.clone()),
-            value: FormDatumValue::String(DOMString::from(str_value.0)),
-        };
-
-        self.data
-            .borrow_mut()
-            .push((NoTrace(LocalName::from(name.0)), datum));
+        self.data.borrow_mut().push((
+            NoTrace(LocalName::from(name.0.clone())),
+            FormDatumUnrooted {
+                ty: DOMString::from("string"),
+                name: DOMString::from(name.0),
+                value: FormDatumValueUnrooted::String(DOMString::from(str_value.0)),
+            },
+        ));
     }
 
     /// <https://xhr.spec.whatwg.org/#dom-formdata-append>
@@ -159,17 +156,16 @@ impl FormDataMethods<crate::DomTypeHolder> for FormData {
         blob: &Blob,
         filename: Option<USVString>,
     ) {
-        let datum = FormDatum {
-            ty: DOMString::from("file"),
-            name: DOMString::from(name.0.clone()),
-            value: FormDatumValue::File(DomRoot::from_ref(
-                &*self.create_an_entry(cx, blob, filename),
-            )),
-        };
+        let file = self.create_an_entry(cx, blob, filename);
 
-        self.data
-            .borrow_mut()
-            .push((NoTrace(LocalName::from(name.0)), datum));
+        self.data.borrow_mut().push((
+            NoTrace(LocalName::from(name.0.clone())),
+            FormDatumUnrooted {
+                ty: DOMString::from("file"),
+                name: DOMString::from(name.0),
+                value: FormDatumValueUnrooted::File(file.as_traced()),
+            },
+        ));
     }
 
     /// <https://xhr.spec.whatwg.org/#dom-formdata-delete>
@@ -186,8 +182,10 @@ impl FormDataMethods<crate::DomTypeHolder> for FormData {
             .iter()
             .find(|(datum_name, _)| datum_name.0 == name.0)
             .map(|(_, datum)| match &datum.value {
-                FormDatumValue::String(s) => FileOrUSVString::USVString(USVString(s.to_string())),
-                FormDatumValue::File(b) => FileOrUSVString::File(DomRoot::from_ref(b)),
+                FormDatumValueUnrooted::String(s) => {
+                    FileOrUSVString::USVString(USVString(s.to_string()))
+                },
+                FormDatumValueUnrooted::File(b) => FileOrUSVString::File(DomRoot::from_ref(b)),
             })
     }
 
@@ -202,10 +200,10 @@ impl FormDataMethods<crate::DomTypeHolder> for FormData {
                 }
 
                 Some(match &datum.value {
-                    FormDatumValue::String(s) => {
+                    FormDatumValueUnrooted::String(s) => {
                         FileOrUSVString::USVString(USVString(s.to_string()))
                     },
-                    FormDatumValue::File(b) => FileOrUSVString::File(DomRoot::from_ref(b)),
+                    FormDatumValueUnrooted::File(b) => FileOrUSVString::File(DomRoot::from_ref(b)),
                 })
             })
             .collect()
@@ -228,10 +226,10 @@ impl FormDataMethods<crate::DomTypeHolder> for FormData {
 
         data.push((
             NoTrace(local_name),
-            FormDatum {
+            FormDatumUnrooted {
                 ty: DOMString::from("string"),
                 name: DOMString::from(name.0),
-                value: FormDatumValue::String(DOMString::from(str_value.0)),
+                value: FormDatumValueUnrooted::String(DOMString::from(str_value.0)),
             },
         ));
     }
@@ -247,10 +245,10 @@ impl FormDataMethods<crate::DomTypeHolder> for FormData {
 
         data.push((
             NoTrace(LocalName::from(name.0.clone())),
-            FormDatum {
+            FormDatumUnrooted {
                 ty: DOMString::from("file"),
                 name: DOMString::from(name.0),
-                value: FormDatumValue::File(file),
+                value: FormDatumValueUnrooted::File(file.as_traced()),
             },
         ));
     }
@@ -294,7 +292,7 @@ impl FormData {
         self.data
             .borrow()
             .iter()
-            .map(|(_, datum)| datum.clone())
+            .map(|(_, datum)| datum.root())
             .collect()
     }
 }
@@ -311,8 +309,10 @@ impl Iterable for FormData {
         let data = self.data.borrow();
         let datum = &data.get(n as usize).unwrap().1;
         match &datum.value {
-            FormDatumValue::String(s) => FileOrUSVString::USVString(USVString(s.to_string())),
-            FormDatumValue::File(b) => FileOrUSVString::File(DomRoot::from_ref(b)),
+            FormDatumValueUnrooted::String(s) => {
+                FileOrUSVString::USVString(USVString(s.to_string()))
+            },
+            FormDatumValueUnrooted::File(b) => FileOrUSVString::File(DomRoot::from_ref(b)),
         }
     }
 

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -1481,13 +1481,54 @@ impl Element {
     }
 }
 
-#[derive(Clone, JSTraceable, MallocSizeOf)]
+#[derive(JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
+pub(crate) enum FormDatumValueUnrooted {
+    File(Dom<File>),
+    String(DOMString),
+}
+
+#[derive(JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
+pub(crate) struct FormDatumUnrooted {
+    pub(crate) ty: DOMString,
+    pub(crate) name: DOMString,
+    pub(crate) value: FormDatumValueUnrooted,
+}
+
+impl FormDatumUnrooted {
+    pub(crate) fn root(&self) -> FormDatum {
+        FormDatum {
+            ty: self.ty.clone(),
+            name: self.name.clone(),
+            value: match &self.value {
+                FormDatumValueUnrooted::File(file) => FormDatumValue::File(file.as_rooted()),
+                FormDatumValueUnrooted::String(s) => FormDatumValue::String(s.clone()),
+            },
+        }
+    }
+}
+
+impl From<FormDatum> for FormDatumUnrooted {
+    fn from(value: FormDatum) -> Self {
+        Self {
+            ty: value.ty,
+            name: value.name,
+            value: match value.value {
+                FormDatumValue::File(file) => FormDatumValueUnrooted::File(file.as_traced()),
+                FormDatumValue::String(s) => FormDatumValueUnrooted::String(s),
+            },
+        }
+    }
+}
+
+#[derive(JSTraceable, MallocSizeOf)]
 pub(crate) enum FormDatumValue {
     File(DomRoot<File>),
     String(DOMString),
 }
 
-#[derive(Clone, JSTraceable, MallocSizeOf)]
+#[derive(JSTraceable, MallocSizeOf)]
 pub(crate) struct FormDatum {
     pub(crate) ty: DOMString,
     pub(crate) name: DOMString,


### PR DESCRIPTION
Both `ElementInternals` and `FormData` could potentially own rooted values, to fix this, an unrooted variant was added.

Testing: It compiles
Part of #39139
