### PR TITLE
script: Have `SVGSVGElement` store `Uuid` directly instead of the `String` representation of a `Uuid`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8255,6 +8255,7 @@ dependencies = [
  "unicode-script",
  "unicode_categories",
  "url",
+ "uuid",
  "web_atoms",
  "webrender_api",
 ]
@@ -8288,6 +8289,7 @@ dependencies = [
  "servo_arc",
  "stylo",
  "stylo_traits",
+ "uuid",
  "webrender_api",
 ]
 

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -68,6 +68,7 @@ unicode-bidi = { workspace = true }
 unicode-script = { workspace = true }
 unicode_categories = { workspace = true }
 url = { workspace = true }
+uuid = { workspace = true }
 web_atoms = { workspace = true }
 webrender_api = { workspace = true }
 

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -26,6 +26,7 @@ use style::dom::OpaqueNode;
 use style::values::computed::color::Color;
 use style::values::computed::image::{Gradient, Image};
 use style_traits::DevicePixel;
+use uuid::Uuid;
 use webrender_api::units::{DeviceIntSize, DeviceSize};
 
 pub(crate) type CachedImageOrError = Result<CachedImage, ResolveImageError>;
@@ -254,7 +255,7 @@ impl ImageResolver {
         image_id: PendingImageId,
         size: DeviceIntSize,
         node: OpaqueNode,
-        svg_id: Option<String>,
+        svg_id: Option<Uuid>,
     ) -> Option<RasterImage> {
         let result = self
             .image_cache

--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -525,7 +525,7 @@ impl ReplacedContents {
                                 vector_image.id,
                                 size,
                                 tag.node,
-                                vector_image.svg_id.clone(),
+                                vector_image.svg_id,
                             )
                             .and_then(|i| i.id)
                     },
@@ -630,7 +630,7 @@ impl ReplacedContents {
                         vector_image.id,
                         raster_size,
                         tag.node,
-                        vector_image.svg_id.clone(),
+                        vector_image.svg_id,
                     )
                     .and_then(|image| image.id)
                     .map(|image_key| {

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -33,6 +33,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use servo_base::id::{PipelineId, WebViewId};
 use servo_base::threadpool::ThreadPool;
 use servo_url::{ImmutableOrigin, ServoUrl};
+use uuid::Uuid;
 use webrender_api::ImageKey as WebRenderImageKey;
 use webrender_api::units::DeviceIntSize;
 
@@ -846,7 +847,7 @@ pub struct ImageCacheImpl {
     /// Per-[`ImageCache`] data.
     store: Arc<Mutex<ImageCacheStore>>,
     /// Maps an SVGElement uuid to a pending image id in the store
-    svg_id_image_id_map: Arc<Mutex<FxHashMap<String, PendingImageId>>>,
+    svg_id_image_id_map: Arc<Mutex<FxHashMap<Uuid, PendingImageId>>>,
     /// The data to use for the broken image icon used when images cannot load.
     broken_image_icon_data: Arc<Vec<u8>>,
     /// Thread pool for image decoding. This is shared with other [`ImageCache`]s in the
@@ -1002,7 +1003,7 @@ impl ImageCache for ImageCacheImpl {
         &self,
         image_id: PendingImageId,
         requested_size: DeviceIntSize,
-        svg_id: Option<String>,
+        svg_id: Option<Uuid>,
     ) -> Option<RasterImage> {
         let mut store = self.store.lock();
         let Some(vector_image) = store.vector_images.get(&image_id).cloned() else {
@@ -1157,7 +1158,7 @@ impl ImageCache for ImageCacheImpl {
         store.remove_loaded_image(url, origin, cors_setting);
     }
 
-    fn evict_rasterized_image(&self, svg_id: &str) {
+    fn evict_rasterized_image(&self, svg_id: &Uuid) {
         let mut store = self.store.lock();
         if let Some(mapped_image_id) = self.svg_id_image_id_map.lock().remove(svg_id) {
             store.pending_loads.remove(&mapped_image_id);

--- a/components/script/dom/svg/svgsvgelement.rs
+++ b/components/script/dom/svg/svgsvgelement.rs
@@ -37,7 +37,8 @@ use crate::dom::svg::svggraphicselement::SVGGraphicsElement;
 #[dom_struct]
 pub(crate) struct SVGSVGElement {
     svggraphicselement: SVGGraphicsElement,
-    uuid: String,
+    #[no_trace]
+    uuid: Uuid,
     // The XML source of subtree rooted at this SVG element, serialized into
     // a base64 encoded `data:` url. This is cached to avoid recomputation
     // on each layout and must be invalidated when the subtree changes.
@@ -53,7 +54,7 @@ impl SVGSVGElement {
     ) -> SVGSVGElement {
         SVGSVGElement {
             svggraphicselement: SVGGraphicsElement::new_inherited(local_name, prefix, document),
-            uuid: Uuid::new_v4().to_string(),
+            uuid: Uuid::new_v4(),
             cached_serialized_data_url: Default::default(),
         }
     }
@@ -184,7 +185,7 @@ impl SVGSVGElement {
 impl<'dom> LayoutDom<'dom, SVGSVGElement> {
     #[expect(unsafe_code)]
     pub(crate) fn data(self) -> SVGElementData<'dom> {
-        let svg_id = self.unsafe_get().uuid.clone();
+        let svg_id = self.unsafe_get().uuid;
         let element = self.upcast::<Element>();
         let width = element.get_attr_for_layout(&ns!(), &local_name!("width"));
         let height = element.get_attr_for_layout(&ns!(), &local_name!("height"));

--- a/components/shared/layout/Cargo.toml
+++ b/components/shared/layout/Cargo.toml
@@ -31,6 +31,7 @@ pixels = { workspace = true }
 profile_traits = { workspace = true }
 rustc-hash = { workspace = true }
 script_traits = { workspace = true }
+uuid = { workspace = true }
 selectors = { workspace = true }
 serde = { workspace = true }
 servo-background-hang-monitor-api = { workspace = true }

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -73,6 +73,7 @@ use style::stylist::Stylist;
 use style::thread_state::{self, ThreadState};
 use style::values::computed::Overflow;
 use style_traits::CSSPixel;
+use uuid::Uuid;
 use webrender_api::units::{DeviceIntSize, LayoutPoint, LayoutVector2D};
 use webrender_api::{ExternalScrollId, ImageKey};
 
@@ -161,7 +162,7 @@ pub struct SVGElementData<'dom> {
     pub source: Option<Result<ServoUrl, ()>>,
     pub width: Option<&'dom AttrValue>,
     pub height: Option<&'dom AttrValue>,
-    pub svg_id: String,
+    pub svg_id: Uuid,
     pub view_box: Option<&'dom AttrValue>,
 }
 

--- a/components/shared/net/image_cache.rs
+++ b/components/shared/net/image_cache.rs
@@ -13,6 +13,7 @@ use profile_traits::mem::Report;
 use serde::{Deserialize, Serialize};
 use servo_base::id::{PipelineId, WebViewId};
 use servo_url::{ImmutableOrigin, ServoUrl};
+use uuid::Uuid;
 use webrender_api::ImageKey;
 use webrender_api::units::DeviceIntSize;
 
@@ -37,7 +38,7 @@ pub enum Image {
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct VectorImage {
     pub id: VectorImageId,
-    pub svg_id: Option<String>,
+    pub svg_id: Option<Uuid>,
     pub metadata: ImageMetadata,
     pub cors_status: CorsStatus,
 }
@@ -207,7 +208,7 @@ pub trait ImageCache: Sync + Send {
         &self,
         image_id: VectorImageId,
         size: DeviceIntSize,
-        svg_id: Option<String>,
+        svg_id: Option<Uuid>,
     ) -> Option<RasterImage>;
 
     /// Adds a new listener to be notified once the given `image_id` has been rasterized at
@@ -223,7 +224,7 @@ pub trait ImageCache: Sync + Send {
     );
 
     /// Removes the rasterized image from the image_cache, identified by the id of the SVG
-    fn evict_rasterized_image(&self, svg_id: &str);
+    fn evict_rasterized_image(&self, svg_id: &Uuid);
 
     /// Removes the completed image from the image_cache, identified by url, origin, and cors
     fn evict_completed_image(


### PR DESCRIPTION
Storing Uuid directly in svgsvgelement is more efficient than storing an string from an uuid. We also change all downstream occurrences of this.

Testing: Compilation is the test.
