### PR TITLE
script: Implement insertimage command

### DIFF
--- a/components/script/dom/execcommand/basecommand.rs
+++ b/components/script/dom/execcommand/basecommand.rs
@@ -29,6 +29,7 @@ use crate::dom::execcommand::commands::fontsize::{
 };
 use crate::dom::execcommand::commands::forecolor::execute_forecolor_command;
 use crate::dom::execcommand::commands::hilitecolor::execute_hilitecolor_command;
+use crate::dom::execcommand::commands::insertimage::execute_insert_image_command;
 use crate::dom::execcommand::commands::insertparagraph::execute_insert_paragraph_command;
 use crate::dom::execcommand::commands::italic::execute_italic_command;
 use crate::dom::execcommand::commands::removeformat::execute_removeformat_command;
@@ -741,6 +742,9 @@ impl CommandName {
             CommandName::FontSize => execute_fontsize_command(cx, document, selection, value),
             CommandName::ForeColor => execute_forecolor_command(cx, document, selection, value),
             CommandName::HiliteColor => execute_hilitecolor_command(cx, document, selection, value),
+            CommandName::InsertImage => {
+                execute_insert_image_command(cx, document, selection, value)
+            },
             CommandName::InsertParagraph => {
                 execute_insert_paragraph_command(cx, document, selection)
             },

--- a/components/script/dom/execcommand/commands/insertimage.rs
+++ b/components/script/dom/execcommand/commands/insertimage.rs
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use js::context::JSContext;
+use script_bindings::codegen::GenericBindings::NodeBinding::NodeMethods;
+use script_bindings::codegen::GenericBindings::SelectionBinding::SelectionMethods;
+use script_bindings::inheritance::Castable;
+use style::attr::AttrValue;
+
+use crate::dom::bindings::codegen::Bindings::RangeBinding::RangeMethods;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::str::DOMString;
+use crate::dom::document::Document;
+use crate::dom::execcommand::contenteditable::selection::SelectionDeletionStripWrappers;
+use crate::dom::html::htmlbrelement::HTMLBRElement;
+use crate::dom::selection::Selection;
+
+/// <https://w3c.github.io/editing/docs/execCommand/#the-insertimage-command>
+pub(crate) fn execute_insert_image_command(
+    cx: &mut JSContext,
+    document: &Document,
+    selection: &Selection,
+    value: DOMString,
+) -> bool {
+    // Step 1. If value is the empty string, return false.
+    if value.is_empty() {
+        return false;
+    }
+
+    // Step 2. Delete the selection, with strip wrappers false.
+    selection.delete_the_selection(
+        cx,
+        document,
+        Default::default(),
+        SelectionDeletionStripWrappers::NoStrip,
+        Default::default(),
+    );
+
+    // Step 3. Let range be the active range.
+    let range = selection
+        .active_range()
+        .expect("Must always have an active range");
+
+    // Step 4. If the active range's start node is neither editable nor an editing host, return true.
+    let start_node = range.start_container();
+    if !start_node.is_editable_or_editing_host() {
+        return true;
+    }
+
+    // Step 5. If range's start node is a block node whose sole child is a br, and its start offset is 0, remove its start node's child from it.
+    if start_node.is_block_node() && start_node.children_count() == 1 {
+        let sole_child = start_node
+            .children()
+            .next()
+            .expect("range's start node has one child.");
+        if sole_child.is::<HTMLBRElement>() {
+            sole_child.remove_self(cx);
+        }
+    }
+
+    // Step 6. Let img be the result of calling createElement("img") on the context object.
+    let img = document.create_element(cx, "img");
+
+    // Step 7. Run setAttribute("src", value) on img.
+    img.set_attribute(
+        cx,
+        &html5ever::local_name!("src"),
+        AttrValue::String(value.str().to_owned()),
+    );
+
+    // Step 8. Run insertNode(img) on range.
+    let img_node = DomRoot::upcast(img);
+    if range.InsertNode(cx, &img_node).is_err() {
+        unreachable!("The image should always be insertable.");
+    }
+
+    // Step 9. Let selection be the result of calling getSelection() on the context object.
+    // Step 10. Run collapse() on selection, with first argument equal to the parent of img and the second argument equal to one plus the index of img.
+    if selection
+        .Collapse(
+            cx,
+            img_node.GetParentNode().as_deref(),
+            1 + img_node.index(),
+        )
+        .is_err()
+    {
+        unreachable!("The selection should always be collapsible.");
+    }
+
+    // Step 11. Return true.
+    true
+}

--- a/components/script/dom/execcommand/commands/mod.rs
+++ b/components/script/dom/execcommand/commands/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod fontname;
 pub(crate) mod fontsize;
 pub(crate) mod forecolor;
 pub(crate) mod hilitecolor;
+pub(crate) mod insertimage;
 pub(crate) mod insertparagraph;
 pub(crate) mod italic;
 pub(crate) mod removeformat;

--- a/components/script/dom/execcommand/contenteditable/selection.rs
+++ b/components/script/dom/execcommand/contenteditable/selection.rs
@@ -40,6 +40,7 @@ pub(crate) enum SelectionDeletionBlockMerging {
 pub(crate) enum SelectionDeletionStripWrappers {
     #[default]
     Strip,
+    NoStrip,
 }
 
 #[derive(Default, PartialEq)]

--- a/components/script/dom/execcommand/execcommands.rs
+++ b/components/script/dom/execcommand/execcommands.rs
@@ -129,6 +129,7 @@ impl Document {
             "fontsize" => CommandName::FontSize,
             "forecolor" => CommandName::ForeColor,
             "hilitecolor" => CommandName::HiliteColor,
+            "insertimage" => CommandName::InsertImage,
             "insertparagraph" => CommandName::InsertParagraph,
             "italic" => CommandName::Italic,
             "removeformat" => CommandName::RemoveFormat,

--- a/tests/wpt/meta/editing/event.html.ini
+++ b/tests/wpt/meta/editing/event.html.ini
@@ -83,12 +83,6 @@
   [Command insertImage, value "": input event]
     expected: FAIL
 
-  [Command insertImage, value "quasit": input event]
-    expected: FAIL
-
-  [Command insertImage, value "../images/green.png": input event]
-    expected: FAIL
-
   [Command insertLineBreak, value "": input event]
     expected: FAIL
 

--- a/tests/wpt/meta/editing/other/exec-command-with-text-editor.tentative.html.ini
+++ b/tests/wpt/meta/editing/other/exec-command-with-text-editor.tentative.html.ini
@@ -74,9 +74,6 @@
   [In <input type="password">, execCommand("inserthorizontalrule", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
-  [In <input type="password">, execCommand("insertimage", false, no-image.png), a[b\]c): The command should be supported]
-    expected: FAIL
-
   [In <input type="password">, execCommand("inserthtml", false, <b>inserted</b>), a[b\]c): The command should be supported]
     expected: FAIL
 
@@ -186,9 +183,6 @@
     expected: FAIL
 
   [In <input type="password"> in contenteditable, execCommand("inserthorizontalrule", false, null), a[b\]c): The command should be supported]
-    expected: FAIL
-
-  [In <input type="password"> in contenteditable, execCommand("insertimage", false, no-image.png), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <input type="password"> in contenteditable, execCommand("inserthtml", false, <b>inserted</b>), a[b\]c): The command should be supported]
@@ -533,6 +527,21 @@
   [In <input type="password"> in contenteditable, execCommand("delete", false, null), a[b\]c): input.inputType should be deleteContentBackward]
     expected: FAIL
 
+  [In <input type="password"> in contenteditable, execCommand("insertimage", false, no-image.png), a[b\]c): The command should not be enabled]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("insertimage", false, no-image.png), a[b\]c): execCommand() should return false]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("insertimage", false, no-image.png), a[b\]c): should not fire beforeinput event]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("insertimage", false, no-image.png), a[b\]c): input.inputType should be undefined]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("insertimage", false, no-image.png), a[b\]c): input.target should be undefined]
+    expected: FAIL
+
 
 [exec-command-with-text-editor.tentative.html?type=text]
   [In <input type="text">, execCommand("cut", false, null), ab[\]c): The command should be supported]
@@ -608,9 +617,6 @@
     expected: FAIL
 
   [In <input type="text">, execCommand("inserthorizontalrule", false, null), a[b\]c): The command should be supported]
-    expected: FAIL
-
-  [In <input type="text">, execCommand("insertimage", false, no-image.png), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <input type="text">, execCommand("inserthtml", false, <b>inserted</b>), a[b\]c): The command should be supported]
@@ -722,9 +728,6 @@
     expected: FAIL
 
   [In <input type="text"> in contenteditable, execCommand("inserthorizontalrule", false, null), a[b\]c): The command should be supported]
-    expected: FAIL
-
-  [In <input type="text"> in contenteditable, execCommand("insertimage", false, no-image.png), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <input type="text"> in contenteditable, execCommand("inserthtml", false, <b>inserted</b>), a[b\]c): The command should be supported]
@@ -1069,6 +1072,21 @@
   [In <input type="text"> in contenteditable, execCommand("delete", false, null), a[b\]c): input.inputType should be deleteContentBackward]
     expected: FAIL
 
+  [In <input type="text"> in contenteditable, execCommand("insertimage", false, no-image.png), a[b\]c): The command should not be enabled]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("insertimage", false, no-image.png), a[b\]c): execCommand() should return false]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("insertimage", false, no-image.png), a[b\]c): should not fire beforeinput event]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("insertimage", false, no-image.png), a[b\]c): input.inputType should be undefined]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("insertimage", false, no-image.png), a[b\]c): input.target should be undefined]
+    expected: FAIL
+
 
 [exec-command-with-text-editor.tentative.html?type=textarea]
   [In <textarea>, execCommand("cut", false, null), ab[\]c): The command should be supported]
@@ -1144,9 +1162,6 @@
     expected: FAIL
 
   [In <textarea>, execCommand("inserthorizontalrule", false, null), a[b\]c): The command should be supported]
-    expected: FAIL
-
-  [In <textarea>, execCommand("insertimage", false, no-image.png), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <textarea>, execCommand("inserthtml", false, <b>inserted</b>), a[b\]c): The command should be supported]
@@ -1264,9 +1279,6 @@
     expected: FAIL
 
   [In <textarea> in contenteditable, execCommand("inserthorizontalrule", false, null), a[b\]c): The command should be supported]
-    expected: FAIL
-
-  [In <textarea> in contenteditable, execCommand("insertimage", false, no-image.png), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <textarea> in contenteditable, execCommand("inserthtml", false, <b>inserted</b>), a[b\]c): The command should be supported]
@@ -1618,4 +1630,19 @@
     expected: FAIL
 
   [In <textarea> in contenteditable, execCommand("delete", false, null), a[b\]c): input.inputType should be deleteContentBackward]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("insertimage", false, no-image.png), a[b\]c): The command should not be enabled]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("insertimage", false, no-image.png), a[b\]c): execCommand() should return false]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("insertimage", false, no-image.png), a[b\]c): should not fire beforeinput event]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("insertimage", false, no-image.png), a[b\]c): input.inputType should be undefined]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("insertimage", false, no-image.png), a[b\]c): input.target should be undefined]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/insertimage.html.ini
+++ b/tests/wpt/meta/editing/run/insertimage.html.ini
@@ -1,449 +1,122 @@
 [insertimage.html]
-  [[["insertimage","/img/lion.svg"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "<span>foo</span>{}<span>bar</span>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "<span>foo</span>{}<span>bar</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "<span>foo[</span><span>\]bar</span>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["insertimage","/img/lion.svg"\]\] "<span>foo[</span><span>\]bar</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "foo[bar\]baz": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "foo<span style=color:#aBcDeF>[bar\]</span>baz": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["insertimage","/img/lion.svg"\]\] "foo<span style=color:#aBcDeF>[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
-  [[["insertimage","/img/lion.svg"\]\] "foo<span style=color:#aBcDeF>{bar}</span>baz": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["insertimage","/img/lion.svg"\]\] "foo<span style=color:#aBcDeF>{bar}</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "foo{<span style=color:#aBcDeF>bar</span>}baz": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["insertimage","/img/lion.svg"\]\] "foo{<span style=color:#aBcDeF>bar</span>}baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["insertimage","/img/lion.svg"\]\] "[foo<span style=color:#aBcDeF>bar\]</span>baz": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["insertimage","/img/lion.svg"\]\] "[foo<span style=color:#aBcDeF>bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["insertimage","/img/lion.svg"\]\] "[foo<span style=color:#aBcDeF>bar\]</span>baz": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["insertimage","/img/lion.svg"\]\] "[foo<span style=color:#aBcDeF>bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["insertimage","/img/lion.svg"\]\] "{foo<span style=color:#aBcDeF>bar}</span>baz": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["insertimage","/img/lion.svg"\]\] "{foo<span style=color:#aBcDeF>bar}</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["insertimage","/img/lion.svg"\]\] "{foo<span style=color:#aBcDeF>bar}</span>baz": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["insertimage","/img/lion.svg"\]\] "{foo<span style=color:#aBcDeF>bar}</span>baz" compare innerHTML]
     expected: FAIL
 
-  [[["insertimage","/img/lion.svg"\]\] "foo<span style=color:#aBcDeF>[bar</span>baz\]": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["insertimage","/img/lion.svg"\]\] "foo<span style=color:#aBcDeF>[bar</span>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "foo<span style=color:#aBcDeF>{bar</span>baz}": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["insertimage","/img/lion.svg"\]\] "foo<span style=color:#aBcDeF>{bar</span>baz}" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["insertimage","/img/lion.svg"\]\] "foo<span style=color:#aBcDeF>[bar</span><span style=color:#fEdCbA>baz\]</span>quz": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["insertimage","/img/lion.svg"\]\] "foo<span style=color:#aBcDeF>[bar</span><span style=color:#fEdCbA>baz\]</span>quz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["insertimage","/img/lion.svg"\]\] "foo<span style=color:#aBcDeF>[bar</span><span style=color:#fEdCbA>baz\]</span>quz": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["insertimage","/img/lion.svg"\]\] "foo<span style=color:#aBcDeF>[bar</span><span style=color:#fEdCbA>baz\]</span>quz" compare innerHTML]
     expected: FAIL
 
-  [[["insertimage","/img/lion.svg"\]\] "foo<b>[bar\]</b>baz": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["insertimage","/img/lion.svg"\]\] "foo<b>[bar\]</b>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "foo<b>{bar}</b>baz": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["insertimage","/img/lion.svg"\]\] "foo<b>{bar}</b>baz" compare innerHTML]
     expected: FAIL
 
-  [[["insertimage","/img/lion.svg"\]\] "foo{<b>bar</b>}baz": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["insertimage","/img/lion.svg"\]\] "foo{<b>bar</b>}baz" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "foo<span>[bar\]</span>baz": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["insertimage","/img/lion.svg"\]\] "foo<span>[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
-  [[["insertimage","/img/lion.svg"\]\] "foo<span>{bar}</span>baz": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["insertimage","/img/lion.svg"\]\] "foo<span>{bar}</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "foo{<span>bar</span>}baz": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["insertimage","/img/lion.svg"\]\] "foo{<span>bar</span>}baz" compare innerHTML]
     expected: FAIL
 
-  [[["insertimage","/img/lion.svg"\]\] "<b>foo[bar</b><i>baz\]quz</i>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["insertimage","/img/lion.svg"\]\] "<b>foo[bar</b><i>baz\]quz</i>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "<p>foo</p><p>[bar\]</p><p>baz</p>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "<p>foo</p><p>[bar\]</p><p>baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "<p>foo</p><p>{bar}</p><p>baz</p>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "<p>foo</p><p>{bar}</p><p>baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<p>foo</p>{<p>bar</p>}<p>baz</p>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<p>foo</p>{<p>bar</p>}<p>baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<p>foo</p>{<p>bar</p>}<p>baz</p>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<p>foo</p>{<p>bar</p>}<p>baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<p>baz\]quz": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<p>baz\]quz" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<p>baz\]quz": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<p>baz\]quz" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<div>baz\]quz</div>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<div>baz\]quz</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<div>baz\]quz</div>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<div>baz\]quz</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "<p>foo[bar<h1>baz\]quz</h1>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "<p>foo[bar<h1>baz\]quz</h1>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<div>foo[bar</div><p>baz\]quz": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<div>foo[bar</div><p>baz\]quz" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<div>foo[bar</div><p>baz\]quz": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<div>foo[bar</div><p>baz\]quz" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "<blockquote>foo[bar</blockquote><pre>baz\]quz</pre>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "<blockquote>foo[bar</blockquote><pre>baz\]quz</pre>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<p><b>foo[bar</b><p>baz\]quz": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<p><b>foo[bar</b><p>baz\]quz" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<p><b>foo[bar</b><p>baz\]quz": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<p><b>foo[bar</b><p>baz\]quz" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<div><p>foo[bar</div><p>baz\]quz": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<div><p>foo[bar</div><p>baz\]quz" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<div><p>foo[bar</div><p>baz\]quz": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<div><p>foo[bar</div><p>baz\]quz" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<blockquote><p>baz\]quz<p>qoz</blockquote": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<blockquote><p>baz\]quz<p>qoz</blockquote" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<blockquote><p>baz\]quz<p>qoz</blockquote": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<blockquote><p>baz\]quz<p>qoz</blockquote" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<p style=color:blue>baz\]quz": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<p style=color:blue>baz\]quz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<p style=color:blue>baz\]quz": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<p style=color:blue>baz\]quz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<p style=color:blue>baz\]quz": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<p style=color:blue>baz\]quz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<p style=color:blue>baz\]quz": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<p style=color:blue>baz\]quz" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<p><b>baz\]quz</b>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<p><b>baz\]quz</b>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<p><b>baz\]quz</b>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<p>foo[bar<p><b>baz\]quz</b>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<div><p>foo<p>[bar<p>baz\]</div>": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<div><p>foo<p>[bar<p>baz\]</div>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<div><p>foo<p>[bar<p>baz\]</div>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<div><p>foo<p>[bar<p>baz\]</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "foo[<br>\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "foo[<br>\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<p>foo[</p><p>\]bar</p>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<p>foo[</p><p>\]bar</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<p>foo[</p><p>\]bar</p>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<p>foo[</p><p>\]bar</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<p>foo[</p><p>\]bar<br>baz</p>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<p>foo[</p><p>\]bar<br>baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<p>foo[</p><p>\]bar<br>baz</p>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<p>foo[</p><p>\]bar<br>baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "foo[<p>\]bar</p>": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "foo[<p>\]bar</p>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "foo[<p>\]bar</p>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "foo[<p>\]bar</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "foo[<p>\]bar<br>baz</p>": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["insertimage","/img/lion.svg"\]\] "foo[<p>\]bar<br>baz</p>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "foo[<p>\]bar</p>baz": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "foo[<p>\]bar</p>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "foo[<p>\]bar</p>baz": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "foo[<p>\]bar</p>baz" compare innerHTML]
     expected: FAIL
 
-  [[["insertimage","/img/lion.svg"\]\] "<p>foo[</p>\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["insertimage","/img/lion.svg"\]\] "<p>foo[</p>\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "<p>foo[</p>\]bar<br>baz": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["insertimage","/img/lion.svg"\]\] "<p>foo[</p>\]bar<br>baz" compare innerHTML]
     expected: FAIL
 
-  [[["insertimage","/img/lion.svg"\]\] "<p>foo[</p>\]bar<p>baz</p>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["insertimage","/img/lion.svg"\]\] "<p>foo[</p>\]bar<p>baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "foo[<div><p>\]bar</div>": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "foo[<div><p>\]bar</div>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "foo[<div><p>\]bar</div>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "foo[<div><p>\]bar</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "<div><p>foo[</p></div>\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["insertimage","/img/lion.svg"\]\] "<div><p>foo[</p></div>\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "foo[<div><p>\]bar</p>baz</div>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "foo[<div><p>\]bar</p>baz</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "foo[<div><p>\]bar</p>baz</div>": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "foo[<div><p>\]bar</p>baz</div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertimage","/img/lion.svg"\]\] "foo[<div>\]bar<p>baz</p></div>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["insertimage","/img/lion.svg"\]\] "foo[<div>\]bar<p>baz</p></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "<div><p>foo</p>bar[</div>\]baz": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["insertimage","/img/lion.svg"\]\] "<div><p>foo</p>bar[</div>\]baz" compare innerHTML]
     expected: FAIL
 
-  [[["insertimage","/img/lion.svg"\]\] "<div>foo<p>bar[</p></div>\]baz": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["insertimage","/img/lion.svg"\]\] "<div>foo<p>bar[</p></div>\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/日本語パス/lion.svg"\]\] "foo[\]bar": execCommand("insertimage", false, "/日本語パス/lion.svg") return value]
-    expected: FAIL
-
-  [[["insertimage","/日本語パス/lion.svg"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "<div>{}<br></div>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "<div>{}<br></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "<div><b>{}<br></b></div>": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["insertimage","/img/lion.svg"\]\] "<div><b>{}<br></b></div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertimage","/img/lion.svg"\]\] "<div><span>{}<br></span></div>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["insertimage","/img/lion.svg"\]\] "<div><span>{}<br></span></div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertimage","/img/lion.svg"\]\] "<div><b>A[\]B</b></div>": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["insertimage","/img/lion.svg"\]\] "<div><b>A[\]B</b></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "<div><span>A[\]B</span></div>": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["insertimage","/img/lion.svg"\]\] "<div><span>A[\]B</span></div>" compare innerHTML]

--- a/tests/wpt/meta/editing/run/multitest.html.ini
+++ b/tests/wpt/meta/editing/run/multitest.html.ini
@@ -104,15 +104,6 @@
   [[["hilitecolor","#00FFFF"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["hilitecolor","#00FFFF"\],["insertimage","/img/lion.svg"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["hilitecolor","#00FFFF"\],["insertimage","/img/lion.svg"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["hilitecolor","#00FFFF"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["hilitecolor","#00FFFF"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
@@ -553,15 +544,6 @@
   [[["bold",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["bold",""\],["insertimage","/img/lion.svg"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["bold",""\],["insertimage","/img/lion.svg"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["bold",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["bold",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
@@ -872,15 +854,6 @@
     expected: FAIL
 
   [[["italic",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["insertimage","/img/lion.svg"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["italic",""\],["insertimage","/img/lion.svg"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["italic",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
@@ -1197,15 +1170,6 @@
   [[["strikethrough",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["strikethrough",""\],["insertimage","/img/lion.svg"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["strikethrough",""\],["insertimage","/img/lion.svg"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["strikethrough",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["strikethrough",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
@@ -1457,15 +1421,6 @@
 
 
 [multitest.html?6001-7000]
-  [[["fontsize","4"\],["insertimage","/img/lion.svg"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertimage","/img/lion.svg"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
@@ -1776,15 +1731,6 @@
     expected: FAIL
 
   [[["forecolor","#0000FF"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forecolor","#0000FF"\],["insertimage","/img/lion.svg"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["forecolor","#0000FF"\],["insertimage","/img/lion.svg"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forecolor","#0000FF"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["forecolor","#0000FF"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
@@ -2170,15 +2116,6 @@
   [[["fontname","sans-serif"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontname","sans-serif"\],["insertimage","/img/lion.svg"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["fontname","sans-serif"\],["insertimage","/img/lion.svg"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontname","sans-serif"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["fontname","sans-serif"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
@@ -2559,15 +2496,6 @@
   [[["subscript",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["subscript",""\],["insertimage","/img/lion.svg"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["subscript",""\],["insertimage","/img/lion.svg"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["subscript",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["subscript",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
@@ -2878,15 +2806,6 @@
     expected: FAIL
 
   [[["superscript",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["superscript",""\],["insertimage","/img/lion.svg"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["superscript",""\],["insertimage","/img/lion.svg"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["superscript",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["superscript",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
@@ -5040,15 +4959,6 @@
   [[["underline",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["underline",""\],["insertimage","/img/lion.svg"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["underline",""\],["insertimage","/img/lion.svg"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["underline",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
@@ -5369,15 +5279,6 @@
   [[["backcolor","#00FFFF"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["backcolor","#00FFFF"\],["insertimage","/img/lion.svg"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["backcolor","#00FFFF"\],["insertimage","/img/lion.svg"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["backcolor","#00FFFF"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["backcolor","#00FFFF"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
@@ -5690,15 +5591,6 @@
   [[["createlink","http://www.google.com/"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["createlink","http://www.google.com/"\],["insertimage","/img/lion.svg"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["insertimage","/img/lion.svg"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
-    expected: FAIL
-
   [[["createlink","http://www.google.com/"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
@@ -5841,4 +5733,10 @@
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("backcolor") after]
+    expected: FAIL
+
+  [[["backcolor","#00FFFF"\],["insertimage","/img/lion.svg"\]\] "foo[\]bar" queryCommandValue("backcolor") after]
+    expected: FAIL
+
+  [[["backcolor","#00FFFF"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("backcolor") after]
     expected: FAIL

--- a/tests/wpt/meta/editing/whitespaces/chrome-compat/insert-or-paste-image.tentative.html.ini
+++ b/tests/wpt/meta/editing/whitespaces/chrome-compat/insert-or-paste-image.tentative.html.ini
@@ -37,9 +37,6 @@
 
 
 [insert-or-paste-image.tentative.html?execCommand-insertImage]
-  [document.execCommand("insertImage") when "[\]a&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;b"]
-    expected: FAIL
-
   [document.execCommand("insertImage") when "a[\]&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;b"]
     expected: FAIL
 
@@ -68,9 +65,6 @@
     expected: FAIL
 
   [document.execCommand("insertImage") when "a&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[\]b"]
-    expected: FAIL
-
-  [document.execCommand("insertImage") when "a&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;b[\]"]
     expected: FAIL
 
 


### PR DESCRIPTION
This implements the "insertimage" command for `document.execCommand()`.

Testing: Gives us a decent amount of new WPT passes in this area. Also some new failures, but those seem to be a more general problem about textarea/input inside contenteditable and so I don't think they're specifically related to this command. One could say the current PASS results there were more coincidental up until now.
