### PR TITLE
script: Ensure event handlers on adopted elements check the owner document.

### DIFF
--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -175,6 +175,7 @@ use crate::dom::trustedtypes::trustedhtml::TrustedHTML;
 use crate::dom::trustedtypes::trustedtypepolicyfactory::TrustedTypePolicyFactory;
 use crate::dom::validation::Validatable;
 use crate::dom::validitystate::ValidationFlags;
+use crate::dom::window::Window;
 use crate::layout_dom::ServoDangerousStyleElement;
 use crate::realms::enter_auto_realm;
 use crate::script_thread::ScriptThread;
@@ -5385,4 +5386,10 @@ pub(crate) fn is_element_affected_by_legacy_background_presentational_hint(
                 local_name!("td") |
                 local_name!("th")
         )
+}
+
+impl script_bindings::callback::OwnerWindow<crate::DomTypeHolder> for Element {
+    fn owner_window(&self) -> Option<DomRoot<Window>> {
+        Some(NodeTraits::owner_window(self))
+    }
 }

--- a/components/script/dom/event/eventtarget.rs
+++ b/components/script/dom/event/eventtarget.rs
@@ -21,6 +21,7 @@ use js::rust::wrappers2::CompileFunction;
 use js::rust::{CompileOptionsWrapper, HandleObject, transform_u16_to_source_text};
 use libc::c_char;
 use rustc_hash::{FxBuildHasher, FxHashSet};
+use script_bindings::callback::OwnerWindow;
 use script_bindings::cell::DomRefCell;
 use script_bindings::cformat;
 use script_bindings::reflector::{DomObject, Reflector, reflect_dom_object_with_proto_and_cx};
@@ -1147,5 +1148,11 @@ impl Convert<EventListenerOptions> for EventListenerOptionsOrBoolean {
             EventListenerOptionsOrBoolean::EventListenerOptions(options) => options,
             EventListenerOptionsOrBoolean::Boolean(capture) => EventListenerOptions { capture },
         }
+    }
+}
+
+impl OwnerWindow<crate::DomTypeHolder> for EventTarget {
+    fn owner_window(&self) -> Option<DomRoot<Window>> {
+        self.downcast::<Node>().map(|node| node.owner_window())
     }
 }

--- a/components/script/dom/geolocation/geolocation.rs
+++ b/components/script/dom/geolocation/geolocation.rs
@@ -9,7 +9,7 @@ use js::context::JSContext;
 use js::gc::HandleValue;
 use js::jsapi::IsCallable;
 use rustc_hash::FxHashSet;
-use script_bindings::callback::ExceptionHandling;
+use script_bindings::callback::{ExceptionHandling, OwnerWindow};
 use script_bindings::codegen::GenericBindings::GeolocationBinding::Geolocation_Binding::GeolocationMethods;
 use script_bindings::codegen::GenericBindings::GeolocationBinding::{
     PositionCallback, PositionErrorCallback, PositionOptions,
@@ -199,3 +199,5 @@ impl GeolocationMethods<DomTypeHolder> for Geolocation {
         }
     }
 }
+
+impl OwnerWindow<crate::DomTypeHolder> for Geolocation {}

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -54,6 +54,7 @@ use profile_traits::{
     time as profile_time,
 };
 use rustc_hash::{FxBuildHasher, FxHashMap};
+use script_bindings::callback::OwnerWindow;
 use script_bindings::cell::{DomRefCell, RefMut};
 use script_bindings::interfaces::GlobalScopeHelpers;
 use script_bindings::reflector::DomObject;
@@ -3615,3 +3616,5 @@ impl GlobalScopeHelpers<crate::DomTypeHolder> for GlobalScope {
         self.is_secure_context()
     }
 }
+
+impl OwnerWindow<DomTypeHolder> for GlobalScope {}

--- a/components/script/dom/intersectionobserver/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver/intersectionobserver.rs
@@ -1075,3 +1075,5 @@ impl IntersectionObservationOutput {
         }
     }
 }
+
+impl script_bindings::callback::OwnerWindow<crate::DomTypeHolder> for IntersectionObserver {}

--- a/components/script/dom/mutationobserver/mutationobserver.rs
+++ b/components/script/dom/mutationobserver/mutationobserver.rs
@@ -10,6 +10,7 @@ use dom_struct::dom_struct;
 use html5ever::{LocalName, Namespace, ns};
 use js::context::JSContext;
 use js::rust::HandleObject;
+use script_bindings::callback::OwnerWindow;
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 
@@ -378,3 +379,5 @@ impl MutationObserverMethods<crate::DomTypeHolder> for MutationObserver {
         self.record_queue.borrow_mut().clear();
     }
 }
+
+impl OwnerWindow<crate::DomTypeHolder> for MutationObserver {}

--- a/components/script/dom/node/nodeiterator.rs
+++ b/components/script/dom/node/nodeiterator.rs
@@ -7,6 +7,7 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
+use script_bindings::callback::OwnerWindow;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
 use crate::dom::bindings::callback::ExceptionHandling::Rethrow;
@@ -232,3 +233,5 @@ pub(crate) enum Filter {
     None,
     Callback(#[ignore_malloc_size_of = "callbacks are hard"] Rc<NodeFilter>),
 }
+
+impl OwnerWindow<crate::DomTypeHolder> for NodeIterator {}

--- a/components/script/dom/node/treewalker.rs
+++ b/components/script/dom/node/treewalker.rs
@@ -7,6 +7,7 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
+use script_bindings::callback::OwnerWindow;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use script_bindings::script_runtime::temp_cx;
 
@@ -504,3 +505,5 @@ pub(crate) enum Filter {
     None,
     Dom(Rc<NodeFilter>),
 }
+
+impl OwnerWindow<crate::DomTypeHolder> for TreeWalker {}

--- a/components/script/dom/performance/performanceobserver.rs
+++ b/components/script/dom/performance/performanceobserver.rs
@@ -8,6 +8,7 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::{HandleObject, MutableHandleValue};
+use script_bindings::callback::OwnerWindow;
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 
@@ -214,3 +215,5 @@ impl PerformanceObserverMethods<crate::DomTypeHolder> for PerformanceObserver {
         taken
     }
 }
+
+impl OwnerWindow<crate::DomTypeHolder> for PerformanceObserver {}

--- a/components/script/dom/reporting/reportingobserver.rs
+++ b/components/script/dom/reporting/reportingobserver.rs
@@ -9,6 +9,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
+use script_bindings::callback::OwnerWindow;
 use script_bindings::cell::DomRefCell;
 use script_bindings::match_domstring_ascii;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
@@ -339,3 +340,5 @@ impl GlobalScope {
         unreachable!();
     }
 }
+
+impl OwnerWindow<crate::DomTypeHolder> for ReportingObserver {}

--- a/components/script/dom/resizeobserver/resizeobserver.rs
+++ b/components/script/dom/resizeobserver/resizeobserver.rs
@@ -425,3 +425,5 @@ fn calculate_box_size(
         },
     }
 }
+
+impl script_bindings::callback::OwnerWindow<crate::DomTypeHolder> for ResizeObserver {}

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -17,6 +17,7 @@ use js::rust::wrappers2::JS_GetScriptedCallerPrivate;
 use js::rust::{HandleValue, IntoHandle};
 use net_traits::request::ParserMetadata;
 use rustc_hash::FxHashMap;
+use script_bindings::callback::OwnerWindow;
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::DomObject;
 use serde::{Deserialize, Serialize};
@@ -25,6 +26,7 @@ use servo_config::pref;
 use servo_url::ServoUrl;
 use timers::{BoxedTimerCallback, TimerEventRequest};
 
+use crate::DomTypeHolder;
 use crate::dom::bindings::callback::ExceptionHandling::Report;
 use crate::dom::bindings::codegen::Bindings::FunctionBinding::Function;
 use crate::dom::bindings::codegen::UnionTypes::TrustedScriptOrString;
@@ -148,7 +150,12 @@ pub(crate) enum OneshotTimerCallback {
 }
 
 impl OneshotTimerCallback {
-    fn invoke<T: DomObject>(self, this: &T, js_timers: &JsTimers, cx: &mut JSContext) {
+    fn invoke<T: DomObject + OwnerWindow<DomTypeHolder>>(
+        self,
+        this: &T,
+        js_timers: &JsTimers,
+        cx: &mut JSContext,
+    ) {
         match self {
             OneshotTimerCallback::XhrTimeout(callback) => callback.invoke(cx),
             OneshotTimerCallback::EventSourceTimeout(callback) => callback.invoke(),
@@ -784,7 +791,12 @@ fn clamp_duration(nesting_level: u32, unclamped: Duration) -> Duration {
 
 impl JsTimerTask {
     // see https://html.spec.whatwg.org/multipage/#timer-initialisation-steps
-    fn invoke<T: DomObject>(self, this: &T, timers: &JsTimers, cx: &mut JSContext) {
+    fn invoke<T: DomObject + OwnerWindow<DomTypeHolder>>(
+        self,
+        this: &T,
+        timers: &JsTimers,
+        cx: &mut JSContext,
+    ) {
         // step 9.2 can be ignored, because we proactively prevent execution
         // of this task when its scheduled execution is canceled.
 

--- a/components/script_bindings/callback.rs
+++ b/components/script_bindings/callback.rs
@@ -16,7 +16,6 @@ use js::rust::{HandleObject, MutableHandleValue, Runtime};
 
 use crate::codegen::GenericBindings::WindowBinding::Window_Binding::WindowMethods;
 use crate::error::{Error, Fallible};
-use crate::inheritance::Castable;
 use crate::interfaces::{DocumentHelpers, DomHelpers, GlobalScopeHelpers};
 use crate::realms::enter_auto_realm;
 use crate::reflector::DomObject;
@@ -26,6 +25,17 @@ use crate::{DomTypes, cformat};
 
 pub trait ThisReflector {
     fn jsobject(&self) -> *mut JSObject;
+}
+
+/// Try to obtain a Window object from a callback target.
+/// This Window may be different than the callback's associated global if the
+/// owner has been adopted into a different realm than it was created in.
+/// As such, the default implementation should be used for any callback target
+/// that cannot be adopted (i.e. is not a descendant of Node).
+pub trait OwnerWindow<D: DomTypes> {
+    fn owner_window(&self) -> Option<crate::root::DomRoot<D::Window>> {
+        None
+    }
 }
 
 impl<T: DomObject> ThisReflector for T {
@@ -39,6 +49,8 @@ impl ThisReflector for HandleObject<'_> {
         self.get()
     }
 }
+
+impl<D: DomTypes> OwnerWindow<D> for HandleObject<'_> {}
 
 /// The exception handling used for a call.
 #[derive(Clone, Copy, PartialEq)]
@@ -253,19 +265,20 @@ pub(crate) fn wrap_call_this_value<T: ThisReflector>(
 /// A function wrapper that performs whatever setup we need to safely make a call.
 ///
 /// <https://webidl.spec.whatwg.org/#es-invoking-callback-functions>
-pub fn call_setup<D: DomTypes, T: CallbackContainer<D>, R>(
+pub(crate) fn call_setup<D: DomTypes, T: CallbackContainer<D>, R>(
     cx: &mut JSContext,
     callback: &T,
+    owner_window: Option<&D::Window>,
     handling: ExceptionHandling,
     f: impl FnOnce(&mut JSContext) -> R,
 ) -> R {
-    // The global for reporting exceptions. This is the global object of the
-    // (possibly wrapped) callback object.
-    let global = unsafe { D::GlobalScope::from_object(callback.callback()) };
-    if let Some(window) = global.downcast::<D::Window>() {
+    if let Some(window) = owner_window {
         window.Document().ensure_safe_to_run_script_or_layout();
     }
 
+    // The global for reporting exceptions. This is the global object of the
+    // (possibly wrapped) callback object.
+    let global = unsafe { D::GlobalScope::from_object(callback.callback()) };
     let global = &global;
 
     // Step 8: Prepare to run script with relevant settings.

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -8485,7 +8485,8 @@ class CGCallback(CGClass):
         argsWithoutThis.insert(0, Argument(None, "&self"))
 
         bodyWithThis = (
-            "call_setup(cx, self, aExceptionHandling, |cx| {\n"
+            "let owner_window = thisObj.owner_window();\n"
+            "call_setup(cx, self, owner_window.as_deref(), aExceptionHandling, |cx| {\n"
             "    rooted!(&in(cx) let mut thisValue: JSVal);\n"
             "    let wrap_result = wrap_call_this_value(cx, thisObj, thisValue.handle_mut());\n"
             "    if !wrap_result {\n"
@@ -8494,12 +8495,12 @@ class CGCallback(CGClass):
             f"    unsafe {{ self.{method.name}({', '.join(argnamesWithThis)}) }}"
             "})")
         bodyWithoutThis = (
-            "call_setup(cx, self, aExceptionHandling, |cx| {\n"
+            "call_setup(cx, self, None, aExceptionHandling, |cx| {\n"
             f"    unsafe {{ self.{method.name}({', '.join(argnamesWithoutThis)}) }}"
             "})")
         return [ClassMethod(f'{method.name}_', method.returnType, args,
                             bodyInHeader=True,
-                            templateArgs=["T: ThisReflector"],
+                            templateArgs=["T: ThisReflector + OwnerWindow<D>"],
                             body=bodyWithThis,
                             visibility='pub'),
                 ClassMethod(f'{method.name}__', method.returnType, argsWithoutThis,

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -32,7 +32,7 @@ pub(crate) mod base {
 
     pub(crate) use crate::callback::{
         CallbackContainer, CallbackFunction, CallbackInterface, CallbackObject, ExceptionHandling,
-        ThisReflector, call_setup, wrap_call_this_value,
+        OwnerWindow, ThisReflector, call_setup, wrap_call_this_value,
     };
     pub(crate) use crate::codegen::DomTypes::DomTypes;
     pub(crate) use crate::codegen::GenericUnionTypes;

--- a/tests/wpt/meta/xhr/open-url-multi-window-6.htm.ini
+++ b/tests/wpt/meta/xhr/open-url-multi-window-6.htm.ini
@@ -1,2 +1,3 @@
 [open-url-multi-window-6.htm]
-  expected: CRASH
+  [XMLHttpRequest: open() in document that is not fully active (but may be active) should throw]
+    expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -25,6 +25,13 @@
     ]
    },
    "mozilla": {
+    "adopt-node-with-event-handler-crash.html": [
+     "7c8773c9184bb18bf4760ee5ea2df3e8bc91d02c",
+     [
+      null,
+      {}
+     ]
+    ],
     "async-html-meta-charset-crash.html": [
      "8743acb152daa256af34bc938f688561abd313c1",
      [

--- a/tests/wpt/mozilla/tests/mozilla/adopt-node-with-event-handler-crash.html
+++ b/tests/wpt/mozilla/tests/mozilla/adopt-node-with-event-handler-crash.html
@@ -1,0 +1,15 @@
+<link rel="help" href="https://github.com/servo/servo/issues/16515">
+<body>
+<script>
+  /*
+    Create an element with a compiled event handler in one realm.
+    Adopt it into another realm and cause the event handler to be invoked.
+    It will not be recompiled against the new realm, but it also should not
+    trigger any assertions.
+   */
+  let i = document.createElement('iframe');
+  document.body.appendChild(i);
+  let i2 = document.createElement('iframe');
+  i2.onload = () => {};
+  i.contentDocument.body.appendChild(i2);
+</script>


### PR DESCRIPTION
To avoid exposing incomplete DOM modifications to script (e.g. firing events before all tree mutations have been performed during a appendChild call), we have checks that run before invoking WebIDL callbacks. These checks attempt to determine the global associated with a callback, but were not handling the case where a callback's owner is adopted into a different document. We now require callback callers to provide an operation to obtain a Window, if that makes sense. Since this has already been implemented for the types that make sense, any future implementations should use the default implementation.

Testing: New crash test added.
Fixes: #46578
