### PR TITLE
fonts: Always bundle freetype on android and ohos

### DIFF
--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -85,6 +85,10 @@ fontconfig_sys = { workspace = true }
 [target.'cfg(target_os = "android")'.dependencies]
 xml = { workspace = true }
 
+[target.'cfg(any(target_os = "android",target_env = "ohos"))'.dependencies]
+# Always bundle freetype on android and openharmony
+freetype-sys = { workspace = true, features = ["bundled"] }
+
 [target.'cfg(target_os = "windows")'.dependencies]
 dwrote = { workspace = true }
 harfbuzz-sys = { workspace = true, features = ["directwrite"] }


### PR DESCRIPTION
Fixes a regression from #46233, which updated freetype-sys to 0.23. Since 0.23 the `bundled` feature needs to be explicitly enabled, and we did do so via our `default-features`. However, non-default features builds should also work, and on ohos (and presumably android) bundled freetype is simply required and not optional. The failure is at runtime (relocation failure due to undefined symbols) instead of build time.

Testing: The harmonyos runtime tests in CI should no longer crash (they use `--no-default-features` and selectively enable some features again)
Fixes: #46479
