### PR TITLE
script: Use safe typed array slice APIs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5235,8 +5235,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.18.1"
-source = "git+https://github.com/jdm/mozjs?branch=inert#91bd78205f69e1cf5adebcc28290a8add0feb145"
+version = "0.18.2"
+source = "git+https://github.com/jdm/mozjs?branch=inert#e872b9c435959151900bf4331acb146d8eea6aa5"
 dependencies = [
  "bindgen",
  "cc",
@@ -5249,8 +5249,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "140.12.0-1"
-source = "git+https://github.com/jdm/mozjs?branch=inert#91bd78205f69e1cf5adebcc28290a8add0feb145"
+version = "140.12.0-2"
+source = "git+https://github.com/jdm/mozjs?branch=inert#e872b9c435959151900bf4331acb146d8eea6aa5"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,7 +823,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -2523,7 +2523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3101,7 +3101,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5236,8 +5236,6 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e22429d9fe0dc27169cb3ce0631d20f64f7d1c8fa5a90e039437e9fa9a7f30f"
 dependencies = [
  "bindgen",
  "cc",
@@ -5251,8 +5249,6 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "140.12.0-1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d2c9df3f8007cf4b37f411602870d73f05f6cb70906766fe8639fcad1133a48"
 dependencies = [
  "bindgen",
  "cc",
@@ -7248,7 +7244,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7305,7 +7301,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10014,7 +10010,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11549,7 +11545,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,7 +823,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -2523,7 +2523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3101,7 +3101,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5236,7 +5236,8 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.18.2"
-source = "git+https://github.com/jdm/mozjs?branch=inert#e872b9c435959151900bf4331acb146d8eea6aa5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17277cebd079c3eb424f8d56d8f9ca9333ec263f9383b3595931b665f544d876"
 dependencies = [
  "bindgen",
  "cc",
@@ -5250,7 +5251,8 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "140.12.0-2"
-source = "git+https://github.com/jdm/mozjs?branch=inert#e872b9c435959151900bf4331acb146d8eea6aa5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf1645d99277fe604091a848fecbde7b9b595cbc3a592247a68d954c8acb596"
 dependencies = [
  "bindgen",
  "cc",
@@ -7246,7 +7248,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7303,7 +7305,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10012,7 +10014,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11547,7 +11549,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,7 +823,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -2523,7 +2523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3101,7 +3101,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5235,7 +5235,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.18.0"
+version = "0.18.1"
+source = "git+https://github.com/jdm/mozjs?branch=inert#91bd78205f69e1cf5adebcc28290a8add0feb145"
 dependencies = [
  "bindgen",
  "cc",
@@ -5249,6 +5250,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "140.12.0-1"
+source = "git+https://github.com/jdm/mozjs?branch=inert#91bd78205f69e1cf5adebcc28290a8add0feb145"
 dependencies = [
  "bindgen",
  "cc",
@@ -7244,7 +7246,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7301,7 +7303,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10010,7 +10012,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11545,7 +11547,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -443,8 +443,8 @@ codegen-units = 1
 #
 # Or for mozjs:
 #
-mozjs = { path = "../mozjs/mozjs" }
-mozjs_sys = { path = "../mozjs/mozjs-sys" }
+mozjs = { git = "https://github.com/jdm/mozjs", branch = "inert" }
+mozjs_sys = { git = "https://github.com/jdm/mozjs", branch = "inert" }
 #
 # Or for CSP crate:
 # content-security-policy = { path = "../rust-content-security-policy" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -443,8 +443,8 @@ codegen-units = 1
 #
 # Or for mozjs:
 #
-# mozjs = { path = "../mozjs/mozjs" }
-# mozjs_sys = { path = "../mozjs/mozjs-sys" }
+mozjs = { path = "../mozjs/mozjs" }
+mozjs_sys = { path = "../mozjs/mozjs-sys" }
 #
 # Or for CSP crate:
 # content-security-policy = { path = "../rust-content-security-policy" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -443,8 +443,8 @@ codegen-units = 1
 #
 # Or for mozjs:
 #
-mozjs = { git = "https://github.com/jdm/mozjs", branch = "inert" }
-mozjs_sys = { git = "https://github.com/jdm/mozjs", branch = "inert" }
+# mozjs = { path = "../mozjs/mozjs" }
+# mozjs_sys = { path = "../mozjs/mozjs-sys" }
 #
 # Or for CSP crate:
 # content-security-policy = { path = "../rust-content-security-policy" }

--- a/components/script/dom/audio/analysernode.rs
+++ b/components/script/dom/audio/analysernode.rs
@@ -147,7 +147,7 @@ impl AnalyserNodeMethods<crate::DomTypeHolder> for AnalyserNode {
         AnalyserNode::new_with_proto(cx, window, proto, context, options)
     }
 
-    #[expect(unsafe_code)]
+    #[expect(unsafe_code, deprecated)]
     /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-getfloatfrequencydata>
     fn GetFloatFrequencyData(&self, mut array: CustomAutoRooterGuard<Float32Array>) {
         // Invariant to maintain: No JS code that may touch the array should
@@ -156,7 +156,7 @@ impl AnalyserNodeMethods<crate::DomTypeHolder> for AnalyserNode {
         self.engine.borrow_mut().fill_frequency_data(dest);
     }
 
-    #[expect(unsafe_code)]
+    #[expect(unsafe_code, deprecated)]
     /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-getbytefrequencydata>
     fn GetByteFrequencyData(&self, mut array: CustomAutoRooterGuard<Uint8Array>) {
         // Invariant to maintain: No JS code that may touch the array should
@@ -165,7 +165,7 @@ impl AnalyserNodeMethods<crate::DomTypeHolder> for AnalyserNode {
         self.engine.borrow_mut().fill_byte_frequency_data(dest);
     }
 
-    #[expect(unsafe_code)]
+    #[expect(unsafe_code, deprecated)]
     /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-getfloattimedomaindata>
     fn GetFloatTimeDomainData(&self, mut array: CustomAutoRooterGuard<Float32Array>) {
         // Invariant to maintain: No JS code that may touch the array should
@@ -174,7 +174,7 @@ impl AnalyserNodeMethods<crate::DomTypeHolder> for AnalyserNode {
         self.engine.borrow().fill_time_domain_data(dest);
     }
 
-    #[expect(unsafe_code)]
+    #[expect(unsafe_code, deprecated)]
     /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-getbytetimedomaindata>
     fn GetByteTimeDomainData(&self, mut array: CustomAutoRooterGuard<Uint8Array>) {
         // Invariant to maintain: No JS code that may touch the array should

--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -481,10 +481,8 @@ where
         else {
             return Err(());
         };
-        unsafe {
-            let slice = (*array).as_slice();
-            dest.copy_from_slice(&slice[source_start..length]);
-        }
+        let slice = (*array).as_slice_safe(cx.no_gc());
+        dest.copy_from_slice(&slice[source_start..length]);
         Ok(())
     }
 
@@ -507,11 +505,9 @@ where
         else {
             return Err(());
         };
-        unsafe {
-            let slice = (*array).as_mut_slice();
-            let (_, dest) = slice.split_at_mut(dest_start);
-            dest[0..length].copy_from_slice(&source.as_slice()[0..length])
-        }
+        let slice = (*array).as_mut_slice_safe(cx.no_gc());
+        let (_, dest) = slice.split_at_mut(dest_start);
+        dest[0..length].copy_from_slice(&source.as_slice_safe(cx.no_gc())[0..length]);
         Ok(())
     }
 

--- a/components/script/dom/canvas/imagedata.rs
+++ b/components/script/dom/canvas/imagedata.rs
@@ -163,7 +163,7 @@ impl ImageData {
     }
 
     /// Nothing must change the array on the JS side while the slice is live.
-    #[expect(unsafe_code)]
+    #[expect(unsafe_code, deprecated)]
     pub(crate) unsafe fn as_slice(&self) -> &[u8] {
         assert!(self.data.is_initialized());
         let internal_data = self

--- a/components/script/dom/encoding/textdecodercommon.rs
+++ b/components/script/dom/encoding/textdecodercommon.rs
@@ -90,7 +90,7 @@ impl TextDecoderCommon {
     ///
     /// <https://encoding.spec.whatwg.org/#dom-textdecoder-decode>
     /// <https://encoding.spec.whatwg.org/#decode-and-enqueue-a-chunk>
-    #[expect(unsafe_code)]
+    #[expect(unsafe_code, deprecated)]
     pub(crate) fn decode(
         &self,
         input: Option<&ArrayBufferViewOrArrayBuffer>,

--- a/components/script/dom/encoding/textencoder.rs
+++ b/components/script/dom/encoding/textencoder.rs
@@ -75,7 +75,7 @@ impl TextEncoderMethods<crate::DomTypeHolder> for TextEncoder {
     }
 
     /// <https://encoding.spec.whatwg.org/#dom-textencoder-encodeinto>
-    #[expect(unsafe_code)]
+    #[expect(unsafe_code, deprecated)]
     fn EncodeInto(
         &self,
         source: USVString,

--- a/components/script/dom/file/blob.rs
+++ b/components/script/dom/file/blob.rs
@@ -198,7 +198,7 @@ fn convert_line_endings_to_native(s: &[u8]) -> Vec<u8> {
 }
 
 /// <https://w3c.github.io/FileAPI/#process-blob-parts>
-#[expect(unsafe_code)]
+#[expect(unsafe_code, deprecated)]
 pub(crate) fn process_blob_parts(
     mut blobparts: Vec<ArrayBufferOrArrayBufferViewOrBlobOrString>,
     endings: BlobBinding::EndingType,

--- a/components/script/dom/webcrypto/crypto.rs
+++ b/components/script/dom/webcrypto/crypto.rs
@@ -48,7 +48,7 @@ impl CryptoMethods<crate::DomTypeHolder> for Crypto {
             .or_init(|| SubtleCrypto::new(cx, &self.global()))
     }
 
-    #[expect(unsafe_code)]
+    #[expect(unsafe_code, deprecated)]
     /// <https://w3c.github.io/webcrypto/#Crypto-method-getRandomValues>
     fn GetRandomValues(
         &self,

--- a/components/script/dom/webgl/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl/webgl2renderingcontext.rs
@@ -10,7 +10,7 @@ use std::{cmp, ptr};
 use bitflags::bitflags;
 use dom_struct::dom_struct;
 use euclid::default::{Point2D, Rect, Size2D};
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::jsapi::{JSObject, Type};
 use js::jsval::{BooleanValue, DoubleValue, Int32Value, NullValue, ObjectValue, UInt32Value};
 use js::rust::{CustomAutoRooterGuard, HandleObject, MutableHandleObject, MutableHandleValue};
@@ -465,10 +465,10 @@ impl WebGL2RenderingContext {
         })
     }
 
-    #[expect(unsafe_code)]
     #[expect(clippy::too_many_arguments)]
     fn read_pixels_into(
         &self,
+        no_gc: &NoGC,
         x: i32,
         y: i32,
         width: i32,
@@ -526,7 +526,7 @@ impl WebGL2RenderingContext {
             Err(error) => return self.base.webgl_error(error),
         };
         let dst_end = dst_byte_offset + skipped_bytes + size;
-        let dst_pixels = unsafe { dst.as_mut_slice() };
+        let dst_pixels = dst.as_mut_slice_safe(no_gc);
         if dst_pixels.len() < dst_end {
             return self.base.webgl_error(InvalidOperation);
         }
@@ -1458,7 +1458,8 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         let usage = handle_potential_webgl_error!(self.base, self.buffer_usage(usage), return);
         let bound_buffer =
             handle_potential_webgl_error!(self.base, self.bound_buffer(cx, target), return);
-        self.base.buffer_data(target, data, usage, bound_buffer)
+        self.base
+            .buffer_data(cx.no_gc(), target, data, usage, bound_buffer)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
@@ -1470,7 +1471,6 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.3>
-    #[expect(unsafe_code)]
     fn BufferData__(
         &self,
         cx: &mut JSContext,
@@ -1510,7 +1510,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         }
 
         let data_end = byte_offset + copy_bytes;
-        let data: &[u8] = unsafe { &data.as_slice()[byte_offset..data_end] };
+        let data: &[u8] = &data.as_slice_safe(cx.no_gc())[byte_offset..data_end];
         handle_potential_webgl_error!(self.base, bound_buffer.buffer_data(target, data, usage));
     }
 
@@ -1525,11 +1525,10 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         let bound_buffer =
             handle_potential_webgl_error!(self.base, self.bound_buffer(cx, target), return);
         self.base
-            .buffer_sub_data(target, offset, data, bound_buffer)
+            .buffer_sub_data(cx.no_gc(), target, offset, data, bound_buffer)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.3>
-    #[expect(unsafe_code)]
     fn BufferSubData_(
         &self,
         cx: &mut JSContext,
@@ -1577,7 +1576,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
             receiver,
         ));
         let src_end = src_byte_offset + copy_bytes;
-        let data: &[u8] = unsafe { &src_data.as_slice()[src_byte_offset..src_end] };
+        let data: &[u8] = &src_data.as_slice_safe(cx.no_gc())[src_byte_offset..src_end];
         let buffer = GenericSharedMemory::from_bytes(data);
         sender.send(buffer).unwrap();
     }
@@ -1640,7 +1639,6 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.3>
-    #[expect(unsafe_code)]
     fn GetBufferSubData(
         &self,
         cx: &mut JSContext,
@@ -1692,15 +1690,13 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         ));
         let data = receiver.recv().unwrap();
         let dst_end = dst_byte_offset + copy_bytes;
-        unsafe {
-            dst_buffer.as_mut_slice()[dst_byte_offset..dst_end].copy_from_slice(&data);
-        }
+        dst_buffer.as_mut_slice_safe(cx.no_gc())[dst_byte_offset..dst_end].copy_from_slice(&data);
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.6>
-    #[expect(unsafe_code)]
     fn CompressedTexImage2D(
         &self,
+        no_gc: &NoGC,
         target: u32,
         level: i32,
         internal_format: u32,
@@ -1711,7 +1707,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         src_offset: u32,
         src_length_override: u32,
     ) {
-        let mut data = unsafe { pixels.as_slice() };
+        let mut data = pixels.as_slice_safe(no_gc);
         let start = src_offset as usize;
         let end = (src_offset + src_length_override) as usize;
         if start > data.len() || end > data.len() {
@@ -1733,9 +1729,9 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
-    #[expect(unsafe_code)]
     fn CompressedTexSubImage2D(
         &self,
+        no_gc: &NoGC,
         target: u32,
         level: i32,
         xoffset: i32,
@@ -1747,7 +1743,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         src_offset: u32,
         src_length_override: u32,
     ) {
-        let mut data = unsafe { pixels.as_slice() };
+        let mut data = pixels.as_slice_safe(no_gc);
         let start = src_offset as usize;
         let end = (src_offset + src_length_override) as usize;
         if start > data.len() || end > data.len() {
@@ -2226,6 +2222,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.12>
     fn ReadPixels(
         &self,
+        no_gc: &NoGC,
         x: i32,
         y: i32,
         width: i32,
@@ -2237,12 +2234,13 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         let pixels =
             handle_potential_webgl_error!(self.base, pixels.as_mut().ok_or(InvalidValue), return);
 
-        self.read_pixels_into(x, y, width, height, format, pixel_type, pixels, 0)
+        self.read_pixels_into(no_gc, x, y, width, height, format, pixel_type, pixels, 0)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.10>
     fn ReadPixels_(
         &self,
+        _no_gc: &NoGC,
         x: i32,
         y: i32,
         width: i32,
@@ -2334,6 +2332,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.10>
     fn ReadPixels__(
         &self,
+        no_gc: &NoGC,
         x: i32,
         y: i32,
         width: i32,
@@ -2344,6 +2343,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         dst_elem_offset: u32,
     ) {
         self.read_pixels_into(
+            no_gc,
             x,
             y,
             width,
@@ -3145,9 +3145,9 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     ///
     /// Allocates and initializes the specified mipmap level of a three-dimensional or
     /// two-dimensional array texture.
-    #[expect(unsafe_code)]
     fn TexImage3D(
         &self,
+        no_gc: &NoGC,
         target: u32,
         level: i32,
         internal_format: i32,
@@ -3235,7 +3235,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
 
         // If srcData is null, a buffer of sufficient size initialized to 0 is passed.
         let buff = match *src_data {
-            Some(ref data) => GenericSharedMemory::from_bytes(unsafe { data.as_slice() }),
+            Some(ref data) => GenericSharedMemory::from_bytes(data.as_slice_safe(no_gc)),
             None => GenericSharedMemory::from_byte(0, expected_byte_len as usize),
         };
         if buff.len() < expected_byte_len as usize {
@@ -3283,6 +3283,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
     fn TexImage2D(
         &self,
+        no_gc: &NoGC,
         target: u32,
         level: i32,
         internal_format: i32,
@@ -3294,6 +3295,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         pixels: CustomAutoRooterGuard<Option<ArrayBufferView>>,
     ) -> Fallible<()> {
         self.base.TexImage2D(
+            no_gc,
             target,
             level,
             internal_format,
@@ -3309,6 +3311,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
     fn TexImage2D_(
         &self,
+        no_gc: &NoGC,
         target: u32,
         level: i32,
         internal_format: i32,
@@ -3316,13 +3319,21 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         data_type: u32,
         source: TexImageSource,
     ) -> ErrorResult {
-        self.base
-            .TexImage2D_(target, level, internal_format, format, data_type, source)
+        self.base.TexImage2D_(
+            no_gc,
+            target,
+            level,
+            internal_format,
+            format,
+            data_type,
+            source,
+        )
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.6>
     fn TexImage2D__(
         &self,
+        _no_gc: &NoGC,
         target: u32,
         level: i32,
         internalformat: i32,
@@ -3401,6 +3412,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.6>
     fn TexImage2D___(
         &self,
+        _no_gc: &NoGC,
         target: u32,
         level: i32,
         internalformat: i32,
@@ -3467,9 +3479,9 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.6>
-    #[expect(unsafe_code)]
     fn TexImage2D____(
         &self,
+        no_gc: &NoGC,
         target: u32,
         level: i32,
         internalformat: i32,
@@ -3529,7 +3541,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         }
 
         let buff =
-            GenericSharedMemory::from_bytes(unsafe { &src_data.as_slice()[src_byte_offset..] });
+            GenericSharedMemory::from_bytes(&src_data.as_slice_safe(no_gc)[src_byte_offset..]);
 
         let expected_byte_length = match self.base.validate_tex_image_2d_data(
             width,
@@ -3577,6 +3589,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
     fn TexSubImage2D(
         &self,
+        no_gc: &NoGC,
         target: u32,
         level: i32,
         xoffset: i32,
@@ -3588,13 +3601,14 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         pixels: CustomAutoRooterGuard<Option<ArrayBufferView>>,
     ) -> Fallible<()> {
         self.base.TexSubImage2D(
-            target, level, xoffset, yoffset, width, height, format, data_type, pixels,
+            no_gc, target, level, xoffset, yoffset, width, height, format, data_type, pixels,
         )
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
     fn TexSubImage2D_(
         &self,
+        no_gc: &NoGC,
         target: u32,
         level: i32,
         xoffset: i32,
@@ -3603,8 +3617,9 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         data_type: u32,
         source: TexImageSource,
     ) -> ErrorResult {
-        self.base
-            .TexSubImage2D_(target, level, xoffset, yoffset, format, data_type, source)
+        self.base.TexSubImage2D_(
+            no_gc, target, level, xoffset, yoffset, format, data_type, source,
+        )
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -12,7 +12,7 @@ use backtrace::Backtrace;
 use bitflags::bitflags;
 use dom_struct::dom_struct;
 use euclid::default::{Point2D, Rect, Size2D};
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::jsapi::{JSObject, Type};
 use js::jsval::{BooleanValue, DoubleValue, Int32Value, NullValue, ObjectValue, UInt32Value};
 use js::rust::{CustomAutoRooterGuard, MutableHandleObject, MutableHandleValue};
@@ -1333,9 +1333,9 @@ impl WebGLRenderingContext {
         &self.extension_manager
     }
 
-    #[expect(unsafe_code)]
     pub(crate) fn buffer_data(
         &self,
+        no_gc: &NoGC,
         target: u32,
         data: Option<ArrayBufferViewOrArrayBuffer>,
         usage: u32,
@@ -1345,12 +1345,9 @@ impl WebGLRenderingContext {
         let bound_buffer =
             handle_potential_webgl_error!(self, bound_buffer.ok_or(InvalidOperation), return);
 
-        let data = unsafe {
-            // Safe because we don't do anything with JS until the end of the method.
-            match data {
-                ArrayBufferViewOrArrayBuffer::ArrayBuffer(ref data) => data.as_slice(),
-                ArrayBufferViewOrArrayBuffer::ArrayBufferView(ref data) => data.as_slice(),
-            }
+        let data = match data {
+            ArrayBufferViewOrArrayBuffer::ArrayBuffer(ref data) => data.as_slice_safe(no_gc),
+            ArrayBufferViewOrArrayBuffer::ArrayBufferView(ref data) => data.as_slice_safe(no_gc),
         };
         handle_potential_webgl_error!(self, bound_buffer.buffer_data(target, data, usage));
     }
@@ -1375,9 +1372,9 @@ impl WebGLRenderingContext {
         handle_potential_webgl_error!(self, bound_buffer.buffer_data(target, &data, usage));
     }
 
-    #[expect(unsafe_code)]
     pub(crate) fn buffer_sub_data(
         &self,
+        no_gc: &NoGC,
         target: u32,
         offset: i64,
         data: ArrayBufferViewOrArrayBuffer,
@@ -1390,12 +1387,9 @@ impl WebGLRenderingContext {
             return self.webgl_error(InvalidValue);
         }
 
-        let data = unsafe {
-            // Safe because we don't do anything with JS until the end of the method.
-            match data {
-                ArrayBufferViewOrArrayBuffer::ArrayBuffer(ref data) => data.as_slice(),
-                ArrayBufferViewOrArrayBuffer::ArrayBufferView(ref data) => data.as_slice(),
-            }
+        let data = match data {
+            ArrayBufferViewOrArrayBuffer::ArrayBuffer(ref data) => data.as_slice_safe(no_gc),
+            ArrayBufferViewOrArrayBuffer::ArrayBufferView(ref data) => data.as_slice_safe(no_gc),
         };
         if (offset as u64) + data.len() as u64 > bound_buffer.capacity() as u64 {
             return self.webgl_error(InvalidValue);
@@ -2783,7 +2777,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         let usage = handle_potential_webgl_error!(self, self.buffer_usage(usage), return);
         let bound_buffer =
             handle_potential_webgl_error!(self, self.bound_buffer(cx, target), return);
-        self.buffer_data(target, data, usage, bound_buffer)
+        self.buffer_data(cx.no_gc(), target, data, usage, bound_buffer)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
@@ -2804,13 +2798,13 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     ) {
         let bound_buffer =
             handle_potential_webgl_error!(self, self.bound_buffer(cx, target), return);
-        self.buffer_sub_data(target, offset, data, bound_buffer)
+        self.buffer_sub_data(cx.no_gc(), target, offset, data, bound_buffer)
     }
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
-    #[expect(unsafe_code)]
     fn CompressedTexImage2D(
         &self,
+        no_gc: &NoGC,
         target: u32,
         level: i32,
         internal_format: u32,
@@ -2819,14 +2813,14 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         border: i32,
         data: CustomAutoRooterGuard<ArrayBufferView>,
     ) {
-        let data = unsafe { data.as_slice() };
+        let data = data.as_slice_safe(no_gc);
         self.compressed_tex_image_2d(target, level, internal_format, width, height, border, data)
     }
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
-    #[expect(unsafe_code)]
     fn CompressedTexSubImage2D(
         &self,
+        no_gc: &NoGC,
         target: u32,
         level: i32,
         xoffset: i32,
@@ -2836,7 +2830,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         format: u32,
         data: CustomAutoRooterGuard<ArrayBufferView>,
     ) {
-        let data = unsafe { data.as_slice() };
+        let data = data.as_slice_safe(no_gc);
         self.compressed_tex_sub_image_2d(
             target, level, xoffset, yoffset, width, height, format, data,
         )
@@ -3924,9 +3918,9 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     }
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.12
-    #[expect(unsafe_code)]
     fn ReadPixels(
         &self,
+        no_gc: &NoGC,
         x: i32,
         y: i32,
         width: i32,
@@ -3988,7 +3982,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             return
         );
 
-        let dest = unsafe { pixels.as_mut_slice() };
+        let dest = pixels.as_mut_slice_safe(no_gc);
         if dest.len() < required_dest_len as usize {
             return self.webgl_error(InvalidOperation);
         }
@@ -4582,9 +4576,9 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     }
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
-    #[expect(unsafe_code)]
     fn TexImage2D(
         &self,
+        no_gc: &NoGC,
         target: u32,
         level: i32,
         internal_format: i32,
@@ -4658,7 +4652,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         // initialized to 0 is passed.
         let buff = match *pixels {
             None => GenericSharedMemory::from_byte(0, expected_byte_length as usize),
-            Some(ref data) => GenericSharedMemory::from_bytes(unsafe { data.as_slice() }),
+            Some(ref data) => GenericSharedMemory::from_bytes(data.as_slice_safe(no_gc)),
         };
 
         // From the WebGL spec:
@@ -4718,6 +4712,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
     fn TexImage2D_(
         &self,
+        _no_gc: &NoGC,
         target: u32,
         level: i32,
         internal_format: i32,
@@ -4803,9 +4798,9 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     }
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
-    #[expect(unsafe_code)]
     fn TexSubImage2D(
         &self,
+        no_gc: &NoGC,
         target: u32,
         level: i32,
         xoffset: i32,
@@ -4851,7 +4846,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             self,
             pixels
                 .as_ref()
-                .map(|p| GenericSharedMemory::from_bytes(unsafe { p.as_slice() }))
+                .map(|p| GenericSharedMemory::from_bytes(p.as_slice_safe(no_gc)))
                 .ok_or(InvalidValue),
             return Ok(())
         );
@@ -4894,6 +4889,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
     fn TexSubImage2D_(
         &self,
+        _no_gc: &NoGC,
         target: u32,
         level: i32,
         xoffset: i32,

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -110,7 +110,7 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueue-writebuffer>
-    #[expect(unsafe_code)]
+    #[expect(unsafe_code, deprecated)]
     fn WriteBuffer(
         &self,
         buffer: &GPUBuffer,

--- a/components/script/indexeddb.rs
+++ b/components/script/indexeddb.rs
@@ -36,7 +36,7 @@ use crate::dom::idbkeyrange::IDBKeyRange;
 use crate::dom::idbobjectstore::KeyPath;
 
 // https://www.w3.org/TR/IndexedDB-3/#convert-key-to-value
-#[expect(unsafe_code)]
+#[expect(unsafe_code, deprecated)]
 pub fn key_type_to_jsval(
     cx: &mut JSContext,
     key: &IndexedDBKeyType,

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1168,6 +1168,15 @@ DOMInterfaces = {
 },
 
 'WebGLRenderingContext': {
+    'no_gc': [
+        'CompressedTexImage2D',
+        'CompressedTexSubImage2D',
+        'ReadPixels',
+        'TexImage2D',
+        'TexImage2D_',
+        'TexSubImage2D',
+        'TexSubImage2D_',
+    ],
     'cx': [
         'GetExtension',
         'MakeXRCompatible',
@@ -1214,6 +1223,21 @@ DOMInterfaces = {
 },
 
 'WebGL2RenderingContext': {
+    'no_gc': [
+        'CompressedTexImage2D',
+        'CompressedTexSubImage2D',
+        'ReadPixels',
+        'ReadPixels_',
+        'ReadPixels__',
+        'TexImage2D',
+        'TexImage2D_',
+        'TexImage2D__',
+        'TexImage2D___',
+        'TexImage2D____',
+        'TexSubImage2D',
+        'TexSubImage2D_',
+        'TexImage3D',
+    ],
     'cx': [
         'GetExtension',
         'MakeXRCompatible',

--- a/tests/wpt/meta/FileAPI/blob/Blob-constructor-detached-buffer.any.js.ini
+++ b/tests/wpt/meta/FileAPI/blob/Blob-constructor-detached-buffer.any.js.ini
@@ -1,0 +1,5 @@
+[Blob-constructor-detached-buffer.any.html]
+  expected: CRASH
+
+[Blob-constructor-detached-buffer.any.worker.html]
+  expected: CRASH


### PR DESCRIPTION
We can remove a lot of unsafe usage around typed arrays by tying the slices to NoGC arguments.

Testing: Existing tests suffice.
