### PR TITLE
layout: Account for nested inline boxes when adjusting floats in RTL inline layout

### DIFF
--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -26,7 +26,8 @@ use crate::cell::ArcRefCell;
 use crate::flow::inline::text_run::FontAndScriptInfo;
 use crate::fragment_tree::{BaseFragment, BaseFragmentInfo, BoxFragment, Fragment, TextFragment};
 use crate::geom::{
-    LogicalRect, LogicalSides, LogicalVec2, PhysicalRect, ToLogical, ToLogicalWithContainingBlock,
+    LogicalRect, LogicalSides, LogicalVec2, PhysicalRect, PhysicalSize, ToLogical,
+    ToLogicalWithContainingBlock,
 };
 use crate::positioned::{
     AbsolutelyPositionedBox, PositioningContext, PositioningContextLength, relative_adjustement,
@@ -61,6 +62,110 @@ bitflags! {
     }
 }
 
+struct FragmentAndData {
+    fragment: Fragment,
+
+    /// The logical rectangle of the fragment, relative within the current inline box (or line).
+    /// This logical rectangle will be converted into a physical one, and the Fragment's
+    /// `content_rect` will be updated once the inline box's final size is known in
+    /// [`LineItemLayout::end_inline_box`].
+    logical_rect: LogicalRect<Au>,
+
+    /// If the fragment is for an inline box, this is the list of floats which are either
+    /// direct children or descendants within other inline boxes. Once the final physical
+    /// rect of the fragment is known, the position of these floats needs to be adjusted.
+    propagated_floats: Vec<Arc<BoxFragment>>,
+}
+
+impl FragmentAndData {
+    fn new(fragment: Fragment, logical_rect: LogicalRect<Au>) -> Self {
+        Self::new_with_propagated_floats(fragment, logical_rect, Vec::new())
+    }
+
+    fn new_with_propagated_floats(
+        fragment: Fragment,
+        logical_rect: LogicalRect<Au>,
+        propagated_floats: Vec<Arc<BoxFragment>>,
+    ) -> Self {
+        Self {
+            fragment,
+            logical_rect,
+            propagated_floats,
+        }
+    }
+
+    /// Updates the physical rect of the fragment, by resolving the logical rect against the
+    /// size and writing mode of the container.
+    /// Note that the container isn't necessarily the containing block, it can be a fragment
+    /// of an inline box.
+    /// This shouldn't be used for floats, since they are anchored to a side of the inline
+    /// formatting context, not to their container.
+    fn resolve_physical_rect_and_adjust_floats(&self, container: &ContainingBlock) {
+        debug_assert!(!matches!(self.fragment, Fragment::Float(_)));
+
+        let Some(base) = self.fragment.base() else {
+            return;
+        };
+
+        // We do not know the actual physical position of a logically laid out inline element, until
+        // we know the width of the containing inline block. This step converts the logical rectangle
+        // into a physical one based on the inline formatting context width.
+        let rect = self.logical_rect.as_physical(Some(container));
+        base.set_rect(rect);
+
+        // Floats are anchored to a side of the inline formatting context, but in the box tree
+        // they can still be children of an inline box. Since the coordinates will be relative
+        // to their parent, when setting the final position of that parent, we need to adjust
+        // the float in order to keep it at the desired position.
+        let float_offset = -rect.origin.to_vector().to_size();
+        for float_fragment in &self.propagated_floats {
+            float_fragment.base.translate_rect(float_offset);
+        }
+    }
+
+    /// Given a vector of [`FragmentAndData`], this resolves the final physical rect for each
+    /// non-floating fragment (storing it), and adjusts the position of the floats inside it,
+    /// then returns a vector with the [`Fragment`]s.
+    fn resolve_physical_rects_and_adjust_floats(
+        fragments_and_data: Vec<Self>,
+        container: &ContainingBlock,
+    ) -> Vec<Fragment> {
+        let mut fragments = Vec::with_capacity(fragments_and_data.len());
+        for fragment_and_data in fragments_and_data {
+            if !matches!(fragment_and_data.fragment, Fragment::Float(_)) {
+                fragment_and_data.resolve_physical_rect_and_adjust_floats(container)
+            }
+            fragments.push(fragment_and_data.fragment);
+        }
+        fragments
+    }
+
+    /// Same as [`resolve_physical_rects_and_adjust_floats()`], but additionally it takes
+    /// a relative adjustment that will be applied to floats. And the return value is a
+    /// pair of the [`Fragment`]s and the propagated floats.
+    fn resolve_physical_rects_and_adjust_and_collect_floats(
+        fragments_and_data: Vec<Self>,
+        container: &ContainingBlock,
+        relative_adjustement: PhysicalSize<Au>,
+    ) -> (Vec<Fragment>, Vec<Arc<BoxFragment>>) {
+        let mut fragments = Vec::with_capacity(fragments_and_data.len());
+        let mut propagated_floats = Vec::new();
+        for mut fragment_and_data in fragments_and_data {
+            if let Fragment::Float(ref float) = fragment_and_data.fragment {
+                if relative_adjustement != PhysicalSize::zero() {
+                    float.base.translate_rect(relative_adjustement);
+                }
+                propagated_floats.push(float.clone());
+            } else {
+                fragment_and_data.resolve_physical_rect_and_adjust_floats(container)
+            }
+            fragments.push(fragment_and_data.fragment);
+            propagated_floats.append(&mut fragment_and_data.propagated_floats);
+        }
+        (fragments, propagated_floats)
+    }
+}
+
 /// The state used when laying out a collection of [`LineItem`]s into a line. This state is stored
 /// per-inline container. For instance, when laying out the conents of a `<span>` a fresh
 /// [`LineItemLayoutInlineContainerState`] is pushed onto [`LineItemLayout`]'s stack of states.
@@ -69,11 +174,8 @@ pub(super) struct LineItemLayoutInlineContainerState {
     /// that is currently being laid out.
     pub identifier: Option<InlineBoxIdentifier>,
 
-    /// The fragments and their logical rectangle relative within the current inline box (or
-    /// line). These logical rectangles will be converted into physical ones and the Fragment's
-    /// `content_rect` will be updated once the inline box's final size is known in
-    /// [`LineItemLayout::end_inline_box`].
-    pub fragments: Vec<(Fragment, LogicalRect<Au>)>,
+    /// The fragments and their associated data.
+    fragments_and_data: Vec<FragmentAndData>,
 
     /// The current inline advance of the layout in the coordinates of this inline box.
     pub inline_advance: Au,
@@ -97,11 +199,6 @@ pub(super) struct LineItemLayoutInlineContainerState {
     /// at the end of layout.
     pub positioning_context_or_start_offset_in_parent:
         Either<PositioningContext, PositioningContextLength>,
-
-    /// List of floats in this inline box or a descendant inline box. This is used in order
-    /// to adjust the inline position of the floats, once we know the padding/border/margin
-    /// of the inlines.
-    pub propagated_floats: Vec<Arc<BoxFragment>>,
 }
 
 impl LineItemLayoutInlineContainerState {
@@ -116,13 +213,12 @@ impl LineItemLayoutInlineContainerState {
     ) -> Self {
         Self {
             identifier,
-            fragments: Vec::new(),
+            fragments_and_data: Vec::new(),
             inline_advance: Au::zero(),
             flags: LineLayoutInlineContainerFlags::empty(),
             parent_offset,
             baseline_offset,
             positioning_context_or_start_offset_in_parent,
-            propagated_floats: Vec::new(),
         }
     }
 
@@ -319,25 +415,10 @@ impl LineItemLayout<'_, '_> {
         // Move back to the root of the inline box tree, so that all boxes are ended.
         self.prepare_layout_for_inline_box(None);
 
-        let fragments_and_rectangles = std::mem::take(&mut self.current_state.fragments);
-        let containing_block = self.containing_block();
-        fragments_and_rectangles
-            .into_iter()
-            .map(|(fragment, logical_rect)| {
-                if matches!(fragment, Fragment::Float(_)) {
-                    return fragment;
-                }
-
-                // We do not know the actual physical position of a logically laid out inline element, until
-                // we know the width of the containing inline block. This step converts the logical rectangle
-                // into a physical one based on the inline formatting context width.
-                if let Some(base) = fragment.base() {
-                    base.set_rect(logical_rect.as_physical(Some(containing_block)));
-                }
-
-                fragment
-            })
-            .collect()
+        FragmentAndData::resolve_physical_rects_and_adjust_floats(
+            std::mem::take(&mut self.current_state.fragments_and_data),
+            self.layout.containing_block(),
+        )
     }
 
     fn current_positioning_context_mut(&mut self) -> &mut PositioningContext {
@@ -403,7 +484,7 @@ impl LineItemLayout<'_, '_> {
         let inline_box = self.layout.ifc.inline_boxes.get(&identifier);
         let inline_box = &*(inline_box.borrow());
 
-        let containing_block = self.containing_block();
+        let containing_block = self.layout.containing_block();
         let containing_block_writing_mode = containing_block.style.writing_mode;
 
         let mut padding = inline_box_state.pbm.padding;
@@ -461,58 +542,32 @@ impl LineItemLayout<'_, '_> {
         // Relative adjustment should not affect the rest of line layout, so we can
         // do it right before creating the Fragment.
         let style = &inline_box.base.style;
-        if style.get_box().position == Position::Relative {
-            content_rect.start_corner += relative_adjustement(style, containing_block);
-        }
-
-        let inline_box_containing_block = ContainingBlock {
-            size: ContainingBlockSize {
-                inline: content_rect.size.inline,
-                block: Default::default(),
-            },
-            style: containing_block.style,
+        let relative_adjustement = if style.get_box().position == Position::Relative {
+            let relative_adjustement = relative_adjustement(style, containing_block);
+            content_rect.start_corner += relative_adjustement;
+            relative_adjustement
+                .to_physical_vector(containing_block_writing_mode)
+                .to_size()
+        } else {
+            PhysicalSize::zero()
         };
 
-        let fragments = inner_state
-            .fragments
-            .into_iter()
-            .map(|(fragment, logical_rect)| {
-                if matches!(fragment, Fragment::Float(_)) {
-                    // For floats, we need to adjust not only the ones directly inside this inline, but also floats
-                    // nested inside inner inlines. So we are handling them below (`propagated_floats`).
-                    return fragment;
-                }
-                if let Some(base) = fragment.base() {
-                    // We do not know the actual physical position of a logically laid out inline element, until
-                    // we know the width of the containing inline block. This step converts the logical rectangle
-                    // into a physical one now that we've computed inline size of the containing inline block above.
-                    base.set_rect(logical_rect.as_physical(Some(&inline_box_containing_block)));
-                }
-                fragment
-            })
-            .collect();
+        let (fragments, propagated_floats) =
+            FragmentAndData::resolve_physical_rects_and_adjust_and_collect_floats(
+                inner_state.fragments_and_data,
+                &ContainingBlock {
+                    size: ContainingBlockSize {
+                        inline: content_rect.size.inline,
+                        block: Default::default(),
+                    },
+                    style: containing_block.style,
+                },
+                relative_adjustement,
+            );
 
         // Previously all the fragment's children were positioned relative to the linebox,
         // but they need to be made relative to this fragment.
         let physical_content_rect = content_rect.as_physical(Some(containing_block));
-
-        self.current_state.propagated_floats.extend(
-            inner_state
-                .propagated_floats
-                .into_iter()
-                .inspect(|float_fragment| {
-                    // When calculating the tentative position of the float, we already knew the block-axis
-                    // padding/border/margin of the inline ancestors. But in the inline axis, we only know
-                    // once ending the inline box. Therefore, we need to adjust here.
-                    float_fragment.base.translate_rect(
-                        LogicalVec2 {
-                            inline: -pbm_sums.inline_start,
-                            block: Au::zero(),
-                        }
-                        .to_physical_size(containing_block_writing_mode),
-                    );
-                }),
-        );
 
         let mut fragment = BoxFragment::new(
             inline_box.base.base_fragment_info,
@@ -555,8 +610,13 @@ impl LineItemLayout<'_, '_> {
 
         let fragment = Fragment::Box(Arc::new(fragment));
         inline_box.base.add_fragment(fragment.clone());
-
-        self.current_state.fragments.push((fragment, content_rect));
+        self.current_state
+            .fragments_and_data
+            .push(FragmentAndData::new_with_propagated_floats(
+                fragment,
+                content_rect,
+                propagated_floats,
+            ));
     }
 
     fn calculate_inline_box_block_start(
@@ -638,23 +698,25 @@ impl LineItemLayout<'_, '_> {
         );
 
         self.current_state.inline_advance += inline_advance;
-        self.current_state.fragments.push((
-            Fragment::Text(Arc::new(TextFragment {
-                base: BaseFragment::new(
-                    text_item.base_fragment_info,
-                    text_item.inline_styles.style.clone(),
-                    PhysicalRect::zero(),
-                ),
-                selected_style: text_item.inline_styles.selected.clone(),
-                font_metrics: font_metrics.clone(),
-                font_key,
-                glyphs: text_item.text,
-                justification_adjustment: self.justification_adjustment,
-                offsets: text_item.offsets,
-                is_empty_for_text_cursor: text_item.is_empty_for_text_cursor,
-            })),
-            content_rect,
-        ));
+        self.current_state
+            .fragments_and_data
+            .push(FragmentAndData::new(
+                Fragment::Text(Arc::new(TextFragment {
+                    base: BaseFragment::new(
+                        text_item.base_fragment_info,
+                        text_item.inline_styles.style.clone(),
+                        PhysicalRect::zero(),
+                    ),
+                    selected_style: text_item.inline_styles.selected.clone(),
+                    font_metrics: font_metrics.clone(),
+                    font_key,
+                    glyphs: text_item.text,
+                    justification_adjustment: self.justification_adjustment,
+                    offsets: text_item.offsets,
+                    is_empty_for_text_cursor: text_item.is_empty_for_text_cursor,
+                })),
+                content_rect,
+            ));
     }
 
     fn layout_atomic(&mut self, atomic: AtomicLineItem) {
@@ -708,8 +770,11 @@ impl LineItemLayout<'_, '_> {
         self.current_state.inline_advance += atomic.size.inline;
 
         self.current_state
-            .fragments
-            .push((Fragment::Box(atomic.fragment), content_rect));
+            .fragments_and_data
+            .push(FragmentAndData::new(
+                Fragment::Box(atomic.fragment),
+                content_rect,
+            ));
     }
 
     fn layout_absolute(&mut self, absolute: AbsolutelyPositionedLineItem) {
@@ -772,17 +837,18 @@ impl LineItemLayout<'_, '_> {
 
         let hoisted_fragment = hoisted_box.fragment.clone();
         self.current_positioning_context_mut().push(hoisted_box);
-        self.current_state.fragments.push((
-            Fragment::AbsoluteOrFixedPositionedPlaceholder(hoisted_fragment),
-            LogicalRect::zero(),
-        ));
+        self.current_state
+            .fragments_and_data
+            .push(FragmentAndData::new(
+                Fragment::AbsoluteOrFixedPositionedPlaceholder(hoisted_fragment),
+                LogicalRect::zero(),
+            ));
     }
 
     fn layout_float(&mut self, float: FloatLineItem) {
         self.current_state
             .flags
             .insert(LineLayoutInlineContainerFlags::HAD_ANY_FLOATS);
-
         // The `BoxFragment` for this float is positioned relative to the IFC, so we need
         // to move it to be positioned relative to our parent InlineBox line item. Float
         // fragments are children of these InlineBoxes and not children of the inline
@@ -792,19 +858,20 @@ impl LineItemLayout<'_, '_> {
         // inline ancestors in the block axis, but not in the inline one, since that's not
         // known yet. Therefore, in `end_inline_box()` we will need to adjust the inline
         // position of the float, for each inline ancestor.
-        let distance_from_parent_to_ifc = LogicalVec2 {
-            inline: self.current_state.parent_offset.inline,
-            block: self.line_metrics.block_offset + self.current_state.parent_offset.block,
+        let offset = LogicalVec2 {
+            inline: Au::zero(),
+            block: -self.line_metrics.block_offset,
         };
-        float.fragment.base.translate_rect(
-            -distance_from_parent_to_ifc
-                .to_physical_size(self.containing_block().style.writing_mode),
-        );
-
+        float
+            .fragment
+            .base
+            .translate_rect(offset.to_physical_size(self.containing_block().style.writing_mode));
         self.current_state
-            .fragments
-            .push((Fragment::Float(float.fragment.clone()), LogicalRect::zero()));
-        self.current_state.propagated_floats.push(float.fragment);
+            .fragments_and_data
+            .push(FragmentAndData::new(
+                Fragment::Float(float.fragment),
+                LogicalRect::zero(),
+            ));
     }
 
     fn layout_block_level(&mut self, block_level: Arc<BoxFragment>) {
@@ -813,8 +880,12 @@ impl LineItemLayout<'_, '_> {
         // Block-level boxes are always placed at the logical origin of the line.
         content_rect.start_corner.inline -= self.current_state.parent_offset.inline;
         content_rect.start_corner.block -= self.line_metrics.block_offset;
-        let fragment_and_rect = (Fragment::Box(block_level), content_rect);
-        self.current_state.fragments.push(fragment_and_rect);
+        self.current_state
+            .fragments_and_data
+            .push(FragmentAndData::new(
+                Fragment::Box(block_level),
+                content_rect,
+            ));
     }
 
     #[inline]

--- a/tests/wpt/meta/css/CSS2/floats/floats-placement-vertical-001b.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-placement-vertical-001b.xht.ini
@@ -1,2 +1,0 @@
-[floats-placement-vertical-001b.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-placement-vertical-001c.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-placement-vertical-001c.xht.ini
@@ -1,2 +1,0 @@
-[floats-placement-vertical-001c.xht]
-  expected: FAIL


### PR DESCRIPTION
Floats are positioned relative to their containing inline formatting context,
but need to be children of their containing inline boxes. This means that
they need their content rectangle offset by the physical distance from the
IFC edge to their containing box. This calculation needs to take into account
directionality. Previously this was a bit buggy and didn't properly take into
account nesting in RTL contexts. This change fixes that.

Testing: 2 tests pass
