### PR TITLE
fonts-traits: Don't implement Eq for FontTemplateDescriptor

### DIFF
--- a/components/shared/fonts/font_template.rs
+++ b/components/shared/fonts/font_template.rs
@@ -57,10 +57,6 @@ impl Default for FontTemplateDescriptor {
     }
 }
 
-/// FontTemplateDescriptor contains floats, which are not Eq because of NaN. However,
-/// we know they will never be NaN, so we can manually implement Eq.
-impl Eq for FontTemplateDescriptor {}
-
 impl FontTemplateDescriptor {
     #[inline]
     pub fn new(weight: FontWeight, stretch: FontStretch, style: FontStyle) -> Self {


### PR DESCRIPTION
The comment seems obsolete: `FontTemplateDescriptor` does not contain floats, and in fact it could just derive `Eq` if the relevant structs in Stylo also derived it.

However, `FontTemplateDescriptor` doesn't seem to need `Eq` at all, so just remove the implementation.

Testing: Not needed, no behavior change
