### PR TITLE
script: Cleanup codegen after JSContext migration

### DIFF
--- a/components/script/dom/promise/promise.rs
+++ b/components/script/dom/promise/promise.rs
@@ -133,8 +133,6 @@ impl Promise {
     }
 
     #[expect(unsafe_code)]
-    // The apparently-unused CanGc parameter reflects the fact that the JS API calls
-    // like JS_NewFunction can trigger a GC.
     fn create_js_promise(cx: &mut JSContext, mut obj: MutableHandleObject) {
         unsafe {
             let do_nothing_func = JS_NewFunction(

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -294,7 +294,6 @@ DOMInterfaces = {
     'cx': [
         'Append',
         'Children',
-        'Constructor',
         'MoveBefore',
         'Prepend',
         'QuerySelector',
@@ -394,62 +393,12 @@ DOMInterfaces = {
         'ScrollTo',
         'ScrollTo_',
         'Scroll_',
-        'SetAriaAtomic',
-        'SetAriaAutoComplete',
-        'SetAriaBrailleLabel',
-        'SetAriaBrailleRoleDescription',
-        'SetAriaBusy',
-        'SetAriaChecked',
-        'SetAriaColCount',
-        'SetAriaColIndex',
-        'SetAriaColIndexText',
-        'SetAriaColSpan',
-        'SetAriaCurrent',
-        'SetAriaDescription',
-        'SetAriaDisabled',
-        'SetAriaExpanded',
-        'SetAriaHasPopup',
-        'SetAriaHidden',
-        'SetAriaInvalid',
-        'SetAriaKeyShortcuts',
-        'SetAriaLabel',
-        'SetAriaLevel',
-        'SetAriaLive',
-        'SetAriaModal',
-        'SetAriaMultiLine',
-        'SetAriaMultiSelectable',
-        'SetAriaOrientation',
-        'SetAriaPlaceholder',
-        'SetAriaPosInSet',
-        'SetAriaPressed',
-        'SetAriaReadOnly',
-        'SetAriaRelevant',
-        'SetAriaRequired',
-        'SetAriaRoleDescription',
-        'SetAriaRowCount',
-        'SetAriaRowIndex',
-        'SetAriaRowIndexText',
-        'SetAriaRowSpan',
-        'SetAriaSelected',
-        'SetAriaSetSize',
-        'SetAriaSort',
-        'SetAriaValueMax',
-        'SetAriaValueMin',
-        'SetAriaValueNow',
-        'SetAriaValueText',
         'SetAttribute',
         'SetAttributeNS',
         'SetAttributeNode',
         'SetAttributeNodeNS',
-        'SetClassName',
         'SetHTML',
         'SetHTMLUnsafe',
-        'SetId',
-        'SetInnerHTML',
-        'SetOuterHTML',
-        'SetRole',
-        'SetScrollLeft',
-        'SetScrollTop',
         'ToggleAttribute',
     ],
     'realm': ['RequestFullscreen'],
@@ -659,12 +608,10 @@ DOMInterfaces = {
 
 "HTMLAnchorElement": {
     "cx": ['RelList'],
-    'implicitCxSetters': True,
 },
 
 "HTMLAreaElement": {
     "cx": ['RelList'],
-    'implicitCxSetters': True,
 },
 
 "HTMLAudioElement": {
@@ -672,13 +619,8 @@ DOMInterfaces = {
     'weakReferenceable': True,
 },
 
-"HTMLBodyElement": {
-    'implicitCxSetters': True,
-},
-
 'HTMLButtonElement': {
     'cx': ['CheckValidity', 'ReportValidity', 'SetCustomValidity', 'Validity', 'ValidationMessage', 'Labels'],
-    'implicitCxSetters': True,
 },
 
 'HTMLCollection': {
@@ -687,7 +629,6 @@ DOMInterfaces = {
 
 'HTMLCanvasElement': {
     'cx': ['CaptureStream', 'GetContext', 'TransferControlToOffscreen'],
-    'implicitCxSetters': True,
     'weakReferenceable': True,
 },
 
@@ -718,15 +659,10 @@ DOMInterfaces = {
         'GetOnscroll',
         'Style',
     ],
-    'implicitCxSetters': True,
 },
 
 'HTMLFieldSetElement': {
     'cx': ['CheckValidity', 'Elements', 'ReportValidity', 'SetCustomValidity', 'Validity', 'ValidationMessage'],
-},
-
-'HTMLFontElement': {
-    'implicitCxSetters': True,
 },
 
 'HTMLFormControlsCollection': {
@@ -735,24 +671,15 @@ DOMInterfaces = {
 },
 
 'HTMLFormElement': {
-    'cx': ['CheckValidity', 'ReportValidity', 'RequestSubmit', 'Submit', 'Reset', 'Elements', 'IndexedGetter', 'Length', 'NamedGetter', 'SetRel', 'RelList'],
-},
-
-'HTMLFrameSetElement': {
-    'implicitCxSetters': True,
+    'cx': ['CheckValidity', 'ReportValidity', 'RequestSubmit', 'Submit', 'Reset', 'Elements', 'IndexedGetter', 'Length', 'NamedGetter', 'RelList'],
 },
 
 'HTMLIFrameElement': {
     'cx': ['Sandbox'],
-    'implicitCxSetters': True,
-},
-
-'HTMLHRElement': {
-    'implicitCxSetters': True,
 },
 
 'HTMLImageElement': {
-    'cx': ['Decode', 'Image', 'ReportValidity', 'SetCrossOrigin'],
+    'cx': ['Decode', 'Image', 'ReportValidity'],
 },
 
 'HTMLInputElement': {
@@ -761,11 +688,7 @@ DOMInterfaces = {
         'GetLabels',
         'GetValueAsDate',
         'ReportValidity',
-        'SetChecked',
         'SetCustomValidity',
-        'SetValue',
-        'SetValueAsDate',
-        'SetValueAsNumber',
         'StepDown',
         'StepUp',
         'ValidationMessage',
@@ -773,27 +696,22 @@ DOMInterfaces = {
     ],
 },
 
-'HTMLLIElement': {
-    'implicitCxSetters': True,
-},
-
 'HTMLLinkElement': {
-    'cx': ['Blocking', 'GetSheet', 'RelList', 'SetCrossOrigin', 'SetRel'],
+    'cx': ['Blocking', 'GetSheet', 'RelList'],
 },
 
 'HTMLMapElement': {
-    'implicitCxSetters': True,
     'cx': ['Areas'],
 },
 
 'HTMLMediaElement': {
     'realm': ['Play'],
     'weakReferenceable': True,
-    'cx': [ 'AddTextTrack', 'AudioTracks', 'Buffered', 'Played', 'Seekable', 'SetCrossOrigin', 'SetSrcObject', 'TextTracks', 'Load', 'Pause', 'VideoTracks'],
+    'cx': ['AddTextTrack', 'AudioTracks', 'Buffered', 'Played', 'Seekable', 'TextTracks', 'Load', 'Pause', 'VideoTracks'],
 },
 
 'HTMLMeterElement': {
-    'cx': ['CheckValidity', 'ReportValidity', 'SetHigh', 'SetLow', 'SetMax', 'SetMin', 'SetOptimum', 'SetValue', 'Labels'],
+    'cx': ['CheckValidity', 'ReportValidity', 'Labels'],
 },
 
 'HTMLObjectElement': {
@@ -801,7 +719,7 @@ DOMInterfaces = {
 },
 
 'HTMLOptionElement': {
-    'cx': ['Option', 'SetSelected', 'SetText'],
+    'cx': ['Option'],
     'cx_no_gc': ['Index'],
 },
 
@@ -811,23 +729,19 @@ DOMInterfaces = {
 },
 
 'HTMLOutputElement': {
-    'cx': ['CheckValidity', 'ReportValidity', 'SetCustomValidity', 'SetDefaultValue', 'SetValue', 'Validity', 'ValidationMessage', 'Labels'],
-},
-
-'HTMLPreElement': {
-    'implicitCxSetters': True,
+    'cx': ['CheckValidity', 'ReportValidity', 'SetCustomValidity', 'Validity', 'ValidationMessage', 'Labels'],
 },
 
 'HTMLProgressElement': {
-    'cx': ['SetValue', 'SetMax', 'Labels']
+    'cx': ['Labels']
 },
 
 'HTMLScriptElement': {
-    'cx': ['Blocking', 'SetAsync', 'SetCrossOrigin', 'SetInnerText', 'SetSrc', 'SetText', 'SetTextContent'],
+    'cx': ['Blocking'],
 },
 
 'HTMLSelectElement': {
-    'cx': ['Add', 'CheckValidity', 'Item', 'IndexedGetter', 'Length', 'IndexedSetter', 'NamedItem', 'Options', 'Remove', 'Remove_', 'ReportValidity', 'SelectedOptions',  'SetCustomValidity', 'SetLength', 'SetSelectedIndex', 'SetValue','Validity', 'ValidationMessage', 'Labels'],
+    'cx': ['Add', 'CheckValidity', 'Item', 'IndexedGetter', 'Length', 'IndexedSetter', 'NamedItem', 'Options', 'Remove', 'Remove_', 'ReportValidity', 'SelectedOptions', 'SetCustomValidity', 'Validity', 'ValidationMessage', 'Labels'],
     'cx_no_gc': [ 'SelectedIndex', 'Value'],
 },
 
@@ -836,7 +750,7 @@ DOMInterfaces = {
 },
 
 'HTMLStyleElement': {
-    'cx': ['GetSheet', 'Disabled', 'SetDisabled', 'Blocking'],
+    'cx': ['GetSheet', 'Disabled', 'Blocking'],
 },
 
 'HTMLTableElement': {
@@ -853,19 +767,10 @@ DOMInterfaces = {
         'Rows',
         'TBodies',
     ],
-    'implicitCxSetters': True,
-},
-
-'HTMLTableCellElement': {
-    'implicitCxSetters': True,
-},
-'HTMLTableColElement': {
-    'implicitCxSetters': True,
 },
 
 'HTMLTableRowElement': {
     'cx': ['Cells', 'DeleteCell', 'InsertCell', 'RowIndex', 'SectionRowIndex'],
-    'implicitCxSetters': True,
 },
 
 'HTMLTableSectionElement': {
@@ -877,11 +782,7 @@ DOMInterfaces = {
 },
 
 'HTMLTextAreaElement': {
-    'cx': ['CheckValidity', 'ReportValidity', 'SetDefaultValue', 'SetValue', 'SetCustomValidity', 'Validity', 'ValidationMessage', 'Labels'],
-},
-
-'HTMLTitleElement': {
-    'implicitCxSetters': True,
+    'cx': ['CheckValidity', 'ReportValidity', 'SetCustomValidity', 'Validity', 'ValidationMessage', 'Labels'],
 },
 
 'HTMLVideoElement': {
@@ -980,7 +881,6 @@ DOMInterfaces = {
 
 'MessagePort': {
     'weakReferenceable': True,
-    'canGc': ['GetOnmessage'],
     'cx': ['Close', 'PostMessage', 'PostMessage_', 'SetOnmessage', 'Start']
 },
 
@@ -1190,7 +1090,7 @@ DOMInterfaces = {
 },
 
 'SVGElement': {
-    'cx': ['Blur', 'Focus', 'SetAutofocus', 'SetTabIndex', 'Style'],
+    'cx': ['Blur', 'Focus', 'Style'],
 },
 
 #FIXME(jdm): This should be 'register': False, but then we don't generate enum types
@@ -1563,15 +1463,11 @@ DOMInterfaces = {
 },
 
 "ReadableStreamBYOBReader": {
-    "cx": ["Cancel", "Constructor", "Read", "ReleaseLock"]
+    "cx": ["Cancel", "Read", "ReleaseLock"]
 },
 
 "ReadableStreamDefaultReader": {
-    "cx": ["Cancel", "Constructor", "Read", "ReleaseLock"]
-},
-
-'ResizeObserver': {
-    'cx': ["Constructor"]
+    "cx": ["Cancel", "Read", "ReleaseLock"]
 },
 
 'ResizeObserverEntry': {

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -1524,9 +1524,8 @@ def wrapForType(jsvalRef: str, result: str = 'result', successCode: str = 'true'
 
 class Context(IntEnum):
     No = 0
-    OldCx = 1
-    Cx = 2
-    CurrentRealm = 3
+    Cx = 1
+    CurrentRealm = 2
 
 
 def typeNeedsCx(type: IDLType | None, retVal: bool = False) -> Context:
@@ -1544,9 +1543,7 @@ def typeNeedsCx(type: IDLType | None, retVal: bool = False) -> Context:
         assert flatMemberTypes is not None
 
         return max(typeNeedsCx(t) for t in flatMemberTypes)
-    if retVal and type.isSpiderMonkeyInterface():
-        return Context.OldCx
-    return Context.OldCx if type.isAny() or type.isObject() else Context.No
+    return Context.No
 
 
 def returnTypeNeedsOutparam(type: IDLType | None) -> bool:
@@ -4224,15 +4221,17 @@ class CGCallGenerator(CGThing):
                 CGGeneric("let mut realm = CurrentRealm::assert(cx);"),
                 CGGeneric("let cx = &mut realm;"),
             ]))
+
+        needs_cx_arg = (
+            nativeMethodName in descriptor.no_gcMethods
+            or nativeMethodName in descriptor.cx_no_gcMethods
+            or nativeMethodName in descriptor.cxMethods
+            or nativeMethodName in descriptor.realmMethods
+            or nativeMethodName.startswith("Constructor")
+            or descriptor.interface.isIteratorInterface()
+        )
+        if needs_cx_arg:
             args.prepend(CGGeneric("cx"))
-        elif nativeMethodName in descriptor.no_gcMethods or nativeMethodName in descriptor.cx_no_gcMethods or nativeMethodName in descriptor.cxMethods or nativeMethodName.startswith("Constructor"):
-            args.prepend(CGGeneric("cx"))
-        # Workaround for iterators `Next` method until `safe_cx` is the default
-        elif descriptor.interface.isIteratorInterface():
-            args.prepend(CGGeneric("cx"))
-        else:
-            if nativeMethodName in descriptor.canGcMethods:
-                args.append(CGGeneric("CanGc::deprecated_note()"))
 
         if returnType and outparamRootType:
             if returnType.isSequence():
@@ -6991,7 +6990,6 @@ class CGInterfaceTrait(CGThing):
                                 cx_no_gc: bool = False,
                                 cx: bool = False,
                                 realm: bool = False,
-                                canGc: bool = False,
                                 retval: bool = False
                                 ) -> Iterable[tuple[str, str]]:
             if realm:
@@ -7003,13 +7001,8 @@ class CGInterfaceTrait(CGThing):
             elif no_gc:
                 yield "cx", "&NoGC"
 
-            safe_cx = cx or cx_no_gc or realm or no_gc
-
             if argument:
                 yield "value", argument_type(descriptor, argument)
-
-            if canGc and not safe_cx:
-                yield "_can_gc", "CanGc"
 
             if retval and returnTypeNeedsOutparam(attribute_type):
                 yield "retval", outparamTypeFromReturnType(attribute_type)
@@ -7035,8 +7028,7 @@ class CGInterfaceTrait(CGThing):
                                                      no_gc=name in descriptor.no_gcMethods,
                                                      cx_no_gc=name in descriptor.cx_no_gcMethods,
                                                      cx=name in descriptor.cxMethods or descriptor.interface.isIteratorInterface(),
-                                                     realm=name in descriptor.realmMethods,
-                                                     canGc=name in descriptor.canGcMethods)
+                                                     realm=name in descriptor.realmMethods)
                         rettype = return_type(descriptor, rettype, infallible)
                         yield f"{name}{'_' * idx}", arguments, rettype, m.isStatic()
                 elif m.isAttr():
@@ -7056,7 +7048,6 @@ class CGInterfaceTrait(CGThing):
                                cx_no_gc=name in descriptor.cx_no_gcMethods,
                                cx=name in descriptor.cxMethods or isEventHandlerCallback(m),
                                realm=name in descriptor.realmMethods,
-                               canGc=name in descriptor.canGcMethods,
                                retval=True
                            ),
                            return_type(descriptor, m.type, infallible),
@@ -7077,7 +7068,6 @@ class CGInterfaceTrait(CGThing):
                                    cx_no_gc=name in descriptor.cx_no_gcMethods,
                                    cx=name in descriptor.cxMethods or descriptor.implicitCxSetters or isEventHandlerCallback(m),
                                    realm=name in descriptor.realmMethods,
-                                   canGc=name in descriptor.canGcMethods,
                                    retval=False,
                                ),
                                rettype,
@@ -7099,8 +7089,7 @@ class CGInterfaceTrait(CGThing):
                                                      no_gc=name in descriptor.no_gcMethods,
                                                      cx_no_gc=name in descriptor.cx_no_gcMethods,
                                                      cx=name in descriptor.cxMethods,
-                                                     realm=name in descriptor.realmMethods,
-                                                     canGc=name in descriptor.canGcMethods)
+                                                     realm=name in descriptor.realmMethods)
 
                         # If this interface 'supports named properties', then we
                         # should be able to access 'supported property names'
@@ -7114,8 +7103,7 @@ class CGInterfaceTrait(CGThing):
                                                      no_gc=name in descriptor.no_gcMethods,
                                                      cx_no_gc=name in descriptor.cx_no_gcMethods,
                                                      cx=name in descriptor.cxMethods,
-                                                     realm=name in descriptor.realmMethods,
-                                                     canGc=name in descriptor.canGcMethods)
+                                                     realm=name in descriptor.realmMethods)
                     rettype = return_type(descriptor, rettype, infallible)
                     yield name, arguments, rettype, False
 
@@ -8342,8 +8330,7 @@ def method_arguments(descriptorProvider: DescriptorProvider,
                      no_gc: bool = False,
                      cx_no_gc: bool = False,
                      cx: bool = False,
-                     realm: bool = False,
-                     canGc: bool = False
+                     realm: bool = False
                      ) -> Iterator[tuple[str, str]]:
 
     match needCx(returnType, arguments, passJSBits):
@@ -8363,8 +8350,6 @@ def method_arguments(descriptorProvider: DescriptorProvider,
     elif no_gc:
         yield "cx", "&NoGC"
 
-    safe_cx = cx or cx_no_gc or realm or no_gc
-
     for argument in arguments:
         ty = argument_type(descriptorProvider, argument.type, argument.optional,
                            argument.defaultValue, argument.variadic)
@@ -8372,9 +8357,6 @@ def method_arguments(descriptorProvider: DescriptorProvider,
 
     if trailing:
         yield trailing
-
-    if canGc and not safe_cx:
-        yield "_can_gc", "CanGc"
 
     if returnTypeNeedsOutparam(returnType):
         yield "rval", outparamTypeFromReturnType(returnType),

--- a/components/script_bindings/codegen/configuration.py
+++ b/components/script_bindings/codegen/configuration.py
@@ -289,13 +289,23 @@ class Descriptor(DescriptorProvider):
         self.register = desc.get('register', True)
         self.path = desc.get('path', pathDefault)
 
-        self.no_gcMethods = [name for name in desc.get('no_gc', [])]
-        self.cx_no_gcMethods = [name for name in desc.get('cx_no_gc', [])]
-        self.cxMethods = [name for name in desc.get('cx', [])]
-        self.realmMethods = [name for name in desc.get('realm', [])]
+        # Specified here to make it explicit for the typechecker
+        self.no_gcMethods: list[str] = []
+        self.cx_no_gcMethods: list[str] = []
+        self.cxMethods: list[str] = []
+        self.realmMethods: list[str] = []
 
-        self.inRealmMethods = [name for name in desc.get('inRealms', [])]
-        self.canGcMethods = [name for name in desc.get('canGc', [])]
+        configurationMethods = ["no_gc", "cx_no_gc", "cx", "realm"]
+        for configurationName in configurationMethods:
+            setattr(self, configurationName + "Methods", [name for name in desc.get(configurationName, [])])
+
+        assert ("Constructor" not in self.cxMethods), "Constructor implicitly receives a cx argument. Remove it from the `cx` array"
+        for i in range(0, len(configurationMethods)):
+            for j in range(i + 1, len(configurationMethods)):
+                first_set = set(getattr(self, configurationMethods[i] + "Methods"))
+                second_set = set(getattr(self, configurationMethods[j] + "Methods"))
+                assert first_set.isdisjoint(second_set), f"In {ifaceName} set {configurationMethods[i]} has overlap with {configurationMethods[j]}. Duplicates: {first_set.intersection(second_set)}"
+
         self.additionalTraits = [name for name in desc.get('additionalTraits', [])]
         self.bindingPath = f"{getModuleFromObject(self.interface)}::{ifaceName}_Binding"
         self.outerObjectHook = desc.get('outerObjectHook', 'None')
@@ -403,24 +413,6 @@ class Descriptor(DescriptorProvider):
                 else:
                     add('all', [config], attribute)
 
-        self._binaryNames = desc.get('binaryNames', {})
-        self._binaryNames.setdefault(('__legacycaller', False), 'LegacyCall')
-        self._binaryNames.setdefault(('__stringifier', False), 'Stringifier')
-
-        self._internalNames = desc.get('internalNames', {})
-
-        for member in self.interface.members:
-            if not member.isAttr() and not member.isMethod():
-                continue
-            binaryName = member.getExtendedAttribute("BinaryName")
-            if binaryName:
-                assert isinstance(binaryName, list)
-                assert len(binaryName) == 1
-                self._binaryNames.setdefault((member.identifier.name, member.isStatic()),
-                                             binaryName[0])
-            self._internalNames.setdefault(member.identifier.name,
-                                           member.identifier.name.replace('-', '_'))
-
         # Build the prototype chain.
         self.prototypeChain = []
         parent: IDLInterfaceOrNamespace | None = interface
@@ -431,6 +423,27 @@ class Descriptor(DescriptorProvider):
         config.maxProtoChainLength = max(config.maxProtoChainLength,
                                          len(self.prototypeChain))
         self.implicitCxSetters = desc.get('implicitCxSetters', "Element" in self.prototypeChain)
+
+        self._binaryNames = desc.get('binaryNames', {})
+        self._binaryNames.setdefault(('__legacycaller', False), 'LegacyCall')
+        self._binaryNames.setdefault(('__stringifier', False), 'Stringifier')
+
+        self._internalNames = desc.get('internalNames', {})
+
+        for member in self.interface.members:
+            if not member.isAttr() and not member.isMethod():
+                continue
+            if member.isAttr() and not member.readonly and self.implicitCxSetters:
+                setterName = f"Set{MakeNativeName(member.identifier.name)}"
+                assert setterName not in self.cxMethods, f"Setter {setterName} in {ifaceName} is implicitly called with cx. Remove it from the list of cx methods"
+            binaryName = member.getExtendedAttribute("BinaryName")
+            if binaryName:
+                assert isinstance(binaryName, list)
+                assert len(binaryName) == 1
+                self._binaryNames.setdefault((member.identifier.name, member.isStatic()),
+                                             binaryName[0])
+            self._internalNames.setdefault(member.identifier.name,
+                                           member.identifier.name.replace('-', '_'))
 
     def maybeGetSuperModule(self) -> str | None:
         """


### PR DESCRIPTION
This cleans up various remnants of the migration. It removes all mentions of `CanGc` and `InRealm`. It also adds assertions for the `Bindings.conf` where it now ensures the lists contain valid values. For example, for implicitly deduced information, we should not specify it in the configuration.

Part of #40600

Fixes #42638
Testing: it compiles