### PR TITLE
script: Mechanically migrate more to `reflect_dom_object_with_proto`

### DIFF
--- a/components/script/dom/audio/audiobuffersourcenode.rs
+++ b/components/script/dom/audio/audiobuffersourcenode.rs
@@ -8,7 +8,7 @@ use std::f32;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_media::audio::buffer_source_node::{
     AudioBufferSourceNodeMessage, AudioBufferSourceNodeOptions,
 };
@@ -120,11 +120,11 @@ impl AudioBufferSourceNode {
         options: &AudioBufferSourceOptions,
     ) -> Fallible<DomRoot<AudioBufferSourceNode>> {
         let node = AudioBufferSourceNode::new_inherited(cx, window, context, options)?;
-        Ok(reflect_dom_object_with_proto_and_cx(
+        Ok(reflect_dom_object_with_proto(
+            cx,
             Box::new(node),
             window,
             proto,
-            cx,
         ))
     }
 }

--- a/components/script/dom/audio/biquadfilternode.rs
+++ b/components/script/dom/audio/biquadfilternode.rs
@@ -8,7 +8,7 @@ use std::f32;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_media::audio::biquad_filter_node::{
     BiquadFilterNodeMessage, BiquadFilterNodeOptions, FilterType,
 };
@@ -138,11 +138,11 @@ impl BiquadFilterNode {
         options: &BiquadFilterOptions,
     ) -> Fallible<DomRoot<BiquadFilterNode>> {
         let node = BiquadFilterNode::new_inherited(cx, window, context, options)?;
-        Ok(reflect_dom_object_with_proto_and_cx(
+        Ok(reflect_dom_object_with_proto(
+            cx,
             Box::new(node),
             window,
             proto,
-            cx,
         ))
     }
 }

--- a/components/script/dom/audio/channelmergernode.rs
+++ b/components/script/dom/audio/channelmergernode.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_media::audio::channel_node::ChannelNodeOptions;
 use servo_media::audio::node::AudioNodeInit;
 
@@ -79,11 +79,11 @@ impl ChannelMergerNode {
         options: &ChannelMergerOptions,
     ) -> Fallible<DomRoot<ChannelMergerNode>> {
         let node = ChannelMergerNode::new_inherited(cx, window, context, options)?;
-        Ok(reflect_dom_object_with_proto_and_cx(
+        Ok(reflect_dom_object_with_proto(
+            cx,
             Box::new(node),
             window,
             proto,
-            cx,
         ))
     }
 }

--- a/components/script/dom/audio/channelsplitternode.rs
+++ b/components/script/dom/audio/channelsplitternode.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_media::audio::node::AudioNodeInit;
 
 use crate::dom::audio::audionode::{AudioNode, AudioNodeOptionsHelper, MAX_CHANNEL_COUNT};
@@ -79,11 +79,11 @@ impl ChannelSplitterNode {
         options: &ChannelSplitterOptions,
     ) -> Fallible<DomRoot<ChannelSplitterNode>> {
         let node = ChannelSplitterNode::new_inherited(cx, window, context, options)?;
-        Ok(reflect_dom_object_with_proto_and_cx(
+        Ok(reflect_dom_object_with_proto(
+            cx,
             Box::new(node),
             window,
             proto,
-            cx,
         ))
     }
 }

--- a/components/script/dom/audio/constantsourcenode.rs
+++ b/components/script/dom/audio/constantsourcenode.rs
@@ -7,7 +7,7 @@ use std::f32;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_media::audio::constant_source_node::ConstantSourceNodeOptions as ServoMediaConstantSourceOptions;
 use servo_media::audio::node::{AudioNodeInit, AudioNodeType};
 use servo_media::audio::param::ParamType;
@@ -86,11 +86,11 @@ impl ConstantSourceNode {
         options: &ConstantSourceOptions,
     ) -> Fallible<DomRoot<ConstantSourceNode>> {
         let node = ConstantSourceNode::new_inherited(cx, window, context, options)?;
-        Ok(reflect_dom_object_with_proto_and_cx(
+        Ok(reflect_dom_object_with_proto(
+            cx,
             Box::new(node),
             window,
             proto,
-            cx,
         ))
     }
 }

--- a/components/script/dom/audio/gainnode.rs
+++ b/components/script/dom/audio/gainnode.rs
@@ -7,7 +7,7 @@ use std::f32;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_media::audio::gain_node::GainNodeOptions;
 use servo_media::audio::node::{AudioNodeInit, AudioNodeType};
 use servo_media::audio::param::ParamType;
@@ -88,11 +88,11 @@ impl GainNode {
         options: &GainOptions,
     ) -> Fallible<DomRoot<GainNode>> {
         let node = GainNode::new_inherited(cx, window, context, options)?;
-        Ok(reflect_dom_object_with_proto_and_cx(
+        Ok(reflect_dom_object_with_proto(
+            cx,
             Box::new(node),
             window,
             proto,
-            cx,
         ))
     }
 }

--- a/components/script/dom/audio/iirfilternode.rs
+++ b/components/script/dom/audio/iirfilternode.rs
@@ -10,7 +10,7 @@ use js::context::JSContext;
 use js::gc::CustomAutoRooterGuard;
 use js::rust::HandleObject;
 use js::typedarray::Float32Array;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_media::audio::iir_filter_node::{IIRFilterNode as IIRFilter, IIRFilterNodeOptions};
 use servo_media::audio::node::AudioNodeInit;
 
@@ -91,11 +91,11 @@ impl IIRFilterNode {
         options: &IIRFilterOptions,
     ) -> Fallible<DomRoot<IIRFilterNode>> {
         let node = IIRFilterNode::new_inherited(cx, window, context, options)?;
-        Ok(reflect_dom_object_with_proto_and_cx(
+        Ok(reflect_dom_object_with_proto(
+            cx,
             Box::new(node),
             window,
             proto,
-            cx,
         ))
     }
 }

--- a/components/script/dom/audio/mediaelementaudiosourcenode.rs
+++ b/components/script/dom/audio/mediaelementaudiosourcenode.rs
@@ -7,7 +7,7 @@ use std::sync::mpsc;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_media::audio::media_element_source_node::MediaElementSourceNodeMessage;
 use servo_media::audio::node::{AudioNodeInit, AudioNodeMessage};
 
@@ -73,11 +73,11 @@ impl MediaElementAudioSourceNode {
         media_element: &HTMLMediaElement,
     ) -> Fallible<DomRoot<MediaElementAudioSourceNode>> {
         let node = MediaElementAudioSourceNode::new_inherited(cx, context, media_element)?;
-        Ok(reflect_dom_object_with_proto_and_cx(
+        Ok(reflect_dom_object_with_proto(
+            cx,
             Box::new(node),
             window,
             proto,
-            cx,
         ))
     }
 }

--- a/components/script/dom/audio/mediastreamaudiodestinationnode.rs
+++ b/components/script/dom/audio/mediastreamaudiodestinationnode.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_media::ServoMedia;
 use servo_media::audio::node::AudioNodeInit;
 use servo_media::streams::MediaStreamType;
@@ -76,11 +76,11 @@ impl MediaStreamAudioDestinationNode {
         options: &AudioNodeOptions,
     ) -> Fallible<DomRoot<MediaStreamAudioDestinationNode>> {
         let node = MediaStreamAudioDestinationNode::new_inherited(cx, context, options)?;
-        Ok(reflect_dom_object_with_proto_and_cx(
+        Ok(reflect_dom_object_with_proto(
+            cx,
             Box::new(node),
             window,
             proto,
-            cx,
         ))
     }
 }

--- a/components/script/dom/audio/mediastreamaudiosourcenode.rs
+++ b/components/script/dom/audio/mediastreamaudiosourcenode.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_media::audio::node::AudioNodeInit;
 use servo_media::streams::MediaStreamType;
 
@@ -71,11 +71,11 @@ impl MediaStreamAudioSourceNode {
         stream: &MediaStream,
     ) -> Fallible<DomRoot<MediaStreamAudioSourceNode>> {
         let node = MediaStreamAudioSourceNode::new_inherited(cx, context, stream)?;
-        Ok(reflect_dom_object_with_proto_and_cx(
+        Ok(reflect_dom_object_with_proto(
+            cx,
             Box::new(node),
             window,
             proto,
-            cx,
         ))
     }
 }

--- a/components/script/dom/audio/mediastreamtrackaudiosourcenode.rs
+++ b/components/script/dom/audio/mediastreamtrackaudiosourcenode.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_media::audio::node::AudioNodeInit;
 
 use crate::dom::audio::audiocontext::AudioContext;
@@ -64,11 +64,11 @@ impl MediaStreamTrackAudioSourceNode {
         track: &MediaStreamTrack,
     ) -> Fallible<DomRoot<MediaStreamTrackAudioSourceNode>> {
         let node = MediaStreamTrackAudioSourceNode::new_inherited(cx, context, track)?;
-        Ok(reflect_dom_object_with_proto_and_cx(
+        Ok(reflect_dom_object_with_proto(
+            cx,
             Box::new(node),
             window,
             proto,
-            cx,
         ))
     }
 }

--- a/components/script/dom/audio/offlineaudiocontext.rs
+++ b/components/script/dom/audio/offlineaudiocontext.rs
@@ -12,7 +12,7 @@ use js::context::JSContext;
 use js::realm::CurrentRealm;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_base::id::PipelineId;
 use servo_media::audio::context::OfflineAudioContextOptions as ServoMediaOfflineAudioContextOptions;
 
@@ -89,11 +89,11 @@ impl OfflineAudioContext {
         let pipeline_id = window.pipeline_id();
         let context =
             OfflineAudioContext::new_inherited(channel_count, length, sample_rate, pipeline_id)?;
-        Ok(reflect_dom_object_with_proto_and_cx(
+        Ok(reflect_dom_object_with_proto(
+            cx,
             Box::new(context),
             window,
             proto,
-            cx,
         ))
     }
 }

--- a/components/script/dom/audio/oscillatornode.rs
+++ b/components/script/dom/audio/oscillatornode.rs
@@ -8,7 +8,7 @@ use std::f32;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_media::audio::node::{AudioNodeInit, AudioNodeMessage, AudioNodeType};
 use servo_media::audio::oscillator_node::{
     OscillatorNodeMessage, OscillatorNodeOptions as ServoMediaOscillatorOptions,
@@ -111,11 +111,11 @@ impl OscillatorNode {
         options: &OscillatorOptions,
     ) -> Fallible<DomRoot<OscillatorNode>> {
         let node = OscillatorNode::new_inherited(cx, window, context, options)?;
-        Ok(reflect_dom_object_with_proto_and_cx(
+        Ok(reflect_dom_object_with_proto(
+            cx,
             Box::new(node),
             window,
             proto,
-            cx,
         ))
     }
 }

--- a/components/script/dom/audio/pannernode.rs
+++ b/components/script/dom/audio/pannernode.rs
@@ -8,7 +8,7 @@ use std::f32;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_media::audio::node::{AudioNodeInit, AudioNodeMessage, AudioNodeType};
 use servo_media::audio::panner_node::{
     DistanceModel, PannerNodeMessage, PannerNodeOptions, PanningModel,
@@ -207,11 +207,11 @@ impl PannerNode {
         options: &PannerOptions,
     ) -> Fallible<DomRoot<PannerNode>> {
         let node = PannerNode::new_inherited(cx, window, context, options)?;
-        Ok(reflect_dom_object_with_proto_and_cx(
+        Ok(reflect_dom_object_with_proto(
+            cx,
             Box::new(node),
             window,
             proto,
-            cx,
         ))
     }
 }

--- a/components/script/dom/audio/stereopannernode.rs
+++ b/components/script/dom/audio/stereopannernode.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_media::audio::node::{AudioNodeInit, AudioNodeType};
 use servo_media::audio::param::ParamType;
 use servo_media::audio::stereo_panner::StereoPannerOptions as ServoMediaStereoPannerOptions;
@@ -98,11 +98,11 @@ impl StereoPannerNode {
         options: &StereoPannerOptions,
     ) -> Fallible<DomRoot<StereoPannerNode>> {
         let node = StereoPannerNode::new_inherited(cx, window, context, options)?;
-        Ok(reflect_dom_object_with_proto_and_cx(
+        Ok(reflect_dom_object_with_proto(
+            cx,
             Box::new(node),
             window,
             proto,
-            cx,
         ))
     }
 }

--- a/components/script/dom/canvas/imagedata.rs
+++ b/components/script/dom/canvas/imagedata.rs
@@ -14,7 +14,7 @@ use js::rust::HandleObject;
 use js::typedarray::{ClampedU8, HeapUint8ClampedArray, TypedArray, Uint8ClampedArray};
 use pixels::{Snapshot, SnapshotAlphaMode, SnapshotPixelFormat};
 use rustc_hash::FxHashMap;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use script_bindings::trace::RootedTraceableBox;
 use servo_base::generic_channel::GenericSharedMemory;
 use servo_base::id::{ImageDataId, ImageDataIndex};
@@ -139,7 +139,8 @@ impl ImageData {
             // 8. Otherwise, initialize the colorSpace attribute of imageData to "srgb".
             .unwrap_or(PredefinedColorSpace::Srgb);
 
-        Ok(reflect_dom_object_with_proto_and_cx(
+        Ok(reflect_dom_object_with_proto(
+            cx,
             Box::new(ImageData {
                 reflector_: Reflector::new(),
                 width,
@@ -150,7 +151,6 @@ impl ImageData {
             }),
             global,
             proto,
-            cx,
         ))
     }
 

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -8,7 +8,7 @@ use js::rust::HandleObject;
 use rustc_hash::FxHashMap;
 use script_bindings::match_domstring_ascii;
 use script_bindings::reflector::{
-    Reflector, reflect_dom_object_with_cx, reflect_dom_object_with_proto_and_cx,
+    Reflector, reflect_dom_object_with_cx, reflect_dom_object_with_proto,
 };
 use servo_base::id::{DomExceptionId, DomExceptionIndex};
 use servo_constellation_traits::DomException;
@@ -221,11 +221,11 @@ impl DOMExceptionMethods<crate::DomTypeHolder> for DOMException {
         message: DOMString,
         name: DOMString,
     ) -> Result<DomRoot<DOMException>, Error> {
-        Ok(reflect_dom_object_with_proto_and_cx(
+        Ok(reflect_dom_object_with_proto(
+            cx,
             Box::new(DOMException::new_inherited(message, name)),
             global,
             proto,
-            cx,
         ))
     }
 

--- a/components/script/dom/encoding/textdecoderstream.rs
+++ b/components/script/dom/encoding/textdecoderstream.rs
@@ -9,7 +9,7 @@ use encoding_rs::Encoding;
 use js::conversions::{FromJSValConvertible, ToJSValConvertible};
 use js::jsval::UndefinedValue;
 use js::rust::{HandleObject as SafeHandleObject, HandleValue as SafeHandleValue};
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::DomTypes;
 use crate::dom::bindings::codegen::Bindings::TextDecoderBinding;
@@ -131,11 +131,11 @@ impl TextDecoderStream {
         let transform_stream = TransformStream::new_with_proto(cx, global, None);
         transform_stream.set_up(cx, global, transformer_type)?;
 
-        Ok(reflect_dom_object_with_proto_and_cx(
+        Ok(reflect_dom_object_with_proto(
+            cx,
             Box::new(TextDecoderStream::new_inherited(decoder, &transform_stream)),
             global,
             proto,
-            cx,
         ))
     }
 }

--- a/components/script/dom/encoding/textencoderstream.rs
+++ b/components/script/dom/encoding/textencoderstream.rs
@@ -18,7 +18,7 @@ use js::rust::{
 };
 use js::typedarray::Uint8;
 use script_bindings::conversions::SafeToJSValConvertible;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::buffer_source::create_buffer_source;
 use crate::dom::bindings::codegen::Bindings::TextEncoderStreamBinding::TextEncoderStreamMethods;
@@ -342,11 +342,11 @@ impl TextEncoderStream {
         transform.set_up(cx, global, transformer_type)?;
 
         // Step 6. Set this’s transform to transformStream.
-        Ok(reflect_dom_object_with_proto_and_cx(
+        Ok(reflect_dom_object_with_proto(
+            cx,
             Box::new(TextEncoderStream::new_inherited(&transform)),
             global,
             proto,
-            cx,
         ))
     }
 }

--- a/components/script/dom/quotaexceedederror.rs
+++ b/components/script/dom/quotaexceedederror.rs
@@ -10,9 +10,7 @@ use script_bindings::codegen::GenericBindings::QuotaExceededErrorBinding::{
     QuotaExceededErrorMethods, QuotaExceededErrorOptions,
 };
 use script_bindings::num::Finite;
-use script_bindings::reflector::{
-    reflect_dom_object_with_cx, reflect_dom_object_with_proto_and_cx,
-};
+use script_bindings::reflector::{reflect_dom_object_with_cx, reflect_dom_object_with_proto};
 use script_bindings::root::DomRoot;
 use script_bindings::str::DOMString;
 use servo_base::id::{QuotaExceededErrorId, QuotaExceededErrorIndex};
@@ -96,7 +94,8 @@ impl QuotaExceededErrorMethods<crate::DomTypeHolder> for QuotaExceededError {
         {
             return Err(Error::Range(c"requested is less than quota".to_owned()));
         }
-        Ok(reflect_dom_object_with_proto_and_cx(
+        Ok(reflect_dom_object_with_proto(
+            cx,
             Box::new(QuotaExceededError::new_inherited(
                 message,
                 options.quota,
@@ -104,7 +103,6 @@ impl QuotaExceededErrorMethods<crate::DomTypeHolder> for QuotaExceededError {
             )),
             global,
             proto,
-            cx,
         ))
     }
 


### PR DESCRIPTION
As a cleanup follow-up to the migration to pass `&mut JSContext`, this PR is the result of applying the following regex replacement to the codebase:

Before:

```
Ok\(reflect_dom_object_with_proto_and_cx\((([^<]|\n)+),\n\s+?cx,\n\s+?\)\)
```

After:

```
Ok(reflect_dom_object_with_proto(cx, $1))
```

Part of #40600

Testing: it compiles