### PR TITLE
layout: Add statistics for accessibility updates.

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -50,6 +50,14 @@ struct AccessibilityUpdate {
     /// `AccessibilityData`. Only set if `pref::expensive_accessibility_test_assertions_enabled`
     /// is set.
     rooted_nodes: Option<FxHashSet<OpaqueNode>>,
+    counters: UpdateCounters,
+}
+
+#[derive(Debug, Default)]
+pub struct UpdateCounters {
+    pub update_node_and_descendants_from_dom_node: u32,
+    pub update_node_local: u32,
+    pub nodes_in_tree_update: u32,
 }
 
 struct AccessibilityNode {
@@ -162,7 +170,7 @@ impl AccessibilityTree {
         root_dom_node: &ServoLayoutNode<'dom>,
         mut damage_from_dom: VecDeque<(ServoLayoutNode<'dom>, AccessibilityDamage)>,
         rooted_nodes: Option<FxHashSet<OpaqueNode>>,
-    ) -> Option<accesskit::TreeUpdate> {
+    ) -> (Option<accesskit::TreeUpdate>, UpdateCounters) {
         let mut update = AccessibilityUpdate::new(rooted_nodes);
 
         self.ensure_root_node(root_dom_node, &mut damage_from_dom, &mut update);
@@ -259,6 +267,8 @@ impl AccessibilityTree {
         dom_damage: AccessibilityDamage,
         update: &mut AccessibilityUpdate,
     ) -> LocalAccessibilityDamage {
+        update.counters.update_node_and_descendants_from_dom_node += 1;
+
         let weak_node = node.downgrade();
         let mut node = node.borrow_mut();
         let mut local_damage = LocalAccessibilityDamage::empty();
@@ -299,7 +309,7 @@ impl AccessibilityTree {
             return;
         };
 
-        node.update_node_local(local_damage);
+        node.update_node_local(local_damage, update);
 
         if local_damage.contains(LocalAccessibilityDamage::SubtreeChanged) {
             for child in node.children() {
@@ -615,7 +625,10 @@ impl AccessibilityNode {
     fn update_node_local(
         &mut self,
         local_damage: LocalAccessibilityDamage,
+        update: &mut AccessibilityUpdate,
     ) -> LocalAccessibilityDamage {
+        update.counters.update_node_local += 1;
+
         let mut new_damage = LocalAccessibilityDamage::empty();
         if local_damage.contains(LocalAccessibilityDamage::SubtreeChanged) ||
             local_damage.contains(LocalAccessibilityDamage::RoleChanged)
@@ -837,6 +850,7 @@ impl AccessibilityUpdate {
             tree_changes: FxHashMap::default(),
             unresolved_local_damage: FxHashMap::default(),
             rooted_nodes,
+            counters: UpdateCounters::default(),
         }
     }
 
@@ -875,7 +889,10 @@ impl AccessibilityUpdate {
     /// been any changes to `tree`.
     /// This will pass `self` into [`AccessibilityTree::remove_stale_nodes()`] to consume
     /// [`Self::tree_changes`].
-    fn finalize(mut self, tree: &mut AccessibilityTree) -> Option<accesskit::TreeUpdate> {
+    fn finalize(
+        mut self,
+        tree: &mut AccessibilityTree,
+    ) -> (Option<accesskit::TreeUpdate>, UpdateCounters) {
         let root_node_id = tree
             .root_node
             .clone()
@@ -886,10 +903,14 @@ impl AccessibilityUpdate {
         if self.changed_nodes.is_empty() {
             assert!(self.tree_changes.is_empty());
             assert!(self.unresolved_local_damage.is_empty());
-            return None;
+            return (None, self.counters);
         }
 
         let changed_nodes = std::mem::take(&mut self.changed_nodes);
+
+        let mut counters = std::mem::take(&mut self.counters);
+        counters.nodes_in_tree_update = changed_nodes.len().try_into().unwrap_or_default();
+
         tree.drop_removed_nodes(self);
 
         let accesskit_tree = accesskit::Tree::new(root_node_id);
@@ -904,7 +925,7 @@ impl AccessibilityUpdate {
             tree_id: tree.tree_id,
         };
 
-        Some(tree_update)
+        (Some(tree_update), counters)
     }
 }
 

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -978,9 +978,8 @@ fn test_accessibility_update_add_some_nodes_twice() {
         update.add(&mut node_3);
     }
 
-    let mut tree_update = update
-        .finalize(&mut tree)
-        .expect("finalize should produce a tree update");
+    let (tree_update, _) = update.finalize(&mut tree);
+    let mut tree_update = tree_update.expect("finalize should produce a tree update");
     tree_update.nodes.sort_by_key(|(node_id, _node)| *node_id);
     assert_eq!(
         tree_update,

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -925,6 +925,7 @@ impl LayoutThread {
         &self,
         root_element: &ServoLayoutNode,
         reflow_request: &mut ReflowRequest,
+        reflow_statistics: &mut ReflowStatistics,
     ) -> bool {
         if !self.needs_accessibility_update() {
             return false;
@@ -946,9 +947,9 @@ impl LayoutThread {
             .map(|(address, damage)| unsafe { (ServoLayoutNode::new(address), *damage) })
             .collect();
 
-        if let Some(tree_update) =
-            accessibility_tree.update_tree(root_element, damage, rooted_nodes)
-        {
+        let (tree_update, counters) =
+            accessibility_tree.update_tree(root_element, damage, rooted_nodes);
+        if let Some(tree_update) = tree_update {
             // FIXME: Handle send error. Could have a method on accessibility tree to
             // finalise after sending, removing accessibility damage? On fail, retain damage
             // for next reflow, as well as retaining document.needs_accessibility_update.
@@ -960,6 +961,12 @@ impl LayoutThread {
                     accessibility_tree.embedder_epoch(),
                 ));
         }
+
+        reflow_statistics.accessibility_nodes_updated_from_dom =
+            counters.update_node_and_descendants_from_dom_node;
+        reflow_statistics.accessibility_nodes_updated_from_tree = counters.update_node_local;
+        reflow_statistics.accessibility_nodes_in_tree_update = counters.nodes_in_tree_update;
+
         self.needs_accessibility_update.set(false);
         true
     }
@@ -1018,7 +1025,11 @@ impl LayoutThread {
         if self.handle_update_scroll_node_request(&reflow_request) {
             reflow_phases_run.insert(ReflowPhasesRun::UpdatedScrollNodeOffset);
         }
-        if self.handle_accessibility_tree_update(&root_element.as_node(), &mut reflow_request) {
+        if self.handle_accessibility_tree_update(
+            &root_element.as_node(),
+            &mut reflow_request,
+            &mut reflow_statistics,
+        ) {
             reflow_phases_run.insert(ReflowPhasesRun::UpdatedAccessibilityTree);
         }
 

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -918,7 +918,9 @@ impl Node {
                     .unwrap()
                     .dirty(NodeDamage::ContentOrHeritage);
 
-                self.add_pending_accessibility_damage(AccessibilityDamage::Text);
+                if damage == NodeDamage::Other {
+                    self.add_pending_accessibility_damage(AccessibilityDamage::Text);
+                }
             },
             NodeTypeId::Element(_) => self.downcast::<Element>().unwrap().restyle(damage),
             NodeTypeId::DocumentFragment(DocumentFragmentTypeId::ShadowRoot) => self

--- a/components/script/dom/testing/accessibilityupdateresult.rs
+++ b/components/script/dom/testing/accessibilityupdateresult.rs
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+use dom_struct::dom_struct;
+use js::context::JSContext;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+
+use crate::dom::bindings::codegen::Bindings::ServoTestUtilsBinding::AccessibilityUpdateResultMethods;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::globalscope::GlobalScope;
+
+#[dom_struct]
+pub(crate) struct AccessibilityUpdateResult {
+    reflector_: Reflector,
+    accessibility_nodes_updated_from_dom: u32,
+    accessibility_nodes_updated_from_tree: u32,
+    accessibility_nodes_in_tree_update: u32,
+}
+
+impl AccessibilityUpdateResult {
+    pub(crate) fn new_inherited(
+        accessibility_nodes_updated_from_dom: u32,
+        accessibility_nodes_updated_from_tree: u32,
+        accessibility_nodes_in_tree_update: u32,
+    ) -> Self {
+        Self {
+            reflector_: Reflector::new(),
+            accessibility_nodes_updated_from_dom,
+            accessibility_nodes_updated_from_tree,
+            accessibility_nodes_in_tree_update,
+        }
+    }
+
+    pub(crate) fn new(
+        cx: &mut JSContext,
+        global: &GlobalScope,
+        accessibility_nodes_updated_from_dom: u32,
+        accessibility_nodes_updated_from_tree: u32,
+        accessibility_nodes_in_tree_update: u32,
+    ) -> DomRoot<Self> {
+        reflect_dom_object_with_cx(
+            Box::new(Self::new_inherited(
+                accessibility_nodes_updated_from_dom,
+                accessibility_nodes_updated_from_tree,
+                accessibility_nodes_in_tree_update,
+            )),
+            global,
+            cx,
+        )
+    }
+}
+
+impl AccessibilityUpdateResultMethods<crate::DomTypeHolder> for AccessibilityUpdateResult {
+    fn AccessibilityNodesUpdatedFromDom(&self) -> u32 {
+        self.accessibility_nodes_updated_from_dom
+    }
+
+    fn AccessibilityNodesUpdatedFromTree(&self) -> u32 {
+        self.accessibility_nodes_updated_from_tree
+    }
+
+    fn AccessibilityNodesInTreeUpdate(&self) -> u32 {
+        self.accessibility_nodes_in_tree_update
+    }
+}

--- a/components/script/dom/testing/mod.rs
+++ b/components/script/dom/testing/mod.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+pub(crate) mod accessibilityupdateresult;
 pub(crate) mod layoutresult;
 pub(crate) mod servotestutils;
 pub(crate) mod testbinding;

--- a/components/script/dom/testing/servotestutils.rs
+++ b/components/script/dom/testing/servotestutils.rs
@@ -12,11 +12,13 @@ use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::domstring::DOMString;
 use script_bindings::reflector::Reflector;
 use script_bindings::root::DomRoot;
+use servo_base::Epoch;
 use time::Duration;
 
 use crate::dom::bindings::codegen::Bindings::ServoTestUtilsBinding::ServoTestUtilsMethods;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::layoutresult::LayoutResult;
+use crate::dom::types::AccessibilityUpdateResult;
 
 #[dom_struct]
 pub(crate) struct ServoTestUtils {
@@ -75,9 +77,27 @@ impl ServoTestUtilsMethods<crate::DomTypeHolder> for ServoTestUtils {
         panic!("explicit panic from script")
     }
 
-    fn ForceAccessibilityUpdate(cx: &mut JSContext, global: &GlobalScope) {
+    fn EnsureAccessibilityActive(global: &GlobalScope) {
+        let window = global.as_window();
+        window
+            .layout()
+            .set_accessibility_active(true, Epoch::default());
+    }
+
+    fn ForceAccessibilityUpdate(
+        cx: &mut JSContext,
+        global: &GlobalScope,
+    ) -> DomRoot<AccessibilityUpdateResult> {
         let window = global.as_window();
         window.layout().set_needs_accessibility_update();
-        let _ = window.Document().update_the_rendering(cx);
+        let (_, statistics) = window.Document().update_the_rendering(cx);
+
+        AccessibilityUpdateResult::new(
+            cx,
+            global,
+            statistics.accessibility_nodes_updated_from_dom,
+            statistics.accessibility_nodes_updated_from_tree,
+            statistics.accessibility_nodes_in_tree_update,
+        )
     }
 }

--- a/components/script_bindings/webidls/ServoTestUtils.webidl
+++ b/components/script_bindings/webidls/ServoTestUtils.webidl
@@ -21,7 +21,10 @@ namespace ServoTestUtils {
 
   undefined panic();
 
-  undefined forceAccessibilityUpdate();
+  undefined ensureAccessibilityActive();
+
+  [Exposed=Window]
+  AccessibilityUpdateResult forceAccessibilityUpdate();
 };
 
 [Exposed=Window, Pref="dom_servo_helpers_enabled"]
@@ -30,4 +33,12 @@ interface LayoutResult {
     readonly attribute unsigned long rebuiltFragmentCount;
     readonly attribute unsigned long restyleFragmentCount;
     readonly attribute unsigned long onlyDescendantsChangedCount;
+
+};
+
+[Exposed=Window, Pref="dom_servo_helpers_enabled"]
+interface AccessibilityUpdateResult {
+    readonly attribute unsigned long accessibilityNodesUpdatedFromDom;
+    readonly attribute unsigned long accessibilityNodesUpdatedFromTree;
+    readonly attribute unsigned long accessibilityNodesInTreeUpdate;
 };

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -660,6 +660,14 @@ pub struct ReflowStatistics {
     /// A count of the number of fragments that are reused, but may have had some descendant
     /// fragment change.
     pub only_descendants_changed_count: u32,
+    /// A count of the number of accessibility nodes which were checked for changes based on their
+    /// corresponding DOM nodes (whether the check resulted in changes or not).
+    pub accessibility_nodes_updated_from_dom: u32,
+    /// A count of the number of accessibility nodes which were checked for changes based on data
+    /// already in the accessibility tree (whether the check resulted in changes or not).
+    pub accessibility_nodes_updated_from_tree: u32,
+    /// A count of the number of accessibility nodes actually serialized to the TreeUpdate.
+    pub accessibility_nodes_in_tree_update: u32,
 }
 
 /// Information needed for a script-initiated reflow that requires a restyle

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -11388,7 +11388,7 @@
      ]
     ],
     "accessibility-update-mutation-move-nodes.html": [
-     "691d958b79cff43fca1ddac97e9af324678ee520",
+     "bef5853f9bbfcbcb766cfc69052ed67f2bac8ef4",
      [
       null,
       {}

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -11379,6 +11379,29 @@
    }
   },
   "testharness": {
+   "accessibility-tree": {
+    "accessibility-update-basic-mutation.html": [
+     "a1d9dab44d95dc6ee217d277ff9555266fcd91cd",
+     [
+      null,
+      {}
+     ]
+    ],
+    "accessibility-update-mutation-move-nodes.html": [
+     "691d958b79cff43fca1ddac97e9af324678ee520",
+     [
+      null,
+      {}
+     ]
+    ],
+    "accessibility-update-text-change.html": [
+     "ebb377d1467e9b734cd325f3c34e17bedf820c2f",
+     [
+      null,
+      {}
+     ]
+    ]
+   },
    "bluetooth": {
     "advertisingEvent": {
      "watchAdvertisements-succeeds.https.html": [

--- a/tests/wpt/mozilla/meta/accessibility-tree/__dir__.ini
+++ b/tests/wpt/mozilla/meta/accessibility-tree/__dir__.ini
@@ -1,0 +1,3 @@
+prefs: [
+  "accessibility_enabled:true",
+]

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-basic-mutation.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-basic-mutation.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<section>
+  <h1 id="h1">This is an h1</h1>
+  <h2 id="h2">This is an h2</h2>
+</section>
+
+<script>
+  setup({ explicit_done: true });
+  window.onload = () => {
+    test((t) => {
+      ServoTestUtils.ensureAccessibilityActive();
+      let initial = ServoTestUtils.forceAccessibilityUpdate();
+
+      assert_equals(
+        initial.accessibilityNodesUpdatedFromDom,
+        19,
+        "accessibilityNodesUpdatedFromDom",
+      );
+      assert_equals(
+        initial.accessibilityNodesUpdatedFromTree,
+        19,
+        "accessibilityNodesUpdatedFromTree",
+      );
+      assert_equals(
+        initial.accessibilityNodesInTreeUpdate,
+        19,
+        "accessibilityNodesInTreeUpdate",
+      );
+
+      document.getElementById("h2").remove();
+      let incremental = ServoTestUtils.forceAccessibilityUpdate();
+
+      // Only the <section> is updated from the DOM
+      assert_equals(
+        incremental.accessibilityNodesUpdatedFromDom,
+        1,
+        "accessibilityNodesUpdatedFromDom",
+      );
+
+      // The <section>, its parent <body> and the document are checked for changes as their subtrees
+      // changed
+      assert_equals(
+        incremental.accessibilityNodesUpdatedFromTree,
+        3,
+        "accessibilityNodesUpdatedFromTree",
+      );
+
+      // The only node in the tree update should be the parent <section> of the removed <h2>
+      assert_equals(
+        incremental.accessibilityNodesInTreeUpdate,
+        1,
+        "accessibilityNodesInTreeUpdate",
+      );
+    }, "Remove h2 should update one node");
+
+    done();
+  };
+</script>

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-mutation-move-nodes.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-mutation-move-nodes.html
@@ -40,10 +40,9 @@
       // - div1 (child added)
       // - div2 (child added)
       // - <section> (children removed)
-      // - text node inside <h1> for some reason?
       assert_equals(
         incremental.accessibilityNodesUpdatedFromDom,
-        4,
+        3,
         "accessibilityNodesUpdatedFromDom",
       );
 

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-mutation-move-nodes.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-mutation-move-nodes.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<section>
+  <div id="div1"></div>
+  <h1 id="h1">This is an h1</h1>
+  <h2 id="h2">This is an h2</h2>
+  <div id="div2"></div>
+</section>
+
+<script>
+  setup({ explicit_done: true });
+  window.onload = () => {
+    test((t) => {
+      ServoTestUtils.ensureAccessibilityActive();
+      let initial = ServoTestUtils.forceAccessibilityUpdate();
+
+      assert_equals(
+        initial.accessibilityNodesUpdatedFromDom,
+        23,
+        "accessibilityNodesUpdatedFromDom",
+      );
+      assert_equals(
+        initial.accessibilityNodesUpdatedFromTree,
+        23,
+        "accessibilityNodesUpdatedFromTree",
+      );
+      assert_equals(
+        initial.accessibilityNodesInTreeUpdate,
+        23,
+        "accessibilityNodesInTreeUpdate",
+      );
+
+      div1.moveBefore(h1, null);
+      div2.appendChild(h2);
+      let incremental = window.ServoTestUtils.forceAccessibilityUpdate();
+
+      // Nodes updated from DOM:
+      // - div1 (child added)
+      // - div2 (child added)
+      // - <section> (children removed)
+      // - text node inside <h1> for some reason?
+      assert_equals(
+        incremental.accessibilityNodesUpdatedFromDom,
+        4,
+        "accessibilityNodesUpdatedFromDom",
+      );
+
+      // Nodes checked for changes based on the tree:
+      // - the document
+      // - <body>
+      // - <section>
+      // - div1
+      // - div2
+      assert_equals(
+        incremental.accessibilityNodesUpdatedFromTree,
+        5,
+        "accessibilityNodesUpdatedFromTree",
+      );
+
+      //  updated nodes:
+      // - <section>, which had 2 children removed
+      // - div1, which had 1 node (<h1>) added
+      // - div2, which had 1 node (<h2>) added
+      assert_equals(
+        incremental.accessibilityNodesInTreeUpdate,
+        3,
+        "accessibilityNodesInTreeUpdate",
+      );
+    }, "Moving two nodes should update 3 nodes");
+
+    done();
+  };
+</script>

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-text-change.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-text-change.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<section>
+  <h1 id="h1">This is an h1</h1>
+</section>
+
+<script>
+  setup({ explicit_done: true });
+  window.onload = () => {
+    test((t) => {
+      ServoTestUtils.ensureAccessibilityActive();
+      let initial = ServoTestUtils.forceAccessibilityUpdate();
+
+      assert_equals(
+        initial.accessibilityNodesUpdatedFromDom,
+        16,
+        "accessibilityNodesUpdatedFromDom",
+      );
+      assert_equals(
+        initial.accessibilityNodesUpdatedFromTree,
+        16,
+        "accessibilityNodesUpdatedFromTree",
+      );
+      assert_equals(
+        initial.accessibilityNodesInTreeUpdate,
+        16,
+        "accessibilityNodesInTreeUpdate",
+      );
+
+      h1.firstChild.appendData(", now with more text");
+      let incremental = window.ServoTestUtils.forceAccessibilityUpdate();
+
+      // Just the text node has changed
+      assert_equals(
+        incremental.accessibilityNodesUpdatedFromDom,
+        1,
+        "accessibilityNodesUpdatedFromDom",
+      );
+
+      // The document, <body>, <section>, <h1> and the text node.
+      assert_equals(
+        incremental.accessibilityNodesUpdatedFromTree,
+        5,
+        "accessibilityNodesUpdatedFromTree",
+      );
+
+      //  updated nodes:
+      // - <h1>, computed label changed
+      // - text child of <h1>, value changed
+      assert_equals(
+        incremental.accessibilityNodesInTreeUpdate,
+        2,
+        "accessibilityNodesInTreeUpdate",
+      );
+    }, "Append data to text node should update 2 nodes");
+
+    done();
+  };
+</script>


### PR DESCRIPTION
For each accessibility update, track the number of times we call a couple of key methods: 
- `update_node_and_descendants_from_dom_node()`
- `update_node_local()`

Also expose the number of nodes added to the `TreeUpdate` which was produced as the output of the update, for comparison.

These are made available to `ServoTestUtils` via a new method, `forceAccessibilityUpdate()`, which works like the existing `forceLayout()` but returns an `AccessibilityResult` containing these three values.

Testing: Adds new "WPT" (not really) tests using the new counters
Fixes: Part of #46346
