### PR TITLE
malloc_size_of: Replace blocking calls with non-blocking

### DIFF
--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -737,31 +737,41 @@ impl<T: MallocSizeOf> MallocSizeOf for std::sync::Weak<T> {
 /// contents.
 impl<T: MallocSizeOf> MallocSizeOf for std::sync::Mutex<T> {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        (*self.lock().unwrap()).size_of(ops)
+        self.try_lock()
+            .map(|guard| guard.size_of(ops))
+            .unwrap_or_default()
     }
 }
 
 impl<T: MallocSizeOf> MallocSizeOf for std::sync::RwLock<T> {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        (*self.read().unwrap()).size_of(ops)
+        self.try_read()
+            .map(|guard| guard.size_of(ops))
+            .unwrap_or_default()
     }
 }
 
 impl<T: MallocSizeOf> MallocSizeOf for parking_lot::Mutex<T> {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        (*self.lock()).size_of(ops)
+        self.try_lock()
+            .map(|guard| guard.size_of(ops))
+            .unwrap_or_default()
     }
 }
 
 impl<T: MallocSizeOf> MallocSizeOf for parking_lot::RwLock<T> {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        (*self.read()).size_of(ops)
+        self.try_read()
+            .map(|guard| guard.size_of(ops))
+            .unwrap_or_default()
     }
 }
 
 impl<T: MallocConditionalSizeOf> MallocConditionalSizeOf for parking_lot::RwLock<T> {
     fn conditional_size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        (*self.read()).conditional_size_of(ops)
+        self.try_read()
+            .map(|guard| guard.conditional_size_of(ops))
+            .unwrap_or_default()
     }
 }
 


### PR DESCRIPTION
Currently we use blocking calls for malloc_size_of which could potentially lead to a deadlock. This replaces the blocking calls with non-blocking calls an a default value if we cannot aquire the lock.
This is in the category of defensive programming.

Testing: The code is equivalent if we do not have blocking content and otherwise will underreport the memory.
