### PR TITLE
servoshell: Flip width and height to correct order

### DIFF
--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -872,8 +872,8 @@ impl PlatformWindow for HeadedWindow {
         let inner_size = self.winit_window.inner_size();
         let outer_size = self.winit_window.outer_size();
         let decoration_size: DeviceIntSize = Size2D::new(
-            outer_size.height - inner_size.height,
             outer_size.width - inner_size.width,
+            outer_size.height - inner_size.height,
         )
         .cast();
 


### PR DESCRIPTION
When setting window size to 800x600 using webdriver, the final size became 765x635. Which is weird. 

Turns out, in the headed_window.rs
```rust
fn request_resize(&self, _: &WebView, new_outer_size: DeviceIntSize) -> Option<DeviceIntSize> {
        ...
        let decoration_size: DeviceIntSize = Size2D::new(
            outer_size.height - inner_size.height,
            outer_size.width - inner_size.width,
        )
        .cast();
```
The `Size2D::new(...` is flipped

as it expects
```rust
/// A 2d size tagged with a unit.
#[repr(C)]
pub struct Size2D<T, U> {
    /// The extent of the element in the `U` units along the `x` axis (usually horizontal).
    pub width: T,
    /// The extent of the element in the `U` units along the `y` axis (usually vertical).
    pub height: T,
    #[doc(hidden)]
    pub _unit: PhantomData<U>,
}
```

Testing: I have a python scenario that I did not add, but can do upon request.

