### PR TITLE
layout: Improvements to a11y update counters, and some extra tests

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -46,11 +46,12 @@ struct AccessibilityUpdate {
     tree_changes: FxHashMap<NodeId, TreeChange>,
     /// Damage to nodes caused by changes in the accessibility tree.
     unresolved_local_damage: FxHashMap<NodeId, LocalAccessibilityDamage>,
+    /// Counters to track how many nodes we've checked for changes or updated in this tree update.
+    counters: UpdateCounters,
     /// Nodes which were removed from the DOM tree since the last reflow, which were rooted in
     /// `AccessibilityData`. Only set if `pref::expensive_accessibility_test_assertions_enabled`
     /// is set.
     rooted_nodes: Option<FxHashSet<OpaqueNode>>,
-    counters: UpdateCounters,
 }
 
 #[derive(Debug, Default)]
@@ -849,8 +850,8 @@ impl AccessibilityUpdate {
             changed_nodes: FxHashSet::default(),
             tree_changes: FxHashMap::default(),
             unresolved_local_damage: FxHashMap::default(),
-            rooted_nodes,
             counters: UpdateCounters::default(),
+            rooted_nodes,
         }
     }
 
@@ -907,19 +908,21 @@ impl AccessibilityUpdate {
         }
 
         let changed_nodes = std::mem::take(&mut self.changed_nodes);
-
         let mut counters = std::mem::take(&mut self.counters);
-        counters.nodes_in_tree_update = changed_nodes.len().try_into().unwrap_or_default();
 
         tree.drop_removed_nodes(self);
+
+        let changed_nodes: Vec<_> = changed_nodes
+            .into_iter()
+            .filter_map(|id| Some((id, tree.node_for_id(id)?.borrow().accesskit_node.clone())))
+            .collect();
+
+        counters.nodes_in_tree_update = changed_nodes.len().try_into().unwrap_or_default();
 
         let accesskit_tree = accesskit::Tree::new(root_node_id);
         let tree_update = accesskit::TreeUpdate {
             // Filter out any nodes which were both changed and removed.
-            nodes: changed_nodes
-                .into_iter()
-                .filter_map(|id| Some((id, tree.node_for_id(id)?.borrow().accesskit_node.clone())))
-                .collect(),
+            nodes: changed_nodes,
             tree: Some(accesskit_tree),
             focus: NodeId(1),
             tree_id: tree.tree_id,

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -962,10 +962,10 @@ impl LayoutThread {
                 ));
         }
 
-        reflow_statistics.accessibility_nodes_updated_from_dom =
+        reflow_statistics.nodes_updated_from_dom =
             counters.update_node_and_descendants_from_dom_node;
-        reflow_statistics.accessibility_nodes_updated_from_tree = counters.update_node_local;
-        reflow_statistics.accessibility_nodes_in_tree_update = counters.nodes_in_tree_update;
+        reflow_statistics.nodes_updated_from_tree = counters.update_node_local;
+        reflow_statistics.nodes_in_tree_update = counters.nodes_in_tree_update;
 
         self.needs_accessibility_update.set(false);
         true

--- a/components/script/dom/testing/accessibilityupdateresult.rs
+++ b/components/script/dom/testing/accessibilityupdateresult.rs
@@ -12,37 +12,37 @@ use crate::dom::globalscope::GlobalScope;
 #[dom_struct]
 pub(crate) struct AccessibilityUpdateResult {
     reflector_: Reflector,
-    accessibility_nodes_updated_from_dom: u32,
-    accessibility_nodes_updated_from_tree: u32,
-    accessibility_nodes_in_tree_update: u32,
+    nodes_updated_from_dom: u32,
+    nodes_updated_from_tree: u32,
+    nodes_in_tree_update: u32,
 }
 
 impl AccessibilityUpdateResult {
     pub(crate) fn new_inherited(
-        accessibility_nodes_updated_from_dom: u32,
-        accessibility_nodes_updated_from_tree: u32,
-        accessibility_nodes_in_tree_update: u32,
+        nodes_updated_from_dom: u32,
+        nodes_updated_from_tree: u32,
+        nodes_in_tree_update: u32,
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
-            accessibility_nodes_updated_from_dom,
-            accessibility_nodes_updated_from_tree,
-            accessibility_nodes_in_tree_update,
+            nodes_updated_from_dom,
+            nodes_updated_from_tree,
+            nodes_in_tree_update,
         }
     }
 
     pub(crate) fn new(
         cx: &mut JSContext,
         global: &GlobalScope,
-        accessibility_nodes_updated_from_dom: u32,
-        accessibility_nodes_updated_from_tree: u32,
-        accessibility_nodes_in_tree_update: u32,
+        nodes_updated_from_dom: u32,
+        nodes_updated_from_tree: u32,
+        nodes_in_tree_update: u32,
     ) -> DomRoot<Self> {
         reflect_dom_object_with_cx(
             Box::new(Self::new_inherited(
-                accessibility_nodes_updated_from_dom,
-                accessibility_nodes_updated_from_tree,
-                accessibility_nodes_in_tree_update,
+                nodes_updated_from_dom,
+                nodes_updated_from_tree,
+                nodes_in_tree_update,
             )),
             global,
             cx,
@@ -51,15 +51,15 @@ impl AccessibilityUpdateResult {
 }
 
 impl AccessibilityUpdateResultMethods<crate::DomTypeHolder> for AccessibilityUpdateResult {
-    fn AccessibilityNodesUpdatedFromDom(&self) -> u32 {
-        self.accessibility_nodes_updated_from_dom
+    fn NodesUpdatedFromDom(&self) -> u32 {
+        self.nodes_updated_from_dom
     }
 
-    fn AccessibilityNodesUpdatedFromTree(&self) -> u32 {
-        self.accessibility_nodes_updated_from_tree
+    fn NodesUpdatedFromTree(&self) -> u32 {
+        self.nodes_updated_from_tree
     }
 
-    fn AccessibilityNodesInTreeUpdate(&self) -> u32 {
-        self.accessibility_nodes_in_tree_update
+    fn NodesInTreeUpdate(&self) -> u32 {
+        self.nodes_in_tree_update
     }
 }

--- a/components/script/dom/testing/servotestutils.rs
+++ b/components/script/dom/testing/servotestutils.rs
@@ -95,9 +95,9 @@ impl ServoTestUtilsMethods<crate::DomTypeHolder> for ServoTestUtils {
         AccessibilityUpdateResult::new(
             cx,
             global,
-            statistics.accessibility_nodes_updated_from_dom,
-            statistics.accessibility_nodes_updated_from_tree,
-            statistics.accessibility_nodes_in_tree_update,
+            statistics.nodes_updated_from_dom,
+            statistics.nodes_updated_from_tree,
+            statistics.nodes_in_tree_update,
         )
     }
 }

--- a/components/script_bindings/webidls/ServoTestUtils.webidl
+++ b/components/script_bindings/webidls/ServoTestUtils.webidl
@@ -38,7 +38,7 @@ interface LayoutResult {
 
 [Exposed=Window, Pref="dom_servo_helpers_enabled"]
 interface AccessibilityUpdateResult {
-    readonly attribute unsigned long accessibilityNodesUpdatedFromDom;
-    readonly attribute unsigned long accessibilityNodesUpdatedFromTree;
-    readonly attribute unsigned long accessibilityNodesInTreeUpdate;
+    readonly attribute unsigned long nodesUpdatedFromDom;
+    readonly attribute unsigned long nodesUpdatedFromTree;
+    readonly attribute unsigned long nodesInTreeUpdate;
 };

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -429,8 +429,7 @@ fn test_accessibility_partial_subtree_move_and_delete() {
         "div3.moveBefore(div2, h2);\
          div3.moveBefore(h1, div2);\
          p.remove();\
-         div1.remove();\
-         window.ServoTestUtils.forceAccessibilityUpdate();",
+         div1.remove();",
     );
     let mut updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
     assert_eq!(updates.len(), 1);
@@ -452,6 +451,95 @@ fn test_accessibility_partial_subtree_move_and_delete() {
     assert_eq!(h2.role(), Role::Heading);
     assert_eq!(h2.label(), Some("This is an h2".to_owned()));
 }
+
+#[test]
+fn test_accessibility_children_of_heading_change() {
+    let url = "data:text/html,<!DOCTYPE html>\
+               <h2>Activating accessibility for a <code>WebView</code></h2>";
+    let (servo_test, delegate, webview, mut tree) = build_webview_and_tree(url);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let children: Vec<accesskit_consumer::Node> = root.children().collect();
+    assert_eq!(children.len(), 1);
+    let heading = children[0];
+    assert_eq!(heading.role(), Role::Heading);
+    assert_eq!(
+        heading.label(),
+        Some("Activating accessibility for a WebView".to_owned())
+    );
+    let heading_children: Vec<_> = heading.children().collect();
+    assert_eq!(heading_children.len(), 2);
+    assert_eq!(heading_children[0].role(), Role::TextRun);
+    assert_eq!(heading_children[1].role(), Role::GenericContainer);
+
+    let _ = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "document.querySelector('code').remove();",
+    );
+
+    let mut updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
+    assert_eq!(updates.len(), 1);
+    let update = updates.pop().expect("Guaranteed by assert above");
+    tree.update_and_process_changes(update, &mut NoOpChangeHandler);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let heading = find_first_matching_node(root, |node| node.role() == Role::Heading)
+        .expect("Heading should still be in the tree");
+    assert_eq!(
+        heading.label(),
+        Some("Activating accessibility for a".to_owned())
+    );
+}
+
+#[test]
+fn test_accessibility_descendants_of_heading_change() {
+    let url = "data:text/html,<!DOCTYPE html>\
+               <h1>We really <em>really <strong>really</strong></em> like owls</h1>";
+    let (servo_test, delegate, webview, mut tree) = build_webview_and_tree(url);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let children: Vec<accesskit_consumer::Node> = root.children().collect();
+    assert_eq!(children.len(), 1);
+    let heading = children[0];
+    assert_eq!(heading.role(), Role::Heading);
+    assert_eq!(
+        heading.label(),
+        Some("We really really really like owls".to_owned())
+    );
+    let heading_children: Vec<_> = heading.children().collect();
+    assert_eq!(heading_children.len(), 3);
+    assert_eq!(heading_children[0].role(), Role::TextRun);
+    assert_eq!(heading_children[1].role(), Role::GenericContainer);
+    assert_eq!(heading_children[2].role(), Role::TextRun);
+
+    let em = heading_children[1];
+    assert_eq!(em.children().collect::<Vec<_>>().len(), 2);
+
+    let _ = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "document.querySelector('strong').remove();",
+    );
+
+    let mut updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
+    assert_eq!(updates.len(), 1);
+    let update = updates.pop().expect("Guaranteed by assert above");
+    tree.update_and_process_changes(update, &mut NoOpChangeHandler);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let heading = find_first_matching_node(root, |node| node.role() == Role::Heading)
+        .expect("Heading should still be in the tree");
+    assert_eq!(
+        heading.label(),
+        Some("We really really  like owls".to_owned())
+    );
+}
+
+// ************************************************************************************************
+// If you're adding a new test here, consider adding a matching test in
+// tests/wpt/mozilla/tests/accessibility-tree/
+// ************************************************************************************************
 
 fn build_test() -> ServoTest {
     let servo_test = ServoTest::new_with_builder(|builder| {

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -666,12 +666,12 @@ pub struct ReflowStatistics {
     pub only_descendants_changed_count: u32,
     /// A count of the number of accessibility nodes which were checked for changes based on their
     /// corresponding DOM nodes (whether the check resulted in changes or not).
-    pub accessibility_nodes_updated_from_dom: u32,
+    pub nodes_updated_from_dom: u32,
     /// A count of the number of accessibility nodes which were checked for changes based on data
     /// already in the accessibility tree (whether the check resulted in changes or not).
-    pub accessibility_nodes_updated_from_tree: u32,
+    pub nodes_updated_from_tree: u32,
     /// A count of the number of accessibility nodes actually serialized to the TreeUpdate.
-    pub accessibility_nodes_in_tree_update: u32,
+    pub nodes_in_tree_update: u32,
 }
 
 /// Information needed for a script-initiated reflow that requires a restyle

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -11381,42 +11381,42 @@
   "testharness": {
    "accessibility-tree": {
     "accessibility-update-basic-mutation.html": [
-     "a1d9dab44d95dc6ee217d277ff9555266fcd91cd",
+     "c5a01a3e528caa3d3925140ea8f575865c549c26",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-children-of-heading-change.html": [
-     "4ba4201f4dd4e8d00d5bb7e968ce68a49d2249fb",
+     "ab99aa03cc40917d5d57159d73ac137db37900b8",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-descendants-of-heading-change.html": [
-     "87c9b0284bf5b4ccd7d1cb9d56a4186ca81fa36f",
+     "93eb71919ef1055271731d9b2aa476cb43dc3b42",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-mutation-move-nodes.html": [
-     "bef5853f9bbfcbcb766cfc69052ed67f2bac8ef4",
+     "37da877ec1f10341d26cd9f6701c304af8ae5952",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-partial-subtree-move-and-delete.html": [
-     "ef369037f48a72fa21ab232fcb7e04c8c056aec9",
+     "5c9a9b12f7fcc87955cc6418c0789320666d5abf",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-text-change.html": [
-     "ebb377d1467e9b734cd325f3c34e17bedf820c2f",
+     "86b2ff626306b6d4aab36baef7fdeed7296fa97d",
      [
       null,
       {}

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -11394,6 +11394,13 @@
       {}
      ]
     ],
+    "accessibility-update-partial-subtree-move-and-delete.html": [
+     "ef369037f48a72fa21ab232fcb7e04c8c056aec9",
+     [
+      null,
+      {}
+     ]
+    ],
     "accessibility-update-text-change.html": [
      "ebb377d1467e9b734cd325f3c34e17bedf820c2f",
      [

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -11387,6 +11387,20 @@
       {}
      ]
     ],
+    "accessibility-update-children-of-heading-change.html": [
+     "4ba4201f4dd4e8d00d5bb7e968ce68a49d2249fb",
+     [
+      null,
+      {}
+     ]
+    ],
+    "accessibility-update-descendants-of-heading-change.html": [
+     "87c9b0284bf5b4ccd7d1cb9d56a4186ca81fa36f",
+     [
+      null,
+      {}
+     ]
+    ],
     "accessibility-update-mutation-move-nodes.html": [
      "bef5853f9bbfcbcb766cfc69052ed67f2bac8ef4",
      [

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-basic-mutation.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-basic-mutation.html
@@ -14,46 +14,22 @@
       ServoTestUtils.ensureAccessibilityActive();
       let initial = ServoTestUtils.forceAccessibilityUpdate();
 
-      assert_equals(
-        initial.accessibilityNodesUpdatedFromDom,
-        19,
-        "accessibilityNodesUpdatedFromDom",
-      );
-      assert_equals(
-        initial.accessibilityNodesUpdatedFromTree,
-        19,
-        "accessibilityNodesUpdatedFromTree",
-      );
-      assert_equals(
-        initial.accessibilityNodesInTreeUpdate,
-        19,
-        "accessibilityNodesInTreeUpdate",
-      );
+      assert_equals(initial.nodesUpdatedFromDom, 19, "nodesUpdatedFromDom");
+      assert_equals(initial.nodesUpdatedFromTree, 19, "nodesUpdatedFromTree");
+      assert_equals(initial.nodesInTreeUpdate, 19, "nodesInTreeUpdate");
 
       document.getElementById("h2").remove();
-      let incremental = ServoTestUtils.forceAccessibilityUpdate();
+      let update = ServoTestUtils.forceAccessibilityUpdate();
 
       // Only the <section> is updated from the DOM
-      assert_equals(
-        incremental.accessibilityNodesUpdatedFromDom,
-        1,
-        "accessibilityNodesUpdatedFromDom",
-      );
+      assert_equals(update.nodesUpdatedFromDom, 1, "nodesUpdatedFromDom");
 
       // The <section>, its parent <body> and the document are checked for changes as their subtrees
       // changed
-      assert_equals(
-        incremental.accessibilityNodesUpdatedFromTree,
-        3,
-        "accessibilityNodesUpdatedFromTree",
-      );
+      assert_equals(update.nodesUpdatedFromTree, 3, "nodesUpdatedFromTree");
 
       // The only node in the tree update should be the parent <section> of the removed <h2>
-      assert_equals(
-        incremental.accessibilityNodesInTreeUpdate,
-        1,
-        "accessibilityNodesInTreeUpdate",
-      );
+      assert_equals(update.nodesInTreeUpdate, 1, "nodesInTreeUpdate");
     }, "Remove h2 should update one node");
 
     done();

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-children-of-heading-change.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-children-of-heading-change.html
@@ -11,48 +11,24 @@
       ServoTestUtils.ensureAccessibilityActive();
       let initial = ServoTestUtils.forceAccessibilityUpdate();
 
-      assert_equals(
-        initial.accessibilityNodesUpdatedFromDom,
-        15,
-        "accessibilityNodesUpdatedFromDom",
-      );
-      assert_equals(
-        initial.accessibilityNodesUpdatedFromTree,
-        15,
-        "accessibilityNodesUpdatedFromTree",
-      );
-      assert_equals(
-        initial.accessibilityNodesInTreeUpdate,
-        15,
-        "accessibilityNodesInTreeUpdate",
-      );
+      assert_equals(initial.nodesUpdatedFromDom, 15, "nodesUpdatedFromDom");
+      assert_equals(initial.nodesUpdatedFromTree, 15, "nodesUpdatedFromTree");
+      assert_equals(initial.nodesInTreeUpdate, 15, "nodesInTreeUpdate");
 
       document.querySelector("code").remove();
 
-      let incremental = ServoTestUtils.forceAccessibilityUpdate();
+      let update = ServoTestUtils.forceAccessibilityUpdate();
 
       // Updated nodes:
       // - h2 (<code> removed)
-      assert_equals(
-        incremental.accessibilityNodesUpdatedFromDom,
-        1,
-        "accessibilityNodesUpdatedFromDom",
-      );
+      assert_equals(update.nodesUpdatedFromDom, 1, "nodesUpdatedFromDom");
 
       // <html>, <body>, <h2>
-      assert_equals(
-        incremental.accessibilityNodesUpdatedFromTree,
-        3,
-        "accessibilityNodesUpdatedFromTree",
-      );
+      assert_equals(update.nodesUpdatedFromTree, 3, "nodesUpdatedFromTree");
 
       // Changed nodes:
       // - <h2>, children and label changed
-      assert_equals(
-        incremental.accessibilityNodesInTreeUpdate,
-        1,
-        "accessibilityNodesInTreeUpdate",
-      );
+      assert_equals(update.nodesInTreeUpdate, 1, "nodesInTreeUpdate");
     }, "");
 
     done();

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-children-of-heading-change.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-children-of-heading-change.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<h2 id="h2">Activating accessibility for a <code>WebView</code></h2>
+
+<script>
+  setup({ explicit_done: true });
+  window.onload = () => {
+    test((t) => {
+      ServoTestUtils.ensureAccessibilityActive();
+      let initial = ServoTestUtils.forceAccessibilityUpdate();
+
+      assert_equals(
+        initial.accessibilityNodesUpdatedFromDom,
+        15,
+        "accessibilityNodesUpdatedFromDom",
+      );
+      assert_equals(
+        initial.accessibilityNodesUpdatedFromTree,
+        15,
+        "accessibilityNodesUpdatedFromTree",
+      );
+      assert_equals(
+        initial.accessibilityNodesInTreeUpdate,
+        15,
+        "accessibilityNodesInTreeUpdate",
+      );
+
+      document.querySelector("code").remove();
+
+      let incremental = ServoTestUtils.forceAccessibilityUpdate();
+
+      // Updated nodes:
+      // - h2 (<code> removed)
+      assert_equals(
+        incremental.accessibilityNodesUpdatedFromDom,
+        1,
+        "accessibilityNodesUpdatedFromDom",
+      );
+
+      // <html>, <body>, <h2>
+      assert_equals(
+        incremental.accessibilityNodesUpdatedFromTree,
+        3,
+        "accessibilityNodesUpdatedFromTree",
+      );
+
+      // Changed nodes:
+      // - <h2>, children and label changed
+      assert_equals(
+        incremental.accessibilityNodesInTreeUpdate,
+        1,
+        "accessibilityNodesInTreeUpdate",
+      );
+    }, "");
+
+    done();
+  };
+</script>

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-descendants-of-heading-change.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-descendants-of-heading-change.html
@@ -13,49 +13,25 @@
       ServoTestUtils.ensureAccessibilityActive();
       let initial = ServoTestUtils.forceAccessibilityUpdate();
 
-      assert_equals(
-        initial.accessibilityNodesUpdatedFromDom,
-        18,
-        "accessibilityNodesUpdatedFromDom",
-      );
-      assert_equals(
-        initial.accessibilityNodesUpdatedFromTree,
-        18,
-        "accessibilityNodesUpdatedFromTree",
-      );
-      assert_equals(
-        initial.accessibilityNodesInTreeUpdate,
-        18,
-        "accessibilityNodesInTreeUpdate",
-      );
+      assert_equals(initial.nodesUpdatedFromDom, 18, "nodesUpdatedFromDom");
+      assert_equals(initial.nodesUpdatedFromTree, 18, "nodesUpdatedFromTree");
+      assert_equals(initial.nodesInTreeUpdate, 18, "nodesInTreeUpdate");
 
       document.querySelector("strong").remove();
 
-      let incremental = ServoTestUtils.forceAccessibilityUpdate();
+      let update = ServoTestUtils.forceAccessibilityUpdate();
 
       // Updated nodes:
       // - em (<strong> removed)
-      assert_equals(
-        incremental.accessibilityNodesUpdatedFromDom,
-        1,
-        "accessibilityNodesUpdatedFromDom",
-      );
+      assert_equals(update.nodesUpdatedFromDom, 1, "nodesUpdatedFromDom");
 
       // <html>, <body>, <h2>, <em>
-      assert_equals(
-        incremental.accessibilityNodesUpdatedFromTree,
-        4,
-        "accessibilityNodesUpdatedFromTree",
-      );
+      assert_equals(update.nodesUpdatedFromTree, 4, "nodesUpdatedFromTree");
 
       // Changed nodes:
       // - <h2>, label changed
       // - <em>, children changed
-      assert_equals(
-        incremental.accessibilityNodesInTreeUpdate,
-        2,
-        "accessibilityNodesInTreeUpdate",
-      );
+      assert_equals(update.nodesInTreeUpdate, 2, "nodesInTreeUpdate");
     }, "");
 
     done();

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-descendants-of-heading-change.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-descendants-of-heading-change.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<h2>
+  We really <em>really <strong>really</strong></em> like owls
+</h2>
+
+<script>
+  setup({ explicit_done: true });
+  window.onload = () => {
+    test((t) => {
+      ServoTestUtils.ensureAccessibilityActive();
+      let initial = ServoTestUtils.forceAccessibilityUpdate();
+
+      assert_equals(
+        initial.accessibilityNodesUpdatedFromDom,
+        18,
+        "accessibilityNodesUpdatedFromDom",
+      );
+      assert_equals(
+        initial.accessibilityNodesUpdatedFromTree,
+        18,
+        "accessibilityNodesUpdatedFromTree",
+      );
+      assert_equals(
+        initial.accessibilityNodesInTreeUpdate,
+        18,
+        "accessibilityNodesInTreeUpdate",
+      );
+
+      document.querySelector("strong").remove();
+
+      let incremental = ServoTestUtils.forceAccessibilityUpdate();
+
+      // Updated nodes:
+      // - em (<strong> removed)
+      assert_equals(
+        incremental.accessibilityNodesUpdatedFromDom,
+        1,
+        "accessibilityNodesUpdatedFromDom",
+      );
+
+      // <html>, <body>, <h2>, <em>
+      assert_equals(
+        incremental.accessibilityNodesUpdatedFromTree,
+        4,
+        "accessibilityNodesUpdatedFromTree",
+      );
+
+      // Changed nodes:
+      // - <h2>, label changed
+      // - <em>, children changed
+      assert_equals(
+        incremental.accessibilityNodesInTreeUpdate,
+        2,
+        "accessibilityNodesInTreeUpdate",
+      );
+    }, "");
+
+    done();
+  };
+</script>

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-mutation-move-nodes.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-mutation-move-nodes.html
@@ -16,35 +16,19 @@
       ServoTestUtils.ensureAccessibilityActive();
       let initial = ServoTestUtils.forceAccessibilityUpdate();
 
-      assert_equals(
-        initial.accessibilityNodesUpdatedFromDom,
-        23,
-        "accessibilityNodesUpdatedFromDom",
-      );
-      assert_equals(
-        initial.accessibilityNodesUpdatedFromTree,
-        23,
-        "accessibilityNodesUpdatedFromTree",
-      );
-      assert_equals(
-        initial.accessibilityNodesInTreeUpdate,
-        23,
-        "accessibilityNodesInTreeUpdate",
-      );
+      assert_equals(initial.nodesUpdatedFromDom, 23, "nodesUpdatedFromDom");
+      assert_equals(initial.nodesUpdatedFromTree, 23, "nodesUpdatedFromTree");
+      assert_equals(initial.nodesInTreeUpdate, 23, "nodesInTreeUpdate");
 
       div1.moveBefore(h1, null);
       div2.appendChild(h2);
-      let incremental = window.ServoTestUtils.forceAccessibilityUpdate();
+      let update = window.ServoTestUtils.forceAccessibilityUpdate();
 
       // Nodes updated from DOM:
       // - div1 (child added)
       // - div2 (child added)
       // - <section> (children removed)
-      assert_equals(
-        incremental.accessibilityNodesUpdatedFromDom,
-        3,
-        "accessibilityNodesUpdatedFromDom",
-      );
+      assert_equals(update.nodesUpdatedFromDom, 3, "nodesUpdatedFromDom");
 
       // Nodes checked for changes based on the tree:
       // - the document
@@ -52,21 +36,13 @@
       // - <section>
       // - div1
       // - div2
-      assert_equals(
-        incremental.accessibilityNodesUpdatedFromTree,
-        5,
-        "accessibilityNodesUpdatedFromTree",
-      );
+      assert_equals(update.nodesUpdatedFromTree, 5, "nodesUpdatedFromTree");
 
       //  updated nodes:
       // - <section>, which had 2 children removed
       // - div1, which had 1 node (<h1>) added
       // - div2, which had 1 node (<h2>) added
-      assert_equals(
-        incremental.accessibilityNodesInTreeUpdate,
-        3,
-        "accessibilityNodesInTreeUpdate",
-      );
+      assert_equals(update.nodesInTreeUpdate, 3, "nodesInTreeUpdate");
     }, "Moving two nodes should update 3 nodes");
 
     done();

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-partial-subtree-move-and-delete.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-partial-subtree-move-and-delete.html
@@ -19,56 +19,32 @@
       ServoTestUtils.ensureAccessibilityActive();
       let initial = ServoTestUtils.forceAccessibilityUpdate();
 
-      assert_equals(
-        initial.accessibilityNodesUpdatedFromDom,
-        29,
-        "accessibilityNodesUpdatedFromDom",
-      );
-      assert_equals(
-        initial.accessibilityNodesUpdatedFromTree,
-        29,
-        "accessibilityNodesUpdatedFromTree",
-      );
-      assert_equals(
-        initial.accessibilityNodesInTreeUpdate,
-        29,
-        "accessibilityNodesInTreeUpdate",
-      );
+      assert_equals(initial.nodesUpdatedFromDom, 29, "nodesUpdatedFromDom");
+      assert_equals(initial.nodesUpdatedFromTree, 29, "nodesUpdatedFromTree");
+      assert_equals(initial.nodesInTreeUpdate, 29, "nodesInTreeUpdate");
 
       div3.moveBefore(div2, h2);
       div3.moveBefore(h1, div2);
       p.remove();
       div1.remove();
 
-      let incremental = ServoTestUtils.forceAccessibilityUpdate();
+      let update = ServoTestUtils.forceAccessibilityUpdate();
 
       // Updated nodes:
       // - div1 (div2 removed - redundant update, since div1 is removed!)
       // - <section> (div1 removed)
       // - div2 (<p> and <h1> removed)
       // - div3 (new children)
-      assert_equals(
-        incremental.accessibilityNodesUpdatedFromDom,
-        4,
-        "accessibilityNodesUpdatedFromDom",
-      );
+      assert_equals(update.nodesUpdatedFromDom, 4, "nodesUpdatedFromDom");
 
       // <html>, <body>, <section>, div3, div2
-      assert_equals(
-        incremental.accessibilityNodesUpdatedFromTree,
-        5,
-        "accessibilityNodesUpdatedFromTree",
-      );
+      assert_equals(update.nodesUpdatedFromTree, 5, "nodesUpdatedFromTree");
 
       // Changed nodes:
       // - <section>, children changed
       // - div2, children changed
       // - div3, children changed
-      assert_equals(
-        incremental.accessibilityNodesInTreeUpdate,
-        3,
-        "accessibilityNodesInTreeUpdate",
-      );
+      assert_equals(update.nodesInTreeUpdate, 3, "nodesInTreeUpdate");
     }, "");
 
     done();

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-partial-subtree-move-and-delete.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-partial-subtree-move-and-delete.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<section>
+  <div id="div1">
+    <div id="div2">
+      <h1 id="h1">This is an h1</h1>
+      <p id="p">This is a paragraph</p>
+    </div>
+  </div>
+  <div id="div3"><h2 id="h2">This is an h2</h2></div>
+</section>
+
+<script>
+  setup({ explicit_done: true });
+  window.onload = () => {
+    test((t) => {
+      ServoTestUtils.ensureAccessibilityActive();
+      let initial = ServoTestUtils.forceAccessibilityUpdate();
+
+      assert_equals(
+        initial.accessibilityNodesUpdatedFromDom,
+        29,
+        "accessibilityNodesUpdatedFromDom",
+      );
+      assert_equals(
+        initial.accessibilityNodesUpdatedFromTree,
+        29,
+        "accessibilityNodesUpdatedFromTree",
+      );
+      assert_equals(
+        initial.accessibilityNodesInTreeUpdate,
+        29,
+        "accessibilityNodesInTreeUpdate",
+      );
+
+      div3.moveBefore(div2, h2);
+      div3.moveBefore(h1, div2);
+      p.remove();
+      div1.remove();
+
+      let incremental = ServoTestUtils.forceAccessibilityUpdate();
+
+      // Updated nodes:
+      // - div1 (div2 removed - redundant update, since div1 is removed!)
+      // - <section> (div1 removed)
+      // - div2 (<p> and <h1> removed)
+      // - div3 (new children)
+      assert_equals(
+        incremental.accessibilityNodesUpdatedFromDom,
+        4,
+        "accessibilityNodesUpdatedFromDom",
+      );
+
+      // <html>, <body>, <section>, div3, div2
+      assert_equals(
+        incremental.accessibilityNodesUpdatedFromTree,
+        5,
+        "accessibilityNodesUpdatedFromTree",
+      );
+
+      // Changed nodes:
+      // - <section>, children changed
+      // - div2, children changed
+      // - div3, children changed
+      assert_equals(
+        incremental.accessibilityNodesInTreeUpdate,
+        3,
+        "accessibilityNodesInTreeUpdate",
+      );
+    }, "");
+
+    done();
+  };
+</script>

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-text-change.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-text-change.html
@@ -13,47 +13,23 @@
       ServoTestUtils.ensureAccessibilityActive();
       let initial = ServoTestUtils.forceAccessibilityUpdate();
 
-      assert_equals(
-        initial.accessibilityNodesUpdatedFromDom,
-        16,
-        "accessibilityNodesUpdatedFromDom",
-      );
-      assert_equals(
-        initial.accessibilityNodesUpdatedFromTree,
-        16,
-        "accessibilityNodesUpdatedFromTree",
-      );
-      assert_equals(
-        initial.accessibilityNodesInTreeUpdate,
-        16,
-        "accessibilityNodesInTreeUpdate",
-      );
+      assert_equals(initial.nodesUpdatedFromDom, 16, "nodesUpdatedFromDom");
+      assert_equals(initial.nodesUpdatedFromTree, 16, "nodesUpdatedFromTree");
+      assert_equals(initial.nodesInTreeUpdate, 16, "nodesInTreeUpdate");
 
       h1.firstChild.appendData(", now with more text");
-      let incremental = window.ServoTestUtils.forceAccessibilityUpdate();
+      let update = window.ServoTestUtils.forceAccessibilityUpdate();
 
       // Just the text node has changed
-      assert_equals(
-        incremental.accessibilityNodesUpdatedFromDom,
-        1,
-        "accessibilityNodesUpdatedFromDom",
-      );
+      assert_equals(update.nodesUpdatedFromDom, 1, "nodesUpdatedFromDom");
 
       // The document, <body>, <section>, <h1> and the text node.
-      assert_equals(
-        incremental.accessibilityNodesUpdatedFromTree,
-        5,
-        "accessibilityNodesUpdatedFromTree",
-      );
+      assert_equals(update.nodesUpdatedFromTree, 5, "nodesUpdatedFromTree");
 
       //  updated nodes:
       // - <h1>, computed label changed
       // - text child of <h1>, value changed
-      assert_equals(
-        incremental.accessibilityNodesInTreeUpdate,
-        2,
-        "accessibilityNodesInTreeUpdate",
-      );
+      assert_equals(update.nodesInTreeUpdate, 2, "nodesInTreeUpdate");
     }, "Append data to text node should update 2 nodes");
 
     done();


### PR DESCRIPTION
Note: this is a bit of a grab-bag of changes. Happy to split it out if necessary.

Improvements:
- Order `counters` above `rooted_nodes` in `AccesibilityUpdate`, and add a doc comment.
- Fix a bug in computing the number of changed nodes in an update:
   - A node may be both changed and removed in a single update, which causes it to be tracked in `changed_nodes`, but we filter out removed nodes from the update (in fact, including them would cause a panic). The counter needs to track the number of nodes actually sent in the update.
   - Future work could avoid updating removed nodes at all, but that's out of scope here.
- Rename fields in `AccessibilityUpdateResult` to remove redundant `accessibility`, making tests easier to read

New tests:
   - Add `accessibility-update-partial-subtree-move-and-delete.html` to match the existing `test_accessibility_partial_subtree_move_and_delete`  in `accessibility.rs`
   - Add `test_accessibility_children_of_heading_change` and `test_accessibility_descendants_of_heading_change`, and matching servo-wpt tests `accessibility-update-children-of-heading-change.html` and `accessibility-update-descendants-of-heading-change.html` to test that changing the subtree of a heading automatically causes its label to be recomputed.
      - These were added as a result of an error in #46530 not being picked up by existing tests.

Testing: Existing and new tests pass.
Fixes: part of #46346 