### PR TITLE
ci: Pin versions for install-action to avoid breakage

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -406,7 +406,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-llvm-cov,cargo-nextest
+          tool: cargo-llvm-cov@0.8.7,cargo-nextest@0.9.140
       - name: Bootstrap dependencies
         if: ${{ runner.environment != 'self-hosted' }}
         timeout-minutes: 30

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -165,7 +165,7 @@ jobs:
         if: ${{ inputs.unit-tests }}
         uses: taiki-e/install-action@v2
         with:
-          tool: nextest
+          tool: nextest@0.9.140
       - name: Bootstrap dependencies
         if: ${{ runner.environment != 'self-hosted' }}
         timeout-minutes: 30

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -348,7 +348,7 @@ jobs:
       - name: Install cargo-c # required by servo-capi-tests's build.rs
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-c@0.10.23+cargo-0.97.1
+          tool: cargo-c@0.10.23
       - name: Build and test servo-capi-tests
         run: cargo test -p servo-capi-tests --locked
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -348,7 +348,7 @@ jobs:
       - name: Install cargo-c # required by servo-capi-tests's build.rs
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-c
+          tool: cargo-c@0.10.23+cargo-0.97.1
       - name: Build and test servo-capi-tests
         run: cargo test -p servo-capi-tests --locked
 

--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -288,7 +288,7 @@ jobs:
       - name: Install cargo-c # required by servo-capi-tests's build.rs
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-c
+          tool: cargo-c@0.10.23+cargo-0.97.1
       - name: Build and test servo-capi-tests
         env:
           # `cargo-c` doesn't seem to work with sccache so disabled it for this job.

--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -139,7 +139,7 @@ jobs:
         if: ${{ inputs.unit-tests }}
         uses: taiki-e/install-action@v2
         with:
-          tool: nextest
+          tool: nextest@0.9.140
 
       - if: runner.environment != 'self-hosted'
         name: Bootstrap

--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -288,7 +288,7 @@ jobs:
       - name: Install cargo-c # required by servo-capi-tests's build.rs
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-c@0.10.23+cargo-0.97.1
+          tool: cargo-c@0.10.23
       - name: Build and test servo-capi-tests
         env:
           # `cargo-c` doesn't seem to work with sccache so disabled it for this job.

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -287,6 +287,6 @@ jobs:
       - name: Install cargo-c # required by servo-capi-tests's build.rs
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-c
+          tool: cargo-c@0.10.23+cargo-0.97.1
       - name: Build and test servo-capi-tests
         run: cargo test -p servo-capi-tests --locked

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -287,6 +287,6 @@ jobs:
       - name: Install cargo-c # required by servo-capi-tests's build.rs
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-c@0.10.23+cargo-0.97.1
+          tool: cargo-c@0.10.23
       - name: Build and test servo-capi-tests
         run: cargo test -p servo-capi-tests --locked

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -138,7 +138,7 @@ jobs:
         if: ${{ inputs.unit-tests }}
         uses: taiki-e/install-action@v2
         with:
-          tool: nextest
+          tool: nextest@0.9.140
 
       - if: runner.environment != 'self-hosted'
         name: Bootstrap

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -158,7 +158,7 @@ jobs:
         if: ${{ runner.environment != 'self-hosted' && inputs.unit-tests }}
         uses: taiki-e/install-action@v2
         with:
-          tool: nextest
+          tool: nextest@0.9.140
       # On self-hosted windows runners the install-action fails
       - name: Install cargo nextest (self-hosted)
         if: ${{ runner.environment == 'self-hosted' && inputs.unit-tests }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -287,7 +287,7 @@ jobs:
       - name: Install cargo-c # required by servo-capi-tests's build.rs
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-c
+          tool: cargo-c@0.10.23+cargo-0.97.1
       - name: Build and test servo-capi-tests
         env:
           CC: "clang-cl.exe"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -287,7 +287,7 @@ jobs:
       - name: Install cargo-c # required by servo-capi-tests's build.rs
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-c@0.10.23+cargo-0.97.1
+          tool: cargo-c@0.10.23
       - name: Build and test servo-capi-tests
         env:
           CC: "clang-cl.exe"


### PR DESCRIPTION
Updates should be explicit, to avoid updates suddenly breaking our CI.
This PR pins all usages of install-action to install specific versions of the tools.

Testing: If CI passes its working.
Fixes: #46491 
