### PR TITLE
Fix borrow hazard in Document::SetAdoptedStyleSheets

### DIFF
--- a/components/script/animations.rs
+++ b/components/script/animations.rs
@@ -360,8 +360,8 @@ impl Animations {
                 continue;
             }
 
-            if set.animations.iter().any(|animation| animation.is_new) ||
-                set.transitions.iter().any(|transition| transition.is_new)
+            if set.animations.iter().any(|animation| animation.is_new)
+                || set.transitions.iter().any(|transition| transition.is_new)
             {
                 let address = UntrustedNodeAddress(opaque_node.0 as *const c_void);
                 unsafe {
@@ -394,8 +394,8 @@ impl Animations {
         // Calculate the `elapsed-time` property of the event and take the absolute
         // value to prevent -0 values.
         let elapsed_time = match event_type {
-            TransitionOrAnimationEventType::TransitionRun |
-            TransitionOrAnimationEventType::TransitionStart => transition
+            TransitionOrAnimationEventType::TransitionRun
+            | TransitionOrAnimationEventType::TransitionStart => transition
                 .property_animation
                 .duration
                 .min((-transition.delay).max(0.)),
@@ -432,8 +432,8 @@ impl Animations {
         pipeline_id: PipelineId,
     ) {
         let iteration_index = match animation.iteration_state {
-            KeyframesIterationState::Finite(current, _) |
-            KeyframesIterationState::Infinite(current) => current,
+            KeyframesIterationState::Finite(current, _)
+            | KeyframesIterationState::Infinite(current) => current,
         };
 
         let active_duration = match animation.iteration_state {
@@ -595,14 +595,14 @@ impl TransitionOrAnimationEventType {
     /// Whether or not this event is a transition-related event.
     pub(crate) fn is_transition_event(&self) -> bool {
         match *self {
-            Self::TransitionRun |
-            Self::TransitionEnd |
-            Self::TransitionCancel |
-            Self::TransitionStart => true,
-            Self::AnimationEnd |
-            Self::AnimationIteration |
-            Self::AnimationStart |
-            Self::AnimationCancel => false,
+            Self::TransitionRun
+            | Self::TransitionEnd
+            | Self::TransitionCancel
+            | Self::TransitionStart => true,
+            Self::AnimationEnd
+            | Self::AnimationIteration
+            | Self::AnimationStart
+            | Self::AnimationCancel => false,
         }
     }
 }

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -305,8 +305,8 @@ pub(crate) fn handle_get_children(
         return;
     };
     let is_whitespace = |node: &NodeInfo| {
-        node.node_type == NodeConstants::TEXT_NODE &&
-            node.node_value.as_ref().is_none_or(|v| v.trim().is_empty())
+        node.node_type == NodeConstants::TEXT_NODE
+            && node.node_value.as_ref().is_none_or(|v| v.trim().is_empty())
     };
     let mut pipeline_state = state.mut_pipeline_state_for(pipeline).unwrap();
 
@@ -324,9 +324,9 @@ pub(crate) fn handle_get_children(
         .collect();
 
     let mut children = vec![];
-    if let Some(shadow_root) = parent.downcast::<Element>().and_then(Element::shadow_root) &&
-        (!shadow_root.is_user_agent_widget() ||
-            pref!(inspector_show_servo_internal_shadow_roots))
+    if let Some(shadow_root) = parent.downcast::<Element>().and_then(Element::shadow_root)
+        && (!shadow_root.is_user_agent_widget()
+            || pref!(inspector_show_servo_internal_shadow_roots))
     {
         children.push(shadow_root.upcast::<Node>().summarize(cx));
     }
@@ -657,8 +657,8 @@ pub(crate) fn handle_get_xpath(
                 let Some(sibling) = sibling.downcast::<Element>() else {
                     return false;
                 };
-                sibling.namespace() == element.namespace() &&
-                    sibling.local_name() == element.local_name()
+                sibling.namespace() == element.namespace()
+                    && sibling.local_name() == element.local_name()
             };
 
             let matching_elements_before = ancestor

--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -80,9 +80,9 @@ impl Drop for LoadBlocker {
         //
         // This destructor can also run from during GC (see #46207), which can lead to
         // accessing already freed memory if we run `finish_load_for_dropped_blocker`.
-        if runtime_is_alive() &&
-            !during_gc_collection() &&
-            let Some(load) = self.load.take()
+        if runtime_is_alive()
+            && !during_gc_collection()
+            && let Some(load) = self.load.take()
         {
             self.doc.finish_load_for_dropped_blocker(load);
         }

--- a/components/script/dom/audio/analysernode.rs
+++ b/components/script/dom/audio/analysernode.rs
@@ -51,9 +51,9 @@ impl AnalyserNode {
                 .parent
                 .unwrap_or(2, ChannelCountMode::Max, ChannelInterpretation::Speakers);
 
-        if options.fftSize > 32768 ||
-            options.fftSize < 32 ||
-            (options.fftSize & (options.fftSize - 1) != 0)
+        if options.fftSize > 32768
+            || options.fftSize < 32
+            || (options.fftSize & (options.fftSize - 1) != 0)
         {
             return Err(Error::IndexSize(None));
         }

--- a/components/script/dom/audio/audiobuffer.rs
+++ b/components/script/dom/audio/audiobuffer.rs
@@ -198,11 +198,11 @@ impl AudioBufferMethods<crate::DomTypeHolder> for AudioBuffer {
         proto: Option<HandleObject>,
         options: &AudioBufferOptions,
     ) -> Fallible<DomRoot<AudioBuffer>> {
-        if options.length == 0 ||
-            options.numberOfChannels == 0 ||
-            options.numberOfChannels > MAX_CHANNEL_COUNT ||
-            *options.sampleRate < MIN_SAMPLE_RATE ||
-            *options.sampleRate > MAX_SAMPLE_RATE
+        if options.length == 0
+            || options.numberOfChannels == 0
+            || options.numberOfChannels > MAX_CHANNEL_COUNT
+            || *options.sampleRate < MIN_SAMPLE_RATE
+            || *options.sampleRate > MAX_SAMPLE_RATE
         {
             return Err(Error::NotSupported(None));
         }
@@ -286,8 +286,8 @@ impl AudioBufferMethods<crate::DomTypeHolder> for AudioBuffer {
             {
                 return Err(Error::IndexSize(None));
             }
-        } else if let Some(ref shared_channels) = *self.shared_channels.borrow() &&
-            let Some(shared_channel) = shared_channels.buffers.get(channel_number)
+        } else if let Some(ref shared_channels) = *self.shared_channels.borrow()
+            && let Some(shared_channel) = shared_channels.buffers.get(channel_number)
         {
             dest.extend_from_slice(&shared_channel.as_slice()[offset..offset + bytes_to_copy]);
         }

--- a/components/script/dom/audio/audiobuffersourcenode.rs
+++ b/components/script/dom/audio/audiobuffersourcenode.rs
@@ -161,8 +161,8 @@ impl AudioBufferSourceNodeMethods<crate::DomTypeHolder> for AudioBufferSourceNod
         self.buffer.set(new_buffer);
 
         // Step 5.
-        if self.source_node.has_start() &&
-            let Some(buffer) = self.buffer.get()
+        if self.source_node.has_start()
+            && let Some(buffer) = self.buffer.get()
         {
             let buffer = buffer.get_channels(cx);
             if buffer.is_some() {
@@ -237,16 +237,16 @@ impl AudioBufferSourceNodeMethods<crate::DomTypeHolder> for AudioBufferSourceNod
         offset: Option<Finite<f64>>,
         duration: Option<Finite<f64>>,
     ) -> Fallible<()> {
-        if let Some(offset) = offset &&
-            *offset < 0.
+        if let Some(offset) = offset
+            && *offset < 0.
         {
             return Err(Error::Range(
                 c"'offset' must be a positive value".to_owned(),
             ));
         }
 
-        if let Some(duration) = duration &&
-            *duration < 0.
+        if let Some(duration) = duration
+            && *duration < 0.
         {
             return Err(Error::Range(
                 c"'duration' must be a positive value".to_owned(),

--- a/components/script/dom/audio/audioparam.rs
+++ b/components/script/dom/audio/audioparam.rs
@@ -128,9 +128,9 @@ impl AudioParamMethods<crate::DomTypeHolder> for AudioParam {
         // > AudioBufferSourceNode
         // > The AudioParams playbackRate and detune MUST be "k-rate". An InvalidStateError must be
         // > thrown if the rate is changed to "a-rate".
-        if automation_rate == AutomationRate::A_rate &&
-            self.node_type == AudioNodeType::AudioBufferSourceNode &&
-            (self.param == ParamType::Detune || self.param == ParamType::PlaybackRate)
+        if automation_rate == AutomationRate::A_rate
+            && self.node_type == AudioNodeType::AudioBufferSourceNode
+            && (self.param == ParamType::Detune || self.param == ParamType::PlaybackRate)
         {
             return Err(Error::InvalidState(None));
         }

--- a/components/script/dom/audio/audiotrack.rs
+++ b/components/script/dom/audio/audiotrack.rs
@@ -116,8 +116,8 @@ impl AudioTrackMethods<crate::DomTypeHolder> for AudioTrack {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-audiotrack-enabled>
     fn SetEnabled(&self, value: bool) {
-        if let Some(list) = self.track_list.borrow().as_ref() &&
-            let Some(idx) = list.find(self)
+        if let Some(list) = self.track_list.borrow().as_ref()
+            && let Some(idx) = list.find(self)
         {
             list.set_enabled(idx, value);
         }

--- a/components/script/dom/audio/baseaudiocontext.rs
+++ b/components/script/dom/audio/baseaudiocontext.rs
@@ -429,10 +429,10 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
         length: u32,
         sample_rate: Finite<f32>,
     ) -> Fallible<DomRoot<AudioBuffer>> {
-        if number_of_channels == 0 ||
-            number_of_channels > MAX_CHANNEL_COUNT ||
-            length == 0 ||
-            *sample_rate <= 0.
+        if number_of_channels == 0
+            || number_of_channels > MAX_CHANNEL_COUNT
+            || length == 0
+            || *sample_rate <= 0.
         {
             return Err(Error::NotSupported(None));
         }

--- a/components/script/dom/audio/channelsplitternode.rs
+++ b/components/script/dom/audio/channelsplitternode.rs
@@ -43,9 +43,9 @@ impl ChannelSplitterNode {
             ChannelInterpretation::Discrete,
         );
 
-        if node_options.count != options.numberOfOutputs ||
-            node_options.mode != ChannelCountMode::Explicit ||
-            node_options.interpretation != ChannelInterpretation::Discrete
+        if node_options.count != options.numberOfOutputs
+            || node_options.mode != ChannelCountMode::Explicit
+            || node_options.interpretation != ChannelInterpretation::Discrete
         {
             return Err(Error::InvalidState(None));
         }

--- a/components/script/dom/audio/iirfilternode.rs
+++ b/components/script/dom/audio/iirfilternode.rs
@@ -43,8 +43,8 @@ impl IIRFilterNode {
         context: &BaseAudioContext,
         options: &IIRFilterOptions,
     ) -> Fallible<IIRFilterNode> {
-        if !(1..=20).contains(&options.feedforward.len()) ||
-            !(1..=20).contains(&options.feedback.len())
+        if !(1..=20).contains(&options.feedforward.len())
+            || !(1..=20).contains(&options.feedback.len())
         {
             return Err(Error::NotSupported(None));
         }

--- a/components/script/dom/audio/offlineaudiocontext.rs
+++ b/components/script/dom/audio/offlineaudiocontext.rs
@@ -79,10 +79,10 @@ impl OfflineAudioContext {
         length: u32,
         sample_rate: f32,
     ) -> Fallible<DomRoot<OfflineAudioContext>> {
-        if channel_count > MAX_CHANNEL_COUNT ||
-            channel_count == 0 ||
-            length == 0 ||
-            !(MIN_SAMPLE_RATE..=MAX_SAMPLE_RATE).contains(&sample_rate)
+        if channel_count > MAX_CHANNEL_COUNT
+            || channel_count == 0
+            || length == 0
+            || !(MIN_SAMPLE_RATE..=MAX_SAMPLE_RATE).contains(&sample_rate)
         {
             return Err(Error::NotSupported(None));
         }

--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -549,8 +549,8 @@ where
         match &self.buffer_source {
             BufferSource::ArrayBufferView(heap) | BufferSource::ArrayBuffer(heap) => {
                 match &from_buffer.buffer_source {
-                    BufferSource::ArrayBufferView(from_heap) |
-                    BufferSource::ArrayBuffer(from_heap) => {
+                    BufferSource::ArrayBufferView(from_heap)
+                    | BufferSource::ArrayBuffer(from_heap) => {
                         if std::ptr::eq(heap.get(), from_heap.get()) {
                             return false;
                         }
@@ -594,8 +594,8 @@ where
         match &self.buffer_source {
             BufferSource::ArrayBufferView(heap) | BufferSource::ArrayBuffer(heap) => unsafe {
                 match &from_buffer.buffer_source {
-                    BufferSource::ArrayBufferView(from_heap) |
-                    BufferSource::ArrayBuffer(from_heap) => ArrayBufferCopyData(
+                    BufferSource::ArrayBufferView(from_heap)
+                    | BufferSource::ArrayBuffer(from_heap) => ArrayBufferCopyData(
                         cx,
                         Handle::from_raw(heap.handle()),
                         dest_start,

--- a/components/script/dom/bindings/domname.rs
+++ b/components/script/dom/bindings/domname.rs
@@ -75,8 +75,8 @@ pub(crate) fn is_valid_element_local_name(name: &str) -> bool {
             // U+002D (-), U+002E (.), U+003A (:), U+005F (_),
             // or in the range U+0080 to U+10FFFF, inclusive,
             // then return false.
-            if !c.is_ascii_alphanumeric() &&
-                !matches!(
+            if !c.is_ascii_alphanumeric()
+                && !matches!(
                     c,
                     '\u{002D}' | '\u{002E}' | '\u{003A}' | '\u{005F}' | '\u{0080}'..='\u{10FFF}'
                 )
@@ -105,11 +105,13 @@ pub(crate) fn is_custom_data_attribute(name: &str, namespace: Option<&str>) -> b
     // A custom data attribute is an attribute in no namespace whose name starts with the string
     // "data-", has at least one character after the hyphen, is a valid attribute local name, and
     // contains no ASCII upper alphas.
-    namespace.is_none() &&
-        name.strip_prefix("data-")
-            .is_some_and(|substring| !substring.is_empty()) &&
-        is_valid_attribute_local_name(name) &&
-        name.chars()
+    namespace.is_none()
+        && name
+            .strip_prefix("data-")
+            .is_some_and(|substring| !substring.is_empty())
+        && is_valid_attribute_local_name(name)
+        && name
+            .chars()
             .all(|code_point| !code_point.is_ascii_uppercase())
 }
 
@@ -199,8 +201,8 @@ pub(crate) fn validate_and_extract(
         Some("xml") if *namespace != *XML_NAMESPACE => Err(Error::Namespace(None)),
         // Step 10. If either qualifiedName or prefix is "xmlns" and namespace
         //      is not the XMLNS namespace, then throw a "NamespaceError" DOMException.
-        p if (qualified_name == "xmlns" || p == Some("xmlns")) &&
-            *namespace != *XMLNS_NAMESPACE =>
+        p if (qualified_name == "xmlns" || p == Some("xmlns"))
+            && *namespace != *XMLNS_NAMESPACE =>
         {
             Err(Error::Namespace(None))
         },
@@ -209,8 +211,8 @@ pub(crate) fn validate_and_extract(
         },
         // Step 11. If namespace is the XMLNS namespace and neither qualifiedName
         //      nor prefix is "xmlns", then throw a "NamespaceError" DOMException.
-        p if *namespace == *XMLNS_NAMESPACE &&
-            (qualified_name != "xmlns" && p != Some("xmlns")) =>
+        p if *namespace == *XMLNS_NAMESPACE
+            && (qualified_name != "xmlns" && p != Some("xmlns")) =>
         {
             Err(Error::Namespace(None))
         },

--- a/components/script/dom/bindings/xmlname.rs
+++ b/components/script/dom/bindings/xmlname.rs
@@ -26,8 +26,8 @@ pub(crate) fn is_valid_start(c: char) -> bool {
 }
 
 pub(crate) fn is_valid_continuation(c: char) -> bool {
-    is_valid_start(c) ||
-        matches!(c,
+    is_valid_start(c)
+        || matches!(c,
             '-' |
             '.' |
             '0'..='9' |

--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -343,11 +343,11 @@ where
 /// <https://webbluetoothcg.github.io/web-bluetooth/#bluetoothlescanfilterinit-canonicalizing>
 fn canonicalize_filter(filter: &BluetoothLEScanFilterInit) -> Fallible<BluetoothScanfilter> {
     // Step 1.
-    if filter.services.is_none() &&
-        filter.name.is_none() &&
-        filter.namePrefix.is_none() &&
-        filter.manufacturerData.is_none() &&
-        filter.serviceData.is_none()
+    if filter.services.is_none()
+        && filter.name.is_none()
+        && filter.namePrefix.is_none()
+        && filter.manufacturerData.is_none()
+        && filter.serviceData.is_none()
     {
         return Err(Type(FILTER_ERROR.to_owned()));
     }
@@ -535,8 +535,8 @@ impl BluetoothMethods<crate::DomTypeHolder> for Bluetooth {
     fn RequestDevice(&self, cx: &mut CurrentRealm, option: &RequestDeviceOptions) -> Rc<Promise> {
         let p = Promise::new_in_realm(cx);
         // Step 1.
-        if (option.filters.is_some() && option.acceptAllDevices) ||
-            (option.filters.is_none() && !option.acceptAllDevices)
+        if (option.filters.is_some() && option.acceptAllDevices)
+            || (option.filters.is_none() && !option.acceptAllDevices)
         {
             p.reject_error(cx, Error::Type(OPTIONS_ERROR.to_owned()));
             return p;
@@ -667,8 +667,8 @@ impl PermissionAlgorithm for Bluetooth {
         // Step 6.
         for allowed_device in allowed_devices.iter() {
             // Step 6.1.
-            if let Some(ref id) = descriptor.deviceId &&
-                &allowed_device.deviceId != id
+            if let Some(ref id) = descriptor.deviceId
+                && &allowed_device.deviceId != id
             {
                 continue;
             }
@@ -767,8 +767,8 @@ impl PermissionAlgorithm for Bluetooth {
         for (id, device) in device_map.iter() {
             let id = DOMString::from(id.clone());
             // Step 2.1.
-            if allowed_devices.iter().any(|d| d.deviceId == id) &&
-                !device.is_represented_device_null()
+            if allowed_devices.iter().any(|d| d.deviceId == id)
+                && !device.is_represented_device_null()
             {
                 // Note: We don't need to update the allowed_services,
                 // because we store it in the lower level

--- a/components/script/dom/bluetooth/bluetoothdevice.rs
+++ b/components/script/dom/bluetooth/bluetoothdevice.rs
@@ -307,8 +307,8 @@ impl BluetoothDeviceMethods<crate::DomTypeHolder> for BluetoothDevice {
             .global()
             .as_window()
             .bluetooth_extra_permission_data()
-            .allowed_devices_contains_id(self.id.clone()) &&
-            !self.is_represented_device_null()
+            .allowed_devices_contains_id(self.id.clone())
+            && !self.is_represented_device_null()
         {
             return Some(self.get_gatt(cx));
         }

--- a/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
@@ -222,9 +222,9 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
         // TODO: Step 7: Implement the `connection-checking-wrapper` algorithm for BluetoothRemoteGATTServer.
 
         // Step 7.1.
-        if !(self.Properties().Write() ||
-            self.Properties().WriteWithoutResponse() ||
-            self.Properties().AuthenticatedSignedWrites())
+        if !(self.Properties().Write()
+            || self.Properties().WriteWithoutResponse()
+            || self.Properties().AuthenticatedSignedWrites())
         {
             p.reject_error(cx, NotSupported(None));
             return p;

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -1472,9 +1472,9 @@ impl CanvasState {
         max_width: Option<f64>,
     ) {
         // Step 1: If any of the arguments are infinite or NaN, then return.
-        if !x.is_finite() ||
-            !y.is_finite() ||
-            max_width.is_some_and(|max_width| !max_width.is_finite())
+        if !x.is_finite()
+            || !y.is_finite()
+            || max_width.is_some_and(|max_width| !max_width.is_finite())
         {
             return;
         }
@@ -1516,9 +1516,9 @@ impl CanvasState {
         max_width: Option<f64>,
     ) {
         // Step 1: If any of the arguments are infinite or NaN, then return.
-        if !x.is_finite() ||
-            !y.is_finite() ||
-            max_width.is_some_and(|max_width| !max_width.is_finite())
+        if !x.is_finite()
+            || !y.is_finite()
+            || max_width.is_some_and(|max_width| !max_width.is_finite())
         {
             return;
         }
@@ -2039,14 +2039,14 @@ impl CanvasState {
         dw: f64,
         dh: f64,
     ) -> ErrorResult {
-        if !(sx.is_finite() &&
-            sy.is_finite() &&
-            sw.is_finite() &&
-            sh.is_finite() &&
-            dx.is_finite() &&
-            dy.is_finite() &&
-            dw.is_finite() &&
-            dh.is_finite())
+        if !(sx.is_finite()
+            && sy.is_finite()
+            && sw.is_finite()
+            && sh.is_finite()
+            && dx.is_finite()
+            && dy.is_finite()
+            && dw.is_finite()
+            && dh.is_finite())
         {
             return Ok(());
         }
@@ -2185,12 +2185,12 @@ impl CanvasState {
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-transform
     pub(super) fn transform(&self, a: f64, b: f64, c: f64, d: f64, e: f64, f: f64) {
-        if !(a.is_finite() &&
-            b.is_finite() &&
-            c.is_finite() &&
-            d.is_finite() &&
-            e.is_finite() &&
-            f.is_finite())
+        if !(a.is_finite()
+            && b.is_finite()
+            && c.is_finite()
+            && d.is_finite()
+            && e.is_finite()
+            && f.is_finite())
         {
             return;
         }
@@ -2212,12 +2212,12 @@ impl CanvasState {
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-settransform>
     pub(super) fn set_transform(&self, a: f64, b: f64, c: f64, d: f64, e: f64, f: f64) {
         // Step 1. If any of the arguments are infinite or NaN, then return.
-        if !a.is_finite() ||
-            !b.is_finite() ||
-            !c.is_finite() ||
-            !d.is_finite() ||
-            !e.is_finite() ||
-            !f.is_finite()
+        if !a.is_finite()
+            || !b.is_finite()
+            || !c.is_finite()
+            || !d.is_finite()
+            || !e.is_finite()
+            || !f.is_finite()
         {
             return;
         }
@@ -2235,12 +2235,12 @@ impl CanvasState {
         // Step 2. If one or more of matrix's m11 element, m12 element, m21
         // element, m22 element, m41 element, or m42 element are infinite or
         // NaN, then return.
-        if !matrix.m11.is_finite() ||
-            !matrix.m12.is_finite() ||
-            !matrix.m21.is_finite() ||
-            !matrix.m22.is_finite() ||
-            !matrix.m31.is_finite() ||
-            !matrix.m32.is_finite()
+        if !matrix.m11.is_finite()
+            || !matrix.m12.is_finite()
+            || !matrix.m21.is_finite()
+            || !matrix.m22.is_finite()
+            || !matrix.m31.is_finite()
+            || !matrix.m32.is_finite()
         {
             return Ok(());
         }
@@ -2459,8 +2459,8 @@ impl CanvasState {
 
             let font = font_group.find_by_codepoint(font_context, character, next_char, language);
 
-            if !is_variation_selector(character) &&
-                !current_text_run.script_and_font_compatible(script, &font)
+            if !is_variation_selector(character)
+                && !current_text_run.script_and_font_compatible(script, &font)
             {
                 let previous_text_run = std::mem::replace(
                     &mut current_text_run,
@@ -2765,10 +2765,11 @@ fn adjust_canvas_size(size: Size2D<u64>) -> Size2D<u64> {
     // Max width/height to 65535 in CSS pixels.
     const MAX_CANVAS_SIZE: u64 = 65535;
 
-    if !size.is_empty() &&
-        size.greater_than(Size2D::new(MAX_CANVAS_SIZE, MAX_CANVAS_SIZE))
-            .none() &&
-        size.area() < MAX_CANVAS_AREA
+    if !size.is_empty()
+        && size
+            .greater_than(Size2D::new(MAX_CANVAS_SIZE, MAX_CANVAS_SIZE))
+            .none()
+        && size.area() < MAX_CANVAS_AREA
     {
         size
     } else {

--- a/components/script/dom/canvas/2d/canvaspattern.rs
+++ b/components/script/dom/canvas/2d/canvaspattern.rs
@@ -91,12 +91,12 @@ impl CanvasPatternMethods<crate::DomTypeHolder> for CanvasPattern {
         // Step 2. If one or more of matrix's m11 element, m12 element, m21
         // element, m22 element, m41 element, or m42 element are infinite or
         // NaN, then return.
-        if !matrix.m11.is_finite() ||
-            !matrix.m12.is_finite() ||
-            !matrix.m21.is_finite() ||
-            !matrix.m22.is_finite() ||
-            !matrix.m31.is_finite() ||
-            !matrix.m32.is_finite()
+        if !matrix.m11.is_finite()
+            || !matrix.m12.is_finite()
+            || !matrix.m21.is_finite()
+            || !matrix.m22.is_finite()
+            || !matrix.m31.is_finite()
+            || !matrix.m32.is_finite()
         {
             return Ok(());
         }

--- a/components/script/dom/canvas/2d/path2d.rs
+++ b/components/script/dom/canvas/2d/path2d.rs
@@ -68,12 +68,12 @@ impl Path2D {
         // Step 3. If one or more of matrix's m11 element, m12 element, m21
         // element, m22 element, m41 element, or m42 element are infinite or
         // NaN, then return.
-        if !matrix.m11.is_finite() ||
-            !matrix.m12.is_finite() ||
-            !matrix.m21.is_finite() ||
-            !matrix.m22.is_finite() ||
-            !matrix.m31.is_finite() ||
-            !matrix.m32.is_finite()
+        if !matrix.m11.is_finite()
+            || !matrix.m12.is_finite()
+            || !matrix.m21.is_finite()
+            || !matrix.m22.is_finite()
+            || !matrix.m31.is_finite()
+            || !matrix.m32.is_finite()
         {
             return Ok(());
         }

--- a/components/script/dom/canvas/imagebitmaprenderingcontext.rs
+++ b/components/script/dom/canvas/imagebitmaprenderingcontext.rs
@@ -177,8 +177,8 @@ impl CanvasContext for ImageBitmapRenderingContext {
             Some(bitmap) => Some(bitmap.clone()),
             None => {
                 let size = self.canvas.size();
-                if size.is_empty() ||
-                    pixels::compute_rgba8_byte_length_if_within_limit(
+                if size.is_empty()
+                    || pixels::compute_rgba8_byte_length_if_within_limit(
                         size.width as usize,
                         size.height as usize,
                     )

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -137,8 +137,8 @@ impl OffscreenCanvas {
             Some(context) => context.get_image_data(),
             None => {
                 let size = self.get_size();
-                if size.is_empty() ||
-                    pixels::compute_rgba8_byte_length_if_within_limit(
+                if size.is_empty()
+                    || pixels::compute_rgba8_byte_length_if_within_limit(
                         size.width as usize,
                         size.height as usize,
                     )

--- a/components/script/dom/characterdata/characterdata.rs
+++ b/components/script/dom/characterdata/characterdata.rs
@@ -86,8 +86,8 @@ impl CharacterData {
         // If this is a Text node, we might need to re-parse (say, if our parent
         // is a <style> element.) We don't need to if this is a Comment or
         // ProcessingInstruction.
-        if self.is::<Text>() &&
-            let Some(parent_node) = node.GetParentNode()
+        if self.is::<Text>()
+            && let Some(parent_node) = node.GetParentNode()
         {
             let mutation = ChildrenMutation::ChangeText;
             vtable_for(&parent_node).children_changed(cx, &mutation);
@@ -228,11 +228,11 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
 
             // Step 5 to 7.
             new_data = String::with_capacity(
-                prefix.len() +
-                    replacement_before.len() +
-                    arg.len() +
-                    replacement_after.len() +
-                    suffix.len(),
+                prefix.len()
+                    + replacement_before.len()
+                    + arg.len()
+                    + replacement_after.len()
+                    + suffix.len(),
             );
             new_data.push_str(prefix);
             new_data.push_str(replacement_before);

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -273,8 +273,8 @@ fn console_map_object_from_handle_value(
         rooted!(&in(cx) let mut value = UndefinedValue());
 
         // Each map entry is a [key, value] pair.
-        if !unsafe { JS_GetElement(cx, entry_object.handle(), 0, key.handle_mut()) } ||
-            !unsafe { JS_GetElement(cx, entry_object.handle(), 1, value.handle_mut()) }
+        if !unsafe { JS_GetElement(cx, entry_object.handle(), 0, key.handle_mut()) }
+            || !unsafe { JS_GetElement(cx, entry_object.handle(), 1, value.handle_mut()) }
         {
             return Err(().into());
         }
@@ -314,10 +314,10 @@ fn console_object_from_handle_value(
     if !unsafe { GetBuiltinClass(cx, object.handle(), &mut object_class as *mut _) } {
         return None;
     }
-    if object_class != ESClass::Object &&
-        object_class != ESClass::Array &&
-        object_class != ESClass::Map &&
-        object_class != ESClass::Function
+    if object_class != ESClass::Object
+        && object_class != ESClass::Array
+        && object_class != ESClass::Map
+        && object_class != ESClass::Function
     {
         return None;
     }
@@ -364,8 +364,8 @@ fn console_object_from_handle_value(
 
         // https://console.spec.whatwg.org/#printer
         // Objects with either generic JavaScript object formatting or optimally useful formatting applied.
-        let is_accessor = (descriptor.hasGetter_() && !descriptor.getter_.is_null()) ||
-            (descriptor.hasSetter_() && !descriptor.setter_.is_null());
+        let is_accessor = (descriptor.hasGetter_() && !descriptor.getter_.is_null())
+            || (descriptor.hasSetter_() && !descriptor.setter_.is_null());
         let value = if is_accessor {
             accessor_value_from_property_descriptor(&descriptor)
         } else {
@@ -590,8 +590,8 @@ pub(crate) fn stringify_handle_value(cx: &mut JSContext, message: HandleValue) -
         }
         parents.push(value_bits);
 
-        if value.is_object() &&
-            let Some(repr) = maybe_stringify_dom_object(cx, value)
+        if value.is_object()
+            && let Some(repr) = maybe_stringify_dom_object(cx, value)
         {
             return repr;
         }

--- a/components/script/dom/cookiestore.rs
+++ b/components/script/dom/cookiestore.rs
@@ -259,8 +259,8 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
             // 6.2. If this’s relevant global object is a Window object and parsed does not equal url with exclude fragments set to true,
             // then return a promise rejected with a TypeError.
-            if let Some(_window) = DomRoot::downcast::<Window>(self.global()) &&
-                parsed_url
+            if let Some(_window) = DomRoot::downcast::<Window>(self.global())
+                && parsed_url
                     .as_ref()
                     .is_ok_and(|parsed| !parsed.is_equal_excluding_fragments(&creation_url))
             {
@@ -376,8 +376,8 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
             // If this’s relevant global object is a Window object and parsed does not equal url with exclude fragments set to true,
             // then return a promise rejected with a TypeError.
-            if let Some(_window) = DomRoot::downcast::<Window>(self.global()) &&
-                parsed_url
+            if let Some(_window) = DomRoot::downcast::<Window>(self.global())
+                && parsed_url
                     .as_ref()
                     .is_ok_and(|parsed| !parsed.is_equal_excluding_fragments(&creation_url))
             {
@@ -618,8 +618,8 @@ impl CookieStore {
         let value = CookieStore::normalize(&properties.value);
 
         // 3. If name or value contain U+003B (;), any C0 control character except U+0009 TAB, or U+007F DELETE, then return failure.
-        if CookieStore::contains_control_characters(&name) ||
-            CookieStore::contains_control_characters(&value)
+        if CookieStore::contains_control_characters(&name)
+            || CookieStore::contains_control_characters(&value)
         {
             return None;
         }

--- a/components/script/dom/css/css.rs
+++ b/components/script/dom/css/css.rs
@@ -91,11 +91,11 @@ impl CSSMethods<crate::DomTypeHolder> for CSS {
         );
         Err(match result {
             SuccessfullyRegistered => return Ok(()),
-            InvalidName |
-            InvalidSyntax |
-            InvalidInitialValue |
-            NoInitialValue |
-            InitialValueNotComputationallyIndependent => Error::Syntax(None),
+            InvalidName
+            | InvalidSyntax
+            | InvalidInitialValue
+            | NoInitialValue
+            | InitialValueNotComputationallyIndependent => Error::Syntax(None),
             AlreadyRegistered => Error::InvalidModification(None),
         })
     }

--- a/components/script/dom/css/cssstyledeclaration.rs
+++ b/components/script/dom/css/cssstyledeclaration.rs
@@ -240,8 +240,8 @@ impl CSSStyleDeclaration {
         // If creating a CSSStyleDeclaration with CSSSStyleOwner::Null, this should always
         // be in read-only mode.
         assert!(
-            !matches!(owner, CSSStyleOwner::Null) ||
-                modification_access == CSSModificationAccess::Readonly
+            !matches!(owner, CSSStyleOwner::Null)
+                || modification_access == CSSModificationAccess::Readonly
         );
 
         CSSStyleDeclaration {

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -150,8 +150,8 @@ impl CustomElementRegistry {
             .values()
             .find(|definition| {
                 // Step 4-5
-                definition.local_name == *local_name &&
-                    (definition.name == *local_name || Some(&definition.name) == is)
+                definition.local_name == *local_name
+                    && (definition.name == *local_name || Some(&definition.name) == is)
             })
             .cloned()
     }
@@ -299,10 +299,10 @@ impl CustomElementRegistry {
                     .custom_element_registry()
                     .is_none_or(|registry| *registry == *self)
             };
-            if *candidate.local_name() == *local_name &&
-                *candidate.namespace() == ns!(html) &&
-                registry_matches &&
-                (*name == *local_name || candidate.get_is().as_ref() == Some(name))
+            if *candidate.local_name() == *local_name
+                && *candidate.namespace() == ns!(html)
+                && registry_matches
+                && (*name == *local_name || candidate.get_is().as_ref() == Some(name))
             {
                 // Step 2. For each element element of upgradeCandidates: enqueue a
                 // custom element upgrade reaction given element and definition.
@@ -725,8 +725,8 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         }
         // Step 3. Otherwise, if root is a ShadowRoot node whose custom element registry
         // is null, then set root's custom element registry to this.
-        else if let Some(shadow_root) = root.downcast::<ShadowRoot>() &&
-            shadow_root.custom_element_registry().is_none()
+        else if let Some(shadow_root) = root.downcast::<ShadowRoot>()
+            && shadow_root.custom_element_registry().is_none()
         {
             shadow_root.set_custom_element_registry(self);
         }
@@ -924,12 +924,12 @@ impl CustomElementDefinition {
         // Step 5.1.3.6. If result’s parent is not null, then throw a "NotSupportedError" DOMException.
         // Step 5.1.3.7. If result’s node document is not document, then throw a "NotSupportedError" DOMException.
         // Step 5.1.3.8. If result’s local name is not equal to localName then throw a "NotSupportedError" DOMException.
-        if element.HasAttributes() ||
-            element.upcast::<Node>().children_count() > 0 ||
-            element.upcast::<Node>().has_parent() ||
-            &*element.upcast::<Node>().owner_doc() != document ||
-            *element.namespace() != ns!(html) ||
-            *element.local_name() != self.local_name
+        if element.HasAttributes()
+            || element.upcast::<Node>().children_count() > 0
+            || element.upcast::<Node>().has_parent()
+            || &*element.upcast::<Node>().owner_doc() != document
+            || *element.namespace() != ns!(html)
+            || *element.local_name() != self.local_name
         {
             return Err(Error::NotSupported(None));
         }
@@ -1028,8 +1028,8 @@ pub(crate) fn upgrade_element(
     }
 
     // Step 9: handle with form-associated custom element
-    if let Some(html_element) = element.downcast::<HTMLElement>() &&
-        html_element.is_form_associated_custom_element()
+    if let Some(html_element) = element.downcast::<HTMLElement>()
+        && html_element.is_form_associated_custom_element()
     {
         // We know this element is is form-associated, so we can use the implementation of
         // `FormControl` for HTMLElement, which makes that assumption.
@@ -1519,14 +1519,14 @@ pub(crate) fn is_valid_custom_element_name(name: &str) -> bool {
         return false;
     }
 
-    if name == "annotation-xml" ||
-        name == "color-profile" ||
-        name == "font-face" ||
-        name == "font-face-src" ||
-        name == "font-face-uri" ||
-        name == "font-face-format" ||
-        name == "font-face-name" ||
-        name == "missing-glyph"
+    if name == "annotation-xml"
+        || name == "color-profile"
+        || name == "font-face"
+        || name == "font-face-src"
+        || name == "font-face-uri"
+        || name == "font-face-format"
+        || name == "font-face-name"
+        || name == "missing-glyph"
     {
         return false;
     }
@@ -1537,152 +1537,152 @@ pub(crate) fn is_valid_custom_element_name(name: &str) -> bool {
 /// Check if this character is a PCENChar
 /// <https://html.spec.whatwg.org/multipage/#prod-pcenchar>
 fn is_potential_custom_element_char(c: char) -> bool {
-    c == '-' ||
-        c == '.' ||
-        c == '_' ||
-        c == '\u{B7}' ||
-        c.is_ascii_digit() ||
-        c.is_ascii_lowercase() ||
-        ('\u{C0}'..='\u{D6}').contains(&c) ||
-        ('\u{D8}'..='\u{F6}').contains(&c) ||
-        ('\u{F8}'..='\u{37D}').contains(&c) ||
-        ('\u{37F}'..='\u{1FFF}').contains(&c) ||
-        ('\u{200C}'..='\u{200D}').contains(&c) ||
-        ('\u{203F}'..='\u{2040}').contains(&c) ||
-        ('\u{2070}'..='\u{218F}').contains(&c) ||
-        ('\u{2C00}'..='\u{2FEF}').contains(&c) ||
-        ('\u{3001}'..='\u{D7FF}').contains(&c) ||
-        ('\u{F900}'..='\u{FDCF}').contains(&c) ||
-        ('\u{FDF0}'..='\u{FFFD}').contains(&c) ||
-        ('\u{10000}'..='\u{EFFFF}').contains(&c)
+    c == '-'
+        || c == '.'
+        || c == '_'
+        || c == '\u{B7}'
+        || c.is_ascii_digit()
+        || c.is_ascii_lowercase()
+        || ('\u{C0}'..='\u{D6}').contains(&c)
+        || ('\u{D8}'..='\u{F6}').contains(&c)
+        || ('\u{F8}'..='\u{37D}').contains(&c)
+        || ('\u{37F}'..='\u{1FFF}').contains(&c)
+        || ('\u{200C}'..='\u{200D}').contains(&c)
+        || ('\u{203F}'..='\u{2040}').contains(&c)
+        || ('\u{2070}'..='\u{218F}').contains(&c)
+        || ('\u{2C00}'..='\u{2FEF}').contains(&c)
+        || ('\u{3001}'..='\u{D7FF}').contains(&c)
+        || ('\u{F900}'..='\u{FDCF}').contains(&c)
+        || ('\u{FDF0}'..='\u{FFFD}').contains(&c)
+        || ('\u{10000}'..='\u{EFFFF}').contains(&c)
 }
 
 fn is_extendable_element_interface(element: &str) -> bool {
-    element == "a" ||
-        element == "abbr" ||
-        element == "acronym" ||
-        element == "address" ||
-        element == "area" ||
-        element == "article" ||
-        element == "aside" ||
-        element == "audio" ||
-        element == "b" ||
-        element == "base" ||
-        element == "bdi" ||
-        element == "bdo" ||
-        element == "big" ||
-        element == "blockquote" ||
-        element == "body" ||
-        element == "br" ||
-        element == "button" ||
-        element == "canvas" ||
-        element == "caption" ||
-        element == "center" ||
-        element == "cite" ||
-        element == "code" ||
-        element == "col" ||
-        element == "colgroup" ||
-        element == "data" ||
-        element == "datalist" ||
-        element == "dd" ||
-        element == "del" ||
-        element == "details" ||
-        element == "dfn" ||
-        element == "dialog" ||
-        element == "dir" ||
-        element == "div" ||
-        element == "dl" ||
-        element == "dt" ||
-        element == "em" ||
-        element == "embed" ||
-        element == "fieldset" ||
-        element == "figcaption" ||
-        element == "figure" ||
-        element == "font" ||
-        element == "footer" ||
-        element == "form" ||
-        element == "frame" ||
-        element == "frameset" ||
-        element == "h1" ||
-        element == "h2" ||
-        element == "h3" ||
-        element == "h4" ||
-        element == "h5" ||
-        element == "h6" ||
-        element == "head" ||
-        element == "header" ||
-        element == "hgroup" ||
-        element == "hr" ||
-        element == "html" ||
-        element == "i" ||
-        element == "iframe" ||
-        element == "img" ||
-        element == "input" ||
-        element == "ins" ||
-        element == "kbd" ||
-        element == "label" ||
-        element == "legend" ||
-        element == "li" ||
-        element == "link" ||
-        element == "listing" ||
-        element == "main" ||
-        element == "map" ||
-        element == "mark" ||
-        element == "marquee" ||
-        element == "menu" ||
-        element == "meta" ||
-        element == "meter" ||
-        element == "nav" ||
-        element == "nobr" ||
-        element == "noframes" ||
-        element == "noscript" ||
-        element == "object" ||
-        element == "ol" ||
-        element == "optgroup" ||
-        element == "option" ||
-        element == "output" ||
-        element == "p" ||
-        element == "param" ||
-        element == "picture" ||
-        element == "plaintext" ||
-        element == "pre" ||
-        element == "progress" ||
-        element == "q" ||
-        element == "rp" ||
-        element == "rt" ||
-        element == "ruby" ||
-        element == "s" ||
-        element == "samp" ||
-        element == "script" ||
-        element == "section" ||
-        element == "select" ||
-        element == "slot" ||
-        element == "small" ||
-        element == "source" ||
-        element == "span" ||
-        element == "strike" ||
-        element == "strong" ||
-        element == "style" ||
-        element == "sub" ||
-        element == "summary" ||
-        element == "sup" ||
-        element == "table" ||
-        element == "tbody" ||
-        element == "td" ||
-        element == "template" ||
-        element == "textarea" ||
-        element == "tfoot" ||
-        element == "th" ||
-        element == "thead" ||
-        element == "time" ||
-        element == "title" ||
-        element == "tr" ||
-        element == "tt" ||
-        element == "track" ||
-        element == "u" ||
-        element == "ul" ||
-        element == "var" ||
-        element == "video" ||
-        element == "wbr" ||
-        element == "xmp"
+    element == "a"
+        || element == "abbr"
+        || element == "acronym"
+        || element == "address"
+        || element == "area"
+        || element == "article"
+        || element == "aside"
+        || element == "audio"
+        || element == "b"
+        || element == "base"
+        || element == "bdi"
+        || element == "bdo"
+        || element == "big"
+        || element == "blockquote"
+        || element == "body"
+        || element == "br"
+        || element == "button"
+        || element == "canvas"
+        || element == "caption"
+        || element == "center"
+        || element == "cite"
+        || element == "code"
+        || element == "col"
+        || element == "colgroup"
+        || element == "data"
+        || element == "datalist"
+        || element == "dd"
+        || element == "del"
+        || element == "details"
+        || element == "dfn"
+        || element == "dialog"
+        || element == "dir"
+        || element == "div"
+        || element == "dl"
+        || element == "dt"
+        || element == "em"
+        || element == "embed"
+        || element == "fieldset"
+        || element == "figcaption"
+        || element == "figure"
+        || element == "font"
+        || element == "footer"
+        || element == "form"
+        || element == "frame"
+        || element == "frameset"
+        || element == "h1"
+        || element == "h2"
+        || element == "h3"
+        || element == "h4"
+        || element == "h5"
+        || element == "h6"
+        || element == "head"
+        || element == "header"
+        || element == "hgroup"
+        || element == "hr"
+        || element == "html"
+        || element == "i"
+        || element == "iframe"
+        || element == "img"
+        || element == "input"
+        || element == "ins"
+        || element == "kbd"
+        || element == "label"
+        || element == "legend"
+        || element == "li"
+        || element == "link"
+        || element == "listing"
+        || element == "main"
+        || element == "map"
+        || element == "mark"
+        || element == "marquee"
+        || element == "menu"
+        || element == "meta"
+        || element == "meter"
+        || element == "nav"
+        || element == "nobr"
+        || element == "noframes"
+        || element == "noscript"
+        || element == "object"
+        || element == "ol"
+        || element == "optgroup"
+        || element == "option"
+        || element == "output"
+        || element == "p"
+        || element == "param"
+        || element == "picture"
+        || element == "plaintext"
+        || element == "pre"
+        || element == "progress"
+        || element == "q"
+        || element == "rp"
+        || element == "rt"
+        || element == "ruby"
+        || element == "s"
+        || element == "samp"
+        || element == "script"
+        || element == "section"
+        || element == "select"
+        || element == "slot"
+        || element == "small"
+        || element == "source"
+        || element == "span"
+        || element == "strike"
+        || element == "strong"
+        || element == "style"
+        || element == "sub"
+        || element == "summary"
+        || element == "sup"
+        || element == "table"
+        || element == "tbody"
+        || element == "td"
+        || element == "template"
+        || element == "textarea"
+        || element == "tfoot"
+        || element == "th"
+        || element == "thead"
+        || element == "time"
+        || element == "title"
+        || element == "tr"
+        || element == "tt"
+        || element == "track"
+        || element == "u"
+        || element == "ul"
+        || element == "var"
+        || element == "video"
+        || element == "wbr"
+        || element == "xmp"
 }

--- a/components/script/dom/datatransfer/datatransfer.rs
+++ b/components/script/dom/datatransfer/datatransfer.rs
@@ -130,8 +130,8 @@ impl DataTransferMethods<crate::DomTypeHolder> for DataTransfer {
             .data_store
             .borrow()
             .as_ref()
-            .is_some_and(|data_store| data_store.mode() == Mode::ReadWrite) &&
-            VALID_EFFECTS_ALLOWED.contains(&&*value.str())
+            .is_some_and(|data_store| data_store.mode() == Mode::ReadWrite)
+            && VALID_EFFECTS_ALLOWED.contains(&&*value.str())
         {
             *self.drop_effect.borrow_mut() = value;
         }

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -452,8 +452,8 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
                 IntroductionType::EVENT_HANDLER_STR,
                 IntroductionType::DOM_TIMER_STR,
             ]
-            .contains(&&*introduction_type.str()) &&
-                url_override.is_none()
+            .contains(&&*introduction_type.str())
+                && url_override.is_none()
             {
                 debug!(
                     "Not creating debuggee: `introductionType` is `{introduction_type}` but no valid url"

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -259,8 +259,8 @@ impl RefreshRedirectDue {
         // automatic features browsing context flag set,
         // then navigate document's node navigable to urlRecord using document,
         // with historyHandling set to "replace".
-        if self.from_meta_element &&
-            self.window.Document().has_active_sandboxing_flag(
+        if self.from_meta_element
+            && self.window.Document().has_active_sandboxing_flag(
                 SandboxingFlagSet::SANDBOXED_AUTOMATIC_FEATURES_BROWSING_CONTEXT_FLAG,
             )
         {
@@ -796,8 +796,8 @@ impl Document {
                 // will trigger a new empty display list.
                 self.root_removal_noted.set(false);
 
-                if let Some(dirty_root) = self.dirty_root.get() &&
-                    dirty_root.is_connected()
+                if let Some(dirty_root) = self.dirty_root.get()
+                    && dirty_root.is_connected()
                 {
                     // There was an existing dirty root so we mark its
                     // ancestors as dirty until the document element.
@@ -1056,8 +1056,8 @@ impl Document {
 
         // Step 2: If document's URL matches about:blank and document's about base URL is
         // non-null, then return document's about base URL.
-        if document_url.matches_about_blank() &&
-            let Some(about_base_url) = self.about_base_url()
+        if document_url.matches_about_blank()
+            && let Some(about_base_url) = self.about_base_url()
         {
             return about_base_url;
         }
@@ -1097,8 +1097,8 @@ impl Document {
         // FIXME: This should check the dirty bit on the document,
         // not the document element. Needs some layout changes to make
         // that workable.
-        if let Some(root) = self.GetDocumentElement() &&
-            root.upcast::<Node>().has_dirty_descendants()
+        if let Some(root) = self.GetDocumentElement()
+            && root.upcast::<Node>().has_dirty_descendants()
         {
             condition.insert(RestyleReason::DOMChanged);
         }
@@ -1982,8 +1982,8 @@ impl Document {
         // to fire an event named hashchange at document's relevant global object, using HashChangeEvent,
         // with the oldURL attribute initialized to the serialization of oldURL
         // and the newURL attribute initialized to the serialization of entry's URL.
-        if old_url.as_url()[Position::BeforeFragment..] !=
-            new_url.as_url()[Position::BeforeFragment..]
+        if old_url.as_url()[Position::BeforeFragment..]
+            != new_url.as_url()[Position::BeforeFragment..]
         {
             let window = Trusted::new(self.owner_window().deref());
             let old_url = old_url.to_string();
@@ -2065,8 +2065,8 @@ impl Document {
             .navigation_timing
             .top_level_dom_complete
             .get()
-            .is_none() &&
-            loader.is_only_blocked_by_iframes()
+            .is_none()
+            && loader.is_only_blocked_by_iframes()
         {
             update_with_current_instant(&self.navigation_timing.top_level_dom_complete);
         }
@@ -2620,8 +2620,8 @@ impl Document {
 
     /// Step 7 of <https://html.spec.whatwg.org/multipage/#the-end>
     fn wait_until_asap_scripts_have_executed(&self) {
-        if self.current_the_end_loading_phase.get() !=
-            TheEndLoadingPhase::ProcessingAsSoonAsPossibleScripts
+        if self.current_the_end_loading_phase.get()
+            != TheEndLoadingPhase::ProcessingAsSoonAsPossibleScripts
         {
             return;
         }
@@ -2654,8 +2654,8 @@ impl Document {
 
     /// Step 8 of <https://html.spec.whatwg.org/multipage/#the-end>
     pub(crate) fn wait_until_load_blockers_have_resolved(&self, _cx: &mut JSContext) {
-        if self.current_the_end_loading_phase.get() !=
-            TheEndLoadingPhase::WaitingForLoadEventBlockers
+        if self.current_the_end_loading_phase.get()
+            != TheEndLoadingPhase::WaitingForLoadEventBlockers
         {
             return;
         }
@@ -2668,8 +2668,8 @@ impl Document {
                 .navigation_timing
                 .top_level_dom_complete
                 .get()
-                .is_none() &&
-                loader.is_only_blocked_by_iframes()
+                .is_none()
+                && loader.is_only_blocked_by_iframes()
             {
                 update_with_current_instant(&self.navigation_timing.top_level_dom_complete);
             }
@@ -3053,10 +3053,10 @@ impl Document {
         if !self.is_fully_active() {
             return false;
         }
-        if !self.window().layout_blocked() &&
-            (!self.restyle_reason().is_empty() ||
-                self.window().layout().needs_new_display_list() ||
-                self.window().layout().needs_accessibility_update())
+        if !self.window().layout_blocked()
+            && (!self.restyle_reason().is_empty()
+                || self.window().layout().needs_new_display_list()
+                || self.window().layout().needs_accessibility_update())
         {
             return true;
         }
@@ -3422,8 +3422,8 @@ impl Document {
     ) {
         let metrics = self.interactive_time.borrow();
         match metric_type {
-            ProgressiveWebMetricType::FirstPaint |
-            ProgressiveWebMetricType::FirstContentfulPaint => {
+            ProgressiveWebMetricType::FirstPaint
+            | ProgressiveWebMetricType::FirstContentfulPaint => {
                 let binding = PerformancePaintTiming::new(
                     cx,
                     self.window.as_global_scope(),
@@ -3520,8 +3520,8 @@ impl Document {
             _ => {
                 // Step 9.1: If document's unload counter is greater than 0 or
                 // document's ignore-destructive-writes counter is greater than 0, then return.
-                if self.is_prompting_or_unloading() ||
-                    self.ignore_destructive_writes_counter.get() > 0
+                if self.is_prompting_or_unloading()
+                    || self.ignore_destructive_writes_counter.get() > 0
                 {
                     return Ok(());
                 }
@@ -3872,8 +3872,8 @@ impl Document {
     pub(crate) fn insecure_requests_policy(&self) -> InsecureRequestsPolicy {
         if let Some(csp_list) = self.get_csp_list().as_ref() {
             for policy in &csp_list.0 {
-                if policy.contains_a_directive_whose_name_is("upgrade-insecure-requests") &&
-                    policy.disposition == PolicyDisposition::Enforce
+                if policy.contains_a_directive_whose_name_is("upgrade-insecure-requests")
+                    && policy.disposition == PolicyDisposition::Enforce
                 {
                     return InsecureRequestsPolicy::Upgrade;
                 }
@@ -4305,8 +4305,8 @@ impl Document {
             entry.hint.insert(RestyleHint::RESTYLE_STYLE_ATTRIBUTE);
         }
 
-        if vtable_for(el.upcast()).attribute_affects_presentational_hints(attr) ||
-            el.check_style_on_self_or_eager_pseudos(|style| {
+        if vtable_for(el.upcast()).attribute_affects_presentational_hints(attr)
+            || el.check_style_on_self_or_eager_pseudos(|style| {
                 if let Some(ref attribute_references) = style.attribute_references {
                     return attribute_references.contains_key(attr.local_name());
                 }
@@ -4549,8 +4549,8 @@ impl Document {
     }
 
     pub(crate) fn switch_font_face_set_to_loading_if_needed(&self, cx: &mut JSContext) {
-        if self.window.font_context().web_fonts_still_loading() != 0 &&
-            let Some(font_face_set) = self.fonts.get()
+        if self.window.font_context().web_fonts_still_loading() != 0
+            && let Some(font_face_set) = self.fonts.get()
         {
             font_face_set.switch_to_loading(cx);
         }
@@ -4854,8 +4854,8 @@ impl Document {
     }
 
     pub(crate) fn has_trustworthy_ancestor_or_current_origin(&self) -> bool {
-        self.has_trustworthy_ancestor_origin.get() ||
-            self.origin().immutable().is_potentially_trustworthy()
+        self.has_trustworthy_ancestor_origin.get()
+            || self.origin().immutable().is_potentially_trustworthy()
     }
 
     pub(crate) fn highlight_dom_node(&self, node: Option<&Node>) {
@@ -5867,8 +5867,8 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
 
         let node = new_body.upcast::<Node>();
         match node.type_id() {
-            NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLBodyElement)) |
-            NodeTypeId::Element(ElementTypeId::HTMLElement(
+            NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLBodyElement))
+            | NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLFrameSetElement,
             )) => {},
             _ => return Err(Error::HierarchyRequest(None)),
@@ -5933,8 +5933,8 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     fn Links(&self, cx: &mut JSContext) -> DomRoot<HTMLCollection> {
         self.links.or_init(|| {
             HTMLCollection::new_with_filter_fn(cx, &self.window, self.upcast(), |element, _| {
-                (element.is::<HTMLAnchorElement>() || element.is::<HTMLAreaElement>()) &&
-                    element.has_attribute(&local_name!("href"))
+                (element.is::<HTMLAnchorElement>() || element.is::<HTMLAreaElement>())
+                    && element.has_attribute(&local_name!("href"))
             })
         })
     }
@@ -6181,8 +6181,8 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                         elem.get_name().as_ref() == Some(&self.name)
                     },
                     HTMLElementTypeId::HTMLImageElement => elem.get_name().is_some_and(|name| {
-                        name == *self.name ||
-                            !name.is_empty() && elem.get_id().as_ref() == Some(&self.name)
+                        name == *self.name
+                            || !name.is_empty() && elem.get_id().as_ref() == Some(&self.name)
                     }),
                     // TODO handle <embed> and <object>; these depend on whether the element is
                     // “exposed”, a concept that doesn’t fully make sense until embed/object
@@ -6695,12 +6695,11 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     fn SetAdoptedStyleSheets(&self, cx: &mut JSContext, val: HandleValue) -> ErrorResult {
         let result = DocumentOrShadowRoot::set_adopted_stylesheet_from_jsval(
             cx,
-            self.adopted_stylesheets.borrow_mut().as_mut(),
+            &self.adopted_stylesheets,
             val,
             &StyleSheetListOwner::Document(Dom::from_ref(self)),
         );
 
-        // If update is successful, clear the FrozenArray cache.
         if result.is_ok() {
             self.adopted_stylesheets_frozen_types.clear()
         }
@@ -6826,9 +6825,9 @@ fn is_named_element_with_name_attribute(elem: &Element) -> bool {
         _ => return false,
     };
     match type_ {
-        HTMLElementTypeId::HTMLFormElement |
-        HTMLElementTypeId::HTMLIFrameElement |
-        HTMLElementTypeId::HTMLImageElement => true,
+        HTMLElementTypeId::HTMLFormElement
+        | HTMLElementTypeId::HTMLIFrameElement
+        | HTMLElementTypeId::HTMLImageElement => true,
         // TODO handle <embed> and <object>; these depend on whether the element is
         // “exposed”, a concept that doesn’t fully make sense until embed/object
         // behaviour is actually implemented

--- a/components/script/dom/document/document_embedder_controls.rs
+++ b/components/script/dom/document/document_embedder_controls.rs
@@ -127,10 +127,10 @@ impl DocumentEmbedderControls {
             .insert(id.index.into(), element);
 
         match request {
-            EmbedderControlRequest::SelectElement(..) |
-            EmbedderControlRequest::ColorPicker(..) |
-            EmbedderControlRequest::InputMethod(..) |
-            EmbedderControlRequest::ContextMenu(..) => self
+            EmbedderControlRequest::SelectElement(..)
+            | EmbedderControlRequest::ColorPicker(..)
+            | EmbedderControlRequest::InputMethod(..)
+            | EmbedderControlRequest::ContextMenu(..) => self
                 .window
                 .send_to_embedder(EmbedderMsg::ShowEmbedderControl(id, rect, request)),
             EmbedderControlRequest::FilePicker(file_picker_request) => {
@@ -259,21 +259,21 @@ impl DocumentEmbedderControls {
             .node
             .inclusive_ancestors(ShadowIncluding::Yes)
         {
-            if anchor_element.is_none() &&
-                let Some(candidate_anchor_element) = node.downcast::<HTMLAnchorElement>() &&
-                candidate_anchor_element.is_instance_activatable()
+            if anchor_element.is_none()
+                && let Some(candidate_anchor_element) = node.downcast::<HTMLAnchorElement>()
+                && candidate_anchor_element.is_instance_activatable()
             {
                 anchor_element = Some(DomRoot::from_ref(candidate_anchor_element));
             }
 
-            if image_element.is_none() &&
-                let Some(candidate_image_element) = node.downcast::<HTMLImageElement>()
+            if image_element.is_none()
+                && let Some(candidate_image_element) = node.downcast::<HTMLImageElement>()
             {
                 image_element = Some(DomRoot::from_ref(candidate_image_element))
             }
 
-            if text_input_element.is_none() &&
-                let Some(candidate_text_input_element) = node.as_text_input()
+            if text_input_element.is_none()
+                && let Some(candidate_text_input_element) = node.as_text_input()
             {
                 text_input_element = Some(candidate_text_input_element);
             }

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -116,9 +116,9 @@ impl ClickCountingInfo {
         // Calculate distance between this click and the previous click.
         let line = point_in_frame - previous_point;
         let distance = (line.dot(line) as f64).sqrt();
-        if previous_button != button ||
-            Instant::now().duration_since(previous_time) > double_click_timeout ||
-            distance > double_click_distance_threshold as f64
+        if previous_button != button
+            || Instant::now().duration_since(previous_time) > double_click_timeout
+            || distance > double_click_distance_threshold as f64
         {
             self.count = 0;
             self.time = None;
@@ -260,10 +260,10 @@ impl DocumentEventHandler {
             if let Some(existing_constellation_wheel_event) = self
                 .wheel_event_index
                 .borrow()
-                .and_then(|index| pending_input_events.get_mut(index)) &&
-                let InputEvent::Wheel(ref mut existing_wheel_event) =
-                    existing_constellation_wheel_event.event.event &&
-                existing_wheel_event.delta.mode == new_wheel_event.delta.mode
+                .and_then(|index| pending_input_events.get_mut(index))
+                && let InputEvent::Wheel(ref mut existing_wheel_event) =
+                    existing_constellation_wheel_event.event.event
+                && existing_wheel_event.delta.mode == new_wheel_event.delta.mode
             {
                 self.coalesced_wheel_event_ids
                     .borrow_mut()
@@ -321,9 +321,9 @@ impl DocumentEventHandler {
             mem::take(&mut *self.coalesced_wheel_event_ids.borrow_mut());
 
         let mut input_event_outcomes = Vec::with_capacity(
-            pending_input_events.len() +
-                coalesced_mouse_move_event_ids.len() +
-                coalesced_wheel_event_ids.len(),
+            pending_input_events.len()
+                + coalesced_mouse_move_event_ids.len()
+                + coalesced_wheel_event_ids.len(),
         );
         // TODO: For some of these we still aren't properly calculating whether or not
         // the event was handled or if `preventDefault()` was called on it. Each of
@@ -758,8 +758,8 @@ impl DocumentEventHandler {
 
         // If the new hover target is an anchor with a status value, inform the embedder
         // of the new value.
-        if let Some(target) = self.current_hover_target.get() &&
-            let Some(anchor) = target
+        if let Some(target) = self.current_hover_target.get()
+            && let Some(anchor) = target
                 .upcast::<Node>()
                 .inclusive_ancestors(ShadowIncluding::Yes)
                 .find_map(DomRoot::downcast::<HTMLAnchorElement>)
@@ -805,15 +805,15 @@ impl DocumentEventHandler {
     fn set_active_element(&self, original_target: &Element) {
         let find_element_for_activation = |element: &Element| {
             let node: &Node = element.upcast();
-            if node.is_in_ua_widget() &&
-                let Some(containing_shadow_root) = node.containing_shadow_root()
+            if node.is_in_ua_widget()
+                && let Some(containing_shadow_root) = node.containing_shadow_root()
             {
                 return containing_shadow_root.Host();
             }
 
             // If the element is a label, the activable element is the control element.
-            if node.type_id() ==
-                NodeTypeId::Element(ElementTypeId::HTMLElement(
+            if node.type_id()
+                == NodeTypeId::Element(ElementTypeId::HTMLElement(
                     HTMLElementTypeId::HTMLLabelElement,
                 ))
             {
@@ -1541,9 +1541,9 @@ impl DocumentEventHandler {
             keyboard_event.event.key,
             Key::Character(_) | Key::Named(NamedKey::Enter)
         );
-        if keyboard_event.event.state == KeyState::Down &&
-            is_character_value_key &&
-            !keyboard_event.event.is_composing
+        if keyboard_event.event.state == KeyState::Down
+            && is_character_value_key
+            && !keyboard_event.event.is_composing
         {
             // https://w3c.github.io/uievents/#keypress-event-order
             let keypress_event = KeyboardEvent::new_with_platform_keyboard_event(
@@ -1629,8 +1629,9 @@ impl DocumentEventHandler {
         let cancelable = EventCancelable::from(
             self.window
                 .upcast::<EventTarget>()
-                .has_non_passive_listener(&event_type) ||
-                node.inclusive_ancestors(ShadowIncluding::Yes)
+                .has_non_passive_listener(&event_type)
+                || node
+                    .inclusive_ancestors(ShadowIncluding::Yes)
                     .any(|target| {
                         target
                             .upcast::<EventTarget>()
@@ -2252,8 +2253,8 @@ impl DocumentEventHandler {
                     KeyboardScroll::Home => Vector2D::new(0.0, -current_scroll_offset.y),
                     KeyboardScroll::End => Vector2D::new(
                         0.0,
-                        -current_scroll_offset.y + scrolling_box.content_size().height -
-                            scrolling_box.size().height,
+                        -current_scroll_offset.y + scrolling_box.content_size().height
+                            - scrolling_box.size().height,
                     ),
                     KeyboardScroll::PageDown => {
                         Vector2D::new(0.0, scrolling_box.size().height - 2.0 * LINE_HEIGHT)
@@ -2558,8 +2559,8 @@ impl DocumentEventHandler {
             .borrow()
             .get(&pointer_id)
             .map(|el| DomRoot::from_ref(&**el));
-        if let Some(capture_element) = capture_target &&
-            !capture_element.upcast::<Node>().is_connected()
+        if let Some(capture_element) = capture_target
+            && !capture_element.upcast::<Node>().is_connected()
         {
             // Fire lostpointercapture at the document, not the disconnected element.
             let document = self.window.Document();

--- a/components/script/dom/document/documentorshadowroot.rs
+++ b/components/script/dom/document/documentorshadowroot.rs
@@ -258,8 +258,8 @@ impl DocumentOrShadowRoot {
 
         // Step 4: If the document has a root element, and the last item in sequence is
         // not the root element, append the root element to sequence.
-        if let Some(root_element) = document_element &&
-            elements.last() != Some(&root_element)
+        if let Some(root_element) = document_element
+            && elements.last() != Some(&root_element)
         {
             elements.push(root_element);
         }
@@ -443,7 +443,7 @@ impl DocumentOrShadowRoot {
     /// values to the inner [DocumentOrShadowRoot::set_adopted_stylesheet].
     pub(crate) fn set_adopted_stylesheet_from_jsval(
         cx: &mut JSContext,
-        adopted_stylesheets: &mut Vec<Dom<CSSStyleSheet>>,
+        adopted_stylesheets: &DomRefCell<Vec<Dom<CSSStyleSheet>>>,
         incoming_value: HandleValue,
         owner: &StyleSheetListOwner,
     ) -> ErrorResult {
@@ -455,12 +455,19 @@ impl DocumentOrShadowRoot {
             ConversionResult::Success(stylesheets) => {
                 rooted_vec!(let stylesheets <- stylesheets.iter().map(|s| s.as_traced()));
 
-                DocumentOrShadowRoot::set_adopted_stylesheet(
-                    cx,
-                    adopted_stylesheets,
-                    &stylesheets,
-                    owner,
-                )
+                // Scope the borrow so it is dropped before returning, avoiding a borrow
+                // hazard if a GC occurs.
+                {
+                    let mut sheets = adopted_stylesheets.borrow_mut();
+                    DocumentOrShadowRoot::set_adopted_stylesheet(
+                        cx,
+                        sheets.as_mut(),
+                        &stylesheets,
+                        owner,
+                    )?;
+                }
+
+                Ok(())
             },
             ConversionResult::Failure(msg) => Err(Error::Type(msg.into_owned())),
         }

--- a/components/script/dom/document/focus.rs
+++ b/components/script/dom/document/focus.rs
@@ -381,8 +381,8 @@ impl DocumentFocusHandler {
             // because of the popping we do at the start of these steps.
             let related_blur_target = match new_focus_chain.last() {
                 Some(FocusableArea::Node { node, .. })
-                    if index == last_old_focus_chain_entry &&
-                        matches!(entry, FocusableArea::Node { .. }) =>
+                    if index == last_old_focus_chain_entry
+                        && matches!(entry, FocusableArea::Node { .. }) =>
                 {
                     Some(node.upcast())
                 },
@@ -404,8 +404,8 @@ impl DocumentFocusHandler {
         // Step 3: Apply any relevant platform-specific conventions for focusing new focus
         // target. (For example, some platforms select the contents of a text control when that
         // control is focused.)
-        if &*self.focused_area() != new_focus_target &&
-            let Some(html_element) = new_focus_target
+        if &*self.focused_area() != new_focus_target
+            && let Some(html_element) = new_focus_target
                 .element()
                 .and_then(|element| element.downcast::<HTMLElement>())
         {
@@ -458,8 +458,8 @@ impl DocumentFocusHandler {
             // because of the popping we do at the start of these steps.
             let related_focus_target = match old_focus_chain.last() {
                 Some(FocusableArea::Node { node, .. })
-                    if index == last_new_focus_chain_entry &&
-                        matches!(entry, FocusableArea::Node { .. }) =>
+                    if index == last_new_focus_chain_entry
+                        && matches!(entry, FocusableArea::Node { .. }) =>
                 {
                     Some(node.upcast())
                 },
@@ -573,8 +573,8 @@ impl DocumentFocusHandler {
         // > starting point, then let starting point be the sequential focus navigation starting point
         // > instead.
         if let Some(sequential_focus_navigation_starting_point) =
-            self.sequential_focus_navigation_starting_point() &&
-            starting_point.as_ref().is_none_or(|starting_point| {
+            self.sequential_focus_navigation_starting_point()
+            && starting_point.as_ref().is_none_or(|starting_point| {
                 starting_point.is_ancestor_of(&sequential_focus_navigation_starting_point)
             })
         {
@@ -905,9 +905,9 @@ impl SequentialFocusNavigationSearch {
             mechanism => *mechanism,
         };
 
-        if self.direction == SequentialFocusDirection::Backward &&
-            let Some(containing_element) = containing_node.downcast::<Element>() &&
-            containing_element.is_sequentially_focusable()
+        if self.direction == SequentialFocusDirection::Backward
+            && let Some(containing_element) = containing_node.downcast::<Element>()
+            && containing_element.is_sequentially_focusable()
         {
             return Some(DomRoot::from_ref(containing_element));
         }
@@ -965,8 +965,8 @@ impl SequentialFocusNavigationSearch {
         // If the search has ascended into a containing scope, never try to search back down
         // into the scope that originated this part of the search. Otherwise the search would
         // cycle endlessly.
-        if Some(node) == self.starting_point.as_deref() &&
-            self.search_context == SequentialFocusNavigationSearchContext::Containing
+        if Some(node) == self.starting_point.as_deref()
+            && self.search_context == SequentialFocusNavigationSearchContext::Containing
         {
             return Continue::Yes;
         }
@@ -1142,8 +1142,8 @@ impl SequentialFocusNavigationSearch {
                 // If the candidate element has a lesser tab index than the current winner,
                 // then it becomes the winner.
                 let should_select =
-                    compare_tab_indices(candidate_element_tab_index, winning_tab_index) ==
-                        Ordering::Less;
+                    compare_tab_indices(candidate_element_tab_index, winning_tab_index)
+                        == Ordering::Less;
 
                 (should_select, Continue::Yes)
             },
@@ -1165,8 +1165,8 @@ impl SequentialFocusNavigationSearch {
                 // then it becomes the new winner. This means that when the tab indices are
                 // equal, we give preference to the last one in DOM order.
                 let should_select =
-                    compare_tab_indices(candidate_element_tab_index, winning_tab_index) !=
-                        Ordering::Less;
+                    compare_tab_indices(candidate_element_tab_index, winning_tab_index)
+                        != Ordering::Less;
                 (should_select, Continue::Yes)
             },
         }

--- a/components/script/dom/document/tree_ordered_index_map.rs
+++ b/components/script/dom/document/tree_ordered_index_map.rs
@@ -150,8 +150,8 @@ impl TreeOrderedIndexMap {
     /// to the entry without having to resolve ordering.
     pub(crate) fn add(&self, key: &Atom, element: &Element) {
         debug_assert!(
-            element.upcast::<Node>().is_in_a_document_tree() ||
-                element.upcast::<Node>().is_in_a_shadow_tree()
+            element.upcast::<Node>().is_in_a_document_tree()
+                || element.upcast::<Node>().is_in_a_shadow_tree()
         );
 
         // Gracefully handle empty keys. The calling code should not try to
@@ -227,8 +227,8 @@ impl TreeOrderedIndexMap {
 
         {
             let mut map = self.map.borrow_mut();
-            if let Entry::Occupied(mut occupied_entry) = map.entry(key.clone()) &&
-                occupied_entry.get().needs_resolution()
+            if let Entry::Occupied(mut occupied_entry) = map.entry(key.clone())
+                && occupied_entry.get().needs_resolution()
             {
                 Self::resolve_one(no_gc, scope, key, occupied_entry.get_mut(), self.index_type);
             }

--- a/components/script/dom/domstringmap.rs
+++ b/components/script/dom/domstringmap.rs
@@ -48,8 +48,8 @@ fn to_camel_case(name: &str) -> Option<DOMString> {
     while let Some(curr_char) = name_chars.next() {
         // Note that we first need to peek, since we shouldn't advance the iterator twice
         // in case there are two consecutive dashes and then followed by a ASCII lower alpha
-        if curr_char == DATA_HYPHEN_SEPARATOR &&
-            name_chars
+        if curr_char == DATA_HYPHEN_SEPARATOR
+            && name_chars
                 .peek()
                 .is_some_and(|next_char| next_char.is_ascii_lowercase())
         {

--- a/components/script/dom/element/attributes/attr.rs
+++ b/components/script/dom/element/attributes/attr.rs
@@ -200,8 +200,8 @@ impl Attr {
                 // Already gone from the list of attributes of old owner.
                 assert!(
                     old.get_attribute_with_namespace(cx, ns, &self.identifier.local_name)
-                        .as_deref() !=
-                        Some(self)
+                        .as_deref()
+                        != Some(self)
                 )
             },
             (Some(old), Some(new)) => assert_eq!(&*old, new),

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -536,8 +536,8 @@ impl Element {
 
         // " - body’s parent element’s computed value of the overflow-x or
         //     overflow-y properties is neither visible nor clip."
-        if let Some(parent) = node.GetParentElement() &&
-            let Some(style) = parent.style()
+        if let Some(parent) = node.GetParentElement()
+            && let Some(style) = parent.style()
         {
             let mut overflow_x = style.get_box().clone_overflow_x();
             let mut overflow_y = style.get_box().clone_overflow_y();
@@ -560,9 +560,9 @@ impl Element {
 
         // " - body’s computed value of the overflow-x or overflow-y properties
         //     is neither visible nor clip."
-        if let Some(style) = self.style() &&
-            !style.get_box().clone_overflow_x().is_scrollable() &&
-            !style.get_box().clone_overflow_y().is_scrollable()
+        if let Some(style) = self.style()
+            && !style.get_box().clone_overflow_x().is_scrollable()
+            && !style.get_box().clone_overflow_y().is_scrollable()
         {
             return false;
         };
@@ -670,8 +670,8 @@ impl Element {
             // Step 4.2. If currentShadowRoot’s declarative is false
             // or currentShadowRoot’s mode is not mode
             // then throw a "NotSupportedError" DOMException.
-            if !current_shadow_root.is_declarative() ||
-                current_shadow_root.shadow_root_mode() != mode
+            if !current_shadow_root.is_declarative()
+                || current_shadow_root.shadow_root_mode() != mode
             {
                 return Err(Error::NotSupported(Some(
                     "Cannot attach a second shadow root to the same element".into(),
@@ -793,8 +793,8 @@ impl Element {
                 _ => {},
             }
         }
-        if let Some(parent) = self.upcast::<Node>().GetParentNode() &&
-            let Some(elem) = parent.downcast::<Element>()
+        if let Some(parent) = self.upcast::<Node>().GetParentNode()
+            && let Some(elem) = parent.downcast::<Element>()
         {
             return elem.is_translate_enabled();
         }
@@ -1057,24 +1057,24 @@ pub(crate) fn is_valid_shadow_host_name(name: &LocalName) -> bool {
     // >   "h4", "h5", "h6", "header", "main", "nav", "p", "section", or "span"
     matches!(
         name,
-        &local_name!("article") |
-            &local_name!("aside") |
-            &local_name!("blockquote") |
-            &local_name!("body") |
-            &local_name!("div") |
-            &local_name!("footer") |
-            &local_name!("h1") |
-            &local_name!("h2") |
-            &local_name!("h3") |
-            &local_name!("h4") |
-            &local_name!("h5") |
-            &local_name!("h6") |
-            &local_name!("header") |
-            &local_name!("main") |
-            &local_name!("nav") |
-            &local_name!("p") |
-            &local_name!("section") |
-            &local_name!("span")
+        &local_name!("article")
+            | &local_name!("aside")
+            | &local_name!("blockquote")
+            | &local_name!("body")
+            | &local_name!("div")
+            | &local_name!("footer")
+            | &local_name!("h1")
+            | &local_name!("h2")
+            | &local_name!("h3")
+            | &local_name!("h4")
+            | &local_name!("h5")
+            | &local_name!("h6")
+            | &local_name!("header")
+            | &local_name!("main")
+            | &local_name!("nav")
+            | &local_name!("p")
+            | &local_name!("section")
+            | &local_name!("span")
     )
 }
 
@@ -1277,9 +1277,9 @@ impl<'dom> LayoutDom<'dom, Element> {
             .and_then(|input_element| {
                 // FIXME(pcwalton): More use of atoms, please!
                 match self.get_attr_val_for_layout(&ns!(), &local_name!("type")) {
-                    Some("hidden") | Some("range") | Some("color") | Some("checkbox") |
-                    Some("radio") | Some("file") | Some("submit") | Some("image") |
-                    Some("reset") | Some("button") => None,
+                    Some("hidden") | Some("range") | Some("color") | Some("checkbox")
+                    | Some("radio") | Some("file") | Some("submit") | Some("image")
+                    | Some("reset") | Some("button") => None,
                     // Others
                     _ => match input_element.size_for_layout() {
                         0 => None,
@@ -1391,9 +1391,9 @@ impl<'dom> LayoutDom<'dom, Element> {
 
         // Aspect ratio when providing both width and height.
         // https://html.spec.whatwg.org/multipage/#attributes-for-embedded-content-and-images
-        if (self.is::<HTMLImageElement>() || self.is::<HTMLVideoElement>()) &&
-            let LengthOrPercentageOrAuto::Length(width) = width &&
-            let LengthOrPercentageOrAuto::Length(height) = height
+        if (self.is::<HTMLImageElement>() || self.is::<HTMLVideoElement>())
+            && let LengthOrPercentageOrAuto::Length(width) = width
+            && let LengthOrPercentageOrAuto::Length(height) = height
         {
             let width_value = NonNegative(specified::Number::new(width.to_f32_px()));
             let height_value = NonNegative(specified::Number::new(height.to_f32_px()));
@@ -1750,8 +1750,8 @@ impl Element {
         // Step 6. Return the result of running locate a namespace on its parent element using prefix.
         for element in inclusive_ancestor_elements {
             // Step 3. If its namespace is non-null and its namespace prefix is prefix, then return namespace.
-            if element.namespace() != &ns!() &&
-                element.prefix().as_ref().map(|p| &**p) == prefix.as_deref()
+            if element.namespace() != &ns!()
+                && element.prefix().as_ref().map(|p| &**p) == prefix.as_deref()
             {
                 return element.namespace().clone();
             }
@@ -1816,24 +1816,24 @@ impl Element {
         match self.local_name {
             /* List of void elements from
             https://html.spec.whatwg.org/multipage/#html-fragment-serialisation-algorithm */
-            local_name!("area") |
-            local_name!("base") |
-            local_name!("basefont") |
-            local_name!("bgsound") |
-            local_name!("br") |
-            local_name!("col") |
-            local_name!("embed") |
-            local_name!("frame") |
-            local_name!("hr") |
-            local_name!("img") |
-            local_name!("input") |
-            local_name!("keygen") |
-            local_name!("link") |
-            local_name!("meta") |
-            local_name!("param") |
-            local_name!("source") |
-            local_name!("track") |
-            local_name!("wbr") => true,
+            local_name!("area")
+            | local_name!("base")
+            | local_name!("basefont")
+            | local_name!("bgsound")
+            | local_name!("br")
+            | local_name!("col")
+            | local_name!("embed")
+            | local_name!("frame")
+            | local_name!("hr")
+            | local_name!("img")
+            | local_name!("input")
+            | local_name!("keygen")
+            | local_name!("link")
+            | local_name!("meta")
+            | local_name!("param")
+            | local_name!("source")
+            | local_name!("track")
+            | local_name!("wbr") => true,
             _ => false,
         }
     }
@@ -1861,16 +1861,16 @@ impl Element {
         {
             let element = node.downcast::<Element>()?;
             // Step 1.
-            if *element.namespace() == namespace &&
-                let Some(prefix) = element.GetPrefix()
+            if *element.namespace() == namespace
+                && let Some(prefix) = element.GetPrefix()
             {
                 return Some(prefix);
             }
 
             // Step 2.
             for attr in element.attrs.borrow().iter() {
-                if attr.prefix() == Some(&namespace_prefix!("xmlns")) &&
-                    **attr.value() == *namespace
+                if attr.prefix() == Some(&namespace_prefix!("xmlns"))
+                    && **attr.value() == *namespace
                 {
                     return Some(DOMString::from(&**attr.local_name()));
                 }
@@ -1907,24 +1907,24 @@ impl Element {
         match node.type_id() {
             NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLButtonElement,
-            )) |
-            NodeTypeId::Element(ElementTypeId::HTMLElement(
+            ))
+            | NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLInputElement,
-            )) |
-            NodeTypeId::Element(ElementTypeId::HTMLElement(
+            ))
+            | NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLSelectElement,
-            )) |
-            NodeTypeId::Element(ElementTypeId::HTMLElement(
+            ))
+            | NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLTextAreaElement,
-            )) |
-            NodeTypeId::Element(ElementTypeId::HTMLElement(
+            ))
+            | NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLOptionElement,
             )) => self.disabled_state(),
             NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLElement)) => {
                 self.downcast::<HTMLElement>()
                     .unwrap()
-                    .is_form_associated_custom_element() &&
-                    self.disabled_state()
+                    .is_form_associated_custom_element()
+                    && self.disabled_state()
             },
             // TODO:
             // an optgroup element that has a disabled attribute
@@ -2397,8 +2397,8 @@ impl Element {
 
         // Step 2. If attr’s element is neither null nor element,
         // throw an "InUseAttributeError" DOMException.
-        if let Some(owner) = attr.GetOwnerElement() &&
-            &*owner != self
+        if let Some(owner) = attr.GetOwnerElement()
+            && &*owner != self
         {
             return Err(Error::InUseAttribute(None));
         }
@@ -2496,8 +2496,8 @@ impl Element {
         };
         // Step 2: If CSP list contains a header-delivered Content Security Policy,
         // and element has a nonce content attribute whose value is not the empty string, then:
-        if !csp_list.contains_a_header_delivered_content_security_policy() ||
-            self.get_string_attribute(&local_name!("nonce")).is_empty()
+        if !csp_list.contains_a_header_delivered_content_security_policy()
+            || self.get_string_attribute(&local_name!("nonce")).is_empty()
         {
             return;
         }
@@ -2611,9 +2611,9 @@ impl Element {
         }
 
         // Step 9
-        if doc.GetBody().as_deref() == self.downcast::<HTMLElement>() &&
-            doc.quirks_mode() == QuirksMode::Quirks &&
-            !self.is_potentially_scrollable_body()
+        if doc.GetBody().as_deref() == self.downcast::<HTMLElement>()
+            && doc.quirks_mode() == QuirksMode::Quirks
+            && !self.is_potentially_scrollable_body()
         {
             win.scroll(cx, x, y, behavior);
             return;
@@ -2764,15 +2764,15 @@ impl Element {
         if matches!(
             self.upcast::<Node>().type_id(),
             NodeTypeId::Element(ElementTypeId::HTMLElement(
-                HTMLElementTypeId::HTMLAnchorElement |
-                    HTMLElementTypeId::HTMLAreaElement |
-                    HTMLElementTypeId::HTMLButtonElement |
-                    HTMLElementTypeId::HTMLFrameElement |
-                    HTMLElementTypeId::HTMLIFrameElement |
-                    HTMLElementTypeId::HTMLInputElement |
-                    HTMLElementTypeId::HTMLObjectElement |
-                    HTMLElementTypeId::HTMLSelectElement |
-                    HTMLElementTypeId::HTMLTextAreaElement
+                HTMLElementTypeId::HTMLAnchorElement
+                    | HTMLElementTypeId::HTMLAreaElement
+                    | HTMLElementTypeId::HTMLButtonElement
+                    | HTMLElementTypeId::HTMLFrameElement
+                    | HTMLElementTypeId::HTMLIFrameElement
+                    | HTMLElementTypeId::HTMLInputElement
+                    | HTMLElementTypeId::HTMLObjectElement
+                    | HTMLElementTypeId::HTMLSelectElement
+                    | HTMLElementTypeId::HTMLTextAreaElement
             ))
         ) {
             return 0;
@@ -2809,8 +2809,9 @@ impl Element {
         // be a bit smarter. For instance, maybe only returning true if any mutation
         // observer is installed on an inclusive ancestor and only if it has an observer
         // with the attribute filter set to include `style`.
-        self.owner_window().get_exists_mut_observer() ||
-            self.get_custom_element_definition()
+        self.owner_window().get_exists_mut_observer()
+            || self
+                .get_custom_element_definition()
                 .is_some_and(|custom_element_definition| {
                     custom_element_definition.has_attribute_changed_callback()
                 })
@@ -3302,9 +3303,9 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         }
 
         // Step 7
-        if doc.GetBody().as_deref() == self.downcast::<HTMLElement>() &&
-            doc.quirks_mode() == QuirksMode::Quirks &&
-            !self.is_potentially_scrollable_body()
+        if doc.GetBody().as_deref() == self.downcast::<HTMLElement>()
+            && doc.quirks_mode() == QuirksMode::Quirks
+            && !self.is_potentially_scrollable_body()
         {
             return win.ScrollY() as f64;
         }
@@ -3353,9 +3354,9 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         }
 
         // Step 9
-        if doc.GetBody().as_deref() == self.downcast::<HTMLElement>() &&
-            doc.quirks_mode() == QuirksMode::Quirks &&
-            !self.is_potentially_scrollable_body()
+        if doc.GetBody().as_deref() == self.downcast::<HTMLElement>()
+            && doc.quirks_mode() == QuirksMode::Quirks
+            && !self.is_potentially_scrollable_body()
         {
             win.scroll(cx, win.ScrollX() as f32, y, behavior);
             return;
@@ -3399,9 +3400,9 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         }
 
         // Step 7
-        if doc.GetBody().as_deref() == self.downcast::<HTMLElement>() &&
-            doc.quirks_mode() == QuirksMode::Quirks &&
-            !self.is_potentially_scrollable_body()
+        if doc.GetBody().as_deref() == self.downcast::<HTMLElement>()
+            && doc.quirks_mode() == QuirksMode::Quirks
+            && !self.is_potentially_scrollable_body()
         {
             return win.ScrollX() as f64;
         }
@@ -3450,9 +3451,9 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         }
 
         // Step 9
-        if doc.GetBody().as_deref() == self.downcast::<HTMLElement>() &&
-            doc.quirks_mode() == QuirksMode::Quirks &&
-            !self.is_potentially_scrollable_body()
+        if doc.GetBody().as_deref() == self.downcast::<HTMLElement>()
+            && doc.quirks_mode() == QuirksMode::Quirks
+            && !self.is_potentially_scrollable_body()
         {
             win.scroll(cx, x, win.ScrollY() as f32, behavior);
             return;
@@ -3663,9 +3664,9 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
 
         // Fast path for when the value is small, doesn't contain any markup and doesn't require
         // extra work to set innerHTML.
-        if !self.node.has_weird_parser_insertion_mode() &&
-            value.len() < 100 &&
-            !value
+        if !self.node.has_weird_parser_insertion_mode()
+            && value.len() < 100
+            && !value
                 .as_bytes()
                 .iter()
                 .any(|c| matches!(*c, b'&' | b'\0' | b'<' | b'\r'))
@@ -4817,8 +4818,8 @@ impl VirtualMethods for Element {
             // All children of this node need to be restyled when any child changes.
             self.upcast::<Node>().dirty(NodeDamage::Other);
         } else {
-            if flags.intersects(ElementSelectorFlags::HAS_SLOW_SELECTOR_LATER_SIBLINGS) &&
-                let Some(next_child) = mutation.next_child()
+            if flags.intersects(ElementSelectorFlags::HAS_SLOW_SELECTOR_LATER_SIBLINGS)
+                && let Some(next_child) = mutation.next_child()
             {
                 for child in next_child.inclusively_following_siblings_unrooted(cx.no_gc()) {
                     if child.is::<Element>() {
@@ -4826,8 +4827,8 @@ impl VirtualMethods for Element {
                     }
                 }
             }
-            if flags.intersects(ElementSelectorFlags::HAS_EDGE_CHILD_SELECTOR) &&
-                let Some(child) = mutation.modified_edge_element(cx.no_gc())
+            if flags.intersects(ElementSelectorFlags::HAS_EDGE_CHILD_SELECTOR)
+                && let Some(child) = mutation.modified_edge_element(cx.no_gc())
             {
                 child.dirty(NodeDamage::Other);
             }
@@ -4875,8 +4876,8 @@ impl Element {
             .rare_data()
             .as_ref()
             .and_then(|data| data.client_rect.as_ref())
-            .and_then(|rect| rect.get().ok()) &&
-            doc.restyle_reason().is_empty()
+            .and_then(|rect| rect.get().ok())
+            && doc.restyle_reason().is_empty()
         {
             return rect;
         }
@@ -4884,8 +4885,8 @@ impl Element {
         let mut rect = self.upcast::<Node>().client_rect();
         let in_quirks_mode = doc.quirks_mode() == QuirksMode::Quirks;
 
-        if (in_quirks_mode && doc.GetBody().as_deref() == self.downcast::<HTMLElement>()) ||
-            (!in_quirks_mode && self.is_document_element())
+        if (in_quirks_mode && doc.GetBody().as_deref() == self.downcast::<HTMLElement>())
+            || (!in_quirks_mode && self.is_document_element())
         {
             rect.size = doc.window().viewport_details().size.round().to_i32();
         }
@@ -5157,8 +5158,8 @@ impl Element {
         let document = self.owner_document();
 
         // Step 1.
-        !document.is_fully_active() ||
-            (
+        !document.is_fully_active()
+            || (
                 // Step 2.
                 !self.is::<HTMLAnchorElement>() && !self.is_connected()
             )
@@ -5200,9 +5201,9 @@ impl Element {
             return;
         }
         let node = self.upcast::<Node>();
-        if let Some(ref parent) = node.GetParentNode() &&
-            parent.is::<HTMLOptGroupElement>() &&
-            parent.downcast::<Element>().unwrap().disabled_state()
+        if let Some(ref parent) = node.GetParentNode()
+            && parent.is::<HTMLOptGroupElement>()
+            && parent.downcast::<Element>().unwrap().disabled_state()
         {
             self.set_disabled_state(true);
             self.set_enabled_state(false);
@@ -5327,14 +5328,14 @@ pub(crate) fn reflect_referrer_policy_attribute(element: &Element) -> DOMString 
         .get_attribute_string_value(&local_name!("referrerpolicy"))
         .map(|value| {
             let value = value.to_ascii_lowercase();
-            if value == "no-referrer" ||
-                value == "no-referrer-when-downgrade" ||
-                value == "same-origin" ||
-                value == "origin" ||
-                value == "strict-origin" ||
-                value == "origin-when-cross-origin" ||
-                value == "strict-origin-when-cross-origin" ||
-                value == "unsafe-url"
+            if value == "no-referrer"
+                || value == "no-referrer-when-downgrade"
+                || value == "same-origin"
+                || value == "origin"
+                || value == "strict-origin"
+                || value == "origin-when-cross-origin"
+                || value == "strict-origin-when-cross-origin"
+                || value == "unsafe-url"
             {
                 DOMString::from(value)
             } else {
@@ -5377,16 +5378,16 @@ pub(crate) fn is_element_affected_by_legacy_background_presentational_hint(
     namespace: &Namespace,
     local_name: &LocalName,
 ) -> bool {
-    *namespace == ns!(html) &&
-        matches!(
+    *namespace == ns!(html)
+        && matches!(
             *local_name,
-            local_name!("body") |
-                local_name!("table") |
-                local_name!("thead") |
-                local_name!("tbody") |
-                local_name!("tfoot") |
-                local_name!("tr") |
-                local_name!("td") |
-                local_name!("th")
+            local_name!("body")
+                | local_name!("table")
+                | local_name!("thead")
+                | local_name!("tbody")
+                | local_name!("tfoot")
+                | local_name!("tr")
+                | local_name!("td")
+                | local_name!("th")
         )
 }

--- a/components/script/dom/element/focus.rs
+++ b/components/script/dom/element/focus.rs
@@ -95,11 +95,11 @@ impl Element {
             //
             // Note: the `hidden` attribute is checked above for all elements.
             NodeTypeId::Element(ElementTypeId::HTMLElement(
-                HTMLElementTypeId::HTMLInputElement |
-                HTMLElementTypeId::HTMLButtonElement |
-                HTMLElementTypeId::HTMLSelectElement |
-                HTMLElementTypeId::HTMLTextAreaElement |
-                HTMLElementTypeId::HTMLIFrameElement,
+                HTMLElementTypeId::HTMLInputElement
+                | HTMLElementTypeId::HTMLButtonElement
+                | HTMLElementTypeId::HTMLSelectElement
+                | HTMLElementTypeId::HTMLTextAreaElement
+                | HTMLElementTypeId::HTMLIFrameElement,
             )) => true,
             _ => {
                 // >  - summary elements that are the first summary element child of a details element
@@ -107,9 +107,9 @@ impl Element {
                 // > -  Elements with a draggable attribute set, if that would enable the user agent to allow
                 // >    the user to begin drag operations for those elements without the use of a pointing device
                 self.downcast::<HTMLElement>()
-                    .is_some_and(|html_element| html_element.is_a_summary_for_its_parent_details()) ||
-                    self.is_editing_host() ||
-                    self.get_string_attribute(&local_name!("draggable")) == "true"
+                    .is_some_and(|html_element| html_element.is_a_summary_for_its_parent_details())
+                    || self.is_editing_host()
+                    || self.get_string_attribute(&local_name!("draggable")) == "true"
             },
         };
 
@@ -128,10 +128,10 @@ impl Element {
             .is_some_and(|axes_overflow| {
                 // This is checking whether there is an input event scrollable overflow value in
                 // a given axis and also overflow in that same axis.
-                (matches!(axes_overflow.x, Overflow::Auto | Overflow::Scroll) &&
-                    self.ScrollWidth() > self.ClientWidth()) ||
-                    (matches!(axes_overflow.y, Overflow::Auto | Overflow::Scroll) &&
-                        self.ScrollHeight() > self.ClientHeight())
+                (matches!(axes_overflow.x, Overflow::Auto | Overflow::Scroll)
+                    && self.ScrollWidth() > self.ClientWidth())
+                    || (matches!(axes_overflow.y, Overflow::Auto | Overflow::Scroll)
+                        && self.ScrollHeight() > self.ClientHeight())
             })
         {
             return FocusableAreaKind::Sequential;

--- a/components/script/dom/elementinternals.rs
+++ b/components/script/dom/elementinternals.rs
@@ -186,9 +186,9 @@ impl ElementInternals {
     }
 
     pub(crate) fn is_invalid(&self, cx: &mut JSContext) -> bool {
-        self.is_target_form_associated() &&
-            self.is_instance_validatable() &&
-            !self.satisfies_constraints(cx)
+        self.is_target_form_associated()
+            && self.is_instance_validatable()
+            && !self.satisfies_constraints(cx)
     }
 
     pub(crate) fn custom_states_for_layout<'a>(&'a self) -> Option<LayoutDom<'a, CustomStateSet>> {
@@ -432,8 +432,8 @@ impl Validatable for ElementInternals {
         // The form-associated custom element is barred from constraint validation,
         // if the readonly attribute is specified, the element is disabled,
         // or the element has a datalist element ancestor.
-        !self.as_element().read_write_state() &&
-            !self.as_element().disabled_state() &&
-            !is_barred_by_datalist_ancestor(self.target_element.upcast::<Node>())
+        !self.as_element().read_write_state()
+            && !self.as_element().disabled_state()
+            && !is_barred_by_datalist_ancestor(self.target_element.upcast::<Node>())
     }
 }

--- a/components/script/dom/event/event.rs
+++ b/components/script/dom/event/event.rs
@@ -347,8 +347,8 @@ impl Event {
 
         // Step 6. If target is not relatedTarget or target is event’s relatedTarget:
         let mut pre_activation_result: Option<InputActivationState> = None;
-        if related_target.as_ref() != Some(&target) ||
-            self.related_target.get().as_ref() == Some(&target)
+        if related_target.as_ref() != Some(&target)
+            || self.related_target.get().as_ref() == Some(&target)
         {
             // Step 6.1. Let touchTargets be a new list.
             // TODO
@@ -373,9 +373,9 @@ impl Event {
 
             // Step 6.5. If isActivationEvent is true and target has activation behavior,
             // then set activationTarget to target.
-            if is_activation_event &&
-                let Some(element) = target.downcast::<Element>() &&
-                element.as_maybe_activatable().is_some()
+            if is_activation_event
+                && let Some(element) = target.downcast::<Element>()
+                && element.as_maybe_activatable().is_some()
             {
                 activation_target = Some(DomRoot::from_ref(element));
             }
@@ -455,11 +455,11 @@ impl Event {
                 if parent.is::<Window>() || root_is_shadow_inclusive_ancestor {
                     // Step 6.9.6.1. If isActivationEvent is true, event’s bubbles attribute is true, activationTarget
                     // is null, and parent has activation behavior, then set activationTarget to parent.
-                    if is_activation_event &&
-                        activation_target.is_none() &&
-                        self.bubbles.get() &&
-                        let Some(element) = parent.downcast::<Element>() &&
-                        element.as_maybe_activatable().is_some()
+                    if is_activation_event
+                        && activation_target.is_none()
+                        && self.bubbles.get()
+                        && let Some(element) = parent.downcast::<Element>()
+                        && element.as_maybe_activatable().is_some()
                     {
                         activation_target = Some(DomRoot::from_ref(element));
                     }
@@ -486,10 +486,10 @@ impl Event {
 
                     // Step 6.9.8.2. If isActivationEvent is true, activationTarget is null, and target has
                     // activation behavior, then set activationTarget to target.
-                    if is_activation_event &&
-                        activation_target.is_none() &&
-                        let Some(element) = parent.downcast::<Element>() &&
-                        element.as_maybe_activatable().is_some()
+                    if is_activation_event
+                        && activation_target.is_none()
+                        && let Some(element) = parent.downcast::<Element>()
+                        && element.as_maybe_activatable().is_some()
                     {
                         activation_target = Some(DomRoot::from_ref(element));
                     }
@@ -534,8 +534,8 @@ impl Event {
                         .shadow_adjusted_target
                         .as_ref()
                         .and_then(|target| target.downcast::<Node>())
-                        .is_some_and(Node::is_in_a_shadow_tree) ||
-                        clear_targets
+                        .is_some_and(Node::is_in_a_shadow_tree)
+                        || clear_targets
                             .related_target
                             .as_ref()
                             .and_then(|target| target.downcast::<Node>())
@@ -636,8 +636,8 @@ impl Event {
                     let vtable = vtable_for(node);
                     vtable.handle_event(cx, self);
                 }
-            } else if let Some(target) = self.GetTarget() &&
-                let Some(node) = target.downcast::<Node>()
+            } else if let Some(target) = self.GetTarget()
+                && let Some(node) = target.downcast::<Node>()
             {
                 let vtable = vtable_for(node);
                 vtable.handle_event(cx, self);
@@ -1407,8 +1407,8 @@ fn inner_invoke(
         let marker = TimelineMarker::start("DOMEvent".to_owned());
         if compiled_listener
             .call_or_handle_event(cx, &event_target, event, ExceptionHandling::Report)
-            .is_err() &&
-            let Some(flag) = legacy_output_did_listeners_throw
+            .is_err()
+            && let Some(flag) = legacy_output_did_listeners_throw
         {
             flag.set(true);
         }

--- a/components/script/dom/event/eventtarget.rs
+++ b/components/script/dom/event/eventtarget.rs
@@ -219,8 +219,8 @@ impl CompiledEventListener {
             CompiledEventListener::Handler(ref handler) => {
                 match *handler {
                     CommonEventHandler::ErrorEventHandler(ref handler) => {
-                        if let Some(event) = event.downcast::<ErrorEvent>() &&
-                            (object.is::<Window>() || object.is::<WorkerGlobalScope>())
+                        if let Some(event) = event.downcast::<ErrorEvent>()
+                            && (object.is::<Window>() || object.is::<WorkerGlobalScope>())
                         {
                             rooted!(&in(cx) let mut error: JSVal);
                             event.Error(error.handle_mut());
@@ -237,9 +237,9 @@ impl CompiledEventListener {
                                 exception_handle,
                             );
                             // Step 4
-                            if let Ok(()) = return_value &&
-                                rooted_return_value.handle().is_boolean() &&
-                                rooted_return_value.handle().to_boolean()
+                            if let Ok(()) = return_value
+                                && rooted_return_value.handle().is_boolean()
+                                && rooted_return_value.handle().to_boolean()
                             {
                                 event.upcast::<Event>().PreventDefault();
                             }
@@ -563,8 +563,8 @@ impl EventTarget {
     pub(crate) fn remove_listener(&self, ty: &Atom, entry: &Rc<RefCell<EventListenerEntry>>) {
         let mut handlers = self.handlers.borrow_mut();
 
-        if let Some(entries) = handlers.get_mut(ty) &&
-            let Some(position) = entries.iter().position(|e| *e == *entry)
+        if let Some(entries) = handlers.get_mut(ty)
+            && let Some(position) = entries.iter().position(|e| *e == *entry)
         {
             entries.remove(position).borrow_mut().removed = true;
             self.notify_listener_removed(ty);
@@ -1036,8 +1036,8 @@ impl EventTarget {
             if !a_root.is::<ShadowRoot>() {
                 return a;
             }
-            if let Some(b_node) = b.downcast::<Node>() &&
-                a_root.is_shadow_including_inclusive_ancestor_of(b_node)
+            if let Some(b_node) = b.downcast::<Node>()
+                && a_root.is_shadow_including_inclusive_ancestor_of(b_node)
             {
                 return a;
             }

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -263,8 +263,8 @@ impl EventSourceContext {
             return;
         }
         // Step 3
-        if let Some(last) = self.data.pop() &&
-            last != '\n'
+        if let Some(last) = self.data.pop()
+            && last != '\n'
         {
             self.data.push(last);
         }

--- a/components/script/dom/execcommand/basecommand.rs
+++ b/components/script/dom/execcommand/basecommand.rs
@@ -381,8 +381,8 @@ impl CommandName {
                 // https://w3c.github.io/editing/docs/execCommand/#the-superscript-command
                 // > or if there is some formattable node effectively contained in
                 // > the active range with effective command value "mixed".
-                if matches!(self, CommandName::Subscript | CommandName::Superscript) &&
-                    effective_command_value == "mixed"
+                if matches!(self, CommandName::Subscript | CommandName::Superscript)
+                    && effective_command_value == "mixed"
                 {
                     at_least_two_different_effective_values = true;
                 }
@@ -494,13 +494,13 @@ impl CommandName {
                         // https://w3c.github.io/editing/docs/execCommand/#the-bold-command
                         // > Either the two strings are equal, or one is "bold" and the other is "700",
                         // > or one is "normal" and the other is "400".
-                        first_str == second_str ||
-                            matches!(
+                        first_str == second_str
+                            || matches!(
                                 (first_str.str().as_ref(), second_str.str().as_ref()),
-                                ("bold", "700") |
-                                    ("700", "bold") |
-                                    ("normal", "400") |
-                                    ("400", "normal")
+                                ("bold", "700")
+                                    | ("700", "bold")
+                                    | ("normal", "400")
+                                    | ("400", "normal")
                             )
                     },
                     CommandName::BackColor | CommandName::ForeColor | CommandName::HiliteColor => {
@@ -622,10 +622,10 @@ impl CommandName {
     pub(crate) fn is_standard_inline_value_command(&self) -> bool {
         matches!(
             self,
-            CommandName::BackColor |
-                CommandName::FontName |
-                CommandName::ForeColor |
-                CommandName::HiliteColor
+            CommandName::BackColor
+                | CommandName::FontName
+                | CommandName::ForeColor
+                | CommandName::HiliteColor
         )
     }
 
@@ -672,21 +672,21 @@ impl CommandName {
     pub(crate) fn is_enabled_in_plaintext_only_state(&self) -> bool {
         matches!(
             self,
-            CommandName::Copy |
-                CommandName::Cut |
-                CommandName::DefaultParagraphSeparator |
-                CommandName::FormatBlock |
-                CommandName::ForwardDelete |
-                CommandName::InsertHtml |
-                CommandName::InsertLineBreak |
-                CommandName::InsertParagraph |
-                CommandName::InsertText |
-                CommandName::Paste |
-                CommandName::Redo |
-                CommandName::StyleWithCss |
-                CommandName::Undo |
-                CommandName::Usecss |
-                CommandName::Delete
+            CommandName::Copy
+                | CommandName::Cut
+                | CommandName::DefaultParagraphSeparator
+                | CommandName::FormatBlock
+                | CommandName::ForwardDelete
+                | CommandName::InsertHtml
+                | CommandName::InsertLineBreak
+                | CommandName::InsertParagraph
+                | CommandName::InsertText
+                | CommandName::Paste
+                | CommandName::Redo
+                | CommandName::StyleWithCss
+                | CommandName::Undo
+                | CommandName::Usecss
+                | CommandName::Delete
         )
     }
 
@@ -694,22 +694,22 @@ impl CommandName {
     fn preserves_overrides(&self) -> bool {
         matches!(
             self,
-            CommandName::Delete |
-                CommandName::FormatBlock |
-                CommandName::ForwardDelete |
-                CommandName::Indent |
-                CommandName::InsertHorizontalRule |
-                CommandName::InsertHtml |
-                CommandName::InsertImage |
-                CommandName::InsertLineBreak |
-                CommandName::InsertOrderedList |
-                CommandName::InsertParagraph |
-                CommandName::InsertUnorderedList |
-                CommandName::JustifyCenter |
-                CommandName::JustifyFull |
-                CommandName::JustifyLeft |
-                CommandName::JustifyRight |
-                CommandName::Outdent
+            CommandName::Delete
+                | CommandName::FormatBlock
+                | CommandName::ForwardDelete
+                | CommandName::Indent
+                | CommandName::InsertHorizontalRule
+                | CommandName::InsertHtml
+                | CommandName::InsertImage
+                | CommandName::InsertLineBreak
+                | CommandName::InsertOrderedList
+                | CommandName::InsertParagraph
+                | CommandName::InsertUnorderedList
+                | CommandName::JustifyCenter
+                | CommandName::JustifyFull
+                | CommandName::JustifyLeft
+                | CommandName::JustifyRight
+                | CommandName::Outdent
         )
     }
 

--- a/components/script/dom/execcommand/commands/delete.rs
+++ b/components/script/dom/execcommand/commands/delete.rs
@@ -54,10 +54,10 @@ pub(crate) fn execute_delete_command(
     loop {
         // Step 4.1. If offset is zero and node's previousSibling is an editable invisible node,
         // remove node's previousSibling from its parent.
-        if offset == 0 &&
-            let Some(sibling) = node.GetPreviousSibling() &&
-            sibling.is_editable() &&
-            sibling.is_invisible(cx.no_gc())
+        if offset == 0
+            && let Some(sibling) = node.GetPreviousSibling()
+            && sibling.is_editable()
+            && sibling.is_invisible(cx.no_gc())
         {
             sibling.remove_self(cx);
             continue;
@@ -69,9 +69,9 @@ pub(crate) fn execute_delete_command(
                 .children_unrooted(cx.no_gc())
                 .nth(offset as usize - 1)
                 .map(|node| node.as_rooted());
-            if let Some(child) = child &&
-                child.is_editable() &&
-                child.is_invisible(cx.no_gc())
+            if let Some(child) = child
+                && child.is_editable()
+                && child.is_invisible(cx.no_gc())
             {
                 child.remove_self(cx);
                 offset -= 1;
@@ -99,9 +99,9 @@ pub(crate) fn execute_delete_command(
                 }
                 // Step 4.5. Otherwise, if node has a child with index offset − 1 and that child is not a block node or a br or an img,
                 // set node to that child, then set offset to the length of node.
-                if !(child.is_block_node() ||
-                    child.is::<HTMLBRElement>() ||
-                    child.is::<HTMLImageElement>())
+                if !(child.is_block_node()
+                    || child.is::<HTMLBRElement>()
+                    || child.is::<HTMLImageElement>())
                 {
                     node = child;
                     offset = node.len();
@@ -115,15 +115,16 @@ pub(crate) fn execute_delete_command(
 
     // Step 5. If node is a Text node and offset is not zero, or if node is
     // a block node that has a child with index offset − 1 and that child is a br or hr or img:
-    if (node.is::<Text>() && offset != 0) ||
-        (offset > 0 &&
-            node.is_block_node() &&
-            node.children_unrooted(cx.no_gc())
+    if (node.is::<Text>() && offset != 0)
+        || (offset > 0
+            && node.is_block_node()
+            && node
+                .children_unrooted(cx.no_gc())
                 .nth(offset as usize - 1)
                 .is_some_and(|child| {
-                    child.is::<HTMLBRElement>() ||
-                        child.is::<HTMLHRElement>() ||
-                        child.is::<HTMLImageElement>()
+                    child.is::<HTMLBRElement>()
+                        || child.is::<HTMLHRElement>()
+                        || child.is::<HTMLImageElement>()
                 }))
     {
         // Step 5.1. Call collapse(node, offset) on the context object's selection.
@@ -154,8 +155,8 @@ pub(crate) fn execute_delete_command(
     ) && node
         .GetParentNode()
         .and_then(|parent| parent.children_unrooted(cx.no_gc()).next())
-        .is_some_and(|first| **first == *node) &&
-        offset == 0
+        .is_some_and(|first| **first == *node)
+        && offset == 0
     {
         // Step 7.1. Let items be a list of all lis that are ancestors of node.
         // TODO
@@ -171,8 +172,8 @@ pub(crate) fn execute_delete_command(
         // any of its ancestors in the same editing host,
         // set the tag name of node to the default single-line container name
         // and let node be the result.
-        if node_matches_local_name!(node, local_name!("dd") | local_name!("dt")) &&
-            node.is_no_allowed_child_in_same_editing_host()
+        if node_matches_local_name!(node, local_name!("dd") | local_name!("dt"))
+            && node.is_no_allowed_child_in_same_editing_host()
         {
             node = node
                 .downcast::<Element>()
@@ -215,9 +216,9 @@ pub(crate) fn execute_delete_command(
             .children_unrooted(cx.no_gc())
             .nth(start_offset as usize - 1)
             .map(|node| node.as_rooted());
-        if let Some(child) = child &&
-            child.is_editable() &&
-            child.is_invisible(cx.no_gc())
+        if let Some(child) = child
+            && child.is_editable()
+            && child.is_invisible(cx.no_gc())
         {
             child.remove_self(cx);
             start_offset -= 1;
@@ -244,15 +245,15 @@ pub(crate) fn execute_delete_command(
 
     // Step 13. If offset is zero; and either the child of start node with index start offset
     // minus one is an hr, or the child is a br whose previousSibling is either a br or not an inline node:
-    if offset == 0 &&
-        (start_offset > 0 &&
-            start_node
+    if offset == 0
+        && (start_offset > 0
+            && start_node
                 .children_unrooted(cx.no_gc())
                 .nth(start_offset as usize - 1)
                 .is_some_and(|child| {
-                    child.is::<HTMLHRElement>() ||
-                        (child.is::<HTMLBRElement>() &&
-                            child.GetPreviousSibling().is_some_and(|previous| {
+                    child.is::<HTMLHRElement>()
+                        || (child.is::<HTMLBRElement>()
+                            && child.GetPreviousSibling().is_some_and(|previous| {
                                 previous.is::<HTMLBRElement>() || !previous.is_inline_node()
                             }))
                 }))

--- a/components/script/dom/execcommand/commands/insertparagraph.rs
+++ b/components/script/dom/execcommand/commands/insertparagraph.rs
@@ -50,10 +50,10 @@ pub(crate) fn execute_insert_paragraph_command(
     }
     // Step 4. If node is a Text node, and offset is neither 0 nor the length of node,
     // call splitText(offset) on node.
-    if offset != 0 &&
-        offset != node.len() &&
-        let Some(text_node) = node.downcast::<Text>() &&
-        text_node.SplitText(cx, offset).is_err()
+    if offset != 0
+        && offset != node.len()
+        && let Some(text_node) = node.downcast::<Text>()
+        && text_node.SplitText(cx, offset).is_err()
     {
         unreachable!("Must always be able to split");
     }
@@ -76,19 +76,19 @@ pub(crate) fn execute_insert_paragraph_command(
     // Step 9. While container is not a single-line container,
     // and container's parent is editable and in the same editing host as node,
     // set container to its parent.
-    while !container.is_single_line_container() &&
-        let Some(parent) = container.GetParentNode() &&
-        parent.is_editable() &&
-        parent.same_editing_host(&node)
+    while !container.is_single_line_container()
+        && let Some(parent) = container.GetParentNode()
+        && parent.is_editable()
+        && parent.same_editing_host(&node)
     {
         container = parent;
     }
     // Step 10. If container is an editable single-line container in the same editing host as node,
     // and its local name is "p" or "div":
-    if container.is_editable() &&
-        container.is_single_line_container() &&
-        container.same_editing_host(&node) &&
-        node_matches_local_name!(container, local_name!("p") | local_name!("div"))
+    if container.is_editable()
+        && container.is_single_line_container()
+        && container.same_editing_host(&node)
+        && node_matches_local_name!(container, local_name!("p") | local_name!("div"))
     {
         // Step 10.1. Let outer container equal container.
         let mut outer_container = container.clone();
@@ -97,8 +97,8 @@ pub(crate) fn execute_insert_paragraph_command(
         while !node_matches_local_name!(
             outer_container,
             local_name!("dd") | local_name!("dt") | local_name!("li")
-        ) && let Some(parent) = outer_container.GetParentNode() &&
-            parent.is_editable()
+        ) && let Some(parent) = outer_container.GetParentNode()
+            && parent.is_editable()
         {
             outer_container = parent;
         }
@@ -111,9 +111,9 @@ pub(crate) fn execute_insert_paragraph_command(
         }
     }
     // Step 11. If container is not editable or not in the same editing host as node or is not a single-line container:
-    if !container.is_editable() ||
-        !container.same_editing_host(&node) ||
-        !container.is_single_line_container()
+    if !container.is_editable()
+        || !container.same_editing_host(&node)
+        || !container.is_single_line_container()
     {
         // Step 11.1. Let tag be the default single-line container name.
         let tag = document.default_single_line_container_name();
@@ -223,9 +223,9 @@ pub(crate) fn execute_insert_paragraph_command(
     if node_matches_local_name!(
         container,
         local_name!("li") | local_name!("dt") | local_name!("dd")
-    ) && (container.children_count() == 0 ||
-        (container.children_count() == 1 &&
-            container
+    ) && (container.children_count() == 0
+        || (container.children_count() == 1
+            && container
                 .children()
                 .next()
                 .expect("has one child")
@@ -244,8 +244,8 @@ pub(crate) fn execute_insert_paragraph_command(
         // Step 13.3. If container is a dd or dt,
         // and it is not an allowed child of any of its ancestors in the same editing host,
         // set the tag name of container to the default single-line container name and let container be the result.
-        if node_matches_local_name!(container, local_name!("dd") | local_name!("dt")) &&
-            container.is_no_allowed_child_in_same_editing_host()
+        if node_matches_local_name!(container, local_name!("dd") | local_name!("dt"))
+            && container.is_no_allowed_child_in_same_editing_host()
         {
             container = container
                 .downcast::<Element>()
@@ -265,8 +265,8 @@ pub(crate) fn execute_insert_paragraph_command(
     // Step 15. While new line range's start offset is zero and its start node
     // is not a prohibited paragraph child,
     // set its start to (parent of start node, index of start node).
-    while new_line_range.start_offset() == 0 &&
-        !new_line_range
+    while new_line_range.start_offset() == 0
+        && !new_line_range
             .start_container()
             .is_prohibited_paragraph_child()
     {
@@ -279,8 +279,8 @@ pub(crate) fn execute_insert_paragraph_command(
     // Step 16. While new line range's start offset is the length of its start node
     // and its start node is not a prohibited paragraph child,
     // set its start to (parent of start node, 1 + index of start node).
-    while new_line_range.start_offset() == new_line_range.start_container().len() &&
-        !new_line_range
+    while new_line_range.start_offset() == new_line_range.start_container().len()
+        && !new_line_range
             .start_container()
             .is_prohibited_paragraph_child()
     {
@@ -295,8 +295,8 @@ pub(crate) fn execute_insert_paragraph_command(
         .contained_children()
         .is_ok_and(|contained_children| {
             let contained_children = contained_children.contained_children;
-            contained_children.is_empty() ||
-                (contained_children.len() == 1 && contained_children[0].is::<HTMLBRElement>())
+            contained_children.is_empty()
+                || (contained_children.len() == 1 && contained_children[0].is::<HTMLBRElement>())
         });
     // Step 18. If the local name of container is "h1", "h2", "h3", "h4", "h5", or "h6",
     // and end of line is true, let new container name be the default single-line container name.
@@ -304,15 +304,15 @@ pub(crate) fn execute_insert_paragraph_command(
         .downcast::<Element>()
         .expect("Must always be an element");
     let container_name = container_as_element.local_name();
-    let new_container_name = if end_of_line &&
-        matches!(
+    let new_container_name = if end_of_line
+        && matches!(
             *container_name,
-            local_name!("h1") |
-                local_name!("h2") |
-                local_name!("h3") |
-                local_name!("h4") |
-                local_name!("h5") |
-                local_name!("h6")
+            local_name!("h1")
+                | local_name!("h2")
+                | local_name!("h3")
+                | local_name!("h4")
+                | local_name!("h5")
+                | local_name!("h6")
         ) {
         document
             .default_single_line_container_name()
@@ -362,8 +362,8 @@ pub(crate) fn execute_insert_paragraph_command(
     // Step 28. Unset the id attribute (if any) of each Element descendant of frag
     // that is not in contained nodes.
     for descendant in frag_as_node.traverse_preorder(ShadowIncluding::No) {
-        if !contained_nodes.contained_children.contains(&descendant) &&
-            let Some(descendant) = descendant.downcast::<Element>()
+        if !contained_nodes.contained_children.contains(&descendant)
+            && let Some(descendant) = descendant.downcast::<Element>()
         {
             descendant.remove_attribute_by_name(cx, &local_name!("id"));
         }

--- a/components/script/dom/execcommand/commands/removeformat.rs
+++ b/components/script/dom/execcommand/commands/removeformat.rs
@@ -25,35 +25,35 @@ fn is_remove_format_candidate(element: &Element) -> bool {
     // > "samp", "small", "span", "strike", "strong", "sub", "sup", "tt", "u", or "var".
     matches!(
         *element.local_name(),
-        local_name!("abbr") |
-            local_name!("acronym") |
-            local_name!("b") |
-            local_name!("bdi") |
-            local_name!("bdo") |
-            local_name!("big") |
-            local_name!("blink") |
-            local_name!("cite") |
-            local_name!("code") |
-            local_name!("dfn") |
-            local_name!("em") |
-            local_name!("font") |
-            local_name!("i") |
-            local_name!("ins") |
-            local_name!("kbd") |
-            local_name!("mark") |
-            local_name!("nobr") |
-            local_name!("q") |
-            local_name!("s") |
-            local_name!("samp") |
-            local_name!("small") |
-            local_name!("span") |
-            local_name!("strike") |
-            local_name!("strong") |
-            local_name!("sub") |
-            local_name!("sup") |
-            local_name!("tt") |
-            local_name!("u") |
-            local_name!("var")
+        local_name!("abbr")
+            | local_name!("acronym")
+            | local_name!("b")
+            | local_name!("bdi")
+            | local_name!("bdo")
+            | local_name!("big")
+            | local_name!("blink")
+            | local_name!("cite")
+            | local_name!("code")
+            | local_name!("dfn")
+            | local_name!("em")
+            | local_name!("font")
+            | local_name!("i")
+            | local_name!("ins")
+            | local_name!("kbd")
+            | local_name!("mark")
+            | local_name!("nobr")
+            | local_name!("q")
+            | local_name!("s")
+            | local_name!("samp")
+            | local_name!("small")
+            | local_name!("span")
+            | local_name!("strike")
+            | local_name!("strong")
+            | local_name!("sub")
+            | local_name!("sup")
+            | local_name!("tt")
+            | local_name!("u")
+            | local_name!("var")
     )
 }
 
@@ -69,8 +69,8 @@ pub(crate) fn execute_removeformat_command(
         .expect("Must always have an active range");
     let mut elements = vec![];
     active_range.for_each_effectively_contained_child(|node| {
-        if let Some(html_element) = node.downcast::<HTMLElement>() &&
-            is_remove_format_candidate(html_element.upcast())
+        if let Some(html_element) = node.downcast::<HTMLElement>()
+            && is_remove_format_candidate(html_element.upcast())
         {
             elements.push(DomRoot::from_ref(node));
         }
@@ -95,10 +95,10 @@ pub(crate) fn execute_removeformat_command(
     // to the result, and its start offset to zero.
     let start_node = active_range.start_container();
     let start_offset = active_range.start_offset();
-    if start_node.is_editable() &&
-        start_offset != 0 &&
-        start_offset != start_node.len() &&
-        let Some(start_text) = start_node.downcast::<Text>()
+    if start_node.is_editable()
+        && start_offset != 0
+        && start_offset != start_node.len()
+        && let Some(start_text) = start_node.downcast::<Text>()
     {
         let Ok(start_text) = start_text.SplitText(cx, start_offset) else {
             unreachable!("Must always be able to split");
@@ -111,11 +111,11 @@ pub(crate) fn execute_removeformat_command(
     // equal to the active range's end offset.
     let end_node = active_range.end_container();
     let end_offset = active_range.end_offset();
-    if end_node.is_editable() &&
-        end_offset != 0 &&
-        end_offset != end_node.len() &&
-        let Some(end_text) = end_node.downcast::<Text>() &&
-        end_text.SplitText(cx, end_offset).is_err()
+    if end_node.is_editable()
+        && end_offset != 0
+        && end_offset != end_node.len()
+        && let Some(end_text) = end_node.downcast::<Text>()
+        && end_text.SplitText(cx, end_offset).is_err()
     {
         unreachable!("Must always be able to split");
     };

--- a/components/script/dom/execcommand/commands/unlink.rs
+++ b/components/script/dom/execcommand/commands/unlink.rs
@@ -22,8 +22,8 @@ pub(crate) fn execute_unlink_command(cx: &mut JSContext, selection: &Selection) 
         .expect("Must always have an active range");
     let mut hyperlinks = vec![];
     active_range.for_each_effectively_contained_child(|node| {
-        if let Some(anchor) = node.downcast::<HTMLAnchorElement>() &&
-            anchor
+        if let Some(anchor) = node.downcast::<HTMLAnchorElement>()
+            && anchor
                 .upcast::<Element>()
                 .has_attribute(&local_name!("href"))
         {

--- a/components/script/dom/execcommand/contenteditable/element.rs
+++ b/components/script/dom/execcommand/contenteditable/element.rs
@@ -101,8 +101,8 @@ impl Element {
         }
         // Step 11. If element is a font element that has an attribute whose effect is to create a presentational hint for property,
         // return the value that the hint sets property to. (For a size of 7, this will be the non-CSS value "xxx-large".)
-        if self.is::<HTMLFontElement>() &&
-            let Some(font_size) = self
+        if self.is::<HTMLFontElement>()
+            && let Some(font_size) = self
                 .with_attribute(&ns!(), &local_name!("size"), |attribute| {
                     if let AttrValue::UInt(_, value) = *attribute.value() {
                         Some(value)
@@ -149,15 +149,15 @@ impl Element {
             ))
         ) || matches!(
             *self.local_name(),
-            local_name!("b") |
-                local_name!("em") |
-                local_name!("i") |
-                local_name!("s") |
-                local_name!("strike") |
-                local_name!("strong") |
-                local_name!("sub") |
-                local_name!("sup") |
-                local_name!("u")
+            local_name!("b")
+                | local_name!("em")
+                | local_name!("i")
+                | local_name!("s")
+                | local_name!("strike")
+                | local_name!("strong")
+                | local_name!("sub")
+                | local_name!("sup")
+                | local_name!("u")
         ) {
             return attrs.all(|attr| attr.local_name() == &local_name!("style"));
         }
@@ -172,10 +172,10 @@ impl Element {
             return attrs.all(|attr| {
                 matches!(
                     *attr.local_name(),
-                    local_name!("style") |
-                        local_name!("color") |
-                        local_name!("face") |
-                        local_name!("size")
+                    local_name!("style")
+                        | local_name!("color")
+                        | local_name!("face")
+                        | local_name!("size")
                 )
             });
         }
@@ -216,18 +216,18 @@ impl Element {
         // > "address", "div", "h1", "h2", "h3", "h4", "h5", "h6", "listing", "p", "pre", or "xmp".
         matches!(
             *self.local_name(),
-            local_name!("address") |
-                local_name!("div") |
-                local_name!("h1") |
-                local_name!("h2") |
-                local_name!("h3") |
-                local_name!("h4") |
-                local_name!("h5") |
-                local_name!("h6") |
-                local_name!("listing") |
-                local_name!("p") |
-                local_name!("pre") |
-                local_name!("xmp")
+            local_name!("address")
+                | local_name!("div")
+                | local_name!("h1")
+                | local_name!("h2")
+                | local_name!("h3")
+                | local_name!("h4")
+                | local_name!("h5")
+                | local_name!("h6")
+                | local_name!("listing")
+                | local_name!("p")
+                | local_name!("pre")
+                | local_name!("xmp")
         )
     }
 
@@ -248,15 +248,15 @@ impl Element {
             ))
         ) || matches!(
             *self.local_name(),
-            local_name!("b") |
-                local_name!("em") |
-                local_name!("i") |
-                local_name!("s") |
-                local_name!("strike") |
-                local_name!("strong") |
-                local_name!("sub") |
-                local_name!("sup") |
-                local_name!("u")
+            local_name!("b")
+                | local_name!("em")
+                | local_name!("i")
+                | local_name!("s")
+                | local_name!("strike")
+                | local_name!("strong")
+                | local_name!("sub")
+                | local_name!("sup")
+                | local_name!("u")
         ) {
             // > It is an a, b, em, font, i, s, span, strike, strong, sub, sup, or u element with no attributes.
             if attr_count == 0 {
@@ -266,9 +266,9 @@ impl Element {
             // > It is an a, b, em, font, i, s, span, strike, strong, sub, sup, or u element
             // > with exactly one attribute, which is style,
             // > which sets no CSS properties (including invalid or unrecognized properties).
-            if attr_count == 1 &&
-                attrs.first().expect("Size is 1").local_name() == &local_name!("style") &&
-                self.has_empty_style_attribute()
+            if attr_count == 1
+                && attrs.first().expect("Size is 1").local_name() == &local_name!("style")
+                && self.has_empty_style_attribute()
             {
                 return true;
             }
@@ -298,9 +298,9 @@ impl Element {
                 HTMLElementTypeId::HTMLFontElement,
             ))
         ) {
-            return only_attribute == &local_name!("color") ||
-                only_attribute == &local_name!("face") ||
-                only_attribute == &local_name!("size");
+            return only_attribute == &local_name!("color")
+                || only_attribute == &local_name!("face")
+                || only_attribute == &local_name!("size");
         }
 
         if only_attribute != &local_name!("style") {
@@ -319,16 +319,16 @@ impl Element {
         // > and the style attribute sets exactly one CSS property
         // > (including invalid or unrecognized properties), which is "font-weight".
         if matches!(*self.local_name(), local_name!("b") | local_name!("strong")) {
-            return style.len() == 1 &&
-                style.contains(PropertyDeclarationId::Longhand(LonghandId::FontWeight));
+            return style.len() == 1
+                && style.contains(PropertyDeclarationId::Longhand(LonghandId::FontWeight));
         }
 
         // > It is an i or em element with exactly one attribute, which is style,
         // > and the style attribute sets exactly one CSS property (including invalid or unrecognized properties),
         // > which is "font-style".
         if matches!(*self.local_name(), local_name!("i") | local_name!("em")) {
-            return style.len() == 1 &&
-                style.contains(PropertyDeclarationId::Longhand(LonghandId::FontStyle));
+            return style.len() == 1
+                && style.contains(PropertyDeclarationId::Longhand(LonghandId::FontStyle));
         }
 
         let a_font_or_span = matches!(
@@ -348,8 +348,8 @@ impl Element {
         if a_font_or_span || s_strike_or_u {
             // Note that the shorthand "text-decoration" expands to 3 longhands. Hence we check if the length
             // is 3 here, instead of 1.
-            if style.len() == 3 &&
-                style
+            if style.len() == 3
+                && style
                     .shorthand_to_css(ShorthandId::TextDecoration, &mut String::new())
                     .is_ok()
             {
@@ -363,10 +363,10 @@ impl Element {
                     return matches!(
                         text_decoration,
                         PropertyDeclaration::TextDecorationLine(
-                            TextDecorationLine::LINE_THROUGH |
-                                TextDecorationLine::UNDERLINE |
-                                TextDecorationLine::OVERLINE |
-                                TextDecorationLine::NONE
+                            TextDecorationLine::LINE_THROUGH
+                                | TextDecorationLine::UNDERLINE
+                                | TextDecorationLine::OVERLINE
+                                | TextDecorationLine::NONE
                         )
                     );
                 }

--- a/components/script/dom/execcommand/contenteditable/htmlelement.rs
+++ b/components/script/dom/execcommand/contenteditable/htmlelement.rs
@@ -155,8 +155,8 @@ impl HTMLElement {
         }
         // Step 9. If element is an a element and command is "createLink" or "unlink",
         // unset the href property of element.
-        if self.is::<HTMLAnchorElement>() &&
-            matches!(command, CommandName::CreateLink | CommandName::Unlink)
+        if self.is::<HTMLAnchorElement>()
+            && matches!(command, CommandName::CreateLink | CommandName::Unlink)
         {
             element.remove_attribute_by_name(cx, &local_name!("href"));
         }
@@ -213,8 +213,8 @@ impl HTMLElement {
                         .GetParentElement()
                         .and_then(|parent| parent.style())
                         .is_some_and(|style| {
-                            style.get_inherited_text().white_space_collapse ==
-                                WhiteSpaceCollapse::Preserve
+                            style.get_inherited_text().white_space_collapse
+                                == WhiteSpaceCollapse::Preserve
                         });
                     if !is_pre_formatted_text_node {
                         // If it isn't pre-formatted, then we should instead select the

--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -161,9 +161,9 @@ where
     // In that case, the spec algorithm would update the selection to the parent of the text node.
     // However, this then breaks the algorithm to compute "effectively contained" nodes. To remedy
     // that, we record the values here and reset them as part of step 2.
-    let end_offsets_if_previously_selected_single_text_node = if active_range.start_container() ==
-        active_range.end_container() &&
-        active_range.start_container().is::<Text>()
+    let end_offsets_if_previously_selected_single_text_node = if active_range.start_container()
+        == active_range.end_container()
+        && active_range.start_container().is::<Text>()
     {
         Some((
             active_range.start_container(),
@@ -258,14 +258,14 @@ pub(crate) fn is_allowed_child(child: NodeOrString, parent: NodeOrString) -> boo
     }
     // Step 2. If parent is "script", "style", "plaintext", or "xmp",
     // or an HTML element with local name equal to one of those, and child is not a Text node, return false.
-    if matches!(parent.name(), "script" | "style" | "plaintext" | "xmp") &&
-        child.as_node().is_none_or(|node| !node.is::<Text>())
+    if matches!(parent.name(), "script" | "style" | "plaintext" | "xmp")
+        && child.as_node().is_none_or(|node| !node.is::<Text>())
     {
         return false;
     }
     // Step 3. If child is a document, DocumentFragment, or DocumentType, return false.
-    if let NodeOrString::Node(ref node) = child &&
-        matches!(
+    if let NodeOrString::Node(ref node) = child
+        && matches!(
             node.type_id(),
             NodeTypeId::Document(_) | NodeTypeId::DocumentFragment(_) | NodeTypeId::DocumentType
         )
@@ -288,8 +288,8 @@ pub(crate) fn is_allowed_child(child: NodeOrString, parent: NodeOrString) -> boo
             // Step 6. If parent is an HTML element:
             if let Some(parent_element) = parent.downcast::<HTMLElement>() {
                 // Step 6.1. If child is "a", and parent or some ancestor of parent is an a, return false.
-                if child == "a" &&
-                    parent
+                if child == "a"
+                    && parent
                         .inclusive_ancestors(ShadowIncluding::No)
                         .any(|node| node.is::<HTMLAnchorElement>())
                 {
@@ -297,8 +297,8 @@ pub(crate) fn is_allowed_child(child: NodeOrString, parent: NodeOrString) -> boo
                 }
                 // Step 6.2. If child is a prohibited paragraph child name and parent or some ancestor of parent
                 // is an element with inline contents, return false.
-                if PROHIBITED_PARAGRAPH_CHILD_NAMES.contains(&child) &&
-                    parent
+                if PROHIBITED_PARAGRAPH_CHILD_NAMES.contains(&child)
+                    && parent
                         .inclusive_ancestors(ShadowIncluding::No)
                         .any(|node| is_element_with_inline_contents(&node))
                 {
@@ -307,8 +307,8 @@ pub(crate) fn is_allowed_child(child: NodeOrString, parent: NodeOrString) -> boo
                 // Step 6.3. If child is "h1", "h2", "h3", "h4", "h5", or "h6",
                 // and parent or some ancestor of parent is an HTML element with local name
                 // "h1", "h2", "h3", "h4", "h5", or "h6", return false.
-                if matches!(child, "h1" | "h2" | "h3" | "h4" | "h5" | "h6") &&
-                    parent.inclusive_ancestors(ShadowIncluding::No).any(|node| {
+                if matches!(child, "h1" | "h2" | "h3" | "h4" | "h5" | "h6")
+                    && parent.inclusive_ancestors(ShadowIncluding::No).any(|node| {
                         node.downcast::<HTMLElement>().is_some_and(|html_element| {
                             matches!(
                                 html_element.local_name(),
@@ -353,20 +353,20 @@ pub(crate) fn is_allowed_child(child: NodeOrString, parent: NodeOrString) -> boo
     // "html", "tbody", "td", "tfoot", "th", "thead", or "tr", return false.
     if matches!(
         child,
-        "body" |
-            "caption" |
-            "col" |
-            "colgroup" |
-            "frame" |
-            "frameset" |
-            "head" |
-            "html" |
-            "tbody" |
-            "td" |
-            "tfoot" |
-            "th" |
-            "thead" |
-            "tr"
+        "body"
+            | "caption"
+            | "col"
+            | "colgroup"
+            | "frame"
+            | "frameset"
+            | "head"
+            | "html"
+            | "tbody"
+            | "td"
+            | "tfoot"
+            | "th"
+            | "thead"
+            | "tr"
     ) {
         return false;
     }
@@ -456,9 +456,9 @@ pub(crate) fn split_the_parent<'a>(cx: &mut JSContext, node_list: &'a [&'a Node]
         }
         // Step 6.2. If precedes line break is true, and the last member of node list does not precede a line break,
         // call createElement("br") on the context object and insert the result immediately after the last member of node list.
-        if precedes_line_break &&
-            let Some(last) = node_list.last() &&
-            !last.precedes_a_line_break(cx.no_gc())
+        if precedes_line_break
+            && let Some(last) = node_list.last()
+            && !last.precedes_a_line_break(cx.no_gc())
         {
             let br = context_object.create_element(cx, "br");
             if last
@@ -498,8 +498,8 @@ pub(crate) fn split_the_parent<'a>(cx: &mut JSContext, node_list: &'a [&'a Node]
             if node_list
                 .first()
                 .and_then(|first| first.GetPreviousSibling())
-                .is_some() &&
-                let Some(first_of_original) = original_parent.children().next()
+                .is_some()
+                && let Some(first_of_original) = original_parent.children().next()
             {
                 move_preserving_ranges(cx, &first_of_original, |cx| {
                     cloned_parent.AppendChild(cx, &first_of_original)
@@ -517,9 +517,9 @@ pub(crate) fn split_the_parent<'a>(cx: &mut JSContext, node_list: &'a [&'a Node]
     }
     // Step 9. If follows line break is true, and the first member of node list does not follow a line break,
     // call createElement("br") on the context object and insert the result immediately before the first member of node list.
-    if follows_line_break &&
-        let Some(first) = node_list.first() &&
-        !first.follows_a_line_break(cx.no_gc())
+    if follows_line_break
+        && let Some(first) = node_list.first()
+        && !first.follows_a_line_break(cx.no_gc())
     {
         let br = context_object.create_element(cx, "br");
         if first
@@ -536,10 +536,10 @@ pub(crate) fn split_the_parent<'a>(cx: &mut JSContext, node_list: &'a [&'a Node]
     // remove the first child of original parent from original parent.
     if node_list
         .last()
-        .is_some_and(|last| last.is_inline_node() && !last.is::<HTMLBRElement>()) &&
-        !original_parent.is_inline_node() &&
-        let Some(first_of_original) = original_parent.children().next() &&
-        first_of_original.is::<HTMLBRElement>()
+        .is_some_and(|last| last.is_inline_node() && !last.is::<HTMLBRElement>())
+        && !original_parent.is_inline_node()
+        && let Some(first_of_original) = original_parent.children().next()
+        && first_of_original.is::<HTMLBRElement>()
     {
         assert!(first_of_original.has_parent());
         first_of_original.remove_self(cx);
@@ -551,9 +551,9 @@ pub(crate) fn split_the_parent<'a>(cx: &mut JSContext, node_list: &'a [&'a Node]
         original_parent.remove_self(cx);
         // Step 11.2. If precedes line break is true, and the last member of node list does not precede a line break,
         // call createElement("br") on the context object and insert the result immediately after the last member of node list.
-        if precedes_line_break &&
-            let Some(last) = node_list.last() &&
-            !last.precedes_a_line_break(cx.no_gc())
+        if precedes_line_break
+            && let Some(last) = node_list.last()
+            && !last.precedes_a_line_break(cx.no_gc())
         {
             let br = context_object.create_element(cx, "br");
             if last
@@ -571,9 +571,9 @@ pub(crate) fn split_the_parent<'a>(cx: &mut JSContext, node_list: &'a [&'a Node]
     }
     // Step 13. If node list's last member's nextSibling is null, but its parent is not null,
     // remove extraneous line breaks at the end of node list's last member's parent.
-    if let Some(last) = node_list.last() &&
-        last.GetNextSibling().is_none() &&
-        let Some(parent_of_last) = last.GetParentNode()
+    if let Some(last) = node_list.last()
+        && last.GetNextSibling().is_none()
+        && let Some(parent_of_last) = last.GetParentNode()
     {
         parent_of_last.remove_extraneous_line_breaks_at_the_end_of(cx);
     }
@@ -603,11 +603,11 @@ where
     // Step 3. If node list's last member is an inline node that's not a br,
     // and node list's last member's nextSibling is a br, append that br to node list.
     let mut node_list = node_list;
-    if let Some(last) = node_list.last() &&
-        last.is_inline_node() &&
-        !last.is::<HTMLBRElement>() &&
-        let Some(next_of_last) = last.GetNextSibling() &&
-        next_of_last.is::<HTMLBRElement>()
+    if let Some(last) = node_list.last()
+        && last.is_inline_node()
+        && !last.is::<HTMLBRElement>()
+        && let Some(next_of_last) = last.GetNextSibling()
+        && next_of_last.is::<HTMLBRElement>()
     {
         node_list.push(next_of_last);
     }
@@ -697,16 +697,16 @@ where
         // and the last child of new parent is not a br,
         // call createElement("br") on the ownerDocument of new parent
         // and append the result as the last child of new parent.
-        if !new_parent.is_inline_node() &&
-            new_parent
+        if !new_parent.is_inline_node()
+            && new_parent
                 .rev_children()
                 .find(|child| child.is_visible(cx.no_gc()))
-                .is_some_and(|child| child.is_inline_node()) &&
-            node_list
+                .is_some_and(|child| child.is_inline_node())
+            && node_list
                 .iter()
                 .find(|node| node.is_visible(cx.no_gc()))
-                .is_some_and(|node| node.is_inline_node()) &&
-            new_parent
+                .is_some_and(|node| node.is_inline_node())
+            && new_parent
                 .children_unrooted(cx.no_gc())
                 .last()
                 .is_none_or(|last_child| !last_child.is::<HTMLBRElement>())
@@ -727,17 +727,17 @@ where
         // and the last member of node list is not a br,
         // call createElement("br") on the ownerDocument of new parent
         // and insert the result as the first child of new parent.
-        if !new_parent.is_inline_node() &&
-            new_parent
+        if !new_parent.is_inline_node()
+            && new_parent
                 .children_unrooted(cx.no_gc())
                 .find(|child| child.is_visible(cx.no_gc()))
-                .is_some_and(|child| child.is_inline_node()) &&
-            node_list
+                .is_some_and(|child| child.is_inline_node())
+            && node_list
                 .iter()
                 .rev()
                 .find(|node| node.is_visible(cx.no_gc()))
-                .is_some_and(|node| node.is_inline_node()) &&
-            node_list
+                .is_some_and(|node| node.is_inline_node())
+            && node_list
                 .last()
                 .is_none_or(|last_child| !last_child.is::<HTMLBRElement>())
         {
@@ -768,9 +768,9 @@ where
         original_parent.remove_self(cx);
     }
     // Step 15. If new parent's nextSibling is editable and running sibling criteria on it returns true:
-    if let Some(next_of_new_parent) = new_parent.GetNextSibling() &&
-        next_of_new_parent.is_editable() &&
-        sibling_criteria(&next_of_new_parent)
+    if let Some(next_of_new_parent) = new_parent.GetNextSibling()
+        && next_of_new_parent.is_editable()
+        && sibling_criteria(&next_of_new_parent)
     {
         // Step 15.1. If new parent is not an inline node,
         // but new parent's last child and new parent's nextSibling's first child are both inline nodes,
@@ -781,10 +781,10 @@ where
                 .children_unrooted(cx.no_gc())
                 .last()
                 .map(|node| node.as_rooted());
-            if let Some(last_child_of_new_parent) = child &&
-                last_child_of_new_parent.is_inline_node() &&
-                !last_child_of_new_parent.is::<HTMLBRElement>() &&
-                next_of_new_parent
+            if let Some(last_child_of_new_parent) = child
+                && last_child_of_new_parent.is_inline_node()
+                && !last_child_of_new_parent.is::<HTMLBRElement>()
+                && next_of_new_parent
                     .children()
                     .next()
                     .is_some_and(|first| first.is_inline_node())
@@ -964,8 +964,8 @@ impl Node {
         // append current ancestor to ancestor list, then set current ancestor to its parent.
         while let Some(ancestor) = current_ancestor {
             let ancestor_node = ancestor.upcast::<Node>();
-            if ancestor_node.is_editable() &&
-                !command.are_loosely_equivalent_values(
+            if ancestor_node.is_editable()
+                && !command.are_loosely_equivalent_values(
                     ancestor_node.effective_command_value(command).as_ref(),
                     new_value.as_ref(),
                 )
@@ -988,8 +988,8 @@ impl Node {
         }
         // Step 10. If the effective command value of command is not loosely equivalent to new value on the parent
         // of the last member of ancestor list, and new value is not null, abort this algorithm.
-        if new_value.is_some() &&
-            !last_ancestor
+        if new_value.is_some()
+            && !last_ancestor
                 .upcast::<Node>()
                 .GetParentNode()
                 .is_some_and(|last_ancestor_parent| {
@@ -1021,8 +1021,8 @@ impl Node {
                 .children()
                 .collect::<Vec<DomRoot<Node>>>();
             // Step 11.5. If the specified command value of current ancestor for command is not null, clear the value of current ancestor.
-            if has_command_value &&
-                let Some(html_element) = current_ancestor.downcast::<HTMLElement>()
+            if has_command_value
+                && let Some(html_element) = current_ancestor.downcast::<HTMLElement>()
             {
                 html_element.clear_the_value(cx, command);
             }
@@ -1036,8 +1036,8 @@ impl Node {
                 // nor equivalent to propagated value, continue with the next child.
                 if let Some(child_element) = child.downcast::<Element>() {
                     let specified_value = child_element.specified_command_value(command);
-                    if specified_value.is_some() &&
-                        !command.are_equivalent_values(
+                    if specified_value.is_some()
+                        && !command.are_equivalent_values(
                             specified_value.as_ref(),
                             propagated_value.as_ref(),
                         )
@@ -1076,19 +1076,19 @@ impl Node {
         // and candidate is not a simple modifiable element or candidate's specified command value
         // for command is not equivalent to new value, set candidate to its child.
         loop {
-            if let Some(candidate_element) = candidate.downcast::<Element>() &&
-                candidate_element.is_modifiable_element() &&
-                candidate.children_count() == 1 &&
-                (!candidate_element.is_simple_modifiable_element() ||
-                    !command.are_equivalent_values(
+            if let Some(candidate_element) = candidate.downcast::<Element>()
+                && candidate_element.is_modifiable_element()
+                && candidate.children_count() == 1
+                && (!candidate_element.is_simple_modifiable_element()
+                    || !command.are_equivalent_values(
                         candidate_element.specified_command_value(command).as_ref(),
                         Some(new_value),
                     ))
             {
                 let child = candidate.children().next().expect("Has one child");
 
-                if let Some(child_element) = child.downcast::<Element>() &&
-                    child_element.is_modifiable_element()
+                if let Some(child_element) = child.downcast::<Element>()
+                    && child_element.is_modifiable_element()
                 {
                     candidate = child;
                     continue;
@@ -1099,17 +1099,17 @@ impl Node {
         // Step 3. If candidate is node, or is not a simple modifiable element,
         // or its specified command value is not equivalent to new value,
         // or its effective command value is not loosely equivalent to new value, abort these steps.
-        if *candidate == *self ||
-            !command.are_loosely_equivalent_values(
+        if *candidate == *self
+            || !command.are_loosely_equivalent_values(
                 candidate.effective_command_value(command).as_ref(),
                 Some(new_value),
             )
         {
             return;
         }
-        if let Some(candidate) = candidate.downcast::<Element>() &&
-            (!candidate.is_simple_modifiable_element() ||
-                !command.are_equivalent_values(
+        if let Some(candidate) = candidate.downcast::<Element>()
+            && (!candidate.is_simple_modifiable_element()
+                || !command.are_equivalent_values(
                     candidate.specified_command_value(command).as_ref(),
                     Some(new_value),
                 ))
@@ -1182,12 +1182,12 @@ impl Node {
                     sibling
                         .downcast::<Element>()
                         .is_some_and(|sibling_element| {
-                            sibling_element.is_simple_modifiable_element() &&
-                                command.are_equivalent_values(
+                            sibling_element.is_simple_modifiable_element()
+                                && command.are_equivalent_values(
                                     sibling_element.specified_command_value(command).as_ref(),
                                     Some(new_value),
-                                ) &&
-                                command.are_loosely_equivalent_values(
+                                )
+                                && command.are_loosely_equivalent_values(
                                     sibling.effective_command_value(command).as_ref(),
                                     Some(new_value),
                                 )
@@ -1219,8 +1219,8 @@ impl Node {
                 .filter(|child| {
                     !child.downcast::<Element>().is_some_and(|child_element| {
                         let specified_value = child_element.specified_command_value(command);
-                        specified_value.is_some() &&
-                            !command
+                        specified_value.is_some()
+                            && !command
                                 .are_equivalent_values(specified_value.as_ref(), Some(new_value))
                     })
                 })
@@ -1272,8 +1272,8 @@ impl Node {
                 // Step 10.5. If command is "foreColor", and new value is fully opaque with
                 // red, green, and blue components in the range 0 to 255:
                 CommandName::ForeColor => {
-                    if let Ok(legacy_color) = parse_legacy_color(&new_value.str()) &&
-                        legacy_color.alpha() == Some(OPAQUE)
+                    if let Ok(legacy_color) = parse_legacy_color(&new_value.str())
+                        && legacy_color.alpha() == Some(OPAQUE)
                     {
                         // Step 10.5.1. Let new parent be the result of calling createElement("font") on the ownerDocument of node.
                         let new_font_element = document.create_element(cx, "font");
@@ -1401,8 +1401,8 @@ impl Node {
             // and the effective command value of "strikethrough" for new parent is not "line-through",
             // set the "text-decoration" property of new parent to "line-through".
             CommandName::Strikethrough => {
-                if new_value == "line-through" &&
-                    new_parent
+                if new_value == "line-through"
+                    && new_parent
                         .upcast::<Node>()
                         .effective_command_value(&CommandName::Strikethrough)
                         .is_none_or(|value| value != "line-through")
@@ -1418,8 +1418,8 @@ impl Node {
             // and the effective command value of "underline" for new parent is not "underline",
             // set the "text-decoration" property of new parent to "underline".
             CommandName::Underline => {
-                if new_value == "underline" &&
-                    new_parent
+                if new_value == "underline"
+                    && new_parent
                         .upcast::<Node>()
                         .effective_command_value(&CommandName::Underline)
                         .is_none_or(|value| value != "underline")
@@ -1437,8 +1437,8 @@ impl Node {
         let new_parent = new_parent.upcast::<Node>();
         move_preserving_ranges(cx, self, |cx| new_parent.AppendChild(cx, self));
         // Step 21. If node is an Element and the effective command value of command for node is not loosely equivalent to new value:
-        if self.is::<Element>() &&
-            !command.are_loosely_equivalent_values(
+        if self.is::<Element>()
+            && !command.are_loosely_equivalent_values(
                 self.effective_command_value(command).as_ref(),
                 Some(new_value),
             )
@@ -1458,8 +1458,8 @@ impl Node {
                     !child.downcast::<Element>().is_some_and(|child_element| {
                         let specified_command_value =
                             child_element.specified_command_value(command);
-                        specified_command_value.is_some() &&
-                            !command.are_equivalent_values(
+                        specified_command_value.is_some()
+                            && !command.are_equivalent_values(
                                 specified_command_value.as_ref(),
                                 Some(new_value),
                             )
@@ -1571,9 +1571,9 @@ impl Node {
     /// <https://w3c.github.io/editing/docs/execCommand/#formattable-node>
     pub(crate) fn is_formattable(&self, no_gc: &NoGC) -> bool {
         // > A formattable node is an editable visible node that is either a Text node, an img, or a br.
-        self.is_editable() &&
-            self.is_visible(no_gc) &&
-            (self.is::<Text>() || self.is::<HTMLImageElement>() || self.is::<HTMLBRElement>())
+        self.is_editable()
+            && self.is_visible(no_gc)
+            && (self.is::<Text>() || self.is::<HTMLImageElement>() || self.is::<HTMLBRElement>())
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#single-line-container>
@@ -1583,8 +1583,8 @@ impl Node {
         let Some(element) = self.downcast::<Element>() else {
             return false;
         };
-        element.is_non_list_single_line_container() ||
-            matches!(
+        element.is_non_list_single_line_container()
+            || matches!(
                 *element.local_name(),
                 local_name!("li") | local_name!("dt") | local_name!("dd")
             )
@@ -1668,8 +1668,8 @@ impl Node {
                             .downcast::<Element>()
                             .is_some_and(|sibling_element| {
                                 let attrs = sibling_element.attrs().borrow();
-                                sibling_element.local_name() == &local_name!("dl") &&
-                                    attrs.is_empty()
+                                sibling_element.local_name() == &local_name!("dl")
+                                    && attrs.is_empty()
                             })
                     },
                     |cx| Some(DomRoot::upcast(context_object.create_element(cx, "dl"))),
@@ -1678,8 +1678,8 @@ impl Node {
             }
             // Step 2.2. If "p" is not an allowed child of the editing host of node,
             // abort these steps.
-            if let Some(editing_host) = self.editing_host_of() &&
-                !is_allowed_child(
+            if let Some(editing_host) = self.editing_host_of()
+                && !is_allowed_child(
                     NodeOrString::String("p".to_owned()),
                     NodeOrString::Node(editing_host),
                 )
@@ -1913,8 +1913,8 @@ impl Node {
             // set start node to that child, then set start offset to start node's length.
             if start_offset > 0 {
                 let child = start_node.children().nth(start_offset as usize - 1);
-                if let Some(child) = child &&
-                    start_node.same_editing_host(&child)
+                if let Some(child) = child
+                    && start_node.same_editing_host(&child)
                 {
                     start_node = child;
                     start_offset = start_node.len();
@@ -1924,10 +1924,10 @@ impl Node {
             // Step 3.2. Otherwise, if start offset is zero and start node does not follow a line break
             // and start node's parent is in the same editing host, set start offset to start node's index,
             // then set start node to its parent.
-            if start_offset == 0 &&
-                !start_node.follows_a_line_break(cx.no_gc()) &&
-                let Some(parent) = start_node.GetParentNode() &&
-                parent.same_editing_host(&start_node)
+            if start_offset == 0
+                && !start_node.follows_a_line_break(cx.no_gc())
+                && let Some(parent) = start_node.GetParentNode()
+                && parent.same_editing_host(&start_node)
             {
                 start_offset = start_node.index();
                 start_node = parent;
@@ -1936,8 +1936,8 @@ impl Node {
             // value for "white-space" is neither "pre" nor "pre-wrap" and start offset is not zero
             // and the (start offset − 1)st code unit of start node's data is a space (0x0020) or
             // non-breaking space (0x00A0), subtract one from start offset.
-            if start_offset != 0 &&
-                start_node.downcast::<Text>().is_some_and(|text| {
+            if start_offset != 0
+                && start_node.downcast::<Text>().is_some_and(|text| {
                     text.has_whitespace_and_has_parent_with_whitespace_preserve(
                         start_offset - 1,
                         &[&'\u{0020}', &'\u{00A0}'],
@@ -1960,8 +1960,8 @@ impl Node {
         loop {
             // Step 7.1. If end node has a child in the same editing host with index end offset,
             // set end node to that child, then set end offset to zero.
-            if let Some(child) = end_node.children().nth(end_offset as usize) &&
-                child.same_editing_host(&end_node)
+            if let Some(child) = end_node.children().nth(end_offset as usize)
+                && child.same_editing_host(&end_node)
             {
                 end_node = child;
                 end_offset = 0;
@@ -1972,8 +1972,8 @@ impl Node {
             // and end node's parent is in the same editing host,
             // set end offset to one plus end node's index, then set end node to its parent.
             if end_offset == end_node.len() && !end_node.precedes_a_line_break(cx.no_gc()) {
-                if let Some(parent) = end_node.GetParentNode() &&
-                    parent.same_editing_host(&end_node)
+                if let Some(parent) = end_node.GetParentNode()
+                    && parent.same_editing_host(&end_node)
                 {
                     end_offset = 1 + end_node.index();
                     end_node = parent;
@@ -1984,8 +1984,8 @@ impl Node {
             // is neither "pre" nor "pre-wrap"
             // and end offset is not end node's length and the end offsetth code unit of end node's data
             // is a space (0x0020) or non-breaking space (0x00A0):
-            if let Some(text) = end_node.downcast::<Text>() &&
-                text.has_whitespace_and_has_parent_with_whitespace_preserve(
+            if let Some(text) = end_node.downcast::<Text>()
+                && text.has_whitespace_and_has_parent_with_whitespace_preserve(
                     end_offset,
                     &[&'\u{0020}', &'\u{00A0}'],
                 )
@@ -2027,14 +2027,14 @@ impl Node {
         // Step 8. If fix collapsed space is true, then while (start node, start offset)
         // is before (end node, end offset):
         if fix_collapsed_space {
-            while bp_position(&start_node, start_offset, &end_node, end_offset) ==
-                Some(Ordering::Less)
+            while bp_position(&start_node, start_offset, &end_node, end_offset)
+                == Some(Ordering::Less)
             {
                 // Step 8.1. If end node has a child in the same editing host with index end offset − 1,
                 // set end node to that child, then set end offset to end node's length.
-                if end_offset > 0 &&
-                    let Some(child) = end_node.children().nth(end_offset as usize - 1) &&
-                    child.same_editing_host(&end_node)
+                if end_offset > 0
+                    && let Some(child) = end_node.children().nth(end_offset as usize - 1)
+                    && child.same_editing_host(&end_node)
                 {
                     end_node = child;
                     end_offset = end_node.len();
@@ -2042,9 +2042,9 @@ impl Node {
                 }
                 // Step 8.2. Otherwise, if end offset is zero and end node's parent is in the same editing host,
                 // set end offset to end node's index, then set end node to its parent.
-                if let Some(parent) = end_node.GetParentNode() &&
-                    end_offset == 0 &&
-                    parent.same_editing_host(&end_node)
+                if let Some(parent) = end_node.GetParentNode()
+                    && end_offset == 0
+                    && parent.same_editing_host(&end_node)
                 {
                     end_offset = end_node.index();
                     end_node = parent;
@@ -2054,12 +2054,12 @@ impl Node {
                 // is neither "pre" nor "pre-wrap"
                 // and end offset is end node's length and the last code unit of end node's data
                 // is a space (0x0020) and end node precedes a line break:
-                if let Some(text) = end_node.downcast::<Text>() &&
-                    text.has_whitespace_and_has_parent_with_whitespace_preserve(
+                if let Some(text) = end_node.downcast::<Text>()
+                    && text.has_whitespace_and_has_parent_with_whitespace_preserve(
                         text.data().len() as u32,
                         &[&'\u{0020}'],
-                    ) &&
-                    end_node.precedes_a_line_break(cx.no_gc())
+                    )
+                    && end_node.precedes_a_line_break(cx.no_gc())
                 {
                     // Step 8.3.1. Subtract one from end offset.
                     end_offset -= 1;
@@ -2148,11 +2148,12 @@ impl Node {
         // Step 4. While ref is invisible but not an extraneous line break,
         // and ref does not equal node's parent, set ref to the node before it in tree order.
         loop {
-            if ref_.is_invisible(cx.no_gc()) &&
-                ref_.downcast::<HTMLBRElement>()
-                    .is_none_or(|br| !br.is_extraneous_line_break()) &&
-                let Some(parent) = parent.as_ref() &&
-                ref_ != *parent
+            if ref_.is_invisible(cx.no_gc())
+                && ref_
+                    .downcast::<HTMLBRElement>()
+                    .is_none_or(|br| !br.is_extraneous_line_break())
+                && let Some(parent) = parent.as_ref()
+                && ref_ != *parent
             {
                 ref_ = match ref_.preceding_nodes(parent).nth(0) {
                     None => break,
@@ -2163,8 +2164,9 @@ impl Node {
             break;
         }
         // Step 5. If ref is an editable extraneous line break, remove it from its parent.
-        if ref_.is_editable() &&
-            ref_.downcast::<HTMLBRElement>()
+        if ref_.is_editable()
+            && ref_
+                .downcast::<HTMLBRElement>()
                 .is_some_and(|br| br.is_extraneous_line_break())
         {
             assert!(ref_.has_parent());
@@ -2183,11 +2185,12 @@ impl Node {
         // Step 3. While ref is invisible but not an extraneous line break, and ref does not equal node,
         // set ref to the node before it in tree order.
         loop {
-            if ref_.is_invisible(cx.no_gc()) &&
-                *ref_ != *self &&
-                ref_.downcast::<HTMLBRElement>()
-                    .is_none_or(|br| !br.is_extraneous_line_break()) &&
-                let Some(parent_of_ref) = ref_.GetParentNode()
+            if ref_.is_invisible(cx.no_gc())
+                && *ref_ != *self
+                && ref_
+                    .downcast::<HTMLBRElement>()
+                    .is_none_or(|br| !br.is_extraneous_line_break())
+                && let Some(parent_of_ref) = ref_.GetParentNode()
             {
                 ref_ = match ref_.preceding_nodes(&parent_of_ref).nth(0) {
                     None => break,
@@ -2198,15 +2201,16 @@ impl Node {
             break;
         }
         // Step 4. If ref is an editable extraneous line break:
-        if ref_.is_editable() &&
-            ref_.downcast::<HTMLBRElement>()
+        if ref_.is_editable()
+            && ref_
+                .downcast::<HTMLBRElement>()
                 .is_some_and(|br| br.is_extraneous_line_break())
         {
             // Step 4.1. While ref's parent is editable and invisible, set ref to its parent.
             loop {
-                if let Some(parent) = ref_.GetParentNode() &&
-                    parent.is_editable() &&
-                    parent.is_invisible(cx.no_gc())
+                if let Some(parent) = ref_.GetParentNode()
+                    && parent.is_editable()
+                    && parent.is_invisible(cx.no_gc())
                 {
                     ref_ = parent;
                     continue;

--- a/components/script/dom/execcommand/contenteditable/range.rs
+++ b/components/script/dom/execcommand/contenteditable/range.rs
@@ -140,8 +140,8 @@ impl Range {
         }
         // Step 4. While start offset is zero and start node's parent is not null,
         // set start offset to start node's index, then set start node to its parent.
-        while start_offset == 0 &&
-            let Some(parent) = start_node.GetParentNode()
+        while start_offset == 0
+            && let Some(parent) = start_node.GetParentNode()
         {
             start_offset = start_node.index();
             start_node = parent;
@@ -177,8 +177,8 @@ impl Range {
         }
         // Step 7. While end offset is end node's length and end node's parent is not null,
         // set end offset to one plus end node's index, then set end node to its parent.
-        while end_offset == end_node.len() &&
-            let Some(parent) = end_node.GetParentNode()
+        while end_offset == end_node.len()
+            && let Some(parent) = end_node.GetParentNode()
         {
             end_offset = 1 + end_node.index();
             end_node = parent;
@@ -316,9 +316,9 @@ impl Range {
                             CommandName::FontSize => {
                                 let value_override =
                                     context_object.value_override(&CommandName::FontSize);
-                                if value_override != optional_string ||
-                                    (value_override.is_none() &&
-                                        !CommandName::FontSize.are_loosely_equivalent_values(
+                                if value_override != optional_string
+                                    || (value_override.is_none()
+                                        && !CommandName::FontSize.are_loosely_equivalent_values(
                                             node.effective_command_value(&CommandName::FontSize)
                                                 .as_ref(),
                                             optional_string.as_ref(),

--- a/components/script/dom/execcommand/contenteditable/selection.rs
+++ b/components/script/dom/execcommand/contenteditable/selection.rs
@@ -67,18 +67,18 @@ impl EquivalentPoint for (DomRoot<Node>, u32) {
         }
         // Step 2. If offset is 0, and node's parent is not null, and node is an inline node,
         // return (node's parent, node's index).
-        if *offset == 0 &&
-            node.is_inline_node() &&
-            let Some(parent) = node.GetParentNode()
+        if *offset == 0
+            && node.is_inline_node()
+            && let Some(parent) = node.GetParentNode()
         {
             return Some((parent, node.index()));
         }
         // Step 3. If node has a child with index offset − 1, and that child's length is not zero,
         // and that child is an inline node, return (that child, that child's length).
-        if *offset > 0 &&
-            let Some(child) = node.children().nth(*offset as usize - 1) &&
-            !child.is_empty() &&
-            child.is_inline_node()
+        if *offset > 0
+            && let Some(child) = node.children().nth(*offset as usize - 1)
+            && !child.is_empty()
+            && child.is_inline_node()
         {
             let len = child.len();
             return Some((child, len));
@@ -103,9 +103,9 @@ impl EquivalentPoint for (DomRoot<Node>, u32) {
 
         // Step 3. If offset is node's length, and node's parent is not null, and node is an inline node,
         // return (node's parent, 1 + node's index).
-        if *offset == len &&
-            node.is_inline_node() &&
-            let Some(parent) = node.GetParentNode()
+        if *offset == len
+            && node.is_inline_node()
+            && let Some(parent) = node.GetParentNode()
         {
             return Some((parent, node.index() + 1));
         }
@@ -116,9 +116,9 @@ impl EquivalentPoint for (DomRoot<Node>, u32) {
 
         // Step 5. If node has a child with index offset, and that child's length is not zero,
         // and that child is an inline node, return (that child, 0).
-        if let Some(child) = node.children().nth(*offset as usize) &&
-            !child.is_empty() &&
-            child.is_inline_node()
+        if let Some(child) = node.children().nth(*offset as usize)
+            && !child.is_empty()
+            && child.is_inline_node()
         {
             return Some((child, 0));
         }
@@ -247,9 +247,9 @@ impl Selection {
         // Step 13. While start block's parent is in the same editing host and start block is an inline node,
         // set start block to its parent.
         loop {
-            if start_block.is_inline_node() &&
-                let Some(parent) = start_block.GetParentNode() &&
-                parent.same_editing_host(&start_node)
+            if start_block.is_inline_node()
+                && let Some(parent) = start_block.GetParentNode()
+                && parent.same_editing_host(&start_node)
             {
                 start_block = parent;
                 continue;
@@ -260,12 +260,12 @@ impl Selection {
         // Step 14. If start block is neither a block node nor an editing host,
         // or "span" is not an allowed child of start block,
         // or start block is a td or th, set start block to null.
-        let start_block = if (!start_block.is_block_node() && !start_block.is_editing_host()) ||
-            !is_allowed_child(
+        let start_block = if (!start_block.is_block_node() && !start_block.is_editing_host())
+            || !is_allowed_child(
                 NodeOrString::String("span".to_owned()),
                 NodeOrString::Node(start_block.clone()),
-            ) ||
-            start_block.is::<HTMLTableCellElement>()
+            )
+            || start_block.is::<HTMLTableCellElement>()
         {
             None
         } else {
@@ -277,9 +277,9 @@ impl Selection {
 
         // Step 16. While end block's parent is in the same editing host and end block is an inline node, set end block to its parent.
         loop {
-            if end_block.is_inline_node() &&
-                let Some(parent) = end_block.GetParentNode() &&
-                parent.same_editing_host(&end_block)
+            if end_block.is_inline_node()
+                && let Some(parent) = end_block.GetParentNode()
+                && parent.same_editing_host(&end_block)
             {
                 end_block = parent;
                 continue;
@@ -289,12 +289,12 @@ impl Selection {
 
         // Step 17. If end block is neither a block node nor an editing host, or "span" is not an allowed child of end block,
         // or end block is a td or th, set end block to null.
-        let end_block = if (!end_block.is_block_node() && !end_block.is_editing_host()) ||
-            !is_allowed_child(
+        let end_block = if (!end_block.is_block_node() && !end_block.is_editing_host())
+            || !is_allowed_child(
                 NodeOrString::String("span".to_owned()),
                 NodeOrString::Node(end_block.clone()),
-            ) ||
-            end_block.is::<HTMLTableCellElement>()
+            )
+            || end_block.is::<HTMLTableCellElement>()
         {
             None
         } else {
@@ -313,9 +313,9 @@ impl Selection {
         // This step does not exist in the spec
 
         // Step 21. If start node and end node are the same, and start node is an editable Text node:
-        if start_node == end_node &&
-            start_node.is_editable() &&
-            let Some(start_text) = start_node.downcast::<Text>()
+        if start_node == end_node
+            && start_node.is_editable()
+            && let Some(start_text) = start_node.downcast::<Text>()
         {
             // Step 21.1. Call deleteData(start offset, end offset − start offset) on start node.
             if start_text
@@ -349,9 +349,9 @@ impl Selection {
 
         // Step 22. If start node is an editable Text node, call deleteData() on it, with start offset as
         // the first argument and (length of start node − start offset) as the second argument.
-        if start_node.is_editable() &&
-            let Some(start_text) = start_node.downcast::<Text>() &&
-            start_text
+        if start_node.is_editable()
+            && let Some(start_text) = start_node.downcast::<Text>()
+            && start_text
                 .upcast::<CharacterData>()
                 .DeleteData(cx, start_offset, start_node.len() - start_offset)
                 .is_err()
@@ -378,11 +378,11 @@ impl Selection {
             // `RootedVec<DomRoot<Node>>`. The type alias here doesn't upset test-tidy,
             // while also providing the necessary information to the compiler to work.
             type DomRootNode = DomRoot<Node>;
-            if node.is_editable() &&
-                !(node.is::<HTMLTableSectionElement>() ||
-                    node.is::<HTMLTableRowElement>() ||
-                    node.is::<HTMLTableCellElement>()) &&
-                node_list
+            if node.is_editable()
+                && !(node.is::<HTMLTableSectionElement>()
+                    || node.is::<HTMLTableRowElement>()
+                    || node.is::<HTMLTableCellElement>())
+                && node_list
                     .last()
                     .is_none_or(|last: &DomRootNode| !last.is_ancestor_of(&node))
             {
@@ -413,8 +413,8 @@ impl Selection {
             // Step 25.4. If strip wrappers is true or parent is not an inclusive ancestor of start node,
             // while parent is an editable inline node with length 0, let grandparent be the parent of parent,
             // then remove parent from grandparent, then set parent to grandparent.
-            if strip_wrappers == SelectionDeletionStripWrappers::Strip ||
-                !parent.is_inclusive_ancestor_of(&start_node)
+            if strip_wrappers == SelectionDeletionStripWrappers::Strip
+                || !parent.is_inclusive_ancestor_of(&start_node)
             {
                 let mut parent = parent;
                 loop {
@@ -432,9 +432,9 @@ impl Selection {
         }
 
         // Step 26. If end node is an editable Text node, call deleteData(0, end offset) on it.
-        if end_node.is_editable() &&
-            let Some(end_text) = end_node.downcast::<Text>() &&
-            end_text
+        if end_node.is_editable()
+            && let Some(end_text) = end_node.downcast::<Text>()
+            && end_text
                 .upcast::<CharacterData>()
                 .DeleteData(cx, 0, end_offset)
                 .is_err()
@@ -460,8 +460,8 @@ impl Selection {
 
         // Step 30. If block merging is false, or start block or end block is null, or start block is not
         // in the same editing host as end block, or start block and end block are the same:
-        if block_merging == SelectionDeletionBlockMerging::Skip ||
-            start_block.as_ref().zip(end_block.as_ref()).is_none_or(
+        if block_merging == SelectionDeletionBlockMerging::Skip
+            || start_block.as_ref().zip(end_block.as_ref()).is_none_or(
                 |(start_block, end_block)| {
                     start_block == end_block || !start_block.same_editing_host(end_block)
                 },
@@ -526,10 +526,10 @@ impl Selection {
                 // Step 32.4.1. While end block is editable and is the only child of its parent and is not a child of start block,
                 // let parent equal end block, then remove end block from parent, then set end block to parent.
                 loop {
-                    if end_block.is_editable() &&
-                        start_block.children().all(|child| child != end_block) &&
-                        let Some(parent) = end_block.GetParentNode() &&
-                        parent.children_count() == 1
+                    if end_block.is_editable()
+                        && start_block.children().all(|child| child != end_block)
+                        && let Some(parent) = end_block.GetParentNode()
+                        && parent.children_count() == 1
                     {
                         assert!(end_block.has_parent());
                         end_block.remove_self(cx);
@@ -541,13 +541,13 @@ impl Selection {
                 // Step 32.4.2. If end block is editable and is not an inline node,
                 // and its previousSibling and nextSibling are both inline nodes,
                 // call createElement("br") on the context object and insert it into end block's parent immediately after end block.
-                if end_block.is_editable() &&
-                    !end_block.is_inline_node() &&
-                    end_block
+                if end_block.is_editable()
+                    && !end_block.is_inline_node()
+                    && end_block
                         .GetPreviousSibling()
-                        .is_some_and(|previous| previous.is_inline_node()) &&
-                    let Some(next_of_end_block) = end_block.GetNextSibling() &&
-                    next_of_end_block.is_inline_node()
+                        .is_some_and(|previous| previous.is_inline_node())
+                    && let Some(next_of_end_block) = end_block.GetNextSibling()
+                    && next_of_end_block.is_inline_node()
                 {
                     let br = context_object.create_element(cx, "br");
                     let parent = end_block
@@ -619,10 +619,10 @@ impl Selection {
             }
             // Step 32.11. If children's first member's previousSibling is an editable br,
             // remove that br from its parent.
-            if let Some(first) = children.first() &&
-                let Some(previous_of_first) = first.GetPreviousSibling() &&
-                previous_of_first.is_editable() &&
-                previous_of_first.is::<HTMLBRElement>()
+            if let Some(first) = children.first()
+                && let Some(previous_of_first) = first.GetPreviousSibling()
+                && previous_of_first.is_editable()
+                && previous_of_first.is::<HTMLBRElement>()
             {
                 assert!(previous_of_first.has_parent());
                 previous_of_first.remove_self(cx);
@@ -638,8 +638,8 @@ impl Selection {
             let mut reference_node = start_block.clone();
             // Step 33.3. While reference node is not a child of end block, set reference node to its parent.
             loop {
-                if end_block.children().all(|child| child != reference_node) &&
-                    let Some(parent) = reference_node.GetParentNode()
+                if end_block.children().all(|child| child != reference_node)
+                    && let Some(parent) = reference_node.GetParentNode()
                 {
                     reference_node = parent;
                     continue;
@@ -650,9 +650,9 @@ impl Selection {
             // remove start block's lastChild from it.
             if reference_node
                 .GetNextSibling()
-                .is_some_and(|next| next.is_inline_node()) &&
-                let Some(last) = start_block.children().last() &&
-                last.is::<HTMLBRElement>()
+                .is_some_and(|next| next.is_inline_node())
+                && let Some(last) = start_block.children().last()
+                && last.is::<HTMLBRElement>()
             {
                 assert!(last.has_parent());
                 last.remove_self(cx);
@@ -661,8 +661,8 @@ impl Selection {
             rooted_vec!(let mut nodes_to_move);
             // Step 33.6. If reference node's nextSibling is neither null nor a block node,
             // append it to nodes to move.
-            if let Some(next) = reference_node.GetNextSibling() &&
-                !next.is_block_node()
+            if let Some(next) = reference_node.GetNextSibling()
+                && !next.is_block_node()
             {
                 nodes_to_move.push(next);
             }
@@ -670,10 +670,10 @@ impl Selection {
             // and its last member's nextSibling is neither null nor a block node,
             // append its last member's nextSibling to nodes to move.
             loop {
-                if let Some(last) = nodes_to_move.last() &&
-                    !last.is::<HTMLBRElement>() &&
-                    let Some(next_of_last) = last.GetNextSibling() &&
-                    !next_of_last.is_block_node()
+                if let Some(last) = nodes_to_move.last()
+                    && !last.is::<HTMLBRElement>()
+                    && let Some(next_of_last) = last.GetNextSibling()
+                    && !next_of_last.is_block_node()
                 {
                     nodes_to_move.push(next_of_last);
                     continue;
@@ -700,9 +700,9 @@ impl Selection {
             if end_block
                 .children()
                 .nth(0)
-                .is_some_and(|next| next.is_inline_node()) &&
-                let Some(last) = start_block.children().last() &&
-                last.is::<HTMLBRElement>()
+                .is_some_and(|next| next.is_inline_node())
+                && let Some(last) = start_block.children().last()
+                && last.is::<HTMLBRElement>()
             {
                 assert!(last.has_parent());
                 last.remove_self(cx);
@@ -726,8 +726,8 @@ impl Selection {
             // then set end block to parent.
             let mut end_block = end_block;
             loop {
-                if end_block.children_count() == 0 &&
-                    let Some(parent) = end_block.GetParentNode()
+                if end_block.children_count() == 0
+                    && let Some(parent) = end_block.GetParentNode()
                 {
                     assert!(end_block.has_parent());
                     end_block.remove_self(cx);
@@ -823,10 +823,10 @@ impl Selection {
         // Then set the active range's start node to the result, and its start offset to zero.
         let start_node = active_range.start_container();
         let start_offset = active_range.start_offset();
-        if start_node.is_editable() &&
-            start_offset != 0 &&
-            start_offset != start_node.len() &&
-            let Some(start_text) = start_node.downcast::<Text>()
+        if start_node.is_editable()
+            && start_offset != 0
+            && start_offset != start_node.len()
+            && let Some(start_text) = start_node.downcast::<Text>()
         {
             let Ok(start_text) = start_text.SplitText(cx, start_offset) else {
                 unreachable!("Must always be able to split");
@@ -839,19 +839,19 @@ impl Selection {
         // with argument equal to the active range's end offset.
         let end_node = active_range.end_container();
         let end_offset = active_range.end_offset();
-        if end_node.is_editable() &&
-            end_offset != 0 &&
-            end_offset != end_node.len() &&
-            let Some(end_text) = end_node.downcast::<Text>() &&
-            end_text.SplitText(cx, end_offset).is_err()
+        if end_node.is_editable()
+            && end_offset != 0
+            && end_offset != end_node.len()
+            && let Some(end_text) = end_node.downcast::<Text>()
+            && end_text.SplitText(cx, end_offset).is_err()
         {
             unreachable!("Must always be able to split");
         };
         // Step 5. Let element list be all editable Elements effectively contained in the active range.
         // Step 6. For each element in element list, clear the value of element.
         active_range.for_each_effectively_contained_child(|child| {
-            if child.is_editable() &&
-                let Some(element_child) = child.downcast::<HTMLElement>()
+            if child.is_editable()
+                && let Some(element_child) = child.downcast::<HTMLElement>()
             {
                 element_child.clear_the_value(cx, &command);
             }

--- a/components/script/dom/execcommand/contenteditable/text.rs
+++ b/components/script/dom/execcommand/contenteditable/text.rs
@@ -103,8 +103,8 @@ impl Text {
             // Step 8.3. If reference is a Text node that is not a whitespace node, or is an img, break from this loop.
             if reference
                 .downcast::<Text>()
-                .is_some_and(|text| !text.is_whitespace_node()) ||
-                reference.is::<HTMLImageElement>()
+                .is_some_and(|text| !text.is_whitespace_node())
+                || reference.is::<HTMLImageElement>()
             {
                 break;
             }
@@ -122,8 +122,8 @@ impl Text {
             // Step 10.3. If reference is a Text node that is not a whitespace node, or is an img, break from this loop.
             if reference
                 .downcast::<Text>()
-                .is_some_and(|text| !text.is_whitespace_node()) ||
-                reference.is::<HTMLImageElement>()
+                .is_some_and(|text| !text.is_whitespace_node())
+                || reference.is::<HTMLImageElement>()
             {
                 break;
             }

--- a/components/script/dom/execcommand/execcommands.rs
+++ b/components/script/dom/execcommand/execcommands.rs
@@ -23,12 +23,12 @@ use crate::dom::selection::Selection;
 fn is_command_listed_in_miscellaneous_section(command_name: CommandName) -> bool {
     matches!(
         command_name,
-        CommandName::DefaultParagraphSeparator |
-            CommandName::Redo |
-            CommandName::SelectAll |
-            CommandName::StyleWithCss |
-            CommandName::Undo |
-            CommandName::Usecss
+        CommandName::DefaultParagraphSeparator
+            | CommandName::Redo
+            | CommandName::SelectAll
+            | CommandName::StyleWithCss
+            | CommandName::Undo
+            | CommandName::Usecss
     )
 }
 
@@ -105,9 +105,9 @@ impl Document {
         }
 
         // Some commands are only enabled if the editing host is *not* in plaintext-only state.
-        if !command_name.is_enabled_in_plaintext_only_state() &&
-            (start_container_editing_host.is_in_plaintext_only_state() ||
-                end_container_editing_host.is_in_plaintext_only_state())
+        if !command_name.is_enabled_in_plaintext_only_state()
+            && (start_container_editing_host.is_in_plaintext_only_state()
+                || end_container_editing_host.is_in_plaintext_only_state())
         {
             None
         } else {

--- a/components/script/dom/fetch/headers.rs
+++ b/components/script/dom/fetch/headers.rs
@@ -149,8 +149,8 @@ impl HeadersMethods<crate::DomTypeHolder> for Headers {
 
         // Step 2 If this’s guard is "request-no-cors", name is not a no-CORS-safelisted request-header name,
         // and name is not a privileged no-CORS request-header name, then return.
-        if self.guard.get() == Guard::RequestNoCors &&
-            !is_cors_safelisted_request_header(&valid_name, &b"invalid".to_vec())
+        if self.guard.get() == Guard::RequestNoCors
+            && !is_cors_safelisted_request_header(&valid_name, &b"invalid".to_vec())
         {
             return Ok(());
         }
@@ -215,8 +215,8 @@ impl HeadersMethods<crate::DomTypeHolder> for Headers {
 
         // 3. If this’s guard is "request-no-cors" and (name, value) is not a
         // no-CORS-safelisted request-header, then return.
-        if self.guard.get() == Guard::RequestNoCors &&
-            !is_cors_safelisted_request_header(&valid_name, &valid_value.to_vec())
+        if self.guard.get() == Guard::RequestNoCors
+            && !is_cors_safelisted_request_header(&valid_name, &valid_value.to_vec())
         {
             return Ok(());
         }

--- a/components/script/dom/fetch/request.rs
+++ b/components/script/dom/fetch/request.rs
@@ -191,18 +191,18 @@ impl Request {
         request.integrity_metadata = temporary_request.integrity_metadata;
 
         // Step 13. If init is not empty, then:
-        if init.body.is_some() ||
-            init.cache.is_some() ||
-            init.credentials.is_some() ||
-            init.integrity.is_some() ||
-            init.headers.is_some() ||
-            init.keepalive.is_some() ||
-            init.method.is_some() ||
-            init.mode.is_some() ||
-            init.redirect.is_some() ||
-            init.referrer.is_some() ||
-            init.referrerPolicy.is_some() ||
-            !init.window.handle().is_undefined()
+        if init.body.is_some()
+            || init.cache.is_some()
+            || init.credentials.is_some()
+            || init.integrity.is_some()
+            || init.headers.is_some()
+            || init.keepalive.is_some()
+            || init.method.is_some()
+            || init.mode.is_some()
+            || init.redirect.is_some()
+            || init.referrer.is_some()
+            || init.referrerPolicy.is_some()
+            || !init.window.handle().is_undefined()
         {
             // Step 13.1. If request’s mode is "navigate", then set it to "same-origin".
             if request.mode == NetTraitsRequestMode::Navigate {
@@ -243,10 +243,10 @@ impl Request {
                 // parsedReferrer’s scheme is "about" and path is the string "client"
                 // parsedReferrer’s origin is not same origin with origin
                 if let Ok(parsed_referrer) = parsed_referrer {
-                    if (parsed_referrer.cannot_be_a_base() &&
-                        parsed_referrer.scheme() == "about" &&
-                        parsed_referrer.path() == "client") ||
-                        parsed_referrer.origin() != *origin
+                    if (parsed_referrer.cannot_be_a_base()
+                        && parsed_referrer.scheme() == "about"
+                        && parsed_referrer.path() == "client")
+                        || parsed_referrer.origin() != *origin
                     {
                         // then set request’s referrer to "client".
                         request.referrer = global.get_referrer();
@@ -291,8 +291,8 @@ impl Request {
 
         // Step 21. If request’s cache mode is "only-if-cached" and request’s mode
         // is not "same-origin", then throw a TypeError.
-        if request.cache_mode == CacheMode::OnlyIfCached &&
-            request.mode != NetTraitsRequestMode::SameOrigin
+        if request.cache_mode == CacheMode::OnlyIfCached
+            && request.mode != NetTraitsRequestMode::SameOrigin
         {
             return Err(Error::Type(
                 c"Cache is 'only-if-cached' and mode is not 'same-origin'".to_owned(),
@@ -513,8 +513,8 @@ impl Request {
             // TODO
             // Step 39.2. If this’s request’s mode is neither "same-origin" nor "cors", then throw a TypeError.
             let request_mode = &r.request.borrow().mode;
-            if *request_mode != NetTraitsRequestMode::CorsMode &&
-                *request_mode != NetTraitsRequestMode::SameOrigin
+            if *request_mode != NetTraitsRequestMode::CorsMode
+                && *request_mode != NetTraitsRequestMode::SameOrigin
             {
                 return Err(Error::Type(
                     c"Request mode must be Cors or SameOrigin".to_owned(),

--- a/components/script/dom/fetch/response.rs
+++ b/components/script/dom/fetch/response.rs
@@ -450,8 +450,8 @@ fn initialize_response(
 
         // 6.3 If body’s type is non-null and response’s header list does not contain `Content-Type`,
         // then append (`Content-Type`, body’s type) to response’s header list.
-        if let Some(content_type_contents) = &body.content_type &&
-            !response
+        if let Some(content_type_contents) = &body.content_type
+            && !response
                 .Headers(cx)
                 .Has(ByteString::new(b"Content-Type".to_vec()))
                 .unwrap()

--- a/components/script/dom/form/validitystate.rs
+++ b/components/script/dom/form/validitystate.rs
@@ -129,8 +129,8 @@ impl ValidityState {
         }
 
         // https://html.spec.whatwg.org/multipage/#suffering-from-a-custom-error
-        if update_flags.contains(ValidationFlags::CUSTOM_ERROR) &&
-            !self.custom_error_message().is_empty()
+        if update_flags.contains(ValidationFlags::CUSTOM_ERROR)
+            && !self.custom_error_message().is_empty()
         {
             invalid_flags.insert(ValidationFlags::CUSTOM_ERROR);
         }
@@ -157,8 +157,8 @@ impl ValidityState {
             self.element.set_state(ElementState::INVALID, false);
         }
 
-        if let Some(form_control) = self.element.as_maybe_form_control() &&
-            let Some(form_owner) = form_control.form_owner()
+        if let Some(form_control) = self.element.as_maybe_form_control()
+            && let Some(form_owner) = form_control.form_owner()
         {
             form_owner.update_validity(cx);
         }

--- a/components/script/dom/fullscreen/lib.rs
+++ b/components/script/dom/fullscreen/lib.rs
@@ -226,8 +226,8 @@ impl DocumentOrShadowRoot {
         fullscreen_element: Option<DomRoot<Element>>,
     ) -> Option<DomRoot<Element>> {
         // Step 1. If this is a shadow root and its host is not connected, then return null.
-        if let Some(shadow_root) = node.downcast::<ShadowRoot>() &&
-            !shadow_root.Host().is_connected()
+        if let Some(shadow_root) = node.downcast::<ShadowRoot>()
+            && !shadow_root.Host().is_connected()
         {
             return None;
         }
@@ -242,8 +242,8 @@ impl DocumentOrShadowRoot {
         // Step 3. If candidate and this are in the same tree, then return candidate.
         if *candidate
             .upcast::<Node>()
-            .GetRootNode(&GetRootNodeOptions::empty()) ==
-            *node
+            .GetRootNode(&GetRootNodeOptions::empty())
+            == *node
         {
             return Some(candidate);
         }
@@ -301,9 +301,9 @@ impl TaskOnce for ElementPerformFullscreenEnter {
         // > If error is true:
         // > - Append (fullscreenerror, this) to pendingDoc’s list of pending fullscreen events.
         // > - Reject promise with a TypeError exception and terminate these steps.
-        if self.document.root() != document ||
-            !element.fullscreen_element_ready_check() ||
-            self.error
+        if self.document.root() != document
+            || !element.fullscreen_element_ready_check()
+            || self.error
         {
             // TODO(#31866): we should queue this and fire them in update the rendering.
             document

--- a/components/script/dom/geometry/dommatrixreadonly.rs
+++ b/components/script/dom/geometry/dommatrixreadonly.rs
@@ -667,22 +667,22 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-isidentity>
     fn IsIdentity(&self) -> bool {
         let matrix = self.matrix.borrow();
-        matrix.m12 == 0.0 &&
-            matrix.m13 == 0.0 &&
-            matrix.m14 == 0.0 &&
-            matrix.m21 == 0.0 &&
-            matrix.m23 == 0.0 &&
-            matrix.m24 == 0.0 &&
-            matrix.m31 == 0.0 &&
-            matrix.m32 == 0.0 &&
-            matrix.m34 == 0.0 &&
-            matrix.m41 == 0.0 &&
-            matrix.m42 == 0.0 &&
-            matrix.m43 == 0.0 &&
-            matrix.m11 == 1.0 &&
-            matrix.m22 == 1.0 &&
-            matrix.m33 == 1.0 &&
-            matrix.m44 == 1.0
+        matrix.m12 == 0.0
+            && matrix.m13 == 0.0
+            && matrix.m14 == 0.0
+            && matrix.m21 == 0.0
+            && matrix.m23 == 0.0
+            && matrix.m24 == 0.0
+            && matrix.m31 == 0.0
+            && matrix.m32 == 0.0
+            && matrix.m34 == 0.0
+            && matrix.m41 == 0.0
+            && matrix.m42 == 0.0
+            && matrix.m43 == 0.0
+            && matrix.m11 == 1.0
+            && matrix.m22 == 1.0
+            && matrix.m33 == 1.0
+            && matrix.m44 == 1.0
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-translate>
@@ -872,22 +872,22 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
         // Step 1. If one or more of m11 element through m44 element are a non-finite value,
         // then throw an "InvalidStateError" DOMException.
         let mat = self.matrix.borrow();
-        if !mat.m11.is_finite() ||
-            !mat.m12.is_finite() ||
-            !mat.m13.is_finite() ||
-            !mat.m14.is_finite() ||
-            !mat.m21.is_finite() ||
-            !mat.m22.is_finite() ||
-            !mat.m23.is_finite() ||
-            !mat.m24.is_finite() ||
-            !mat.m31.is_finite() ||
-            !mat.m32.is_finite() ||
-            !mat.m33.is_finite() ||
-            !mat.m34.is_finite() ||
-            !mat.m41.is_finite() ||
-            !mat.m42.is_finite() ||
-            !mat.m43.is_finite() ||
-            !mat.m44.is_finite()
+        if !mat.m11.is_finite()
+            || !mat.m12.is_finite()
+            || !mat.m13.is_finite()
+            || !mat.m14.is_finite()
+            || !mat.m21.is_finite()
+            || !mat.m22.is_finite()
+            || !mat.m23.is_finite()
+            || !mat.m24.is_finite()
+            || !mat.m31.is_finite()
+            || !mat.m32.is_finite()
+            || !mat.m33.is_finite()
+            || !mat.m34.is_finite()
+            || !mat.m41.is_finite()
+            || !mat.m42.is_finite()
+            || !mat.m43.is_finite()
+            || !mat.m44.is_finite()
         {
             return Err(error::Error::InvalidState(None));
         }
@@ -1085,24 +1085,24 @@ fn validate_and_fixup_2d(dict: &DOMMatrix2DInit) -> Fallible<Transform2D<f64>> {
 
     // Step 1. If if at least one of the following conditions are true for dict,
     // then throw a TypeError exception and abort these steps.
-    if dict.a.is_some() &&
-        dict.m11.is_some() &&
-        !same_value_zero(dict.a.unwrap(), dict.m11.unwrap()) ||
-        dict.b.is_some() &&
-            dict.m12.is_some() &&
-            !same_value_zero(dict.b.unwrap(), dict.m12.unwrap()) ||
-        dict.c.is_some() &&
-            dict.m21.is_some() &&
-            !same_value_zero(dict.c.unwrap(), dict.m21.unwrap()) ||
-        dict.d.is_some() &&
-            dict.m22.is_some() &&
-            !same_value_zero(dict.d.unwrap(), dict.m22.unwrap()) ||
-        dict.e.is_some() &&
-            dict.m41.is_some() &&
-            !same_value_zero(dict.e.unwrap(), dict.m41.unwrap()) ||
-        dict.f.is_some() &&
-            dict.m42.is_some() &&
-            !same_value_zero(dict.f.unwrap(), dict.m42.unwrap())
+    if dict.a.is_some()
+        && dict.m11.is_some()
+        && !same_value_zero(dict.a.unwrap(), dict.m11.unwrap())
+        || dict.b.is_some()
+            && dict.m12.is_some()
+            && !same_value_zero(dict.b.unwrap(), dict.m12.unwrap())
+        || dict.c.is_some()
+            && dict.m21.is_some()
+            && !same_value_zero(dict.c.unwrap(), dict.m21.unwrap())
+        || dict.d.is_some()
+            && dict.m22.is_some()
+            && !same_value_zero(dict.d.unwrap(), dict.m22.unwrap())
+        || dict.e.is_some()
+            && dict.m41.is_some()
+            && !same_value_zero(dict.e.unwrap(), dict.m41.unwrap())
+        || dict.f.is_some()
+            && dict.m42.is_some()
+            && !same_value_zero(dict.f.unwrap(), dict.m42.unwrap())
     {
         return Err(error::Error::Type(
             c"Property mismatch on matrix initialization.".to_owned(),
@@ -1145,17 +1145,17 @@ fn validate_and_fixup(dict: &DOMMatrixInit) -> Fallible<(bool, Transform3D<f64>)
     // m32, m34, m43 are present with a value other than 0 or -0, or at least
     // one of m33, m44 are present with a value other than 1, then throw
     // a TypeError exception and abort these steps.
-    if dict.is2D == Some(true) &&
-        (dict.m13 != 0.0 ||
-            dict.m14 != 0.0 ||
-            dict.m23 != 0.0 ||
-            dict.m24 != 0.0 ||
-            dict.m31 != 0.0 ||
-            dict.m32 != 0.0 ||
-            dict.m34 != 0.0 ||
-            dict.m43 != 0.0 ||
-            dict.m33 != 1.0 ||
-            dict.m44 != 1.0)
+    if dict.is2D == Some(true)
+        && (dict.m13 != 0.0
+            || dict.m14 != 0.0
+            || dict.m23 != 0.0
+            || dict.m24 != 0.0
+            || dict.m31 != 0.0
+            || dict.m32 != 0.0
+            || dict.m34 != 0.0
+            || dict.m43 != 0.0
+            || dict.m33 != 1.0
+            || dict.m44 != 1.0)
     {
         return Err(error::Error::Type(
             c"The is2D member is set to true but the input matrix is a 3d matrix.".to_owned(),
@@ -1168,17 +1168,17 @@ fn validate_and_fixup(dict: &DOMMatrixInit) -> Fallible<(bool, Transform3D<f64>)
     // m31, m32, m34, m43 are present with a value other than 0 or -0, or at
     // least one of m33, m44 are present with a value other than 1, set is2D
     // to false.
-    if is_2d.is_none() &&
-        (dict.m13 != 0.0 ||
-            dict.m14 != 0.0 ||
-            dict.m23 != 0.0 ||
-            dict.m24 != 0.0 ||
-            dict.m31 != 0.0 ||
-            dict.m32 != 0.0 ||
-            dict.m34 != 0.0 ||
-            dict.m43 != 0.0 ||
-            dict.m33 != 1.0 ||
-            dict.m44 != 1.0)
+    if is_2d.is_none()
+        && (dict.m13 != 0.0
+            || dict.m14 != 0.0
+            || dict.m23 != 0.0
+            || dict.m24 != 0.0
+            || dict.m31 != 0.0
+            || dict.m32 != 0.0
+            || dict.m34 != 0.0
+            || dict.m43 != 0.0
+            || dict.m33 != 1.0
+            || dict.m44 != 1.0)
     {
         is_2d = Some(false);
     }

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -703,8 +703,8 @@ impl FileListener {
                 },
             },
             Err(_) => match self.state.take() {
-                Some(FileListenerState::Receiving(_, target)) |
-                Some(FileListenerState::Empty(target)) => {
+                Some(FileListenerState::Receiving(_, target))
+                | Some(FileListenerState::Empty(target)) => {
                     let error = Err(Error::Network(None));
 
                     match target {
@@ -1337,15 +1337,15 @@ impl GlobalScope {
         // Step 7, a few preliminary steps.
 
         // - Check the worker is not closing.
-        if let Some(worker) = self.downcast::<WorkerGlobalScope>() &&
-            worker.is_closing()
+        if let Some(worker) = self.downcast::<WorkerGlobalScope>()
+            && worker.is_closing()
         {
             return;
         }
 
         // - Check the associated document is fully-active.
-        if let Some(window) = self.downcast::<Window>() &&
-            !window.Document().is_fully_active()
+        if let Some(window) = self.downcast::<Window>()
+            && !window.Document().is_fully_active()
         {
             return;
         }
@@ -3200,8 +3200,8 @@ impl GlobalScope {
                 // Step 2. If the result of Is url potentially trustworthy?
                 // given environment's top-level creation URL is "Potentially Trustworthy", then return true.
                 // Step 3. Return false.
-                if top_level_creation_url.scheme() == "blob" &&
-                    Some(true) == self.inherited_secure_context
+                if top_level_creation_url.scheme() == "blob"
+                    && Some(true) == self.inherited_secure_context
                 {
                     return true;
                 }

--- a/components/script/dom/globalscope/messageport.rs
+++ b/components/script/dom/globalscope/messageport.rs
@@ -138,8 +138,8 @@ impl MessagePort {
             }
 
             // Step 4
-            if let Some(target_id) = target_port.as_ref() &&
-                port.message_port_id() == target_id
+            if let Some(target_id) = target_port.as_ref()
+                && port.message_port_id() == target_id
             {
                 doomed = true;
             }

--- a/components/script/dom/globalscope/script_execution.rs
+++ b/components/script/dom/globalscope/script_execution.rs
@@ -319,8 +319,8 @@ impl GlobalScope {
         // does not have its sandboxed scripts browsing context flag set.
         if let Some(window) = self.downcast::<Window>() {
             let doc = window.Document();
-            doc.is_fully_active() &&
-                !doc.has_active_sandboxing_flag(
+            doc.is_fully_active()
+                && !doc.has_active_sandboxing_flag(
                     SandboxingFlagSet::SANDBOXED_SCRIPTS_BROWSING_CONTEXT_FLAG,
                 )
         } else {

--- a/components/script/dom/html/documentmetadata/htmllinkelement.rs
+++ b/components/script/dom/html/documentmetadata/htmllinkelement.rs
@@ -216,16 +216,17 @@ impl HTMLLinkElement {
     }
 
     pub(crate) fn is_alternate(&self) -> bool {
-        self.relations.get().contains(LinkRelations::ALTERNATE) &&
-            !self
+        self.relations.get().contains(LinkRelations::ALTERNATE)
+            && !self
                 .upcast::<Element>()
                 .get_string_attribute(&local_name!("title"))
                 .is_empty()
     }
 
     pub(crate) fn is_effectively_disabled(&self) -> bool {
-        (self.is_alternate() && !self.is_explicitly_enabled.get()) ||
-            self.upcast::<Element>()
+        (self.is_alternate() && !self.is_explicitly_enabled.get())
+            || self
+                .upcast::<Element>()
                 .has_attribute(&local_name!("disabled"))
     }
 
@@ -279,9 +280,9 @@ impl VirtualMethods for HTMLLinkElement {
 
         // For stylesheets, we should only refetch when the actual attribute value
         // has been changed.
-        if self.relations.get().contains(LinkRelations::STYLESHEET) &&
-            let AttributeMutation::Set(Some(previous_value), _) = mutation &&
-            **previous_value == **attr.value()
+        if self.relations.get().contains(LinkRelations::STYLESHEET)
+            && let AttributeMutation::Set(Some(previous_value), _) = mutation
+            && **previous_value == **attr.value()
         {
             return;
         }
@@ -361,8 +362,8 @@ impl VirtualMethods for HTMLLinkElement {
                 // https://html.spec.whatwg.org/multipage/#link-type-preload
                 // When the as attribute of the link element of an external resource link
                 // that is already browsing-context connected is changed.
-                if self.relations.get().contains(LinkRelations::PRELOAD) &&
-                    let AttributeMutation::Set(Some(_), _) = mutation
+                if self.relations.get().contains(LinkRelations::PRELOAD)
+                    && let AttributeMutation::Set(Some(_), _) = mutation
                 {
                     self.handle_preload_url();
                 }
@@ -384,8 +385,8 @@ impl VirtualMethods for HTMLLinkElement {
                 // is already browsing-context connected, but was previously not obtained due to
                 // the type attribute specifying an unsupported type for the request destination,
                 // is set, removed, or changed.
-                if self.relations.get().contains(LinkRelations::PRELOAD) &&
-                    !self.previous_type_matched.get()
+                if self.relations.get().contains(LinkRelations::PRELOAD)
+                    && !self.previous_type_matched.get()
                 {
                     self.handle_preload_url();
                 }
@@ -395,8 +396,8 @@ impl VirtualMethods for HTMLLinkElement {
                 // When the media attribute of the link element of an external resource link that
                 // is already browsing-context connected, but was previously not obtained due to
                 // the media attribute not matching the environment, is changed or removed.
-                if self.relations.get().contains(LinkRelations::PRELOAD) &&
-                    !self.previous_media_environment_matched.get()
+                if self.relations.get().contains(LinkRelations::PRELOAD)
+                    && !self.previous_media_environment_matched.get()
                 {
                     match mutation {
                         AttributeMutation::Removed | AttributeMutation::Set(Some(_), _) => {
@@ -404,8 +405,8 @@ impl VirtualMethods for HTMLLinkElement {
                         },
                         _ => {},
                     };
-                } else if self.relations.get().contains(LinkRelations::STYLESHEET) &&
-                    let Some(ref stylesheet) = *self.stylesheet.borrow_mut()
+                } else if self.relations.get().contains(LinkRelations::STYLESHEET)
+                    && let Some(ref stylesheet) = *self.stylesheet.borrow_mut()
                 {
                     let document = self.owner_document();
                     let shared_lock = document.style_shared_author_lock().clone();
@@ -444,8 +445,8 @@ impl VirtualMethods for HTMLLinkElement {
             s.bind_to_tree(cx, context);
         }
 
-        if context.tree_connected &&
-            let Some(href) = self
+        if context.tree_connected
+            && let Some(href) = self
                 .upcast::<Element>()
                 .get_attribute_string_value(&local_name!("href"))
         {
@@ -726,8 +727,8 @@ impl HTMLLinkElement {
         if is_removal {
             self.is_explicitly_enabled.set(true);
         }
-        if let Some(stylesheet) = self.get_stylesheet() &&
-            stylesheet.set_disabled(!is_removal)
+        if let Some(stylesheet) = self.get_stylesheet()
+            && stylesheet.set_disabled(!is_removal)
         {
             self.stylesheet_list_owner().invalidate_stylesheets();
         }
@@ -765,8 +766,8 @@ impl HTMLLinkElement {
             }) => {
                 self.process_favicon_response(image);
             },
-            ImageCacheResult::Available(ImageOrMetadataAvailable::MetadataAvailable(_, id)) |
-            ImageCacheResult::Pending(id) => {
+            ImageCacheResult::Available(ImageOrMetadataAvailable::MetadataAvailable(_, id))
+            | ImageCacheResult::Pending(id) => {
                 let sender = self.register_image_cache_callback(id);
                 window.image_cache().add_listener(ImageLoadListener::new(
                     sender,
@@ -1082,8 +1083,9 @@ impl StylesheetOwner for HTMLLinkElement {
         //
         // https://html.spec.whatwg.org/multipage/#link-type-stylesheet:implicitly-potentially-render-blocking
         // > A link element of this type is implicitly potentially render-blocking if the element was created by its node document's parser.
-        self.parser_inserted() ||
-            self.blocking
+        self.parser_inserted()
+            || self
+                .blocking
                 .get()
                 .is_some_and(|list| list.Contains("render".into()))
     }

--- a/components/script/dom/html/documentmetadata/htmlstyleelement.rs
+++ b/components/script/dom/html/documentmetadata/htmlstyleelement.rs
@@ -374,22 +374,22 @@ impl VirtualMethods for HTMLStyleElement {
         }
 
         let node = self.upcast::<Node>();
-        if !(node.is_in_a_document_tree() || node.is_in_a_shadow_tree()) ||
-            self.in_stack_of_open_elements.get()
+        if !(node.is_in_a_document_tree() || node.is_in_a_shadow_tree())
+            || self.in_stack_of_open_elements.get()
         {
             return;
         }
 
         if attr.name() == "type" {
-            if let AttributeMutation::Set(Some(old_value), _) = mutation &&
-                **old_value == **attr.value()
+            if let AttributeMutation::Set(Some(old_value), _) = mutation
+                && **old_value == **attr.value()
             {
                 return;
             }
             self.remove_stylesheet();
             self.update_a_style_block(cx);
-        } else if attr.name() == "media" &&
-            let Some(ref stylesheet) = *self.stylesheet.borrow_mut()
+        } else if attr.name() == "media"
+            && let Some(ref stylesheet) = *self.stylesheet.borrow_mut()
         {
             let shared_lock = node.owner_doc().style_shared_author_lock().clone();
             let mut guard = shared_lock.write();
@@ -436,8 +436,9 @@ impl StylesheetOwner for HTMLStyleElement {
         //
         // https://html.spec.whatwg.org/multipage/#the-style-element:implicitly-potentially-render-blocking
         // > A style element is implicitly potentially render-blocking if the element was created by its node document's parser.
-        self.parser_inserted() ||
-            self.blocking
+        self.parser_inserted()
+            || self
+                .blocking
                 .get()
                 .is_some_and(|list| list.Contains("render".into()))
     }

--- a/components/script/dom/html/htmlanchorelement.rs
+++ b/components/script/dom/html/htmlanchorelement.rs
@@ -358,9 +358,9 @@ impl Activatable for HTMLAnchorElement {
 
         // Step 1: If the target of the click event is an img element with an ismap attribute
         // specified, then server-side image map processing must be performed.
-        if let Some(element) = target.downcast::<Element>() &&
-            target.is::<HTMLImageElement>() &&
-            element.has_attribute(&local_name!("ismap"))
+        if let Some(element) = target.downcast::<Element>()
+            && target.is::<HTMLImageElement>()
+            && element.has_attribute(&local_name!("ismap"))
         {
             let target_node = element.upcast::<Node>();
             let rect = target_node.border_box().unwrap_or_default();

--- a/components/script/dom/html/htmlareaelement.rs
+++ b/components/script/dom/html/htmlareaelement.rs
@@ -200,10 +200,10 @@ impl Area {
                 top_left,
                 bottom_right,
             } => {
-                p.x <= bottom_right.0 &&
-                    p.x >= top_left.0 &&
-                    p.y <= bottom_right.1 &&
-                    p.y >= top_left.1
+                p.x <= bottom_right.0
+                    && p.x >= top_left.0
+                    && p.y <= bottom_right.1
+                    && p.y >= top_left.1
             },
 
             Area::Polygon { ref points } => {

--- a/components/script/dom/html/htmlbodyelement.rs
+++ b/components/script/dom/html/htmlbodyelement.rs
@@ -157,29 +157,29 @@ impl VirtualMethods for HTMLBodyElement {
                 // https://html.spec.whatwg.org/multipage/
                 // #event-handlers-on-elements,-document-objects,-and-window-objects:event-handlers-6
                 match name {
-                    &local_name!("onafterprint") |
-                    &local_name!("onbeforeprint") |
-                    &local_name!("onbeforeunload") |
-                    &local_name!("onerror") |
-                    &local_name!("onfocus") |
-                    &local_name!("onhashchange") |
-                    &local_name!("onload") |
-                    &local_name!("onlanguagechange") |
-                    &local_name!("onmessage") |
-                    &local_name!("onmessageerror") |
-                    &local_name!("onoffline") |
-                    &local_name!("ononline") |
-                    &local_name!("onpagehide") |
-                    &local_name!("onpagereveal") |
-                    &local_name!("onpageshow") |
-                    &local_name!("onpageswap") |
-                    &local_name!("onpopstate") |
-                    &local_name!("onrejectionhandled") |
-                    &local_name!("onresize") |
-                    &local_name!("onscroll") |
-                    &local_name!("onstorage") |
-                    &local_name!("onunhandledrejection") |
-                    &local_name!("onunload") => {
+                    &local_name!("onafterprint")
+                    | &local_name!("onbeforeprint")
+                    | &local_name!("onbeforeunload")
+                    | &local_name!("onerror")
+                    | &local_name!("onfocus")
+                    | &local_name!("onhashchange")
+                    | &local_name!("onload")
+                    | &local_name!("onlanguagechange")
+                    | &local_name!("onmessage")
+                    | &local_name!("onmessageerror")
+                    | &local_name!("onoffline")
+                    | &local_name!("ononline")
+                    | &local_name!("onpagehide")
+                    | &local_name!("onpagereveal")
+                    | &local_name!("onpageshow")
+                    | &local_name!("onpageswap")
+                    | &local_name!("onpopstate")
+                    | &local_name!("onrejectionhandled")
+                    | &local_name!("onresize")
+                    | &local_name!("onscroll")
+                    | &local_name!("onstorage")
+                    | &local_name!("onunhandledrejection")
+                    | &local_name!("onunload") => {
                         if document.has_browsing_context() {
                             // https://html.spec.whatwg.org/multipage/webappapis.html
                             // #event-handler-attributes%3Aevent-handler-content-attributes-3

--- a/components/script/dom/html/htmlbuttonelement.rs
+++ b/components/script/dom/html/htmlbuttonelement.rs
@@ -269,8 +269,8 @@ impl HTMLButtonElement {
             "submit" => ButtonType::Submit,
             _ => {
                 let element = self.upcast::<Element>();
-                if element.has_attribute(&local_name!("command")) ||
-                    element.has_attribute(&local_name!("commandfor"))
+                if element.has_attribute(&local_name!("command"))
+                    || element.has_attribute(&local_name!("commandfor"))
                 {
                     ButtonType::Button
                 } else {
@@ -461,9 +461,9 @@ impl Validatable for HTMLButtonElement {
         // https://html.spec.whatwg.org/multipage/#the-button-element%3Abarred-from-constraint-validation
         // https://html.spec.whatwg.org/multipage/#enabling-and-disabling-form-controls%3A-the-disabled-attribute%3Abarred-from-constraint-validation
         // https://html.spec.whatwg.org/multipage/#the-datalist-element%3Abarred-from-constraint-validation
-        self.button_type.get() == ButtonType::Submit &&
-            !self.upcast::<Element>().disabled_state() &&
-            !is_barred_by_datalist_ancestor(self.upcast())
+        self.button_type.get() == ButtonType::Submit
+            && !self.upcast::<Element>().disabled_state()
+            && !is_barred_by_datalist_ancestor(self.upcast())
     }
 }
 
@@ -512,11 +512,12 @@ impl Activatable for HTMLButtonElement {
                 return;
             }
             // Step 3.3 If element's type attribute is in the Auto state, then return.
-            if button_type == ButtonType::Button &&
-                self.upcast::<Element>()
+            if button_type == ButtonType::Button
+                && self
+                    .upcast::<Element>()
                     .get_string_attribute(&local_name!("type"))
-                    .to_ascii_lowercase() !=
-                    "button"
+                    .to_ascii_lowercase()
+                    != "button"
             {
                 return;
             }

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -366,8 +366,8 @@ impl HTMLCanvasElement {
             Some(context) => context.get_image_data(),
             None => {
                 let size = self.get_size();
-                if size.is_empty() ||
-                    pixels::compute_rgba8_byte_length_if_within_limit(
+                if size.is_empty()
+                    || pixels::compute_rgba8_byte_length_if_within_limit(
                         size.width as usize,
                         size.height as usize,
                     )

--- a/components/script/dom/html/htmlcollection.rs
+++ b/components/script/dom/html/htmlcollection.rs
@@ -271,9 +271,9 @@ impl HTMLCollection {
         match elem.prefix().as_ref() {
             None => elem.local_name() == qualified_name,
             Some(prefix) => {
-                qualified_name.starts_with(&**prefix) &&
-                    qualified_name.find(':') == Some(prefix.len()) &&
-                    qualified_name.ends_with(&**elem.local_name())
+                qualified_name.starts_with(&**prefix)
+                    && qualified_name.find(':') == Some(prefix.len())
+                    && qualified_name.ends_with(&**elem.local_name())
             },
         }
     }
@@ -304,9 +304,9 @@ impl HTMLCollection {
         }
         impl CollectionFilter for TagNameNSFilter {
             fn filter(&self, elem: &Element, _root: &Node) -> bool {
-                ((self.qname.ns == namespace_url!("*")) || (self.qname.ns == *elem.namespace())) &&
-                    ((self.qname.local == local_name!("*")) ||
-                        (self.qname.local == *elem.local_name()))
+                ((self.qname.ns == namespace_url!("*")) || (self.qname.ns == *elem.namespace()))
+                    && ((self.qname.local == local_name!("*"))
+                        || (self.qname.local == *elem.local_name()))
             }
         }
         let filter = TagNameNSFilter { qname };
@@ -491,9 +491,9 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
         // Step 2.
         self.elements_iter(cx.no_gc())
             .find(|elem| {
-                elem.get_id().is_some_and(|id| id == key) ||
-                    (elem.namespace() == &ns!(html) &&
-                        elem.get_name().is_some_and(|id| id == key))
+                elem.get_id().is_some_and(|id| id == key)
+                    || (elem.namespace() == &ns!(html)
+                        && elem.get_name().is_some_and(|id| id == key))
             })
             .map(|node| node.as_rooted())
     }
@@ -523,8 +523,8 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
                 }
             }
             // Step 2.2
-            if *elem.namespace() == ns!(html) &&
-                let Some(name_atom) = elem.get_name()
+            if *elem.namespace() == ns!(html)
+                && let Some(name_atom) = elem.get_name()
             {
                 let name_str = DOMString::from(&*name_atom);
                 if !result.contains(&name_str) {

--- a/components/script/dom/html/htmldetailselement.rs
+++ b/components/script/dom/html/htmldetailselement.rs
@@ -308,8 +308,8 @@ impl HTMLDetailsElement {
         // Step 1. Assert: element has an open attribute.
         // Step 1. If element does not have an open attribute, then return.
         if !self.Open() {
-            if conflict_resolution_behaviour ==
-                ExclusivityConflictResolution::CloseExistingOpenElement
+            if conflict_resolution_behaviour
+                == ExclusivityConflictResolution::CloseExistingOpenElement
             {
                 unreachable!()
             } else {
@@ -350,8 +350,8 @@ impl HTMLDetailsElement {
                 .filter(|details_element| {
                     details_element
                         .upcast::<Element>()
-                        .get_string_attribute(&local_name!("name")) ==
-                        name
+                        .get_string_attribute(&local_name!("name"))
+                        == name
                 })
                 .filter(|group_member| &**group_member != self)
                 .find(|group_member| group_member.Open())
@@ -538,8 +538,8 @@ impl VirtualMethods for HTMLDetailsElement {
                 .unregister_details_element(self.Name(), self);
         }
 
-        if !self.upcast::<Node>().is_in_a_shadow_tree() &&
-            let Some(old_shadow_root) = self.containing_shadow_root()
+        if !self.upcast::<Node>().is_in_a_shadow_tree()
+            && let Some(old_shadow_root) = self.containing_shadow_root()
         {
             // If we used to be in a shadow root, but aren't anymore, then unregister this details
             // element.

--- a/components/script/dom/html/htmldialogelement.rs
+++ b/components/script/dom/html/htmldialogelement.rs
@@ -70,8 +70,8 @@ impl HTMLDialogElement {
     ) -> ErrorResult {
         let subject = self.upcast::<Element>();
         // Step 1. If subject has an open attribute and is modal of subject is true, then return.
-        if subject.has_attribute(&local_name!("open")) &&
-            subject.state().contains(ElementState::MODAL)
+        if subject.has_attribute(&local_name!("open"))
+            && subject.state().contains(ElementState::MODAL)
         {
             return Ok(());
         }
@@ -239,8 +239,8 @@ impl HTMLDialogElement {
                 .focused_area()
                 .dom_anchor(&document)
                 .traverse_preorder(ShadowIncluding::Yes)
-                .any(|node| &*node == subject_node) ||
-                was_modal
+                .any(|node| &*node == subject_node)
+                || was_modal
             {
                 element.upcast::<Node>().run_the_focusing_steps(cx, None);
             }
@@ -357,8 +357,8 @@ impl HTMLDialogElementMethods<crate::DomTypeHolder> for HTMLDialogElement {
     fn Show(&self, cx: &mut js::context::JSContext) -> ErrorResult {
         let element = self.upcast::<Element>();
         // Step 1. If this has an open attribute and is modal of this is false, then return.
-        if element.has_attribute(&local_name!("open")) &&
-            !element.state().contains(ElementState::MODAL)
+        if element.has_attribute(&local_name!("open"))
+            && !element.state().contains(ElementState::MODAL)
         {
             return Ok(());
         }

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -642,8 +642,8 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
 
         // Step 7: If next is non-null and next's previous sibling is a Text node, then merge with
         // the next text node given next's previous sibling.
-        if let Some(next_sibling) = next &&
-            let Some(node) = next_sibling.GetPreviousSibling()
+        if let Some(next_sibling) = next
+            && let Some(node) = next_sibling.GetPreviousSibling()
         {
             Self::merge_with_the_next_text_node(cx, node);
         }
@@ -842,12 +842,12 @@ impl HTMLElement {
                     *self.downcast::<HTMLInputElement>().unwrap().input_type(),
                     InputType::Hidden(_)
                 ),
-                HTMLElementTypeId::HTMLButtonElement |
-                HTMLElementTypeId::HTMLMeterElement |
-                HTMLElementTypeId::HTMLOutputElement |
-                HTMLElementTypeId::HTMLProgressElement |
-                HTMLElementTypeId::HTMLSelectElement |
-                HTMLElementTypeId::HTMLTextAreaElement => true,
+                HTMLElementTypeId::HTMLButtonElement
+                | HTMLElementTypeId::HTMLMeterElement
+                | HTMLElementTypeId::HTMLOutputElement
+                | HTMLElementTypeId::HTMLProgressElement
+                | HTMLElementTypeId::HTMLSelectElement
+                | HTMLElementTypeId::HTMLTextAreaElement => true,
                 _ => self.is_form_associated_custom_element(),
             },
             _ => false,
@@ -867,13 +867,13 @@ impl HTMLElement {
     pub(crate) fn is_listed_element(&self) -> bool {
         match self.upcast::<Node>().type_id() {
             NodeTypeId::Element(ElementTypeId::HTMLElement(type_id)) => match type_id {
-                HTMLElementTypeId::HTMLButtonElement |
-                HTMLElementTypeId::HTMLFieldSetElement |
-                HTMLElementTypeId::HTMLInputElement |
-                HTMLElementTypeId::HTMLObjectElement |
-                HTMLElementTypeId::HTMLOutputElement |
-                HTMLElementTypeId::HTMLSelectElement |
-                HTMLElementTypeId::HTMLTextAreaElement => true,
+                HTMLElementTypeId::HTMLButtonElement
+                | HTMLElementTypeId::HTMLFieldSetElement
+                | HTMLElementTypeId::HTMLInputElement
+                | HTMLElementTypeId::HTMLObjectElement
+                | HTMLElementTypeId::HTMLOutputElement
+                | HTMLElementTypeId::HTMLSelectElement
+                | HTMLElementTypeId::HTMLTextAreaElement => true,
                 _ => self.is_form_associated_custom_element(),
             },
             _ => false,
@@ -885,9 +885,9 @@ impl HTMLElement {
         let self_node = self.upcast::<Node>();
         self_node.GetParentNode().is_some_and(|parent| {
             let parent_node = parent.upcast::<Node>();
-            (self_node.is::<HTMLBodyElement>() || self_node.is::<HTMLFrameSetElement>()) &&
-                parent_node.is::<HTMLHtmlElement>() &&
-                self_node
+            (self_node.is::<HTMLBodyElement>() || self_node.is::<HTMLFrameSetElement>())
+                && parent_node.is::<HTMLHtmlElement>()
+                && self_node
                     .preceding_siblings()
                     .all(|n| !n.is::<HTMLBodyElement>() && !n.is::<HTMLFrameSetElement>())
         })
@@ -897,10 +897,10 @@ impl HTMLElement {
     pub(crate) fn is_submittable_element(&self) -> bool {
         match self.upcast::<Node>().type_id() {
             NodeTypeId::Element(ElementTypeId::HTMLElement(type_id)) => match type_id {
-                HTMLElementTypeId::HTMLButtonElement |
-                HTMLElementTypeId::HTMLInputElement |
-                HTMLElementTypeId::HTMLSelectElement |
-                HTMLElementTypeId::HTMLTextAreaElement => true,
+                HTMLElementTypeId::HTMLButtonElement
+                | HTMLElementTypeId::HTMLInputElement
+                | HTMLElementTypeId::HTMLSelectElement
+                | HTMLElementTypeId::HTMLTextAreaElement => true,
                 _ => self.is_form_associated_custom_element(),
             },
             _ => false,
@@ -966,8 +966,8 @@ impl HTMLElement {
             return Some("rtl".to_owned());
         }
 
-        if let Some(input) = self.downcast::<HTMLInputElement>() &&
-            matches!(*input.input_type(), InputType::Tel(_))
+        if let Some(input) = self.downcast::<HTMLInputElement>()
+            && matches!(*input.input_type(), InputType::Tel(_))
         {
             return Some("ltr".to_owned());
         }

--- a/components/script/dom/html/htmlfieldsetelement.rs
+++ b/components/script/dom/html/htmlfieldsetelement.rs
@@ -192,10 +192,10 @@ impl VirtualMethods for HTMLFieldSetElement {
                         .traverse_preorder(ShadowIncluding::No)
                         .filter(|descendant| match descendant.type_id() {
                             NodeTypeId::Element(ElementTypeId::HTMLElement(
-                                HTMLElementTypeId::HTMLButtonElement |
-                                HTMLElementTypeId::HTMLInputElement |
-                                HTMLElementTypeId::HTMLSelectElement |
-                                HTMLElementTypeId::HTMLTextAreaElement,
+                                HTMLElementTypeId::HTMLButtonElement
+                                | HTMLElementTypeId::HTMLInputElement
+                                | HTMLElementTypeId::HTMLSelectElement
+                                | HTMLElementTypeId::HTMLTextAreaElement,
                             )) => true,
                             NodeTypeId::Element(ElementTypeId::HTMLElement(
                                 HTMLElementTypeId::HTMLElement,
@@ -232,8 +232,8 @@ impl VirtualMethods for HTMLFieldSetElement {
                             element.check_disabled_attribute();
                             element.check_ancestors_disabled_state_for_form_control();
                             // Fire callback only if this has actually enabled the custom element
-                            if element.enabled_state() &&
-                                element
+                            if element.enabled_state()
+                                && element
                                     .downcast::<HTMLElement>()
                                     .is_some_and(|h| h.is_form_associated_custom_element())
                             {

--- a/components/script/dom/html/htmlfontelement.rs
+++ b/components/script/dom/html/htmlfontelement.rs
@@ -118,9 +118,9 @@ impl VirtualMethods for HTMLFontElement {
     }
 
     fn attribute_affects_presentational_hints(&self, attr: AttrRef<'_>) -> bool {
-        if attr.local_name() == &local_name!("color") ||
-            attr.local_name() == &local_name!("size") ||
-            attr.local_name() == &local_name!("face")
+        if attr.local_name() == &local_name!("color")
+            || attr.local_name() == &local_name!("size")
+            || attr.local_name() == &local_name!("face")
         {
             return true;
         }

--- a/components/script/dom/html/htmlformcontrolscollection.rs
+++ b/components/script/dom/html/htmlformcontrolscollection.rs
@@ -77,8 +77,8 @@ impl HTMLFormControlsCollectionMethods<crate::DomTypeHolder> for HTMLFormControl
                 .collection
                 .elements_iter(cx.no_gc())
                 .filter_map(|elem| {
-                    if elem.get_name().is_some_and(|n| n == name) ||
-                        elem.get_id().is_some_and(|i| i == name)
+                    if elem.get_name().is_some_and(|n| n == name)
+                        || elem.get_id().is_some_and(|i| i == name)
                     {
                         Some(elem)
                     } else {

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -162,9 +162,9 @@ impl HTMLFormElement {
                 RadioListMode::ControlsExceptImageInputs => {
                     if child
                         .downcast::<HTMLElement>()
-                        .is_some_and(|c| c.is_listed_element()) &&
-                        (child.get_id().is_some_and(|i| i == *name) ||
-                            child.get_name().is_some_and(|n| n == *name))
+                        .is_some_and(|c| c.is_listed_element())
+                        && (child.get_id().is_some_and(|i| i == *name)
+                            || child.get_name().is_some_and(|n| n == *name))
                     {
                         if let Some(inp) = child.downcast::<HTMLInputElement>() {
                             // input, only return it if it's not image-button state
@@ -177,9 +177,9 @@ impl HTMLFormElement {
                     return false;
                 },
                 RadioListMode::Images => {
-                    return child.is::<HTMLImageElement>() &&
-                        (child.get_id().is_some_and(|i| i == *name) ||
-                            child.get_name().is_some_and(|n| n == *name));
+                    return child.is::<HTMLImageElement>()
+                        && (child.get_id().is_some_and(|i| i == *name)
+                            || child.get_name().is_some_and(|n| n == *name));
                 },
             }
         }
@@ -614,8 +614,8 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
         sourced_names_vec.sort_by(|a, b| {
             if a.element
                 .upcast::<Node>()
-                .CompareDocumentPosition(b.element.upcast::<Node>()) ==
-                0
+                .CompareDocumentPosition(b.element.upcast::<Node>())
+                == 0
             {
                 if a.source.is_past() && b.source.is_past() {
                     b.source.cmp(&a.source)
@@ -625,9 +625,9 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
             } else if a
                 .element
                 .upcast::<Node>()
-                .CompareDocumentPosition(b.element.upcast::<Node>()) &
-                NodeConstants::DOCUMENT_POSITION_FOLLOWING ==
-                NodeConstants::DOCUMENT_POSITION_FOLLOWING
+                .CompareDocumentPosition(b.element.upcast::<Node>())
+                & NodeConstants::DOCUMENT_POSITION_FOLLOWING
+                == NodeConstants::DOCUMENT_POSITION_FOLLOWING
             {
                 std::cmp::Ordering::Less
             } else {
@@ -831,8 +831,8 @@ impl HTMLFormElement {
         // Step 19. If the submitter element is a submit button and it has a formtarget attribute,
         // then set formTarget to the formtarget attribute value.
         let form_target_attribute = submitter.target();
-        let form_target = if submitter.is_submit_button() &&
-            valid_navigable_target_name_or_keyword(&form_target_attribute)
+        let form_target = if submitter.is_submit_button()
+            && valid_navigable_target_name_or_keyword(&form_target_attribute)
         {
             Some(form_target_attribute)
         } else {
@@ -914,11 +914,11 @@ impl HTMLFormElement {
                 );
             },
             // https://html.spec.whatwg.org/multipage/#submit-get-action
-            ("file", _) |
-            ("about", _) |
-            ("data", FormMethod::Post) |
-            ("ftp", _) |
-            ("javascript", _) => {
+            ("file", _)
+            | ("about", _)
+            | ("data", FormMethod::Post)
+            | ("ftp", _)
+            | ("javascript", _) => {
                 self.plan_to_navigate(load_data, target_window, history_handling);
             },
             ("mailto", FormMethod::Post) => {
@@ -1091,8 +1091,8 @@ impl HTMLFormElement {
 
         // Note the pending form navigation if this is an iframe;
         // necessary for deciding whether to run the iframe load event steps.
-        if let Some(window_proxy) = target.undiscarded_window_proxy() &&
-            let Some(frame) = window_proxy
+        if let Some(window_proxy) = target.undiscarded_window_proxy()
+            && let Some(frame) = window_proxy
                 .frame_element()
                 .and_then(|e| e.downcast::<HTMLIFrameElement>())
         {
@@ -1303,8 +1303,8 @@ impl HTMLFormElement {
                 .downcast::<HTMLInputElement>()
                 .is_some_and(|input| input.is_auto_directionality_form_associated_element());
             let is_textarea_element = child_element.is::<HTMLTextAreaElement>();
-            if !dirname.is_empty() &&
-                (is_input_auto_directionality_form_associated_element || is_textarea_element)
+            if !dirname.is_empty()
+                && (is_input_auto_directionality_form_associated_element || is_textarea_element)
             {
                 // Step: 5.11.2 Let dir be the string "ltr" if the directionality of the element is 'ltr',
                 // and "rtl" otherwise (i.e., when the directionality of the element is 'rtl').
@@ -1447,11 +1447,11 @@ impl Element {
         };
         matches!(
             element_type,
-            HTMLElementTypeId::HTMLInputElement |
-                HTMLElementTypeId::HTMLSelectElement |
-                HTMLElementTypeId::HTMLTextAreaElement |
-                HTMLElementTypeId::HTMLOutputElement |
-                HTMLElementTypeId::HTMLElement
+            HTMLElementTypeId::HTMLInputElement
+                | HTMLElementTypeId::HTMLSelectElement
+                | HTMLElementTypeId::HTMLTextAreaElement
+                | HTMLElementTypeId::HTMLOutputElement
+                | HTMLElementTypeId::HTMLElement
         )
     }
 
@@ -1468,8 +1468,8 @@ impl Element {
             textarea_element.reset(cx);
         } else if let Some(output_element) = self.downcast::<HTMLOutputElement>() {
             output_element.reset(cx);
-        } else if let Some(html_element) = self.downcast::<HTMLElement>() &&
-            html_element.is_form_associated_custom_element()
+        } else if let Some(html_element) = self.downcast::<HTMLElement>()
+            && html_element.is_form_associated_custom_element()
         {
             ScriptThread::enqueue_callback_reaction(
                 cx,
@@ -1720,9 +1720,9 @@ pub(crate) trait FormControl: DomObject<ReflectorType = ()> + NodeTraits {
             .find_map(DomRoot::downcast::<HTMLFormElement>);
 
         // Step 1
-        if old_owner.is_some() &&
-            !(self.is_listed() && has_form_id) &&
-            nearest_form_ancestor == old_owner
+        if old_owner.is_some()
+            && !(self.is_listed() && has_form_id)
+            && nearest_form_ancestor == old_owner
         {
             return;
         }
@@ -1755,8 +1755,8 @@ pub(crate) trait FormControl: DomObject<ReflectorType = ()> + NodeTraits {
                 new_owner.add_control(cx, self);
             }
             // https://html.spec.whatwg.org/multipage/#custom-element-reactions:reset-the-form-owner
-            if let Some(html_elem) = elem.downcast::<HTMLElement>() &&
-                html_elem.is_form_associated_custom_element()
+            if let Some(html_elem) = elem.downcast::<HTMLElement>()
+                && html_elem.is_form_associated_custom_element()
             {
                 ScriptThread::enqueue_callback_reaction(
                     cx,

--- a/components/script/dom/html/htmlhrelement.rs
+++ b/components/script/dom/html/htmlhrelement.rs
@@ -125,8 +125,8 @@ impl LayoutDom<'_, HTMLHRElement> {
 
         let hint = if element
             .get_attr_for_layout(&ns!(), &local_name!("color"))
-            .is_some() ||
-            element
+            .is_some()
+            || element
                 .get_attr_for_layout(&ns!(), &local_name!("noshade"))
                 .is_some()
         {

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -463,8 +463,8 @@ impl HTMLIFrameElement {
         // Note: the spec says to set the name 'when the nested browsing context is created'.
         // The current implementation sets the name on the window,
         // when the iframe attributes are first processed.
-        if mode == ProcessingMode::FirstTime &&
-            let Some(window) = self.GetContentWindow()
+        if mode == ProcessingMode::FirstTime
+            && let Some(window) = self.GetContentWindow()
         {
             window.set_name(
                 element
@@ -514,14 +514,14 @@ impl HTMLIFrameElement {
         // against simple typo self-includes but nothing more elaborate.
         let mut ancestor = window.GetParent();
         while let Some(a) = ancestor {
-            if let Some(ancestor_url) = a.document().map(|d| d.url()) &&
-                ancestor_url.scheme() == url.scheme() &&
-                ancestor_url.username() == url.username() &&
-                ancestor_url.password() == url.password() &&
-                ancestor_url.host() == url.host() &&
-                ancestor_url.port() == url.port() &&
-                ancestor_url.path() == url.path() &&
-                ancestor_url.query() == url.query()
+            if let Some(ancestor_url) = a.document().map(|d| d.url())
+                && ancestor_url.scheme() == url.scheme()
+                && ancestor_url.username() == url.username()
+                && ancestor_url.password() == url.password()
+                && ancestor_url.host() == url.host()
+                && ancestor_url.port() == url.port()
+                && ancestor_url.path() == url.path()
+                && ancestor_url.query() == url.query()
             {
                 return;
             }
@@ -644,8 +644,8 @@ impl HTMLIFrameElement {
         if !self.is_initial_blank_document() {
             self.pending_navigation.set(false);
         }
-        if self.pending_pipeline_id.get() != Some(new_pipeline_id) &&
-            reason == UpdatePipelineIdReason::Navigation
+        if self.pending_pipeline_id.get() != Some(new_pipeline_id)
+            && reason == UpdatePipelineIdReason::Navigation
         {
             return false;
         }
@@ -779,8 +779,8 @@ impl HTMLIFrameElement {
             // If this is the initial blank doc:
             // do not fire if there is a pending navigation,
             // or if the iframe has an src.
-            !self.pending_navigation.get() &&
-                !self.upcast::<Element>().has_attribute(&local_name!("src"))
+            !self.pending_navigation.get()
+                && !self.upcast::<Element>().has_attribute(&local_name!("src"))
         } else {
             // If this is not the initial blank doc:
             // do not fire if there is a pending navigation.

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -266,8 +266,8 @@ impl FetchResponseListener for ImageContext {
         });
 
         // Step 14.5 of https://html.spec.whatwg.org/multipage/#img-environment-changes
-        if let Some(metadata) = metadata.as_ref() &&
-            let Some(ref content_type) = metadata.content_type
+        if let Some(metadata) = metadata.as_ref()
+            && let Some(ref content_type) = metadata.content_type
         {
             let mime: Mime = content_type.clone().into_inner().into();
             if mime.type_() == mime::MULTIPART && mime.subtype().as_str() == "x-mixed-replace" {
@@ -746,8 +746,8 @@ impl HTMLImageElement {
 
             // Step 5.6. If child has a media attribute, and its value does not match the
             // environment, continue to the next child.
-            if let Some(media) = element.get_attribute_string_value(&local_name!("media")) &&
-                !MediaList::matches_environment(&element.owner_document(), &media)
+            if let Some(media) = element.get_attribute_string_value(&local_name!("media"))
+                && !MediaList::matches_environment(&element.owner_document(), &media)
             {
                 continue;
             }
@@ -760,16 +760,16 @@ impl HTMLImageElement {
 
             // Step 5.8. If child has a type attribute, and its value is an unknown or unsupported
             // MIME type, continue to the next child.
-            if let Some(type_) = element.get_attribute_string_value(&local_name!("type")) &&
-                !is_supported_image_mime_type(&type_)
+            if let Some(type_) = element.get_attribute_string_value(&local_name!("type"))
+                && !is_supported_image_mime_type(&type_)
             {
                 continue;
             }
 
             // Step 5.9. If child has width or height attributes, set el's dimension attribute
             // source to child. Otherwise, set el's dimension attribute source to el.
-            if element.has_attribute(&local_name!("width")) ||
-                element.has_attribute(&local_name!("height"))
+            if element.has_attribute(&local_name!("width"))
+                || element.has_attribute(&local_name!("height"))
             {
                 self.dimension_attribute_source.set(Some(element));
             } else {
@@ -1267,8 +1267,9 @@ impl HTMLImageElement {
         // There are missing steps for the element's last selected source in specification so let's
         // check the current request's current URL as well.
         // <https://github.com/whatwg/html/issues/5060>
-        same_selected_source = same_selected_source ||
-            self.current_request
+        same_selected_source = same_selected_source
+            || self
+                .current_request
                 .borrow()
                 .source_url
                 .as_ref()
@@ -1356,8 +1357,8 @@ impl HTMLImageElement {
         // Step 2.2. If any of the following are true: this's node document is not fully active; or
         // this's current request's state is broken, then reject promise with an "EncodingError"
         // DOMException.
-        if !self.owner_document().is_fully_active() ||
-            matches!(self.current_request.borrow().state, State::Broken)
+        if !self.owner_document().is_fully_active()
+            || matches!(self.current_request.borrow().state, State::Broken)
         {
             promise.reject_error(cx, Error::Encoding(None));
         } else if matches!(
@@ -1366,8 +1367,8 @@ impl HTMLImageElement {
         ) {
             // this doesn't follow the spec, but it's been discussed in <https://github.com/whatwg/html/issues/4217>
             promise.resolve_native(cx, &());
-        } else if matches!(self.current_request.borrow().state, State::Unavailable) &&
-            self.current_request.borrow().source_url.is_none()
+        } else if matches!(self.current_request.borrow().state, State::Unavailable)
+            && self.current_request.borrow().source_url.is_none()
         {
             // Note: Despite being not explicitly stated in the specification but if current
             // request's state is unavailable and current URL is empty string (<img> without "src"
@@ -1675,9 +1676,9 @@ impl MicrotaskRunnable for ImageElementMicrotask {
 
     fn enter_realm<'cx>(&self, cx: &'cx mut js::context::JSContext) -> AutoRealm<'cx> {
         match self {
-            &ImageElementMicrotask::UpdateImageData { ref elem, .. } |
-            &ImageElementMicrotask::EnvironmentChanges { ref elem, .. } |
-            &ImageElementMicrotask::Decode { ref elem, .. } => enter_auto_realm(cx, &**elem),
+            &ImageElementMicrotask::UpdateImageData { ref elem, .. }
+            | &ImageElementMicrotask::EnvironmentChanges { ref elem, .. }
+            | &ImageElementMicrotask::Decode { ref elem, .. } => enter_auto_realm(cx, &**elem),
         }
     }
 }
@@ -1897,8 +1898,8 @@ impl HTMLImageElementMethods<crate::DomTypeHolder> for HTMLImageElement {
         // the img element's current request's state is completely available and its pending request
         // is null; or the img element's current request's state is broken and its pending request
         // is null, then return true.
-        if matches!(self.image_request.get(), ImageRequestPhase::Current) &&
-            matches!(
+        if matches!(self.image_request.get(), ImageRequestPhase::Current)
+            && matches!(
                 self.current_request.borrow().state,
                 State::CompletelyAvailable | State::Broken
             )
@@ -2008,10 +2009,10 @@ impl VirtualMethods for HTMLImageElement {
             .unwrap()
             .attribute_mutated(cx, attr, mutation);
         match attr.local_name() {
-            &local_name!("src") |
-            &local_name!("srcset") |
-            &local_name!("width") |
-            &local_name!("sizes") => {
+            &local_name!("src")
+            | &local_name!("srcset")
+            | &local_name!("width")
+            | &local_name!("sizes") => {
                 // <https://html.spec.whatwg.org/multipage/#reacting-to-dom-mutations>
                 // The element's src, srcset, width, or sizes attributes are set, changed, or
                 // removed.
@@ -2155,8 +2156,8 @@ impl VirtualMethods for HTMLImageElement {
         }
 
         // Step 1. If oldParent is a picture element, then, count this as a relevant mutation for movedNode.
-        if let Some(old_parent) = context.old_parent &&
-            old_parent.is::<HTMLPictureElement>()
+        if let Some(old_parent) = context.old_parent
+            && old_parent.is::<HTMLPictureElement>()
         {
             self.update_the_image_data(cx);
         }
@@ -2385,9 +2386,9 @@ pub fn parse_a_srcset_attribute(input: &str) -> Vec<ImageSource> {
                 // > 2. If width and density are not both absent, then let error be yes.
                 // > 3. Apply the rules for parsing non-negative integers to the descriptor.
                 // >    If the result is 0, let error be yes. Otherwise, let width be the result.
-                'w' if is_valid_non_negative_integer_string(first_part_of_string) &&
-                    density.is_none() &&
-                    width.is_none() =>
+                'w' if is_valid_non_negative_integer_string(first_part_of_string)
+                    && density.is_none()
+                    && width.is_none() =>
                 {
                     match parse_unsigned_integer(first_part_of_string.chars()) {
                         Ok(number) if number > 0 => {
@@ -2411,10 +2412,10 @@ pub fn parse_a_srcset_attribute(input: &str) -> Vec<ImageSource> {
                 // what Gecko does, but it also checks to see if the number is a valid HTML-spec compliant
                 // number first. Not doing that means that we might be parsing numbers that otherwise
                 // wouldn't parse.
-                'x' if is_valid_floating_point_number_string(first_part_of_string) &&
-                    width.is_none() &&
-                    density.is_none() &&
-                    future_compat_h.is_none() =>
+                'x' if is_valid_floating_point_number_string(first_part_of_string)
+                    && width.is_none()
+                    && density.is_none()
+                    && future_compat_h.is_none() =>
                 {
                     match first_part_of_string.parse::<f64>() {
                         Ok(number) if number.is_finite() && number >= 0. => {
@@ -2433,9 +2434,9 @@ pub fn parse_a_srcset_attribute(input: &str) -> Vec<ImageSource> {
                 // > 2. Apply the rules for parsing non-negative integers to the descriptor.
                 // >    If the result is 0, let error be yes. Otherwise, let future-compat-h be the
                 // >    result.
-                'h' if is_valid_non_negative_integer_string(first_part_of_string) &&
-                    future_compat_h.is_none() &&
-                    density.is_none() =>
+                'h' if is_valid_non_negative_integer_string(first_part_of_string)
+                    && future_compat_h.is_none()
+                    && density.is_none() =>
                 {
                     match parse_unsigned_integer(first_part_of_string.chars()) {
                         Ok(number) if number > 0 => {

--- a/components/script/dom/html/htmllabelelement.rs
+++ b/components/script/dom/html/htmllabelelement.rs
@@ -145,8 +145,8 @@ impl HTMLLabelElementMethods<crate::DomTypeHolder> for HTMLLabelElement {
             });
         // We now have the element that we would return, but only return it
         // if it's labelable.
-        if let Some(ref maybe_labelable) = maybe_found &&
-            maybe_labelable.is_labelable_element()
+        if let Some(ref maybe_labelable) = maybe_found
+            && maybe_labelable.is_labelable_element()
         {
             return maybe_found;
         }

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -316,8 +316,8 @@ impl Drop for MediaFrameRenderer {
 
 impl VideoFrameRenderer for MediaFrameRenderer {
     fn render(&mut self, frame: VideoFrame) {
-        if self.player_id.is_none() ||
-            (frame.is_gl_texture() && self.glplayer_id.read().unwrap().is_none())
+        if self.player_id.is_none()
+            || (frame.is_gl_texture() && self.glplayer_id.read().unwrap().is_none())
         {
             return;
         }
@@ -337,8 +337,8 @@ impl VideoFrameRenderer for MediaFrameRenderer {
 
         match &mut self.current_frame {
             Some(current_frame)
-                if current_frame.width == frame.get_width() &&
-                    current_frame.height == frame.get_height() =>
+                if current_frame.width == frame.get_width()
+                    && current_frame.height == frame.get_height() =>
             {
                 if !frame.is_gl_texture() {
                     updates.push(ImageUpdate::UpdateImage(
@@ -736,9 +736,9 @@ impl HTMLMediaElement {
                     error!("Could not play media: {error:?}");
                 }
             }
-        } else if is_playing &&
-            let Some(ref player) = *self.player.borrow() &&
-            let Err(error) = player.lock().unwrap().pause()
+        } else if is_playing
+            && let Some(ref player) = *self.player.borrow()
+            && let Err(error) = player.lock().unwrap().pause()
         {
             error!("Could not pause player: {error:?}");
         }
@@ -790,8 +790,8 @@ impl HTMLMediaElement {
         // Generally "ended" and "looping" are exclusive. Here, the loop attribute is ignored to
         // seek back to start in case loop was set after playback ended.
         // <https://github.com/whatwg/html/issues/4487>
-        if self.ended_playback(LoopCondition::Ignored) &&
-            self.direction_of_playback() == PlaybackDirection::Forwards
+        if self.ended_playback(LoopCondition::Ignored)
+            && self.direction_of_playback() == PlaybackDirection::Forwards
         {
             self.seek(
                 self.earliest_possible_position(),
@@ -823,9 +823,9 @@ impl HTMLMediaElement {
             // readyState attribute has the value HAVE_FUTURE_DATA or HAVE_ENOUGH_DATA: notify about
             // playing for the element.
             match state {
-                ReadyState::HaveNothing |
-                ReadyState::HaveMetadata |
-                ReadyState::HaveCurrentData => {
+                ReadyState::HaveNothing
+                | ReadyState::HaveMetadata
+                | ReadyState::HaveCurrentData => {
                     self.queue_media_element_task_to_fire_event(atom!("waiting"));
                 },
                 ReadyState::HaveFutureData | ReadyState::HaveEnoughData => {
@@ -1016,8 +1016,8 @@ impl HTMLMediaElement {
 
         // => "If the previous ready state was HAVE_CURRENT_DATA or less, and the new ready state is
         // HAVE_FUTURE_DATA or more"
-        if old_ready_state <= ReadyState::HaveCurrentData &&
-            ready_state >= ReadyState::HaveFutureData
+        if old_ready_state <= ReadyState::HaveCurrentData
+            && ready_state >= ReadyState::HaveFutureData
         {
             // The user agent must queue a media element task given the media element to fire an
             // event named canplay at the element.
@@ -1241,8 +1241,8 @@ impl HTMLMediaElement {
         // Step 9.children.3. If candidate has a media attribute whose value does not match the
         // environment, then end the synchronous section, and jump down to the failed with elements
         // step below.
-        if let Some(media) = element.get_attribute_string_value(&local_name!("media")) &&
-            !MediaList::matches_environment(&element.owner_document(), &media)
+        if let Some(media) = element.get_attribute_string_value(&local_name!("media"))
+            && !MediaList::matches_environment(&element.owner_document(), &media)
         {
             self.load_from_source_child_failure_steps(cx, source);
             return;
@@ -1262,8 +1262,8 @@ impl HTMLMediaElement {
         // type (including any codecs described by the codecs parameter, for types that define that
         // parameter), represents a type that the user agent knows it cannot render, then end the
         // synchronous section, and jump down to the failed with elements step below.
-        if let Some(type_) = element.get_attribute_string_value(&local_name!("type")) &&
-            ServoMedia::get().can_play_type(&type_) == SupportsMediaType::No
+        if let Some(type_) = element.get_attribute_string_value(&local_name!("type"))
+            && ServoMedia::get().can_play_type(&type_) == SupportsMediaType::No
         {
             self.load_from_source_child_failure_steps(cx, source);
             return;
@@ -1673,17 +1673,17 @@ impl HTMLMediaElement {
 
     /// <https://html.spec.whatwg.org/multipage/#potentially-playing>
     fn is_potentially_playing(&self) -> bool {
-        !self.paused.get() &&
-            !self.ended_playback(LoopCondition::Included) &&
-            self.error.get().is_none() &&
-            !self.is_blocked_media_element()
+        !self.paused.get()
+            && !self.ended_playback(LoopCondition::Included)
+            && self.error.get().is_none()
+            && !self.is_blocked_media_element()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#blocked-media-element>
     fn is_blocked_media_element(&self) -> bool {
-        self.ready_state.get() <= ReadyState::HaveCurrentData ||
-            self.is_paused_for_user_interaction() ||
-            self.is_paused_for_in_band_content()
+        self.ready_state.get() <= ReadyState::HaveCurrentData
+            || self.is_paused_for_user_interaction()
+            || self.is_paused_for_in_band_content()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#paused-for-user-interaction>
@@ -2061,8 +2061,8 @@ impl HTMLMediaElement {
         // Step 11. Set the current playback position to the new playback position.
         self.current_playback_position.set(time);
 
-        if let Some(ref player) = *self.player.borrow() &&
-            let Err(error) = player.lock().unwrap().seek(time)
+        if let Some(ref player) = *self.player.borrow()
+            && let Err(error) = player.lock().unwrap().seek(time)
         {
             error!("Could not seek player: {error:?}");
         }
@@ -2227,8 +2227,8 @@ impl HTMLMediaElement {
             return;
         }
 
-        if let Some(ref player) = *self.player.borrow() &&
-            let Err(error) = player.lock().unwrap().stop()
+        if let Some(ref player) = *self.player.borrow()
+            && let Err(error) = player.lock().unwrap().stop()
         {
             error!("Could not stop player: {error:?}");
         }
@@ -2243,16 +2243,16 @@ impl HTMLMediaElement {
     }
 
     pub(crate) fn set_audio_track(&self, idx: usize, enabled: bool) {
-        if let Some(ref player) = *self.player.borrow() &&
-            let Err(error) = player.lock().unwrap().set_audio_track(idx as i32, enabled)
+        if let Some(ref player) = *self.player.borrow()
+            && let Err(error) = player.lock().unwrap().set_audio_track(idx as i32, enabled)
         {
             warn!("Could not set audio track {error:?}");
         }
     }
 
     pub(crate) fn set_video_track(&self, idx: usize, enabled: bool) {
-        if let Some(ref player) = *self.player.borrow() &&
-            let Err(error) = player.lock().unwrap().set_video_track(idx as i32, enabled)
+        if let Some(ref player) = *self.player.borrow()
+            && let Err(error) = player.lock().unwrap().set_video_track(idx as i32, enabled)
         {
             warn!("Could not set video track: {error:?}");
         }
@@ -2285,8 +2285,8 @@ impl HTMLMediaElement {
             // direction of playback is forwards, and the media element does not have a loop
             // attribute specified.
             PlaybackDirection::Forwards => {
-                playback_position >= self.Duration() &&
-                    (loop_condition == LoopCondition::Ignored || !self.Loop())
+                playback_position >= self.Duration()
+                    && (loop_condition == LoopCondition::Ignored || !self.Loop())
             },
             // Or: The current playback position is the earliest possible position, and the
             // direction of playback is backwards.
@@ -2441,8 +2441,8 @@ impl HTMLMediaElement {
             // enable, then set enable to true, otherwise, set enable to false.
             if let Some(servo_url) = self.resource_url.borrow().as_ref() {
                 let fragment = MediaFragmentParser::from(servo_url);
-                if let Some(id) = fragment.id() &&
-                    audio_track.id() == id
+                if let Some(id) = fragment.id()
+                    && audio_track.id() == id
                 {
                     audio_track_list.set_enabled(audio_track_list.len() - 1, true);
                 }
@@ -2506,8 +2506,8 @@ impl HTMLMediaElement {
             // information that would facilitate the selection of specific video tracks to
             // improve the user's experience, then: if this video track is the first such video
             // track, then set enable to true, otherwise, set enable to false.
-            if let Some(track) = video_track_list.item(0) &&
-                let Some(servo_url) = self.resource_url.borrow().as_ref()
+            if let Some(track) = video_track_list.item(0)
+                && let Some(servo_url) = self.resource_url.borrow().as_ref()
             {
                 let fragment = MediaFragmentParser::from(servo_url);
                 if let Some(id) = fragment.id() {
@@ -2607,10 +2607,10 @@ impl HTMLMediaElement {
         // is still false, seek to that time.
         if let Some(servo_url) = self.resource_url.borrow().as_ref() {
             let fragment = MediaFragmentParser::from(servo_url);
-            if let Some(initial_playback_position) = fragment.start() &&
-                initial_playback_position > 0. &&
-                initial_playback_position < self.duration.get() &&
-                !jumped
+            if let Some(initial_playback_position) = fragment.start()
+                && initial_playback_position > 0.
+                && initial_playback_position < self.duration.get()
+                && !jumped
             {
                 self.seek(
                     initial_playback_position,
@@ -2695,8 +2695,8 @@ impl HTMLMediaElement {
         // The media engine signals that the source needs more data. If we already have a valid
         // fetch request, we do nothing. Otherwise, if we have no request and the previous request
         // was cancelled because we got an EnoughData event, we restart fetching where we left.
-        if let Some(ref current_fetch_context) = *self.current_fetch_context.borrow() &&
-            let Some(reason) = current_fetch_context.cancel_reason()
+        if let Some(ref current_fetch_context) = *self.current_fetch_context.borrow()
+            && let Some(reason) = current_fetch_context.cancel_reason()
         {
             // XXX(ferjm) Ideally we should just create a fetch request from
             // where we left. But keeping track of the exact next byte that the
@@ -2712,8 +2712,8 @@ impl HTMLMediaElement {
             return;
         }
 
-        if let Some(ref mut current_fetch_context) = *self.current_fetch_context.borrow_mut() &&
-            let Err(e) = {
+        if let Some(ref mut current_fetch_context) = *self.current_fetch_context.borrow_mut()
+            && let Err(e) = {
                 let mut data_source = current_fetch_context.data_source().borrow_mut();
                 data_source.set_locked(false);
                 data_source.process_into_player_from_queue(self.player.borrow().as_ref().unwrap())
@@ -2734,8 +2734,8 @@ impl HTMLMediaElement {
         // to avoid excessive buffer queueing, so we cancel the ongoing fetch request if we are able
         // to restart it from where we left. Otherwise, we continue the current fetch request,
         // assuming that some frames will be dropped.
-        if let Some(ref mut current_fetch_context) = *self.current_fetch_context.borrow_mut() &&
-            current_fetch_context.is_seekable()
+        if let Some(ref mut current_fetch_context) = *self.current_fetch_context.borrow_mut()
+            && current_fetch_context.is_seekable()
         {
             current_fetch_context.cancel(CancelReason::Backoff);
         }
@@ -3131,8 +3131,8 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
 
         self.muted.set(value);
 
-        if let Some(ref player) = *self.player.borrow() &&
-            let Err(error) = player.lock().unwrap().set_mute(value)
+        if let Some(ref player) = *self.player.borrow()
+            && let Err(error) = player.lock().unwrap().set_mute(value)
         {
             warn!("Could not set mute state: {error:?}");
         }
@@ -3303,9 +3303,9 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
         // change the playback speed.
         self.playback_rate.set(*value);
 
-        if self.is_potentially_playing() &&
-            let Some(ref player) = *self.player.borrow() &&
-            let Err(error) = player.lock().unwrap().set_playback_rate(*value)
+        if self.is_potentially_playing()
+            && let Some(ref player) = *self.player.borrow()
+            && let Err(error) = player.lock().unwrap().set_playback_rate(*value)
         {
             warn!("Could not set the playback rate: {error:?}");
         }
@@ -3354,8 +3354,8 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-media-ended>
     fn Ended(&self) -> bool {
-        self.ended_playback(LoopCondition::Included) &&
-            self.direction_of_playback() == PlaybackDirection::Forwards
+        self.ended_playback(LoopCondition::Included)
+            && self.direction_of_playback() == PlaybackDirection::Forwards
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-media-fastseek>
@@ -3466,8 +3466,8 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
 
         self.volume.set(*value);
 
-        if let Some(ref player) = *self.player.borrow() &&
-            let Err(error) = player.lock().unwrap().set_volume(*value)
+        if let Some(ref player) = *self.player.borrow()
+            && let Err(error) = player.lock().unwrap().set_volume(*value)
         {
             warn!("Could not set the volume: {error:?}");
         }
@@ -3645,11 +3645,11 @@ impl MicrotaskRunnable for MediaElementMicrotask {
 
     fn enter_realm<'cx>(&self, cx: &'cx mut js::context::JSContext) -> AutoRealm<'cx> {
         match self {
-            &MediaElementMicrotask::ResourceSelection { ref elem, .. } |
-            &MediaElementMicrotask::PauseIfNotInDocument { ref elem } |
-            &MediaElementMicrotask::Seeked { ref elem, .. } |
-            &MediaElementMicrotask::SelectNextSourceChild { ref elem, .. } |
-            &MediaElementMicrotask::SelectNextSourceChildAfterWait { ref elem, .. } => {
+            &MediaElementMicrotask::ResourceSelection { ref elem, .. }
+            | &MediaElementMicrotask::PauseIfNotInDocument { ref elem }
+            | &MediaElementMicrotask::Seeked { ref elem, .. }
+            | &MediaElementMicrotask::SelectNextSourceChild { ref elem, .. }
+            | &MediaElementMicrotask::SelectNextSourceChildAfterWait { ref elem, .. } => {
                 enter_auto_realm(cx, &**elem)
             },
         }
@@ -3885,8 +3885,8 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
             current_fetch_context.set_origin_clean(origin_clean);
         }
 
-        if let Some(metadata) = metadata.as_ref() &&
-            let Some(headers) = metadata.headers.as_ref()
+        if let Some(metadata) = metadata.as_ref()
+            && let Some(headers) = metadata.headers.as_ref()
         {
             // For range requests we get the size of the media asset from the Content-Range
             // header. Otherwise, we get it from the Content-Length header.
@@ -3899,8 +3899,8 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
             };
 
             // We only set the expected input size if it changes.
-            if content_length != self.expected_content_length &&
-                let Some(content_length) = content_length
+            if content_length != self.expected_content_length
+                && let Some(content_length) = content_length
             {
                 self.expected_content_length = Some(content_length);
             }
@@ -3919,8 +3919,8 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
             warn!("Could not set player seekable {:?}", e);
         }
 
-        if let Some(expected_content_length) = self.expected_content_length &&
-            let Err(e) = element
+        if let Some(expected_content_length) = self.expected_content_length
+            && let Err(e) = element
                 .player
                 .borrow()
                 .as_ref()
@@ -3945,8 +3945,8 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
             }
 
             // Discard chunk of the response body if fetch context doesn't support range requests.
-            let payload = if !current_fetch_context.is_seekable() &&
-                self.content_length_to_discard != 0
+            let payload = if !current_fetch_context.is_seekable()
+                && self.content_length_to_discard != 0
             {
                 if chunk.len() as u64 > self.content_length_to_discard {
                     let shrink_chunk = chunk[self.content_length_to_discard as usize..].to_vec();
@@ -4011,8 +4011,8 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
                 // start and stop positions without the total size of the stream is not
                 // possible. As fallback the media player perform seek with BYTES format
                 // and initiate seek request via "seek-data" callback with required offset.
-                if self.expected_content_length.is_none() &&
-                    let Err(e) = element
+                if self.expected_content_length.is_none()
+                    && let Err(e) = element
                         .player
                         .borrow()
                         .as_ref()
@@ -4083,8 +4083,8 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
 
         // Whether the current fetch request was cancelled due to a network or decoding error, or
         // was aborted by the user.
-        if let Some(cancel_reason) = current_fetch_context.cancel_reason() &&
-            matches!(*cancel_reason, CancelReason::Error | CancelReason::Abort)
+        if let Some(cancel_reason) = current_fetch_context.cancel_reason()
+            && matches!(*cancel_reason, CancelReason::Error | CancelReason::Abort)
         {
             return false;
         }

--- a/components/script/dom/html/htmlmeterelement.rs
+++ b/components/script/dom/html/htmlmeterelement.rs
@@ -318,12 +318,12 @@ impl VirtualMethods for HTMLMeterElement {
 
         let is_important_attribute = matches!(
             attr.local_name(),
-            &local_name!("high") |
-                &local_name!("low") |
-                &local_name!("min") |
-                &local_name!("max") |
-                &local_name!("optimum") |
-                &local_name!("value")
+            &local_name!("high")
+                | &local_name!("low")
+                | &local_name!("min")
+                | &local_name!("max")
+                | &local_name!("optimum")
+                | &local_name!("value")
         );
         if is_important_attribute {
             self.update_state(cx);

--- a/components/script/dom/html/htmloptionelement.rs
+++ b/components/script/dom/html/htmloptionelement.rs
@@ -209,8 +209,8 @@ impl HTMLOptionElement {
         // * option's selectedness is true; and
         // * select's enabled selectedcontent is not null,
         // * then run clone an option into a selectedcontent given option and select's enabled selectedcontent.
-        if self.selectedness.get() &&
-            let Some(selectedcontent) =
+        if self.selectedness.get()
+            && let Some(selectedcontent) =
                 select.and_then(|select| select.get_enabled_selectedcontent())
         {
             self.clone_an_option_into_selectedcontent(cx, &selectedcontent);
@@ -295,8 +295,8 @@ impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
         while let Some(node) = iterator.peek() {
             if let Some(element) = node.downcast::<Element>() {
                 let html_script = element.is::<HTMLScriptElement>();
-                let svg_script = *element.namespace() == ns!(svg) &&
-                    element.local_name() == &local_name!("script");
+                let svg_script = *element.namespace() == ns!(svg)
+                    && element.local_name() == &local_name!("script");
                 if html_script || svg_script {
                     iterator.next_skipping_children();
                     continue;
@@ -500,9 +500,9 @@ impl VirtualMethods for HTMLOptionElement {
         // if it does not have a label attribute
         if !self
             .upcast::<Element>()
-            .has_attribute(&local_name!("label")) &&
-            let Some(owner_select) = self.owner_select_element() &&
-            owner_select
+            .has_attribute(&local_name!("label"))
+            && let Some(owner_select) = self.owner_select_element()
+            && owner_select
                 .selected_option(cx.no_gc())
                 .is_some_and(|selected_option| *self == **selected_option)
         {

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -382,8 +382,8 @@ impl FetchResponseListener for ClassicContext {
 
         let global = elem.global();
 
-        if let Some(window) = global.downcast::<Window>() &&
-            let Some(script_source) = window.local_script_source()
+        if let Some(window) = global.downcast::<Window>()
+            && let Some(script_source) = window.local_script_source()
         {
             substitute_with_local_script(script_source, &mut source_text, final_url.clone());
         }
@@ -578,10 +578,10 @@ impl HTMLScriptElement {
         // > A script element el is implicitly potentially render-blocking if el's type is "classic",
         // > el is parser-inserted, and el does not have an async or defer attribute.
         self.get_script_type()
-            .is_some_and(|script_type| script_type == ScriptType::Classic) &&
-            self.parser_inserted.get() &&
-            !element.has_attribute(&local_name!("async")) &&
-            !element.has_attribute(&local_name!("defer"))
+            .is_some_and(|script_type| script_type == ScriptType::Classic)
+            && self.parser_inserted.get()
+            && !element.has_attribute(&local_name!("async"))
+            && !element.has_attribute(&local_name!("defer"))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#prepare-the-script-element>
@@ -674,8 +674,8 @@ impl HTMLScriptElement {
         let global = &doc.global();
 
         // Step 19. CSP.
-        if !element.has_attribute(&local_name!("src")) &&
-            global
+        if !element.has_attribute(&local_name!("src"))
+            && global
                 .get_csp_list()
                 .should_elements_inline_type_behavior_be_blocked(
                     cx,
@@ -870,10 +870,11 @@ impl HTMLScriptElement {
                     );
                     let result = Ok(Script::Classic(script));
 
-                    if was_parser_inserted &&
-                        doc.get_current_parser()
-                            .is_some_and(|parser| parser.script_nesting_level() <= 1) &&
-                        doc.has_a_stylesheet_that_is_blocking_scripts()
+                    if was_parser_inserted
+                        && doc
+                            .get_current_parser()
+                            .is_some_and(|parser| parser.script_nesting_level() <= 1)
+                        && doc.has_a_stylesheet_that_is_blocking_scripts()
                     {
                         // Step 34.2: classic, has no src, was parser-inserted, is blocked on stylesheet.
                         doc.set_pending_parsing_blocking_script(self, Some(result));
@@ -888,8 +889,8 @@ impl HTMLScriptElement {
                     self.delay_load_event(&delayed_document, base_url.clone());
 
                     // Step 32.2.2.2 If el is potentially render-blocking, then:
-                    if self.potentially_render_blocking() &&
-                        doc.allows_adding_render_blocking_elements()
+                    if self.potentially_render_blocking()
+                        && doc.allows_adding_render_blocking_elements()
                     {
                         // Step 32.2.2.2.1 Block rendering on el.
                         self.marked_as_render_blocking.set(true);
@@ -1131,15 +1132,15 @@ impl VirtualMethods for HTMLScriptElement {
             .unwrap()
             .attribute_mutated(cx, attr, mutation);
         if *attr.local_name() == local_name!("src") {
-            if let AttributeMutation::Set(..) = mutation &&
-                !self.parser_inserted.get() &&
-                self.upcast::<Node>().is_connected()
+            if let AttributeMutation::Set(..) = mutation
+                && !self.parser_inserted.get()
+                && self.upcast::<Node>().is_connected()
             {
                 self.prepare(cx, Some(IntroductionType::INJECTED_SCRIPT));
             }
-        } else if *attr.local_name() == local_name!("blocking") &&
-            !self.has_render_blocking_attribute() &&
-            self.marked_as_render_blocking.replace(false)
+        } else if *attr.local_name() == local_name!("blocking")
+            && !self.has_render_blocking_attribute()
+            && self.marked_as_render_blocking.replace(false)
         {
             let document = self.owner_document();
             document.decrement_render_blocking_element_count();
@@ -1238,8 +1239,9 @@ impl HTMLScriptElementMethods<crate::DomTypeHolder> for HTMLScriptElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-script-async>
     fn Async(&self) -> bool {
-        self.non_blocking.get() ||
-            self.upcast::<Element>()
+        self.non_blocking.get()
+            || self
+                .upcast::<Element>()
                 .has_attribute(&local_name!("async"))
     }
 

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -252,8 +252,8 @@ impl HTMLSelectElement {
 
         if let Some(last_selected) = last_selected {
             last_selected.set_selectedness(true);
-        } else if self.display_size() == 1 &&
-            let Some(first_enabled) = first_enabled
+        } else if self.display_size() == 1
+            && let Some(first_enabled) = first_enabled
         {
             first_enabled.set_selectedness(true);
         }
@@ -520,8 +520,8 @@ impl HTMLSelectElement {
 
             if let Some(first_selected) = first_selected {
                 first_selected.set_selectedness(true);
-            } else if self.display_size() == 1 &&
-                let Some(first_enabled) = first_enabled
+            } else if self.display_size() == 1
+                && let Some(first_enabled) = first_enabled
             {
                 first_enabled.set_selectedness(true);
             }
@@ -912,8 +912,8 @@ impl VirtualMethods for HTMLSelectElement {
 
     fn handle_event(&self, cx: &mut js::context::JSContext, event: &Event) {
         self.super_type().unwrap().handle_event(cx, event);
-        if let Some(event) = event.downcast::<FocusEvent>() &&
-            *event.upcast::<Event>().type_() != *"blur"
+        if let Some(event) = event.downcast::<FocusEvent>()
+            && *event.upcast::<Event>().type_() != *"blur"
         {
             self.owner_document()
                 .embedder_controls()
@@ -964,8 +964,8 @@ impl Validatable for HTMLSelectElement {
         if validate_flags.contains(ValidationFlags::VALUE_MISSING) && self.Required() {
             let placeholder = self.get_placeholder_label_option(cx.no_gc());
             let is_value_missing = !self.list_of_options(cx.no_gc()).any(|e| {
-                e.Selected() &&
-                    placeholder
+                e.Selected()
+                    && placeholder
                         .as_ref()
                         .map(|placeholder| **placeholder != **e)
                         .unwrap_or(true)

--- a/components/script/dom/html/htmlslotelement.rs
+++ b/components/script/dom/html/htmlslotelement.rs
@@ -223,8 +223,8 @@ impl HTMLSlotElement {
             for child in self.upcast::<Node>().children_unrooted(cx) {
                 let is_slottable = matches!(
                     child.type_id(),
-                    NodeTypeId::Element(_) |
-                        NodeTypeId::CharacterData(CharacterDataTypeId::Text(_))
+                    NodeTypeId::Element(_)
+                        | NodeTypeId::CharacterData(CharacterDataTypeId::Text(_))
                 );
                 if is_slottable {
                     slottables.push(Slottable(Dom::from_ref(&*child)));
@@ -290,8 +290,8 @@ impl HTMLSlotElement {
             for child in host.upcast::<Node>().children_unrooted(cx) {
                 let is_slottable = matches!(
                     child.type_id(),
-                    NodeTypeId::Element(_) |
-                        NodeTypeId::CharacterData(CharacterDataTypeId::Text(_))
+                    NodeTypeId::Element(_)
+                        | NodeTypeId::CharacterData(CharacterDataTypeId::Text(_))
                 );
                 if is_slottable {
                     rooted!(&in(cx) let slottable = Slottable(Dom::from_ref(&*child)));
@@ -523,8 +523,8 @@ impl VirtualMethods for HTMLSlotElement {
             s.unbind_from_tree(cx, context);
         }
 
-        if !self.upcast::<Node>().is_in_a_shadow_tree() &&
-            let Some(old_shadow_root) = self.containing_shadow_root()
+        if !self.upcast::<Node>().is_in_a_shadow_tree()
+            && let Some(old_shadow_root) = self.containing_shadow_root()
         {
             // If we used to be in a shadow root, but aren't anymore, then unregister this slot
             old_shadow_root.unregister_slot(self.Name(), self);

--- a/components/script/dom/html/htmlsourceelement.rs
+++ b/components/script/dom/html/htmlsourceelement.rs
@@ -96,15 +96,15 @@ impl VirtualMethods for HTMLSourceElement {
             .attribute_mutated(cx, attr, mutation);
 
         match attr.local_name() {
-            &local_name!("srcset") |
-            &local_name!("sizes") |
-            &local_name!("media") |
-            &local_name!("type") => {
+            &local_name!("srcset")
+            | &local_name!("sizes")
+            | &local_name!("media")
+            | &local_name!("type") => {
                 // <https://html.spec.whatwg.org/multipage/#reacting-to-dom-mutations>
                 // The element's parent is a picture element and a source element that is a previous
                 // sibling has its srcset, sizes, media, type attributes set, changed, or removed.
-                if let Some(parent) = self.upcast::<Node>().GetParentElement() &&
-                    parent.is::<HTMLPictureElement>()
+                if let Some(parent) = self.upcast::<Node>().GetParentElement()
+                    && parent.is::<HTMLPictureElement>()
                 {
                     let next_sibling_iterator = self.upcast::<Node>().following_siblings();
                     HTMLSourceElement::iterate_next_html_image_element_siblings_with_cx(
@@ -119,8 +119,8 @@ impl VirtualMethods for HTMLSourceElement {
                 // height attributes changes (set, changed, removed) of the source element should be
                 // counted as relevant mutation for the sibling image element, these attributes
                 // affect only the style presentational hints of the image element.
-                if let Some(parent) = self.upcast::<Node>().GetParentElement() &&
-                    parent.is::<HTMLPictureElement>()
+                if let Some(parent) = self.upcast::<Node>().GetParentElement()
+                    && parent.is::<HTMLPictureElement>()
                 {
                     let next_sibling_iterator = self.upcast::<Node>().following_siblings();
                     HTMLSourceElement::iterate_next_html_image_element_siblings(
@@ -179,9 +179,9 @@ impl VirtualMethods for HTMLSourceElement {
 
         // Step 1. If oldParent is a picture element, then for each child of oldParent's children,
         // if child is an img element, then count this as a relevant mutation for child.
-        if context.parent.is::<HTMLPictureElement>() &&
-            !self.upcast::<Node>().has_parent() &&
-            let Some(next_sibling) = context.next_sibling
+        if context.parent.is::<HTMLPictureElement>()
+            && !self.upcast::<Node>().has_parent()
+            && let Some(next_sibling) = context.next_sibling
         {
             let next_sibling_iterator = next_sibling.inclusively_following_siblings();
             HTMLSourceElement::iterate_next_html_image_element_siblings_with_cx(

--- a/components/script/dom/html/htmltableelement.rs
+++ b/components/script/dom/html/htmltableelement.rs
@@ -47,9 +47,10 @@ struct TableRowFilter {
 
 impl CollectionFilter for TableRowFilter {
     fn filter(&self, elem: &Element, root: &Node) -> bool {
-        elem.is::<HTMLTableRowElement>() &&
-            (root.is_parent_of(elem.upcast()) ||
-                self.sections
+        elem.is::<HTMLTableRowElement>()
+            && (root.is_parent_of(elem.upcast())
+                || self
+                    .sections
                     .iter()
                     .any(|section| section.is_parent_of(elem.upcast())))
     }
@@ -114,8 +115,8 @@ impl HTMLTableElement {
     where
         P: FnMut(&DomRoot<Element>) -> bool,
     {
-        if let Some(e) = section &&
-            e.upcast::<Element>().local_name() != atom
+        if let Some(e) = section
+            && e.upcast::<Element>().local_name() != atom
         {
             return Err(Error::HierarchyRequest(None));
         }
@@ -312,9 +313,9 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
                 &self.owner_window(),
                 self.upcast(),
                 |element, root| {
-                    element.is::<HTMLTableSectionElement>() &&
-                        element.local_name() == &local_name!("tbody") &&
-                        element.upcast::<Node>().GetParentNode().as_deref() == Some(root)
+                    element.is::<HTMLTableSectionElement>()
+                        && element.local_name() == &local_name!("tbody")
+                        && element.upcast::<Node>().GetParentNode().as_deref() == Some(root)
                 },
             )
         })

--- a/components/script/dom/html/htmltablerowelement.rs
+++ b/components/script/dom/html/htmltablerowelement.rs
@@ -91,8 +91,8 @@ impl HTMLTableRowElementMethods<crate::DomTypeHolder> for HTMLTableRowElement {
                 &self.owner_window(),
                 self.upcast(),
                 |element, root| {
-                    (element.is::<HTMLTableCellElement>()) &&
-                        element.upcast::<Node>().GetParentNode().as_deref() == Some(root)
+                    (element.is::<HTMLTableCellElement>())
+                        && element.upcast::<Node>().GetParentNode().as_deref() == Some(root)
                 },
             )
         })

--- a/components/script/dom/html/htmltablesectionelement.rs
+++ b/components/script/dom/html/htmltablesectionelement.rs
@@ -69,8 +69,8 @@ impl HTMLTableSectionElementMethods<crate::DomTypeHolder> for HTMLTableSectionEl
             &self.owner_window(),
             self.upcast(),
             |element, root| {
-                element.is::<HTMLTableRowElement>() &&
-                    element.upcast::<Node>().GetParentNode().as_deref() == Some(root)
+                element.is::<HTMLTableRowElement>()
+                    && element.upcast::<Node>().GetParentNode().as_deref() == Some(root)
             },
         )
     }

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -792,9 +792,9 @@ impl VirtualMethods for HTMLTextAreaElement {
                 let action = self.textinput.borrow_mut().handle_keydown(keyboard_event);
                 self.handle_key_reaction(cx, action, event);
             }
-        } else if event.type_() == atom!("compositionstart") ||
-            event.type_() == atom!("compositionupdate") ||
-            event.type_() == atom!("compositionend")
+        } else if event.type_() == atom!("compositionstart")
+            || event.type_() == atom!("compositionupdate")
+            || event.type_() == atom!("compositionend")
         {
             if let Some(compositionevent) = event.downcast::<CompositionEvent>() {
                 if event.type_() == atom!("compositionend") {
@@ -889,9 +889,9 @@ impl Validatable for HTMLTextAreaElement {
         // https://html.spec.whatwg.org/multipage/#enabling-and-disabling-form-controls%3A-the-disabled-attribute%3Abarred-from-constraint-validation
         // https://html.spec.whatwg.org/multipage/#the-textarea-element%3Abarred-from-constraint-validation
         // https://html.spec.whatwg.org/multipage/#the-datalist-element%3Abarred-from-constraint-validation
-        !self.upcast::<Element>().disabled_state() &&
-            !self.ReadOnly() &&
-            !is_barred_by_datalist_ancestor(self.upcast())
+        !self.upcast::<Element>().disabled_state()
+            && !self.ReadOnly()
+            && !is_barred_by_datalist_ancestor(self.upcast())
     }
 
     fn perform_validation(
@@ -908,10 +908,10 @@ impl Validatable for HTMLTextAreaElement {
 
         // https://html.spec.whatwg.org/multipage/#suffering-from-being-missing
         // https://html.spec.whatwg.org/multipage/#the-textarea-element%3Asuffering-from-being-missing
-        if validate_flags.contains(ValidationFlags::VALUE_MISSING) &&
-            self.Required() &&
-            self.is_mutable() &&
-            value_len == 0
+        if validate_flags.contains(ValidationFlags::VALUE_MISSING)
+            && self.Required()
+            && self.is_mutable()
+            && value_len == 0
         {
             failed_flags.insert(ValidationFlags::VALUE_MISSING);
         }

--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -183,8 +183,8 @@ impl HTMLVideoElement {
             let mut planar_texture = self.planar_texture.borrow_mut();
             match planar_texture.as_ref() {
                 Some(planar_texture) => {
-                    if planar_texture.is_expired() &&
-                        let Some(snapshot) = self.get_current_frame_data()
+                    if planar_texture.is_expired()
+                        && let Some(snapshot) = self.get_current_frame_data()
                     {
                         planar_texture.update(snapshot);
                     }

--- a/components/script/dom/html/input_element/file_input_type.rs
+++ b/components/script/dom/html/input_element/file_input_type.rs
@@ -91,8 +91,8 @@ impl FileInputType {
             // element's selected files."
             //
             // Note: This is annoying.
-            if input.Multiple() &&
-                let Some(filelist) = self.get_files()
+            if input.Multiple()
+                && let Some(filelist) = self.get_files()
             {
                 files = filelist.iter_files().map(|file| file.as_rooted()).collect();
             }

--- a/components/script/dom/html/input_element/input_type.rs
+++ b/components/script/dom/html/input_element/input_type.rs
@@ -219,18 +219,18 @@ impl InputType {
     pub(crate) fn is_textual(&self) -> bool {
         matches!(
             *self,
-            Self::Date(_) |
-                Self::DatetimeLocal(_) |
-                Self::Email(_) |
-                Self::Hidden(_) |
-                Self::Month(_) |
-                Self::Number(_) |
-                Self::Search(_) |
-                Self::Tel(_) |
-                Self::Text(_) |
-                Self::Time(_) |
-                Self::Url(_) |
-                Self::Week(_)
+            Self::Date(_)
+                | Self::DatetimeLocal(_)
+                | Self::Email(_)
+                | Self::Hidden(_)
+                | Self::Month(_)
+                | Self::Number(_)
+                | Self::Search(_)
+                | Self::Tel(_)
+                | Self::Text(_)
+                | Self::Time(_)
+                | Self::Url(_)
+                | Self::Week(_)
         )
     }
 
@@ -321,10 +321,10 @@ pub(crate) trait SpecificInputType {
 
     /// <https://html.spec.whatwg.org/multipage/#the-required-attribute%3Asuffering-from-being-missing>
     fn suffers_from_being_missing(&self, input: &HTMLInputElement, value: &DOMString) -> bool {
-        input.Required() &&
-            input.value_mode() == ValueMode::Value &&
-            input.is_mutable() &&
-            value.is_empty()
+        input.Required()
+            && input.value_mode() == ValueMode::Value
+            && input.is_mutable()
+            && value.is_empty()
     }
 
     fn suffers_from_bad_input(&self, _value: &DOMString) -> bool {

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -270,28 +270,28 @@ impl HTMLInputElement {
     /// <https://html.spec.whatwg.org/multipage/#concept-input-apply>
     fn value_mode(&self) -> ValueMode {
         match *self.input_type() {
-            InputType::Submit(_) |
-            InputType::Reset(_) |
-            InputType::Button(_) |
-            InputType::Image(_) |
-            InputType::Hidden(_) => ValueMode::Default,
+            InputType::Submit(_)
+            | InputType::Reset(_)
+            | InputType::Button(_)
+            | InputType::Image(_)
+            | InputType::Hidden(_) => ValueMode::Default,
 
             InputType::Checkbox(_) | InputType::Radio(_) => ValueMode::DefaultOn,
 
-            InputType::Color(_) |
-            InputType::Date(_) |
-            InputType::DatetimeLocal(_) |
-            InputType::Email(_) |
-            InputType::Month(_) |
-            InputType::Number(_) |
-            InputType::Password(_) |
-            InputType::Range(_) |
-            InputType::Search(_) |
-            InputType::Tel(_) |
-            InputType::Text(_) |
-            InputType::Time(_) |
-            InputType::Url(_) |
-            InputType::Week(_) => ValueMode::Value,
+            InputType::Color(_)
+            | InputType::Date(_)
+            | InputType::DatetimeLocal(_)
+            | InputType::Email(_)
+            | InputType::Month(_)
+            | InputType::Number(_)
+            | InputType::Password(_)
+            | InputType::Range(_)
+            | InputType::Search(_)
+            | InputType::Tel(_)
+            | InputType::Text(_)
+            | InputType::Time(_)
+            | InputType::Url(_)
+            | InputType::Week(_) => ValueMode::Value,
 
             InputType::File(_) => ValueMode::Filename,
         }
@@ -306,16 +306,16 @@ impl HTMLInputElement {
     pub(crate) fn is_nontypeable(&self) -> bool {
         matches!(
             *self.input_type(),
-            InputType::Button(_) |
-                InputType::Checkbox(_) |
-                InputType::Color(_) |
-                InputType::File(_) |
-                InputType::Hidden(_) |
-                InputType::Image(_) |
-                InputType::Radio(_) |
-                InputType::Range(_) |
-                InputType::Reset(_) |
-                InputType::Submit(_)
+            InputType::Button(_)
+                | InputType::Checkbox(_)
+                | InputType::Color(_)
+                | InputType::File(_)
+                | InputType::Hidden(_)
+                | InputType::Image(_)
+                | InputType::Radio(_)
+                | InputType::Range(_)
+                | InputType::Reset(_)
+                | InputType::Submit(_)
         )
     }
 
@@ -331,40 +331,40 @@ impl HTMLInputElement {
     pub(crate) fn is_auto_directionality_form_associated_element(&self) -> bool {
         matches!(
             *self.input_type(),
-            InputType::Hidden(_) |
-                InputType::Text(_) |
-                InputType::Search(_) |
-                InputType::Tel(_) |
-                InputType::Url(_) |
-                InputType::Email(_) |
-                InputType::Password(_) |
-                InputType::Submit(_) |
-                InputType::Reset(_) |
-                InputType::Button(_)
+            InputType::Hidden(_)
+                | InputType::Text(_)
+                | InputType::Search(_)
+                | InputType::Tel(_)
+                | InputType::Url(_)
+                | InputType::Email(_)
+                | InputType::Password(_)
+                | InputType::Submit(_)
+                | InputType::Reset(_)
+                | InputType::Button(_)
         )
     }
 
     fn does_minmaxlength_apply(&self) -> bool {
         matches!(
             *self.input_type(),
-            InputType::Text(_) |
-                InputType::Search(_) |
-                InputType::Url(_) |
-                InputType::Tel(_) |
-                InputType::Email(_) |
-                InputType::Password(_)
+            InputType::Text(_)
+                | InputType::Search(_)
+                | InputType::Url(_)
+                | InputType::Tel(_)
+                | InputType::Email(_)
+                | InputType::Password(_)
         )
     }
 
     fn does_pattern_apply(&self) -> bool {
         matches!(
             *self.input_type(),
-            InputType::Text(_) |
-                InputType::Search(_) |
-                InputType::Url(_) |
-                InputType::Tel(_) |
-                InputType::Email(_) |
-                InputType::Password(_)
+            InputType::Text(_)
+                | InputType::Search(_)
+                | InputType::Url(_)
+                | InputType::Tel(_)
+                | InputType::Email(_)
+                | InputType::Password(_)
         )
     }
 
@@ -377,13 +377,13 @@ impl HTMLInputElement {
     fn does_value_as_number_apply(&self) -> bool {
         matches!(
             *self.input_type(),
-            InputType::Date(_) |
-                InputType::Month(_) |
-                InputType::Week(_) |
-                InputType::Time(_) |
-                InputType::DatetimeLocal(_) |
-                InputType::Number(_) |
-                InputType::Range(_)
+            InputType::Date(_)
+                | InputType::Month(_)
+                | InputType::Week(_)
+                | InputType::Time(_)
+                | InputType::DatetimeLocal(_)
+                | InputType::Number(_)
+                | InputType::Range(_)
         )
     }
 
@@ -600,8 +600,8 @@ impl HTMLInputElement {
             // Step 4. If the element has a minimum and a maximum and there is no value greater than or equal to the
             // element's minimum and less than or equal to the element's maximum that, when subtracted from the step
             // base, is an integral multiple of the allowed value step, then return.
-            if let Some(stepped_minimum) = self.stepped_minimum() &&
-                stepped_minimum > max
+            if let Some(stepped_minimum) = self.stepped_minimum()
+                && stepped_minimum > max
             {
                 return Ok(());
             }
@@ -652,8 +652,8 @@ impl HTMLInputElement {
         // Step 8. If the element has a minimum, and value is less than that minimum, then set value to the smallest
         // value that, when subtracted from the step base, is an integral multiple of the allowed value step, and that
         // is more than or equal to that minimum.
-        if let Some(min) = minimum &&
-            value < min
+        if let Some(min) = minimum
+            && value < min
         {
             value = self.stepped_minimum().unwrap_or(value);
         }
@@ -661,8 +661,8 @@ impl HTMLInputElement {
         // Step 9. If the element has a maximum, and value is greater than that maximum, then set value to the largest
         // value that, when subtracted from the step base, is an integral multiple of the allowed value step, and that
         // is less than or equal to that maximum.
-        if let Some(max) = maximum &&
-            value > max
+        if let Some(max) = maximum
+            && value > max
         {
             value = self.stepped_maximum().unwrap_or(value);
         }
@@ -827,14 +827,14 @@ impl HTMLInputElement {
             }
         } else {
             // https://html.spec.whatwg.org/multipage/#the-min-and-max-attributes%3Asuffering-from-an-underflow-2
-            if let Some(min_value) = min_value &&
-                value_as_number < min_value
+            if let Some(min_value) = min_value
+                && value_as_number < min_value
             {
                 failed_flags.insert(ValidationFlags::RANGE_UNDERFLOW);
             }
             // https://html.spec.whatwg.org/multipage/#the-min-and-max-attributes%3Asuffering-from-an-overflow-2
-            if let Some(max_value) = max_value &&
-                value_as_number > max_value
+            if let Some(max_value) = max_value
+                && value_as_number > max_value
             {
                 failed_flags.insert(ValidationFlags::RANGE_OVERFLOW);
             }
@@ -896,11 +896,11 @@ impl HTMLInputElement {
     fn value_for_shadow_dom(&self) -> DOMString {
         let input_type = &*self.input_type();
         match input_type {
-            InputType::Checkbox(_) |
-            InputType::Radio(_) |
-            InputType::Image(_) |
-            InputType::Hidden(_) |
-            InputType::Range(_) => input_type.as_specific().value_for_shadow_dom(self),
+            InputType::Checkbox(_)
+            | InputType::Radio(_)
+            | InputType::Image(_)
+            | InputType::Hidden(_)
+            | InputType::Range(_) => input_type.as_specific().value_for_shadow_dom(self),
             _ => {
                 if let Some(attribute_value) = self
                     .upcast::<Element>()
@@ -980,11 +980,11 @@ impl TextControlElement for HTMLInputElement {
     fn selection_api_applies(&self) -> bool {
         matches!(
             *self.input_type(),
-            InputType::Text(_) |
-                InputType::Search(_) |
-                InputType::Url(_) |
-                InputType::Tel(_) |
-                InputType::Password(_)
+            InputType::Text(_)
+                | InputType::Search(_)
+                | InputType::Url(_)
+                | InputType::Tel(_)
+                | InputType::Password(_)
         )
     }
 
@@ -1872,21 +1872,21 @@ impl HTMLInputElement {
                     .traverse_preorder(ShadowIncluding::No)
                     .filter_map(DomRoot::downcast::<HTMLInputElement>)
                     .filter(|input| {
-                        input.form_owner() == owner &&
-                            matches!(
+                        input.form_owner() == owner
+                            && matches!(
                                 *input.input_type(),
-                                InputType::Text(_) |
-                                    InputType::Search(_) |
-                                    InputType::Url(_) |
-                                    InputType::Tel(_) |
-                                    InputType::Email(_) |
-                                    InputType::Password(_) |
-                                    InputType::Date(_) |
-                                    InputType::Month(_) |
-                                    InputType::Week(_) |
-                                    InputType::Time(_) |
-                                    InputType::DatetimeLocal(_) |
-                                    InputType::Number(_)
+                                InputType::Text(_)
+                                    | InputType::Search(_)
+                                    | InputType::Url(_)
+                                    | InputType::Tel(_)
+                                    | InputType::Email(_)
+                                    | InputType::Password(_)
+                                    | InputType::Date(_)
+                                    | InputType::Month(_)
+                                    | InputType::Week(_)
+                                    | InputType::Time(_)
+                                    | InputType::DatetimeLocal(_)
+                                    | InputType::Number(_)
                             )
                     });
 
@@ -2104,8 +2104,8 @@ impl VirtualMethods for HTMLInputElement {
                         let new_value_mode = self.value_mode();
                         match (&old_value_mode, old_idl_value.is_empty(), new_value_mode) {
                             // Step 1
-                            (&ValueMode::Value, false, ValueMode::Default) |
-                            (&ValueMode::Value, false, ValueMode::DefaultOn) => {
+                            (&ValueMode::Value, false, ValueMode::Default)
+                            | (&ValueMode::Value, false, ValueMode::DefaultOn) => {
                                 self.SetValue(cx, old_idl_value)
                                     .expect("Failed to set input value on type change to a default ValueMode.");
                             },
@@ -2325,9 +2325,9 @@ impl VirtualMethods for HTMLInputElement {
         if let Some(mouse_event) = event.downcast::<MouseEvent>() {
             self.handle_mouse_event(mouse_event);
             event.mark_as_handled();
-        } else if event.type_() == atom!("keydown") &&
-            !event.DefaultPrevented() &&
-            self.input_type().is_textual_or_password()
+        } else if event.type_() == atom!("keydown")
+            && !event.DefaultPrevented()
+            && self.input_type().is_textual_or_password()
         {
             if let Some(keyevent) = event.downcast::<KeyboardEvent>() {
                 // This can't be inlined, as holding on to textinput.borrow_mut()
@@ -2335,10 +2335,10 @@ impl VirtualMethods for HTMLInputElement {
                 let action = self.textinput.borrow_mut().handle_keydown(keyevent);
                 self.handle_key_reaction(cx, action, event);
             }
-        } else if (event.type_() == atom!("compositionstart") ||
-            event.type_() == atom!("compositionupdate") ||
-            event.type_() == atom!("compositionend")) &&
-            self.input_type().is_textual_or_password()
+        } else if (event.type_() == atom!("compositionstart")
+            || event.type_() == atom!("compositionupdate")
+            || event.type_() == atom!("compositionend"))
+            && self.input_type().is_textual_or_password()
         {
             if let Some(compositionevent) = event.downcast::<CompositionEvent>() {
                 if event.type_() == atom!("compositionend") {
@@ -2460,9 +2460,9 @@ impl Validatable for HTMLInputElement {
         match *self.input_type() {
             InputType::Hidden(_) | InputType::Button(_) | InputType::Reset(_) => false,
             _ => {
-                !(self.upcast::<Element>().disabled_state() ||
-                    self.ReadOnly() ||
-                    is_barred_by_datalist_ancestor(self.upcast()))
+                !(self.upcast::<Element>().disabled_state()
+                    || self.ReadOnly()
+                    || is_barred_by_datalist_ancestor(self.upcast()))
             },
         }
     }
@@ -2475,26 +2475,26 @@ impl Validatable for HTMLInputElement {
         let mut failed_flags = ValidationFlags::empty();
         let value = self.Value();
 
-        if validate_flags.contains(ValidationFlags::VALUE_MISSING) &&
-            self.suffers_from_being_missing(&value)
+        if validate_flags.contains(ValidationFlags::VALUE_MISSING)
+            && self.suffers_from_being_missing(&value)
         {
             failed_flags.insert(ValidationFlags::VALUE_MISSING);
         }
 
-        if validate_flags.contains(ValidationFlags::TYPE_MISMATCH) &&
-            self.suffers_from_type_mismatch(&value)
+        if validate_flags.contains(ValidationFlags::TYPE_MISMATCH)
+            && self.suffers_from_type_mismatch(&value)
         {
             failed_flags.insert(ValidationFlags::TYPE_MISMATCH);
         }
 
-        if validate_flags.contains(ValidationFlags::PATTERN_MISMATCH) &&
-            self.suffers_from_pattern_mismatch(cx, &value)
+        if validate_flags.contains(ValidationFlags::PATTERN_MISMATCH)
+            && self.suffers_from_pattern_mismatch(cx, &value)
         {
             failed_flags.insert(ValidationFlags::PATTERN_MISMATCH);
         }
 
-        if validate_flags.contains(ValidationFlags::BAD_INPUT) &&
-            self.suffers_from_bad_input(&value)
+        if validate_flags.contains(ValidationFlags::BAD_INPUT)
+            && self.suffers_from_bad_input(&value)
         {
             failed_flags.insert(ValidationFlags::BAD_INPUT);
         }
@@ -2504,9 +2504,9 @@ impl Validatable for HTMLInputElement {
         }
 
         if validate_flags.intersects(
-            ValidationFlags::RANGE_UNDERFLOW |
-                ValidationFlags::RANGE_OVERFLOW |
-                ValidationFlags::STEP_MISMATCH,
+            ValidationFlags::RANGE_UNDERFLOW
+                | ValidationFlags::RANGE_OVERFLOW
+                | ValidationFlags::STEP_MISMATCH,
         ) {
             failed_flags |= self.suffers_from_range_issues(&value);
         }
@@ -2528,11 +2528,11 @@ impl Activatable for HTMLInputElement {
             // https://html.spec.whatwg.org/multipage/#image-button-state-(type=image):input-activation-behavior
             //
             // Although they do not have implicit activation behaviors, `type=button` is an activatable input event.
-            InputType::Submit(_) |
-            InputType::Reset(_) |
-            InputType::File(_) |
-            InputType::Image(_) |
-            InputType::Button(_) => self.is_mutable(),
+            InputType::Submit(_)
+            | InputType::Reset(_)
+            | InputType::File(_)
+            | InputType::Image(_)
+            | InputType::Button(_) => self.is_mutable(),
             // https://html.spec.whatwg.org/multipage/#checkbox-state-(type=checkbox):input-activation-behavior
             // https://html.spec.whatwg.org/multipage/#radio-button-state-(type=radio):input-activation-behavior
             // https://html.spec.whatwg.org/multipage/#color-state-(type=color):input-activation-behavior
@@ -2565,8 +2565,8 @@ impl Activatable for HTMLInputElement {
         let ty = self.input_type();
         let cache = match cache {
             Some(cache) => {
-                if (cache.was_radio && !matches!(*ty, InputType::Radio(_))) ||
-                    (cache.was_checkbox && !matches!(*ty, InputType::Checkbox(_)))
+                if (cache.was_radio && !matches!(*ty, InputType::Radio(_)))
+                    || (cache.was_checkbox && !matches!(*ty, InputType::Checkbox(_)))
                 {
                     // Type changed, abandon ship
                     // https://www.w3.org/Bugs/Public/show_bug.cgi?id=27414

--- a/components/script/dom/html/input_element/radio_input_type.rs
+++ b/components/script/dom/html/input_element/radio_input_type.rs
@@ -259,9 +259,9 @@ pub(crate) fn in_same_group(
         return false;
     }
 
-    if !matches!(*other.input_type(), InputType::Radio(_)) ||
-        other.form_owner().as_deref() != owner ||
-        other.radio_group_name().as_ref() != group
+    if !matches!(*other.input_type(), InputType::Radio(_))
+        || other.form_owner().as_deref() != owner
+        || other.radio_group_name().as_ref() != group
     {
         return false;
     }

--- a/components/script/dom/html/input_element/range_input_type.rs
+++ b/components/script/dom/html/input_element/range_input_type.rs
@@ -62,13 +62,13 @@ impl SpecificInputType for RangeInputType {
             let mut fval = *fval;
             // comparing max first, because if they contradict
             // the spec wants min to be the one that applies
-            if let Some(max) = input.maximum() &&
-                fval > max
+            if let Some(max) = input.maximum()
+                && fval > max
             {
                 fval = max;
             }
-            if let Some(min) = input.minimum() &&
-                fval < min
+            if let Some(min) = input.minimum()
+                && fval < min
             {
                 fval = min;
             }
@@ -89,13 +89,13 @@ impl SpecificInputType for RangeInputType {
                     // but if after snapping we're now outside min..max
                     // we have to adjust! (adjusting to min last because
                     // that "wins" over max in the spec)
-                    if let Some(stepped_maximum) = input.stepped_maximum() &&
-                        fval > stepped_maximum
+                    if let Some(stepped_maximum) = input.stepped_maximum()
+                        && fval > stepped_maximum
                     {
                         fval = stepped_maximum;
                     }
-                    if let Some(stepped_minimum) = input.stepped_minimum() &&
-                        fval < stepped_minimum
+                    if let Some(stepped_minimum) = input.stepped_minimum()
+                        && fval < stepped_minimum
                     {
                         fval = stepped_minimum;
                     }

--- a/components/script/dom/html/input_element/text_input_widget.rs
+++ b/components/script/dom/html/input_element/text_input_widget.rs
@@ -210,8 +210,8 @@ impl TextInputWidgetShadowTree {
             (true, _) => "\u{200B}".into(),
         };
 
-        if let Some(character_data) = self.value_character_data() &&
-            character_data.Data() != value_text
+        if let Some(character_data) = self.value_character_data()
+            && character_data.Data() != value_text
         {
             character_data.SetData(cx, value_text);
         }

--- a/components/script/dom/html/interactive_element_command.rs
+++ b/components/script/dom/html/interactive_element_command.rs
@@ -130,8 +130,8 @@ impl InteractiveElementCommand {
             // > inert, and false otherwise.
             // TODO: We do not support `inert` yet.
             InteractiveElementCommand::Option(option) => {
-                option.Disabled() ||
-                    option
+                option.Disabled()
+                    || option
                         .nearest_ancestor_select()
                         .is_some_and(|select| select.Disabled())
             },

--- a/components/script/dom/indexeddb/idbcursor.rs
+++ b/components/script/dom/indexeddb/idbcursor.rs
@@ -327,8 +327,8 @@ pub(crate) fn iterate_cursor(
                 // than key.
                 let requirement2 = || match &primary_key {
                     Some(primary_key) => key.as_ref().is_some_and(|key| {
-                        (&record.key == key && &record.primary_key >= primary_key) ||
-                            &record.key > key
+                        (&record.key == key && &record.primary_key >= primary_key)
+                            || &record.key > key
                     }),
                     _ => true,
                 };
@@ -345,11 +345,11 @@ pub(crate) fn iterate_cursor(
                 // record’s key is greater than position.
                 let requirement4 = || match (&position, source) {
                     (Some(position), ObjectStoreOrIndex::Index(_)) => {
-                        (&record.key == position &&
-                            object_store_position.as_ref().is_some_and(
+                        (&record.key == position
+                            && object_store_position.as_ref().is_some_and(
                                 |object_store_position| &record.primary_key > object_store_position,
-                            )) ||
-                            &record.key > position
+                            ))
+                            || &record.key > position
                     },
                     _ => true,
                 };
@@ -358,11 +358,11 @@ pub(crate) fn iterate_cursor(
                 let requirement5 = || range.contains(&record.key);
 
                 // NOTE: Use closures here for lazy computation on requirements.
-                requirement1() &&
-                    requirement2() &&
-                    requirement3() &&
-                    requirement4() &&
-                    requirement5()
+                requirement1()
+                    && requirement2()
+                    && requirement3()
+                    && requirement4()
+                    && requirement5()
             }),
             // "nextunique"
             IDBCursorDirection::Nextunique => records.iter().find(|record| {
@@ -404,8 +404,8 @@ pub(crate) fn iterate_cursor(
                     // key.
                     let requirement2 = || match &primary_key {
                         Some(primary_key) => key.as_ref().is_some_and(|key| {
-                            (&record.key == key && &record.primary_key <= primary_key) ||
-                                &record.key < key
+                            (&record.key == key && &record.primary_key <= primary_key)
+                                || &record.key < key
                         }),
                         _ => true,
                     };
@@ -424,13 +424,13 @@ pub(crate) fn iterate_cursor(
                     // record’s key is less than position.
                     let requirement4 = || match (&position, source) {
                         (Some(position), ObjectStoreOrIndex::Index(_)) => {
-                            (&record.key == position &&
-                                object_store_position.as_ref().is_some_and(
+                            (&record.key == position
+                                && object_store_position.as_ref().is_some_and(
                                     |object_store_position| {
                                         &record.primary_key < object_store_position
                                     },
-                                )) ||
-                                &record.key < position
+                                ))
+                                || &record.key < position
                         },
                         _ => true,
                     };
@@ -439,11 +439,11 @@ pub(crate) fn iterate_cursor(
                     let requirement5 = || range.contains(&record.key);
 
                     // NOTE: Use closures here for lazy computation on requirements.
-                    requirement1() &&
-                        requirement2() &&
-                        requirement3() &&
-                        requirement4() &&
-                        requirement5()
+                    requirement1()
+                        && requirement2()
+                        && requirement3()
+                        && requirement4()
+                        && requirement5()
                 })
             },
             // "prevunique"

--- a/components/script/dom/indexeddb/idbdatabase.rs
+++ b/components/script/dom/indexeddb/idbdatabase.rs
@@ -278,8 +278,8 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
 
         // Step 5. If keyPath is not null and is not a valid key path, throw a
         // "SyntaxError" DOMException.
-        if let Some(path) = key_path &&
-            !is_valid_key_path(cx, path)?
+        if let Some(path) = key_path
+            && !is_valid_key_path(cx, path)?
         {
             return Err(Error::Syntax(None));
         }

--- a/components/script/dom/indexeddb/idbobjectstore.rs
+++ b/components/script/dom/indexeddb/idbobjectstore.rs
@@ -196,8 +196,8 @@ impl IDBObjectStore {
 
         // Step 5.1. If handle’s object store was not newly created during transaction,
         // set handle’s name to its object store’s name.
-        if !abort_state.newly_created_during_transaction &&
-            let Some(name) = abort_state.rollback_name
+        if !abort_state.newly_created_during_transaction
+            && let Some(name) = abort_state.rollback_name
         {
             *self.name.borrow_mut() = name;
         }
@@ -901,8 +901,8 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         }
 
         let old_name = self.name.borrow().clone();
-        if let Some(abort_state) = self.abort_state_on_abort.borrow_mut().as_mut() &&
-            abort_state.rollback_name.is_none()
+        if let Some(abort_state) = self.abort_state_on_abort.borrow_mut().as_mut()
+            && abort_state.rollback_name.is_none()
         {
             abort_state.rollback_name = Some(old_name.clone());
         }

--- a/components/script/dom/indexeddb/idbtransaction.rs
+++ b/components/script/dom/indexeddb/idbtransaction.rs
@@ -223,10 +223,10 @@ impl IDBTransaction {
     }
 
     pub(crate) fn is_inactive(&self) -> bool {
-        !self.active.get() &&
-            !self.finished.get() &&
-            !self.abort_initiated.get() &&
-            !self.committing.get()
+        !self.active.get()
+            && !self.finished.get()
+            && !self.abort_initiated.get()
+            && !self.committing.get()
     }
 
     pub(crate) fn is_committing(&self) -> bool {
@@ -500,8 +500,8 @@ impl IDBTransaction {
         // https://w3c.github.io/IndexedDB/#transaction-concept
         // A transaction has a error which is set if the transaction is aborted.
         // NOTE: Implementors need to keep in mind that the value "null" is considered an error, as it is set from abort()
-        if self.error.get().is_none() &&
-            let Ok(exception) = create_dom_exception(cx, &self.global(), error)
+        if self.error.get().is_none()
+            && let Ok(exception) = create_dom_exception(cx, &self.global(), error)
         {
             self.error.set(Some(&exception));
         }

--- a/components/script/dom/intersectionobserver/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver/intersectionobserver.rs
@@ -567,8 +567,8 @@ impl IntersectionObserver {
         {
             is_intersecting.into()
         } else {
-            (intersection_rect.size.width.0 as f64 / target_rect.size.width.0 as f64) *
-                (intersection_rect.size.height.0 as f64 / target_rect.size.height.0 as f64)
+            (intersection_rect.size.width.0 as f64 / target_rect.size.width.0 as f64)
+                * (intersection_rect.size.height.0 as f64 / target_rect.size.height.0 as f64)
         };
 
         // Step 13
@@ -629,8 +629,8 @@ impl IntersectionObserver {
 
             // Step 2
             // > If (time - registration.lastUpdateTime < observer.delay), skip further processing for target.
-            if time - registration.last_update_time.get() <
-                Duration::from_millis(self.delay.get().max(0) as u64)
+            if time - registration.last_update_time.get()
+                < Duration::from_millis(self.delay.get().max(0) as u64)
             {
                 return;
             }
@@ -656,9 +656,9 @@ impl IntersectionObserver {
             // > if isVisible does not equal previousIsVisible,
             // > queue an IntersectionObserverEntry, passing in observer, time, rootBounds,
             // > targetRect, intersectionRect, isIntersecting, isVisible, and target.
-            if Some(intersection_output.threshold_index) != previous_threshold_index ||
-                intersection_output.is_intersecting != previous_is_intersecting ||
-                intersection_output.is_visible != previous_is_visible
+            if Some(intersection_output.threshold_index) != previous_threshold_index
+                || intersection_output.is_intersecting != previous_is_intersecting
+                || intersection_output.is_visible != previous_is_visible
             {
                 // TODO(stevennovaryo): Per IntersectionObserverEntry interface, the rootBounds
                 //                      should be null for cross-origin-domain target.
@@ -958,8 +958,8 @@ fn compute_the_intersection(
         // >      by applying container’s clip.
         // TODO(#35767): handle `overflow: clip` and resolve clipping for x-axis and y-axis independently.
         // Additionally, handle css `clip-path` as well.
-        if IntersectionObserver::has_content_clip(&containing_element) &&
-            let Some(container_padding_box) = containing_element
+        if IntersectionObserver::has_content_clip(&containing_element)
+            && let Some(container_padding_box) = containing_element
                 .upcast::<Node>()
                 .padding_box_without_reflow()
         {

--- a/components/script/dom/media/mediadevices.rs
+++ b/components/script/dom/media/mediadevices.rs
@@ -56,14 +56,14 @@ impl MediaDevicesMethods<crate::DomTypeHolder> for MediaDevices {
         let p = Promise::new_in_realm(cx);
         let media = ServoMedia::get();
         let stream = MediaStream::new(cx, &self.global());
-        if let Some(constraints) = convert_constraints(&constraints.audio) &&
-            let Some(audio) = media.create_audioinput_stream(constraints)
+        if let Some(constraints) = convert_constraints(&constraints.audio)
+            && let Some(audio) = media.create_audioinput_stream(constraints)
         {
             let track = MediaStreamTrack::new(cx, &self.global(), audio, MediaStreamType::Audio);
             stream.add_track(&track);
         }
-        if let Some(constraints) = convert_constraints(&constraints.video) &&
-            let Some(video) = media.create_videoinput_stream(constraints)
+        if let Some(constraints) = convert_constraints(&constraints.video)
+            && let Some(video) = media.create_videoinput_stream(constraints)
         {
             let track = MediaStreamTrack::new(cx, &self.global(), video, MediaStreamType::Video);
             stream.add_track(&track);

--- a/components/script/dom/media/mediafragmentparser.rs
+++ b/components/script/dom/media/mediafragmentparser.rs
@@ -177,8 +177,8 @@ impl MediaFragmentParser {
 
         if let Some(s) = prefix {
             let region = SpatialRegion::from_str(s)?;
-            if region.eq(&SpatialRegion::Percent) &&
-                (clipping.x + clipping.width > 100 || clipping.y + clipping.height > 100)
+            if region.eq(&SpatialRegion::Percent)
+                && (clipping.x + clipping.width > 100 || clipping.y + clipping.height > 100)
             {
                 return Err(());
             }

--- a/components/script/dom/media/videotrack.rs
+++ b/components/script/dom/media/videotrack.rs
@@ -116,8 +116,8 @@ impl VideoTrackMethods<crate::DomTypeHolder> for VideoTrack {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-videotrack-selected>
     fn SetSelected(&self, value: bool) {
-        if let Some(list) = self.track_list.borrow().as_ref() &&
-            let Some(idx) = list.find(self)
+        if let Some(list) = self.track_list.borrow().as_ref()
+            && let Some(idx) = list.find(self)
         {
             list.set_selected(idx, value);
         }

--- a/components/script/dom/media/videotracklist.rs
+++ b/components/script/dom/media/videotracklist.rs
@@ -104,8 +104,8 @@ impl VideoTrackList {
 
     pub(crate) fn add(&self, track: &VideoTrack) {
         self.tracks.borrow_mut().push(Dom::from_ref(track));
-        if track.selected() &&
-            let Some(idx) = self.selected_index()
+        if track.selected()
+            && let Some(idx) = self.selected_index()
         {
             self.set_selected(idx, false);
         }

--- a/components/script/dom/mutationobserver/mutationobserver.rs
+++ b/components/script/dom/mutationobserver/mutationobserver.rs
@@ -264,8 +264,8 @@ impl MutationObserverMethods<crate::DomTypeHolder> for MutationObserver {
         let subtree = options.subtree;
 
         // Step 1
-        if (options.attributeOldValue.is_some() || options.attributeFilter.is_some()) &&
-            options.attributes.is_none()
+        if (options.attributeOldValue.is_some() || options.attributeFilter.is_some())
+            && options.attributes.is_none()
         {
             attributes = true;
         }

--- a/components/script/dom/node/children_mutation.rs
+++ b/components/script/dom/node/children_mutation.rs
@@ -82,8 +82,8 @@ impl<'a> ChildrenMutation<'a> {
     pub(crate) fn modified_edge_element(&self, no_gc: &NoGC) -> Option<DomRoot<Node>> {
         match *self {
             // Add/remove at start of container: Return the first following element.
-            ChildrenMutation::Prepend { next, .. } |
-            ChildrenMutation::Replace {
+            ChildrenMutation::Prepend { next, .. }
+            | ChildrenMutation::Replace {
                 prev: None,
                 next: Some(next),
                 ..
@@ -92,8 +92,8 @@ impl<'a> ChildrenMutation<'a> {
                 .find(|node| node.is::<Element>())
                 .map(|node| node.as_rooted()),
             // Add/remove at end of container: Return the last preceding element.
-            ChildrenMutation::Append { prev } |
-            ChildrenMutation::Replace {
+            ChildrenMutation::Append { prev }
+            | ChildrenMutation::Replace {
                 prev: Some(prev),
                 next: None,
                 ..
@@ -102,8 +102,8 @@ impl<'a> ChildrenMutation<'a> {
                 .find(|node| node.is::<Element>())
                 .map(|node| node.as_rooted()),
             // Insert or replace in the middle:
-            ChildrenMutation::Insert { prev, next, .. } |
-            ChildrenMutation::Replace {
+            ChildrenMutation::Insert { prev, next, .. }
+            | ChildrenMutation::Replace {
                 prev: Some(prev),
                 next: Some(next),
                 ..

--- a/components/script/dom/node/focus.rs
+++ b/components/script/dom/node/focus.rs
@@ -69,8 +69,8 @@ impl Iterator for FocusNavigationScopeIterator {
 
     fn next(&mut self) -> Option<Self::Item> {
         let should_skip_element_children = |element: &Element| {
-            element.is_shadow_host() ||
-                element
+            element.is_shadow_host()
+                || element
                     .downcast::<HTMLSlotElement>()
                     .is_some_and(|html_slot_element| html_slot_element.has_assigned_nodes())
         };

--- a/components/script/dom/node/iterators.rs
+++ b/components/script/dom/node/iterators.rs
@@ -381,9 +381,9 @@ impl Iterator for TreeIterator {
         let current = self.current.take()?;
 
         // Handle a potential shadow root on the element
-        if let Some(element) = current.downcast::<Element>() &&
-            let Some(shadow_root) = element.shadow_root() &&
-            self.shadow_including == ShadowIncluding::Yes
+        if let Some(element) = current.downcast::<Element>()
+            && let Some(shadow_root) = element.shadow_root()
+            && self.shadow_including == ShadowIncluding::Yes
         {
             self.current = Some(DomRoot::from_ref(shadow_root.upcast::<Node>()));
             self.depth += 1;
@@ -477,9 +477,9 @@ impl<'b> Iterator for UnrootedTreeIterator<'b> {
         let current = self.current.take()?;
 
         // Handle a potential shadow root on the element
-        if let Some(element) = current.downcast::<Element>() &&
-            let Some(shadow_root) = element.shadow_root() &&
-            self.shadow_including == ShadowIncluding::Yes
+        if let Some(element) = current.downcast::<Element>()
+            && let Some(shadow_root) = element.shadow_root()
+            && self.shadow_including == ShadowIncluding::Yes
         {
             self.current = Some(UnrootedDom::from_dom(
                 Dom::from_ref(shadow_root.upcast::<Node>()),

--- a/components/script/dom/node/layout_dom.rs
+++ b/components/script/dom/node/layout_dom.rs
@@ -63,8 +63,8 @@ impl<'dom> LayoutDom<'dom, Node> {
     #[inline]
     pub(crate) fn composed_parent_node_ref(self) -> Option<LayoutDom<'dom, Node>> {
         let parent = self.parent_node_ref();
-        if let Some(parent) = parent &&
-            let Some(shadow_root) = parent.downcast::<ShadowRoot>()
+        if let Some(parent) = parent
+            && let Some(shadow_root) = parent.downcast::<ShadowRoot>()
         {
             return Some(shadow_root.get_host_for_layout().upcast());
         }
@@ -234,8 +234,9 @@ impl<'dom> LayoutDom<'dom, Node> {
         );
         // Currently `::placeholder` is only implemented for single line text input element.
         debug_assert!(
-            !is_single_line_text_inner_placeholder ||
-                self.containing_shadow_root_for_layout()
+            !is_single_line_text_inner_placeholder
+                || self
+                    .containing_shadow_root_for_layout()
                     .map(|root| root.get_host_for_layout())
                     .map(|host| host.downcast::<HTMLInputElement>())
                     .is_some()

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -1003,8 +1003,8 @@ impl Node {
     fn is_host_including_inclusive_ancestor(&self, child: &Node) -> bool {
         // An object A is a host-including inclusive ancestor of an object B, if either A is an inclusive ancestor of B,
         // or if B’s root has a non-null host and A is a host-including inclusive ancestor of B’s root’s host.
-        self.is_inclusive_ancestor_of(child) ||
-            child
+        self.is_inclusive_ancestor_of(child)
+            || child
                 .GetRootNode(&GetRootNodeOptions::empty())
                 .downcast::<DocumentFragment>()
                 .and_then(|fragment| fragment.host())
@@ -1350,8 +1350,8 @@ impl Node {
 
         // Step 3. If child is non-null and its parent is not newParent, then throw a
         // "NotFoundError" DOMException.
-        if let Some(child) = child &&
-            !new_parent.is_parent_of(child)
+        if let Some(child) = child
+            && !new_parent.is_parent_of(child)
         {
             return Err(Error::NotFound(None));
         }
@@ -1366,13 +1366,13 @@ impl Node {
                     return Err(Error::HierarchyRequest(None));
                 }
             },
-            NodeTypeId::CharacterData(CharacterDataTypeId::ProcessingInstruction) |
-            NodeTypeId::CharacterData(CharacterDataTypeId::Comment) |
-            NodeTypeId::Element(_) => (),
-            NodeTypeId::DocumentFragment(_) |
-            NodeTypeId::DocumentType |
-            NodeTypeId::Document(_) |
-            NodeTypeId::Attr => {
+            NodeTypeId::CharacterData(CharacterDataTypeId::ProcessingInstruction)
+            | NodeTypeId::CharacterData(CharacterDataTypeId::Comment)
+            | NodeTypeId::Element(_) => (),
+            NodeTypeId::DocumentFragment(_)
+            | NodeTypeId::DocumentType
+            | NodeTypeId::Document(_)
+            | NodeTypeId::Attr => {
                 return Err(Error::HierarchyRequest(None));
             },
         }
@@ -1456,9 +1456,9 @@ impl Node {
 
         // Step 15. If oldParent’s root is a shadow root, and oldParent is a slot whose assigned
         // nodes is empty, then run signal a slot change for oldParent.
-        if old_parent.is_in_a_shadow_tree() &&
-            let Some(slot_element) = old_parent.downcast::<HTMLSlotElement>() &&
-            !slot_element.has_assigned_nodes()
+        if old_parent.is_in_a_shadow_tree()
+            && let Some(slot_element) = old_parent.downcast::<HTMLSlotElement>()
+            && !slot_element.has_assigned_nodes()
         {
             slot_element.signal_a_slot_change(cx);
         }
@@ -1503,9 +1503,9 @@ impl Node {
         // node is a slottable, then assign a slot for node.
         if let Some(shadow_root) = new_parent
             .downcast::<Element>()
-            .and_then(Element::shadow_root) &&
-            shadow_root.SlotAssignment() == SlotAssignmentMode::Named &&
-            (node.is::<Element>() || node.is::<Text>())
+            .and_then(Element::shadow_root)
+            && shadow_root.SlotAssignment() == SlotAssignmentMode::Named
+            && (node.is::<Element>() || node.is::<Text>())
         {
             rooted!(&in(cx) let slottable = Slottable(Dom::from_ref(node)));
             slottable.assign_a_slot(cx);
@@ -1513,9 +1513,9 @@ impl Node {
 
         // Step 22. If newParent’s root is a shadow root, and newParent is a slot whose assigned
         // nodes is empty, then run signal a slot change for newParent.
-        if new_parent.is_in_a_shadow_tree() &&
-            let Some(slot_element) = new_parent.downcast::<HTMLSlotElement>() &&
-            !slot_element.has_assigned_nodes()
+        if new_parent.is_in_a_shadow_tree()
+            && let Some(slot_element) = new_parent.downcast::<HTMLSlotElement>()
+            && !slot_element.has_assigned_nodes()
         {
             slot_element.signal_a_slot_change(cx);
         }
@@ -1538,9 +1538,9 @@ impl Node {
             }
 
             // Step 24.2. If inclusiveDescendant is custom and newParent is connected,
-            if let Some(descendant) = descendant.downcast::<Element>() &&
-                descendant.is_custom() &&
-                new_parent.is_connected()
+            if let Some(descendant) = descendant.downcast::<Element>()
+                && descendant.is_custom()
+                && new_parent.is_connected()
             {
                 // then enqueue a custom element callback reaction with
                 // inclusiveDescendant, callback name "connectedMoveCallback", and « ».
@@ -1652,8 +1652,8 @@ impl Node {
         shadow_including: ShadowIncluding,
     ) -> impl Iterator<Item = DomRoot<Node>> + use<> {
         SimpleNodeIterator::new(Some(DomRoot::from_ref(self)), move |n| {
-            if shadow_including == ShadowIncluding::Yes &&
-                let Some(shadow_root) = n.downcast::<ShadowRoot>()
+            if shadow_including == ShadowIncluding::Yes
+                && let Some(shadow_root) = n.downcast::<ShadowRoot>()
             {
                 return Some(DomRoot::from_ref(shadow_root.Host().upcast::<Node>()));
             }
@@ -1669,8 +1669,8 @@ impl Node {
         UnrootedSimpleNodeIterator::new(
             Some(UnrootedDom::from_dom(Dom::from_ref(self), no_gc)),
             move |n, no_gc| {
-                if shadow_including == ShadowIncluding::Yes &&
-                    let Some(shadow_root) = n.downcast::<ShadowRoot>()
+                if shadow_including == ShadowIncluding::Yes
+                    && let Some(shadow_root) = n.downcast::<ShadowRoot>()
                 {
                     return Some(UnrootedDom::from_dom(
                         Dom::from_ref(shadow_root.Host().upcast::<Node>()),
@@ -1977,9 +1977,9 @@ impl Node {
         let is_shadow_root_with_slots = self
             .downcast::<ShadowRoot>()
             .is_some_and(|shadow_root| shadow_root.has_slot_descendants());
-        if !is_shadow_root_with_slots &&
-            !self.is::<HTMLSlotElement>() &&
-            matches!(force, ForceSlottableNodeReconciliation::Skip)
+        if !is_shadow_root_with_slots
+            && !self.is::<HTMLSlotElement>()
+            && matches!(force, ForceSlottableNodeReconciliation::Skip)
         {
             return;
         }
@@ -2325,8 +2325,8 @@ impl Node {
         }
 
         // Step 3. If child is non-null and its parent is not parent, then throw a "NotFoundError" DOMException.
-        if let Some(child) = child &&
-            !parent.is_parent_of(child)
+        if let Some(child) = child
+            && !parent.is_parent_of(child)
         {
             return Err(Error::NotFound(Some(
                 "Child is non-null and its parent is not parent".to_owned(),
@@ -2351,10 +2351,10 @@ impl Node {
                     )));
                 }
             },
-            NodeTypeId::DocumentFragment(_) |
-            NodeTypeId::Element(_) |
-            NodeTypeId::CharacterData(CharacterDataTypeId::ProcessingInstruction) |
-            NodeTypeId::CharacterData(CharacterDataTypeId::Comment) => (),
+            NodeTypeId::DocumentFragment(_)
+            | NodeTypeId::Element(_)
+            | NodeTypeId::CharacterData(CharacterDataTypeId::ProcessingInstruction)
+            | NodeTypeId::CharacterData(CharacterDataTypeId::Comment) => (),
             // Step 4. If node is not a DocumentFragment, DocumentType, Element,
             // or CharacterData node, then throw a "HierarchyRequestError" DOMException.
             NodeTypeId::Document(_) | NodeTypeId::Attr => {
@@ -2382,8 +2382,8 @@ impl Node {
                             if parent.child_elements_unrooted(no_gc).next().is_some() {
                                 return Err(Error::HierarchyRequest(None));
                             }
-                            if let Some(child) = child &&
-                                child
+                            if let Some(child) = child
+                                && child
                                     .inclusively_following_siblings_unrooted(no_gc)
                                     .any(|child| child.is_doctype())
                             {
@@ -2400,8 +2400,8 @@ impl Node {
                             "Parent has an element child".to_owned(),
                         )));
                     }
-                    if let Some(child) = child &&
-                        child
+                    if let Some(child) = child
+                        && child
                             .inclusively_following_siblings_unrooted(no_gc)
                             .any(|following| following.is_doctype())
                     {
@@ -2536,8 +2536,8 @@ impl Node {
         //        greater than child’s index, increase its start offset by count.
         //     2. For each live range whose end node is parent and end offset is
         //        greater than child’s index, increase its end offset by count.
-        if let Some(child) = child &&
-            !parent.ranges_is_empty()
+        if let Some(child) = child
+            && !parent.ranges_is_empty()
         {
             parent
                 .ranges()
@@ -2571,9 +2571,9 @@ impl Node {
 
             // Step 7.4 If parent is a shadow host whose shadow root’s slot assignment is "named"
             // and node is a slottable, then assign a slot for node.
-            if let Some(ref shadow_root) = parent_shadow_root &&
-                shadow_root.SlotAssignment() == SlotAssignmentMode::Named &&
-                (kid.is::<Element>() || kid.is::<Text>())
+            if let Some(ref shadow_root) = parent_shadow_root
+                && shadow_root.SlotAssignment() == SlotAssignmentMode::Named
+                && (kid.is::<Element>() || kid.is::<Text>())
             {
                 rooted!(&in(cx) let slottable = Slottable(Dom::from_ref(kid)));
                 slottable.assign_a_slot(cx);
@@ -2581,9 +2581,9 @@ impl Node {
 
             // Step 7.5 If parent’s root is a shadow root, and parent is a slot whose assigned nodes
             // is the empty list, then run signal a slot change for parent.
-            if parent_in_shadow_tree &&
-                let Some(slot_element) = parent_as_slot &&
-                !slot_element.has_assigned_nodes()
+            if parent_in_shadow_tree
+                && let Some(slot_element) = parent_as_slot
+                && !slot_element.has_assigned_nodes()
             {
                 slot_element.signal_a_slot_change(cx);
             }
@@ -2600,8 +2600,8 @@ impl Node {
 
                 // From <https://github.com/whatwg/dom/issues/833>:
                 // try_upgrade_element fires even for disconnected elements.
-                if let Some(element) = DomRoot::downcast::<Element>(descendant.clone()) &&
-                    !element.is_custom()
+                if let Some(element) = DomRoot::downcast::<Element>(descendant.clone())
+                    && !element.is_custom()
                 {
                     try_upgrade_element(cx, &element);
                 }
@@ -2650,9 +2650,9 @@ impl Node {
                 // document to inclusiveDescendant’s custom element registry’s
                 // scoped document set.
                 else if let Some(shadow_root) =
-                    DomRoot::downcast::<ShadowRoot>(descendant.clone()) &&
-                    let Some(custom_element_registry) = shadow_root.custom_element_registry() &&
-                    custom_element_registry.is_scoped()
+                    DomRoot::downcast::<ShadowRoot>(descendant.clone())
+                    && let Some(custom_element_registry) = shadow_root.custom_element_registry()
+                    && custom_element_registry.is_scoped()
                 {
                     custom_element_registry.add_scoped_document(shadow_root.owner_doc());
                 }
@@ -2826,9 +2826,9 @@ impl Node {
 
         // Step 9. If parent’s root is a shadow root, and parent is a slot whose assigned nodes is the empty list,
         // then run signal a slot change for parent.
-        if parent.is_in_a_shadow_tree() &&
-            let Some(slot_element) = parent.downcast::<HTMLSlotElement>() &&
-            !slot_element.has_assigned_nodes()
+        if parent.is_in_a_shadow_tree()
+            && let Some(slot_element) = parent.downcast::<HTMLSlotElement>()
+            && !slot_element.has_assigned_nodes()
         {
             slot_element.signal_a_slot_change(cx);
         }
@@ -3470,8 +3470,8 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
 
     /// <https://dom.spec.whatwg.org/#dom-node-getrootnode>
     fn GetRootNode(&self, options: &GetRootNodeOptions) -> DomRoot<Node> {
-        if !options.composed &&
-            let Some(shadow_root) = self.containing_shadow_root()
+        if !options.composed
+            && let Some(shadow_root) = self.containing_shadow_root()
         {
             return DomRoot::upcast(shadow_root);
         }
@@ -3751,9 +3751,9 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
 
         // Step 12. Let nodes be node’s children if node is a DocumentFragment node; otherwise « node ».
         rooted_vec!(let mut nodes);
-        let nodes = if node.type_id() ==
-            NodeTypeId::DocumentFragment(DocumentFragmentTypeId::DocumentFragment) ||
-            node.type_id() == NodeTypeId::DocumentFragment(DocumentFragmentTypeId::ShadowRoot)
+        let nodes = if node.type_id()
+            == NodeTypeId::DocumentFragment(DocumentFragmentTypeId::DocumentFragment)
+            || node.type_id() == NodeTypeId::DocumentFragment(DocumentFragmentTypeId::ShadowRoot)
         {
             nodes.extend(node.children().map(|node| Dom::from_ref(&*node)));
             nodes.r()
@@ -3861,24 +3861,24 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
         fn is_equal_doctype(node: &Node, other: &Node) -> bool {
             let doctype = node.downcast::<DocumentType>().unwrap();
             let other_doctype = other.downcast::<DocumentType>().unwrap();
-            (*doctype.name() == *other_doctype.name()) &&
-                (*doctype.public_id() == *other_doctype.public_id()) &&
-                (*doctype.system_id() == *other_doctype.system_id())
+            (*doctype.name() == *other_doctype.name())
+                && (*doctype.public_id() == *other_doctype.public_id())
+                && (*doctype.system_id() == *other_doctype.system_id())
         }
         fn is_equal_element(node: &Node, other: &Node) -> bool {
             let element = node.downcast::<Element>().unwrap();
             let other_element = other.downcast::<Element>().unwrap();
-            (*element.namespace() == *other_element.namespace()) &&
-                (*element.prefix() == *other_element.prefix()) &&
-                (*element.local_name() == *other_element.local_name()) &&
-                (element.attrs().borrow().len() == other_element.attrs().borrow().len())
+            (*element.namespace() == *other_element.namespace())
+                && (*element.prefix() == *other_element.prefix())
+                && (*element.local_name() == *other_element.local_name())
+                && (element.attrs().borrow().len() == other_element.attrs().borrow().len())
         }
         fn is_equal_processinginstruction(node: &Node, other: &Node) -> bool {
             let pi = node.downcast::<ProcessingInstruction>().unwrap();
             let other_pi = other.downcast::<ProcessingInstruction>().unwrap();
-            (*pi.target() == *other_pi.target()) &&
-                (*pi.upcast::<CharacterData>().data() ==
-                    *other_pi.upcast::<CharacterData>().data())
+            (*pi.target() == *other_pi.target())
+                && (*pi.upcast::<CharacterData>().data()
+                    == *other_pi.upcast::<CharacterData>().data())
         }
         fn is_equal_characterdata(node: &Node, other: &Node) -> bool {
             let characterdata = node.downcast::<CharacterData>().unwrap();
@@ -3888,9 +3888,9 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
         fn is_equal_attr(node: &Node, other: &Node) -> bool {
             let attr = node.downcast::<Attr>().unwrap();
             let other_attr = other.downcast::<Attr>().unwrap();
-            (*attr.namespace() == *other_attr.namespace()) &&
-                (attr.local_name() == other_attr.local_name()) &&
-                (**attr.value() == **other_attr.value())
+            (*attr.namespace() == *other_attr.namespace())
+                && (attr.local_name() == other_attr.local_name())
+                && (**attr.value() == **other_attr.value())
         }
         fn is_equal_element_attrs(node: &Node, other: &Node) -> bool {
             let element = node.downcast::<Element>().unwrap();
@@ -3898,9 +3898,9 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
             assert!(element.attrs().borrow().len() == other_element.attrs().borrow().len());
             element.attrs().borrow().iter().all(|attr| {
                 other_element.attrs().borrow().iter().any(|other_attr| {
-                    (*attr.namespace() == *other_attr.namespace()) &&
-                        (attr.local_name() == other_attr.local_name()) &&
-                        (**attr.value() == **other_attr.value())
+                    (*attr.namespace() == *other_attr.namespace())
+                        && (attr.local_name() == other_attr.local_name())
+                        && (**attr.value() == **other_attr.value())
                 })
             })
         }
@@ -3920,8 +3920,8 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
                 {
                     return false;
                 },
-                NodeTypeId::CharacterData(CharacterDataTypeId::Text(_)) |
-                NodeTypeId::CharacterData(CharacterDataTypeId::Comment)
+                NodeTypeId::CharacterData(CharacterDataTypeId::Text(_))
+                | NodeTypeId::CharacterData(CharacterDataTypeId::Comment)
                     if !is_equal_characterdata(this, node) =>
                 {
                     return false;
@@ -4004,28 +4004,28 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
         // This substep seems lacking in test coverage.
         // We hit this when comparing two attributes that have the
         // same owner element.
-        if let Some(node2) = node2 &&
-            Some(node2) == node1 &&
-            let (Some(a1), Some(a2)) = (attr1, attr2)
+        if let Some(node2) = node2
+            && Some(node2) == node1
+            && let (Some(a1), Some(a2)) = (attr1, attr2)
         {
             let attrs = node2.downcast::<Element>().unwrap().attrs();
             // go through the attrs in order to see if self
             // or other is first; spec is clear that we
             // want value-equality, not reference-equality
             for attr in attrs.borrow().iter() {
-                if (*attr.namespace() == *a1.namespace()) &&
-                    (attr.local_name() == a1.local_name()) &&
-                    (**attr.value() == **a1.value())
+                if (*attr.namespace() == *a1.namespace())
+                    && (attr.local_name() == a1.local_name())
+                    && (**attr.value() == **a1.value())
                 {
-                    return NodeConstants::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC +
-                        NodeConstants::DOCUMENT_POSITION_PRECEDING;
+                    return NodeConstants::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC
+                        + NodeConstants::DOCUMENT_POSITION_PRECEDING;
                 }
-                if (*attr.namespace() == *a2.namespace()) &&
-                    (attr.local_name() == a2.local_name()) &&
-                    (**attr.value() == **a2.value())
+                if (*attr.namespace() == *a2.namespace())
+                    && (attr.local_name() == a2.local_name())
+                    && (**attr.value() == **a2.value())
                 {
-                    return NodeConstants::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC +
-                        NodeConstants::DOCUMENT_POSITION_FOLLOWING;
+                    return NodeConstants::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC
+                        + NodeConstants::DOCUMENT_POSITION_FOLLOWING;
                 }
             }
             // both attrs have node2 as their owner element, so
@@ -4037,15 +4037,15 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
         match (node1, node2) {
             (None, _) => {
                 // node1 is null
-                NodeConstants::DOCUMENT_POSITION_FOLLOWING +
-                    NodeConstants::DOCUMENT_POSITION_DISCONNECTED +
-                    NodeConstants::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC
+                NodeConstants::DOCUMENT_POSITION_FOLLOWING
+                    + NodeConstants::DOCUMENT_POSITION_DISCONNECTED
+                    + NodeConstants::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC
             },
             (_, None) => {
                 // node2 is null
-                NodeConstants::DOCUMENT_POSITION_PRECEDING +
-                    NodeConstants::DOCUMENT_POSITION_DISCONNECTED +
-                    NodeConstants::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC
+                NodeConstants::DOCUMENT_POSITION_PRECEDING
+                    + NodeConstants::DOCUMENT_POSITION_DISCONNECTED
+                    + NodeConstants::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC
             },
             (Some(node1), Some(node2)) => {
                 // still step 6, testing if node1 and 2 share a root
@@ -4057,8 +4057,8 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
                     .collect::<SmallVec<[_; 20]>>();
 
                 if self_and_ancestors.last() != other_and_ancestors.last() {
-                    let random = as_uintptr(self_and_ancestors.last().unwrap()) <
-                        as_uintptr(other_and_ancestors.last().unwrap());
+                    let random = as_uintptr(self_and_ancestors.last().unwrap())
+                        < as_uintptr(other_and_ancestors.last().unwrap());
                     let random = if random {
                         NodeConstants::DOCUMENT_POSITION_FOLLOWING
                     } else {
@@ -4066,9 +4066,9 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
                     };
 
                     // Disconnected.
-                    return random +
-                        NodeConstants::DOCUMENT_POSITION_DISCONNECTED +
-                        NodeConstants::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC;
+                    return random
+                        + NodeConstants::DOCUMENT_POSITION_DISCONNECTED
+                        + NodeConstants::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC;
                 }
                 // steps 7-10
                 let mut parent = self_and_ancestors.pop().unwrap();
@@ -4103,11 +4103,11 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
                 //
                 // If we're the container, return that `other` is contained by us.
                 if self_and_ancestors.len() < other_and_ancestors.len() {
-                    NodeConstants::DOCUMENT_POSITION_FOLLOWING +
-                        NodeConstants::DOCUMENT_POSITION_CONTAINED_BY
+                    NodeConstants::DOCUMENT_POSITION_FOLLOWING
+                        + NodeConstants::DOCUMENT_POSITION_CONTAINED_BY
                 } else {
-                    NodeConstants::DOCUMENT_POSITION_PRECEDING +
-                        NodeConstants::DOCUMENT_POSITION_CONTAINS
+                    NodeConstants::DOCUMENT_POSITION_PRECEDING
+                        + NodeConstants::DOCUMENT_POSITION_CONTAINS
                 }
             },
         }
@@ -4224,8 +4224,8 @@ impl VirtualMethods for Node {
             s.children_changed(cx, mutation);
         }
 
-        if let Some(data) = self.rare_data.borrow().as_ref() &&
-            let Some(list) = data.child_list.get()
+        if let Some(data) = self.rare_data.borrow().as_ref()
+            && let Some(list) = data.child_list.get()
         {
             list.as_children_list().children_changed(mutation);
         }
@@ -4263,9 +4263,9 @@ impl VirtualMethods for Node {
         // including descendants. If we're in a shadow tree at this point then the
         // unbind operation happened further up in the tree and we should not
         // drain any ranges.
-        if let Some(old_parent) = context.old_parent &&
-            !self.is_in_a_shadow_tree() &&
-            !self.ranges_is_empty()
+        if let Some(old_parent) = context.old_parent
+            && !self.is_in_a_shadow_tree()
+            && !self.ranges_is_empty()
         {
             self.ranges()
                 .drain_to_parent(old_parent, context.index(), self);

--- a/components/script/dom/node/nodelist.rs
+++ b/components/script/dom/node/nodelist.rs
@@ -197,11 +197,11 @@ impl ChildrenList {
 
     pub(crate) fn children_changed(&self, mutation: &ChildrenMutation) {
         match mutation {
-            ChildrenMutation::Append { .. } |
-            ChildrenMutation::Insert { .. } |
-            ChildrenMutation::Prepend { .. } |
-            ChildrenMutation::Replace { .. } |
-            ChildrenMutation::ReplaceAll { .. } => *self.cached_children.borrow_mut() = None,
+            ChildrenMutation::Append { .. }
+            | ChildrenMutation::Insert { .. }
+            | ChildrenMutation::Prepend { .. }
+            | ChildrenMutation::Replace { .. }
+            | ChildrenMutation::ReplaceAll { .. } => *self.cached_children.borrow_mut() = None,
             ChildrenMutation::ChangeText => {},
         }
     }

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -854,30 +854,30 @@ impl Notification {
     /// <https://notifications.spec.whatwg.org/#fetch-steps>
     fn fetch_resources_and_show_when_ready(&self) {
         let mut pending_requests: Vec<(RequestBuilder, ResourceType)> = vec![];
-        if let Some(image_url) = &self.image &&
-            let Ok(url) = ServoUrl::parse(image_url)
+        if let Some(image_url) = &self.image
+            && let Ok(url) = ServoUrl::parse(image_url)
         {
             let request = self.build_resource_request(&url);
             self.pending_request_ids.borrow_mut().insert(request.id);
             pending_requests.push((request, ResourceType::Image));
         }
-        if let Some(icon_url) = &self.icon &&
-            let Ok(url) = ServoUrl::parse(icon_url)
+        if let Some(icon_url) = &self.icon
+            && let Ok(url) = ServoUrl::parse(icon_url)
         {
             let request = self.build_resource_request(&url);
             self.pending_request_ids.borrow_mut().insert(request.id);
             pending_requests.push((request, ResourceType::Icon));
         }
-        if let Some(badge_url) = &self.badge &&
-            let Ok(url) = ServoUrl::parse(badge_url)
+        if let Some(badge_url) = &self.badge
+            && let Ok(url) = ServoUrl::parse(badge_url)
         {
             let request = self.build_resource_request(&url);
             self.pending_request_ids.borrow_mut().insert(request.id);
             pending_requests.push((request, ResourceType::Badge));
         }
         for action in self.actions.iter() {
-            if let Some(icon_url) = &action.icon_url &&
-                let Ok(url) = ServoUrl::parse(icon_url)
+            if let Some(icon_url) = &action.icon_url
+                && let Ok(url) = ServoUrl::parse(icon_url)
             {
                 let request = self.build_resource_request(&url);
                 self.pending_request_ids.borrow_mut().insert(request.id);

--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -69,8 +69,8 @@ impl PerformanceEntryList {
             .entries
             .iter()
             .filter(|e| {
-                name.as_ref().is_none_or(|name_| *e.name() == *name_) &&
-                    entry_type
+                name.as_ref().is_none_or(|name_| *e.name() == *name_)
+                    && entry_type
                         .as_ref()
                         .is_none_or(|type_| e.entry_type() == *type_)
             })
@@ -353,8 +353,8 @@ impl Performance {
     fn can_add_resource_timing_entry(&self) -> bool {
         // Step 1. If resource timing buffer current size is smaller than resource timing buffer size limit, return true.
         // Step 2. Return false.
-        self.resource_timing_buffer_current_size.get() <
-            self.resource_timing_buffer_size_limit.get()
+        self.resource_timing_buffer_current_size.get()
+            < self.resource_timing_buffer_size_limit.get()
     }
 
     /// <https://w3c.github.io/resource-timing/#dfn-copy-secondary-buffer>
@@ -510,8 +510,8 @@ impl Performance {
                 // Step 3.2 Otherwise, let end time be mark.
                 // NOTE: I think the spec wants us to return the value.
                 Ok(
-                    self.time_origin +
-                        Duration::microseconds(timestamp.mul_add(1000.0, 0.0) as i64),
+                    self.time_origin
+                        + Duration::microseconds(timestamp.mul_add(1000.0, 0.0) as i64),
                 )
             },
         }
@@ -623,11 +623,11 @@ impl PerformanceMethods<crate::DomTypeHolder> for Performance {
         // Step 1. If startOrMeasureOptions is a PerformanceMeasureOptions object and at least one of start,
         // end, duration, and detail exist, run the following checks:
         if let StringOrPerformanceMeasureOptions::PerformanceMeasureOptions(options) =
-            &start_or_measure_options &&
-            (options.start.is_some() ||
-                options.duration.is_some() ||
-                options.end.is_some() ||
-                options.detail.get().is_object_or_null())
+            &start_or_measure_options
+            && (options.start.is_some()
+                || options.duration.is_some()
+                || options.end.is_some()
+                || options.detail.get().is_object_or_null())
         {
             // Step 1.1 If endMark is given, throw a TypeError.
             if end_mark.is_some() {
@@ -677,8 +677,8 @@ impl PerformanceMethods<crate::DomTypeHolder> for Performance {
                         // Step 2.3.2 Let duration be the value returned by running the convert a mark to a timestamp
                         // algorithm passing in duration.
                         let duration = self
-                            .convert_a_mark_to_a_timestamp(&StringOrDouble::Double(duration))? -
-                            self.time_origin;
+                            .convert_a_mark_to_a_timestamp(&StringOrDouble::Double(duration))?
+                            - self.time_origin;
 
                         // Step 2.3.3 Let end time be start plus duration.
                         start + duration
@@ -711,8 +711,8 @@ impl PerformanceMethods<crate::DomTypeHolder> for Performance {
                     // Step 3.2.1 Let duration be the value returned by running the convert a mark to a timestamp
                     // algorithm passing in duration.
                     let duration = self
-                        .convert_a_mark_to_a_timestamp(&StringOrDouble::Double(duration))? -
-                        self.time_origin;
+                        .convert_a_mark_to_a_timestamp(&StringOrDouble::Double(duration))?
+                        - self.time_origin;
 
                     // Step 3.2.2 Let end be the value returned by running the convert a mark to a timestamp algorithm
                     // passing in end.
@@ -752,8 +752,8 @@ impl PerformanceMethods<crate::DomTypeHolder> for Performance {
         rooted!(&in(cx) let mut detail = NullValue());
         // Step 9.1. If startOrMeasureOptions is a PerformanceMeasureOptions object and startOrMeasureOptions’s detail member exists:
         if let StringOrPerformanceMeasureOptions::PerformanceMeasureOptions(options) =
-            &start_or_measure_options &&
-            !options.detail.get().is_null_or_undefined()
+            &start_or_measure_options
+            && !options.detail.get().is_null_or_undefined()
         {
             // Step 9.1.1. Let record be the result of calling the StructuredSerialize algorithm on startOrMeasureOptions’s detail.
             let record = structuredclone::write(cx, options.detail.handle(), None)?;

--- a/components/script/dom/performance/performancemark.rs
+++ b/components/script/dom/performance/performancemark.rs
@@ -103,8 +103,8 @@ impl PerformanceMarkMethods<crate::DomTypeHolder> for PerformanceMark {
                     return Err(Error::Type(c"startTime must not be negative".to_owned()));
                 }
                 // Step 5.1.2. Otherwise, set entry’s startTime to the value of markOptions’s startTime.
-                global.performance(cx).time_origin() +
-                    Duration::microseconds(start_time.mul_add(1000.0, 0.0) as i64)
+                global.performance(cx).time_origin()
+                    + Duration::microseconds(start_time.mul_add(1000.0, 0.0) as i64)
             },
             // Step 5.2. Otherwise, set it to the value that would be returned by the Performance object’s now() method.
             None => CrossProcessInstant::now(),

--- a/components/script/dom/permission/permissions.rs
+++ b/components/script/dom/permission/permissions.rs
@@ -310,8 +310,8 @@ pub(crate) fn descriptor_permission_state(
     // relevant global object has an associated Document run the following step:
     //   1. Let document be settings' relevant global object's associated Document.
     //   2. If document is not allowed to use feature, return "denied".
-    if let Some(window) = global_scope.downcast::<Window>() &&
-        !window.Document().allowed_to_use_feature(feature)
+    if let Some(window) = global_scope.downcast::<Window>()
+        && !window.Document().allowed_to_use_feature(feature)
     {
         return PermissionState::Denied;
     }

--- a/components/script/dom/processingoptions.rs
+++ b/components/script/dom/processingoptions.rs
@@ -376,9 +376,9 @@ pub(crate) fn process_link_headers(
         // Not applicable, that's in `link_object.params`
         // Step 2.3. Let expectedPhase be "media" if either "srcset", "imagesrcset",
         // or "media" exist in attribs; otherwise "pre-media".
-        let expected_phase = if link_object.has_key_in_link_header("srcset") ||
-            link_object.has_key_in_link_header("imagesrcset") ||
-            link_object.has_key_in_link_header("media")
+        let expected_phase = if link_object.has_key_in_link_header("srcset")
+            || link_object.has_key_in_link_header("imagesrcset")
+            || link_object.has_key_in_link_header("media")
         {
             LinkProcessingPhase::Media
         } else {
@@ -389,8 +389,8 @@ pub(crate) fn process_link_headers(
             continue;
         }
         // Step 2.5. If attribs["media"] exists and attribs["media"] does not match the environment, then continue.
-        if let Some(media) = link_object.value_for_key_in_link_header("media") &&
-            !MediaList::matches_environment(document, media)
+        if let Some(media) = link_object.value_for_key_in_link_header("media")
+            && !MediaList::matches_environment(document, media)
         {
             continue;
         }

--- a/components/script/dom/quotaexceedederror.rs
+++ b/components/script/dom/quotaexceedederror.rs
@@ -91,8 +91,8 @@ impl QuotaExceededErrorMethods<crate::DomTypeHolder> for QuotaExceededError {
         }
         // If this’s quota is not null, this’s requested is not null, and this’s requested
         // is less than this’s quota, then throw a RangeError.
-        if let (Some(quota), Some(requested)) = (options.quota, options.requested) &&
-            *requested < *quota
+        if let (Some(quota), Some(requested)) = (options.quota, options.requested)
+            && *requested < *quota
         {
             return Err(Error::Range(c"requested is less than quota".to_owned()));
         }

--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -161,8 +161,9 @@ impl Range {
         // > of the live range’s start node but not its end node, or vice versa.
         self.start_container()
             .inclusive_ancestors(ShadowIncluding::No)
-            .any(|n| &*n == node) !=
-            self.end_container()
+            .any(|n| &*n == node)
+            != self
+                .end_container()
                 .inclusive_ancestors(ShadowIncluding::No)
                 .any(|n| &*n == node)
     }
@@ -319,8 +320,8 @@ impl Range {
     }
 
     pub(crate) fn start_and_end_are_in_document_tree(&self) -> bool {
-        self.start_container().is_in_a_document_tree() &&
-            self.end_container().is_in_a_document_tree()
+        self.start_container().is_in_a_document_tree()
+            && self.end_container().is_in_a_document_tree()
     }
 
     pub(crate) fn start_container(&self) -> DomRoot<Node> {
@@ -611,11 +612,10 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         // Step 4.
         let offset = node.index();
         // Step 5.
-        Ordering::Greater ==
-            bp_position(&parent, offset + 1, &start_node, self.start_offset()).unwrap() &&
-            Ordering::Less ==
-                bp_position(&parent, offset, &self.end_container(), self.end_offset())
-                    .unwrap()
+        Ordering::Greater
+            == bp_position(&parent, offset + 1, &start_node, self.start_offset()).unwrap()
+            && Ordering::Less
+                == bp_position(&parent, offset, &self.end_container(), self.end_offset()).unwrap()
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-clonecontents>
@@ -635,8 +635,8 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             return Ok(fragment);
         }
 
-        if end_node == start_node &&
-            let Some(cdata) = start_node.downcast::<CharacterData>()
+        if end_node == start_node
+            && let Some(cdata) = start_node.downcast::<CharacterData>()
         {
             // Steps 4.1-2.
             let data = cdata
@@ -740,8 +740,8 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             return Ok(fragment);
         }
 
-        if end_node == start_node &&
-            let Some(end_data) = end_node.downcast::<CharacterData>()
+        if end_node == start_node
+            && let Some(end_data) = end_node.downcast::<CharacterData>()
         {
             // Step 4.1.
             let clone = end_node.CloneNode(cx, /* deep */ true)?;
@@ -943,8 +943,8 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             .map_or(parent.len(), |node| node.index());
 
         // Step 11
-        let new_offset = new_offset +
-            if let NodeTypeId::DocumentFragment(_) = node.type_id() {
+        let new_offset = new_offset
+            + if let NodeTypeId::DocumentFragment(_) = node.type_id() {
                 node.len()
             } else {
                 1
@@ -976,8 +976,8 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         let end_offset = self.end_offset();
 
         // Step 3. If originalStartNode is originalEndNode and it is a CharacterData node:
-        if start_node == end_node &&
-            let Some(text) = start_node.downcast::<CharacterData>()
+        if start_node == end_node
+            && let Some(text) = start_node.downcast::<CharacterData>()
         {
             if end_offset > start_offset {
                 self.report_change();
@@ -1076,8 +1076,9 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
 
         if start
             .inclusive_ancestors(ShadowIncluding::No)
-            .any(|n| !n.is_inclusive_ancestor_of(&end) && !n.is::<Text>()) ||
-            end.inclusive_ancestors(ShadowIncluding::No)
+            .any(|n| !n.is_inclusive_ancestor_of(&end) && !n.is::<Text>())
+            || end
+                .inclusive_ancestors(ShadowIncluding::No)
                 .any(|n| !n.is_inclusive_ancestor_of(&start) && !n.is::<Text>())
         {
             return Err(Error::InvalidState(None));
@@ -1085,9 +1086,9 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
 
         // Step 2.
         match new_parent.type_id() {
-            NodeTypeId::Document(_) |
-            NodeTypeId::DocumentType |
-            NodeTypeId::DocumentFragment(_) => {
+            NodeTypeId::Document(_)
+            | NodeTypeId::DocumentType
+            | NodeTypeId::DocumentFragment(_) => {
                 return Err(Error::InvalidNodeType(None));
             },
             _ => (),
@@ -1195,8 +1196,8 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         // Step 5. Otherwise, if node implements Text or Comment, set element to node's parent element.
         let element = match node.type_id() {
             NodeTypeId::Element(_) => Some(DomRoot::downcast::<Element>(node).unwrap()),
-            NodeTypeId::CharacterData(CharacterDataTypeId::Comment) |
-            NodeTypeId::CharacterData(CharacterDataTypeId::Text(_)) => node.GetParentElement(),
+            NodeTypeId::CharacterData(CharacterDataTypeId::Comment)
+            | NodeTypeId::CharacterData(CharacterDataTypeId::Text(_)) => node.GetParentElement(),
             _ => None,
         };
 

--- a/components/script/dom/resizeobserver/resizeobserver.rs
+++ b/components/script/dom/resizeobserver/resizeobserver.rs
@@ -352,8 +352,8 @@ impl ResizeObservation {
             return true;
         };
         let box_size = calculate_box_size(target, &self.observed_box);
-        box_size.width() != last_reported_size.inline_size() ||
-            box_size.height() != last_reported_size.block_size()
+        box_size.width() != last_reported_size.inline_size()
+            || box_size.height() != last_reported_size.block_size()
     }
 }
 

--- a/components/script/dom/scrolling_box.rs
+++ b/components/script/dom/scrolling_box.rs
@@ -268,8 +268,8 @@ impl ScrollingBox {
 
         let element_size = element_end - element_start;
 
-        current_scroll_offset +
-            match state.position {
+        current_scroll_offset
+            + match state.position {
                 // Step 1 & 5: If inline is "start", then align element start edge with scrolling box start edge.
                 ScrollLogicalPosition::Start => element_start,
                 // Step 2 & 6: If inline is "end", then align element end edge with
@@ -289,8 +289,8 @@ impl ScrollingBox {
                     // size is less than scrolling box size or If element end edge is outside
                     // scrolling box end edge and element size is greater than scrolling box size:
                     // Align element start edge with scrolling box start edge.
-                    if (element_start < scrollport_start && element_size <= container_size) ||
-                        (element_end > scrollport_end && element_size >= container_size)
+                    if (element_start < scrollport_start && element_size <= container_size)
+                        || (element_end > scrollport_end && element_size >= container_size)
                     {
                         element_start
                     }
@@ -298,8 +298,8 @@ impl ScrollingBox {
                     // size is greater than scrolling box size or If element start edge is outside
                     // scrolling box end edge and element size is less than scrolling box size:
                     // Align element end edge with scrolling box end edge.
-                    else if (element_end > scrollport_end && element_size < container_size) ||
-                        (element_start < scrollport_start && element_size > container_size)
+                    else if (element_end > scrollport_end && element_size < container_size)
+                        || (element_start < scrollport_start && element_size > container_size)
                     {
                         element_end - container_size
                     }

--- a/components/script/dom/security/sanitizer.rs
+++ b/components/script/dom/security/sanitizer.rs
@@ -90,9 +90,9 @@ impl Sanitizer {
         // SanitizerPresets member, or a dictionary.
         assert!(matches!(
             sanitizer_spec,
-            SanitizerOrSanitizerConfigOrSanitizerPresets::Sanitizer(_) |
-                SanitizerOrSanitizerConfigOrSanitizerPresets::SanitizerPresets(_) |
-                SanitizerOrSanitizerConfigOrSanitizerPresets::SanitizerConfig(_)
+            SanitizerOrSanitizerConfigOrSanitizerPresets::Sanitizer(_)
+                | SanitizerOrSanitizerConfigOrSanitizerPresets::SanitizerPresets(_)
+                | SanitizerOrSanitizerConfigOrSanitizerPresets::SanitizerConfig(_)
         ));
 
         // Step 4. If sanitizerSpec is a string:
@@ -112,8 +112,8 @@ impl Sanitizer {
         // Step 5. Assert: sanitizerSpec is either a Sanitizer instance, or a dictionary.
         assert!(matches!(
             sanitizer_spec,
-            SanitizerOrSanitizerConfigOrSanitizerPresets::Sanitizer(_) |
-                SanitizerOrSanitizerConfigOrSanitizerPresets::SanitizerConfig(_)
+            SanitizerOrSanitizerConfigOrSanitizerPresets::Sanitizer(_)
+                | SanitizerOrSanitizerConfigOrSanitizerPresets::SanitizerConfig(_)
         ));
 
         // Step 6. If sanitizerSpec is a dictionary:
@@ -184,10 +184,10 @@ impl Sanitizer {
     ) -> ErrorResult {
         // Step 1. If safe and contextElement’s local name is "script" and contextElement’s
         // namespace is the HTML namespace or the SVG namespace, then return.
-        if safe &&
-            context_element.local_name() == &local_name!("script") &&
-            (context_element.namespace() == &ns!(html) ||
-                context_element.namespace() == &ns!(svg))
+        if safe
+            && context_element.local_name() == &local_name!("script")
+            && (context_element.namespace() == &ns!(html)
+                || context_element.namespace() == &ns!(svg))
         {
             return Ok(());
         }
@@ -262,11 +262,11 @@ fn sanitize_core(
         // DocumentType.
         assert!(matches!(
             child.type_id(),
-            NodeTypeId::CharacterData(CharacterDataTypeId::Text(_)) |
-                NodeTypeId::CharacterData(CharacterDataTypeId::Comment) |
-                NodeTypeId::Element(_) |
-                NodeTypeId::CharacterData(CharacterDataTypeId::ProcessingInstruction) |
-                NodeTypeId::DocumentType
+            NodeTypeId::CharacterData(CharacterDataTypeId::Text(_))
+                | NodeTypeId::CharacterData(CharacterDataTypeId::Comment)
+                | NodeTypeId::Element(_)
+                | NodeTypeId::CharacterData(CharacterDataTypeId::ProcessingInstruction)
+                | NodeTypeId::DocumentType
         ));
 
         match child.type_id() {
@@ -406,8 +406,8 @@ fn sanitize_core(
                 // Step 1.6.5. If elementName equals «[ "name" → "template", "namespace" → HTML
                 // namespace ]», then call sanitize core on child’s template contents with
                 // configuration and handleJavascriptNavigationUrls.
-                if element_name.name().str() == "template" &&
-                    element_name
+                if element_name.name().str() == "template"
+                    && element_name
                         .namespace()
                         .is_some_and(|namespace| *namespace.str() == ns!(html))
                 {
@@ -440,10 +440,10 @@ fn sanitize_core(
 
                 // Step 1.6.8. If configuration["elements"] exists and configuration["elements"]
                 // contains elementName:
-                if let Some(configuration_elements) = &configuration.elements &&
-                    let Some(found) = configuration_elements.iter().find(|entry| {
-                        entry.name() == element_name.name() &&
-                            entry.namespace() == element_name.namespace()
+                if let Some(configuration_elements) = &configuration.elements
+                    && let Some(found) = configuration_elements.iter().find(|entry| {
+                        entry.name() == element_name.name()
+                            && entry.namespace() == element_name.namespace()
                     })
                 {
                     // Step 1.6.8.1. Set elementWithLocalAttributes to
@@ -503,14 +503,14 @@ fn sanitize_core(
                     // FIXME: <https://github.com/WICG/sanitizer-api/issues/380>
                     else if let Some(configuration_attributes) = configuration.attributes.as_ref()
                     {
-                        if (!configuration_attributes.contains_item(&attribute_name) &&
-                            !element_with_local_attributes
+                        if (!configuration_attributes.contains_item(&attribute_name)
+                            && !element_with_local_attributes
                                 .attributes()
                                 .unwrap_or_default()
-                                .contains_item(&attribute_name)) &&
-                            (!attribute_local_name.starts_with("data-") ||
-                                !attribute_namespace.is_empty() ||
-                                configuration.dataAttributes != Some(true))
+                                .contains_item(&attribute_name))
+                            && (!attribute_local_name.starts_with("data-")
+                                || !attribute_namespace.is_empty()
+                                || configuration.dataAttributes != Some(true))
                         {
                             // Step 1.6.9.3.1.1. Remove attribute.
                             child.remove_attribute(cx, attribute_namespace, attribute_local_name);
@@ -570,11 +570,11 @@ fn sanitize_core(
                         // Step 1.6.9.5.2. If child’s namespace is the MathML Namespace and attr’s
                         // local name is "href" and attr’s namespace is null or the XLink namespace
                         // and attr contains a javascript: URL, then remove attribute.
-                        if child.namespace() == &ns!(mathml) &&
-                            attribute_local_name == &local_name!("href") &&
-                            (attribute_namespace.is_empty() ||
-                                attribute_namespace == &ns!(xlink)) &&
-                            contains_javascript_url(attribute_value)
+                        if child.namespace() == &ns!(mathml)
+                            && attribute_local_name == &local_name!("href")
+                            && (attribute_namespace.is_empty()
+                                || attribute_namespace == &ns!(xlink))
+                            && contains_javascript_url(attribute_value)
                         {
                             child.remove_attribute(cx, attribute_namespace, attribute_local_name);
                         }
@@ -936,8 +936,8 @@ impl SanitizerMethods<crate::DomTypeHolder> for Sanitizer {
         else {
             // Step 5.1. If element["attributes"] exists or element["removeAttributes"] with default
             // « » is not empty:
-            if element.attributes().is_some() ||
-                !element.remove_attributes().unwrap_or_default().is_empty()
+            if element.attributes().is_some()
+                || !element.remove_attributes().unwrap_or_default().is_empty()
             {
                 // Step 5.1.1. The user agent may report a warning to the console that this
                 // operation is not supported.
@@ -1572,8 +1572,8 @@ impl SanitizerConfigAlgorithm for SanitizerConfig {
                         // Step 16.2.1.5. If config["dataAttributes"] is true and
                         // element["attributes"] contains a custom data attribute, then return
                         // false.
-                        if self.dataAttributes == Some(true) &&
-                            element.attributes().is_some_and(|attributes| {
+                        if self.dataAttributes == Some(true)
+                            && element.attributes().is_some_and(|attributes| {
                                 attributes
                                     .iter()
                                     .any(|attribute| attribute.is_custom_data_attribute())
@@ -1586,8 +1586,8 @@ impl SanitizerConfigAlgorithm for SanitizerConfig {
 
                 // Step 16.3. If config["dataAttributes"] is true and config["attributes"] contains
                 // a custom data attribute, then return false.
-                if self.dataAttributes == Some(true) &&
-                    config_attributes
+                if self.dataAttributes == Some(true)
+                    && config_attributes
                         .iter()
                         .any(|attribute| attribute.is_custom_data_attribute())
                 {

--- a/components/script/dom/security/xframeoptions.rs
+++ b/components/script/dom/security/xframeoptions.rs
@@ -51,8 +51,8 @@ pub(crate) fn check_a_navigation_response_adherence_to_x_frame_options(
         FxHashSet::from_iter(raw_xframe_options.iter().map(|value| value.to_lowercase()));
     // Step 6. If xFrameOptions's size is greater than 1,
     // and xFrameOptions contains any of "deny", "allowall", or "sameorigin", then return false.
-    if x_frame_options.len() > 1 &&
-        x_frame_options
+    if x_frame_options.len() > 1
+        && x_frame_options
             .iter()
             .any(|value| value == "deny" || value == "allowall" || value == "sameorigin")
     {

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -64,8 +64,8 @@ impl Selection {
         // If we are setting to literally the same Range object
         // (not just the same positions), then there's nothing changing
         // and no task to queue.
-        if let Some(existing) = self.range.get() &&
-            &*existing == range
+        if let Some(existing) = self.range.get()
+            && &*existing == range
         {
             return;
         }
@@ -328,8 +328,8 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     fn RemoveRange(&self, range: &Range) -> ErrorResult {
         // > The method must make this empty by disassociating its range if this's range
         // > is range. Otherwise, it must throw a NotFoundError.
-        if let Some(own_range) = self.range.get() &&
-            &*own_range == range
+        if let Some(own_range) = self.range.get()
+            && &*own_range == range
         {
             self.clear_range();
             return Ok(());
@@ -556,8 +556,8 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // and its end to focus. Otherwise, set the start them to focus and anchor
         // respectively.
         let is_anchor_before_focus =
-            bp_position(anchor_node, anchor_offset, focus_node, focus_offset) ==
-                Some(Ordering::Less);
+            bp_position(anchor_node, anchor_offset, focus_node, focus_offset)
+                == Some(Ordering::Less);
         if is_anchor_before_focus {
             new_range = Range::new(
                 cx,

--- a/components/script/dom/serviceworker/navigationpreloadmanager.rs
+++ b/components/script/dom/serviceworker/navigationpreloadmanager.rs
@@ -114,8 +114,9 @@ impl NavigationPreloadManagerMethods<crate::DomTypeHolder> for NavigationPreload
         let mut state = NavigationPreloadState::empty();
 
         // 3.
-        if self.serviceworker_registration.is_active() &&
-            self.serviceworker_registration
+        if self.serviceworker_registration.is_active()
+            && self
+                .serviceworker_registration
                 .get_navigation_preload_enabled()
         {
             state.enabled = true;

--- a/components/script/dom/serviceworker/serviceworkercontainer.rs
+++ b/components/script/dom/serviceworker/serviceworkercontainer.rs
@@ -374,8 +374,8 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
             },
         }
         // B: Step 4
-        if script_url.path().to_ascii_lowercase().contains("%2f") ||
-            script_url.path().to_ascii_lowercase().contains("%5c")
+        if script_url.path().to_ascii_lowercase().contains("%2f")
+            || script_url.path().to_ascii_lowercase().contains("%5c")
         {
             promise.reject_error(
                 realm,
@@ -396,8 +396,8 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
             },
         }
         // B: Step 7
-        if scope.path().to_ascii_lowercase().contains("%2f") ||
-            scope.path().to_ascii_lowercase().contains("%5c")
+        if scope.path().to_ascii_lowercase().contains("%2f")
+            || scope.path().to_ascii_lowercase().contains("%5c")
         {
             promise.reject_error(
                 realm,

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -214,8 +214,8 @@ impl ServoInternalsHelpers for ServoInternals {
         let mut realm = CurrentRealm::assert(cx);
         let global_scope = GlobalScope::from_current_realm(&mut realm);
         let url = global_scope.get_url();
-        (url.scheme() == "about" && url.as_str() != "about:blank") ||
-            ScriptThread::is_servo_privileged(url) ||
-            prefs::get().expose_servointernals_globally
+        (url.scheme() == "about" && url.as_str() != "about:blank")
+            || ScriptThread::is_servo_privileged(url)
+            || prefs::get().expose_servointernals_globally
     }
 }

--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -373,9 +373,9 @@ impl Tokenizer {
                 FromParserThreadMsg::ProcessOperation(parse_op) => {
                     self.process_operation(parse_op, cx);
                 },
-                FromParserThreadMsg::TokenizerResultDone { updated_input: _ } |
-                FromParserThreadMsg::TokenizerResultScript { .. } |
-                FromParserThreadMsg::EncodingIndicator { .. } => continue,
+                FromParserThreadMsg::TokenizerResultDone { updated_input: _ }
+                | FromParserThreadMsg::TokenizerResultScript { .. }
+                | FromParserThreadMsg::EncodingIndicator { .. } => continue,
                 FromParserThreadMsg::End => return,
             };
         }
@@ -842,9 +842,9 @@ impl TreeSink for Sink {
             let mut node_data = self.get_parse_node_data_mut(&node.id);
             node_data.is_integration_point = html_attrs.iter().any(|attr| {
                 let attr_value = &String::from(attr.value.clone());
-                (attr.name.local == local_name!("encoding") && attr.name.ns == ns!()) &&
-                    (attr_value.eq_ignore_ascii_case("text/html") ||
-                        attr_value.eq_ignore_ascii_case("application/xhtml+xml"))
+                (attr.name.local == local_name!("encoding") && attr.name.ns == ns!())
+                    && (attr_value.eq_ignore_ascii_case("text/html")
+                        || attr_value.eq_ignore_ascii_case("application/xhtml+xml"))
             });
         }
         let attrs = html_attrs

--- a/components/script/dom/servoparser/encoding.rs
+++ b/components/script/dom/servoparser/encoding.rs
@@ -139,9 +139,9 @@ impl DetectingState {
             // Step 6.2 If parentDocument's origin is same origin with d's origin and parentDocument's character encoding
             // is not UTF-16BE/LE, then return parentDocument's character encoding, with the confidence tentative.
             // NOTE: This should not happen for XML documents
-            if let Some(encoding) = self.encoding_of_container_document &&
-                encoding != UTF_16LE &&
-                encoding != UTF_16BE
+            if let Some(encoding) = self.encoding_of_container_document
+                && encoding != UTF_16LE
+                && encoding != UTF_16BE
             {
                 log::debug!(
                     "Inferred encoding to be that of the container document, which is {}",
@@ -353,10 +353,10 @@ pub fn prescan_the_byte_stream_to_determine_the_encoding(
         else if remaining_byte_stream
             .get(..b"<meta ".len())
             .is_some_and(|candidate| {
-                candidate[..b"<meta".len()].eq_ignore_ascii_case(b"<meta") &&
-                    candidate.last().is_some_and(|byte| {
-                        matches!(byte, 0x09 | 0x0A | 0x0C | 0x0D | 0x20 | 0x2F)
-                    })
+                candidate[..b"<meta".len()].eq_ignore_ascii_case(b"<meta")
+                    && candidate
+                        .last()
+                        .is_some_and(|byte| matches!(byte, 0x09 | 0x0A | 0x0C | 0x0D | 0x20 | 0x2F))
             })
         {
             // Step 1. Advance the position pointer so that it points at the next 0x09, 0x0A, 0x0C, 0x0D, 0x20,
@@ -406,11 +406,9 @@ pub fn prescan_the_byte_stream_to_determine_the_encoding(
                         // giving the attribute's value as the string to parse. If a character encoding
                         // is returned, and if charset is still set to null, let charset be the encoding
                         // returned, and set need pragma to true.
-                        if charset.is_none() &&
-                            let Some(extracted_charset) =
-                                extract_a_character_encoding_from_a_meta_element(
-                                    &attribute.value,
-                                )
+                        if charset.is_none()
+                            && let Some(extracted_charset) =
+                                extract_a_character_encoding_from_a_meta_element(&attribute.value)
                         {
                             need_pragma = Some(true);
                             charset = Some(extracted_charset);
@@ -455,8 +453,8 @@ pub fn prescan_the_byte_stream_to_determine_the_encoding(
         }
         // A sequence of bytes starting with a 0x3C byte (<), optionally a 0x2F byte (/),
         // and finally a byte in the range 0x41-0x5A or 0x61-0x7A (A-Z or a-z)
-        else if *remaining_byte_stream.first()? == b'<' &&
-            remaining_byte_stream
+        else if *remaining_byte_stream.first()? == b'<'
+            && remaining_byte_stream
                 .get(1)
                 .filter(|byte| **byte != b'=')
                 .or(remaining_byte_stream.get(2))?
@@ -475,9 +473,9 @@ pub fn prescan_the_byte_stream_to_determine_the_encoding(
         // A sequence of bytes starting with: 0x3C 0x21 (`<!`)
         // A sequence of bytes starting with: 0x3C 0x2F (`</`)
         // A sequence of bytes starting with: 0x3C 0x3F (`<?`)
-        else if remaining_byte_stream.starts_with(b"<!") ||
-            remaining_byte_stream.starts_with(b"</") ||
-            remaining_byte_stream.starts_with(b"<?")
+        else if remaining_byte_stream.starts_with(b"<!")
+            || remaining_byte_stream.starts_with(b"</")
+            || remaining_byte_stream.starts_with(b"<?")
         {
             // Advance the position pointer so that it points at the first 0x3E byte (>) that comes after the 0x3C byte that was found.
             position += remaining_byte_stream
@@ -681,8 +679,8 @@ fn extract_a_character_encoding_from_a_meta_element(input: &[u8]) -> Option<&'st
         // NOTE: In our case, the attribute value always comes from "get_an_attribute" and is already lowercased.
         position += input[position..]
             .windows(7)
-            .position(|window| window == b"charset")? +
-            b"charset".len();
+            .position(|window| window == b"charset")?
+            + b"charset".len();
 
         // Step 3. Skip any ASCII whitespace that immediately follow the word "charset" (there might not be any).
         position += &input[position..]

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -139,8 +139,8 @@ fn start_element<S: Serializer>(element: &Element, serializer: &mut S) -> io::Re
 
     // The "is" value of an element is treated as if it was an attribute and it is serialized before all
     // other attributes. If the element already has an "is" attribute then the "is" value is ignored.
-    if !element.has_attribute(&LocalName::from("is")) &&
-        let Some(is_value) = element.get_is()
+    if !element.has_attribute(&LocalName::from("is"))
+        && let Some(is_value) = element.get_is()
     {
         let qualified_name = QualName::new(None, ns!(), LocalName::from("is"));
 
@@ -216,8 +216,8 @@ impl SerializationIterator {
         }
 
         if let Some(shadow_root) = node.downcast::<Element>().and_then(Element::shadow_root) {
-            let should_be_serialized = (self.serialize_shadow_roots && shadow_root.Serializable()) ||
-                self.shadow_roots.contains(&shadow_root);
+            let should_be_serialized = (self.serialize_shadow_roots && shadow_root.Serializable())
+                || self.shadow_roots.contains(&shadow_root);
             if !shadow_root.is_user_agent_widget() && should_be_serialized {
                 self.stack
                     .push(SerializationCommand::SerializeShadowRoot(shadow_root));

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -512,8 +512,8 @@ impl ServoParser {
         // Store the whole input for the devtools Sources panel, if the devtools server is running
         // and we are parsing for a document load (not just things like innerHTML).
         // TODO: check if a devtools client is actually connected and/or wants the sources?
-        let content_for_devtools = (document.global().devtools_chan().is_some() &&
-            document.has_browsing_context())
+        let content_for_devtools = (document.global().devtools_chan().is_some()
+            && document.has_browsing_context())
         .then_some(DomRefCell::new(String::new()));
 
         ServoParser {
@@ -1437,11 +1437,11 @@ impl FetchResponseListener for ParserContext {
                     let page = page.replace("${bytes}", encoded_bytes.as_str());
                     page.replace("${secret}", &net_traits::PRIVILEGED_SECRET.to_string())
                 },
-                NetworkError::BlobURLStoreError(reason) |
-                NetworkError::WebsocketConnectionFailure(reason) |
-                NetworkError::HttpError(reason) |
-                NetworkError::ResourceLoadError(reason) |
-                NetworkError::MimeType(reason) => {
+                NetworkError::BlobURLStoreError(reason)
+                | NetworkError::WebsocketConnectionFailure(reason)
+                | NetworkError::HttpError(reason)
+                | NetworkError::ResourceLoadError(reason)
+                | NetworkError::MimeType(reason) => {
                     let page = resources::read_string(Resource::NetErrorHTML);
                     page.replace("${reason}", &reason)
                 },
@@ -1449,30 +1449,30 @@ impl FetchResponseListener for ParserContext {
                     let page = resources::read_string(Resource::CrashHTML);
                     page.replace("${details}", &details)
                 },
-                NetworkError::UnsupportedScheme |
-                NetworkError::CorsGeneral |
-                NetworkError::CrossOriginResponse |
-                NetworkError::CorsCredentials |
-                NetworkError::CorsAllowMethods |
-                NetworkError::CorsAllowHeaders |
-                NetworkError::CorsMethod |
-                NetworkError::CorsAuthorization |
-                NetworkError::CorsHeaders |
-                NetworkError::ConnectionFailure |
-                NetworkError::RedirectError |
-                NetworkError::TooManyRedirects |
-                NetworkError::TooManyInFlightKeepAliveRequests |
-                NetworkError::InvalidMethod |
-                NetworkError::ContentSecurityPolicy |
-                NetworkError::Nosniff |
-                NetworkError::SubresourceIntegrity |
-                NetworkError::MixedContent |
-                NetworkError::CacheError |
-                NetworkError::InvalidPort |
-                NetworkError::LocalDirectoryError |
-                NetworkError::PartialResponseToNonRangeRequestError |
-                NetworkError::ProtocolHandlerSubstitutionError |
-                NetworkError::DecompressionError => {
+                NetworkError::UnsupportedScheme
+                | NetworkError::CorsGeneral
+                | NetworkError::CrossOriginResponse
+                | NetworkError::CorsCredentials
+                | NetworkError::CorsAllowMethods
+                | NetworkError::CorsAllowHeaders
+                | NetworkError::CorsMethod
+                | NetworkError::CorsAuthorization
+                | NetworkError::CorsHeaders
+                | NetworkError::ConnectionFailure
+                | NetworkError::RedirectError
+                | NetworkError::TooManyRedirects
+                | NetworkError::TooManyInFlightKeepAliveRequests
+                | NetworkError::InvalidMethod
+                | NetworkError::ContentSecurityPolicy
+                | NetworkError::Nosniff
+                | NetworkError::SubresourceIntegrity
+                | NetworkError::MixedContent
+                | NetworkError::CacheError
+                | NetworkError::InvalidPort
+                | NetworkError::LocalDirectoryError
+                | NetworkError::PartialResponseToNonRangeRequestError
+                | NetworkError::ProtocolHandlerSubstitutionError
+                | NetworkError::DecompressionError => {
                     let page = resources::read_string(Resource::NetErrorHTML);
                     page.replace("${reason}", &format!("{:?}", error))
                 },
@@ -1980,8 +1980,8 @@ impl TreeSink for Sink {
         let elem = handle.downcast::<Element>().unwrap();
         elem.get_attribute_string_value(&local_name!("encoding"))
             .is_some_and(|value| {
-                value.eq_ignore_ascii_case("text/html") ||
-                    value.eq_ignore_ascii_case("application/xhtml+xml")
+                value.eq_ignore_ascii_case("text/html")
+                    || value.eq_ignore_ascii_case("application/xhtml+xml")
             })
     }
 
@@ -2140,9 +2140,9 @@ fn create_element_for_token(
     // Step 14. If element is a resettable element and not a form-associated custom
     // element, then invoke its reset algorithm. (This initializes the element's value and
     // checkedness based on the element's attributes.)
-    if let Some(html_element) = element.downcast::<HTMLElement>() &&
-        element.is_resettable() &&
-        !html_element.is_form_associated_custom_element()
+    if let Some(html_element) = element.downcast::<HTMLElement>()
+        && element.is_resettable()
+        && !html_element.is_form_associated_custom_element()
     {
         element.reset(cx);
     }

--- a/components/script/dom/servoparser/prefetch.rs
+++ b/components/script/dom/servoparser/prefetch.rs
@@ -175,9 +175,9 @@ impl TokenSink for PrefetchSink {
                 TokenSinkResult::Continue
             },
             (TagKind::StartTag, &local_name!("link")) if self.prefetching.get() => {
-                if let Some(rel) = self.get_attr(tag, local_name!("rel")) &&
-                    rel.value.eq_ignore_ascii_case("stylesheet") &&
-                    let Some(url) = self.get_url(tag, local_name!("href"))
+                if let Some(rel) = self.get_attr(tag, local_name!("rel"))
+                    && rel.value.eq_ignore_ascii_case("stylesheet")
+                    && let Some(url) = self.get_url(tag, local_name!("href"))
                 {
                     debug!("Prefetch {} {}", tag.name, url);
                     let cors_setting = self.get_cors_settings(tag, local_name!("crossorigin"));
@@ -217,8 +217,8 @@ impl TokenSink for PrefetchSink {
                 TokenSinkResult::Script(PrefetchHandle)
             },
             (TagKind::StartTag, &local_name!("base")) => {
-                if let Some(url) = self.get_url(tag, local_name!("href")) &&
-                    self.base_url.borrow().is_none()
+                if let Some(url) = self.get_url(tag, local_name!("href"))
+                    && self.base_url.borrow().is_none()
                 {
                     debug!("Setting base {}", url);
                     *self.base_url.borrow_mut() = Some(url);

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -588,12 +588,11 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     fn SetAdoptedStyleSheets(&self, cx: &mut JSContext, val: HandleValue) -> ErrorResult {
         let result = DocumentOrShadowRoot::set_adopted_stylesheet_from_jsval(
             cx,
-            self.adopted_stylesheets.borrow_mut().as_mut(),
+            &self.adopted_stylesheets,
             val,
             &StyleSheetListOwner::ShadowRoot(Dom::from_ref(self)),
         );
 
-        // If update is successful, clear the FrozenArray cache.
         if result.is_ok() {
             self.adopted_stylesheets_frozen_types.clear();
         }

--- a/components/script/dom/storage/storagemanager.rs
+++ b/components/script/dom/storage/storagemanager.rs
@@ -155,8 +155,8 @@ impl StorageManagerMethods<crate::DomTypeHolder> for StorageManager {
         if global
             .storage_threads()
             .persisted(global.origin().immutable().clone(), callback.clone())
-            .is_err() &&
-            let Err(error) = callback.send(Err("Failed to queue storage task".to_owned()))
+            .is_err()
+            && let Err(error) = callback.send(Err("Failed to queue storage task".to_owned()))
         {
             error!("Failed to deliver StorageManager persisted error: {error}");
         }
@@ -211,8 +211,8 @@ impl StorageManagerMethods<crate::DomTypeHolder> for StorageManager {
                 permission == PermissionState::Granted,
                 callback.clone(),
             )
-            .is_err() &&
-            let Err(error) = callback.send(Err("Failed to queue storage task".to_owned()))
+            .is_err()
+            && let Err(error) = callback.send(Err("Failed to queue storage task".to_owned()))
         {
             error!("Failed to deliver StorageManager persist error: {error}");
         }
@@ -259,8 +259,8 @@ impl StorageManagerMethods<crate::DomTypeHolder> for StorageManager {
         if global
             .storage_threads()
             .estimate(global.origin().immutable().clone(), callback.clone())
-            .is_err() &&
-            let Err(error) = callback.send(Err("Failed to queue storage task".to_owned()))
+            .is_err()
+            && let Err(error) = callback.send(Err("Failed to queue storage task".to_owned()))
         {
             error!("Failed to deliver StorageManager estimate error: {error}");
         }

--- a/components/script/dom/stream/byteteeunderlyingsource.rs
+++ b/components/script/dom/stream/byteteeunderlyingsource.rs
@@ -176,8 +176,8 @@ impl ByteTeeUnderlyingSource {
                         byte_reader
                             .get()
                             .expect("Reader should be set.")
-                            .get_num_read_into_requests() ==
-                            0
+                            .get_num_read_into_requests()
+                            == 0
                     );
 
                     // Release BYOB reader.
@@ -302,8 +302,8 @@ impl ByteTeeUnderlyingSource {
                         default_reader
                             .get()
                             .expect("Reader should be set.")
-                            .get_num_read_requests() ==
-                            0
+                            .get_num_read_requests()
+                            == 0
                     );
 
                     // Perform ! ReadableStreamDefaultReaderRelease(reader).

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -486,8 +486,8 @@ impl ReadableByteStreamController {
 
                 // If firstDescriptor’s bytes filled + bytesWritten > firstDescriptor’s byte length,
                 // throw a RangeError exception.
-                if first_descriptor.bytes_filled.get() + bytes_written >
-                    first_descriptor.byte_length
+                if first_descriptor.bytes_filled.get() + bytes_written
+                    > first_descriptor.byte_length
                 {
                     return Err(Error::Range(
                         c"bytes filled + bytesWritten > byte length".to_owned(),
@@ -729,8 +729,8 @@ impl ReadableByteStreamController {
 
             // If firstDescriptor’s byte offset + firstDescriptor’ bytes filled is not view.[[ByteOffset]],
             // throw a RangeError exception.
-            if first_descriptor.byte_offset + first_descriptor.bytes_filled.get() !=
-                (view.get_byte_offset() as u64)
+            if first_descriptor.byte_offset + first_descriptor.bytes_filled.get()
+                != (view.get_byte_offset() as u64)
             {
                 return Err(Error::Range(
                     c"firstDescriptor's byte offset + bytes filled is not view byte offset"
@@ -740,8 +740,8 @@ impl ReadableByteStreamController {
 
             // If firstDescriptor’s buffer byte length is not view.[[ViewedArrayBuffer]].[[ByteLength]],
             // throw a RangeError exception.
-            if first_descriptor.buffer_byte_length !=
-                (view.viewed_buffer_array_byte_length(cx) as u64)
+            if first_descriptor.buffer_byte_length
+                != (view.viewed_buffer_array_byte_length(cx) as u64)
             {
                 return Err(Error::Range(
                 c"firstDescriptor's buffer byte length is not view viewed buffer array byte length"
@@ -751,8 +751,8 @@ impl ReadableByteStreamController {
 
             // If firstDescriptor’s bytes filled + view.[[ByteLength]] > firstDescriptor’s byte length,
             // throw a RangeError exception.
-            if first_descriptor.bytes_filled.get() + (view.byte_length()) as u64 >
-                first_descriptor.byte_length
+            if first_descriptor.bytes_filled.get() + (view.byte_length()) as u64
+                > first_descriptor.byte_length
             {
                 return Err(Error::Range(
                     c"bytes filled + view byte length > byte length".to_owned(),
@@ -1379,8 +1379,8 @@ impl ReadableByteStreamController {
         {
             let pending_pull_intos = self.pending_pull_intos.borrow();
             assert!(
-                pending_pull_intos.is_empty() ||
-                    pending_pull_intos.first().unwrap() == pull_into_descriptor
+                pending_pull_intos.is_empty()
+                    || pending_pull_intos.first().unwrap() == pull_into_descriptor
             );
         }
 

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -816,8 +816,8 @@ impl PartialEq for ReaderType {
     fn eq(&self, other: &Self) -> bool {
         matches!(
             (self, other),
-            (ReaderType::BYOB(_), ReaderType::BYOB(_)) |
-                (ReaderType::Default(_), ReaderType::Default(_))
+            (ReaderType::BYOB(_), ReaderType::BYOB(_))
+                | (ReaderType::Default(_), ReaderType::Default(_))
         )
     }
 }

--- a/components/script/dom/stream/underlyingsourcecontainer.rs
+++ b/components/script/dom/stream/underlyingsourcecontainer.rs
@@ -98,10 +98,10 @@ impl UnderlyingSourceType<'_> {
     pub(crate) fn is_native(&self) -> bool {
         matches!(
             self,
-            UnderlyingSourceType::Memory(_) |
-                UnderlyingSourceType::Blob(_) |
-                UnderlyingSourceType::FetchResponse |
-                UnderlyingSourceType::Transfer(_)
+            UnderlyingSourceType::Memory(_)
+                | UnderlyingSourceType::Blob(_)
+                | UnderlyingSourceType::FetchResponse
+                | UnderlyingSourceType::Transfer(_)
         )
     }
 }

--- a/components/script/dom/svg/svgimageelement.rs
+++ b/components/script/dom/svg/svgimageelement.rs
@@ -77,9 +77,9 @@ impl VirtualMethods for SVGImageElement {
         self.super_type()
             .unwrap()
             .attribute_mutated(cx, attr, mutation);
-        if attr.local_name() == &local_name!("href") &&
-            matches!(attr.namespace(), &ns!() | &ns!(xlink)) &&
-            let AttributeMutation::Set(..) = mutation
+        if attr.local_name() == &local_name!("href")
+            && matches!(attr.namespace(), &ns!() | &ns!(xlink))
+            && let AttributeMutation::Set(..) = mutation
         {
             self.fetch_image_resource();
         }

--- a/components/script/dom/svg/svgsvgelement.rs
+++ b/components/script/dom/svg/svgsvgelement.rs
@@ -111,8 +111,8 @@ impl SVGSVGElement {
 
     fn process_use_elements(&self, cx: &mut JSContext, root_node: &Node) {
         for node in root_node.traverse_preorder(ShadowIncluding::No) {
-            if let Some(element) = node.downcast::<Element>() &&
-                element.local_name() == &local_name!("use")
+            if let Some(element) = node.downcast::<Element>()
+                && element.local_name() == &local_name!("use")
             {
                 self.process_single_use_element(cx, element, root_node)
             }

--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -647,11 +647,11 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     }
 
     fn DictMatchesPassedValues(&self, arg: RootedTraceableBox<TestDictionary>) -> bool {
-        arg.type_.as_ref().is_some_and(|s| s == "success") &&
-            arg.nonRequiredNullable.is_none() &&
-            arg.nonRequiredNullable2 == Some(None) &&
-            arg.noCallbackImport.is_none() &&
-            arg.noCallbackImport2.is_none()
+        arg.type_.as_ref().is_some_and(|s| s == "success")
+            && arg.nonRequiredNullable.is_none()
+            && arg.nonRequiredNullable2 == Some(None)
+            && arg.noCallbackImport.is_none()
+            && arg.noCallbackImport2.is_none()
     }
 
     fn PassBoolean(&self, _: bool) {}

--- a/components/script/dom/timeranges.rs
+++ b/components/script/dom/timeranges.rs
@@ -99,15 +99,15 @@ impl TimeRangesContainer {
         //   in between two ranges.
         let mut idx = 0;
         while idx < self.ranges.len() {
-            if new_range.is_overlapping(&self.ranges[idx]) ||
-                new_range.is_contiguous(&self.ranges[idx])
+            if new_range.is_overlapping(&self.ranges[idx])
+                || new_range.is_contiguous(&self.ranges[idx])
             {
                 // The ranges are either overlapping or contiguous,
                 // we need to merge the new range with the existing one.
                 new_range.union(&self.ranges[idx]);
                 self.ranges.remove(idx);
-            } else if new_range.is_before(&self.ranges[idx]) &&
-                (idx == 0 || self.ranges[idx - 1].is_before(&new_range))
+            } else if new_range.is_before(&self.ranges[idx])
+                && (idx == 0 || self.ranges[idx - 1].is_before(&new_range))
             {
                 // We are exactly after the current previous range and before the current
                 // range, while not overlapping with none of them.

--- a/components/script/dom/touch/touch.rs
+++ b/components/script/dom/touch/touch.rs
@@ -96,10 +96,10 @@ impl Touch {
         // Pressure is 0.5 for active touches, 0.0 for up/cancel/out/leave
         // <https://w3c.github.io/pointerevents/#dom-pointerevent-pressure>
         // TODO: add proper force support.
-        let pressure = if event_type == "pointerup" ||
-            event_type == "pointercancel" ||
-            event_type == "pointerout" ||
-            event_type == "pointerleave"
+        let pressure = if event_type == "pointerup"
+            || event_type == "pointercancel"
+            || event_type == "pointerout"
+            || event_type == "pointerleave"
         {
             0.0
         } else {
@@ -109,11 +109,11 @@ impl Touch {
         // <https://w3c.github.io/pointerevents/#the-button-property>
         // For pointermove, pointerover, pointerenter, pointerout, pointerleave: button is -1
         // For pointerdown, pointerup, pointercancel: button is 0 (primary button)
-        let button = if event_type == "pointermove" ||
-            event_type == "pointerover" ||
-            event_type == "pointerenter" ||
-            event_type == "pointerout" ||
-            event_type == "pointerleave"
+        let button = if event_type == "pointermove"
+            || event_type == "pointerover"
+            || event_type == "pointerenter"
+            || event_type == "pointerout"
+            || event_type == "pointerleave"
         {
             -1
         } else {
@@ -122,10 +122,10 @@ impl Touch {
 
         // Buttons: 1 if a button is pressed during the event, 0 otherwise
         // For touch: button is pressed during over/enter/down/move, not during up/cancel/out/leave
-        let buttons = if event_type == "pointermove" ||
-            event_type == "pointerover" ||
-            event_type == "pointerenter" ||
-            event_type == "pointerdown"
+        let buttons = if event_type == "pointermove"
+            || event_type == "pointerover"
+            || event_type == "pointerenter"
+            || event_type == "pointerdown"
         {
             1
         } else {

--- a/components/script/dom/trustedtypes/trustedtypepolicyfactory.rs
+++ b/components/script/dom/trustedtypes/trustedtypepolicyfactory.rs
@@ -133,9 +133,9 @@ impl TrustedTypePolicyFactory {
         // We return the if directly
         // Step 2: If attributeNs is null, « HTML namespace, SVG namespace, MathML namespace » contains
         // element’s namespace, and attribute is the name of an event handler content attribute:
-        if attribute_namespace.is_none() &&
-            matches!(*element_namespace, ns!(html) | ns!(svg) | ns!(mathml)) &&
-            EventTarget::is_content_event_handler(attribute)
+        if attribute_namespace.is_none()
+            && matches!(*element_namespace, ns!(html) | ns!(svg) | ns!(mathml))
+            && EventTarget::is_content_event_handler(attribute)
         {
             // Step 2.1. Return (Element, null, attribute, TrustedScript, "Element " + attribute).
             return Some((
@@ -147,37 +147,37 @@ impl TrustedTypePolicyFactory {
         // attributeNs is in the second column, and attribute is in the third column.
         // If a matching row is found, set data to that row.
         // Step 4: Return data.
-        if *element_namespace == ns!(html) &&
-            *element_name == local_name!("iframe") &&
-            attribute_namespace.is_none() &&
-            attribute == "srcdoc"
+        if *element_namespace == ns!(html)
+            && *element_name == local_name!("iframe")
+            && attribute_namespace.is_none()
+            && attribute == "srcdoc"
         {
             Some((
                 TrustedType::TrustedHTML,
                 "HTMLIFrameElement srcdoc".to_owned(),
             ))
-        } else if *element_namespace == ns!(html) &&
-            *element_name == local_name!("script") &&
-            attribute_namespace.is_none() &&
-            attribute == "src"
+        } else if *element_namespace == ns!(html)
+            && *element_name == local_name!("script")
+            && attribute_namespace.is_none()
+            && attribute == "src"
         {
             Some((
                 TrustedType::TrustedScriptURL,
                 "HTMLScriptElement src".to_owned(),
             ))
-        } else if *element_namespace == ns!(svg) &&
-            *element_name == local_name!("script") &&
-            attribute_namespace.is_none() &&
-            attribute == "href"
+        } else if *element_namespace == ns!(svg)
+            && *element_name == local_name!("script")
+            && attribute_namespace.is_none()
+            && attribute == "href"
         {
             Some((
                 TrustedType::TrustedScriptURL,
                 "SVGScriptElement href".to_owned(),
             ))
-        } else if *element_namespace == ns!(svg) &&
-            *element_name == local_name!("script") &&
-            attribute_namespace == Some(&ns!(xlink)) &&
-            attribute == "href"
+        } else if *element_namespace == ns!(svg)
+            && *element_name == local_name!("script")
+            && attribute_namespace == Some(&ns!(xlink))
+            && attribute == "href"
         {
             Some((
                 TrustedType::TrustedScriptURL,
@@ -446,29 +446,29 @@ impl TrustedTypePolicyFactoryMethods<crate::DomTypeHolder> for TrustedTypePolicy
         // and property is in the second column. If a matching row is found, set expectedType to
         // the interface’s name of the value of the third column.
         let property = property.str();
-        if interface.ns == ns!(html) &&
-            interface.local == local_name!("iframe") &&
-            property == "srcdoc"
+        if interface.ns == ns!(html)
+            && interface.local == local_name!("iframe")
+            && property == "srcdoc"
         {
             expected_type = Some(DOMString::from("TrustedHTML"))
-        } else if interface.ns == ns!(html) &&
-            interface.local == local_name!("script") &&
-            property == "innerText"
+        } else if interface.ns == ns!(html)
+            && interface.local == local_name!("script")
+            && property == "innerText"
         {
             expected_type = Some(DOMString::from("TrustedScript"))
-        } else if interface.ns == ns!(html) &&
-            interface.local == local_name!("script") &&
-            property == "src"
+        } else if interface.ns == ns!(html)
+            && interface.local == local_name!("script")
+            && property == "src"
         {
             expected_type = Some(DOMString::from("TrustedScriptURL"))
-        } else if interface.ns == ns!(html) &&
-            interface.local == local_name!("script") &&
-            property == "text"
+        } else if interface.ns == ns!(html)
+            && interface.local == local_name!("script")
+            && property == "text"
         {
             expected_type = Some(DOMString::from("TrustedScript"))
-        } else if interface.ns == ns!(html) &&
-            interface.local == local_name!("script") &&
-            property == "textContent"
+        } else if interface.ns == ns!(html)
+            && interface.local == local_name!("script")
+            && property == "textContent"
         {
             expected_type = Some(DOMString::from("TrustedScript"))
         } else if property == "innerHTML" {

--- a/components/script/dom/url/url.rs
+++ b/components/script/dom/url/url.rs
@@ -203,9 +203,9 @@ impl URLMethods<crate::DomTypeHolder> for URL {
         // this method call does nothing. User agents may display a message on the error console.
         let origin = global.origin().immutable().clone();
 
-        if let Ok(url) = ServoUrl::parse(&url.str()) &&
-            url.fragment().is_none() &&
-            let Ok((id, _)) = parse_blob_url(&url)
+        if let Ok(url) = ServoUrl::parse(&url.str())
+            && url.fragment().is_none()
+            && let Ok((id, _)) = parse_blob_url(&url)
         {
             let resource_threads = global.resource_threads();
             let (tx, rx) = generic_channel::channel(global.time_profiler_chan().clone()).unwrap();

--- a/components/script/dom/webcrypto/crypto.rs
+++ b/components/script/dom/webcrypto/crypto.rs
@@ -93,14 +93,14 @@ impl CryptoMethods<crate::DomTypeHolder> for Crypto {
 fn is_integer_buffer(array_type: Type) -> bool {
     matches!(
         array_type,
-        Type::Uint8 |
-            Type::Uint8Clamped |
-            Type::Int8 |
-            Type::Uint16 |
-            Type::Int16 |
-            Type::Uint32 |
-            Type::Int32 |
-            Type::BigInt64 |
-            Type::BigUint64
+        Type::Uint8
+            | Type::Uint8Clamped
+            | Type::Int8
+            | Type::Uint16
+            | Type::Int16
+            | Type::Uint32
+            | Type::Int32
+            | Type::BigInt64
+            | Type::BigUint64
     )
 }

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -1153,8 +1153,8 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             // If format is equal to the string "jwk":
             KeyFormat::Jwk => {
                 match key_data {
-                    ArrayBufferViewOrArrayBufferOrJsonWebKey::ArrayBufferView(_) |
-                    ArrayBufferViewOrArrayBufferOrJsonWebKey::ArrayBuffer(_) => {
+                    ArrayBufferViewOrArrayBufferOrJsonWebKey::ArrayBufferView(_)
+                    | ArrayBufferViewOrArrayBufferOrJsonWebKey::ArrayBuffer(_) => {
                         // Step 4.1. If the keyData parameter passed to the importKey() method is
                         // not a JsonWebKey dictionary, throw a TypeError.
                         let promise = Promise::new_in_realm(cx);
@@ -2301,23 +2301,23 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         let operation = &*operation.str();
         if !matches!(
             operation,
-            "encrypt" |
-                "decrypt" |
-                "sign" |
-                "verify" |
-                "digest" |
-                "generateKey" |
-                "deriveKey" |
-                "deriveBits" |
-                "importKey" |
-                "exportKey" |
-                "wrapKey" |
-                "unwrapKey" |
-                "encapsulateKey" |
-                "encapsulateBits" |
-                "decapsulateKey" |
-                "decapsulateBits" |
-                "getPublicKey"
+            "encrypt"
+                | "decrypt"
+                | "sign"
+                | "verify"
+                | "digest"
+                | "generateKey"
+                | "deriveKey"
+                | "deriveBits"
+                | "importKey"
+                | "exportKey"
+                | "wrapKey"
+                | "unwrapKey"
+                | "encapsulateKey"
+                | "encapsulateBits"
+                | "decapsulateKey"
+                | "decapsulateBits"
+                | "getPublicKey"
         ) {
             return false;
         }
@@ -2342,23 +2342,23 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         let mut operation = &*operation.str();
         if !matches!(
             operation,
-            "encrypt" |
-                "decrypt" |
-                "sign" |
-                "verify" |
-                "digest" |
-                "generateKey" |
-                "deriveKey" |
-                "deriveBits" |
-                "importKey" |
-                "exportKey" |
-                "wrapKey" |
-                "unwrapKey" |
-                "encapsulateKey" |
-                "encapsulateBits" |
-                "decapsulateKey" |
-                "decapsulateBits" |
-                "getPublicKey"
+            "encrypt"
+                | "decrypt"
+                | "sign"
+                | "verify"
+                | "digest"
+                | "generateKey"
+                | "deriveKey"
+                | "deriveBits"
+                | "importKey"
+                | "exportKey"
+                | "wrapKey"
+                | "unwrapKey"
+                | "encapsulateKey"
+                | "encapsulateBits"
+                | "decapsulateKey"
+                | "decapsulateBits"
+                | "getPublicKey"
         ) {
             return false;
         }
@@ -2377,8 +2377,8 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         {
             return false;
         }
-        if operation == "wrapKey" &&
-            !check_support_for_algorithm(cx, "exportKey", &additional_algorithm, None)
+        if operation == "wrapKey"
+            && !check_support_for_algorithm(cx, "exportKey", &additional_algorithm, None)
         {
             return false;
         }
@@ -2509,28 +2509,28 @@ pub(crate) fn check_support_for_algorithm(
             match normalized_algorithm {
                 EncryptAlgorithm::RsaOaep(_) => true,
                 EncryptAlgorithm::AesCtr(normalized_algorithm) => {
-                    normalized_algorithm.counter.len() == 16 &&
-                        normalized_algorithm.length != 0 &&
-                        normalized_algorithm.length <= 128
+                    normalized_algorithm.counter.len() == 16
+                        && normalized_algorithm.length != 0
+                        && normalized_algorithm.length <= 128
                 },
                 EncryptAlgorithm::AesCbc(normalized_algorithm) => {
                     normalized_algorithm.iv.len() == 16
                 },
                 EncryptAlgorithm::AesGcm(normalized_algorithm) => {
-                    normalized_algorithm.iv.len() <= u32::MAX as usize &&
-                        normalized_algorithm.tag_length.is_none_or(|length| {
+                    normalized_algorithm.iv.len() <= u32::MAX as usize
+                        && normalized_algorithm.tag_length.is_none_or(|length| {
                             matches!(length, 32 | 64 | 96 | 104 | 112 | 120 | 128)
                         })
                 },
                 EncryptAlgorithm::AesOcb(normalized_algorithm) => {
-                    normalized_algorithm.iv.len() <= 15 &&
-                        normalized_algorithm
+                    normalized_algorithm.iv.len() <= 15
+                        && normalized_algorithm
                             .tag_length
                             .is_none_or(|length| matches!(length, 64 | 96 | 128))
                 },
                 EncryptAlgorithm::ChaCha20Poly1305(normalized_algorithm) => {
-                    normalized_algorithm.iv.len() == 12 &&
-                        normalized_algorithm
+                    normalized_algorithm.iv.len() == 12
+                        && normalized_algorithm
                             .tag_length
                             .is_none_or(|length| length == 128)
                 },
@@ -2545,9 +2545,9 @@ pub(crate) fn check_support_for_algorithm(
             match normalized_algorithm {
                 DecryptAlgorithm::RsaOaep(_) => true,
                 DecryptAlgorithm::AesCtr(normalized_algorithm) => {
-                    normalized_algorithm.counter.len() == 16 &&
-                        normalized_algorithm.length != 0 &&
-                        normalized_algorithm.length <= 128
+                    normalized_algorithm.counter.len() == 16
+                        && normalized_algorithm.length != 0
+                        && normalized_algorithm.length <= 128
                 },
                 DecryptAlgorithm::AesCbc(normalized_algorithm) => {
                     normalized_algorithm.iv.len() == 16
@@ -2555,21 +2555,21 @@ pub(crate) fn check_support_for_algorithm(
                 DecryptAlgorithm::AesGcm(normalized_algorithm) => {
                     normalized_algorithm
                         .tag_length
-                        .is_none_or(|length| matches!(length, 32 | 64 | 96 | 104 | 112 | 120 | 128)) &&
-                        normalized_algorithm.iv.len() <= u32::MAX as usize &&
-                        normalized_algorithm
+                        .is_none_or(|length| matches!(length, 32 | 64 | 96 | 104 | 112 | 120 | 128))
+                        && normalized_algorithm.iv.len() <= u32::MAX as usize
+                        && normalized_algorithm
                             .additional_data
                             .is_none_or(|data| data.len() <= u32::MAX as usize)
                 },
                 DecryptAlgorithm::AesOcb(normalized_algorithm) => {
-                    normalized_algorithm.iv.len() <= 15 &&
-                        normalized_algorithm
+                    normalized_algorithm.iv.len() <= 15
+                        && normalized_algorithm
                             .tag_length
                             .is_none_or(|length| matches!(length, 64 | 96 | 128))
                 },
                 DecryptAlgorithm::ChaCha20Poly1305(normalized_algorithm) => {
-                    normalized_algorithm.iv.len() == 12 &&
-                        normalized_algorithm
+                    normalized_algorithm.iv.len() == 12
+                        && normalized_algorithm
                             .tag_length
                             .is_none_or(|length| length == 128)
                 },
@@ -2582,10 +2582,10 @@ pub(crate) fn check_support_for_algorithm(
             };
 
             match normalized_algorithm {
-                SignAlgorithm::RsassaPkcs1V1_5(_) |
-                SignAlgorithm::RsaPss(_) |
-                SignAlgorithm::Ecdsa(_) |
-                SignAlgorithm::Ed25519(_) => true,
+                SignAlgorithm::RsassaPkcs1V1_5(_)
+                | SignAlgorithm::RsaPss(_)
+                | SignAlgorithm::Ecdsa(_)
+                | SignAlgorithm::Ed25519(_) => true,
                 SignAlgorithm::Ed448(normalized_algorithm) => normalized_algorithm
                     .context
                     .is_none_or(|context| context.len() <= 255),
@@ -2599,10 +2599,10 @@ pub(crate) fn check_support_for_algorithm(
             };
 
             match normalized_algorithm {
-                VerifyAlgorithm::RsassaPkcs1V1_5(_) |
-                VerifyAlgorithm::RsaPss(_) |
-                VerifyAlgorithm::Ecdsa(_) |
-                VerifyAlgorithm::Ed25519(_) => true,
+                VerifyAlgorithm::RsassaPkcs1V1_5(_)
+                | VerifyAlgorithm::RsaPss(_)
+                | VerifyAlgorithm::Ecdsa(_)
+                | VerifyAlgorithm::Ed25519(_) => true,
                 VerifyAlgorithm::Ed448(normalized_algorithm) => normalized_algorithm
                     .context
                     .is_none_or(|context| context.len() <= 255),
@@ -2616,13 +2616,13 @@ pub(crate) fn check_support_for_algorithm(
             };
 
             match normalized_algorithm {
-                DigestAlgorithm::Sha(_) |
-                DigestAlgorithm::Sha3(_) |
-                DigestAlgorithm::CShake(_) |
-                DigestAlgorithm::TurboShake(_) => true,
+                DigestAlgorithm::Sha(_)
+                | DigestAlgorithm::Sha3(_)
+                | DigestAlgorithm::CShake(_)
+                | DigestAlgorithm::TurboShake(_) => true,
                 DigestAlgorithm::KangarooTwelve(normalized_algorithm) => {
-                    normalized_algorithm.output_length != 0 &&
-                        normalized_algorithm.output_length.is_multiple_of(8)
+                    normalized_algorithm.output_length != 0
+                        && normalized_algorithm.output_length.is_multiple_of(8)
                 },
             }
         },
@@ -2646,18 +2646,18 @@ pub(crate) fn check_support_for_algorithm(
                 },
                 DeriveBitsAlgorithm::Hkdf(_) => length.is_some_and(|length| length % 8 == 0),
                 DeriveBitsAlgorithm::Pbkdf2(normalized_algorithm) => {
-                    length.is_some_and(|length| length % 8 == 0) &&
-                        normalized_algorithm.iterations != 0
+                    length.is_some_and(|length| length % 8 == 0)
+                        && normalized_algorithm.iterations != 0
                 },
                 DeriveBitsAlgorithm::Argon2(normalized_algorithm) => {
-                    length.is_some_and(|length| length >= 32 && length % 8 == 0) &&
-                        normalized_algorithm
+                    length.is_some_and(|length| length >= 32 && length % 8 == 0)
+                        && normalized_algorithm
                             .version
-                            .is_none_or(|version| version == 19) &&
-                        normalized_algorithm.parallelism != 0 &&
-                        normalized_algorithm.parallelism <= 16777215 &&
-                        normalized_algorithm.memory >= 8 * normalized_algorithm.parallelism &&
-                        normalized_algorithm.passes != 0
+                            .is_none_or(|version| version == 19)
+                        && normalized_algorithm.parallelism != 0
+                        && normalized_algorithm.parallelism <= 16777215
+                        && normalized_algorithm.memory >= 8 * normalized_algorithm.parallelism
+                        && normalized_algorithm.passes != 0
                 },
             }
         },
@@ -2689,21 +2689,21 @@ pub(crate) fn check_support_for_algorithm(
             };
 
             match normalized_algorithm {
-                GenerateKeyAlgorithm::RsassaPkcs1V1_5(_) |
-                GenerateKeyAlgorithm::RsaPss(_) |
-                GenerateKeyAlgorithm::RsaOaep(_) => true,
-                GenerateKeyAlgorithm::Ecdsa(normalized_algorithm) |
-                GenerateKeyAlgorithm::Ecdh(normalized_algorithm) => {
+                GenerateKeyAlgorithm::RsassaPkcs1V1_5(_)
+                | GenerateKeyAlgorithm::RsaPss(_)
+                | GenerateKeyAlgorithm::RsaOaep(_) => true,
+                GenerateKeyAlgorithm::Ecdsa(normalized_algorithm)
+                | GenerateKeyAlgorithm::Ecdh(normalized_algorithm) => {
                     SUPPORTED_CURVES.contains(&normalized_algorithm.named_curve.as_str())
                 },
-                GenerateKeyAlgorithm::Ed25519(_) |
-                GenerateKeyAlgorithm::X25519(_) |
-                GenerateKeyAlgorithm::Ed448(_) |
-                GenerateKeyAlgorithm::X448(_) => true,
-                GenerateKeyAlgorithm::AesCtr(normalized_algorithm) |
-                GenerateKeyAlgorithm::AesCbc(normalized_algorithm) |
-                GenerateKeyAlgorithm::AesGcm(normalized_algorithm) |
-                GenerateKeyAlgorithm::AesKw(normalized_algorithm) => {
+                GenerateKeyAlgorithm::Ed25519(_)
+                | GenerateKeyAlgorithm::X25519(_)
+                | GenerateKeyAlgorithm::Ed448(_)
+                | GenerateKeyAlgorithm::X448(_) => true,
+                GenerateKeyAlgorithm::AesCtr(normalized_algorithm)
+                | GenerateKeyAlgorithm::AesCbc(normalized_algorithm)
+                | GenerateKeyAlgorithm::AesGcm(normalized_algorithm)
+                | GenerateKeyAlgorithm::AesKw(normalized_algorithm) => {
                     matches!(normalized_algorithm.length, 128 | 192 | 256)
                 },
                 GenerateKeyAlgorithm::Hmac(normalized_algorithm) => {
@@ -2723,27 +2723,27 @@ pub(crate) fn check_support_for_algorithm(
             };
 
             match normalized_algorithm {
-                ImportKeyAlgorithm::RsassaPkcs1V1_5(_) |
-                ImportKeyAlgorithm::RsaPss(_) |
-                ImportKeyAlgorithm::RsaOaep(_) |
-                ImportKeyAlgorithm::Ecdsa(_) |
-                ImportKeyAlgorithm::Ecdh(_) |
-                ImportKeyAlgorithm::Ed25519(_) |
-                ImportKeyAlgorithm::X25519(_) |
-                ImportKeyAlgorithm::Ed448(_) |
-                ImportKeyAlgorithm::X448(_) |
-                ImportKeyAlgorithm::AesCtr(_) |
-                ImportKeyAlgorithm::AesCbc(_) |
-                ImportKeyAlgorithm::AesGcm(_) |
-                ImportKeyAlgorithm::AesKw(_) |
-                ImportKeyAlgorithm::Hmac(_) |
-                ImportKeyAlgorithm::Hkdf(_) |
-                ImportKeyAlgorithm::Pbkdf2(_) |
-                ImportKeyAlgorithm::MlKem(_) |
-                ImportKeyAlgorithm::MlDsa(_) |
-                ImportKeyAlgorithm::AesOcb(_) |
-                ImportKeyAlgorithm::ChaCha20Poly1305(_) |
-                ImportKeyAlgorithm::Argon2(_) => true,
+                ImportKeyAlgorithm::RsassaPkcs1V1_5(_)
+                | ImportKeyAlgorithm::RsaPss(_)
+                | ImportKeyAlgorithm::RsaOaep(_)
+                | ImportKeyAlgorithm::Ecdsa(_)
+                | ImportKeyAlgorithm::Ecdh(_)
+                | ImportKeyAlgorithm::Ed25519(_)
+                | ImportKeyAlgorithm::X25519(_)
+                | ImportKeyAlgorithm::Ed448(_)
+                | ImportKeyAlgorithm::X448(_)
+                | ImportKeyAlgorithm::AesCtr(_)
+                | ImportKeyAlgorithm::AesCbc(_)
+                | ImportKeyAlgorithm::AesGcm(_)
+                | ImportKeyAlgorithm::AesKw(_)
+                | ImportKeyAlgorithm::Hmac(_)
+                | ImportKeyAlgorithm::Hkdf(_)
+                | ImportKeyAlgorithm::Pbkdf2(_)
+                | ImportKeyAlgorithm::MlKem(_)
+                | ImportKeyAlgorithm::MlDsa(_)
+                | ImportKeyAlgorithm::AesOcb(_)
+                | ImportKeyAlgorithm::ChaCha20Poly1305(_)
+                | ImportKeyAlgorithm::Argon2(_) => true,
             }
         },
         "exportKey" => {
@@ -2753,24 +2753,24 @@ pub(crate) fn check_support_for_algorithm(
             };
 
             match normalized_algorithm {
-                ExportKeyAlgorithm::RsassaPkcs1V1_5(_) |
-                ExportKeyAlgorithm::RsaPss(_) |
-                ExportKeyAlgorithm::RsaOaep(_) |
-                ExportKeyAlgorithm::Ecdsa(_) |
-                ExportKeyAlgorithm::Ecdh(_) |
-                ExportKeyAlgorithm::Ed25519(_) |
-                ExportKeyAlgorithm::X25519(_) |
-                ExportKeyAlgorithm::Ed448(_) |
-                ExportKeyAlgorithm::X448(_) |
-                ExportKeyAlgorithm::AesCtr(_) |
-                ExportKeyAlgorithm::AesCbc(_) |
-                ExportKeyAlgorithm::AesGcm(_) |
-                ExportKeyAlgorithm::AesKw(_) |
-                ExportKeyAlgorithm::Hmac(_) |
-                ExportKeyAlgorithm::MlKem(_) |
-                ExportKeyAlgorithm::MlDsa(_) |
-                ExportKeyAlgorithm::AesOcb(_) |
-                ExportKeyAlgorithm::ChaCha20Poly1305(_) => true,
+                ExportKeyAlgorithm::RsassaPkcs1V1_5(_)
+                | ExportKeyAlgorithm::RsaPss(_)
+                | ExportKeyAlgorithm::RsaOaep(_)
+                | ExportKeyAlgorithm::Ecdsa(_)
+                | ExportKeyAlgorithm::Ecdh(_)
+                | ExportKeyAlgorithm::Ed25519(_)
+                | ExportKeyAlgorithm::X25519(_)
+                | ExportKeyAlgorithm::Ed448(_)
+                | ExportKeyAlgorithm::X448(_)
+                | ExportKeyAlgorithm::AesCtr(_)
+                | ExportKeyAlgorithm::AesCbc(_)
+                | ExportKeyAlgorithm::AesGcm(_)
+                | ExportKeyAlgorithm::AesKw(_)
+                | ExportKeyAlgorithm::Hmac(_)
+                | ExportKeyAlgorithm::MlKem(_)
+                | ExportKeyAlgorithm::MlDsa(_)
+                | ExportKeyAlgorithm::AesOcb(_)
+                | ExportKeyAlgorithm::ChaCha20Poly1305(_) => true,
             }
         },
         "get key length" => {
@@ -2781,10 +2781,10 @@ pub(crate) fn check_support_for_algorithm(
             };
 
             match normalized_algorithm {
-                GetKeyLengthAlgorithm::AesCtr(normalized_derived_key_algorithm) |
-                GetKeyLengthAlgorithm::AesCbc(normalized_derived_key_algorithm) |
-                GetKeyLengthAlgorithm::AesGcm(normalized_derived_key_algorithm) |
-                GetKeyLengthAlgorithm::AesKw(normalized_derived_key_algorithm) => {
+                GetKeyLengthAlgorithm::AesCtr(normalized_derived_key_algorithm)
+                | GetKeyLengthAlgorithm::AesCbc(normalized_derived_key_algorithm)
+                | GetKeyLengthAlgorithm::AesGcm(normalized_derived_key_algorithm)
+                | GetKeyLengthAlgorithm::AesKw(normalized_derived_key_algorithm) => {
                     matches!(normalized_derived_key_algorithm.length, 128 | 192 | 256)
                 },
                 GetKeyLengthAlgorithm::Hmac(normalized_derived_key_algorithm) => {
@@ -4341,15 +4341,15 @@ impl JsonWebKeyExt for JsonWebKey {
             if key_ops
                 .iter()
                 .collect::<std::collections::HashSet<_>>()
-                .len() <
-                key_ops.len()
+                .len()
+                < key_ops.len()
             {
                 return Err(Error::Data(None));
             }
             // 2. The "use" and "key_ops" JWK members SHOULD NOT be used together; however, if both
             //    are used, the information they convey MUST be consistent.
-            if let Some(ref use_) = self.use_ &&
-                key_ops.iter().any(|op| op != use_)
+            if let Some(ref use_) = self.use_
+                && key_ops.iter().any(|op| op != use_)
             {
                 return Err(Error::Data(None));
             }
@@ -4454,12 +4454,12 @@ impl JsonWebKeyExt for JsonWebKey {
         &self,
         primes: &mut Vec<Zeroizing<Vec<u8>>>,
     ) -> Result<(), Error> {
-        if self.oth.is_some() &&
-            (self.p.is_none() ||
-                self.q.is_none() ||
-                self.dp.is_none() ||
-                self.dq.is_none() ||
-                self.qi.is_none())
+        if self.oth.is_some()
+            && (self.p.is_none()
+                || self.q.is_none()
+                || self.dp.is_none()
+                || self.dq.is_none()
+                || self.qi.is_none())
         {
             return Err(Error::Data(Some(
                 "The oth field is present while at least one of p, q, dp, dq, qi is missing, in jwk".to_string()
@@ -5050,10 +5050,10 @@ impl NormalizedAlgorithm for DigestAlgorithm {
         object: HandleObject,
     ) -> Fallible<Self> {
         match algorithm_name {
-            CryptoAlgorithm::Sha1 |
-            CryptoAlgorithm::Sha256 |
-            CryptoAlgorithm::Sha384 |
-            CryptoAlgorithm::Sha512 => Ok(DigestAlgorithm::Sha(
+            CryptoAlgorithm::Sha1
+            | CryptoAlgorithm::Sha256
+            | CryptoAlgorithm::Sha384
+            | CryptoAlgorithm::Sha512 => Ok(DigestAlgorithm::Sha(
                 object.try_into_with_cx_and_name(cx, algorithm_name)?,
             )),
             CryptoAlgorithm::Sha3_256 | CryptoAlgorithm::Sha3_384 | CryptoAlgorithm::Sha3_512 => {

--- a/components/script/dom/webcrypto/subtlecrypto/aes_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_common.rs
@@ -47,10 +47,10 @@ pub(crate) fn generate_key(
     usages: Vec<KeyUsage>,
 ) -> Result<DomRoot<CryptoKey>, Error> {
     match aes_algorithm {
-        AesAlgorithm::AesCtr |
-        AesAlgorithm::AesCbc |
-        AesAlgorithm::AesGcm |
-        AesAlgorithm::AesOcb => {
+        AesAlgorithm::AesCtr
+        | AesAlgorithm::AesCbc
+        | AesAlgorithm::AesGcm
+        | AesAlgorithm::AesOcb => {
             // Step 1. If usages contains any entry which is not one of "encrypt", "decrypt",
             // "wrapKey" or "unwrapKey", then throw a SyntaxError.
             if usages.iter().any(|usage| {
@@ -178,10 +178,10 @@ pub(crate) fn import_key(
     usages: Vec<KeyUsage>,
 ) -> Result<DomRoot<CryptoKey>, Error> {
     match &aes_algorithm {
-        AesAlgorithm::AesCtr |
-        AesAlgorithm::AesCbc |
-        AesAlgorithm::AesGcm |
-        AesAlgorithm::AesOcb => {
+        AesAlgorithm::AesCtr
+        | AesAlgorithm::AesCbc
+        | AesAlgorithm::AesGcm
+        | AesAlgorithm::AesOcb => {
             // Step 1. If usages contains an entry which is not one of "encrypt", "decrypt",
             // "wrapKey" or "unwrapKey", then throw a SyntaxError.
             if usages.iter().any(|usage| {
@@ -219,10 +219,10 @@ pub(crate) fn import_key(
         KeyFormat::Raw
             if matches!(
                 aes_algorithm,
-                AesAlgorithm::AesCtr |
-                    AesAlgorithm::AesCbc |
-                    AesAlgorithm::AesGcm |
-                    AesAlgorithm::AesKw
+                AesAlgorithm::AesCtr
+                    | AesAlgorithm::AesCbc
+                    | AesAlgorithm::AesGcm
+                    | AesAlgorithm::AesKw
             ) =>
         {
             // Step 2.1. Let data be keyData.
@@ -538,10 +538,10 @@ pub(crate) fn export_key(
         KeyFormat::Raw
             if matches!(
                 aes_algorithm,
-                AesAlgorithm::AesCtr |
-                    AesAlgorithm::AesCbc |
-                    AesAlgorithm::AesGcm |
-                    AesAlgorithm::AesKw
+                AesAlgorithm::AesCtr
+                    | AesAlgorithm::AesCbc
+                    | AesAlgorithm::AesGcm
+                    | AesAlgorithm::AesKw
             ) =>
         {
             // Step 2.1. Let data be a byte sequence containing the raw octets of the key

--- a/components/script/dom/webcrypto/subtlecrypto/ec_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ec_common.rs
@@ -507,8 +507,8 @@ pub(crate) fn import_key(
                     // Step 2.2. If the d field is present and if usages contains an entry which is
                     // not "deriveKey" or "deriveBits" then throw a SyntaxError. If the d field is
                     // not present and if usages is not empty then throw a SyntaxError.
-                    if jwk.d.as_ref().is_some() &&
-                        usages.iter().any(|usage| {
+                    if jwk.d.as_ref().is_some()
+                        && usages.iter().any(|usage| {
                             !matches!(usage, KeyUsage::DeriveKey | KeyUsage::DeriveBits)
                         })
                     {

--- a/components/script/dom/webcrypto/subtlecrypto/hkdf_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/hkdf_operation.rs
@@ -100,8 +100,8 @@ pub(crate) fn import_key(
         // a SyntaxError.
         if usages
             .iter()
-            .any(|usage| !matches!(usage, KeyUsage::DeriveKey | KeyUsage::DeriveBits)) ||
-            usages.is_empty()
+            .any(|usage| !matches!(usage, KeyUsage::DeriveKey | KeyUsage::DeriveBits))
+            || usages.is_empty()
         {
             return Err(Error::Syntax(Some(
                 "Usages contains an entry which is not \"deriveKey\" or \"deriveBits\"".into(),

--- a/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
@@ -180,8 +180,8 @@ pub(crate) fn import_key(
     // Note: This is not explicitly spec'ed, but also throw a SyntaxError if usages is empty
     if usages
         .iter()
-        .any(|usage| !matches!(usage, KeyUsage::Sign | KeyUsage::Verify)) ||
-        usages.is_empty()
+        .any(|usage| !matches!(usage, KeyUsage::Sign | KeyUsage::Verify))
+        || usages.is_empty()
     {
         return Err(Error::Syntax(Some(
             "Usages contains an entry which is not \"sign\" or \"verify\", or is empty".into(),

--- a/components/script/dom/webcrypto/subtlecrypto/ml_kem_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ml_kem_operation.rs
@@ -184,10 +184,10 @@ pub(crate) fn generate_key(
     if usages.iter().any(|usage| {
         !matches!(
             usage,
-            KeyUsage::EncapsulateKey |
-                KeyUsage::EncapsulateBits |
-                KeyUsage::DecapsulateKey |
-                KeyUsage::DecapsulateBits
+            KeyUsage::EncapsulateKey
+                | KeyUsage::EncapsulateBits
+                | KeyUsage::DecapsulateKey
+                | KeyUsage::DecapsulateBits
         )
     }) {
         return Err(Error::Syntax(Some(
@@ -655,8 +655,8 @@ pub(crate) fn import_key(
 
             // Step 2.2. If the priv field of jwk is present and if usages contains an entry which
             // is not "decapsulateKey" or "decapsulateBits" then throw a SyntaxError.
-            if jwk.priv_.is_some() &&
-                usages.iter().any(|usage| {
+            if jwk.priv_.is_some()
+                && usages.iter().any(|usage| {
                     !matches!(usage, KeyUsage::DecapsulateKey | KeyUsage::DecapsulateBits)
                 })
             {
@@ -669,8 +669,8 @@ pub(crate) fn import_key(
 
             // Step 2.3. If the priv field of jwk is not present and if usages contains an entry
             // which is not "encapsulateKey" or "encapsulateBits" then throw a SyntaxError.
-            if jwk.priv_.is_none() &&
-                usages.iter().any(|usage| {
+            if jwk.priv_.is_none()
+                && usages.iter().any(|usage| {
                     !matches!(usage, KeyUsage::EncapsulateKey | KeyUsage::EncapsulateBits)
                 })
             {

--- a/components/script/dom/webcrypto/subtlecrypto/pbkdf2_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/pbkdf2_operation.rs
@@ -94,8 +94,8 @@ pub(crate) fn import_key(
     // Step 2. If usages contains a value that is not "deriveKey" or "deriveBits", then throw a SyntaxError.
     if usages
         .iter()
-        .any(|usage| !matches!(usage, KeyUsage::DeriveKey | KeyUsage::DeriveBits)) ||
-        usages.is_empty()
+        .any(|usage| !matches!(usage, KeyUsage::DeriveKey | KeyUsage::DeriveBits))
+        || usages.is_empty()
     {
         return Err(Error::Syntax(None));
     }

--- a/components/script/dom/webcrypto/subtlecrypto/rsa_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsa_common.rs
@@ -364,10 +364,10 @@ pub(crate) fn import_key(
                     // "decrypt" or "unwrapKey", then throw a SyntaxError.
                     // * If the d field of jwk is not present and usages contains an entry which is
                     // not "encrypt" or "wrapKey", then throw a SyntaxError.
-                    if jwk.d.is_some() &&
-                        usages.iter().any(|usage| {
-                            !matches!(usage, KeyUsage::Decrypt | KeyUsage::UnwrapKey)
-                        })
+                    if jwk.d.is_some()
+                        && usages
+                            .iter()
+                            .any(|usage| !matches!(usage, KeyUsage::Decrypt | KeyUsage::UnwrapKey))
                     {
                         return Err(Error::Syntax(Some(
                             "The d field of jwk is present and usages contains an entry which is \
@@ -375,8 +375,8 @@ pub(crate) fn import_key(
                                 .to_string(),
                         )));
                     }
-                    if jwk.d.is_none() &&
-                        usages
+                    if jwk.d.is_none()
+                        && usages
                             .iter()
                             .any(|usage| !matches!(usage, KeyUsage::Encrypt | KeyUsage::WrapKey))
                     {

--- a/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
@@ -337,8 +337,8 @@ pub(crate) fn import_key(
 
             // Step 2.2. If the d field is present and if usages contains an entry which is not
             // "deriveKey" or "deriveBits" then throw a SyntaxError.
-            if jwk.d.is_some() &&
-                usages
+            if jwk.d.is_some()
+                && usages
                     .iter()
                     .any(|usage| !matches!(usage, KeyUsage::DeriveKey | KeyUsage::DeriveBits))
             {

--- a/components/script/dom/webcrypto/subtlecrypto/x448_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/x448_operation.rs
@@ -372,8 +372,8 @@ pub(crate) fn import_key(
 
             // Step 2.2. If the d field is present and if usages contains an entry which is not
             // "deriveKey" or "deriveBits" then throw a SyntaxError.
-            if jwk.d.is_some() &&
-                usages
+            if jwk.d.is_some()
+                && usages
                     .iter()
                     .any(|usage| !matches!(usage, KeyUsage::DeriveKey | KeyUsage::DeriveBits))
             {

--- a/components/script/dom/webgl/extensions/ext/webglcompressedtextures3tc.rs
+++ b/components/script/dom/webgl/extensions/ext/webglcompressedtextures3tc.rs
@@ -37,8 +37,8 @@ impl WebGLExtension for WEBGLCompressedTextureS3TC {
     }
 
     fn is_supported(ext: &WebGLExtensions) -> bool {
-        ext.supports_gl_extension("GL_EXT_texture_compression_s3tc") ||
-            ext.supports_all_gl_extension(&[
+        ext.supports_gl_extension("GL_EXT_texture_compression_s3tc")
+            || ext.supports_all_gl_extension(&[
                 "GL_EXT_texture_compression_dxt1",
                 "GL_ANGLE_texture_compression_dxt3",
                 "GL_ANGLE_texture_compression_dxt5",

--- a/components/script/dom/webgl/extensions/extensions.rs
+++ b/components/script/dom/webgl/extensions/extensions.rs
@@ -219,8 +219,8 @@ impl WebGLExtensions {
             .borrow()
             .iter()
             .filter(|v| {
-                if let WebGLExtensionSpec::Specific(version) = v.1.spec() &&
-                    self.webgl_version != version
+                if let WebGLExtensionSpec::Specific(version) = v.1.spec()
+                    && self.webgl_version != version
                 {
                     return false;
                 }
@@ -462,8 +462,8 @@ impl WebGLExtensions {
     }
 
     pub(crate) fn effective_type(&self, type_: u32) -> u32 {
-        if type_ == OESTextureHalfFloatConstants::HALF_FLOAT_OES &&
-            !self.supports_gl_extension("GL_OES_texture_half_float")
+        if type_ == OESTextureHalfFloatConstants::HALF_FLOAT_OES
+            && !self.supports_gl_extension("GL_OES_texture_half_float")
         {
             return glow::HALF_FLOAT;
         }

--- a/components/script/dom/webgl/validations/tex_image_2d.rs
+++ b/components/script/dom/webgl/validations/tex_image_2d.rs
@@ -150,8 +150,8 @@ impl WebGLValidator for CommonTexImage2DValidator<'_> {
         // format.
         let internal_format = match TexFormat::from_gl_constant(self.internal_format) {
             Some(format)
-                if format.required_webgl_version() <= self.context.webgl_version() &&
-                    format.usable_as_internal() =>
+                if format.required_webgl_version() <= self.context.webgl_version()
+                    && format.usable_as_internal() =>
             {
                 format
             },
@@ -455,9 +455,9 @@ fn is_subimage_blockaligned(
     let block_width = compression.block_width as u32;
     let block_height = compression.block_height as u32;
 
-    (xoffset.is_multiple_of(block_width) && yoffset.is_multiple_of(block_height)) &&
-        (width.is_multiple_of(block_width) || xoffset + width == tex_info.width()) &&
-        (height.is_multiple_of(block_height) || yoffset + height == tex_info.height())
+    (xoffset.is_multiple_of(block_width) && yoffset.is_multiple_of(block_height))
+        && (width.is_multiple_of(block_width) || xoffset + width == tex_info.width())
+        && (height.is_multiple_of(block_height) || yoffset + height == tex_info.height())
 }
 
 impl WebGLValidator for CommonCompressedTexImage2DValidator<'_> {
@@ -644,10 +644,10 @@ impl WebGLValidator for CompressedTexSubImage2DValidator<'_> {
         //   - xoffset or yoffset is less than 0
         //   - x offset plus the width is greater than the texture width
         //   - y offset plus the height is greater than the texture height
-        if self.xoffset < 0 ||
-            (self.xoffset as u32 + width) > tex_info.width() ||
-            self.yoffset < 0 ||
-            (self.yoffset as u32 + height) > tex_info.height()
+        if self.xoffset < 0
+            || (self.xoffset as u32 + width) > tex_info.width()
+            || self.yoffset < 0
+            || (self.yoffset as u32 + height) > tex_info.height()
         {
             context.webgl_error(InvalidValue);
             return Err(TexImageValidationError::InvalidOffsets);

--- a/components/script/dom/webgl/validations/tex_image_3d.rs
+++ b/components/script/dom/webgl/validations/tex_image_3d.rs
@@ -71,8 +71,8 @@ impl WebGLValidator for CommonTexImage3DValidator<'_> {
         // format.
         let internal_format = match TexFormat::from_gl_constant(self.internal_format) {
             Some(format)
-                if format.required_webgl_version() <= self.context.webgl_version() &&
-                    format.usable_as_internal() =>
+                if format.required_webgl_version() <= self.context.webgl_version()
+                    && format.usable_as_internal() =>
             {
                 format
             },
@@ -264,8 +264,8 @@ impl WebGLValidator for TexImage3DValidator<'_> {
 
         // GL_INVALID_OPERATION is generated if target is GL_TEXTURE_3D and
         // format is GL_DEPTH_COMPONENT, or GL_DEPTH_STENCIL.
-        if target == TexImageTarget::Texture3D &&
-            (format == TexFormat::DepthComponent || format == TexFormat::DepthStencil)
+        if target == TexImageTarget::Texture3D
+            && (format == TexFormat::DepthComponent || format == TexFormat::DepthStencil)
         {
             context.webgl_error(InvalidOperation);
             return Err(TexImageValidationError::InvalidTypeForFormat);

--- a/components/script/dom/webgl/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl/webgl2renderingcontext.rs
@@ -347,12 +347,12 @@ impl WebGL2RenderingContext {
 
     pub(crate) fn buffer_usage(&self, usage: u32) -> WebGLResult<u32> {
         match usage {
-            constants::STATIC_READ |
-            constants::DYNAMIC_READ |
-            constants::STREAM_READ |
-            constants::STATIC_COPY |
-            constants::DYNAMIC_COPY |
-            constants::STREAM_COPY => Ok(usage),
+            constants::STATIC_READ
+            | constants::DYNAMIC_READ
+            | constants::STREAM_READ
+            | constants::STATIC_COPY
+            | constants::DYNAMIC_COPY
+            | constants::STREAM_COPY => Ok(usage),
             _ => self.base.buffer_usage(usage),
         }
     }
@@ -374,14 +374,14 @@ impl WebGL2RenderingContext {
             constants::SHORT => &[Type::Int16][..],
             constants::INT => &[Type::Int32][..],
             constants::UNSIGNED_BYTE => &[Type::Uint8, Type::Uint8Clamped][..],
-            constants::UNSIGNED_SHORT |
-            constants::UNSIGNED_SHORT_4_4_4_4 |
-            constants::UNSIGNED_SHORT_5_5_5_1 |
-            constants::UNSIGNED_SHORT_5_6_5 => &[Type::Uint16][..],
-            constants::UNSIGNED_INT |
-            constants::UNSIGNED_INT_2_10_10_10_REV |
-            constants::UNSIGNED_INT_10F_11F_11F_REV |
-            constants::UNSIGNED_INT_5_9_9_9_REV => &[Type::Uint32][..],
+            constants::UNSIGNED_SHORT
+            | constants::UNSIGNED_SHORT_4_4_4_4
+            | constants::UNSIGNED_SHORT_5_5_5_1
+            | constants::UNSIGNED_SHORT_5_6_5 => &[Type::Uint16][..],
+            constants::UNSIGNED_INT
+            | constants::UNSIGNED_INT_2_10_10_10_REV
+            | constants::UNSIGNED_INT_10F_11F_11F_REV
+            | constants::UNSIGNED_INT_5_9_9_9_REV => &[Type::Uint32][..],
             constants::FLOAT => &[Type::Float32][..],
             constants::HALF_FLOAT => &[Type::Uint16][..],
             _ => return Err(InvalidEnum),
@@ -534,10 +534,10 @@ impl WebGL2RenderingContext {
         let dst_byte_offset = {
             let margin_left = cmp::max(0, -x) as usize;
             let margin_top = cmp::max(0, -y) as usize;
-            dst_byte_offset +
-                skipped_bytes +
-                margin_left * bytes_per_pixel +
-                margin_top * row_stride
+            dst_byte_offset
+                + skipped_bytes
+                + margin_left * bytes_per_pixel
+                + margin_top * row_stride
         };
         let src_rect = {
             let (fb_width, fb_height) = handle_potential_webgl_error!(
@@ -621,9 +621,9 @@ impl WebGL2RenderingContext {
                 constants::STENCIL if !attrs.stencil => constants::NONE as _,
                 _ => constants::FRAMEBUFFER_DEFAULT as _,
             },
-            constants::FRAMEBUFFER_ATTACHMENT_RED_SIZE |
-            constants::FRAMEBUFFER_ATTACHMENT_GREEN_SIZE |
-            constants::FRAMEBUFFER_ATTACHMENT_BLUE_SIZE => match attachment {
+            constants::FRAMEBUFFER_ATTACHMENT_RED_SIZE
+            | constants::FRAMEBUFFER_ATTACHMENT_GREEN_SIZE
+            | constants::FRAMEBUFFER_ATTACHMENT_BLUE_SIZE => match attachment {
                 constants::BACK => 8,
                 _ => 0,
             },
@@ -721,20 +721,20 @@ impl WebGL2RenderingContext {
             constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE => {},
             _ => match fb.attachment(attachment) {
                 Some(webgl_attachment) => match pname {
-                    constants::FRAMEBUFFER_ATTACHMENT_RED_SIZE |
-                    constants::FRAMEBUFFER_ATTACHMENT_GREEN_SIZE |
-                    constants::FRAMEBUFFER_ATTACHMENT_BLUE_SIZE |
-                    constants::FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE |
-                    constants::FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE |
-                    constants::FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE |
-                    constants::FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE |
-                    constants::FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING => {},
+                    constants::FRAMEBUFFER_ATTACHMENT_RED_SIZE
+                    | constants::FRAMEBUFFER_ATTACHMENT_GREEN_SIZE
+                    | constants::FRAMEBUFFER_ATTACHMENT_BLUE_SIZE
+                    | constants::FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE
+                    | constants::FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE
+                    | constants::FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE
+                    | constants::FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE
+                    | constants::FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING => {},
                     _ => match webgl_attachment {
                         WebGLFramebufferAttachmentRoot::Renderbuffer(_) => return Err(InvalidEnum),
                         WebGLFramebufferAttachmentRoot::Texture(_) => match pname {
-                            constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL |
-                            constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE |
-                            constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER => {},
+                            constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL
+                            | constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE
+                            | constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER => {},
                             _ => return Err(InvalidEnum),
                         },
                     },
@@ -819,13 +819,13 @@ impl WebGL2RenderingContext {
 
             for &attachment in attachments {
                 match attachment {
-                    constants::DEPTH_ATTACHMENT |
-                    constants::STENCIL_ATTACHMENT |
-                    constants::DEPTH_STENCIL_ATTACHMENT => {},
+                    constants::DEPTH_ATTACHMENT
+                    | constants::STENCIL_ATTACHMENT
+                    | constants::DEPTH_STENCIL_ATTACHMENT => {},
                     constants::COLOR_ATTACHMENT0..=constants::COLOR_ATTACHMENT15 => {
-                        let last_slot = constants::COLOR_ATTACHMENT0 +
-                            self.base.limits().max_color_attachments -
-                            1;
+                        let last_slot = constants::COLOR_ATTACHMENT0
+                            + self.base.limits().max_color_attachments
+                            - 1;
                         if last_slot < attachment {
                             return false;
                         }
@@ -1564,8 +1564,8 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         let copy_bytes = copy_count * src_elem_size;
 
         let dst_byte_offset = dst_byte_offset as usize;
-        if dst_byte_offset + copy_bytes > bound_buffer.capacity() ||
-            src_byte_offset + copy_bytes > src_data.len()
+        if dst_byte_offset + copy_bytes > bound_buffer.capacity()
+            || src_byte_offset + copy_bytes > src_data.len()
         {
             return self.base.webgl_error(InvalidValue);
         }
@@ -1608,8 +1608,8 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
 
         let read_until = read_offset + size;
         let write_until = write_offset + size;
-        if read_until as usize > read_buffer.capacity() ||
-            write_until as usize > write_buffer.capacity()
+        if read_until as usize > read_buffer.capacity()
+            || write_until as usize > write_buffer.capacity()
         {
             return self.base.webgl_error(InvalidValue);
         }
@@ -1677,8 +1677,8 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         // TODO(mmatyas): Transform Feedback
 
         let src_byte_offset = src_byte_offset as usize;
-        if src_byte_offset + copy_bytes > bound_buffer.capacity() ||
-            dst_byte_offset + copy_bytes > dst_buffer.len()
+        if src_byte_offset + copy_bytes > bound_buffer.capacity()
+            || dst_byte_offset + copy_bytes > dst_buffer.len()
         {
             return self.base.webgl_error(InvalidValue);
         }
@@ -2088,14 +2088,14 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         mut retval: MutableHandleValue,
     ) {
         let bindings = match target {
-            constants::TRANSFORM_FEEDBACK_BUFFER_BINDING |
-            constants::TRANSFORM_FEEDBACK_BUFFER_SIZE |
-            constants::TRANSFORM_FEEDBACK_BUFFER_START => {
+            constants::TRANSFORM_FEEDBACK_BUFFER_BINDING
+            | constants::TRANSFORM_FEEDBACK_BUFFER_SIZE
+            | constants::TRANSFORM_FEEDBACK_BUFFER_START => {
                 &self.indexed_transform_feedback_buffer_bindings
             },
-            constants::UNIFORM_BUFFER_BINDING |
-            constants::UNIFORM_BUFFER_SIZE |
-            constants::UNIFORM_BUFFER_START => &self.indexed_uniform_buffer_bindings,
+            constants::UNIFORM_BUFFER_BINDING
+            | constants::UNIFORM_BUFFER_SIZE
+            | constants::UNIFORM_BUFFER_START => &self.indexed_uniform_buffer_bindings,
             _ => {
                 self.base.webgl_error(InvalidEnum);
                 return retval.set(NullValue());
@@ -2454,12 +2454,12 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     ) {
         self.base.with_location(location, |location| {
             match location.type_() {
-                constants::BOOL |
-                constants::UNSIGNED_INT |
-                constants::SAMPLER_2D |
-                constants::SAMPLER_2D_ARRAY |
-                constants::SAMPLER_3D |
-                constants::SAMPLER_CUBE => {},
+                constants::BOOL
+                | constants::UNSIGNED_INT
+                | constants::SAMPLER_2D
+                | constants::SAMPLER_2D_ARRAY
+                | constants::SAMPLER_3D
+                | constants::SAMPLER_CUBE => {},
                 _ => return Err(InvalidOperation),
             }
 
@@ -3124,12 +3124,12 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         offset: i64,
     ) {
         match type_ {
-            constants::BYTE |
-            constants::UNSIGNED_BYTE |
-            constants::SHORT |
-            constants::UNSIGNED_SHORT |
-            constants::INT |
-            constants::UNSIGNED_INT => {},
+            constants::BYTE
+            | constants::UNSIGNED_BYTE
+            | constants::SHORT
+            | constants::UNSIGNED_SHORT
+            | constants::INT
+            | constants::UNSIGNED_INT => {},
             _ => return self.base.webgl_error(InvalidEnum),
         };
         self.base
@@ -3250,8 +3250,8 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         // generate an INVALID_OPERATION error if they upload data from a PIXEL_UNPACK_BUFFER or a non-null client
         // side ArrayBufferView.
         if let (Some(AlphaTreatment::Premultiply), YAxisTreatment::Flipped) =
-            (alpha_treatment, y_axis_treatment) &&
-            src_data.is_some()
+            (alpha_treatment, y_axis_treatment)
+            && src_data.is_some()
         {
             self.base.webgl_error(InvalidOperation);
             return Ok(());
@@ -3341,8 +3341,8 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
             },
         };
 
-        if let Some(tf_buffer) = self.bound_transform_feedback_buffer.get() &&
-            pixel_unpack_buffer == tf_buffer
+        if let Some(tf_buffer) = self.bound_transform_feedback_buffer.get()
+            && pixel_unpack_buffer == tf_buffer
         {
             self.base.webgl_error(InvalidOperation);
             return Ok(());
@@ -3729,10 +3729,10 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         let src_height = src_y1.checked_sub(src_y0);
         let dst_height = dst_y1.checked_sub(dst_y0);
 
-        if src_width.is_none() ||
-            dst_width.is_none() ||
-            src_height.is_none() ||
-            dst_height.is_none()
+        if src_width.is_none()
+            || dst_width.is_none()
+            || src_height.is_none()
+            || dst_height.is_none()
         {
             return self.base.webgl_error(InvalidOperation);
         }
@@ -3902,8 +3902,8 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
                     constants::TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN => &self.primitives_query,
                     _ => unreachable!(),
                 };
-                if let Some(stored_query) = slot.get() &&
-                    stored_query.target() == query.target()
+                if let Some(stored_query) = slot.get()
+                    && stored_query.target() == query.target()
                 {
                     slot.set(None);
                 }
@@ -4011,8 +4011,8 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
                 None
             },
         };
-        if let Some(query) = active_query.as_ref() &&
-            query.target() != Some(target)
+        if let Some(query) = active_query.as_ref()
+            && query.target() != Some(target)
         {
             return None;
         }
@@ -4320,9 +4320,9 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
                     self.base.webgl_error(InvalidOperation);
                     return;
                 }
-                if let Some(current_tf) = self.current_transform_feedback.get() &&
-                    current_tf.is_active() &&
-                    !current_tf.is_paused()
+                if let Some(current_tf) = self.current_transform_feedback.get()
+                    && current_tf.is_active()
+                    && !current_tf.is_paused()
                 {
                     self.base.webgl_error(InvalidOperation);
                     return;
@@ -4650,12 +4650,12 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         );
 
         match pname {
-            constants::UNIFORM_SIZE |
-            constants::UNIFORM_TYPE |
-            constants::UNIFORM_BLOCK_INDEX |
-            constants::UNIFORM_OFFSET |
-            constants::UNIFORM_ARRAY_STRIDE |
-            constants::UNIFORM_MATRIX_STRIDE => {
+            constants::UNIFORM_SIZE
+            | constants::UNIFORM_TYPE
+            | constants::UNIFORM_BLOCK_INDEX
+            | constants::UNIFORM_OFFSET
+            | constants::UNIFORM_ARRAY_STRIDE
+            | constants::UNIFORM_MATRIX_STRIDE => {
                 values.safe_to_jsval(cx, rval);
             },
             constants::UNIFORM_IS_ROW_MAJOR => {
@@ -4701,9 +4701,9 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
             return retval.set(NullValue())
         );
         match pname {
-            constants::UNIFORM_BLOCK_BINDING |
-            constants::UNIFORM_BLOCK_DATA_SIZE |
-            constants::UNIFORM_BLOCK_ACTIVE_UNIFORMS => {
+            constants::UNIFORM_BLOCK_BINDING
+            | constants::UNIFORM_BLOCK_DATA_SIZE
+            | constants::UNIFORM_BLOCK_ACTIVE_UNIFORMS => {
                 assert!(values.len() == 1);
                 retval.set(UInt32Value(values[0] as u32))
             },
@@ -4714,8 +4714,8 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
                     .unwrap();
                 retval.set(ObjectValue(result.get()))
             },
-            constants::UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER |
-            constants::UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER => {
+            constants::UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER
+            | constants::UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER => {
                 assert!(values.len() == 1);
                 retval.set(BooleanValue(values[0] != 0))
             },

--- a/components/script/dom/webgl/webglbuffer.rs
+++ b/components/script/dom/webgl/webglbuffer.rs
@@ -23,8 +23,8 @@ use crate::dom::webgl::webglobject::WebGLObject;
 use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
 
 fn target_is_copy_buffer(target: u32) -> bool {
-    target == WebGL2RenderingContextConstants::COPY_READ_BUFFER ||
-        target == WebGL2RenderingContextConstants::COPY_WRITE_BUFFER
+    target == WebGL2RenderingContextConstants::COPY_READ_BUFFER
+        || target == WebGL2RenderingContextConstants::COPY_WRITE_BUFFER
 }
 
 #[derive(JSTraceable, MallocSizeOf)]
@@ -168,15 +168,15 @@ impl WebGLBuffer {
 
     pub(crate) fn buffer_data(&self, target: u32, data: &[u8], usage: u32) -> WebGLResult<()> {
         match usage {
-            WebGLRenderingContextConstants::STREAM_DRAW |
-            WebGLRenderingContextConstants::STATIC_DRAW |
-            WebGLRenderingContextConstants::DYNAMIC_DRAW |
-            WebGL2RenderingContextConstants::STATIC_READ |
-            WebGL2RenderingContextConstants::DYNAMIC_READ |
-            WebGL2RenderingContextConstants::STREAM_READ |
-            WebGL2RenderingContextConstants::STATIC_COPY |
-            WebGL2RenderingContextConstants::DYNAMIC_COPY |
-            WebGL2RenderingContextConstants::STREAM_COPY => (),
+            WebGLRenderingContextConstants::STREAM_DRAW
+            | WebGLRenderingContextConstants::STATIC_DRAW
+            | WebGLRenderingContextConstants::DYNAMIC_DRAW
+            | WebGL2RenderingContextConstants::STATIC_READ
+            | WebGL2RenderingContextConstants::DYNAMIC_READ
+            | WebGL2RenderingContextConstants::STREAM_READ
+            | WebGL2RenderingContextConstants::STATIC_COPY
+            | WebGL2RenderingContextConstants::DYNAMIC_COPY
+            | WebGL2RenderingContextConstants::STREAM_COPY => (),
             _ => return Err(WebGLError::InvalidEnum),
         }
 
@@ -226,8 +226,8 @@ impl WebGLBuffer {
 
     /// <https://registry.khronos.org/webgl/specs/latest/2.0/#5.1>
     fn can_bind_to(&self, new_target: u32) -> bool {
-        if let Some(current_target) = self.target.get() &&
-            [current_target, new_target]
+        if let Some(current_target) = self.target.get()
+            && [current_target, new_target]
                 .contains(&WebGLRenderingContextConstants::ELEMENT_ARRAY_BUFFER)
         {
             return target_is_copy_buffer(new_target) || new_target == current_target;

--- a/components/script/dom/webgl/webglframebuffer.rs
+++ b/components/script/dom/webgl/webglframebuffer.rs
@@ -337,8 +337,8 @@ impl WebGLFramebuffer {
             }
         }
 
-        if let Some(format) = format &&
-            constraints.all(|c| *c != format)
+        if let Some(format) = format
+            && constraints.all(|c| *c != format)
         {
             return Err(constants::FRAMEBUFFER_INCOMPLETE_ATTACHMENT);
         }
@@ -572,16 +572,16 @@ impl WebGLFramebuffer {
             ];
             let mut clear_bits = 0;
             for &(attachment, bits) in &attachments {
-                if let Some(ref att) = *attachment.borrow() &&
-                    att.needs_initialization()
+                if let Some(ref att) = *attachment.borrow()
+                    && att.needs_initialization()
                 {
                     att.mark_initialized();
                     clear_bits |= bits;
                 }
             }
             for attachment in self.colors.iter() {
-                if let Some(ref att) = *attachment.borrow() &&
-                    att.needs_initialization()
+                if let Some(ref att) = *attachment.borrow()
+                    && att.needs_initialization()
                 {
                     att.mark_initialized();
                     clear_bits |= constants::COLOR_BUFFER_BIT;

--- a/components/script/dom/webgl/webglprogram.rs
+++ b/components/script/dom/webgl/webglprogram.rs
@@ -640,13 +640,13 @@ impl WebGLProgram {
         }
 
         match pname {
-            constants2::UNIFORM_TYPE |
-            constants2::UNIFORM_SIZE |
-            constants2::UNIFORM_BLOCK_INDEX |
-            constants2::UNIFORM_OFFSET |
-            constants2::UNIFORM_ARRAY_STRIDE |
-            constants2::UNIFORM_MATRIX_STRIDE |
-            constants2::UNIFORM_IS_ROW_MAJOR => {},
+            constants2::UNIFORM_TYPE
+            | constants2::UNIFORM_SIZE
+            | constants2::UNIFORM_BLOCK_INDEX
+            | constants2::UNIFORM_OFFSET
+            | constants2::UNIFORM_ARRAY_STRIDE
+            | constants2::UNIFORM_MATRIX_STRIDE
+            | constants2::UNIFORM_IS_ROW_MAJOR => {},
             _ => return Err(WebGLError::InvalidEnum),
         }
 
@@ -678,12 +678,12 @@ impl WebGLProgram {
         }
 
         match pname {
-            constants2::UNIFORM_BLOCK_BINDING |
-            constants2::UNIFORM_BLOCK_DATA_SIZE |
-            constants2::UNIFORM_BLOCK_ACTIVE_UNIFORMS |
-            constants2::UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES |
-            constants2::UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER |
-            constants2::UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER => {},
+            constants2::UNIFORM_BLOCK_BINDING
+            | constants2::UNIFORM_BLOCK_DATA_SIZE
+            | constants2::UNIFORM_BLOCK_ACTIVE_UNIFORMS
+            | constants2::UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES
+            | constants2::UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER
+            | constants2::UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER => {},
             _ => return Err(WebGLError::InvalidEnum),
         }
 
@@ -814,40 +814,40 @@ fn validate_glsl_name(name: &DOMString) -> WebGLResult<bool> {
 
 fn validate_glsl_char(c: char) -> WebGLResult<()> {
     match c {
-        'a'..='z' |
-        'A'..='Z' |
-        '0'..='9' |
-        ' ' |
-        '\t' |
-        '\u{11}' |
-        '\u{12}' |
-        '\r' |
-        '\n' |
-        '_' |
-        '.' |
-        '+' |
-        '-' |
-        '/' |
-        '*' |
-        '%' |
-        '<' |
-        '>' |
-        '[' |
-        ']' |
-        '(' |
-        ')' |
-        '{' |
-        '}' |
-        '^' |
-        '|' |
-        '&' |
-        '~' |
-        '=' |
-        '!' |
-        ':' |
-        ';' |
-        ',' |
-        '?' => Ok(()),
+        'a'..='z'
+        | 'A'..='Z'
+        | '0'..='9'
+        | ' '
+        | '\t'
+        | '\u{11}'
+        | '\u{12}'
+        | '\r'
+        | '\n'
+        | '_'
+        | '.'
+        | '+'
+        | '-'
+        | '/'
+        | '*'
+        | '%'
+        | '<'
+        | '>'
+        | '['
+        | ']'
+        | '('
+        | ')'
+        | '{'
+        | '}'
+        | '^'
+        | '|'
+        | '&'
+        | '~'
+        | '='
+        | '!'
+        | ':'
+        | ';'
+        | ','
+        | '?' => Ok(()),
         _ => Err(WebGLError::InvalidValue),
     }
 }

--- a/components/script/dom/webgl/webglquery.rs
+++ b/components/script/dom/webgl/webglquery.rs
@@ -98,15 +98,15 @@ impl WebGLQuery {
         if self.droppable.marked_for_deletion.get() {
             return Err(InvalidOperation);
         }
-        if let Some(current_target) = self.gl_target.get() &&
-            current_target != target
+        if let Some(current_target) = self.gl_target.get()
+            && current_target != target
         {
             return Err(InvalidOperation);
         }
         match target {
-            constants::ANY_SAMPLES_PASSED |
-            constants::ANY_SAMPLES_PASSED_CONSERVATIVE |
-            constants::TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN => (),
+            constants::ANY_SAMPLES_PASSED
+            | constants::ANY_SAMPLES_PASSED_CONSERVATIVE
+            | constants::TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN => (),
             _ => return Err(InvalidEnum),
         }
         self.gl_target.set(Some(target));
@@ -123,15 +123,15 @@ impl WebGLQuery {
         if self.droppable.marked_for_deletion.get() {
             return Err(InvalidOperation);
         }
-        if let Some(current_target) = self.gl_target.get() &&
-            current_target != target
+        if let Some(current_target) = self.gl_target.get()
+            && current_target != target
         {
             return Err(InvalidOperation);
         }
         match target {
-            constants::ANY_SAMPLES_PASSED |
-            constants::ANY_SAMPLES_PASSED_CONSERVATIVE |
-            constants::TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN => (),
+            constants::ANY_SAMPLES_PASSED
+            | constants::ANY_SAMPLES_PASSED_CONSERVATIVE
+            | constants::TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN => (),
             _ => return Err(InvalidEnum),
         }
         context.send_command(WebGLCommand::EndQuery(target));

--- a/components/script/dom/webgl/webglrenderbuffer.rs
+++ b/components/script/dom/webgl/webglrenderbuffer.rs
@@ -192,35 +192,35 @@ impl WebGLRenderbuffer {
             constants::RGBA4 | constants::DEPTH_COMPONENT16 | constants::STENCIL_INDEX8 => {
                 internal_format
             },
-            constants::R8 |
-            constants::R8UI |
-            constants::R8I |
-            constants::R16UI |
-            constants::R16I |
-            constants::R32UI |
-            constants::R32I |
-            constants::RG8 |
-            constants::RG8UI |
-            constants::RG8I |
-            constants::RG16UI |
-            constants::RG16I |
-            constants::RG32UI |
-            constants::RG32I |
-            constants::RGB8 |
-            constants::RGBA8 |
-            constants::SRGB8_ALPHA8 |
-            constants::RGB10_A2 |
-            constants::RGBA8UI |
-            constants::RGBA8I |
-            constants::RGB10_A2UI |
-            constants::RGBA16UI |
-            constants::RGBA16I |
-            constants::RGBA32I |
-            constants::RGBA32UI |
-            constants::DEPTH_COMPONENT24 |
-            constants::DEPTH_COMPONENT32F |
-            constants::DEPTH24_STENCIL8 |
-            constants::DEPTH32F_STENCIL8 => match webgl_version {
+            constants::R8
+            | constants::R8UI
+            | constants::R8I
+            | constants::R16UI
+            | constants::R16I
+            | constants::R32UI
+            | constants::R32I
+            | constants::RG8
+            | constants::RG8UI
+            | constants::RG8I
+            | constants::RG16UI
+            | constants::RG16I
+            | constants::RG32UI
+            | constants::RG32I
+            | constants::RGB8
+            | constants::RGBA8
+            | constants::SRGB8_ALPHA8
+            | constants::RGB10_A2
+            | constants::RGBA8UI
+            | constants::RGBA8I
+            | constants::RGB10_A2UI
+            | constants::RGBA16UI
+            | constants::RGBA16I
+            | constants::RGBA32I
+            | constants::RGBA32UI
+            | constants::DEPTH_COMPONENT24
+            | constants::DEPTH_COMPONENT32F
+            | constants::DEPTH24_STENCIL8
+            | constants::DEPTH32F_STENCIL8 => match webgl_version {
                 WebGLVersion::WebGL1 => return Err(WebGLError::InvalidEnum),
                 _ => internal_format,
             },
@@ -242,8 +242,8 @@ impl WebGLRenderbuffer {
                     constants::RGB8
                 }
             },
-            EXTColorBufferHalfFloatConstants::RGBA16F_EXT |
-            EXTColorBufferHalfFloatConstants::RGB16F_EXT => {
+            EXTColorBufferHalfFloatConstants::RGBA16F_EXT
+            | EXTColorBufferHalfFloatConstants::RGB16F_EXT => {
                 if !context
                     .extension_manager()
                     .is_half_float_buffer_renderable()

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -480,8 +480,8 @@ impl WebGLRenderingContext {
         };
         match self.current_program.get() {
             Some(ref program)
-                if program.id() == location.program_id() &&
-                    program.link_generation() == location.link_generation() => {},
+                if program.id() == location.program_id()
+                    && program.link_generation() == location.link_generation() => {},
             _ => return self.webgl_error(InvalidOperation),
         }
         handle_potential_webgl_error!(self, f(location));
@@ -594,8 +594,8 @@ impl WebGLRenderingContext {
     ) -> bool {
         if self
             .extension_manager
-            .is_filterable(data_type.as_gl_constant()) ||
-            !texture.is_using_linear_filtering()
+            .is_filterable(data_type.as_gl_constant())
+            || !texture.is_using_linear_filtering()
         {
             return true;
         }
@@ -637,13 +637,13 @@ impl WebGLRenderingContext {
     fn validate_stencil_actions(&self, action: u32) -> bool {
         matches!(
             action,
-            0 | constants::KEEP |
-                constants::REPLACE |
-                constants::INCR |
-                constants::DECR |
-                constants::INVERT |
-                constants::INCR_WRAP |
-                constants::DECR_WRAP
+            0 | constants::KEEP
+                | constants::REPLACE
+                | constants::INCR
+                | constants::DECR
+                | constants::INVERT
+                | constants::INCR_WRAP
+                | constants::DECR_WRAP
         )
     }
 
@@ -812,9 +812,9 @@ impl WebGLRenderingContext {
         // or FLOAT, a Float32Array must be supplied.
         // If the types do not match, an INVALID_OPERATION error is generated.
         let data_type_matches = data.as_ref().is_none_or(|buffer| {
-            Some(data_type.sized_data_type()) ==
-                array_buffer_type_to_sized_type(buffer.get_array_type()) &&
-                data_type.required_webgl_version() <= self.webgl_version()
+            Some(data_type.sized_data_type())
+                == array_buffer_type_to_sized_type(buffer.get_array_type())
+                && data_type.required_webgl_version() <= self.webgl_version()
         });
 
         if !data_type_matches {
@@ -932,10 +932,10 @@ impl WebGLRenderingContext {
         //   - xoffset or yoffset is less than 0
         //   - x offset plus the width is greater than the texture width
         //   - y offset plus the height is greater than the texture height
-        if xoffset < 0 ||
-            (xoffset as u32 + pixels.size().width) > image_info.width() ||
-            yoffset < 0 ||
-            (yoffset as u32 + pixels.size().height) > image_info.height()
+        if xoffset < 0
+            || (xoffset as u32 + pixels.size().width) > image_info.width()
+            || yoffset < 0
+            || (yoffset as u32 + pixels.size().height) > image_info.height()
         {
             return self.webgl_error(InvalidValue);
         }
@@ -947,8 +947,8 @@ impl WebGLRenderingContext {
         }
 
         // See https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.1.6
-        if self.webgl_version() == WebGLVersion::WebGL1 &&
-            data_type != image_info.data_type().unwrap()
+        if self.webgl_version() == WebGLVersion::WebGL1
+            && data_type != image_info.data_type().unwrap()
         {
             return self.webgl_error(InvalidOperation);
         }
@@ -991,13 +991,13 @@ impl WebGLRenderingContext {
         primcount: i32,
     ) -> WebGLResult<()> {
         match mode {
-            constants::POINTS |
-            constants::LINE_STRIP |
-            constants::LINE_LOOP |
-            constants::LINES |
-            constants::TRIANGLE_STRIP |
-            constants::TRIANGLE_FAN |
-            constants::TRIANGLES => {},
+            constants::POINTS
+            | constants::LINE_STRIP
+            | constants::LINE_LOOP
+            | constants::LINES
+            | constants::TRIANGLE_STRIP
+            | constants::TRIANGLE_FAN
+            | constants::TRIANGLES => {},
             _ => {
                 return Err(InvalidEnum);
             },
@@ -1061,13 +1061,13 @@ impl WebGLRenderingContext {
         primcount: i32,
     ) -> WebGLResult<()> {
         match mode {
-            constants::POINTS |
-            constants::LINE_STRIP |
-            constants::LINE_LOOP |
-            constants::LINES |
-            constants::TRIANGLE_STRIP |
-            constants::TRIANGLE_FAN |
-            constants::TRIANGLES => {},
+            constants::POINTS
+            | constants::LINE_STRIP
+            | constants::LINE_LOOP
+            | constants::LINES
+            | constants::TRIANGLE_STRIP
+            | constants::TRIANGLE_FAN
+            | constants::TRIANGLES => {},
             _ => {
                 return Err(InvalidEnum);
             },
@@ -1445,11 +1445,11 @@ impl WebGLRenderingContext {
     ) -> WebGLResult<()> {
         self.validate_ownership(program)?;
 
-        if program.is_deleted() ||
-            !program.is_linked() ||
-            self.context_id() != location.context_id() ||
-            program.id() != location.program_id() ||
-            program.link_generation() != location.link_generation()
+        if program.is_deleted()
+            || !program.is_linked()
+            || self.context_id() != location.context_id()
+            || program.id() != location.program_id()
+            || program.link_generation() != location.link_generation()
         {
             return Err(InvalidOperation);
         }
@@ -1750,22 +1750,22 @@ impl WebGLRenderingContext {
     ) {
         self.with_location(location, |location| {
             match location.type_() {
-                constants::BOOL |
-                constants::INT |
-                constants::SAMPLER_2D |
-                WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY |
-                WebGL2RenderingContextConstants::SAMPLER_3D |
-                constants::SAMPLER_CUBE => {},
+                constants::BOOL
+                | constants::INT
+                | constants::SAMPLER_2D
+                | WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY
+                | WebGL2RenderingContextConstants::SAMPLER_3D
+                | constants::SAMPLER_CUBE => {},
                 _ => return Err(InvalidOperation),
             }
 
             let val = self.uniform_vec_section_int(val, src_offset, src_length, 1, location)?;
 
             match location.type_() {
-                constants::SAMPLER_2D |
-                constants::SAMPLER_CUBE |
-                WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY |
-                WebGL2RenderingContextConstants::SAMPLER_3D => {
+                constants::SAMPLER_2D
+                | constants::SAMPLER_CUBE
+                | WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY
+                | WebGL2RenderingContextConstants::SAMPLER_3D => {
                     for &v in val
                         .iter()
                         .take(cmp::min(location.size().unwrap_or(1) as usize, val.len()))
@@ -2993,10 +2993,10 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         //   - xoffset or yoffset is less than 0
         //   - x offset plus the width is greater than the texture width
         //   - y offset plus the height is greater than the texture height
-        if xoffset < 0 ||
-            (xoffset as u32 + width) > image_info.width() ||
-            yoffset < 0 ||
-            (yoffset as u32 + height) > image_info.height()
+        if xoffset < 0
+            || (xoffset as u32 + width) > image_info.width()
+            || yoffset < 0
+            || (yoffset as u32 + height) > image_info.height()
         {
             self.webgl_error(InvalidValue);
             return;
@@ -3019,11 +3019,11 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11>
     fn Clear(&self, mask: u32) {
         handle_potential_webgl_error!(self, self.validate_framebuffer(), return);
-        if mask &
-            !(constants::DEPTH_BUFFER_BIT |
-                constants::STENCIL_BUFFER_BIT |
-                constants::COLOR_BUFFER_BIT) !=
-            0
+        if mask
+            & !(constants::DEPTH_BUFFER_BIT
+                | constants::STENCIL_BUFFER_BIT
+                | constants::COLOR_BUFFER_BIT)
+            != 0
         {
             return self.webgl_error(InvalidValue);
         }
@@ -3073,14 +3073,14 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn DepthFunc(&self, func: u32) {
         match func {
-            constants::NEVER |
-            constants::LESS |
-            constants::EQUAL |
-            constants::LEQUAL |
-            constants::GREATER |
-            constants::NOTEQUAL |
-            constants::GEQUAL |
-            constants::ALWAYS => self.send_command(WebGLCommand::DepthFunc(func)),
+            constants::NEVER
+            | constants::LESS
+            | constants::EQUAL
+            | constants::LEQUAL
+            | constants::GREATER
+            | constants::NOTEQUAL
+            | constants::GEQUAL
+            | constants::ALWAYS => self.send_command(WebGLCommand::DepthFunc(func)),
             _ => self.webgl_error(InvalidEnum),
         }
     }
@@ -3191,8 +3191,8 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             // https://github.com/immersive-web/webxr/issues/855
             handle_potential_webgl_error!(self, framebuffer.validate_transparent(), return);
             handle_potential_webgl_error!(self, self.validate_ownership(framebuffer), return);
-            if let Some(bound_object) = self.bound_draw_framebuffer.get() &&
-                bound_object.id() == framebuffer.id()
+            if let Some(bound_object) = self.bound_draw_framebuffer.get()
+                && bound_object.id() == framebuffer.id()
             {
                 self.bound_draw_framebuffer.set(None);
                 self.send_command(WebGLCommand::BindFramebuffer(
@@ -3208,8 +3208,8 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     fn DeleteRenderbuffer(&self, renderbuffer: Option<&WebGLRenderbuffer>) {
         if let Some(renderbuffer) = renderbuffer {
             handle_potential_webgl_error!(self, self.validate_ownership(renderbuffer), return);
-            if let Some(bound_object) = self.bound_renderbuffer.get() &&
-                bound_object.id() == renderbuffer.id()
+            if let Some(bound_object) = self.bound_renderbuffer.get()
+                && bound_object.id() == renderbuffer.id()
             {
                 self.bound_renderbuffer.set(None);
                 self.send_command(WebGLCommand::BindRenderbuffer(
@@ -3384,10 +3384,10 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         let attachment_matches = match attachment {
             // constants::MAX_COLOR_ATTACHMENTS ... gl::COLOR_ATTACHMENT0 |
             // constants::BACK |
-            constants::COLOR_ATTACHMENT0 |
-            constants::DEPTH_STENCIL_ATTACHMENT |
-            constants::DEPTH_ATTACHMENT |
-            constants::STENCIL_ATTACHMENT => true,
+            constants::COLOR_ATTACHMENT0
+            | constants::DEPTH_STENCIL_ATTACHMENT
+            | constants::DEPTH_ATTACHMENT
+            | constants::STENCIL_ATTACHMENT => true,
             _ => false,
         };
         let pname_matches = match pname {
@@ -3400,10 +3400,10 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             // constants::FRAMEBUFFER_ATTACHMENT_RED_SIZE |
             // constants::FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE |
             // constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER |
-            constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME |
-            constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE |
-            constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE |
-            constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL => true,
+            constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME
+            | constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE
+            | constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE
+            | constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL => true,
             _ => false,
         };
 
@@ -3416,15 +3416,15 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             Some(attachment_root) => match attachment_root {
                 WebGLFramebufferAttachmentRoot::Renderbuffer(_) => matches!(
                     pname,
-                    constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE |
-                        constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME
+                    constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE
+                        | constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME
                 ),
                 WebGLFramebufferAttachmentRoot::Texture(_) => matches!(
                     pname,
-                    constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE |
-                        constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME |
-                        constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL |
-                        constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE
+                    constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE
+                        | constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME
+                        | constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL
+                        | constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE
                 ),
             },
             _ => matches!(pname, constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE),
@@ -3483,15 +3483,15 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
 
         let pname_matches = matches!(
             pname,
-            constants::RENDERBUFFER_WIDTH |
-                constants::RENDERBUFFER_HEIGHT |
-                constants::RENDERBUFFER_INTERNAL_FORMAT |
-                constants::RENDERBUFFER_RED_SIZE |
-                constants::RENDERBUFFER_GREEN_SIZE |
-                constants::RENDERBUFFER_BLUE_SIZE |
-                constants::RENDERBUFFER_ALPHA_SIZE |
-                constants::RENDERBUFFER_DEPTH_SIZE |
-                constants::RENDERBUFFER_STENCIL_SIZE
+            constants::RENDERBUFFER_WIDTH
+                | constants::RENDERBUFFER_HEIGHT
+                | constants::RENDERBUFFER_INTERNAL_FORMAT
+                | constants::RENDERBUFFER_RED_SIZE
+                | constants::RENDERBUFFER_GREEN_SIZE
+                | constants::RENDERBUFFER_BLUE_SIZE
+                | constants::RENDERBUFFER_ALPHA_SIZE
+                | constants::RENDERBUFFER_DEPTH_SIZE
+                | constants::RENDERBUFFER_STENCIL_SIZE
         );
 
         if !target_matches || !pname_matches {
@@ -3625,12 +3625,12 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         }
 
         match precision_type {
-            constants::LOW_FLOAT |
-            constants::MEDIUM_FLOAT |
-            constants::HIGH_FLOAT |
-            constants::LOW_INT |
-            constants::MEDIUM_INT |
-            constants::HIGH_INT => (),
+            constants::LOW_FLOAT
+            | constants::MEDIUM_FLOAT
+            | constants::HIGH_FLOAT
+            | constants::LOW_INT
+            | constants::MEDIUM_INT
+            | constants::HIGH_INT => (),
             _ => {
                 self.webgl_error(InvalidEnum);
                 return None;
@@ -3806,8 +3806,8 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn Hint(&self, target: u32, mode: u32) {
-        if target != constants::GENERATE_MIPMAP_HINT &&
-            !self.extension_manager.is_hint_target_enabled(target)
+        if target != constants::GENERATE_MIPMAP_HINT
+            && !self.extension_manager.is_hint_target_enabled(target)
         {
             return self.webgl_error(InvalidEnum);
         }
@@ -4051,14 +4051,14 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn StencilFunc(&self, func: u32, ref_: i32, mask: u32) {
         match func {
-            constants::NEVER |
-            constants::LESS |
-            constants::EQUAL |
-            constants::LEQUAL |
-            constants::GREATER |
-            constants::NOTEQUAL |
-            constants::GEQUAL |
-            constants::ALWAYS => self.send_command(WebGLCommand::StencilFunc(func, ref_, mask)),
+            constants::NEVER
+            | constants::LESS
+            | constants::EQUAL
+            | constants::LEQUAL
+            | constants::GREATER
+            | constants::NOTEQUAL
+            | constants::GEQUAL
+            | constants::ALWAYS => self.send_command(WebGLCommand::StencilFunc(func, ref_, mask)),
             _ => self.webgl_error(InvalidEnum),
         }
     }
@@ -4071,14 +4071,14 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         }
 
         match func {
-            constants::NEVER |
-            constants::LESS |
-            constants::EQUAL |
-            constants::LEQUAL |
-            constants::GREATER |
-            constants::NOTEQUAL |
-            constants::GEQUAL |
-            constants::ALWAYS => {
+            constants::NEVER
+            | constants::LESS
+            | constants::EQUAL
+            | constants::LEQUAL
+            | constants::GREATER
+            | constants::NOTEQUAL
+            | constants::GEQUAL
+            | constants::ALWAYS => {
                 self.send_command(WebGLCommand::StencilFuncSeparate(face, func, ref_, mask))
             },
             _ => self.webgl_error(InvalidEnum),
@@ -4102,9 +4102,9 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn StencilOp(&self, fail: u32, zfail: u32, zpass: u32) {
-        if self.validate_stencil_actions(fail) &&
-            self.validate_stencil_actions(zfail) &&
-            self.validate_stencil_actions(zpass)
+        if self.validate_stencil_actions(fail)
+            && self.validate_stencil_actions(zfail)
+            && self.validate_stencil_actions(zpass)
         {
             self.send_command(WebGLCommand::StencilOp(fail, zfail, zpass));
         } else {
@@ -4119,9 +4119,9 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             _ => return self.webgl_error(InvalidEnum),
         }
 
-        if self.validate_stencil_actions(fail) &&
-            self.validate_stencil_actions(zfail) &&
-            self.validate_stencil_actions(zpass)
+        if self.validate_stencil_actions(fail)
+            && self.validate_stencil_actions(zfail)
+            && self.validate_stencil_actions(zpass)
         {
             self.send_command(WebGLCommand::StencilOpSeparate(face, fail, zfail, zpass))
         } else {
@@ -4167,10 +4167,10 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         self.with_location(location, |location| {
             match location.type_() {
                 constants::BOOL | constants::INT => {},
-                constants::SAMPLER_2D |
-                WebGL2RenderingContextConstants::SAMPLER_3D |
-                WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY |
-                constants::SAMPLER_CUBE => {
+                constants::SAMPLER_2D
+                | WebGL2RenderingContextConstants::SAMPLER_3D
+                | WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY
+                | constants::SAMPLER_CUBE => {
                     if val < 0 || val as u32 >= self.limits.max_combined_texture_image_units {
                         return Err(InvalidValue);
                     }
@@ -4371,11 +4371,11 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             constants::BOOL_VEC4 => {
                 uniform_get(triple, WebGLCommand::GetUniformBool4).safe_to_jsval(cx, rval)
             },
-            constants::INT |
-            constants::SAMPLER_2D |
-            constants::SAMPLER_CUBE |
-            WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY |
-            WebGL2RenderingContextConstants::SAMPLER_3D => {
+            constants::INT
+            | constants::SAMPLER_2D
+            | constants::SAMPLER_CUBE
+            | WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY
+            | WebGL2RenderingContextConstants::SAMPLER_3D => {
                 rval.set(Int32Value(uniform_get(triple, WebGLCommand::GetUniformInt)))
             },
             constants::INT_VEC2 => unsafe {
@@ -5166,13 +5166,13 @@ impl Textures {
             TexImageTarget::Texture2D => active_unit.tex_2d.get(),
             TexImageTarget::Texture2DArray => active_unit.tex_2d_array.get(),
             TexImageTarget::Texture3D => active_unit.tex_3d.get(),
-            TexImageTarget::CubeMap |
-            TexImageTarget::CubeMapPositiveX |
-            TexImageTarget::CubeMapNegativeX |
-            TexImageTarget::CubeMapPositiveY |
-            TexImageTarget::CubeMapNegativeY |
-            TexImageTarget::CubeMapPositiveZ |
-            TexImageTarget::CubeMapNegativeZ => active_unit.tex_cube_map.get(),
+            TexImageTarget::CubeMap
+            | TexImageTarget::CubeMapPositiveX
+            | TexImageTarget::CubeMapNegativeX
+            | TexImageTarget::CubeMapPositiveY
+            | TexImageTarget::CubeMapNegativeY
+            | TexImageTarget::CubeMapPositiveZ
+            | TexImageTarget::CubeMapNegativeZ => active_unit.tex_cube_map.get(),
         }
     }
 
@@ -5293,12 +5293,12 @@ fn array_buffer_type_to_sized_type(type_: Type) -> Option<SizedDataType> {
         Type::Int16 => Some(SizedDataType::Int16),
         Type::Int32 => Some(SizedDataType::Int32),
         Type::Float32 => Some(SizedDataType::Float32),
-        Type::Float16 |
-        Type::Float64 |
-        Type::BigInt64 |
-        Type::BigUint64 |
-        Type::MaxTypedArrayViewType |
-        Type::Int64 |
-        Type::Simd128 => None,
+        Type::Float16
+        | Type::Float64
+        | Type::BigInt64
+        | Type::BigUint64
+        | Type::MaxTypedArrayViewType
+        | Type::Int64
+        | Type::Simd128 => None,
     }
 }

--- a/components/script/dom/webgl/webglsampler.rs
+++ b/components/script/dom/webgl/webglsampler.rs
@@ -78,9 +78,9 @@ fn validate_params(pname: u32, value: WebGLSamplerValue) -> bool {
                     constants::LINEAR_MIPMAP_LINEAR,
                 ][..],
                 constants::TEXTURE_MAG_FILTER => &[constants::NEAREST, constants::LINEAR][..],
-                constants::TEXTURE_WRAP_R |
-                constants::TEXTURE_WRAP_S |
-                constants::TEXTURE_WRAP_T => &[
+                constants::TEXTURE_WRAP_R
+                | constants::TEXTURE_WRAP_S
+                | constants::TEXTURE_WRAP_T => &[
                     constants::CLAMP_TO_EDGE,
                     constants::MIRRORED_REPEAT,
                     constants::REPEAT,
@@ -190,13 +190,13 @@ impl WebGLSampler {
             return Err(InvalidOperation);
         }
         match pname {
-            constants::TEXTURE_MIN_FILTER |
-            constants::TEXTURE_MAG_FILTER |
-            constants::TEXTURE_WRAP_R |
-            constants::TEXTURE_WRAP_S |
-            constants::TEXTURE_WRAP_T |
-            constants::TEXTURE_COMPARE_FUNC |
-            constants::TEXTURE_COMPARE_MODE => {
+            constants::TEXTURE_MIN_FILTER
+            | constants::TEXTURE_MAG_FILTER
+            | constants::TEXTURE_WRAP_R
+            | constants::TEXTURE_WRAP_S
+            | constants::TEXTURE_WRAP_T
+            | constants::TEXTURE_COMPARE_FUNC
+            | constants::TEXTURE_COMPARE_MODE => {
                 let (sender, receiver) = webgl_channel().unwrap();
                 context.send_command(WebGLCommand::GetSamplerParameterInt(
                     self.id(),

--- a/components/script/dom/webgl/webgltexture.rs
+++ b/components/script/dom/webgl/webgltexture.rs
@@ -307,9 +307,9 @@ impl WebGLTexture {
     pub(crate) fn is_invalid(&self) -> bool {
         // https://immersive-web.github.io/layers/#xrwebglsubimagetype
         #[cfg(feature = "webxr")]
-        if let WebGLTextureOwner::WebXR(ref session) = self.droppable.owner &&
-            let Some(xr) = session.root() &&
-            xr.is_outside_raf()
+        if let WebGLTextureOwner::WebXR(ref session) = self.droppable.owner
+            && let Some(xr) = session.root()
+            && xr.is_outside_raf()
         {
             return true;
         }
@@ -367,14 +367,14 @@ impl WebGLTexture {
                     return Ok(());
                 },
                 constants::TEXTURE_COMPARE_FUNC => match int_value as u32 {
-                    constants::LEQUAL |
-                    constants::GEQUAL |
-                    constants::LESS |
-                    constants::GREATER |
-                    constants::EQUAL |
-                    constants::NOTEQUAL |
-                    constants::ALWAYS |
-                    constants::NEVER => {
+                    constants::LEQUAL
+                    | constants::GEQUAL
+                    | constants::LESS
+                    | constants::GREATER
+                    | constants::EQUAL
+                    | constants::NOTEQUAL
+                    | constants::ALWAYS
+                    | constants::NEVER => {
                         context.send_command(WebGLCommand::TexParameteri(target, param, int_value));
                         return Ok(());
                     },
@@ -404,12 +404,12 @@ impl WebGLTexture {
         }
         match param {
             constants::TEXTURE_MIN_FILTER => match int_value as u32 {
-                constants::NEAREST |
-                constants::LINEAR |
-                constants::NEAREST_MIPMAP_NEAREST |
-                constants::LINEAR_MIPMAP_NEAREST |
-                constants::NEAREST_MIPMAP_LINEAR |
-                constants::LINEAR_MIPMAP_LINEAR => update_filter(&self.min_filter),
+                constants::NEAREST
+                | constants::LINEAR
+                | constants::NEAREST_MIPMAP_NEAREST
+                | constants::LINEAR_MIPMAP_NEAREST
+                | constants::NEAREST_MIPMAP_LINEAR
+                | constants::LINEAR_MIPMAP_LINEAR => update_filter(&self.min_filter),
                 _ => Err(WebGLError::InvalidEnum),
             },
             constants::TEXTURE_MAG_FILTER => match int_value as u32 {
@@ -448,10 +448,10 @@ impl WebGLTexture {
         filters.iter().any(|filter| {
             matches!(
                 *filter,
-                constants::LINEAR |
-                    constants::NEAREST_MIPMAP_LINEAR |
-                    constants::LINEAR_MIPMAP_NEAREST |
-                    constants::LINEAR_MIPMAP_LINEAR
+                constants::LINEAR
+                    | constants::NEAREST_MIPMAP_LINEAR
+                    | constants::LINEAR_MIPMAP_NEAREST
+                    | constants::LINEAR_MIPMAP_LINEAR
             )
         })
     }
@@ -509,9 +509,9 @@ impl WebGLTexture {
             };
 
             // Compares height with width to enforce square dimensions
-            if current_image_info.internal_format != ref_format ||
-                current_image_info.width != ref_width ||
-                current_image_info.height != ref_width
+            if current_image_info.internal_format != ref_format
+                || current_image_info.width != ref_width
+                || current_image_info.height != ref_width
             {
                 return false;
             }
@@ -667,9 +667,9 @@ impl ImageInfo {
     }
 
     fn is_power_of_two(&self) -> bool {
-        self.width.is_power_of_two() &&
-            self.height.is_power_of_two() &&
-            self.depth.is_power_of_two()
+        self.width.is_power_of_two()
+            && self.height.is_power_of_two()
+            && self.depth.is_power_of_two()
     }
 
     fn get_max_mimap_levels(&self) -> u32 {
@@ -687,10 +687,10 @@ impl ImageInfo {
 
     /// Returns approximate physical size
     pub(crate) fn physical_size(&self) -> usize {
-        self.width as usize *
-            self.height as usize *
-            self.depth as usize *
-            self.internal_format.components() as usize
+        self.width as usize
+            * self.height as usize
+            * self.depth as usize
+            * self.internal_format.components() as usize
     }
 }
 

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -328,10 +328,10 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
             .map(RootedTraceableBox::new)
             .ok_or(Error::Operation(None))?;
 
-        let valid = offset.is_multiple_of(wgpu_types::MAP_ALIGNMENT) &&
-            range_size % wgpu_types::COPY_BUFFER_ALIGNMENT == 0 &&
-            offset >= mapping.range.start &&
-            offset + range_size <= mapping.range.end;
+        let valid = offset.is_multiple_of(wgpu_types::MAP_ALIGNMENT)
+            && range_size % wgpu_types::COPY_BUFFER_ALIGNMENT == 0
+            && offset >= mapping.range.start
+            && offset + range_size <= mapping.range.end;
         if !valid {
             self.mapping
                 .safe_borrow_mut(cx)

--- a/components/script/dom/webgpu/gpuconvert.rs
+++ b/components/script/dom/webgpu/gpuconvert.rs
@@ -590,10 +590,10 @@ pub(crate) fn convert_bind_group_layout_entry(
     bgle: &GPUBindGroupLayoutEntry,
     device: &GPUDevice,
 ) -> Fallible<Result<wgpu_types::BindGroupLayoutEntry, webgpu_traits::Error>> {
-    let number_of_provided_bindings = bgle.buffer.is_some() as u8 +
-        bgle.sampler.is_some() as u8 +
-        bgle.storageTexture.is_some() as u8 +
-        bgle.texture.is_some() as u8;
+    let number_of_provided_bindings = bgle.buffer.is_some() as u8
+        + bgle.sampler.is_some() as u8
+        + bgle.storageTexture.is_some() as u8
+        + bgle.texture.is_some() as u8;
     let ty = if let Some(buffer) = &bgle.buffer {
         Some(wgpu_types::BindingType::Buffer {
             ty: match buffer.type_ {

--- a/components/script/dom/webgpu/gpuqueryset.rs
+++ b/components/script/dom/webgpu/gpuqueryset.rs
@@ -93,8 +93,8 @@ impl GPUQuerySet {
         descriptor: &GPUQuerySetDescriptor,
     ) -> Fallible<DomRoot<Self>> {
         // 1. If descriptor.type is "timestamp", but "timestamp-query" is not enabled for this:
-        if descriptor.type_ == GPUQueryType::Timestamp &&
-            !device
+        if descriptor.type_ == GPUQueryType::Timestamp
+            && !device
                 .Features()
                 .wgpu_features()
                 .contains(wgpu_types::Features::TIMESTAMP_QUERY)

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -139,8 +139,8 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
         };
 
         // Step 4
-        let valid = data_offset + content_size <= data_size as u64 &&
-            (content_size * sizeof_element as u64)
+        let valid = data_offset + content_size <= data_size as u64
+            && (content_size * sizeof_element as u64)
                 .is_multiple_of(wgpu_types::COPY_BUFFER_ALIGNMENT);
         if !valid {
             return Err(Error::Operation(None));
@@ -339,10 +339,10 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
         let texture_descriptor = destination.parent.texture.wgpu_texture_descriptor();
         let target_snapshot_format =
             match texture_descriptor.format {
-                wgpu_types::TextureFormat::Bgra8Unorm |
-                wgpu_types::TextureFormat::Bgra8UnormSrgb => SnapshotPixelFormat::BGRA,
-                wgpu_types::TextureFormat::Rgba8Unorm |
-                wgpu_types::TextureFormat::Rgba8UnormSrgb => SnapshotPixelFormat::RGBA,
+                wgpu_types::TextureFormat::Bgra8Unorm
+                | wgpu_types::TextureFormat::Bgra8UnormSrgb => SnapshotPixelFormat::BGRA,
+                wgpu_types::TextureFormat::Rgba8Unorm
+                | wgpu_types::TextureFormat::Rgba8UnormSrgb => SnapshotPixelFormat::RGBA,
                 _ => {
                     return Err(Error::Operation(Some(
                         "Unsupported texture format for copy".to_string(),

--- a/components/script/dom/webgpu/gputexture.rs
+++ b/components/script/dom/webgpu/gputexture.rs
@@ -211,8 +211,8 @@ impl GPUTextureMethods<crate::DomTypeHolder> for GPUTexture {
         cx: &mut JSContext,
         descriptor: &GPUTextureViewDescriptor,
     ) -> Fallible<DomRoot<GPUTextureView>> {
-        let desc = if !matches!(descriptor.mipLevelCount, Some(0)) &&
-            !matches!(descriptor.arrayLayerCount, Some(0))
+        let desc = if !matches!(descriptor.mipLevelCount, Some(0))
+            && !matches!(descriptor.arrayLayerCount, Some(0))
         {
             Some(resource::TextureViewDescriptor {
                 label: (&descriptor.parent).convert(),

--- a/components/script/dom/webrtc/rtcpeerconnection.rs
+++ b/components/script/dom/webrtc/rtcpeerconnection.rs
@@ -191,8 +191,8 @@ impl RTCPeerConnection {
         );
         let signaller = this.make_signaller();
         *this.controller.borrow_mut() = Some(ServoMedia::get().create_webrtc(signaller));
-        if let Some(ref servers) = config.iceServers &&
-            let Some(server) = servers.first()
+        if let Some(ref servers) = config.iceServers
+            && let Some(server) = servers.first()
         {
             let server = match server.urls {
                 StringOrStringSequence::String(ref s) => Some(s.clone()),

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -449,8 +449,8 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
                 return Err(Error::InvalidAccess(None));
             }
         }
-        if let Some(ref reason) = reason &&
-            reason.0.len() > 123
+        if let Some(ref reason) = reason
+            && reason.0.len() > 123
         {
             // reason cannot be larger than 123 bytes
             return Err(Error::Syntax(Some("Reason too long".to_string())));

--- a/components/script/dom/webvtt/vttcue.rs
+++ b/components/script/dom/webvtt/vttcue.rs
@@ -150,8 +150,8 @@ impl VTTCueMethods<crate::DomTypeHolder> for VTTCue {
 
     /// <https://w3c.github.io/webvtt/#dom-vttcue-position>
     fn SetPosition(&self, value: VTTCueBinding::LineAndPositionSetting) -> ErrorResult {
-        if let VTTCueBinding::LineAndPositionSetting::Double(x) = value &&
-            (*x < 0_f64 || *x > 100_f64)
+        if let VTTCueBinding::LineAndPositionSetting::Double(x) = value
+            && (*x < 0_f64 || *x > 100_f64)
         {
             return Err(Error::IndexSize(None));
         }

--- a/components/script/dom/webxr/xrframe.rs
+++ b/components/script/dom/webxr/xrframe.rs
@@ -161,8 +161,8 @@ impl XRFrameMethods<crate::DomTypeHolder> for XRFrame {
         space: &XRJointSpace,
         base_space: &XRSpace,
     ) -> Result<Option<DomRoot<XRJointPose>>, Error> {
-        if self.session != space.upcast::<XRSpace>().session() ||
-            self.session != base_space.session()
+        if self.session != space.upcast::<XRSpace>().session()
+            || self.session != base_space.session()
         {
             return Err(Error::InvalidState(None));
         }

--- a/components/script/dom/webxr/xrrenderstate.rs
+++ b/components/script/dom/webxr/xrrenderstate.rs
@@ -119,8 +119,8 @@ impl XRRenderState {
         } else {
             // The layers API is only for immersive sessions
             let layers = self.layers.borrow();
-            sub_images.len() == layers.len() &&
-                sub_images
+            sub_images.len() == layers.len()
+                && sub_images
                     .iter()
                     .zip(layers.iter())
                     .all(|(sub_image, layer)| Some(sub_image.layer_id) == layer.layer_id())

--- a/components/script/dom/webxr/xrrigidtransform.rs
+++ b/components/script/dom/webxr/xrrigidtransform.rs
@@ -89,20 +89,20 @@ impl XRRigidTransformMethods<crate::DomTypeHolder> for XRRigidTransform {
             )));
         }
 
-        if !position.x.is_finite() ||
-            !position.y.is_finite() ||
-            !position.z.is_finite() ||
-            !position.w.is_finite()
+        if !position.x.is_finite()
+            || !position.y.is_finite()
+            || !position.z.is_finite()
+            || !position.w.is_finite()
         {
             return Err(Error::Type(
                 c"Position must not contain non-finite values".into(),
             ));
         }
 
-        if !orientation.x.is_finite() ||
-            !orientation.y.is_finite() ||
-            !orientation.z.is_finite() ||
-            !orientation.w.is_finite()
+        if !orientation.x.is_finite()
+            || !orientation.y.is_finite()
+            || !orientation.z.is_finite()
+            || !orientation.w.is_finite()
         {
             return Err(Error::Type(
                 c"Orientation must not contain non-finite values".into(),

--- a/components/script/dom/webxr/xrsession.rs
+++ b/components/script/dom/webxr/xrsession.rs
@@ -8,20 +8,20 @@ use std::f64::consts::{FRAC_PI_2, PI};
 use std::rc::Rc;
 use std::{mem, ptr};
 
-use script_bindings::reflector::reflect_dom_object_with_cx;
-use servo_base::cross_process_instant::CrossProcessInstant;
 use dom_struct::dom_struct;
-use js::context::JSContext;
-use js::realm::CurrentRealm;
 use euclid::{RigidTransform3D, Transform3D, Vector3D};
 use ipc_channel::ipc::IpcReceiver;
 use ipc_channel::router::ROUTER;
+use js::context::JSContext;
 use js::jsapi::JSObject;
+use js::realm::CurrentRealm;
 use js::rust::MutableHandleValue;
 use js::typedarray::HeapFloat32Array;
 use profile_traits::generic_callback::GenericCallback as ProfileGenericCallback;
 use rustc_hash::FxBuildHasher;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use script_bindings::trace::RootedTraceableBox;
+use servo_base::cross_process_instant::CrossProcessInstant;
 use stylo_atoms::Atom;
 use webxr_api::{
     self, ApiSpace, ContextId as WebXRContextId, Display, EntityTypes, EnvironmentBlendMode,
@@ -521,8 +521,8 @@ impl XRSession {
         clip_planes.update(near, far);
         let top = *render_state
             .GetInlineVerticalFieldOfView()
-            .expect("IVFOV should be non null for inline sessions") /
-            2.;
+            .expect("IVFOV should be non null for inline sessions")
+            / 2.;
         let top = near * top.tan() as f32;
         let bottom = top;
         let left = top * size.width as f32 / size.height as f32;
@@ -675,8 +675,8 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
             return Err(Error::InvalidState(None));
         }
         // Step 3:
-        if let Some(Some(ref layer)) = init.baseLayer &&
-            Dom::from_ref(layer.session()) != Dom::from_ref(self)
+        if let Some(Some(ref layer)) = init.baseLayer
+            && Dom::from_ref(layer.session()) != Dom::from_ref(self)
         {
             return Err(Error::InvalidState(None));
         }
@@ -842,8 +842,8 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
         // XXXManishearth reject based on session type
         // https://github.com/immersive-web/webxr/blob/master/spatial-tracking-explainer.md#practical-usage-guidelines
 
-        if !self.is_immersive() &&
-            (ty == XRReferenceSpaceType::Bounded_floor || ty == XRReferenceSpaceType::Unbounded)
+        if !self.is_immersive()
+            && (ty == XRReferenceSpaceType::Bounded_floor || ty == XRReferenceSpaceType::Unbounded)
         {
             p.reject_error(cx, Error::NotSupported(None));
             return p;
@@ -855,8 +855,8 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
                 p.reject_error(cx, Error::NotSupported(None))
             },
             ty => {
-                if ty != XRReferenceSpaceType::Viewer &&
-                    (!self.is_immersive() || ty != XRReferenceSpaceType::Local)
+                if ty != XRReferenceSpaceType::Viewer
+                    && (!self.is_immersive() || ty != XRReferenceSpaceType::Local)
                 {
                     let s = ty.as_str();
                     if !self
@@ -1045,9 +1045,9 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
             let session = self.session.borrow();
             let supported_frame_rates = session.supported_frame_rates();
 
-            if self.mode == XRSessionMode::Inline ||
-                supported_frame_rates.is_empty() ||
-                self.ended.get()
+            if self.mode == XRSessionMode::Inline
+                || supported_frame_rates.is_empty()
+                || self.ended.get()
             {
                 promise.reject_error(cx, Error::InvalidState(None));
                 return promise;

--- a/components/script/dom/webxr/xrsystem.rs
+++ b/components/script/dom/webxr/xrsystem.rs
@@ -88,8 +88,8 @@ impl XRSystem {
     /// <https://immersive-web.github.io/webxr/#ref-for-eventdef-xrsession-end>
     pub(crate) fn end_session(&self, session: &XRSession) {
         // Step 3
-        if let Some(active) = self.active_immersive_session.get() &&
-            Dom::from_ref(&*active) == Dom::from_ref(session)
+        if let Some(active) = self.active_immersive_session.get()
+            && Dom::from_ref(&*active) == Dom::from_ref(session)
         {
             self.active_immersive_session.set(None);
             // Dirty the canvas, since it has been skipping this step whilst in immersive

--- a/components/script/dom/webxr/xrview.rs
+++ b/components/script/dom/webxr/xrview.rs
@@ -121,8 +121,8 @@ impl XRViewMethods<crate::DomTypeHolder> for XRView {
 
     /// <https://www.w3.org/TR/webxr/#dom-xrview-requestviewportscale>
     fn RequestViewportScale(&self, scale: Option<Finite<f64>>) {
-        if let Some(scale) = scale &&
-            *scale > 0.0
+        if let Some(scale) = scale
+            && *scale > 0.0
         {
             let clamped_scale = scale.clamp(0.0, 1.0);
             self.requested_viewport_scale.set(clamped_scale);

--- a/components/script/dom/webxr/xrwebglbinding.rs
+++ b/components/script/dom/webxr/xrwebglbinding.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::rust::HandleObject;
 use js::context::JSContext;
+use js::rust::HandleObject;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 
 use crate::dom::bindings::codegen::Bindings::XRViewBinding::XREye;

--- a/components/script/dom/window/history.rs
+++ b/components/script/dom/window/history.rs
@@ -299,11 +299,11 @@ impl History {
     fn can_have_url_rewritten(document_url: &ServoUrl, target_url: &ServoUrl) -> bool {
         // Step 2. If targetURL and documentURL differ in their scheme, username,
         // password, host, or port components, then return false.
-        if target_url.scheme() != document_url.scheme() ||
-            target_url.username() != document_url.username() ||
-            target_url.password() != document_url.password() ||
-            target_url.host() != document_url.host() ||
-            target_url.port() != document_url.port()
+        if target_url.scheme() != document_url.scheme()
+            || target_url.username() != document_url.username()
+            || target_url.password() != document_url.password()
+            || target_url.host() != document_url.host()
+            || target_url.port() != document_url.port()
         {
             return false;
         }

--- a/components/script/dom/window/location.rs
+++ b/components/script/dom/window/location.rs
@@ -471,9 +471,9 @@ impl LocationMethods<crate::DomTypeHolder> for Location {
         self.setter_common(cx, |mut copy_url| {
             // Step 4: If copyURL cannot have a username/password/port, then return.
             // https://url.spec.whatwg.org/#cannot-have-a-username-password-port
-            if copy_url.host().is_none() ||
-                copy_url.cannot_be_a_base() ||
-                copy_url.scheme() == "file"
+            if copy_url.host().is_none()
+                || copy_url.cannot_be_a_base()
+                || copy_url.scheme() == "file"
             {
                 return Ok(None);
             }
@@ -512,8 +512,8 @@ impl LocationMethods<crate::DomTypeHolder> for Location {
             }
 
             // Step 6: If copyURL's scheme is not an HTTP(S) scheme, then terminate these steps.
-            if !copy_url.scheme().eq_ignore_ascii_case("http") &&
-                !copy_url.scheme().eq_ignore_ascii_case("https")
+            if !copy_url.scheme().eq_ignore_ascii_case("http")
+                && !copy_url.scheme().eq_ignore_ascii_case("https")
             {
                 return Ok(None);
             }

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -1430,9 +1430,9 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             let is_auxiliary = window_proxy.is_auxiliary();
 
             // https://html.spec.whatwg.org/multipage/#script-closable
-            let is_script_closable = (self.is_top_level() && history_length == 1) ||
-                is_auxiliary ||
-                pref!(dom_allow_scripts_to_close_windows);
+            let is_script_closable = (self.is_top_level() && history_length == 1)
+                || is_auxiliary
+                || pref!(dom_allow_scripts_to_close_windows);
 
             // TODO: rest of Step 3:
             // Is the incumbent settings object's responsible browsing context familiar with current?
@@ -1898,8 +1898,8 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
                 iframe
                     .browsing_context_id()
                     .as_ref()
-                    .map(BrowsingContextId::to_string) ==
-                    Some(browsing_context_id.to_string())
+                    .map(BrowsingContextId::to_string)
+                    == Some(browsing_context_id.to_string())
             })
             .and_then(|iframe| iframe.GetContentWindow())
     }
@@ -2343,10 +2343,10 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
                     return true;
                 }
                 match type_ {
-                    HTMLElementTypeId::HTMLEmbedElement |
-                    HTMLElementTypeId::HTMLFormElement |
-                    HTMLElementTypeId::HTMLImageElement |
-                    HTMLElementTypeId::HTMLObjectElement => {
+                    HTMLElementTypeId::HTMLEmbedElement
+                    | HTMLElementTypeId::HTMLFormElement
+                    | HTMLElementTypeId::HTMLImageElement
+                    | HTMLElementTypeId::HTMLObjectElement => {
                         elem.get_name().as_ref() == Some(&self.name)
                     },
                     _ => false,
@@ -2609,8 +2609,8 @@ impl Window {
         // layouts (for queries and scrolling) are not blocked, as they do not display
         // anything and script expects the layout to be up-to-date after they run.
         let pipeline_id = self.pipeline_id();
-        if reflow_goal == ReflowGoal::UpdateTheRendering &&
-            self.layout_blocker.get().layout_blocked()
+        if reflow_goal == ReflowGoal::UpdateTheRendering
+            && self.layout_blocker.get().layout_blocked()
         {
             debug!("Suppressing pre-load-event reflow pipeline {pipeline_id}");
             return Default::default();
@@ -2737,8 +2737,8 @@ impl Window {
         // See http://testthewebforward.org/docs/reftests.html
         // and https://web-platform-tests.org/writing-tests/crashtest.html
         if document.GetDocumentElement().is_some_and(|elem| {
-            elem.has_class(&atom!("reftest-wait"), CaseSensitivity::CaseSensitive) ||
-                elem.has_class(&Atom::from("test-wait"), CaseSensitivity::CaseSensitive)
+            elem.has_class(&atom!("reftest-wait"), CaseSensitivity::CaseSensitive)
+                || elem.has_class(&Atom::from("test-wait"), CaseSensitivity::CaseSensitive)
         }) {
             return;
         }
@@ -2751,8 +2751,8 @@ impl Window {
             return;
         }
 
-        if !self.pending_layout_images.borrow().is_empty() ||
-            !self.pending_images_for_rasterization.borrow().is_empty()
+        if !self.pending_layout_images.borrow().is_empty()
+            || !self.pending_images_for_rasterization.borrow().is_empty()
         {
             return;
         }
@@ -3250,8 +3250,8 @@ impl Window {
     ) {
         // We doesn't need to do anything if the following condition is fulfilled. Since there are no JS listener
         // to fire and we could reconstruct visual viewport from layout viewport in case JS access it.
-        if pinch_zoom_infos.rect == Rect::from_size(self.viewport_details().size) &&
-            self.visual_viewport.get().is_none()
+        if pinch_zoom_infos.rect == Rect::from_size(self.viewport_details().size)
+            && self.visual_viewport.get().is_none()
         {
             return;
         }
@@ -3653,8 +3653,8 @@ impl Window {
     /// <https://html.spec.whatwg.org/multipage/#sticky-activation>
     pub(crate) fn has_sticky_activation(&self) -> bool {
         // > When the current high resolution time given W is greater than or equal to the last activation timestamp in W, W is said to have sticky activation.
-        UserActivationTimestamp::TimeStamp(CrossProcessInstant::now()) >=
-            self.last_activation_timestamp.get()
+        UserActivationTimestamp::TimeStamp(CrossProcessInstant::now())
+            >= self.last_activation_timestamp.get()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#transient-activation>
@@ -3662,10 +3662,9 @@ impl Window {
         // > When the current high resolution time given W is greater than or equal to the last activation timestamp in W, and less than the last activation
         // > timestamp in W plus the transient activation duration, then W is said to have transient activation.
         let current_time = CrossProcessInstant::now();
-        UserActivationTimestamp::TimeStamp(current_time) >= self.last_activation_timestamp.get() &&
-            UserActivationTimestamp::TimeStamp(current_time) <
-                self.last_activation_timestamp.get() +
-                    pref!(dom_transient_activation_duration_ms)
+        UserActivationTimestamp::TimeStamp(current_time) >= self.last_activation_timestamp.get()
+            && UserActivationTimestamp::TimeStamp(current_time)
+                < self.last_activation_timestamp.get() + pref!(dom_transient_activation_duration_ms)
     }
 
     pub(crate) fn consume_last_activation_timestamp(&self) {
@@ -3996,10 +3995,10 @@ fn is_named_element_with_name_attribute(elem: &Element) -> bool {
     };
     matches!(
         type_,
-        HTMLElementTypeId::HTMLEmbedElement |
-            HTMLElementTypeId::HTMLFormElement |
-            HTMLElementTypeId::HTMLImageElement |
-            HTMLElementTypeId::HTMLObjectElement
+        HTMLElementTypeId::HTMLEmbedElement
+            | HTMLElementTypeId::HTMLFormElement
+            | HTMLElementTypeId::HTMLImageElement
+            | HTMLElementTypeId::HTMLObjectElement
     )
 }
 

--- a/components/script/dom/window/windowproxy.rs
+++ b/components/script/dom/window/windowproxy.rs
@@ -423,8 +423,8 @@ impl WindowProxy {
     /// <https://html.spec.whatwg.org/multipage/#delaying-load-events-mode>
     pub(crate) fn stop_delaying_load_events_mode(&self) {
         self.delaying_load_events_mode.set(false);
-        if let Some(document) = self.document() &&
-            !document.loader().events_inhibited()
+        if let Some(document) = self.document()
+            && !document.loader().events_inhibited()
         {
             ScriptThread::mark_document_with_no_blocked_loads(&document);
         }
@@ -781,8 +781,8 @@ impl WindowProxy {
     }
 
     pub(crate) fn set_currently_active(&self, cx: &mut JSContext, window: &Window) {
-        if let Some(pipeline_id) = self.currently_active() &&
-            pipeline_id == window.pipeline_id()
+        if let Some(pipeline_id) = self.currently_active()
+            && pipeline_id == window.pipeline_id()
         {
             return debug!(
                 "Attempt to set the currently active window to the currently active window."

--- a/components/script/dom/workers/sharedworker.rs
+++ b/components/script/dom/workers/sharedworker.rs
@@ -74,10 +74,10 @@ impl SharedWorkerKey {
         constructor_url: &ServoUrl,
         name: &str,
     ) -> bool {
-        self.storage_key == *storage_key &&
-            self.constructor_origin == *constructor_origin &&
-            self.constructor_url == *constructor_url &&
-            self.name == name
+        self.storage_key == *storage_key
+            && self.constructor_origin == *constructor_origin
+            && self.constructor_url == *constructor_url
+            && self.name == name
     }
 }
 
@@ -493,9 +493,9 @@ impl SharedWorkerMethods<crate::DomTypeHolder> for SharedWorker {
                 // workerGlobalScope's type is not equal to options["type"];
                 // workerGlobalScope's credentials is not equal to options["credentials"]; or
                 // workerGlobalScope's extended lifetime is not equal to options["extendedLifetime"],
-                if registration.worker_type != worker_type ||
-                    registration.credentials != credentials ||
-                    registration.extended_lifetime != extended_lifetime
+                if registration.worker_type != worker_type
+                    || registration.credentials != credentials
+                    || registration.extended_lifetime != extended_lifetime
                 {
                     // Step 11.4.1. Queue a global task on the DOM manipulation task source given worker's relevant global object to fire an event named error at worker.
                     SharedWorker::queue_simple_error(global, worker_addr);

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -174,8 +174,8 @@ impl FetchResponseListener for ScriptFetchContext {
         if response
             .as_ref()
             .inspect_err(|e| error!("error loading script {} ({:?})", self.url, e))
-            .is_err() ||
-            self.response.is_none()
+            .is_err()
+            || self.response.is_none()
         {
             scope.on_complete(cx, None);
             return;

--- a/components/script/dom/worklet/paintworkletglobalscope.rs
+++ b/components/script/dom/worklet/paintworkletglobalscope.rs
@@ -138,11 +138,11 @@ impl PaintWorkletGlobalScope {
                 arguments,
                 sender,
             ) => {
-                let cache_hit = (*self.cached_name.borrow() == name) &&
-                    (self.cached_size.get() == size) &&
-                    (self.cached_device_pixel_ratio.get() == device_pixel_ratio) &&
-                    (*self.cached_properties.borrow() == properties) &&
-                    (*self.cached_arguments.borrow() == arguments);
+                let cache_hit = (*self.cached_name.borrow() == name)
+                    && (self.cached_size.get() == size)
+                    && (self.cached_device_pixel_ratio.get() == device_pixel_ratio)
+                    && (*self.cached_properties.borrow() == properties)
+                    && (*self.cached_arguments.borrow() == arguments);
                 let result = if cache_hit {
                     debug!("Cache hit on paint worklet {}!", name);
                     self.cached_result.borrow().clone()
@@ -174,9 +174,9 @@ impl PaintWorkletGlobalScope {
                 let _ = sender.send(result);
             },
             PaintWorkletTask::SpeculativelyDrawAPaintImage(name, properties, arguments) => {
-                let should_speculate = (*self.cached_name.borrow() != name) ||
-                    (*self.cached_properties.borrow() != properties) ||
-                    (*self.cached_arguments.borrow() != arguments);
+                let should_speculate = (*self.cached_name.borrow() != name)
+                    || (*self.cached_properties.borrow() != properties)
+                    || (*self.cached_arguments.borrow() != arguments);
                 if should_speculate {
                     let size = self.cached_size.get();
                     let device_pixel_ratio = self.cached_device_pixel_ratio.get();

--- a/components/script/dom/worklet/worklet.rs
+++ b/components/script/dom/worklet/worklet.rs
@@ -581,8 +581,8 @@ impl WorkletThread {
                     self.process_control(control, cx);
                 }
                 self.gc(cx);
-            } else if self.control_buffer.is_none() &&
-                let Ok(control) = self.control_receiver.try_recv()
+            } else if self.control_buffer.is_none()
+                && let Ok(control) = self.control_receiver.try_recv()
             {
                 self.control_buffer = Some(control);
                 let msg = WorkletData::StartSwapRoles(self.role.sender.clone());

--- a/components/script/dom/xmlhttprequest/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest/xmlhttprequest.rs
@@ -184,10 +184,10 @@ pub(crate) enum XHRProgress {
 impl XHRProgress {
     fn generation_id(&self) -> GenerationId {
         match *self {
-            XHRProgress::HeadersReceived(id, _, _) |
-            XHRProgress::Loading(id, _) |
-            XHRProgress::Done(id) |
-            XHRProgress::Errored(id, _) => id,
+            XHRProgress::HeadersReceived(id, _, _)
+            | XHRProgress::Loading(id, _)
+            | XHRProgress::Done(id)
+            | XHRProgress::Errored(id, _) => id,
         }
     }
 }
@@ -337,8 +337,8 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
         // Step 1. If this’s relevant global object is a Window object and its associated
         // Document is not fully active, then throw an "InvalidStateError" DOMException.
         let global = self.global();
-        if let Some(window) = global.downcast::<Window>() &&
-            !window.Document().is_fully_active()
+        if let Some(window) = global.downcast::<Window>()
+            && !window.Document().is_fully_active()
         {
             return Err(Error::InvalidState(None));
         }
@@ -353,8 +353,8 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
             // despite the there being a rust-http method variant for them
             let upper = s.to_ascii_uppercase();
             match &*upper {
-                "DELETE" | "GET" | "HEAD" | "OPTIONS" | "POST" | "PUT" | "CONNECT" | "TRACE" |
-                "TRACK" => upper.parse().ok(),
+                "DELETE" | "GET" | "HEAD" | "OPTIONS" | "POST" | "PUT" | "CONNECT" | "TRACE"
+                | "TRACK" => upper.parse().ok(),
                 _ => s.parse().ok(),
             }
         });
@@ -401,8 +401,8 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
                 // then throw an "InvalidAccessError" DOMException.
                 if !asynch {
                     // FIXME: This should only happen if the global environment is a document environment
-                    if !self.timeout.get().is_zero() ||
-                        self.response_type.get() != XMLHttpRequestResponseType::_empty
+                    if !self.timeout.get().is_zero()
+                        || self.response_type.get() != XMLHttpRequestResponseType::_empty
                     {
                         return Err(Error::InvalidAccess(None));
                     }
@@ -530,9 +530,9 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
     fn SetWithCredentials(&self, with_credentials: bool) -> ErrorResult {
         match self.ready_state.get() {
             // Step 1
-            XMLHttpRequestState::HeadersReceived |
-            XMLHttpRequestState::Loading |
-            XMLHttpRequestState::Done => Err(Error::InvalidState(None)),
+            XMLHttpRequestState::HeadersReceived
+            | XMLHttpRequestState::Loading
+            | XMLHttpRequestState::Done => Err(Error::InvalidState(None)),
             // Step 2
             _ if self.send_flag.get() => Err(Error::InvalidState(None)),
             // Step 3
@@ -726,8 +726,8 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
         // step 4 (second half)
         if let Some(content_type) = content_type {
             let encoding = match data {
-                Some(DocumentOrXMLHttpRequestBodyInit::String(_)) |
-                Some(DocumentOrXMLHttpRequestBodyInit::Document(_)) =>
+                Some(DocumentOrXMLHttpRequestBodyInit::String(_))
+                | Some(DocumentOrXMLHttpRequestBodyInit::Document(_)) =>
                 // XHR spec differs from http, and says UTF-8 should be in capitals,
                 // instead of "utf-8", which is what Hyper defaults to. So not
                 // using content types provided by Hyper.
@@ -748,8 +748,8 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
 
             if !content_type_set {
                 let ct = request.headers.typed_get::<ContentType>();
-                if let Some(ct) = ct &&
-                    let Some(encoding) = encoding
+                if let Some(ct) = ct
+                    && let Some(encoding) = encoding
                 {
                     let mime: Mime = ct.to_string().parse().unwrap();
                     for param in mime.parameters.iter() {
@@ -804,9 +804,9 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
         self.terminate_ongoing_fetch();
         // Step 2
         let state = self.ready_state.get();
-        if (state == XMLHttpRequestState::Opened && self.send_flag.get()) ||
-            state == XMLHttpRequestState::HeadersReceived ||
-            state == XMLHttpRequestState::Loading
+        if (state == XMLHttpRequestState::Opened && self.send_flag.get())
+            || state == XMLHttpRequestState::HeadersReceived
+            || state == XMLHttpRequestState::Loading
         {
             let gen_id = self.generation_id.get();
             self.process_partial_response(cx, XHRProgress::Errored(gen_id, Error::Abort(None)));
@@ -921,8 +921,8 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
     /// <https://xhr.spec.whatwg.org/#the-responsetype-attribute>
     fn SetResponseType(&self, response_type: XMLHttpRequestResponseType) -> ErrorResult {
         // Step 1
-        if self.global().is::<WorkerGlobalScope>() &&
-            response_type == XMLHttpRequestResponseType::Document
+        if self.global().is::<WorkerGlobalScope>()
+            && response_type == XMLHttpRequestResponseType::Document
         {
             return Ok(());
         }
@@ -950,8 +950,8 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
             XMLHttpRequestResponseType::_empty | XMLHttpRequestResponseType::Text => {
                 let ready_state = self.ready_state.get();
                 // Step 2
-                if ready_state == XMLHttpRequestState::Done ||
-                    ready_state == XMLHttpRequestState::Loading
+                if ready_state == XMLHttpRequestState::Done
+                    || ready_state == XMLHttpRequestState::Loading
                 {
                     self.text_response().safe_to_jsval(cx, rval);
                 } else {
@@ -1188,9 +1188,9 @@ impl XMLHttpRequest {
             },
             XHRProgress::Done(_) => {
                 assert!(
-                    self.ready_state.get() == XMLHttpRequestState::HeadersReceived ||
-                        self.ready_state.get() == XMLHttpRequestState::Loading ||
-                        self.sync.get()
+                    self.ready_state.get() == XMLHttpRequestState::HeadersReceived
+                        || self.ready_state.get() == XMLHttpRequestState::Loading
+                        || self.sync.get()
                 );
 
                 self.cancel_timeout();
@@ -1398,9 +1398,9 @@ impl XMLHttpRequest {
         let final_mime = self.final_mime_type();
 
         // Step 3: If finalMIME is not an HTML MIME type or an XML MIME type, then return.
-        let is_xml_mime_type = final_mime.matches(TEXT, XML) ||
-            final_mime.matches(APPLICATION, XML) ||
-            final_mime.has_suffix(XML);
+        let is_xml_mime_type = final_mime.matches(TEXT, XML)
+            || final_mime.matches(APPLICATION, XML)
+            || final_mime.has_suffix(XML);
         if !final_mime.matches(TEXT, HTML) && !is_xml_mime_type {
             return None;
         }

--- a/components/script/dom/xpath/xpathexpression.rs
+++ b/components/script/dom/xpath/xpathexpression.rs
@@ -58,14 +58,14 @@ impl XPathExpression {
     ) -> Fallible<DomRoot<XPathResult>> {
         let is_allowed_context_node_type = matches!(
             context_node.type_id(),
-            NodeTypeId::Attr |
-                NodeTypeId::CharacterData(
-                    CharacterDataTypeId::Comment |
-                        CharacterDataTypeId::Text(_) |
-                        CharacterDataTypeId::ProcessingInstruction
-                ) |
-                NodeTypeId::Document(_) |
-                NodeTypeId::Element(_)
+            NodeTypeId::Attr
+                | NodeTypeId::CharacterData(
+                    CharacterDataTypeId::Comment
+                        | CharacterDataTypeId::Text(_)
+                        | CharacterDataTypeId::ProcessingInstruction
+                )
+                | NodeTypeId::Document(_)
+                | NodeTypeId::Element(_)
         );
         if !is_allowed_context_node_type {
             return Err(Error::NotSupported(None));

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -185,8 +185,8 @@ fn abort_fetch_call(
     // Step 1. Reject promise with error.
     promise.reject(cx, abort_reason);
     // Step 2. If request’s body is non-null and is readable, then cancel request’s body with error.
-    if let Some(body) = request.body() &&
-        body.is_readable()
+    if let Some(body) = request.body()
+        && body.is_readable()
     {
         body.cancel(cx, global, abort_reason);
     }
@@ -196,8 +196,8 @@ fn abort_fetch_call(
         return;
     };
     // Step 5. If response’s body is non-null and is readable, then error response’s body with error.
-    if let Some(body) = response.body() &&
-        body.is_readable()
+    if let Some(body) = response.body()
+        && body.is_readable()
     {
         body.error(cx, abort_reason);
     }
@@ -612,8 +612,8 @@ impl FetchResponseListener for FetchContext {
         let response_object = self.response_object.root();
         let mut realm = enter_auto_realm(cx, &*response_object);
         let cx = &mut realm.current_realm();
-        if let Err(ref error) = response &&
-            *error == NetworkError::DecompressionError
+        if let Err(ref error) = response
+            && *error == NetworkError::DecompressionError
         {
             response_object.error_stream(cx, Error::Type(c"Network error occurred".to_owned()));
         }
@@ -749,8 +749,8 @@ pub(crate) fn load_whole_resource(
                 }
                 return Ok((metadata, buf, muted_errors));
             },
-            FetchResponseMsg::ProcessResponse(_, Err(e)) |
-            FetchResponseMsg::ProcessResponseEOF(_, Err(e), _) => return Err(e),
+            FetchResponseMsg::ProcessResponse(_, Err(e))
+            | FetchResponseMsg::ProcessResponseEOF(_, Err(e), _) => return Err(e),
             FetchResponseMsg::ProcessCspViolations(_, violations) => {
                 csp_violations_processor.process_csp_violations(cx, violations);
             },

--- a/components/script/indexeddb.rs
+++ b/components/script/indexeddb.rs
@@ -543,8 +543,8 @@ pub(crate) fn evaluate_key_path_on_value(
                 }
 
                 // If value is a Blob and identifier is "size"
-                if identifier == "size" &&
-                    let Ok(blob) = root_from_handlevalue::<Blob>(cx, current_value.handle())
+                if identifier == "size"
+                    && let Ok(blob) = root_from_handlevalue::<Blob>(cx, current_value.handle())
                 {
                     // Let value be a Number equal to value’s size.
                     blob.Size().safe_to_jsval(cx, current_value.handle_mut());
@@ -553,8 +553,8 @@ pub(crate) fn evaluate_key_path_on_value(
                 }
 
                 // If value is a Blob and identifier is "type"
-                if identifier == "type" &&
-                    let Ok(blob) = root_from_handlevalue::<Blob>(cx, current_value.handle())
+                if identifier == "type"
+                    && let Ok(blob) = root_from_handlevalue::<Blob>(cx, current_value.handle())
                 {
                     // Let value be a String equal to value’s type.
                     blob.Type().safe_to_jsval(cx, current_value.handle_mut());
@@ -563,8 +563,8 @@ pub(crate) fn evaluate_key_path_on_value(
                 }
 
                 // If value is a File and identifier is "name"
-                if identifier == "name" &&
-                    let Ok(file) = root_from_handlevalue::<File>(cx, current_value.handle())
+                if identifier == "name"
+                    && let Ok(file) = root_from_handlevalue::<File>(cx, current_value.handle())
                 {
                     // Let value be a String equal to value’s name.
                     file.name().safe_to_jsval(cx, current_value.handle_mut());
@@ -573,8 +573,8 @@ pub(crate) fn evaluate_key_path_on_value(
                 }
 
                 // If value is a File and identifier is "lastModified"
-                if identifier == "lastModified" &&
-                    let Ok(file) = root_from_handlevalue::<File>(cx, current_value.handle())
+                if identifier == "lastModified"
+                    && let Ok(file) = root_from_handlevalue::<File>(cx, current_value.handle())
                 {
                     // Let value be a Number equal to value’s lastModified.
                     file.LastModified()
@@ -584,8 +584,8 @@ pub(crate) fn evaluate_key_path_on_value(
                 }
 
                 // If value is a File and identifier is "lastModifiedDate"
-                if identifier == "lastModifiedDate" &&
-                    let Ok(file) = root_from_handlevalue::<File>(cx, current_value.handle())
+                if identifier == "lastModifiedDate"
+                    && let Ok(file) = root_from_handlevalue::<File>(cx, current_value.handle())
                 {
                     // Let value be a new Date object with [[DateValue]] internal slot equal to value’s lastModified.
                     let time = ClippedTime {

--- a/components/script/layout_dom/servo_dangerous_style_element.rs
+++ b/components/script/layout_dom/servo_dangerous_style_element.rs
@@ -356,8 +356,8 @@ impl<'dom> style::dom::TElement for ServoDangerousStyleElement<'dom> {
 
     fn has_animations(&self, context: &SharedStyleContext) -> bool {
         // This is not used for pseudo elements currently so we can pass None.
-        self.has_css_animations(context, /* pseudo_element = */ None) ||
-            self.has_css_transitions(context, /* pseudo_element = */ None)
+        self.has_css_animations(context, /* pseudo_element = */ None)
+            || self.has_css_transitions(context, /* pseudo_element = */ None)
     }
 
     fn has_css_animations(
@@ -513,22 +513,22 @@ impl<'dom> style::dom::TElement for ServoDangerousStyleElement<'dom> {
             let old_box = old.get_box();
             let new_box = new.get_box();
 
-            if old_box.display != new_box.display ||
-                old_box.float != new_box.float ||
-                old_box.position != new_box.position
+            if old_box.display != new_box.display
+                || old_box.float != new_box.float
+                || old_box.position != new_box.position
             {
                 return true;
             }
 
-            if new_box.position.is_absolutely_positioned() &&
-                old_box.original_display != new_box.original_display
+            if new_box.position.is_absolutely_positioned()
+                && old_box.original_display != new_box.original_display
             {
                 // The original display only affects the static position, which is only used
                 // when both insets in some axis are auto.
                 // <https://drafts.csswg.org/css-position/#resolving-insets>
                 let position = new.get_position();
-                if (position.top.is_auto() && position.bottom.is_auto()) ||
-                    (position.left.is_auto() && position.right.is_auto())
+                if (position.top.is_auto() && position.bottom.is_auto())
+                    || (position.left.is_auto() && position.right.is_auto())
                 {
                     return true;
                 }
@@ -555,8 +555,8 @@ impl<'dom> style::dom::TElement for ServoDangerousStyleElement<'dom> {
             // NOTE: This should be kept in sync with the checks in `impl
             // StyleExt::establishes_block_formatting_context` for `ComputedValues` in
             // `components/layout/style_ext.rs`.
-            if new_box.display.outside() == DisplayOutside::Block &&
-                new_box.display.inside() == DisplayInside::Flow
+            if new_box.display.outside() == DisplayOutside::Block
+                && new_box.display.inside() == DisplayInside::Flow
             {
                 let alignment_establishes_new_block_formatting_context =
                     |style: &ComputedValues| {
@@ -565,11 +565,11 @@ impl<'dom> style::dom::TElement for ServoDangerousStyleElement<'dom> {
 
                 let old_column = old.get_column();
                 let new_column = new.get_column();
-                if old_box.overflow_x.is_scrollable() != new_box.overflow_x.is_scrollable() ||
-                    old_column.is_multicol() != new_column.is_multicol() ||
-                    old_column.column_span != new_column.column_span ||
-                    alignment_establishes_new_block_formatting_context(old) !=
-                        alignment_establishes_new_block_formatting_context(new)
+                if old_box.overflow_x.is_scrollable() != new_box.overflow_x.is_scrollable()
+                    || old_column.is_multicol() != new_column.is_multicol()
+                    || old_column.column_span != new_column.column_span
+                    || alignment_establishes_new_block_formatting_context(old)
+                        != alignment_establishes_new_block_formatting_context(new)
                 {
                     return true;
                 }
@@ -578,10 +578,10 @@ impl<'dom> style::dom::TElement for ServoDangerousStyleElement<'dom> {
             if old_box.display.is_list_item() {
                 let old_list = old.get_list();
                 let new_list = new.get_list();
-                if old_list.list_style_position != new_list.list_style_position ||
-                    old_list.list_style_image != new_list.list_style_image ||
-                    (new_list.list_style_image == Image::None &&
-                        old_list.list_style_type != new_list.list_style_type)
+                if old_list.list_style_position != new_list.list_style_position
+                    || old_list.list_style_image != new_list.list_style_image
+                    || (new_list.list_style_image == Image::None
+                        && old_list.list_style_type != new_list.list_style_type)
                 {
                     return true;
                 }
@@ -611,21 +611,21 @@ impl<'dom> style::dom::TElement for ServoDangerousStyleElement<'dom> {
         };
 
         let text_shaping_needs_recollect = || {
-            if old.clone_direction() != new.clone_direction() ||
-                old.clone_unicode_bidi() != new.clone_unicode_bidi()
+            if old.clone_direction() != new.clone_direction()
+                || old.clone_unicode_bidi() != new.clone_unicode_bidi()
             {
                 return true;
             }
 
             let old_text = old.get_inherited_text().clone();
             let new_text = new.get_inherited_text().clone();
-            if old_text.white_space_collapse != new_text.white_space_collapse ||
-                old_text.text_transform != new_text.text_transform ||
-                old_text.word_break != new_text.word_break ||
-                old_text.overflow_wrap != new_text.overflow_wrap ||
-                old_text.letter_spacing != new_text.letter_spacing ||
-                old_text.word_spacing != new_text.word_spacing ||
-                old_text.text_rendering != new_text.text_rendering
+            if old_text.white_space_collapse != new_text.white_space_collapse
+                || old_text.text_transform != new_text.text_transform
+                || old_text.word_break != new_text.word_break
+                || old_text.overflow_wrap != new_text.overflow_wrap
+                || old_text.letter_spacing != new_text.letter_spacing
+                || old_text.word_spacing != new_text.word_spacing
+                || old_text.text_rendering != new_text.text_rendering
             {
                 return true;
             }
@@ -671,8 +671,8 @@ impl<'dom> ::selectors::Element for ServoDangerousStyleElement<'dom> {
 
     fn parent_node_is_shadow_root(&self) -> bool {
         self.as_node().parent_node().is_some_and(|parent_node| {
-            parent_node.node.type_id_for_layout() ==
-                NodeTypeId::DocumentFragment(DocumentFragmentTypeId::ShadowRoot)
+            parent_node.node.type_id_for_layout()
+                == NodeTypeId::DocumentFragment(DocumentFragmentTypeId::ShadowRoot)
         })
     }
 
@@ -768,8 +768,8 @@ impl<'dom> ::selectors::Element for ServoDangerousStyleElement<'dom> {
 
     #[inline]
     fn is_same_type(&self, other: &Self) -> bool {
-        self.element.local_name() == other.element.local_name() &&
-            self.element.namespace() == other.element.namespace()
+        self.element.local_name() == other.element.local_name()
+            && self.element.namespace() == other.element.namespace()
     }
 
     fn match_non_ts_pseudo_class(
@@ -795,36 +795,36 @@ impl<'dom> ::selectors::Element for ServoDangerousStyleElement<'dom> {
                 .get_state_for_layout()
                 .contains(NonTSPseudoClass::ReadWrite.state_flag()),
 
-            NonTSPseudoClass::Active |
-            NonTSPseudoClass::Autofill |
-            NonTSPseudoClass::Checked |
-            NonTSPseudoClass::Default |
-            NonTSPseudoClass::Defined |
-            NonTSPseudoClass::Disabled |
-            NonTSPseudoClass::Enabled |
-            NonTSPseudoClass::Focus |
-            NonTSPseudoClass::FocusVisible |
-            NonTSPseudoClass::FocusWithin |
-            NonTSPseudoClass::Fullscreen |
-            NonTSPseudoClass::Hover |
-            NonTSPseudoClass::InRange |
-            NonTSPseudoClass::Indeterminate |
-            NonTSPseudoClass::Invalid |
-            NonTSPseudoClass::Modal |
-            NonTSPseudoClass::MozMeterOptimum |
-            NonTSPseudoClass::MozMeterSubOptimum |
-            NonTSPseudoClass::MozMeterSubSubOptimum |
-            NonTSPseudoClass::Open |
-            NonTSPseudoClass::Optional |
-            NonTSPseudoClass::OutOfRange |
-            NonTSPseudoClass::PlaceholderShown |
-            NonTSPseudoClass::PopoverOpen |
-            NonTSPseudoClass::ReadWrite |
-            NonTSPseudoClass::Required |
-            NonTSPseudoClass::Target |
-            NonTSPseudoClass::UserInvalid |
-            NonTSPseudoClass::UserValid |
-            NonTSPseudoClass::Valid => self
+            NonTSPseudoClass::Active
+            | NonTSPseudoClass::Autofill
+            | NonTSPseudoClass::Checked
+            | NonTSPseudoClass::Default
+            | NonTSPseudoClass::Defined
+            | NonTSPseudoClass::Disabled
+            | NonTSPseudoClass::Enabled
+            | NonTSPseudoClass::Focus
+            | NonTSPseudoClass::FocusVisible
+            | NonTSPseudoClass::FocusWithin
+            | NonTSPseudoClass::Fullscreen
+            | NonTSPseudoClass::Hover
+            | NonTSPseudoClass::InRange
+            | NonTSPseudoClass::Indeterminate
+            | NonTSPseudoClass::Invalid
+            | NonTSPseudoClass::Modal
+            | NonTSPseudoClass::MozMeterOptimum
+            | NonTSPseudoClass::MozMeterSubOptimum
+            | NonTSPseudoClass::MozMeterSubSubOptimum
+            | NonTSPseudoClass::Open
+            | NonTSPseudoClass::Optional
+            | NonTSPseudoClass::OutOfRange
+            | NonTSPseudoClass::PlaceholderShown
+            | NonTSPseudoClass::PopoverOpen
+            | NonTSPseudoClass::ReadWrite
+            | NonTSPseudoClass::Required
+            | NonTSPseudoClass::Target
+            | NonTSPseudoClass::UserInvalid
+            | NonTSPseudoClass::UserValid
+            | NonTSPseudoClass::Valid => self
                 .element
                 .get_state_for_layout()
                 .contains(pseudo_class.state_flag()),
@@ -845,9 +845,9 @@ impl<'dom> ::selectors::Element for ServoDangerousStyleElement<'dom> {
             // https://html.spec.whatwg.org/multipage/#selector-link
             NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLAnchorElement,
-            )) |
-            NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLAreaElement)) |
-            NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLLinkElement)) => {
+            ))
+            | NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLAreaElement))
+            | NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLLinkElement)) => {
                 self.element
                     .get_attr_val_for_layout(&ns!(), &local_name!("href"))
                     .is_some()
@@ -915,8 +915,8 @@ impl<'dom> ::selectors::Element for ServoDangerousStyleElement<'dom> {
 
         // Handle flags that apply to the parent.
         let parent_flags = flags.for_parent();
-        if !parent_flags.is_empty() &&
-            let Some(p) = self.as_node().parent_element()
+        if !parent_flags.is_empty()
+            && let Some(p) = self.as_node().parent_element()
         {
             p.element.insert_selector_flags(flags);
         }

--- a/components/script/layout_dom/servo_layout_element.rs
+++ b/components/script/layout_dom/servo_layout_element.rs
@@ -76,8 +76,9 @@ impl<'dom> LayoutElement<'dom> for ServoLayoutElement<'dom> {
     type ConcreteTypeBundle = ServoLayoutDomTypeBundle<'dom>;
 
     fn with_pseudo(&self, pseudo_element: PseudoElement) -> Option<Self> {
-        if pseudo_element.is_eager() &&
-            self.element_data()
+        if pseudo_element.is_eager()
+            && self
+                .element_data()
                 .styles
                 .pseudos
                 .get(&pseudo_element)
@@ -86,10 +87,10 @@ impl<'dom> LayoutElement<'dom> for ServoLayoutElement<'dom> {
             return None;
         }
 
-        if pseudo_element == PseudoElement::DetailsContent &&
-            (self.element.local_name() != &local_name!("details") ||
-                self.element.namespace() != &ns!(html) ||
-                self.attribute(&ns!(), &local_name!("open")).is_none())
+        if pseudo_element == PseudoElement::DetailsContent
+            && (self.element.local_name() != &local_name!("details")
+                || self.element.namespace() != &ns!(html)
+                || self.attribute(&ns!(), &local_name!("open")).is_none())
         {
             return None;
         }
@@ -243,8 +244,9 @@ impl<'dom> LayoutElement<'dom> for ServoLayoutElement<'dom> {
     }
 
     fn is_html_element_in_html_document(&self) -> bool {
-        self.element.is_html_element() &&
-            self.element
+        self.element.is_html_element()
+            && self
+                .element
                 .upcast::<Node>()
                 .owner_doc_for_layout()
                 .is_html_document_for_layout()

--- a/components/script/links.rs
+++ b/components/script/links.rs
@@ -234,9 +234,9 @@ impl LinkRelations {
             Self::EXTERNAL
         } else if keyword.eq_ignore_ascii_case("help") {
             Self::HELP
-        } else if keyword.eq_ignore_ascii_case("icon") ||
-            keyword.eq_ignore_ascii_case("shortcut icon") ||
-            keyword.eq_ignore_ascii_case("apple-touch-icon")
+        } else if keyword.eq_ignore_ascii_case("icon")
+            || keyword.eq_ignore_ascii_case("shortcut icon")
+            || keyword.eq_ignore_ascii_case("apple-touch-icon")
         {
             // TODO: "apple-touch-icon" is not in the spec. Where did it come from? Do we need it?
             //       There is also "apple-touch-icon-precomposed" listed in
@@ -246,8 +246,8 @@ impl LinkRelations {
             Self::MANIFEST
         } else if keyword.eq_ignore_ascii_case("modulepreload") {
             Self::MODULE_PRELOAD
-        } else if keyword.eq_ignore_ascii_case("license") ||
-            keyword.eq_ignore_ascii_case("copyright")
+        } else if keyword.eq_ignore_ascii_case("license")
+            || keyword.eq_ignore_ascii_case("copyright")
         {
             Self::LICENSE
         } else if keyword.eq_ignore_ascii_case("next") {
@@ -341,9 +341,9 @@ pub(crate) fn get_element_target(
     target: Option<DOMString>,
 ) -> Option<DOMString> {
     assert!(
-        subject.is::<HTMLAreaElement>() ||
-            subject.is::<HTMLAnchorElement>() ||
-            subject.is::<HTMLFormElement>()
+        subject.is::<HTMLAreaElement>()
+            || subject.is::<HTMLAnchorElement>()
+            || subject.is::<HTMLFormElement>()
     );
 
     // Step 1. If target is null, then:
@@ -372,9 +372,9 @@ pub(crate) fn get_element_target(
         }
     });
     // Step 2. If target is not null, and contains an ASCII tab or newline and a U+003C (<), then set target to "_blank".
-    if let Some(ref target) = target &&
-        target.contains_tab_or_newline() &&
-        target.contains("\u{003C}")
+    if let Some(ref target) = target
+        && target.contains_tab_or_newline()
+        && target.contains("\u{003C}")
     {
         return Some("_blank".into());
     }

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -291,8 +291,8 @@ pub(crate) fn determine_the_origin(
     }
 
     // Step 4. If url matches about:blank and sourceOrigin is non-null, then return sourceOrigin.
-    if url.as_str() == "about:blank" &&
-        let Some(source_origin) = source_origin
+    if url.as_str() == "about:blank"
+        && let Some(source_origin) = source_origin
     {
         return source_origin;
     }
@@ -371,9 +371,9 @@ pub(crate) fn navigate(
     // Step 4 and 5
     let pipeline_id = window.pipeline_id();
     let window_proxy = window.window_proxy();
-    if let Some(active) = window_proxy.currently_active() &&
-        pipeline_id == active &&
-        doc.is_prompting_or_unloading()
+    if let Some(active) = window_proxy.currently_active()
+        && pipeline_id == active
+        && doc.is_prompting_or_unloading()
     {
         return;
     }

--- a/components/script/network_listener.rs
+++ b/components/script/network_listener.rs
@@ -38,8 +38,8 @@ pub(crate) fn submit_timing<T: ResourceTimingListener>(
     // (e.g. mixed content, CORS restriction, CSP policy, etc), then this resource
     // will not be included as a PerformanceResourceTiming object in
     // the Performance Timeline.
-    if let Err(error) = &result &&
-        error.is_permanent_failure()
+    if let Err(error) = &result
+        && error.is_permanent_failure()
     {
         return;
     }
@@ -53,8 +53,8 @@ pub(crate) fn submit_timing<T: ResourceTimingListener>(
     // (e.g. due to a network error) MAY be included as PerformanceResourceTiming
     // objects in the Performance Timeline and MUST contain initialized attribute
     // values for processed substeps of the processing model.
-    if resource_timing.timing_type != ResourceTimingType::Resource &&
-        resource_timing.timing_type != ResourceTimingType::Error
+    if resource_timing.timing_type != ResourceTimingType::Resource
+        && resource_timing.timing_type != ResourceTimingType::Error
     {
         warn!(
             "Submitting non-resource ({:?}) timing as resource",

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -541,8 +541,8 @@ impl ModuleTree {
                 // Step 10.1 If scopePrefix is serializedBaseURL, or if scopePrefix ends with U+002F (/)
                 // and scopePrefix is a code unit prefix of serializedBaseURL, then:
                 let prefix = prefix.as_str();
-                if prefix == serialized_base_url ||
-                    (serialized_base_url.starts_with(prefix) && prefix.ends_with('\u{002f}'))
+                if prefix == serialized_base_url
+                    || (serialized_base_url.starts_with(prefix) && prefix.ends_with('\u{002f}'))
                 {
                     // Step 10.1.1 Let scopeImportsMatch be the result of resolving an imports match
                     // given normalizedSpecifier, asURL, and scopeImports.
@@ -786,11 +786,11 @@ impl FetchResponseListener for ModuleContext {
 
             // Step 7.2 If mimeType is a JavaScript MIME type and moduleType is "javascript-or-wasm", then set moduleScript
             // to the result of creating a JavaScript module script given sourceText, settingsObject, response's URL, and options.
-            if SCRIPT_JS_MIMES.contains(&mime.essence_str()) &&
-                matches!(module_type, ModuleType::JavaScript)
+            if SCRIPT_JS_MIMES.contains(&mime.essence_str())
+                && matches!(module_type, ModuleType::JavaScript)
             {
-                if let Some(window) = global.downcast::<Window>() &&
-                    let Some(script_souce) = window.local_script_source()
+                if let Some(window) = global.downcast::<Window>()
+                    && let Some(script_souce) = window.local_script_source()
                 {
                     substitute_with_local_script(script_souce, &mut source_text, final_url.clone());
                 }
@@ -1308,8 +1308,8 @@ pub(crate) fn fetch_a_modulepreload_module(
 
             // Step 3. If result is not null, optionally fetch the descendants of and link result
             // given settingsObject, destination, and an empty algorithm.
-            if pref!(dom_allow_preloading_module_descendants) &&
-                let Some(module) = result
+            if pref!(dom_allow_preloading_module_descendants)
+                && let Some(module) = result
             {
                 fetch_the_descendants_and_link_module_script(
                     cx,
@@ -1700,8 +1700,8 @@ fn merge_existing_and_new_import_maps(
             // If scopePrefix is record's serialized base URL, or if scopePrefix ends with
             // U+002F (/) and scopePrefix is a code unit prefix of record's serialized base URL, then:
             let prefix = scope_prefix.as_str();
-            if prefix == record.base_url ||
-                (record.base_url.starts_with(prefix) && prefix.ends_with('\u{002f}'))
+            if prefix == record.base_url
+                || (record.base_url.starts_with(prefix) && prefix.ends_with('\u{002f}'))
             {
                 // For each specifierKey → resolutionResult of scopeImports:
                 scope_imports.retain(|key, val| {
@@ -1709,11 +1709,11 @@ fn merge_existing_and_new_import_maps(
                     // specifierKey ends with U+002F (/);
                     // specifierKey is a code unit prefix of record's specifier;
                     // either record's specifier as a URL is null or is special,
-                    if *key == record.specifier ||
-                        (key.ends_with('\u{002f}') &&
-                            record.specifier.starts_with(key) &&
-                            (record.specifier_url.is_none() ||
-                                record
+                    if *key == record.specifier
+                        || (key.ends_with('\u{002f}')
+                            && record.specifier.starts_with(key)
+                            && (record.specifier_url.is_none()
+                                || record
                                     .specifier_url
                                     .as_ref()
                                     .is_some_and(|u| u.is_special_scheme())))
@@ -2170,9 +2170,9 @@ fn resolve_imports_match(
         // - specifierKey ends with U+002F (/)
         // - specifierKey is a code unit prefix of normalizedSpecifier
         // - either asURL is null, or asURL is special, then:
-        if specifier_key.ends_with('\u{002f}') &&
-            normalized_specifier.starts_with(specifier_key) &&
-            (as_url.is_none() || as_url.is_some_and(|u| u.is_special_scheme()))
+        if specifier_key.ends_with('\u{002f}')
+            && normalized_specifier.starts_with(specifier_key)
+            && (as_url.is_none() || as_url.is_some_and(|u| u.is_special_scheme()))
         {
             // Step 1.2.1 If resolutionResult is null, then throw a TypeError.
             // Step 1.2.2 Assert: resolutionResult is a URL.

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -565,8 +565,8 @@ unsafe extern "C" fn content_security_policy_allows(
         let csp_list = global.get_csp_list();
 
         // If we don't have any CSP checks to run, short-circuit all logic here
-        allowed = csp_list.is_none() ||
-            match runtime_code {
+        allowed = csp_list.is_none()
+            || match runtime_code {
                 RuntimeCode::JS => {
                     let parameter_strings = unsafe { Handle::from_raw(parameter_strings) };
                     let parameter_strings_length = parameter_strings.len();

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1325,10 +1325,10 @@ impl ScriptThread {
             .iter()
             .any(|(_, document)| document.needs_rendering_update());
         let running_animations = self.documents.borrow().iter().any(|(_, document)| {
-            document.is_fully_active() &&
-                !document.window().throttled() &&
-                (document.animations().running_animation_count() != 0 ||
-                    document.has_active_request_animation_frame_callbacks())
+            document.is_fully_active()
+                && !document.window().throttled()
+                && (document.animations().running_animation_count() != 0
+                    || document.has_active_request_animation_frame_callbacks())
         });
 
         // If we are not running animations and no rendering update is
@@ -1763,9 +1763,9 @@ impl ScriptThread {
         };
         let task_duration = start.elapsed();
         for (doc_id, doc) in self.documents.borrow().iter() {
-            if let Some(pipeline_id) = pipeline_id &&
-                pipeline_id == doc_id &&
-                task_duration.as_nanos() > MAX_TASK_NS
+            if let Some(pipeline_id) = pipeline_id
+                && pipeline_id == doc_id
+                && task_duration.as_nanos() > MAX_TASK_NS
             {
                 if opts::get()
                     .debug
@@ -1946,9 +1946,9 @@ impl ScriptThread {
                     document.handle_no_longer_waiting_on_asynchronous_image_updates();
                 }
             },
-            msg @ ScriptThreadMessage::SpawnPipeline(..) |
-            msg @ ScriptThreadMessage::ExitFullScreen(..) |
-            msg @ ScriptThreadMessage::ExitScriptThread => {
+            msg @ ScriptThreadMessage::SpawnPipeline(..)
+            | msg @ ScriptThreadMessage::ExitFullScreen(..)
+            | msg @ ScriptThreadMessage::ExitScriptThread => {
                 panic!("should have handled {:?} already", msg)
             },
             ScriptThreadMessage::SetScrollStates(pipeline_id, scroll_states) => {
@@ -4009,8 +4009,8 @@ impl ScriptThread {
             // we need to register an iframe entry to the performance timeline if present
             if let Some(window_proxy) = context
                 .get_document()
-                .and_then(|document| document.browsing_context()) &&
-                let Some(frame_element) = window_proxy.frame_element()
+                .and_then(|document| document.browsing_context())
+                && let Some(frame_element) = window_proxy.frame_element()
             {
                 let iframe_ctx = IframeContext::new(
                     frame_element
@@ -4213,8 +4213,8 @@ impl ScriptThread {
             return;
         };
 
-        if let Some(window) = self.documents.borrow().find_window(pipeline_id) &&
-            window.live_devtools_updates()
+        if let Some(window) = self.documents.borrow().find_window(pipeline_id)
+            && window.live_devtools_updates()
         {
             let css_error = CSSError {
                 filename,

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -286,10 +286,10 @@ impl ServiceWorkerManager {
     }
 
     fn handle_message_from_resource(&mut self, mediator: CustomResponseMediator) -> bool {
-        if serviceworker_enabled() &&
-            let Some(scope) = self.get_matching_scope(&mediator.load_url) &&
-            let Some(registration) = self.registrations.get(&scope) &&
-            let Some(ref worker) = registration.active_worker
+        if serviceworker_enabled()
+            && let Some(scope) = self.get_matching_scope(&mediator.load_url)
+            && let Some(registration) = self.registrations.get(&scope)
+            && let Some(ref worker) = registration.active_worker
         {
             worker.send_message(ServiceWorkerScriptMsg::Response(mediator));
             return true;
@@ -535,8 +535,8 @@ impl ServiceWorkerManager {
         // Step 2: If job’s script url’s origin and job’s referrer’s origin are not same origin, then:
         // Step 3: If job’s scope url’s origin and job’s referrer’s origin are not same origin, then:
         // Note: both steps done in one conditional.
-        if job.script_url.origin() != job.referrer.origin() ||
-            job.scope_url.origin() != job.referrer.origin()
+        if job.script_url.origin() != job.referrer.origin()
+            || job.scope_url.origin() != job.referrer.origin()
         {
             // Step 2.1: Invoke Reject Job Promise with job and "SecurityError" DOMException
             if job
@@ -666,8 +666,8 @@ impl ServiceWorkerManager {
                 let newest_worker = registration.get_newest_worker();
 
                 // Step 4.
-                if let Some(worker) = newest_worker &&
-                    worker.script_url != job.script_url
+                if let Some(worker) = newest_worker
+                    && worker.script_url != job.script_url
                 {
                     let _ = job.client.send(ServiceWorkerAlgorithmResult::Job(
                         JobResult::RejectPromise(JobError::TypeError),
@@ -725,8 +725,8 @@ fn update_serviceworker(
     let (devtools_sender, devtools_receiver) = generic_channel::channel().unwrap();
     scope_things.init.from_devtools_sender = Some(devtools_sender);
 
-    if let Some(ref chan) = scope_things.devtools_chan &&
-        let Some(ref sender) = scope_things.init.from_devtools_sender
+    if let Some(ref chan) = scope_things.devtools_chan
+        && let Some(ref sender) = scope_things.init.from_devtools_sender
     {
         let page_info = DevtoolsPageInfo {
             title: format!("Service Worker for {}", scope_things.script_url),

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -126,8 +126,8 @@ impl StylesheetContext {
         };
 
         let mut style_content = std::mem::take(&mut self.data);
-        if let Some((input, mut output)) = create_temp_files() &&
-            execute_js_beautify(
+        if let Some((input, mut output)) = create_temp_files()
+            && execute_js_beautify(
                 input.path(),
                 output.try_clone().unwrap(),
                 BeautifyFileType::Css,
@@ -400,8 +400,8 @@ impl FetchResponseListener for StylesheetContext {
                 // > the URL of the external resource, and the Content-Type metadata of the
                 // > external resource is not a supported style sheet type, the user agent must
                 // > instead assume it to be text/css.
-                document.quirks_mode() == QuirksMode::Quirks &&
-                    document.origin().immutable().clone() == metadata.final_url.origin()
+                document.quirks_mode() == QuirksMode::Quirks
+                    && document.origin().immutable().clone() == metadata.final_url.origin()
             );
 
             if !is_css {
@@ -531,9 +531,9 @@ impl ElementStylesheetLoader<'_> {
 
         // If element's media attribute's value matches the environment and
         // element is potentially render-blocking, then block rendering on element.
-        context.is_render_blocking = element.media_attribute_matches_media_environment() &&
-            owner.potentially_render_blocking() &&
-            document.allows_adding_render_blocking_elements();
+        context.is_render_blocking = element.media_attribute_matches_media_environment()
+            && owner.potentially_render_blocking()
+            && document.allows_adding_render_blocking_elements();
         if context.is_render_blocking {
             document.increment_render_blocking_element_count();
         }

--- a/components/script/task_queue.rs
+++ b/components/script/task_queue.rs
@@ -155,8 +155,8 @@ impl<T: QueuedTaskConversion> TaskQueue<T> {
                 self.msg_queue.borrow_mut().push_back(msg);
                 continue;
             }
-            if let Some(pipeline_id) = msg.pipeline_id() &&
-                !fully_active.contains(&pipeline_id)
+            if let Some(pipeline_id) = msg.pipeline_id()
+                && !fully_active.contains(&pipeline_id)
             {
                 self.store_task_for_inactive_pipeline(msg, &pipeline_id);
                 continue;
@@ -242,8 +242,8 @@ impl<T: QueuedTaskConversion> TaskQueue<T> {
                     let msg = T::from_queued_task(queued_task);
 
                     // Hold back tasks for currently inactive documents.
-                    if let Some(pipeline_id) = msg.pipeline_id() &&
-                        !fully_active.contains(&pipeline_id)
+                    if let Some(pipeline_id) = msg.pipeline_id()
+                        && !fully_active.contains(&pipeline_id)
                     {
                         self.store_task_for_inactive_pipeline(msg, &pipeline_id);
                         // Reduce the length of throttles,

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -391,8 +391,8 @@ impl<T: ClipboardProvider> TextInput<T> {
     ///
     /// If there is no selection, returns an empty range at the edit point.
     pub(crate) fn sorted_selection_character_offsets_range(&self) -> Range<usize> {
-        self.rope.index_to_character_offset(self.selection_start())..
-            self.rope.index_to_character_offset(self.selection_end())
+        self.rope.index_to_character_offset(self.selection_start())
+            ..self.rope.index_to_character_offset(self.selection_end())
     }
 
     /// The state of the current selection. Can be used to compare whether selection state has changed.

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -838,8 +838,8 @@ impl JsTimerTask {
         //
         // Since we choose proactively prevent execution (see 4.1 above), we must only
         // reschedule repeating timers when they were not canceled as part of step 4.2.
-        if self.is_interval == IsInterval::Interval &&
-            timers.active_timers.borrow().contains_key(&self.handle)
+        if self.is_interval == IsInterval::Interval
+            && timers.active_timers.borrow().contains_key(&self.handle)
         {
             timers.initialize_and_schedule(&this.global(), self);
         }

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -151,8 +151,8 @@ pub(crate) fn handle_get_known_window(
                 .map_or(Err(ErrorStatus::NoSuchWindow), |window| {
                     let window_proxy = window.window_proxy();
                     // Step 3-4: Window must be top level browsing context.
-                    if window_proxy.browsing_context_id() != window_proxy.webview_id() ||
-                        window_proxy.webview_id().to_string() != webview_id
+                    if window_proxy.browsing_context_id() != window_proxy.webview_id()
+                        || window_proxy.webview_id().to_string() != webview_id
                     {
                         Err(ErrorStatus::NoSuchWindow)
                     } else {
@@ -199,8 +199,8 @@ fn get_known_shadow_root(
 
     // Step 3. If node is not null and node does not implement ShadowRoot
     // return error with error code no such shadow root.
-    if let Some(ref node) = node &&
-        !node.is::<ShadowRoot>()
+    if let Some(ref node) = node
+        && !node.is::<ShadowRoot>()
     {
         return Err(ErrorStatus::NoSuchShadowRoot);
     }
@@ -253,8 +253,8 @@ fn get_known_element(
 
     // Step 3. If node is not null and node does not implement Element
     // return error with error code no such element.
-    if let Some(ref node) = node &&
-        !node.is::<Element>()
+    if let Some(ref node) = node
+        && !node.is::<Element>()
     {
         return Err(ErrorStatus::NoSuchElement);
     }
@@ -504,8 +504,8 @@ fn clone_an_object(
     // Step 2. Append value to `seen`.
     seen.insert(hashable.clone());
 
-    let return_val = if is_array_like::<crate::DomTypeHolder>(cx, val) ||
-        is_arguments_object(cx, val)
+    let return_val = if is_array_like::<crate::DomTypeHolder>(cx, val)
+        || is_arguments_object(cx, val)
     {
         let mut result: Vec<JSValue> = Vec::new();
 
@@ -1778,24 +1778,24 @@ pub(crate) fn handle_get_url(
 /// <https://w3c.github.io/webdriver/#dfn-mutable-form-control-element>
 fn element_is_mutable_form_control(element: &Element) -> bool {
     if let Some(input_element) = element.downcast::<HTMLInputElement>() {
-        input_element.is_mutable() &&
-            matches!(
+        input_element.is_mutable()
+            && matches!(
                 *input_element.input_type(),
-                InputType::Text(_) |
-                    InputType::Search(_) |
-                    InputType::Url(_) |
-                    InputType::Tel(_) |
-                    InputType::Email(_) |
-                    InputType::Password(_) |
-                    InputType::Date(_) |
-                    InputType::Month(_) |
-                    InputType::Week(_) |
-                    InputType::Time(_) |
-                    InputType::DatetimeLocal(_) |
-                    InputType::Number(_) |
-                    InputType::Range(_) |
-                    InputType::Color(_) |
-                    InputType::File(_)
+                InputType::Text(_)
+                    | InputType::Search(_)
+                    | InputType::Url(_)
+                    | InputType::Tel(_)
+                    | InputType::Email(_)
+                    | InputType::Password(_)
+                    | InputType::Date(_)
+                    | InputType::Month(_)
+                    | InputType::Week(_)
+                    | InputType::Time(_)
+                    | InputType::DatetimeLocal(_)
+                    | InputType::Number(_)
+                    | InputType::Range(_)
+                    | InputType::Color(_)
+                    | InputType::File(_)
             )
     } else if let Some(textarea_element) = element.downcast::<HTMLTextAreaElement>() {
         textarea_element.is_mutable()
@@ -1817,8 +1817,8 @@ fn clear_a_resettable_element(cx: &mut JSContext, element: &Element) -> Result<(
             if input_element.Value().is_empty() {
                 return Ok(());
             }
-        } else if let Some(textarea_element) = element.downcast::<HTMLTextAreaElement>() &&
-            textarea_element.Value().is_empty()
+        } else if let Some(textarea_element) = element.downcast::<HTMLTextAreaElement>()
+            && textarea_element.Value().is_empty()
         {
             return Ok(());
         }
@@ -1941,8 +1941,8 @@ pub(crate) fn handle_element_click(
             get_known_element(documents, pipeline, element_id).and_then(|element| {
                 // Step 4. If the element is an input element in the file upload state
                 // return error with error code invalid argument.
-                if let Some(input_element) = element.downcast::<HTMLInputElement>() &&
-                    matches!(*input_element.input_type(), InputType::File(_))
+                if let Some(input_element) = element.downcast::<HTMLInputElement>()
+                    && matches!(*input_element.input_type(), InputType::File(_))
                 {
                     return Err(ErrorStatus::InvalidArgument);
                 }

--- a/components/script/window_named_properties.rs
+++ b/components/script/window_named_properties.rs
@@ -89,8 +89,8 @@ unsafe extern "C" fn get_own_property_descriptor(
     let mut cx = unsafe { js::context::JSContext::from_ptr(ptr::NonNull::new(cx).unwrap()) };
 
     if id.is_symbol() {
-        if id.get().asBits_ ==
-            SymbolId(unsafe { GetWellKnownSymbol(&cx, SymbolCode::toStringTag) }).asBits_
+        if id.get().asBits_
+            == SymbolId(unsafe { GetWellKnownSymbol(&cx, SymbolCode::toStringTag) }).asBits_
         {
             rooted!(&in(cx) let mut rval = UndefinedValue());
             "WindowProperties".safe_to_jsval(&mut cx, rval.handle_mut());
@@ -240,10 +240,10 @@ unsafe extern "C" fn class_name(_cx: *mut JSContext, _proxy: HandleObject) -> *c
 #[expect(unsafe_code)]
 static CLASS: JSClass = JSClass {
     name: c"WindowProperties".as_ptr(),
-    flags: JSClass_NON_NATIVE |
-        JSCLASS_IS_PROXY |
-        JSCLASS_DELAY_METADATA_BUILDER |
-        ((1 & JSCLASS_RESERVED_SLOTS_MASK) << JSCLASS_RESERVED_SLOTS_SHIFT), /* JSCLASS_HAS_RESERVED_SLOTS(1) */
+    flags: JSClass_NON_NATIVE
+        | JSCLASS_IS_PROXY
+        | JSCLASS_DELAY_METADATA_BUILDER
+        | ((1 & JSCLASS_RESERVED_SLOTS_MASK) << JSCLASS_RESERVED_SLOTS_SHIFT), /* JSCLASS_HAS_RESERVED_SLOTS(1) */
     cOps: unsafe { &ProxyClassOps },
     spec: ptr::null(),
     ext: unsafe { &ProxyClassExtension },

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -69,6 +69,15 @@
       ]
      ]
     },
+    "css": {
+     "adoptedstylesheets-borrow-hazard-crash.html": [
+      "26f2b449100cb36da91e2422e72fdcddf7a8a73a",
+      [
+       null,
+       {}
+      ]
+     ]
+    },
     "datatransferitem-crash.html": [
      "d11355ab38c1e99e0ba3e10d7dfed18bf26af60b",
      [

--- a/tests/wpt/mozilla/meta/mozilla/css/adoptedstylesheets-borrow-hazard-crash.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css/adoptedstylesheets-borrow-hazard-crash.html.ini
@@ -1,0 +1,2 @@
+[adoptedstylesheets-borrow-hazard-crash.html]
+  prefs: ["dom_adoptedstylesheet_enabled:true"]

--- a/tests/wpt/mozilla/tests/mozilla/css/adoptedstylesheets-borrow-hazard-crash.html
+++ b/tests/wpt/mozilla/tests/mozilla/css/adoptedstylesheets-borrow-hazard-crash.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head><title>adoptedStyleSheets borrow hazard (#46369)</title></head>
+<body>
+<script>
+const sheet = new CSSStyleSheet();
+sheet.replaceSync("a { color: red; }");
+const host = document.createElement("div");
+const shadow = host.attachShadow({ mode: "open" });
+document.body.appendChild(host);
+document.adoptedStyleSheets = [sheet, sheet];
+shadow.adoptedStyleSheets = [sheet];
+try { document.adoptedStyleSheets = [sheet, "invalid"]; } catch (e) {}
+if (typeof gc === "function") gc();
+</script>
+</body>
+</html>


### PR DESCRIPTION
The issue occurred because a RefCell borrow was help across a GC-capable JS conversion , causing a panic when the garbage collector tried to trace the same RefCell, the fix clones the `adopted_stylesheets` vector out of the RefCell before the conversion, ensuring no borrow is held during potential GC 

Fixes: #46369 
