### PR TITLE
script_bindings: Remove the `LayoutFromRaw` trait

### DIFF
--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -63,12 +63,6 @@ impl LayoutDom<'_, Node> {
     }
 }
 
-unsafe impl<'dom, T: DomObject> LayoutFromRaw<'dom, T> for LayoutDom<'dom, T> {
-    fn from_raw(d: &'dom T) -> Self {
-        LayoutDom { value: d }
-    }
-}
-
 impl<'dom, T> LayoutDom<'dom, T>
 where
     T: 'dom + DomObject,
@@ -167,6 +161,51 @@ impl<T> Clone for LayoutDom<'_, T> {
     fn clone(&self) -> Self {
         assert_in_layout();
         *self
+    }
+}
+
+pub(crate) trait ToLayout<'dom, T: DomObject> {
+    /// Get a reference to the contents of this smart pointer as a [`LayoutDom`],
+    /// for use during layout. Note that this should only be called in the course
+    /// of layout.
+    ///
+    /// # Safety
+    /// The return value holds a Rust reference to the underlying data, which should be
+    /// safe as long as `unsafe` is not used to override the lifetime in some way.
+    ///
+    /// - The caller *must not* modify the underlying DOM object via non-layout handles.
+    /// - The caller *must ensure* that garbage collection does not occur while the
+    ///   [`LayoutDom`] handle is alive.
+    unsafe fn to_layout(&self) -> LayoutDom<'dom, T>;
+}
+
+impl<'dom, T: DomObject> ToLayout<'dom, T> for Dom<T> {
+    unsafe fn to_layout(&self) -> LayoutDom<'dom, T> {
+        assert_in_layout();
+        LayoutDom {
+            value: unsafe { self.as_ptr().as_ref().unwrap() },
+        }
+    }
+}
+
+pub(crate) trait ToLayoutOptional<'dom, T: DomObject> {
+    /// Retrieve a copy of the inner optional `Dom<T>` as `LayoutDom<T>`.
+    /// For use by layout, which can't use safe types like Temporary.
+    ///
+    /// # Safety
+    /// The return value holds a Rust reference to the underlying data, which should be
+    /// safe as long as `unsafe` is not used to override the lifetime in some way.
+    ///
+    /// - The caller *must not* modify the underlying DOM object via non-layout handles.
+    /// - The caller *must ensure* that garbage collection does not occur while the
+    ///   [`LayoutDom`] handle is alive.
+    unsafe fn to_layout(&self) -> Option<LayoutDom<'dom, T>>;
+}
+
+impl<'dom, T: DomObject> ToLayoutOptional<'dom, T> for MutNullableDom<T> {
+    unsafe fn to_layout(&self) -> Option<LayoutDom<'dom, T>> {
+        assert_in_layout();
+        unsafe { self.as_ref_unsafe().map(|dom_ref| dom_ref.to_layout()) }
     }
 }
 

--- a/components/script/dom/document/documentfragment.rs
+++ b/components/script/dom/document/documentfragment.rs
@@ -12,7 +12,7 @@ use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::codegen::UnionTypes::NodeOrString;
 use crate::dom::bindings::error::{ErrorResult, Fallible};
 use crate::dom::bindings::inheritance::Castable;
-use crate::dom::bindings::root::{DomRoot, LayoutDom, MutNullableDom};
+use crate::dom::bindings::root::{DomRoot, LayoutDom, MutNullableDom, ToLayoutOptional};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::document::tree_ordered_index_map::TreeOrderedIndexMap;
@@ -86,7 +86,7 @@ impl<'dom> LayoutDom<'dom, DocumentFragment> {
             // > Shadow roots’s associated host is never null.
             self.unsafe_get()
                 .host
-                .get_inner_as_layout()
+                .to_layout()
                 .expect("Shadow roots's associated host is never null")
         }
     }

--- a/components/script/dom/elementinternals.rs
+++ b/components/script/dom/elementinternals.rs
@@ -16,7 +16,7 @@ use crate::dom::bindings::codegen::Bindings::ElementInternalsBinding::{
 use crate::dom::bindings::codegen::UnionTypes::FileOrUSVStringOrFormData;
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
 use crate::dom::bindings::inheritance::Castable;
-use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, MutNullableDom};
+use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, MutNullableDom, ToLayoutOptional};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::customstateset::CustomStateSet;
 use crate::dom::element::Element;
@@ -194,7 +194,7 @@ impl ElementInternals {
     pub(crate) fn custom_states_for_layout<'a>(&'a self) -> Option<LayoutDom<'a, CustomStateSet>> {
         #[expect(unsafe_code)]
         unsafe {
-            self.states.get_inner_as_layout()
+            self.states.to_layout()
         }
     }
 }

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -52,7 +52,7 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
 use crate::dom::bindings::reflector::DomGlobal;
-use crate::dom::bindings::root::{DomRoot, LayoutDom, MutNullableDom};
+use crate::dom::bindings::root::{DomRoot, LayoutDom, MutNullableDom, ToLayoutOptional};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::csp::{GlobalCspReporting, Violation};
 use crate::dom::document::Document;
@@ -1693,7 +1693,7 @@ impl<'dom> LayoutDom<'dom, HTMLImageElement> {
         unsafe {
             self.unsafe_get()
                 .dimension_attribute_source
-                .get_inner_as_layout()
+                .to_layout()
                 .expect("dimension attribute source should be always non-null")
         }
     }

--- a/components/script/dom/node/layout_dom.rs
+++ b/components/script/dom/node/layout_dom.rs
@@ -21,7 +21,7 @@ use style::dom::OpaqueNode;
 use style::selector_parser::PseudoElement;
 
 use crate::dom::bindings::inheritance::{CharacterDataTypeId, NodeTypeId};
-use crate::dom::bindings::root::{LayoutDom, ToLayout};
+use crate::dom::bindings::root::{LayoutDom, ToLayout, ToLayoutOptional};
 use crate::dom::document::Document;
 use crate::dom::element::Element;
 use crate::dom::html::htmlcanvaselement::HTMLCanvasElement;
@@ -40,7 +40,7 @@ impl<'dom> LayoutDom<'dom, Node> {
     #[inline]
     #[expect(unsafe_code)]
     pub(crate) fn parent_node_ref(self) -> Option<LayoutDom<'dom, Node>> {
-        unsafe { self.unsafe_get().parent_node().get_inner_as_layout() }
+        unsafe { self.unsafe_get().parent_node().to_layout() }
     }
 
     #[inline]
@@ -86,36 +86,31 @@ impl<'dom> LayoutDom<'dom, Node> {
     #[inline]
     #[expect(unsafe_code)]
     pub(crate) fn first_child_ref(self) -> Option<LayoutDom<'dom, Node>> {
-        unsafe { self.unsafe_get().first_child().get_inner_as_layout() }
+        unsafe { self.unsafe_get().first_child().to_layout() }
     }
 
     #[inline]
     #[expect(unsafe_code)]
     pub(crate) fn last_child_ref(self) -> Option<LayoutDom<'dom, Node>> {
-        unsafe { self.unsafe_get().last_child().get_inner_as_layout() }
+        unsafe { self.unsafe_get().last_child().to_layout() }
     }
 
     #[inline]
     #[expect(unsafe_code)]
     pub(crate) fn prev_sibling_ref(self) -> Option<LayoutDom<'dom, Node>> {
-        unsafe { self.unsafe_get().prev_sibling().get_inner_as_layout() }
+        unsafe { self.unsafe_get().prev_sibling().to_layout() }
     }
 
     #[inline]
     #[expect(unsafe_code)]
     pub(crate) fn next_sibling_ref(self) -> Option<LayoutDom<'dom, Node>> {
-        unsafe { self.unsafe_get().next_sibling().get_inner_as_layout() }
+        unsafe { self.unsafe_get().next_sibling().to_layout() }
     }
 
     #[inline]
     #[expect(unsafe_code)]
     pub(crate) fn owner_doc_for_layout(self) -> LayoutDom<'dom, Document> {
-        unsafe {
-            self.unsafe_get()
-                .get_owner_doc()
-                .get_inner_as_layout()
-                .unwrap()
-        }
+        unsafe { self.unsafe_get().get_owner_doc().to_layout().unwrap() }
     }
 
     #[inline]

--- a/components/script_bindings/dom.rs
+++ b/components/script_bindings/dom.rs
@@ -10,26 +10,10 @@ use js::context::NoGC;
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 
 use crate::DomObject;
-use crate::assert::{assert_in_layout, assert_in_script};
+use crate::assert::assert_in_script;
 use crate::conversions::DerivedFrom;
 use crate::inheritance::Castable;
 use crate::root::{Dom, DomRoot};
-
-pub trait ToLayout<'dom, T: DomObject, L: LayoutFromRaw<'dom, T>> {
-    /// Returns `LayoutDom<T>` containing the same pointer.
-    ///
-    /// # Safety
-    ///
-    /// The `self` parameter to this method must meet all the requirements of [`ptr::NonNull::as_ref`].
-    unsafe fn to_layout(&self) -> L;
-}
-
-impl<'dom, T: DomObject, L: LayoutFromRaw<'dom, T>> ToLayout<'dom, T, L> for Dom<T> {
-    unsafe fn to_layout(&self) -> L {
-        assert_in_layout();
-        L::from_raw(unsafe { self.as_ptr().as_ref().unwrap() })
-    }
-}
 
 /// A holder that provides interior mutability for GC-managed values such as
 /// `Dom<T>`.  Essentially a `Cell<Dom<T>>`, but safer.
@@ -172,16 +156,6 @@ impl<'a, T: DomObject> PartialEq<UnrootedDom<'a, T>> for UnrootedDom<'a, T> {
     }
 }
 
-/// Trait that creates a specific struct from a raw DomObject. The implementer needs to be
-/// sure that this does not violate any lifetimes
-///
-/// # Safety
-/// The dom object needs the lifetimes to be safe.
-/// Only [`LayoutDom`] should implement this.
-pub unsafe trait LayoutFromRaw<'dom, T: DomObject> {
-    fn from_raw(d: &'dom T) -> Self;
-}
-
 /// A holder that provides interior mutability for GC-managed values such as
 /// `Dom<T>`, with nullability represented by an enclosing Option wrapper.
 /// Essentially a `Cell<Option<Dom<T>>>`, but safer.
@@ -220,20 +194,23 @@ impl<T: DomObject> MutNullableDom<T> {
         }
     }
 
-    /// Retrieve a copy of the inner optional `Dom<T>` as `LayoutDom<T>`.
-    /// For use by layout, which can't use safe types like Temporary.
-    ///
-    /// # Safety
-    /// Needs to meet the safety requirements of [`LayoutFromRaw`].
-    pub unsafe fn get_inner_as_layout<'dom, L: LayoutFromRaw<'dom, T>>(&'dom self) -> Option<L> {
-        assert_in_layout();
-        unsafe { (*self.ptr.get()).as_ref().map(|js| js.to_layout()) }
-    }
-
-    /// Get a rooted value out of this object
+    /// Get a rooted ([`DomRoot`]) reference to the value contained in this
+    /// [`MutNullableDom`].
     pub fn get(&self) -> Option<DomRoot<T>> {
         assert_in_script();
         unsafe { ptr::read(self.ptr.get()).map(|o| DomRoot::from_ref(&*o)) }
+    }
+
+    /// Get a reference to the traced inner value of this [`MutNullableDom`].
+    ///
+    /// # Safety
+    ///
+    /// - The caller *must not* modify the value of the [`MutNullableDom`] while the
+    ///   reference is alive.
+    /// - The caller *must ensure* that no garbage collection happens while the
+    ///   reference is alive.
+    pub unsafe fn as_ref_unsafe(&self) -> Option<&Dom<T>> {
+        unsafe { (*self.ptr.get()).as_ref() }
     }
 
     /// Get the `DomObject` without rooting it. Constructing an UnrootedDom. This is safe


### PR DESCRIPTION
The `LayoutFromRaw` trait is a bit confusing because it is defined in
`script_bindings` and it is used to convert to `LayoutDom` which is in
`script`. This change replaces it with a pair of traits defined in
`script` with simple implementations that follow them directly, which
simplifies the way that types are converted to `LayoutDom`.

Testing: This should not change behavior, so existing tests should suffice.
