### PR TITLE
Use `fontsan` with `wuff`-backed (pure rust) WOFF decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2774,25 +2774,15 @@ dependencies = [
 
 [[package]]
 name = "fontsan"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fd401b496627c46f35318272508fcdcb77927868507ed2ad796408aa903923"
+checksum = "cff76797a10ce7f8439f6e0a5ed06783e26e60d97e28c8c1c623a608ca67cff9"
 dependencies = [
  "cc",
- "fontsan-woff2",
  "glob",
  "libc",
  "libz-sys",
-]
-
-[[package]]
-name = "fontsan-woff2"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106ebe29445505f3860765d2597ddad20a3e90174d6e8539a10d58253b3e5c0f"
-dependencies = [
- "brotli-decompressor",
- "cc",
+ "wuff-capi",
 ]
 
 [[package]]
@@ -12315,6 +12305,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 dependencies = [
  "either",
+]
+
+[[package]]
+name = "wuff"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f0bd4b3863c66b53b6569ff8470434a7191ab07642fe8ddb3f9558ced547fe0"
+dependencies = [
+ "arrayvec",
+ "brotli-decompressor",
+ "bytes",
+]
+
+[[package]]
+name = "wuff-capi"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4dbb1eebaa6782421e6aeac4ab5f9f3b9c665eb2f8650073f5235408b3898e2"
+dependencies = [
+ "wuff",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ env_logger = "0.11"
 euclid = "0.22"
 flate2 = "1.1"
 fontconfig_sys = { package = "yeslogic-fontconfig-sys", version = "6" }
-fontsan = "0.6.1"
+fontsan = { version = "0.7", default-features = false, features = ["libz-sys", "wuff"] }
 freetype-sys = "0.23"
 fst = "0.4"
 futures = { version = "0.3", default-features = false }


### PR DESCRIPTION
Upgrades to a version of [`fontsan`](https://github.com/servo/fontsan) with WOFF decoding backed by the pure-Rust [`wuff`](https://github.com/nicoburns/wuff) crate.

Depends on:
- https://github.com/nicoburns/wuff/pull/11
- https://github.com/servo/fontsan/pull/48

~~I've run the `css/WOFF2` WPT tests locally, and updated the expectations here. This is currently failing a number of WPT tests around decoding *invalid* WOFF fonts (decoding *should* fail, but it should not panic), which will need to be fixed before this can land.~~ (EDIT: the WPT test failures have now been addressed.)

Testing: WPT tests
