### PR TITLE
script: Decrement running count of loading fonts only after marking document tree as dirty

### DIFF
--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -16,7 +16,7 @@ use content_security_policy::Violation;
 use fonts_traits::{
     CSSFontFaceDescriptors, FontDescriptor, FontFaceRuleWithOrigin, FontIdentifier, FontTemplate,
     FontTemplateRef, FontTemplateRefMethods, StylesheetWebFontLoadFinishedCallback,
-    WebFontSetDifference,
+    WebFontLoadEvent, WebFontSetDifference,
 };
 use log::{debug, trace};
 use malloc_size_of::MallocSizeOf;
@@ -564,7 +564,6 @@ impl FontContext {
         self.font_data.write().insert(identifier.clone(), font_data);
         let descriptor = handle.descriptor();
         for download_state in download_states {
-            // See if the download has been cancelled while we waited for the font to load
             let mut descriptor = descriptor.clone();
             descriptor.override_values_with_css_font_template_descriptors(
                 &download_state.css_font_face_descriptors,
@@ -588,7 +587,7 @@ impl FontContext {
             .fetch_sub(1, Ordering::SeqCst);
     }
 
-    /// Returns true iff a `@font-face` rule is part of the active set,
+    /// Returns true iff a `@font-face` rule is part of the active set.
     ///
     /// A font face rule might be removed from this set if its stylesheet is removed for example.
     pub(crate) fn is_font_face_rule_active(
@@ -648,14 +647,19 @@ impl WebFontDownloadState {
                     .is_font_face_rule_active(&initiator.created_by)
                 {
                     // This font load was cancelled.
-                    self.font_context.decrement_count_of_loading_fonts_by_one();
+                    if self
+                        .font_context
+                        .number_of_loading_web_fonts
+                        .fetch_sub(1, Ordering::SeqCst) ==
+                        1
+                    {
+                        // This was the last loading font - we must inform the script thread that the load
+                        // has finished because this an opportunity to resolve document.fonts.ready.
+                        (initiator.callback)(WebFontLoadEvent::UnblockedFontReadyPromise);
+                    }
                     return;
                 }
 
-                // FIXME: There are likely (mostly theoretical) race conditions here.
-                // We should be enforcing some sort of critical section to ensure that the font
-                // does not get cancelled in the time after the check above and the addition of the
-                // new template below.
                 self.font_context
                     .web_fonts
                     .write()
@@ -666,7 +670,7 @@ impl WebFontDownloadState {
                 // Note: We intentionally do not call decrement_count_of_loading_fonts_by_one here.
                 // That is handled in the callback, which avoids document.fonts.ready being resolved
                 // prematurely.
-                (initiator.callback)(true);
+                (initiator.callback)(WebFontLoadEvent::LoadedSuccessfully);
             },
             WebFontLoadInitiator::Script(callback) => {
                 self.font_context.decrement_count_of_loading_fonts_by_one();
@@ -680,8 +684,16 @@ impl WebFontDownloadState {
         let family_name = self.css_font_face_descriptors.family_name.clone();
         match self.initiator {
             WebFontLoadInitiator::Stylesheet(initiator) => {
-                self.font_context.decrement_count_of_loading_fonts_by_one();
-                (initiator.callback)(false);
+                if self
+                    .font_context
+                    .number_of_loading_web_fonts
+                    .fetch_sub(1, Ordering::SeqCst) ==
+                    1
+                {
+                    // This was the last loading font - we must inform the script thread that the load
+                    // has finished because this an opportunity to resolve document.fonts.ready.
+                    (initiator.callback)(WebFontLoadEvent::UnblockedFontReadyPromise);
+                }
             },
             WebFontLoadInitiator::Script(callback) => {
                 self.font_context.decrement_count_of_loading_fonts_by_one();
@@ -820,7 +832,15 @@ impl FontContextWebFontMethods for Arc<FontContext> {
                 !self.is_font_face_rule_active(&stylesheet_initiator.created_by)
             {
                 // This font load was cancelled.
-                self.decrement_count_of_loading_fonts_by_one();
+                if self
+                    .number_of_loading_web_fonts
+                    .fetch_sub(1, Ordering::SeqCst) ==
+                    1
+                {
+                    // This was the last loading font - we must inform the script thread that the load
+                    // has finished because this an opportunity to resolve document.fonts.ready.
+                    (stylesheet_initiator.callback)(WebFontLoadEvent::UnblockedFontReadyPromise);
+                }
                 return;
             }
 

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -8,7 +8,7 @@ use std::default::Default;
 use std::hash::{Hash, Hasher};
 use std::iter;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use app_units::Au;
 use atomic_refcell::AtomicRefCell;
@@ -45,7 +45,7 @@ use style::font_face::{
 use style::properties::generated::font_face::Descriptors as FontFaceRuleDescriptors;
 use style::properties::style_structs::Font as FontStyleStruct;
 use style::shared_lock::StylesheetGuards;
-use style::stylesheets::FontFaceRule;
+use style::stylesheets::LockedFontFaceRule;
 use style::stylist::Stylist;
 use style::values::computed::FontVariantAlternates;
 use style::values::computed::font::{FamilyName, FontFamilyNameSyntax, SingleFontFamily};
@@ -126,6 +126,9 @@ pub struct FontContext {
 
     /// A lazily-computed map of feature names from `@font-feature-value` rules.
     font_feature_value_map: AtomicRefCell<Option<FontFeatureValueMap>>,
+
+    /// The number of fonts that are currently loading.
+    number_of_loading_web_fonts: AtomicUsize,
 }
 
 /// A callback that will be invoked on the Fetch thread if a web font download
@@ -185,11 +188,12 @@ impl FontContext {
             currently_downloading_fonts: Default::default(),
             known_font_face_rules: Default::default(),
             font_feature_value_map: Default::default(),
+            number_of_loading_web_fonts: Default::default(),
         }
     }
 
     pub fn web_fonts_still_loading(&self) -> usize {
-        self.currently_downloading_fonts.lock().len()
+        self.number_of_loading_web_fonts.load(Ordering::SeqCst)
     }
 
     fn get_font_data(&self, identifier: &FontIdentifier) -> Option<FontData> {
@@ -560,6 +564,7 @@ impl FontContext {
         self.font_data.write().insert(identifier.clone(), font_data);
         let descriptor = handle.descriptor();
         for download_state in download_states {
+            // See if the download has been cancelled while we waited for the font to load
             let mut descriptor = descriptor.clone();
             descriptor.override_values_with_css_font_template_descriptors(
                 &download_state.css_font_face_descriptors,
@@ -577,10 +582,25 @@ impl FontContext {
         true
     }
 
-    pub(crate) fn has_pending_font_requests_for_url(&self, url: ServoArc<Url>) -> bool {
-        self.currently_downloading_fonts
+    /// Decrement the count of font loads blocking the `document.fonts.ready` promise by one.
+    pub fn decrement_count_of_loading_fonts_by_one(&self) {
+        self.number_of_loading_web_fonts
+            .fetch_sub(1, Ordering::SeqCst);
+    }
+
+    /// Returns true iff a `@font-face` rule is part of the active set,
+    ///
+    /// A font face rule might be removed from this set if its stylesheet is removed for example.
+    pub(crate) fn is_font_face_rule_active(
+        &self,
+        target_rule: &ServoArc<LockedFontFaceRule>,
+    ) -> bool {
+        self.known_font_face_rules
             .lock()
-            .contains_key(&url.into())
+            .contents
+            .values()
+            .flat_map(|bucket| bucket.iter())
+            .any(|known_rule| ServoArc::ptr_eq(&known_rule.rule_with_origin.rule, target_rule))
     }
 }
 
@@ -623,15 +643,33 @@ impl WebFontDownloadState {
         let family_name = self.css_font_face_descriptors.family_name.clone();
         match self.initiator {
             WebFontLoadInitiator::Stylesheet(initiator) => {
+                if !self
+                    .font_context
+                    .is_font_face_rule_active(&initiator.created_by)
+                {
+                    // This font load was cancelled.
+                    self.font_context.decrement_count_of_loading_fonts_by_one();
+                    return;
+                }
+
+                // FIXME: There are likely (mostly theoretical) race conditions here.
+                // We should be enforcing some sort of critical section to ensure that the font
+                // does not get cancelled in the time after the check above and the addition of the
+                // new template below.
                 self.font_context
                     .web_fonts
                     .write()
                     .add_new_template(family_name, new_template);
                 self.font_context
                     .invalidate_font_groups_after_web_font_load();
+
+                // Note: We intentionally do not call decrement_count_of_loading_fonts_by_one here.
+                // That is handled in the callback, which avoids document.fonts.ready being resolved
+                // prematurely.
                 (initiator.callback)(true);
             },
             WebFontLoadInitiator::Script(callback) => {
+                self.font_context.decrement_count_of_loading_fonts_by_one();
                 callback(family_name, Some(new_template));
             },
         }
@@ -642,18 +680,14 @@ impl WebFontDownloadState {
         let family_name = self.css_font_face_descriptors.family_name.clone();
         match self.initiator {
             WebFontLoadInitiator::Stylesheet(initiator) => {
+                self.font_context.decrement_count_of_loading_fonts_by_one();
                 (initiator.callback)(false);
             },
             WebFontLoadInitiator::Script(callback) => {
+                self.font_context.decrement_count_of_loading_fonts_by_one();
                 callback(family_name, None);
             },
         }
-    }
-
-    fn was_created_for_font_face_rule(&self, font_face_rule: &FontFaceRuleDescriptors) -> bool {
-        self.initiator
-            .font_face_rule()
-            .is_some_and(|initiating_rule| initiating_rule == font_face_rule)
     }
 }
 
@@ -668,8 +702,9 @@ pub trait FontContextWebFontMethods {
     ) -> WebFontSetDifference;
     fn load_single_font_face_rule(
         &self,
-        font_face_rule: &FontFaceRule,
         webview_id: WebViewId,
+        locked_font_face_rule: &FontFaceRuleWithOrigin,
+        guards: &StylesheetGuards<'_>,
         callback: StylesheetWebFontLoadFinishedCallback,
         document_context: &WebFontDocumentContext,
     );
@@ -687,11 +722,13 @@ pub trait FontContextWebFontMethods {
 impl FontContextWebFontMethods for Arc<FontContext> {
     fn load_single_font_face_rule(
         &self,
-        font_face_rule: &FontFaceRule,
         webview_id: WebViewId,
+        locked_font_face_rule: &FontFaceRuleWithOrigin,
+        guards: &StylesheetGuards<'_>,
         callback: StylesheetWebFontLoadFinishedCallback,
         document_context: &WebFontDocumentContext,
     ) {
+        let font_face_rule = locked_font_face_rule.read_with(guards);
         let Some(ref sources) = font_face_rule.descriptors.src else {
             return;
         };
@@ -699,6 +736,7 @@ impl FontContextWebFontMethods for Arc<FontContext> {
         let css_font_face_descriptors = font_face_rule.into();
 
         let initiator = FontFaceRuleInitiator {
+            created_by: locked_font_face_rule.rule.clone(),
             font_face_rule: font_face_rule.descriptors.clone(),
             callback: callback.clone(),
         };
@@ -725,10 +763,10 @@ impl FontContextWebFontMethods for Arc<FontContext> {
             .diff_old_and_new_font_face_rules(stylist, guards);
 
         for added_rule in &difference.added_font_faces {
-            let added_rule = added_rule.read_with(guards);
             self.load_single_font_face_rule(
-                added_rule,
                 webview_id,
+                added_rule,
+                guards,
                 callback.clone(),
                 document_context,
             );
@@ -777,6 +815,15 @@ impl FontContextWebFontMethods for Arc<FontContext> {
         };
 
         for subscriber in subscribers {
+            // See if the font load was cancelled in the meantime
+            if let WebFontLoadInitiator::Stylesheet(stylesheet_initiator) = &subscriber.initiator &&
+                !self.is_font_face_rule_active(&stylesheet_initiator.created_by)
+            {
+                // This font load was cancelled.
+                self.decrement_count_of_loading_fonts_by_one();
+                return;
+            }
+
             self.process_next_web_font_source(subscriber);
         }
     }
@@ -860,17 +907,6 @@ impl FontContext {
             return false;
         };
 
-        // Mark any ongoing load operations for this font as cancelled.
-        self.currently_downloading_fonts
-            .lock()
-            .retain(|_, download_states| {
-                download_states.retain(|download_state| {
-                    !download_state.was_created_for_font_face_rule(font_face_rule)
-                });
-
-                !download_states.is_empty()
-            });
-
         let lowercase_family_name: LowercaseFontFamilyName = family.name.clone().into();
         let Some(known_family) = font_store.families.get_mut(&lowercase_family_name) else {
             return false;
@@ -934,6 +970,9 @@ impl FontContext {
         completion_handler: WebFontLoadInitiator,
         document_context: &WebFontDocumentContext,
     ) {
+        self.number_of_loading_web_fonts
+            .fetch_add(1, Ordering::SeqCst);
+
         let sources: Vec<Source> = source_list
             .0
             .iter()
@@ -1188,6 +1227,13 @@ pub(crate) type ScriptWebFontLoadFinishedCallback =
 
 #[derive(MallocSizeOf)]
 pub(crate) struct FontFaceRuleInitiator {
+    /// A reference to the `@font-face` rule that created this web font load.
+    /// This is only used to identify the font in case it is
+    // TODO: It is awkward that we have to carry both the locked font face rule and the
+    // unlocked copy around. Perhaps the FontContext should have access to the shared
+    // lock in the future.
+    #[conditional_malloc_size_of]
+    created_by: ServoArc<LockedFontFaceRule>,
     font_face_rule: FontFaceRuleDescriptors,
     #[ignore_malloc_size_of = "dyn Fn"]
     callback: StylesheetWebFontLoadFinishedCallback,
@@ -1291,15 +1337,6 @@ impl RemoteWebFontDownloader {
     /// After a download finishes, try to process the downloaded data, returning true if
     /// the font is added successfully to the [`FontContext`] or false if it isn't.
     fn process_downloaded_font_and_signal_completion(&mut self) {
-        // Check if we still need this web font. If the stylesheet has been removed in the meantime
-        // then there is no need to process it any further.
-        if !self
-            .font_context
-            .has_pending_font_requests_for_url(self.url.clone())
-        {
-            return;
-        }
-
         let font_data = std::mem::take(&mut self.response_data);
         trace!(
             "Downloaded @font-face {} ({} bytes)",

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -786,12 +786,10 @@ impl LayoutThread {
 
         let locked_script_channel = Mutex::new(config.script_chan.clone());
         let pipeline_id = config.id;
-        let web_font_finished_loading_callback = move |succeeded: bool| {
-            if succeeded {
-                let _ = locked_script_channel
-                    .lock()
-                    .send(ScriptThreadMessage::WebFontLoaded(pipeline_id));
-            }
+        let web_font_finished_loading_callback = move |event| {
+            let _ = locked_script_channel
+                .lock()
+                .send(ScriptThreadMessage::WebFontLoadFinished(pipeline_id, event));
         };
 
         LayoutThread {

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -83,7 +83,7 @@ impl MixedMessage {
                 ScriptThreadMessage::FocusDocument(id, ..) => Some(*id),
                 ScriptThreadMessage::WebDriverScriptCommand(id, ..) => Some(*id),
                 ScriptThreadMessage::TickAllAnimations(..) => None,
-                ScriptThreadMessage::WebFontLoaded(id) => Some(*id),
+                ScriptThreadMessage::WebFontLoadFinished(id, ..) => Some(*id),
                 ScriptThreadMessage::DispatchIFrameLoadEvent {
                     target: _,
                     parent: id,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -46,7 +46,7 @@ use embedder_traits::{
     Theme, ViewportDetails, WebDriverScriptCommand,
 };
 use encoding_rs::Encoding;
-use fonts::{FontContext, SystemFontServiceProxy};
+use fonts::{FontContext, SystemFontServiceProxy, WebFontLoadEvent};
 use headers::{HeaderMapExt, LastModified, ReferrerPolicy as ReferrerPolicyHeader};
 use http::header::REFRESH;
 use hyper_serde::Serde;
@@ -1904,8 +1904,13 @@ impl ScriptThread {
             ScriptThreadMessage::WebDriverScriptCommand(pipeline_id, msg) => {
                 self.handle_webdriver_msg(pipeline_id, msg, cx)
             },
-            ScriptThreadMessage::WebFontLoaded(pipeline_id) => {
-                self.handle_web_font_loaded(cx.no_gc(), pipeline_id)
+            ScriptThreadMessage::WebFontLoadFinished(pipeline_id, event) => {
+                // If the font load did not succeed then this message only serves to bump the script thread
+                // so it attempts to resolve the document.fonts.ready promise. This happens as a result
+                // of processing this message, so there's nothing more to do.
+                if event == WebFontLoadEvent::LoadedSuccessfully {
+                    self.handle_web_font_loaded(cx.no_gc(), pipeline_id)
+                }
             },
             ScriptThreadMessage::DispatchIFrameLoadEvent {
                 target: browsing_context_id,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3351,6 +3351,11 @@ impl ScriptThread {
 
         // TODO: This should only dirty nodes that are waiting for a web font to finish loading!
         document.dirty_all_nodes(no_gc);
+
+        document
+            .window()
+            .font_context()
+            .decrement_count_of_loading_fonts_by_one();
     }
 
     /// Handles a worklet being loaded by triggering a relayout of the page. Does nothing if the

--- a/components/shared/fonts/lib.rs
+++ b/components/shared/fonts/lib.rs
@@ -128,7 +128,14 @@ impl TextByteRange {
     }
 }
 
-pub type StylesheetWebFontLoadFinishedCallback = Arc<dyn Fn(bool) + Send + Sync + 'static>;
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum WebFontLoadEvent {
+    LoadedSuccessfully,
+    UnblockedFontReadyPromise,
+}
+
+pub type StylesheetWebFontLoadFinishedCallback =
+    Arc<dyn Fn(WebFontLoadEvent) + Send + Sync + 'static>;
 
 /// A data structure to store data for fonts. Data is stored internally in an
 /// [`GenericSharedMemory`] handle, so that it can be sent without serialization

--- a/components/shared/fonts/lib.rs
+++ b/components/shared/fonts/lib.rs
@@ -188,7 +188,7 @@ impl WebFontSetDifference {
 #[derive(Clone, MallocSizeOf)]
 pub struct FontFaceRuleWithOrigin {
     #[conditional_malloc_size_of]
-    rule: ServoArc<LockedFontFaceRule>,
+    pub rule: ServoArc<LockedFontFaceRule>,
     origin: Origin,
 }
 

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -20,7 +20,7 @@ use embedder_traits::{
     Theme, ViewportDetails, WebDriverScriptCommand,
 };
 use euclid::{Scale, Size2D};
-use fonts_traits::SystemFontServiceProxySender;
+use fonts_traits::{SystemFontServiceProxySender, WebFontLoadEvent};
 use keyboard_types::Modifiers;
 use malloc_size_of_derive::MallocSizeOf;
 use media::WindowGLContext;
@@ -247,9 +247,12 @@ pub enum ScriptThreadMessage {
     WebDriverScriptCommand(PipelineId, WebDriverScriptCommand),
     /// Notifies script thread that all animations are done
     TickAllAnimations(Vec<WebViewId>),
-    /// Notifies the script thread that a new Web font has been loaded, and thus the page should be
-    /// reflowed.
-    WebFontLoaded(PipelineId),
+    /// Notifies the script thread that a web font has finished loading.
+    ///
+    /// This is sent if either the web font loaded successfully, or to notify the script thread
+    /// that it should try to resolve `document.fonts.ready` because the font was the last one
+    /// loading.
+    WebFontLoadFinished(PipelineId, WebFontLoadEvent),
     /// Cause a `load` event to be dispatched at the appropriate iframe element.
     DispatchIFrameLoadEvent {
         /// The frame that has been marked as loaded.


### PR DESCRIPTION
This fixes a race condition which occurs right after a web font loads.

The script thread won't mark nodes as dirty until it receives `ScriptThreadMessage::WebFontLoaded`, but if `Document::maybe_fulfill_font_ready_promise runs` before that then will notice that no more fonts are loading and subsequently resolve `document.fonts.ready`. And then a promise handler attached to document.fonts.ready can observe outdated layout data.

Instead, I've applied the suggestion from martin (https://github.com/servo/servo/issues/36094#issuecomment-5000826287) to delay decrementing the running count of loading web fonts until the script thread has dirtied the document tree.

Testing: This is very timing-dependent and we do not have a reliable way to test this. I did run the test from https://github.com/servo/servo/issues/36094 around 1000 times and did not observe intermittent failures. 

Fixes https://github.com/servo/servo/issues/36094
Fixes https://github.com/servo/servo/issues/46581
Fixes https://github.com/servo/servo/issues/46579
Fixes https://github.com/servo/servo/issues/46566
Fixes https://github.com/servo/servo/issues/46520
Fixes https://github.com/servo/servo/issues/46591

