### PR TITLE
script: Replace deprecated as_mut_slice with as_mut_slice_safe

### DIFF
--- a/components/script/dom/audio/analysernode.rs
+++ b/components/script/dom/audio/analysernode.rs
@@ -151,7 +151,7 @@ impl AnalyserNodeMethods<crate::DomTypeHolder> for AnalyserNode {
     fn GetFloatFrequencyData(&self, no_gc: &NoGC, mut array: CustomAutoRooterGuard<Float32Array>) {
         // Invariant to maintain: No JS code that may touch the array should
         // run whilst we're writing to it
-        let dest = { array.as_mut_slice_safe(no_gc) };
+        let dest = array.as_mut_slice_safe(no_gc);
         self.engine.borrow_mut().fill_frequency_data(dest);
     }
 
@@ -159,7 +159,7 @@ impl AnalyserNodeMethods<crate::DomTypeHolder> for AnalyserNode {
     fn GetByteFrequencyData(&self, no_gc: &NoGC, mut array: CustomAutoRooterGuard<Uint8Array>) {
         // Invariant to maintain: No JS code that may touch the array should
         // run whilst we're writing to it
-        let dest = { array.as_mut_slice_safe(no_gc) };
+        let dest = array.as_mut_slice_safe(no_gc);
         self.engine.borrow_mut().fill_byte_frequency_data(dest);
     }
 
@@ -167,7 +167,7 @@ impl AnalyserNodeMethods<crate::DomTypeHolder> for AnalyserNode {
     fn GetFloatTimeDomainData(&self, no_gc: &NoGC, mut array: CustomAutoRooterGuard<Float32Array>) {
         // Invariant to maintain: No JS code that may touch the array should
         // run whilst we're writing to it
-        let dest = { array.as_mut_slice_safe(no_gc) };
+        let dest = array.as_mut_slice_safe(no_gc);
         self.engine.borrow().fill_time_domain_data(dest);
     }
 
@@ -175,7 +175,7 @@ impl AnalyserNodeMethods<crate::DomTypeHolder> for AnalyserNode {
     fn GetByteTimeDomainData(&self, no_gc: &NoGC, mut array: CustomAutoRooterGuard<Uint8Array>) {
         // Invariant to maintain: No JS code that may touch the array should
         // run whilst we're writing to it
-        let dest = { array.as_mut_slice_safe(no_gc) };
+        let dest = array.as_mut_slice_safe(no_gc);
         self.engine.borrow().fill_byte_time_domain_data(dest);
     }
 

--- a/components/script/dom/audio/analysernode.rs
+++ b/components/script/dom/audio/analysernode.rs
@@ -5,7 +5,7 @@
 use std::sync::{Arc, OnceLock};
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::rust::{CustomAutoRooterGuard, HandleObject};
 use js::typedarray::{Float32Array, Uint8Array};
 use script_bindings::cell::DomRefCell;
@@ -147,39 +147,35 @@ impl AnalyserNodeMethods<crate::DomTypeHolder> for AnalyserNode {
         AnalyserNode::new_with_proto(cx, window, proto, context, options)
     }
 
-    #[expect(unsafe_code, deprecated)]
     /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-getfloatfrequencydata>
-    fn GetFloatFrequencyData(&self, mut array: CustomAutoRooterGuard<Float32Array>) {
+    fn GetFloatFrequencyData(&self, no_gc: &NoGC, mut array: CustomAutoRooterGuard<Float32Array>) {
         // Invariant to maintain: No JS code that may touch the array should
         // run whilst we're writing to it
-        let dest = unsafe { array.as_mut_slice() };
+        let dest = { array.as_mut_slice_safe(no_gc) };
         self.engine.borrow_mut().fill_frequency_data(dest);
     }
 
-    #[expect(unsafe_code, deprecated)]
     /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-getbytefrequencydata>
-    fn GetByteFrequencyData(&self, mut array: CustomAutoRooterGuard<Uint8Array>) {
+    fn GetByteFrequencyData(&self, no_gc: &NoGC, mut array: CustomAutoRooterGuard<Uint8Array>) {
         // Invariant to maintain: No JS code that may touch the array should
         // run whilst we're writing to it
-        let dest = unsafe { array.as_mut_slice() };
+        let dest = { array.as_mut_slice_safe(no_gc) };
         self.engine.borrow_mut().fill_byte_frequency_data(dest);
     }
 
-    #[expect(unsafe_code, deprecated)]
     /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-getfloattimedomaindata>
-    fn GetFloatTimeDomainData(&self, mut array: CustomAutoRooterGuard<Float32Array>) {
+    fn GetFloatTimeDomainData(&self, no_gc: &NoGC, mut array: CustomAutoRooterGuard<Float32Array>) {
         // Invariant to maintain: No JS code that may touch the array should
         // run whilst we're writing to it
-        let dest = unsafe { array.as_mut_slice() };
+        let dest = { array.as_mut_slice_safe(no_gc) };
         self.engine.borrow().fill_time_domain_data(dest);
     }
 
-    #[expect(unsafe_code, deprecated)]
     /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-getbytetimedomaindata>
-    fn GetByteTimeDomainData(&self, mut array: CustomAutoRooterGuard<Uint8Array>) {
+    fn GetByteTimeDomainData(&self, no_gc: &NoGC, mut array: CustomAutoRooterGuard<Uint8Array>) {
         // Invariant to maintain: No JS code that may touch the array should
         // run whilst we're writing to it
-        let dest = unsafe { array.as_mut_slice() };
+        let dest = { array.as_mut_slice_safe(no_gc) };
         self.engine.borrow().fill_byte_time_domain_data(dest);
     }
 

--- a/components/script/dom/encoding/textencoder.rs
+++ b/components/script/dom/encoding/textencoder.rs
@@ -5,7 +5,7 @@
 use std::ptr;
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::gc::CustomAutoRooterGuard;
 use js::jsapi::JSObject;
 use js::rust::HandleObject;
@@ -70,9 +70,9 @@ impl TextEncoderMethods<crate::DomTypeHolder> for TextEncoder {
     }
 
     /// <https://encoding.spec.whatwg.org/#dom-textencoder-encodeinto>
-    #[expect(unsafe_code, deprecated)]
     fn EncodeInto(
         &self,
+        no_gc: &NoGC,
         source: USVString,
         mut destination: CustomAutoRooterGuard<typedarray::Uint8Array>,
     ) -> TextEncoderEncodeIntoResult {
@@ -89,7 +89,7 @@ impl TextEncoderMethods<crate::DomTypeHolder> for TextEncoder {
         let mut read = 0;
         let mut written = 0;
 
-        let dest = unsafe { destination.as_mut_slice() };
+        let dest = destination.as_mut_slice_safe(no_gc);
 
         // Step 3, 4, 5, 6
         // Turn the source into a queue of scalar values.

--- a/components/script/dom/webcrypto/crypto.rs
+++ b/components/script/dom/webcrypto/crypto.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::jsapi::{Heap, JSObject, Type};
 use js::rust::CustomAutoRooterGuard;
 use js::typedarray::{ArrayBufferView, ArrayBufferViewU8, HeapArrayBufferView, TypedArray};
@@ -48,10 +48,11 @@ impl CryptoMethods<crate::DomTypeHolder> for Crypto {
             .or_init(|| SubtleCrypto::new(cx, &self.global()))
     }
 
-    #[expect(unsafe_code, deprecated)]
+    #[expect(unsafe_code)]
     /// <https://w3c.github.io/webcrypto/#Crypto-method-getRandomValues>
     fn GetRandomValues(
         &self,
+        no_gc: &NoGC,
         mut input: CustomAutoRooterGuard<ArrayBufferView>,
     ) -> Fallible<RootedTraceableBox<HeapArrayBufferView>> {
         let array_type = input.get_array_type();
@@ -59,7 +60,7 @@ impl CryptoMethods<crate::DomTypeHolder> for Crypto {
         if !is_integer_buffer(array_type) {
             Err(Error::TypeMismatch(None))
         } else {
-            let data = unsafe { input.as_mut_slice() };
+            let data = input.as_mut_slice_safe(no_gc);
             if data.len() > 65536 {
                 return Err(Error::QuotaExceeded {
                     quota: None,

--- a/components/script/indexeddb.rs
+++ b/components/script/indexeddb.rs
@@ -36,7 +36,7 @@ use crate::dom::idbkeyrange::IDBKeyRange;
 use crate::dom::idbobjectstore::KeyPath;
 
 // https://www.w3.org/TR/IndexedDB-3/#convert-key-to-value
-#[expect(unsafe_code, deprecated)]
+#[expect(unsafe_code)]
 pub fn key_type_to_jsval(
     cx: &mut JSContext,
     key: &IndexedDBKeyType,
@@ -86,7 +86,9 @@ pub fn key_type_to_jsval(
             // entries in value.
             let mut array_buffer = ArrayBuffer::from(buffer.get())
                 .expect("ArrayBuffer::create should create an ArrayBuffer object");
-            array_buffer.as_mut_slice().copy_from_slice(b);
+            array_buffer
+                .as_mut_slice_safe(cx.no_gc())
+                .copy_from_slice(b);
 
             // Step 3.5. Return buffer.
             result.set(ObjectValue(buffer.get()));

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -31,6 +31,10 @@ DOMInterfaces = {
     'cx': ['DrawArraysInstancedANGLE', 'DrawElementsInstancedANGLE', 'VertexAttribDivisorANGLE']
 },
 
+'AnalyserNode': {
+    'no_gc': ['GetFloatFrequencyData', 'GetByteFrequencyData', 'GetFloatTimeDomainData', 'GetByteTimeDomainData']
+},
+
 'Attr': {
     'implicitCxSetters': True,
 },
@@ -180,6 +184,7 @@ DOMInterfaces = {
 
 'Crypto': {
     'cx': ['Subtle'],
+    'no_gc': ['GetRandomValues']
 },
 
 'CSSStyleDeclaration': {
@@ -1128,7 +1133,8 @@ DOMInterfaces = {
 },
 
 'TextEncoder': {
-    'cx': ['Encode']
+    'cx': ['Encode'],
+    'no_gc': ['EncodeInto']
 },
 
 'TextTrack': {


### PR DESCRIPTION
Replace now deprecated `as_mut_slice` calls with safe `as_mut_slice_safe` calls. 

Only one deprecated call remaining in [ImageData](https://github.com/servo/servo/blob/1fe19604071280b31144a675079be7f5d308d792/components/script/dom/canvas/imagedata.rs#L178-L181), I'm not sure how to replace it. It touches too many things including Serializable trait (as_slice -> to_vec -> serialize call). Should just drill down NoGC too all methods?

Testing: It compiles
Fixes: part of #46474