### PR TITLE
script: Remove `Document::switch_the_fontfaceset_to_loading_if_needed`

### DIFF
--- a/components/script/dom/css/csskeyframesrule.rs
+++ b/components/script/dom/css/csskeyframesrule.rs
@@ -115,7 +115,7 @@ impl CSSKeyframesRuleMethods<crate::DomTypeHolder> for CSSKeyframesRule {
     }
 
     /// <https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-appendrule>
-    fn AppendRule(&self, cx: &mut JSContext, rule: DOMString) {
+    fn AppendRule(&self, rule: DOMString) {
         let style_stylesheet = self.css_rule.parent_stylesheet().style_stylesheet();
         let rule = rule.str();
         let rule = {
@@ -128,7 +128,7 @@ impl CSSKeyframesRuleMethods<crate::DomTypeHolder> for CSSKeyframesRule {
         };
 
         if let Ok(rule) = rule {
-            self.css_rule.parent_stylesheet().will_modify(cx);
+            self.css_rule.parent_stylesheet().will_modify();
             {
                 let mut guard = self.css_rule.shared_lock().write();
                 self.keyframes_rule
@@ -178,11 +178,11 @@ impl CSSKeyframesRuleMethods<crate::DomTypeHolder> for CSSKeyframesRule {
     }
 
     /// <https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-name>
-    fn SetName(&self, cx: &mut JSContext, value: DOMString) -> ErrorResult {
+    fn SetName(&self, value: DOMString) -> ErrorResult {
         // Spec deviation: https://github.com/w3c/csswg-drafts/issues/801
         // Setting this property to a CSS-wide keyword or `none` does not throw,
         // it stores a value that serializes as a quoted string.
-        self.css_rule.parent_stylesheet().will_modify(cx);
+        self.css_rule.parent_stylesheet().will_modify();
         let name = KeyframesName::from_ident(&value.str());
         let mut guard = self.css_rule.shared_lock().write();
         self.keyframes_rule.borrow().write_with(&mut guard).name = name;

--- a/components/script/dom/css/cssrulelist.rs
+++ b/components/script/dom/css/cssrulelist.rs
@@ -110,7 +110,7 @@ impl CSSRuleList {
         containing_rule_types: CssRuleTypes,
         parse_relative_rule_type: Option<CssRuleType>,
     ) -> Fallible<u32> {
-        self.parent_stylesheet.will_modify(cx);
+        self.parent_stylesheet.will_modify();
         let css_rules = if let RulesSource::Rules(rules) = &*self.rules.borrow() {
             rules.clone()
         } else {
@@ -159,7 +159,7 @@ impl CSSRuleList {
         }
 
         let parent_stylesheet = &*self.parent_stylesheet;
-        parent_stylesheet.will_modify(cx);
+        parent_stylesheet.will_modify();
         let dom_rule = CSSRule::new_specific(cx, window, parent_stylesheet, new_rule);
         self.dom_rules
             .safe_borrow_mut(cx.no_gc())
@@ -170,7 +170,7 @@ impl CSSRuleList {
 
     /// In case of a keyframe rule, index must be valid.
     pub(crate) fn remove_rule(&self, cx: &mut JSContext, index: u32) -> ErrorResult {
-        self.parent_stylesheet.will_modify(cx);
+        self.parent_stylesheet.will_modify();
 
         let index = index as usize;
         let mut guard = self.parent_stylesheet.shared_lock().write();

--- a/components/script/dom/css/cssstyledeclaration.rs
+++ b/components/script/dom/css/cssstyledeclaration.rs
@@ -125,7 +125,7 @@ impl CSSStyleOwner {
                 result
             },
             CSSStyleOwner::CSSRule(ref rule, ref pdb) => {
-                rule.parent_stylesheet().will_modify(cx);
+                rule.parent_stylesheet().will_modify();
                 let result = {
                     let mut guard = rule.shared_lock().write();
                     f(&mut *pdb.borrow().write_with(&mut guard), &mut changed)

--- a/components/script/dom/css/cssstylerule.rs
+++ b/components/script/dom/css/cssstylerule.rs
@@ -143,7 +143,7 @@ impl CSSStyleRuleMethods<crate::DomTypeHolder> for CSSStyleRule {
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-cssstylerule-selectortext>
-    fn SetSelectorText(&self, cx: &mut JSContext, value: DOMString) {
+    fn SetSelectorText(&self, value: DOMString) {
         let value = value.str();
         let Ok(mut selector) = ({
             let guard = self.css_grouping_rule.shared_lock().read();
@@ -168,7 +168,7 @@ impl CSSStyleRuleMethods<crate::DomTypeHolder> for CSSStyleRule {
         }) else {
             return;
         };
-        self.css_grouping_rule.parent_stylesheet().will_modify(cx);
+        self.css_grouping_rule.parent_stylesheet().will_modify();
         // This mirrors what we do in CSSStyleOwner::mutate_associated_block.
         let mut guard = self.css_grouping_rule.shared_lock().write();
         mem::swap(

--- a/components/script/dom/css/cssstylesheet.rs
+++ b/components/script/dom/css/cssstylesheet.rs
@@ -259,7 +259,7 @@ impl CSSStyleSheet {
         }
     }
 
-    pub(crate) fn will_modify(&self, cx: &mut JSContext) {
+    pub(crate) fn will_modify(&self) {
         let Some(node) = self.owner_node.get() else {
             return;
         };
@@ -268,7 +268,7 @@ impl CSSStyleSheet {
             return;
         };
 
-        node.will_modify_stylesheet(cx);
+        node.will_modify_stylesheet();
     }
 
     pub(crate) fn update_style_stylesheet(
@@ -305,12 +305,12 @@ impl CSSStyleSheet {
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-cssstylesheet-replacesync> Steps 2+
-    fn do_replace_sync(&self, cx: &mut JSContext, text: USVString) {
+    fn do_replace_sync(&self, text: USVString) {
         // Step 2. Let rules be the result of running parse a stylesheet’s contents from text.
         let global = self.global();
         let window = global.as_window();
 
-        self.will_modify(cx);
+        self.will_modify();
 
         let _span = profile_traits::trace_span!("ParseStylesheet").entered();
         let sheet = self.style_stylesheet();
@@ -509,7 +509,7 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
                 let sheet = trusted_sheet.root();
 
                 // Step 4.1..4.3
-                sheet.do_replace_sync(cx, text);
+                sheet.do_replace_sync(text);
 
                 // Step 4.4. Unset sheet’s disallow modification flag.
                 sheet.disallow_modification.set(false);
@@ -522,7 +522,7 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-cssstylesheet-replacesync>
-    fn ReplaceSync(&self, cx: &mut js::context::JSContext, text: USVString) -> Result<(), Error> {
+    fn ReplaceSync(&self, text: USVString) -> Result<(), Error> {
         // Step 1. If the constructed flag is not set, or the disallow modification flag is set,
         // throw a NotAllowedError DOMException.
         if !self.is_constructed() || self.disallow_modification() {
@@ -535,7 +535,7 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
                 "This method can only be called on modifiable style sheets".to_string(),
             )));
         }
-        self.do_replace_sync(cx, text);
+        self.do_replace_sync(text);
         Ok(())
     }
 }

--- a/components/script/dom/css/stylesheetlist.rs
+++ b/components/script/dom/css/stylesheetlist.rs
@@ -46,30 +46,19 @@ impl StyleSheetListOwner {
         }
     }
 
-    pub(crate) fn add_owned_stylesheet(
-        &self,
-        cx: &mut js::context::JSContext,
-        owner_node: &Element,
-        sheet: Arc<Stylesheet>,
-    ) {
+    pub(crate) fn add_owned_stylesheet(&self, owner_node: &Element, sheet: Arc<Stylesheet>) {
         match *self {
-            StyleSheetListOwner::Document(ref doc) => {
-                doc.add_owned_stylesheet(cx, owner_node, sheet)
-            },
+            StyleSheetListOwner::Document(ref doc) => doc.add_owned_stylesheet(owner_node, sheet),
             StyleSheetListOwner::ShadowRoot(ref shadow_root) => {
                 shadow_root.add_owned_stylesheet(owner_node, sheet)
             },
         }
     }
 
-    pub(crate) fn append_constructed_stylesheet(
-        &self,
-        cx: &mut js::context::JSContext,
-        cssom_stylesheet: &CSSStyleSheet,
-    ) {
+    pub(crate) fn append_constructed_stylesheet(&self, cssom_stylesheet: &CSSStyleSheet) {
         match *self {
             StyleSheetListOwner::Document(ref doc) => {
-                doc.append_constructed_stylesheet(cx, cssom_stylesheet)
+                doc.append_constructed_stylesheet(cssom_stylesheet)
             },
             StyleSheetListOwner::ShadowRoot(ref shadow_root) => {
                 shadow_root.append_constructed_stylesheet(cssom_stylesheet)

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -4443,12 +4443,7 @@ impl Document {
     ///
     /// <https://drafts.csswg.org/cssom/#documentorshadowroot-final-css-style-sheets>
     #[cfg_attr(crown, expect(crown::unrooted_must_root))] // Owner needs to be rooted already necessarily.
-    pub(crate) fn add_owned_stylesheet(
-        &self,
-        cx: &mut JSContext,
-        owner_node: &Element,
-        sheet: Arc<Stylesheet>,
-    ) {
+    pub(crate) fn add_owned_stylesheet(&self, owner_node: &Element, sheet: Arc<Stylesheet>) {
         let insertion_point = {
             let stylesheets = &mut *self.stylesheets.borrow_mut();
 
@@ -4471,7 +4466,6 @@ impl Document {
 
         if self.has_browsing_context() {
             self.add_stylesheet_to_stylist(
-                cx,
                 sheet.clone(),
                 insertion_point.as_ref().map(|s| s.sheet.clone()),
             );
@@ -4492,11 +4486,7 @@ impl Document {
     ///
     /// <https://drafts.csswg.org/cssom/#documentorshadowroot-final-css-style-sheets>
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-    pub(crate) fn append_constructed_stylesheet(
-        &self,
-        cx: &mut JSContext,
-        cssom_stylesheet: &CSSStyleSheet,
-    ) {
+    pub(crate) fn append_constructed_stylesheet(&self, cssom_stylesheet: &CSSStyleSheet) {
         debug_assert!(cssom_stylesheet.is_constructed());
 
         let sheet = cssom_stylesheet.style_stylesheet().clone();
@@ -4512,7 +4502,6 @@ impl Document {
 
         if self.has_browsing_context() {
             self.add_stylesheet_to_stylist(
-                cx,
                 sheet.clone(),
                 insertion_point.as_ref().map(|s| s.sheet.clone()),
             );
@@ -4528,24 +4517,14 @@ impl Document {
         );
     }
 
-    pub(crate) fn switch_font_face_set_to_loading_if_needed(&self, cx: &mut JSContext) {
-        if self.window.font_context().web_fonts_still_loading() != 0 &&
-            let Some(font_face_set) = self.fonts.get()
-        {
-            font_face_set.switch_to_loading(cx);
-        }
-    }
-
     pub(crate) fn add_stylesheet_to_stylist(
         &self,
-        cx: &mut JSContext,
         stylesheet: Arc<Stylesheet>,
         before_stylesheet: Option<Arc<Stylesheet>>,
     ) {
         self.window
             .layout_mut()
             .add_stylesheet(stylesheet, before_stylesheet);
-        self.switch_font_face_set_to_loading_if_needed(cx);
     }
 
     /// Remove a stylesheet owned by `owner` from the list of document sheets.

--- a/components/script/dom/document/documentorshadowroot.rs
+++ b/components/script/dom/document/documentorshadowroot.rs
@@ -372,7 +372,6 @@ impl DocumentOrShadowRoot {
     // TODO: Handle duplicated adoptedstylesheet correctly, Stylo is preventing duplicates inside a
     //       Stylesheet Set. But this is not ideal. https://bugzilla.mozilla.org/show_bug.cgi?id=1978755
     fn set_adopted_stylesheet(
-        cx: &mut JSContext,
         adopted_stylesheets: &mut Vec<Dom<CSSStyleSheet>>,
         incoming_stylesheets: &[Dom<CSSStyleSheet>],
         owner: &StyleSheetListOwner,
@@ -431,7 +430,7 @@ impl DocumentOrShadowRoot {
                 sheet.add_adopter(owner.clone());
             }
 
-            owner.append_constructed_stylesheet(cx, sheet);
+            owner.append_constructed_stylesheet(sheet);
         }
 
         *adopted_stylesheets = incoming_stylesheets.to_vec();
@@ -456,7 +455,6 @@ impl DocumentOrShadowRoot {
                 rooted_vec!(let stylesheets <- stylesheets.iter().map(|s| s.as_traced()));
 
                 DocumentOrShadowRoot::set_adopted_stylesheet(
-                    cx,
                     adopted_stylesheets,
                     &stylesheets,
                     owner,

--- a/components/script/dom/html/documentmetadata/htmllinkelement.rs
+++ b/components/script/dom/html/documentmetadata/htmllinkelement.rs
@@ -176,11 +176,7 @@ impl HTMLLinkElement {
     // FIXME(emilio): These methods are duplicated with
     // HTMLStyleElement::set_stylesheet.
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-    pub(crate) fn set_stylesheet(
-        &self,
-        cx: &mut js::context::JSContext,
-        new_stylesheet: Arc<Stylesheet>,
-    ) {
+    pub(crate) fn set_stylesheet(&self, new_stylesheet: Arc<Stylesheet>) {
         let owner = self.stylesheet_list_owner();
         if let Some(old_stylesheet) = self.stylesheet.borrow_mut().replace(new_stylesheet.clone()) {
             owner.remove_stylesheet(
@@ -188,7 +184,7 @@ impl HTMLLinkElement {
                 &old_stylesheet,
             );
         }
-        owner.add_owned_stylesheet(cx, self.upcast(), new_stylesheet);
+        owner.add_owned_stylesheet(self.upcast(), new_stylesheet);
     }
 
     pub(crate) fn get_stylesheet(&self) -> Option<Arc<Stylesheet>> {

--- a/components/script/dom/html/documentmetadata/htmlstyleelement.rs
+++ b/components/script/dom/html/documentmetadata/htmlstyleelement.rs
@@ -210,7 +210,7 @@ impl HTMLStyleElement {
 
         // Finally, update our stylesheet, regardless of which scenario we ran into
         self.clean_stylesheet_ownership();
-        self.set_stylesheet(cx, sheet, cache_key);
+        self.set_stylesheet(sheet, cache_key);
     }
 
     // FIXME(emilio): This is duplicated with HTMLLinkElement::set_stylesheet.
@@ -219,24 +219,23 @@ impl HTMLStyleElement {
     // this function has a bit difference with `HTMLLinkElement::set_stylesheet` now.
     pub(crate) fn set_stylesheet(
         &self,
-        cx: &mut JSContext,
         s: Arc<Stylesheet>,
         cache_key: Option<StylesheetContentsCacheKey>,
     ) {
         *self.stylesheet.borrow_mut() = Some(s.clone());
         *self.stylesheetcontents_cache_key.borrow_mut() = cache_key;
         self.stylesheet_list_owner()
-            .add_owned_stylesheet(cx, self.upcast(), s);
+            .add_owned_stylesheet(self.upcast(), s);
     }
 
-    pub(crate) fn will_modify_stylesheet(&self, cx: &mut JSContext) {
+    pub(crate) fn will_modify_stylesheet(&self) {
         if let Some(stylesheet_with_owned_contents) = self.create_owned_contents_stylesheet() {
             self.remove_stylesheet();
             if let Some(cssom_stylesheet) = self.cssom_stylesheet.get() {
                 let guard = stylesheet_with_owned_contents.shared_lock.read();
                 cssom_stylesheet.update_style_stylesheet(&stylesheet_with_owned_contents, &guard);
             }
-            self.set_stylesheet(cx, stylesheet_with_owned_contents, None);
+            self.set_stylesheet(stylesheet_with_owned_contents, None);
         }
     }
 

--- a/components/script/dom/media/medialist.rs
+++ b/components/script/dom/media/medialist.rs
@@ -156,8 +156,8 @@ impl MediaListMethods<crate::DomTypeHolder> for MediaList {
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-medialist-mediatext>
-    fn SetMediaText(&self, cx: &mut JSContext, value: DOMString) {
-        self.parent_stylesheet.will_modify(cx);
+    fn SetMediaText(&self, value: DOMString) {
+        self.parent_stylesheet.will_modify();
         let global = self.global();
         let mut guard = self.shared_lock().write();
         let media_queries_borrowed = self.media_queries.borrow();
@@ -193,7 +193,7 @@ impl MediaListMethods<crate::DomTypeHolder> for MediaList {
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-medialist-appendmedium>
-    fn AppendMedium(&self, cx: &mut JSContext, medium: DOMString) {
+    fn AppendMedium(&self, medium: DOMString) {
         // Step 1
         let global = self.global();
         let medium = medium.str();
@@ -218,7 +218,7 @@ impl MediaListMethods<crate::DomTypeHolder> for MediaList {
             }
         }
         // Step 4
-        self.parent_stylesheet.will_modify(cx);
+        self.parent_stylesheet.will_modify();
         let mut guard = self.shared_lock().write();
         self.media_queries
             .borrow()
@@ -229,7 +229,7 @@ impl MediaListMethods<crate::DomTypeHolder> for MediaList {
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-medialist-deletemedium>
-    fn DeleteMedium(&self, cx: &mut JSContext, medium: DOMString) {
+    fn DeleteMedium(&self, medium: DOMString) {
         // Step 1
         let global = self.global();
         let medium = medium.str();
@@ -239,7 +239,7 @@ impl MediaListMethods<crate::DomTypeHolder> for MediaList {
             return;
         }
         // Step 3
-        self.parent_stylesheet.will_modify(cx);
+        self.parent_stylesheet.will_modify();
         let m_serialized = m.unwrap().to_css_string();
         let mut guard = self.shared_lock().write();
         let media_queries_borrowed = self.media_queries.borrow();

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -300,7 +300,7 @@ impl StylesheetContext {
                 //
                 // Note that even in the failure case, we should create an empty stylesheet.
                 // That's why `set_stylesheet` also removes the previous stylesheet
-                link.set_stylesheet(cx, stylesheet);
+                link.set_stylesheet(stylesheet);
             },
             StylesheetContextSource::Import(import_rule) => {
                 let mut guard = document.style_shared_author_lock().write();

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -143,7 +143,7 @@ DOMInterfaces = {
 },
 
 'CSSKeyframesRule': {
-    'cx': ['AppendRule', 'CssRules', 'DeleteRule', 'FindRule', 'SetName'],
+    'cx': ['CssRules', 'DeleteRule', 'FindRule'],
 },
 
 'CSSLayerStatementRule': {
@@ -163,7 +163,7 @@ DOMInterfaces = {
 },
 
 'CSSStyleRule': {
-    'cx': ['SetSelectorText', 'Style'],
+    'cx': ['Style'],
 },
 
 'CSSStyleSheet': {
@@ -174,7 +174,6 @@ DOMInterfaces = {
         'GetCssRules',
         'GetRules',
         'InsertRule',
-        'ReplaceSync',
         'RemoveRule'
     ],
 },
@@ -837,14 +836,6 @@ DOMInterfaces = {
 'MediaDevices': {
     'realm': ['GetUserMedia'],
     'cx': ['EnumerateDevices'],
-},
-
-'MediaList': {
-    'cx': [
-        'AppendMedium',
-        'DeleteMedium',
-        'SetMediaText',
-    ],
 },
 
 'MediaQueryList': {

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -283,13 +283,14 @@ pub trait Layout {
     /// if the [`ViewportDetails`] actually changed or `false` otherwise.
     fn set_viewport_details(&mut self, viewport_details: ViewportDetails) -> bool;
 
-    /// Add a stylesheet to this Layout. This will add it to the Layout's `Stylist` as well as
-    /// loading all web fonts defined in the stylesheet. The second stylesheet is the insertion
-    /// point (if it exists, the sheet needs to be inserted before it).
+    /// Add a stylesheet to this Layout's `Stylist`.
+    ///
+    /// The second stylesheet is the insertion point (if it exists, the sheet needs to be
+    /// inserted before it).
     fn add_stylesheet(
         &mut self,
         stylesheet: ServoArc<Stylesheet>,
-        before_stylsheet: Option<ServoArc<Stylesheet>>,
+        before_stylesheet: Option<ServoArc<Stylesheet>>,
     );
 
     /// Inform the layout that its ScriptThread is about to exit.


### PR DESCRIPTION
After https://github.com/servo/servo/pull/46541 this method is only used in one place where it can never possibly discover any fonts (that is a leftover from the migration to loading fonts from the `Stylist` instead of the stylesheet).

Testing: Regressions are covered by existing tests, no change in behaviour is intended.