### PR TITLE
script: Mechanically migrate to `reflect_dom_object_with_proto`

### DIFF
--- a/components/script/dom/abort/abortcontroller.rs
+++ b/components/script/dom/abort/abortcontroller.rs
@@ -6,7 +6,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::realm::CurrentRealm;
 use js::rust::{HandleObject, HandleValue};
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::abortsignal::AbortSignal;
 use crate::dom::bindings::codegen::Bindings::AbortControllerBinding::AbortControllerMethods;
@@ -43,11 +43,11 @@ impl AbortController {
         // Step 1. Let signal be a new AbortSignal object.
         let signal = AbortSignal::new_with_proto(cx, global, None);
         // Step 2. Set this’s signal to signal.
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(AbortController::new_inherited(&signal)),
             global,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/animations/documenttimeline.rs
+++ b/components/script/dom/animations/documenttimeline.rs
@@ -7,9 +7,7 @@ use js::context::JSContext;
 use js::gc::HandleObject;
 use num_traits::ToPrimitive;
 use script_bindings::codegen::GenericBindings::DocumentTimelineBinding::DocumentTimelineOptions;
-use script_bindings::reflector::{
-    reflect_dom_object_with_cx, reflect_dom_object_with_proto_and_cx,
-};
+use script_bindings::reflector::{reflect_dom_object_with_cx, reflect_dom_object_with_proto};
 use script_bindings::root::DomRoot;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_config::pref;
@@ -42,14 +40,14 @@ impl DocumentTimeline {
     ) -> DomRoot<Self> {
         let duration_since_time_origin =
             CrossProcessInstant::now() - window.navigation_start() - origin_time;
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(Self {
                 animation_timeline: AnimationTimeline::new_inherited(duration_since_time_origin),
                 origin_offset: origin_time,
             }),
             window,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/animations/keyframeeffect.rs
+++ b/components/script/dom/animations/keyframeeffect.rs
@@ -30,7 +30,7 @@ use script_bindings::codegen::GenericUnionTypes::UnrestrictedDoubleOrKeyframeEff
 use script_bindings::conversions::StringificationBehavior;
 use script_bindings::error::{Error, Fallible};
 use script_bindings::num::Finite;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use script_bindings::root::{Dom, DomRoot};
 use script_bindings::str::DOMString;
 use style::parser::ParserContext;
@@ -87,12 +87,7 @@ impl KeyframeEffect {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(Self::new_inherited(window)),
-            window,
-            proto,
-            cx,
-        )
+        reflect_dom_object_with_proto(cx, Box::new(Self::new_inherited(window)), window, proto)
     }
 
     pub(crate) fn new(cx: &mut JSContext, window: &Window) -> DomRoot<Self> {

--- a/components/script/dom/canvas/2d/path2d.rs
+++ b/components/script/dom/canvas/2d/path2d.rs
@@ -9,7 +9,7 @@ use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::codegen::GenericBindings::DOMMatrixBinding::DOMMatrix2DInit;
 use script_bindings::error::ErrorResult;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use script_bindings::str::DOMString;
 use servo_canvas_traits::canvas::Path;
 
@@ -196,7 +196,7 @@ impl Path2DMethods<crate::DomTypeHolder> for Path2D {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<Path2D> {
-        reflect_dom_object_with_proto_and_cx(Box::new(Self::new()), global, proto, cx)
+        reflect_dom_object_with_proto(cx, Box::new(Self::new()), global, proto)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-path2d-dev>
@@ -206,12 +206,7 @@ impl Path2DMethods<crate::DomTypeHolder> for Path2D {
         proto: Option<HandleObject>,
         other: &Path2D,
     ) -> DomRoot<Path2D> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(Self::new_with_path(other)),
-            global,
-            proto,
-            cx,
-        )
+        reflect_dom_object_with_proto(cx, Box::new(Self::new_with_path(other)), global, proto)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-path2d-dev>
@@ -221,11 +216,11 @@ impl Path2DMethods<crate::DomTypeHolder> for Path2D {
         proto: Option<HandleObject>,
         path_string: DOMString,
     ) -> DomRoot<Path2D> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(Self::new_with_str(&path_string.str())),
             global,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -14,7 +14,7 @@ use pixels::{EncodedImageType, Snapshot};
 use rustc_hash::FxHashMap;
 use script_bindings::cell::{DomRefCell, Ref};
 use script_bindings::inheritance::Castable;
-use script_bindings::reflector::{DomObject, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{DomObject, reflect_dom_object_with_proto};
 use script_bindings::weakref::WeakRef;
 use servo_base::id::{OffscreenCanvasId, OffscreenCanvasIndex};
 use servo_canvas_traits::webgl::{GLContextAttributes, WebGLVersion};
@@ -86,11 +86,11 @@ impl OffscreenCanvas {
         height: u64,
         placeholder: Option<WeakRef<HTMLCanvasElement>>,
     ) -> DomRoot<OffscreenCanvas> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(OffscreenCanvas::new_inherited(width, height, placeholder)),
             global,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/clipboard/clipboarditem.rs
+++ b/components/script/dom/clipboard/clipboarditem.rs
@@ -13,7 +13,7 @@ use js::realm::CurrentRealm;
 use js::rust::{HandleObject, HandleValue as SafeHandleValue, MutableHandleValue};
 use script_bindings::cell::DomRefCell;
 use script_bindings::record::Record;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use servo_constellation_traits::BlobImpl;
 
 use crate::dom::bindings::codegen::Bindings::ClipboardBinding::{
@@ -127,12 +127,7 @@ impl ClipboardItem {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<ClipboardItem> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(ClipboardItem::new_inherited()),
-            window,
-            proto,
-            cx,
-        )
+        reflect_dom_object_with_proto(cx, Box::new(ClipboardItem::new_inherited()), window, proto)
     }
 }
 

--- a/components/script/dom/credentialmanagement/passwordcredential.rs
+++ b/components/script/dom/credentialmanagement/passwordcredential.rs
@@ -7,7 +7,7 @@ use js::context::JSContext;
 use js::gc::HandleObject;
 use script_bindings::codegen::GenericBindings::PasswordCredentialBinding::PasswordCredentialData;
 use script_bindings::error::{Error, Fallible};
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use script_bindings::str::USVString;
 
 use crate::dom::bindings::codegen::Bindings::PasswordCredentialBinding::PasswordCredentialMethods;
@@ -42,11 +42,11 @@ impl PasswordCredential {
         origin: USVString,
         password: USVString,
     ) -> DomRoot<PasswordCredential> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(PasswordCredential::new_inherited(id, origin, password)),
             global,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/css/cssstylesheet.rs
+++ b/components/script/dom/css/cssstylesheet.rs
@@ -12,9 +12,7 @@ use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::StyleSheetBinding::StyleSheetMethods;
 use script_bindings::inheritance::Castable;
-use script_bindings::reflector::{
-    reflect_dom_object_with_cx, reflect_dom_object_with_proto_and_cx,
-};
+use script_bindings::reflector::{reflect_dom_object_with_cx, reflect_dom_object_with_proto};
 use script_bindings::root::Dom;
 use servo_arc::Arc;
 use style::media_queries::MediaList as StyleMediaList;
@@ -142,7 +140,8 @@ impl CSSStyleSheet {
         stylesheet: Arc<StyleStyleSheet>,
         constructor_document: Option<&Document>,
     ) -> DomRoot<CSSStyleSheet> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(CSSStyleSheet::new_inherited(
                 owner,
                 type_,
@@ -153,7 +152,6 @@ impl CSSStyleSheet {
             )),
             window,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/css/fontfaceset.rs
+++ b/components/script/dom/css/fontfaceset.rs
@@ -17,7 +17,7 @@ use script_bindings::codegen::GenericBindings::FontFaceBinding::{
     FontFaceLoadStatus, FontFaceMethods,
 };
 use script_bindings::like::Setlike;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 
 use crate::dom::bindings::codegen::Bindings::FontFaceSetBinding::FontFaceSetMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
@@ -47,10 +47,10 @@ pub(crate) struct FontFaceSet {
 }
 
 impl FontFaceSet {
-    fn new_inherited(cx: &mut JSContext, global: &GlobalScope) -> Self {
+    fn new_inherited(promise: Rc<Promise>) -> Self {
         FontFaceSet {
             target: EventTarget::new_inherited(),
-            promise: Promise::new(cx, global).into(),
+            promise: promise.into(),
             set_entries: Default::default(),
         }
     }
@@ -60,11 +60,12 @@ impl FontFaceSet {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(FontFaceSet::new_inherited(cx, global)),
+        let promise = Promise::new(cx, global);
+        reflect_dom_object_with_proto(
+            cx,
+            Box::new(FontFaceSet::new_inherited(promise)),
             global,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -22,7 +22,7 @@ use js::rust::{HandleObject, MutableHandleValue};
 use rustc_hash::FxBuildHasher;
 use script_bindings::cell::DomRefCell;
 use script_bindings::conversions::SafeToJSValConvertible;
-use script_bindings::reflector::{DomObject, Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{DomObject, Reflector, reflect_dom_object_with_proto};
 use script_bindings::settings_stack::{run_a_callback, run_a_script};
 use style::attr::AttrValue;
 
@@ -119,11 +119,11 @@ impl CustomElementRegistry {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<CustomElementRegistry> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(CustomElementRegistry::new_inherited(window)),
             window,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/datatransfer/datatransfer.rs
+++ b/components/script/dom/datatransfer/datatransfer.rs
@@ -11,7 +11,7 @@ use js::rust::{HandleObject, MutableHandleValue};
 use net_traits::image_cache::Image;
 use script_bindings::cell::DomRefCell;
 use script_bindings::match_domstring_ascii;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::DataTransferBinding::DataTransferMethods;
 use crate::dom::bindings::inheritance::Castable;
@@ -71,11 +71,11 @@ impl DataTransfer {
     ) -> DomRoot<DataTransfer> {
         let item_list = DataTransferItemList::new(cx, window, Rc::clone(&data_store));
 
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(DataTransfer::new_inherited(data_store, &item_list)),
             window,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use script_traits::DocumentActivity;
 
 use crate::document_loader::DocumentLoader;
@@ -42,11 +42,11 @@ impl DOMParser {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<DOMParser> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(DOMParser::new_inherited(window)),
             window,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/encoding/textdecoder.rs
+++ b/components/script/dom/encoding/textdecoder.rs
@@ -9,7 +9,7 @@ use dom_struct::dom_struct;
 use encoding_rs::Encoding;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::TextDecoderBinding;
 use crate::dom::bindings::codegen::Bindings::TextDecoderBinding::{
@@ -58,11 +58,11 @@ impl TextDecoder {
         fatal: bool,
         ignore_bom: bool,
     ) -> DomRoot<TextDecoder> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(TextDecoder::new_inherited(encoding, fatal, ignore_bom)),
             global,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/encoding/textencoder.rs
+++ b/components/script/dom/encoding/textencoder.rs
@@ -11,7 +11,7 @@ use js::jsapi::JSObject;
 use js::rust::HandleObject;
 use js::typedarray;
 use js::typedarray::HeapUint8Array;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use script_bindings::trace::RootedTraceableBox;
 
 use crate::dom::bindings::buffer_source::create_buffer_source;
@@ -41,12 +41,7 @@ impl TextEncoder {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<TextEncoder> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(TextEncoder::new_inherited()),
-            global,
-            proto,
-            cx,
-        )
+        reflect_dom_object_with_proto(cx, Box::new(TextEncoder::new_inherited()), global, proto)
     }
 }
 

--- a/components/script/dom/event/customevent.rs
+++ b/components/script/dom/event/customevent.rs
@@ -7,7 +7,7 @@ use js::context::JSContext;
 use js::jsapi::Heap;
 use js::jsval::JSVal;
 use js::rust::{HandleObject, HandleValue, MutableHandleValue};
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::CustomEventBinding;
@@ -48,12 +48,7 @@ impl CustomEvent {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<CustomEvent> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(CustomEvent::new_inherited()),
-            global,
-            proto,
-            cx,
-        )
+        reflect_dom_object_with_proto(cx, Box::new(CustomEvent::new_inherited()), global, proto)
     }
 
     fn new(

--- a/components/script/dom/event/errorevent.rs
+++ b/components/script/dom/event/errorevent.rs
@@ -10,7 +10,7 @@ use js::jsapi::Heap;
 use js::jsval::JSVal;
 use js::rust::{HandleObject, HandleValue, MutableHandleValue};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::ErrorEventBinding;
@@ -52,12 +52,7 @@ impl ErrorEvent {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<ErrorEvent> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(ErrorEvent::new_inherited()),
-            global,
-            proto,
-            cx,
-        )
+        reflect_dom_object_with_proto(cx, Box::new(ErrorEvent::new_inherited()), global, proto)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/components/script/dom/event/eventtarget.rs
+++ b/components/script/dom/event/eventtarget.rs
@@ -23,7 +23,7 @@ use libc::c_char;
 use rustc_hash::{FxBuildHasher, FxHashSet};
 use script_bindings::cell::DomRefCell;
 use script_bindings::cformat;
-use script_bindings::reflector::{DomObject, Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{DomObject, Reflector, reflect_dom_object_with_proto};
 use servo_constellation_traits::ConstellationInterest;
 use servo_url::ServoUrl;
 use style::str::HTML_SPACE_CHARACTERS;
@@ -425,12 +425,7 @@ impl EventTarget {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<EventTarget> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(EventTarget::new_inherited()),
-            global,
-            proto,
-            cx,
-        )
+        reflect_dom_object_with_proto(cx, Box::new(EventTarget::new_inherited()), global, proto)
     }
 
     /// Returns the [`ConstellationInterest`] associated with a given event type

--- a/components/script/dom/event/focusevent.rs
+++ b/components/script/dom/event/focusevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use style::Atom;
 
 use crate::dom::bindings::codegen::Bindings::FocusEventBinding;
@@ -49,12 +49,7 @@ impl FocusEvent {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<FocusEvent> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(FocusEvent::new_inherited()),
-            window,
-            proto,
-            cx,
-        )
+        reflect_dom_object_with_proto(cx, Box::new(FocusEvent::new_inherited()), window, proto)
     }
 
     #[expect(clippy::too_many_arguments)]

--- a/components/script/dom/event/hashchangeevent.rs
+++ b/components/script/dom/event/hashchangeevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -47,11 +47,11 @@ impl HashChangeEvent {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<HashChangeEvent> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(HashChangeEvent::new_inherited(String::new(), String::new())),
             window,
             proto,
-            cx,
         )
     }
 
@@ -80,11 +80,11 @@ impl HashChangeEvent {
         old_url: String,
         new_url: String,
     ) -> DomRoot<HashChangeEvent> {
-        let ev = reflect_dom_object_with_proto_and_cx(
+        let ev = reflect_dom_object_with_proto(
+            cx,
             Box::new(HashChangeEvent::new_inherited(old_url, new_url)),
             window,
             proto,
-            cx,
         );
         {
             let event = ev.upcast::<Event>();

--- a/components/script/dom/event/keyboardevent.rs
+++ b/components/script/dom/event/keyboardevent.rs
@@ -10,7 +10,7 @@ use js::context::JSContext;
 use js::rust::HandleObject;
 use keyboard_types::{Code, Key, Modifiers, NamedKey};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use style::Atom;
 
 use crate::dom::bindings::codegen::Bindings::KeyboardEventBinding;
@@ -68,12 +68,7 @@ impl KeyboardEvent {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<KeyboardEvent> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(KeyboardEvent::new_inherited()),
-            window,
-            proto,
-            cx,
-        )
+        reflect_dom_object_with_proto(cx, Box::new(KeyboardEvent::new_inherited()), window, proto)
     }
 
     pub(crate) fn new_with_platform_keyboard_event(

--- a/components/script/dom/event/mouseevent.rs
+++ b/components/script/dom/event/mouseevent.rs
@@ -13,7 +13,7 @@ use js::rust::HandleObject;
 use keyboard_types::Modifiers;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::match_domstring_ascii;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use script_traits::ConstellationInputEvent;
 use style::Atom;
 use style_traits::CSSPixel;
@@ -105,12 +105,7 @@ impl MouseEvent {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<MouseEvent> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(MouseEvent::new_inherited()),
-            window,
-            proto,
-            cx,
-        )
+        reflect_dom_object_with_proto(cx, Box::new(MouseEvent::new_inherited()), window, proto)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/components/script/dom/event/pagetransitionevent.rs
+++ b/components/script/dom/event/pagetransitionevent.rs
@@ -7,7 +7,7 @@ use std::cell::Cell;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -40,11 +40,11 @@ impl PageTransitionEvent {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<PageTransitionEvent> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(PageTransitionEvent::new_inherited()),
             window,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/event/pointerevent.rs
+++ b/components/script/dom/event/pointerevent.rs
@@ -10,7 +10,7 @@ use js::context::JSContext;
 use js::rust::HandleObject;
 use keyboard_types::Modifiers;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use style::Atom;
 use style_traits::CSSPixel;
 
@@ -78,12 +78,7 @@ impl PointerEvent {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<PointerEvent> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(PointerEvent::new_inherited()),
-            window,
-            proto,
-            cx,
-        )
+        reflect_dom_object_with_proto(cx, Box::new(PointerEvent::new_inherited()), window, proto)
     }
 
     #[expect(clippy::too_many_arguments)]

--- a/components/script/dom/event/popstateevent.rs
+++ b/components/script/dom/event/popstateevent.rs
@@ -7,7 +7,7 @@ use js::context::JSContext;
 use js::jsapi::Heap;
 use js::jsval::JSVal;
 use js::rust::{HandleObject, HandleValue, MutableHandleValue};
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -43,12 +43,7 @@ impl PopStateEvent {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<PopStateEvent> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(PopStateEvent::new_inherited()),
-            window,
-            proto,
-            cx,
-        )
+        reflect_dom_object_with_proto(cx, Box::new(PopStateEvent::new_inherited()), window, proto)
     }
 
     fn new(

--- a/components/script/dom/event/storageevent.rs
+++ b/components/script/dom/event/storageevent.rs
@@ -6,7 +6,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -63,11 +63,11 @@ impl StorageEvent {
         proto: Option<HandleObject>,
         url: DOMString,
     ) -> DomRoot<StorageEvent> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(StorageEvent::new_inherited(None, None, None, url, None)),
             window,
             proto,
-            cx,
         )
     }
 
@@ -113,7 +113,8 @@ impl StorageEvent {
         url: DOMString,
         storageArea: Option<&Storage>,
     ) -> DomRoot<StorageEvent> {
-        let ev = reflect_dom_object_with_proto_and_cx(
+        let ev = reflect_dom_object_with_proto(
+            cx,
             Box::new(StorageEvent::new_inherited(
                 key,
                 oldValue,
@@ -123,7 +124,6 @@ impl StorageEvent {
             )),
             global,
             proto,
-            cx,
         );
         {
             let event = ev.upcast::<Event>();

--- a/components/script/dom/event/wheelevent.rs
+++ b/components/script/dom/event/wheelevent.rs
@@ -9,7 +9,7 @@ use euclid::Point2D;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use keyboard_types::Modifiers;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use style::Atom;
 use style_traits::CSSPixel;
 
@@ -51,12 +51,7 @@ impl WheelEvent {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<WheelEvent> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(WheelEvent::new_inherited()),
-            window,
-            proto,
-            cx,
-        )
+        reflect_dom_object_with_proto(cx, Box::new(WheelEvent::new_inherited()), window, proto)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/components/script/dom/fetch/request.rs
+++ b/components/script/dom/fetch/request.rs
@@ -21,7 +21,7 @@ use net_traits::request::{
 };
 use script_bindings::cell::DomRefCell;
 use script_bindings::cformat;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use servo_url::ServoUrl;
 
 use crate::body::{
@@ -78,11 +78,11 @@ impl Request {
         proto: Option<HandleObject>,
         url: ServoUrl,
     ) -> DomRoot<Request> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(Request::new_inherited(global, url)),
             global,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/fetch/response.rs
+++ b/components/script/dom/fetch/response.rs
@@ -13,7 +13,7 @@ use js::rust::{HandleObject, HandleValue};
 use net_traits::http_status::HttpStatus;
 use script_bindings::cell::DomRefCell;
 use script_bindings::cformat;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use servo_url::ServoUrl;
 use url::Position;
 
@@ -64,13 +64,7 @@ pub(crate) struct Response {
 }
 
 impl Response {
-    pub(crate) fn new_inherited(cx: &mut js::context::JSContext, global: &GlobalScope) -> Response {
-        let stream = ReadableStream::new_with_external_underlying_source(
-            cx,
-            global,
-            UnderlyingSourceType::FetchResponse,
-        )
-        .expect("Failed to create ReadableStream with external underlying source");
+    pub(crate) fn new_inherited(stream: DomRoot<ReadableStream>) -> Response {
         Response {
             reflector_: Reflector::new(),
             headers_reflector: Default::default(),
@@ -95,12 +89,13 @@ impl Response {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<Response> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(Response::new_inherited(cx, global)),
-            global,
-            proto,
+        let stream = ReadableStream::new_with_external_underlying_source(
             cx,
+            global,
+            UnderlyingSourceType::FetchResponse,
         )
+        .expect("Failed to create ReadableStream with external underlying source");
+        reflect_dom_object_with_proto(cx, Box::new(Response::new_inherited(stream)), global, proto)
     }
 
     pub(crate) fn error_stream(&self, cx: &mut js::context::JSContext, error: Error) {

--- a/components/script/dom/file/filereader.rs
+++ b/components/script/dom/file/filereader.rs
@@ -16,7 +16,7 @@ use js::typedarray::{ArrayBuffer, CreateWith};
 use mime::{self, Mime};
 use script_bindings::cell::DomRefCell;
 use script_bindings::num::Finite;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::BlobBinding::BlobMethods;
@@ -208,12 +208,7 @@ impl FileReader {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<FileReader> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(FileReader::new_inherited()),
-            global,
-            proto,
-            cx,
-        )
+        reflect_dom_object_with_proto(cx, Box::new(FileReader::new_inherited()), global, proto)
     }
 
     // https://w3c.github.io/FileAPI/#dfn-error-steps

--- a/components/script/dom/file/filereadersync.rs
+++ b/components/script/dom/file/filereadersync.rs
@@ -9,7 +9,7 @@ use js::context::JSContext;
 use js::jsapi::JSObject;
 use js::rust::HandleObject;
 use js::typedarray::{ArrayBufferU8, HeapArrayBuffer};
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use script_bindings::trace::RootedTraceableBox;
 
 use crate::dom::bindings::buffer_source::create_buffer_source;
@@ -39,12 +39,7 @@ impl FileReaderSync {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<FileReaderSync> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(FileReaderSync::new_inherited()),
-            global,
-            proto,
-            cx,
-        )
+        reflect_dom_object_with_proto(cx, Box::new(FileReaderSync::new_inherited()), global, proto)
     }
 
     fn get_blob_bytes(blob: &Blob) -> Result<Vec<u8>, Error> {

--- a/components/script/dom/form/formdata.rs
+++ b/components/script/dom/form/formdata.rs
@@ -7,7 +7,7 @@ use html5ever::LocalName;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use servo_constellation_traits::BlobImpl;
 
 use crate::dom::bindings::codegen::Bindings::FormDataBinding::FormDataMethods;
@@ -63,11 +63,11 @@ impl FormData {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<FormData> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(FormData::new_inherited(form_datums)),
             global,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/geometry/dompoint.rs
+++ b/components/script/dom/geometry/dompoint.rs
@@ -6,7 +6,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use rustc_hash::FxHashMap;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_base::id::{DomPointId, DomPointIndex};
 use servo_constellation_traits::DomPoint;
 
@@ -52,11 +52,11 @@ impl DOMPoint {
         z: f64,
         w: f64,
     ) -> DomRoot<DOMPoint> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(DOMPoint::new_inherited(x, y, z, w)),
             global,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/geometry/dompointreadonly.rs
+++ b/components/script/dom/geometry/dompointreadonly.rs
@@ -8,7 +8,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use rustc_hash::FxHashMap;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use servo_base::id::{DomPointId, DomPointIndex};
 use servo_constellation_traits::DomPoint;
 
@@ -65,11 +65,11 @@ impl DOMPointReadOnly {
         z: f64,
         w: f64,
     ) -> DomRoot<DOMPointReadOnly> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(DOMPointReadOnly::new_inherited(x, y, z, w)),
             global,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/geometry/domquad.rs
+++ b/components/script/dom/geometry/domquad.rs
@@ -6,7 +6,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use rustc_hash::FxHashMap;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use servo_base::id::{DomQuadId, DomQuadIndex};
 use servo_constellation_traits::{DomPoint, DomQuad};
 
@@ -63,11 +63,11 @@ impl DOMQuad {
         p3: &DOMPoint,
         p4: &DOMPoint,
     ) -> DomRoot<DOMQuad> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(DOMQuad::new_inherited(p1, p2, p3, p4)),
             global,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/geometry/domrect.rs
+++ b/components/script/dom/geometry/domrect.rs
@@ -6,9 +6,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use rustc_hash::FxHashMap;
-use script_bindings::reflector::{
-    reflect_dom_object_with_cx, reflect_dom_object_with_proto_and_cx,
-};
+use script_bindings::reflector::{reflect_dom_object_with_cx, reflect_dom_object_with_proto};
 use servo_base::id::{DomRectId, DomRectIndex};
 use servo_constellation_traits::DomRect;
 
@@ -55,11 +53,11 @@ impl DOMRect {
         width: f64,
         height: f64,
     ) -> DomRoot<DOMRect> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(DOMRect::new_inherited(x, y, width, height)),
             global,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/geometry/domrectlist.rs
+++ b/components/script/dom/geometry/domrectlist.rs
@@ -4,7 +4,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::DOMRectListBinding::DOMRectListMethods;
 use crate::dom::bindings::root::{Dom, DomRoot};
@@ -35,11 +35,11 @@ impl DOMRectList {
         window: &Window,
         rects: Vec<DomRoot<DOMRect>>,
     ) -> DomRoot<DOMRectList> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(DOMRectList::new_inherited(rects)),
             window,
             None,
-            cx,
         )
     }
 

--- a/components/script/dom/geometry/domrectreadonly.rs
+++ b/components/script/dom/geometry/domrectreadonly.rs
@@ -9,7 +9,7 @@ use js::context::JSContext;
 use js::rust::HandleObject;
 use rustc_hash::FxHashMap;
 use script_bindings::reflector::{
-    Reflector, reflect_dom_object_with_cx, reflect_dom_object_with_proto_and_cx,
+    Reflector, reflect_dom_object_with_cx, reflect_dom_object_with_proto,
 };
 use servo_base::id::{DomRectId, DomRectIndex};
 use servo_constellation_traits::DomRect;
@@ -52,11 +52,11 @@ impl DOMRectReadOnly {
         width: f64,
         height: f64,
     ) -> DomRoot<DOMRectReadOnly> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(DOMRectReadOnly::new_inherited(x, y, width, height)),
             global,
             proto,
-            cx,
         )
     }
 
@@ -66,11 +66,11 @@ impl DOMRectReadOnly {
         proto: Option<HandleObject>,
         dictionary: &DOMRectInit,
     ) -> DomRoot<DOMRectReadOnly> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(create_a_domrectreadonly_from_the_dictionary(dictionary)),
             global,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/globalscope/messagechannel.rs
+++ b/components/script/dom/globalscope/messagechannel.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::MessageChannelBinding::MessageChannelMethods;
 use crate::dom::bindings::root::{Dom, DomRoot};
@@ -39,11 +39,11 @@ impl MessageChannel {
         incumbent.entangle_ports(*port1.message_port_id(), *port2.message_port_id());
 
         // Steps 4-6
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(MessageChannel::new_inherited(&port1, &port2)),
             incumbent,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/globalscope/origin.rs
+++ b/components/script/dom/globalscope/origin.rs
@@ -6,7 +6,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::{HandleObject, HandleValue};
 use net_traits::pub_domains::is_same_site;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use servo_url::{ImmutableOrigin, ServoUrl};
 
 use crate::dom::bindings::codegen::Bindings::OriginBinding::OriginMethods;
@@ -45,12 +45,7 @@ impl Origin {
         proto: Option<HandleObject>,
         origin: ImmutableOrigin,
     ) -> DomRoot<Origin> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(Origin::new_inherited(origin)),
-            global,
-            proto,
-            cx,
-        )
+        reflect_dom_object_with_proto(cx, Box::new(Origin::new_inherited(origin)), global, proto)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#extract-an-origin>

--- a/components/script/dom/media/mediametadata.rs
+++ b/components/script/dom/media/mediametadata.rs
@@ -6,7 +6,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::MediaMetadataBinding::{
     MediaMetadataInit, MediaMetadataMethods,
@@ -51,11 +51,11 @@ impl MediaMetadata {
         proto: Option<HandleObject>,
         init: &MediaMetadataInit,
     ) -> DomRoot<MediaMetadata> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(MediaMetadata::new_inherited(init)),
             global,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/media/mediastream.rs
+++ b/components/script/dom/media/mediastream.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
 use script_bindings::cell::{DomRefCell, Ref};
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_media::streams::MediaStreamType;
 use servo_media::streams::registry::MediaStreamId;
 
@@ -45,12 +45,7 @@ impl MediaStream {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<MediaStream> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(MediaStream::new_inherited()),
-            global,
-            proto,
-            cx,
-        )
+        reflect_dom_object_with_proto(cx, Box::new(MediaStream::new_inherited()), global, proto)
     }
 
     pub(crate) fn new_single(

--- a/components/script/dom/performance/performancemark.rs
+++ b/components/script/dom/performance/performancemark.rs
@@ -8,7 +8,7 @@ use js::jsapi::Heap;
 use js::jsval::{JSVal, NullValue};
 use js::rust::{HandleObject, MutableHandleValue};
 use script_bindings::codegen::GenericBindings::PerformanceBinding::PerformanceMarkOptions;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use time::Duration;
 
@@ -60,11 +60,11 @@ impl PerformanceMark {
         start_time: CrossProcessInstant,
         duration: Duration,
     ) -> DomRoot<PerformanceMark> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(PerformanceMark::new_inherited(name, start_time, duration)),
             global,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/performance/performanceobserver.rs
+++ b/components/script/dom/performance/performanceobserver.rs
@@ -9,7 +9,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::{HandleObject, MutableHandleValue};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use super::performanceentry::{EntryType, PerformanceEntry};
 use super::performanceobserverentrylist::PerformanceObserverEntryList;
@@ -55,11 +55,11 @@ impl PerformanceObserver {
         proto: Option<HandleObject>,
         callback: Rc<PerformanceObserverCallback>,
     ) -> DomRoot<PerformanceObserver> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(PerformanceObserver::new_inherited(callback)),
             global,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/reporting/reportingobserver.rs
+++ b/components/script/dom/reporting/reportingobserver.rs
@@ -11,7 +11,7 @@ use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
 use script_bindings::match_domstring_ascii;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use script_bindings::str::DOMString;
 use servo_url::ServoUrl;
 
@@ -62,11 +62,11 @@ impl ReportingObserver {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(Self::new_inherited(callback, options)),
             global,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/security/sanitizer.rs
+++ b/components/script/dom/security/sanitizer.rs
@@ -11,7 +11,7 @@ use html5ever::{LocalName, Namespace, local_name, ns};
 use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use style::attr::AttrValue;
 use url::Url;
 
@@ -64,11 +64,11 @@ impl Sanitizer {
         proto: Option<HandleObject>,
         configuration: SanitizerConfig,
     ) -> DomRoot<Sanitizer> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(Sanitizer::new_inherited(configuration)),
             window,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/security/securitypolicyviolationevent.rs
+++ b/components/script/dom/security/securitypolicyviolationevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
@@ -62,11 +62,11 @@ impl SecurityPolicyViolationEvent {
         init: &SecurityPolicyViolationEventInit,
         proto: Option<HandleObject>,
     ) -> DomRoot<SecurityPolicyViolationEvent> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(SecurityPolicyViolationEvent::new_inherited(init)),
             global,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/stream/compressionstream.rs
+++ b/components/script/dom/stream/compressionstream.rs
@@ -17,7 +17,7 @@ use js::jsval::UndefinedValue;
 use js::rust::{HandleObject as SafeHandleObject, HandleValue as SafeHandleValue};
 use js::typedarray::Uint8;
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::buffer_source::{create_buffer_source, get_buffer_source_copy};
 use crate::dom::bindings::codegen::Bindings::CompressionStreamBinding::{
@@ -69,11 +69,11 @@ impl CompressionStream {
         transform: &TransformStream,
         format: CompressionFormat,
     ) -> DomRoot<CompressionStream> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(CompressionStream::new_inherited(transform, format)),
             global,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/stream/decompressionstream.rs
+++ b/components/script/dom/stream/decompressionstream.rs
@@ -14,7 +14,7 @@ use js::jsval::UndefinedValue;
 use js::rust::{HandleObject as SafeHandleObject, HandleValue as SafeHandleValue};
 use js::typedarray::Uint8;
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::buffer_source::create_buffer_source;
 use crate::dom::bindings::codegen::Bindings::CompressionStreamBinding::CompressionFormat;
@@ -64,11 +64,11 @@ impl DecompressionStream {
         transform: &TransformStream,
         format: CompressionFormat,
     ) -> DomRoot<DecompressionStream> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(DecompressionStream::new_inherited(transform, format)),
             global,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -45,7 +45,7 @@ use crate::dom::bindings::codegen::GenericBindings::WritableStreamDefaultWriterB
 use crate::dom::stream::writablestream::WritableStream;
 use crate::dom::bindings::codegen::UnionTypes::ReadableStreamDefaultReaderOrReadableStreamBYOBReader as ReadableStreamReader;
 use crate::dom::bindings::reflector::DomGlobal;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use crate::dom::bindings::root::{DomRoot, MutNullableDom, Dom};
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::stream::byteteeunderlyingsource::{ByteTeeCancelAlgorithm, ByteTeePullAlgorithm, ByteTeeUnderlyingSource};
@@ -927,12 +927,7 @@ impl ReadableStream {
         global: &GlobalScope,
         proto: Option<SafeHandleObject>,
     ) -> DomRoot<ReadableStream> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(ReadableStream::new_inherited()),
-            global,
-            proto,
-            cx,
-        )
+        reflect_dom_object_with_proto(cx, Box::new(ReadableStream::new_inherited()), global, proto)
     }
 
     /// Used as part of

--- a/components/script/dom/stream/readablestreambyobreader.rs
+++ b/components/script/dom/stream/readablestreambyobreader.rs
@@ -17,7 +17,7 @@ use js::rust::{HandleObject as SafeHandleObject, HandleValue as SafeHandleValue}
 use js::typedarray::{ArrayBufferView, ArrayBufferViewU8};
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{
-    Reflector, reflect_dom_object_with_cx, reflect_dom_object_with_proto_and_cx,
+    Reflector, reflect_dom_object_with_cx, reflect_dom_object_with_proto,
 };
 use script_bindings::root::Dom;
 
@@ -202,20 +202,21 @@ impl ReadableStreamBYOBReader {
         global: &GlobalScope,
         proto: Option<SafeHandleObject>,
     ) -> DomRoot<ReadableStreamBYOBReader> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(ReadableStreamBYOBReader::new_inherited(cx, global)),
+        let closed_promise = Promise::new(cx, global);
+        reflect_dom_object_with_proto(
+            cx,
+            Box::new(ReadableStreamBYOBReader::new_inherited(closed_promise)),
             global,
             proto,
-            cx,
         )
     }
 
-    fn new_inherited(cx: &mut JSContext, global: &GlobalScope) -> ReadableStreamBYOBReader {
+    fn new_inherited(promise: Rc<Promise>) -> ReadableStreamBYOBReader {
         ReadableStreamBYOBReader {
             reflector_: Reflector::new(),
             stream: MutNullableDom::new(None),
             read_into_requests: DomRefCell::new(Default::default()),
-            closed_promise: DomRefCell::new(Promise::new(cx, global)),
+            closed_promise: DomRefCell::new(promise),
         }
     }
 
@@ -223,7 +224,8 @@ impl ReadableStreamBYOBReader {
         cx: &mut JSContext,
         global: &GlobalScope,
     ) -> DomRoot<ReadableStreamBYOBReader> {
-        reflect_dom_object_with_cx(Box::new(Self::new_inherited(cx, global)), global, cx)
+        let closed_promise = Promise::new(cx, global);
+        reflect_dom_object_with_cx(Box::new(Self::new_inherited(closed_promise)), global, cx)
     }
 
     /// <https://streams.spec.whatwg.org/#set-up-readable-stream-byob-reader>

--- a/components/script/dom/stream/readablestreamdefaultreader.rs
+++ b/components/script/dom/stream/readablestreamdefaultreader.rs
@@ -15,7 +15,7 @@ use js::realm::CurrentRealm;
 use js::rust::{HandleObject as SafeHandleObject, HandleValue as SafeHandleValue};
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{
-    Reflector, reflect_dom_object_with_cx, reflect_dom_object_with_proto_and_cx,
+    Reflector, reflect_dom_object_with_cx, reflect_dom_object_with_proto,
 };
 
 use super::byteteereadrequest::ByteTeeReadRequest;
@@ -348,20 +348,21 @@ impl ReadableStreamDefaultReader {
         global: &GlobalScope,
         proto: Option<SafeHandleObject>,
     ) -> DomRoot<ReadableStreamDefaultReader> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(ReadableStreamDefaultReader::new_inherited(cx, global)),
+        let closed_promise = Promise::new(cx, global);
+        reflect_dom_object_with_proto(
+            cx,
+            Box::new(ReadableStreamDefaultReader::new_inherited(closed_promise)),
             global,
             proto,
-            cx,
         )
     }
 
-    fn new_inherited(cx: &mut JSContext, global: &GlobalScope) -> ReadableStreamDefaultReader {
+    fn new_inherited(promise: Rc<Promise>) -> ReadableStreamDefaultReader {
         ReadableStreamDefaultReader {
             reflector_: Reflector::new(),
             stream: MutNullableDom::new(None),
             read_requests: DomRefCell::new(Default::default()),
-            closed_promise: DomRefCell::new(Promise::new(cx, global)),
+            closed_promise: DomRefCell::new(promise),
         }
     }
 
@@ -369,7 +370,8 @@ impl ReadableStreamDefaultReader {
         cx: &mut JSContext,
         global: &GlobalScope,
     ) -> DomRoot<ReadableStreamDefaultReader> {
-        reflect_dom_object_with_cx(Box::new(Self::new_inherited(cx, global)), global, cx)
+        let closed_promise = Promise::new(cx, global);
+        reflect_dom_object_with_cx(Box::new(Self::new_inherited(closed_promise)), global, cx)
     }
 
     /// <https://streams.spec.whatwg.org/#set-up-readable-stream-default-reader>

--- a/components/script/dom/stream/transformstream.rs
+++ b/components/script/dom/stream/transformstream.rs
@@ -15,7 +15,7 @@ use js::rust::{HandleObject as SafeHandleObject, HandleValue as SafeHandleValue,
 use rustc_hash::FxHashMap;
 use script_bindings::callback::ExceptionHandling;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use servo_base::id::{MessagePortId, MessagePortIndex};
 use servo_constellation_traits::TransformStreamData;
 
@@ -425,11 +425,11 @@ impl TransformStream {
         global: &GlobalScope,
         proto: Option<SafeHandleObject>,
     ) -> DomRoot<TransformStream> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(TransformStream::new_inherited()),
             global,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/stream/writablestream.rs
+++ b/components/script/dom/stream/writablestream.rs
@@ -21,7 +21,7 @@ use rustc_hash::FxHashMap;
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::MessagePortBinding::MessagePortMethods;
 use script_bindings::conversions::SafeToJSValConvertible;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use servo_base::id::{MessagePortId, MessagePortIndex};
 use servo_constellation_traits::MessagePortImpl;
 
@@ -193,12 +193,7 @@ impl WritableStream {
         global: &GlobalScope,
         proto: Option<SafeHandleObject>,
     ) -> DomRoot<WritableStream> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(WritableStream::new_inherited()),
-            global,
-            proto,
-            cx,
-        )
+        reflect_dom_object_with_proto(cx, Box::new(WritableStream::new_inherited()), global, proto)
     }
 
     /// Used as part of

--- a/components/script/dom/stream/writablestreamdefaultwriter.rs
+++ b/components/script/dom/stream/writablestreamdefaultwriter.rs
@@ -10,7 +10,7 @@ use js::context::JSContext;
 use js::jsval::UndefinedValue;
 use js::realm::CurrentRealm;
 use js::rust::{HandleObject as SafeHandleObject, HandleValue as SafeHandleValue};
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::WritableStreamDefaultWriterBinding::WritableStreamDefaultWriterMethods;
 use crate::dom::bindings::error::{Error, ErrorToJsval};
@@ -39,12 +39,15 @@ pub struct WritableStreamDefaultWriter {
 impl WritableStreamDefaultWriter {
     /// <https://streams.spec.whatwg.org/#set-up-writable-stream-default-writer>
     /// The parts that create a new promise.
-    fn new_inherited(cx: &mut CurrentRealm) -> WritableStreamDefaultWriter {
+    fn new_inherited(
+        closed_promise: Rc<Promise>,
+        ready_promise: Rc<Promise>,
+    ) -> WritableStreamDefaultWriter {
         WritableStreamDefaultWriter {
             reflector_: Reflector::new(),
             stream: Default::default(),
-            closed_promise: RefCell::new(Promise::new_in_realm(cx)),
-            ready_promise: RefCell::new(Promise::new_in_realm(cx)),
+            closed_promise: RefCell::new(closed_promise),
+            ready_promise: RefCell::new(ready_promise),
         }
     }
 
@@ -53,11 +56,16 @@ impl WritableStreamDefaultWriter {
         global: &GlobalScope,
         proto: Option<SafeHandleObject>,
     ) -> DomRoot<WritableStreamDefaultWriter> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(WritableStreamDefaultWriter::new_inherited(cx)),
+        let closed_promise = Promise::new_in_realm(cx);
+        let ready_promise = Promise::new_in_realm(cx);
+        reflect_dom_object_with_proto(
+            cx,
+            Box::new(WritableStreamDefaultWriter::new_inherited(
+                closed_promise,
+                ready_promise,
+            )),
             global,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -23,7 +23,7 @@ use js::typedarray::{self, HeapUint8ClampedArray};
 use script_bindings::cformat;
 use script_bindings::interfaces::TestBindingHelpers;
 use script_bindings::record::Record;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use servo_config::prefs;
 use servo_constellation_traits::BlobImpl;
 
@@ -79,12 +79,7 @@ impl TestBinding {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<TestBinding> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(TestBinding::new_inherited()),
-            global,
-            proto,
-            cx,
-        )
+        reflect_dom_object_with_proto(cx, Box::new(TestBinding::new_inherited()), global, proto)
     }
 }
 

--- a/components/script/dom/testing/testbindingiterable.rs
+++ b/components/script/dom/testing/testbindingiterable.rs
@@ -8,7 +8,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::TestBindingIterableBinding::TestBindingIterableMethods;
 use crate::dom::bindings::error::Fallible;
@@ -28,14 +28,14 @@ impl TestBindingIterable {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<TestBindingIterable> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(TestBindingIterable {
                 reflector: Reflector::new(),
                 vals: DomRefCell::new(vec![]),
             }),
             global,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/testing/testbindingmaplikewithinterface.rs
+++ b/components/script/dom/testing/testbindingmaplikewithinterface.rs
@@ -11,7 +11,7 @@ use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
 use script_bindings::cformat;
 use script_bindings::like::Maplike;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::TestBindingMaplikeWithInterfaceBinding::TestBindingMaplikeWithInterfaceMethods;
 use crate::dom::bindings::error::{Error, Fallible};
@@ -35,14 +35,14 @@ impl TestBindingMaplikeWithInterface {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<TestBindingMaplikeWithInterface> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(TestBindingMaplikeWithInterface {
                 reflector: Reflector::new(),
                 internal: DomRefCell::new(IndexMap::new()),
             }),
             global,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/testing/testbindingmaplikewithprimitive.rs
+++ b/components/script/dom/testing/testbindingmaplikewithprimitive.rs
@@ -11,7 +11,7 @@ use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
 use script_bindings::cformat;
 use script_bindings::like::Maplike;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::TestBindingMaplikeWithPrimitiveBinding::TestBindingMaplikeWithPrimitiveMethods;
 use crate::dom::bindings::error::{Error, Fallible};
@@ -34,14 +34,14 @@ impl TestBindingMaplikeWithPrimitive {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<TestBindingMaplikeWithPrimitive> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(TestBindingMaplikeWithPrimitive {
                 reflector: Reflector::new(),
                 internal: DomRefCell::new(IndexMap::new()),
             }),
             global,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/testing/testbindingpairiterable.rs
+++ b/components/script/dom/testing/testbindingpairiterable.rs
@@ -8,7 +8,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::TestBindingPairIterableBinding::TestBindingPairIterableMethods;
 use crate::dom::bindings::error::Fallible;
@@ -49,14 +49,14 @@ impl TestBindingPairIterable {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<TestBindingPairIterable> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(TestBindingPairIterable {
                 reflector: Reflector::new(),
                 map: DomRefCell::new(vec![]),
             }),
             global,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/testing/testbindingsetlikewithinterface.rs
+++ b/components/script/dom/testing/testbindingsetlikewithinterface.rs
@@ -10,7 +10,7 @@ use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
 use script_bindings::like::Setlike;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::TestBindingSetlikeWithInterfaceBinding::TestBindingSetlikeWithInterfaceMethods;
 use crate::dom::bindings::error::Fallible;
@@ -33,14 +33,14 @@ impl TestBindingSetlikeWithInterface {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<TestBindingSetlikeWithInterface> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(TestBindingSetlikeWithInterface {
                 reflector: Reflector::new(),
                 internal: DomRefCell::new(IndexSet::new()),
             }),
             global,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/testing/testbindingsetlikewithprimitive.rs
+++ b/components/script/dom/testing/testbindingsetlikewithprimitive.rs
@@ -10,7 +10,7 @@ use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
 use script_bindings::like::Setlike;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::TestBindingSetlikeWithPrimitiveBinding::TestBindingSetlikeWithPrimitiveMethods;
 use crate::dom::bindings::error::Fallible;
@@ -33,14 +33,14 @@ impl TestBindingSetlikeWithPrimitive {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<TestBindingSetlikeWithPrimitive> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(TestBindingSetlikeWithPrimitive {
                 reflector: Reflector::new(),
                 internal: DomRefCell::new(IndexSet::new()),
             }),
             global,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/testing/testworklet.rs
+++ b/components/script/dom/testing/testworklet.rs
@@ -9,7 +9,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::realm::CurrentRealm;
 use js::rust::HandleObject;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::TestWorkletBinding::TestWorkletMethods;
 use crate::dom::bindings::codegen::Bindings::WorkletBinding::Worklet_Binding::WorkletMethods;
@@ -44,11 +44,11 @@ impl TestWorklet {
         proto: Option<HandleObject>,
     ) -> DomRoot<TestWorklet> {
         let worklet = Worklet::new(cx, window, WorkletGlobalScopeType::Test);
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(TestWorklet::new_inherited(&worklet)),
             window,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/url/urlsearchparams.rs
+++ b/components/script/dom/url/urlsearchparams.rs
@@ -6,7 +6,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use url::form_urlencoded;
 
 use crate::dom::bindings::codegen::Bindings::URLSearchParamsBinding::URLSearchParamsMethods;
@@ -52,11 +52,11 @@ impl URLSearchParams {
         proto: Option<HandleObject>,
         url: Option<&URL>,
     ) -> DomRoot<URLSearchParams> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(URLSearchParams::new_inherited(url)),
             global,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/webgpu/gpuerror.rs
+++ b/components/script/dom/webgpu/gpuerror.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use webgpu_traits::{Error, ErrorFilter};
 
 use crate::conversions::Convert;
@@ -44,11 +44,11 @@ impl GPUError {
         proto: Option<HandleObject>,
         message: DOMString,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(GPUError::new_inherited(message)),
             global,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/webgpu/gpuinternalerror.rs
+++ b/components/script/dom/webgpu/gpuinternalerror.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUInternalError_Binding::GPUInternalErrorMethods;
 use crate::dom::bindings::root::DomRoot;
@@ -31,12 +31,7 @@ impl GPUInternalError {
         proto: Option<HandleObject>,
         message: DOMString,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(Self::new_inherited(message)),
-            global,
-            proto,
-            cx,
-        )
+        reflect_dom_object_with_proto(cx, Box::new(Self::new_inherited(message)), global, proto)
     }
 }
 

--- a/components/script/dom/webgpu/gpuoutofmemoryerror.rs
+++ b/components/script/dom/webgpu/gpuoutofmemoryerror.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUOutOfMemoryError_Binding::GPUOutOfMemoryErrorMethods;
 use crate::dom::bindings::root::DomRoot;
@@ -31,12 +31,7 @@ impl GPUOutOfMemoryError {
         proto: Option<HandleObject>,
         message: DOMString,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(Self::new_inherited(message)),
-            global,
-            proto,
-            cx,
-        )
+        reflect_dom_object_with_proto(cx, Box::new(Self::new_inherited(message)), global, proto)
     }
 }
 

--- a/components/script/dom/webgpu/gpupipelineerror.rs
+++ b/components/script/dom/webgpu/gpupipelineerror.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUPipelineErrorInit, GPUPipelineErrorMethods, GPUPipelineErrorReason,
@@ -37,11 +37,11 @@ impl GPUPipelineError {
         message: DOMString,
         reason: GPUPipelineErrorReason,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(Self::new_inherited(message, reason)),
             global,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/webgpu/gpusupportedfeatures.rs
+++ b/components/script/dom/webgpu/gpusupportedfeatures.rs
@@ -10,7 +10,7 @@ use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
 use script_bindings::like::Setlike;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use wgpu_types::Features;
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
@@ -92,7 +92,8 @@ impl GPUSupportedFeatures {
         }
         */
 
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(GPUSupportedFeatures {
                 reflector: Reflector::new(),
                 internal: DomRefCell::new(set),
@@ -100,7 +101,6 @@ impl GPUSupportedFeatures {
             }),
             global,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/webgpu/gpuvalidationerror.rs
+++ b/components/script/dom/webgpu/gpuvalidationerror.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUValidationError_Binding::GPUValidationErrorMethods;
 use crate::dom::bindings::root::DomRoot;
@@ -31,12 +31,7 @@ impl GPUValidationError {
         proto: Option<HandleObject>,
         message: DOMString,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(Self::new_inherited(message)),
-            global,
-            proto,
-            cx,
-        )
+        reflect_dom_object_with_proto(cx, Box::new(Self::new_inherited(message)), global, proto)
     }
 }
 

--- a/components/script/dom/webgpu/wgsllanguagefeatures.rs
+++ b/components/script/dom/webgpu/wgsllanguagefeatures.rs
@@ -10,7 +10,7 @@ use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
 use script_bindings::like::Setlike;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use wgpu_core::naga::front::wgsl::ImplementedLanguageExtension;
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::WGSLLanguageFeaturesMethods;
@@ -36,14 +36,14 @@ impl WGSLLanguageFeatures {
             .iter()
             .map(|le| le.to_ident().into())
             .collect();
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(Self {
                 reflector: Reflector::new(),
                 internal: DomRefCell::new(set),
             }),
             global,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/webrtc/rtcerror.rs
+++ b/components/script/dom/webrtc/rtcerror.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 
 use crate::dom::bindings::codegen::Bindings::RTCErrorBinding::{
     RTCErrorDetailType, RTCErrorInit, RTCErrorMethods,
@@ -55,11 +55,11 @@ impl RTCError {
         init: &RTCErrorInit,
         message: DOMString,
     ) -> DomRoot<RTCError> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(RTCError::new_inherited(init, message)),
             window,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/webrtc/rtcicecandidate.rs
+++ b/components/script/dom/webrtc/rtcicecandidate.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::RTCIceCandidateBinding::{
     RTCIceCandidateInit, RTCIceCandidateMethods,
@@ -68,7 +68,8 @@ impl RTCIceCandidate {
         sdp_m_line_index: Option<u16>,
         username_fragment: Option<DOMString>,
     ) -> DomRoot<RTCIceCandidate> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(RTCIceCandidate::new_inherited(
                 candidate,
                 sdp_m_id,
@@ -77,7 +78,6 @@ impl RTCIceCandidate {
             )),
             window,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/webrtc/rtcsessiondescription.rs
+++ b/components/script/dom/webrtc/rtcsessiondescription.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::RTCSessionDescriptionBinding::{
     RTCSdpType, RTCSessionDescriptionInit, RTCSessionDescriptionMethods,
@@ -38,11 +38,11 @@ impl RTCSessionDescription {
         ty: RTCSdpType,
         sdp: DOMString,
     ) -> DomRoot<RTCSessionDescription> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(RTCSessionDescription::new_inherited(ty, sdp)),
             window,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/webxr/xrlayerevent.rs
+++ b/components/script/dom/webxr/xrlayerevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
@@ -39,11 +39,11 @@ impl XRLayerEvent {
         proto: Option<HandleObject>,
         layer: &XRLayer,
     ) -> DomRoot<XRLayerEvent> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(XRLayerEvent::new_inherited(layer)),
             window,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/webxr/xrmediabinding.rs
+++ b/components/script/dom/webxr/xrmediabinding.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::XRMediaBindingBinding::XRMediaBinding_Binding::XRMediaBindingMethods;
 use crate::dom::bindings::codegen::Bindings::XRMediaBindingBinding::XRMediaLayerInit;
@@ -38,11 +38,11 @@ impl XRMediaBinding {
         proto: Option<HandleObject>,
         session: &XRSession,
     ) -> DomRoot<XRMediaBinding> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(XRMediaBinding::new_inherited(session)),
             global,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/webxr/xrrigidtransform.rs
+++ b/components/script/dom/webxr/xrrigidtransform.rs
@@ -8,7 +8,7 @@ use js::context::JSContext;
 use js::rust::HandleObject;
 use js::typedarray::{Float32, HeapFloat32Array};
 use script_bindings::cformat;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use script_bindings::trace::RootedTraceableBox;
 
 use crate::dom::bindings::buffer_source::HeapBufferSource;
@@ -59,11 +59,11 @@ impl XRRigidTransform {
         proto: Option<HandleObject>,
         transform: ApiRigidTransform,
     ) -> DomRoot<XRRigidTransform> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(XRRigidTransform::new_inherited(transform)),
             window,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/webxr/xrwebglbinding.rs
+++ b/components/script/dom/webxr/xrwebglbinding.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::XRViewBinding::XREye;
 use crate::dom::bindings::codegen::Bindings::XRWebGLBindingBinding::XRWebGLBinding_Binding::XRWebGLBindingMethods;
@@ -56,11 +56,11 @@ impl XRWebGLBinding {
         session: &XRSession,
         context: &WebGLRenderingContext,
     ) -> DomRoot<XRWebGLBinding> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(XRWebGLBinding::new_inherited(session, context)),
             global,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/webxr/xrwebgllayer.rs
+++ b/components/script/dom/webxr/xrwebgllayer.rs
@@ -8,7 +8,7 @@ use dom_struct::dom_struct;
 use euclid::{Rect, Size2D};
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_canvas_traits::webgl::{WebGLCommand, WebGLContextId, WebGLTextureId};
 use webxr_api::{ContextId as WebXRContextId, LayerId, LayerInit, Viewport};
 
@@ -90,7 +90,8 @@ impl XRWebGLLayer {
         framebuffer: Option<&WebGLFramebuffer>,
         layer_id: Option<LayerId>,
     ) -> DomRoot<XRWebGLLayer> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(XRWebGLLayer::new_inherited(
                 session,
                 context,
@@ -100,7 +101,6 @@ impl XRWebGLLayer {
             )),
             global,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/workers/sharedworker.rs
+++ b/components/script/dom/workers/sharedworker.rs
@@ -13,7 +13,7 @@ use js::rust::HandleObject;
 use malloc_size_of_derive::MallocSizeOf;
 use net_traits::pub_domains::reg_suffix;
 use net_traits::request::{CredentialsMode, Referrer};
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_base::generic_channel;
 use servo_constellation_traits::{MessagePortImpl, WorkerScriptLoadOrigin};
 use servo_url::{Host, ImmutableOrigin, ServoUrl};
@@ -344,11 +344,11 @@ impl SharedWorker {
         control_sender: Sender<SharedWorkerControlMsg>,
         cx: &mut js::context::JSContext,
     ) -> DomRoot<SharedWorker> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(SharedWorker::new_inherited(port, control_sender)),
             global,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/workers/worker.rs
+++ b/components/script/dom/workers/worker.rs
@@ -15,7 +15,7 @@ use js::jsval::UndefinedValue;
 use js::rust::{CustomAutoRooter, CustomAutoRooterGuard, HandleObject, HandleValue};
 use net_traits::request::Referrer;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_base::generic_channel;
 use servo_constellation_traits::{StructuredSerializedData, WorkerScriptLoadOrigin};
 use uuid::Uuid;
@@ -81,11 +81,11 @@ impl Worker {
         sender: Sender<DedicatedWorkerScriptMsg>,
         closing: Arc<AtomicBool>,
     ) -> DomRoot<Worker> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(Worker::new_inherited(sender, closing)),
             global,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/xmlhttprequest/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest/xmlhttprequest.rs
@@ -37,7 +37,7 @@ use net_traits::{
 use script_bindings::cell::DomRefCell;
 use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::num::Finite;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use script_bindings::trace::RootedTraceableBox;
 use script_traits::DocumentActivity;
 use servo_constellation_traits::BlobImpl;
@@ -283,11 +283,11 @@ impl XMLHttpRequest {
         proto: Option<HandleObject>,
     ) -> DomRoot<XMLHttpRequest> {
         let upload = XMLHttpRequestUpload::new(cx, global);
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(XMLHttpRequest::new_inherited(global, &upload)),
             global,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/xmlserializer.rs
+++ b/components/script/dom/xmlserializer.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use xml5ever::serialize::{SerializeOpts, TraversalScope, serialize};
 
 use crate::dom::bindings::codegen::Bindings::XMLSerializerBinding::XMLSerializerMethods;
@@ -35,11 +35,11 @@ impl XMLSerializer {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<XMLSerializer> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(XMLSerializer::new_inherited(window)),
             window,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/xpath/xpathevaluator.rs
+++ b/components/script/dom/xpath/xpathevaluator.rs
@@ -8,7 +8,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::XPathEvaluatorBinding::XPathEvaluatorMethods;
 use crate::dom::bindings::codegen::Bindings::XPathNSResolverBinding::XPathNSResolver;
@@ -40,11 +40,11 @@ impl XPathEvaluator {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<XPathEvaluator> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(XPathEvaluator::new_inherited(window)),
             window,
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/xpath/xpathexpression.rs
+++ b/components/script/dom/xpath/xpathexpression.rs
@@ -6,7 +6,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::codegen::InheritTypes::{CharacterDataTypeId, NodeTypeId};
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use xpath::{Expression, evaluate_parsed_xpath};
 
 use crate::dom::bindings::codegen::Bindings::XPathExpressionBinding::XPathExpressionMethods;
@@ -41,11 +41,11 @@ impl XPathExpression {
         proto: Option<HandleObject>,
         parsed_expression: Expression,
     ) -> DomRoot<XPathExpression> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(XPathExpression::new_inherited(window, parsed_expression)),
             window,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/xpath/xpathresult.rs
+++ b/components/script/dom/xpath/xpathresult.rs
@@ -8,7 +8,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::XPathResultBinding::{
     XPathResultConstants, XPathResultMethods,
@@ -131,11 +131,11 @@ impl XPathResult {
         result_type: XPathResultType,
         value: XPathResultValue,
     ) -> DomRoot<XPathResult> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(XPathResult::new_inherited(window, result_type, value)),
             window,
             proto,
-            cx,
         )
     }
 


### PR DESCRIPTION
As a cleanup follow-up to the migration to pass `&mut JSContext`, this PR is the result of applying the following regex replacement to the codebase:

Before:

```
reflect_dom_object_with_proto_and_cx\((([^<]|\n)+),\n\s+?cx,\n\s+?\)\n
```

After:

```
reflect_dom_object_with_proto(cx, $1)\n
```

This did not catch all usages, but is a good start.

Part of #40600

Testing: it compiles