### PR TITLE
webxr: Properly destroy layer `Surface`s if removal happens between `begin_frame` and `end_frame`

### DIFF
--- a/components/webxr/surfman_layer_manager.rs
+++ b/components/webxr/surfman_layer_manager.rs
@@ -120,7 +120,13 @@ impl LayerManagerAPI<SurfmanGL> for SurfmanLayerManager {
         };
         self.layers.retain(|&ids| ids != (context_id, layer_id));
         let _ = self.swap_chains.destroy(layer_id, &device, context);
-        self.surface_textures.remove(&layer_id);
+
+        if let Some(surface_texture) = self.surface_textures.remove(&layer_id) &&
+            let Ok(mut surface) = device.destroy_surface_texture(context, surface_texture)
+        {
+            let _ = device.destroy_surface(context, &mut surface);
+        }
+
         if let Some(depth_stencil_texture) = self.depth_stencil_textures.remove(&layer_id) {
             let gl = contexts.bindings(context_id).unwrap();
             if let Some(depth_stencil_texture) = depth_stencil_texture {


### PR DESCRIPTION
Surfman does not allow simply dropping a `Surface`. They need to be
destroyed via the `Device`. `SurfmanLayerManager::begin_frame` takes a
`SurfaceTexture` from the shared `SwapChain`. If `destroy_layer` is
called before `end_frame`, this change properly destroys both the stored
`SurfaceTexture` and `Surface` instead of just dropping them.

Testing: This should fix an intermittent crashes in WebXR tests.
