### PR TITLE
LTS: Backport several security fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,9 +1621,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9221,9 +9221,9 @@ checksum = "b72d540d5c565dbe1f891d7e21ceb21d2649508306782f1066989fccb0b363d3"
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spirv"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4947,9 +4947,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4457,7 +4457,7 @@ dependencies = [
  "libc",
  "mio",
  "postcard",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rustc-hash 2.1.2",
  "serde_core",
  "tempfile",
@@ -6623,9 +6623,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -7556,7 +7556,7 @@ dependencies = [
  "btleplug",
  "futures",
  "log",
- "rand 0.9.2",
+ "rand 0.9.5",
  "servo-base",
  "servo-bluetooth-traits",
  "servo-config",
@@ -7657,7 +7657,7 @@ dependencies = [
  "keyboard-types",
  "log",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rustc-hash 2.1.2",
  "serde",
  "servo-background-hang-monitor",
@@ -7750,7 +7750,7 @@ dependencies = [
  "http 1.4.0",
  "log",
  "malloc_size_of_derive",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rustc-hash 2.1.2",
  "serde",
  "serde_json",
@@ -8132,7 +8132,7 @@ name = "servo-media-examples"
 version = "0.1.2"
 dependencies = [
  "euclid",
- "rand 0.9.2",
+ "rand 0.9.5",
  "serde",
  "servo-media",
  "servo-media-auto",
@@ -8367,7 +8367,7 @@ dependencies = [
  "num-traits",
  "parking_lot",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rustc-hash 2.1.2",
  "rustls-pki-types",
  "serde",
@@ -8583,7 +8583,7 @@ dependencies = [
  "phf",
  "pkcs8",
  "postcard",
- "rand 0.9.2",
+ "rand 0.9.5",
  "regex",
  "rsa",
  "rustc-hash 2.1.2",
@@ -10183,7 +10183,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rustls",
  "rustls-pki-types",
  "sha1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ pkcs8 = { version = "0.10", features = ["rand_core"] }
 postcard = { version = "1.1.3", default-features = false, features = ["use-std"] }
 proc-macro2 = "1"
 quote = "1"
-rand = "0.9"
+rand = "0.9.5"
 raw-window-handle = "0.6"
 rayon = "1"
 read-fonts = "0.35.0"

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -235,6 +235,11 @@ pub struct Preferences {
     pub js_mem_gc_high_frequency_high_limit_mb: i64,
     pub js_mem_gc_high_frequency_low_limit_mb: i64,
     pub js_mem_gc_high_frequency_time_limit_ms: i64,
+    /// Whether or not incremental garbage collection is turned on. This is currently
+    /// turned off by default as pre-barriers are not implemented yet. If turned on, it
+    /// will likely lead to memory corruption.
+    ///
+    /// See <https://github.com/servo/servo/issues/7621>.
     pub js_mem_gc_incremental_enabled: bool,
     pub js_mem_gc_incremental_slice_ms: i64,
     pub js_mem_gc_low_frequency_heap_growth: i64,
@@ -436,7 +441,7 @@ impl Preferences {
             js_mem_gc_high_frequency_high_limit_mb: 500,
             js_mem_gc_high_frequency_low_limit_mb: 100,
             js_mem_gc_high_frequency_time_limit_ms: 1000,
-            js_mem_gc_incremental_enabled: true,
+            js_mem_gc_incremental_enabled: false,
             js_mem_gc_incremental_slice_ms: 10,
             js_mem_gc_low_frequency_heap_growth: 150,
             js_mem_gc_per_zone_enabled: false,

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -810,8 +810,6 @@ impl Runtime {
                 Some(empty_wrapper_callback),
                 Some(empty_has_released_callback),
             );
-            // Pre barriers aren't working correctly at the moment
-            JS_SetGCParameter(cx, JSGCParamKey::JSGC_INCREMENTAL_GC_ENABLED, 0);
         }
 
         unsafe extern "C" fn dispatch_to_event_loop(
@@ -965,12 +963,15 @@ impl Runtime {
                     .map(|val| (val * 1024 * 1024) as u32)
                     .unwrap_or(u32::MAX),
             );
-            // NOTE: This is disabled above, so enabling it here will do nothing for now.
+
+            // Pre-barriers aren't implemented correctly at the moment, so this preference
+            // defaults to false.
             JS_SetGCParameter(
                 cx,
                 JSGCParamKey::JSGC_INCREMENTAL_GC_ENABLED,
                 pref!(js_mem_gc_incremental_enabled) as u32,
             );
+
             JS_SetGCParameter(
                 cx,
                 JSGCParamKey::JSGC_PER_ZONE_GC_ENABLED,

--- a/deny.toml
+++ b/deny.toml
@@ -53,6 +53,9 @@ ignore = [
     #
     # We must use this version of quick-xml until `winit` upgrades `sctk`.
     "RUSTSEC-2026-0195",
+    # `rustybuzz` is unmaintained. Switch to harfrust.
+    # However, this is a dependecy of `resvg`, there's nothing we can do.
+    "RUSTSEC-2026-0206",
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
This PR is mainly about disabling incremental garbage collection in SM. The other commits are to make `cargo-deny` happy and are dependency bumps for crates with security advisories. We ignore `rustybuzz` as on main, since there isn't much we can do downstream.

Testing: [mach try](https://github.com/jschwe/servo/actions/runs/29647674406)

