### PR TITLE
script: Store microtasks as `Box<dyn MicroTaskRunnable>`

### DIFF
--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -54,7 +54,7 @@ use crate::dom::node::{Node, NodeTraits};
 use crate::dom::promise::Promise;
 use crate::dom::shadowroot::ShadowRoot;
 use crate::dom::window::Window;
-use crate::microtask::Microtask;
+use crate::microtask::CustomElementReactionMicrotask;
 use crate::realms::enter_auto_realm;
 use crate::script_thread::ScriptThread;
 
@@ -1316,7 +1316,7 @@ impl CustomElementReactionStack {
                 .set(BackupElementQueueFlag::Processing);
 
             // Step 4
-            ScriptThread::enqueue_microtask(cx, Microtask::CustomElementReaction);
+            ScriptThread::enqueue_microtask(cx, Box::new(CustomElementReactionMicrotask::new()));
         }
     }
 

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -145,7 +145,7 @@ use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::dom::workletglobalscope::WorkletGlobalScope;
 use crate::fetch::{DeferredFetchRecordId, FetchGroup, QueuedDeferredFetchRecord};
 use crate::messaging::{CommonScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
-use crate::microtask::Microtask;
+use crate::microtask::MicrotaskRunnable;
 use crate::network_listener::{FetchResponseListener, NetworkListener};
 use crate::realms::enter_auto_realm;
 use crate::script_module::{
@@ -3068,7 +3068,11 @@ impl GlobalScope {
     }
 
     /// Enqueue a microtask for subsequent execution.
-    pub(crate) fn enqueue_microtask(&self, cx: &js::context::JSContext, job: Microtask) {
+    pub(crate) fn enqueue_microtask(
+        &self,
+        cx: &js::context::JSContext,
+        job: Box<dyn MicrotaskRunnable>,
+    ) {
         if self.is::<Window>() {
             ScriptThread::enqueue_microtask(cx, job);
         } else if let Some(worker) = self.downcast::<WorkerGlobalScope>() {

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -14,7 +14,6 @@ use dom_struct::dom_struct;
 use euclid::default::Point2D;
 use html5ever::{LocalName, Prefix, QualName, local_name, ns};
 use js::context::JSContext;
-use js::realm::AutoRealm;
 use js::rust::HandleObject;
 use mime::{self, Mime};
 use net_traits::http_status::HttpStatus;
@@ -1648,6 +1647,12 @@ pub(crate) enum ImageElementMicrotask {
 
 impl MicrotaskRunnable for ImageElementMicrotask {
     fn handler(&self, cx: &mut js::context::JSContext) {
+        let mut realm = match self {
+            &ImageElementMicrotask::UpdateImageData { ref elem, .. } |
+            &ImageElementMicrotask::EnvironmentChanges { ref elem, .. } |
+            &ImageElementMicrotask::Decode { ref elem, .. } => enter_auto_realm(cx, &**elem),
+        };
+        let cx = &mut realm;
         match *self {
             ImageElementMicrotask::UpdateImageData {
                 ref elem,
@@ -1672,14 +1677,6 @@ impl MicrotaskRunnable for ImageElementMicrotask {
             } => {
                 elem.react_to_decode_image_sync_steps(cx, promise.clone());
             },
-        }
-    }
-
-    fn enter_realm<'cx>(&self, cx: &'cx mut js::context::JSContext) -> AutoRealm<'cx> {
-        match self {
-            &ImageElementMicrotask::UpdateImageData { ref elem, .. } |
-            &ImageElementMicrotask::EnvironmentChanges { ref elem, .. } |
-            &ImageElementMicrotask::Decode { ref elem, .. } => enter_auto_realm(cx, &**elem),
         }
     }
 }

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -79,7 +79,7 @@ use crate::dom::performance::performanceresourcetiming::InitiatorType;
 use crate::dom::promise::Promise;
 use crate::dom::window::Window;
 use crate::fetch::{RequestWithGlobalScope, create_a_potential_cors_request};
-use crate::microtask::{Microtask, MicrotaskRunnable};
+use crate::microtask::MicrotaskRunnable;
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::realms::enter_auto_realm;
 use crate::script_thread::ScriptThread;
@@ -1225,7 +1225,7 @@ impl HTMLImageElement {
             generation: self.generation.get(),
         };
 
-        ScriptThread::await_stable_state(cx, Microtask::ImageElement(task));
+        ScriptThread::await_stable_state(cx, Box::new(task));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#img-environment-changes>
@@ -1236,7 +1236,7 @@ impl HTMLImageElement {
             generation: self.generation.get(),
         };
 
-        ScriptThread::await_stable_state(cx, Microtask::ImageElement(task));
+        ScriptThread::await_stable_state(cx, Box::new(task));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#img-environment-changes>
@@ -1944,7 +1944,7 @@ impl HTMLImageElementMethods<crate::DomTypeHolder> for HTMLImageElement {
             promise: promise.clone(),
         };
 
-        ScriptThread::await_stable_state(cx, Microtask::ImageElement(task));
+        ScriptThread::await_stable_state(cx, Box::new(task));
 
         // Step 3. Return promise.
         promise

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -18,7 +18,7 @@ use html5ever::{LocalName, Prefix, QualName, local_name, ns};
 use http::StatusCode;
 use http::header::{self, HeaderMap, HeaderValue};
 use js::context::JSContext;
-use js::realm::{AutoRealm, CurrentRealm};
+use js::realm::CurrentRealm;
 use layout_api::MediaFrame;
 use media::{GLPlayerMsg, GLPlayerMsgForward, WindowGLContext};
 use net_traits::request::{Destination, RequestId};
@@ -3597,6 +3597,16 @@ pub(crate) enum MediaElementMicrotask {
 
 impl MicrotaskRunnable for MediaElementMicrotask {
     fn handler(&self, cx: &mut JSContext) {
+        let mut realm = match self {
+            &MediaElementMicrotask::ResourceSelection { ref elem, .. } |
+            &MediaElementMicrotask::PauseIfNotInDocument { ref elem } |
+            &MediaElementMicrotask::Seeked { ref elem, .. } |
+            &MediaElementMicrotask::SelectNextSourceChild { ref elem, .. } |
+            &MediaElementMicrotask::SelectNextSourceChildAfterWait { ref elem, .. } => {
+                enter_auto_realm(cx, &**elem)
+            },
+        };
+        let cx = &mut realm;
         match self {
             &MediaElementMicrotask::ResourceSelection {
                 ref elem,
@@ -3639,18 +3649,6 @@ impl MicrotaskRunnable for MediaElementMicrotask {
                 if generation_id == elem.generation_id.get() {
                     elem.select_next_source_child_after_wait(cx);
                 }
-            },
-        }
-    }
-
-    fn enter_realm<'cx>(&self, cx: &'cx mut js::context::JSContext) -> AutoRealm<'cx> {
-        match self {
-            &MediaElementMicrotask::ResourceSelection { ref elem, .. } |
-            &MediaElementMicrotask::PauseIfNotInDocument { ref elem } |
-            &MediaElementMicrotask::Seeked { ref elem, .. } |
-            &MediaElementMicrotask::SelectNextSourceChild { ref elem, .. } |
-            &MediaElementMicrotask::SelectNextSourceChildAfterWait { ref elem, .. } => {
-                enter_auto_realm(cx, &**elem)
             },
         }
     }

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -104,7 +104,7 @@ use crate::dom::url::URL;
 use crate::dom::videotrack::VideoTrack;
 use crate::dom::videotracklist::VideoTrackList;
 use crate::fetch::{FetchCanceller, RequestWithGlobalScope, create_a_potential_cors_request};
-use crate::microtask::{Microtask, MicrotaskRunnable};
+use crate::microtask::MicrotaskRunnable;
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::realms::enter_auto_realm;
 use crate::script_thread::ScriptThread;
@@ -1089,7 +1089,7 @@ impl HTMLMediaElement {
         // method from below, if microtasks were trait objects, we would be able
         // to put the code directly in this method, without the boilerplate
         // indirections.
-        ScriptThread::await_stable_state(cx, Microtask::MediaElement(task));
+        ScriptThread::await_stable_state(cx, Box::new(task));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-media-load-algorithm>
@@ -1312,7 +1312,7 @@ impl HTMLMediaElement {
             generation_id: self.generation_id.get(),
         };
 
-        ScriptThread::await_stable_state(cx, Microtask::MediaElement(task));
+        ScriptThread::await_stable_state(cx, Box::new(task));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-media-load-algorithm>
@@ -1915,7 +1915,7 @@ impl HTMLMediaElement {
             generation_id: self.generation_id.get(),
         };
 
-        ScriptThread::await_stable_state(cx, Microtask::MediaElement(task));
+        ScriptThread::await_stable_state(cx, Box::new(task));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-media-load-algorithm>
@@ -2782,7 +2782,7 @@ impl HTMLMediaElement {
             generation_id: self.generation_id.get(),
         };
 
-        ScriptThread::await_stable_state(cx, Microtask::MediaElement(task));
+        ScriptThread::await_stable_state(cx, Box::new(task));
     }
 
     fn playback_state_changed(&self, cx: &mut JSContext, state: &PlaybackState) {
@@ -3547,7 +3547,7 @@ impl VirtualMethods for HTMLMediaElement {
             let task = MediaElementMicrotask::PauseIfNotInDocument {
                 elem: DomRoot::from_ref(self),
             };
-            ScriptThread::await_stable_state(cx, Microtask::MediaElement(task));
+            ScriptThread::await_stable_state(cx, Box::new(task));
         }
     }
 

--- a/components/script/dom/html/htmltrackelement.rs
+++ b/components/script/dom/html/htmltrackelement.rs
@@ -8,7 +8,6 @@ use content_security_policy::Destination;
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name};
 use js::context::JSContext;
-use js::realm::AutoRealm;
 use js::rust::HandleObject;
 use net_traits::request::{CorsSettings, RequestId};
 use net_traits::{FetchMetadata, NetworkError, ResourceFetchTiming};
@@ -357,7 +356,10 @@ pub(crate) enum TrackElementMicrotask {
 }
 
 impl MicrotaskRunnable for TrackElementMicrotask {
-    fn handler(&self, _cx: &mut JSContext) {
+    fn handler(&self, cx: &mut JSContext) {
+        let _realm = match self {
+            TrackElementMicrotask::ProcessingModel { elem, .. } => enter_auto_realm(cx, &**elem),
+        };
         match self {
             // https://html.spec.whatwg.org/multipage/#start-the-track-processing-model
             TrackElementMicrotask::ProcessingModel {
@@ -405,12 +407,6 @@ impl MicrotaskRunnable for TrackElementMicrotask {
                 // Step 13. Jump to the step labeled top.
                 // TODO
             },
-        }
-    }
-
-    fn enter_realm<'cx>(&self, cx: &'cx mut JSContext) -> AutoRealm<'cx> {
-        match self {
-            TrackElementMicrotask::ProcessingModel { elem, .. } => enter_auto_realm(cx, &**elem),
         }
     }
 }

--- a/components/script/dom/html/htmltrackelement.rs
+++ b/components/script/dom/html/htmltrackelement.rs
@@ -41,7 +41,7 @@ use crate::dom::texttrack::TextTrack;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::{AttributeMutation, cors_setting_for_element};
 use crate::fetch::{RequestWithGlobalScope, create_a_potential_cors_request};
-use crate::microtask::{Microtask, MicrotaskRunnable};
+use crate::microtask::MicrotaskRunnable;
 use crate::network_listener::{FetchResponseListener, ResourceTimingListener};
 use crate::realms::enter_auto_realm;
 use crate::{ScriptThread, network_listener};
@@ -163,7 +163,7 @@ impl HTMLTrackElement {
         };
         self.is_running_processing_model_algorithm.set(true);
 
-        ScriptThread::await_stable_state(cx, Microtask::TrackElement(task));
+        ScriptThread::await_stable_state(cx, Box::new(task));
     }
 
     fn check_if_track_parent_element_changed(&self, cx: &mut JSContext) {

--- a/components/script/dom/promise/promise.rs
+++ b/components/script/dom/promise/promise.rs
@@ -44,7 +44,7 @@ use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{AsHandleValue, DomRoot};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
-use crate::microtask::{Microtask, MicrotaskRunnable};
+use crate::microtask::MicrotaskRunnable;
 use crate::realms::enter_auto_realm;
 use crate::script_thread::ScriptThread;
 
@@ -534,7 +534,7 @@ fn wait_for_all(
         // Queue a microtask to perform successSteps given « ».
         global.enqueue_microtask(
             cx,
-            Microtask::WaitForAllSuccessSteps(WaitForAllSuccessStepsMicrotask {
+            Box::new(WaitForAllSuccessStepsMicrotask {
                 global: DomRoot::from_ref(global),
                 success_steps,
             }),

--- a/components/script/dom/promise/promise.rs
+++ b/components/script/dom/promise/promise.rs
@@ -25,7 +25,7 @@ use js::jsapi::{
     SetFunctionNativeReserved,
 };
 use js::jsval::{Int32Value, JSVal, NullValue, ObjectValue, UndefinedValue};
-use js::realm::{AutoRealm, CurrentRealm};
+use js::realm::CurrentRealm;
 use js::rust::wrappers2::{
     AddPromiseReactions, AddRawValueRoot, CallOriginalPromiseReject, CallOriginalPromiseResolve,
     GetPromiseIsHandled, GetPromiseState, IsPromiseObject, JS_ClearPendingException,
@@ -496,11 +496,8 @@ pub(crate) struct WaitForAllSuccessStepsMicrotask {
 
 impl MicrotaskRunnable for WaitForAllSuccessStepsMicrotask {
     fn handler(&self, cx: &mut JSContext) {
-        (self.success_steps)(cx, vec![]);
-    }
-
-    fn enter_realm<'cx>(&self, cx: &'cx mut JSContext) -> AutoRealm<'cx> {
-        enter_auto_realm(cx, &*self.global)
+        let mut realm = enter_auto_realm(cx, &*self.global);
+        (self.success_steps)(&mut realm, vec![]);
     }
 }
 

--- a/components/script/dom/stream/byteteereadintorequest.rs
+++ b/components/script/dom/stream/byteteereadintorequest.rs
@@ -22,7 +22,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::stream::byteteeunderlyingsource::ByteTeeUnderlyingSource;
 use crate::dom::stream::readablestream::ReadableStream;
-use crate::microtask::{Microtask, MicrotaskRunnable};
+use crate::microtask::MicrotaskRunnable;
 
 #[derive(JSTraceable, MallocSizeOf)]
 pub(crate) struct ByteTeeReadIntoRequestMicrotask {
@@ -109,10 +109,8 @@ impl ByteTeeReadIntoRequest {
             tee_read_request: Trusted::new(self),
         };
 
-        self.global().enqueue_microtask(
-            cx,
-            Microtask::ReadableStreamByteTeeReadIntoRequest(byte_tee_read_request_chunk),
-        );
+        self.global()
+            .enqueue_microtask(cx, Box::new(byte_tee_read_request_chunk));
     }
 
     /// <https://streams.spec.whatwg.org/#ref-for-read-into-request-chunk-steps%E2%91%A0>

--- a/components/script/dom/stream/byteteereadintorequest.rs
+++ b/components/script/dom/stream/byteteereadintorequest.rs
@@ -22,7 +22,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::stream::byteteeunderlyingsource::ByteTeeUnderlyingSource;
 use crate::dom::stream::readablestream::ReadableStream;
-use crate::microtask::Microtask;
+use crate::microtask::{Microtask, MicrotaskRunnable};
 
 #[derive(JSTraceable, MallocSizeOf)]
 pub(crate) struct ByteTeeReadIntoRequestMicrotask {
@@ -31,8 +31,8 @@ pub(crate) struct ByteTeeReadIntoRequestMicrotask {
     tee_read_request: Trusted<ByteTeeReadIntoRequest>,
 }
 
-impl ByteTeeReadIntoRequestMicrotask {
-    pub(crate) fn microtask_chunk_steps(&self, cx: &mut JSContext) {
+impl MicrotaskRunnable for ByteTeeReadIntoRequestMicrotask {
+    fn handler(&self, cx: &mut JSContext) {
         self.tee_read_request
             .root()
             .chunk_steps(&self.chunk, cx)

--- a/components/script/dom/stream/byteteereadrequest.rs
+++ b/components/script/dom/stream/byteteereadrequest.rs
@@ -23,7 +23,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::stream::byteteeunderlyingsource::ByteTeeUnderlyingSource;
 use crate::dom::stream::readablestream::ReadableStream;
-use crate::microtask::{Microtask, MicrotaskRunnable};
+use crate::microtask::MicrotaskRunnable;
 
 #[derive(JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, expect(crown::unrooted_must_root))]
@@ -110,10 +110,7 @@ impl ByteTeeReadRequest {
             chunk: Heap::boxed(*chunk.handle()),
             tee_read_request: Dom::from_ref(self),
         };
-        global.enqueue_microtask(
-            cx,
-            Microtask::ReadableStreamByteTeeReadRequest(byte_tee_read_request_chunk),
-        );
+        global.enqueue_microtask(cx, Box::new(byte_tee_read_request_chunk));
     }
 
     /// <https://streams.spec.whatwg.org/#ref-for-read-request-chunk-steps%E2%91%A3>

--- a/components/script/dom/stream/byteteereadrequest.rs
+++ b/components/script/dom/stream/byteteereadrequest.rs
@@ -23,7 +23,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::stream::byteteeunderlyingsource::ByteTeeUnderlyingSource;
 use crate::dom::stream::readablestream::ReadableStream;
-use crate::microtask::Microtask;
+use crate::microtask::{Microtask, MicrotaskRunnable};
 
 #[derive(JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, expect(crown::unrooted_must_root))]
@@ -33,8 +33,8 @@ pub(crate) struct ByteTeeReadRequestMicrotask {
     tee_read_request: Dom<ByteTeeReadRequest>,
 }
 
-impl ByteTeeReadRequestMicrotask {
-    pub(crate) fn microtask_chunk_steps(&self, cx: &mut JSContext) {
+impl MicrotaskRunnable for ByteTeeReadRequestMicrotask {
+    fn handler(&self, cx: &mut JSContext) {
         self.tee_read_request
             .chunk_steps(&self.chunk, cx)
             .expect("ByteTeeReadRequestMicrotask::microtask_chunk_steps failed");

--- a/components/script/dom/stream/defaultteereadrequest.rs
+++ b/components/script/dom/stream/defaultteereadrequest.rs
@@ -9,7 +9,6 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::jsapi::Heap;
 use js::jsval::{JSVal, UndefinedValue};
-use js::realm::AutoRealm;
 use js::rust::HandleValue as SafeHandleValue;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
@@ -35,11 +34,8 @@ pub(crate) struct DefaultTeeReadRequestMicrotask {
 
 impl MicrotaskRunnable for DefaultTeeReadRequestMicrotask {
     fn handler(&self, cx: &mut JSContext) {
-        self.tee_read_request.chunk_steps(cx, &self.chunk);
-    }
-
-    fn enter_realm<'cx>(&self, cx: &'cx mut js::context::JSContext) -> AutoRealm<'cx> {
-        enter_auto_realm(cx, &*self.tee_read_request)
+        let mut realm = enter_auto_realm(cx, &*self.tee_read_request);
+        self.tee_read_request.chunk_steps(&mut realm, &self.chunk);
     }
 }
 

--- a/components/script/dom/stream/defaultteereadrequest.rs
+++ b/components/script/dom/stream/defaultteereadrequest.rs
@@ -21,7 +21,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::stream::defaultteeunderlyingsource::DefaultTeeUnderlyingSource;
 use crate::dom::stream::readablestream::ReadableStream;
-use crate::microtask::{Microtask, MicrotaskRunnable};
+use crate::microtask::MicrotaskRunnable;
 use crate::realms::enter_auto_realm;
 
 #[derive(JSTraceable, MallocSizeOf)]
@@ -115,10 +115,9 @@ impl DefaultTeeReadRequest {
             chunk: Heap::boxed(*chunk.handle()),
             tee_read_request: Dom::from_ref(self),
         };
-        self.stream.global().enqueue_microtask(
-            cx,
-            Microtask::ReadableStreamTeeReadRequest(tee_read_request_chunk),
-        );
+        self.stream
+            .global()
+            .enqueue_microtask(cx, Box::new(tee_read_request_chunk));
     }
     /// <https://streams.spec.whatwg.org/#ref-for-read-request-chunk-steps%E2%91%A2>
     #[expect(clippy::borrowed_box)]

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -1671,7 +1671,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             cx,
             Box::new(UserMicrotask {
                 callback,
-                global: self.global(),
+                global: Dom::from_ref(&self.globalscope),
             }),
         );
     }

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -1671,7 +1671,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             cx,
             Microtask::User(UserMicrotask {
                 callback,
-                pipeline: self.pipeline_id(),
+                global: self.global(),
             }),
         );
     }

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -191,7 +191,7 @@ use crate::dom::worklet::Worklet;
 use crate::dom::workletglobalscope::WorkletGlobalScopeType;
 use crate::layout_image::fetch_image_for_layout;
 use crate::messaging::{MainThreadScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
-use crate::microtask::{Microtask, UserMicrotask};
+use crate::microtask::UserMicrotask;
 use crate::network_listener::{ResourceTimingListener, submit_timing};
 use crate::realms::enter_auto_realm;
 use crate::script_runtime::Runtime;
@@ -1669,7 +1669,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     fn QueueMicrotask(&self, cx: &JSContext, callback: Rc<VoidFunction>) {
         ScriptThread::enqueue_microtask(
             cx,
-            Microtask::User(UserMicrotask {
+            Box::new(UserMicrotask {
                 callback,
                 global: self.global(),
             }),

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -86,7 +86,7 @@ use crate::dom::workerlocation::WorkerLocation;
 use crate::dom::workernavigator::WorkerNavigator;
 use crate::fetch::{CspViolationsProcessor, Fetch, RequestWithGlobalScope, load_whole_resource};
 use crate::messaging::{CommonScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
-use crate::microtask::{Microtask, MicrotaskQueue, UserMicrotask};
+use crate::microtask::{MicrotaskQueue, MicrotaskRunnable, UserMicrotask};
 use crate::network_listener::{FetchResponseListener, ResourceTimingListener, submit_timing};
 use crate::realms::enter_auto_realm;
 use crate::script_module::ScriptFetchOptions;
@@ -430,7 +430,7 @@ impl WorkerGlobalScope {
             .get_or_init(|| OneshotTimers::new(self.upcast()))
     }
 
-    pub(crate) fn enqueue_microtask(&self, cx: &JSContext, job: Microtask) {
+    pub(crate) fn enqueue_microtask(&self, cx: &JSContext, job: Box<dyn MicrotaskRunnable>) {
         self.microtask_queue.enqueue(cx, job);
     }
 
@@ -949,7 +949,7 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
     fn QueueMicrotask(&self, cx: &mut JSContext, callback: Rc<VoidFunction>) {
         self.enqueue_microtask(
             cx,
-            Microtask::User(UserMicrotask {
+            Box::new(UserMicrotask {
                 callback,
                 global: self.global(),
             }),

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -951,7 +951,7 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
             cx,
             Box::new(UserMicrotask {
                 callback,
-                global: self.global(),
+                global: Dom::from_ref(&self.globalscope),
             }),
         );
     }

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -438,11 +438,8 @@ impl WorkerGlobalScope {
     pub(crate) fn perform_a_microtask_checkpoint(&self, cx: &mut JSContext) {
         // Only perform the checkpoint if we're not shutting down.
         if !self.is_closing() {
-            self.microtask_queue.checkpoint(
-                cx,
-                |_| Some(DomRoot::from_ref(&self.globalscope)),
-                vec![DomRoot::from_ref(&self.globalscope)],
-            );
+            self.microtask_queue
+                .checkpoint(cx, vec![DomRoot::from_ref(&self.globalscope)]);
         }
     }
 
@@ -954,7 +951,7 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
             cx,
             Microtask::User(UserMicrotask {
                 callback,
-                pipeline: self.pipeline_id(),
+                global: self.global(),
             }),
         );
     }

--- a/components/script/microtask.rs
+++ b/components/script/microtask.rs
@@ -21,13 +21,6 @@ use crate::dom::bindings::codegen::Bindings::PromiseBinding::PromiseJobCallback;
 use crate::dom::bindings::codegen::Bindings::VoidFunctionBinding::VoidFunction;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::html::htmlimageelement::ImageElementMicrotask;
-use crate::dom::html::htmlmediaelement::MediaElementMicrotask;
-use crate::dom::html::htmltrackelement::TrackElementMicrotask;
-use crate::dom::promise::WaitForAllSuccessStepsMicrotask;
-use crate::dom::stream::byteteereadintorequest::ByteTeeReadIntoRequestMicrotask;
-use crate::dom::stream::byteteereadrequest::ByteTeeReadRequestMicrotask;
-use crate::dom::stream::defaultteereadrequest::DefaultTeeReadRequestMicrotask;
 use crate::realms::enter_auto_realm;
 use crate::script_runtime::notify_about_rejected_promises;
 use crate::script_thread::ScriptThread;
@@ -36,24 +29,39 @@ use crate::script_thread::ScriptThread;
 #[derive(Default, JSTraceable, MallocSizeOf)]
 pub(crate) struct MicrotaskQueue {
     /// The list of enqueued microtasks that will be invoked at the next microtask checkpoint.
-    microtask_queue: DomRefCell<Vec<Microtask>>,
+    microtask_queue: DomRefCell<Vec<Box<dyn MicrotaskRunnable>>>,
     /// <https://html.spec.whatwg.org/multipage/#performing-a-microtask-checkpoint>
     performing_a_microtask_checkpoint: Cell<bool>,
 }
 
 #[derive(JSTraceable, MallocSizeOf)]
-pub(crate) enum Microtask {
-    Promise(EnqueuedPromiseCallback),
-    User(UserMicrotask),
-    MediaElement(MediaElementMicrotask),
-    ImageElement(ImageElementMicrotask),
-    TrackElement(TrackElementMicrotask),
-    ReadableStreamTeeReadRequest(DefaultTeeReadRequestMicrotask),
-    WaitForAllSuccessSteps(WaitForAllSuccessStepsMicrotask),
-    ReadableStreamByteTeeReadRequest(ByteTeeReadRequestMicrotask),
-    ReadableStreamByteTeeReadIntoRequest(ByteTeeReadIntoRequestMicrotask),
-    CustomElementReaction,
-    NotifyMutationObservers,
+pub struct NotifyMutationObserversMicrotask;
+
+impl NotifyMutationObserversMicrotask {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+}
+
+impl MicrotaskRunnable for NotifyMutationObserversMicrotask {
+    fn handler(&self, cx: &mut JSContext) {
+        ScriptThread::mutation_observers().notify_mutation_observers(cx);
+    }
+}
+
+#[derive(JSTraceable, MallocSizeOf)]
+pub struct CustomElementReactionMicrotask;
+
+impl CustomElementReactionMicrotask {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+}
+
+impl MicrotaskRunnable for CustomElementReactionMicrotask {
+    fn handler(&self, cx: &mut JSContext) {
+        ScriptThread::invoke_backup_element_queue(cx);
+    }
 }
 
 pub(crate) trait MicrotaskRunnable: JSTraceable + MallocSizeOf {
@@ -104,8 +112,8 @@ impl MicrotaskQueue {
     /// Add a new microtask to this queue. It will be invoked as part of the next
     /// microtask checkpoint.
     #[expect(unsafe_code)]
-    pub(crate) fn enqueue(&self, cx: &JSContext, job: Microtask) {
-        self.microtask_queue.borrow_mut().push(job);
+    pub(crate) fn enqueue(&self, cx: &JSContext, task: Box<dyn MicrotaskRunnable>) {
+        self.microtask_queue.borrow_mut().push(task);
         unsafe { JobQueueMayNotBeEmpty(cx) };
     }
 
@@ -133,37 +141,7 @@ impl MicrotaskQueue {
                     unsafe { js::rust::wrappers2::JobQueueIsEmpty(cx) };
                 }
 
-                match *job {
-                    Microtask::Promise(ref task) => {
-                        task.handler(cx);
-                    },
-                    Microtask::User(ref task) => {
-                        task.handler(cx);
-                    },
-                    Microtask::MediaElement(ref task) => {
-                        task.handler(cx);
-                    },
-                    Microtask::ImageElement(ref task) => {
-                        task.handler(cx);
-                    },
-                    Microtask::TrackElement(ref task) => {
-                        task.handler(cx);
-                    },
-                    Microtask::ReadableStreamTeeReadRequest(ref task) => {
-                        task.handler(cx);
-                    },
-                    Microtask::WaitForAllSuccessSteps(ref task) => {
-                        task.handler(cx);
-                    },
-                    Microtask::CustomElementReaction => {
-                        ScriptThread::invoke_backup_element_queue(cx);
-                    },
-                    Microtask::NotifyMutationObservers => {
-                        ScriptThread::mutation_observers().notify_mutation_observers(cx);
-                    },
-                    Microtask::ReadableStreamByteTeeReadRequest(ref task) => task.handler(cx),
-                    Microtask::ReadableStreamByteTeeReadIntoRequest(ref task) => task.handler(cx),
-                }
+                job.handler(cx);
             }
         }
 

--- a/components/script/microtask.rs
+++ b/components/script/microtask.rs
@@ -14,6 +14,7 @@ use js::context::JSContext;
 use js::rust::wrappers2::JobQueueMayNotBeEmpty;
 use malloc_size_of::MallocSizeOf;
 use script_bindings::cell::DomRefCell;
+use script_bindings::root::Dom;
 
 use crate::JSTraceable;
 use crate::dom::bindings::callback::ExceptionHandling;
@@ -71,10 +72,11 @@ pub(crate) trait MicrotaskRunnable: JSTraceable + MallocSizeOf {
 
 /// A promise callback scheduled to run during the next microtask checkpoint (#4283).
 #[derive(JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct EnqueuedPromiseCallback {
     #[conditional_malloc_size_of]
     pub(crate) callback: Rc<PromiseJobCallback>,
-    pub(crate) global: DomRoot<GlobalScope>,
+    pub(crate) global: Dom<GlobalScope>,
     pub(crate) is_user_interacting: bool,
 }
 
@@ -92,10 +94,11 @@ impl MicrotaskRunnable for EnqueuedPromiseCallback {
 /// A microtask that comes from a queueMicrotask() Javascript call,
 /// identical to EnqueuedPromiseCallback once it's on the queue
 #[derive(JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct UserMicrotask {
     #[conditional_malloc_size_of]
     pub(crate) callback: Rc<VoidFunction>,
-    pub(crate) global: DomRoot<GlobalScope>,
+    pub(crate) global: Dom<GlobalScope>,
 }
 
 impl MicrotaskRunnable for UserMicrotask {

--- a/components/script/microtask.rs
+++ b/components/script/microtask.rs
@@ -13,9 +13,10 @@ use std::rc::Rc;
 use js::context::JSContext;
 use js::realm::AutoRealm;
 use js::rust::wrappers2::JobQueueMayNotBeEmpty;
+use malloc_size_of::MallocSizeOf;
 use script_bindings::cell::DomRefCell;
-use servo_base::id::PipelineId;
 
+use crate::JSTraceable;
 use crate::dom::bindings::callback::ExceptionHandling;
 use crate::dom::bindings::codegen::Bindings::PromiseBinding::PromiseJobCallback;
 use crate::dom::bindings::codegen::Bindings::VoidFunctionBinding::VoidFunction;
@@ -56,7 +57,7 @@ pub(crate) enum Microtask {
     NotifyMutationObservers,
 }
 
-pub(crate) trait MicrotaskRunnable {
+pub(crate) trait MicrotaskRunnable: JSTraceable + MallocSizeOf {
     fn handler(&self, _cx: &mut JSContext) {}
     fn enter_realm<'cx>(&self, cx: &'cx mut JSContext) -> AutoRealm<'cx>;
 }
@@ -66,8 +67,7 @@ pub(crate) trait MicrotaskRunnable {
 pub(crate) struct EnqueuedPromiseCallback {
     #[conditional_malloc_size_of]
     pub(crate) callback: Rc<PromiseJobCallback>,
-    #[no_trace]
-    pub(crate) pipeline: PipelineId,
+    pub(crate) global: DomRoot<GlobalScope>,
     pub(crate) is_user_interacting: bool,
 }
 
@@ -77,8 +77,7 @@ pub(crate) struct EnqueuedPromiseCallback {
 pub(crate) struct UserMicrotask {
     #[conditional_malloc_size_of]
     pub(crate) callback: Rc<VoidFunction>,
-    #[no_trace]
-    pub(crate) pipeline: PipelineId,
+    pub(crate) global: DomRoot<GlobalScope>,
 }
 
 impl MicrotaskQueue {
@@ -93,14 +92,7 @@ impl MicrotaskQueue {
     /// <https://html.spec.whatwg.org/multipage/#perform-a-microtask-checkpoint>
     /// Perform a microtask checkpoint, executing all queued microtasks until the queue is empty.
     #[expect(unsafe_code)]
-    pub(crate) fn checkpoint<F>(
-        &self,
-        cx: &mut JSContext,
-        target_provider: F,
-        globalscopes: Vec<DomRoot<GlobalScope>>,
-    ) where
-        F: Fn(PipelineId) -> Option<DomRoot<GlobalScope>>,
-    {
+    pub(crate) fn checkpoint(&self, cx: &mut JSContext, globalscopes: Vec<DomRoot<GlobalScope>>) {
         // Step 1. If the event loop's performing a microtask checkpoint is true, then return.
         if self.performing_a_microtask_checkpoint.get() {
             return;
@@ -123,19 +115,19 @@ impl MicrotaskQueue {
 
                 match *job {
                     Microtask::Promise(ref job) => {
-                        if let Some(target) = target_provider(job.pipeline) {
-                            let _guard = ScriptThread::user_interacting_guard();
-                            let mut realm = enter_auto_realm(cx, &*target);
-                            let cx = &mut realm;
-                            let _ = job.callback.Call_(cx, &*target, ExceptionHandling::Report);
-                        }
+                        let _guard = ScriptThread::user_interacting_guard();
+                        let mut realm = enter_auto_realm(cx, &*job.global);
+                        let cx = &mut realm;
+                        let _ = job
+                            .callback
+                            .Call_(cx, &*job.global, ExceptionHandling::Report);
                     },
                     Microtask::User(ref job) => {
-                        if let Some(target) = target_provider(job.pipeline) {
-                            let mut realm = enter_auto_realm(cx, &*target);
-                            let cx = &mut realm;
-                            let _ = job.callback.Call_(cx, &*target, ExceptionHandling::Report);
-                        }
+                        let mut realm = enter_auto_realm(cx, &*job.global);
+                        let cx = &mut realm;
+                        let _ = job
+                            .callback
+                            .Call_(cx, &*job.global, ExceptionHandling::Report);
                     },
                     Microtask::MediaElement(ref task) => {
                         let mut realm = task.enter_realm(cx);

--- a/components/script/microtask.rs
+++ b/components/script/microtask.rs
@@ -11,7 +11,6 @@ use std::mem;
 use std::rc::Rc;
 
 use js::context::JSContext;
-use js::realm::AutoRealm;
 use js::rust::wrappers2::JobQueueMayNotBeEmpty;
 use malloc_size_of::MallocSizeOf;
 use script_bindings::cell::DomRefCell;
@@ -58,8 +57,8 @@ pub(crate) enum Microtask {
 }
 
 pub(crate) trait MicrotaskRunnable: JSTraceable + MallocSizeOf {
+    // must also take care of entering the realm
     fn handler(&self, _cx: &mut JSContext) {}
-    fn enter_realm<'cx>(&self, cx: &'cx mut JSContext) -> AutoRealm<'cx>;
 }
 
 /// A promise callback scheduled to run during the next microtask checkpoint (#4283).
@@ -130,28 +129,18 @@ impl MicrotaskQueue {
                             .Call_(cx, &*job.global, ExceptionHandling::Report);
                     },
                     Microtask::MediaElement(ref task) => {
-                        let mut realm = task.enter_realm(cx);
-                        let cx = &mut realm;
                         task.handler(cx);
                     },
                     Microtask::ImageElement(ref task) => {
-                        let mut realm = task.enter_realm(cx);
-                        let cx = &mut realm;
                         task.handler(cx);
                     },
                     Microtask::TrackElement(ref task) => {
-                        let mut realm = task.enter_realm(cx);
-                        let cx = &mut realm;
                         task.handler(cx);
                     },
                     Microtask::ReadableStreamTeeReadRequest(ref task) => {
-                        let mut realm = task.enter_realm(cx);
-                        let cx = &mut realm;
                         task.handler(cx);
                     },
                     Microtask::WaitForAllSuccessSteps(ref task) => {
-                        let mut realm = task.enter_realm(cx);
-                        let cx = &mut realm;
                         task.handler(cx);
                     },
                     Microtask::CustomElementReaction => {

--- a/components/script/microtask.rs
+++ b/components/script/microtask.rs
@@ -149,12 +149,8 @@ impl MicrotaskQueue {
                     Microtask::NotifyMutationObservers => {
                         ScriptThread::mutation_observers().notify_mutation_observers(cx);
                     },
-                    Microtask::ReadableStreamByteTeeReadRequest(ref task) => {
-                        task.microtask_chunk_steps(cx)
-                    },
-                    Microtask::ReadableStreamByteTeeReadIntoRequest(ref task) => {
-                        task.microtask_chunk_steps(cx)
-                    },
+                    Microtask::ReadableStreamByteTeeReadRequest(ref task) => task.handler(cx),
+                    Microtask::ReadableStreamByteTeeReadIntoRequest(ref task) => task.handler(cx),
                 }
             }
         }

--- a/components/script/microtask.rs
+++ b/components/script/microtask.rs
@@ -70,6 +70,17 @@ pub(crate) struct EnqueuedPromiseCallback {
     pub(crate) is_user_interacting: bool,
 }
 
+impl MicrotaskRunnable for EnqueuedPromiseCallback {
+    fn handler(&self, cx: &mut JSContext) {
+        let _guard = ScriptThread::user_interacting_guard();
+        let mut realm = enter_auto_realm(cx, &*self.global);
+        let cx = &mut realm;
+        let _ = self
+            .callback
+            .Call_(cx, &*self.global, ExceptionHandling::Report);
+    }
+}
+
 /// A microtask that comes from a queueMicrotask() Javascript call,
 /// identical to EnqueuedPromiseCallback once it's on the queue
 #[derive(JSTraceable, MallocSizeOf)]
@@ -77,6 +88,16 @@ pub(crate) struct UserMicrotask {
     #[conditional_malloc_size_of]
     pub(crate) callback: Rc<VoidFunction>,
     pub(crate) global: DomRoot<GlobalScope>,
+}
+
+impl MicrotaskRunnable for UserMicrotask {
+    fn handler(&self, cx: &mut JSContext) {
+        let mut realm = enter_auto_realm(cx, &*self.global);
+        let cx = &mut realm;
+        let _ = self
+            .callback
+            .Call_(cx, &*self.global, ExceptionHandling::Report);
+    }
 }
 
 impl MicrotaskQueue {
@@ -113,20 +134,11 @@ impl MicrotaskQueue {
                 }
 
                 match *job {
-                    Microtask::Promise(ref job) => {
-                        let _guard = ScriptThread::user_interacting_guard();
-                        let mut realm = enter_auto_realm(cx, &*job.global);
-                        let cx = &mut realm;
-                        let _ = job
-                            .callback
-                            .Call_(cx, &*job.global, ExceptionHandling::Report);
+                    Microtask::Promise(ref task) => {
+                        task.handler(cx);
                     },
-                    Microtask::User(ref job) => {
-                        let mut realm = enter_auto_realm(cx, &*job.global);
-                        let cx = &mut realm;
-                        let _ = job
-                            .callback
-                            .Call_(cx, &*job.global, ExceptionHandling::Report);
+                    Microtask::User(ref task) => {
+                        task.handler(cx);
                     },
                     Microtask::MediaElement(ref task) => {
                         task.handler(cx);

--- a/components/script/script_mutation_observers.rs
+++ b/components/script/script_mutation_observers.rs
@@ -12,7 +12,7 @@ use script_bindings::inheritance::Castable;
 use script_bindings::root::{Dom, DomRoot};
 
 use crate::dom::types::{EventTarget, HTMLSlotElement, MutationObserver, MutationRecord};
-use crate::microtask::{Microtask, MicrotaskQueue};
+use crate::microtask::{MicrotaskQueue, NotifyMutationObserversMicrotask};
 
 /// A helper struct for mutation observers used in `ScriptThread`
 /// Since the Rc is always stored in ScriptThread, it's always reachable by the GC.
@@ -99,7 +99,7 @@ impl ScriptMutationObservers {
         self.mutation_observer_microtask_queued.set(true);
 
         // Step 3. Queue a microtask to notify mutation observers.
-        microtask_queue.enqueue(cx, Microtask::NotifyMutationObservers);
+        microtask_queue.enqueue(cx, Box::new(NotifyMutationObserversMicrotask::new()));
     }
 
     pub(crate) fn add_signal_slot(&self, observer: &HTMLSlotElement) {

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -419,7 +419,7 @@ unsafe extern "C" fn enqueue_promise_job(
             cx,
             Box::new(EnqueuedPromiseCallback {
                 callback: unsafe { PromiseJobCallback::new(cx, job.get()) },
-                global,
+                global: global.as_traced(),
                 is_user_interacting,
             }),
         );

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -322,8 +322,8 @@ unsafe extern "C" fn run_jobs(microtask_queue: *const c_void, cx: *mut RawJSCont
     wrap_panic(&mut || {
         let microtask_queue = unsafe { &*(microtask_queue as *const MicrotaskQueue) };
         // TODO: run Promise- and User-variant Microtasks, and do #notify-about-rejected-promises.
-        // Those will require real `target_provider` and `globalscopes` values.
-        microtask_queue.checkpoint(&mut cx, |_| None, vec![]);
+        // Those will require real `globalscopes` values.
+        microtask_queue.checkpoint(&mut cx, vec![]);
     });
 }
 
@@ -408,7 +408,6 @@ unsafe extern "C" fn enqueue_promise_job(
             let mut realm = CurrentRealm::assert(cx);
             GlobalScope::from_current_realm(&mut realm)
         };
-        let pipeline = global.pipeline_id();
         let interaction = if promise.get().is_null() {
             PromiseUserInputEventHandlingState::DontCare
         } else {
@@ -420,7 +419,7 @@ unsafe extern "C" fn enqueue_promise_job(
             cx,
             Microtask::Promise(EnqueuedPromiseCallback {
                 callback: unsafe { PromiseJobCallback::new(cx, job.get()) },
-                pipeline,
+                global,
                 is_user_interacting,
             }),
         );

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -95,7 +95,7 @@ use crate::dom::promiserejectionevent::PromiseRejectionEvent;
 use crate::dom::response::Response;
 use crate::dom::trustedtypes::trustedscript::TrustedScript;
 use crate::messaging::{CommonScriptMsg, ScriptEventLoopSender};
-use crate::microtask::{EnqueuedPromiseCallback, Microtask, MicrotaskQueue};
+use crate::microtask::{EnqueuedPromiseCallback, MicrotaskQueue};
 use crate::realms::enter_auto_realm;
 use crate::script_module::EnsureModuleHooksInitialized;
 use crate::task_source::TaskSourceName;
@@ -417,7 +417,7 @@ unsafe extern "C" fn enqueue_promise_job(
             interaction == PromiseUserInputEventHandlingState::HadUserInteractionAtCreation;
         microtask_queue.enqueue(
             cx,
-            Microtask::Promise(EnqueuedPromiseCallback {
+            Box::new(EnqueuedPromiseCallback {
                 callback: unsafe { PromiseJobCallback::new(cx, job.get()) },
                 global,
                 is_user_interacting,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -150,7 +150,7 @@ use crate::messaging::{
     CommonScriptMsg, MainThreadScriptMsg, MixedMessage, ScriptEventLoopSender,
     ScriptThreadReceivers, ScriptThreadSenders,
 };
-use crate::microtask::{Microtask, MicrotaskQueue};
+use crate::microtask::{MicrotaskQueue, MicrotaskRunnable};
 use crate::mime::{APPLICATION, CHARSET, MimeExt, TEXT, XML};
 use crate::navigation::{InProgressLoad, NavigationListener};
 use crate::network_listener::{FetchResponseListener, submit_timing};
@@ -606,7 +606,7 @@ impl ScriptThread {
     }
 
     // https://html.spec.whatwg.org/multipage/#await-a-stable-state
-    pub(crate) fn await_stable_state(cx: &JSContext, task: Microtask) {
+    pub(crate) fn await_stable_state(cx: &JSContext, task: Box<dyn MicrotaskRunnable>) {
         with_script_thread(|script_thread| {
             script_thread.microtask_queue.enqueue(cx, task);
         });
@@ -4313,7 +4313,7 @@ impl ScriptThread {
         };
     }
 
-    pub(crate) fn enqueue_microtask(cx: &js::context::JSContext, job: Microtask) {
+    pub(crate) fn enqueue_microtask(cx: &js::context::JSContext, job: Box<dyn MicrotaskRunnable>) {
         with_script_thread(|script_thread| {
             script_thread.microtask_queue.enqueue(cx, job);
         });

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -4329,11 +4329,7 @@ impl ScriptThread {
                 .map(|(_id, document)| DomRoot::from_ref(document.window().upcast()))
                 .collect();
 
-            self.microtask_queue.checkpoint(
-                cx,
-                |id| self.documents.borrow().find_global(id),
-                globals,
-            )
+            self.microtask_queue.checkpoint(cx, globals)
         }
     }
 


### PR DESCRIPTION
This does simplify stuff, but it does require more alloc. This is what FF does and we will need this for SM bump (as microtasks are now "stored" in SM queue https://spidermonkey.dev/blog/2026/01/15/job-responsibility.html - tho we could use HashMap trick with uniq id).

Testing: Should be covered by WPT.
try run: https://github.com/sagudev/servo/actions/runs/29638052656
Towards https://github.com/servo/mozjs/issues/687
Reviewable per commit.
