### PR TITLE
ci: Remove vello compilation check from Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -148,11 +148,6 @@ jobs:
         run: |
           .\mach build --use-crown --locked --profile ${{ inputs.profile }} ${{ inputs.build-args }}
           mv C:\a\servo\servo\target\cargo-timings C:\a\servo\servo\target\cargo-timings-windows
-      - name: Build with vello backend (${{ inputs.profile }})
-        env:
-          RUSTFLAGS: ${{ inputs.profile == 'checked-release' && '-D warnings' || '' }}
-        run: |
-          .\mach build --use-crown --locked --profile ${{ inputs.profile }} ${{ inputs.build-args }} --feature vello
       - name: Copy resources
         # GitHub-hosted runners sometimes check out the repo on D: drive.
         if: ${{ runner.environment != 'self-hosted' && startsWith(github.workspace, 'D:\') }}


### PR DESCRIPTION
I added this in #45037. But it is probably a mistake.
This adds 10 extra minutes for GitHub hosted runner.

See https://servo.zulipchat.com/#narrow/channel/263398-general/topic/Proposal.3A.20Remove.20vello.20backend/near/609241859