### PR TITLE
devtools: Add an initial basic autocomplete implementation

### DIFF
--- a/components/default-resources/resources/debugger.js
+++ b/components/default-resources/resources/debugger.js
@@ -50,6 +50,16 @@ function findKeyByValue(map, search) {
     return undefined;
 }
 
+// The === operator isn't really applicable to pipelineId
+function findDebuggeeByPipelineId(search) {
+    for (const [key, value] of debuggeesToPipelineIds) {
+        if (value.namespaceId == search.namespaceId && value.index == search.index) {
+            return key;
+        }
+    }
+    return undefined;
+}
+
 dbg.uncaughtExceptionHook = function(error) {
     console.error(`[debugger] Uncaught exception at ${error.fileName}:${error.lineNumber}:${error.columnNumber}: ${error.name}: ${error.message}`);
 };
@@ -401,7 +411,7 @@ addEventListener("eval", event => {
     } else {
         const object = workerId !== undefined ?
             findKeyByValue(debuggeesToWorkerIds, workerId) :
-            findKeyByValue(debuggeesToPipelineIds, pipelineId);
+            findDebuggeeByPipelineId(pipelineId);
         completionValue = object.executeInGlobal(code);
     }
 
@@ -776,10 +786,15 @@ function buildBindings(environment) {
 // Get a `Debugger.Environment` instance within which evaluation is taking place.
 // <https://searchfox.org/firefox-main/source/devtools/server/actors/frame.js#109>
 addEventListener("getEnvironment", event => {
-    const {frameActorId} = event;
-    frame = frameActorsToFrames.get(frameActorId);
+    const { frameActorId, pipelineId } = event;
+    let environment;
+    if (frameActorId) {
+        environment = frameActorsToFrames.get(frameActorId).environment;
+    } else {
+        environment = findDebuggeeByPipelineId(pipelineId).asEnvironment();
+    }
 
-    const actor = createEnvironmentActor(frame.environment);
+    const actor = createEnvironmentActor(environment);
     getEnvironmentResult(actor);
 });
 

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-//! Liberally derived from the [Firefox JS implementation](http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/webconsole.js).
+//! Liberally derived from the [Firefox JS implementation](https://searchfox.org/firefox-main/source/devtools/server/actors/webconsole.js).
 //! Mediates interaction between the remote web console and equivalent functionality (object
 //! inspection, JS evaluation, autocompletion) in Servo.
 
@@ -12,18 +12,19 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use atomic_refcell::AtomicRefCell;
 use devtools_traits::{
-    ConsoleMessage, ConsoleMessageFields, DevtoolScriptControlMsg, PageError, StackFrame,
-    get_time_stamp,
+    ConsoleMessage, ConsoleMessageFields, DevtoolScriptControlMsg, GetEnvironmentRequest,
+    PageError, StackFrame, get_time_stamp,
 };
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{self, Map, Value};
-use servo_base::generic_channel::{self, GenericSender};
-use servo_base::id::TEST_PIPELINE_ID;
+use servo_base::generic_channel::{self, GenericSender, channel};
+use servo_base::id::{PipelineId, TEST_PIPELINE_ID};
 use uuid::Uuid;
 
 use crate::actor::{Actor, ActorError, ActorRegistry};
 use crate::actors::browsing_context::BrowsingContextActor;
+use crate::actors::environment::EnvironmentActor;
 use crate::actors::worker::WorkerTargetActor;
 use crate::protocol::{ClientRequest, DevtoolsConnection, JsonPacketStream};
 use crate::resource::{ResourceArrayType, ResourceAvailable};
@@ -130,6 +131,7 @@ struct AutocompleteReply {
     from: String,
     matches: Vec<String>,
     match_prop: String,
+    is_element_access: bool,
 }
 
 #[derive(Serialize)]
@@ -230,6 +232,14 @@ impl ConsoleActor {
         }
     }
 
+    fn pipeline_id(&self, registry: &ActorRegistry) -> PipelineId {
+        // FIXME: Redesign messages so we don't have to fake pipeline ids when communicating with workers.
+        match self.current_unique_id(registry) {
+            UniqueId::Pipeline(p) => p,
+            UniqueId::Worker(_) => TEST_PIPELINE_ID,
+        }
+    }
+
     fn evaluate_js(
         &self,
         registry: &ActorRegistry,
@@ -241,15 +251,10 @@ impl ConsoleActor {
             .and_then(|v| v.as_str())
             .map(String::from);
         let (chan, port) = generic_channel::channel().unwrap();
-        // FIXME: Redesign messages so we don't have to fake pipeline ids when communicating with workers.
-        let pipeline = match self.current_unique_id(registry) {
-            UniqueId::Pipeline(p) => p,
-            UniqueId::Worker(_) => TEST_PIPELINE_ID,
-        };
         self.script_chan(registry)
             .send(DevtoolScriptControlMsg::Eval(
                 input.clone(),
-                pipeline,
+                self.pipeline_id(registry),
                 frame_actor_id,
                 chan,
             ))
@@ -357,6 +362,19 @@ impl ConsoleActor {
         self.client_ready_to_receive_messages
             .store(true, Ordering::Relaxed);
     }
+
+    /// Matching function with conditional case-sensitivity as per:
+    /// <https://searchfox.org/firefox-main/rev/7fa9b602777418732e08b26d1ef6c9945c4bbd72/devtools/shared/webconsole/js-property-provider.js#617-622>
+    pub(crate) fn autocomplete_match(prefix: &str, identifier: &str) -> bool {
+        let is_insensitive = prefix.chars().next().is_some_and(|c| c.is_lowercase());
+        if is_insensitive {
+            identifier
+                .to_lowercase()
+                .starts_with(&prefix.to_lowercase())
+        } else {
+            identifier.starts_with(prefix)
+        }
+    }
 }
 
 impl Actor for ConsoleActor {
@@ -383,13 +401,55 @@ impl Actor for ConsoleActor {
                 request.reply_final(&msg)?
             },
 
-            // TODO: implement autocompletion like onAutocomplete in
-            //      http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/webconsole.js
             "autocomplete" => {
-                let msg = AutocompleteReply {
-                    from: self.name().into(),
-                    matches: vec![],
-                    match_prop: "".to_owned(),
+                let Some((tx, rx)) = channel() else {
+                    return Err(ActorError::Internal);
+                };
+
+                let env_request = if let Some(frame_actor) = msg
+                    .get("frameActor")
+                    .and_then(|v| v.as_str())
+                    .map(String::from)
+                {
+                    GetEnvironmentRequest::Frame(frame_actor)
+                } else {
+                    GetEnvironmentRequest::Global(self.pipeline_id(registry))
+                };
+
+                self.script_chan(registry)
+                    .send(DevtoolScriptControlMsg::GetEnvironment(env_request, tx))
+                    .map_err(|_| ActorError::Internal)?;
+
+                let environment_name = rx.recv().map_err(|_| ActorError::Internal)?;
+                let environment_actor = registry.find::<EnvironmentActor>(&environment_name);
+
+                let prompt = msg
+                    .get("text")
+                    .and_then(|v| v.as_str())
+                    .map(String::from)
+                    .ok_or(ActorError::Internal)?;
+
+                let identifiers = environment_actor.search_identifiers_recursive(registry, &prompt);
+
+                let matches: Vec<String> = identifiers
+                    .into_iter()
+                    .filter(|name| ConsoleActor::autocomplete_match(&prompt, name))
+                    .collect();
+
+                let msg = if matches.is_empty() {
+                    AutocompleteReply {
+                        from: self.name().into(),
+                        matches: vec![],
+                        match_prop: "".to_owned(),
+                        is_element_access: false,
+                    }
+                } else {
+                    AutocompleteReply {
+                        from: self.name().into(),
+                        matches,
+                        match_prop: prompt,
+                        is_element_access: false,
+                    }
                 };
                 request.reply_final(&msg)?
             },

--- a/components/devtools/actors/environment.rs
+++ b/components/devtools/actors/environment.rs
@@ -5,12 +5,13 @@
 use std::collections::HashMap;
 
 use atomic_refcell::AtomicRefCell;
-use devtools_traits::EnvironmentInfo;
+use devtools_traits::{DebuggerValue, EnvironmentInfo};
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::Value;
 
 use crate::actor::{Actor, ActorEncode, ActorRegistry, new_actor_name};
+use crate::actors::console::ConsoleActor;
 use crate::actors::object::ObjectPropertyDescriptor;
 use crate::debugger_value_to_json;
 
@@ -82,6 +83,54 @@ impl EnvironmentActor {
         };
         registry.register(environment_actor);
         environment_name
+    }
+
+    /// Recursively searches for property and variable names in this lineage of environments.
+    /// The resulting vec is sorted and deduplicated. Intended for autocomplete.
+    pub(crate) fn search_identifiers_recursive(
+        &self,
+        registry: &ActorRegistry,
+        prefix: &str,
+    ) -> Vec<String> {
+        let mut names: Vec<String> = vec![];
+        self.recurse_identifiers(registry, prefix, &mut names);
+
+        names.sort_unstable();
+        names.dedup();
+        names
+    }
+
+    fn recurse_identifiers(&self, registry: &ActorRegistry, prefix: &str, names: &mut Vec<String>) {
+        let environment = self.environment.borrow();
+        names.extend(
+            environment
+                .binding_variables
+                .iter()
+                .map(|bind| &bind.name)
+                .filter(|name| ConsoleActor::autocomplete_match(prefix, name))
+                .cloned(),
+        );
+
+        if let Some(DebuggerValue::ObjectValue {
+            preview: Some(preview),
+            ..
+        }) = &environment.object &&
+            let Some(props) = &preview.own_properties
+        {
+            names.extend(
+                props
+                    .iter()
+                    .map(|p| &p.name)
+                    .filter(|name| ConsoleActor::autocomplete_match(prefix, name))
+                    .cloned(),
+            );
+        }
+
+        if let Some(parent_name) = &self.parent_name {
+            registry
+                .find::<EnvironmentActor>(parent_name)
+                .recurse_identifiers(registry, prefix, names);
+        }
     }
 }
 

--- a/components/devtools/actors/frame.rs
+++ b/components/devtools/actors/frame.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
-use devtools_traits::{DevtoolScriptControlMsg, FrameInfo};
+use devtools_traits::{DevtoolScriptControlMsg, FrameInfo, GetEnvironmentRequest};
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -88,7 +88,7 @@ impl Actor for FrameActor {
                 source_actor
                     .script_sender
                     .send(DevtoolScriptControlMsg::GetEnvironment(
-                        self.name().into(),
+                        GetEnvironmentRequest::Frame(self.name().into()),
                         tx,
                     ))
                     .map_err(|_| ActorError::Internal)?;

--- a/components/script/dom/debugger/debuggergetenvironmentevent.rs
+++ b/components/script/dom/debugger/debuggergetenvironmentevent.rs
@@ -4,35 +4,56 @@
 
 use std::fmt::Debug;
 
+use devtools_traits::GetEnvironmentRequest;
 use dom_struct::dom_struct;
 use js::context::JSContext;
+use script_bindings::inheritance::Castable;
 use script_bindings::reflector::reflect_dom_object_with_cx;
 use script_bindings::str::DOMString;
 
+use crate::dom::GlobalScope;
 use crate::dom::bindings::codegen::Bindings::DebuggerGetEnvironmentEventBinding::DebuggerGetEnvironmentEventMethods;
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::event::Event;
-use crate::dom::types::GlobalScope;
+use crate::dom::pipelineid::PipelineId;
+use crate::dom::types::DebuggerGlobalScope;
 
 #[dom_struct]
 /// Event for Rust → JS calls in [`crate::dom::debugger::DebuggerGlobalScope`].
 pub(crate) struct DebuggerGetEnvironmentEvent {
     event: Event,
-    frame_actor_id: DOMString,
+    frame_actor_id: Option<DOMString>,
+    pipeline_id: Option<DomRoot<PipelineId>>,
 }
 
 impl DebuggerGetEnvironmentEvent {
     pub(crate) fn new(
         cx: &mut JSContext,
-        debugger_global: &GlobalScope,
-        frame_actor_id: DOMString,
+        debugger_global_scope: &DebuggerGlobalScope,
+        request: GetEnvironmentRequest,
     ) -> DomRoot<Self> {
-        let result = Box::new(Self {
-            event: Event::new_inherited(),
-            frame_actor_id,
+        let result = Box::new(match request {
+            GetEnvironmentRequest::Frame(frame_actor_id) => Self {
+                event: Event::new_inherited(),
+                frame_actor_id: Some(frame_actor_id.into()),
+                pipeline_id: None,
+            },
+            GetEnvironmentRequest::Global(debuggee_pipeline_id) => {
+                let debuggee_pipeline_id = crate::dom::pipelineid::PipelineId::new(
+                    cx,
+                    debugger_global_scope.upcast(),
+                    debuggee_pipeline_id,
+                );
+                Self {
+                    event: Event::new_inherited(),
+                    frame_actor_id: None,
+                    pipeline_id: Some(debuggee_pipeline_id),
+                }
+            },
         });
-        let result = reflect_dom_object_with_cx(result, debugger_global, cx);
+        let result =
+            reflect_dom_object_with_cx(result, debugger_global_scope.upcast::<GlobalScope>(), cx);
         result
             .event
             .init_event("getEnvironment".into(), false, false);
@@ -43,8 +64,14 @@ impl DebuggerGetEnvironmentEvent {
 
 impl DebuggerGetEnvironmentEventMethods<crate::DomTypeHolder> for DebuggerGetEnvironmentEvent {
     // check-tidy: no specs after this line
-    fn FrameActorId(&self) -> DOMString {
+    fn GetFrameActorId(&self) -> Option<DOMString> {
         self.frame_actor_id.clone()
+    }
+
+    fn GetPipelineId(
+        &self,
+    ) -> Option<DomRoot<<crate::DomTypeHolder as script_bindings::DomTypes>::PipelineId>> {
+        self.pipeline_id.clone()
     }
 
     fn IsTrusted(&self) -> bool {

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -6,7 +6,7 @@ use std::cell::RefCell;
 
 use devtools_traits::{
     BlackboxCoverage, DebuggerValue, DevtoolScriptControlMsg, EvaluateJSReply,
-    ScriptToDevtoolsControlMsg, SourceInfo, WorkerId,
+    GetEnvironmentRequest, ScriptToDevtoolsControlMsg, SourceInfo, WorkerId,
 };
 use dom_struct::dom_struct;
 use embedder_traits::ScriptToEmbedderChan;
@@ -301,7 +301,7 @@ impl DebuggerGlobalScope {
     pub(crate) fn fire_get_environment(
         &self,
         cx: &mut JSContext,
-        frame_actor_id: String,
+        request: GetEnvironmentRequest,
         result_sender: GenericSender<String>,
     ) {
         assert!(
@@ -311,11 +311,8 @@ impl DebuggerGlobalScope {
         );
         let mut realm = enter_auto_realm(cx, self);
         let cx = &mut realm.current_realm();
-        let event = DomRoot::upcast::<Event>(DebuggerGetEnvironmentEvent::new(
-            cx,
-            self.upcast(),
-            frame_actor_id.into(),
-        ));
+
+        let event = DomRoot::upcast::<Event>(DebuggerGetEnvironmentEvent::new(cx, self, request));
         assert!(
             event.fire(cx, self.upcast()),
             "Guaranteed by DebuggerGetEnvironmentEvent::new"

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2325,9 +2325,9 @@ impl ScriptThread {
                 self.debugger_global
                     .fire_list_frames(cx, pipeline_id, start, count, result_sender);
             },
-            DevtoolScriptControlMsg::GetEnvironment(frame_actor_id, result_sender) => {
+            DevtoolScriptControlMsg::GetEnvironment(request, result_sender) => {
                 self.debugger_global
-                    .fire_get_environment(cx, frame_actor_id, result_sender);
+                    .fire_get_environment(cx, request, result_sender);
             },
             DevtoolScriptControlMsg::Resume(resume_limit_type, frame_actor_id) => {
                 self.debugger_global

--- a/components/script_bindings/webidls/DebuggerGetEnvironmentEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerGetEnvironmentEvent.webidl
@@ -6,7 +6,8 @@
 // web pages.
 [Exposed=DebuggerGlobalScope]
 interface DebuggerGetEnvironmentEvent : Event {
-    readonly attribute DOMString frameActorId;
+    readonly attribute DOMString? frameActorId;
+    readonly attribute PipelineId? pipelineId;
 };
 
 partial interface DebuggerGlobalScope {

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -483,9 +483,15 @@ pub enum DevtoolScriptControlMsg {
     Interrupt,
     Resume(Option<String>, Option<String>),
     ListFrames(PipelineId, u32, u32, GenericSender<Vec<String>>),
-    GetEnvironment(String, GenericSender<String>),
+    GetEnvironment(GetEnvironmentRequest, GenericSender<String>),
     Blackbox(u32, BlackboxCoverage),
     Unblackbox(u32, BlackboxCoverage),
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum GetEnvironmentRequest {
+    Global(PipelineId),
+    Frame(String),
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/python/servo/devtools_tests/console/autocomplete_scoped.html
+++ b/python/servo/devtools_tests/console/autocomplete_scoped.html
@@ -1,0 +1,10 @@
+<!doctype html><meta charset="utf-8" />
+<script>
+    function loop() {
+        valOuter += 1;
+        const valInner = "";
+        setTimeout(loop, 200);
+    }
+    let valOuter = 0;
+    loop();
+</script>

--- a/python/servo/devtools_tests/test_console_tab.py
+++ b/python/servo/devtools_tests/test_console_tab.py
@@ -14,7 +14,7 @@ from geckordp.actors.events import Events
 from geckordp.actors.resources import Resources
 from geckordp.actors.web_console import WebConsoleActor
 
-from .utils import Devtools
+from .utils import Devtools, attach_thread, set_breakpoint, wait_for_pause, wait_for_source
 
 
 def evaluate_and_capture_console_log_output(js: str, timeout: float = 1) -> dict:
@@ -190,3 +190,80 @@ class TestConsoleTab:
             assert not result["result"]
             assert result["exception"]
             assert "Not enough arguments" in result["exceptionMessage"]
+
+    def test_global_autocomplete(self, run_servoshell):
+        script_tag = "<script>console_test_value = 5;</script>"
+        run_servoshell(url=f"data:text/html,{script_tag}")
+
+        with Devtools.connect() as devtools:
+            console = WebConsoleActor(devtools.client, devtools.targets[0]["consoleActor"])
+            prompt = "con"
+            result = console.autocomplete(text=prompt, frame_actor=None)
+
+            # TODO: These are not supported yet
+            # assert "console" in result["matches"]
+            # assert "const" in result["matches"]
+            # assert "continue" in result["matches"]
+
+            assert "console_test_value" in result["matches"]
+            assert result["matchProp"] == prompt
+
+    def test_frame_autocomplete(self, run_servoshell, web_server_urls):
+        run_servoshell(url=f"{web_server_urls[0]}/console/autocomplete_scoped.html")
+        with Devtools.connect() as devtools:
+            thread_actor = attach_thread(devtools)
+            source_actor = wait_for_source(devtools, "console/autocomplete_scoped.html")
+
+            # Get valid breakpoint position
+            positions = devtools.client.send_receive(
+                {"to": source_actor, "type": "getBreakpointPositionsCompressed"}
+            ).get("positions", {})
+
+            line_str = str(6)
+            line, column = int(line_str), positions[line_str][0]
+
+            def trigger():
+                set_breakpoint(devtools, f"{web_server_urls[0]}/console/autocomplete_scoped.html", line, column)
+
+            pause_data = wait_for_pause(devtools.client, thread_actor, trigger)
+            frame_actor = pause_data["frame"]["actor"]
+
+            prompt = "val"
+            console = WebConsoleActor(devtools.client, devtools.targets[0]["consoleActor"])
+            result = console.autocomplete(text=prompt, frame_actor=frame_actor)
+
+            assert "valInner" in result["matches"]
+            assert "valOuter" in result["matches"]
+            assert result["matchProp"] == prompt
+
+    # Console autocomplete is case-insensitive when the first character is lowercase
+    def test_console_case_sensitivity(self, run_servoshell):
+        run_servoshell(url="data:text/html,")
+        with Devtools.connect() as devtools:
+            console = WebConsoleActor(devtools.client, devtools.targets[0]["consoleActor"])
+            future = Future()
+
+            def on_evaluation(data):
+                future.set_result(data)
+
+            devtools.client.add_event_listener(console.actor_id, Events.WebConsole.EVALUATION_RESULT, on_evaluation)
+            console.evaluate_js_async("let case_; let CASE_;")
+            eval_result = future.result(1)
+            assert not eval_result["exception"]
+
+            result_uu = console.autocomplete(text="CA", frame_actor=None)
+            result_ul = console.autocomplete(text="Ca", frame_actor=None)
+            result_lu = console.autocomplete(text="cA", frame_actor=None)
+            result_ll = console.autocomplete(text="ca", frame_actor=None)
+
+            assert "case_" not in result_uu["matches"]
+            assert "CASE_" in result_uu["matches"]
+
+            assert "case_" not in result_ul["matches"]
+            assert "CASE_" not in result_ul["matches"]
+
+            assert "case_" in result_lu["matches"]
+            assert "CASE_" in result_lu["matches"]
+
+            assert "case_" in result_ll["matches"]
+            assert "CASE_" in result_ll["matches"]


### PR DESCRIPTION
This PR adds autocomplete for the console tab in devtools. Currently this is a simple match against environment identifiers without any parsing or indexing.

Both frame environments and the global environment is supported.

Testing: Added a test each against frame and global scopes, as well as one test for case-sensitivity
Fixes: Part of #39858