### PR TITLE
script: Mechanically migrate more to `reflect_dom_object_with_proto`

### DIFF
--- a/components/script/dom/bluetooth/bluetoothadvertisingevent.rs
+++ b/components/script/dom/bluetooth/bluetoothadvertisingevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::BluetoothAdvertisingEventBinding::{
@@ -65,13 +65,13 @@ impl BluetoothAdvertisingEvent {
         txPower: Option<i8>,
         rssi: Option<i8>,
     ) -> DomRoot<BluetoothAdvertisingEvent> {
-        let ev = reflect_dom_object_with_proto_and_cx(
+        let ev = reflect_dom_object_with_proto(
+            cx,
             Box::new(BluetoothAdvertisingEvent::new_inherited(
                 device, name, appearance, txPower, rssi,
             )),
             global,
             proto,
-            cx,
         );
         {
             let event = ev.upcast::<Event>();

--- a/components/script/dom/broadcastchannel.rs
+++ b/components/script/dom/broadcastchannel.rs
@@ -7,7 +7,7 @@ use std::cell::Cell;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::{HandleObject, HandleValue};
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_constellation_traits::BroadcastChannelMsg;
 use uuid::Uuid;
 
@@ -36,11 +36,11 @@ impl BroadcastChannel {
         proto: Option<HandleObject>,
         name: DOMString,
     ) -> DomRoot<BroadcastChannel> {
-        let channel = reflect_dom_object_with_proto_and_cx(
+        let channel = reflect_dom_object_with_proto(
+            cx,
             Box::new(BroadcastChannel::new_inherited(name)),
             global,
             proto,
-            cx,
         );
         global.track_broadcast_channel(&channel);
         channel

--- a/components/script/dom/clipboard/clipboardevent.rs
+++ b/components/script/dom/clipboard/clipboardevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use script_bindings::str::DOMString;
 use style::Atom;
 
@@ -64,11 +64,11 @@ impl ClipboardEvent {
         cancelable: EventCancelable,
         clipboard_data: Option<&DataTransfer>,
     ) -> DomRoot<ClipboardEvent> {
-        let ev = reflect_dom_object_with_proto_and_cx(
+        let ev = reflect_dom_object_with_proto(
+            cx,
             Box::new(ClipboardEvent::new_inherited()),
             window,
             proto,
-            cx,
         );
         ev.upcast::<Event>()
             .init_event(event_type, bool::from(can_bubble), bool::from(cancelable));

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -52,7 +52,7 @@ use regex::bytes::Regex;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use script_bindings::cell::{DomRefCell, Ref, RefMut};
 use script_bindings::interfaces::DocumentHelpers;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use script_bindings::trace::CustomTraceable;
 use script_traits::{DocumentActivity, ProgressiveWebMetricType};
 use servo_arc::Arc;
@@ -4028,7 +4028,8 @@ impl Document {
         image_cache: StdArc<dyn ImageCache>,
     ) -> DomRoot<Document> {
         let timeline = DocumentTimeline::new(cx, window);
-        let document = reflect_dom_object_with_proto_and_cx(
+        let document = reflect_dom_object_with_proto(
+            cx,
             Box::new(Document::new_inherited(
                 window,
                 has_browsing_context,
@@ -4056,7 +4057,6 @@ impl Document {
             )),
             window,
             proto,
-            cx,
         );
         {
             let node = document.upcast::<Node>();

--- a/components/script/dom/event/animationevent.rs
+++ b/components/script/dom/event/animationevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::AnimationEventBinding::{
@@ -54,11 +54,11 @@ impl AnimationEvent {
         type_: Atom,
         init: &AnimationEventInit,
     ) -> DomRoot<AnimationEvent> {
-        let ev = reflect_dom_object_with_proto_and_cx(
+        let ev = reflect_dom_object_with_proto(
+            cx,
             Box::new(AnimationEvent::new_inherited(init)),
             window,
             proto,
-            cx,
         );
         {
             let event = ev.upcast::<Event>();

--- a/components/script/dom/event/compositionevent.rs
+++ b/components/script/dom/event/compositionevent.rs
@@ -5,9 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::{
-    reflect_dom_object_with_cx, reflect_dom_object_with_proto_and_cx,
-};
+use script_bindings::reflector::{reflect_dom_object_with_cx, reflect_dom_object_with_proto};
 use style::Atom;
 
 use crate::dom::bindings::codegen::Bindings::CompositionEventBinding::{
@@ -69,14 +67,14 @@ impl CompositionEvent {
         detail: i32,
         data: DOMString,
     ) -> DomRoot<CompositionEvent> {
-        let ev = reflect_dom_object_with_proto_and_cx(
+        let ev = reflect_dom_object_with_proto(
+            cx,
             Box::new(CompositionEvent {
                 uievent: UIEvent::new_inherited(),
                 data,
             }),
             window,
             proto,
-            cx,
         );
         ev.uievent
             .init_event(event_type, can_bubble, cancelable, view, detail);

--- a/components/script/dom/event/formdataevent.rs
+++ b/components/script/dom/event/formdataevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -46,14 +46,14 @@ impl FormDataEvent {
         cancelable: EventCancelable,
         form_data: &FormData,
     ) -> DomRoot<FormDataEvent> {
-        let ev = reflect_dom_object_with_proto_and_cx(
+        let ev = reflect_dom_object_with_proto(
+            cx,
             Box::new(FormDataEvent {
                 event: Event::new_inherited(),
                 form_data: Dom::from_ref(form_data),
             }),
             window,
             proto,
-            cx,
         );
 
         {

--- a/components/script/dom/event/inputevent.rs
+++ b/components/script/dom/event/inputevent.rs
@@ -7,7 +7,7 @@ use embedder_traits::Cursor;
 use euclid::Point2D;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use style::Atom;
 use style_traits::CSSPixel;
 
@@ -45,7 +45,8 @@ impl InputEvent {
         is_composing: bool,
         input_type: DOMString,
     ) -> DomRoot<InputEvent> {
-        let event = reflect_dom_object_with_proto_and_cx(
+        let event = reflect_dom_object_with_proto(
+            cx,
             Box::new(InputEvent {
                 uievent: UIEvent::new_inherited(),
                 data,
@@ -54,7 +55,6 @@ impl InputEvent {
             }),
             window,
             proto,
-            cx,
         );
         event
             .uievent

--- a/components/script/dom/event/progressevent.rs
+++ b/components/script/dom/event/progressevent.rs
@@ -6,7 +6,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::num::Finite;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -77,7 +77,8 @@ impl ProgressEvent {
         loaded: Finite<f64>,
         total: Finite<f64>,
     ) -> DomRoot<ProgressEvent> {
-        let ev = reflect_dom_object_with_proto_and_cx(
+        let ev = reflect_dom_object_with_proto(
+            cx,
             Box::new(ProgressEvent::new_inherited(
                 length_computable,
                 loaded,
@@ -85,7 +86,6 @@ impl ProgressEvent {
             )),
             global,
             proto,
-            cx,
         );
         {
             let event = ev.upcast::<Event>();

--- a/components/script/dom/event/promiserejectionevent.rs
+++ b/components/script/dom/event/promiserejectionevent.rs
@@ -9,7 +9,7 @@ use js::context::JSContext;
 use js::jsapi::{Heap, JSObject};
 use js::jsval::JSVal;
 use js::rust::{HandleObject, HandleValue, MutableHandleObject, MutableHandleValue};
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -74,11 +74,11 @@ impl PromiseRejectionEvent {
         promise: HandleObject,
         reason: HandleValue,
     ) -> DomRoot<Self> {
-        let ev = reflect_dom_object_with_proto_and_cx(
+        let ev = reflect_dom_object_with_proto(
+            cx,
             Box::new(PromiseRejectionEvent::new_inherited()),
             global,
             proto,
-            cx,
         );
         ev.promise.set(promise.get());
 

--- a/components/script/dom/event/submitevent.rs
+++ b/components/script/dom/event/submitevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -52,11 +52,11 @@ impl SubmitEvent {
         cancelable: bool,
         submitter: Option<&HTMLElement>,
     ) -> DomRoot<SubmitEvent> {
-        let ev = reflect_dom_object_with_proto_and_cx(
+        let ev = reflect_dom_object_with_proto(
+            cx,
             Box::new(SubmitEvent::new_inherited(submitter)),
             window,
             proto,
-            cx,
         );
         {
             let event = ev.upcast::<Event>();

--- a/components/script/dom/event/transitionevent.rs
+++ b/components/script/dom/event/transitionevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -55,11 +55,11 @@ impl TransitionEvent {
         type_: Atom,
         init: &TransitionEventInit,
     ) -> DomRoot<TransitionEvent> {
-        let ev = reflect_dom_object_with_proto_and_cx(
+        let ev = reflect_dom_object_with_proto(
+            cx,
             Box::new(TransitionEvent::new_inherited(init)),
             window,
             proto,
-            cx,
         );
         {
             let event = ev.upcast::<Event>();

--- a/components/script/dom/gamepad/gamepadevent.rs
+++ b/components/script/dom/gamepad/gamepadevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use super::gamepad::Gamepad;
@@ -58,11 +58,11 @@ impl GamepadEvent {
         cancelable: bool,
         gamepad: &Gamepad,
     ) -> DomRoot<GamepadEvent> {
-        let ev = reflect_dom_object_with_proto_and_cx(
+        let ev = reflect_dom_object_with_proto(
+            cx,
             Box::new(GamepadEvent::new_inherited(gamepad)),
             window,
             proto,
-            cx,
         );
         {
             let event = ev.upcast::<Event>();

--- a/components/script/dom/indexeddb/idbversionchangeevent.rs
+++ b/components/script/dom/indexeddb/idbversionchangeevent.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -69,14 +69,14 @@ impl IDBVersionChangeEvent {
         old_version: u64,
         new_version: Option<u64>,
     ) -> DomRoot<Self> {
-        let ev = reflect_dom_object_with_proto_and_cx(
+        let ev = reflect_dom_object_with_proto(
+            cx,
             Box::new(IDBVersionChangeEvent::new_inherited(
                 old_version,
                 new_version,
             )),
             global,
             proto,
-            cx,
         );
         {
             let event = ev.upcast::<Event>();

--- a/components/script/dom/intersectionobserver/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver/intersectionobserver.rs
@@ -13,7 +13,7 @@ use euclid::{Rect, SideOffsets2D, Size2D, Vector2D};
 use js::context::JSContext;
 use js::rust::{HandleObject, MutableHandleValue};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_geometry::f32_rect_to_au_rect;
 use style::parser::Parse;
@@ -159,7 +159,8 @@ impl IntersectionObserver {
         // > 2. Set this’s internal [[callback]] slot to callback.
         // > 3. ... set this’s internal [[rootMargin]] slot to that.
         // > 4. ... set this’s internal [[scrollMargin]] slot to that.
-        let observer = reflect_dom_object_with_proto_and_cx(
+        let observer = reflect_dom_object_with_proto(
+            cx,
             Box::new(Self::new_inherited(
                 window,
                 callback,
@@ -169,7 +170,6 @@ impl IntersectionObserver {
             )),
             window,
             proto,
-            cx,
         );
 
         // Step 5-13

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -25,7 +25,7 @@ use net_traits::{FetchMetadata, FetchResponseMsg, NetworkError, ResourceFetchTim
 use pixels::RasterImage;
 use rustc_hash::FxHashSet;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use uuid::Uuid;
 
@@ -130,7 +130,8 @@ impl Notification {
         fallback_timestamp: u64,
         proto: Option<HandleObject>,
     ) -> DomRoot<Self> {
-        let notification = reflect_dom_object_with_proto_and_cx(
+        let notification = reflect_dom_object_with_proto(
+            cx,
             Box::new(Notification::new_inherited(
                 global,
                 title,
@@ -141,7 +142,6 @@ impl Notification {
             )),
             global,
             proto,
-            cx,
         );
 
         notification.data.set(options.data.get());

--- a/components/script/dom/serviceworker/extendableevent.rs
+++ b/components/script/dom/serviceworker/extendableevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::{HandleObject, HandleValue};
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -52,11 +52,11 @@ impl ExtendableEvent {
         bubbles: bool,
         cancelable: bool,
     ) -> DomRoot<ExtendableEvent> {
-        let ev = reflect_dom_object_with_proto_and_cx(
+        let ev = reflect_dom_object_with_proto(
+            cx,
             Box::new(ExtendableEvent::new_inherited()),
             worker,
             proto,
-            cx,
         );
         {
             let event = ev.upcast::<Event>();

--- a/components/script/dom/url/urlpattern.rs
+++ b/components/script/dom/url/urlpattern.rs
@@ -9,7 +9,7 @@ use script_bindings::cformat;
 use script_bindings::codegen::GenericBindings::URLPatternBinding::URLPatternResult;
 use script_bindings::codegen::GenericUnionTypes::USVStringOrURLPatternInit;
 use script_bindings::error::{Error, Fallible};
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use script_bindings::root::DomRoot;
 use script_bindings::str::USVString;
 
@@ -59,11 +59,11 @@ impl URLPattern {
         let pattern = urlpattern::UrlPattern::parse(pattern_init, options)
             .map_err(|error| Error::Type(cformat!("{error}")))?;
 
-        let url_pattern = reflect_dom_object_with_proto_and_cx(
+        let url_pattern = reflect_dom_object_with_proto(
+            cx,
             Box::new(URLPattern::new_inherited(pattern)),
             global,
             proto,
-            cx,
         );
         Ok(url_pattern)
     }

--- a/components/script/dom/webgl/webglcontextevent.rs
+++ b/components/script/dom/webgl/webglcontextevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -93,11 +93,11 @@ impl WebGLContextEvent {
         cancelable: EventCancelable,
         status_message: DOMString,
     ) -> DomRoot<WebGLContextEvent> {
-        let event = reflect_dom_object_with_proto_and_cx(
+        let event = reflect_dom_object_with_proto(
+            cx,
             Box::new(WebGLContextEvent::new_inherited(status_message)),
             window,
             proto,
-            cx,
         );
 
         {

--- a/components/script/dom/webgpu/gpuuncapturederrorevent.rs
+++ b/components/script/dom/webgpu/gpuuncapturederrorevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
@@ -49,11 +49,11 @@ impl GPUUncapturedErrorEvent {
         event_type: Atom,
         init: &GPUUncapturedErrorEventInit,
     ) -> DomRoot<Self> {
-        let event = reflect_dom_object_with_proto_and_cx(
+        let event = reflect_dom_object_with_proto(
+            cx,
             Box::new(GPUUncapturedErrorEvent::new_inherited(init)),
             global,
             proto,
-            cx,
         );
         event
             .event

--- a/components/script/dom/webrtc/rtcdatachannelevent.rs
+++ b/components/script/dom/webrtc/rtcdatachannelevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -53,11 +53,11 @@ impl RTCDataChannelEvent {
         cancelable: bool,
         channel: &RTCDataChannel,
     ) -> DomRoot<RTCDataChannelEvent> {
-        let event = reflect_dom_object_with_proto_and_cx(
+        let event = reflect_dom_object_with_proto(
+            cx,
             Box::new(RTCDataChannelEvent::new_inherited(channel)),
             window,
             proto,
-            cx,
         );
         {
             let event = event.upcast::<Event>();

--- a/components/script/dom/webrtc/rtcerrorevent.rs
+++ b/components/script/dom/webrtc/rtcerrorevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -53,11 +53,11 @@ impl RTCErrorEvent {
         cancelable: bool,
         error: &RTCError,
     ) -> DomRoot<RTCErrorEvent> {
-        let event = reflect_dom_object_with_proto_and_cx(
+        let event = reflect_dom_object_with_proto(
+            cx,
             Box::new(RTCErrorEvent::new_inherited(error)),
             window,
             proto,
-            cx,
         );
         {
             let event = event.upcast::<Event>();

--- a/components/script/dom/webrtc/rtcpeerconnectioniceevent.rs
+++ b/components/script/dom/webrtc/rtcpeerconnectioniceevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -59,11 +59,11 @@ impl RTCPeerConnectionIceEvent {
         url: Option<DOMString>,
         trusted: bool,
     ) -> DomRoot<RTCPeerConnectionIceEvent> {
-        let e = reflect_dom_object_with_proto_and_cx(
+        let e = reflect_dom_object_with_proto(
+            cx,
             Box::new(RTCPeerConnectionIceEvent::new_inherited(candidate, url)),
             window,
             proto,
-            cx,
         );
         let evt = e.upcast::<Event>();
         evt.init_event(ty, false, false); // XXXManishearth bubbles/cancelable?

--- a/components/script/dom/webrtc/rtctrackevent.rs
+++ b/components/script/dom/webrtc/rtctrackevent.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
@@ -51,11 +51,11 @@ impl RTCTrackEvent {
         cancelable: bool,
         track: &MediaStreamTrack,
     ) -> DomRoot<RTCTrackEvent> {
-        let trackevent = reflect_dom_object_with_proto_and_cx(
+        let trackevent = reflect_dom_object_with_proto(
+            cx,
             Box::new(RTCTrackEvent::new_inherited(track)),
             window,
             proto,
-            cx,
         );
         {
             let event = trackevent.upcast::<Event>();

--- a/components/script/dom/webvtt/trackevent.rs
+++ b/components/script/dom/webvtt/trackevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::audio::audiotrack::AudioTrack;
@@ -79,11 +79,11 @@ impl TrackEvent {
         cancelable: bool,
         track: &Option<VideoTrackOrAudioTrackOrTextTrack>,
     ) -> DomRoot<TrackEvent> {
-        let te = reflect_dom_object_with_proto_and_cx(
+        let te = reflect_dom_object_with_proto(
+            cx,
             Box::new(TrackEvent::new_inherited(track)),
             window,
             proto,
-            cx,
         );
         {
             let event = te.upcast::<Event>();

--- a/components/script/dom/webxr/xrinputsourceevent.rs
+++ b/components/script/dom/webxr/xrinputsourceevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
@@ -60,11 +60,11 @@ impl XRInputSourceEvent {
         frame: &XRFrame,
         source: &XRInputSource,
     ) -> DomRoot<XRInputSourceEvent> {
-        let trackevent = reflect_dom_object_with_proto_and_cx(
+        let trackevent = reflect_dom_object_with_proto(
+            cx,
             Box::new(XRInputSourceEvent::new_inherited(frame, source)),
             window,
             proto,
-            cx,
         );
         {
             let event = trackevent.upcast::<Event>();

--- a/components/script/dom/webxr/xrinputsourceschangeevent.rs
+++ b/components/script/dom/webxr/xrinputsourceschangeevent.rs
@@ -7,7 +7,7 @@ use js::context::JSContext;
 use js::jsapi::Heap;
 use js::jsval::JSVal;
 use js::rust::{HandleObject, MutableHandleValue};
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
@@ -72,11 +72,11 @@ impl XRInputSourcesChangeEvent {
         added: &[DomRoot<XRInputSource>],
         removed: &[DomRoot<XRInputSource>],
     ) -> DomRoot<XRInputSourcesChangeEvent> {
-        let changeevent = reflect_dom_object_with_proto_and_cx(
+        let changeevent = reflect_dom_object_with_proto(
+            cx,
             Box::new(XRInputSourcesChangeEvent::new_inherited(session)),
             window,
             proto,
-            cx,
         );
         {
             let event = changeevent.upcast::<Event>();

--- a/components/script/dom/webxr/xrreferencespaceevent.rs
+++ b/components/script/dom/webxr/xrreferencespaceevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
@@ -65,11 +65,11 @@ impl XRReferenceSpaceEvent {
         space: &XRReferenceSpace,
         transform: Option<&XRRigidTransform>,
     ) -> DomRoot<XRReferenceSpaceEvent> {
-        let trackevent = reflect_dom_object_with_proto_and_cx(
+        let trackevent = reflect_dom_object_with_proto(
+            cx,
             Box::new(XRReferenceSpaceEvent::new_inherited(space, transform)),
             window,
             proto,
-            cx,
         );
         {
             let event = trackevent.upcast::<Event>();

--- a/components/script/dom/webxr/xrsessionevent.rs
+++ b/components/script/dom/webxr/xrsessionevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
@@ -52,11 +52,11 @@ impl XRSessionEvent {
         cancelable: bool,
         session: &XRSession,
     ) -> DomRoot<XRSessionEvent> {
-        let trackevent = reflect_dom_object_with_proto_and_cx(
+        let trackevent = reflect_dom_object_with_proto(
+            cx,
             Box::new(XRSessionEvent::new_inherited(session)),
             window,
             proto,
-            cx,
         );
         {
             let event = trackevent.upcast::<Event>();


### PR DESCRIPTION
As a cleanup follow-up to the migration to pass `&mut JSContext`, this PR is the result of applying the following regex replacement to the codebase:

Before:

```
reflect_dom_object_with_proto_and_cx\((([^<]|\n)+),\n\s+?cx,\n\s+?\);
```

After:

```
reflect_dom_object_with_proto(cx, $1);
```

Part of #40600

Testing: it compiles