### PR TITLE
paint: Fix a race condition in the WebGL image handler

### DIFF
--- a/components/paint/webrender_external_images.rs
+++ b/components/paint/webrender_external_images.rs
@@ -58,20 +58,20 @@ impl WebGLExternalImages {
     fn unlock_swap_chain(&mut self, id: WebGLContextId) -> Option<()> {
         debug!("... unlocked chain {:?}", id);
 
+        if let Some(locked_front_buffer) = self.locked_front_buffers.remove(&id) &&
+            let Some(locked_front_buffer) =
+                self.rendering_context.destroy_texture(locked_front_buffer)
+        {
+            self.swap_chains
+                .get(id)
+                .expect("Should always have a SwapChain for a busy WebGLContext")
+                .recycle_surface(locked_front_buffer);
+        }
+
         {
             let mut busy_webgl_context_map = self.busy_webgl_context_map.write();
             *busy_webgl_context_map.entry(id).or_insert(1) -= 1;
         }
-
-        let locked_front_buffer = self.locked_front_buffers.remove(&id)?;
-        let locked_front_buffer = self
-            .rendering_context
-            .destroy_texture(locked_front_buffer)?;
-
-        self.swap_chains
-            .get(id)
-            .expect("Should always have a SwapChain for a busy WebGLContext")
-            .recycle_surface(locked_front_buffer);
 
         let _ = self.webgl_threads.finished_rendering_to_context(id);
 


### PR DESCRIPTION
The changes in #41094 introduced a race condition into
`WebGLExternalImages::unlock_swap_chain`. The `busy_webgl_context_map`
is used to ensure that the WebGL context is not destroyed while the
`SwapChain` is locked. Decrementing before destroying the surface means
that the `WebGLThread` may destroy the context between the decrement and
the destruction, leading to a panic.

Testing: This panic happens rarely when I run WebGL tests locally. I ran all
tests 5 times and didn't see the panic after this change.
