### PR TITLE
canvas: Enable multithreading in vello_cpu & workaround panic (improve 27% FPS , 7% power efficiency)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6195,6 +6195,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-channel"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95be4d57809897b5a7539fc15a7dfe0e84141bc3dfaa2e9b1b27caa90acf61ab"
+dependencies = [
+ "crossbeam-channel",
+]
+
+[[package]]
 name = "ordered-float"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10944,9 +10953,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "588691169aed86b5c8fb487266afee01323234e6fd0a3f2aaec0eaa8e4007f23"
 dependencies = [
  "bytemuck",
+ "crossbeam-channel",
  "glifo",
  "hashbrown 0.17.1",
+ "ordered-channel",
  "png",
+ "rayon",
+ "thread_local",
  "vello_common 0.0.9",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -269,7 +269,7 @@ url = "2.5"
 urlpattern = "0.3"
 uuid = { version = "1.23.3", features = ["v4", "v5"] }
 vello = "0.9"
-vello_cpu = "0.0.9"
+vello_cpu = { version = "0.0.9", features = ["multithreading"] }
 warp = "0.4.2"
 web_atoms = "0.2.4"
 webdriver = { version = "0.53.0", default-features = false }

--- a/components/canvas/vello_cpu_backend.rs
+++ b/components/canvas/vello_cpu_backend.rs
@@ -164,6 +164,11 @@ impl GenericDrawTarget for VelloCPUDrawTarget {
         // vello_cpu RenderingContext only ever grows,
         // so we need to use every opportunity to shrink it
         if self.is_viewport_cleared(rect, transform) {
+            // This is to workaround panic until https://github.com/linebender/vello/pull/1732
+            // can be merged and release a new version.
+            if self.state == State::Drawing {
+                self.ctx.flush();
+            }
             self.ctx.reset();
             self.clips.clear(); // no clips are affecting rendering
             self.state = State::Drawing;


### PR DESCRIPTION
This is a workaround against panic before https://github.com/linebender/vello/pull/1732 can be merged and release a new version.

TL;DR: Improve 27.5% FPS , 7% power efficiency for example in #45199, much closer to Chromium software rendering.
This parallelizes most of the 74% part of cost (mainly strip computation[^1]). In the future I will check the 26% part.

Testing: 
For example in #45199, mate 60 Pro, tested 5 times, 1 min per time. Power consumption measured without plugged in.
85% battery, no auto brightness.
|  | FPS | Power (mw) | Power/Frame |
| :--- | :--- | :--- | :---  |
| Previous | 36.7 | 3059 | 83.3515 |
| Multithreading enabled | 46.8 | 3632.775 | 77.62 | 
| Chromium | 51.3 | 4534.2 | 88.3860  |

### Canvas Power efficiency improvement?
We measure the power of entire device.
Denote Canvas-specific Power per frame by $$\eta$$. We have

$$ Power/Frame = \frac{\eta * Frame + \text{Power for rest} }{Frame} $$

When Frame rate ↑, "Power for rest" certainly does not ↑ with same portion (as some are fixed, like brightness). So Power/Frame decreases as long as $\eta_{\text{multithreading}}$ is not much larger than $\eta_{\text{previous}}$.

But I don't know how to measure $\eta_{\text{multithreading}}$. Not clear if it is better, but can be sure the worst-case isn't bad.

### What was the bottleneck?
Profiling log for a frame shows, script took less than 1% time, 74% on CPT canvas commands other than `CanvasCommand::UpdateImage`,  26% in `CanvasCommand::UpdateImage`.

This parallelizes most of the 74% part (mainly strip computation[^1]). In the future I will check the 26% part.

### Feasibility
The testing is done on Mate 60 pro released 3 years ago, with 1 prime core, 3 big cores, 4 small cores with 12 threads.
vello_cpu would cap it at 8: https://github.com/linebender/vello/blob/cd852dc06bc0f9011385fc63a4852b0fc853f4b1/sparse_strips/vello_cpu/src/render.rs#L190-L195
Most existing devices on market should benefit from this as they would have much more powerful CPU, given the embargo on Huawei.

I believe once the new version released with https://github.com/linebender/vello/pull/1701 included, Servo can also reach 50.

Part of #45199

Fixes: #46404

[^1]: https://infinitecanvas.cc/guide/lesson-035#flattening
