### PR TITLE
script: Halt "update the rendering" for `Document` if rAF blocks rendering

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1289,6 +1289,14 @@ impl ScriptThread {
 
             // TODO: Mark paint timing from https://w3c.github.io/paint-timing.
 
+            // See <https://github.com/whatwg/html/issues/12704>.
+            // Unspecified, but necessary: Any of the previous callbacks may have put the
+            // document into a render-blocked state. If that's the case, then abort the
+            // rendering process now.
+            if document.is_render_blocked() {
+                continue;
+            }
+
             // > Step 22: For each doc of docs, update the rendering or user interface of
             // > doc and its node navigable to reflect the current state.
             if document.update_the_rendering(cx).0.needs_frame() {

--- a/tests/wpt/tests/html/dom/render-blocking/render-blocking-during-update-the-rendering-crash.html
+++ b/tests/wpt/tests/html/dom/render-blocking/render-blocking-during-update-the-rendering-crash.html
@@ -1,0 +1,11 @@
+<body>
+    <link rel="help" href="https://github.com/servo/servo/issues/46303">
+    <div id="container">
+        <link id="link" href="x">
+    </div>
+
+    <script>
+        document.replaceChild(container, document.childNodes[0]);
+        requestAnimationFrame(() => { link.rel = "stylesheet" });
+    </script>
+</body>


### PR DESCRIPTION
A `requestAnimationFrame` can do things that put a `Document` in
render-blocking mode during the process of "update the rendering." If
that happens we should just bail out of the rendering update for the
`Document` until it is time to render. This prevents a panic due to an
assertion failure.

Testing: This change adds a new WPT crash test.
Fixes: #46303.
