### PR TITLE
If there is an abnormality in network transmission, the system will return a prompt message indicating the error.

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -907,6 +907,11 @@ pub(crate) async fn http_fetch(
 
         // Step 4.4. If request’s response tainting is "cors" and a CORS check for request
         // and response returns failure, then return a network error.
+        if fetch_result.is_network_error() {
+            // If the response is already a network error (e.g. Cronet upload failure),
+            // return it directly instead of wrapping it in a misleading CorsGeneral error.
+            return fetch_result;
+        }
         if cors_flag && cors_check(&fetch_params.request, &fetch_result).is_err() {
             return Response::network_error(NetworkError::CorsGeneral);
         }


### PR DESCRIPTION
Step 4.4 is not designed to "check CORS first and then check network errors". Instead, it does not consider that the response is already a network error. The prerequisite is that "response is a normal response but the CORS header is not compliant" instead of "response itself is a network error". Adding is_network_error() to return early is a practical fix for specification omissions so that error messages are not overwritten by CORS.
The problem scenario is as follows:
When fetch_result is already a network error:
1. The network error response does not contain a normal CORS header.
2. The cors_check() fails to respond to a response without the Access-Control-Allow-Origin header.
3. So go to return Response::network_error(NetworkError::CorsGeneral) and return NetworkError::CorsGeneral, which is misleading.