### PR TITLE
script: don't store a `Window` inside `RefreshRedirectDue`

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -251,7 +251,7 @@ impl RefreshRedirectDue {
     pub(crate) fn invoke(self, cx: &mut JSContext, global: &GlobalScope) {
         let window = global
             .downcast::<Window>()
-            .expect("Queued a RefreshRedirectDue on a non Window globalscope");
+            .expect("Queued a RefreshRedirectDue on a non-Window globalscope");
 
         // After the refresh has come due (as defined below),
         // if the user has not canceled the redirect and, if meta is given,
@@ -266,10 +266,10 @@ impl RefreshRedirectDue {
         {
             return;
         }
-        let load_data = window.load_data_for_document(self.url.clone(), window.pipeline_id());
+        let load_data = window.load_data_for_document(self.url, window.pipeline_id());
         navigate(
             cx,
-            &window,
+            window,
             NavigationHistoryBehavior::Replace,
             false,
             load_data,

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -243,14 +243,16 @@ impl FireMouseEventType {
 pub(crate) struct RefreshRedirectDue {
     #[no_trace]
     pub(crate) url: ServoUrl,
-    #[ignore_malloc_size_of = "non-owning"]
-    pub(crate) window: DomRoot<Window>,
     /// Whether the refresh originated from a `<meta>` element.
     pub(crate) from_meta_element: bool,
 }
 impl RefreshRedirectDue {
     /// Step 13 of <https://html.spec.whatwg.org/multipage/#shared-declarative-refresh-steps>
-    pub(crate) fn invoke(self, cx: &mut JSContext) {
+    pub(crate) fn invoke(self, cx: &mut JSContext, global: &GlobalScope) {
+        let window = global
+            .downcast::<Window>()
+            .expect("Queued a RefreshRedirectDue on a non Window globalscope");
+
         // After the refresh has come due (as defined below),
         // if the user has not canceled the redirect and, if meta is given,
         // document's active sandboxing flag set does not have the sandboxed
@@ -258,18 +260,16 @@ impl RefreshRedirectDue {
         // then navigate document's node navigable to urlRecord using document,
         // with historyHandling set to "replace".
         if self.from_meta_element &&
-            self.window.Document().has_active_sandboxing_flag(
+            window.Document().has_active_sandboxing_flag(
                 SandboxingFlagSet::SANDBOXED_AUTOMATIC_FEATURES_BROWSING_CONTEXT_FLAG,
             )
         {
             return;
         }
-        let load_data = self
-            .window
-            .load_data_for_document(self.url.clone(), self.window.pipeline_id());
+        let load_data = window.load_data_for_document(self.url.clone(), window.pipeline_id());
         navigate(
             cx,
-            &self.window,
+            &window,
             NavigationHistoryBehavior::Replace,
             false,
             load_data,
@@ -2258,7 +2258,6 @@ impl Document {
         {
             self.window.as_global_scope().schedule_callback(
                 OneshotTimerCallback::RefreshRedirectDue(RefreshRedirectDue {
-                    window: DomRoot::from_ref(self.window()),
                     url: url.clone(),
                     from_meta_element: *from_meta_element,
                 }),
@@ -4734,7 +4733,6 @@ impl Document {
         if self.completely_loaded() {
             self.window.as_global_scope().schedule_callback(
                 OneshotTimerCallback::RefreshRedirectDue(RefreshRedirectDue {
-                    window: DomRoot::from_ref(self.window()),
                     url: url_record,
                     from_meta_element,
                 }),

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -3007,7 +3007,7 @@ impl GlobalScope {
     }
 
     pub(crate) fn fire_timer(&self, handle: TimerEventId, cx: &mut js::context::JSContext) {
-        self.with_timers(|timers| timers.fire_timer(handle, self, cx));
+        self.with_timers(|timers| timers.fire_timer(handle, cx));
     }
 
     pub(crate) fn resume(&self) {

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -325,7 +325,7 @@ impl OneshotTimers {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#timer-initialisation-steps>
-    pub(crate) fn fire_timer(&self, id: TimerEventId, global: &GlobalScope, cx: &mut JSContext) {
+    pub(crate) fn fire_timer(&self, id: TimerEventId, cx: &mut JSContext) {
         // Step 9.2. If id does not exist in global's map of setTimeout and setInterval IDs, then abort these steps.
         let expected_id = self.expected_event_id.get();
         if expected_id != id {
@@ -365,7 +365,7 @@ impl OneshotTimers {
             // this loop can keep running, including after an interrupt of the JS,
             // and prevent a clean-shutdown of a JS-running thread.
             // This check prevents such a situation.
-            if !global.can_continue_running() {
+            if !self.global_scope.can_continue_running() {
                 return;
             }
             match &timer.callback {
@@ -409,7 +409,7 @@ impl OneshotTimers {
                     // (No additional delay applied.)
 
                     // Step 4.4 Perform completionSteps.
-                    (completion)(cx, global);
+                    (completion)(cx, &self.global_scope);
 
                     // Step 4.5 Remove global's map of active timers[timerKey].
                     self.map_of_active_timers.borrow_mut().remove(&timer_key);

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -146,11 +146,11 @@ pub(crate) enum OneshotTimerCallback {
 }
 
 impl OneshotTimerCallback {
-    fn invoke(self, global: &GlobalScope, js_timers: &JsTimers, cx: &mut JSContext) {
+    fn invoke(self, cx: &mut JSContext, global: &GlobalScope, js_timers: &JsTimers) {
         match self {
             OneshotTimerCallback::XhrTimeout(callback) => callback.invoke(cx),
             OneshotTimerCallback::EventSourceTimeout(callback) => callback.invoke(),
-            OneshotTimerCallback::JsTimer(task) => task.invoke(global, js_timers, cx),
+            OneshotTimerCallback::JsTimer(task) => task.invoke(cx, global, js_timers),
             #[cfg(feature = "testbinding")]
             OneshotTimerCallback::TestBindingCallback(callback) => callback.invoke(cx),
             OneshotTimerCallback::RefreshRedirectDue(callback) => callback.invoke(cx, global),
@@ -424,7 +424,7 @@ impl OneshotTimers {
                 },
                 _ => {
                     let cb = timer.callback;
-                    cb.invoke(&self.global_scope, &self.js_timers, cx);
+                    cb.invoke(cx, &self.global_scope, &self.js_timers);
                 },
             }
         }
@@ -782,7 +782,7 @@ fn clamp_duration(nesting_level: u32, unclamped: Duration) -> Duration {
 
 impl JsTimerTask {
     // see https://html.spec.whatwg.org/multipage/#timer-initialisation-steps
-    fn invoke(self, global: &GlobalScope, timers: &JsTimers, cx: &mut JSContext) {
+    fn invoke(self, cx: &mut JSContext, global: &GlobalScope, timers: &JsTimers) {
         // step 9.2 can be ignored, because we proactively prevent execution
         // of this task when its scheduled execution is canceled.
 

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -162,7 +162,9 @@ impl OneshotTimerCallback {
             OneshotTimerCallback::JsTimer(task) => task.invoke(this, js_timers, cx),
             #[cfg(feature = "testbinding")]
             OneshotTimerCallback::TestBindingCallback(callback) => callback.invoke(cx),
-            OneshotTimerCallback::RefreshRedirectDue(callback) => callback.invoke(cx),
+            OneshotTimerCallback::RefreshRedirectDue(callback) => {
+                callback.invoke(cx, &this.global())
+            },
             OneshotTimerCallback::RunStepsAfterTimeout { completion, .. } => {
                 // <https://html.spec.whatwg.org/multipage/#run-steps-after-a-timeout>
                 // Step 4.4 Perform completionSteps.

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -17,23 +17,19 @@ use js::rust::wrappers2::JS_GetScriptedCallerPrivate;
 use js::rust::{HandleValue, IntoHandle};
 use net_traits::request::ParserMetadata;
 use rustc_hash::FxHashMap;
-use script_bindings::callback::OwnerWindow;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::DomObject;
 use serde::{Deserialize, Serialize};
 use servo_base::id::PipelineId;
 use servo_config::pref;
 use servo_url::ServoUrl;
 use timers::{BoxedTimerCallback, TimerEventRequest};
 
-use crate::DomTypeHolder;
 use crate::dom::bindings::callback::ExceptionHandling::Report;
 use crate::dom::bindings::codegen::Bindings::FunctionBinding::Function;
 use crate::dom::bindings::codegen::UnionTypes::TrustedScriptOrString;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
-use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{AsHandleValue, Dom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::csp::CspReporting;
@@ -786,12 +782,7 @@ fn clamp_duration(nesting_level: u32, unclamped: Duration) -> Duration {
 
 impl JsTimerTask {
     // see https://html.spec.whatwg.org/multipage/#timer-initialisation-steps
-    fn invoke<T: DomObject + OwnerWindow<DomTypeHolder>>(
-        self,
-        this: &T,
-        timers: &JsTimers,
-        cx: &mut JSContext,
-    ) {
+    fn invoke(self, global: &GlobalScope, timers: &JsTimers, cx: &mut JSContext) {
         // step 9.2 can be ignored, because we proactively prevent execution
         // of this task when its scheduled execution is canceled.
 
@@ -803,7 +794,6 @@ impl JsTimerTask {
             InternalTimerCallback::StringTimerCallback(ref code_str, ref fetch_info) => {
                 // Step 6.4. Let settings object be global's relevant settings object.
                 // Step 6. Let realm be global's relevant realm.
-                let global = this.global();
 
                 // Note: the steps to retrieve *fetch options* and *base URL* are performed in
                 // `active_script_fetch_info`.
@@ -833,7 +823,7 @@ impl JsTimerTask {
             InternalTimerCallback::FunctionTimerCallback(ref function, ref arguments) => {
                 let arguments = self.collect_heap_args(arguments);
                 rooted!(&in(cx) let mut value: JSVal);
-                let _ = function.Call_(cx, this, arguments, value.handle_mut(), Report);
+                let _ = function.Call_(cx, global, arguments, value.handle_mut(), Report);
             },
         };
 
@@ -848,7 +838,7 @@ impl JsTimerTask {
         if self.is_interval == IsInterval::Interval &&
             timers.active_timers.borrow().contains_key(&self.handle)
         {
-            timers.initialize_and_schedule(&this.global(), self);
+            timers.initialize_and_schedule(global, self);
         }
     }
 

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -150,25 +150,18 @@ pub(crate) enum OneshotTimerCallback {
 }
 
 impl OneshotTimerCallback {
-    fn invoke<T: DomObject + OwnerWindow<DomTypeHolder>>(
-        self,
-        this: &T,
-        js_timers: &JsTimers,
-        cx: &mut JSContext,
-    ) {
+    fn invoke(self, global: &GlobalScope, js_timers: &JsTimers, cx: &mut JSContext) {
         match self {
             OneshotTimerCallback::XhrTimeout(callback) => callback.invoke(cx),
             OneshotTimerCallback::EventSourceTimeout(callback) => callback.invoke(),
-            OneshotTimerCallback::JsTimer(task) => task.invoke(this, js_timers, cx),
+            OneshotTimerCallback::JsTimer(task) => task.invoke(global, js_timers, cx),
             #[cfg(feature = "testbinding")]
             OneshotTimerCallback::TestBindingCallback(callback) => callback.invoke(cx),
-            OneshotTimerCallback::RefreshRedirectDue(callback) => {
-                callback.invoke(cx, &this.global())
-            },
+            OneshotTimerCallback::RefreshRedirectDue(callback) => callback.invoke(cx, global),
             OneshotTimerCallback::RunStepsAfterTimeout { completion, .. } => {
                 // <https://html.spec.whatwg.org/multipage/#run-steps-after-a-timeout>
                 // Step 4.4 Perform completionSteps.
-                completion(cx, &this.global());
+                completion(cx, global);
             },
         }
     }
@@ -435,7 +428,7 @@ impl OneshotTimers {
                 },
                 _ => {
                     let cb = timer.callback;
-                    cb.invoke(global, &self.js_timers, cx);
+                    cb.invoke(&self.global_scope, &self.js_timers, cx);
                 },
             }
         }


### PR DESCRIPTION
Part of #39139, instead of replacing `DomRoot` with `Dom`, simply remove it and pass down a `GlobalScope` ref when the callback is invoked.
Additionally, the generic parameter of `invoke` is removed, since `this` is always a `GlobalScope`.

Testing: It compiles
