### PR TITLE
script: Remove duplicate `LargestContentfulPaint` in `Bindings.conf`

### DIFF
--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -817,10 +817,6 @@ DOMInterfaces = {
     'cx': ['Thresholds']
 },
 
-'LargestContentfulPaint': {
-    'cx': ['LoadTime', 'RenderTime'],
-},
-
 'KeyframeEffect': {
     'cx': ['GetKeyframes', 'SetKeyframes']
 },


### PR DESCRIPTION
Remove duplicate `LargestContentfulPaint` in `Bindings.conf`

First Addition in #46318
Second Addition in #46333

Testing: Existing WPT 