### PR TITLE
script: Bump to mozjs with safe APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5243,9 +5243,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17277cebd079c3eb424f8d56d8f9ca9333ec263f9383b3595931b665f544d876"
+version = "0.18.3"
+source = "git+https://github.com/servo/mozjs.git?rev=refs%2Fpull%2F778%2Fhead#ebe7f8c0accad1ea2c40ed832880c1e0bf9486ea"
 dependencies = [
  "bindgen",
  "cc",
@@ -5259,8 +5258,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "140.12.0-2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf1645d99277fe604091a848fecbde7b9b595cbc3a592247a68d954c8acb596"
+source = "git+https://github.com/servo/mozjs.git?rev=refs%2Fpull%2F778%2Fhead#ebe7f8c0accad1ea2c40ed832880c1e0bf9486ea"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5244,7 +5244,8 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.18.3"
-source = "git+https://github.com/servo/mozjs.git?rev=refs%2Fpull%2F778%2Fhead#ebe7f8c0accad1ea2c40ed832880c1e0bf9486ea"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1010e76ba206fc91295b355d5924f6c632772e5646915a223e3c650e996023ef"
 dependencies = [
  "bindgen",
  "cc",
@@ -5258,7 +5259,8 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "140.12.0-2"
-source = "git+https://github.com/servo/mozjs.git?rev=refs%2Fpull%2F778%2Fhead#ebe7f8c0accad1ea2c40ed832880c1e0bf9486ea"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf1645d99277fe604091a848fecbde7b9b595cbc3a592247a68d954c8acb596"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -445,6 +445,8 @@ codegen-units = 1
 #
 # mozjs = { path = "../mozjs/mozjs" }
 # mozjs_sys = { path = "../mozjs/mozjs-sys" }
+mozjs = { git = "https://github.com/servo/mozjs.git", rev = "refs/pull/778/head" }
+mozjs_sys = { git = "https://github.com/servo/mozjs.git", rev = "refs/pull/778/head" }
 #
 # Or for CSP crate:
 # content-security-policy = { path = "../rust-content-security-policy" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -445,8 +445,6 @@ codegen-units = 1
 #
 # mozjs = { path = "../mozjs/mozjs" }
 # mozjs_sys = { path = "../mozjs/mozjs-sys" }
-mozjs = { git = "https://github.com/servo/mozjs.git", rev = "refs/pull/778/head" }
-mozjs_sys = { git = "https://github.com/servo/mozjs.git", rev = "refs/pull/778/head" }
 #
 # Or for CSP crate:
 # content-security-policy = { path = "../rust-content-security-policy" }

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -24,7 +24,7 @@ use js::rust::wrappers2::{
     JS_ClearPendingException, JS_ErrorFromException, JS_GetPendingException, JS_GetProperty,
     JS_IsExceptionPending, JS_SetPendingException,
 };
-use js::rust::{describe_scripted_caller, error_info_from_exception_stack};
+use js::rust::{describe_scripted_caller_safe, error_info_from_exception_stack_safe};
 use libc::c_uint;
 #[cfg(feature = "js_backtrace")]
 use script_bindings::cell::DomRefCell;
@@ -296,7 +296,7 @@ impl ErrorInfo {
 
     fn from_dom_exception(cx: &mut JSContext, object: HandleObject) -> Option<ErrorInfo> {
         let exception = root_from_handleobject::<DOMException>(cx, object).ok()?;
-        let scripted_caller = unsafe { describe_scripted_caller(cx.raw_cx()) }.unwrap_or_default();
+        let scripted_caller = describe_scripted_caller_safe(cx).unwrap_or_default();
         Some(ErrorInfo {
             message: exception.stringifier().into(),
             filename: scripted_caller.filename,
@@ -326,8 +326,7 @@ impl ErrorInfo {
 
         match USVString::safe_from_jsval(cx, value, ()) {
             Ok(ConversionResult::Success(USVString(string))) => {
-                let scripted_caller =
-                    unsafe { describe_scripted_caller(cx.raw_cx()) }.unwrap_or_default();
+                let scripted_caller = describe_scripted_caller_safe(cx).unwrap_or_default();
                 ErrorInfo {
                     message: format!("uncaught exception: {}", string),
                     filename: scripted_caller.filename,
@@ -358,7 +357,7 @@ fn error_info_from_pending_exception(
         return None;
     }
 
-    let error_info = unsafe { error_info_from_exception_stack(cx.raw_cx(), value.into())? };
+    let error_info = error_info_from_exception_stack_safe(cx, value)?;
 
     Some(ErrorInfo {
         message: error_info.message,

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -26,7 +26,7 @@ use js::rust::wrappers2::{
 };
 use js::rust::{
     CapturedJSStack, HandleObject, HandleValue, IdVector, ToNumber, ToString,
-    describe_scripted_caller, for_of,
+    describe_scripted_caller_safe, for_of,
 };
 use script_bindings::conversions::get_dom_class;
 
@@ -47,14 +47,13 @@ const MAX_LOG_CHILDREN: usize = 15;
 pub(crate) struct Console;
 
 impl Console {
-    #[expect(unsafe_code)]
     fn build_message(
         cx: &mut JSContext,
         level: ConsoleLogLevel,
         arguments: Vec<DebuggerValue>,
         stacktrace: Option<Vec<StackFrame>>,
     ) -> ConsoleMessage {
-        let caller = unsafe { describe_scripted_caller(cx.raw_cx()) }.unwrap_or_default();
+        let caller = describe_scripted_caller_safe(cx).unwrap_or_default();
 
         ConsoleMessage {
             fields: ConsoleMessageFields {

--- a/components/script/dom/security/csp.rs
+++ b/components/script/dom/security/csp.rs
@@ -17,7 +17,7 @@ use http::header::{HeaderMap, HeaderValue, ValueIter};
 use hyper_serde::Serde;
 use js::context::JSContext;
 use js::realm::CurrentRealm;
-use js::rust::describe_scripted_caller;
+use js::rust::describe_scripted_caller_safe;
 use log::warn;
 use servo_constellation_traits::{LoadData, LoadOrigin};
 use url::Url;
@@ -379,9 +379,8 @@ pub(crate) trait GlobalCspReporting {
     );
 }
 
-#[expect(unsafe_code)]
 fn compute_scripted_caller_source_position(cx: &mut JSContext) -> SourcePosition {
-    match unsafe { describe_scripted_caller(cx.raw_cx()) } {
+    match describe_scripted_caller_safe(cx) {
         Ok(scripted_caller) => SourcePosition {
             source_file: scripted_caller.filename,
             line_number: scripted_caller.line,


### PR DESCRIPTION
Switch to safe variants of `describe_scripted_caller` and `error_info_from_exception_stack`.

Testing: It compiles
