### PR TITLE
script: Always reset document.fonts.ready after starting to load web fonts

### DIFF
--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -2712,8 +2712,6 @@ impl Window {
 
         document.update_animations_post_reflow();
 
-        document.switch_font_face_set_to_loading_if_needed(cx);
-
         (
             reflow_result.reflow_phases_run,
             reflow_result.reflow_statistics,
@@ -3598,6 +3596,8 @@ impl Window {
         }
 
         if !changed_web_fonts.added_font_faces.is_empty() {
+            fonts.switch_to_loading(cx);
+
             let shared_locks = document.shared_style_locks();
             let guards = StylesheetGuards {
                 author: &shared_locks.author.read(),


### PR DESCRIPTION
Whenever we load new `@font-face` rules we want to re-initialize `document.fonts.ready` with a fresh promise. Previously we ran layout (which at the very beginning starts to load new fonts) and then afterwards counted the number of loading fonts - if it was nonzero then we reinitialized the promise. But that misses the case where the font has finished downloading before we finish the reflow. This causes intermittent failures.

Luckily after a reflow we get a summary of the changes to the author font set from layout, so we can just look at that to see if any new fonts were added.

Before this change https://github.com/servo/servo/issues/36094 would flake reliably within around 100 repetitions, afterwards it did not fail once after 500 attempts. The issue surfaces somewhat reliably in this test because it is structured in a way where the web font is already in the HTTP cache, so there is a reasonable chance that the reflow is slower than the fetch operation. 

Fixes: https://github.com/servo/servo/issues/36094. Its possible that this fixes other issues like https://github.com/servo/servo/issues/46520 as well, but I have never been able to reproduce them so there's no way for me to tell.
Testing: This interaction requires one of two things, either a font that loads very quickly or a layout that takes very long. None of these can reliably be caused inside a test.