### PR TITLE
ci: pin third-party actions to full commit SHAs

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -44,7 +44,7 @@ jobs:
         target: ['aarch64-linux-android', 'armv7-linux-androideabi', 'x86_64-linux-android']
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: true
           android: false

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -102,7 +102,7 @@ jobs:
           sudo apt update
           sudo apt install -qy --no-install-recommends mesa-vulkan-drivers
           ./mach bootstrap --yes --skip-lints --skip-nextest
-      - uses: bencherdev/bencher@main
+      - uses: bencherdev/bencher@5f9d4cf890255c35e0354af1ed325108a6a0babd # v0.6.8
       - name: File size
         if: ${{ inputs.file-size == true }}
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
           large-packages: false

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -73,7 +73,7 @@ jobs:
         chunk_id: ${{ fromJSON(needs.runner-select.outputs.selected-runner-indices) }}
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         if: ${{ runner.environment != 'self-hosted' }}
         with:
           tool-cache: false

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -146,7 +146,7 @@ jobs:
     steps:
       - uses: servo/ci-runners/actions/checkout@f0b81b95522256c64ee207b4236ec71fc23b99a1
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         if: ${{ runner.environment != 'self-hosted' }}
         with:
           tool-cache: false
@@ -283,7 +283,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         if: ${{ runner.environment != 'self-hosted' }}
         with:
           tool-cache: false
@@ -330,7 +330,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
           large-packages: false
@@ -387,7 +387,7 @@ jobs:
     steps:
       - uses: servo/ci-runners/actions/checkout@f0b81b95522256c64ee207b4236ec71fc23b99a1
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         if: ${{ runner.environment != 'self-hosted' }}
         with:
           tool-cache: false

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -259,7 +259,7 @@ jobs:
       - name: Install hitrace-bench
         run: cargo install --locked hitrace-bench --version $HITRACE_BENCH_VERSION
         if: ${{ env.INSTALLED_HITRACE_BENCH_VERSION != env.HITRACE_BENCH_VERSION }}
-      - uses: bencherdev/bencher@main
+      - uses: bencherdev/bencher@5f9d4cf890255c35e0354af1ed325108a6a0babd # v0.6.8
         # set options
       - name: Set bencher opts for PRs (label try run)
         if: github.event_name == 'pull_request_target'

--- a/.github/workflows/scheduled-wpt-import.yml
+++ b/.github/workflows/scheduled-wpt-import.yml
@@ -59,7 +59,7 @@ jobs:
           uv lock
           git commit -a --amend -s --no-edit
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0
         with:
           branch: wpt_update_${{ env.CURRENT_DATE }}
       - name: Open PR


### PR DESCRIPTION
## What
Pin the three third-party actions currently referenced by mutable branches to full commit SHAs (comments record the version):
- `jlumbroso/free-disk-space` `@main` → v1.3.1
- `bencherdev/bencher` `@main` → v0.6.8
- `ad-m/github-push-action` `@master` → v1.3.0

## Why
A mutable ref means the code that runs in these jobs can change without any change in this repo. It matters most for `ad-m/github-push-action` in `scheduled-wpt-import.yml`, which is handed `GH_TOKEN: ${{ secrets.WPT_SYNC_TOKEN }}`, but pinning all three is consistent hardening. Behaviour is unchanged (each SHA is the tip the branch resolves to).

I used AI assistance to help identify this and draft the change; I verified every line against the live workflow myself and take responsibility for it.