### PR TITLE
servo: Allow registering the `WebXrRegistry` after `Servo` handle creation

### DIFF
--- a/components/paint/lib.rs
+++ b/components/paint/lib.rs
@@ -13,8 +13,6 @@ use paint_api::{PaintMessage, PaintProxy};
 use profile_traits::{mem, time};
 use servo_base::generic_channel::RoutedReceiver;
 use servo_constellation_traits::EmbedderToConstellationMessage;
-#[cfg(feature = "webxr")]
-use webxr::WebXrRegistry;
 
 pub use crate::paint::{Paint, WebRenderDebugOption};
 
@@ -52,7 +50,4 @@ pub struct InitialPaintState {
     /// An [`EventLoopWaker`] used in order to wake up the embedder when it is
     /// time to paint.
     pub event_loop_waker: Box<dyn EventLoopWaker>,
-    /// If WebXR is enabled, a [`WebXrRegistry`] to register WebXR threads.
-    #[cfg(feature = "webxr")]
-    pub webxr_registry: Box<dyn WebXrRegistry>,
 }

--- a/components/paint/paint.rs
+++ b/components/paint/paint.rs
@@ -47,6 +47,7 @@ use webgpu::canvas_context::WebGpuExternalImageMap;
 use webrender::{CaptureBits, MemoryReport};
 use webrender_api::units::{DevicePixel, DevicePoint};
 use webrender_api::{FontInstanceKey, FontKey, ImageKey};
+use webxr::WebXrRegistry;
 
 use crate::InitialPaintState;
 use crate::painter::Painter;
@@ -187,19 +188,11 @@ impl Paint {
 
         // Create the WebXR main thread
         #[cfg(feature = "webxr")]
-        let webxr_main_thread = {
-            use servo_config::pref;
-
-            let mut webxr_main_thread = webxr::MainThreadRegistry::new(
-                state.event_loop_waker.clone(),
-                webxr_layer_grand_manager,
-            )
-            .expect("Failed to create WebXR device registry");
-            if pref!(dom_webxr_enabled) {
-                state.webxr_registry.register(&mut webxr_main_thread);
-            }
-            webxr_main_thread
-        };
+        let webxr_main_thread = webxr::MainThreadRegistry::new(
+            state.event_loop_waker.clone(),
+            webxr_layer_grand_manager,
+        )
+        .expect("Failed to create WebXR device registry");
 
         Rc::new(RefCell::new(Paint {
             painters: Default::default(),
@@ -221,6 +214,12 @@ impl Paint {
             #[cfg(feature = "webgpu")]
             webgpu_image_map: Default::default(),
         }))
+    }
+
+    #[cfg(feature = "webxr")]
+    pub fn register_webxr_registry(&self, registry: Box<dyn WebXrRegistry>) {
+        let mut webxr_main_thread = self.webxr_main_thread.borrow_mut();
+        registry.register(&mut webxr_main_thread)
     }
 
     pub fn register_rendering_context(

--- a/components/paint/paint.rs
+++ b/components/paint/paint.rs
@@ -47,6 +47,7 @@ use webgpu::canvas_context::WebGpuExternalImageMap;
 use webrender::{CaptureBits, MemoryReport};
 use webrender_api::units::{DevicePixel, DevicePoint};
 use webrender_api::{FontInstanceKey, FontKey, ImageKey};
+#[cfg(feature = "webxr")]
 use webxr::WebXrRegistry;
 
 use crate::InitialPaintState;

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -77,6 +77,7 @@ use servo_wakelock::DefaultWakeLockDelegate;
 use storage::new_storage_threads;
 use storage_traits::StorageThreads;
 use style::global_style_data::StyleThreadPool;
+#[cfg(feature = "webxr")]
 use webxr::WebXrRegistry;
 
 use crate::clipboard_delegate::StringRequest;

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -77,6 +77,7 @@ use servo_wakelock::DefaultWakeLockDelegate;
 use storage::new_storage_threads;
 use storage_traits::StorageThreads;
 use style::global_style_data::StyleThreadPool;
+use webxr::WebXrRegistry;
 
 use crate::clipboard_delegate::StringRequest;
 #[cfg(feature = "gamepad")]
@@ -956,8 +957,6 @@ impl Servo {
             mem_profiler_chan: mem_profiler_chan.clone(),
             shutdown_state: shutdown_state.clone(),
             event_loop_waker: event_loop_waker.clone(),
-            #[cfg(feature = "webxr")]
-            webxr_registry: builder.webxr_registry,
         });
 
         let protocols = Arc::new(protocols);
@@ -1124,6 +1123,12 @@ impl Servo {
             .pending_handled_input_events
             .borrow_mut()
             .push(residue_event);
+    }
+
+    #[cfg(feature = "webxr")]
+    /// Registers a [`WebXrRegistry`]
+    pub fn register_webxr_registry(&self, registry: Box<dyn WebXrRegistry>) {
+        self.0.paint.borrow().register_webxr_registry(registry);
     }
 }
 
@@ -1403,19 +1408,12 @@ impl EventLoopWaker for DefaultEventLoopWaker {
     fn wake(&self) {}
 }
 
-#[cfg(feature = "webxr")]
-struct DefaultWebXrRegistry;
-#[cfg(feature = "webxr")]
-impl webxr::WebXrRegistry for DefaultWebXrRegistry {}
-
 /// Builder for [`Servo`].
 pub struct ServoBuilder {
     opts: Option<Box<Opts>>,
     preferences: Option<Box<Preferences>>,
     event_loop_waker: Box<dyn EventLoopWaker>,
     protocol_registry: ProtocolRegistry,
-    #[cfg(feature = "webxr")]
-    webxr_registry: Box<dyn webxr::WebXrRegistry>,
 }
 
 impl Default for ServoBuilder {
@@ -1425,8 +1423,6 @@ impl Default for ServoBuilder {
             preferences: Default::default(),
             event_loop_waker: Box::new(DefaultEventLoopWaker),
             protocol_registry: Default::default(),
-            #[cfg(feature = "webxr")]
-            webxr_registry: Box::new(DefaultWebXrRegistry),
         }
     }
 }
@@ -1453,12 +1449,6 @@ impl ServoBuilder {
 
     pub fn protocol_registry(mut self, protocol_registry: ProtocolRegistry) -> Self {
         self.protocol_registry = protocol_registry;
-        self
-    }
-
-    #[cfg(feature = "webxr")]
-    pub fn webxr_registry(mut self, webxr_registry: Box<dyn webxr::WebXrRegistry>) -> Self {
-        self.webxr_registry = webxr_registry;
         self
     }
 }

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -99,17 +99,17 @@ impl App {
             .event_loop_waker(self.waker.clone());
 
         let url = self.initial_url.as_url().clone();
+
+        let servo = servo_builder.build();
         let platform_window = self.create_platform_window(url, active_event_loop);
 
         #[cfg(feature = "webxr")]
-        let servo_builder =
-            servo_builder.webxr_registry(super::webxr::XrDiscoveryWebXrRegistry::new_boxed(
-                platform_window.clone(),
-                active_event_loop,
-                &self.preferences,
-            ));
+        servo.register_webxr_registry(super::webxr::XrDiscoveryWebXrRegistry::new_boxed(
+            platform_window.clone(),
+            active_event_loop,
+            &self.preferences,
+        ));
 
-        let servo = servo_builder.build();
         servo.setup_logging();
 
         let user_content_manager = Rc::new(UserContentManager::new(&servo));

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -310,10 +310,9 @@ impl App {
             .opts(init.opts)
             .preferences(init.preferences.clone())
             .event_loop_waker(init.event_loop_waker.clone());
-        #[cfg(feature = "webxr")]
-        let servo_builder = servo_builder
-            .webxr_registry(Box::new(XrDiscoveryWebXrRegistry::new(init.xr_discovery)));
         let servo = servo_builder.build();
+        #[cfg(feature = "webxr")]
+        servo.register_webxr_registry(Box::new(XrDiscoveryWebXrRegistry::new(init.xr_discovery)));
 
         let initial_url = init.initial_url.and_then(|string| Url::parse(&string).ok());
         let initial_url = initial_url


### PR DESCRIPTION
This PR reorders the startup of servoshell (desktop) by 30ms (to ocnstellation startup) 62ms to 29ms with a reduction to first script thread start from 62ms to 48ms.

We achieve this by not initializing the WebXR registry (which needs a window) in servo builder but after servo is started. We introduce a new method to register the registry.

Testing: No automated tests for servoshell but build on all platforms: https://github.com/Narfinger/servo/actions/runs/29496354016
