### PR TITLE
script: Don't always allocate `NodeRareData` when accessing `WeakRangeVec`

### DIFF
--- a/components/script/dom/characterdata/characterdata.rs
+++ b/components/script/dom/characterdata/characterdata.rs
@@ -116,9 +116,11 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
         let new_length = data.str().encode_utf16().count() as u32;
         *self.data.borrow_mut() = String::from(data.str());
         self.content_changed(cx);
+
         let node = self.upcast::<Node>();
-        node.ranges()
-            .replace_code_units(node, 0, old_length, new_length);
+        if let Some(weak_ranges) = node.weak_ranges_mut() {
+            weak_ranges.replace_code_units(node, 0, old_length, new_length);
+        }
     }
 
     /// <https://dom.spec.whatwg.org/#dom-characterdata-length>
@@ -242,14 +244,40 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
         }
         *self.data.borrow_mut() = new_data;
         self.content_changed(cx);
-        // Steps 8-11.
+
+        // Step 8: For each live range whose start node is node and start offset is
+        // greater than offset but less than or equal to offset + count: set its start
+        // offset to offset.
+        //
+        // Step 9: For each live range whose end node is node and end offset is greater
+        // than offset but less than or equal to offset + count: set its end offset to
+        // offset.
+        //
+        // Step 10: For each live range whose start node is node and start offset is
+        // greater than offset + count: increase its start offset by data’s length and
+        // decrease it by count.
+        //
+        // Step 11: For each live range whose end node is node and end offset is greater
+        // than offset + count: increase its end offset by data’s length and decrease it
+        // by count.
         let node = self.upcast::<Node>();
-        node.ranges().replace_code_units(
-            node,
-            offset,
-            count,
-            arg.str().encode_utf16().count() as u32,
-        );
+        if let Some(weak_ranges) = node.weak_ranges_mut() {
+            weak_ranges.replace_code_units(
+                node,
+                offset,
+                count,
+                arg.str().encode_utf16().count() as u32,
+            );
+        }
+
+        // Step 12: If node is a ProcessingInstruction node and piAttributesAlreadyUpdated
+        // is false, then update attributes from data given node.
+        // TODO: Implement this.
+
+        // Step 13: If node’s parent is non-null, then run the children changed steps for
+        // node’s parent.
+        // TODO: This is handled above, but it should be handled here.
+
         Ok(())
     }
 

--- a/components/script/dom/characterdata/text.rs
+++ b/components/script/dom/characterdata/text.rs
@@ -94,11 +94,26 @@ impl TextMethods<crate::DomTypeHolder> for Text {
             parent
                 .InsertBefore(cx, new_node.upcast(), node.GetNextSibling().as_deref())
                 .unwrap();
-            // Steps 7.2-3.
-            node.ranges()
-                .move_to_following_text_sibling_above(node, offset, new_node.upcast());
-            // Steps 7.4-5.
-            parent.ranges().increment_at(parent, node.index() + 1);
+
+            // Step 7.2. For each live range whose start node is node and start offset is
+            // greater than offset, set its start node to newNode and decrease its start
+            // offset by offset.
+            //
+            // Step 7.3. For each live range whose end node is node and end offset is
+            // greater than offset, set its end node to newNode and decrease its end
+            // offset by offset.
+            if let Some(weak_ranges) = node.weak_ranges_mut() {
+                weak_ranges.move_to_following_text_sibling_above(node, offset, new_node.upcast());
+            }
+
+            // Step 7.4. For each live range whose start node is parent and start offset
+            // is equal to the index of node plus 1, increase its start offset by 1.
+            //
+            // Step 7.5. For each live range whose end node is parent and end offset is
+            // equal to the index of node plus 1, increase its end offset by 1.
+            if let Some(parent_weak_ranges) = parent.weak_ranges_mut() {
+                parent_weak_ranges.increment_at(parent, node.index() + 1);
+            }
         }
         // Step 8.
         cdata.DeleteData(cx, offset, count).unwrap();

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -714,8 +714,7 @@ impl Node {
     }
 
     pub(crate) fn registered_mutation_observers(&self) -> Option<Ref<'_, Vec<RegisteredObserver>>> {
-        let rare_data: Ref<'_, _> = self.rare_data.borrow();
-
+        let rare_data = self.rare_data.borrow();
         if rare_data.is_none() {
             return None;
         }
@@ -732,9 +731,13 @@ impl Node {
 
     /// Removes the mutation observer for a given node.
     pub(crate) fn remove_mutation_observer(&self, observer: &MutationObserver) {
-        self.ensure_rare_data()
+        let mut rare_data = self.rare_data.borrow_mut();
+        let Some(rare_data) = rare_data.as_mut() else {
+            return;
+        };
+        rare_data
             .mutation_observers
-            .retain(|reg_obs| &*reg_obs.observer != observer)
+            .retain(|registered_observer| &*registered_observer.observer != observer)
     }
 
     /// Returns a string that describes this node.
@@ -811,15 +814,27 @@ impl Node {
         self.children_count.get()
     }
 
-    pub(crate) fn ranges(&self) -> RefMut<'_, WeakRangeVec> {
-        RefMut::map(self.ensure_rare_data(), |rare_data| &mut rare_data.ranges)
+    pub(crate) fn weak_ranges_mut(&self) -> Option<RefMut<'_, WeakRangeVec>> {
+        let rare_data = self.rare_data.borrow_mut();
+        if rare_data.is_none() {
+            return None;
+        }
+        Some(RefMut::map(rare_data, |rare_data| {
+            &mut rare_data.as_mut().unwrap().weak_ranges
+        }))
     }
 
-    pub(crate) fn ranges_is_empty(&self) -> bool {
+    pub(crate) fn ensure_weak_ranges(&self) -> RefMut<'_, WeakRangeVec> {
+        RefMut::map(self.ensure_rare_data(), |rare_data| {
+            &mut rare_data.weak_ranges
+        })
+    }
+
+    pub(crate) fn weak_ranges_is_empty(&self) -> bool {
         self.rare_data
             .borrow()
             .as_ref()
-            .is_none_or(|data| data.ranges.is_empty())
+            .is_none_or(|data| data.weak_ranges.is_empty())
     }
 
     #[inline]
@@ -1478,14 +1493,14 @@ impl Node {
         }
 
         // Step 17. If child is non-null:
-        if let Some(child) = child {
+        if let Some(child) = child &&
+            let Some(new_parent_ranges) = new_parent.weak_ranges_mut()
+        {
             // Step 17.1. For each live range whose start node is newParent and start offset is
             // greater than child’s index: increase its start offset by 1.
             // Step 17.2. For each live range whose end node is newParent and end offset is greater
             // than child’s index: increase its end offset by 1.
-            new_parent
-                .ranges()
-                .increase_above(new_parent, child.index(), 1)
+            new_parent_ranges.increase_above(new_parent, child.index(), 1)
         }
 
         // Step 18. Let newPreviousSibling be child’s previous sibling if child is non-null, and
@@ -2537,11 +2552,9 @@ impl Node {
         //     2. For each live range whose end node is parent and end offset is
         //        greater than child’s index, increase its end offset by count.
         if let Some(child) = child &&
-            !parent.ranges_is_empty()
+            let Some(parent_weak_ranges) = parent.weak_ranges_mut()
         {
-            parent
-                .ranges()
-                .increase_above(parent, child.index(), count.try_into().unwrap());
+            parent_weak_ranges.increase_above(parent, child.index(), count.try_into().unwrap());
         }
 
         // Step 6. Let previousSibling be child’s previous sibling or parent’s last child if child is null.
@@ -2874,7 +2887,7 @@ impl Node {
 
     /// <https://dom.spec.whatwg.org/#live-range-pre-remove-steps>
     fn live_range_pre_remove_steps(node: &Node, parent: &Node) -> Option<u32> {
-        if parent.ranges_is_empty() {
+        if parent.weak_ranges_is_empty() {
             return None;
         }
 
@@ -2891,7 +2904,9 @@ impl Node {
         // decrease its start offset by 1.
         // Step 7. For each live range whose end node is parent and end offset is greater than index,
         // decrease its end offset by 1.
-        parent.ranges().decrease_above(parent, index, 1);
+        if let Some(parent_weak_ranges) = parent.weak_ranges_mut() {
+            parent_weak_ranges.decrease_above(parent, index, 1);
+        }
 
         // Parent had ranges, we needed the index, let's keep track of
         // it to avoid computing it for other ranges when calling
@@ -3818,11 +3833,13 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
                     sibling.is::<Text>() && !sibling.is::<CDATASection>()
                 }) {
                     let (index, sibling) = children.next().unwrap();
-                    sibling
-                        .ranges()
-                        .drain_to_preceding_text_sibling(&sibling, &node, length);
-                    self.ranges()
-                        .move_to_text_child_at(self, index as u32, &node, length);
+                    if let Some(sibling_weak_ranges) = sibling.weak_ranges_mut() {
+                        sibling_weak_ranges
+                            .drain_to_preceding_text_sibling(&sibling, &node, length);
+                    }
+                    if let Some(weak_ranges) = self.weak_ranges_mut() {
+                        weak_ranges.move_to_text_child_at(self, index as u32, &node, length);
+                    }
                     let sibling_cdata = sibling.downcast::<CharacterData>().unwrap();
                     length += sibling_cdata.Length();
                     cdata.append_data(cx, &sibling_cdata.data());
@@ -4242,9 +4259,11 @@ impl VirtualMethods for Node {
         // including descendants. If we're in a shadow tree at this point then the
         // unbind operation happened further up in the tree and we should not
         // drain any ranges.
-        if !self.is_in_a_shadow_tree() && !self.ranges_is_empty() {
-            self.ranges()
-                .drain_to_parent(context.parent, context.index(), self);
+        if !self.is_in_a_shadow_tree() &&
+            let Some(weak_ranges) = self.weak_ranges_mut() &&
+            !weak_ranges.is_empty()
+        {
+            weak_ranges.drain_to_parent(context.parent, context.index(), self);
         }
 
         if self.owner_document().accessibility_active() {
@@ -4265,10 +4284,10 @@ impl VirtualMethods for Node {
         // drain any ranges.
         if let Some(old_parent) = context.old_parent &&
             !self.is_in_a_shadow_tree() &&
-            !self.ranges_is_empty()
+            let Some(weak_ranges) = self.weak_ranges_mut() &&
+            !weak_ranges.is_empty()
         {
-            self.ranges()
-                .drain_to_parent(old_parent, context.index(), self);
+            weak_ranges.drain_to_parent(old_parent, context.index(), self);
         }
 
         self.owner_doc().content_and_heritage_changed(self);

--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -135,9 +135,13 @@ impl Range {
             proto,
             cx,
         );
-        start_container.ranges().push(WeakRef::new(&range));
+        start_container
+            .ensure_weak_ranges()
+            .push(WeakRef::new(&range));
         if start_container != end_container {
-            end_container.ranges().push(WeakRef::new(&range));
+            end_container
+                .ensure_weak_ranges()
+                .push(WeakRef::new(&range));
         }
         range
     }
@@ -219,12 +223,12 @@ impl Range {
         }
         if self.start().node() != node {
             if self.start().node() == self.end().node() {
-                node.ranges().push(WeakRef::new(self));
+                node.ensure_weak_ranges().push(WeakRef::new(self));
             } else if self.end().node() == node {
-                self.start_container().ranges().remove(self);
+                self.start_container().ensure_weak_ranges().remove(self);
             } else {
-                node.ranges()
-                    .push(self.start_container().ranges().remove(self));
+                node.ensure_weak_ranges()
+                    .push(self.start_container().ensure_weak_ranges().remove(self));
             }
         }
         self.start().set(node, offset);
@@ -237,12 +241,12 @@ impl Range {
         }
         if self.end().node() != node {
             if self.end().node() == self.start().node() {
-                node.ranges().push(WeakRef::new(self));
+                node.ensure_weak_ranges().push(WeakRef::new(self));
             } else if self.start().node() == node {
-                self.end_container().ranges().remove(self);
+                self.end_container().ensure_weak_ranges().remove(self);
             } else {
-                node.ranges()
-                    .push(self.end_container().ranges().remove(self));
+                node.ensure_weak_ranges()
+                    .push(self.end_container().ensure_weak_ranges().remove(self));
             }
         }
         self.end().set(node, offset);
@@ -1325,7 +1329,11 @@ impl WeakRangeVec {
             }
         });
 
-        parent.ranges().cell.borrow_mut().extend(ranges.drain(..));
+        parent
+            .ensure_weak_ranges()
+            .cell
+            .borrow_mut()
+            .extend(ranges.drain(..));
     }
 
     /// Used for steps 6.1-2. when normalizing a node.
@@ -1352,7 +1360,11 @@ impl WeakRangeVec {
             }
         });
 
-        sibling.ranges().cell.borrow_mut().extend(ranges.drain(..));
+        sibling
+            .ensure_weak_ranges()
+            .cell
+            .borrow_mut()
+            .extend(ranges.drain(..));
     }
 
     /// Used for steps 6.3-4. when normalizing a node.
@@ -1364,9 +1376,6 @@ impl WeakRangeVec {
         child: &Node,
         new_offset: u32,
     ) {
-        let child_ranges = child.ranges();
-        let mut child_ranges = child_ranges.cell.borrow_mut();
-
         self.cell.borrow_mut().update(|entry| {
             let range = entry.root().unwrap();
 
@@ -1383,12 +1392,20 @@ impl WeakRangeVec {
             let push_to_child = !already_in_child && (move_start || move_end);
 
             if remove_from_node {
-                let ref_ = entry.remove();
+                let weak_range = entry.remove();
                 if push_to_child {
-                    child_ranges.push(ref_);
+                    child
+                        .ensure_weak_ranges()
+                        .cell
+                        .borrow_mut()
+                        .push(weak_range);
                 }
             } else if push_to_child {
-                child_ranges.push(WeakRef::new(&range));
+                child
+                    .ensure_weak_ranges()
+                    .cell
+                    .borrow_mut()
+                    .push(WeakRef::new(&range));
             }
 
             if move_start {
@@ -1428,9 +1445,6 @@ impl WeakRangeVec {
         offset: u32,
         sibling: &Node,
     ) {
-        let sibling_ranges = sibling.ranges();
-        let mut sibling_ranges = sibling_ranges.cell.borrow_mut();
-
         self.cell.borrow_mut().update(|entry| {
             let range = entry.root().unwrap();
             let start_offset = range.start_offset();
@@ -1450,12 +1464,20 @@ impl WeakRangeVec {
             let push_to_sibling = !already_in_sibling && (move_start || move_end);
 
             if remove_from_node {
-                let ref_ = entry.remove();
+                let weak_range = entry.remove();
                 if push_to_sibling {
-                    sibling_ranges.push(ref_);
+                    sibling
+                        .ensure_weak_ranges()
+                        .cell
+                        .borrow_mut()
+                        .push(weak_range);
                 }
             } else if push_to_sibling {
-                sibling_ranges.push(WeakRef::new(&range));
+                sibling
+                    .ensure_weak_ranges()
+                    .cell
+                    .borrow_mut()
+                    .push(WeakRef::new(&range));
             }
 
             if move_start {

--- a/components/script/dom/raredata.rs
+++ b/components/script/dom/raredata.rs
@@ -46,7 +46,7 @@ pub(crate) struct NodeRareData {
     /// or end containers are this node. No range should ever be found
     /// twice in this vector, even if both the start and end containers
     /// are this node.
-    pub(crate) ranges: WeakRangeVec,
+    pub(crate) weak_ranges: WeakRangeVec,
 
     /// The live list of children return by .childNodes.
     pub(crate) child_list: MutNullableDom<NodeList>,


### PR DESCRIPTION
Previously the code would eagerly allocate `NodeRareData` when trying to
access a Node's `WeakRangeVec` (essentially live ranges) during
mutation. Some of the callsites were guarded with calls to
`weak_ranges_is_empty`, but others were not. This kind of thing can lead
to a lot of extra allocation during DOM mutation. This change splits the
getter into one that returns an `Option` and another that ensures that
the `WeakRangeVec` and `NodeRareData` exist. In addition, some addition
specification text is added naer edit sites.

Finally, a similar optimization is done for `remove_mutation_observer`.
When there is no rare data there is no mutation observer to remove.

This work might be useful if selection tracking is done via live ranges.

Testing: This should not change observable behavior, so is covered by existing tests.
