### PR TITLE
webgpu: Proper cleanup in GPUBuffer

### DIFF
--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -954,9 +954,17 @@ impl DataBlock {
         Arc::get_mut(&mut self.data).unwrap()
     }
 
+    #[cfg_attr(
+        crown,
+        expect(
+            crown::unrooted_must_root,
+            reason = "Underlying content is rooted when GC can happen"
+        )
+    )]
     pub(crate) fn clear_views(&mut self, cx: &mut JSContext) {
-        for view in self.data_views.drain(..) {
-            view.destroy(cx);
+        while let Some(DataView { buffer, .. }) = self.data_views.pop() {
+            rooted!(&in(cx) let b = unsafe { buffer.underlying_object().get() });
+            assert!(unsafe { DetachArrayBuffer(cx, b.handle()) })
         }
     }
 
@@ -1014,9 +1022,6 @@ impl DataBlock {
 
 /// DataView are created from `NewExternalArrayBuffer`,
 /// so SM will detach the underlying buffer when the DataView is GCed.
-///
-/// But manual destruction is still possible via [`DataView::destroy`],
-/// which will detach the underlying buffer immediately.
 #[cfg(feature = "webgpu")]
 #[derive(JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
@@ -1032,15 +1037,6 @@ impl DataView {
     pub(crate) fn array_buffer(&self) -> RootedTraceableBox<HeapArrayBuffer> {
         RootedTraceableBox::new(unsafe {
             HeapArrayBuffer::from(self.buffer.underlying_object().get()).unwrap()
-        })
-    }
-
-    pub(crate) fn destroy(self, cx: &mut JSContext) {
-        assert!(unsafe {
-            DetachArrayBuffer(
-                cx,
-                Handle::from_raw(self.buffer.underlying_object().handle()),
-            )
         })
     }
 }

--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -962,6 +962,7 @@ impl DataBlock {
         )
     )]
     pub(crate) fn clear_views(&mut self, cx: &mut JSContext) {
+        // we need to pop one by one so we can root one by one for detach
         while let Some(DataView { buffer, .. }) = self.data_views.pop() {
             rooted!(&in(cx) let b = unsafe { buffer.underlying_object().get() });
             assert!(unsafe { DetachArrayBuffer(cx, b.handle()) })

--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -954,8 +954,10 @@ impl DataBlock {
         Arc::get_mut(&mut self.data).unwrap()
     }
 
-    pub(crate) fn clear_views(&mut self) {
-        self.data_views.clear()
+    pub(crate) fn clear_views(&mut self, cx: &mut JSContext) {
+        for view in self.data_views.drain(..) {
+            view.destroy(cx);
+        }
     }
 
     /// Returns error if requested range is already mapped
@@ -1010,6 +1012,11 @@ impl DataBlock {
     }
 }
 
+/// DataView are created from `NewExternalArrayBuffer`,
+/// so SM will detach the underlying buffer when the DataView is GCed.
+///
+/// But manual destruction is still possible via [`DataView::destroy`],
+/// which will detach the underlying buffer immediately.
 #[cfg(feature = "webgpu")]
 #[derive(JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
@@ -1027,17 +1034,11 @@ impl DataView {
             HeapArrayBuffer::from(self.buffer.underlying_object().get()).unwrap()
         })
     }
-}
 
-#[cfg(feature = "webgpu")]
-impl Drop for DataView {
-    #[expect(unsafe_code)]
-    fn drop(&mut self) {
-        // TODO: https://github.com/servo/servo/issues/44640
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+    pub(crate) fn destroy(self, cx: &mut JSContext) {
         assert!(unsafe {
             DetachArrayBuffer(
-                &mut cx,
+                cx,
                 Handle::from_raw(self.buffer.underlying_object().handle()),
             )
         })

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -69,14 +69,34 @@ impl ActiveBufferMapping {
     }
 }
 
+#[derive(JSTraceable, MallocSizeOf)]
+pub struct DroppableGPUBuffer {
+    #[no_trace]
+    channel: WebGPU,
+    #[no_trace]
+    buffer: WebGPUBuffer,
+}
+
+impl Drop for DroppableGPUBuffer {
+    fn drop(&mut self) {
+        if let Err(e) = self
+            .channel
+            .0
+            .send(WebGPURequest::DropBuffer(self.buffer.0))
+        {
+            error!(
+                "Failed to send WebGPURequest::DropBuffer({:?}) ({}) - Potential leak",
+                self.buffer.0, e
+            );
+        }
+    }
+}
+
 #[dom_struct]
 pub(crate) struct GPUBuffer {
     reflector_: Reflector,
-    #[no_trace]
-    channel: WebGPU,
+    droppable: DroppableGPUBuffer,
     label: DomRefCell<USVString>,
-    #[no_trace]
-    buffer: WebGPUBuffer,
     device: Dom<GPUDevice>,
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-size>
     size: GPUSize64,
@@ -101,10 +121,9 @@ impl GPUBuffer {
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
-            channel,
+            droppable: DroppableGPUBuffer { channel, buffer },
             label: DomRefCell::new(label),
             device: Dom::from_ref(device),
-            buffer,
             pending_map: DomRefCell::new(None),
             size,
             usage,
@@ -136,7 +155,7 @@ impl GPUBuffer {
 
 impl GPUBuffer {
     pub(crate) fn id(&self) -> WebGPUBuffer {
-        self.buffer
+        self.droppable.buffer
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbuffer>
@@ -187,21 +206,6 @@ impl GPUBuffer {
     }
 }
 
-impl Drop for GPUBuffer {
-    fn drop(&mut self) {
-        if let Err(e) = self
-            .channel
-            .0
-            .send(WebGPURequest::DropBuffer(self.buffer.0))
-        {
-            error!(
-                "Failed to send WebGPURequest::DropBuffer({:?}) ({}) - Potential leak",
-                self.buffer.0, e
-            );
-        }
-    }
-}
-
 impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-unmap>
     fn Unmap(&self, cx: &mut js::context::JSContext) {
@@ -221,7 +225,7 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
         // Step 3
         mapping.data.clear_views(cx);
         // Step 5&7
-        if let Err(e) = self.channel.0.send(WebGPURequest::UnmapBuffer {
+        if let Err(e) = self.droppable.channel.0.send(WebGPURequest::UnmapBuffer {
             buffer_id: self.id().0,
             mapping: if mapping.mode >= GPUMapModeConstants::WRITE {
                 Some(Mapping {
@@ -233,7 +237,10 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
                 None
             },
         }) {
-            warn!("Failed to send Buffer unmap ({:?}) ({})", self.buffer.0, e);
+            warn!(
+                "Failed to send Buffer unmap ({:?}) ({})",
+                self.droppable.buffer.0, e
+            );
         }
     }
 
@@ -243,13 +250,14 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
         self.Unmap(cx);
         // Step 2
         if let Err(e) = self
+            .droppable
             .channel
             .0
-            .send(WebGPURequest::DestroyBuffer(self.buffer.0))
+            .send(WebGPURequest::DestroyBuffer(self.droppable.buffer.0))
         {
             warn!(
                 "Failed to send WebGPURequest::DestroyBuffer({:?}) ({})",
-                self.buffer.0, e
+                self.droppable.buffer.0, e
             );
         };
     }
@@ -289,17 +297,22 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
             self,
             self.global().task_manager().dom_manipulation_task_source(),
         );
-        if let Err(e) = self.channel.0.send(WebGPURequest::BufferMapAsync {
-            callback,
-            buffer_id: self.buffer.0,
-            device_id: self.device.id().0,
-            host_map,
-            offset,
-            size,
-        }) {
+        if let Err(e) = self
+            .droppable
+            .channel
+            .0
+            .send(WebGPURequest::BufferMapAsync {
+                callback,
+                buffer_id: self.droppable.buffer.0,
+                device_id: self.device.id().0,
+                host_map,
+                offset,
+                size,
+            })
+        {
             warn!(
                 "Failed to send BufferMapAsync ({:?}) ({})",
-                self.buffer.0, e
+                self.droppable.buffer.0, e
             );
             self.map_failure(cx, &promise);
             return promise;

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -219,7 +219,7 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
         };
 
         // Step 3
-        mapping.data.clear_views();
+        mapping.data.clear_views(cx);
         // Step 5&7
         if let Err(e) = self.channel.0.send(WebGPURequest::UnmapBuffer {
             buffer_id: self.id().0,

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -491,7 +491,6 @@ DOMInterfaces = {
 'GPUBuffer': {
     'realm': ['MapAsync'],
     'cx': ['Destroy', 'GetMappedRange',  'Unmap', 'PopErrorScope'],
-    'allowDropImpl': True,
     'no_gc': ['SetLabel'],
 },
 


### PR DESCRIPTION
In first commit we remove drop from DataView (JSTraceable should have no drop). This is safe because on GC SM will take care for calling freeFunc of externalArrayBuffer. For manual destruction (detach array buffer) we simply pass `&mut JSContext`. In second commit we add droppable struct.

Testing: Should be covered by WebGPU CTS.
Fixes: #45504
Fixes: #44640
