### PR TITLE
script: Fix Web Audio borrow hazards

### DIFF
--- a/components/script/dom/audio/audiobuffer.rs
+++ b/components/script/dom/audio/audiobuffer.rs
@@ -163,7 +163,7 @@ impl AudioBuffer {
             self.length as usize,
             self.sample_rate,
         );
-        for (i, channel) in self.js_channels.borrow_mut().iter().enumerate() {
+        for (i, channel) in self.js_channels.borrow().iter().enumerate() {
             // Step 1.
             if !channel.is_initialized() {
                 return None;

--- a/components/script/dom/audio/offlineaudiocontext.rs
+++ b/components/script/dom/audio/offlineaudiocontext.rs
@@ -192,10 +192,14 @@ impl OfflineAudioContextMethods<crate::DomTypeHolder> for OfflineAudioContext {
                         *this.context.SampleRate(),
                         Some(processed_audio.as_slice()),
                     );
-                    (*this.pending_rendering_promise.borrow_mut())
-                        .take()
-                        .unwrap()
-                        .resolve_native(cx, &buffer);
+                    let promise = {
+                        (*this
+                            .pending_rendering_promise
+                            .safe_borrow_mut(cx.no_gc()))
+                            .take()
+                            .unwrap()
+                    };
+                    promise.resolve_native(cx, &buffer);
                     let global = &this.global();
                     let window = global.as_window();
                     let event = OfflineAudioCompletionEvent::new(cx, window,


### PR DESCRIPTION
Avoid holding mutable DOM borrows across GC-capable calls.

Testing: no WPT test effeected.

Fixes: https://github.com/servo/servo/issues/46432
Fixes: https://github.com/servo/servo/issues/46433