### PR TITLE
servoshell: Call `RenderingContext::resize` when a window is resized synchronously after `Window::request_inner_size`

### DIFF
--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -894,6 +894,13 @@ impl PlatformWindow for HeadedWindow {
                 new_inner_size.height,
             ))
             .map(|resulting_size| {
+                // `Some` means that winit applied the resize synchronously, in which case it may
+                // not emit a subsequent `WindowEvent::Resized`.
+                if self.inner_size.get() != resulting_size {
+                    self.inner_size.set(resulting_size);
+                    self.window_rendering_context.resize(resulting_size);
+                }
+
                 DeviceIntSize::new(
                     resulting_size.width as i32 + decoration_size.width,
                     resulting_size.height as i32 + decoration_size.height,


### PR DESCRIPTION
This PR is to address the issue with python WebDriver, when it tries to resize the servo on Linux, and it does resize the window, but the resulting window is just scaled, without proper "re-render" that is usually done on "hand dragged resize event".

When doing selenium resize
```Python
def resize_window(driver: WebDriver, width: int, height: int) -> None:
    try:
        driver.set_window_rect(width=width, height=height)
    except WebDriverException:
        driver.set_window_size(width, height)
```
<img width="708" height="588" alt="image" src="https://github.com/user-attachments/assets/9eb1ad7b-8d79-4967-ade1-bbfc149d5a21" />


Testing: We do not really have tests for this, as typically WPT-type tests run in headless mode.