### PR TITLE
script: Reduce rooting in serialization of `DOMQuad`

### DIFF
--- a/components/script/dom/geometry/domquad.rs
+++ b/components/script/dom/geometry/domquad.rs
@@ -200,7 +200,7 @@ impl Serializable for DOMQuad {
     type Data = DomQuad;
 
     fn serialize(&self) -> Result<(DomQuadId, Self::Data), ()> {
-        let make_point = |src: DomRoot<DOMPoint>| -> DomPoint {
+        let make_point = |src: &DOMPoint| -> DomPoint {
             DomPoint {
                 x: src.X(),
                 y: src.Y(),
@@ -209,10 +209,10 @@ impl Serializable for DOMQuad {
             }
         };
         let serialized = DomQuad {
-            p1: make_point(self.P1()),
-            p2: make_point(self.P2()),
-            p3: make_point(self.P3()),
-            p4: make_point(self.P4()),
+            p1: make_point(&self.p1),
+            p2: make_point(&self.p2),
+            p3: make_point(&self.p3),
+            p4: make_point(&self.p4),
         };
         Ok((DomQuadId::new(), serialized))
     }


### PR DESCRIPTION
Instead of using JS binding function to pass to closure which creates new root, directly use the `Dom` field.
Reduces 4 roots per serialize call.

Part of #34464

Testing: Covered by existing tests.
