### PR TITLE
script: Require rooted handles in HeapBufferSource::new

### DIFF
--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -92,7 +92,7 @@ where
     }
 
     Ok(RootedTraceableBox::new(HeapBufferSource::<T>::new(
-        BufferSource::ArrayBufferView(Heap::boxed(*array.handle())),
+        array.handle(),
     )))
 }
 
@@ -137,20 +137,28 @@ impl<T> HeapBufferSource<T>
 where
     T: TypedArrayElement,
 {
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-    pub(crate) fn new(buffer_source: BufferSource) -> HeapBufferSource<T> {
+    /// Create a buffer source from a rooted ArrayBuffer or ArrayBufferView.
+    pub(crate) fn new(object: Handle<*mut JSObject>) -> HeapBufferSource<T> {
+        let object = object.get();
+        assert!(!object.is_null());
+
         HeapBufferSource {
-            buffer_source,
+            buffer_source: if unsafe { IsArrayBufferObject(object) } {
+                BufferSource::ArrayBuffer(Heap::boxed(object))
+            } else {
+                assert!(unsafe { JS_IsArrayBufferViewObject(object) });
+                BufferSource::ArrayBufferView(Heap::boxed(object))
+            },
             phantom: PhantomData,
         }
     }
 
     pub(crate) fn from_view(
+        cx: &mut JSContext,
         chunk: CustomAutoRooterGuard<TypedArray<T, *mut JSObject>>,
     ) -> RootedTraceableBox<HeapBufferSource<T>> {
-        RootedTraceableBox::new(HeapBufferSource::<T>::new(BufferSource::ArrayBufferView(
-            Heap::boxed(unsafe { *chunk.underlying_object() }),
-        )))
+        rooted!(&in(cx) let object = unsafe { *chunk.underlying_object() });
+        RootedTraceableBox::new(HeapBufferSource::<T>::new(object.handle()))
     }
 
     pub(crate) fn default() -> Self {
@@ -204,7 +212,7 @@ where
                          JS_GetArrayBufferViewBuffer(cx, Handle::from_raw(buffer.handle()), &mut is_shared));
 
                 RootedTraceableBox::new(HeapBufferSource::<ArrayBufferU8>::new(
-                    BufferSource::ArrayBuffer(Heap::boxed(*view_buffer.handle())),
+                    view_buffer.handle(),
                 ))
             },
             BufferSource::ArrayBuffer(_) => {
@@ -369,6 +377,8 @@ where
             },
         };
 
+        rooted!(&in(cx) let result = result);
+
         if result.is_null() {
             // Normalize SpiderMonkey failure: consume pending exception and
             // map it to a DOM Error.
@@ -383,9 +393,7 @@ where
             Err(Error::Type(c"can't clone array buffer".to_owned()))
         } else {
             Ok(RootedTraceableBox::new(
-                HeapBufferSource::<ArrayBufferU8>::new(BufferSource::ArrayBuffer(Heap::boxed(
-                    result,
-                ))),
+                HeapBufferSource::<ArrayBufferU8>::new(result.handle()),
             ))
         }
     }
@@ -674,10 +682,14 @@ where
             // Return a new ArrayBuffer object, created in the current Realm,
             // whose [[ArrayBufferData]] internal slot value is arrayBufferData and
             // whose [[ArrayBufferByteLength]] internal slot value is arrayBufferByteLength.
+            rooted!(&in(cx) let result = unsafe {
+                NewArrayBufferWithContents(cx, buffer_length, buffer_data)
+            });
+            if result.is_null() {
+                return Err(Error::JSFailed);
+            }
             Ok(RootedTraceableBox::new(
-                HeapBufferSource::<ArrayBufferU8>::new(BufferSource::ArrayBuffer(Heap::boxed(
-                    unsafe { NewArrayBufferWithContents(cx, buffer_length, buffer_data) },
-                ))),
+                HeapBufferSource::<ArrayBufferU8>::new(result.handle()),
             ))
         }
     }
@@ -771,16 +783,22 @@ pub(crate) fn create_buffer_source_with_constructor(
 ) -> Fallible<RootedTraceableBox<HeapBufferSource<ArrayBufferViewU8>>> {
     match &buffer_source.buffer_source {
         BufferSource::ArrayBuffer(heap) => match constructor {
-            Constructor::DataView => Ok(RootedTraceableBox::new(HeapBufferSource::new(
-                BufferSource::ArrayBufferView(Heap::boxed(unsafe {
+            Constructor::DataView => {
+                rooted!(&in(cx) let view = unsafe {
                     JS_NewDataView(
                         cx,
                         Handle::from_raw(heap.handle()),
                         byte_offset,
                         byte_length,
                     )
-                })),
-            ))),
+                });
+                if view.is_null() {
+                    return Err(Error::JSFailed);
+                }
+                Ok(RootedTraceableBox::new(HeapBufferSource::new(
+                    view.handle(),
+                )))
+            },
             Constructor::Name(name_type) => construct_typed_array(
                 cx,
                 name_type,
@@ -805,7 +823,7 @@ fn construct_typed_array(
 ) -> Fallible<RootedTraceableBox<HeapBufferSource<ArrayBufferViewU8>>> {
     match &buffer_source.buffer_source {
         BufferSource::ArrayBuffer(heap) => {
-            let array_view = unsafe {
+            rooted!(&in(cx) let array_view = unsafe {
                 match name_type {
                     Type::Int8 => JS_NewInt8ArrayWithBuffer(
                         cx,
@@ -883,10 +901,13 @@ fn construct_typed_array(
                         unreachable!("Invalid TypedArray type")
                     },
                 }
-            };
+            });
+            if array_view.is_null() {
+                return Err(Error::JSFailed);
+            }
 
             Ok(RootedTraceableBox::new(HeapBufferSource::new(
-                BufferSource::ArrayBufferView(Heap::boxed(array_view)),
+                array_view.handle(),
             )))
         },
         BufferSource::ArrayBufferView(_) => {
@@ -899,7 +920,7 @@ pub(crate) fn create_array_buffer_with_size(
     cx: &mut JSContext,
     size: usize,
 ) -> Fallible<RootedTraceableBox<HeapBufferSource<ArrayBufferU8>>> {
-    let result = unsafe { NewArrayBuffer(cx, size) };
+    rooted!(&in(cx) let result = unsafe { NewArrayBuffer(cx, size) });
     if result.is_null() {
         rooted!(&in(cx) let mut rval = UndefinedValue());
         unsafe {
@@ -910,7 +931,7 @@ pub(crate) fn create_array_buffer_with_size(
         Err(Error::Type(c"can't create array buffer".to_owned()))
     } else {
         Ok(RootedTraceableBox::new(
-            HeapBufferSource::<ArrayBufferU8>::new(BufferSource::ArrayBuffer(Heap::boxed(result))),
+            HeapBufferSource::<ArrayBufferU8>::new(result.handle()),
         ))
     }
 }

--- a/components/script/dom/canvas/imagedata.rs
+++ b/components/script/dom/canvas/imagedata.rs
@@ -101,7 +101,7 @@ impl ImageData {
                 return Err(Error::InvalidState(None));
             }
             // 3. Initialize the data attribute of imageData to source.
-            HeapBufferSource::<ClampedU8>::from_view(source)
+            HeapBufferSource::<ClampedU8>::from_view(cx, source)
         } else {
             // 2. Otherwise (source was not given):
             match settings.pixelFormat {

--- a/components/script/dom/stream/byteteereadrequest.rs
+++ b/components/script/dom/stream/byteteereadrequest.rs
@@ -14,7 +14,7 @@ use script_bindings::error::Fallible;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
 use super::byteteeunderlyingsource::ByteTeePullAlgorithm;
-use crate::dom::bindings::buffer_source::{BufferSource, HeapBufferSource};
+use crate::dom::bindings::buffer_source::HeapBufferSource;
 use crate::dom::bindings::error::{Error, ErrorToJsval};
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
@@ -126,8 +126,7 @@ impl ByteTeeReadRequest {
         self.read_again_for_branch_2.set(false);
 
         // Let chunk1 and chunk2 be chunk.
-        let chunk1 = chunk;
-        let chunk2 = chunk;
+        rooted!(&in(cx) let chunk_object = chunk.get().to_object());
 
         // Helper to surface clone failures exactly once
         let handle_clone_error = |cx: &mut JSContext, error: Error| {
@@ -149,9 +148,7 @@ impl ByteTeeReadRequest {
         // Prepare per branch chunks ahead of the spec enqueue steps.
         let chunk1_view = if !self.canceled_1.get() {
             Some(RootedTraceableBox::new(
-                HeapBufferSource::<ArrayBufferViewU8>::new(BufferSource::ArrayBufferView(
-                    Heap::boxed(chunk1.get().to_object()),
-                )),
+                HeapBufferSource::<ArrayBufferViewU8>::new(chunk_object.handle()),
             ))
         } else {
             None
@@ -162,10 +159,9 @@ impl ByteTeeReadRequest {
         // If canceled1 is false and canceled2 is false,
         if !self.canceled_1.get() && !self.canceled_2.get() {
             // Let cloneResult be CloneAsUint8Array(chunk).
-            let chunk2_source =
-                RootedTraceableBox::new(HeapBufferSource::<ArrayBufferViewU8>::new(
-                    BufferSource::ArrayBufferView(Heap::boxed(chunk2.get().to_object())),
-                ));
+            let chunk2_source = RootedTraceableBox::new(
+                HeapBufferSource::<ArrayBufferViewU8>::new(chunk_object.handle()),
+            );
             let clone_result = chunk2_source.clone_as_uint8_array(cx);
 
             // If cloneResult is an abrupt completion,
@@ -178,10 +174,9 @@ impl ByteTeeReadRequest {
             }
         } else if !self.canceled_2.get() {
             // Only branch2 needs data; clone once for it.
-            let chunk2_source =
-                RootedTraceableBox::new(HeapBufferSource::<ArrayBufferViewU8>::new(
-                    BufferSource::ArrayBufferView(Heap::boxed(chunk2.get().to_object())),
-                ));
+            let chunk2_source = RootedTraceableBox::new(
+                HeapBufferSource::<ArrayBufferViewU8>::new(chunk_object.handle()),
+            );
             match chunk2_source.clone_as_uint8_array(cx) {
                 Ok(clone) => chunk2_view = Some(clone),
                 Err(error) => {

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -1970,7 +1970,7 @@ impl ReadableByteStreamControllerMethods<crate::DomTypeHolder> for ReadableByteS
         cx: &mut JSContext,
         chunk: js::gc::CustomAutoRooterGuard<js::typedarray::ArrayBufferView>,
     ) -> Fallible<()> {
-        let chunk = HeapBufferSource::<ArrayBufferViewU8>::from_view(chunk);
+        let chunk = HeapBufferSource::<ArrayBufferViewU8>::from_view(cx, chunk);
 
         // If chunk.[[ByteLength]] is 0, throw a TypeError exception.
         if chunk.byte_length() == 0 {

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -69,7 +69,7 @@ use crate::dom::bindings::transferable::Transferable;
 use crate::dom::bindings::structuredclone::StructuredData;
 
 use super::readablestreambyobreader::ReadIntoRequest;
-use crate::dom::bindings::buffer_source::{BufferSource, HeapBufferSource, create_buffer_source};
+use crate::dom::bindings::buffer_source::{HeapBufferSource, create_buffer_source};
 
 /// State Machine for `PipeTo`.
 #[derive(Clone, Debug, Default, MallocSizeOf, PartialEq)]
@@ -1159,7 +1159,7 @@ impl ReadableStream {
                     .expect("failed to create buffer source for native byte chunk.");
 
                 let chunk = RootedTraceableBox::new(HeapBufferSource::<ArrayBufferViewU8>::new(
-                    BufferSource::ArrayBufferView(Heap::boxed(*chunk_object.handle())),
+                    chunk_object.handle(),
                 ));
                 controller
                     .enqueue(cx, chunk)

--- a/components/script/dom/stream/readablestreambyobreader.rs
+++ b/components/script/dom/stream/readablestreambyobreader.rs
@@ -24,7 +24,7 @@ use script_bindings::root::Dom;
 use super::byteteereadintorequest::ByteTeeReadIntoRequest;
 use super::readablebytestreamcontroller::ReadableByteStreamController;
 use super::readablestreamgenericreader::ReadableStreamGenericReader;
-use crate::dom::bindings::buffer_source::{BufferSource, HeapBufferSource};
+use crate::dom::bindings::buffer_source::HeapBufferSource;
 use crate::dom::bindings::codegen::Bindings::ReadableStreamBYOBReaderBinding::{
     ReadableStreamBYOBReaderMethods, ReadableStreamBYOBReaderReadOptions,
 };
@@ -66,12 +66,15 @@ impl ReadIntoRequest {
             },
             ReadIntoRequest::ByteTee {
                 byte_tee_read_into_request,
-            } => byte_tee_read_into_request.enqueue_chunk_steps(
-                cx,
-                RootedTraceableBox::new(HeapBufferSource::<ArrayBufferViewU8>::new(
-                    BufferSource::ArrayBufferView(Heap::boxed(chunk.get().to_object())),
-                )),
-            ),
+            } => {
+                rooted!(&in(cx) let chunk_object = chunk.get().to_object());
+                byte_tee_read_into_request.enqueue_chunk_steps(
+                    cx,
+                    RootedTraceableBox::new(HeapBufferSource::<ArrayBufferViewU8>::new(
+                        chunk_object.handle(),
+                    )),
+                )
+            },
         }
     }
 
@@ -103,16 +106,17 @@ impl ReadIntoRequest {
             ReadIntoRequest::ByteTee {
                 byte_tee_read_into_request,
             } => match chunk {
-                Some(chunk) => byte_tee_read_into_request
-                    .close_steps(
-                        cx,
-                        Some(RootedTraceableBox::new(
-                            HeapBufferSource::<ArrayBufferViewU8>::new(
-                                BufferSource::ArrayBufferView(Heap::boxed(chunk.get().to_object())),
-                            ),
-                        )),
-                    )
-                    .expect("close steps should not fail"),
+                Some(chunk) => {
+                    rooted!(&in(cx) let chunk_object = chunk.get().to_object());
+                    byte_tee_read_into_request
+                        .close_steps(
+                            cx,
+                            Some(RootedTraceableBox::new(
+                                HeapBufferSource::<ArrayBufferViewU8>::new(chunk_object.handle()),
+                            )),
+                        )
+                        .expect("close steps should not fail")
+                },
                 None => byte_tee_read_into_request
                     .close_steps(cx, None)
                     .expect("close steps should not fail"),
@@ -419,7 +423,7 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
         view: CustomAutoRooterGuard<ArrayBufferView>,
         options: &ReadableStreamBYOBReaderReadOptions,
     ) -> Rc<Promise> {
-        let view = HeapBufferSource::<ArrayBufferViewU8>::from_view(view);
+        let view = HeapBufferSource::<ArrayBufferViewU8>::from_view(cx, view);
         let min = options.min;
         // Let promise be a new promise.
         let promise = Promise::new(cx, &self.global());

--- a/components/script/dom/stream/readablestreambyobrequest.rs
+++ b/components/script/dom/stream/readablestreambyobrequest.rs
@@ -105,7 +105,7 @@ impl ReadableStreamBYOBRequestMethods<crate::DomTypeHolder> for ReadableStreamBY
         cx: &mut JSContext,
         view: CustomAutoRooterGuard<ArrayBufferView>,
     ) -> Fallible<()> {
-        let view = HeapBufferSource::<ArrayBufferViewU8>::from_view(view);
+        let view = HeapBufferSource::<ArrayBufferViewU8>::from_view(cx, view);
 
         // If this.[[controller]] is undefined, throw a TypeError exception.
         let controller = if let Some(controller) = self.controller.get() {


### PR DESCRIPTION
Make HeapBufferSource::new take a rooted JS object handle and determine the BufferSource variant internally. 

Testing: No new tests covered by ./mach build --use-crown.

Fixes: #44646