### PR TITLE
ci: Fix broken windows self-hosted builds

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -126,7 +126,7 @@ jobs:
         # copied from https://chocolatey.org/install
         run: |
           Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
-
+          echo "C:\\ProgramData\\chocolatey\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       # To be removed once we update to WiX 7.
       - name: Add WiX to PATH (self-hosted)
         if: ${{ runner.environment == 'self-hosted' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -121,6 +121,12 @@ jobs:
         run: |
           echo CCACHE=ccache >> $GITHUB_ENV
 
+      # To be removed once we update to WiX 7.
+      - name: Add WiX to PATH (self-hosted)
+        if: ${{ runner.environment == 'self-hosted' }}
+        run: echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" >> $env:GITHUB_PATH
+
+
       # Install missing tools in a GitHub-hosted runner.
       - name: Setup Python
         if: ${{ runner.environment != 'self-hosted' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -124,7 +124,9 @@ jobs:
       # To be removed once we update to WiX 7.
       - name: Add WiX to PATH (self-hosted)
         if: ${{ runner.environment == 'self-hosted' }}
-        run: echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" >> $env:GITHUB_PATH
+        run: |
+          choco install wixtoolset
+          echo "C:\\Program Files (x86)\\WiX Toolset v3.11\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
 
       # Install missing tools in a GitHub-hosted runner.

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -121,6 +121,12 @@ jobs:
         run: |
           echo CCACHE=ccache >> $GITHUB_ENV
 
+      - name: install choco
+        if: ${{ runner.environment == 'self-hosted' }}
+        # copied from https://chocolatey.org/install
+        run: |
+          Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+
       # To be removed once we update to WiX 7.
       - name: Add WiX to PATH (self-hosted)
         if: ${{ runner.environment == 'self-hosted' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -131,8 +131,8 @@ jobs:
       - name: Add WiX to PATH (self-hosted)
         if: ${{ runner.environment == 'self-hosted' }}
         run: |
-          choco install wixtoolset
-          echo "C:\\Program Files (x86)\\WiX Toolset v3.11\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          choco install wixtoolset -y
+          echo "C:\\Program Files (x86)\\WiX Toolset v3.14\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
 
       # Install missing tools in a GitHub-hosted runner.


### PR DESCRIPTION
https://github.com/servo/ci-runners/pull/144 removed the wix bin path from path, and this is currently causing all builds on self-hosted windows runners to fail. Fix this by adding wix back to path manually, until fixed in the ci-runner repo or until we migrated to wix 7, whichever happens first.

Testing: This is a speculative CI fix.
Fixes: #46527
