### PR TITLE
script: Implement getPublicKey operations of Ed448 and X448

### DIFF
--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -6195,6 +6195,8 @@ enum GetPublicKeyAlgorithm {
     Ecdh(SubtleAlgorithm),
     Ed25519(SubtleAlgorithm),
     X25519(SubtleAlgorithm),
+    Ed448(SubtleAlgorithm),
+    X448(SubtleAlgorithm),
     MlKem(SubtleAlgorithm),
     MlDsa(SubtleAlgorithm),
 }
@@ -6227,6 +6229,12 @@ impl NormalizedAlgorithm for GetPublicKeyAlgorithm {
             CryptoAlgorithm::X25519 => Ok(GetPublicKeyAlgorithm::X25519(
                 object.try_into_with_cx_and_name(cx, algorithm_name)?,
             )),
+            CryptoAlgorithm::Ed448 => Ok(GetPublicKeyAlgorithm::Ed448(
+                object.try_into_with_cx_and_name(cx, algorithm_name)?,
+            )),
+            CryptoAlgorithm::X448 => Ok(GetPublicKeyAlgorithm::X448(
+                object.try_into_with_cx_and_name(cx, algorithm_name)?,
+            )),
             CryptoAlgorithm::MlKem512 | CryptoAlgorithm::MlKem768 | CryptoAlgorithm::MlKem1024 => {
                 Ok(GetPublicKeyAlgorithm::MlKem(
                     object.try_into_with_cx_and_name(cx, algorithm_name)?,
@@ -6251,6 +6259,8 @@ impl NormalizedAlgorithm for GetPublicKeyAlgorithm {
             GetPublicKeyAlgorithm::Ecdh(algorithm) => algorithm.name,
             GetPublicKeyAlgorithm::Ed25519(algorithm) => algorithm.name,
             GetPublicKeyAlgorithm::X25519(algorithm) => algorithm.name,
+            GetPublicKeyAlgorithm::Ed448(algorithm) => algorithm.name,
+            GetPublicKeyAlgorithm::X448(algorithm) => algorithm.name,
             GetPublicKeyAlgorithm::MlKem(algorithm) => algorithm.name,
             GetPublicKeyAlgorithm::MlDsa(algorithm) => algorithm.name,
         }
@@ -6287,6 +6297,12 @@ impl GetPublicKeyAlgorithm {
             },
             GetPublicKeyAlgorithm::X25519(_algorithm) => {
                 x25519_operation::get_public_key(cx, global, key, algorithm, usages)
+            },
+            GetPublicKeyAlgorithm::Ed448(_algorithm) => {
+                ed448_operation::get_public_key(cx, global, key, algorithm, usages)
+            },
+            GetPublicKeyAlgorithm::X448(_algorithm) => {
+                x448_operation::get_public_key(cx, global, key, algorithm, usages)
             },
             GetPublicKeyAlgorithm::MlKem(_algorithm) => {
                 ml_kem_operation::get_public_key(cx, global, key, algorithm, usages)

--- a/components/script/dom/webcrypto/subtlecrypto/ed25519_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ed25519_operation.rs
@@ -640,7 +640,7 @@ pub(crate) fn get_public_key(
     // Step 9. If usages contains an entry which is not supported for a public key by the algorithm
     // identified by algorithm, then throw a SyntaxError.
     //
-    // NOTE: See "impportKey" operation for supported usages
+    // NOTE: See "importKey" operation for supported usages
     if usages.iter().any(|usage| *usage != KeyUsage::Verify) {
         return Err(Error::Syntax(Some(
             "Usages contains an entry which is not supported for a public key by the algorithm \

--- a/components/script/dom/webcrypto/subtlecrypto/ed448_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ed448_operation.rs
@@ -737,3 +737,47 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
     // Step 4. Return result.
     Ok(result)
 }
+
+/// <https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-getPublicKey>
+/// Step 9 - 15, for Ed448
+pub(crate) fn get_public_key(
+    cx: &mut JSContext,
+    global: &GlobalScope,
+    key: &CryptoKey,
+    algorithm: &KeyAlgorithmAndDerivatives,
+    usages: Vec<KeyUsage>,
+) -> Result<DomRoot<CryptoKey>, Error> {
+    // Step 9. If usages contains an entry which is not supported for a public key by the algorithm
+    // identified by algorithm, then throw a SyntaxError.
+    //
+    // NOTE: See "impportKey" operation for supported usages
+    if usages.iter().any(|usage| *usage != KeyUsage::Verify) {
+        return Err(Error::Syntax(Some(
+            "Usages contains an entry which is not \"verify\"".into(),
+        )));
+    }
+
+    // Step 10. Let publicKey be a new CryptoKey representing the public key corresponding to the
+    // private key represented by the [[handle]] internal slot of key.
+    // Step 11. If an error occurred, then throw a OperationError.
+    // Step 12. Set the [[type]] internal slot of publicKey to "public".
+    // Step 13. Set the [[algorithm]] internal slot of publicKey to algorithm.
+    // Step 14. Set the [[extractable]] internal slot of publicKey to true.
+    // Step 15. Set the [[usages]] internal slot of publicKey to usages.
+    let Handle::Ed448PrivateKey(private_key) = key.handle() else {
+        return Err(Error::Operation(Some(
+            "[[handle]] internal slot of key is not an Ed448 private key".into(),
+        )));
+    };
+    let public_key = CryptoKey::new(
+        cx,
+        global,
+        KeyType::Public,
+        true,
+        algorithm.clone(),
+        usages,
+        Handle::Ed448PublicKey(private_key.verifying_key()),
+    );
+
+    Ok(public_key)
+}

--- a/components/script/dom/webcrypto/subtlecrypto/ed448_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ed448_operation.rs
@@ -750,7 +750,7 @@ pub(crate) fn get_public_key(
     // Step 9. If usages contains an entry which is not supported for a public key by the algorithm
     // identified by algorithm, then throw a SyntaxError.
     //
-    // NOTE: See "impportKey" operation for supported usages
+    // NOTE: See "importKey" operation for supported usages
     if usages.iter().any(|usage| *usage != KeyUsage::Verify) {
         return Err(Error::Syntax(Some(
             "Usages contains an entry which is not \"verify\"".into(),

--- a/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
@@ -672,7 +672,7 @@ pub(crate) fn get_public_key(
     // Step 9. If usages contains an entry which is not supported for a public key by the algorithm
     // identified by algorithm, then throw a SyntaxError.
     //
-    // NOTE: See "impportKey" operation for supported usages
+    // NOTE: See "importKey" operation for supported usages
     if !usages.is_empty() {
         return Err(Error::Syntax(Some("Usages is not empty".to_string())));
     }

--- a/components/script/dom/webcrypto/subtlecrypto/x448_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/x448_operation.rs
@@ -772,7 +772,7 @@ pub(crate) fn get_public_key(
     // Step 9. If usages contains an entry which is not supported for a public key by the algorithm
     // identified by algorithm, then throw a SyntaxError.
     //
-    // NOTE: See "impportKey" operation for supported usages
+    // NOTE: See "importKey" operation for supported usages
     if !usages.is_empty() {
         return Err(Error::Syntax(Some("Usages is not empty".to_string())));
     }

--- a/components/script/dom/webcrypto/subtlecrypto/x448_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/x448_operation.rs
@@ -759,3 +759,45 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
     // Step 4. Return result.
     Ok(result)
 }
+
+/// <https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-getPublicKey>
+/// Step 9 - 15, for X448
+pub(crate) fn get_public_key(
+    cx: &mut JSContext,
+    global: &GlobalScope,
+    key: &CryptoKey,
+    algorithm: &KeyAlgorithmAndDerivatives,
+    usages: Vec<KeyUsage>,
+) -> Result<DomRoot<CryptoKey>, Error> {
+    // Step 9. If usages contains an entry which is not supported for a public key by the algorithm
+    // identified by algorithm, then throw a SyntaxError.
+    //
+    // NOTE: See "impportKey" operation for supported usages
+    if !usages.is_empty() {
+        return Err(Error::Syntax(Some("Usages is not empty".to_string())));
+    }
+
+    // Step 10. Let publicKey be a new CryptoKey representing the public key corresponding to the
+    // private key represented by the [[handle]] internal slot of key.
+    // Step 11. If an error occurred, then throw a OperationError.
+    // Step 12. Set the [[type]] internal slot of publicKey to "public".
+    // Step 13. Set the [[algorithm]] internal slot of publicKey to algorithm.
+    // Step 14. Set the [[extractable]] internal slot of publicKey to true.
+    // Step 15. Set the [[usages]] internal slot of publicKey to usages.
+    let Handle::X448PrivateKey(private_key) = key.handle() else {
+        return Err(Error::Operation(Some(
+            "[[handle]] internal slot of key is not an X448 private key".into(),
+        )));
+    };
+    let public_key = CryptoKey::new(
+        cx,
+        global,
+        KeyType::Public,
+        true,
+        algorithm.clone(),
+        usages,
+        Handle::X448PublicKey(PublicKey::from(private_key)),
+    );
+
+    Ok(public_key)
+}

--- a/tests/wpt/tests/WebCryptoAPI/getPublicKey.tentative.https.any.js
+++ b/tests/wpt/tests/WebCryptoAPI/getPublicKey.tentative.https.any.js
@@ -24,6 +24,12 @@ const algorithms = [
         publicKeyUsages: ["verify"]
     },
     {
+        name: "Ed448",
+        generateKeyParams: { name: "Ed448" },
+        usages: ["sign", "verify"],
+        publicKeyUsages: ["verify"]
+    },
+    {
         name: "RSA-OAEP",
         generateKeyParams: {
             name: "RSA-OAEP",
@@ -59,6 +65,12 @@ const algorithms = [
     {
         name: "X25519",
         generateKeyParams: { name: "X25519" },
+        usages: ["deriveKey", "deriveBits"],
+        publicKeyUsages: []
+    },
+    {
+        name: "X448",
+        generateKeyParams: { name: "X448" },
         usages: ["deriveKey", "deriveBits"],
         publicKeyUsages: []
     },


### PR DESCRIPTION
This patch implements the getPublicKey operations of Ed448 and X448 in our WebCrypto API implementation. New test cases are added to `tests/wpt/tests/WebCryptoAPI/getPublicKey.tentative.https.any.js` for testing `SubtleCrypto.getPublicKey()` method on input Ed448 and X448 private keys.

Specification:
<https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-supports>

Testing: Pass new WPT subtests in `getPublicKey.tentative.https.any.js`
Part-of: #46140
