### PR TITLE
Replace `RefCell<bool / u32 / usize>` with `Cell`

### DIFF
--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -74,7 +74,7 @@ pub mod line;
 mod line_breaker;
 pub mod text_run;
 
-use std::cell::{OnceCell, RefCell};
+use std::cell::{Cell, OnceCell};
 use std::mem;
 use std::rc::Rc;
 use std::sync::{Arc, OnceLock};
@@ -789,7 +789,7 @@ struct InlineContainerState {
 
     /// Whether or not we have processed any content (an atomic element or text) for
     /// this inline box on the current line OR any previous line.
-    has_content: RefCell<bool>,
+    has_content: Cell<bool>,
 
     /// The block size contribution of this container's default font ie the size of the
     /// "strut." Whether this is integrated into the [`Self::nested_strut_block_sizes`]
@@ -1035,7 +1035,7 @@ impl InlineFormattingContextLayout<'_> {
         // the `white-space` property of its parent to future inline children. This is because
         // when a soft wrap opportunity is defined by the boundary between two elements, the
         // `white-space` used is that of their nearest common ancestor.
-        if *inline_box_state.base.has_content.borrow() {
+        if inline_box_state.base.has_content.get() {
             self.propagate_current_nesting_level_white_space_style();
         }
 
@@ -1710,10 +1710,7 @@ impl InlineFormattingContextLayout<'_> {
         self.current_line_segment.inline_size += inline_size;
 
         // Propagate the whitespace setting to the current nesting level.
-        *self
-            .current_inline_container_state()
-            .has_content
-            .borrow_mut() = true;
+        self.current_inline_container_state().has_content.set(true);
         self.propagate_current_nesting_level_white_space_style();
     }
 
@@ -2331,7 +2328,7 @@ impl InlineContainerState {
         Self {
             style,
             flags,
-            has_content: RefCell::new(false),
+            has_content: Cell::new(false),
             nested_strut_block_sizes: nested_block_sizes,
             strut_block_sizes,
             baseline_offset,

--- a/components/script/dom/promise/promise.rs
+++ b/components/script/dom/promise/promise.rs
@@ -426,7 +426,7 @@ struct WaitForAllFulfillmentHandler {
 
     /// A count of fulfilled promises.
     #[conditional_malloc_size_of]
-    fulfilled_count: Rc<RefCell<usize>>,
+    fulfilled_count: Rc<Cell<usize>>,
 }
 
 impl Callback for WaitForAllFulfillmentHandler {
@@ -439,10 +439,11 @@ impl Callback for WaitForAllFulfillmentHandler {
             result[self.promise_index].set(v.get());
 
             // Set fulfilledCount to fulfilledCount + 1.
-            let mut fulfilled_count = self.fulfilled_count.borrow_mut();
-            *fulfilled_count += 1;
+            let mut fulfilled_count = self.fulfilled_count.get();
+            fulfilled_count += 1;
+            self.fulfilled_count.set(fulfilled_count);
 
-            *fulfilled_count == result.len()
+            fulfilled_count == result.len()
         };
 
         // If fulfilledCount equals total, then perform successSteps given result.
@@ -515,7 +516,7 @@ fn wait_for_all(
     failure_steps: WaitForAllFailureSteps,
 ) {
     // Let fulfilledCount be 0.
-    let fulfilled_count: Rc<RefCell<usize>> = Default::default();
+    let fulfilled_count: Rc<Cell<usize>> = Default::default();
 
     // Let rejected be false.
     // Note: done below when constructing a rejection handler.

--- a/components/script/dom/reporting/reportingobserver.rs
+++ b/components/script/dom/reporting/reportingobserver.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::RefCell;
+use std::cell::Cell;
 use std::rc::Rc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -36,7 +36,7 @@ pub(crate) struct ReportingObserver {
 
     #[conditional_malloc_size_of]
     callback: Rc<ReportingObserverCallback>,
-    buffered: RefCell<bool>,
+    buffered: Cell<bool>,
     types: DomRefCell<Vec<DOMString>>,
     report_queue: DomRefCell<Vec<Report>>,
 }
@@ -49,7 +49,7 @@ impl ReportingObserver {
         Self {
             reflector_: Reflector::new(),
             callback,
-            buffered: RefCell::new(options.buffered),
+            buffered: Cell::new(options.buffered),
             types: DomRefCell::new(options.types.clone().unwrap_or_default()),
             report_queue: Default::default(),
         }
@@ -255,11 +255,11 @@ impl ReportingObserverMethods<crate::DomTypeHolder> for ReportingObserver {
         // Step 2. Append this to the global’s registered reporting observer list.
         global.append_reporting_observer(self);
         // Step 3. If this’s buffered option is false, return.
-        if !*self.buffered.borrow() {
+        if !self.buffered.get() {
             return;
         }
         // Step 4. Set this’s buffered option to false.
-        *self.buffered.borrow_mut() = false;
+        self.buffered.set(false);
         // Step 5.For each report in global’s report buffer, queue a task to
         // execute § 4.3 Add report to observer with report and this.
         for report in global.buffered_reports() {

--- a/components/script/dom/webgl/webglframebuffer.rs
+++ b/components/script/dom/webgl/webglframebuffer.rs
@@ -158,7 +158,7 @@ pub(crate) struct WebGLFramebuffer {
     depth: DomRefCell<Option<WebGLFramebufferAttachment>>,
     stencil: DomRefCell<Option<WebGLFramebufferAttachment>>,
     depthstencil: DomRefCell<Option<WebGLFramebufferAttachment>>,
-    color_read_buffer: DomRefCell<u32>,
+    color_read_buffer: Cell<u32>,
     color_draw_buffers: DomRefCell<Vec<u32>>,
     is_initialized: Cell<bool>,
     // Framebuffers for XR keep a reference to the XR session.
@@ -180,7 +180,7 @@ impl WebGLFramebuffer {
             depth: DomRefCell::new(None),
             stencil: DomRefCell::new(None),
             depthstencil: DomRefCell::new(None),
-            color_read_buffer: DomRefCell::new(constants::COLOR_ATTACHMENT0),
+            color_read_buffer: Cell::new(constants::COLOR_ATTACHMENT0),
             color_draw_buffers: DomRefCell::new(vec![constants::COLOR_ATTACHMENT0]),
             is_initialized: Cell::new(false),
             #[cfg(feature = "webxr")]
@@ -1029,7 +1029,7 @@ impl WebGLFramebuffer {
             _ => return Err(WebGLError::InvalidOperation),
         };
 
-        *self.color_read_buffer.borrow_mut() = buffer;
+        self.color_read_buffer.set(buffer);
         context.send_command(WebGLCommand::ReadBuffer(buffer));
         Ok(())
     }
@@ -1063,7 +1063,7 @@ impl WebGLFramebuffer {
     }
 
     pub(crate) fn read_buffer(&self) -> u32 {
-        *self.color_read_buffer.borrow()
+        self.color_read_buffer.get()
     }
 
     pub(crate) fn draw_buffer_i(&self, index: usize) -> u32 {


### PR DESCRIPTION
This avoids the need to store and increment/decrement a borrow counter.

Proposed Clippy lint: https://github.com/rust-lang/rust-clippy/issues/17380

Testing: expecting no change in existing tests
