### PR TITLE
script: use `JSCell` in webgpu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5244,9 +5244,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e22429d9fe0dc27169cb3ce0631d20f64f7d1c8fa5a90e039437e9fa9a7f30f"
+version = "0.18.2"
+source = "git+https://github.com/sagudev/mozjs?branch=cell#bd1df5d6db70744ff4592cd096ba523f5db34b36"
 dependencies = [
  "bindgen",
  "cc",
@@ -5259,9 +5258,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "140.12.0-1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d2c9df3f8007cf4b37f411602870d73f05f6cb70906766fe8639fcad1133a48"
+version = "140.12.0-2"
+source = "git+https://github.com/sagudev/mozjs?branch=cell#bd1df5d6db70744ff4592cd096ba523f5db34b36"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ inventory = "0.3.24"
 ipc-channel = "0.22"
 itertools = "0.15"
 jni = "0.22"
-js = { package = "mozjs", version = "=0.18", default-features = false, features = ["intl", "libz-sys"] }
+js = { package = "mozjs", git = "https://github.com/sagudev/mozjs", branch = "cell", default-features = false, features = ["intl", "libz-sys"] }
 k12 = "0.5"
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.13.1", features = ["euclid"] }

--- a/components/script/dom/webgpu/gpubindgroup.rs
+++ b/components/script/dom/webgpu/gpubindgroup.rs
@@ -5,8 +5,8 @@
 use std::borrow::Cow;
 
 use dom_struct::dom_struct;
+use js::cell::JSCell;
 use js::context::{JSContext, NoGC};
-use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPUBindGroup, WebGPUDevice, WebGPURequest};
 use wgpu_core::binding_model::BindGroupDescriptor;
@@ -49,7 +49,8 @@ impl Drop for DroppableGPUBindGroup {
 #[dom_struct]
 pub(crate) struct GPUBindGroup {
     reflector_: Reflector,
-    label: DomRefCell<USVString>,
+    #[ignore_malloc_size_of = "JSCell is hard to measure"]
+    label: JSCell<USVString>,
     #[no_trace]
     device: WebGPUDevice,
     layout: Dom<GPUBindGroupLayout>,
@@ -66,7 +67,7 @@ impl GPUBindGroup {
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
-            label: DomRefCell::new(label),
+            label: JSCell::new(label),
             device,
             layout: Dom::from_ref(layout),
             droppable: DroppableGPUBindGroup {
@@ -145,12 +146,12 @@ impl GPUBindGroup {
 
 impl GPUBindGroupMethods<crate::DomTypeHolder> for GPUBindGroup {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn Label(&self) -> USVString {
-        self.label.borrow().clone()
+    fn Label(&self, no_gc: &NoGC) -> USVString {
+        self.label.borrow(no_gc).clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
-        *self.label.safe_borrow_mut(no_gc) = value;
+    fn SetLabel(&self, no_gc_mut: &mut NoGC, value: USVString) {
+        *self.label.borrow_mut(no_gc_mut) = value;
     }
 }

--- a/components/script/dom/webgpu/gpubindgrouplayout.rs
+++ b/components/script/dom/webgpu/gpubindgrouplayout.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
-use script_bindings::cell::DomRefCell;
+use js::cell::JSCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPUBindGroupLayout, WebGPURequest};
 use wgpu_core::binding_model::BindGroupLayoutDescriptor;
@@ -49,7 +49,8 @@ impl Drop for DroppableGPUBindGroupLayout {
 #[dom_struct]
 pub(crate) struct GPUBindGroupLayout {
     reflector_: Reflector,
-    label: DomRefCell<USVString>,
+    #[ignore_malloc_size_of = "JSCell is hard to measure"]
+    label: JSCell<USVString>,
     droppable: DroppableGPUBindGroupLayout,
 }
 
@@ -61,7 +62,7 @@ impl GPUBindGroupLayout {
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
-            label: DomRefCell::new(label),
+            label: JSCell::new(label),
             droppable: DroppableGPUBindGroupLayout {
                 channel,
                 bind_group_layout,
@@ -141,12 +142,12 @@ impl GPUBindGroupLayout {
 
 impl GPUBindGroupLayoutMethods<crate::DomTypeHolder> for GPUBindGroupLayout {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn Label(&self) -> USVString {
-        self.label.borrow().clone()
+    fn Label(&self, no_gc: &NoGC) -> USVString {
+        self.label.borrow(no_gc).clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
-        *self.label.safe_borrow_mut(no_gc) = value;
+    fn SetLabel(&self, no_gc_mut: &mut NoGC, value: USVString) {
+        *self.label.borrow_mut(no_gc_mut) = value;
     }
 }

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -8,6 +8,7 @@ use std::string::String;
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
+use js::cell::JSCell;
 use js::realm::CurrentRealm;
 use js::typedarray::HeapArrayBuffer;
 use script_bindings::cell::DomRefCell;
@@ -74,7 +75,8 @@ pub(crate) struct GPUBuffer {
     reflector_: Reflector,
     #[no_trace]
     channel: WebGPU,
-    label: DomRefCell<USVString>,
+    #[ignore_malloc_size_of = "JSCell is hard to measure"]
+    label: JSCell<USVString>,
     #[no_trace]
     buffer: WebGPUBuffer,
     device: Dom<GPUDevice>,
@@ -102,7 +104,7 @@ impl GPUBuffer {
         Self {
             reflector_: Reflector::new(),
             channel,
-            label: DomRefCell::new(label),
+            label: JSCell::new(label),
             device: Dom::from_ref(device),
             buffer,
             pending_map: DomRefCell::new(None),
@@ -356,13 +358,13 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn Label(&self) -> USVString {
-        self.label.borrow().clone()
+    fn Label(&self, no_gc: &NoGC) -> USVString {
+        self.label.borrow(no_gc).clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
-        *self.label.safe_borrow_mut(no_gc) = value;
+    fn SetLabel(&self, no_gc_mut: &mut NoGC, value: USVString) {
+        *self.label.borrow_mut(no_gc_mut) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-size>

--- a/components/script/dom/webgpu/gpucommandbuffer.rs
+++ b/components/script/dom/webgpu/gpucommandbuffer.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
-use script_bindings::cell::DomRefCell;
+use js::cell::JSCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPUCommandBuffer, WebGPURequest};
 
@@ -39,7 +39,8 @@ impl Drop for DroppableGPUCommandBuffer {
 #[dom_struct]
 pub(crate) struct GPUCommandBuffer {
     reflector_: Reflector,
-    label: DomRefCell<USVString>,
+    #[ignore_malloc_size_of = "JSCell is hard to measure"]
+    label: JSCell<USVString>,
     droppable: DroppableGPUCommandBuffer,
 }
 
@@ -51,7 +52,7 @@ impl GPUCommandBuffer {
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
-            label: DomRefCell::new(label),
+            label: JSCell::new(label),
             droppable: DroppableGPUCommandBuffer {
                 channel,
                 command_buffer,
@@ -86,12 +87,12 @@ impl GPUCommandBuffer {
 
 impl GPUCommandBufferMethods<crate::DomTypeHolder> for GPUCommandBuffer {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn Label(&self) -> USVString {
-        self.label.borrow().clone()
+    fn Label(&self, no_gc: &NoGC) -> USVString {
+        self.label.borrow(no_gc).clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
-        *self.label.safe_borrow_mut(no_gc) = value;
+    fn SetLabel(&self, no_gc_mut: &mut NoGC, value: USVString) {
+        *self.label.borrow_mut(no_gc_mut) = value;
     }
 }

--- a/components/script/dom/webgpu/gpucommandencoder.rs
+++ b/components/script/dom/webgpu/gpucommandencoder.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
-use script_bindings::cell::DomRefCell;
+use js::cell::JSCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{
     WebGPU, WebGPUCommandBuffer, WebGPUCommandEncoder, WebGPUComputePass, WebGPUDevice,
@@ -43,7 +43,8 @@ struct DroppableGPUCommandEncoder {
 pub(crate) struct GPUCommandEncoder {
     reflector_: Reflector,
     droppable: DroppableGPUCommandEncoder,
-    label: DomRefCell<USVString>,
+    #[ignore_malloc_size_of = "JSCell is hard to measure"]
+    label: JSCell<USVString>,
     device: Dom<GPUDevice>,
 }
 
@@ -69,7 +70,7 @@ impl GPUCommandEncoder {
         Self {
             droppable: DroppableGPUCommandEncoder { channel, encoder },
             reflector_: Reflector::new(),
-            label: DomRefCell::new(label),
+            label: JSCell::new(label),
             device: Dom::from_ref(device),
         }
     }
@@ -135,13 +136,13 @@ impl GPUCommandEncoder {
 
 impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn Label(&self) -> USVString {
-        self.label.borrow().clone()
+    fn Label(&self, no_gc: &NoGC) -> USVString {
+        self.label.borrow(no_gc).clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
-        *self.label.safe_borrow_mut(no_gc) = value;
+    fn SetLabel(&self, no_gc_mut: &mut NoGC, value: USVString) {
+        *self.label.borrow_mut(no_gc_mut) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-begincomputepass>

--- a/components/script/dom/webgpu/gpucomputepassencoder.rs
+++ b/components/script/dom/webgpu/gpucomputepassencoder.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
-use script_bindings::cell::DomRefCell;
+use js::cell::JSCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPUComputePass, WebGPURequest};
 
@@ -40,7 +40,8 @@ impl Drop for DroppableGPUComputePassEncoder {
 #[dom_struct]
 pub(crate) struct GPUComputePassEncoder {
     reflector_: Reflector,
-    label: DomRefCell<USVString>,
+    #[ignore_malloc_size_of = "JSCell is hard to measure"]
+    label: JSCell<USVString>,
     command_encoder: Dom<GPUCommandEncoder>,
     droppable: DroppableGPUComputePassEncoder,
 }
@@ -54,7 +55,7 @@ impl GPUComputePassEncoder {
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
-            label: DomRefCell::new(label),
+            label: JSCell::new(label),
             command_encoder: Dom::from_ref(parent),
             droppable: DroppableGPUComputePassEncoder {
                 channel,
@@ -86,13 +87,13 @@ impl GPUComputePassEncoder {
 
 impl GPUComputePassEncoderMethods<crate::DomTypeHolder> for GPUComputePassEncoder {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn Label(&self) -> USVString {
-        self.label.borrow().clone()
+    fn Label(&self, no_gc: &NoGC) -> USVString {
+        self.label.borrow(no_gc).clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
-        *self.label.safe_borrow_mut(no_gc) = value;
+    fn SetLabel(&self, no_gc_mut: &mut NoGC, value: USVString) {
+        *self.label.borrow_mut(no_gc_mut) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucomputepassencoder-dispatchworkgroups>

--- a/components/script/dom/webgpu/gpucomputepipeline.rs
+++ b/components/script/dom/webgpu/gpucomputepipeline.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
-use script_bindings::cell::DomRefCell;
+use js::cell::JSCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::generic_channel::GenericCallback;
 use webgpu_traits::{
@@ -51,7 +51,8 @@ impl Drop for DroppableGPUComputePipeline {
 #[dom_struct]
 pub(crate) struct GPUComputePipeline {
     reflector_: Reflector,
-    label: DomRefCell<USVString>,
+    #[ignore_malloc_size_of = "JSCell is hard to measure"]
+    label: JSCell<USVString>,
     device: Dom<GPUDevice>,
     droppable: DroppableGPUComputePipeline,
 }
@@ -64,7 +65,7 @@ impl GPUComputePipeline {
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
-            label: DomRefCell::new(label),
+            label: JSCell::new(label),
             device: Dom::from_ref(device),
             droppable: DroppableGPUComputePipeline {
                 channel: device.channel(),
@@ -131,13 +132,13 @@ impl GPUComputePipeline {
 
 impl GPUComputePipelineMethods<crate::DomTypeHolder> for GPUComputePipeline {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn Label(&self) -> USVString {
-        self.label.borrow().clone()
+    fn Label(&self, no_gc: &NoGC) -> USVString {
+        self.label.borrow(no_gc).clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
-        *self.label.safe_borrow_mut(no_gc) = value;
+    fn SetLabel(&self, no_gc_mut: &mut NoGC, value: USVString) {
+        *self.label.borrow_mut(no_gc_mut) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpupipelinebase-getbindgrouplayout>

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -10,6 +10,7 @@ use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
 use js::jsapi::{HandleObject, Heap, JSObject};
 use js::realm::CurrentRealm;
+use js::cell::JSCell;
 use script_bindings::cell::DomRefCell;
 use script_bindings::cformat;
 use script_bindings::reflector::reflect_dom_object_with_cx;
@@ -98,7 +99,8 @@ pub(crate) struct GPUDevice {
     features: Dom<GPUSupportedFeatures>,
     limits: Dom<GPUSupportedLimits>,
     adapter_info: Dom<GPUAdapterInfo>,
-    label: DomRefCell<USVString>,
+    #[ignore_malloc_size_of = "JSCell is hard to measure"]
+    label: JSCell<USVString>,
     default_queue: Dom<GPUQueue>,
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-lost>
     #[conditional_malloc_size_of]
@@ -141,7 +143,7 @@ impl GPUDevice {
             features: Dom::from_ref(features),
             limits: Dom::from_ref(limits),
             adapter_info: Dom::from_ref(adapter_info),
-            label: DomRefCell::new(USVString::from(label)),
+            label: JSCell::new(USVString::from(label)),
             default_queue: Dom::from_ref(queue),
             lost_promise: DomRefCell::new(lost_promise),
             valid: Cell::new(true),
@@ -434,13 +436,13 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn Label(&self) -> USVString {
-        self.label.borrow().clone()
+    fn Label(&self, no_gc: &NoGC) -> USVString {
+        self.label.borrow(no_gc).clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
-        *self.label.safe_borrow_mut(no_gc) = value;
+    fn SetLabel(&self, no_gc_mut: &mut NoGC, value: USVString) {
+        *self.label.borrow_mut(no_gc_mut) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-lost>

--- a/components/script/dom/webgpu/gpupipelinelayout.rs
+++ b/components/script/dom/webgpu/gpupipelinelayout.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
-use script_bindings::cell::DomRefCell;
+use js::cell::JSCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPUBindGroupLayout, WebGPUPipelineLayout, WebGPURequest};
 use wgpu_core::binding_model::PipelineLayoutDescriptor;
@@ -47,7 +47,8 @@ impl Drop for DroppableGPUPipelineLayout {
 #[dom_struct]
 pub(crate) struct GPUPipelineLayout {
     reflector_: Reflector,
-    label: DomRefCell<USVString>,
+    #[ignore_malloc_size_of = "JSCell is hard to measure"]
+    label: JSCell<USVString>,
     #[no_trace]
     bind_group_layouts: Vec<WebGPUBindGroupLayout>,
     droppable: DroppableGPUPipelineLayout,
@@ -62,7 +63,7 @@ impl GPUPipelineLayout {
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
-            label: DomRefCell::new(label),
+            label: JSCell::new(label),
             bind_group_layouts: bgls,
             droppable: DroppableGPUPipelineLayout {
                 channel,
@@ -145,12 +146,12 @@ impl GPUPipelineLayout {
 
 impl GPUPipelineLayoutMethods<crate::DomTypeHolder> for GPUPipelineLayout {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn Label(&self) -> USVString {
-        self.label.borrow().clone()
+    fn Label(&self, no_gc: &NoGC) -> USVString {
+        self.label.borrow(no_gc).clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
-        *self.label.safe_borrow_mut(no_gc) = value;
+    fn SetLabel(&self, no_gc_mut: &mut NoGC, value: USVString) {
+        *self.label.borrow_mut(no_gc_mut) = value;
     }
 }

--- a/components/script/dom/webgpu/gpuqueryset.rs
+++ b/components/script/dom/webgpu/gpuqueryset.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
-use script_bindings::cell::DomRefCell;
+use js::cell::JSCell;
 use script_bindings::codegen::GenericBindings::WebGPUBinding::{GPUDeviceMethods, GPUQueryType};
 use script_bindings::error::{Error, Fallible};
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
@@ -46,7 +46,8 @@ impl Drop for DroppableGPUQuerySet {
 pub(crate) struct GPUQuerySet {
     reflector_: Reflector,
     droppable: DroppableGPUQuerySet,
-    label: DomRefCell<USVString>,
+    #[ignore_malloc_size_of = "JSCell is hard to measure"]
+    label: JSCell<USVString>,
     r#type: GPUQueryType,
     count: u32,
 }
@@ -61,7 +62,7 @@ impl GPUQuerySet {
     ) -> Self {
         GPUQuerySet {
             reflector_: Reflector::new(),
-            label: DomRefCell::new(label),
+            label: JSCell::new(label),
             droppable: DroppableGPUQuerySet { channel, query_set },
             r#type,
             count,
@@ -152,13 +153,13 @@ impl GPUQuerySetMethods<crate::DomTypeHolder> for GPUQuerySet {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn Label(&self) -> USVString {
-        self.label.borrow().clone()
+    fn Label(&self, no_gc: &NoGC) -> USVString {
+        self.label.borrow(no_gc).clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
-        *self.label.safe_borrow_mut(no_gc) = value;
+    fn SetLabel(&self, no_gc_mut: &mut NoGC, value: USVString) {
+        *self.label.borrow_mut(no_gc_mut) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueryset-type>

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -6,8 +6,8 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
+use js::cell::JSCell;
 use pixels::{SnapshotAlphaMode, SnapshotPixelFormat};
-use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::CanvasRenderingContext2DBinding::ImageDataMethods;
 use script_bindings::codegen::GenericBindings::HTMLCanvasElementBinding::HTMLCanvasElementMethods;
 use script_bindings::codegen::GenericBindings::HTMLImageElementBinding::HTMLImageElementMethods;
@@ -44,8 +44,10 @@ pub(crate) struct GPUQueue {
     #[ignore_malloc_size_of = "defined in webgpu"]
     #[no_trace]
     channel: WebGPU,
-    device: DomRefCell<Option<Dom<GPUDevice>>>,
-    label: DomRefCell<USVString>,
+    #[ignore_malloc_size_of = "JSCell is hard to measure"]
+    device: JSCell<Option<Dom<GPUDevice>>>,
+    #[ignore_malloc_size_of = "JSCell is hard to measure"]
+    label: JSCell<USVString>,
     #[no_trace]
     queue: WebGPUQueue,
 }
@@ -55,8 +57,8 @@ impl GPUQueue {
         GPUQueue {
             channel,
             reflector_: Reflector::new(),
-            device: DomRefCell::new(None),
-            label: DomRefCell::new(USVString::default()),
+            device: JSCell::new(None),
+            label: JSCell::new(USVString::default()),
             queue,
         }
     }
@@ -76,8 +78,8 @@ impl GPUQueue {
 }
 
 impl GPUQueue {
-    pub(crate) fn set_device(&self, no_gc: &NoGC, device: &GPUDevice) {
-        *self.device.safe_borrow_mut(no_gc) = Some(Dom::from_ref(device));
+    pub(crate) fn set_device(&self, no_gc: &mut NoGC, device: &GPUDevice) {
+        *self.device.borrow_mut(no_gc) = Some(Dom::from_ref(device));
     }
 
     pub(crate) fn id(&self) -> WebGPUQueue {
@@ -87,22 +89,22 @@ impl GPUQueue {
 
 impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn Label(&self) -> USVString {
-        self.label.borrow().clone()
+    fn Label(&self, no_gc: &NoGC) -> USVString {
+        self.label.borrow(no_gc).clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
-        *self.label.safe_borrow_mut(no_gc) = value;
+    fn SetLabel(&self, no_gc_mut: &mut NoGC, value: USVString) {
+        *self.label.borrow_mut(no_gc_mut) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueue-submit>
-    fn Submit(&self, command_buffers: Vec<DomRoot<GPUCommandBuffer>>) {
+    fn Submit(&self, no_gc: &NoGC, command_buffers: Vec<DomRoot<GPUCommandBuffer>>) {
         let command_buffers = command_buffers.iter().map(|cb| cb.id().0).collect();
         self.channel
             .0
             .send(WebGPURequest::Submit {
-                device_id: self.device.borrow().as_ref().unwrap().id().0,
+                device_id: self.device.borrow(no_gc).as_ref().unwrap().id().0,
                 queue_id: self.queue.0,
                 command_buffers,
             })
@@ -113,6 +115,7 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
     #[expect(unsafe_code)]
     fn WriteBuffer(
         &self,
+        no_gc: &NoGC,
         buffer: &GPUBuffer,
         buffer_offset: GPUSize64,
         data: BufferSource,
@@ -162,7 +165,7 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
             },
         };
         if let Err(e) = self.channel.0.send(WebGPURequest::WriteBuffer {
-            device_id: self.device.borrow().as_ref().unwrap().id().0,
+            device_id: self.device.borrow(no_gc).as_ref().unwrap().id().0,
             queue_id: self.queue.0,
             buffer_id: buffer.id().0,
             buffer_offset,
@@ -178,6 +181,7 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueue-writetexture>
     fn WriteTexture(
         &self,
+        no_gc: &NoGC,
         destination: &GPUTexelCopyTextureInfo,
         data: BufferSource,
         data_layout: &GPUTexelCopyBufferLayout,
@@ -199,7 +203,7 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
         let final_data = GenericSharedMemory::from_bytes(&bytes);
 
         if let Err(e) = self.channel.0.send(WebGPURequest::WriteTexture {
-            device_id: self.device.borrow().as_ref().unwrap().id().0,
+            device_id: self.device.borrow(no_gc).as_ref().unwrap().id().0,
             queue_id: self.queue.0,
             texture_cv,
             data_layout: texture_layout,
@@ -336,7 +340,7 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
             },
         };
         // this is out ouf spec, but we currently do not support more
-        let texture_descriptor = destination.parent.texture.wgpu_texture_descriptor();
+        let texture_descriptor = destination.parent.texture.wgpu_texture_descriptor(cx);
         let target_snapshot_format =
             match texture_descriptor.format {
                 wgpu_types::TextureFormat::Bgra8Unorm |
@@ -366,7 +370,7 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
             .channel
             .0
             .send(WebGPURequest::CopyExternalImageToTexture {
-                device_id: self.device.borrow().as_ref().unwrap().id().0,
+                device_id: self.device.borrow(cx).as_ref().unwrap().id().0,
                 queue_id: self.queue.0,
                 usable_source: usable_snapshot,
                 destination: destination_tex_info,

--- a/components/script/dom/webgpu/gpurenderbundle.rs
+++ b/components/script/dom/webgpu/gpurenderbundle.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
-use script_bindings::cell::DomRefCell;
+use js::cell::JSCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPUDevice, WebGPURenderBundle, WebGPURequest};
 
@@ -41,7 +41,8 @@ pub(crate) struct GPURenderBundle {
     reflector_: Reflector,
     #[no_trace]
     device: WebGPUDevice,
-    label: DomRefCell<USVString>,
+    #[ignore_malloc_size_of = "JSCell is hard to measure"]
+    label: JSCell<USVString>,
     droppable: DroppableGPURenderBundle,
 }
 
@@ -55,7 +56,7 @@ impl GPURenderBundle {
         Self {
             reflector_: Reflector::new(),
             device,
-            label: DomRefCell::new(label),
+            label: JSCell::new(label),
             droppable: DroppableGPURenderBundle {
                 channel,
                 render_bundle,
@@ -92,12 +93,12 @@ impl GPURenderBundle {
 
 impl GPURenderBundleMethods<crate::DomTypeHolder> for GPURenderBundle {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn Label(&self) -> USVString {
-        self.label.borrow().clone()
+    fn Label(&self, no_gc: &NoGC) -> USVString {
+        self.label.borrow(no_gc).clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
-        *self.label.safe_borrow_mut(no_gc) = value;
+    fn SetLabel(&self, no_gc_mut: &mut NoGC, value: USVString) {
+        *self.label.borrow_mut(no_gc_mut) = value;
     }
 }

--- a/components/script/dom/webgpu/gpurenderbundleencoder.rs
+++ b/components/script/dom/webgpu/gpurenderbundleencoder.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
-use script_bindings::cell::DomRefCell;
+use js::cell::JSCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{
     RenderBundleCommand, WebGPU, WebGPURenderBundle, WebGPURenderBundleEncoder, WebGPURequest,
@@ -54,7 +54,8 @@ impl Drop for DroppableGPURenderBundleEncoder {
 pub(crate) struct GPURenderBundleEncoder {
     reflector_: Reflector,
     device: Dom<GPUDevice>,
-    label: DomRefCell<USVString>,
+    #[ignore_malloc_size_of = "JSCell is hard to measure"]
+    label: JSCell<USVString>,
     droppable: DroppableGPURenderBundleEncoder,
 }
 
@@ -72,7 +73,7 @@ impl GPURenderBundleEncoder {
                 channel,
                 render_bundle_encoder,
             },
-            label: DomRefCell::new(label),
+            label: JSCell::new(label),
         }
     }
 
@@ -171,13 +172,13 @@ impl GPURenderBundleEncoder {
 
 impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEncoder {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn Label(&self) -> USVString {
-        self.label.borrow().clone()
+    fn Label(&self, no_gc: &NoGC) -> USVString {
+        self.label.borrow(no_gc).clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
-        *self.label.safe_borrow_mut(no_gc) = value;
+    fn SetLabel(&self, no_gc_mut: &mut NoGC, value: USVString) {
+        *self.label.borrow_mut(no_gc_mut) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuprogrammablepassencoder-setbindgroup>

--- a/components/script/dom/webgpu/gpurenderpassencoder.rs
+++ b/components/script/dom/webgpu/gpurenderpassencoder.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
-use script_bindings::cell::DomRefCell;
+use js::cell::JSCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{RenderCommand, WebGPU, WebGPURenderPass, WebGPURequest};
 
@@ -45,7 +45,8 @@ impl Drop for DroppableGPURenderPassEncoder {
 #[dom_struct]
 pub(crate) struct GPURenderPassEncoder {
     reflector_: Reflector,
-    label: DomRefCell<USVString>,
+    #[ignore_malloc_size_of = "JSCell is hard to measure"]
+    label: JSCell<USVString>,
     command_encoder: Dom<GPUCommandEncoder>,
     droppable: DroppableGPURenderPassEncoder,
 }
@@ -59,7 +60,7 @@ impl GPURenderPassEncoder {
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
-            label: DomRefCell::new(label),
+            label: JSCell::new(label),
             command_encoder: Dom::from_ref(parent),
             droppable: DroppableGPURenderPassEncoder {
                 channel,
@@ -112,13 +113,13 @@ impl GPURenderPassEncoder {
 
 impl GPURenderPassEncoderMethods<crate::DomTypeHolder> for GPURenderPassEncoder {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn Label(&self) -> USVString {
-        self.label.borrow().clone()
+    fn Label(&self, no_gc: &NoGC) -> USVString {
+        self.label.borrow(no_gc).clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
-        *self.label.safe_borrow_mut(no_gc) = value;
+    fn SetLabel(&self, no_gc_mut: &mut NoGC, value: USVString) {
+        *self.label.borrow_mut(no_gc_mut) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuprogrammablepassencoder-setbindgroup>

--- a/components/script/dom/webgpu/gpurenderpipeline.rs
+++ b/components/script/dom/webgpu/gpurenderpipeline.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
-use script_bindings::cell::DomRefCell;
+use js::cell::JSCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::generic_channel::GenericCallback;
 use webgpu_traits::{
@@ -48,7 +48,8 @@ impl Drop for DroppableGPURenderPipeline {
 #[dom_struct]
 pub(crate) struct GPURenderPipeline {
     reflector_: Reflector,
-    label: DomRefCell<USVString>,
+    #[ignore_malloc_size_of = "JSCell is hard to measure"]
+    label: JSCell<USVString>,
     device: Dom<GPUDevice>,
     droppable: DroppableGPURenderPipeline,
 }
@@ -61,7 +62,7 @@ impl GPURenderPipeline {
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
-            label: DomRefCell::new(label),
+            label: JSCell::new(label),
             device: Dom::from_ref(device),
             droppable: DroppableGPURenderPipeline {
                 channel: device.channel(),
@@ -119,13 +120,13 @@ impl GPURenderPipeline {
 
 impl GPURenderPipelineMethods<crate::DomTypeHolder> for GPURenderPipeline {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn Label(&self) -> USVString {
-        self.label.borrow().clone()
+    fn Label(&self, no_gc: &NoGC) -> USVString {
+        self.label.borrow(no_gc).clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
-        *self.label.safe_borrow_mut(no_gc) = value;
+    fn SetLabel(&self, no_gc_mut: &mut NoGC, value: USVString) {
+        *self.label.borrow_mut(no_gc_mut) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpupipelinebase-getbindgrouplayout>

--- a/components/script/dom/webgpu/gpusampler.rs
+++ b/components/script/dom/webgpu/gpusampler.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
-use script_bindings::cell::DomRefCell;
+use js::cell::JSCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPUDevice, WebGPURequest, WebGPUSampler};
 use wgpu_core::resource::SamplerDescriptor;
@@ -42,7 +42,8 @@ impl Drop for DroppableGPUSampler {
 #[dom_struct]
 pub(crate) struct GPUSampler {
     reflector_: Reflector,
-    label: DomRefCell<USVString>,
+    #[ignore_malloc_size_of = "JSCell is hard to measure"]
+    label: JSCell<USVString>,
     #[no_trace]
     device: WebGPUDevice,
     compare_enable: bool,
@@ -59,7 +60,7 @@ impl GPUSampler {
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
-            label: DomRefCell::new(label),
+            label: JSCell::new(label),
             device,
             compare_enable,
             dropppable: DroppableGPUSampler { channel, sampler },
@@ -145,12 +146,12 @@ impl GPUSampler {
 
 impl GPUSamplerMethods<crate::DomTypeHolder> for GPUSampler {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn Label(&self) -> USVString {
-        self.label.borrow().clone()
+    fn Label(&self, no_gc: &NoGC) -> USVString {
+        self.label.borrow(no_gc).clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
-        *self.label.safe_borrow_mut(no_gc) = value;
+    fn SetLabel(&self, no_gc_mut: &mut NoGC, value: USVString) {
+        *self.label.borrow_mut(no_gc_mut) = value;
     }
 }

--- a/components/script/dom/webgpu/gpushadermodule.rs
+++ b/components/script/dom/webgpu/gpushadermodule.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
 use js::realm::CurrentRealm;
-use script_bindings::cell::DomRefCell;
+use js::cell::JSCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{ShaderCompilationInfo, WebGPU, WebGPURequest, WebGPUShaderModule};
 
@@ -50,7 +50,8 @@ impl Drop for DroppableGPUShaderModule {
 #[dom_struct]
 pub(crate) struct GPUShaderModule {
     reflector_: Reflector,
-    label: DomRefCell<USVString>,
+    #[ignore_malloc_size_of = "JSCell is hard to measure"]
+    label: JSCell<USVString>,
     #[ignore_malloc_size_of = "promise"]
     compilation_info_promise: Rc<Promise>,
     droppable: DroppableGPUShaderModule,
@@ -65,7 +66,7 @@ impl GPUShaderModule {
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
-            label: DomRefCell::new(label),
+            label: JSCell::new(label),
             compilation_info_promise: promise,
             droppable: DroppableGPUShaderModule {
                 channel,
@@ -141,13 +142,13 @@ impl GPUShaderModule {
 
 impl GPUShaderModuleMethods<crate::DomTypeHolder> for GPUShaderModule {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn Label(&self) -> USVString {
-        self.label.borrow().clone()
+    fn Label(&self, no_gc: &NoGC) -> USVString {
+        self.label.borrow(no_gc).clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
-        *self.label.safe_borrow_mut(no_gc) = value;
+    fn SetLabel(&self, no_gc_mut: &mut NoGC, value: USVString) {
+        *self.label.borrow_mut(no_gc_mut) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpushadermodule-getcompilationinfo>

--- a/components/script/dom/webgpu/gputexture.rs
+++ b/components/script/dom/webgpu/gputexture.rs
@@ -6,7 +6,7 @@ use std::string::String;
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
-use script_bindings::cell::DomRefCell;
+use js::cell::JSCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPURequest, WebGPUTexture, WebGPUTextureView};
 use wgpu_core::resource::{self, TextureDescriptor};
@@ -51,7 +51,8 @@ impl Drop for DroppableGPUTexture {
 #[dom_struct]
 pub(crate) struct GPUTexture {
     reflector_: Reflector,
-    label: DomRefCell<USVString>,
+    #[ignore_malloc_size_of = "JSCell is hard to measure"]
+    label: JSCell<USVString>,
     device: Dom<GPUDevice>,
     #[no_trace]
     #[ignore_malloc_size_of = "External type"]
@@ -81,7 +82,7 @@ impl GPUTexture {
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
-            label: DomRefCell::new(label),
+            label: JSCell::new(label),
             device: Dom::from_ref(device),
             texture_size,
             mip_level_count,
@@ -133,9 +134,9 @@ impl GPUTexture {
         self.droppable.texture
     }
 
-    pub(crate) fn wgpu_texture_descriptor(&self) -> TextureDescriptor<'static> {
+    pub(crate) fn wgpu_texture_descriptor(&self, no_gc: &NoGC) -> TextureDescriptor<'static> {
         TextureDescriptor {
-            label: Some(self.label.borrow().to_string().into()),
+            label: Some(self.label.borrow(no_gc).to_string().into()),
             size: self.texture_size,
             mip_level_count: self.mip_level_count,
             sample_count: self.sample_count,
@@ -196,13 +197,13 @@ impl GPUTexture {
 
 impl GPUTextureMethods<crate::DomTypeHolder> for GPUTexture {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn Label(&self) -> USVString {
-        self.label.borrow().clone()
+    fn Label(&self, no_gc: &NoGC) -> USVString {
+        self.label.borrow(no_gc).clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
-        *self.label.safe_borrow_mut(no_gc) = value;
+    fn SetLabel(&self, no_gc_mut: &mut NoGC, value: USVString) {
+        *self.label.borrow_mut(no_gc_mut) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gputexture-createview>

--- a/components/script/dom/webgpu/gputextureview.rs
+++ b/components/script/dom/webgpu/gputextureview.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
-use script_bindings::cell::DomRefCell;
+use js::cell::JSCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPURequest, WebGPUTextureView};
 
@@ -41,7 +41,8 @@ impl Drop for DroppableGPUTextureView {
 #[dom_struct]
 pub(crate) struct GPUTextureView {
     reflector_: Reflector,
-    label: DomRefCell<USVString>,
+    #[ignore_malloc_size_of = "JSCell is hard to measure"]
+    label: JSCell<USVString>,
     texture: Dom<GPUTexture>,
     droppable: DroppableGPUTextureView,
 }
@@ -56,7 +57,7 @@ impl GPUTextureView {
         Self {
             reflector_: Reflector::new(),
             texture: Dom::from_ref(texture),
-            label: DomRefCell::new(label),
+            label: JSCell::new(label),
             droppable: DroppableGPUTextureView {
                 channel,
                 texture_view,
@@ -93,12 +94,12 @@ impl GPUTextureView {
 
 impl GPUTextureViewMethods<crate::DomTypeHolder> for GPUTextureView {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn Label(&self) -> USVString {
-        self.label.borrow().clone()
+    fn Label(&self, no_gc: &NoGC) -> USVString {
+        self.label.borrow(no_gc).clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
-        *self.label.safe_borrow_mut(no_gc) = value;
+    fn SetLabel(&self, no_gc_mut: &mut NoGC, value: USVString) {
+        *self.label.borrow_mut(no_gc_mut) = value;
     }
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -481,18 +481,21 @@ DOMInterfaces = {
 },
 
 'GPUBindGroup': {
-    'no_gc': ['SetLabel'],
+    'no_gc': ['Label'],
+    'no_gc_mut': ['SetLabel'],
 },
 
 'GPUBindGroupLayout': {
-    'no_gc': ['SetLabel'],
+    'no_gc': ['Label'],
+    'no_gc_mut': ['SetLabel'],
 },
 
 'GPUBuffer': {
     'realm': ['MapAsync'],
     'cx': ['Destroy', 'GetMappedRange',  'Unmap', 'PopErrorScope'],
     'allowDropImpl': True,
-    'no_gc': ['SetLabel'],
+    'no_gc': ['Label'],
+    'no_gc_mut': ['SetLabel'],
 },
 
 'GPUCanvasContext': {
@@ -502,11 +505,13 @@ DOMInterfaces = {
 
 'GPUCommandEncoder': {
     'cx': ['BeginComputePass', 'BeginRenderPass', 'Finish'],
-    'no_gc': ['SetLabel'],
+    'no_gc': ['Label'],
+    'no_gc_mut': ['SetLabel'],
 },
 
 'GPUCommandBuffer': {
-    'no_gc': ['SetLabel'],
+    'no_gc': ['Label'],
+    'no_gc_mut': ['SetLabel'],
 },
 
 'GPUCompilationInfo': {
@@ -515,11 +520,13 @@ DOMInterfaces = {
 
 'GPUComputePipeline': {
     'cx': ['GetBindGroupLayout'],
-    'no_gc': ['SetLabel'],
+    'no_gc': ['Label'],
+    'no_gc_mut': ['SetLabel'],
 },
 
 'GPUComputePassEncoder': {
-    'no_gc': ['SetLabel'],
+    'no_gc': ['Label'],
+    'no_gc_mut': ['SetLabel'],
 },
 
 'GPUDevice': {
@@ -538,57 +545,71 @@ DOMInterfaces = {
         'ImportExternalTexture',
     ],
     'weakReferenceable': True, # for usage in GlobalScope https://github.com/servo/servo/issues/32519
-    'no_gc': ['SetLabel'],
+    'no_gc': ['Label'],
+    'no_gc_mut': ['SetLabel'],
 },
 
 'GPUQueue': {
     'cx': ['OnSubmittedWorkDone', 'CopyExternalImageToTexture'],
-    'no_gc': ['SetLabel'],
+    'no_gc': ['Label', 'Submit', 'WriteBuffer', 'WriteTexture'],
+    'no_gc_mut': ['SetLabel'],
 },
 
 'GPUPipelineLayout': {
-    'no_gc': ['SetLabel'],
+    'no_gc': ['Label'],
+    'no_gc_mut': ['SetLabel'],
 },
 
 'GPUQuerySet': {
-    'no_gc': ['SetLabel'],
+    'no_gc': ['Label'],
+    'no_gc_mut': ['SetLabel'],
 },
 
 'GPURenderBundleEncoder': {
     'cx': ['Finish'],
     'no_gc': [
+        'Label',
+    ],
+    'no_gc_mut': [
         'SetLabel',
     ],
 },
 
 'GPURenderBundle': {
-    'no_gc': ['SetLabel'],
+    'no_gc': ['Label'],
+    'no_gc_mut': ['SetLabel'],
 },
 
 'GPURenderPipeline': {
     'cx': ['GetBindGroupLayout'],
-    'no_gc': ['SetLabel'],
+    'no_gc': ['Label'],
+    'no_gc_mut': ['SetLabel'],
 },
 
 'GPURenderPassEncoder': {
-    'no_gc': ['SetLabel'],
+    'no_gc': ['Label'],
+    'no_gc_mut': ['SetLabel'],
 },
 
 'GPUSampler': {
-    'no_gc': ['SetLabel'],
+    'no_gc': ['Label'],
+    'no_gc_mut': ['SetLabel'],
 },
 
 'GPUShaderModule': {
-    'no_gc': ['SetLabel'],
+    'no_gc': ['Label'],
+    'no_gc_mut': ['SetLabel'],
 },
 
 'GPUTexture': {
     'cx': ['CreateView'],
-    'no_gc': ['SetLabel'],
+    'no_gc': ['Label'],
+    'no_gc_mut': ['SetLabel'],
 },
 
 'GPUTextureView': {
-    'no_gc': ['SetLabel'],
+    'no_gc': ['Label'],
+    'no_gc_mut': ['SetLabel'],
 },
 
 'History': {

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -4224,6 +4224,7 @@ class CGCallGenerator(CGThing):
 
         needs_cx_arg = (
             nativeMethodName in descriptor.no_gcMethods
+            or nativeMethodName in descriptor.no_gc_mutMethods
             or nativeMethodName in descriptor.cx_no_gcMethods
             or nativeMethodName in descriptor.cxMethods
             or nativeMethodName in descriptor.realmMethods
@@ -6987,6 +6988,7 @@ class CGInterfaceTrait(CGThing):
         def attribute_arguments(attribute_type: IDLType,
                                 argument: IDLType | None = None,
                                 no_gc: bool = False,
+                                no_gc_mut: bool = False,
                                 cx_no_gc: bool = False,
                                 cx: bool = False,
                                 realm: bool = False,
@@ -6994,10 +6996,12 @@ class CGInterfaceTrait(CGThing):
                                 ) -> Iterable[tuple[str, str]]:
             if realm:
                 yield "realm", "&mut CurrentRealm"
-            elif cx:
+            elif cx or (cx_no_gc and no_gc_mut):
                 yield "cx", "&mut JSContext"
             elif cx_no_gc:
                 yield "cx", "&JSContext"
+            elif no_gc_mut:
+                yield "cx", "&mut NoGC"
             elif no_gc:
                 yield "cx", "&NoGC"
 
@@ -7026,6 +7030,7 @@ class CGInterfaceTrait(CGThing):
                         arguments = cast(list[IDLArgument], arguments)
                         arguments = method_arguments(descriptor, rettype, arguments,
                                                      no_gc=name in descriptor.no_gcMethods,
+                                                     no_gc_mut=name in descriptor.no_gc_mutMethods,
                                                      cx_no_gc=name in descriptor.cx_no_gcMethods,
                                                      cx=name in descriptor.cxMethods or descriptor.interface.isIteratorInterface(),
                                                      realm=name in descriptor.realmMethods)
@@ -7045,6 +7050,7 @@ class CGInterfaceTrait(CGThing):
                            attribute_arguments(
                                m.type,
                                no_gc=name in descriptor.no_gcMethods,
+                               no_gc_mut=name in descriptor.no_gc_mutMethods,
                                cx_no_gc=name in descriptor.cx_no_gcMethods,
                                cx=name in descriptor.cxMethods or isEventHandlerCallback(m),
                                realm=name in descriptor.realmMethods,
@@ -7065,6 +7071,7 @@ class CGInterfaceTrait(CGThing):
                                    m.type,
                                    m.type,
                                    no_gc=name in descriptor.no_gcMethods,
+                                   no_gc_mut=name in descriptor.no_gc_mutMethods,
                                    cx_no_gc=name in descriptor.cx_no_gcMethods,
                                    cx=name in descriptor.cxMethods or descriptor.implicitCxSetters or isEventHandlerCallback(m),
                                    realm=name in descriptor.realmMethods,
@@ -7087,6 +7094,7 @@ class CGInterfaceTrait(CGThing):
                             rettype = IDLNullableType(rettype.location, rettype)
                         arguments = method_arguments(descriptor, rettype, arguments,
                                                      no_gc=name in descriptor.no_gcMethods,
+                                                     no_gc_mut=name in descriptor.no_gc_mutMethods,
                                                      cx_no_gc=name in descriptor.cx_no_gcMethods,
                                                      cx=name in descriptor.cxMethods,
                                                      realm=name in descriptor.realmMethods)
@@ -7101,6 +7109,7 @@ class CGInterfaceTrait(CGThing):
                     else:
                         arguments = method_arguments(descriptor, rettype, arguments,
                                                      no_gc=name in descriptor.no_gcMethods,
+                                                     no_gc_mut=name in descriptor.no_gc_mutMethods,
                                                      cx_no_gc=name in descriptor.cx_no_gcMethods,
                                                      cx=name in descriptor.cxMethods,
                                                      realm=name in descriptor.realmMethods)
@@ -8328,6 +8337,7 @@ def method_arguments(descriptorProvider: DescriptorProvider,
                      passJSBits: bool = True,
                      trailing: tuple[str, str] | None = None,
                      no_gc: bool = False,
+                     no_gc_mut: bool = False,
                      cx_no_gc: bool = False,
                      cx: bool = False,
                      realm: bool = False
@@ -8343,10 +8353,12 @@ def method_arguments(descriptorProvider: DescriptorProvider,
 
     if realm:
         yield "realm", "&mut CurrentRealm"
-    elif cx:
+    elif cx or (cx_no_gc and no_gc_mut):
         yield "cx", "&mut JSContext"
     elif cx_no_gc:
         yield "cx", "&JSContext"
+    elif no_gc_mut:
+        yield "cx", "&mut NoGC"
     elif no_gc:
         yield "cx", "&NoGC"
 

--- a/components/script_bindings/codegen/configuration.py
+++ b/components/script_bindings/codegen/configuration.py
@@ -291,11 +291,12 @@ class Descriptor(DescriptorProvider):
 
         # Specified here to make it explicit for the typechecker
         self.no_gcMethods: list[str] = []
+        self.no_gc_mutMethods: list[str] = []
         self.cx_no_gcMethods: list[str] = []
         self.cxMethods: list[str] = []
         self.realmMethods: list[str] = []
 
-        configurationMethods = ["no_gc", "cx_no_gc", "cx", "realm"]
+        configurationMethods = ["no_gc", "no_gc_mut", "cx_no_gc", "cx", "realm"]
         for configurationName in configurationMethods:
             setattr(self, configurationName + "Methods", [name for name in desc.get(configurationName, [])])
 


### PR DESCRIPTION
Companion PR to https://github.com/servo/mozjs/pull/773

Some interesting notes:
- layout should be taking `&mut NoGC`
- MallocSizeOf::size_of should be taking `&NoGC` (for this reason we should roll own malloc size of for script/mozjs)

Testing: It compiles and covered by WebGPU CTS.
