### PR TITLE
layout/script/fonts: Implement size_hint for iterator if easy

### DIFF
--- a/components/layout/taffy/layout.rs
+++ b/components/layout/taffy/layout.rs
@@ -79,6 +79,10 @@ impl Iterator for ChildIter {
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next().map(taffy::NodeId::from)
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.0.len(), Some(self.0.len()))
+    }
 }
 
 impl taffy::TraversePartialTree for TaffyContainerContext<'_> {

--- a/components/script/document_collection.rs
+++ b/components/script/document_collection.rs
@@ -112,6 +112,10 @@ impl Iterator for DocumentsIter<'_> {
             .next()
             .map(|(id, doc)| (*id, DomRoot::from_ref(&**doc)))
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
 
 #[derive(Default)]

--- a/components/script/dom/node/layout_dom.rs
+++ b/components/script/dom/node/layout_dom.rs
@@ -350,6 +350,10 @@ impl<'dom> LayoutDom<'dom, Node> {
                 .is_some_and(|shadow_root| shadow_root.is_user_agent_widget())
         })
     }
+
+    pub(crate) fn children_count(&self) -> u32 {
+        self.unsafe_get().children_count()
+    }
 }
 
 pub(crate) struct NodeTypeIdWrapper(pub(crate) NodeTypeId);

--- a/components/script/layout_dom/iterators.rs
+++ b/components/script/layout_dom/iterators.rs
@@ -22,6 +22,14 @@ impl<'dom> Iterator for ReverseChildrenIterator<'dom> {
         self.current = node.and_then(|node| unsafe { node.dangerous_previous_sibling() });
         node
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if let Some(node) = self.current {
+            (node.node.children_count() as usize, None)
+        } else {
+            (0, None)
+        }
+    }
 }
 
 pub enum ServoLayoutNodeChildrenIterator<'dom> {
@@ -67,6 +75,15 @@ impl<'dom> Iterator for ServoLayoutNodeChildrenIterator<'dom> {
                 std::mem::replace(node, next_sibling)
             },
             Self::Slottables(slots) => slots.next().map(|node| node.layout_node()),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            Self::Node(node) if node.is_some() => {
+                (node.unwrap().node.children_count() as usize, None)
+            },
+            _ => (0, None),
         }
     }
 }

--- a/components/shared/fonts/lib.rs
+++ b/components/shared/fonts/lib.rs
@@ -95,6 +95,13 @@ impl Iterator for TextByteRange {
             Some(next)
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (
+            self.0.end.0 - self.0.start.0,
+            Some(self.0.end.0 - self.0.start.0),
+        )
+    }
 }
 
 impl DoubleEndedIterator for TextByteRange {


### PR DESCRIPTION
This implements size_hint for structs that `impl Iterator` if it is reasonably easy to get the size. This allows the compiler to optimize if these structs are collected into an array.

Testing: This does not need the test as per the documentation even "incorrect" size_hints are correct.
