### PR TITLE
script: Make `bp_position` comply more closely to the specification

### DIFF
--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -2027,9 +2027,7 @@ impl Node {
         // Step 8. If fix collapsed space is true, then while (start node, start offset)
         // is before (end node, end offset):
         if fix_collapsed_space {
-            while bp_position(&start_node, start_offset, &end_node, end_offset) ==
-                Some(Ordering::Less)
-            {
+            while bp_position(&start_node, start_offset, &end_node, end_offset) == Ordering::Less {
                 // Step 8.1. If end node has a child in the same editing host with index end offset − 1,
                 // set end node to that child, then set end offset to end node's length.
                 if end_offset > 0 &&
@@ -2089,8 +2087,7 @@ impl Node {
         );
         let mut replacement_whitespace_chars = replacement_whitespace.chars();
         // Step 10. While (start node, start offset) is before (end node, end offset):
-        while bp_position(&start_node, start_offset, &end_node, end_offset) == Some(Ordering::Less)
-        {
+        while bp_position(&start_node, start_offset, &end_node, end_offset) == Ordering::Less {
             // Step 10.1. If start node has a child with index start offset, set start node to that child, then set start offset to zero.
             if let Some(child) = start_node.children().nth(start_offset as usize) {
                 start_node = child;

--- a/components/script/dom/execcommand/contenteditable/selection.rs
+++ b/components/script/dom/execcommand/contenteditable/selection.rs
@@ -196,8 +196,7 @@ impl Selection {
             (active_range.end_container(), active_range.end_offset()).first_equivalent_point();
 
         // Step 6. If (end node, end offset) is not after (start node, start offset):
-        if bp_position(&end_node, end_offset, &start_node, start_offset) != Some(Ordering::Greater)
-        {
+        if bp_position(&end_node, end_offset, &start_node, start_offset) != Ordering::Greater {
             // Step 6.1. If direction is "forward", call collapseToStart() on the context object's selection.
             if direction == SelectionDeleteDirection::Forward {
                 self.collapse_current_range(

--- a/components/script/dom/range/abstractrange.rs
+++ b/components/script/dom/range/abstractrange.rs
@@ -84,7 +84,7 @@ pub(crate) struct BoundaryPoint {
 }
 
 impl BoundaryPoint {
-    fn new(node: &Node, offset: u32) -> BoundaryPoint {
+    pub(crate) fn new(node: &Node, offset: u32) -> BoundaryPoint {
         debug_assert!(!node.is_doctype());
         BoundaryPoint {
             node: MutDom::new(node),
@@ -108,12 +108,12 @@ impl BoundaryPoint {
 
 impl PartialOrd for BoundaryPoint {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        bp_position(
+        Some(bp_position(
             &self.node.get(),
             self.offset.get(),
             &other.node.get(),
             other.offset.get(),
-        )
+        ))
     }
 }
 
@@ -126,42 +126,47 @@ impl PartialEq for BoundaryPoint {
 }
 
 /// <https://dom.spec.whatwg.org/#concept-range-bp-position>
-pub(crate) fn bp_position(
-    a_node: &Node,
-    a_offset: u32,
-    b_node: &Node,
-    b_offset: u32,
-) -> Option<Ordering> {
+pub(crate) fn bp_position(a_node: &Node, a_offset: u32, b_node: &Node, b_offset: u32) -> Ordering {
+    // Step 1: Assert: nodeA and nodeB have the same root.
+    debug_assert!(
+        a_node.GetRootNode(&Default::default()) == b_node.GetRootNode(&Default::default())
+    );
+
+    // Step 2: If nodeA is nodeB, then return equal if offsetA is offsetB, before if
+    // offsetA is less than offsetB, and after if offsetA is greater than offsetB.
     if std::ptr::eq(a_node, b_node) {
-        // Step 1.
-        return Some(a_offset.cmp(&b_offset));
+        return a_offset.cmp(&b_offset);
     }
+
     let position = b_node.CompareDocumentPosition(a_node);
-    if position & NodeConstants::DOCUMENT_POSITION_DISCONNECTED != 0 {
-        // No order is defined for nodes not in the same tree.
-        None
-    } else if position & NodeConstants::DOCUMENT_POSITION_FOLLOWING != 0 {
-        // Step 2.
-        match bp_position(b_node, b_offset, a_node, a_offset).unwrap() {
-            Ordering::Less => Some(Ordering::Greater),
-            Ordering::Greater => Some(Ordering::Less),
-            Ordering::Equal => unreachable!(),
-        }
+    assert!(
+        position & NodeConstants::DOCUMENT_POSITION_DISCONNECTED == 0,
+        "Nodes should be in the same tree"
+    );
+    if position & NodeConstants::DOCUMENT_POSITION_FOLLOWING != 0 {
+        // Step 3: If nodeA is following nodeB, then if the position of (nodeB, offsetB)
+        // relative to (nodeA, offsetA) is before, return after, and if it is after,
+        // return before.
+        return match bp_position(b_node, b_offset, a_node, a_offset) {
+            Ordering::Less => Ordering::Greater,
+            Ordering::Greater => Ordering::Less,
+            Ordering::Equal => unreachable!("Should be impossible due to Step 2."),
+        };
     } else if position & NodeConstants::DOCUMENT_POSITION_CONTAINS != 0 {
-        // Step 3-1, 3-2.
+        // Step 4: If nodeA is an ancestor of nodeB:
+        // Step 4.1: Let child be nodeB.
+        // Step 4.2: While child is not a child of nodeA, set child to its parent.
         let mut b_ancestors = b_node.inclusive_ancestors(ShadowIncluding::No);
         let child = b_ancestors
             .find(|child| &*child.GetParentNode().unwrap() == a_node)
             .unwrap();
-        // Step 3-3.
+
+        // Step 4.3: If child’s index is less than offsetA, then return after.
         if child.index() < a_offset {
-            Some(Ordering::Greater)
-        } else {
-            // Step 4.
-            Some(Ordering::Less)
+            return Ordering::Greater;
         }
-    } else {
-        // Step 4.
-        Some(Ordering::Less)
     }
+
+    // Step 5: Return before.
+    Ordering::Less
 }

--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -147,17 +147,25 @@ impl Range {
         range
     }
 
+    /// <https://dom.spec.whatwg.org/#concept-range-root>
+    ///
+    /// > The root of a live range is the root of its start node.
+    pub(crate) fn root(&self) -> DomRoot<Node> {
+        self.start_container().GetRootNode(&Default::default())
+    }
+
     /// <https://dom.spec.whatwg.org/#contained>
     pub(crate) fn contains(&self, node: &Node) -> bool {
         // > A node node is contained in a live range range if node’s root is range’s root,
         // > and (node, 0) is after range’s start, and (node, node’s length) is before range’s end.
-        matches!(
-            (
-                bp_position(node, 0, &self.start_container(), self.start_offset()),
-                bp_position(node, node.len(), &self.end_container(), self.end_offset()),
-            ),
-            (Some(Ordering::Greater), Some(Ordering::Less))
-        )
+        node.GetRootNode(&Default::default()) == self.root() &&
+            matches!(
+                (
+                    bp_position(node, 0, &self.start_container(), self.start_offset()),
+                    bp_position(node, node.len(), &self.end_container(), self.end_offset()),
+                ),
+                (Ordering::Greater, Ordering::Less)
+            )
     }
 
     /// <https://dom.spec.whatwg.org/#partially-contained>
@@ -255,39 +263,33 @@ impl Range {
 
     /// <https://dom.spec.whatwg.org/#dom-range-comparepointnode-offset>
     fn compare_point(&self, node: &Node, offset: u32) -> Fallible<Ordering> {
-        let start_node = self.start_container();
-        let start_node_root = start_node
-            .inclusive_ancestors(ShadowIncluding::No)
-            .last()
-            .unwrap();
-        let node_root = node
-            .inclusive_ancestors(ShadowIncluding::No)
-            .last()
-            .unwrap();
-        if start_node_root != node_root {
-            // Step 1.
+        // Step 1. If node’s root is not this’s root, then throw a "WrongDocumentError"
+        // DOMException.
+        if node.GetRootNode(&Default::default()) != self.root() {
             return Err(Error::WrongDocument(None));
         }
+        // Step 2. If node is a doctype, then throw an "InvalidNodeTypeError"
+        // DOMException.
         if node.is_doctype() {
-            // Step 2.
             return Err(Error::InvalidNodeType(None));
         }
+        // Step 3. If offset is greater than node’s length, then throw an "IndexSizeError"
+        // DOMException.
         if offset > node.len() {
-            // Step 3.
             return Err(Error::IndexSize(None));
         }
-        if let Ordering::Less = bp_position(node, offset, &start_node, self.start_offset()).unwrap()
-        {
-            // Step 4.
+        // Step 4. If (node, offset) is before start, then return −1.
+        let start_node = self.start_container();
+        if let Ordering::Less = bp_position(node, offset, &start_node, self.start_offset()) {
             return Ok(Ordering::Less);
         }
+        // Step 5. If (node, offset) is after end, then return 1.
         if let Ordering::Greater =
-            bp_position(node, offset, &self.end_container(), self.end_offset()).unwrap()
+            bp_position(node, offset, &self.end_container(), self.end_offset())
         {
-            // Step 5.
             return Ok(Ordering::Greater);
         }
-        // Step 6.
+        // Step 6. Return 0.
         Ok(Ordering::Equal)
     }
 
@@ -363,46 +365,54 @@ impl Range {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-range-bp-set>
-    #[expect(clippy::neg_cmp_op_on_partial_ord)]
     fn set_the_start_or_end(
         &self,
         node: &Node,
         offset: u32,
         start_or_end: StartOrEnd,
     ) -> ErrorResult {
-        // Step 1. If node is a doctype, then throw an "InvalidNodeTypeError" DOMException.
+        // Step 1. If node is a doctype, then throw an "InvalidNodeTypeError"
+        // DOMException.
         if node.is_doctype() {
             return Err(Error::InvalidNodeType(None));
         }
 
-        // Step 2. If offset is greater than node’s length, then throw an "IndexSizeError" DOMException.
+        // Step 2. If offset is greater than node’s length, then throw an "IndexSizeError"
+        // DOMException.
         if offset > node.len() {
             return Err(Error::IndexSize(None));
         }
 
         // Step 3. Let bp be the boundary point (node, offset).
         // NOTE: We don't need this part.
-
         match start_or_end {
             // If these steps were invoked as "set the start"
             StartOrEnd::Start => {
-                // Step 4.1  If range’s root is not equal to node’s root, or if bp is after the range’s end,
-                // set range’s end to bp.
-                // Step 4.2 Set range’s start to bp.
-                self.set_start(node, offset);
-                if !(self.start() <= self.end()) {
+                // Step 4.1. If range’s root is not equal to node’s root, or if bp is after
+                // the range’s end, set range’s end to bp.
+                if self.root() != node.GetRootNode(&Default::default()) ||
+                    bp_position(node, offset, &self.end_container(), self.end_offset()) ==
+                        Ordering::Greater
+                {
                     self.set_end(node, offset);
                 }
+
+                // Step 4.2. Set range’s start to bp.
+                self.set_start(node, offset);
             },
             // If these steps were invoked as "set the end"
             StartOrEnd::End => {
-                // Step 4.1 If range’s root is not equal to node’s root, or if bp is before the range’s start,
-                // set range’s start to bp.
-                // Step 4.2 Set range’s end to bp.
-                self.set_end(node, offset);
-                if !(self.end() >= self.start()) {
+                // Step 4.1. If range’s root is not equal to node’s root, or if bp is
+                // before the range’s start, set range’s start to bp.
+                if self.root() != node.GetRootNode(&Default::default()) ||
+                    bp_position(node, offset, &self.start_container(), self.start_offset()) ==
+                        Ordering::Less
+                {
                     self.set_start(node, offset);
                 }
+
+                // Step 4.2. Set range’s end to bp.
+                self.set_end(node, offset);
             },
         }
 
@@ -518,35 +528,46 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-compareboundarypoints>
-    fn CompareBoundaryPoints(&self, how: u16, other: &Range) -> Fallible<i16> {
+    fn CompareBoundaryPoints(&self, how: u16, source_range: &Range) -> Fallible<i16> {
+        // Step 1. If how is not one of
+        //    * START_TO_START,
+        //    * START_TO_END,
+        //    * END_TO_END, and
+        //    * END_TO_START,
+        // then throw a "NotSupportedError" DOMException.
         if how > RangeConstants::END_TO_START {
-            // Step 1.
             return Err(Error::NotSupported(None));
         }
-        let this_root = self
-            .start_container()
-            .inclusive_ancestors(ShadowIncluding::No)
-            .last()
-            .unwrap();
-        let other_root = other
-            .start_container()
-            .inclusive_ancestors(ShadowIncluding::No)
-            .last()
-            .unwrap();
-        if this_root != other_root {
-            // Step 2.
+        // Step 2. If this’s root is not sourceRange’s root, then throw a
+        // "WrongDocumentError" DOMException.
+        if self.root() != source_range.root() {
             return Err(Error::WrongDocument(None));
         }
-        // Step 3.
-        let (this_point, other_point) = match how {
-            RangeConstants::START_TO_START => (self.start(), other.start()),
-            RangeConstants::START_TO_END => (self.end(), other.start()),
-            RangeConstants::END_TO_END => (self.end(), other.end()),
-            RangeConstants::END_TO_START => (self.start(), other.end()),
+        // Step 3. Let thisPoint and sourcePoint be null.
+        // Step 4.  Switch on how:
+        //  ↪ START_TO_START:
+        //     Set thisPoint to this’s start and sourcePoint to sourceRange’s start.
+        //  ↪ START_TO_END:
+        //     Set thisPoint to this’s end and sourcePoint to sourceRange’s start.
+        //  ↪ END_TO_END:
+        //     Set thisPoint to this’s end and sourcePoint to sourceRange’s end.
+        //  ↪ END_TO_START:
+        //     Set thisPoint to this’s start and sourcePoint to sourceRange’s end.
+        let (this_point, source_point) = match how {
+            RangeConstants::START_TO_START => (self.start(), source_range.start()),
+            RangeConstants::START_TO_END => (self.end(), source_range.start()),
+            RangeConstants::END_TO_END => (self.end(), source_range.end()),
+            RangeConstants::END_TO_START => (self.start(), source_range.end()),
             _ => unreachable!(),
         };
-        // step 4.
-        match this_point.partial_cmp(other_point).unwrap() {
+        // Step 5. Switch on the position of thisPoint relative to sourcePoint:
+        //  ↪ before
+        //      Return −1.
+        //  ↪ equal
+        //      Return 0.
+        //  ↪ after
+        //      Return 1.
+        match this_point.partial_cmp(source_point).unwrap() {
             Ordering::Less => Ok(-1),
             Ordering::Equal => Ok(0),
             Ordering::Greater => Ok(1),
@@ -574,7 +595,8 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             Ok(Ordering::Equal) => Ok(true),
             Ok(Ordering::Greater) => Ok(false),
             Err(Error::WrongDocument(None)) => {
-                // Step 2.
+                // Step 2.  If node’s root is not this’s root, then return false.
+                // Note: This is the only step that differs from `Self::compare_point`.
                 Ok(false)
             },
             Err(error) => Err(error),
@@ -592,35 +614,24 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
 
     /// <https://dom.spec.whatwg.org/#dom-range-intersectsnode>
     fn IntersectsNode(&self, node: &Node) -> bool {
-        let start_node = self.start_container();
-        let start_node_root = self
-            .start_container()
-            .inclusive_ancestors(ShadowIncluding::No)
-            .last()
-            .unwrap();
-        let node_root = node
-            .inclusive_ancestors(ShadowIncluding::No)
-            .last()
-            .unwrap();
-        if start_node_root != node_root {
-            // Step 1.
+        // Step 1. If node’s root is not this’s root, then return false.
+        if self.root() != node.GetRootNode(&Default::default()) {
             return false;
         }
-        let parent = match node.GetParentNode() {
-            Some(parent) => parent,
-            None => {
-                // Step 3.
-                return true;
-            },
+        // Step 2. Let parent be node’s parent.
+        let Some(parent) = node.GetParentNode() else {
+            // Step 3. If parent is null, then return true.
+            return true;
         };
-        // Step 4.
+        // Step 4. Let offset be node’s index.
         let offset = node.index();
-        // Step 5.
-        Ordering::Greater ==
-            bp_position(&parent, offset + 1, &start_node, self.start_offset()).unwrap() &&
+        // Step 5. If (parent, offset) is before end and (parent, offset + 1) is after
+        // start, then return true.
+        // Step 6. Return false.
+        let start_node = self.start_container();
+        Ordering::Greater == bp_position(&parent, offset + 1, &start_node, self.start_offset()) &&
             Ordering::Less ==
                 bp_position(&parent, offset, &self.end_container(), self.end_offset())
-                    .unwrap()
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-clonecontents>

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -126,8 +126,12 @@ impl Selection {
             );
     }
 
-    fn is_same_root(&self, node: &Node) -> bool {
-        &*node.GetRootNode(&GetRootNodeOptions::empty()) == self.document.upcast::<Node>()
+    fn is_in_document_of_range(&self, node: &Node) -> bool {
+        // TODO(mrobinson): This should eventually allow nodes in the same composed tree (and
+        // not just the same tree), but this requires more work to allow `Selection` to cross
+        // shadow tree boundaries.
+        &*node.GetRootNode(&GetRootNodeOptions { composed: false }) ==
+            self.document.upcast::<Node>()
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#active-range>
@@ -308,7 +312,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     fn AddRange(&self, range: &Range) {
         // Step 1. If the root of the range's boundary points are not the document
         // associated with this, abort these steps.
-        if !self.is_same_root(&range.start_container()) {
+        if !self.is_in_document_of_range(&range.start_container()) {
             return;
         }
 
@@ -374,9 +378,12 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // Step 4. If document associated with this is not a shadow-including inclusive
         // ancestor of node, abort these steps.
         //
-        // TODO: `is_same_root` does reach beyond shadow root boundaries, so this check is
-        // wrong.
-        if !self.is_same_root(node) {
+        // TODO(mrobinson): This should eventually allow nodes in the same composed tree (and
+        // not just the same tree), but this requires more work to allow `Selection` to cross
+        // shadow tree boundaries.
+        if &*node.GetRootNode(&GetRootNodeOptions { composed: false }) !=
+            self.document.upcast::<Node>()
+        {
             return Ok(());
         }
 
@@ -429,9 +436,12 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // Step 1. If the document associated with this is not a shadow-including
         // inclusive ancestor of node, abort these steps.
         //
-        // TODO: `is_same_root` does reach beyond shadow root boundaries, so this check is
-        // wrong.
-        if !self.is_same_root(node) {
+        // TODO(mrobinson): This should eventually allow nodes in the same composed tree (and
+        // not just the same tree), but this requires more work to allow `Selection` to cross
+        // shadow tree boundaries.
+        if &*node.GetRootNode(&GetRootNodeOptions { composed: false }) !=
+            self.document.upcast::<Node>()
+        {
             return Ok(());
         }
 
@@ -467,13 +477,13 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
 
         // Step 5. If node's root is not the same as the this's range's root, set the
         // start newRange's start and end to newFocus.
-        if !self.is_same_root(&range.start_container()) {
+        if !self.is_in_document_of_range(&range.start_container()) {
             new_range = Range::new(cx, &self.document, node, offset, node, offset);
             direction = Direction::Forwards;
         } else {
             let is_old_anchor_before_or_equal = matches!(
                 bp_position(old_anchor_node, old_anchor_offset, node, offset),
-                Some(Ordering::Less) | Some(Ordering::Equal)
+                Ordering::Less | Ordering::Equal
             );
             if is_old_anchor_before_or_equal {
                 // Step 6. Otherwise, if oldAnchor is before or equal to newFocus, set the start
@@ -537,9 +547,17 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // Step 2. If document associated with this is not a shadow-including inclusive
         // ancestor of anchorNode or focusNode, abort these steps.
         //
-        // TODO: `is_same_root` does reach beyond shadow root boundaries, so this check is
-        // wrong.
-        if !self.is_same_root(anchor_node) || !self.is_same_root(focus_node) {
+        // TODO(mrobinson): This should eventually allow nodes in the same composed tree (and
+        // not just the same tree), but this requires more work to allow `Selection` to cross
+        // shadow tree boundaries.
+        if &*anchor_node.GetRootNode(&GetRootNodeOptions { composed: false }) !=
+            self.document.upcast::<Node>()
+        {
+            return Ok(());
+        }
+        if &*focus_node.GetRootNode(&GetRootNodeOptions { composed: false }) !=
+            self.document.upcast::<Node>()
+        {
             return Ok(());
         }
 
@@ -556,8 +574,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // and its end to focus. Otherwise, set the start them to focus and anchor
         // respectively.
         let is_anchor_before_focus =
-            bp_position(anchor_node, anchor_offset, focus_node, focus_offset) ==
-                Some(Ordering::Less);
+            bp_position(anchor_node, anchor_offset, focus_node, focus_offset) == Ordering::Less;
         if is_anchor_before_focus {
             new_range = Range::new(
                 cx,
@@ -600,7 +617,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
 
         // Step 2. If node's root is not the document associated with this, abort these
         // steps.
-        if !self.is_same_root(node) {
+        if !self.is_in_document_of_range(node) {
             return Ok(());
         }
 
@@ -650,15 +667,14 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // > end of its range is after or visually equivalent to the first boundary point in the
         // > node.
 
-        if !self.is_same_root(node) {
+        if !self.is_in_document_of_range(node) {
             return false;
         }
         let Some(range) = self.range.get() else {
             return false;
         };
         let start_node = &*range.start_container();
-        if !self.is_same_root(start_node) {
-            // node can't be contained in a range with a different root
+        if !self.is_in_document_of_range(start_node) {
             return false;
         }
         let end_node = &*range.end_container();
@@ -676,10 +692,10 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // For now it is simplified to "position is equal".
         matches!(
             bp_position(start_node, range.start_offset(), node, compare_start_to),
-            Some(Ordering::Less) | Some(Ordering::Equal)
+            Ordering::Less | Ordering::Equal
         ) && matches!(
             bp_position(end_node, range.end_offset(), node, compare_end_to),
-            Some(Ordering::Greater) | Some(Ordering::Equal)
+            Ordering::Greater | Ordering::Equal
         )
     }
 


### PR DESCRIPTION
The specification for `bp_position` ("the position of a boundary point
A relative to a boundary point B") asserts that two points share
the same root. The specification ensures that all callers bail out
when this isn't the case. These preliminary checks were often
not implemented or implemented wrongly. This changes fixes that and
brings the implementation closer to the specification.

This is preliminary work to properly allow selections that span shadow
tree boundaries.

Testing: Generally this doesn't change overall behavior. It just moves some checks earlier in the logic and adds a debug assertion.
