### PR TITLE
Use subfont when setting harfbuzz font funcs

### DIFF
--- a/components/fonts/shapers/harfbuzz.rs
+++ b/components/fonts/shapers/harfbuzz.rs
@@ -225,15 +225,15 @@ impl Shaper {
                 }
             }
 
-            // Create subfont before setting font-funcs so that we can
-            // inherit the default font-funcs for the funcs we don't set
+            // Create a subfont before setting font-funcs so that we can
+            // inherit the default font-funcs for the funcs we don't set.
             let hb_font = {
                 let sub_font = hb_font_create_sub_font(hb_font);
                 hb_font_destroy(hb_font);
                 sub_font
             };
 
-            // configure static function callbacks.
+            // Now configure the subset of function callbacks that we do implement.
             hb_font_set_funcs(
                 hb_font,
                 HB_FONT_FUNCS.0,

--- a/components/fonts/shapers/harfbuzz.rs
+++ b/components/fonts/shapers/harfbuzz.rs
@@ -20,11 +20,12 @@ use harfbuzz_sys::{
     hb_buffer_get_glyph_infos, hb_buffer_get_glyph_positions, hb_buffer_get_length,
     hb_buffer_set_cluster_level, hb_buffer_set_direction, hb_buffer_set_language,
     hb_buffer_set_script, hb_buffer_t, hb_codepoint_t, hb_face_create_for_tables, hb_face_destroy,
-    hb_face_t, hb_feature_t, hb_font_create, hb_font_destroy, hb_font_funcs_create,
-    hb_font_funcs_set_glyph_h_advance_func, hb_font_funcs_set_nominal_glyph_func, hb_font_funcs_t,
-    hb_font_set_funcs, hb_font_set_ppem, hb_font_set_scale, hb_font_set_variations, hb_font_t,
-    hb_glyph_info_t, hb_glyph_position_t, hb_language_from_string, hb_ot_layout_get_baseline,
-    hb_position_t, hb_script_from_iso15924_tag, hb_shape, hb_tag_t, hb_variation_t,
+    hb_face_t, hb_feature_t, hb_font_create, hb_font_create_sub_font, hb_font_destroy,
+    hb_font_funcs_create, hb_font_funcs_set_glyph_h_advance_func,
+    hb_font_funcs_set_nominal_glyph_func, hb_font_funcs_t, hb_font_set_funcs, hb_font_set_ppem,
+    hb_font_set_scale, hb_font_set_variations, hb_font_t, hb_glyph_info_t, hb_glyph_position_t,
+    hb_language_from_string, hb_ot_layout_get_baseline, hb_position_t, hb_script_from_iso15924_tag,
+    hb_shape, hb_tag_t, hb_variation_t,
 };
 use num_traits::Zero;
 use read_fonts::types::Tag;
@@ -208,14 +209,6 @@ impl Shaper {
                 Shaper::float_to_fixed(pt_size) as c_int,
             );
 
-            // configure static function callbacks.
-            hb_font_set_funcs(
-                hb_font,
-                HB_FONT_FUNCS.0,
-                font as *const Font as *mut c_void,
-                None,
-            );
-
             if servo_config::pref!(layout_variable_fonts_enabled) {
                 let variations = &font.variations();
                 if !variations.is_empty() {
@@ -231,6 +224,22 @@ impl Shaper {
                     hb_font_set_variations(hb_font, variations.as_ptr(), variations.len() as u32);
                 }
             }
+
+            // Create subfont before setting font-funcs so that we can
+            // inherit the default font-funcs for the funcs we don't set
+            let hb_font = {
+                let sub_font = hb_font_create_sub_font(hb_font);
+                hb_font_destroy(hb_font);
+                sub_font
+            };
+
+            // configure static function callbacks.
+            hb_font_set_funcs(
+                hb_font,
+                HB_FONT_FUNCS.0,
+                font as *const Font as *mut c_void,
+                None,
+            );
 
             Shaper {
                 hb_face,


### PR DESCRIPTION
Within a single font, HarfBuzz expects you to either set all of the font funcs or none of them. Setting just one or two as Servo does clobbers the default implementations for the other font funcs. The workaround for this is to create a subfont and set your font funcs on the subfont. The subfont will then inherit the default implementations from it's parent font.

Suggested by Behdad in https://github.com/servo/servo/pull/38707#issuecomment-4588087403

Testing: Not sure how to test this
