### PR TITLE
backport CI blocking fixes to release/v0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,9 +1673,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -45,6 +45,9 @@ ignore = [
     #
     # We must use this version of quick-xml until `winit` upgrades `sctk`.
     "RUSTSEC-2026-0195",
+    # `rustybuzz` is unmaintained. Switch to harfrust.
+    # However, this is a dependecy of `resvg`, there's nothing we can do.
+    "RUSTSEC-2026-0206",
 ]
 
 # This section is considered when running `cargo deny check licenses`

--- a/python/wpt/exporter/step.py
+++ b/python/wpt/exporter/step.py
@@ -111,10 +111,10 @@ class CreateOrUpdateBranchForPRStep(Step):
             # TODO: If we could cleverly parse and manipulate the full commit diff
             # we could avoid cloning the servo repository altogether and only
             # have to fetch the commit diffs from GitHub.
-            # NB: The output of git show might include binary files or non-UTF8 text,
+            # NB: The output of git might include binary files or non-UTF8 text,
             # so store the content of the diff as a `bytes`.
             diff = local_servo_repo.run_without_encoding(
-                "show", "--binary", "--format=%b", sha, "--", UPSTREAMABLE_PATH
+                "diff-tree", "--binary", "--no-commit-id", "-p", sha, "--", UPSTREAMABLE_PATH
             )
 
             # Retrieve the diff of any changes to files that are relevant

--- a/python/wpt/test.py
+++ b/python/wpt/test.py
@@ -624,6 +624,10 @@ def setUpModule() -> None:
     def setup_mock_repo(repo_name: str, local_repo: LocalGitRepo, default_branch: str) -> None:
         subprocess.check_output(["cp", "-R", "-p", os.path.join(TESTS_DIR, repo_name), local_repo.path])
         local_repo.run("init", "-b", default_branch)
+        # Prevent git from doing auto maintenance in the background, which can interfere
+        # with file operations.
+        local_repo.run("config", "gc.auto", "0")
+        local_repo.run("config", "maintenance.auto", "false")
         local_repo.run("add", ".")
         local_repo.run("commit", "-a", "-m", "Initial commit")
 
@@ -636,7 +640,7 @@ def setUpModule() -> None:
 
 def tearDownModule() -> None:
     # pylint: disable=invalid-name
-    shutil.rmtree(TMP_DIR)
+    shutil.rmtree(TMP_DIR, ignore_errors=True)
 
 
 def run_tests() -> bool:


### PR DESCRIPTION
Backports several commits to the release/v0.4 branch which are required to fix the CI.

[mach try](https://github.com/jschwe/servo/actions/runs/29238102380)
