### PR TITLE
deps: Update mozangle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5231,9 +5231,9 @@ dependencies = [
 
 [[package]]
 name = "mozangle"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298bc7f83d5cca3789e47779e92cda492b75f11e03995bf558475bd9df2f639b"
+checksum = "60b428c032f0af701a3ca440c92e7b552c25b2a5af2b08a85077ee8e9d2ae699"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ mime = "0.3.13"
 mime_guess = "2.0.5"
 ml-dsa = { version = "0.1", features = ["zeroize"] }
 ml-kem = { version = "0.3", features = ["getrandom", "pkcs8", "zeroize"] }
-mozangle = "0.5.5"
+mozangle = { version = "0.6" }
 napi-derive-ohos = "1.2.0"
 napi-ohos = "1.2.0"
 nix = "0.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ mime = "0.3.13"
 mime_guess = "2.0.5"
 ml-dsa = { version = "0.1", features = ["zeroize"] }
 ml-kem = { version = "0.3", features = ["getrandom", "pkcs8", "zeroize"] }
-mozangle = { version = "0.6" }
+mozangle = "0.6"
 napi-derive-ohos = "1.2.0"
 napi-ohos = "1.2.0"
 nix = "0.30"


### PR DESCRIPTION
mozangle was updated based on the latest upstream ESR (140.12.0, from 115 ESR), which also fixes a number of security issues.

[mach try](https://github.com/jschwe/servo/actions/runs/29230655722)

Testing: Dependency updated, covered by existing tests
