### PR TITLE
script: Reduce unnecessary rooting in `ScriptWindowProxies::insert`

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3031,7 +3031,7 @@ impl ScriptThread {
                         CreatorBrowsingContextInfo::from(last.as_deref(), None),
                     );
                     self.window_proxies
-                        .insert(browsing_context_id, window_proxy.clone());
+                        .insert(browsing_context_id, &window_proxy);
                     last = Some(window_proxy);
                 }
 

--- a/components/script/script_window_proxies.rs
+++ b/components/script/script_window_proxies.rs
@@ -45,8 +45,8 @@ impl ScriptWindowProxies {
         None
     }
 
-    pub(crate) fn insert(&self, id: BrowsingContextId, proxy: DomRoot<WindowProxy>) {
-        self.map.borrow_mut().insert(id, Dom::from_ref(&*proxy));
+    pub(crate) fn insert(&self, id: BrowsingContextId, proxy: &WindowProxy) {
+        self.map.borrow_mut().insert(id, Dom::from_ref(proxy));
     }
 
     pub(crate) fn remove(&self, id: BrowsingContextId) {
@@ -94,7 +94,7 @@ impl ScriptWindowProxies {
             opener,
             creator,
         );
-        self.insert(browsing_context_id, DomRoot::from_ref(&*window_proxy));
+        self.insert(browsing_context_id, &window_proxy);
         Some(window_proxy)
     }
 
@@ -156,7 +156,7 @@ impl ScriptWindowProxies {
             opener,
             creator,
         );
-        self.insert(browsing_context_id, DomRoot::from_ref(&*window_proxy));
+        self.insert(browsing_context_id, &window_proxy);
         window_proxy
     }
 


### PR DESCRIPTION
This was pretty ugly too. We were doing `DomRoot::from_ref(&*window_proxy)` on an existing DomRoot.

Testing: Existing tests.

Part of https://github.com/servo/servo/issues/34464