### PR TITLE
script: Remove cx argument from macros

### DIFF
--- a/components/script/dom/html/htmlanchorelement.rs
+++ b/components/script/dom/html/htmlanchorelement.rs
@@ -173,49 +173,49 @@ impl HTMLAnchorElementMethods<crate::DomTypeHolder> for HTMLAnchorElement {
     make_getter!(Hreflang, "hreflang");
 
     // https://html.spec.whatwg.org/multipage/#dom-a-hreflang
-    make_setter!(cx, SetHreflang, "hreflang");
+    make_setter!(SetHreflang, "hreflang");
 
     // https://html.spec.whatwg.org/multipage/#dom-a-type
     make_getter!(Type, "type");
 
     // https://html.spec.whatwg.org/multipage/#dom-a-type
-    make_setter!(cx, SetType, "type");
+    make_setter!(SetType, "type");
 
     // https://html.spec.whatwg.org/multipage/#dom-a-coords
     make_getter!(Coords, "coords");
 
     // https://html.spec.whatwg.org/multipage/#dom-a-coords
-    make_setter!(cx, SetCoords, "coords");
+    make_setter!(SetCoords, "coords");
 
     // https://html.spec.whatwg.org/multipage/#dom-a-charset
     make_getter!(Charset, "charset");
 
     // https://html.spec.whatwg.org/multipage/#dom-a-charset
-    make_setter!(cx, SetCharset, "charset");
+    make_setter!(SetCharset, "charset");
 
     // https://html.spec.whatwg.org/multipage/#dom-a-name
     make_getter!(Name, "name");
 
     // https://html.spec.whatwg.org/multipage/#dom-a-name
-    make_atomic_setter!(cx, SetName, "name");
+    make_atomic_setter!(SetName, "name");
 
     // https://html.spec.whatwg.org/multipage/#dom-a-rev
     make_getter!(Rev, "rev");
 
     // https://html.spec.whatwg.org/multipage/#dom-a-rev
-    make_setter!(cx, SetRev, "rev");
+    make_setter!(SetRev, "rev");
 
     // https://html.spec.whatwg.org/multipage/#dom-a-shape
     make_getter!(Shape, "shape");
 
     // https://html.spec.whatwg.org/multipage/#dom-a-shape
-    make_setter!(cx, SetShape, "shape");
+    make_setter!(SetShape, "shape");
 
     // https://html.spec.whatwg.org/multipage/#attr-hyperlink-target
     make_getter!(Target, "target");
 
     // https://html.spec.whatwg.org/multipage/#attr-hyperlink-target
-    make_setter!(cx, SetTarget, "target");
+    make_setter!(SetTarget, "target");
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-href>
     fn Href(&self) -> USVString {
@@ -328,7 +328,7 @@ impl HTMLAnchorElementMethods<crate::DomTypeHolder> for HTMLAnchorElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-script-referrerpolicy
-    make_setter!(cx, SetReferrerPolicy, "referrerpolicy");
+    make_setter!(SetReferrerPolicy, "referrerpolicy");
 }
 
 impl Activatable for HTMLAnchorElement {

--- a/components/script/dom/html/htmlareaelement.rs
+++ b/components/script/dom/html/htmlareaelement.rs
@@ -371,7 +371,7 @@ impl HTMLAreaElementMethods<crate::DomTypeHolder> for HTMLAreaElement {
     make_getter!(Target, "target");
 
     // https://html.spec.whatwg.org/multipage/#attr-hyperlink-target
-    make_setter!(cx, SetTarget, "target");
+    make_setter!(SetTarget, "target");
 
     // https://html.spec.whatwg.org/multipage/#dom-a-rel
     make_getter!(Rel, "rel");
@@ -404,7 +404,7 @@ impl HTMLAreaElementMethods<crate::DomTypeHolder> for HTMLAreaElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#attr-iframe-referrerpolicy
-    make_setter!(cx, SetReferrerPolicy, "referrerpolicy");
+    make_setter!(SetReferrerPolicy, "referrerpolicy");
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-href>
     fn Href(&self) -> USVString {
@@ -515,7 +515,7 @@ impl HTMLAreaElementMethods<crate::DomTypeHolder> for HTMLAreaElement {
     make_bool_getter!(NoHref, "nohref");
 
     // https://html.spec.whatwg.org/multipage/#dom-area-nohref
-    make_bool_setter!(cx, SetNoHref, "nohref");
+    make_bool_setter!(SetNoHref, "nohref");
 }
 
 impl Activatable for HTMLAreaElement {

--- a/components/script/dom/html/htmlbuttonelement.rs
+++ b/components/script/dom/html/htmlbuttonelement.rs
@@ -119,13 +119,13 @@ impl HTMLButtonElementMethods<crate::DomTypeHolder> for HTMLButtonElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-button-command
-    make_setter!(cx, SetCommand, "command");
+    make_setter!(SetCommand, "command");
 
     // https://html.spec.whatwg.org/multipage/#dom-fe-disabled
     make_bool_getter!(Disabled, "disabled");
 
     // https://html.spec.whatwg.org/multipage/#dom-fe-disabled
-    make_bool_setter!(cx, SetDisabled, "disabled");
+    make_bool_setter!(SetDisabled, "disabled");
 
     /// <https://html.spec.whatwg.org/multipage/#dom-fae-form>
     fn GetForm(&self) -> Option<DomRoot<HTMLFormElement>> {
@@ -142,13 +142,13 @@ impl HTMLButtonElementMethods<crate::DomTypeHolder> for HTMLButtonElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-button-type
-    make_setter!(cx, SetType, "type");
+    make_setter!(SetType, "type");
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-formaction
     make_form_action_getter!(FormAction, "formaction");
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-formaction
-    make_setter!(cx, SetFormAction, "formaction");
+    make_setter!(SetFormAction, "formaction");
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-formenctype
     make_enumerated_getter!(
@@ -159,7 +159,7 @@ impl HTMLButtonElementMethods<crate::DomTypeHolder> for HTMLButtonElement {
     );
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-formenctype
-    make_setter!(cx, SetFormEnctype, "formenctype");
+    make_setter!(SetFormEnctype, "formenctype");
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-formmethod
     make_enumerated_getter!(
@@ -170,31 +170,31 @@ impl HTMLButtonElementMethods<crate::DomTypeHolder> for HTMLButtonElement {
     );
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-formmethod
-    make_setter!(cx, SetFormMethod, "formmethod");
+    make_setter!(SetFormMethod, "formmethod");
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-formtarget
     make_getter!(FormTarget, "formtarget");
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-formtarget
-    make_setter!(cx, SetFormTarget, "formtarget");
+    make_setter!(SetFormTarget, "formtarget");
 
     // https://html.spec.whatwg.org/multipage/#attr-fs-formnovalidate
     make_bool_getter!(FormNoValidate, "formnovalidate");
 
     // https://html.spec.whatwg.org/multipage/#attr-fs-formnovalidate
-    make_bool_setter!(cx, SetFormNoValidate, "formnovalidate");
+    make_bool_setter!(SetFormNoValidate, "formnovalidate");
 
     // https://html.spec.whatwg.org/multipage/#dom-fe-name
     make_getter!(Name, "name");
 
     // https://html.spec.whatwg.org/multipage/#dom-fe-name
-    make_atomic_setter!(cx, SetName, "name");
+    make_atomic_setter!(SetName, "name");
 
     // https://html.spec.whatwg.org/multipage/#dom-button-value
     make_getter!(Value, "value");
 
     // https://html.spec.whatwg.org/multipage/#dom-button-value
-    make_setter!(cx, SetValue, "value");
+    make_setter!(SetValue, "value");
 
     // https://html.spec.whatwg.org/multipage/#dom-lfe-labels
     make_labels_getter!(Labels, labels_node_list);

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -211,12 +211,12 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     // https://html.spec.whatwg.org/multipage/#attr-title
     make_getter!(Title, "title");
     // https://html.spec.whatwg.org/multipage/#attr-title
-    make_setter!(cx, SetTitle, "title");
+    make_setter!(SetTitle, "title");
 
     // https://html.spec.whatwg.org/multipage/#attr-lang
     make_getter!(Lang, "lang");
     // https://html.spec.whatwg.org/multipage/#attr-lang
-    make_setter!(cx, SetLang, "lang");
+    make_setter!(SetLang, "lang");
 
     // https://html.spec.whatwg.org/multipage/#the-dir-attribute
     make_enumerated_getter!(
@@ -228,12 +228,12 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     );
 
     // https://html.spec.whatwg.org/multipage/#the-dir-attribute
-    make_setter!(cx, SetDir, "dir");
+    make_setter!(SetDir, "dir");
 
     // https://html.spec.whatwg.org/multipage/#dom-hidden
     make_bool_getter!(Hidden, "hidden");
     // https://html.spec.whatwg.org/multipage/#dom-hidden
-    make_bool_setter!(cx, SetHidden, "hidden");
+    make_bool_setter!(SetHidden, "hidden");
 
     // https://html.spec.whatwg.org/multipage/#globaleventhandlers
     global_event_handlers!(NoOnload);
@@ -797,7 +797,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     make_getter!(AccessKey, "accesskey");
 
     // https://html.spec.whatwg.org/multipage/#dom-accesskey
-    make_setter!(cx, SetAccessKey, "accesskey");
+    make_setter!(SetAccessKey, "accesskey");
 
     /// <https://html.spec.whatwg.org/multipage/#dom-accesskeylabel>
     fn AccessKeyLabel(&self) -> DOMString {

--- a/components/script/dom/html/htmlfontelement.rs
+++ b/components/script/dom/html/htmlfontelement.rs
@@ -100,7 +100,7 @@ impl HTMLFontElementMethods<crate::DomTypeHolder> for HTMLFontElement {
     make_getter!(Face, "face");
 
     // https://html.spec.whatwg.org/multipage/#dom-font-face
-    make_atomic_setter!(cx, SetFace, "face");
+    make_atomic_setter!(SetFace, "face");
 
     // https://html.spec.whatwg.org/multipage/#dom-font-size
     make_getter!(Size, "size");

--- a/components/script/dom/html/htmlhrelement.rs
+++ b/components/script/dom/html/htmlhrelement.rs
@@ -62,7 +62,7 @@ impl HTMLHRElementMethods<crate::DomTypeHolder> for HTMLHRElement {
     make_getter!(Align, "align");
 
     // https://html.spec.whatwg.org/multipage/#dom-hr-align
-    make_atomic_setter!(cx, SetAlign, "align");
+    make_atomic_setter!(SetAlign, "align");
 
     // https://html.spec.whatwg.org/multipage/#dom-hr-color
     make_getter!(Color, "color");
@@ -74,7 +74,7 @@ impl HTMLHRElementMethods<crate::DomTypeHolder> for HTMLHRElement {
     make_bool_getter!(NoShade, "noshade");
 
     // https://html.spec.whatwg.org/multipage/#dom-hr-noshade
-    make_bool_setter!(cx, SetNoShade, "noshade");
+    make_bool_setter!(SetNoShade, "noshade");
 
     // https://html.spec.whatwg.org/multipage/#dom-hr-size
     make_getter!(Size, "size");

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -957,7 +957,7 @@ impl HTMLIFrameElementMethods<crate::DomTypeHolder> for HTMLIFrameElement {
     make_url_getter!(Src, "src");
 
     // https://html.spec.whatwg.org/multipage/#dom-iframe-src
-    make_url_setter!(cx, SetSrc, "src");
+    make_url_setter!(SetSrc, "src");
 
     /// <https://html.spec.whatwg.org/multipage/#dom-iframe-srcdoc>
     fn Srcdoc(&self) -> TrustedHTMLOrString {
@@ -1050,12 +1050,12 @@ impl HTMLIFrameElementMethods<crate::DomTypeHolder> for HTMLIFrameElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#attr-iframe-referrerpolicy
-    make_setter!(cx, SetReferrerPolicy, "referrerpolicy");
+    make_setter!(SetReferrerPolicy, "referrerpolicy");
 
     // https://html.spec.whatwg.org/multipage/#attr-iframe-allowfullscreen
     make_bool_getter!(AllowFullscreen, "allowfullscreen");
     // https://html.spec.whatwg.org/multipage/#attr-iframe-allowfullscreen
-    make_bool_setter!(cx, SetAllowFullscreen, "allowfullscreen");
+    make_bool_setter!(SetAllowFullscreen, "allowfullscreen");
 
     // <https://html.spec.whatwg.org/multipage/#dom-dim-width>
     make_getter!(Width, "width");
@@ -1070,12 +1070,12 @@ impl HTMLIFrameElementMethods<crate::DomTypeHolder> for HTMLIFrameElement {
     // https://html.spec.whatwg.org/multipage/#other-elements,-attributes-and-apis:attr-iframe-frameborder
     make_getter!(FrameBorder, "frameborder");
     // https://html.spec.whatwg.org/multipage/#other-elements,-attributes-and-apis:attr-iframe-frameborder
-    make_setter!(cx, SetFrameBorder, "frameborder");
+    make_setter!(SetFrameBorder, "frameborder");
 
     // https://html.spec.whatwg.org/multipage/#dom-iframe-name
     // A child browsing context checks the name of its iframe only at the time
     // it is created; subsequent name sets have no special effect.
-    make_atomic_setter!(cx, SetName, "name");
+    make_atomic_setter!(SetName, "name");
 
     // https://html.spec.whatwg.org/multipage/#dom-iframe-name
     // This is specified as reflecting the name content attribute of the
@@ -1095,13 +1095,13 @@ impl HTMLIFrameElementMethods<crate::DomTypeHolder> for HTMLIFrameElement {
     );
 
     // https://html.spec.whatwg.org/multipage/#attr-iframe-loading
-    make_setter!(cx, SetLoading, "loading");
+    make_setter!(SetLoading, "loading");
 
     // https://html.spec.whatwg.org/multipage/#dom-iframe-longdesc
     make_url_getter!(LongDesc, "longdesc");
 
     // https://html.spec.whatwg.org/multipage/#dom-iframe-longdesc
-    make_url_setter!(cx, SetLongDesc, "longdesc");
+    make_url_setter!(SetLongDesc, "longdesc");
 }
 
 impl VirtualMethods for HTMLIFrameElement {

--- a/components/script/dom/html/htmlmapelement.rs
+++ b/components/script/dom/html/htmlmapelement.rs
@@ -65,7 +65,7 @@ impl HTMLMapElementMethods<crate::DomTypeHolder> for HTMLMapElement {
     make_getter!(Name, "name");
 
     // <https://html.spec.whatwg.org/multipage/#dom-map-name>
-    make_atomic_setter!(cx, SetName, "name");
+    make_atomic_setter!(SetName, "name");
 
     /// <https://html.spec.whatwg.org/multipage/#dom-map-areas>
     fn Areas(&self, cx: &mut JSContext) -> DomRoot<HTMLCollection> {

--- a/components/script/dom/html/htmltableelement.rs
+++ b/components/script/dom/html/htmltableelement.rs
@@ -465,15 +465,15 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     make_nonzero_dimension_setter!(SetWidth, "width");
 
     // <https://html.spec.whatwg.org/multipage/#dom-table-align>
-    make_setter!(cx, SetAlign, "align");
+    make_setter!(SetAlign, "align");
     make_getter!(Align, "align");
 
     // <https://html.spec.whatwg.org/multipage/#dom-table-cellpadding>
-    make_setter!(cx, SetCellPadding, "cellpadding");
+    make_setter!(SetCellPadding, "cellpadding");
     make_getter!(CellPadding, "cellpadding");
 
     // <https://html.spec.whatwg.org/multipage/#dom-table-cellspacing>
-    make_setter!(cx, SetCellSpacing, "cellspacing");
+    make_setter!(SetCellSpacing, "cellspacing");
     make_getter!(CellSpacing, "cellspacing");
 }
 

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -102,25 +102,14 @@ macro_rules! make_url_getter(
     );
 );
 
-macro_rules! make_url_setter_inner(
-    ( $self:ident, $value:ident, $htmlname:tt, $cx:expr ) => (
-        use $crate::dom::bindings::inheritance::Castable;
-        use $crate::dom::element::Element;
-        let element = $self.upcast::<Element>();
-        element.set_url_attribute($cx, &html5ever::local_name!($htmlname), $value)
-    );
-);
-
 #[macro_export]
 macro_rules! make_url_setter(
     ( $attr:ident, $htmlname:tt ) => (
         fn $attr(&self, cx: &mut js::context::JSContext, value: USVString) {
-            make_url_setter_inner!(self, value, $htmlname, cx);
-        }
-    );
-    ( $cx:ident, $attr:ident, $htmlname:tt ) => (
-        fn $attr(&self, $cx: &mut js::context::JSContext, value: USVString) {
-            make_url_setter_inner!(self, value, $htmlname, $cx);
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
+            let element = self.upcast::<Element>();
+            element.set_url_attribute(cx, &html5ever::local_name!($htmlname), value)
         }
     );
 );
@@ -269,37 +258,17 @@ macro_rules! make_enumerated_getter(
     );
 );
 
-macro_rules! make_setter_inner(
-    ( $self:ident, $value:ident, $htmlname:tt, $cx:expr ) => (
-        use $crate::dom::bindings::inheritance::Castable;
-        use $crate::dom::element::Element;
-        let element = $self.upcast::<Element>();
-        element.set_string_attribute($cx, &html5ever::local_name!($htmlname), $value)
-    );
-);
-
 // concat_idents! doesn't work for function name positions, so
 // we have to specify both the content name and the HTML name here
 #[macro_export]
 macro_rules! make_setter(
     ( $attr:ident, $htmlname:tt ) => (
         fn $attr(&self, cx: &mut js::context::JSContext, value: DOMString) {
-            make_setter_inner!(self, value, $htmlname, cx);
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
+            let element = self.upcast::<Element>();
+            element.set_string_attribute(cx, &html5ever::local_name!($htmlname), value)
         }
-    );
-    ( $cx:ident, $attr:ident, $htmlname:tt ) => (
-        fn $attr(&self, $cx: &mut js::context::JSContext, value: DOMString) {
-            make_setter_inner!(self, value, $htmlname, $cx);
-        }
-    );
-);
-
-macro_rules! make_bool_setter_inner(
-    ( $self:ident, $value:ident, $htmlname:tt, $cx:expr ) => (
-        use $crate::dom::bindings::inheritance::Castable;
-        use $crate::dom::element::Element;
-        let element = $self.upcast::<Element>();
-        element.set_bool_attribute($cx, &html5ever::local_name!($htmlname), $value)
     );
 );
 
@@ -307,12 +276,10 @@ macro_rules! make_bool_setter_inner(
 macro_rules! make_bool_setter(
     ( $attr:ident, $htmlname:tt ) => (
         fn $attr(&self, cx: &mut js::context::JSContext, value: bool) {
-            make_bool_setter_inner!(self, value, $htmlname, cx);
-        }
-    );
-    ( $cx:ident, $attr:ident, $htmlname:tt ) => (
-        fn $attr(&self, $cx: &mut js::context::JSContext, value: bool) {
-            make_bool_setter_inner!(self, value, $htmlname, $cx);
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
+            let element = self.upcast::<Element>();
+            element.set_bool_attribute(cx, &html5ever::local_name!($htmlname), value)
         }
     );
 );
@@ -378,25 +345,14 @@ macro_rules! make_limited_uint_setter(
     );
 );
 
-macro_rules! make_atomic_setter_inner(
-    ( $self:ident, $value:ident, $htmlname:tt, $cx:expr ) => (
-        use $crate::dom::bindings::inheritance::Castable;
-        use $crate::dom::element::Element;
-        let element = $self.upcast::<Element>();
-        element.set_atomic_attribute($cx, &html5ever::local_name!($htmlname), $value)
-    );
-);
-
 #[macro_export]
 macro_rules! make_atomic_setter(
     ( $attr:ident, $htmlname:tt ) => (
         fn $attr(&self, cx: &mut js::context::JSContext, value: DOMString) {
-            make_atomic_setter_inner!(self, value, $htmlname, cx);
-        }
-    );
-    ( $cx:ident, $attr:ident, $htmlname:tt ) => (
-        fn $attr(&self, $cx: &mut js::context::JSContext, value: DOMString) {
-            make_atomic_setter_inner!(self, value, $htmlname, $cx);
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
+            let element = self.upcast::<Element>();
+            element.set_atomic_attribute(cx, &html5ever::local_name!($htmlname), value)
         }
     );
 );


### PR DESCRIPTION
This was used during the migration to JSContext, but now this is done with `cxImplicitSetters` in codegen.

Part of #40600

Testing: it compiles