### PR TITLE
script: Wire `element` for `LargestContentfulPaint`

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -5928,8 +5928,8 @@ where
                 metric_value,
                 first_reflow,
             ),
-            PaintMetricEvent::LargestContentfulPaint(metric_value, area, url) => (
-                ProgressiveWebMetricType::LargestContentfulPaint { area, url },
+            PaintMetricEvent::LargestContentfulPaint(metric_value, area, url, id) => (
+                ProgressiveWebMetricType::LargestContentfulPaint { area, url, id },
                 metric_value,
                 false, // LCP doesn't care about first reflow
             ),

--- a/components/layout/display_list/paint_timing_handler.rs
+++ b/components/layout/display_list/paint_timing_handler.rs
@@ -6,6 +6,7 @@ use euclid::Rect;
 use paint_api::largest_contentful_paint_candidate::{LCPCandidate, LCPCandidateID};
 use servo_geometry::{FastLayoutTransform, au_rect_to_f32_rect, f32_rect_to_au_rect};
 use servo_url::ServoUrl;
+use style::dom::OpaqueNode;
 use style_traits::CSSPixel;
 use webrender_api::units::{LayoutRect, LayoutSize};
 
@@ -13,12 +14,16 @@ use crate::fragment_tree::Tag;
 use crate::query::transform_au_rectangle;
 
 pub(crate) struct PaintTimingHandler {
-    /// The document’s largest contentful paint size
-    lcp_size: f32,
-    /// The LCP candidate, it may be a image or text.
-    lcp_candidate: Option<LCPCandidate>,
     /// The rect of viewport.
     viewport_rect: LayoutRect,
+    /// The document’s largest contentful paint size
+    lcp_size: f32,
+    /// Counter for generating unique LCP candidate UUIDs.
+    lcp_next_uuid: u64,
+    /// The LCP candidate, it may be a image or text.
+    lcp_candidate: Option<LCPCandidate>,
+    /// The DOM node for the LCP candidate. Only used in ReflowResult
+    lcp_node_id: Option<OpaqueNode>,
     /// Flag to indicate if there is an update to LCP candidate.
     /// This is used to avoid sending duplicate LCP candidates to `Paint`.
     lcp_candidate_updated: bool,
@@ -28,9 +33,11 @@ impl PaintTimingHandler {
     pub(crate) fn new(viewport_size: LayoutSize) -> Self {
         Self {
             lcp_size: 0.0,
+            lcp_next_uuid: 0,
+            lcp_node_id: None,
             lcp_candidate: None,
-            viewport_rect: LayoutRect::from_size(viewport_size),
             lcp_candidate_updated: false,
+            viewport_rect: LayoutRect::from_size(viewport_size),
         }
     }
 
@@ -92,13 +99,13 @@ impl PaintTimingHandler {
             return;
         }
 
-        let id = tag
-            .map(|tag| LCPCandidateID(tag.node.id()))
-            .unwrap_or(LCPCandidateID(0));
+        let uuid = self.lcp_next_uuid;
+        self.lcp_next_uuid += 1;
 
-        // Set newCandidate to be a new largest contentful paint candidate
-        self.lcp_candidate = Some(LCPCandidate::new(id, size as usize, url));
         self.lcp_size = size;
+        self.lcp_node_id = tag.map(|tag| tag.node);
+        self.lcp_candidate = Some(LCPCandidate::new(LCPCandidateID(uuid), size as usize, url));
+
         self.lcp_candidate_updated = true;
     }
 
@@ -112,5 +119,9 @@ impl PaintTimingHandler {
 
     pub(crate) fn largest_contentful_paint_candidate(&self) -> Option<LCPCandidate> {
         self.lcp_candidate.clone()
+    }
+
+    pub(crate) fn lcp_node_id(&self) -> Option<OpaqueNode> {
+        self.lcp_node_id
     }
 }

--- a/components/layout/display_list/paint_timing_handler.rs
+++ b/components/layout/display_list/paint_timing_handler.rs
@@ -23,7 +23,7 @@ pub(crate) struct PaintTimingHandler {
     /// The LCP candidate, it may be a image or text.
     lcp_candidate: Option<LCPCandidate>,
     /// The DOM node for the LCP candidate. Only used in ReflowResult
-    lcp_node_id: Option<OpaqueNode>,
+    lcp_node: Option<OpaqueNode>,
     /// Flag to indicate if there is an update to LCP candidate.
     /// This is used to avoid sending duplicate LCP candidates to `Paint`.
     lcp_candidate_updated: bool,
@@ -34,7 +34,7 @@ impl PaintTimingHandler {
         Self {
             lcp_size: 0.0,
             lcp_next_uuid: 0,
-            lcp_node_id: None,
+            lcp_node: None,
             lcp_candidate: None,
             lcp_candidate_updated: false,
             viewport_rect: LayoutRect::from_size(viewport_size),
@@ -103,7 +103,7 @@ impl PaintTimingHandler {
         self.lcp_next_uuid += 1;
 
         self.lcp_size = size;
-        self.lcp_node_id = tag.map(|tag| tag.node);
+        self.lcp_node = tag.map(|tag| tag.node);
         self.lcp_candidate = Some(LCPCandidate::new(LCPCandidateID(uuid), size as usize, url));
 
         self.lcp_candidate_updated = true;
@@ -121,7 +121,7 @@ impl PaintTimingHandler {
         self.lcp_candidate.clone()
     }
 
-    pub(crate) fn lcp_node_id(&self) -> Option<OpaqueNode> {
-        self.lcp_node_id
+    pub(crate) fn lcp_node(&self) -> Option<OpaqueNode> {
+        self.lcp_node
     }
 }

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1042,6 +1042,18 @@ impl LayoutThread {
         let pending_svg_elements_for_serialization =
             std::mem::take(&mut *image_resolver.pending_svg_elements_for_serialization.lock());
 
+        let (lcp_candidate, lcp_node_id) = self
+            .paint_timing_handler
+            .borrow()
+            .as_ref()
+            .map(|handler| {
+                (
+                    handler.largest_contentful_paint_candidate(),
+                    handler.lcp_node_id().map(|node| node.id()),
+                )
+            })
+            .unwrap_or_default();
+
         Some(ReflowResult {
             reflow_phases_run,
             pending_images,
@@ -1050,6 +1062,8 @@ impl LayoutThread {
             iframe_sizes: Some(iframe_sizes),
             reflow_statistics,
             changed_web_fonts,
+            lcp_candidate,
+            lcp_node_id,
         })
     }
 

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -6,6 +6,7 @@
 
 use std::cell::{Cell, OnceCell, RefCell};
 use std::collections::{HashMap, VecDeque};
+use std::ffi::c_void;
 use std::fmt::Debug;
 use std::rc::Rc;
 use std::sync::{Arc, LazyLock};
@@ -1042,14 +1043,16 @@ impl LayoutThread {
         let pending_svg_elements_for_serialization =
             std::mem::take(&mut *image_resolver.pending_svg_elements_for_serialization.lock());
 
-        let (lcp_candidate, lcp_node_id) = self
+        let (lcp_candidate, lcp_node_address) = self
             .paint_timing_handler
             .borrow()
             .as_ref()
             .map(|handler| {
                 (
                     handler.largest_contentful_paint_candidate(),
-                    handler.lcp_node_id().map(|node| node.id()),
+                    handler
+                        .lcp_node()
+                        .map(|node| UntrustedNodeAddress(node.id() as *const c_void)),
                 )
             })
             .unwrap_or_default();
@@ -1063,7 +1066,7 @@ impl LayoutThread {
             reflow_statistics,
             changed_web_fonts,
             lcp_candidate,
-            lcp_node_id,
+            lcp_node_address,
         })
     }
 

--- a/components/metrics/lib.rs
+++ b/components/metrics/lib.rs
@@ -7,6 +7,7 @@ use std::cmp::Ordering;
 use std::time::Duration;
 
 use malloc_size_of_derive::MallocSizeOf;
+use paint_api::largest_contentful_paint_candidate::LCPCandidateID;
 use profile_traits::time::{
     ProfilerCategory, ProfilerChan, TimerMetadata, TimerMetadataFrameType, TimerMetadataReflowType,
     send_profile_data,
@@ -243,11 +244,20 @@ impl ProgressiveWebMetrics {
         );
     }
 
-    pub fn set_largest_contentful_paint(&self, paint_time: CrossProcessInstant, area: usize) {
+    pub fn set_largest_contentful_paint(
+        &self,
+        id: LCPCandidateID,
+        paint_time: CrossProcessInstant,
+        area: usize,
+    ) {
         set_metric(
             self,
             Some(self.make_metadata(false)),
-            ProgressiveWebMetricType::LargestContentfulPaint { area, url: None },
+            ProgressiveWebMetricType::LargestContentfulPaint {
+                id,
+                area,
+                url: None,
+            },
             ProfilerCategory::TimeToLargestContentfulPaint,
             &self.largest_contentful_paint,
             paint_time,

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -536,6 +536,7 @@ impl Painter {
                                         lcp.paint_time,
                                         lcp.area,
                                         lcp.url.clone(),
+                                        lcp.id,
                                     ),
                                 ),
                             );

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -45,6 +45,7 @@ use net_traits::request::{
     InsecureRequestsPolicy, PreloadId, PreloadKey, PreloadedResources, RequestBuilder,
 };
 use net_traits::{ReferrerPolicy, ResourceFetchTiming};
+use paint_api::largest_contentful_paint_candidate::LCPCandidateID;
 use percent_encoding::percent_decode;
 use profile_traits::generic_channel as profile_generic_channel;
 use profile_traits::time::TimerMetadataFrameType;
@@ -609,6 +610,8 @@ pub(crate) struct Document {
     intersection_observers: DomRefCell<Vec<Dom<IntersectionObserver>>>,
     /// The node that is currently highlighted by the devtools
     highlighted_dom_node: MutNullableDom<Node>,
+    /// Resolved LCP candidate elements, keyed by their [LCPCandidateID].
+    lcp_candidates: DomRefCell<HashMapTracedValues<LCPCandidateID, Dom<Element>>>,
     /// The constructed stylesheet that is adopted by this [Document].
     /// <https://drafts.csswg.org/cssom/#dom-documentorshadowroot-adoptedstylesheets>
     adopted_stylesheets: DomRefCell<Vec<Dom<CSSStyleSheet>>>,
@@ -3395,6 +3398,12 @@ impl Document {
             }));
     }
 
+    pub(crate) fn store_lcp_candidate(&self, id: LCPCandidateID, element: &Element) {
+        self.lcp_candidates
+            .borrow_mut()
+            .insert(id, Dom::from_ref(element));
+    }
+
     pub(crate) fn handle_paint_metric(
         &self,
         cx: &mut JSContext,
@@ -3416,15 +3425,16 @@ impl Document {
                 let entry = binding.upcast::<PerformanceEntry>();
                 self.window.Performance(cx).queue_entry(entry);
             },
-            ProgressiveWebMetricType::LargestContentfulPaint { area, url } => {
+            ProgressiveWebMetricType::LargestContentfulPaint { area, url, id } => {
                 let binding = LargestContentfulPaint::new(
                     cx,
                     self.window.as_global_scope(),
                     metric_value,
                     area,
                     url,
+                    self.lcp_candidates.borrow_mut().remove(&id).as_deref(),
                 );
-                metrics.set_largest_contentful_paint(metric_value, area);
+                metrics.set_largest_contentful_paint(id, metric_value, area);
                 let entry = binding.upcast::<PerformanceEntry>();
                 self.window.Performance(cx).queue_entry(entry);
             },
@@ -3833,6 +3843,7 @@ impl Document {
             intersection_observer_task_queued: Cell::new(false),
             intersection_observers: Default::default(),
             highlighted_dom_node: Default::default(),
+            lcp_candidates: DomRefCell::new(Default::default()),
             adopted_stylesheets: Default::default(),
             adopted_stylesheets_frozen_types: CachedFrozenArray::new(),
             pending_scroll_events: Default::default(),

--- a/components/script/dom/performance/largestcontentfulpaint.rs
+++ b/components/script/dom/performance/largestcontentfulpaint.rs
@@ -13,11 +13,13 @@ use super::performanceentry::{EntryType, PerformanceEntry};
 use crate::dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
 use crate::dom::bindings::codegen::Bindings::LargestContentfulPaintBinding::LargestContentfulPaintMethods;
 use crate::dom::bindings::codegen::Bindings::PerformanceBinding::DOMHighResTimeStamp;
+use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::element::Element;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::node::Node;
 
 #[dom_struct]
 pub(crate) struct LargestContentfulPaint {
@@ -36,6 +38,7 @@ impl LargestContentfulPaint {
         render_time: CrossProcessInstant,
         size: usize,
         url: Option<ServoUrl>,
+        element: Option<&Element>,
     ) -> LargestContentfulPaint {
         LargestContentfulPaint {
             entry: PerformanceEntry::new_inherited(
@@ -48,7 +51,9 @@ impl LargestContentfulPaint {
             render_time,
             size,
             url: url.map(|u| DOMString::from(u.as_str())).unwrap_or_default(),
-            element: None,
+            element: Some(Dom::from_ref(
+                element.expect("Element for LCP entry should be non-null"),
+            )),
         }
     }
 
@@ -58,12 +63,14 @@ impl LargestContentfulPaint {
         render_time: CrossProcessInstant,
         size: usize,
         url: Option<ServoUrl>,
+        element: Option<&Element>,
     ) -> DomRoot<LargestContentfulPaint> {
         reflect_dom_object_with_cx(
             Box::new(LargestContentfulPaint::new_inherited(
                 render_time,
                 size,
                 url,
+                element,
             )),
             global,
             cx,
@@ -105,6 +112,13 @@ impl LargestContentfulPaintMethods<crate::DomTypeHolder> for LargestContentfulPa
 
     /// <https://www.w3.org/TR/largest-contentful-paint/#dom-largestcontentfulpaint-element>
     fn GetElement(&self) -> Option<DomRoot<Element>> {
-        self.element.as_ref().map(|element| element.as_rooted())
+        self.element
+            .as_ref()
+            .filter(|element| {
+                element
+                    .upcast::<Node>()
+                    .is_connected_with_browsing_context()
+            })
+            .map(|element| element.as_rooted())
     }
 }

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -59,6 +59,7 @@ use net_traits::image_cache::{
 use net_traits::request::{Origin, Referrer, RequestClient};
 use net_traits::{ResourceFetchTiming, ResourceThreads};
 use num_traits::ToPrimitive;
+use paint_api::largest_contentful_paint_candidate::LCPCandidate;
 use paint_api::{CrossProcessPaintApi, PinchZoomInfos};
 use profile_traits::generic_channel as ProfiledGenericChannel;
 use profile_traits::mem::ProfilerChan as MemProfilerChan;
@@ -2752,6 +2753,12 @@ impl Window {
             reflow_result.pending_svg_elements_for_serialization,
         );
 
+        if let Some(candidate) = &reflow_result.lcp_candidate &&
+            let Some(node_id) = reflow_result.lcp_node_id
+        {
+            self.process_lcp_candidate_post_reflow(candidate, node_id, &document);
+        }
+
         if let Some(iframe_sizes) = reflow_result.iframe_sizes {
             document
                 .iframes_mut()
@@ -3690,6 +3697,21 @@ impl Window {
                     fonts.add(cx, font_face);
                 }
             }
+        }
+    }
+
+    /// Resolve the LCP candidate OpaqueNode to a DOM Element and store it on the document.
+    #[expect(unsafe_code)]
+    fn process_lcp_candidate_post_reflow(
+        &self,
+        candidate: &LCPCandidate,
+        node_id: usize,
+        document: &Document,
+    ) {
+        let address = UntrustedNodeAddress(node_id as *const c_void);
+        let node = unsafe { from_untrusted_node_address(address) };
+        if let Some(element) = DomRoot::downcast::<Element>(node) {
+            document.store_lcp_candidate(candidate.id, &element);
         }
     }
 

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -2754,9 +2754,9 @@ impl Window {
         );
 
         if let Some(candidate) = &reflow_result.lcp_candidate &&
-            let Some(node_id) = reflow_result.lcp_node_id
+            let Some(node_address) = reflow_result.lcp_node_address
         {
-            self.process_lcp_candidate_post_reflow(candidate, node_id, &document);
+            self.process_lcp_candidate_post_reflow(candidate, node_address, &document);
         }
 
         if let Some(iframe_sizes) = reflow_result.iframe_sizes {
@@ -3705,11 +3705,10 @@ impl Window {
     fn process_lcp_candidate_post_reflow(
         &self,
         candidate: &LCPCandidate,
-        node_id: usize,
+        node_address: UntrustedNodeAddress,
         document: &Document,
     ) {
-        let address = UntrustedNodeAddress(node_id as *const c_void);
-        let node = unsafe { from_untrusted_node_address(address) };
+        let node = unsafe { from_untrusted_node_address(node_address) };
         if let Some(element) = DomRoot::downcast::<Element>(node) {
             document.store_lcp_candidate(candidate.id, &element);
         }

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -26,6 +26,7 @@ use embedder_traits::{
 pub use from_script_message::*;
 use malloc_size_of_derive::MallocSizeOf;
 use paint_api::PinchZoomInfos;
+use paint_api::largest_contentful_paint_candidate::LCPCandidateID;
 use profile_traits::mem::MemoryReportResult;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
@@ -131,7 +132,12 @@ pub enum UserContentManagerAction {
 pub enum PaintMetricEvent {
     FirstPaint(CrossProcessInstant, bool /* first_reflow */),
     FirstContentfulPaint(CrossProcessInstant, bool /* first_reflow */),
-    LargestContentfulPaint(CrossProcessInstant, usize /* area */, Option<ServoUrl>),
+    LargestContentfulPaint(
+        CrossProcessInstant,
+        usize, /* area */
+        Option<ServoUrl>,
+        LCPCandidateID,
+    ),
 }
 
 impl fmt::Debug for EmbedderToConstellationMessage {

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -42,6 +42,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use net_traits::image_cache::{ImageCache, ImageCacheFactory, PendingImageId};
 use net_traits::request::InternalRequest;
 use paint_api::CrossProcessPaintApi;
+use paint_api::largest_contentful_paint_candidate::LCPCandidate;
 use parking_lot::RwLock;
 use pixels::{RasterImage, Repeat};
 use profile_traits::mem::Report;
@@ -629,6 +630,10 @@ pub struct ReflowResult {
     pub iframe_sizes: Option<IFrameSizes>,
     /// Enumerates web fonts that were added or removed as part of restyling.
     pub changed_web_fonts: WebFontSetDifference,
+    /// The LCP candidate during this layout pass, if any.
+    pub lcp_candidate: Option<LCPCandidate>,
+    /// The OpaqueNode ID for the LCP candidate if any.
+    pub lcp_node_id: Option<usize>,
 }
 
 bitflags! {

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -632,8 +632,8 @@ pub struct ReflowResult {
     pub changed_web_fonts: WebFontSetDifference,
     /// The LCP candidate during this layout pass, if any.
     pub lcp_candidate: Option<LCPCandidate>,
-    /// The OpaqueNode ID for the LCP candidate if any.
-    pub lcp_node_id: Option<usize>,
+    /// The UntrustedNodeAddress for the LCP candidate if any.
+    pub lcp_node_address: Option<UntrustedNodeAddress>,
 }
 
 bitflags! {

--- a/components/shared/paint/largest_contentful_paint_candidate.rs
+++ b/components/shared/paint/largest_contentful_paint_candidate.rs
@@ -4,6 +4,7 @@
 
 //! Definitions for Largest Contentful Paint Candidate and Largest Contentful Paint.
 
+use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_url::ServoUrl;
@@ -11,7 +12,7 @@ use servo_url::ServoUrl;
 /// Largest Contentful Paint Candidate, include image and block-level element containing text
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct LCPCandidate {
-    /// The identity of the element.
+    /// A unique identifier for this candidate.
     pub id: LCPCandidateID,
     /// The size of the visual area
     pub area: usize,
@@ -25,8 +26,9 @@ impl LCPCandidate {
     }
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-pub struct LCPCandidateID(pub usize);
+/// A unique identifier for an LCP candidate, generated at layout time.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
+pub struct LCPCandidateID(pub u64);
 
 #[derive(Clone, Debug)]
 pub struct LargestContentfulPaint {
@@ -37,12 +39,12 @@ pub struct LargestContentfulPaint {
 }
 
 impl LargestContentfulPaint {
-    pub fn from(lcp_candidate: LCPCandidate, paint_time: CrossProcessInstant) -> Self {
+    pub fn from(candidate: LCPCandidate, paint_time: CrossProcessInstant) -> Self {
         Self {
-            id: lcp_candidate.id,
-            area: lcp_candidate.area,
+            id: candidate.id,
+            area: candidate.area,
             paint_time,
-            url: lcp_candidate.url,
+            url: candidate.url,
         }
     }
 }

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -25,6 +25,7 @@ use keyboard_types::Modifiers;
 use malloc_size_of_derive::MallocSizeOf;
 use media::WindowGLContext;
 use net_traits::ResourceThreads;
+use paint_api::largest_contentful_paint_candidate::LCPCandidateID;
 use paint_api::{CrossProcessPaintApi, PinchZoomInfos};
 use pixels::PixelFormat;
 use profile_traits::mem;
@@ -118,6 +119,8 @@ pub enum ProgressiveWebMetricType {
     FirstContentfulPaint,
     /// Time for the largest contentful paint
     LargestContentfulPaint {
+        /// The identity of the element, if any.
+        id: LCPCandidateID,
         /// The pixel area of the largest contentful element.
         area: usize,
         /// The URL of the largest contentful element, if any.

--- a/tests/wpt/meta/largest-contentful-paint/image-removed-before-load.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/image-removed-before-load.html.ini
@@ -1,4 +1,3 @@
 [image-removed-before-load.html]
-  expected: TIMEOUT
   [Largest Contentful Paint: image removed before loaded does not produce entry.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/image-upscaling-empty-url.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/image-upscaling-empty-url.html.ini
@@ -1,31 +1,6 @@
 [image-upscaling-empty-url.html]
-  expected: TIMEOUT
-  [Non-scaled image should report the natural size]
-    expected: TIMEOUT
-
-  [A downscaled image (width/height) should report the displayed size]
-    expected: NOTRUN
-
-  [A downscaled image (using scale) should report the displayed size]
-    expected: NOTRUN
-
   [An upscaled image (width/height) should report the natural size]
-    expected: NOTRUN
-
-  [An upscaled image (using scale) should report the natural size]
-    expected: NOTRUN
-
-  [An upscaled image (using object-size) should report the natural size]
-    expected: NOTRUN
-
-  [Intersecting element with partial-intersecting image to report image intersection]
-    expected: NOTRUN
-
-  [A background image larger than the container should report the container size]
-    expected: NOTRUN
+    expected: FAIL
 
   [A background image smaller than the container should report the natural size]
-    expected: NOTRUN
-
-  [A scaled-down background image should report the background size]
-    expected: NOTRUN
+    expected: FAIL


### PR DESCRIPTION
Wire the logic for `element` on `LargestContentfulPaint` using `OpaqueNode`

While processing the `ReflowResult`, `OpaqueNode` is resolved and `Element` is stored in HashMap located in  `document`. 

Testing: New WPT Passed (+ To be Added in #46851)
Fixes: Part of #42000
