### PR TITLE
android: Remove needless key interceptors in `MainActivity`

### DIFF
--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
@@ -12,7 +12,6 @@ import android.os.Bundle
 import android.system.ErrnoException
 import android.system.Os
 import android.util.Log
-import android.view.KeyEvent
 import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
@@ -39,7 +38,6 @@ class MainActivity : AppCompatActivity(), Servo.Client {
     private lateinit var servoView: ServoView
 
     private lateinit var urlField: EditText
-    private var urlFieldIsFocused = false
 
     private lateinit var progressBar: CircularProgressIndicator
     private var canGoBackState = mutableStateOf(false)
@@ -237,11 +235,8 @@ class MainActivity : AppCompatActivity(), Servo.Client {
             }
         }
         urlField.setOnFocusChangeListener { v, hasFocus ->
-            if (v.id == R.id.urlfield) {
-                urlFieldIsFocused = hasFocus
-                if (!hasFocus) {
-                    getSystemService<InputMethodManager>()?.hideSoftInputFromWindow(v.windowToken, 0)
-                }
+            if (v.id == R.id.urlfield && !hasFocus) {
+                getSystemService<InputMethodManager>()?.hideSoftInputFromWindow(v.windowToken, 0)
             }
         }
     }
@@ -256,20 +251,6 @@ class MainActivity : AppCompatActivity(), Servo.Client {
 
     override fun onImeHide() {
         getSystemService<InputMethodManager>()?.hideSoftInputFromWindow(servoView.windowToken, InputMethodManager.SHOW_IMPLICIT)
-    }
-
-    override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
-        if (urlFieldIsFocused) {
-            return true
-        }
-        return servoView.onKeyDown(keyCode, event)
-    }
-
-    override fun onKeyUp(keyCode: Int, event: KeyEvent?): Boolean {
-        if (urlFieldIsFocused) {
-            return true
-        }
-        return servoView.onKeyUp(keyCode, event)
     }
 
     override fun onAlert(message: String?) {


### PR DESCRIPTION
Per [the docs for `onKeyDown`](https://developer.android.com/reference/kotlin/android/app/Activity#onkeydown) (the docs for `onKeyUp` are similar and the following emphasis is mine):

> Called when a key was pressed down **and not handled by any of the views inside of the activity**.

We have two views that can take user input: the URL field and the Servo view.

- The URL field handles its own key presses, so the `MainActivity`'s `onKey[Down|Up]` function will never be triggered.
- The Servo view also handles its own key presses in `ServoView#onKey[Down|Up]`, so the `MainActivity`'s `onKey[Down|Up]` function will also never be triggered.

If we for some reason have a third view in the future that takes user input but doesn't handle it itself, it'd be surprising if these were all passed to `ServoView` (as they currently would be).

Testing: There are no automated tests for Android.