### PR TITLE
url: Add a fast path for matching about:blank against non about: URLs.

### DIFF
--- a/components/url/lib.rs
+++ b/components/url/lib.rs
@@ -268,7 +268,7 @@ impl ServoUrl {
         // and its host is null.
         let null_host = self.0.host().is_none();
 
-        scheme_is_about && path_is_blank && empty_username_and_password && null_host
+        path_is_blank && empty_username_and_password && null_host
     }
 }
 

--- a/components/url/lib.rs
+++ b/components/url/lib.rs
@@ -255,6 +255,9 @@ impl ServoUrl {
 
         // its scheme is "about",
         let scheme_is_about = self.scheme() == "about";
+        if !scheme_is_about {
+            return false;
+        }
 
         // its path contains a single string "blank",
         let path_is_blank = self.0.path() == "blank";

--- a/components/url/lib.rs
+++ b/components/url/lib.rs
@@ -254,8 +254,7 @@ impl ServoUrl {
         // A URL matches about:blank if
 
         // its scheme is "about",
-        let scheme_is_about = self.scheme() == "about";
-        if !scheme_is_about {
+        if self.scheme() != "about" {
             return false;
         }
 


### PR DESCRIPTION
While profiling #46368 I saw Url::matches_about_blank taking 1.7% of execution, when there are no about:blank URLs anywhere in the testcase. There's no need to check any other properties of the URL if the scheme is not about:. This change cut time sampled under Url::matches_about_blank from 46ms to 10ms in the testcase.

Testing: Existing test coverage ensures the change is safe.