### PR TITLE
script: Convert `DomRoot` usages to `Dom` inside event types

### DIFF
--- a/components/script/dom/event/commandevent.rs
+++ b/components/script/dom/event/commandevent.rs
@@ -14,7 +14,7 @@ use crate::dom::bindings::codegen::Bindings::CommandEventBinding;
 use crate::dom::bindings::codegen::Bindings::CommandEventBinding::CommandEventMethods;
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use crate::dom::bindings::error::Fallible;
-use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::element::Element;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
@@ -26,19 +26,16 @@ use crate::dom::types::Window;
 pub(crate) struct CommandEvent {
     event: Event,
     /// <https://html.spec.whatwg.org/multipage/#dom-commandevent-source>
-    source: Option<DomRoot<Element>>,
+    source: Option<Dom<Element>>,
     /// <https://html.spec.whatwg.org/multipage/#dom-commandevent-command>
     command: DOMString,
 }
 
 impl CommandEvent {
-    pub(crate) fn new_inherited(
-        source: Option<DomRoot<Element>>,
-        command: DOMString,
-    ) -> CommandEvent {
+    pub(crate) fn new_inherited(source: Option<&Element>, command: DOMString) -> CommandEvent {
         CommandEvent {
             event: Event::new_inherited(),
-            source,
+            source: source.map(Dom::from_ref),
             command,
         }
     }
@@ -51,7 +48,7 @@ impl CommandEvent {
         type_: Atom,
         bubbles: EventBubbles,
         cancelable: EventCancelable,
-        source: Option<DomRoot<Element>>,
+        source: Option<&Element>,
         command: DOMString,
     ) -> DomRoot<CommandEvent> {
         let event = Box::new(CommandEvent::new_inherited(source, command));
@@ -70,7 +67,7 @@ impl CommandEvent {
         type_: Atom,
         bubbles: EventBubbles,
         cancelable: EventCancelable,
-        source: Option<DomRoot<Element>>,
+        source: Option<&Element>,
         command: DOMString,
     ) -> DomRoot<CommandEvent> {
         Self::new_with_proto(
@@ -97,7 +94,7 @@ impl CommandEventMethods<crate::DomTypeHolder> for CommandEvent {
             Atom::from(type_),
             bubbles,
             cancelable,
-            init.source.as_ref().map(|s| DomRoot::from_ref(&**s)),
+            init.source.as_deref(),
             init.command.clone(),
         ))
     }

--- a/components/script/dom/event/pointerevent.rs
+++ b/components/script/dom/event/pointerevent.rs
@@ -19,7 +19,7 @@ use crate::dom::bindings::codegen::Bindings::PointerEventBinding::{
     PointerEventInit, PointerEventMethods,
 };
 use crate::dom::bindings::num::Finite;
-use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::{EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
@@ -48,12 +48,12 @@ pub(crate) struct PointerEvent {
     azimuth_angle: Cell<f64>,
     pointer_type: DomRefCell<DOMString>,
     is_primary: Cell<bool>,
-    coalesced_events: DomRefCell<Vec<DomRoot<PointerEvent>>>,
-    predicted_events: DomRefCell<Vec<DomRoot<PointerEvent>>>,
+    coalesced_events: DomRefCell<Vec<Dom<PointerEvent>>>,
+    predicted_events: DomRefCell<Vec<Dom<PointerEvent>>>,
 }
 
 impl PointerEvent {
-    pub(crate) fn new_inherited() -> PointerEvent {
+    fn new_inherited() -> PointerEvent {
         PointerEvent {
             mouseevent: MouseEvent::new_inherited(),
             pointer_id: Cell::new(0),
@@ -213,8 +213,14 @@ impl PointerEvent {
         ev.azimuth_angle.set(azimuth_angle);
         *ev.pointer_type.borrow_mut() = pointer_type;
         ev.is_primary.set(is_primary);
-        *ev.coalesced_events.borrow_mut() = coalesced_events;
-        *ev.predicted_events.borrow_mut() = predicted_events;
+        *ev.coalesced_events.borrow_mut() = coalesced_events
+            .into_iter()
+            .map(|event| event.as_traced())
+            .collect();
+        *ev.predicted_events.borrow_mut() = predicted_events
+            .into_iter()
+            .map(|event| event.as_traced())
+            .collect();
         ev
     }
 }
@@ -331,12 +337,20 @@ impl PointerEventMethods<crate::DomTypeHolder> for PointerEvent {
 
     /// <https://w3c.github.io/pointerevents/#dom-pointerevent-getcoalescedevents>
     fn GetCoalescedEvents(&self) -> Vec<DomRoot<PointerEvent>> {
-        self.coalesced_events.borrow().clone()
+        self.coalesced_events
+            .borrow()
+            .iter()
+            .map(|event| event.as_rooted())
+            .collect()
     }
 
     /// <https://w3c.github.io/pointerevents/#dom-pointerevent-getpredictedevents>
     fn GetPredictedEvents(&self) -> Vec<DomRoot<PointerEvent>> {
-        self.predicted_events.borrow().clone()
+        self.predicted_events
+            .borrow()
+            .iter()
+            .map(|event| event.as_rooted())
+            .collect()
     }
 
     /// <https://dom.spec.whatwg.org/#dom-event-istrusted>

--- a/components/script/dom/event/submitevent.rs
+++ b/components/script/dom/event/submitevent.rs
@@ -12,7 +12,7 @@ use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use crate::dom::bindings::codegen::Bindings::SubmitEventBinding;
 use crate::dom::bindings::codegen::Bindings::SubmitEventBinding::SubmitEventMethods;
 use crate::dom::bindings::inheritance::Castable;
-use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::html::htmlelement::HTMLElement;
@@ -21,14 +21,14 @@ use crate::dom::window::Window;
 #[dom_struct]
 pub(crate) struct SubmitEvent {
     event: Event,
-    submitter: Option<DomRoot<HTMLElement>>,
+    submitter: Option<Dom<HTMLElement>>,
 }
 
 impl SubmitEvent {
-    fn new_inherited(submitter: Option<DomRoot<HTMLElement>>) -> SubmitEvent {
+    fn new_inherited(submitter: Option<&HTMLElement>) -> SubmitEvent {
         SubmitEvent {
             event: Event::new_inherited(),
-            submitter,
+            submitter: submitter.map(Dom::from_ref),
         }
     }
 
@@ -38,7 +38,7 @@ impl SubmitEvent {
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
-        submitter: Option<DomRoot<HTMLElement>>,
+        submitter: Option<&HTMLElement>,
     ) -> DomRoot<SubmitEvent> {
         Self::new_with_proto(cx, window, None, type_, bubbles, cancelable, submitter)
     }
@@ -50,7 +50,7 @@ impl SubmitEvent {
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
-        submitter: Option<DomRoot<HTMLElement>>,
+        submitter: Option<&HTMLElement>,
     ) -> DomRoot<SubmitEvent> {
         let ev = reflect_dom_object_with_proto_and_cx(
             Box::new(SubmitEvent::new_inherited(submitter)),
@@ -82,7 +82,7 @@ impl SubmitEventMethods<crate::DomTypeHolder> for SubmitEvent {
             Atom::from(type_),
             init.parent.bubbles,
             init.parent.cancelable,
-            init.submitter.as_ref().map(|s| DomRoot::from_ref(&**s)),
+            init.submitter.as_deref(),
         )
     }
 

--- a/components/script/dom/event/toggleevent.rs
+++ b/components/script/dom/event/toggleevent.rs
@@ -14,7 +14,7 @@ use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use crate::dom::bindings::codegen::Bindings::ToggleEventBinding;
 use crate::dom::bindings::codegen::Bindings::ToggleEventBinding::ToggleEventMethods;
 use crate::dom::bindings::error::Fallible;
-use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::element::Element;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
@@ -30,20 +30,20 @@ pub(crate) struct ToggleEvent {
     /// <https://html.spec.whatwg.org/multipage/#dom-toggleevent-newstate>
     new_state: DOMString,
     /// <https://html.spec.whatwg.org/multipage/#dom-toggleevent-source>
-    source: Option<DomRoot<Element>>,
+    source: Option<Dom<Element>>,
 }
 
 impl ToggleEvent {
     pub(crate) fn new_inherited(
         old_state: DOMString,
         new_state: DOMString,
-        source: Option<DomRoot<Element>>,
+        source: Option<&Element>,
     ) -> ToggleEvent {
         ToggleEvent {
             event: Event::new_inherited(),
             old_state,
             new_state,
-            source,
+            source: source.map(Dom::from_ref),
         }
     }
 
@@ -56,7 +56,7 @@ impl ToggleEvent {
         cancelable: EventCancelable,
         old_state: DOMString,
         new_state: DOMString,
-        source: Option<DomRoot<Element>>,
+        source: Option<&Element>,
     ) -> DomRoot<ToggleEvent> {
         Self::new_with_proto(
             cx, window, None, type_, bubbles, cancelable, old_state, new_state, source,
@@ -73,7 +73,7 @@ impl ToggleEvent {
         cancelable: EventCancelable,
         old_state: DOMString,
         new_state: DOMString,
-        source: Option<DomRoot<Element>>,
+        source: Option<&Element>,
     ) -> DomRoot<ToggleEvent> {
         let event = Box::new(ToggleEvent::new_inherited(old_state, new_state, source));
         let event = reflect_dom_object_with_proto_and_cx(event, window, proto, cx);
@@ -106,7 +106,7 @@ impl ToggleEventMethods<crate::DomTypeHolder> for ToggleEvent {
             cancelable,
             init.oldState.clone(),
             init.newState.clone(),
-            init.source.as_ref().map(|s| DomRoot::from_ref(&**s)),
+            init.source.as_deref(),
         ))
     }
 

--- a/components/script/dom/html/htmlbuttonelement.rs
+++ b/components/script/dom/html/htmlbuttonelement.rs
@@ -559,7 +559,7 @@ impl Activatable for HTMLButtonElement {
                 atom!("command"),
                 EventBubbles::DoesNotBubble,
                 EventCancelable::Cancelable,
-                Some(DomRoot::from_ref(self.upcast())),
+                Some(self.upcast()),
                 self.upcast::<Element>()
                     .get_string_attribute(&local_name!("command")),
             );

--- a/components/script/dom/html/htmldialogelement.rs
+++ b/components/script/dom/html/htmldialogelement.rs
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-use std::borrow::Borrow;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name, ns};
@@ -109,7 +108,7 @@ impl HTMLDialogElement {
             EventCancelable::Cancelable,
             DOMString::from("closed"),
             DOMString::from("open"),
-            source.borrow().clone(),
+            source.as_deref(),
         );
         let event = event.upcast::<Event>();
         if !event.fire(cx, self.upcast::<EventTarget>()) {
@@ -189,7 +188,7 @@ impl HTMLDialogElement {
             EventCancelable::NotCancelable,
             DOMString::from("open"),
             DOMString::from("closed"),
-            source.borrow().clone(),
+            source.as_deref(),
         );
         let event = event.upcast::<Event>();
         event.fire(cx, self.upcast::<EventTarget>());
@@ -271,9 +270,7 @@ impl HTMLDialogElement {
         let old_state = old_state.to_string();
         let new_state = new_state.to_string();
 
-        let trusted_source = source
-            .as_ref()
-            .map(|el| Trusted::new(el.upcast::<EventTarget>()));
+        let trusted_source = source.map(|el| Trusted::new(&*el));
 
         self.owner_global()
             .task_manager()
@@ -281,9 +278,7 @@ impl HTMLDialogElement {
             .queue(task!(fire_toggle_event: move |cx| {
                 let this = this.root();
 
-                let source = trusted_source.as_ref().map(|s| {
-                    DomRoot::from_ref(s.root().downcast::<Element>().unwrap())
-                });
+                let source = trusted_source.map(|s| s.root());
 
                 // Step 2.1. Fire an event named toggle at element, using ToggleEvent, with the oldState attribute initialized to oldState, the newState attribute initialized to newState, and the source attribute initialized to source.
                 let event = ToggleEvent::new(
@@ -294,7 +289,7 @@ impl HTMLDialogElement {
                     EventCancelable::NotCancelable,
                     DOMString::from(old_state),
                     DOMString::from(new_state),
-                    source,
+                    source.as_deref(),
                 );
                 let event = event.upcast::<Event>();
                 event.fire(cx, this.upcast::<EventTarget>());

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -774,7 +774,7 @@ impl HTMLFormElement {
                 atom!("submit"),
                 true,
                 true,
-                submitter_button.map(DomRoot::from_ref),
+                submitter_button,
             );
             let event = event.upcast::<Event>();
             event.fire(cx, self.upcast::<EventTarget>());


### PR DESCRIPTION

Testing: It compiles
Part of #39139
