### PR TITLE
fonts: Do not create a web font document context until it's required.

### DIFF
--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::cell::LazyCell;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::default::Default;
@@ -141,6 +142,10 @@ pub trait CspViolationHandler: Send + std::fmt::Debug + MallocSizeOf {
 pub trait NetworkTimingHandler: Send + std::fmt::Debug + MallocSizeOf {
     fn submit_timing(&self, url: ServoUrl, response: ResourceFetchTiming);
     fn clone(&self) -> Box<dyn NetworkTimingHandler>;
+}
+
+pub trait WebFontContextCreator: std::fmt::Debug {
+    fn create_web_font_context(&self) -> WebFontDocumentContext;
 }
 
 /// Document-specific data required to fetch a web font.
@@ -664,7 +669,7 @@ pub trait FontContextWebFontMethods {
         stylist: &Stylist,
         guards: &StylesheetGuards<'_>,
         callback: StylesheetWebFontLoadFinishedCallback,
-        document_context: &WebFontDocumentContext,
+        document_context_creator: &dyn WebFontContextCreator,
     ) -> WebFontSetDifference;
     fn load_single_font_face_rule(
         &self,
@@ -717,8 +722,9 @@ impl FontContextWebFontMethods for Arc<FontContext> {
         stylist: &Stylist,
         guards: &StylesheetGuards<'_>,
         callback: StylesheetWebFontLoadFinishedCallback,
-        document_context: &WebFontDocumentContext,
+        document_context_creator: &dyn WebFontContextCreator,
     ) -> WebFontSetDifference {
+        let document_context = LazyCell::new(|| document_context_creator.create_web_font_context());
         let difference = self
             .known_font_face_rules
             .lock()
@@ -730,7 +736,7 @@ impl FontContextWebFontMethods for Arc<FontContext> {
                 added_rule,
                 webview_id,
                 callback.clone(),
-                document_context,
+                &document_context,
             );
         }
         for removed_rule in &difference.removed_font_faces {

--- a/components/fonts/lib.rs
+++ b/components/fonts/lib.rs
@@ -23,7 +23,7 @@ pub use font::{
 };
 pub use font_context::{
     CspViolationHandler, FontContext, FontContextWebFontMethods, NetworkTimingHandler,
-    WebFontDocumentContext,
+    WebFontContextCreator, WebFontDocumentContext,
 };
 pub use font_store::FontTemplates;
 pub use fonts_traits::*;

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1111,7 +1111,7 @@ impl LayoutThread {
                     &self.stylist,
                     guards,
                     self.web_font_finished_loading_callback.clone(),
-                    &reflow_request.document_context,
+                    reflow_request.document_context_creator,
                 )
             } else {
                 WebFontSetDifference::default()

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -8,6 +8,7 @@ use std::collections::HashSet;
 use std::collections::hash_map::Entry;
 use std::default::Default;
 use std::ffi::c_void;
+use std::fmt;
 use std::io::{Write, stderr, stdout};
 use std::ptr::NonNull;
 use std::rc::{Rc, Weak};
@@ -922,6 +923,16 @@ impl Window {
 
     pub(crate) fn perform_a_microtask_checkpoint(&self, cx: &mut JSContext) {
         self.script_thread().perform_a_microtask_checkpoint(cx);
+    }
+
+    pub(crate) fn web_font_context_creator<'a, 'b>(
+        &'a self,
+        no_gc: &'b NoGC,
+    ) -> WebFontContextCreator<'a, 'b> {
+        WebFontContextCreator {
+            window: self,
+            no_gc,
+        }
     }
 
     pub(crate) fn web_font_context(&self, no_gc: &NoGC) -> WebFontDocumentContext {
@@ -2659,7 +2670,7 @@ impl Window {
         // layout runs, so that the map can gather their elements in DOM order.
         document.id_map().resolve_all(cx.no_gc(), document.upcast());
 
-        let document_context = self.web_font_context(cx.no_gc());
+        let document_context_creator = self.web_font_context_creator(cx.no_gc());
 
         let rooted_nodes_for_accessibility_integrity_check =
             document.rooted_nodes_for_accessibility_integrity_check();
@@ -2681,7 +2692,7 @@ impl Window {
             animations: document.animations().sets.clone(),
             animating_images: document.image_animation_manager().animating_images(),
             highlighted_dom_node: document.highlighted_dom_node().map(|node| node.to_opaque()),
-            document_context,
+            document_context_creator: &document_context_creator,
             accessibility_damage,
             rooted_nodes_for_accessibility_integrity_check,
         };
@@ -4068,5 +4079,22 @@ impl WindowHelpers for Window {
 impl HasOrigin for Window {
     fn origin(&self) -> MutableOrigin {
         Window::origin(self)
+    }
+}
+
+pub(crate) struct WebFontContextCreator<'a, 'b> {
+    window: &'a Window,
+    no_gc: &'b NoGC,
+}
+
+impl fmt::Debug for WebFontContextCreator<'_, '_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "WebFontContextCreator")
+    }
+}
+
+impl fonts::WebFontContextCreator for WebFontContextCreator<'_, '_> {
+    fn create_web_font_context(&self) -> WebFontDocumentContext {
+        self.window.web_font_context(self.no_gc)
     }
 }

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -28,7 +28,7 @@ use background_hang_monitor_api::BackgroundHangMonitorRegister;
 use bitflags::bitflags;
 use embedder_traits::{Cursor, ScriptToEmbedderChan, Theme, UntrustedNodeAddress, ViewportDetails};
 use euclid::{Point2D, Rect};
-use fonts::{FontContext, TextByteRange, WebFontDocumentContext, WebFontSetDifference};
+use fonts::{FontContext, TextByteRange, WebFontContextCreator, WebFontSetDifference};
 pub use layout_damage::{AccessibilityDamage, LayoutDamage};
 pub use layout_dom::{
     DangerousStyleElementOf, DangerousStyleNodeOf, LayoutDomTypeBundle, LayoutElementOf,
@@ -311,7 +311,7 @@ pub trait Layout {
     fn remove_cached_image(&mut self, image_url: &ServoUrl);
 
     /// Requests a reflow.
-    fn reflow(&mut self, reflow_request: ReflowRequest) -> Option<ReflowResult>;
+    fn reflow(&mut self, reflow_request: ReflowRequest<'_>) -> Option<ReflowResult>;
 
     /// Do not request a reflow, but ensure that any previous reflow completes building a stacking
     /// context tree so that it is ready to query the final size of any elements in script.
@@ -690,7 +690,7 @@ pub struct ReflowRequestRestyle {
 
 /// Information needed for a script-initiated reflow.
 #[derive(Debug)]
-pub struct ReflowRequest {
+pub struct ReflowRequest<'a> {
     /// The document node.
     pub document: TrustedNodeAddress,
     /// The current layout [`Epoch`] managed by the script thread.
@@ -712,7 +712,7 @@ pub struct ReflowRequest {
     /// The node highlighted by the devtools, if any
     pub highlighted_dom_node: Option<OpaqueNode>,
     /// The current font context.
-    pub document_context: WebFontDocumentContext,
+    pub document_context_creator: &'a dyn WebFontContextCreator,
     /// Damage to the accessibility tree from DOM mutations.
     pub accessibility_damage: Option<Vec<(TrustedNodeAddress, AccessibilityDamage)>>,
     /// Nodes which were removed from the DOM tree since the last reflow, which were rooted in
@@ -721,7 +721,7 @@ pub struct ReflowRequest {
     pub rooted_nodes_for_accessibility_integrity_check: Option<FxHashSet<OpaqueNode>>,
 }
 
-impl ReflowRequest {
+impl ReflowRequest<'_> {
     pub fn stylesheets_changed(&self) -> bool {
         self.restyle
             .as_ref()


### PR DESCRIPTION
Creating a web font document context object involves a bunch of cloning and global downcasting. In many cases this is wasted work when there are no web fonts present in a stylesheet, so this change delays that work until a web font is encountered. This saves 700ms out of 2500ms in the testcase from #46368.

Testing: Existing test coverage is sufficient.