### PR TITLE
script: Move more into script_webgpu crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9131,6 +9131,7 @@ dependencies = [
  "servo-jstraceable-derive",
  "servo-malloc-size-of",
  "servo-script-bindings",
+ "servo-webgpu-traits",
 ]
 
 [[package]]

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -8,12 +8,10 @@ use std::cell::RefCell;
 use std::thread::LocalKey;
 
 use js::context::JSContext;
-use js::conversions::ToJSValConvertible;
 use js::glue::{IsWrapper, JSPrincipalsCallbacks, UnwrapObjectStatic};
 use js::jsapi::{CallArgs, DOMCallbacks, JSObject};
 use js::realm::CurrentRealm;
-use js::rust::wrappers2::JS_FreezeObject;
-use js::rust::{HandleObject, MutableHandleValue, get_object_class, is_dom_class};
+use js::rust::{HandleObject, get_object_class, is_dom_class};
 use script_bindings::interfaces::{DomHelpers, Interface};
 use script_bindings::reflector::{DomObject, DomObjectWrap, reflect_dom_object_with_cx};
 use script_bindings::settings_stack::StackEntry;
@@ -48,22 +46,6 @@ impl GlobalStaticData {
 }
 
 pub(crate) use script_bindings::utils::*;
-
-/// Returns a JSVal representing the frozen JavaScript array
-pub(crate) fn to_frozen_array<T: ToJSValConvertible>(
-    cx: &mut JSContext,
-    convertibles: &[T],
-    mut rval: MutableHandleValue,
-) {
-    script_bindings::conversions::SafeToJSValConvertible::safe_to_jsval(
-        convertibles,
-        cx,
-        rval.reborrow(),
-    );
-
-    rooted!(&in(cx) let obj = rval.to_object());
-    unsafe { JS_FreezeObject(cx, obj.handle()) };
-}
 
 /// Returns wether `obj` is a platform object using static unwrap
 /// <https://heycam.github.io/webidl/#dfn-platform-object>

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -205,6 +205,7 @@
 #[macro_use]
 pub(crate) mod macros;
 
+#[expect(unused)]
 pub(crate) mod types {
     include!(concat!(env!("OUT_DIR"), "/InterfaceTypes.rs"));
 }

--- a/components/script/dom/webgpu/mod.rs
+++ b/components/script/dom/webgpu/mod.rs
@@ -19,8 +19,14 @@ pub(crate) mod gpucanvascontext;
 pub(crate) mod gpucolorwrite;
 pub(crate) mod gpucommandbuffer;
 pub(crate) mod gpucommandencoder;
-pub(crate) mod gpucompilationinfo;
-pub(crate) mod gpucompilationmessage;
+pub(crate) mod gpucompilationinfo {
+    pub(crate) type GPUCompilationInfo =
+        script_webgpu::gpucompilationinfo::GPUCompilationInfo<crate::DomTypeHolder>;
+}
+pub(crate) mod gpucompilationmessage {
+    pub(crate) type GPUCompilationMessage =
+        script_webgpu::gpucompilationmessage::GPUCompilationMessage<crate::DomTypeHolder>;
+}
 pub(crate) mod gpucomputepassencoder;
 pub(crate) mod gpucomputepipeline;
 pub(crate) mod gpuconvert;

--- a/components/script/dom/webgpu/mod.rs
+++ b/components/script/dom/webgpu/mod.rs
@@ -11,7 +11,10 @@ pub(crate) mod gpuadapterinfo {
 pub(crate) mod gpubindgroup;
 pub(crate) mod gpubindgrouplayout;
 pub(crate) mod gpubuffer;
-pub(crate) mod gpubufferusage;
+pub(crate) mod gpubufferusage {
+    pub(crate) type GPUBufferUsage =
+        script_webgpu::gpubufferusage::GPUBufferUsage<crate::DomTypeHolder>;
+}
 pub(crate) mod gpucanvascontext;
 pub(crate) mod gpucolorwrite;
 pub(crate) mod gpucommandbuffer;

--- a/components/script/dom/webgpu/mod.rs
+++ b/components/script/dom/webgpu/mod.rs
@@ -31,7 +31,10 @@ pub(crate) mod gpucomputepassencoder;
 pub(crate) mod gpucomputepipeline;
 pub(crate) mod gpuconvert;
 pub(crate) mod gpudevice;
-pub(crate) mod gpudevicelostinfo;
+pub(crate) mod gpudevicelostinfo {
+    pub(crate) type GPUDeviceLostInfo =
+        script_webgpu::gpudevicelostinfo::GPUDeviceLostInfo<crate::DomTypeHolder>;
+}
 pub(crate) mod gpuerror;
 pub(crate) mod gpuexternaltexture;
 pub(crate) mod gpuinternalerror;

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1688,5 +1688,5 @@ Unions = {
 }
 
 SubCrates = {
-    'script_webgpu': ['GPUAdapterInfo', 'GPUBufferUsage'],
+    'script_webgpu': ['GPUAdapterInfo', 'GPUBufferUsage', 'GPUCompilationInfo', 'GPUCompilationMessage'],
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1688,5 +1688,5 @@ Unions = {
 }
 
 SubCrates = {
-    'script_webgpu': ['GPUAdapterInfo', 'GPUBufferUsage', 'GPUCompilationInfo', 'GPUCompilationMessage'],
+    'script_webgpu': ['GPUAdapterInfo', 'GPUBufferUsage', 'GPUCompilationInfo', 'GPUCompilationMessage', 'GPUDeviceLostInfo',],
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1688,5 +1688,5 @@ Unions = {
 }
 
 SubCrates = {
-    'script_webgpu': ['GPUAdapterInfo'],
+    'script_webgpu': ['GPUAdapterInfo', 'GPUBufferUsage'],
 }

--- a/components/script_bindings/reflector.rs
+++ b/components/script_bindings/reflector.rs
@@ -369,6 +369,26 @@ type WrapFn<D, AbstractType> = unsafe fn(
 
 /// Create the reflector for a new DOM object and yield ownership to the
 /// reflector.
+pub fn reflect_dom_object_with_proto_and_cx_and_wrap<D, AbstractType, GlobalType>(
+    obj: Box<AbstractType>,
+    global: &GlobalType,
+    proto: Option<HandleObject>,
+    cx: &mut js::context::JSContext,
+    wrap: WrapFn<D, AbstractType>,
+) -> DomRoot<AbstractType>
+where
+    D: DomTypes,
+    AbstractType: DomObject,
+    GlobalType: DerivedFrom<D::GlobalScope>,
+    Box<AbstractType>: From<Box<AbstractType>>,
+    DomRoot<AbstractType>: From<DomRoot<AbstractType>>,
+{
+    let global_scope = global.upcast();
+    unsafe { wrap(cx, global_scope, proto, obj) }
+}
+
+/// Create the reflector for a new DOM object and yield ownership to the
+/// reflector.
 pub fn reflect_dom_object_with_cx_and_wrap<D, AbstractType, GlobalType>(
     obj: Box<AbstractType>,
     global: &GlobalType,

--- a/components/script_bindings/reflector.rs
+++ b/components/script_bindings/reflector.rs
@@ -369,7 +369,7 @@ type WrapFn<D, AbstractType> = unsafe fn(
 
 /// Create the reflector for a new DOM object and yield ownership to the
 /// reflector.
-pub fn reflect_dom_object_with_proto_and_cx_and_wrap<D, AbstractType, GlobalType>(
+pub fn reflect_dom_object_with_proto_and_wrap<D, AbstractType, GlobalType>(
     obj: Box<AbstractType>,
     global: &GlobalType,
     proto: Option<HandleObject>,
@@ -389,7 +389,7 @@ where
 
 /// Create the reflector for a new DOM object and yield ownership to the
 /// reflector.
-pub fn reflect_dom_object_with_cx_and_wrap<D, AbstractType, GlobalType>(
+pub fn reflect_dom_object_with_wrap<D, AbstractType, GlobalType>(
     obj: Box<AbstractType>,
     global: &GlobalType,
     cx: &mut js::context::JSContext,

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -24,9 +24,9 @@ use js::jsid::StringId;
 use js::jsval::{JSVal, UndefinedValue};
 use js::rust::wrappers2::{
     CallJitGetterOp, CallJitMethodOp, CallJitSetterOp, CallOriginalPromiseReject,
-    JS_ClearPendingException, JS_DefineProperty, JS_ForwardGetPropertyTo, JS_GetPendingException,
-    JS_GetProperty, JS_GetPrototype, JS_HasOwnProperty, JS_HasProperty, JS_HasPropertyById,
-    JS_IsExceptionPending, JS_SetPendingException, JS_SetProperty,
+    JS_ClearPendingException, JS_DefineProperty, JS_ForwardGetPropertyTo, JS_FreezeObject,
+    JS_GetPendingException, JS_GetProperty, JS_GetPrototype, JS_HasOwnProperty, JS_HasProperty,
+    JS_HasPropertyById, JS_IsExceptionPending, JS_SetPendingException, JS_SetProperty,
 };
 use js::rust::{
     HandleId, HandleObject, HandleValue, MutableHandleValue, Runtime, ToString, get_object_class,
@@ -867,4 +867,16 @@ unsafe fn latin1_bytes_from_id(cx: *mut RawJSContext, id: jsid) -> Result<&'stat
     let ptr = JS_GetLatin1StringCharsAndLength(cx, ptr::null(), string, &mut length);
     assert!(!ptr.is_null());
     Ok(slice::from_raw_parts(ptr, length))
+}
+
+/// Returns a JSVal representing the frozen JavaScript array
+pub fn to_frozen_array<T: ToJSValConvertible>(
+    cx: &mut JSContext,
+    convertibles: &[T],
+    mut rval: MutableHandleValue,
+) {
+    crate::conversions::SafeToJSValConvertible::safe_to_jsval(convertibles, cx, rval.reborrow());
+
+    rooted!(&in(cx) let obj = rval.to_object());
+    unsafe { JS_FreezeObject(cx, obj.handle()) };
 }

--- a/components/script_webgpu/Cargo.toml
+++ b/components/script_webgpu/Cargo.toml
@@ -25,3 +25,4 @@ jstraceable_derive = { workspace = true }
 script_bindings = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
+webgpu_traits = { workspace = true }

--- a/components/script_webgpu/gpuadapterinfo.rs
+++ b/components/script_webgpu/gpuadapterinfo.rs
@@ -12,7 +12,7 @@ use script_bindings::DomTypes;
 use script_bindings::codegen::GenericBindings::WebGPUBinding::{
     GPUAdapterInfoMethods, GPUAdapterInfoWrap,
 };
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx_and_wrap};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_wrap};
 
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
@@ -69,7 +69,7 @@ where
         subgroup_max_size: u32,
         is_fallback_adapter: bool,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx_and_wrap::<D, _, _>(
+        reflect_dom_object_with_wrap::<D, _, _>(
             Box::new(Self::new_inherited(
                 vendor,
                 architecture,

--- a/components/script_webgpu/gpubufferusage.rs
+++ b/components/script_webgpu/gpubufferusage.rs
@@ -2,10 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::marker::PhantomData;
+
 use dom_struct::dom_struct;
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
 use script_bindings::reflector::Reflector;
 
+use crate::JSTraceable;
+
 #[dom_struct]
-pub(crate) struct GPUBufferUsage {
+pub struct GPUBufferUsage<D: DomTypes> {
     reflector_: Reflector,
+    #[no_trace = "PhantomData does not exist"]
+    phantom: PhantomData<D>,
 }

--- a/components/script_webgpu/gpucompilationinfo.rs
+++ b/components/script_webgpu/gpucompilationinfo.rs
@@ -10,7 +10,7 @@ use script_bindings::DomTypes;
 use script_bindings::codegen::GenericBindings::WebGPUBinding::{
     GPUCompilationInfoMethods, GPUCompilationInfoWrap,
 };
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx_and_wrap};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_wrap};
 use script_bindings::utils::to_frozen_array;
 use webgpu_traits::ShaderCompilationInfo;
 
@@ -44,7 +44,7 @@ where
         global: &D::GlobalScope,
         msg: Vec<DomRoot<GPUCompilationMessage<D>>>,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto_and_cx_and_wrap::<D, _, _>(
+        reflect_dom_object_with_proto_and_wrap::<D, _, _>(
             Box::new(Self::new_inherited(msg)),
             global,
             None,

--- a/components/script_webgpu/gpucompilationinfo.rs
+++ b/components/script_webgpu/gpucompilationinfo.rs
@@ -5,24 +5,34 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::MutableHandleValue;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{
+    GPUCompilationInfoMethods, GPUCompilationInfoWrap,
+};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx_and_wrap};
+use script_bindings::utils::to_frozen_array;
 use webgpu_traits::ShaderCompilationInfo;
 
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUCompilationInfoMethods;
+use crate::JSTraceable;
 use crate::dom::bindings::root::{Dom, DomRoot};
-use crate::dom::bindings::utils::to_frozen_array;
-use crate::dom::globalscope::GlobalScope;
-use crate::dom::types::GPUCompilationMessage;
+use crate::gpucompilationmessage::GPUCompilationMessage;
 
 #[dom_struct]
-pub(crate) struct GPUCompilationInfo {
+pub struct GPUCompilationInfo<D: DomTypes> {
     reflector_: Reflector,
     // currently we only get one message from wgpu
-    msg: Vec<Dom<GPUCompilationMessage>>,
+    msg: Vec<Dom<GPUCompilationMessage<D>>>,
 }
 
-impl GPUCompilationInfo {
-    pub(crate) fn new_inherited(msg: Vec<DomRoot<GPUCompilationMessage>>) -> Self {
+impl<D> GPUCompilationInfo<D>
+where
+    D: DomTypes<
+            GPUCompilationInfo = GPUCompilationInfo<D>,
+            GPUCompilationMessage = GPUCompilationMessage<D>,
+        >,
+{
+    pub(crate) fn new_inherited(msg: Vec<DomRoot<GPUCompilationMessage<D>>>) -> Self {
         Self {
             reflector_: Reflector::new(),
             msg: msg.into_iter().map(|event| event.as_traced()).collect(),
@@ -31,15 +41,21 @@ impl GPUCompilationInfo {
 
     pub(crate) fn new(
         cx: &mut JSContext,
-        global: &GlobalScope,
-        msg: Vec<DomRoot<GPUCompilationMessage>>,
+        global: &D::GlobalScope,
+        msg: Vec<DomRoot<GPUCompilationMessage<D>>>,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto_and_cx(Box::new(Self::new_inherited(msg)), global, None, cx)
+        reflect_dom_object_with_proto_and_cx_and_wrap::<D, _, _>(
+            Box::new(Self::new_inherited(msg)),
+            global,
+            None,
+            cx,
+            GPUCompilationInfoWrap::<D>,
+        )
     }
 
-    pub(crate) fn from(
+    pub fn from(
         cx: &mut JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         error: Option<ShaderCompilationInfo>,
     ) -> DomRoot<Self> {
         let msg = error
@@ -49,10 +65,10 @@ impl GPUCompilationInfo {
     }
 }
 
-impl GPUCompilationInfoMethods<crate::DomTypeHolder> for GPUCompilationInfo {
+impl<D: DomTypes> GPUCompilationInfoMethods<D> for GPUCompilationInfo<D> {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucompilationinfo-messages>
     fn Messages(&self, cx: &mut JSContext, retval: MutableHandleValue) {
-        let messages: Vec<DomRoot<GPUCompilationMessage>> =
+        let messages: Vec<DomRoot<GPUCompilationMessage<D>>> =
             self.msg.iter().map(|msg| msg.as_rooted()).collect();
         to_frozen_array(cx, messages.as_slice(), retval)
     }

--- a/components/script_webgpu/gpucompilationmessage.rs
+++ b/components/script_webgpu/gpucompilationmessage.rs
@@ -2,20 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::marker::PhantomData;
+
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{
+    GPUCompilationMessageMethods, GPUCompilationMessageType, GPUCompilationMessageWrap,
+};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx_and_wrap};
 use webgpu_traits::ShaderCompilationInfo;
 
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
-    GPUCompilationMessageMethods, GPUCompilationMessageType,
-};
+use crate::JSTraceable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
-use crate::dom::types::GlobalScope;
 
 #[dom_struct]
-pub(crate) struct GPUCompilationMessage {
+pub struct GPUCompilationMessage<D: DomTypes> {
     reflector_: Reflector,
     message: DOMString,
     mtype: GPUCompilationMessageType,
@@ -23,9 +27,14 @@ pub(crate) struct GPUCompilationMessage {
     line_pos: u64,
     offset: u64,
     length: u64,
+    #[no_trace = "PhantomData does not exist"]
+    phantom: PhantomData<D>,
 }
 
-impl GPUCompilationMessage {
+impl<D> GPUCompilationMessage<D>
+where
+    D: DomTypes<GPUCompilationMessage = GPUCompilationMessage<D>>,
+{
     fn new_inherited(
         message: DOMString,
         mtype: GPUCompilationMessageType,
@@ -42,13 +51,14 @@ impl GPUCompilationMessage {
             line_pos,
             offset,
             length,
+            phantom: PhantomData,
         }
     }
 
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         cx: &mut JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         message: DOMString,
         mtype: GPUCompilationMessageType,
         line_num: u64,
@@ -56,18 +66,19 @@ impl GPUCompilationMessage {
         offset: u64,
         length: u64,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object_with_cx_and_wrap::<D, _, _>(
             Box::new(Self::new_inherited(
                 message, mtype, line_num, line_pos, offset, length,
             )),
             global,
             cx,
+            GPUCompilationMessageWrap::<D>,
         )
     }
 
     pub(crate) fn from(
         cx: &mut JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         info: ShaderCompilationInfo,
     ) -> DomRoot<Self> {
         GPUCompilationMessage::new(
@@ -83,7 +94,7 @@ impl GPUCompilationMessage {
     }
 }
 
-impl GPUCompilationMessageMethods<crate::DomTypeHolder> for GPUCompilationMessage {
+impl<D: DomTypes> GPUCompilationMessageMethods<D> for GPUCompilationMessage<D> {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucompilationmessage-message>
     fn Message(&self) -> DOMString {
         self.message.to_owned()

--- a/components/script_webgpu/gpucompilationmessage.rs
+++ b/components/script_webgpu/gpucompilationmessage.rs
@@ -11,7 +11,7 @@ use script_bindings::DomTypes;
 use script_bindings::codegen::GenericBindings::WebGPUBinding::{
     GPUCompilationMessageMethods, GPUCompilationMessageType, GPUCompilationMessageWrap,
 };
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx_and_wrap};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_wrap};
 use webgpu_traits::ShaderCompilationInfo;
 
 use crate::JSTraceable;
@@ -66,7 +66,7 @@ where
         offset: u64,
         length: u64,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx_and_wrap::<D, _, _>(
+        reflect_dom_object_with_wrap::<D, _, _>(
             Box::new(Self::new_inherited(
                 message, mtype, line_num, line_pos, offset, length,
             )),

--- a/components/script_webgpu/gpudevicelostinfo.rs
+++ b/components/script_webgpu/gpudevicelostinfo.rs
@@ -2,48 +2,59 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::marker::PhantomData;
+
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
-
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
-    GPUDeviceLostInfoMethods, GPUDeviceLostReason,
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{
+    GPUDeviceLostInfoMethods, GPUDeviceLostInfoWrap, GPUDeviceLostReason,
 };
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx_and_wrap};
+
+use crate::JSTraceable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
-use crate::dom::globalscope::GlobalScope;
 
 #[dom_struct]
-pub(crate) struct GPUDeviceLostInfo {
+pub struct GPUDeviceLostInfo<D: DomTypes> {
     reflector_: Reflector,
     message: DOMString,
     reason: GPUDeviceLostReason,
+    #[no_trace = "PhantomData does not exist"]
+    phantom: PhantomData<D>,
 }
 
-impl GPUDeviceLostInfo {
+impl<D> GPUDeviceLostInfo<D>
+where
+    D: DomTypes<GPUDeviceLostInfo = GPUDeviceLostInfo<D>>,
+{
     fn new_inherited(message: DOMString, reason: GPUDeviceLostReason) -> Self {
         Self {
             reflector_: Reflector::new(),
             message,
             reason,
+            phantom: PhantomData,
         }
     }
 
-    pub(crate) fn new(
+    pub fn new(
         cx: &mut JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         message: DOMString,
         reason: GPUDeviceLostReason,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object_with_cx_and_wrap::<D, _, _>(
             Box::new(GPUDeviceLostInfo::new_inherited(message, reason)),
             global,
             cx,
+            GPUDeviceLostInfoWrap::<D>,
         )
     }
 }
 
-impl GPUDeviceLostInfoMethods<crate::DomTypeHolder> for GPUDeviceLostInfo {
+impl<D: DomTypes> GPUDeviceLostInfoMethods<D> for GPUDeviceLostInfo<D> {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevicelostinfo-message>
     fn Message(&self) -> DOMString {
         self.message.clone()

--- a/components/script_webgpu/gpudevicelostinfo.rs
+++ b/components/script_webgpu/gpudevicelostinfo.rs
@@ -11,7 +11,7 @@ use script_bindings::DomTypes;
 use script_bindings::codegen::GenericBindings::WebGPUBinding::{
     GPUDeviceLostInfoMethods, GPUDeviceLostInfoWrap, GPUDeviceLostReason,
 };
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx_and_wrap};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_wrap};
 
 use crate::JSTraceable;
 use crate::dom::bindings::root::DomRoot;
@@ -45,7 +45,7 @@ where
         message: DOMString,
         reason: GPUDeviceLostReason,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx_and_wrap::<D, _, _>(
+        reflect_dom_object_with_wrap::<D, _, _>(
             Box::new(GPUDeviceLostInfo::new_inherited(message, reason)),
             global,
             cx,

--- a/components/script_webgpu/lib.rs
+++ b/components/script_webgpu/lib.rs
@@ -7,6 +7,8 @@
 #![cfg_attr(crown, register_tool(crown))]
 
 pub mod gpuadapterinfo;
+pub mod gpubufferusage;
+
 pub(crate) use js::gc::Traceable as JSTraceable;
 pub(crate) use jstraceable_derive::JSTraceable;
 pub(crate) use script_bindings::reflector::{DomObject, MutDomObject, Reflector};
@@ -37,7 +39,8 @@ pub(crate) mod codegen {
         use script_bindings::root::{Dom, DomRoot, Root};
         use script_bindings::utils::DOMClass;
 
-        pub(crate) use crate::gpuadapterinfo::GPUAdapterInfo;
+        use crate::gpuadapterinfo::GPUAdapterInfo;
+        use crate::gpubufferusage::GPUBufferUsage;
         include!(concat!(
             env!("OUT_DIR"),
             "/ConcreteBindings/WebGPUBinding.rs"

--- a/components/script_webgpu/lib.rs
+++ b/components/script_webgpu/lib.rs
@@ -8,6 +8,8 @@
 
 pub mod gpuadapterinfo;
 pub mod gpubufferusage;
+pub mod gpucompilationinfo;
+pub mod gpucompilationmessage;
 
 pub(crate) use js::gc::Traceable as JSTraceable;
 pub(crate) use jstraceable_derive::JSTraceable;
@@ -41,6 +43,8 @@ pub(crate) mod codegen {
 
         use crate::gpuadapterinfo::GPUAdapterInfo;
         use crate::gpubufferusage::GPUBufferUsage;
+        use crate::gpucompilationinfo::GPUCompilationInfo;
+        use crate::gpucompilationmessage::GPUCompilationMessage;
         include!(concat!(
             env!("OUT_DIR"),
             "/ConcreteBindings/WebGPUBinding.rs"

--- a/components/script_webgpu/lib.rs
+++ b/components/script_webgpu/lib.rs
@@ -10,6 +10,7 @@ pub mod gpuadapterinfo;
 pub mod gpubufferusage;
 pub mod gpucompilationinfo;
 pub mod gpucompilationmessage;
+pub mod gpudevicelostinfo;
 
 pub(crate) use js::gc::Traceable as JSTraceable;
 pub(crate) use jstraceable_derive::JSTraceable;
@@ -45,6 +46,7 @@ pub(crate) mod codegen {
         use crate::gpubufferusage::GPUBufferUsage;
         use crate::gpucompilationinfo::GPUCompilationInfo;
         use crate::gpucompilationmessage::GPUCompilationMessage;
+        use crate::gpudevicelostinfo::GPUDeviceLostInfo;
         include!(concat!(
             env!("OUT_DIR"),
             "/ConcreteBindings/WebGPUBinding.rs"


### PR DESCRIPTION
This moves more into script_webgpu crate and can be reviewed per commit.

This moves the following types to the new script_webgpu crate.
-  GPUBufferUsage
-  GPUCompilationInfo
-  GPUCompilationMessage
-  GPUDeviceLostInfo
Most of these changes are mechanical.
Of note are the moving of `to_frozen_array` to script_bindings::utils and the creation of `reflect_dom_object_with_proto_and_wrap` and the ranming of `reflect_dom_object_with_cx_and_wrap` to `reflect_dom_object_with_wrap`.

Testing: This is just a mostly refactor and hence, previous tests apply.
