### PR TITLE
layout: Remove outdated comment.

### DIFF
--- a/components/layout/flow/construct.rs
+++ b/components/layout/flow/construct.rs
@@ -566,7 +566,6 @@ impl<'dom> BlockContainerBuilder<'dom, '_> {
             self.handle_list_item_marker_inside(&marker_info, marker_contents)
         }
 
-        // `unwrap` doesn’t panic here because `is_replaced` returned `false`.
         non_replaced_contents.traverse(self.context, info, self);
 
         self.finish_anonymous_table_if_needed();


### PR DESCRIPTION
The relevant unwrap was removed in 7375d09887b75c518dec00528d1d5a5f38d330c4.

Testing: Comment only change.