### PR TITLE
script: Throw meaningful exception for Element.matches.

### DIFF
--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -3859,7 +3859,11 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
             &selectors.str(),
             &UrlExtraData(url.get_arc()),
         ) {
-            Err(_) => return Err(Error::Syntax(None)),
+            Err(_) => {
+                return Err(Error::Syntax(
+                    format!("'{selectors}' is not a valid selector").into(),
+                ));
+            },
             Ok(selectors) => selectors,
         };
 


### PR DESCRIPTION
This matches the output of Firefox: https://searchfox.org/firefox-main/rev/76725a83d79957b14072bde359520e8de4c58c74/dom/base/nsINode.cpp#3777-3781 . This makes diagnosing problems with sites like https://wordgard.net/try/ much easier.

Testing: No testing policy for the content of error messages.
Part of #40756