### PR TITLE
script: Don't store rooted values inside `FocusableArea`

### DIFF
--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -999,7 +999,7 @@ impl DocumentEventHandler {
                     // See documentation for [`Node::find_click_focusable_area`].
                     document
                         .focus_handler()
-                        .focus(cx, node.find_click_focusable_area(cx));
+                        .focus(cx, &node.find_click_focusable_area(cx));
                 }
 
                 // Step 9. If mbutton is the secondary mouse button, then
@@ -1572,7 +1572,7 @@ impl DocumentEventHandler {
         let document = self.window.Document();
         let composition_event = match event {
             ImeEvent::Dismissed => {
-                document.focus_handler().focus(cx, FocusableArea::Viewport);
+                document.focus_handler().focus(cx, &FocusableArea::Viewport);
                 return Default::default();
             },
             ImeEvent::Composition(composition_event) => composition_event,

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -999,7 +999,7 @@ impl DocumentEventHandler {
                     // See documentation for [`Node::find_click_focusable_area`].
                     document
                         .focus_handler()
-                        .focus(cx, node.find_click_focusable_area(cx.no_gc()));
+                        .focus(cx, node.find_click_focusable_area(cx));
                 }
 
                 // Step 9. If mbutton is the secondary mouse button, then

--- a/components/script/dom/document/focus.rs
+++ b/components/script/dom/document/focus.rs
@@ -53,20 +53,23 @@ bitflags! {
 
 /// <https://html.spec.whatwg.org/multipage/#focusable-area>
 #[derive(Clone, Default, JSTraceable, MallocSizeOf, PartialEq)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) enum FocusableArea {
     Node {
-        node: DomRoot<Node>,
+        node: Dom<Node>,
         kind: FocusableAreaKind,
     },
     /// The viewport of an `<iframe>` element in its containing `Document`. `<iframe>`s
     /// are focusable areas, but have special behavior when focusing.
     IFrameViewport {
-        iframe_element: DomRoot<HTMLIFrameElement>,
+        iframe_element: Dom<HTMLIFrameElement>,
         kind: FocusableAreaKind,
     },
     #[default]
     Viewport,
 }
+
+impl js::gc::Rootable for FocusableArea {}
 
 impl std::fmt::Debug for FocusableArea {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -114,7 +117,7 @@ impl FocusableArea {
     /// <https://html.spec.whatwg.org/multipage/#dom-anchor>
     pub(crate) fn dom_anchor(&self, document: &Document) -> DomRoot<Node> {
         match self {
-            Self::Node { node, .. } => node.clone(),
+            Self::Node { node, .. } => node.as_rooted(),
             Self::IFrameViewport { iframe_element, .. } => {
                 DomRoot::from_ref(iframe_element.upcast())
             },
@@ -183,6 +186,7 @@ impl DocumentFocusHandler {
     /// set element (if any) and the new one, as well as the new one. This will not do anything if
     /// the new element is the same as the previous one. Note that this *will not* fire any focus
     /// events. If that is necessary the [`DocumentFocusHandler::focus`] should be used.
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn set_focused_area(&self, new_focusable_area: FocusableArea) {
         if new_focusable_area == *self.focused_area.borrow() {
             return;
@@ -255,10 +259,14 @@ impl DocumentFocusHandler {
 
     /// Reassign the focus context to the element that last requested focus during this
     /// transaction, or the document if no elements requested it.
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn focus(&self, cx: &mut JSContext, new_focus_target: FocusableArea) {
-        let old_focus_chain = self.current_focus_chain();
-        let new_focus_chain = new_focus_target.focus_chain();
-        self.focus_update_steps(cx, new_focus_chain, old_focus_chain, &new_focus_target);
+        self.focus_update_steps(
+            cx,
+            new_focus_target.focus_chain(),
+            self.current_focus_chain(),
+            &new_focus_target,
+        );
 
         // Advertise the change in the focus chain.
         // <https://html.spec.whatwg.org/multipage/#focus-chain>
@@ -283,9 +291,9 @@ impl DocumentFocusHandler {
         // >     `new focus target` to the nested browsing context's
         // >     active document.
         let child_browsing_context_id = match new_focus_target {
-            FocusableArea::IFrameViewport { iframe_element, .. } => {
-                iframe_element.browsing_context_id()
-            },
+            FocusableArea::IFrameViewport {
+                ref iframe_element, ..
+            } => iframe_element.browsing_context_id(),
             _ => None,
         };
         let sequence = self.increment_fetch_focus_sequence();
@@ -304,6 +312,7 @@ impl DocumentFocusHandler {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#focus-update-steps>
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn focus_update_steps(
         &self,
         cx: &mut JSContext,

--- a/components/script/dom/document/focus.rs
+++ b/components/script/dom/document/focus.rs
@@ -260,12 +260,11 @@ impl DocumentFocusHandler {
 
     /// Reassign the focus context to the element that last requested focus during this
     /// transaction, or the document if no elements requested it.
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-    pub(crate) fn focus(&self, cx: &mut JSContext, new_focus_target: FocusableArea) {
+    pub(crate) fn focus(&self, cx: &mut JSContext, new_focus_target: &FocusableArea) {
         rooted!(&in(cx) let new_focus_chain = new_focus_target.focus_chain());
         rooted!(&in(cx) let old_focus_chain = self.current_focus_chain());
 
-        self.focus_update_steps(cx, new_focus_chain, old_focus_chain, &new_focus_target);
+        self.focus_update_steps(cx, new_focus_chain, old_focus_chain, new_focus_target);
 
         // Advertise the change in the focus chain.
         // <https://html.spec.whatwg.org/multipage/#focus-chain>
@@ -290,9 +289,9 @@ impl DocumentFocusHandler {
         // >     `new focus target` to the nested browsing context's
         // >     active document.
         let child_browsing_context_id = match new_focus_target {
-            FocusableArea::IFrameViewport {
-                ref iframe_element, ..
-            } => iframe_element.browsing_context_id(),
+            FocusableArea::IFrameViewport { iframe_element, .. } => {
+                iframe_element.browsing_context_id()
+            },
             _ => None,
         };
         let sequence = self.increment_fetch_focus_sequence();
@@ -529,7 +528,7 @@ impl DocumentFocusHandler {
         {
             return;
         }
-        self.focus(cx, FocusableArea::Viewport);
+        self.focus(cx, &FocusableArea::Viewport);
     }
 
     pub(crate) fn set_sequential_focus_navigation_starting_point(&self, node: &Node) {
@@ -673,7 +672,7 @@ impl DocumentFocusHandler {
         // a child `<iframe>` and within a Document. If no suitable focusable area can be found
         // when moving into an `<iframe>`, we want to focus the `<iframe>`'s viewport itself.
         if allow_focusing_viewport {
-            self.focus(cx, FocusableArea::Viewport);
+            self.focus(cx, &FocusableArea::Viewport);
             return;
         }
 

--- a/components/script/dom/document/focus.rs
+++ b/components/script/dom/document/focus.rs
@@ -8,6 +8,7 @@ use std::cmp::Ordering;
 use bitflags::bitflags;
 use embedder_traits::FocusSequenceNumber;
 use js::context::{JSContext, NoGC};
+use js::gc::RootedGuard;
 use keyboard_types::Modifiers;
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::HTMLIFrameElementBinding::HTMLIFrameElementMethods;
@@ -261,12 +262,10 @@ impl DocumentFocusHandler {
     /// transaction, or the document if no elements requested it.
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn focus(&self, cx: &mut JSContext, new_focus_target: FocusableArea) {
-        self.focus_update_steps(
-            cx,
-            new_focus_target.focus_chain(),
-            self.current_focus_chain(),
-            &new_focus_target,
-        );
+        rooted!(&in(cx) let new_focus_chain = new_focus_target.focus_chain());
+        rooted!(&in(cx) let old_focus_chain = self.current_focus_chain());
+
+        self.focus_update_steps(cx, new_focus_chain, old_focus_chain, &new_focus_target);
 
         // Advertise the change in the focus chain.
         // <https://html.spec.whatwg.org/multipage/#focus-chain>
@@ -312,12 +311,11 @@ impl DocumentFocusHandler {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#focus-update-steps>
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn focus_update_steps(
         &self,
         cx: &mut JSContext,
-        mut new_focus_chain: Vec<FocusableArea>,
-        mut old_focus_chain: Vec<FocusableArea>,
+        mut new_focus_chain: RootedGuard<'_, Vec<FocusableArea>>,
+        mut old_focus_chain: RootedGuard<'_, Vec<FocusableArea>>,
         new_focus_target: &FocusableArea,
     ) {
         let new_focus_chain_was_empty = new_focus_chain.is_empty();
@@ -331,8 +329,8 @@ impl DocumentFocusHandler {
             (new_focus_chain.last(), old_focus_chain.last())
         {
             if last_new == last_old {
-                new_focus_chain.pop();
-                old_focus_chain.pop();
+                new_focus_chain.as_mut_ref(cx.no_gc()).pop();
+                old_focus_chain.as_mut_ref(cx.no_gc()).pop();
             } else {
                 break;
             }

--- a/components/script/dom/html/htmldialogelement.rs
+++ b/components/script/dom/html/htmldialogelement.rs
@@ -325,7 +325,7 @@ impl HTMLDialogElement {
         // FIXME: Use the focusing step once they support a focusable area as an argument
         if control.is_some() {
             let document = self.owner_document();
-            document.focus_handler().focus(cx, control.take().unwrap());
+            document.focus_handler().focus(cx, &control.take().unwrap());
         }
 
         // TODO: Step 7. Let topDocument be control's node navigable's top-level traversable's active document.

--- a/components/script/dom/html/htmldialogelement.rs
+++ b/components/script/dom/html/htmldialogelement.rs
@@ -304,28 +304,28 @@ impl HTMLDialogElement {
         // TODO: Step 1. If the allow focus steps given subject's node document return false, then return.
 
         // Step 2. Let control be null.
-        let mut control = None;
+        rooted!(&in(cx) let mut control = None);
 
         // Step 3. If subject has the autofocus attribute, then set control to subject.
         if self.upcast::<HTMLElement>().Autofocus() {
-            control = self.upcast::<Node>().get_the_focusable_area(cx.no_gc());
+            control.set(self.upcast::<Node>().get_the_focusable_area(cx));
         }
 
         // Step 4. If control is null, then set control to the focus delegate of subject.
         if control.is_none() {
-            control = self.upcast::<Node>().focus_delegate(cx.no_gc());
+            control.set(self.upcast::<Node>().focus_delegate(cx));
         }
 
         // Step 5. If control is null, then set control to subject.
         if control.is_none() {
-            control = self.upcast::<Node>().get_the_focusable_area(cx.no_gc());
+            control.set(self.upcast::<Node>().get_the_focusable_area(cx));
         }
 
         // Step 6. Run the focusing steps for control.
         // FIXME: Use the focusing step once they support a focusable area as an argument
-        if let Some(control) = control {
+        if control.is_some() {
             let document = self.owner_document();
-            document.focus_handler().focus(cx, control);
+            document.focus_handler().focus(cx, control.take().unwrap());
         }
 
         // TODO: Step 7. Let topDocument be control's node navigable's top-level traversable's active document.

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -518,7 +518,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         // <https://html.spec.whatwg.org/multipage/#unfocusing-steps>
         self.owner_document()
             .focus_handler()
-            .focus(cx, FocusableArea::Viewport);
+            .focus(cx, &FocusableArea::Viewport);
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-htmlelement-scrollparent>

--- a/components/script/dom/node/focus.rs
+++ b/components/script/dom/node/focus.rs
@@ -4,10 +4,10 @@
 
 use std::collections::VecDeque;
 
-use js::context::{JSContext, NoGC};
+use js::context::JSContext;
 use script_bindings::codegen::GenericBindings::ShadowRootBinding::ShadowRootMethods;
 use script_bindings::inheritance::Castable;
-use script_bindings::root::DomRoot;
+use script_bindings::root::{Dom, DomRoot};
 
 use crate::dom::document::focus::{FocusableArea, FocusableAreaKind};
 use crate::dom::iterators::ShadowIncluding;
@@ -104,10 +104,10 @@ impl Node {
     /// the node from the hit test. This isn't exactly how browsers work though, as they seem
     /// to look for the first inclusive ancestor node that has a focusable area associated with it.
     /// Note also that this may return [`FocusableArea::Viewport`].
-    pub(crate) fn find_click_focusable_area(&self, no_gc: &NoGC) -> FocusableArea {
+    pub(crate) fn find_click_focusable_area(&self, cx: &JSContext) -> FocusableArea {
         self.inclusive_ancestors(ShadowIncluding::Yes)
             .find_map(|node| {
-                node.get_the_focusable_area(no_gc).filter(|focusable_area| {
+                node.get_the_focusable_area(cx).filter(|focusable_area| {
                     focusable_area.kind().contains(FocusableAreaKind::Click)
                 })
             })
@@ -121,25 +121,25 @@ impl Node {
     /// this for a focus target that actually *is* a focusable area. The obvious thing is to
     /// just return the focus target, but it's still odd that this isn't mentioned in the
     /// specification.
-    pub(crate) fn get_the_focusable_area(&self, no_gc: &NoGC) -> Option<FocusableArea> {
+    pub(crate) fn get_the_focusable_area(&self, cx: &JSContext) -> Option<FocusableArea> {
         let kind = self
             .downcast::<Element>()
-            .map(|element| Element::focusable_area_kind(element, no_gc))
+            .map(|element| Element::focusable_area_kind(element, cx.no_gc()))
             .unwrap_or_default();
         if !kind.is_empty() {
             if let Some(iframe_element) = self.downcast::<HTMLIFrameElement>() {
                 return Some(FocusableArea::IFrameViewport {
-                    iframe_element: DomRoot::from_ref(iframe_element),
+                    iframe_element: Dom::from_ref(iframe_element),
                     kind,
                 });
             }
 
             return Some(FocusableArea::Node {
-                node: DomRoot::from_ref(self),
+                node: Dom::from_ref(self),
                 kind,
             });
         }
-        self.get_the_focusable_area_if_not_a_focusable_area(no_gc)
+        self.get_the_focusable_area_if_not_a_focusable_area(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#get-the-focusable-area>
@@ -152,7 +152,7 @@ impl Node {
     /// TODO: It might be better to distinguish these two cases in the future.
     fn get_the_focusable_area_if_not_a_focusable_area(
         &self,
-        no_gc: &NoGC,
+        cx: &JSContext,
     ) -> Option<FocusableArea> {
         // > To get the focusable area for a focus target that is either an element that is not a
         // > focusable area, or is a navigable, given an optional string focus trigger (default
@@ -206,7 +206,7 @@ impl Node {
             }
 
             // >   Step 3. Return the focus delegate for focus target given focus trigger.
-            return self.focus_delegate(no_gc);
+            return self.focus_delegate(cx);
         }
 
         None
@@ -216,7 +216,7 @@ impl Node {
     ///
     /// In addition to returning the focus delegate for this [`Node`], this method also returns
     /// the [`FocusableAreaKind`] for efficiency reasons.
-    pub(crate) fn focus_delegate(&self, no_gc: &NoGC) -> Option<FocusableArea> {
+    pub(crate) fn focus_delegate(&self, cx: &JSContext) -> Option<FocusableArea> {
         // > 1. If focusTarget is a shadow host and its shadow root's delegates focus is false, then
         // >    return null.
         let shadow_root = self.downcast::<Element>().and_then(Element::shadow_root);
@@ -251,11 +251,11 @@ impl Node {
             // >      set focusableArea to descendant.
             let kind = descendant
                 .downcast::<Element>()
-                .map(|node| Element::focusable_area_kind(node, no_gc))
+                .map(|node| Element::focusable_area_kind(node, cx.no_gc()))
                 .unwrap_or_default();
             if is_dialog_element && kind.contains(FocusableAreaKind::Sequential) {
                 return Some(FocusableArea::Node {
-                    node: descendant,
+                    node: descendant.as_traced(),
                     kind,
                 });
             }
@@ -264,18 +264,17 @@ impl Node {
             // >      focusableArea to descendant.
             if !kind.is_empty() {
                 return Some(FocusableArea::Node {
-                    node: descendant,
+                    node: descendant.as_traced(),
                     kind,
                 });
             }
 
             // > 6.4. Otherwise, set focusableArea to the result of getting the focusable area for
             //        descendant given focusTrigger.
-            if let Some(focusable_area) =
-                descendant.get_the_focusable_area_if_not_a_focusable_area(no_gc)
-            {
+            rooted!(&in(cx) let focusable_area = descendant.get_the_focusable_area_if_not_a_focusable_area(cx));
+            if let Some(focusable_area) = &*focusable_area {
                 // > 6.5. If focusableArea is not null, then return focusableArea.
-                return Some(focusable_area);
+                return Some(focusable_area.clone());
             }
         }
 
@@ -291,6 +290,7 @@ impl Node {
     /// specification yet.
     ///
     /// Return `true` if anything was focused or `false` otherwise.
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn run_the_focusing_steps(
         &self,
         cx: &mut JSContext,
@@ -302,10 +302,11 @@ impl Node {
         // > 2. If new focus target is null, then:
         // > 2.1 If no fallback target was specified, then return.
         // > 2.2 Otherwise, set new focus target to the fallback target.
-        let Some(focusable_area) = self.get_the_focusable_area(cx.no_gc()).or(fallback_target)
-        else {
+        rooted!(&in(cx) let mut focusable_area = self.get_the_focusable_area(cx).or(fallback_target));
+
+        if focusable_area.is_none() {
             return false;
-        };
+        }
 
         // > 3. If new focus target is a navigable container with non-null content navigable, then
         // >    set new focus target to the content navigable's active document.
@@ -321,7 +322,9 @@ impl Node {
         // TODO: Handle all of these steps by converting the focus transaction code to follow
         // the HTML focus specification.
         let document = self.owner_document();
-        document.focus_handler().focus(cx, focusable_area);
+        document
+            .focus_handler()
+            .focus(cx, focusable_area.take().unwrap());
         true
     }
 

--- a/components/script/dom/node/focus.rs
+++ b/components/script/dom/node/focus.rs
@@ -324,7 +324,7 @@ impl Node {
         let document = self.owner_document();
         document
             .focus_handler()
-            .focus(cx, focusable_area.take().unwrap());
+            .focus(cx, &focusable_area.take().unwrap());
         true
     }
 

--- a/components/script/dom/svg/svgelement.rs
+++ b/components/script/dom/svg/svgelement.rs
@@ -234,7 +234,7 @@ impl SVGElementMethods<crate::DomTypeHolder> for SVGElement {
         // <https://html.spec.whatwg.org/multipage/#unfocusing-steps>
         self.owner_document()
             .focus_handler()
-            .focus(cx, FocusableArea::Viewport);
+            .focus(cx, &FocusableArea::Viewport);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-tabindex>

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -1356,7 +1356,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         // TODO: Implement this.
 
         // Step 4. Run the focusing steps with current.
-        document.focus_handler().focus(cx, FocusableArea::Viewport);
+        document.focus_handler().focus(cx, &FocusableArea::Viewport);
 
         // Step 5. If current is a top-level traversable, user agents are encouraged to trigger some
         // sort of notification to indicate to the user that the page is attempting to gain focus.

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2956,12 +2956,10 @@ impl ScriptThread {
             .unwrap_or(FocusableArea::Viewport)
         );
 
-        focus_handler.focus_update_steps(
-            cx,
-            focusable_area.focus_chain(),
-            focus_handler.current_focus_chain(),
-            &*focusable_area,
-        );
+        rooted!(&in(cx) let new_focus_chain = focusable_area.focus_chain());
+        rooted!(&in(cx) let old_focus_chain = focus_handler.current_focus_chain());
+
+        focus_handler.focus_update_steps(cx, new_focus_chain, old_focus_chain, &focusable_area);
     }
 
     fn handle_focus_document(
@@ -3011,10 +3009,13 @@ impl ScriptThread {
             return;
         }
 
+        rooted!(&in(cx) let new_focus_chain = vec![]);
+        rooted!(&in(cx) let old_focus_chain = focus_handler.current_focus_chain());
+
         focus_handler.focus_update_steps(
             cx,
-            vec![],
-            focus_handler.current_focus_chain(),
+            new_focus_chain,
+            old_focus_chain,
             &FocusableArea::Viewport,
         );
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2945,23 +2945,22 @@ impl ScriptThread {
                 .get(browsing_context_id)
                 .map(|iframe| iframe.element.as_rooted())
         });
-        let focusable_area = iframe_element
-            .map(|iframe_element| {
-                let kind = iframe_element
+
+        rooted!(&in(cx) let focusable_area = iframe_element
+            .map(|iframe_element| FocusableArea::IFrameViewport {
+                iframe_element: iframe_element.as_traced(),
+                kind: iframe_element
                     .upcast::<Element>()
-                    .focusable_area_kind(cx.no_gc());
-                FocusableArea::IFrameViewport {
-                    iframe_element,
-                    kind,
-                }
+                    .focusable_area_kind(cx.no_gc()),
             })
-            .unwrap_or(FocusableArea::Viewport);
+            .unwrap_or(FocusableArea::Viewport)
+        );
 
         focus_handler.focus_update_steps(
             cx,
             focusable_area.focus_chain(),
             focus_handler.current_focus_chain(),
-            &focusable_area,
+            &*focusable_area,
         );
     }
 


### PR DESCRIPTION


Testing: It compiles
Part of #39139
