### PR TITLE
script: Optimize element::has_class()

### DIFF
--- a/components/script/dom/element/attributes/accessors.rs
+++ b/components/script/dom/element/attributes/accessors.rs
@@ -157,6 +157,19 @@ impl Element {
         }
     }
 
+    /// Returns true if any attribute in the tokenlist fulfill `f`. Equivalent to
+    /// ```get_tokenlist_attribute(name).iiter().any(f)```.
+    pub(crate) fn any_tokenlist_attribute(
+        &self,
+        local_name: &LocalName,
+        f: impl Fn(&Atom) -> bool,
+    ) -> bool {
+        self.with_attribute(&ns!(), local_name, |attribute| {
+            attribute.value().as_tokens().iter().any(f)
+        })
+        .unwrap_or(false)
+    }
+
     pub(crate) fn get_tokenlist_attribute(&self, local_name: &LocalName) -> Vec<Atom> {
         self.with_attribute(&ns!(), local_name, |attribute| {
             attribute.value().as_tokens().to_vec()

--- a/components/script/dom/element/attributes/accessors.rs
+++ b/components/script/dom/element/attributes/accessors.rs
@@ -158,7 +158,7 @@ impl Element {
     }
 
     /// Returns true if any attribute in the tokenlist fulfill `f`. Equivalent to
-    /// ```get_tokenlist_attribute(name).iiter().any(f)```.
+    /// `get_tokenlist_attribute(name).iter().any(f)`.
     pub(crate) fn any_tokenlist_attribute(
         &self,
         local_name: &LocalName,

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -2299,9 +2299,9 @@ impl Element {
     }
 
     pub(crate) fn has_class(&self, name: &Atom, case_sensitivity: CaseSensitivity) -> bool {
-        self.get_tokenlist_attribute(&local_name!("class"))
-            .iter()
-            .any(|atom| case_sensitivity.eq_atom(name, atom))
+        self.any_tokenlist_attribute(&local_name!("class"), |atom| {
+            case_sensitivity.eq_atom(name, atom)
+        })
     }
 
     pub(crate) fn has_attribute(&self, local_name: &LocalName) -> bool {


### PR DESCRIPTION
Elements can have many classes and Element::with_attribute will clone the vector. This makes a special function `any_tokenlist_attribute` which is equivalent to `get_tokenlist_attribute(name).iter().any(f)`.

On a simple run of thomann.de this reduces the overall time spend on has_class from 1.2% to 0.1%.

Testing: The code should be equivalent. WPT tests should find if it is not.
