### PR TITLE
script: Fix Borrow Hazards in ByteTeeUnderlyingSource

### DIFF
--- a/components/script/dom/stream/byteteeunderlyingsource.rs
+++ b/components/script/dom/stream/byteteeunderlyingsource.rs
@@ -166,66 +166,75 @@ impl ByteTeeUnderlyingSource {
     }
 
     fn pull_with_default_reader(&self, cx: &mut JSContext, global: &GlobalScope) -> Fallible<()> {
-        let mut reader = self.reader.borrow_mut();
-        match &*reader {
-            ReaderType::BYOB(byte_reader) => {
-                // Assert: readIntoRequests is empty.
-                assert!(
+        rooted!(&in(cx) let mut reader_to_set = None);
+        {
+            let reader = self.reader.borrow();
+            match &*reader {
+                ReaderType::BYOB(byte_reader) => {
+                    // Assert: readIntoRequests is empty.
+                    assert!(
+                        byte_reader
+                            .get()
+                            .expect("Reader should be set.")
+                            .get_num_read_into_requests() ==
+                            0
+                    );
+
+                    // Release BYOB reader.
                     byte_reader
                         .get()
                         .expect("Reader should be set.")
-                        .get_num_read_into_requests() ==
-                        0
-                );
+                        .release(cx)?;
 
-                // Release BYOB reader.
-                byte_reader
-                    .get()
-                    .expect("Reader should be set.")
-                    .release(cx)?;
+                    // Acquire default reader.
+                    let default_reader = self
+                        .stream
+                        .acquire_default_reader(cx)
+                        .expect("AcquireReadableStreamDefaultReader should not fail");
 
-                // Acquire default reader.
-                let default_reader = self
-                    .stream
-                    .acquire_default_reader(cx)
-                    .expect("AcquireReadableStreamDefaultReader should not fail");
+                    reader_to_set.set(Some(ReaderType::Default(MutNullableDom::new(Some(
+                        &default_reader,
+                    )))));
+                    // We continue after the reader is set, after this match.
+                },
+                ReaderType::Default(reader) => {
+                    let byte_tee_read_request = ByteTeeReadRequest::new(
+                        cx,
+                        &self.branch_1.get().expect("Branch 1 should be set."),
+                        &self.branch_2.get().expect("Branch 2 should be set."),
+                        &self.stream,
+                        self.read_again_for_branch_1.clone(),
+                        self.read_again_for_branch_2.clone(),
+                        self.reading.clone(),
+                        self.canceled_1.clone(),
+                        self.canceled_2.clone(),
+                        self.cancel_promise.clone(),
+                        self,
+                        global,
+                    );
 
-                *reader = ReaderType::Default(MutNullableDom::new(Some(&default_reader)));
-                self.reader_version
-                    .set(self.reader_version.get().wrapping_add(1));
-                drop(reader);
+                    let read_request = ReadRequest::ByteTee {
+                        byte_tee_read_request: Dom::from_ref(&byte_tee_read_request),
+                    };
 
-                // Attach error forwarding for the new reader.
-                self.forward_reader_error(cx, self.reader.clone());
+                    reader
+                        .get()
+                        .expect("Reader should be set.")
+                        .read(cx, &read_request);
+                },
+            }
+        }
 
-                // IMPORTANT: now actually perform the pull we were asked to do.
-                return self.pull_with_default_reader(cx, global);
-            },
-            ReaderType::Default(reader) => {
-                let byte_tee_read_request = ByteTeeReadRequest::new(
-                    cx,
-                    &self.branch_1.get().expect("Branch 1 should be set."),
-                    &self.branch_2.get().expect("Branch 2 should be set."),
-                    &self.stream,
-                    self.read_again_for_branch_1.clone(),
-                    self.read_again_for_branch_2.clone(),
-                    self.reading.clone(),
-                    self.canceled_1.clone(),
-                    self.canceled_2.clone(),
-                    self.cancel_promise.clone(),
-                    self,
-                    global,
-                );
+        if reader_to_set.is_some() {
+            *self.reader.borrow_mut() = reader_to_set.take().unwrap();
+            self.reader_version
+                .set(self.reader_version.get().wrapping_add(1));
 
-                let read_request = ReadRequest::ByteTee {
-                    byte_tee_read_request: Dom::from_ref(&byte_tee_read_request),
-                };
+            // Attach error forwarding for the new reader.
+            self.forward_reader_error(cx, self.reader.clone());
 
-                reader
-                    .get()
-                    .expect("Reader should be set.")
-                    .read(cx, &read_request);
-            },
+            // IMPORTANT: now actually perform the pull we were asked to do.
+            return self.pull_with_default_reader(cx, global);
         }
 
         Ok(())

--- a/components/script/dom/stream/byteteeunderlyingsource.rs
+++ b/components/script/dom/stream/byteteeunderlyingsource.rs
@@ -247,86 +247,96 @@ impl ByteTeeUnderlyingSource {
         for_branch2: bool,
         global: &GlobalScope,
     ) {
-        let mut reader = self.reader.borrow_mut();
-        match &*reader {
-            ReaderType::BYOB(reader) => {
-                // Let byobBranch be branch2 if forBranch2 is true, and branch1 otherwise.
-                let byob_branch = if for_branch2 {
-                    self.branch_2.get().expect("Branch 2 should be set.")
-                } else {
-                    self.branch_1.get().expect("Branch 1 should be set.")
-                };
+        rooted!(&in(cx) let mut reader_to_set = None);
+        {
+            let reader = self.reader.borrow();
+            match &*reader {
+                ReaderType::BYOB(reader) => {
+                    // Let byobBranch be branch2 if forBranch2 is true, and branch1 otherwise.
+                    let byob_branch = if for_branch2 {
+                        self.branch_2.get().expect("Branch 2 should be set.")
+                    } else {
+                        self.branch_1.get().expect("Branch 1 should be set.")
+                    };
 
-                // let otherBranch be branch2 if forBranch2 is false, and branch1 otherwise.
-                let other_branch = if for_branch2 {
-                    self.branch_1.get().expect("Branch 1 should be set.")
-                } else {
-                    self.branch_2.get().expect("Branch 2 should be set.")
-                };
+                    // let otherBranch be branch2 if forBranch2 is false, and branch1 otherwise.
+                    let other_branch = if for_branch2 {
+                        self.branch_1.get().expect("Branch 1 should be set.")
+                    } else {
+                        self.branch_2.get().expect("Branch 2 should be set.")
+                    };
 
-                // Let readIntoRequest be a read-into request with the following items:
-                let byte_tee_read_into_request = ByteTeeReadIntoRequest::new(
-                    cx,
-                    for_branch2,
-                    &byob_branch,
-                    &other_branch,
-                    &self.stream,
-                    self.read_again_for_branch_1.clone(),
-                    self.read_again_for_branch_2.clone(),
-                    self.reading.clone(),
-                    self.canceled_1.clone(),
-                    self.canceled_2.clone(),
-                    self.cancel_promise.clone(),
-                    self,
-                    global,
-                );
+                    // Let readIntoRequest be a read-into request with the following items:
+                    let byte_tee_read_into_request = ByteTeeReadIntoRequest::new(
+                        cx,
+                        for_branch2,
+                        &byob_branch,
+                        &other_branch,
+                        &self.stream,
+                        self.read_again_for_branch_1.clone(),
+                        self.read_again_for_branch_2.clone(),
+                        self.reading.clone(),
+                        self.canceled_1.clone(),
+                        self.canceled_2.clone(),
+                        self.cancel_promise.clone(),
+                        self,
+                        global,
+                    );
 
-                let read_into_request = ReadIntoRequest::ByteTee {
-                    byte_tee_read_into_request: Dom::from_ref(&byte_tee_read_into_request),
-                };
+                    let read_into_request = ReadIntoRequest::ByteTee {
+                        byte_tee_read_into_request: Dom::from_ref(&byte_tee_read_into_request),
+                    };
 
-                // Perform ! ReadableStreamBYOBReaderRead(reader, view, 1, readIntoRequest).
-                reader
-                    .get()
-                    .expect("Reader should be set.")
-                    .read(cx, view, 1, &read_into_request);
-            },
-            ReaderType::Default(default_reader) => {
-                // If reader implements ReadableStreamDefaultReader,
-                // Assert: reader.[[readRequests]] is empty.
-                assert!(
+                    // Perform ! ReadableStreamBYOBReaderRead(reader, view, 1, readIntoRequest).
+                    reader.get().expect("Reader should be set.").read(
+                        cx,
+                        view,
+                        1,
+                        &read_into_request,
+                    );
+                },
+                ReaderType::Default(default_reader) => {
+                    // If reader implements ReadableStreamDefaultReader,
+                    // Assert: reader.[[readRequests]] is empty.
+                    assert!(
+                        default_reader
+                            .get()
+                            .expect("Reader should be set.")
+                            .get_num_read_requests() ==
+                            0
+                    );
+
+                    // Perform ! ReadableStreamDefaultReaderRelease(reader).
                     default_reader
                         .get()
                         .expect("Reader should be set.")
-                        .get_num_read_requests() ==
-                        0
-                );
+                        .release(cx)
+                        .expect("Release should be successful.");
 
-                // Perform ! ReadableStreamDefaultReaderRelease(reader).
-                default_reader
-                    .get()
-                    .expect("Reader should be set.")
-                    .release(cx)
-                    .expect("Release should be successful.");
+                    // Set reader to ! AcquireReadableStreamBYOBReader(stream).
+                    let byob_reader = self
+                        .stream
+                        .acquire_byob_reader(cx)
+                        .expect("Reader should be set.");
 
-                // Set reader to ! AcquireReadableStreamBYOBReader(stream).
-                let byob_reader = self
-                    .stream
-                    .acquire_byob_reader(cx)
-                    .expect("Reader should be set.");
+                    reader_to_set.set(Some(ReaderType::BYOB(MutNullableDom::new(Some(
+                        &byob_reader,
+                    )))));
+                    // This execution path continues after we set the reader.
+                },
+            }
+        }
 
-                *reader = ReaderType::BYOB(MutNullableDom::new(Some(&byob_reader)));
-                self.reader_version
-                    .set(self.reader_version.get().wrapping_add(1));
+        if reader_to_set.is_some() {
+            *self.reader.borrow_mut() = reader_to_set.take().unwrap();
+            self.reader_version
+                .set(self.reader_version.get().wrapping_add(1));
 
-                drop(reader);
+            // Perform forwardReaderError, given reader.
+            self.forward_reader_error(cx, self.reader.clone());
 
-                // Perform forwardReaderError, given reader.
-                self.forward_reader_error(cx, self.reader.clone());
-
-                // Retry the pull using the BYOB reader we just acquired.
-                self.pull_with_byob_reader(cx, view, for_branch2, global);
-            },
+            // Retry the pull using the BYOB reader we just acquired.
+            self.pull_with_byob_reader(cx, view, for_branch2, global);
         }
     }
 

--- a/components/script/dom/stream/byteteeunderlyingsource.rs
+++ b/components/script/dom/stream/byteteeunderlyingsource.rs
@@ -126,7 +126,7 @@ impl ByteTeeUnderlyingSource {
         cx: &mut JSContext,
         this_reader: Rc<RefCell<ReaderType>>,
     ) {
-        let this_reader = this_reader.borrow_mut();
+        let this_reader = this_reader.borrow();
         match &*this_reader {
             ReaderType::Default(reader) => {
                 let expected_version = self.reader_version.get();

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -809,6 +809,8 @@ pub(crate) enum ReaderType {
     Default(MutNullableDom<ReadableStreamDefaultReader>),
 }
 
+impl js::gc::Rootable for ReaderType {}
+
 impl Eq for ReaderType {}
 impl PartialEq for ReaderType {
     fn eq(&self, other: &Self) -> bool {


### PR DESCRIPTION
This fixes the potential borrow hazards in ByteTeeUnderlyingSource by basic refactoring.

Testing: WPT test should find if there was any mistake made but it should be equivalent code.
Fixes: https://github.com/servo/servo/issues/46380
