### PR TITLE
layout: Correctly slice decorations on fragmented boxes

### DIFF
--- a/components/layout/display_list/background.rs
+++ b/components/layout/display_list/background.rs
@@ -72,9 +72,9 @@ impl<'a> BackgroundPainter<'a> {
         }
 
         match get_cyclic(&background.background_clip.0, layer_index) {
-            Clip::ContentBox => *fragment_builder.content_rect(),
-            Clip::PaddingBox => *fragment_builder.padding_rect(),
-            Clip::BorderBox | Clip::BorderArea => fragment_builder.border_rect,
+            Clip::ContentBox => *fragment_builder.fragmented_content_rect(),
+            Clip::PaddingBox => *fragment_builder.fragmented_padding_rect(),
+            Clip::BorderBox | Clip::BorderArea => *fragment_builder.fragmented_border_rect(),
         }
     }
 

--- a/components/layout/display_list/hit_test.rs
+++ b/components/layout/display_list/hit_test.rs
@@ -191,6 +191,7 @@ impl Fragment {
         let mut hit_test_fragment_inner =
             |style: &ComputedValues,
              fragment_rect: PhysicalRect<Au>,
+             fragmentation_clip_rect: Option<PhysicalRect<Au>>,
              border_radius: BorderRadius,
              fragment_flags: FragmentFlags,
              auto_cursor: Cursor| {
@@ -232,12 +233,25 @@ impl Fragment {
                     if !viewport_rect.contains(hit_test.point_to_test) {
                         return false;
                     }
-                } else if !rounded_rect_contains_point(
-                    fragment_rect.to_webrender(),
-                    &border_radius,
-                    point_in_spatial_node,
-                ) {
-                    return false;
+                } else {
+                    if !rounded_rect_contains_point(
+                        fragment_rect.to_webrender(),
+                        &border_radius,
+                        point_in_spatial_node,
+                    ) {
+                        return false;
+                    }
+                    if let Some(fragmentation_clip_rect) = fragmentation_clip_rect &&
+                        !rounded_rect_contains_point(
+                            fragmentation_clip_rect
+                                .translate(state.origin.to_vector())
+                                .to_webrender(),
+                            &BorderRadius::zero(),
+                            point_in_spatial_node,
+                        )
+                    {
+                        return false;
+                    }
                 }
 
                 let point_in_target = point_in_spatial_node.cast_unit() -
@@ -266,7 +280,8 @@ impl Fragment {
             },
             Fragment::Box(box_fragment) | Fragment::Float(box_fragment) => hit_test_fragment_inner(
                 &box_fragment.style(),
-                box_fragment.border_rect(),
+                box_fragment.unfragmented_border_rect(),
+                box_fragment.fragmentation_clip_rect(),
                 box_fragment.border_radius(),
                 box_fragment.base.flags,
                 Cursor::Default,
@@ -274,6 +289,8 @@ impl Fragment {
             Fragment::Text(text) => hit_test_fragment_inner(
                 &text.base.style(),
                 text.base.rect(),
+                // Text should generally not fragment.
+                None,
                 BorderRadius::zero(),
                 FragmentFlags::empty(),
                 Cursor::Text,

--- a/components/layout/display_list/hit_test.rs
+++ b/components/layout/display_list/hit_test.rs
@@ -236,6 +236,7 @@ impl Fragment {
         let mut hit_test_fragment_inner =
             |style: &ComputedValues,
              fragment_rect: PhysicalRect<Au>,
+             fragmentation_clip_rect: Option<PhysicalRect<Au>>,
              border_radius: BorderRadius,
              fragment_flags: FragmentFlags,
              auto_cursor: Cursor| {
@@ -277,12 +278,25 @@ impl Fragment {
                     if !viewport_rect.contains(hit_test.point_to_test) {
                         return false;
                     }
-                } else if !rounded_rect_contains_point(
-                    fragment_rect.to_webrender(),
-                    &border_radius,
-                    point_in_spatial_node,
-                ) {
-                    return false;
+                } else {
+                    if !rounded_rect_contains_point(
+                        fragment_rect.to_webrender(),
+                        &border_radius,
+                        point_in_spatial_node,
+                    ) {
+                        return false;
+                    }
+                    if let Some(fragmentation_clip_rect) = fragmentation_clip_rect &&
+                        !rounded_rect_contains_point(
+                            fragmentation_clip_rect
+                                .translate(state.origin.to_vector())
+                                .to_webrender(),
+                            &BorderRadius::zero(),
+                            point_in_spatial_node,
+                        )
+                    {
+                        return false;
+                    }
                 }
 
                 let point_in_target = point_in_spatial_node.cast_unit() -
@@ -323,7 +337,8 @@ impl Fragment {
             },
             Fragment::Box(box_fragment) | Fragment::Float(box_fragment) => hit_test_fragment_inner(
                 &box_fragment.style(),
-                box_fragment.border_rect(),
+                box_fragment.unfragmented_border_rect(),
+                box_fragment.fragmentation_clip_rect(),
                 box_fragment.border_radius(),
                 box_fragment.base.flags,
                 Cursor::Default,
@@ -331,6 +346,8 @@ impl Fragment {
             Fragment::Text(text) => hit_test_fragment_inner(
                 &text.style(),
                 text.base.rect(),
+                // Text should generally not fragment.
+                None,
                 BorderRadius::zero(),
                 FragmentFlags::empty(),
                 Cursor::Text,

--- a/components/layout/display_list/hit_test.rs
+++ b/components/layout/display_list/hit_test.rs
@@ -278,25 +278,22 @@ impl Fragment {
                     if !viewport_rect.contains(hit_test.point_to_test) {
                         return false;
                     }
-                } else {
-                    if !rounded_rect_contains_point(
-                        fragment_rect.to_webrender(),
-                        &border_radius,
+                } else if !rounded_rect_contains_point(
+                    fragment_rect.to_webrender(),
+                    &border_radius,
+                    point_in_spatial_node,
+                ) {
+                    return false;
+                } else if let Some(fragmentation_clip_rect) = fragmentation_clip_rect &&
+                    !rounded_rect_contains_point(
+                        fragmentation_clip_rect
+                            .translate(state.origin.to_vector())
+                            .to_webrender(),
+                        &BorderRadius::zero(),
                         point_in_spatial_node,
-                    ) {
-                        return false;
-                    }
-                    if let Some(fragmentation_clip_rect) = fragmentation_clip_rect &&
-                        !rounded_rect_contains_point(
-                            fragmentation_clip_rect
-                                .translate(state.origin.to_vector())
-                                .to_webrender(),
-                            &BorderRadius::zero(),
-                            point_in_spatial_node,
-                        )
-                    {
-                        return false;
-                    }
+                    )
+                {
+                    return false;
                 }
 
                 let point_in_target = point_in_spatial_node.cast_unit() -
@@ -346,7 +343,7 @@ impl Fragment {
             Fragment::Text(text) => hit_test_fragment_inner(
                 &text.style(),
                 text.base.rect(),
-                // Text should generally not fragment.
+                // Text currently never fragments in Servo.
                 None,
                 BorderRadius::zero(),
                 FragmentFlags::empty(),

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -378,18 +378,32 @@ impl DisplayListBuilder<'_> {
         radii: wr::BorderRadius,
         rect: units::LayoutRect,
         force_clip_creation: bool,
+        fragmentation_rect: Option<units::LayoutRect>,
     ) -> Option<ClipChainId> {
-        if radii.is_zero() && !force_clip_creation {
-            return None;
+        let mut clip_chain_id = None;
+        let mut parent_clip_id = state.clip_id;
+        if !radii.is_zero() || force_clip_creation {
+            clip_chain_id = Some(self.add_clip_to_display_list(&Clip {
+                id: ClipId(self.clip_map.len()),
+                radii,
+                rect,
+                parent_scroll_node_id: state.spatial_id,
+                parent_clip_id,
+            }));
+            parent_clip_id = ClipId(self.clip_map.len() - 1)
         }
 
-        Some(self.add_clip_to_display_list(&Clip {
-            id: ClipId(self.clip_map.len()),
-            radii,
-            rect,
-            parent_scroll_node_id: state.spatial_id,
-            parent_clip_id: state.clip_id,
-        }))
+        if let Some(fragmentation_rect) = fragmentation_rect {
+            clip_chain_id = Some(self.add_clip_to_display_list(&Clip {
+                id: ClipId(self.clip_map.len()),
+                radii: BorderRadius::zero(),
+                rect: fragmentation_rect,
+                parent_scroll_node_id: state.spatial_id,
+                parent_clip_id,
+            }));
+        }
+
+        clip_chain_id
     }
 
     fn push_webrender_stacking_context_if_necessary(
@@ -1369,6 +1383,8 @@ struct BuilderForBoxFragment<'a> {
     margin_rect: OnceCell<units::LayoutRect>,
     padding_rect: OnceCell<units::LayoutRect>,
     content_rect: OnceCell<units::LayoutRect>,
+    fragmented_border_rect: OnceCell<units::LayoutRect>,
+    fragmentation_clip_rect: OnceCell<Option<units::LayoutRect>>,
     border_radius: OnceCell<wr::BorderRadius>,
     border_edge_clip_chain_id: RefCell<Option<ClipChainId>>,
     padding_edge_clip_chain_id: RefCell<Option<ClipChainId>>,
@@ -1381,7 +1397,7 @@ impl<'a> BuilderForBoxFragment<'a> {
         containing_block_origin: PhysicalPoint<Au>,
     ) -> Self {
         let border_rect = fragment
-            .border_rect()
+            .unfragmented_border_rect()
             .translate(containing_block_origin.to_vector());
         Self {
             fragment,
@@ -1391,6 +1407,8 @@ impl<'a> BuilderForBoxFragment<'a> {
             margin_rect: OnceCell::new(),
             padding_rect: OnceCell::new(),
             content_rect: OnceCell::new(),
+            fragmented_border_rect: OnceCell::new(),
+            fragmentation_clip_rect: OnceCell::new(),
             border_edge_clip_chain_id: RefCell::new(None),
             padding_edge_clip_chain_id: RefCell::new(None),
             content_edge_clip_chain_id: RefCell::new(None),
@@ -1406,7 +1424,7 @@ impl<'a> BuilderForBoxFragment<'a> {
     fn content_rect(&self) -> &units::LayoutRect {
         self.content_rect.get_or_init(|| {
             self.fragment
-                .content_rect()
+                .unfragmented_content_rect()
                 .translate(self.containing_block_origin.to_vector())
                 .to_webrender()
         })
@@ -1415,7 +1433,7 @@ impl<'a> BuilderForBoxFragment<'a> {
     fn padding_rect(&self) -> &units::LayoutRect {
         self.padding_rect.get_or_init(|| {
             self.fragment
-                .padding_rect()
+                .unfragmented_padding_rect()
                 .translate(self.containing_block_origin.to_vector())
                 .to_webrender()
         })
@@ -1424,9 +1442,31 @@ impl<'a> BuilderForBoxFragment<'a> {
     fn margin_rect(&self) -> &units::LayoutRect {
         self.margin_rect.get_or_init(|| {
             self.fragment
-                .margin_rect()
+                .unfragmented_margin_rect()
                 .translate(self.containing_block_origin.to_vector())
                 .to_webrender()
+        })
+    }
+
+    fn fragmented_border_rect(&self) -> &units::LayoutRect {
+        self.fragmented_border_rect.get_or_init(|| {
+            self.fragment
+                .border_rect()
+                .translate(self.containing_block_origin.to_vector())
+                .to_webrender()
+        })
+    }
+
+    fn fragmentation_clip_rect(&self) -> &Option<units::LayoutRect> {
+        self.fragmentation_clip_rect.get_or_init(|| {
+            if let Some(fragmentation_clip_rect) = self.fragment.fragmentation_clip_rect() {
+                return Some(
+                    fragmentation_clip_rect
+                        .translate(self.containing_block_origin.to_vector())
+                        .to_webrender(),
+                );
+            }
+            None
         })
     }
 
@@ -1445,6 +1485,7 @@ impl<'a> BuilderForBoxFragment<'a> {
             self.border_radius(),
             self.border_rect,
             force_clip_creation,
+            *self.fragmentation_clip_rect(),
         );
         *self.border_edge_clip_chain_id.borrow_mut() = maybe_clip;
         maybe_clip
@@ -1461,8 +1502,13 @@ impl<'a> BuilderForBoxFragment<'a> {
         }
 
         let radii = offset_radii(self.border_radius(), -self.fragment.border.to_webrender());
-        let maybe_clip =
-            builder.maybe_create_clip(state, radii, *self.padding_rect(), force_clip_creation);
+        let maybe_clip = builder.maybe_create_clip(
+            state,
+            radii,
+            *self.padding_rect(),
+            force_clip_creation,
+            *self.fragmentation_clip_rect(),
+        );
         *self.padding_edge_clip_chain_id.borrow_mut() = maybe_clip;
         maybe_clip
     }
@@ -1481,8 +1527,13 @@ impl<'a> BuilderForBoxFragment<'a> {
             self.border_radius(),
             -(self.fragment.border + self.fragment.padding).to_webrender(),
         );
-        let maybe_clip =
-            builder.maybe_create_clip(state, radii, *self.content_rect(), force_clip_creation);
+        let maybe_clip = builder.maybe_create_clip(
+            state,
+            radii,
+            *self.content_rect(),
+            force_clip_creation,
+            *self.fragmentation_clip_rect(),
+        );
         *self.content_edge_clip_chain_id.borrow_mut() = maybe_clip;
         maybe_clip
     }
@@ -1978,7 +2029,11 @@ impl<'a> BuilderForBoxFragment<'a> {
             radius: self.border_radius(),
             do_aa: true,
         });
-        let common = builder.common_properties(state, self.border_rect, style);
+        let common = builder.common_properties(
+            state,
+            self.fragmentation_clip_rect().unwrap_or(self.border_rect),
+            style,
+        );
         builder
             .wr()
             .push_border(&common, self.border_rect, border_widths, details)
@@ -2132,9 +2187,9 @@ impl<'a> BuilderForBoxFragment<'a> {
         // > each dimension. If the outline is drawn as multiple disconnected shapes, this
         // > constraint applies to each shape separately.
         let offset = outline.outline_offset.to_f32_px() + width;
-        let outline_rect = self.border_rect.inflate(
-            offset.max(-self.border_rect.width() / 2.0 + width),
-            offset.max(-self.border_rect.height() / 2.0 + width),
+        let outline_rect = self.fragmented_border_rect().inflate(
+            offset.max(-self.fragmented_border_rect().width() / 2.0 + width),
+            offset.max(-self.fragmented_border_rect().height() / 2.0 + width),
         );
         let common = builder.common_properties(state, outline_rect, style);
         let widths = SideOffsets2D::new_all_same(width);
@@ -2473,7 +2528,7 @@ impl BoxFragment {
             return BorderRadius::zero();
         }
 
-        let border_rect = self.border_rect();
+        let border_rect = self.unfragmented_border_rect();
         let resolve =
             |radius: &LengthPercentage, box_size: Au| radius.to_used_value(box_size).to_f32_px();
         let corner = |corner: &style::values::computed::BorderCornerRadius| {

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -2325,7 +2325,7 @@ impl<'a> BuilderForBoxFragment<'a> {
             );
             let spread = box_shadow.spread.px();
             let blur = box_shadow.base.blur.px();
-            let clip_rect = match clip_mode {
+            let mut clip_rect = match clip_mode {
                 // Inset shadows are always inside the rect.
                 BoxShadowClipMode::Inset => rect,
                 // Match webrender's box_shadow.rs Gaussian blur inflation.
@@ -2337,6 +2337,63 @@ impl<'a> BuilderForBoxFragment<'a> {
                         .inflate(extra_size_from_blur, extra_size_from_blur)
                 },
             };
+            if self.fragment.is_fragmented_along_left_edge() {
+                let difference = self
+                    .fragmentation_clip_rect()
+                    .expect("Must have fragmentation clip rect")
+                    .min
+                    .x -
+                    clip_rect.min.x;
+                if difference > 0.0 {
+                    clip_rect = clip_rect.translate(LayoutVector2D::new(difference, 0.0));
+                    clip_rect.set_size(LayoutSize::new(
+                        clip_rect.size().width - difference,
+                        clip_rect.size().height,
+                    ));
+                }
+            }
+            if self.fragment.is_fragmented_along_top_edge() {
+                let difference = self
+                    .fragmentation_clip_rect()
+                    .expect("Must have fragmentation clip rect")
+                    .min
+                    .x -
+                    clip_rect.min.x;
+                if difference > 0.0 {
+                    clip_rect = clip_rect.translate(LayoutVector2D::new(difference, 0.0));
+                    clip_rect.set_size(LayoutSize::new(
+                        clip_rect.size().width,
+                        clip_rect.size().height - difference,
+                    ));
+                }
+            }
+            if self.fragment.is_fragmented_along_right_edge() {
+                let difference = clip_rect.max.x -
+                    self.fragmentation_clip_rect()
+                        .expect("Must have fragmentation clip rect")
+                        .max
+                        .x;
+                if difference > 0.0 {
+                    clip_rect.set_size(LayoutSize::new(
+                        clip_rect.size().width - difference,
+                        clip_rect.size().height,
+                    ));
+                }
+            }
+            if self.fragment.is_fragmented_along_bottom_edge() {
+                let difference = clip_rect.max.y -
+                    self.fragmentation_clip_rect()
+                        .expect("Must have fragmentation clip rect")
+                        .max
+                        .y;
+                if difference > 0.0 {
+                    clip_rect.set_size(LayoutSize::new(
+                        clip_rect.size().width,
+                        clip_rect.size().height - difference,
+                    ));
+                }
+            }
+
             let border_radius = match clip_mode {
                 BoxShadowClipMode::Inset => {
                     // The `border-radius` value applies to the border box, but inset shadows

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -380,18 +380,32 @@ impl DisplayListBuilder<'_> {
         radii: wr::BorderRadius,
         rect: units::LayoutRect,
         force_clip_creation: bool,
+        fragmentation_rect: Option<units::LayoutRect>,
     ) -> Option<ClipChainId> {
-        if radii.is_zero() && !force_clip_creation {
-            return None;
+        let mut clip_chain_id = None;
+        let mut parent_clip_id = state.clip_id;
+        if !radii.is_zero() || force_clip_creation {
+            clip_chain_id = Some(self.add_clip_to_display_list(&Clip {
+                id: ClipId(self.clip_map.len()),
+                radii,
+                rect,
+                parent_scroll_node_id: state.spatial_id,
+                parent_clip_id,
+            }));
+            parent_clip_id = ClipId(self.clip_map.len() - 1)
         }
 
-        Some(self.add_clip_to_display_list(&Clip {
-            id: ClipId(self.clip_map.len()),
-            radii,
-            rect,
-            parent_scroll_node_id: state.spatial_id,
-            parent_clip_id: state.clip_id,
-        }))
+        if let Some(fragmentation_rect) = fragmentation_rect {
+            clip_chain_id = Some(self.add_clip_to_display_list(&Clip {
+                id: ClipId(self.clip_map.len()),
+                radii: BorderRadius::zero(),
+                rect: fragmentation_rect,
+                parent_scroll_node_id: state.spatial_id,
+                parent_clip_id,
+            }));
+        }
+
+        clip_chain_id
     }
 
     fn push_webrender_stacking_context_if_necessary(
@@ -1453,6 +1467,8 @@ struct BuilderForBoxFragment<'a> {
     margin_rect: OnceCell<units::LayoutRect>,
     padding_rect: OnceCell<units::LayoutRect>,
     content_rect: OnceCell<units::LayoutRect>,
+    fragmented_border_rect: OnceCell<units::LayoutRect>,
+    fragmentation_clip_rect: OnceCell<Option<units::LayoutRect>>,
     border_radius: OnceCell<wr::BorderRadius>,
     border_edge_clip_chain_id: RefCell<Option<ClipChainId>>,
     padding_edge_clip_chain_id: RefCell<Option<ClipChainId>>,
@@ -1465,7 +1481,7 @@ impl<'a> BuilderForBoxFragment<'a> {
         containing_block_origin: PhysicalPoint<Au>,
     ) -> Self {
         let border_rect = fragment
-            .border_rect()
+            .unfragmented_border_rect()
             .translate(containing_block_origin.to_vector());
         Self {
             fragment,
@@ -1475,6 +1491,8 @@ impl<'a> BuilderForBoxFragment<'a> {
             margin_rect: OnceCell::new(),
             padding_rect: OnceCell::new(),
             content_rect: OnceCell::new(),
+            fragmented_border_rect: OnceCell::new(),
+            fragmentation_clip_rect: OnceCell::new(),
             border_edge_clip_chain_id: RefCell::new(None),
             padding_edge_clip_chain_id: RefCell::new(None),
             content_edge_clip_chain_id: RefCell::new(None),
@@ -1490,7 +1508,7 @@ impl<'a> BuilderForBoxFragment<'a> {
     fn content_rect(&self) -> &units::LayoutRect {
         self.content_rect.get_or_init(|| {
             self.fragment
-                .content_rect()
+                .unfragmented_content_rect()
                 .translate(self.containing_block_origin.to_vector())
                 .to_webrender()
         })
@@ -1499,7 +1517,7 @@ impl<'a> BuilderForBoxFragment<'a> {
     fn padding_rect(&self) -> &units::LayoutRect {
         self.padding_rect.get_or_init(|| {
             self.fragment
-                .padding_rect()
+                .unfragmented_padding_rect()
                 .translate(self.containing_block_origin.to_vector())
                 .to_webrender()
         })
@@ -1508,9 +1526,31 @@ impl<'a> BuilderForBoxFragment<'a> {
     fn margin_rect(&self) -> &units::LayoutRect {
         self.margin_rect.get_or_init(|| {
             self.fragment
-                .margin_rect()
+                .unfragmented_margin_rect()
                 .translate(self.containing_block_origin.to_vector())
                 .to_webrender()
+        })
+    }
+
+    fn fragmented_border_rect(&self) -> &units::LayoutRect {
+        self.fragmented_border_rect.get_or_init(|| {
+            self.fragment
+                .border_rect()
+                .translate(self.containing_block_origin.to_vector())
+                .to_webrender()
+        })
+    }
+
+    fn fragmentation_clip_rect(&self) -> &Option<units::LayoutRect> {
+        self.fragmentation_clip_rect.get_or_init(|| {
+            if let Some(fragmentation_clip_rect) = self.fragment.fragmentation_clip_rect() {
+                return Some(
+                    fragmentation_clip_rect
+                        .translate(self.containing_block_origin.to_vector())
+                        .to_webrender(),
+                );
+            }
+            None
         })
     }
 
@@ -1529,6 +1569,7 @@ impl<'a> BuilderForBoxFragment<'a> {
             self.border_radius(),
             self.border_rect,
             force_clip_creation,
+            *self.fragmentation_clip_rect(),
         );
         *self.border_edge_clip_chain_id.borrow_mut() = maybe_clip;
         maybe_clip
@@ -1545,8 +1586,13 @@ impl<'a> BuilderForBoxFragment<'a> {
         }
 
         let radii = offset_radii(self.border_radius(), -self.fragment.border.to_webrender());
-        let maybe_clip =
-            builder.maybe_create_clip(state, radii, *self.padding_rect(), force_clip_creation);
+        let maybe_clip = builder.maybe_create_clip(
+            state,
+            radii,
+            *self.padding_rect(),
+            force_clip_creation,
+            *self.fragmentation_clip_rect(),
+        );
         *self.padding_edge_clip_chain_id.borrow_mut() = maybe_clip;
         maybe_clip
     }
@@ -1565,8 +1611,13 @@ impl<'a> BuilderForBoxFragment<'a> {
             self.border_radius(),
             -(self.fragment.border + self.fragment.padding).to_webrender(),
         );
-        let maybe_clip =
-            builder.maybe_create_clip(state, radii, *self.content_rect(), force_clip_creation);
+        let maybe_clip = builder.maybe_create_clip(
+            state,
+            radii,
+            *self.content_rect(),
+            force_clip_creation,
+            *self.fragmentation_clip_rect(),
+        );
         *self.content_edge_clip_chain_id.borrow_mut() = maybe_clip;
         maybe_clip
     }
@@ -2066,7 +2117,11 @@ impl<'a> BuilderForBoxFragment<'a> {
             radius: self.border_radius(),
             do_aa: true,
         });
-        let common = builder.common_properties(state, self.border_rect, style);
+        let common = builder.common_properties(
+            state,
+            self.fragmentation_clip_rect().unwrap_or(self.border_rect),
+            style,
+        );
         builder
             .wr()
             .push_border(&common, self.border_rect, border_widths, details)
@@ -2220,9 +2275,9 @@ impl<'a> BuilderForBoxFragment<'a> {
         // > each dimension. If the outline is drawn as multiple disconnected shapes, this
         // > constraint applies to each shape separately.
         let offset = outline.outline_offset.to_f32_px() + width;
-        let outline_rect = self.border_rect.inflate(
-            offset.max(-self.border_rect.width() / 2.0 + width),
-            offset.max(-self.border_rect.height() / 2.0 + width),
+        let outline_rect = self.fragmented_border_rect().inflate(
+            offset.max(-self.fragmented_border_rect().width() / 2.0 + width),
+            offset.max(-self.fragmented_border_rect().height() / 2.0 + width),
         );
         let common = builder.common_properties(state, outline_rect, style);
         let widths = SideOffsets2D::new_all_same(width);
@@ -2561,7 +2616,7 @@ impl BoxFragment {
             return BorderRadius::zero();
         }
 
-        let border_rect = self.border_rect();
+        let border_rect = self.unfragmented_border_rect();
         let resolve =
             |radius: &LengthPercentage, box_size: Au| radius.to_used_value(box_size).to_f32_px();
         let corner = |corner: &style::values::computed::BorderCornerRadius| {

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::{OnceCell, RefCell};
+use std::cell::{LazyCell, OnceCell, RefCell};
 use std::sync::Arc;
 
 use app_units::{AU_PER_PX, Au};
@@ -380,32 +380,18 @@ impl DisplayListBuilder<'_> {
         radii: wr::BorderRadius,
         rect: units::LayoutRect,
         force_clip_creation: bool,
-        fragmentation_rect: Option<units::LayoutRect>,
     ) -> Option<ClipChainId> {
-        let mut clip_chain_id = None;
-        let mut parent_clip_id = state.clip_id;
-        if !radii.is_zero() || force_clip_creation {
-            clip_chain_id = Some(self.add_clip_to_display_list(&Clip {
-                id: ClipId(self.clip_map.len()),
-                radii,
-                rect,
-                parent_scroll_node_id: state.spatial_id,
-                parent_clip_id,
-            }));
-            parent_clip_id = ClipId(self.clip_map.len() - 1)
+        if radii.is_zero() && !force_clip_creation {
+            return None;
         }
 
-        if let Some(fragmentation_rect) = fragmentation_rect {
-            clip_chain_id = Some(self.add_clip_to_display_list(&Clip {
-                id: ClipId(self.clip_map.len()),
-                radii: BorderRadius::zero(),
-                rect: fragmentation_rect,
-                parent_scroll_node_id: state.spatial_id,
-                parent_clip_id,
-            }));
-        }
-
-        clip_chain_id
+        Some(self.add_clip_to_display_list(&Clip {
+            id: ClipId(self.clip_map.len()),
+            radii,
+            rect,
+            parent_scroll_node_id: state.spatial_id,
+            parent_clip_id: state.clip_id,
+        }))
     }
 
     fn push_webrender_stacking_context_if_necessary(
@@ -1468,6 +1454,8 @@ struct BuilderForBoxFragment<'a> {
     padding_rect: OnceCell<units::LayoutRect>,
     content_rect: OnceCell<units::LayoutRect>,
     fragmented_border_rect: OnceCell<units::LayoutRect>,
+    fragmented_padding_rect: OnceCell<units::LayoutRect>,
+    fragmented_content_rect: OnceCell<units::LayoutRect>,
     fragmentation_clip_rect: OnceCell<Option<units::LayoutRect>>,
     border_radius: OnceCell<wr::BorderRadius>,
     border_edge_clip_chain_id: RefCell<Option<ClipChainId>>,
@@ -1492,6 +1480,8 @@ impl<'a> BuilderForBoxFragment<'a> {
             padding_rect: OnceCell::new(),
             content_rect: OnceCell::new(),
             fragmented_border_rect: OnceCell::new(),
+            fragmented_padding_rect: OnceCell::new(),
+            fragmented_content_rect: OnceCell::new(),
             fragmentation_clip_rect: OnceCell::new(),
             border_edge_clip_chain_id: RefCell::new(None),
             padding_edge_clip_chain_id: RefCell::new(None),
@@ -1541,6 +1531,24 @@ impl<'a> BuilderForBoxFragment<'a> {
         })
     }
 
+    fn fragmented_padding_rect(&self) -> &units::LayoutRect {
+        self.fragmented_padding_rect.get_or_init(|| {
+            self.fragment
+                .padding_rect()
+                .translate(self.containing_block_origin.to_vector())
+                .to_webrender()
+        })
+    }
+
+    fn fragmented_content_rect(&self) -> &units::LayoutRect {
+        self.fragmented_content_rect.get_or_init(|| {
+            self.fragment
+                .content_rect()
+                .translate(self.containing_block_origin.to_vector())
+                .to_webrender()
+        })
+    }
+
     fn fragmentation_clip_rect(&self) -> &Option<units::LayoutRect> {
         self.fragmentation_clip_rect.get_or_init(|| {
             if let Some(fragmentation_clip_rect) = self.fragment.fragmentation_clip_rect() {
@@ -1569,7 +1577,6 @@ impl<'a> BuilderForBoxFragment<'a> {
             self.border_radius(),
             self.border_rect,
             force_clip_creation,
-            *self.fragmentation_clip_rect(),
         );
         *self.border_edge_clip_chain_id.borrow_mut() = maybe_clip;
         maybe_clip
@@ -1586,13 +1593,8 @@ impl<'a> BuilderForBoxFragment<'a> {
         }
 
         let radii = offset_radii(self.border_radius(), -self.fragment.border.to_webrender());
-        let maybe_clip = builder.maybe_create_clip(
-            state,
-            radii,
-            *self.padding_rect(),
-            force_clip_creation,
-            *self.fragmentation_clip_rect(),
-        );
+        let maybe_clip =
+            builder.maybe_create_clip(state, radii, *self.padding_rect(), force_clip_creation);
         *self.padding_edge_clip_chain_id.borrow_mut() = maybe_clip;
         maybe_clip
     }
@@ -1611,13 +1613,8 @@ impl<'a> BuilderForBoxFragment<'a> {
             self.border_radius(),
             -(self.fragment.border + self.fragment.padding).to_webrender(),
         );
-        let maybe_clip = builder.maybe_create_clip(
-            state,
-            radii,
-            *self.content_rect(),
-            force_clip_creation,
-            *self.fragmentation_clip_rect(),
-        );
+        let maybe_clip =
+            builder.maybe_create_clip(state, radii, *self.content_rect(), force_clip_creation);
         *self.content_edge_clip_chain_id.borrow_mut() = maybe_clip;
         maybe_clip
     }
@@ -2337,62 +2334,36 @@ impl<'a> BuilderForBoxFragment<'a> {
                         .inflate(extra_size_from_blur, extra_size_from_blur)
                 },
             };
+            let fragmentation_clip_rect = LazyCell::new(|| {
+                self.fragmentation_clip_rect()
+                    .expect("Must have fragmentation clip rect.")
+            });
+            let mut fragmentation_side_offsets = SideOffsets2D::new_all_same(0.0);
             if self.fragment.is_fragmented_along_left_edge() {
-                let difference = self
-                    .fragmentation_clip_rect()
-                    .expect("Must have fragmentation clip rect")
-                    .min
-                    .x -
-                    clip_rect.min.x;
+                let difference = fragmentation_clip_rect.min.x - clip_rect.min.x;
                 if difference > 0.0 {
-                    clip_rect = clip_rect.translate(LayoutVector2D::new(difference, 0.0));
-                    clip_rect.set_size(LayoutSize::new(
-                        clip_rect.size().width - difference,
-                        clip_rect.size().height,
-                    ));
+                    fragmentation_side_offsets.left = difference;
                 }
             }
             if self.fragment.is_fragmented_along_top_edge() {
-                let difference = self
-                    .fragmentation_clip_rect()
-                    .expect("Must have fragmentation clip rect")
-                    .min
-                    .x -
-                    clip_rect.min.x;
+                let difference = fragmentation_clip_rect.min.y - clip_rect.min.y;
                 if difference > 0.0 {
-                    clip_rect = clip_rect.translate(LayoutVector2D::new(difference, 0.0));
-                    clip_rect.set_size(LayoutSize::new(
-                        clip_rect.size().width,
-                        clip_rect.size().height - difference,
-                    ));
+                    fragmentation_side_offsets.top = -difference;
                 }
             }
             if self.fragment.is_fragmented_along_right_edge() {
-                let difference = clip_rect.max.x -
-                    self.fragmentation_clip_rect()
-                        .expect("Must have fragmentation clip rect")
-                        .max
-                        .x;
+                let difference = clip_rect.max.x - fragmentation_clip_rect.max.x;
                 if difference > 0.0 {
-                    clip_rect.set_size(LayoutSize::new(
-                        clip_rect.size().width - difference,
-                        clip_rect.size().height,
-                    ));
+                    fragmentation_side_offsets.right = difference;
                 }
             }
             if self.fragment.is_fragmented_along_bottom_edge() {
-                let difference = clip_rect.max.y -
-                    self.fragmentation_clip_rect()
-                        .expect("Must have fragmentation clip rect")
-                        .max
-                        .y;
+                let difference = clip_rect.max.y - fragmentation_clip_rect.max.y;
                 if difference > 0.0 {
-                    clip_rect.set_size(LayoutSize::new(
-                        clip_rect.size().width,
-                        clip_rect.size().height - difference,
-                    ));
+                    fragmentation_side_offsets.bottom = difference;
                 }
             }
+            clip_rect = clip_rect.inner_box(fragmentation_side_offsets);
 
             let border_radius = match clip_mode {
                 BoxShadowClipMode::Inset => {

--- a/components/layout/flow/inline/inline_box.rs
+++ b/components/layout/flow/inline/inline_box.rs
@@ -18,7 +18,8 @@ use style::computed_values::box_decoration_break::T as BoxDecorationBreak;
 use style::context::SharedStyleContext;
 use style::logical_geometry::LogicalSize;
 use style::properties::ComputedValues;
-use style::values::computed::{BaselineShift, LengthPercentage};
+use style::values::computed::image::Image;
+use style::values::computed::{BaselineShift, BorderStyle, LengthPercentage};
 
 use super::{
     InlineContainerState, InlineContainerStateFlags, SharedInlineStyles,
@@ -87,7 +88,60 @@ impl InlineBox {
     // For the painting of backgrounds and borders on fragmented boxes, each box needs to know what part of the
     // unfragmented whole it is. This determines that for this inline box's fragments.
     pub(crate) fn assign_fragmentation_info(&self) {
-        if self.base.style.get_border().box_decoration_break != BoxDecorationBreak::Slice {
+        let style = &self.base.style;
+        if style.get_border().box_decoration_break != BoxDecorationBreak::Slice {
+            return;
+        }
+
+        // We can avoid all this work (and the extra BoxFragmentRareData it incurs) in most situations. In particular,
+        // it should (for inlines) only be necessary when there is:
+        // - Backgrounds that change in the inline direction and cross fragments
+        // - Border-radii that are larger than the end fragments
+        // - Block-axis dashed, dotted and image borders
+        // - Some values of `clip-path` and `mask`
+
+        // Notably, some things that we do not need to consider are:
+        // - `overflow: hidden` or similar, since `overflow` does not apply to inline elements
+        // - the `clip` property, since it only applies to fixed- or abspos elements which do not fragment across lines
+
+        // So below are some heuristics that should let us early-exit in the most common case of text with basically no
+        // decorations at all, as well as some text that only has basic decorations.
+        let mut can_early_exit = true;
+
+        // TODO: Also check for any CSS `mask`
+        if !style
+            .get_background()
+            .background_image
+            .0
+            .iter()
+            .all(|image| *image == Image::None) ||
+            !style.get_border().border_top_left_radius.is_zero() ||
+            !style.get_border().border_top_right_radius.is_zero() ||
+            !style.get_border().border_bottom_left_radius.is_zero() ||
+            !style.get_border().border_bottom_right_radius.is_zero() ||
+            matches!(
+                style.get_border().border_top_style,
+                BorderStyle::Dashed | BorderStyle::Dotted
+            ) ||
+            matches!(
+                style.get_border().border_bottom_style,
+                BorderStyle::Dashed | BorderStyle::Dotted
+            ) ||
+            matches!(
+                style.get_border().border_left_style,
+                BorderStyle::Dashed | BorderStyle::Dotted
+            ) ||
+            matches!(
+                style.get_border().border_right_style,
+                BorderStyle::Dashed | BorderStyle::Dotted
+            ) ||
+            style.get_border().border_image_source != Image::None ||
+            !style.get_effects().clip.is_auto()
+        {
+            can_early_exit = false;
+        }
+
+        if can_early_exit {
             return;
         }
 
@@ -102,11 +156,13 @@ impl InlineBox {
                 }
             })
             .collect();
+
+        // Also early exit if there is only one fragment, since a single fragment cannot get sliced.
         if box_fragments.len() <= 1 {
             return;
         }
 
-        let writing_mode = self.base.style.writing_mode;
+        let writing_mode = style.writing_mode;
         let mut total_inline_size = Au::zero();
         for fragment in &box_fragments {
             total_inline_size += fragment.base.rect().size.to_logical(writing_mode).inline;

--- a/components/layout/flow/inline/inline_box.rs
+++ b/components/layout/flow/inline/inline_box.rs
@@ -29,7 +29,7 @@ use crate::ContainingBlock;
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::dom_traversal::NodeAndStyleInfo;
-use crate::fragment_tree::{BaseFragmentInfo, Fragment};
+use crate::fragment_tree::BaseFragmentInfo;
 use crate::geom::{SyncPhysicalRectAu, ToLogical};
 use crate::layout_box_base::LayoutBoxBase;
 use crate::style_ext::{ComputedValuesExt, LayoutStyle, PaddingBorderMargin};
@@ -148,30 +148,29 @@ impl InlineBox {
         }
 
         let fragments = self.base.fragments.borrow();
-        let box_fragments: Vec<_> = fragments
-            .iter()
-            .filter_map(|fragment| {
-                if let Fragment::Box(box_fragment) = fragment {
-                    Some(box_fragment)
-                } else {
-                    None
-                }
-            })
-            .collect();
-
         // Also early exit if there is only one fragment, since a single fragment cannot get sliced.
-        if box_fragments.len() <= 1 {
+        if fragments.len() <= 1 {
             return;
         }
 
         let writing_mode = style.writing_mode;
         let mut total_inline_size = Au::zero();
-        for fragment in &box_fragments {
-            total_inline_size += fragment.base.rect().size.to_logical(writing_mode).inline;
+        for fragment in fragments.iter() {
+            total_inline_size += fragment
+                .base()
+                .expect("Should always have a base fragment.")
+                .rect()
+                .size
+                .to_logical(writing_mode)
+                .inline;
         }
 
         let mut current_inline_offset = Au::zero();
-        for fragment in &box_fragments {
+        for fragment in fragments.iter().map(|fragment| {
+            fragment
+                .retrieve_box_fragment()
+                .expect("Should always be a box fragment.")
+        }) {
             let fragment_inline_size = fragment.base.rect().size.to_logical(writing_mode).inline;
 
             let mut origin = fragment.base.rect().origin;
@@ -208,8 +207,12 @@ impl InlineBox {
             current_inline_offset += fragment_inline_size;
         }
         // Fix up the fragmentation at the very beginning and end
-        if let Some(first_fragment) = box_fragments.first() &&
-            let Some(last_fragment) = box_fragments.last()
+        if let Some(first_fragment) = fragments
+            .first()
+            .and_then(|fragment| fragment.retrieve_box_fragment()) &&
+            let Some(last_fragment) = fragments
+                .last()
+                .and_then(|fragment| fragment.retrieve_box_fragment())
         {
             if writing_mode.is_horizontal() {
                 if writing_mode.is_bidi_ltr() {

--- a/components/layout/flow/inline/inline_box.rs
+++ b/components/layout/flow/inline/inline_box.rs
@@ -95,10 +95,11 @@ impl InlineBox {
 
         // We can avoid all this work (and the extra BoxFragmentRareData it incurs) in most situations. In particular,
         // it should (for inlines) only be necessary when there is:
-        // - Backgrounds that change in the inline direction and cross fragments
-        // - Border-radii that are larger than the end fragments
-        // - Block-axis dashed, dotted and image borders
+        // - backgrounds that change in the inline direction and cross fragments
+        // - border-radii that are larger than the end fragments
+        // - block-axis dashed, dotted and image borders
         // - Some values of `clip-path` and `mask`
+        // - any `box-shadow`
 
         // Notably, some things that we do not need to consider are:
         // - `overflow: hidden` or similar, since `overflow` does not apply to inline elements
@@ -135,6 +136,7 @@ impl InlineBox {
                 style.get_border().border_right_style,
                 BorderStyle::Dashed | BorderStyle::Dotted
             ) ||
+            !style.get_effects().box_shadow.0.is_empty() ||
             style.get_border().border_image_source != Image::None ||
             !style.get_effects().clip.is_auto()
         {

--- a/components/layout/flow/inline/inline_box.rs
+++ b/components/layout/flow/inline/inline_box.rs
@@ -5,6 +5,7 @@
 use std::vec::IntoIter;
 
 use app_units::Au;
+use euclid::Rect;
 use fonts::FontRef;
 use layout_api::LayoutNode;
 use malloc_size_of_derive::MallocSizeOf;
@@ -15,6 +16,7 @@ use style::computed_values::alignment_baseline::T as AlignmentBaseline;
 use style::computed_values::baseline_source::T as BaselineSource;
 use style::computed_values::box_decoration_break::T as BoxDecorationBreak;
 use style::context::SharedStyleContext;
+use style::logical_geometry::LogicalSize;
 use style::properties::ComputedValues;
 use style::values::computed::{BaselineShift, LengthPercentage};
 
@@ -26,7 +28,8 @@ use crate::ContainingBlock;
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::dom_traversal::NodeAndStyleInfo;
-use crate::fragment_tree::BaseFragmentInfo;
+use crate::fragment_tree::{BaseFragmentInfo, Fragment};
+use crate::geom::{SyncPhysicalRectAu, ToLogical};
 use crate::layout_box_base::LayoutBoxBase;
 use crate::style_ext::{ComputedValuesExt, LayoutStyle, PaddingBorderMargin};
 
@@ -79,6 +82,95 @@ impl InlineBox {
         self.base.repair_style(new_style);
         *self.shared_inline_styles.style.borrow_mut() = new_style.clone();
         *self.shared_inline_styles.selected.borrow_mut() = node.selected_style(context);
+    }
+
+    // For the painting of backgrounds and borders on fragmented boxes, each box needs to know what part of the
+    // unfragmented whole it is. This determines that for this inline box's fragments.
+    pub(crate) fn assign_fragmentation_info(&self) {
+        if self.base.style.get_border().box_decoration_break != BoxDecorationBreak::Slice {
+            return;
+        }
+
+        let fragments = self.base.fragments.borrow();
+        let box_fragments: Vec<_> = fragments
+            .iter()
+            .filter_map(|fragment| {
+                if let Fragment::Box(box_fragment) = fragment {
+                    Some(box_fragment)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if box_fragments.len() <= 1 {
+            return;
+        }
+
+        let writing_mode = self.base.style.writing_mode;
+        let mut total_inline_size = Au::zero();
+        for fragment in &box_fragments {
+            total_inline_size += fragment.base.rect().size.to_logical(writing_mode).inline;
+        }
+
+        let mut current_inline_offset = Au::zero();
+        for fragment in &box_fragments {
+            let fragment_inline_size = fragment.base.rect().size.to_logical(writing_mode).inline;
+
+            let mut origin = fragment.base.rect().origin;
+            if writing_mode.is_horizontal() {
+                fragment.set_is_fragmented_along_left_edge(true);
+                fragment.set_is_fragmented_along_right_edge(true);
+                if writing_mode.is_bidi_ltr() {
+                    origin.x -= current_inline_offset;
+                } else {
+                    origin.x += current_inline_offset;
+                    origin.x -= total_inline_size - fragment_inline_size;
+                }
+            } else {
+                fragment.set_is_fragmented_along_top_edge(true);
+                fragment.set_is_fragmented_along_bottom_edge(true);
+                if writing_mode.is_bidi_ltr() {
+                    origin.y -= current_inline_offset;
+                } else {
+                    origin.x += current_inline_offset;
+                    origin.x -= total_inline_size - fragment_inline_size;
+                }
+            }
+            fragment.set_unfragmented_rect(SyncPhysicalRectAu::new(Rect::new(
+                origin,
+                LogicalSize::new(
+                    writing_mode,
+                    total_inline_size,
+                    fragment.base.rect().size.to_logical(writing_mode).block,
+                )
+                .to_physical(writing_mode)
+                .cast_unit(),
+            )));
+
+            current_inline_offset += fragment_inline_size;
+        }
+        // Fix up the fragmentation at the very beginning and end
+        if let Some(first_fragment) = box_fragments.first() &&
+            let Some(last_fragment) = box_fragments.last()
+        {
+            if writing_mode.is_horizontal() {
+                if writing_mode.is_bidi_ltr() {
+                    first_fragment.set_is_fragmented_along_left_edge(false);
+                    last_fragment.set_is_fragmented_along_right_edge(false);
+                } else {
+                    first_fragment.set_is_fragmented_along_right_edge(false);
+                    last_fragment.set_is_fragmented_along_left_edge(false);
+                }
+            } else {
+                if writing_mode.is_bidi_ltr() {
+                    first_fragment.set_is_fragmented_along_top_edge(false);
+                    last_fragment.set_is_fragmented_along_bottom_edge(false);
+                } else {
+                    first_fragment.set_is_fragmented_along_bottom_edge(false);
+                    last_fragment.set_is_fragmented_along_top_edge(false);
+                }
+            }
+        }
     }
 }
 

--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -26,7 +26,7 @@ use crate::cell::ArcRefCell;
 use crate::flow::inline::text_run::FontAndScriptInfo;
 use crate::fragment_tree::{BaseFragment, BaseFragmentInfo, BoxFragment, Fragment, TextFragment};
 use crate::geom::{
-    LogicalRect, LogicalSides, LogicalVec2, PhysicalRect, PhysicalSize, ToLogical,
+    LogicalRect, LogicalSides, LogicalVec2, PhysicalRect, PhysicalSides, PhysicalSize, ToLogical,
     ToLogicalWithContainingBlock,
 };
 use crate::positioned::{
@@ -569,13 +569,33 @@ impl LineItemLayout<'_, '_> {
         // but they need to be made relative to this fragment.
         let physical_content_rect = content_rect.as_physical(Some(containing_block));
 
+        // When creating the fragment, if it's on a line that got made for a block-level box, we zero out the start and
+        // end paddings/borders so that it ends up not being drawn. Otherwise we preserve the box's paddings/borders so
+        // that the fragment gets drawn correctly. This is separate from the calculations above, which mainly determine
+        // where the fragment's contents ends up being positioned. (i.e. they also zero things in response to line
+        // breaks)
+        // See also: https://github.com/w3c/csswg-drafts/issues/14104
         let mut fragment = BoxFragment::new(
             inline_box.base.base_fragment_info,
             style.clone(),
             fragments,
             physical_content_rect,
-            padding.to_physical(containing_block_writing_mode),
-            border.to_physical(containing_block_writing_mode),
+            if self.for_block_level {
+                PhysicalSides::zero()
+            } else {
+                inline_box_state
+                    .pbm
+                    .padding
+                    .to_physical(containing_block_writing_mode)
+            },
+            if self.for_block_level {
+                PhysicalSides::zero()
+            } else {
+                inline_box_state
+                    .pbm
+                    .border
+                    .to_physical(containing_block_writing_mode)
+            },
             margin.to_physical(containing_block_writing_mode),
             None, /* specific_layout_info */
         );

--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -25,7 +25,7 @@ use crate::cell::ArcRefCell;
 use crate::flow::inline::text_run::{FontAndScriptInfo, SharedTextRunData};
 use crate::fragment_tree::{BaseFragment, BaseFragmentInfo, BoxFragment, Fragment, TextFragment};
 use crate::geom::{
-    LogicalRect, LogicalSides, LogicalVec2, PhysicalRect, PhysicalSize, ToLogical,
+    LogicalRect, LogicalSides, LogicalVec2, PhysicalRect, PhysicalSides, PhysicalSize, ToLogical,
     ToLogicalWithContainingBlock,
 };
 use crate::positioned::{
@@ -568,13 +568,33 @@ impl LineItemLayout<'_, '_> {
         // but they need to be made relative to this fragment.
         let physical_content_rect = content_rect.as_physical(Some(containing_block));
 
+        // When creating the fragment, if it's on a line that got made for a block-level box, we zero out the start and
+        // end paddings/borders so that it ends up not being drawn. Otherwise we preserve the box's paddings/borders so
+        // that the fragment gets drawn correctly. This is separate from the calculations above, which mainly determine
+        // where the fragment's contents ends up being positioned. (i.e. they also zero things in response to line
+        // breaks)
+        // See also: https://github.com/w3c/csswg-drafts/issues/14104
         let mut fragment = BoxFragment::new(
             inline_box.base.base_fragment_info,
             style.clone(),
             fragments,
             physical_content_rect,
-            padding.to_physical(containing_block_writing_mode),
-            border.to_physical(containing_block_writing_mode),
+            if self.for_block_level {
+                PhysicalSides::zero()
+            } else {
+                inline_box_state
+                    .pbm
+                    .padding
+                    .to_physical(containing_block_writing_mode)
+            },
+            if self.for_block_level {
+                PhysicalSides::zero()
+            } else {
+                inline_box_state
+                    .pbm
+                    .border
+                    .to_physical(containing_block_writing_mode)
+            },
             margin.to_physical(containing_block_writing_mode),
             None, /* specific_layout_info */
         );

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -83,6 +83,7 @@ use app_units::{Au, MAX_AU};
 use atomic_refcell::AtomicRef;
 use bitflags::bitflags;
 use construct::InlineFormattingContextBuilder;
+use euclid::Rect;
 use fonts::{FontMetrics, FontRef, ShapedTextSlice};
 use icu_locid::LanguageIdentifier;
 use icu_locid::subtags::{Language, language};
@@ -99,11 +100,13 @@ use malloc_size_of_derive::MallocSizeOf;
 use script::layout_dom::ServoLayoutNode;
 use servo_arc::Arc as ServoArc;
 use style::Zero;
+use style::computed_values::box_decoration_break::T as BoxDecorationBreak;
 use style::computed_values::line_break::T as LineBreak;
 use style::computed_values::text_wrap_mode::T as TextWrapMode;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::computed_values::word_break::T as WordBreak;
 use style::context::{QuirksMode, SharedStyleContext};
+use style::logical_geometry::LogicalSize;
 use style::properties::ComputedValues;
 use style::properties::style_structs::InheritedText;
 use style::values::computed::BaselineShift;
@@ -132,7 +135,7 @@ use crate::formatting_contexts::{Baselines, IndependentFormattingContext};
 use crate::fragment_tree::{
     BaseFragmentInfo, BoxFragment, CollapsedMargin, Fragment, FragmentFlags, PositioningFragment,
 };
-use crate::geom::{LogicalRect, LogicalSides1D, LogicalVec2, ToLogical};
+use crate::geom::{LogicalRect, LogicalSides1D, LogicalVec2, SyncPhysicalRectAu, ToLogical};
 use crate::layout_box_base::LayoutBoxBase;
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext};
 use crate::sizing::{ComputeInlineContentSizes, ContentSizes, InlineContentSizesResult};
@@ -2146,6 +2149,106 @@ impl InlineFormattingContext {
         }
 
         layout.finish_last_line();
+
+        // For the painting of backgrounds and borders on fragmented boxes, each box needs to know what part of the
+        // unfragmented whole it is. This determines that for all of our inline boxes.
+        for inline_box in self.inline_boxes.iter() {
+            let borrowed_box = inline_box.borrow();
+            if borrowed_box.base.style.get_border().box_decoration_break !=
+                BoxDecorationBreak::Slice
+            {
+                continue;
+            }
+            let fragments = borrowed_box.base.fragments.borrow();
+            let box_fragments: Vec<&Fragment> = fragments
+                .iter()
+                .filter(|fragment| matches!(fragment, Fragment::Box(_)))
+                .collect();
+            if box_fragments.len() <= 1 {
+                continue;
+            }
+
+            let writing_mode = borrowed_box.base.style.writing_mode;
+            let mut total_inline_size = Au::zero();
+            for fragment in &box_fragments {
+                if let Fragment::Box(box_fragment) = fragment {
+                    total_inline_size += box_fragment
+                        .base
+                        .rect()
+                        .size
+                        .to_logical(writing_mode)
+                        .inline;
+                }
+            }
+
+            let mut current_inline_offset = Au::zero();
+            for fragment in &box_fragments {
+                if let Fragment::Box(box_fragment) = fragment {
+                    let fragment_inline_size = box_fragment
+                        .base
+                        .rect()
+                        .size
+                        .to_logical(writing_mode)
+                        .inline;
+
+                    let mut origin = box_fragment.base.rect().origin;
+                    if writing_mode.is_horizontal() {
+                        box_fragment.set_is_fragmented_along_left_edge(true);
+                        box_fragment.set_is_fragmented_along_right_edge(true);
+                        if writing_mode.is_bidi_ltr() {
+                            origin.x -= current_inline_offset;
+                        } else {
+                            origin.x += current_inline_offset;
+                            origin.x -= total_inline_size - fragment_inline_size;
+                        }
+                    } else {
+                        box_fragment.set_is_fragmented_along_top_edge(true);
+                        box_fragment.set_is_fragmented_along_bottom_edge(true);
+                        if writing_mode.is_bidi_ltr() {
+                            origin.y -= current_inline_offset;
+                        } else {
+                            origin.x += current_inline_offset;
+                            origin.x -= total_inline_size - fragment_inline_size;
+                        }
+                    }
+                    box_fragment.set_unfragmented_rect(SyncPhysicalRectAu::new(Rect::new(
+                        origin,
+                        LogicalSize::new(
+                            writing_mode,
+                            total_inline_size,
+                            box_fragment.base.rect().size.to_logical(writing_mode).block,
+                        )
+                        .to_physical(writing_mode)
+                        .cast_unit(),
+                    )));
+
+                    current_inline_offset += fragment_inline_size;
+                }
+            }
+            // Fix up the fragmentation at the very beginning and end
+            if let Some(Fragment::Box(first_fragment)) = box_fragments.first() &&
+                let Some(Fragment::Box(last_fragment)) = box_fragments.last()
+            {
+                if writing_mode.is_horizontal() {
+                    if writing_mode.is_bidi_ltr() {
+                        first_fragment.set_is_fragmented_along_left_edge(false);
+                        last_fragment.set_is_fragmented_along_right_edge(false);
+                    } else {
+                        first_fragment.set_is_fragmented_along_right_edge(false);
+                        last_fragment.set_is_fragmented_along_left_edge(false);
+                    }
+                } else {
+                    if writing_mode.is_bidi_ltr() {
+                        first_fragment.set_is_fragmented_along_top_edge(false);
+                        last_fragment.set_is_fragmented_along_bottom_edge(false);
+                    } else {
+                        first_fragment.set_is_fragmented_along_bottom_edge(false);
+                        last_fragment.set_is_fragmented_along_top_edge(false);
+                    }
+                }
+            }
+        }
+
         let (content_block_size, collapsible_margins_in_children, baselines) =
             layout.placement_state.finish();
 

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -89,7 +89,6 @@ use app_units::{Au, MAX_AU};
 use atomic_refcell::AtomicRef;
 use bitflags::bitflags;
 use construct::InlineFormattingContextBuilder;
-use euclid::Rect;
 use fonts::{FontMetrics, FontRef, ShapedTextSlice};
 use icu_locid::LanguageIdentifier;
 use icu_locid::subtags::{Language, language};
@@ -106,13 +105,11 @@ use script::layout_dom::ServoLayoutNode;
 use servo_arc::Arc as ServoArc;
 use servo_base::text::Utf32CodeUnits;
 use style::Zero;
-use style::computed_values::box_decoration_break::T as BoxDecorationBreak;
 use style::computed_values::line_break::T as LineBreak;
 use style::computed_values::text_wrap_mode::T as TextWrapMode;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::computed_values::word_break::T as WordBreak;
 use style::context::{QuirksMode, SharedStyleContext};
-use style::logical_geometry::LogicalSize;
 use style::properties::ComputedValues;
 use style::properties::style_structs::InheritedText;
 use style::values::computed::BaselineShift;
@@ -141,7 +138,7 @@ use crate::flow::{
 };
 use crate::formatting_contexts::{Baselines, IndependentFormattingContext};
 use crate::fragment_tree::{CollapsedMargin, Fragment, FragmentFlags, PositioningFragment};
-use crate::geom::{LogicalRect, LogicalSides1D, LogicalVec2, SyncPhysicalRectAu, ToLogical};
+use crate::geom::{LogicalRect, LogicalSides1D, LogicalVec2, ToLogical};
 use crate::layout_box_base::LayoutBoxBase;
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext};
 use crate::sizing::{ComputeInlineContentSizes, ContentSizes, InlineContentSizesResult};
@@ -2166,100 +2163,7 @@ impl InlineFormattingContext {
         // For the painting of backgrounds and borders on fragmented boxes, each box needs to know what part of the
         // unfragmented whole it is. This determines that for all of our inline boxes.
         for inline_box in self.inline_boxes.iter() {
-            let borrowed_box = inline_box.borrow();
-            if borrowed_box.base.style.get_border().box_decoration_break !=
-                BoxDecorationBreak::Slice
-            {
-                continue;
-            }
-            let fragments = borrowed_box.base.fragments.borrow();
-            let box_fragments: Vec<&Fragment> = fragments
-                .iter()
-                .filter(|fragment| matches!(fragment, Fragment::Box(_)))
-                .collect();
-            if box_fragments.len() <= 1 {
-                continue;
-            }
-
-            let writing_mode = borrowed_box.base.style.writing_mode;
-            let mut total_inline_size = Au::zero();
-            for fragment in &box_fragments {
-                if let Fragment::Box(box_fragment) = fragment {
-                    total_inline_size += box_fragment
-                        .base
-                        .rect()
-                        .size
-                        .to_logical(writing_mode)
-                        .inline;
-                }
-            }
-
-            let mut current_inline_offset = Au::zero();
-            for fragment in &box_fragments {
-                if let Fragment::Box(box_fragment) = fragment {
-                    let fragment_inline_size = box_fragment
-                        .base
-                        .rect()
-                        .size
-                        .to_logical(writing_mode)
-                        .inline;
-
-                    let mut origin = box_fragment.base.rect().origin;
-                    if writing_mode.is_horizontal() {
-                        box_fragment.set_is_fragmented_along_left_edge(true);
-                        box_fragment.set_is_fragmented_along_right_edge(true);
-                        if writing_mode.is_bidi_ltr() {
-                            origin.x -= current_inline_offset;
-                        } else {
-                            origin.x += current_inline_offset;
-                            origin.x -= total_inline_size - fragment_inline_size;
-                        }
-                    } else {
-                        box_fragment.set_is_fragmented_along_top_edge(true);
-                        box_fragment.set_is_fragmented_along_bottom_edge(true);
-                        if writing_mode.is_bidi_ltr() {
-                            origin.y -= current_inline_offset;
-                        } else {
-                            origin.x += current_inline_offset;
-                            origin.x -= total_inline_size - fragment_inline_size;
-                        }
-                    }
-                    box_fragment.set_unfragmented_rect(SyncPhysicalRectAu::new(Rect::new(
-                        origin,
-                        LogicalSize::new(
-                            writing_mode,
-                            total_inline_size,
-                            box_fragment.base.rect().size.to_logical(writing_mode).block,
-                        )
-                        .to_physical(writing_mode)
-                        .cast_unit(),
-                    )));
-
-                    current_inline_offset += fragment_inline_size;
-                }
-            }
-            // Fix up the fragmentation at the very beginning and end
-            if let Some(Fragment::Box(first_fragment)) = box_fragments.first() &&
-                let Some(Fragment::Box(last_fragment)) = box_fragments.last()
-            {
-                if writing_mode.is_horizontal() {
-                    if writing_mode.is_bidi_ltr() {
-                        first_fragment.set_is_fragmented_along_left_edge(false);
-                        last_fragment.set_is_fragmented_along_right_edge(false);
-                    } else {
-                        first_fragment.set_is_fragmented_along_right_edge(false);
-                        last_fragment.set_is_fragmented_along_left_edge(false);
-                    }
-                } else {
-                    if writing_mode.is_bidi_ltr() {
-                        first_fragment.set_is_fragmented_along_top_edge(false);
-                        last_fragment.set_is_fragmented_along_bottom_edge(false);
-                    } else {
-                        first_fragment.set_is_fragmented_along_bottom_edge(false);
-                        last_fragment.set_is_fragmented_along_top_edge(false);
-                    }
-                }
-            }
+            inline_box.borrow().assign_fragmentation_info();
         }
 
         let (content_block_size, collapsible_margins_in_children, baselines) =

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -89,6 +89,7 @@ use app_units::{Au, MAX_AU};
 use atomic_refcell::AtomicRef;
 use bitflags::bitflags;
 use construct::InlineFormattingContextBuilder;
+use euclid::Rect;
 use fonts::{FontMetrics, FontRef, ShapedTextSlice};
 use icu_locid::LanguageIdentifier;
 use icu_locid::subtags::{Language, language};
@@ -105,11 +106,13 @@ use script::layout_dom::ServoLayoutNode;
 use servo_arc::Arc as ServoArc;
 use servo_base::text::Utf32CodeUnits;
 use style::Zero;
+use style::computed_values::box_decoration_break::T as BoxDecorationBreak;
 use style::computed_values::line_break::T as LineBreak;
 use style::computed_values::text_wrap_mode::T as TextWrapMode;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::computed_values::word_break::T as WordBreak;
 use style::context::{QuirksMode, SharedStyleContext};
+use style::logical_geometry::LogicalSize;
 use style::properties::ComputedValues;
 use style::properties::style_structs::InheritedText;
 use style::values::computed::BaselineShift;
@@ -138,7 +141,7 @@ use crate::flow::{
 };
 use crate::formatting_contexts::{Baselines, IndependentFormattingContext};
 use crate::fragment_tree::{CollapsedMargin, Fragment, FragmentFlags, PositioningFragment};
-use crate::geom::{LogicalRect, LogicalSides1D, LogicalVec2, ToLogical};
+use crate::geom::{LogicalRect, LogicalSides1D, LogicalVec2, SyncPhysicalRectAu, ToLogical};
 use crate::layout_box_base::LayoutBoxBase;
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext};
 use crate::sizing::{ComputeInlineContentSizes, ContentSizes, InlineContentSizesResult};
@@ -2159,6 +2162,106 @@ impl InlineFormattingContext {
         }
 
         layout.finish_last_line();
+
+        // For the painting of backgrounds and borders on fragmented boxes, each box needs to know what part of the
+        // unfragmented whole it is. This determines that for all of our inline boxes.
+        for inline_box in self.inline_boxes.iter() {
+            let borrowed_box = inline_box.borrow();
+            if borrowed_box.base.style.get_border().box_decoration_break !=
+                BoxDecorationBreak::Slice
+            {
+                continue;
+            }
+            let fragments = borrowed_box.base.fragments.borrow();
+            let box_fragments: Vec<&Fragment> = fragments
+                .iter()
+                .filter(|fragment| matches!(fragment, Fragment::Box(_)))
+                .collect();
+            if box_fragments.len() <= 1 {
+                continue;
+            }
+
+            let writing_mode = borrowed_box.base.style.writing_mode;
+            let mut total_inline_size = Au::zero();
+            for fragment in &box_fragments {
+                if let Fragment::Box(box_fragment) = fragment {
+                    total_inline_size += box_fragment
+                        .base
+                        .rect()
+                        .size
+                        .to_logical(writing_mode)
+                        .inline;
+                }
+            }
+
+            let mut current_inline_offset = Au::zero();
+            for fragment in &box_fragments {
+                if let Fragment::Box(box_fragment) = fragment {
+                    let fragment_inline_size = box_fragment
+                        .base
+                        .rect()
+                        .size
+                        .to_logical(writing_mode)
+                        .inline;
+
+                    let mut origin = box_fragment.base.rect().origin;
+                    if writing_mode.is_horizontal() {
+                        box_fragment.set_is_fragmented_along_left_edge(true);
+                        box_fragment.set_is_fragmented_along_right_edge(true);
+                        if writing_mode.is_bidi_ltr() {
+                            origin.x -= current_inline_offset;
+                        } else {
+                            origin.x += current_inline_offset;
+                            origin.x -= total_inline_size - fragment_inline_size;
+                        }
+                    } else {
+                        box_fragment.set_is_fragmented_along_top_edge(true);
+                        box_fragment.set_is_fragmented_along_bottom_edge(true);
+                        if writing_mode.is_bidi_ltr() {
+                            origin.y -= current_inline_offset;
+                        } else {
+                            origin.x += current_inline_offset;
+                            origin.x -= total_inline_size - fragment_inline_size;
+                        }
+                    }
+                    box_fragment.set_unfragmented_rect(SyncPhysicalRectAu::new(Rect::new(
+                        origin,
+                        LogicalSize::new(
+                            writing_mode,
+                            total_inline_size,
+                            box_fragment.base.rect().size.to_logical(writing_mode).block,
+                        )
+                        .to_physical(writing_mode)
+                        .cast_unit(),
+                    )));
+
+                    current_inline_offset += fragment_inline_size;
+                }
+            }
+            // Fix up the fragmentation at the very beginning and end
+            if let Some(Fragment::Box(first_fragment)) = box_fragments.first() &&
+                let Some(Fragment::Box(last_fragment)) = box_fragments.last()
+            {
+                if writing_mode.is_horizontal() {
+                    if writing_mode.is_bidi_ltr() {
+                        first_fragment.set_is_fragmented_along_left_edge(false);
+                        last_fragment.set_is_fragmented_along_right_edge(false);
+                    } else {
+                        first_fragment.set_is_fragmented_along_right_edge(false);
+                        last_fragment.set_is_fragmented_along_left_edge(false);
+                    }
+                } else {
+                    if writing_mode.is_bidi_ltr() {
+                        first_fragment.set_is_fragmented_along_top_edge(false);
+                        last_fragment.set_is_fragmented_along_bottom_edge(false);
+                    } else {
+                        first_fragment.set_is_fragmented_along_bottom_edge(false);
+                        last_fragment.set_is_fragmented_along_top_edge(false);
+                    }
+                }
+            }
+        }
+
         let (content_block_size, collapsible_margins_in_children, baselines) =
             layout.placement_state.finish();
 

--- a/components/layout/fragment_tree/base_fragment.rs
+++ b/components/layout/fragment_tree/base_fragment.rs
@@ -275,7 +275,7 @@ malloc_size_of_is_0!(FragmentFlags);
 
 /// A data structure used to hold DOM and pseudo-element information about
 /// a particular layout object.
-#[derive(Clone, Copy, Eq, MallocSizeOf, PartialEq)]
+#[derive(Clone, Copy, Eq, Hash, MallocSizeOf, PartialEq)]
 pub(crate) struct Tag {
     pub(crate) node: OpaqueNode,
     pub(crate) pseudo_element_chain: PseudoElementChain,

--- a/components/layout/fragment_tree/base_fragment.rs
+++ b/components/layout/fragment_tree/base_fragment.rs
@@ -283,7 +283,7 @@ malloc_size_of_is_0!(FragmentFlags);
 
 /// A data structure used to hold DOM and pseudo-element information about
 /// a particular layout object.
-#[derive(Clone, Copy, Eq, MallocSizeOf, PartialEq)]
+#[derive(Clone, Copy, Eq, Hash, MallocSizeOf, PartialEq)]
 pub(crate) struct Tag {
     pub(crate) node: OpaqueNode,
     pub(crate) pseudo_element_chain: PseudoElementChain,

--- a/components/layout/fragment_tree/base_fragment.rs
+++ b/components/layout/fragment_tree/base_fragment.rs
@@ -283,7 +283,7 @@ malloc_size_of_is_0!(FragmentFlags);
 
 /// A data structure used to hold DOM and pseudo-element information about
 /// a particular layout object.
-#[derive(Clone, Copy, Eq, Hash, MallocSizeOf, PartialEq)]
+#[derive(Clone, Copy, Eq, MallocSizeOf, PartialEq)]
 pub(crate) struct Tag {
     pub(crate) node: OpaqueNode,
     pub(crate) pseudo_element_chain: PseudoElementChain,

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use app_units::{Au, MAX_AU, MIN_AU};
 use atomic_refcell::{AtomicRef, AtomicRefCell, AtomicRefMut};
-use euclid::Rect;
+use euclid::{Point2D, Rect, Size2D};
 use malloc_size_of_derive::MallocSizeOf;
 use once_cell::race::OnceBox;
 use servo_arc::Arc as ServoArc;
@@ -76,7 +76,7 @@ pub(crate) struct BlockLevelLayoutInfo {
     pub block_margins_collapsed_with_children: CollapsedBlockMargins,
 }
 
-#[derive(Clone, Default, MallocSizeOf)]
+#[derive(Default, MallocSizeOf)]
 pub(crate) struct BoxFragmentRareData {
     /// The resolved box insets if this box is `position: sticky`. These are calculated
     /// during `StackingContextTree` construction because they rely on the size of the
@@ -93,6 +93,14 @@ pub(crate) struct BoxFragmentRareData {
     /// If the associated [`BoxFragment`] establishes a spatial node via CSS this holds the
     /// [`ScrollTreeNodeId`] for the generated node set during stacking context tree construction.
     pub generated_scroll_tree_node_id: Option<ScrollTreeNodeId>,
+
+    /// In the case that this fragment actually represents a piece of an original, larger box which has
+    /// been sliced apart and must be rendered as such, this stores the original size, needed for drawing.
+    pub unfragmented_rect: Option<SyncPhysicalRectAu>,
+    pub is_fragmented_along_top_edge: bool,
+    pub is_fragmented_along_bottom_edge: bool,
+    pub is_fragmented_along_left_edge: bool,
+    pub is_fragmented_along_right_edge: bool,
 }
 
 impl BoxFragmentRareData {
@@ -106,6 +114,11 @@ impl BoxFragmentRareData {
                     specific_layout_info: Some(info),
                     generated_clip_id: None,
                     generated_scroll_tree_node_id: None,
+                    unfragmented_rect: None,
+                    is_fragmented_along_top_edge: false,
+                    is_fragmented_along_bottom_edge: false,
+                    is_fragmented_along_left_edge: false,
+                    is_fragmented_along_right_edge: false,
                 })))
             })
             .unwrap_or_default()
@@ -297,6 +310,35 @@ impl BoxFragment {
         self.ensure_rare_data().generated_scroll_tree_node_id = Some(generated_scroll_tree_node_id);
     }
 
+    pub(crate) fn unfragmented_rect(&self) -> Option<AtomicRef<'_, SyncPhysicalRectAu>> {
+        let rare_data = self.rare_data.get()?.borrow();
+
+        AtomicRef::filter_map(rare_data, |rare_data| rare_data.unfragmented_rect.as_ref())
+    }
+
+    pub(crate) fn set_unfragmented_rect(&self, unfragmented_rect: SyncPhysicalRectAu) {
+        self.ensure_rare_data().unfragmented_rect = Some(unfragmented_rect);
+    }
+
+    pub(crate) fn set_is_fragmented_along_top_edge(&self, is_fragmented_along_top_edge: bool) {
+        self.ensure_rare_data().is_fragmented_along_top_edge = is_fragmented_along_top_edge;
+    }
+
+    pub(crate) fn set_is_fragmented_along_bottom_edge(
+        &self,
+        is_fragmented_along_bottom_edge: bool,
+    ) {
+        self.ensure_rare_data().is_fragmented_along_bottom_edge = is_fragmented_along_bottom_edge;
+    }
+
+    pub(crate) fn set_is_fragmented_along_left_edge(&self, is_fragmented_along_left_edge: bool) {
+        self.ensure_rare_data().is_fragmented_along_left_edge = is_fragmented_along_left_edge;
+    }
+
+    pub(crate) fn set_is_fragmented_along_right_edge(&self, is_fragmented_along_right_edge: bool) {
+        self.ensure_rare_data().is_fragmented_along_right_edge = is_fragmented_along_right_edge;
+    }
+
     pub(crate) fn with_block_level_layout_info(
         mut self,
         block_margins_collapsed_with_children: CollapsedBlockMargins,
@@ -366,6 +408,90 @@ impl BoxFragment {
 
     pub(crate) fn margin_rect(&self) -> PhysicalRect<Au> {
         self.border_rect().outer_rect(self.margin)
+    }
+
+    pub(crate) fn unfragmented_content_rect(&self) -> PhysicalRect<Au> {
+        self.unfragmented_rect()
+            .map_or(self.base.rect(), |r| r.get())
+    }
+
+    pub(crate) fn unfragmented_padding_rect(&self) -> PhysicalRect<Au> {
+        self.unfragmented_content_rect().outer_rect(self.padding)
+    }
+
+    pub(crate) fn unfragmented_border_rect(&self) -> PhysicalRect<Au> {
+        self.unfragmented_padding_rect().outer_rect(self.border)
+    }
+
+    pub(crate) fn unfragmented_margin_rect(&self) -> PhysicalRect<Au> {
+        self.unfragmented_border_rect().outer_rect(self.margin)
+    }
+
+    fn is_fragmented(&self) -> bool {
+        self.is_fragmented_along_top_edge() ||
+            self.is_fragmented_along_bottom_edge() ||
+            self.is_fragmented_along_left_edge() ||
+            self.is_fragmented_along_right_edge()
+    }
+
+    fn is_fragmented_along_top_edge(&self) -> bool {
+        self.rare_data
+            .get()
+            .is_some_and(|rare_data| rare_data.borrow().is_fragmented_along_top_edge)
+    }
+
+    fn is_fragmented_along_bottom_edge(&self) -> bool {
+        self.rare_data
+            .get()
+            .is_some_and(|rare_data| rare_data.borrow().is_fragmented_along_bottom_edge)
+    }
+
+    fn is_fragmented_along_left_edge(&self) -> bool {
+        self.rare_data
+            .get()
+            .is_some_and(|rare_data| rare_data.borrow().is_fragmented_along_left_edge)
+    }
+
+    fn is_fragmented_along_right_edge(&self) -> bool {
+        self.rare_data
+            .get()
+            .is_some_and(|rare_data| rare_data.borrow().is_fragmented_along_right_edge)
+    }
+
+    pub(crate) fn fragmentation_clip_rect(&self) -> Option<PhysicalRect<Au>> {
+        if !self.is_fragmented() {
+            return None;
+        }
+        let content_rect = self.content_rect();
+        let border_rect = self.border_rect();
+        let x = if self.is_fragmented_along_left_edge() {
+            content_rect.origin.x
+        } else {
+            border_rect.origin.x
+        };
+        let y = if self.is_fragmented_along_top_edge() {
+            content_rect.origin.y
+        } else {
+            border_rect.origin.y
+        };
+        let mut width = border_rect.width();
+        if self.is_fragmented_along_left_edge() {
+            width -= content_rect.min_x() - border_rect.min_x();
+        }
+        if self.is_fragmented_along_right_edge() {
+            width -= border_rect.max_x() - content_rect.max_x();
+        }
+        let mut height = border_rect.height();
+        if self.is_fragmented_along_top_edge() {
+            height -= content_rect.min_y() - border_rect.min_y();
+        }
+        if self.is_fragmented_along_bottom_edge() {
+            height -= border_rect.max_y() - content_rect.max_y();
+        }
+        Some(PhysicalRect::new(
+            Point2D::new(x, y),
+            Size2D::new(width, height),
+        ))
     }
 
     pub(crate) fn padding_border_margin(&self) -> PhysicalSides<Au> {

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use app_units::{Au, MAX_AU, MIN_AU};
 use atomic_refcell::{AtomicRef, AtomicRefCell, AtomicRefMut};
-use euclid::Rect;
+use euclid::{Point2D, Rect, Size2D};
 use malloc_size_of_derive::MallocSizeOf;
 use once_cell::race::OnceBox;
 use servo_arc::Arc as ServoArc;
@@ -76,7 +76,7 @@ pub(crate) struct BlockLevelLayoutInfo {
     pub block_margins_collapsed_with_children: CollapsedBlockMargins,
 }
 
-#[derive(Clone, Default, MallocSizeOf)]
+#[derive(Default, MallocSizeOf)]
 pub(crate) struct BoxFragmentRareData {
     /// The resolved box insets if this box is `position: sticky`. These are calculated
     /// during `StackingContextTree` construction because they rely on the size of the
@@ -93,6 +93,14 @@ pub(crate) struct BoxFragmentRareData {
     /// If the associated [`BoxFragment`] establishes a spatial node via CSS this holds the
     /// [`ScrollTreeNodeId`] for the generated node set during stacking context tree construction.
     pub generated_scroll_tree_node_id: Option<ScrollTreeNodeId>,
+
+    /// In the case that this fragment actually represents a piece of an original, larger box which has
+    /// been sliced apart and must be rendered as such, this stores the original size, needed for drawing.
+    pub unfragmented_rect: Option<SyncPhysicalRectAu>,
+    pub is_fragmented_along_top_edge: bool,
+    pub is_fragmented_along_bottom_edge: bool,
+    pub is_fragmented_along_left_edge: bool,
+    pub is_fragmented_along_right_edge: bool,
 }
 
 impl BoxFragmentRareData {
@@ -106,6 +114,11 @@ impl BoxFragmentRareData {
                     specific_layout_info: Some(info),
                     generated_clip_id: None,
                     generated_scroll_tree_node_id: None,
+                    unfragmented_rect: None,
+                    is_fragmented_along_top_edge: false,
+                    is_fragmented_along_bottom_edge: false,
+                    is_fragmented_along_left_edge: false,
+                    is_fragmented_along_right_edge: false,
                 })))
             })
             .unwrap_or_default()
@@ -301,6 +314,35 @@ impl BoxFragment {
         self.ensure_rare_data().generated_scroll_tree_node_id = Some(generated_scroll_tree_node_id);
     }
 
+    pub(crate) fn unfragmented_rect(&self) -> Option<AtomicRef<'_, SyncPhysicalRectAu>> {
+        let rare_data = self.rare_data.get()?.borrow();
+
+        AtomicRef::filter_map(rare_data, |rare_data| rare_data.unfragmented_rect.as_ref())
+    }
+
+    pub(crate) fn set_unfragmented_rect(&self, unfragmented_rect: SyncPhysicalRectAu) {
+        self.ensure_rare_data().unfragmented_rect = Some(unfragmented_rect);
+    }
+
+    pub(crate) fn set_is_fragmented_along_top_edge(&self, is_fragmented_along_top_edge: bool) {
+        self.ensure_rare_data().is_fragmented_along_top_edge = is_fragmented_along_top_edge;
+    }
+
+    pub(crate) fn set_is_fragmented_along_bottom_edge(
+        &self,
+        is_fragmented_along_bottom_edge: bool,
+    ) {
+        self.ensure_rare_data().is_fragmented_along_bottom_edge = is_fragmented_along_bottom_edge;
+    }
+
+    pub(crate) fn set_is_fragmented_along_left_edge(&self, is_fragmented_along_left_edge: bool) {
+        self.ensure_rare_data().is_fragmented_along_left_edge = is_fragmented_along_left_edge;
+    }
+
+    pub(crate) fn set_is_fragmented_along_right_edge(&self, is_fragmented_along_right_edge: bool) {
+        self.ensure_rare_data().is_fragmented_along_right_edge = is_fragmented_along_right_edge;
+    }
+
     pub(crate) fn with_block_level_layout_info(
         mut self,
         block_margins_collapsed_with_children: CollapsedBlockMargins,
@@ -370,6 +412,90 @@ impl BoxFragment {
 
     pub(crate) fn margin_rect(&self) -> PhysicalRect<Au> {
         self.border_rect().outer_rect(self.margin)
+    }
+
+    pub(crate) fn unfragmented_content_rect(&self) -> PhysicalRect<Au> {
+        self.unfragmented_rect()
+            .map_or(self.base.rect(), |r| r.get())
+    }
+
+    pub(crate) fn unfragmented_padding_rect(&self) -> PhysicalRect<Au> {
+        self.unfragmented_content_rect().outer_rect(self.padding)
+    }
+
+    pub(crate) fn unfragmented_border_rect(&self) -> PhysicalRect<Au> {
+        self.unfragmented_padding_rect().outer_rect(self.border)
+    }
+
+    pub(crate) fn unfragmented_margin_rect(&self) -> PhysicalRect<Au> {
+        self.unfragmented_border_rect().outer_rect(self.margin)
+    }
+
+    fn is_fragmented(&self) -> bool {
+        self.is_fragmented_along_top_edge() ||
+            self.is_fragmented_along_bottom_edge() ||
+            self.is_fragmented_along_left_edge() ||
+            self.is_fragmented_along_right_edge()
+    }
+
+    fn is_fragmented_along_top_edge(&self) -> bool {
+        self.rare_data
+            .get()
+            .is_some_and(|rare_data| rare_data.borrow().is_fragmented_along_top_edge)
+    }
+
+    fn is_fragmented_along_bottom_edge(&self) -> bool {
+        self.rare_data
+            .get()
+            .is_some_and(|rare_data| rare_data.borrow().is_fragmented_along_bottom_edge)
+    }
+
+    fn is_fragmented_along_left_edge(&self) -> bool {
+        self.rare_data
+            .get()
+            .is_some_and(|rare_data| rare_data.borrow().is_fragmented_along_left_edge)
+    }
+
+    fn is_fragmented_along_right_edge(&self) -> bool {
+        self.rare_data
+            .get()
+            .is_some_and(|rare_data| rare_data.borrow().is_fragmented_along_right_edge)
+    }
+
+    pub(crate) fn fragmentation_clip_rect(&self) -> Option<PhysicalRect<Au>> {
+        if !self.is_fragmented() {
+            return None;
+        }
+        let content_rect = self.content_rect();
+        let border_rect = self.border_rect();
+        let x = if self.is_fragmented_along_left_edge() {
+            content_rect.origin.x
+        } else {
+            border_rect.origin.x
+        };
+        let y = if self.is_fragmented_along_top_edge() {
+            content_rect.origin.y
+        } else {
+            border_rect.origin.y
+        };
+        let mut width = border_rect.width();
+        if self.is_fragmented_along_left_edge() {
+            width -= content_rect.min_x() - border_rect.min_x();
+        }
+        if self.is_fragmented_along_right_edge() {
+            width -= border_rect.max_x() - content_rect.max_x();
+        }
+        let mut height = border_rect.height();
+        if self.is_fragmented_along_top_edge() {
+            height -= content_rect.min_y() - border_rect.min_y();
+        }
+        if self.is_fragmented_along_bottom_edge() {
+            height -= border_rect.max_y() - content_rect.max_y();
+        }
+        Some(PhysicalRect::new(
+            Point2D::new(x, y),
+            Size2D::new(width, height),
+        ))
     }
 
     pub(crate) fn padding_border_margin(&self) -> PhysicalSides<Au> {

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -398,25 +398,53 @@ impl BoxFragment {
         self.offset_by_containing_block(&self.border_rect(), containing_block_computation)
     }
 
+    fn fragmented_box_offsets(&self, offsets: PhysicalSides<Au>) -> PhysicalSides<Au> {
+        PhysicalSides::<Au>::new(
+            if self.is_fragmented_along_top_edge() {
+                Au::zero()
+            } else {
+                offsets.top
+            },
+            if self.is_fragmented_along_right_edge() {
+                Au::zero()
+            } else {
+                offsets.right
+            },
+            if self.is_fragmented_along_bottom_edge() {
+                Au::zero()
+            } else {
+                offsets.bottom
+            },
+            if self.is_fragmented_along_left_edge() {
+                Au::zero()
+            } else {
+                offsets.left
+            },
+        )
+    }
+
     pub(crate) fn content_rect(&self) -> PhysicalRect<Au> {
         self.base.rect()
     }
 
     pub(crate) fn padding_rect(&self) -> PhysicalRect<Au> {
-        self.content_rect().outer_rect(self.padding)
+        self.content_rect()
+            .outer_rect(self.fragmented_box_offsets(self.padding))
     }
 
     pub(crate) fn border_rect(&self) -> PhysicalRect<Au> {
-        self.padding_rect().outer_rect(self.border)
+        self.padding_rect()
+            .outer_rect(self.fragmented_box_offsets(self.border))
     }
 
     pub(crate) fn margin_rect(&self) -> PhysicalRect<Au> {
-        self.border_rect().outer_rect(self.margin)
+        self.border_rect()
+            .outer_rect(self.fragmented_box_offsets(self.margin))
     }
 
     pub(crate) fn unfragmented_content_rect(&self) -> PhysicalRect<Au> {
         self.unfragmented_rect()
-            .map_or(self.base.rect(), |r| r.get())
+            .map_or(self.base.rect(), |rect| rect.get())
     }
 
     pub(crate) fn unfragmented_padding_rect(&self) -> PhysicalRect<Au> {

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -438,25 +438,25 @@ impl BoxFragment {
             self.is_fragmented_along_right_edge()
     }
 
-    fn is_fragmented_along_top_edge(&self) -> bool {
+    pub(crate) fn is_fragmented_along_top_edge(&self) -> bool {
         self.rare_data
             .get()
             .is_some_and(|rare_data| rare_data.borrow().is_fragmented_along_top_edge)
     }
 
-    fn is_fragmented_along_bottom_edge(&self) -> bool {
+    pub(crate) fn is_fragmented_along_bottom_edge(&self) -> bool {
         self.rare_data
             .get()
             .is_some_and(|rare_data| rare_data.borrow().is_fragmented_along_bottom_edge)
     }
 
-    fn is_fragmented_along_left_edge(&self) -> bool {
+    pub(crate) fn is_fragmented_along_left_edge(&self) -> bool {
         self.rare_data
             .get()
             .is_some_and(|rare_data| rare_data.borrow().is_fragmented_along_left_edge)
     }
 
-    fn is_fragmented_along_right_edge(&self) -> bool {
+    pub(crate) fn is_fragmented_along_right_edge(&self) -> bool {
         self.rare_data
             .get()
             .is_some_and(|rare_data| rare_data.borrow().is_fragmented_along_right_edge)

--- a/tests/wpt/meta/css/css-backgrounds/border-radius-012.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/border-radius-012.html.ini
@@ -1,2 +1,0 @@
-[border-radius-012.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/box-shadow/slice-inline-fragmentation-001.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/box-shadow/slice-inline-fragmentation-001.html.ini
@@ -1,2 +1,0 @@
-[slice-inline-fragmentation-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/box-shadow/slice-inline-fragmentation-002.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/box-shadow/slice-inline-fragmentation-002.html.ini
@@ -1,2 +1,0 @@
-[slice-inline-fragmentation-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/box-shadow/slice-inline-fragmentation-003.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/box-shadow/slice-inline-fragmentation-003.html.ini
@@ -1,2 +1,0 @@
-[slice-inline-fragmentation-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-break/hit-test-inline-fragmentation-with-border-radius.html.ini
+++ b/tests/wpt/meta/css/css-break/hit-test-inline-fragmentation-with-border-radius.html.ini
@@ -34,3 +34,24 @@
 
   [Vertical RL line 2, hit test inside top-right right-angled corner]
     expected: FAIL
+
+  [Vertical LR line 1, hit test inside top-right rounded corner]
+    expected: FAIL
+
+  [Vertical LR line 2, hit test outside bottom-left rounded corner]
+    expected: FAIL
+
+  [Vertical RL line 1, hit test inside top-right rounded corner]
+    expected: FAIL
+
+  [Vertical RL line 2, hit test outside bottom-left rounded corner]
+    expected: FAIL
+
+  [Vertical RL line 2, hit test inside bottom-left rounded corner]
+    expected: FAIL
+
+  [Vertical RL line 2, hit test outside bottom-right rounded corner]
+    expected: FAIL
+
+  [Vertical RL line 2, hit test inside bottom-right rounded corner]
+    expected: FAIL

--- a/tests/wpt/tests/css/css-break/box-decoration-break-clone-clip-path-ref.html
+++ b/tests/wpt/tests/css/css-break/box-decoration-break-clone-clip-path-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<style>
+  .inner {
+    display: inline-block;
+    background-color: purple;
+    margin-left: 10px;
+    width: 10px;
+    height: 10px;
+  }
+</style>
+<p>This test passes if below there is two purple squares on top of one another.</p>
+<span>
+  <span class="inner"></span>
+  <br>
+  <span class="inner"></span>
+</span>

--- a/tests/wpt/tests/css/css-break/box-decoration-break-clone-clip-path.html
+++ b/tests/wpt/tests/css/css-break/box-decoration-break-clone-clip-path.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<title>clip-path should apply to each fragment individually with box-decoration-break: clone.</title>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-masking/#the-clip-path">
+<link rel="help" href="https://drafts.csswg.org/css-break/#break-decoration">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/6383#issuecomment-960244091">
+<link rel="match" href="box-decoration-break-clone-clip-path-ref.html">
+<meta name="assert" content="clip-path should apply to each fragment individually with box-decoration-break: clone.">
+<style>
+  #fragmented {
+    clip-path: inset(0px 10px 0px 10px);
+    box-decoration-break: clone;
+  }
+  .inner {
+    display: inline-block;
+    background-color: purple;
+    width: 30px;
+    height: 10px;
+  }
+</style>
+<p>This test passes if below there is two purple squares on top of one another.</p>
+<span id="fragmented">
+  <span class="inner"></span>
+  <br>
+  <span class="inner"></span>
+</span>

--- a/tests/wpt/tests/css/css-break/box-decoration-break-slice-border-radius-ref.html
+++ b/tests/wpt/tests/css/css-break/box-decoration-break-slice-border-radius-ref.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<style>
+  body {
+    margin-left: 100px;
+    line-height: 3em;
+  }
+  .breakable {
+    border: 2px solid black;
+    background: linear-gradient(to right, pink, lightblue);
+    border-radius: 50%;
+    padding: 6px;
+  }
+  .long, .short {
+    display: inline-block;
+    border: 1px solid black;
+    box-sizing: border-box;
+  }
+  .long {
+    width: 100px;
+  }
+  .short {
+    width: 50px;
+  }
+  .cover {
+    position: absolute;
+    background-color: white;
+    width: 300px;
+    height: 1lh;
+  }
+</style>
+Unbroken span for reference:<br>
+<span class="breakable" id="reference">
+  <span class="long"></span><span class="short"></span>
+</span><br>
+The span, broken into two pieces that could conceivably be put back together in a seamless fashion:<br>
+<span class="breakable">
+  <span class="long"></span><span class="cover"></span><span class="short"></span>
+</span><br>
+
+<span class="breakable" style="margin-left:-108px">
+  <span class="long"></span><span class="cover" style="transform: translateX(-300px)"></span><span class="short"></span>
+</span>
+

--- a/tests/wpt/tests/css/css-break/box-decoration-break-slice-border-radius-ref.html
+++ b/tests/wpt/tests/css/css-break/box-decoration-break-slice-border-radius-ref.html
@@ -7,7 +7,7 @@
   }
   .breakable {
     border: 2px solid black;
-    background: linear-gradient(to right, pink, lightblue);
+    background: lightgray;
     border-radius: 50%;
     padding: 6px;
   }

--- a/tests/wpt/tests/css/css-break/box-decoration-break-slice-border-radius.html
+++ b/tests/wpt/tests/css/css-break/box-decoration-break-slice-border-radius.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<title>box-decoration-break:slice should be able to slice a border radius in half.</title>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-break/#break-decoration">
+<link rel="match" href="box-decoration-break-slice-border-radius-ref.html">
+<meta name="assert" content="box-decoration-break:slice should be able to slice a border radius in half.">
+<!--
+  Feel free to expand these fuzzyness values as needed, so long as the box fragments correctly.
+  This could be solved by getting rid of the gradient instead, but I very much like the gradient as a visual aid.
+-->
+<meta name=fuzzy content="maxDifference=0-2;totalPixels=0-2000">
+<style>
+  body {
+    margin-left: 100px;
+    line-height: 3em;
+  }
+  .breakable {
+    border: 2px solid black;
+    background: linear-gradient(to right, pink, lightblue);
+    border-radius: 50%;
+    padding: 6px;
+  }
+  .long, .short {
+    display: inline-block;
+    border: 1px solid black;
+    box-sizing: border-box;
+  }
+  .long {
+    width: 100px;
+  }
+  .short {
+    width: 50px;
+  }
+</style>
+Unbroken span for reference:<br>
+<span class="breakable">
+  <span class="long"></span><span class="short"></span>
+</span><br>
+The span, broken into two pieces that could conceivably be put back together in a seamless fashion:<br>
+<span class="breakable">
+  <span class="long"></span><br>
+  <span class="short"></span>
+</span>

--- a/tests/wpt/tests/css/css-break/box-decoration-break-slice-border-radius.html
+++ b/tests/wpt/tests/css/css-break/box-decoration-break-slice-border-radius.html
@@ -4,11 +4,6 @@
 <link rel="help" href="https://drafts.csswg.org/css-break/#break-decoration">
 <link rel="match" href="box-decoration-break-slice-border-radius-ref.html">
 <meta name="assert" content="box-decoration-break:slice should be able to slice a border radius in half.">
-<!--
-  Feel free to expand these fuzzyness values as needed, so long as the box fragments correctly.
-  This could be solved by getting rid of the gradient instead, but I very much like the gradient as a visual aid.
--->
-<meta name=fuzzy content="maxDifference=0-2;totalPixels=0-2000">
 <style>
   body {
     margin-left: 100px;
@@ -16,7 +11,7 @@
   }
   .breakable {
     border: 2px solid black;
-    background: linear-gradient(to right, pink, lightblue);
+    background: lightgray;
     border-radius: 50%;
     padding: 6px;
   }

--- a/tests/wpt/tests/css/css-break/box-decoration-break-slice-clip-path-ref.html
+++ b/tests/wpt/tests/css/css-break/box-decoration-break-slice-clip-path-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<style>
+  .inner {
+    display: inline-block;
+    background-color: purple;
+    width: 40px;
+    height: 10px;
+  }
+</style>
+<p>This test passes if there is two boxes of equal size below, with the first one offset towards the right by 20px.</p>
+<span>
+  <span class="inner" style="margin-left: 20px"></span>
+  <br>
+  <span class="inner"></span>
+</span>

--- a/tests/wpt/tests/css/css-break/box-decoration-break-slice-clip-path.html
+++ b/tests/wpt/tests/css/css-break/box-decoration-break-slice-clip-path.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>clip-path should apply to the unfragmented box as a whole.</title>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-masking/#the-clip-path">
+<link rel="help" href="https://drafts.csswg.org/css-break/#break-decoration">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/6383#issuecomment-960244091">
+<link rel="match" href="box-decoration-break-slice-clip-path-ref.html">
+<meta name="assert" content="clip-path should apply to the unfragmented box as a whole.">
+<style>
+  #fragmented {
+    clip-path: inset(0px 20px 0px 20px);
+  }
+  .inner {
+    display: inline-block;
+    background-color: purple;
+    width: 60px;
+    height: 10px;
+  }
+</style>
+<p>This test passes if there is two boxes of equal size below, with the first one offset towards the right by 20px.</p>
+<span id="fragmented">
+  <span class="inner"></span>
+  <br>
+  <span class="inner"></span>
+</span>


### PR DESCRIPTION
Specifically, this makes it so that the original, unfragmented size of fragmented inline boxes is tracked on the fragments, so that they can draw their backgrounds and borders as if unfragmented and then clip them to what is actually part of the fragment in question.
This draw-then-clip seems to me like the most reasonable way to do this, since the fragmentation should be able to cut something like a border-radius in half. (as verified by the newly added web platform test)

There's a new web platform test for this that verifies that a border radius is sized correctly and can be sliced in half by fragmentation:
<img width="900" height="287" alt="image" src="https://github.com/user-attachments/assets/c5042832-7355-47e6-8504-2f234ae7a27d" />

There are also some new failures around hit-testing on rounded fragments with vertical text. These are expected since Servo does not do vertical text correctly yet and so we've gone from rounding all corners to rounding only some corners, with respect to an incorrect inline direction.

Fixes: #20747
