### PR TITLE
script: Allow calling get_buffer_source_copy with members of webidl unions.

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -27,7 +27,7 @@ use servo_base::generic_channel::GenericSharedMemory;
 use servo_constellation_traits::BlobImpl;
 use url::form_urlencoded;
 
-use crate::dom::bindings::buffer_source::create_buffer_source;
+use crate::dom::bindings::buffer_source::{create_buffer_source, get_buffer_source_copy};
 use crate::dom::bindings::codegen::Bindings::BlobBinding::Blob_Binding::BlobMethods;
 use crate::dom::bindings::codegen::Bindings::FormDataBinding::FormDataMethods;
 use crate::dom::bindings::codegen::Bindings::XMLHttpRequestBinding::BodyInit;
@@ -526,7 +526,8 @@ impl Extractable for BodyInit {
             BodyInit::Blob(b) => b.extract(cx, global, keep_alive),
             BodyInit::FormData(formdata) => formdata.extract(cx, global, keep_alive),
             BodyInit::ArrayBuffer(typedarray) => {
-                let bytes = typedarray.to_vec();
+                // Set source to a copy of the bytes held by object.
+                let bytes = get_buffer_source_copy(typedarray.into());
                 let total_bytes = bytes.len();
                 let stream = stream_from_body_init_bytes(cx, global, bytes)?;
                 Ok(ExtractedBody {
@@ -537,7 +538,8 @@ impl Extractable for BodyInit {
                 })
             },
             BodyInit::ArrayBufferView(typedarray) => {
-                let bytes = typedarray.to_vec();
+                // Set source to a copy of the bytes held by object.
+                let bytes = get_buffer_source_copy(typedarray.into());
                 let total_bytes = bytes.len();
                 let stream = stream_from_body_init_bytes(cx, global, bytes)?;
                 Ok(ExtractedBody {

--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -77,6 +77,36 @@ impl Clone for BufferSource {
     }
 }
 
+pub(crate) enum ArrayBufferViewOrArrayBufferRef<'a> {
+    ArrayBufferView(&'a RootedTypedArray<ArrayBufferViewU8>),
+    ArrayBuffer(&'a RootedTypedArray<ArrayBufferU8>),
+}
+
+impl<'a> From<&'a RootedTypedArray<ArrayBufferViewU8>> for ArrayBufferViewOrArrayBufferRef<'a> {
+    fn from(view: &'a RootedTypedArray<ArrayBufferViewU8>) -> Self {
+        ArrayBufferViewOrArrayBufferRef::ArrayBufferView(view)
+    }
+}
+
+impl<'a> From<&'a RootedTypedArray<ArrayBufferU8>> for ArrayBufferViewOrArrayBufferRef<'a> {
+    fn from(buffer: &'a RootedTypedArray<ArrayBufferU8>) -> Self {
+        ArrayBufferViewOrArrayBufferRef::ArrayBuffer(buffer)
+    }
+}
+
+impl<'a> From<&'a ArrayBufferViewOrArrayBuffer> for ArrayBufferViewOrArrayBufferRef<'a> {
+    fn from(view_or_buffer: &'a ArrayBufferViewOrArrayBuffer) -> Self {
+        match view_or_buffer {
+            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => {
+                ArrayBufferViewOrArrayBufferRef::ArrayBufferView(view)
+            },
+            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => {
+                ArrayBufferViewOrArrayBufferRef::ArrayBuffer(buffer)
+            },
+        }
+    }
+}
+
 /// <https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy>
 ///
 /// Spec steps and how they're covered:
@@ -97,10 +127,10 @@ impl Clone for BufferSource {
 ///
 /// - **SharedArrayBuffer**: Not applicable — `ArrayBufferViewOrArrayBuffer`
 ///   does not include a SharedArrayBuffer variant.
-pub(crate) fn get_buffer_source_copy(source: &ArrayBufferViewOrArrayBuffer) -> Vec<u8> {
+pub(crate) fn get_buffer_source_copy(source: ArrayBufferViewOrArrayBufferRef<'_>) -> Vec<u8> {
     match source {
-        ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => view.to_vec(),
-        ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
+        ArrayBufferViewOrArrayBufferRef::ArrayBufferView(view) => view.to_vec(),
+        ArrayBufferViewOrArrayBufferRef::ArrayBuffer(buffer) => buffer.to_vec(),
     }
 }
 

--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -495,7 +495,7 @@ fn canonicalize_bluetooth_data_filter_init(
 ) -> Fallible<(Vec<u8>, Vec<u8>)> {
     // Step 1.
     let data_prefix = match &bdfi.dataPrefix {
-        Some(buffer_source) => get_buffer_source_copy(buffer_source),
+        Some(buffer_source) => get_buffer_source_copy(buffer_source.into()),
         None => vec![],
     };
 
@@ -503,7 +503,7 @@ fn canonicalize_bluetooth_data_filter_init(
     // If no mask present, mask will be a sequence of 0xFF bytes the same length as dataPrefix.
     // Masking dataPrefix with this, leaves dataPrefix untouched.
     let mask = match &bdfi.mask {
-        Some(buffer_source) => get_buffer_source_copy(buffer_source),
+        Some(buffer_source) => get_buffer_source_copy(buffer_source.into()),
         None => vec![0xFF; data_prefix.len()],
     };
 

--- a/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
@@ -204,7 +204,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
         }
 
         // Step 2 - 3.
-        let vec = get_buffer_source_copy(&value);
+        let vec = get_buffer_source_copy((&value).into());
 
         if vec.len() > MAXIMUM_ATTRIBUTE_LENGTH {
             p.reject_error(cx, InvalidModification(None));

--- a/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
@@ -145,7 +145,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
         }
 
         // Step 2 - 3.
-        let vec = get_buffer_source_copy(&value);
+        let vec = get_buffer_source_copy((&value).into());
         if vec.len() > MAXIMUM_ATTRIBUTE_LENGTH {
             p.reject_error(cx, InvalidModification(None));
             return p;

--- a/components/script/dom/css/fontface.rs
+++ b/components/script/dom/css/fontface.rs
@@ -29,9 +29,7 @@ use crate::dom::bindings::codegen::Bindings::FontFaceBinding::{
 };
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::codegen::UnionTypes;
-use crate::dom::bindings::codegen::UnionTypes::{
-    ArrayBufferViewOrArrayBuffer, StringOrArrayBufferViewOrArrayBuffer,
-};
+use crate::dom::bindings::codegen::UnionTypes::StringOrArrayBufferViewOrArrayBuffer;
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
@@ -767,16 +765,16 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
         // [[Data]] slot to the passed argument.
         // Step 3. If font face’s [[Data]] slot is not null, queue a task to run the following steps
         // synchronously:
-        let font_face_bytes = match source {
+        let font_face_bytes = match &source {
             StringOrArrayBufferViewOrArrayBuffer::String(_) => {
                 // Return font face.
                 return font_face;
             },
             StringOrArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => {
-                get_buffer_source_copy(&ArrayBufferViewOrArrayBuffer::ArrayBufferView(view))
+                get_buffer_source_copy(view.into())
             },
             StringOrArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => {
-                get_buffer_source_copy(&ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer))
+                get_buffer_source_copy(buffer.into())
             },
         };
         let trusted_font_face = Trusted::new(&*font_face);

--- a/components/script/dom/stream/compressionstream.rs
+++ b/components/script/dom/stream/compressionstream.rs
@@ -321,5 +321,5 @@ pub(crate) fn convert_chunk_to_vec(
     let buffer_source = conversion_result.get_success_value().ok_or_else(|| {
         Error::Type(c"Unable to convert chunk into ArrayBuffer or ArrayBufferView".to_owned())
     })?;
-    Ok(get_buffer_source_copy(buffer_source))
+    Ok(get_buffer_source_copy(buffer_source.into()))
 }

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -401,7 +401,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
 
         // Step 4. Let data be the result of getting a copy of the bytes held by the data parameter
         // passed to the encrypt() method.
-        let data = Zeroizing::new(get_buffer_source_copy(&data));
+        let data = Zeroizing::new(get_buffer_source_copy((&data).into()));
 
         // Step 5. Let realm be the relevant realm of this.
         // Step 6. Let promise be a new Promise.
@@ -485,7 +485,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
 
         // Step 4. Let data be the result of getting a copy of the bytes held by the data parameter
         // passed to the decrypt() method.
-        let data = get_buffer_source_copy(&data);
+        let data = get_buffer_source_copy((&data).into());
 
         // Step 5. Let realm be the relevant realm of this.
         // Step 6. Let promise be a new Promise.
@@ -569,7 +569,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
 
         // Step 4. Let data be the result of getting a copy of the bytes held by the data parameter
         // passed to the sign() method.
-        let data = get_buffer_source_copy(&data);
+        let data = get_buffer_source_copy((&data).into());
 
         // Step 5. Let realm be the relevant realm of this.
         // Step 6. Let promise be a new Promise.
@@ -653,11 +653,11 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
 
         // Step 4. Let signature be the result of getting a copy of the bytes held by the signature
         // parameter passed to the verify() method.
-        let signature = get_buffer_source_copy(&signature);
+        let signature = get_buffer_source_copy((&signature).into());
 
         // Step 5. Let data be the result of getting a copy of the bytes held by the data parameter
         // passed to the verify() method.
-        let data = get_buffer_source_copy(&data);
+        let data = get_buffer_source_copy((&data).into());
 
         // Step 6. Let realm be the relevant realm of this.
         // Step 7. Let promise be a new Promise.
@@ -737,7 +737,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
 
         // Step 4. Let data be the result of getting a copy of the bytes held by the
         // data parameter passed to the digest() method.
-        let data = get_buffer_source_copy(&data);
+        let data = get_buffer_source_copy((&data).into());
 
         // Step 5. Let realm be the relevant realm of this.
         // Step 6. Let promise be a new Promise.
@@ -1173,7 +1173,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             },
             // Otherwise:
             _ => {
-                match key_data {
+                match &key_data {
                     // Step 4.1. If the keyData parameter passed to the importKey() method is a
                     // JsonWebKey dictionary, throw a TypeError.
                     ArrayBufferViewOrArrayBufferOrJsonWebKey::JsonWebKey(_) => {
@@ -1188,14 +1188,10 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                     // Step 4.2. Let keyData be the result of getting a copy of the bytes held by
                     // the keyData parameter passed to the importKey() method.
                     ArrayBufferViewOrArrayBufferOrJsonWebKey::ArrayBufferView(view) => {
-                        Zeroizing::new(get_buffer_source_copy(
-                            &ArrayBufferViewOrArrayBuffer::ArrayBufferView(view),
-                        ))
+                        Zeroizing::new(get_buffer_source_copy(view.into()))
                     },
                     ArrayBufferViewOrArrayBufferOrJsonWebKey::ArrayBuffer(buffer) => {
-                        Zeroizing::new(get_buffer_source_copy(
-                            &ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer),
-                        ))
+                        Zeroizing::new(get_buffer_source_copy(buffer.into()))
                     },
                 }
             },
@@ -1575,7 +1571,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
 
         // Step 7. Let wrappedKey be the result of getting a copy of the bytes held by the
         // wrappedKey parameter passed to the unwrapKey() method.
-        let wrapped_key = get_buffer_source_copy(&wrapped_key);
+        let wrapped_key = get_buffer_source_copy((&wrapped_key).into());
 
         // Step 8. Let realm be the relevant realm of this.
         // Step 9. Let promise be a new Promise.
@@ -1983,7 +1979,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
 
         // Step 6. Let ciphertext be the result of getting a copy of the bytes held by the
         // ciphertext parameter passed to the decapsulateKey() method.
-        let ciphertext = get_buffer_source_copy(&ciphertext);
+        let ciphertext = get_buffer_source_copy((&ciphertext).into());
 
         // Step 7. Let realm be the relevant realm of this.
         // Step 8. Let promise be a new Promise.
@@ -2103,7 +2099,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
 
         // Step 4. Let ciphertext be the result of getting a copy of the bytes held by the
         // ciphertext parameter passed to the decapsulateBits() method.
-        let ciphertext = get_buffer_source_copy(&ciphertext);
+        let ciphertext = get_buffer_source_copy((&ciphertext).into());
 
         // Step 5. Let realm be the relevant realm of this.
         // Step 6. Let promise be a new Promise.
@@ -4141,7 +4137,9 @@ fn get_optional_buffer_source(
     parameter: &std::ffi::CStr,
 ) -> Fallible<Option<Vec<u8>>> {
     let buffer_source = get_property::<ArrayBufferViewOrArrayBuffer>(cx, object, parameter, ())?;
-    Ok(buffer_source.as_ref().map(get_buffer_source_copy))
+    Ok(buffer_source
+        .as_ref()
+        .map(|buffer| get_buffer_source_copy(buffer.into())))
 }
 
 /// Helper to retrieve a required paramter in BufferSource from WebIDL dictionary, and get a copy


### PR DESCRIPTION
In preparation for the changes from https://github.com/servo/mozjs/pull/780, this enables replacing more hand-rolled logic for interacting with typed arrays with the consolidated spec logic in [get_buffer_source_copy](https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy).

Testing: Existing tests suffice.