### PR TITLE
android: Convert toolbar on small screens to Compose UI

### DIFF
--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -147,6 +147,7 @@ dependencies {
     implementation("androidx.activity:activity-compose:1.13.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.13.0")
+    implementation("androidx.compose.material3.adaptive:adaptive:1.2.0")
     implementation("androidx.compose.material3:material3:1.4.0")
     implementation("androidx.preference:preference-ktx:1.2.0")
 }

--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.SearchBar
 import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.rememberSearchBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -132,21 +133,24 @@ class MainActivity : AppCompatActivity(), Servo.Client {
             }
         }
 
-        findViewById<ComposeView>(R.id.toolbar)?.setContent {
+        findViewById<ComposeView>(R.id.toolbar).setContent {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                IconButton(onClick = ::onHistoryBackMenuItemClicked, enabled = canGoBackState.value) {
-                    Icon(painterResource(R.drawable.arrow_back), stringResource(R.string.history_back))
-                }
-                IconButton(onClick = ::onHistoryForwardMenuItemClicked, enabled = canGoForwardState.value) {
-                    Icon(painterResource(R.drawable.arrow_forward), stringResource(R.string.history_forward))
-                }
-                IconButton(onClick = { if (isRefreshingState.value) onCancelMenuItemClicked() else onRefreshMenuItemClicked() }) {
-                    if (isRefreshingState.value) {
-                        Icon(painterResource(R.drawable.cancel), stringResource(R.string.cancel))
-                    } else {
-                        Icon(painterResource(R.drawable.refresh), stringResource(R.string.refresh))
+                val isWindowWidthAtLeastMedium = currentWindowAdaptiveInfo().windowSizeClass.isWidthAtLeastBreakpoint(600)
+                if (isWindowWidthAtLeastMedium) {
+                    IconButton(onClick = ::onHistoryBackMenuItemClicked, enabled = canGoBackState.value) {
+                        Icon(painterResource(R.drawable.arrow_back), stringResource(R.string.history_back))
+                    }
+                    IconButton(onClick = ::onHistoryForwardMenuItemClicked, enabled = canGoForwardState.value) {
+                        Icon(painterResource(R.drawable.arrow_forward), stringResource(R.string.history_forward))
+                    }
+                    IconButton(onClick = { if (isRefreshingState.value) onCancelMenuItemClicked() else onRefreshMenuItemClicked() }) {
+                        if (isRefreshingState.value) {
+                            Icon(painterResource(R.drawable.cancel), stringResource(R.string.cancel))
+                        } else {
+                            Icon(painterResource(R.drawable.refresh), stringResource(R.string.refresh))
+                        }
                     }
                 }
                 Omnibox(
@@ -166,35 +170,15 @@ class MainActivity : AppCompatActivity(), Servo.Client {
                             .size(20.dp),
                     )
                 }
-                IconButton(onClick = ::onSettingsMenuItemClicked) {
-                    Icon(painterResource(R.drawable.settings), stringResource(R.string.options))
-                }
-                IconButton(onClick = ::onHistoryMenuItemClicked) {
-                    Icon(painterResource(R.drawable.history), stringResource(R.string.history_title))
+                if (isWindowWidthAtLeastMedium) {
+                    IconButton(onClick = ::onSettingsMenuItemClicked) {
+                        Icon(painterResource(R.drawable.settings), stringResource(R.string.options))
+                    }
+                    IconButton(onClick = ::onHistoryMenuItemClicked) {
+                        Icon(painterResource(R.drawable.history), stringResource(R.string.history_title))
+                    }
                 }
             }
-        }
-
-        findViewById<ComposeView>(R.id.progressbar)?.setContent {
-            if (isRefreshingState.value) {
-                CircularProgressIndicator(
-                    modifier = Modifier
-                        .padding(end = 10.dp)
-                        .size(20.dp),
-                )
-            }
-        }
-
-        findViewById<ComposeView>(R.id.urlfield)?.setContent {
-            Omnibox(
-                urlTextFieldState,
-                onSearch = { search ->
-                    loadUrl(search)
-                    servoView.requestFocus()
-                },
-                modifier = Modifier
-                    .padding(end = 10.dp),
-            )
         }
 
         servoView.setClient(this)

--- a/support/android/apk/servoapp/src/main/res/layout/activity_main.xml
+++ b/support/android/apk/servoapp/src/main/res/layout/activity_main.xml
@@ -7,29 +7,11 @@
     tools:context="org.servo.servoshell.MainActivity"
     android:orientation="vertical">
 
-    <com.google.android.material.appbar.MaterialToolbar
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        >
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:gravity="center">
-
-            <androidx.compose.ui.platform.ComposeView
-                android:id="@+id/urlfield"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1" />
-
-            <androidx.compose.ui.platform.ComposeView
-                android:id="@+id/progressbar"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
-
-        </LinearLayout>
-    </com.google.android.material.appbar.MaterialToolbar>
+        />
 
     <org.servo.servoview.ServoView
         android:id="@+id/servoview"


### PR DESCRIPTION
Conditionally display whether certain menu items are displayed based off of screen size. This is identical to what is currently being done via the resource qualifiers (i.e., `layout-w600dp`). In a follow up, `layout-w600dp` will be deleted, so we can have a SSOT via the Compose UI code when it comes to what is displayed on larger and smaller screens.

Testing: There are no automated tests for Android.
Fixes: Part of #45715.