### PR TITLE
script: Migrate some calls from `DomRefCell::borrow_mut` to `safe_borrow_mut(cx.no_gc())`

### DIFF
--- a/components/script/animations.rs
+++ b/components/script/animations.rs
@@ -480,7 +480,7 @@ impl Animations {
         //
         // Take all of the events here, in case sending one of these events
         // triggers adding new events by forcing a layout.
-        let events = std::mem::take(&mut *self.pending_events.borrow_mut());
+        let events = std::mem::take(&mut *self.pending_events.safe_borrow_mut(cx.no_gc()));
         if events.is_empty() {
             return;
         }

--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -54,7 +54,7 @@ impl LoadBlocker {
         cx: &mut js::context::JSContext,
     ) {
         let Some(load) = blocker
-            .borrow_mut()
+            .safe_borrow_mut(cx.no_gc())
             .as_mut()
             .and_then(|blocker| blocker.load.take())
         else {
@@ -65,7 +65,7 @@ impl LoadBlocker {
             blocker.doc.finish_load(load, cx);
         }
 
-        *blocker.borrow_mut() = None;
+        *blocker.safe_borrow_mut(cx.no_gc()) = None;
     }
 }
 

--- a/components/script/dom/abort/abortsignal.rs
+++ b/components/script/dom/abort/abortsignal.rs
@@ -256,12 +256,12 @@ impl AbortSignal {
                 // Step 4.1.1. Append signal to resultSignal’s source signals.
                 result_signal
                     .source_signals
-                    .borrow_mut()
+                    .safe_borrow_mut(cx.no_gc())
                     .insert(WeakRef::new(signal));
                 // Step 4.1.2. Append resultSignal to signal’s dependent signals.
                 signal
                     .dependent_signals
-                    .borrow_mut()
+                    .safe_borrow_mut(cx.no_gc())
                     .insert(WeakRef::new(&*result_signal));
             } else {
                 // Step 4.2. Otherwise, for each sourceSignal of signal’s source signals:
@@ -272,12 +272,12 @@ impl AbortSignal {
                         // Step 4.2.2. Append sourceSignal to resultSignal’s source signals.
                         result_signal
                             .source_signals
-                            .borrow_mut()
+                            .safe_borrow_mut(cx.no_gc())
                             .insert(WeakRef::new(&*source_signal));
                         // Step 4.2.3. Append resultSignal to sourceSignal’s dependent signals.
                         source_signal
                             .dependent_signals
-                            .borrow_mut()
+                            .safe_borrow_mut(cx.no_gc())
                             .insert(WeakRef::new(&*result_signal));
                     }
                 }

--- a/components/script/dom/animations/keyframeeffect.rs
+++ b/components/script/dom/animations/keyframeeffect.rs
@@ -253,7 +253,7 @@ impl KeyframeEffectMethods<crate::DomTypeHolder> for KeyframeEffect {
         let Ok(keyframes) = process_a_keyframes_argument(cx, &document, keyframes) else {
             return;
         };
-        *self.keyframes.borrow_mut() = keyframes;
+        *self.keyframes.safe_borrow_mut(cx.no_gc()) = keyframes;
     }
 }
 

--- a/components/script/dom/audio/audiobuffer.rs
+++ b/components/script/dom/audio/audiobuffer.rs
@@ -183,7 +183,7 @@ impl AudioBuffer {
         if self.shared_channels.borrow().is_none() {
             let channels = self.acquire_contents(cx);
             if channels.is_some() {
-                *self.shared_channels.borrow_mut() = channels;
+                *self.shared_channels.safe_borrow_mut(cx.no_gc()) = channels;
             }
         }
         self.shared_channels.borrow()

--- a/components/script/dom/audio/baseaudiocontext.rs
+++ b/components/script/dom/audio/baseaudiocontext.rs
@@ -472,7 +472,7 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
             // XXX detach array buffer.
             let uuid = Uuid::new_v4().simple().to_string();
             let uuid_ = uuid.clone();
-            self.decode_resolvers.borrow_mut().insert(
+            self.decode_resolvers.safe_borrow_mut(cx.no_gc()).insert(
                 uuid.clone(),
                 DecodeResolver {
                     promise: promise.clone(),
@@ -535,7 +535,7 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
                         );
                         // Potential borrow hazard
                         let resolver = {
-                            let mut resolvers = this.decode_resolvers.borrow_mut();
+                            let mut resolvers = this.decode_resolvers.safe_borrow_mut(cx.no_gc());
                             assert!(resolvers.contains_key(&uuid_));
                             resolvers.remove(&uuid_).unwrap()
                         };
@@ -550,7 +550,7 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
                         let this = this_.root();
                         // potential borrow hazard
                         let resolver = {
-                            let mut resolvers = this.decode_resolvers.borrow_mut();
+                            let mut resolvers = this.decode_resolvers.safe_borrow_mut(cx.no_gc());
                             assert!(resolvers.contains_key(&uuid));
                             resolvers.remove(&uuid).unwrap()
                         };

--- a/components/script/dom/audio/offlineaudiocontext.rs
+++ b/components/script/dom/audio/offlineaudiocontext.rs
@@ -145,7 +145,7 @@ impl OfflineAudioContextMethods<crate::DomTypeHolder> for OfflineAudioContext {
         }
         self.rendering_started.set(true);
 
-        *self.pending_rendering_promise.borrow_mut() = Some(promise.clone());
+        *self.pending_rendering_promise.safe_borrow_mut(cx.no_gc()) = Some(promise.clone());
 
         let processed_audio = Arc::new(Mutex::new(Vec::new()));
         let processed_audio_ = processed_audio.clone();

--- a/components/script/dom/bindings/constructor.rs
+++ b/components/script/dom/bindings/constructor.rs
@@ -197,7 +197,8 @@ fn html_constructor(
 
             // Step 12
             {
-                let mut construction_stack = definition.construction_stack.borrow_mut();
+                let mut construction_stack =
+                    definition.construction_stack.safe_borrow_mut(cx.no_gc());
                 construction_stack.pop();
                 construction_stack.push(ConstructionStackEntry::AlreadyConstructedMarker);
             }

--- a/components/script/dom/bindings/frozenarray.rs
+++ b/components/script/dom/bindings/frozenarray.rs
@@ -39,7 +39,7 @@ impl CachedFrozenArray {
         to_frozen_array(cx, array.as_slice(), retval.reborrow());
 
         // Safety: need to create the Heap value in its final memory location before setting it.
-        *self.frozen_value.borrow_mut() = Some(Heap::default());
+        *self.frozen_value.safe_borrow_mut(cx.no_gc()) = Some(Heap::default());
         self.frozen_value
             .borrow()
             .as_ref()

--- a/components/script/dom/bluetooth/bluetoothdevice.rs
+++ b/components/script/dom/bluetooth/bluetoothdevice.rs
@@ -122,7 +122,7 @@ impl BluetoothDevice {
             service.instance_id.clone(),
         );
         service_map_ref
-            .borrow_mut()
+            .safe_borrow_mut(cx.no_gc())
             .insert(service.instance_id.clone(), Dom::from_ref(&bt_service));
         bt_service
     }
@@ -163,7 +163,7 @@ impl BluetoothDevice {
             &properties,
             characteristic.instance_id.clone(),
         );
-        characteristic_map_ref.borrow_mut().insert(
+        characteristic_map_ref.safe_borrow_mut(cx.no_gc()).insert(
             characteristic.instance_id.clone(),
             Dom::from_ref(&bt_characteristic),
         );
@@ -202,7 +202,7 @@ impl BluetoothDevice {
             DOMString::from(descriptor.uuid.clone()),
             descriptor.instance_id.clone(),
         );
-        descriptor_map_ref.borrow_mut().insert(
+        descriptor_map_ref.safe_borrow_mut(cx.no_gc()).insert(
             descriptor.instance_id.clone(),
             Dom::from_ref(&bt_descriptor),
         );
@@ -225,18 +225,26 @@ impl BluetoothDevice {
 
         // Step 4.
         let service_ids = {
-            let mut service_map = self.attribute_instance_map.service_map.borrow_mut();
+            let mut service_map = self
+                .attribute_instance_map
+                .service_map
+                .safe_borrow_mut(cx.no_gc());
             service_map.drain().map(|(id, _)| id).collect()
         };
 
         let characteristic_ids = {
-            let mut characteristic_map =
-                self.attribute_instance_map.characteristic_map.borrow_mut();
+            let mut characteristic_map = self
+                .attribute_instance_map
+                .characteristic_map
+                .safe_borrow_mut(cx.no_gc());
             characteristic_map.drain().map(|(id, _)| id).collect()
         };
 
         let descriptor_ids = {
-            let mut descriptor_map = self.attribute_instance_map.descriptor_map.borrow_mut();
+            let mut descriptor_map = self
+                .attribute_instance_map
+                .descriptor_map
+                .safe_borrow_mut(cx.no_gc());
             descriptor_map.drain().map(|(id, _)| id).collect()
         };
 

--- a/components/script/dom/bluetooth/bluetoothpermissionresult.rs
+++ b/components/script/dom/bluetooth/bluetoothpermissionresult.rs
@@ -131,7 +131,7 @@ impl AsyncBluetoothListener for BluetoothPermissionResult {
                 );
                 bluetooth
                     .get_device_map()
-                    .borrow_mut()
+                    .safe_borrow_mut(cx.no_gc())
                     .insert(device.id.clone(), Dom::from_ref(&bt_device));
                 self.global()
                     .as_window()

--- a/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
@@ -338,7 +338,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTCharacteristic {
                 // Step 5.5.2.
                 // TODO(#5014): Replace ByteString with ArrayBuffer when it is implemented.
                 let value = ByteString::new(result);
-                *self.value.borrow_mut() = Some(value.clone());
+                *self.value.safe_borrow_mut(cx.no_gc()) = Some(value.clone());
 
                 // Step 5.5.3.
                 self.upcast::<EventTarget>()
@@ -353,7 +353,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTCharacteristic {
 
                 // Step 7.5.2.
                 // TODO(#5014): Replace ByteString with an ArrayBuffer wrapped in a DataView.
-                *self.value.borrow_mut() = Some(ByteString::new(result));
+                *self.value.safe_borrow_mut(cx.no_gc()) = Some(ByteString::new(result));
 
                 // Step 7.5.3.
                 promise.resolve_native(cx, &());

--- a/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
@@ -195,7 +195,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTDescriptor {
                 // Step 5.4.2.
                 // TODO(#5014): Replace ByteString with ArrayBuffer when it is implemented.
                 let value = ByteString::new(result);
-                *self.value.borrow_mut() = Some(value.clone());
+                *self.value.safe_borrow_mut(cx.no_gc()) = Some(value.clone());
 
                 // Step 5.4.3.
                 promise.resolve_native(cx, &value);
@@ -206,7 +206,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTDescriptor {
 
                 // Step 7.4.2.
                 // TODO(#5014): Replace ByteString with an ArrayBuffer wrapped in a DataView.
-                *self.value.borrow_mut() = Some(ByteString::new(result));
+                *self.value.safe_borrow_mut(cx.no_gc()) = Some(ByteString::new(result));
 
                 // Step 7.4.3.
                 // TODO: Resolve promise with undefined instead of a value.

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -2205,7 +2205,7 @@ impl CanvasState {
         global: &GlobalScope,
         cx: &mut JSContext,
     ) -> DomRoot<DOMMatrix> {
-        let transform = self.state.borrow_mut().transform;
+        let transform = self.state.safe_borrow_mut(cx.no_gc()).transform;
         DOMMatrix::new(cx, global, true, transform.to_3d())
     }
 

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -164,9 +164,9 @@ impl OffscreenCanvas {
         }
         let context =
             OffscreenCanvasRenderingContext2D::new(cx, &self.global(), self, self.get_size())?;
-        *self.context.borrow_mut() = Some(OffscreenRenderingContext::Context2d(Dom::from_ref(
-            &*context,
-        )));
+        *self.context.safe_borrow_mut(cx.no_gc()) = Some(OffscreenRenderingContext::Context2d(
+            Dom::from_ref(&*context),
+        ));
         Some(context)
     }
 
@@ -193,9 +193,9 @@ impl OffscreenCanvas {
         let context = ImageBitmapRenderingContext::new(cx, &self.global(), &canvas);
 
         // Step 2. Set this's context mode to bitmaprenderer.
-        *self.context.borrow_mut() = Some(OffscreenRenderingContext::BitmapRenderer(
-            Dom::from_ref(&*context),
-        ));
+        *self.context.safe_borrow_mut(cx.no_gc()) = Some(
+            OffscreenRenderingContext::BitmapRenderer(Dom::from_ref(&*context)),
+        );
 
         // Step 3. Return context.
         Some(context)
@@ -228,7 +228,7 @@ impl OffscreenCanvas {
             .map(|context| {
                 // Step 2. If context is null, then return null;
                 // otherwise set this's context mode to webgl or webgl2.
-                *self.context.borrow_mut() =
+                *self.context.safe_borrow_mut(cx.no_gc()) =
                     Some(OffscreenRenderingContext::WebGL(Dom::from_ref(&*context)));
 
                 // Step 3. Return context.
@@ -265,7 +265,7 @@ impl OffscreenCanvas {
             .map(|context| {
                 // Step 2. If context is null, then return null;
                 // otherwise set this's context mode to webgl or webgl2.
-                *self.context.borrow_mut() =
+                *self.context.safe_borrow_mut(cx.no_gc()) =
                     Some(OffscreenRenderingContext::WebGL2(Dom::from_ref(&*context)));
 
                 // Step 3. Return context.
@@ -287,7 +287,7 @@ impl Transferable for OffscreenCanvas {
     /// <https://html.spec.whatwg.org/multipage/#the-offscreencanvas-interface:transfer-steps>
     fn transfer(
         &self,
-        _cx: &mut js::context::JSContext,
+        cx: &mut js::context::JSContext,
     ) -> Fallible<(OffscreenCanvasId, TransferableOffscreenCanvas)> {
         // <https://html.spec.whatwg.org/multipage/#structuredserializewithtransfer>
         // Step 5.2. If transferable has a [[Detached]] internal slot and
@@ -309,7 +309,7 @@ impl Transferable for OffscreenCanvas {
         }
 
         // Step 2. Set value's context mode to detached.
-        *self.context.borrow_mut() = Some(OffscreenRenderingContext::Detached);
+        *self.context.safe_borrow_mut(cx.no_gc()) = Some(OffscreenRenderingContext::Detached);
 
         // Step 3. Let width and height be the dimensions of value's bitmap.
         // Step 5. Unset value's bitmap.

--- a/components/script/dom/characterdata/characterdata.rs
+++ b/components/script/dom/characterdata/characterdata.rs
@@ -75,7 +75,7 @@ impl CharacterData {
     #[inline]
     pub(crate) fn append_data(&self, cx: &mut JSContext, data: &str) {
         self.queue_mutation_record(cx);
-        self.data.borrow_mut().push_str(data);
+        self.data.safe_borrow_mut(cx.no_gc()).push_str(data);
         self.content_changed(cx);
     }
 
@@ -114,7 +114,7 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
         self.queue_mutation_record(cx);
         let old_length = self.Length();
         let new_length = data.str().encode_utf16().count() as u32;
-        *self.data.borrow_mut() = String::from(data.str());
+        *self.data.safe_borrow_mut(cx.no_gc()) = String::from(data.str());
         self.content_changed(cx);
         let node = self.upcast::<Node>();
         node.ranges()
@@ -240,7 +240,7 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
             new_data.push_str(replacement_after);
             new_data.push_str(suffix);
         }
-        *self.data.borrow_mut() = new_data;
+        *self.data.safe_borrow_mut(cx.no_gc()) = new_data;
         self.content_changed(cx);
         // Steps 8-11.
         let node = self.upcast::<Node>();

--- a/components/script/dom/clipboard/clipboarditem.rs
+++ b/components/script/dom/clipboard/clipboarditem.rs
@@ -157,7 +157,9 @@ impl ClipboardItemMethods<crate::DomTypeHolder> for ClipboardItem {
         let clipboard_item = ClipboardItem::new(cx, global, proto);
 
         // Step 4 Set this's clipboard item's presentation style to options["presentationStyle"].
-        *clipboard_item.presentation_style.borrow_mut() = options.presentationStyle;
+        *clipboard_item
+            .presentation_style
+            .safe_borrow_mut(cx.no_gc()) = options.presentationStyle;
 
         // Step 6 For each (key, value) in items:
         for (key, value) in items.deref() {
@@ -203,7 +205,7 @@ impl ClipboardItemMethods<crate::DomTypeHolder> for ClipboardItem {
             // Step 6.10 Append representation to this's clipboard item's list of representations.
             clipboard_item
                 .representations
-                .borrow_mut()
+                .safe_borrow_mut(cx.no_gc())
                 .push(representation);
         }
 

--- a/components/script/dom/cookiestore.rs
+++ b/components/script/dom/cookiestore.rs
@@ -79,7 +79,7 @@ impl CookieListener {
     pub(crate) fn handle(&self, message: CookieAsyncResponse) {
         let context = self.context.clone();
         self.task_source.queue(task!(cookie_message: move |cx| {
-            let Some(promise) = context.root().in_flight.borrow_mut().pop_front() else {
+            let Some(promise) = context.root().in_flight.safe_borrow_mut(cx.no_gc()).pop_front() else {
                 warn!("No promise exists for cookie store response");
                 return;
             };
@@ -214,7 +214,9 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         if res.is_err() {
             error!("Failed to send cookiestore message to resource threads");
         } else {
-            self.in_flight.borrow_mut().push_back(p.clone());
+            self.in_flight
+                .safe_borrow_mut(cx.no_gc())
+                .push_back(p.clone());
         }
 
         // 7. Return p.
@@ -294,7 +296,9 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         if res.is_err() {
             error!("Failed to send cookiestore message to resource threads");
         } else {
-            self.in_flight.borrow_mut().push_back(p.clone());
+            self.in_flight
+                .safe_borrow_mut(cx.no_gc())
+                .push_back(p.clone());
         }
 
         p
@@ -334,7 +338,9 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         if res.is_err() {
             error!("Failed to send cookiestore message to resource threads");
         } else {
-            self.in_flight.borrow_mut().push_back(p.clone());
+            self.in_flight
+                .safe_borrow_mut(cx.no_gc())
+                .push_back(p.clone());
         }
 
         // 7. Return p.
@@ -407,7 +413,9 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         if res.is_err() {
             error!("Failed to send cookiestore message to resource threads");
         } else {
-            self.in_flight.borrow_mut().push_back(p.clone());
+            self.in_flight
+                .safe_borrow_mut(cx.no_gc())
+                .push_back(p.clone());
         }
 
         // 8. Return p
@@ -461,7 +469,9 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         if res.is_err() {
             error!("Failed to send cookiestore message to resource threads");
         } else {
-            self.in_flight.borrow_mut().push_back(p.clone());
+            self.in_flight
+                .safe_borrow_mut(cx.no_gc())
+                .push_back(p.clone());
         }
 
         // 7. Return p.
@@ -508,7 +518,9 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         if res.is_err() {
             error!("Failed to send cookiestore message to resource threads");
         } else {
-            self.in_flight.borrow_mut().push_back(p.clone());
+            self.in_flight
+                .safe_borrow_mut(cx.no_gc())
+                .push_back(p.clone());
         }
 
         // 7. Return p
@@ -544,7 +556,9 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         if res.is_err() {
             error!("Failed to send cookiestore message to resource threads");
         } else {
-            self.in_flight.borrow_mut().push_back(p.clone());
+            self.in_flight
+                .safe_borrow_mut(cx.no_gc())
+                .push_back(p.clone());
         }
 
         // 7. Return p.
@@ -580,7 +594,9 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         if res.is_err() {
             error!("Failed to send cookiestore message to resource threads");
         } else {
-            self.in_flight.borrow_mut().push_back(p.clone());
+            self.in_flight
+                .safe_borrow_mut(cx.no_gc())
+                .push_back(p.clone());
         }
 
         // 7. Return p.

--- a/components/script/dom/css/cssrulelist.rs
+++ b/components/script/dom/css/cssrulelist.rs
@@ -162,7 +162,7 @@ impl CSSRuleList {
         parent_stylesheet.will_modify(cx);
         let dom_rule = CSSRule::new_specific(cx, window, parent_stylesheet, new_rule);
         self.dom_rules
-            .borrow_mut()
+            .safe_borrow_mut(cx.no_gc())
             .insert(index, MutNullableDom::new(Some(&*dom_rule)));
         parent_stylesheet.notify_invalidations();
         Ok(idx)
@@ -181,7 +181,7 @@ impl CSSRuleList {
                     .write_with(&mut guard)
                     .remove_rule(index)
                     .map_err(Convert::convert)?;
-                let mut dom_rules = self.dom_rules.borrow_mut();
+                let mut dom_rules = self.dom_rules.safe_borrow_mut(cx.no_gc());
                 if let Some(r) = dom_rules[index].get() {
                     r.detach()
                 }
@@ -191,7 +191,7 @@ impl CSSRuleList {
             },
             RulesSource::Keyframes(ref kf) => {
                 // https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-deleterule
-                let mut dom_rules = self.dom_rules.borrow_mut();
+                let mut dom_rules = self.dom_rules.safe_borrow_mut(cx.no_gc());
                 if let Some(r) = dom_rules[index].get() {
                     r.detach()
                 }

--- a/components/script/dom/css/cssstyledeclaration.rs
+++ b/components/script/dom/css/cssstyledeclaration.rs
@@ -77,7 +77,8 @@ impl CSSStyleOwner {
             CSSStyleOwner::Element(ref element) => {
                 let document = element.owner_document();
                 let shared_lock = document.style_shared_author_lock();
-                let mut attribute_pdb = element.style_attribute().borrow_mut().take();
+                let mut attribute_pdb =
+                    element.style_attribute().safe_borrow_mut(cx.no_gc()).take();
 
                 // When there are mutation observers, the old PDB and the new PDB need to
                 // co-exist so that both attribute values can be serialized and sent to
@@ -112,7 +113,7 @@ impl CSSStyleOwner {
                 // declaration block is empty (see
                 // https://github.com/whatwg/html/issues/2306).
                 if !changed {
-                    *element.style_attribute().borrow_mut() = Some(attribute_pdb);
+                    *element.style_attribute().safe_borrow_mut(cx.no_gc()) = Some(attribute_pdb);
                     return result;
                 }
 

--- a/components/script/dom/event/keyboardevent.rs
+++ b/components/script/dom/event/keyboardevent.rs
@@ -133,9 +133,9 @@ impl KeyboardEvent {
             location,
             repeat,
         );
-        *event.typed_key.borrow_mut() = key;
-        *event.code.borrow_mut() = code;
-        *event.original_code.borrow_mut() = original_code;
+        *event.typed_key.safe_borrow_mut(cx.no_gc()) = key;
+        *event.code.safe_borrow_mut(cx.no_gc()) = code;
+        *event.original_code.safe_borrow_mut(cx.no_gc()) = original_code;
         event.modifiers.set(modifiers);
         event.is_composing.set(is_composing);
         event.char_code.set(char_code);
@@ -218,7 +218,7 @@ impl KeyboardEventMethods<crate::DomTypeHolder> for KeyboardEvent {
             init.charCode,
             init.keyCode,
         );
-        *event.key.borrow_mut() = init.key.clone();
+        *event.key.safe_borrow_mut(cx.no_gc()) = init.key.clone();
         Ok(event)
     }
 

--- a/components/script/dom/event/messageevent.rs
+++ b/components/script/dom/event/messageevent.rs
@@ -322,7 +322,7 @@ impl MessageEventMethods<crate::DomTypeHolder> for MessageEvent {
     #[expect(non_snake_case)]
     fn InitMessageEvent(
         &self,
-        _cx: &mut JSContext,
+        cx: &mut JSContext,
         type_: DOMString,
         bubbles: bool,
         cancelable: bool,
@@ -333,10 +333,10 @@ impl MessageEventMethods<crate::DomTypeHolder> for MessageEvent {
         ports: Vec<DomRoot<MessagePort>>,
     ) {
         self.data.set(data.get());
-        *self.origin.borrow_mut() = origin;
-        *self.source.borrow_mut() = source.as_ref().map(|source| source.into());
-        *self.lastEventId.borrow_mut() = lastEventId;
-        *self.ports.borrow_mut() = ports
+        *self.origin.safe_borrow_mut(cx.no_gc()) = origin;
+        *self.source.safe_borrow_mut(cx.no_gc()) = source.as_ref().map(|source| source.into());
+        *self.lastEventId.safe_borrow_mut(cx.no_gc()) = lastEventId;
+        *self.ports.safe_borrow_mut(cx.no_gc()) = ports
             .into_iter()
             .map(|port| Dom::from_ref(&*port))
             .collect();

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -254,7 +254,8 @@ impl EventSourceContext {
     fn dispatch_event(&mut self, cx: &mut JSContext) {
         let event_source = self.event_source.root();
         // Step 1
-        *event_source.last_event_id.borrow_mut() = DOMString::from(self.last_event_id.clone());
+        *event_source.last_event_id.safe_borrow_mut(cx.no_gc()) =
+            DOMString::from(self.last_event_id.clone());
         // Step 2
         if self.data.is_empty() {
             self.data.clear();
@@ -627,7 +628,7 @@ impl EventSourceMethods<crate::DomTypeHolder> for EventSource {
         // Step 11 Set request's cache mode to "no-store".
         request.cache_mode = CacheMode::NoStore;
         // Step 13 Set ev's request to request.
-        *event_source.request.borrow_mut() = Some(request.clone());
+        *event_source.request.safe_borrow_mut(cx.no_gc()) = Some(request.clone());
         // Step 14 Let processEventSourceEndOfBody given response res be the following step:
         // if res is not a network error, then reestablish the connection.
 


### PR DESCRIPTION

This statically guarantees that no borrow hazards are present in the code. While working on this change I found https://github.com/servo/servo/issues/46433 and https://github.com/servo/servo/issues/46432.

Testing: If it compiles then it works.
Part of #40600 