### PR TITLE
layout: Adjust the static position of abspos inside float in inline layout

### DIFF
--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -1052,6 +1052,10 @@ pub(super) struct FloatLineItem {
     /// do not fit on a line need to be placed after the hypothetical block start
     /// of the next line.
     pub needs_placement: bool,
+    /// The range of indices of the absolutes that escaped this `FloatBox`.
+    /// This is used to adjust their static positioning rect once the final
+    /// position of this float is known.
+    pub range: Range<PositioningContextLength>,
 }
 
 /// Sort a mutable slice by the given indices array in place, reording the slice so that final

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -130,7 +130,7 @@ use crate::flow::{
 };
 use crate::formatting_contexts::{Baselines, IndependentFormattingContext};
 use crate::fragment_tree::{
-    BaseFragmentInfo, BoxFragment, CollapsedMargin, Fragment, FragmentFlags, PositioningFragment,
+    BaseFragmentInfo, CollapsedMargin, Fragment, FragmentFlags, PositioningFragment,
 };
 use crate::geom::{LogicalRect, LogicalSides1D, LogicalVec2, ToLogical};
 use crate::layout_box_base::LayoutBoxBase;
@@ -1382,7 +1382,7 @@ impl InlineFormattingContextLayout<'_> {
         (adjusted_line_start, justification_adjustment)
     }
 
-    fn place_float_fragment(&mut self, fragment: &BoxFragment) {
+    fn place_float_fragment(&mut self, float: &FloatLineItem) {
         let state = self
             .sequential_layout_state
             .as_mut()
@@ -1392,11 +1392,16 @@ impl InlineFormattingContextLayout<'_> {
             .current_block_position_including_margins() -
             state.current_containing_block_offset();
         state.place_float_fragment(
-            fragment,
+            &float.fragment,
             self.placement_state.containing_block,
             CollapsedMargin::zero(),
             block_offset_from_containining_block_top,
         );
+        self.positioning_context
+            .adjust_static_position_of_hoisted_fragments_in_range(
+                &float.fragment.base.rect().origin.to_vector(),
+                &float.range,
+            )
     }
 
     /// Place a FloatLineItem. This is done when an unbreakable segment is committed to
@@ -1438,7 +1443,7 @@ impl InlineFormattingContextLayout<'_> {
         if needs_placement_later {
             self.current_line.has_floats_waiting_to_be_placed = true;
         } else {
-            self.place_float_fragment(float_fragment);
+            self.place_float_fragment(float_item);
             float_item.needs_placement = false;
         }
 
@@ -2691,11 +2696,13 @@ impl IndependentFormattingContext {
 
 impl FloatBox {
     fn layout_into_line_items(&self, layout: &mut InlineFormattingContextLayout) {
+        let old_len = layout.positioning_context.len();
         let fragment = Arc::new(self.layout(
             layout.layout_context,
             layout.positioning_context,
             layout.placement_state.containing_block,
         ));
+        let new_len = layout.positioning_context.len();
 
         self.contents
             .base
@@ -2705,6 +2712,7 @@ impl FloatBox {
             FloatLineItem {
                 fragment,
                 needs_placement: true,
+                range: old_len..new_len,
             },
         ));
     }
@@ -2715,7 +2723,7 @@ fn place_pending_floats(ifc: &mut InlineFormattingContextLayout, line_items: &[L
         if let LineItem::Float(_, float_line_item) = item &&
             float_line_item.needs_placement
         {
-            ifc.place_float_fragment(&float_line_item.fragment);
+            ifc.place_float_fragment(float_line_item);
         }
     }
 }

--- a/components/layout/positioned.rs
+++ b/components/layout/positioned.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::mem;
+use std::ops::Range;
 use std::sync::Arc;
 
 use app_units::Au;
@@ -172,12 +173,18 @@ impl PositioningContext {
         offset: &PhysicalVec<Au>,
         index: PositioningContextLength,
     ) {
-        self.absolutes
-            .iter_mut()
-            .skip(index.0)
-            .for_each(|hoisted_box| {
-                hoisted_box.adjust_static_position_with_offset(offset);
-            })
+        self.adjust_static_position_of_hoisted_fragments_in_range(offset, &(index..self.len()))
+    }
+
+    /// See documentation for [PositioningContext::adjust_static_position_of_hoisted_fragments].
+    pub(crate) fn adjust_static_position_of_hoisted_fragments_in_range(
+        &mut self,
+        offset: &PhysicalVec<Au>,
+        range: &Range<PositioningContextLength>,
+    ) {
+        for hoisted_box in &mut self.absolutes[range.start.0..range.end.0] {
+            hoisted_box.adjust_static_position_with_offset(offset);
+        }
     }
 
     /// Given `fragment_layout_fn`, a closure which lays out a fragment in a provided

--- a/tests/wpt/meta/css/css-flexbox/abspos/flex-abspos-staticpos-justify-self-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/abspos/flex-abspos-staticpos-justify-self-001.html.ini
@@ -1,2 +1,0 @@
-[flex-abspos-staticpos-justify-self-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/abspos/flex-abspos-staticpos-margin-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/abspos/flex-abspos-staticpos-margin-001.html.ini
@@ -1,2 +1,0 @@
-[flex-abspos-staticpos-margin-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/abspos/flex-abspos-staticpos-margin-002.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/abspos/flex-abspos-staticpos-margin-002.html.ini
@@ -1,2 +1,0 @@
-[flex-abspos-staticpos-margin-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/abspos/flex-abspos-staticpos-margin-003.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/abspos/flex-abspos-staticpos-margin-003.html.ini
@@ -1,2 +1,0 @@
-[flex-abspos-staticpos-margin-003.html]
-  expected: FAIL

--- a/tests/wpt/tests/css/CSS2/abspos/static-inside-float-inside-inline.html
+++ b/tests/wpt/tests/css/CSS2/abspos/static-inside-float-inside-inline.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>Static position inside float inside inline</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#abs-non-replaced-height">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visuren.html#floats">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visuren.html#inline-formatting">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="
+  Due to `line-height: 200px`, the `<br>` places the float 200px below the top of the
+  inline formatting context. Therefore, the static position of the abspos should also
+  be there, not at the top of the inline formatting context.
+">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div style="overflow: hidden; margin-top: -200px">
+  <span style="line-height: 200px">
+    <br>
+    <div style="float: left; width: 200px; height: 200px; background: red">
+      <div style="position: absolute; width: 200px; height: 200px; background: green"></div>
+    </div>
+  </span>
+</div>


### PR DESCRIPTION
When we decide the position of a float within an inline formatting context, we need to adjust the static position of absolutely positioned elements inside the float.

Testing: 4 flexbox tests pass. Also adding a basic CSS2 test.
