### PR TITLE
script: Do not load all fonts for SVG font database

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -598,7 +598,7 @@ impl Font {
         glyph_index
     }
 
-    pub(crate) fn has_glyph_for(&self, codepoint: char) -> bool {
+    pub fn has_glyph_for(&self, codepoint: char) -> bool {
         self.glyph_index(codepoint).is_some()
     }
 

--- a/components/fonts/lib.rs
+++ b/components/fonts/lib.rs
@@ -62,7 +62,7 @@ impl Default for FallbackFontSelectionOptions {
 }
 
 impl FallbackFontSelectionOptions {
-    pub(crate) fn new(character: char, next_character: Option<char>, language: Language) -> Self {
+    pub fn new(character: char, next_character: Option<char>, language: Language) -> Self {
         let presentation_preference = match next_character {
             Some(next_character) if emoji::is_emoji_presentation_selector(next_character) => {
                 EmojiPresentationPreference::Emoji

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -1071,6 +1071,16 @@ impl MallocSizeOf for usvg::ClipPath {
     }
 }
 
+impl<'a> MallocSizeOf for usvg::Options<'a> {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        self.font_family.size_of(ops) +
+            self.languages.size_of(ops) +
+            self.style_sheet.size_of(ops) +
+            self.fontdb.conditional_shallow_size_of(ops) +
+            self.resources_dir.size_of(ops)
+    }
+}
+
 // Placeholder for unique case where internals of Sender cannot be measured.
 // malloc size of is 0 macro complains about type supplied!
 impl<T> MallocSizeOf for crossbeam_channel::Sender<T> {

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -81,30 +81,9 @@ const MAX_SVG_PIXMAP_DIMENSION: u32 = 5000;
 
 fn parse_svg_document_in_memory(
     bytes: &[u8],
-    fontdb: Arc<fontdb::Database>,
-    font_resolver: Arc<dyn FontResolver>,
+    usvg_options: Arc<usvg::Options>,
 ) -> Result<usvg::Tree, &'static str> {
-    let image_string_href_resolver = Box::new(move |_: &str, _: &usvg::Options| {
-        // Do not try to load `href` in <image> as local file path.
-        None
-    });
-
-    let font_resolver = usvg::FontResolver {
-        select_font: Box::new(move |font, database| font_resolver.resolve(font, database)),
-        select_fallback: usvg::FontResolver::default_fallback_selector(),
-    };
-
-    let opt = usvg::Options {
-        image_href_resolver: usvg::ImageHrefResolver {
-            resolve_data: usvg::ImageHrefResolver::default_data_resolver(),
-            resolve_string: image_string_href_resolver,
-        },
-        font_resolver,
-        fontdb,
-        ..usvg::Options::default()
-    };
-
-    usvg::Tree::from_data(bytes, &opt)
+    usvg::Tree::from_data(bytes, &usvg_options)
         .inspect_err(|error| {
             warn!("Error when parsing SVG data: {error}");
         })
@@ -116,8 +95,7 @@ fn decode_bytes_sync(
     bytes: &[u8],
     cors: CorsStatus,
     content_type: Option<Mime>,
-    fontdb: Arc<fontdb::Database>,
-    font_resolver: Arc<dyn FontResolver>,
+    usvg_options: Arc<usvg::Options>,
 ) -> DecoderMsg {
     let is_svg_document = content_type.is_some_and(|content_type| {
         (
@@ -128,7 +106,7 @@ fn decode_bytes_sync(
     });
 
     let image = if is_svg_document {
-        parse_svg_document_in_memory(bytes, fontdb, font_resolver.clone())
+        parse_svg_document_in_memory(bytes, usvg_options)
             .ok()
             .map(|svg_tree| {
                 DecodedImage::Vector(VectorImageData {
@@ -811,21 +789,15 @@ pub struct ImageCacheFactoryImpl {
     broken_image_icon_data: Arc<Vec<u8>>,
     /// Thread pool for image decoding
     thread_pool: Arc<ThreadPool>,
-    /// A shared font database to be used by system fonts accessed when rasterizing vector
-    /// images.
-    fontdb: Arc<fontdb::Database>,
 }
 
 impl ImageCacheFactoryImpl {
     pub fn new(broken_image_icon_data: Vec<u8>) -> Self {
         debug!("Creating new ImageCacheFactoryImpl");
-        let mut fontdb = fontdb::Database::new();
-        fontdb.load_system_fonts();
 
         Self {
             broken_image_icon_data: Arc::new(broken_image_icon_data),
             thread_pool: ThreadPool::global(),
-            fontdb: Arc::new(fontdb),
         }
     }
 }
@@ -838,6 +810,28 @@ impl ImageCacheFactory for ImageCacheFactoryImpl {
         paint_api: &CrossProcessPaintApi,
         font_resolver: Arc<dyn FontResolver>,
     ) -> Arc<dyn ImageCache> {
+        let image_string_href_resolver = Box::new(move |_: &str, _: &usvg::Options| {
+            // Do not try to load `href` in <image> as local file path.
+            None
+        });
+        let font_resolver2 = font_resolver.clone();
+        let font_resolver = usvg::FontResolver {
+            select_font: Box::new(move |font, database| font_resolver.resolve(font, database)),
+            select_fallback: Box::new(move |char, ids, database| {
+                font_resolver2.backup_resolve(char, ids, database)
+            }),
+        };
+
+        let opt = usvg::Options {
+            image_href_resolver: usvg::ImageHrefResolver {
+                resolve_data: usvg::ImageHrefResolver::default_data_resolver(),
+                resolve_string: image_string_href_resolver,
+            },
+            font_resolver,
+            fontdb: Arc::new(fontdb::Database::new()),
+            ..usvg::Options::default()
+        };
+
         Arc::new(ImageCacheImpl {
             store: Arc::new(Mutex::new(ImageCacheStore {
                 pending_loads: AllPendingLoads::new(),
@@ -854,8 +848,7 @@ impl ImageCacheFactory for ImageCacheFactoryImpl {
             svg_id_image_id_map: Arc::new(Mutex::new(FxHashMap::default())),
             broken_image_icon_data: self.broken_image_icon_data.clone(),
             thread_pool: self.thread_pool.clone(),
-            fontdb: self.fontdb.clone(),
-            font_resolver: font_resolver.clone(),
+            usvg_options: Arc::new(opt),
         })
     }
 }
@@ -870,17 +863,14 @@ pub struct ImageCacheImpl {
     /// Thread pool for image decoding. This is shared with other [`ImageCache`]s in the
     /// same process.
     thread_pool: Arc<ThreadPool>,
-    /// A shared font database to be used by system fonts accessed when rasterizing vector
-    /// images. This is shared with other [`ImageCache`]s in the same process.
-    fontdb: Arc<fontdb::Database>,
-    /// the font_resolver callback to query and append the fonts to fontdb in svg
-    font_resolver: Arc<dyn FontResolver>,
+    /// The options for usvg. Contains a fontdb::Database and fontresolver.
+    usvg_options: Arc<usvg::Options<'static>>,
 }
 
 impl ImageCache for ImageCacheImpl {
     fn memory_reports(&self, prefix: &str, ops: &mut MallocSizeOfOps) -> Vec<Report> {
         let store_size = self.store.lock().size_of(ops);
-        let fontdb_size = self.fontdb.conditional_size_of(ops);
+        let fontdb_size = self.usvg_options.conditional_size_of(ops);
         vec![
             Report {
                 path: path![prefix, "image-cache"],
@@ -888,7 +878,7 @@ impl ImageCache for ImageCacheImpl {
                 size: store_size,
             },
             Report {
-                path: path![prefix, "image-cache", "fontdb"],
+                path: path![prefix, "image-cache", "usvg_options"],
                 kind: ReportKind::ExplicitSystemHeapSize,
                 size: fontdb_size,
             },
@@ -1288,16 +1278,14 @@ impl ImageCache for ImageCacheImpl {
                         };
 
                         let local_store = self.store.clone();
-                        let fontdb = self.fontdb.clone();
-                        let font_resolver = self.font_resolver.clone();
+                        let usvg_options = self.usvg_options.clone();
                         self.thread_pool.spawn(move || {
                             let msg = decode_bytes_sync(
                                 key,
                                 &bytes,
                                 cors_status,
                                 content_type,
-                                fontdb,
-                                font_resolver,
+                                usvg_options,
                             );
                             local_store.lock().handle_decoder(msg);
                         });

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -818,7 +818,7 @@ impl ImageCacheFactory for ImageCacheFactoryImpl {
         let font_resolver = usvg::FontResolver {
             select_font: Box::new(move |font, database| font_resolver.resolve(font, database)),
             select_fallback: Box::new(move |char, ids, database| {
-                font_resolver2.backup_resolve(char, ids, database)
+                font_resolver2.resolve_fallback(char, ids, database)
             }),
         };
 

--- a/components/net/tests/image_cache.rs
+++ b/components/net/tests/image_cache.rs
@@ -32,6 +32,15 @@ impl FontResolver for DummyFontResolver {
     fn resolve(&self, _: &Font, _: &mut Arc<fontdb::Database>) -> Option<fontdb::ID> {
         None
     }
+
+    fn backup_resolve(
+        &self,
+        _: char,
+        _: &[fontdb::ID],
+        _: &mut Arc<fontdb::Database>,
+    ) -> Option<fontdb::ID> {
+        None
+    }
 }
 
 fn create_test_image_cache() -> (Arc<dyn ImageCache>, Receiver<PipelineId>) {

--- a/components/net/tests/image_cache.rs
+++ b/components/net/tests/image_cache.rs
@@ -33,7 +33,7 @@ impl FontResolver for DummyFontResolver {
         None
     }
 
-    fn backup_resolve(
+    fn resolve_fallback(
         &self,
         _: char,
         _: &[fontdb::ID],

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3466,9 +3466,7 @@ impl ScriptThread {
             self.resource_threads.clone(),
         ));
 
-        let font_resolver = Arc::new(SvgFontResolver {
-            context: font_context.clone(),
-        });
+        let font_resolver = Arc::new(SvgFontResolver::new(font_context.clone()));
 
         let image_cache = self.image_cache_factory.create(
             incomplete.webview_id,

--- a/components/script/svg_font.rs
+++ b/components/script/svg_font.rs
@@ -26,7 +26,7 @@ use webrender_api::FontVariation;
 pub struct SvgFontResolver {
     /// Cache for Font to ID
     font_id_cache: Mutex<FxHashMap<Font, fontdb::ID>>,
-    fallback_id_cache: Mutex<FxHashMap<char, fontdb::ID>>,
+    fallback_id_cache: Mutex<FxHashMap<char, Vec<fontdb::ID>>>,
     context: Arc<FontContext>,
 }
 
@@ -164,7 +164,7 @@ impl FontResolver for SvgFontResolver {
         self.insert_into_database(font, database)
     }
 
-    fn backup_resolve(
+    fn resolve_fallback(
         &self,
         character: char,
         excluded: &[fontdb::ID],
@@ -172,7 +172,10 @@ impl FontResolver for SvgFontResolver {
     ) -> Option<fontdb::ID> {
         {
             let id_cache = self.fallback_id_cache.lock().unwrap();
-            if let Some(font_id) = id_cache.get(&character) {
+            if let Some(font_id) = id_cache
+                .get(&character)
+                .and_then(|font_ids| font_ids.iter().find(|font_id| !excluded.contains(font_id)))
+            {
                 return Some(*font_id);
             }
         }
@@ -216,10 +219,13 @@ impl FontResolver for SvgFontResolver {
                     continue;
                 }
 
-                if let Some(id) = ids.get(data_and_index.index as usize).copied() {
-                    self.fallback_id_cache.lock().unwrap().insert(character, id);
-                    return Some(id);
-                }
+                self.fallback_id_cache
+                    .lock()
+                    .unwrap()
+                    .entry(character)
+                    .or_default()
+                    .push(*id);
+                return Some(*id);
             }
         }
         None

--- a/components/script/svg_font.rs
+++ b/components/script/svg_font.rs
@@ -176,7 +176,6 @@ impl FontResolver for SvgFontResolver {
                 return Some(*font_id);
             }
         }
-        log::error!("FONT BACKUP CCALLED");
         let fallback_options =
             FallbackFontSelectionOptions::new(character, None, icu_locid::subtags::Language::UND);
         for family in fallback_font_families(fallback_options) {

--- a/components/script/svg_font.rs
+++ b/components/script/svg_font.rs
@@ -22,7 +22,7 @@ use style::values::computed::{
 };
 use webrender_api::FontVariation;
 
-/// Used to dynamically query fonts used in SVGs and insert them into the fontDB that [`ImageCacheImpl`] via usvg_options.
+/// Used to dynamically query fonts used in SVGs and insert them into the fontDB used when rasterizing.
 pub struct SvgFontResolver {
     /// Cache for Font to ID
     font_id_cache: Mutex<FxHashMap<Font, fontdb::ID>>,

--- a/components/script/svg_font.rs
+++ b/components/script/svg_font.rs
@@ -2,12 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use app_units::Au;
-use fonts::{FontContext, FontDescriptor, FontFamilyDescriptor, FontSearchScope};
+use fonts::{
+    FallbackFontSelectionOptions, FontContext, FontDescriptor, FontFamilyDescriptor,
+    FontSearchScope, fallback_font_families,
+};
 use net_traits::image_cache::FontResolver;
 use resvg::usvg::{Font, FontFamily, FontStretch, FontStyle, fontdb};
+use rustc_hash::FxHashMap;
 use style::computed_values::font_optical_sizing::T as FontOpticalSizing;
 use style::properties::longhands::font_variant_caps::computed_value::T as FontVariantCaps;
 use style::values::computed::font::{
@@ -18,11 +22,71 @@ use style::values::computed::{
 };
 use webrender_api::FontVariation;
 
+/// Used to dynamically query fonts used in SVGs and insert them into the fontDB that [`ImageCacheImpl`] via usvg_options.
 pub struct SvgFontResolver {
-    pub context: Arc<FontContext>,
+    /// Cache for Font to ID
+    font_id_cache: Mutex<FxHashMap<Font, fontdb::ID>>,
+    fallback_id_cache: Mutex<FxHashMap<char, fontdb::ID>>,
+    context: Arc<FontContext>,
 }
 
-fn convert_font_descriptor(font: &Font) -> FontDescriptor {
+impl SvgFontResolver {
+    pub(crate) fn new(context: Arc<FontContext>) -> Self {
+        Self {
+            font_id_cache: Mutex::new(FxHashMap::default()),
+            fallback_id_cache: Mutex::new(FxHashMap::default()),
+            context,
+        }
+    }
+
+    /// Insert the font into the database in [`SvgFontResolver`] and into the cache.
+    fn insert_into_database(
+        &self,
+        font: &Font,
+        database: &mut Arc<fontdb::Database>,
+    ) -> Option<fontdb::ID> {
+        let font_descriptor = font_to_fontdescriptor(font);
+
+        for family in font.families() {
+            let family_descriptor = FontFamilyDescriptor::new(
+                fontfamily_to_singlefontfamily(family),
+                FontSearchScope::Any,
+            );
+
+            let Some(font_template) = self
+                .context
+                .matching_templates(&font_descriptor, &family_descriptor)
+                .into_iter()
+                .next()
+            else {
+                log::debug!(
+                    "Cannot find matching font_template from font {font:?}, font-descriptor {font_descriptor:?}, family_descriptor: {family_descriptor:?} for this family {family:?}"
+                );
+                continue;
+            };
+
+            let Some(font_ref) = self.context.font(font_template, &font_descriptor) else {
+                continue;
+            };
+
+            let Ok(data_and_index) = font_ref.font_data_and_index() else {
+                continue;
+            };
+            let ids = Arc::make_mut(database).load_font_source(fontdb::Source::Binary(
+                data_and_index.data.as_ipc_shared_memory(),
+            ));
+
+            if let Some(id) = ids.get(data_and_index.index as usize).copied() {
+                self.font_id_cache.lock().unwrap().insert(font.clone(), id);
+                return Some(id);
+            }
+        }
+
+        None
+    }
+}
+
+fn font_to_fontdescriptor(font: &Font) -> FontDescriptor {
     let style = match font.style() {
         FontStyle::Normal => ServoFontStyle::normal(),
         FontStyle::Italic => ServoFontStyle::ITALIC,
@@ -62,7 +126,20 @@ fn convert_font_descriptor(font: &Font) -> FontDescriptor {
     }
 }
 
-fn convert_font_family(family: &FontFamily) -> SingleFontFamily {
+fn fallback_descriptor() -> FontDescriptor {
+    FontDescriptor {
+        weight: FontWeight::normal(),
+        stretch: ServoFontStretch::hundred(),
+        style: ServoFontStyle::normal(),
+        variant: FontVariantCaps::Normal,
+        pt_size: Au::from_px(16),
+        variation_settings: vec![],
+        synthesis_weight: FontSynthesis::Auto,
+        optical_sizing: FontOpticalSizing::Auto,
+    }
+}
+
+fn fontfamily_to_singlefontfamily(family: &FontFamily) -> SingleFontFamily {
     match family {
         FontFamily::Serif => SingleFontFamily::Generic(GenericFontFamily::Serif),
         FontFamily::SansSerif => SingleFontFamily::Generic(GenericFontFamily::SansSerif),
@@ -78,33 +155,74 @@ fn convert_font_family(family: &FontFamily) -> SingleFontFamily {
 
 impl FontResolver for SvgFontResolver {
     fn resolve(&self, font: &Font, database: &mut Arc<fontdb::Database>) -> Option<fontdb::ID> {
-        let font_descriptor = convert_font_descriptor(font);
-
-        for family in font.families() {
-            let family_descriptor =
-                FontFamilyDescriptor::new(convert_font_family(family), FontSearchScope::Any);
-            let Some(font_template) = self
-                .context
-                .matching_templates(&font_descriptor, &family_descriptor)
-                .into_iter()
-                .next()
-            else {
-                continue;
-            };
-            let Some(font) = self.context.font(font_template, &font_descriptor) else {
-                continue;
-            };
-            let Ok(data_and_index) = font.font_data_and_index() else {
-                continue;
-            };
-            let ids = Arc::make_mut(database).load_font_source(fontdb::Source::Binary(Arc::new(
-                data_and_index.data.clone(),
-            )));
-            if let Some(id) = ids.get(data_and_index.index as usize).copied() {
-                return Some(id);
+        {
+            let id_cache = self.font_id_cache.lock().unwrap();
+            if let Some(font_id) = id_cache.get(font) {
+                return Some(*font_id);
             }
         }
+        self.insert_into_database(font, database)
+    }
 
+    fn backup_resolve(
+        &self,
+        character: char,
+        excluded: &[fontdb::ID],
+        database: &mut Arc<fontdb::Database>,
+    ) -> Option<fontdb::ID> {
+        {
+            let id_cache = self.fallback_id_cache.lock().unwrap();
+            if let Some(font_id) = id_cache.get(&character) {
+                return Some(*font_id);
+            }
+        }
+        log::error!("FONT BACKUP CCALLED");
+        let fallback_options =
+            FallbackFontSelectionOptions::new(character, None, icu_locid::subtags::Language::UND);
+        for family in fallback_font_families(fallback_options) {
+            let family = FontFamilyDescriptor::new(
+                SingleFontFamily::FamilyName(FamilyName {
+                    name: family.into(),
+                    syntax: FontFamilyNameSyntax::Quoted,
+                }),
+                FontSearchScope::Any,
+            );
+            let fallback_descriptor = fallback_descriptor();
+
+            let font_templates = self
+                .context
+                .matching_templates(&fallback_descriptor, &family);
+
+            for font_template in font_templates {
+                let Some(font_ref) = self.context.font(font_template, &fallback_descriptor) else {
+                    continue;
+                };
+                if !font_ref.has_glyph_for(character) {
+                    continue;
+                }
+
+                let Ok(data_and_index) = font_ref.font_data_and_index() else {
+                    continue;
+                };
+
+                let ids = Arc::make_mut(database).load_font_source(fontdb::Source::Binary(
+                    data_and_index.data.as_ipc_shared_memory(),
+                ));
+
+                let Some(id) = ids.get(data_and_index.index as usize) else {
+                    continue;
+                };
+
+                if excluded.contains(id) {
+                    continue;
+                }
+
+                if let Some(id) = ids.get(data_and_index.index as usize).copied() {
+                    self.fallback_id_cache.lock().unwrap().insert(character, id);
+                    return Some(id);
+                }
+            }
+        }
         None
     }
 }

--- a/components/shared/base/generic_channel/shared_memory.rs
+++ b/components/shared/base/generic_channel/shared_memory.rs
@@ -21,6 +21,12 @@ enum GenericSharedMemoryVariant {
     InProcess(Arc<Vec<u8>>),
 }
 
+impl AsRef<[u8]> for GenericSharedMemory {
+    fn as_ref(&self) -> &[u8] {
+        self
+    }
+}
+
 impl Deref for GenericSharedMemory {
     type Target = [u8];
 

--- a/components/shared/net/image_cache.rs
+++ b/components/shared/net/image_cache.rs
@@ -31,6 +31,13 @@ pub trait FontResolver: Sync + Send {
     /// Adding new fonts to the database is allowed. Return an index into the database
     /// if the font resolves to an entry, otherwise return None.
     fn resolve(&self, font: &Font, database: &mut Arc<fontdb::Database>) -> Option<fontdb::ID>;
+    /// Backup resolve.
+    fn backup_resolve(
+        &self,
+        char: char,
+        ids: &[fontdb::ID],
+        database: &mut Arc<fontdb::Database>,
+    ) -> Option<fontdb::ID>;
 }
 
 pub type VectorImageId = PendingImageId;

--- a/components/shared/net/image_cache.rs
+++ b/components/shared/net/image_cache.rs
@@ -31,11 +31,11 @@ pub trait FontResolver: Sync + Send {
     /// Adding new fonts to the database is allowed. Return an index into the database
     /// if the font resolves to an entry, otherwise return None.
     fn resolve(&self, font: &Font, database: &mut Arc<fontdb::Database>) -> Option<fontdb::ID>;
-    /// Backup resolve.
-    fn backup_resolve(
+    /// Backup resolve. Find a font that can represent `char` and is not in `excluded`.
+    fn resolve_fallback(
         &self,
         char: char,
-        ids: &[fontdb::ID],
+        excluded: &[fontdb::ID],
         database: &mut Arc<fontdb::Database>,
     ) -> Option<fontdb::ID>;
 }


### PR DESCRIPTION
Currently the SVG font database loads all system fonts at the start and also inserts any fonts it loads.
This removes both of these.
Additionally, we add a small cache that handles the returned fontdb::IDs if they are already entered.
This will also improve the startup time of constellation (and hence everything depending on it) as we do not need to wait for all fonts to be loaded.

Testing: WPT test run https://github.com/Narfinger/servo/actions/runs/30888001779
