### PR TITLE
script: Don't store rooted values inside `ControlElement`

### DIFF
--- a/components/script/dom/document/document_embedder_controls.rs
+++ b/components/script/dom/document/document_embedder_controls.rs
@@ -42,11 +42,12 @@ use crate::messaging::MainThreadScriptMsg;
 use crate::navigation::navigate;
 
 #[derive(JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) enum ControlElement {
-    Select(DomRoot<HTMLSelectElement>),
-    ColorInput(DomRoot<HTMLInputElement>),
-    FileInput(DomRoot<HTMLInputElement>),
-    Ime(DomRoot<HTMLElement>),
+    Select(Dom<HTMLSelectElement>),
+    ColorInput(Dom<HTMLInputElement>),
+    FileInput(Dom<HTMLInputElement>),
+    Ime(Dom<HTMLElement>),
     ContextMenu(ContextMenuNodes),
 }
 
@@ -62,8 +63,10 @@ impl ControlElement {
     }
 }
 
+impl js::gc::Rootable for ControlElement {}
+
 #[derive(JSTraceable, MallocSizeOf)]
-#[cfg_attr(crown, expect(crown::unrooted_must_root))]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct DocumentEmbedderControls {
     /// The [`Window`] element for this [`DocumentUserInterfaceElements`].
     window: Dom<Window>,
@@ -96,6 +99,7 @@ impl DocumentEmbedderControls {
         }
     }
 
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn show_embedder_control(
         &self,
         element: ControlElement,
@@ -126,6 +130,16 @@ impl DocumentEmbedderControls {
             .borrow_mut()
             .insert(id.index.into(), element);
 
+        self.send_embedder_control_request(request, id, rect);
+        id
+    }
+
+    fn send_embedder_control_request(
+        &self,
+        request: EmbedderControlRequest,
+        id: EmbedderControlId,
+        rect: DeviceIntRect,
+    ) {
         match request {
             EmbedderControlRequest::SelectElement(..) |
             EmbedderControlRequest::ColorPicker(..) |
@@ -162,8 +176,6 @@ impl DocumentEmbedderControls {
                     .unwrap();
             },
         }
-
-        id
     }
 
     pub(crate) fn hide_embedder_control(&self, element: &Element) {
@@ -193,7 +205,9 @@ impl DocumentEmbedderControls {
         assert_eq!(self.window.pipeline_id(), id.pipeline_id);
         assert_eq!(self.window.webview_id(), id.webview_id);
 
-        let Some(element) = self.visible_elements.borrow_mut().remove(&id.index.into()) else {
+        rooted!(&in(cx) let visible_element = self.visible_elements.borrow_mut().remove(&id.index.into()));
+
+        let Some(element) = &*visible_element else {
             return;
         };
 
@@ -376,15 +390,13 @@ impl DocumentEmbedderControls {
             },
         ]);
 
-        let context_menu_nodes = ContextMenuNodes {
-            node: hit_test_result.node.clone(),
-            anchor_element,
-            image_element,
-            text_input_element,
-        };
-
         self.show_embedder_control(
-            ControlElement::ContextMenu(context_menu_nodes),
+            ControlElement::ContextMenu(ContextMenuNodes {
+                node: hit_test_result.node.as_traced(),
+                anchor_element: anchor_element.map(|element| element.as_traced()),
+                image_element: image_element.map(|element| element.as_traced()),
+                text_input_element: text_input_element.map(|element| element.as_traced()),
+            }),
             EmbedderControlRequest::ContextMenu(ContextMenuRequest {
                 element_info: info,
                 items,
@@ -395,15 +407,16 @@ impl DocumentEmbedderControls {
 }
 
 #[derive(JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct ContextMenuNodes {
     /// The node that this menu was triggered on.
-    node: DomRoot<Node>,
+    node: Dom<Node>,
     /// The first inclusive ancestor of this node that is an `<a>` if one exists.
-    anchor_element: Option<DomRoot<HTMLAnchorElement>>,
+    anchor_element: Option<Dom<HTMLAnchorElement>>,
     /// The first inclusive ancestor of this node that is an `<img>` if one exists.
-    image_element: Option<DomRoot<HTMLImageElement>>,
+    image_element: Option<Dom<HTMLImageElement>>,
     /// The first inclusive ancestor of this node which is a text entry field.
-    text_input_element: Option<DomRoot<Element>>,
+    text_input_element: Option<Dom<Element>>,
 }
 
 impl ContextMenuNodes {
@@ -503,21 +516,21 @@ impl ContextMenuNodes {
             ContextMenuAction::Cut => {
                 window.Document().event_handler().handle_editing_action(
                     cx,
-                    self.text_input_element.clone(),
+                    self.text_input_element.as_deref().map(DomRoot::from_ref),
                     EditingActionEvent::Cut,
                 );
             },
             ContextMenuAction::Copy => {
                 window.Document().event_handler().handle_editing_action(
                     cx,
-                    self.text_input_element.clone(),
+                    self.text_input_element.as_deref().map(DomRoot::from_ref),
                     EditingActionEvent::Copy,
                 );
             },
             ContextMenuAction::Paste => {
                 window.Document().event_handler().handle_editing_action(
                     cx,
-                    self.text_input_element.clone(),
+                    self.text_input_element.as_deref().map(DomRoot::from_ref),
                     EditingActionEvent::Paste,
                 );
             },

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -460,7 +460,7 @@ impl HTMLSelectElement {
         self.owner_document()
             .embedder_controls()
             .show_embedder_control(
-                ControlElement::Select(DomRoot::from_ref(self)),
+                ControlElement::Select(Dom::from_ref(self)),
                 EmbedderControlRequest::SelectElement(SelectElementRequest {
                     options,
                     selected_options,

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -25,7 +25,7 @@ use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use crate::dom::bindings::error::ErrorResult;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
-use crate::dom::bindings::root::{DomRoot, LayoutDom, MutNullableDom};
+use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::clipboardevent::{ClipboardEvent, ClipboardEventType};
 use crate::dom::compositionevent::CompositionEvent;
@@ -179,7 +179,7 @@ impl HTMLTextAreaElement {
             self.owner_document()
                 .embedder_controls()
                 .show_embedder_control(
-                    ControlElement::Ime(DomRoot::from_ref(self.upcast())),
+                    ControlElement::Ime(Dom::from_ref(self.upcast())),
                     EmbedderControlRequest::InputMethod(InputMethodRequest {
                         input_method_type: InputMethodType::Text,
                         text: String::from(self.Value()),

--- a/components/script/dom/html/input_element/color_input_type.rs
+++ b/components/script/dom/html/input_element/color_input_type.rs
@@ -210,7 +210,7 @@ impl SpecificInputType for ColorInputType {
             blue: (current_color.components.2 * 255.0).round() as u8,
         };
         document.embedder_controls().show_embedder_control(
-            ControlElement::ColorInput(DomRoot::from_ref(input)),
+            ControlElement::ColorInput(Dom::from_ref(input)),
             EmbedderControlRequest::ColorPicker(current_color),
             None,
         );

--- a/components/script/dom/html/input_element/file_input_type.rs
+++ b/components/script/dom/html/input_element/file_input_type.rs
@@ -184,7 +184,7 @@ impl SpecificInputType for FileInputType {
             .owner_document()
             .embedder_controls()
             .show_embedder_control(
-                ControlElement::FileInput(DomRoot::from_ref(input)),
+                ControlElement::FileInput(Dom::from_ref(input)),
                 EmbedderControlRequest::FilePicker(FilePickerRequest {
                     origin: input.owner_window().origin().immutable().clone(),
                     current_paths,

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -43,7 +43,7 @@ use crate::dom::bindings::codegen::Bindings::NodeBinding::{GetRootNodeOptions, N
 use crate::dom::bindings::error::{Error, ErrorResult};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
-use crate::dom::bindings::root::{DomRoot, LayoutDom, MutNullableDom};
+use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::clipboardevent::{ClipboardEvent, ClipboardEventType};
 use crate::dom::compositionevent::CompositionEvent;
@@ -1986,7 +1986,7 @@ impl HTMLInputElement {
             self.owner_document()
                 .embedder_controls()
                 .show_embedder_control(
-                    ControlElement::Ime(DomRoot::from_ref(self.upcast())),
+                    ControlElement::Ime(Dom::from_ref(self.upcast())),
                     EmbedderControlRequest::InputMethod(InputMethodRequest {
                         input_method_type,
                         text: String::from(self.Value()),


### PR DESCRIPTION
Used by `DocumentEmbedderControls`.

Testing: It compiles
Part of #39139
