### PR TITLE
layout: Implement block-axis centering for buttons

### DIFF
--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -29,7 +29,7 @@ use crate::flow::same_formatting_context_block::SameFormattingContextBlock;
 use crate::formatting_contexts::{Baselines, IndependentFormattingContext};
 use crate::fragment_tree::{
     BaseFragmentInfo, BlockLevelLayoutInfo, BoxFragment, CollapsedBlockMargins, CollapsedMargin,
-    Fragment, FragmentFlags,
+    Fragment, FragmentFlags, PositioningFragment,
 };
 use crate::geom::{
     AuOrAuto, LogicalRect, LogicalSides, LogicalSides1D, LogicalVec2, PhysicalPoint, PhysicalRect,
@@ -424,6 +424,8 @@ impl BlockFormattingContext {
         layout_context: &LayoutContext,
         positioning_context: &mut PositioningContext,
         containing_block: &ContainingBlock,
+        lazy_block_size: &LazySize,
+        base: Option<&LayoutBoxBase>,
     ) -> IndependentFormattingContextLayoutResult {
         let mut sequential_layout_state =
             if self.contains_floats || !layout_context.allow_parallel_layout {
@@ -437,7 +439,11 @@ impl BlockFormattingContext {
         // https://drafts.csswg.org/css-sizing-4/#stretch-fit-sizing
         let ignore_block_margins_for_stretch = LogicalSides1D::new(false, false);
 
-        let flow_layout = self.contents.layout(
+        // Store the current length of the positioning context, because below we may need to
+        // adjust the static positions of the abspos within this BFC.
+        let previous_positioning_context_len = positioning_context.len();
+
+        let mut flow_layout = self.contents.layout(
             layout_context,
             positioning_context,
             containing_block,
@@ -458,11 +464,47 @@ impl BlockFormattingContext {
             sequential_layout_state.calculate_clearance(Clear::Both, &CollapsedMargin::zero())
         });
 
+        let content_block_size = flow_layout.content_block_size +
+            flow_layout.collapsible_margins_in_children.end.solve() +
+            clearance.unwrap_or_default();
+
+        // Buttons center their contents in the block axis. Therefore, create an `AnonymousFragment`
+        // that contains the fragments of the contents, and place it as desired.
+        // TODO: Use `align-content` instead, see https://github.com/w3c/csswg-drafts/issues/14190
+        if let Some(base) = base &&
+            base.base_fragment_info
+                .flags
+                .contains(FragmentFlags::IS_BUTTON)
+        {
+            flow_layout.depends_on_block_constraints = true;
+            let final_block_size = lazy_block_size.resolve(|| content_block_size);
+            let align_fragment_rect = LogicalRect {
+                start_corner: LogicalVec2 {
+                    inline: Au::zero(),
+                    block: Au::zero().max((final_block_size - content_block_size) / 2),
+                },
+                size: LogicalVec2 {
+                    inline: containing_block.size.inline,
+                    block: content_block_size,
+                },
+            }
+            .as_physical(Some(containing_block));
+            positioning_context.adjust_static_position_of_hoisted_fragments_with_offset(
+                &align_fragment_rect.origin.to_vector(),
+                previous_positioning_context_len,
+            );
+            let align_fragment = PositioningFragment::new_anonymous(
+                base.style.clone(),
+                align_fragment_rect,
+                flow_layout.fragments,
+                false, /* is_line_box */
+            );
+            flow_layout.fragments = vec![Fragment::Positioning(align_fragment)];
+        }
+
         IndependentFormattingContextLayoutResult {
             fragments: flow_layout.fragments,
-            content_block_size: flow_layout.content_block_size +
-                flow_layout.collapsible_margins_in_children.end.solve() +
-                clearance.unwrap_or_default(),
+            content_block_size,
             content_inline_size_for_table: None,
             baselines: flow_layout.baselines,
             depends_on_block_constraints: flow_layout.depends_on_block_constraints,

--- a/components/layout/flow/root.rs
+++ b/components/layout/flow/root.rs
@@ -198,6 +198,8 @@ impl BoxTree {
             layout_context,
             &mut positioning_context,
             &(&initial_containing_block).into(),
+            &initial_containing_block.size.block.into(),
+            None,
         );
 
         let mut root_fragments = independent_layout.fragments;

--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -469,6 +469,8 @@ impl IndependentFormattingContext {
                 layout_context,
                 positioning_context,
                 containing_block_for_children,
+                lazy_block_size,
+                Some(&self.base),
             ),
             IndependentFormattingContextContents::Flex(fc) => fc.layout(
                 layout_context,

--- a/components/layout/fragment_tree/base_fragment.rs
+++ b/components/layout/fragment_tree/base_fragment.rs
@@ -17,7 +17,8 @@ use servo_arc::Arc as ServoArc;
 use style::dom::OpaqueNode;
 use style::properties::ComputedValues;
 use style::selector_parser::PseudoElement;
-use web_atoms::local_name;
+use stylo_atoms::atom;
+use web_atoms::{local_name, ns};
 
 use crate::SharedStyle;
 use crate::dom_traversal::NodeAndStyleInfo;
@@ -213,6 +214,20 @@ impl From<ServoLayoutNode<'_>> for BaseFragmentInfo {
                 },
                 &local_name!("input") => {
                     flags.insert(FragmentFlags::IS_INPUT_ELEMENT);
+                    if element
+                        .attribute(&ns!(), &local_name!("type"))
+                        .is_some_and(|attr| {
+                            matches!(
+                                attr.as_atom().to_ascii_lowercase(),
+                                atom!("button") | atom!("color") | atom!("reset") | atom!("submit")
+                            )
+                        })
+                    {
+                        flags.insert(FragmentFlags::IS_BUTTON);
+                    }
+                },
+                &local_name!("button") => {
+                    flags.insert(FragmentFlags::IS_BUTTON);
                 },
                 _ => {},
             }
@@ -267,7 +282,8 @@ bitflags! {
         const IS_COLLAPSED = 1 << 11;
         /// Whether or not the node that created this Fragment is a `<input>` element.
         const IS_INPUT_ELEMENT = 1 << 12;
-
+        /// Whether this is a <button> element, or an <input> that uses button layout.
+        const IS_BUTTON = 1 << 13;
     }
 }
 

--- a/tests/wpt/meta/css/css-position/containing-block-change-button.html.ini
+++ b/tests/wpt/meta/css/css-position/containing-block-change-button.html.ini
@@ -1,2 +1,0 @@
-[containing-block-change-button.html]
-  expected: FAIL

--- a/tests/wpt/tests/html/rendering/widgets/button-layout/centering-001-ref.html
+++ b/tests/wpt/tests/html/rendering/widgets/button-layout/centering-001-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+div {
+  display: table-cell;
+  width: 200px;
+  height: 200px;
+  text-align: center;
+  vertical-align: middle;
+}
+</style>
+<button><div>ABC</div></button>

--- a/tests/wpt/tests/html/rendering/widgets/button-layout/centering-001.html
+++ b/tests/wpt/tests/html/rendering/widgets/button-layout/centering-001.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Text inside of a button gets centered vertically and horizontally</title>
+<link rel="author" href="mailto:obrufau@igalia.com" title="Oriol Brufau">
+<link rel="help" href="https://html.spec.whatwg.org/#button-layout">
+<link rel="match" href="centering-001-ref.html">
+<style>
+button {
+  box-sizing: content-box;
+  width: 200px;
+  height: 200px;
+}
+</style>
+<button>ABC</button>

--- a/tests/wpt/tests/html/rendering/widgets/button-layout/centering-002.html
+++ b/tests/wpt/tests/html/rendering/widgets/button-layout/centering-002.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Text inside of an input with button layout gets centered vertically and horizontally</title>
+<link rel="author" href="mailto:obrufau@igalia.com" title="Oriol Brufau">
+<link rel="help" href="https://html.spec.whatwg.org/#button-layout">
+<link rel="match" href="centering-001-ref.html">
+<style>
+input {
+  box-sizing: content-box;
+  width: 200px;
+  height: 200px;
+}
+</style>
+<input type="button" value="ABC">

--- a/tests/wpt/tests/html/rendering/widgets/button-layout/centering-003-ref.html
+++ b/tests/wpt/tests/html/rendering/widgets/button-layout/centering-003-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+.wrapper {
+  display: table-cell;
+  width: 200px;
+  height: 200px;
+  vertical-align: middle;
+}
+.wrapper > div {
+  width: 100px;
+  border: solid;
+  text-align: center;
+}
+</style>
+<button>
+  <div class="wrapper">
+    <div>ABC</div>
+  </div>
+</button>

--- a/tests/wpt/tests/html/rendering/widgets/button-layout/centering-003.html
+++ b/tests/wpt/tests/html/rendering/widgets/button-layout/centering-003.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Block-level inside of a button gets centered vertically but not horizontally</title>
+<link rel="author" href="mailto:obrufau@igalia.com" title="Oriol Brufau">
+<link rel="help" href="https://html.spec.whatwg.org/#button-layout">
+<link rel="help" href="https://github.com/whatwg/html/issues/12701">
+<link rel="match" href="centering-003-ref.html">
+<style>
+button {
+  box-sizing: content-box;
+  width: 200px;
+  height: 200px;
+}
+button > div {
+  width: 100px;
+  border: solid;
+}
+</style>
+<button>
+  <div>ABC</div>
+</button>


### PR DESCRIPTION
Mark `<button>` elements and `<input>` that lay out as buttons with a new `FragmentFlags::IS_BUTTON` flag. Then, if they contain a block formatting context, center their contents in the block axis.

This is done similarly as for `vertical-align` on table cells: we wrap the contents inside a `PositioningFragment`, which is then shifted to appear at the correct place. But unlike table cells, this is done before caching the layout results, not afterwards.

In the future, when we implement `align-content` for block containers, we should probably switch to that.

Testing: 1 tests passes, and adding 3 new tests
Fixes: #41432
