### PR TITLE
deny: Ignore `rustybuzz` unmaintained

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -46,6 +46,7 @@ ignore = [
     # We must use this version of quick-xml until `winit` upgrades `sctk`.
     "RUSTSEC-2026-0195",
     # `rustybuzz` is unmaintained. Switch to harfrust.
+    # However, this is a dependecy of `resvg`, there's nothing we can do.
     "RUSTSEC-2026-0206",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -45,6 +45,8 @@ ignore = [
     #
     # We must use this version of quick-xml until `winit` upgrades `sctk`.
     "RUSTSEC-2026-0195",
+    # `rustybuzz` is unmaintained. Switch to harfrust.
+    "RUSTSEC-2026-0206",
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
`rustybuzz` is unmaintained. Switch to harfrust. Ignore for now.

Fixes: Lint check.
Testing: No change to code itself.