### PR TITLE
layout:  Avoid potential n² comparisons when updating children of accessibility nodes

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -9,8 +9,6 @@ use std::sync::{LazyLock, atomic};
 
 use accesskit::{NodeId, Role};
 use bitflags::bitflags;
-use itertools::EitherOrBoth::Both;
-use itertools::Itertools;
 use layout_api::{AccessibilityDamage, LayoutElement, LayoutNode, LayoutNodeType};
 use log::trace;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -574,37 +572,39 @@ impl AccessibilityNode {
 
         let mut damage_from_children = LocalAccessibilityDamage::empty();
 
-        let dom_children = dom_node.flat_tree_children();
-        let mut matching_nodes = 0usize;
+        let mut remaining_dom_children = dom_node.flat_tree_children().peekable();
+        let mut old_child_ids = self.child_ids().iter().peekable();
+        let mut unchanged_count = 0usize;
 
-        let mut zip = self.child_ids().iter().zip_longest(dom_children).peekable();
-        while zip
-            .next_if(|either| match either {
-                Both(old_id, dom_child) => {
-                    tree.existing_id_for_opaque(dom_child.opaque()) == Some(**old_id)
-                },
-                _ => false,
-            })
-            .is_some()
+        // For the first `unchanged_count` children, no action is necessary.
+        while let Some(&old_id) = old_child_ids.peek() &&
+            let Some(dom_child) = remaining_dom_children.peek()
         {
-            matching_nodes += 1;
+            if tree.existing_id_for_opaque(dom_child.opaque()) == Some(*old_id) {
+                unchanged_count += 1;
+                old_child_ids.next();
+                remaining_dom_children.next();
+            } else {
+                break;
+            }
         }
 
-        if zip.peek().is_none() {
+        // If we iterated over all the dom children without finding any changes, we're done.
+        if old_child_ids.peek().is_none() && remaining_dom_children.peek().is_none() {
             return damage_from_children;
         }
 
+        // Remove all child nodes after the first `unchanged_count`.
+        self.child_nodes.truncate(unchanged_count);
         let mut new_child_ids = Vec::from(self.child_ids());
-        let removed_child_ids = new_child_ids.split_off(matching_nodes);
-        let _removed_children = self.child_nodes.split_off(matching_nodes);
-
-        for removed_child_id in removed_child_ids {
-            dbg!(removed_child_id);
+        for removed_child_id in new_child_ids.split_off(unchanged_count) {
             update.set_tree_state_change(removed_child_id, TreeChange::Removed);
         }
 
-        for dom_child in dom_node.flat_tree_children().skip(matching_nodes) {
-            dbg!(dom_child);
+        // Then, (re-)add all the remaining DOM children. Note that this means that some children
+        // may end up being "Moved" even though they haven't changed parents, and may even be in the
+        // same position as previously.
+        for dom_child in remaining_dom_children {
             let (new_id, new_child) = tree.get_or_create_node(&dom_child, update);
             if update.is_new(&new_id) {
                 let child_damage = tree.update_node_and_descendants_from_dom_node(
@@ -617,12 +617,17 @@ impl AccessibilityNode {
             } else {
                 update.set_tree_state_change(new_id, TreeChange::PendingMove);
             }
+
+            // Update self.child_nodes in place.
             self.child_nodes.push(new_child.clone());
             new_child_ids.push(new_id);
+
             let mut new_child = new_child.borrow_mut();
             new_child.parent_node = Some(weak_self.clone());
         }
 
+        // We can't update the AccessKit node's `children` in place, so we build up the full list
+        // and then set it here.
         self.accesskit_node.set_children(new_child_ids);
         self.updated = true;
 

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -565,12 +565,9 @@ impl AccessibilityNode {
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate,
     ) -> LocalAccessibilityDamage {
-        let mut local_damage = LocalAccessibilityDamage::empty();
         if !dom_damage.contains(AccessibilityDamage::Children) {
-            return local_damage;
+            return LocalAccessibilityDamage::empty();
         }
-
-        let mut damage_from_children = LocalAccessibilityDamage::empty();
 
         let mut remaining_dom_children = dom_node.flat_tree_children().peekable();
         let mut old_child_ids = self.child_ids().iter().peekable();
@@ -591,7 +588,7 @@ impl AccessibilityNode {
 
         // If we iterated over all the dom children without finding any changes, we're done.
         if old_child_ids.peek().is_none() && remaining_dom_children.peek().is_none() {
-            return damage_from_children;
+            return LocalAccessibilityDamage::empty();
         }
 
         // Remove all child nodes after the first `unchanged_count`.
@@ -607,13 +604,12 @@ impl AccessibilityNode {
         for dom_child in remaining_dom_children {
             let (new_id, new_child) = tree.get_or_create_node(&dom_child, update);
             if update.is_new(&new_id) {
-                let child_damage = tree.update_node_and_descendants_from_dom_node(
+                tree.update_node_and_descendants_from_dom_node(
                     new_child.clone(),
                     &dom_child,
                     AccessibilityDamage::Rebuild,
                     update,
                 );
-                damage_from_children.insert(child_damage);
             } else {
                 update.set_tree_state_change(new_id, TreeChange::PendingMove);
             }
@@ -631,11 +627,7 @@ impl AccessibilityNode {
         self.accesskit_node.set_children(new_child_ids);
         self.updated = true;
 
-        if !damage_from_children.is_empty() {
-            local_damage.insert(LocalAccessibilityDamage::SubtreeChanged);
-        }
-
-        local_damage
+        LocalAccessibilityDamage::SubtreeChanged
     }
 
     /// Update this node's properties from its corresponding DOM node.

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -9,6 +9,8 @@ use std::sync::{LazyLock, atomic};
 
 use accesskit::{NodeId, Role};
 use bitflags::bitflags;
+use itertools::EitherOrBoth::{Both, Left, Right};
+use itertools::{Itertools, izip};
 use layout_api::{AccessibilityDamage, LayoutElement, LayoutNode, LayoutNodeType};
 use log::trace;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -565,35 +567,83 @@ impl AccessibilityNode {
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate,
     ) -> LocalAccessibilityDamage {
+        dbg!(dom_node);
+
         let mut local_damage = LocalAccessibilityDamage::empty();
         if !dom_damage.contains(AccessibilityDamage::Children) {
             return local_damage;
         }
 
-        let dom_children: Vec<ServoLayoutNode> = dom_node.flat_tree_children().collect();
-
         let mut damage_from_children = LocalAccessibilityDamage::empty();
-        let mut new_child_ids = vec![];
-        let mut new_child_nodes = vec![];
-        for dom_child in dom_children {
-            let (child_id, child_node) = tree.get_or_create_node(&dom_child, update);
-            if update.is_new(&child_id) {
+
+        let dom_children = dom_node.flat_tree_children();
+        let mut matching_nodes = 0usize;
+
+        let mut zip = self.child_ids().iter().zip_longest(dom_children).peekable();
+        while zip
+            .next_if(|either| match either {
+                Both(old_id, dom_child) => {
+                    dbg!(dom_child);
+                    if let Some(new_id) = tree.existing_id_for_opaque(dom_child.opaque()) {
+                        return new_id == **old_id;
+                    }
+                    false
+                },
+                Left(old_id) => {
+                    dbg!(old_id);
+                    false
+                },
+                Right(new_dom_child) => {
+                    dbg!(new_dom_child);
+                    false
+                },
+            })
+            .is_some()
+        {
+            matching_nodes += 1;
+        }
+
+        if zip.peek().is_none() {
+            dbg!("no change");
+            return damage_from_children;
+        }
+
+        let mut new_child_ids = Vec::from(self.child_ids());
+        let removed_child_ids = new_child_ids.split_off(matching_nodes);
+        let _removed_children = self.child_nodes.split_off(matching_nodes);
+
+        for removed_child_id in removed_child_ids {
+            dbg!(removed_child_id);
+            update.set_tree_state_change(removed_child_id, TreeChange::Removed);
+        }
+
+        for dom_child in dom_node.flat_tree_children().skip(matching_nodes) {
+            dbg!(dom_child);
+            let (new_id, new_child) = tree.get_or_create_node(&dom_child, update);
+            if update.is_new(&new_id) {
                 let child_damage = tree.update_node_and_descendants_from_dom_node(
-                    child_node.clone(),
+                    new_child.clone(),
                     &dom_child,
                     AccessibilityDamage::Rebuild,
                     update,
                 );
                 damage_from_children.insert(child_damage);
+            } else {
+                update.set_tree_state_change(new_id, TreeChange::PendingMove);
             }
-            new_child_ids.push(child_id);
-            new_child_nodes.push(child_node);
+            self.child_nodes.push(new_child.clone());
+            new_child_ids.push(new_id);
+            let mut new_child = new_child.borrow_mut();
+            new_child.parent_node = Some(weak_self.clone());
         }
+
+        self.accesskit_node.set_children(new_child_ids);
+        self.updated = true;
+
         if !damage_from_children.is_empty() {
             local_damage.insert(LocalAccessibilityDamage::SubtreeChanged);
         }
 
-        local_damage.insert(self.set_children(weak_self, new_child_ids, new_child_nodes, update));
         local_damage
     }
 
@@ -693,50 +743,6 @@ impl AccessibilityNode {
 
     fn child_ids(&self) -> &[NodeId] {
         self.accesskit_node.children()
-    }
-
-    /// Set the children for this node, and set the subtree state change for any moved or removed
-    /// children.
-    fn set_children(
-        &mut self,
-        weak_self: WeakRefCell<Self>,
-        new_child_ids: Vec<NodeId>,
-        new_child_nodes: Vec<ArcRefCell<AccessibilityNode>>,
-        update: &mut AccessibilityUpdate,
-    ) -> LocalAccessibilityDamage {
-        if new_child_ids == self.child_ids() {
-            return LocalAccessibilityDamage::empty();
-        }
-
-        let old_child_ids = self.child_ids();
-
-        for (old_id, old_child) in old_child_ids.iter().zip(self.children().iter()) {
-            if !new_child_ids.contains(old_id) {
-                let mut removed_child = old_child.borrow_mut();
-                update.set_tree_state_change(*old_id, TreeChange::Removed);
-                if let Some(parent_node) = removed_child.parent_node.clone() &&
-                    parent_node.ptr_eq(&weak_self)
-                {
-                    removed_child.parent_node = None;
-                }
-            }
-        }
-
-        for (new_id, new_child) in new_child_ids.iter().zip(new_child_nodes.iter()) {
-            if !old_child_ids.contains(new_id) {
-                let mut new_child = new_child.borrow_mut();
-                new_child.parent_node = Some(weak_self.clone());
-                if !update.is_new(new_id) {
-                    update.set_tree_state_change(*new_id, TreeChange::PendingMove);
-                }
-            }
-        }
-
-        self.child_nodes = new_child_nodes;
-        self.accesskit_node.set_children(new_child_ids);
-        self.updated = true;
-
-        LocalAccessibilityDamage::SubtreeChanged
     }
 
     fn role(&self) -> Role {
@@ -952,12 +958,9 @@ fn test_accessibility_update_add_some_nodes_twice() {
     })
     .collect();
     let (child_node_ids, child_nodes) = nodes.iter().cloned().unzip();
-    root_node.borrow_mut().set_children(
-        root_node.downgrade(),
-        child_node_ids,
-        child_nodes,
-        &mut root_update,
-    );
+    let mut root_node = root_node.borrow_mut();
+    root_node.accesskit_node.set_children(child_node_ids);
+    root_node.child_nodes = child_nodes;
 
     let mut update = AccessibilityUpdate::new(None);
 

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -9,8 +9,8 @@ use std::sync::{LazyLock, atomic};
 
 use accesskit::{NodeId, Role};
 use bitflags::bitflags;
-use itertools::EitherOrBoth::{Both, Left, Right};
-use itertools::{Itertools, izip};
+use itertools::EitherOrBoth::Both;
+use itertools::Itertools;
 use layout_api::{AccessibilityDamage, LayoutElement, LayoutNode, LayoutNodeType};
 use log::trace;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -567,8 +567,6 @@ impl AccessibilityNode {
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate,
     ) -> LocalAccessibilityDamage {
-        dbg!(dom_node);
-
         let mut local_damage = LocalAccessibilityDamage::empty();
         if !dom_damage.contains(AccessibilityDamage::Children) {
             return local_damage;
@@ -583,20 +581,9 @@ impl AccessibilityNode {
         while zip
             .next_if(|either| match either {
                 Both(old_id, dom_child) => {
-                    dbg!(dom_child);
-                    if let Some(new_id) = tree.existing_id_for_opaque(dom_child.opaque()) {
-                        return new_id == **old_id;
-                    }
-                    false
+                    tree.existing_id_for_opaque(dom_child.opaque()) == Some(**old_id)
                 },
-                Left(old_id) => {
-                    dbg!(old_id);
-                    false
-                },
-                Right(new_dom_child) => {
-                    dbg!(new_dom_child);
-                    false
-                },
+                _ => false,
             })
             .is_some()
         {
@@ -604,7 +591,6 @@ impl AccessibilityNode {
         }
 
         if zip.peek().is_none() {
-            dbg!("no change");
             return damage_from_children;
         }
 

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -948,10 +948,13 @@ fn test_accessibility_update_add_some_nodes_twice() {
         (id, node)
     })
     .collect();
-    let (child_node_ids, child_nodes) = nodes.iter().cloned().unzip();
-    let mut root_node = root_node.borrow_mut();
-    root_node.accesskit_node.set_children(child_node_ids);
-    root_node.child_nodes = child_nodes;
+
+    {
+        let (child_node_ids, child_nodes): (Vec<_>, Vec<_>) = nodes.iter().cloned().unzip();
+        let mut root_node = root_node.borrow_mut();
+        root_node.accesskit_node.set_children(child_node_ids);
+        root_node.child_nodes = child_nodes;
+    }
 
     let mut update = AccessibilityUpdate::new(None);
 

--- a/components/layout/cell.rs
+++ b/components/layout/cell.rs
@@ -92,10 +92,6 @@ impl<T> WeakRefCell<T> {
     pub(crate) fn upgrade(&self) -> Option<ArcRefCell<T>> {
         self.value.upgrade().map(|value| ArcRefCell { value })
     }
-
-    pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
-        self.value.ptr_eq(&other.value)
-    }
 }
 
 pub(crate) enum RefOrAtomicRef<'a, T> {


### PR DESCRIPTION
Previously, we always built a pair of vecs for the new children based on the DOM children, representing the child nodes and their IDs respectively, and then compared the old and new children to set the appropriate `TreeChange` on each added/removed child node.

This change instead iterates over the existing child IDs and the new DOM children in parallel for as long as the two iterators match up, then removes the remaining children of the accessibility node and reconstructs the remaining children from the DOM children (reusing any existing accessibility nodes).

This also allows us to update the `child_nodes` vec in-place, although we can't update the `children` property of the AccessKit node the same way so we still need to re-create that if there is any change.

Profiles:
before: https://share.firefox.dev/4f33Hlp
after: https://share.firefox.dev/4fePVuK

Testing: No behaviour change, covered by existing tests.
Fixes: #46237
