### PR TITLE
script: Dirty old parents during `moveBy`

### DIFF
--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -555,6 +555,7 @@ impl Node {
 
     fn move_child(&self, cx: &mut JSContext, child: &Node) {
         assert!(child.parent_node.get().as_deref() == Some(self));
+        self.dirty(NodeDamage::ContentOrHeritage);
         self.note_dirty_descendants();
         self.add_pending_accessibility_damage(AccessibilityDamage::Children);
 

--- a/tests/wpt/meta/dom/nodes/moveBefore/focus-preserve-render.html.ini
+++ b/tests/wpt/meta/dom/nodes/moveBefore/focus-preserve-render.html.ini
@@ -1,2 +1,0 @@
-[focus-preserve-render.html]
-  expected: FAIL


### PR DESCRIPTION
Previously, old parents of nodes moving via `moveBy` were not dirtied
for layout. This meant that old contents could have been displayed
inside of them.

Testing: This change fixes a WPT test.
