### PR TITLE
script: Properly return parent from `Node::parent_in_flat_tree` when `self` is a `ShadowRoot`

### DIFF
--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -2061,6 +2061,7 @@ impl Node {
     ///
     /// If the node and its parent have a flat tree relationship, this returns:
     ///  - The node's assigned slot.
+    ///  - The node's shadow host if the node is a shadow root.
     ///  - The parent node's shadow host if it's a shadow root.
     ///  - Or the node's parent.
     ///
@@ -2070,6 +2071,10 @@ impl Node {
     pub(crate) fn parent_in_flat_tree(&self) -> FlatTreeParent {
         if let Some(assigned_slot) = self.assigned_slot() {
             return FlatTreeParent::Parent(DomRoot::upcast(assigned_slot));
+        }
+
+        if let Some(shadow_root) = self.downcast::<ShadowRoot>() {
+            return FlatTreeParent::Parent(DomRoot::from_ref(shadow_root.Host().upcast::<Node>()));
         }
 
         let Some(parent) = self.GetParentNode() else {


### PR DESCRIPTION
This function was properly handling the case where `self`'s parent was a
`ShadowRoot` by returning the shadow host, but not when `self` itself
was a `ShadowRoot`. Instead it was returning `FlatTreeParent::RootNode`.
This change fixes that by ensuring the method returns the shadow host in
this case as well.

Testing: This will ensure that tests pass once support for visible selection is merged.
