### PR TITLE
layout: Trace `reflow_goal` parameter in `Layout::handle_reflow`

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -965,7 +965,10 @@ impl LayoutThread {
     }
 
     /// The high-level routine that performs layout.
-    #[servo_tracing::instrument(skip_all)]
+    #[servo_tracing::instrument(
+        skip_all,
+        fields(goal = tracing::field::debug(&reflow_request.reflow_goal))
+    )]
     fn handle_reflow(&mut self, mut reflow_request: ReflowRequest) -> Option<ReflowResult> {
         self.maybe_print_reflow_event(&reflow_request);
 


### PR DESCRIPTION
This is useful when analyzing reflow via perfetto / hitrace.

Testing: The tracing feature is enabled in the HarmonyOS build job in CI, hence compilation is tested.

