### PR TITLE
script: Reduce rooting in various places

### DIFF
--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -473,7 +473,7 @@ impl DocumentEventHandler {
 
                 self.handle_mouse_enter_leave_event(
                     cx,
-                    DomRoot::from_ref(current_hover_target),
+                    current_hover_target,
                     None,
                     FireMouseEventType::Leave,
                     &hit_test_result,
@@ -504,8 +504,8 @@ impl DocumentEventHandler {
     fn handle_mouse_enter_leave_event(
         &self,
         cx: &mut JSContext,
-        event_target: DomRoot<Node>,
-        related_target: Option<DomRoot<Node>>,
+        event_target: &Node,
+        related_target: Option<&Node>,
         event_type: FireMouseEventType,
         hit_test_result: &HitTestResult,
         input_event: &ConstellationInputEvent,
@@ -652,8 +652,8 @@ impl DocumentEventHandler {
                         .fire(cx, old_target.upcast());
 
                     if !old_target_is_ancestor_of_new_target {
-                        let event_target = DomRoot::from_ref(old_target.upcast::<Node>());
-                        let moving_into = Some(DomRoot::from_ref(new_target.upcast::<Node>()));
+                        let event_target = old_target.upcast::<Node>();
+                        let moving_into = Some(new_target.upcast::<Node>());
                         self.handle_mouse_enter_leave_event(
                             cx,
                             event_target,
@@ -698,8 +698,9 @@ impl DocumentEventHandler {
                     .dispatch(cx, new_target.upcast(), false);
 
                 let moving_from = old_hover_target
-                    .map(|old_target| DomRoot::from_ref(old_target.upcast::<Node>()));
-                let event_target = DomRoot::from_ref(new_target.upcast::<Node>());
+                    .as_ref()
+                    .map(|old_target| old_target.upcast::<Node>());
+                let event_target = new_target.upcast::<Node>();
                 self.handle_mouse_enter_leave_event(
                     cx,
                     event_target,

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -518,8 +518,8 @@ impl DocumentEventHandler {
         let common_ancestor = match related_target.as_ref() {
             Some(related_target) => event_target
                 .common_ancestor_in_flat_tree(related_target)
-                .unwrap_or_else(|| DomRoot::from_ref(&*event_target)),
-            None => DomRoot::from_ref(&*event_target),
+                .unwrap_or_else(|| DomRoot::from_ref(event_target)),
+            None => DomRoot::from_ref(event_target),
         };
 
         // We need to create a target chain in case the event target shares

--- a/components/script/dom/document/documentorshadowroot.rs
+++ b/components/script/dom/document/documentorshadowroot.rs
@@ -146,7 +146,7 @@ impl DocumentOrShadowRoot {
     pub(crate) fn retarget_hit_test_result(
         &self,
         this: &Node,
-        node: DomRoot<Node>,
+        node: &Node,
     ) -> Option<DomRoot<Element>> {
         let retargeted_node =
             DomRoot::downcast::<Node>(node.upcast::<EventTarget>().retarget(this.upcast()))?;
@@ -199,7 +199,7 @@ impl DocumentOrShadowRoot {
         let address = UntrustedNodeAddress(result.node.0 as *const c_void);
         let node = unsafe { node::from_untrusted_node_address(address) };
 
-        self.retarget_hit_test_result(this, node)
+        self.retarget_hit_test_result(this, &node)
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-document-elementsfrompoint>
@@ -241,7 +241,7 @@ impl DocumentOrShadowRoot {
                 // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
                 let address = UntrustedNodeAddress(result.node.0 as *const c_void);
                 let node = unsafe { node::from_untrusted_node_address(address) };
-                self.retarget_hit_test_result(this, node)
+                self.retarget_hit_test_result(this, &node)
             })
             .collect();
 

--- a/components/script/dom/html/htmlbuttonelement.rs
+++ b/components/script/dom/html/htmlbuttonelement.rs
@@ -320,10 +320,7 @@ impl HTMLButtonElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#determine-if-command-is-valid>
-    fn determine_if_command_is_valid_for_target(
-        command: CommandState,
-        target: DomRoot<Element>,
-    ) -> bool {
+    fn determine_if_command_is_valid_for_target(command: CommandState, target: &Element) -> bool {
         // Step 1. If command is in the Unknown state, then return false.
         if command == CommandState::Unknown {
             return false;
@@ -545,7 +542,7 @@ impl Activatable for HTMLButtonElement {
             // Steps 5.1 Let command be element's command attribute.
             let command = self.command_state();
             // Step 5.2 If the result of determining if a command is valid for a target given command and target is false, then return.
-            if !Self::determine_if_command_is_valid_for_target(command, target.clone()) {
+            if !Self::determine_if_command_is_valid_for_target(command, &target) {
                 return;
             }
             // Step 5.3 Let continue be the result of firing an event named command at target, using

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -645,12 +645,12 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         if let Some(next_sibling) = next &&
             let Some(node) = next_sibling.GetPreviousSibling()
         {
-            Self::merge_with_the_next_text_node(cx, node);
+            Self::merge_with_the_next_text_node(cx, &node);
         }
 
         // Step 8: If previous is a Text node, then merge with the next text node given previous.
         if let Some(previous) = previous {
-            Self::merge_with_the_next_text_node(cx, previous)
+            Self::merge_with_the_next_text_node(cx, &previous)
         }
 
         Ok(())
@@ -1124,7 +1124,7 @@ impl HTMLElement {
     /// node.
     ///
     /// <https://html.spec.whatwg.org/multipage/#merge-with-the-next-text-node>
-    fn merge_with_the_next_text_node(cx: &mut JSContext, node: DomRoot<Node>) {
+    fn merge_with_the_next_text_node(cx: &mut JSContext, node: &Node) {
         // Make sure node is a Text node
         if !node.is::<Text>() {
             return;

--- a/components/script/dom/html/htmltablerowelement.rs
+++ b/components/script/dom/html/htmltablerowelement.rs
@@ -68,7 +68,7 @@ impl HTMLTableRowElement {
 
     /// Determine the index for this `HTMLTableRowElement` within the given
     /// `HTMLCollection`. Returns `-1` if not found within collection.
-    fn row_index(&self, no_gc: &NoGC, collection: DomRoot<HTMLCollection>) -> i32 {
+    fn row_index(&self, no_gc: &NoGC, collection: &HTMLCollection) -> i32 {
         collection
             .elements_iter(no_gc)
             .position(|elem| (&elem as &Element) == self.upcast())
@@ -139,7 +139,7 @@ impl HTMLTableRowElementMethods<crate::DomTypeHolder> for HTMLTableRowElement {
         };
         if let Some(table) = parent.downcast::<HTMLTableElement>() {
             let rows = table.Rows(cx);
-            return self.row_index(cx.no_gc(), rows);
+            return self.row_index(cx.no_gc(), &rows);
         }
         if !parent.is::<HTMLTableSectionElement>() {
             return -1;
@@ -152,7 +152,7 @@ impl HTMLTableRowElementMethods<crate::DomTypeHolder> for HTMLTableRowElement {
             .downcast::<HTMLTableElement>()
             .map_or(-1, |table| {
                 let rows = table.Rows(cx);
-                self.row_index(cx.no_gc(), rows)
+                self.row_index(cx.no_gc(), &rows)
             })
     }
 
@@ -169,7 +169,7 @@ impl HTMLTableRowElementMethods<crate::DomTypeHolder> for HTMLTableRowElement {
         } else {
             return -1;
         };
-        self.row_index(cx.no_gc(), collection)
+        self.row_index(cx.no_gc(), &collection)
     }
 }
 

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -286,7 +286,7 @@ impl IDBFactory {
                 // set request’s result to result,
                 // set request’s done flag,
                 // and fire an event named success at request.
-                request.dispatch_success(cx, connection);
+                request.dispatch_success(cx, &connection);
             },
             ConnectionMsg::Upgrade {
                 name,

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -294,7 +294,7 @@ impl IDBOpenDBRequest {
         let global = self.global();
         self.idbrequest.set_ready_state_done();
 
-        let mut realm = enter_auto_realm(cx, &*result);
+        let mut realm = enter_auto_realm(cx, result);
         let cx = &mut realm.current_realm();
         rooted!(&in(cx) let mut result_val = UndefinedValue());
         result.safe_to_jsval(cx, result_val.handle_mut());

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -290,7 +290,7 @@ impl IDBOpenDBRequest {
         matches
     }
 
-    pub fn dispatch_success(&self, cx: &mut JSContext, result: DomRoot<IDBDatabase>) {
+    pub fn dispatch_success(&self, cx: &mut JSContext, result: &IDBDatabase) {
         let global = self.global();
         self.idbrequest.set_ready_state_done();
 

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -276,7 +276,7 @@ impl SubtleCrypto {
 
     /// Queue a global task on the crypto task source, given realm's global object, to resolve
     /// promise with a CryptoKey.
-    fn resolve_promise_with_key(&self, promise: Rc<Promise>, key: DomRoot<CryptoKey>) {
+    fn resolve_promise_with_key(&self, promise: Rc<Promise>, key: &CryptoKey) {
         let trusted_key = Trusted::new(&*key);
         let trusted_promise = TrustedPromise::new(promise);
         self.global()
@@ -882,7 +882,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // Step 12. Resolve promise with result.
                 match result {
                     CryptoKeyOrCryptoKeyPair::CryptoKey(key) => {
-                        subtle.resolve_promise_with_key(promise, key);
+                        subtle.resolve_promise_with_key(promise, &key);
                     },
                     CryptoKeyOrCryptoKeyPair::CryptoKeyPair(key_pair) => {
                         subtle.resolve_promise_with_key_pair(promise, key_pair);
@@ -1037,7 +1037,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // Step 20. Let result be the result of converting result to an ECMAScript Object
                 // in realm, as defined by [WebIDL].
                 // Step 20. Resolve promise with result.
-                subtle.resolve_promise_with_key(promise, result);
+                subtle.resolve_promise_with_key(promise, &result);
             }),
         );
         promise
@@ -1264,7 +1264,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // Step 14. Let result be the result of converting result to an ECMAScript Object
                 // in realm, as defined by [WebIDL].
                 // Step 15. Resolve promise with result.
-                subtle.resolve_promise_with_key(promise, result);
+                subtle.resolve_promise_with_key(promise, &result);
             }));
 
         promise
@@ -1709,7 +1709,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // Step 21. Let result be the result of converting result to an ECMAScript Object
                 // in realm, as defined by [WebIDL].
                 // Step 22. Resolve promise with result.
-                subtle.resolve_promise_with_key(promise, result);
+                subtle.resolve_promise_with_key(promise, &result);
             }),
         );
         promise
@@ -2086,7 +2086,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // Step 18. Let result be the result of converting sharedKey to an ECMAScript
                 // Object in realm, as defined by [WebIDL].
                 // Step 19. Resolve promise with result.
-                subtle.resolve_promise_with_key(promise, shared_key);
+                subtle.resolve_promise_with_key(promise, &shared_key);
             }));
         promise
     }
@@ -2281,7 +2281,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // Step 17. Let result be the result of converting publicKey to an ECMAScript
                 // Object in realm, as defined by [WebIDL].
                 // Step 18. Resolve promise with result.
-                subtle.resolve_promise_with_key(promise, result);
+                subtle.resolve_promise_with_key(promise, &result);
             }));
         promise
     }

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -277,7 +277,7 @@ impl SubtleCrypto {
     /// Queue a global task on the crypto task source, given realm's global object, to resolve
     /// promise with a CryptoKey.
     fn resolve_promise_with_key(&self, promise: Rc<Promise>, key: &CryptoKey) {
-        let trusted_key = Trusted::new(&*key);
+        let trusted_key = Trusted::new(key);
         let trusted_promise = TrustedPromise::new(promise);
         self.global()
             .task_manager()


### PR DESCRIPTION
Most of these are just style change, as the functions were just moving `DomRoot`,
except for `htmlbuttonelement.rs` and `document_event_handler.rs` where we do avoid new root.

Testing: This is an optimization that should not change test result.
Part of #34464