### PR TITLE
script: Close open IndexedDB databases when tearing down a `Document`

### DIFF
--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -3050,12 +3050,16 @@ impl GlobalScope {
         true
     }
 
-    /// Returns the idb factory for this global.
-    pub(crate) fn get_indexeddb(&self, cx: &mut js::context::JSContext) -> DomRoot<IDBFactory> {
+    /// Potentially instantiate and return this [`GlobalScope`]'s [`IDBFactory`].
+    pub(crate) fn ensure_indexeddb_factory(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) -> DomRoot<IDBFactory> {
         self.indexeddb.or_init(|| IDBFactory::new(cx, self))
     }
 
-    pub(crate) fn get_existing_indexeddb(&self) -> Option<DomRoot<IDBFactory>> {
+    /// Return this [`GlobalScope`]'s [`IDBFactory`] if it has previously been instantiated.
+    pub(crate) fn indexeddb_factory(&self) -> Option<DomRoot<IDBFactory>> {
         self.indexeddb.get()
     }
 

--- a/components/script/dom/indexeddb/idbdatabase.rs
+++ b/components/script/dom/indexeddb/idbdatabase.rs
@@ -177,6 +177,23 @@ impl IDBDatabase {
             new_version,
         );
     }
+
+    /// <https://w3c.github.io/IndexedDB/#close-a-database-connection>
+    pub(crate) fn close_a_database_connection(&self, _forced: bool) {
+        // Step 1: Set connection’s close pending flag to true.
+        self.close_pending.set(true);
+
+        // Note: rest of the steps run in the storage backend.
+        // TODO: `_forced` either needs to be used here or passed to the backend.
+        let operation = SyncOperation::CloseDatabase(
+            self.global().origin().immutable().clone(),
+            self.id,
+            self.name.to_string(),
+        );
+        let _ = self
+            .get_idb_thread()
+            .send(IndexedDBThreadMsg::Sync(operation));
+    }
 }
 
 impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
@@ -243,7 +260,7 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
         // https://w3c.github.io/IndexedDB/#transaction-concept
         // A transaction optionally has a cleanup event loop which is an event loop.
         self.global()
-            .get_indexeddb(cx)
+            .ensure_indexeddb_factory(cx)
             .register_indexeddb_transaction(&transaction);
 
         // Step 9. Return an IDBTransaction object representing transaction.
@@ -431,21 +448,8 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
 
     /// <https://w3c.github.io/IndexedDB/#dom-idbdatabase-close>
     fn Close(&self) {
-        // Step 1: Run close a database connection with this connection.
-
-        // <https://w3c.github.io/IndexedDB/#close-a-database-connection>
-        // Step 1: Set connection’s close pending flag to true.
-        self.close_pending.set(true);
-
-        // Note: rest of algo runs in-parallel.
-        let operation = SyncOperation::CloseDatabase(
-            self.global().origin().immutable().clone(),
-            self.id,
-            self.name.to_string(),
-        );
-        let _ = self
-            .get_idb_thread()
-            .send(IndexedDBThreadMsg::Sync(operation));
+        // Step 1. Run close a database connection with this connection.
+        self.close_a_database_connection(false);
     }
 
     // https://www.w3.org/TR/IndexedDB-3/#dom-idbdatabase-onabort

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -491,10 +491,10 @@ impl IDBFactory {
         Ok(())
     }
 
-    pub(crate) fn abort_pending_upgrades(&self) {
+    pub(crate) fn abort_pending_upgrades_and_close_databases(&self) {
         let global = self.global();
-        let pending = self.connections.borrow();
-        let pending_upgrades = pending
+        let connections = self.connections.borrow();
+        let pending_upgrades = connections
             .iter()
             .map(|(key, val)| {
                 let ids: HashSet<Uuid> = val.iter().map(|(k, _v)| *k).collect();
@@ -518,6 +518,14 @@ impl IDBFactory {
             .is_err()
         {
             error!("Failed to send SyncOperation::AbortPendingUpgrade");
+        }
+
+        for (_, requests) in connections.iter() {
+            for (_, request) in requests.iter() {
+                if let Some(database) = request.pending_connection() {
+                    database.close_a_database_connection(true /* forced */);
+                }
+            }
         }
     }
 

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -227,6 +227,10 @@ impl IDBOpenDBRequest {
         }
     }
 
+    pub(crate) fn pending_connection(&self) -> Option<DomRoot<IDBDatabase>> {
+        self.pending_connection.get()
+    }
+
     pub(crate) fn delete_database(
         &self,
         storage_key: ImmutableOrigin,

--- a/components/script/dom/indexeddb/idbtransaction.rs
+++ b/components/script/dom/indexeddb/idbtransaction.rs
@@ -587,7 +587,7 @@ impl IDBTransaction {
                 event.fire(cx, this.upcast());
                 if this.mode == IDBTransactionMode::Versionchange {
                     this.global()
-                        .get_indexeddb(cx)
+                        .ensure_indexeddb_factory(cx)
                         .clear_open_request_transaction_for_txn(&this);
                     let origin = this.global().origin().immutable().clone();
                     let db_name = String::from(this.db.get_name());
@@ -608,7 +608,7 @@ impl IDBTransaction {
                 this.version_change_old_object_store_names.borrow_mut().take();
                 this.notify_backend_transaction_finished();
                 if this.registered_in_global.get() {
-                    this.global().get_indexeddb(cx).unregister_indexeddb_transaction(&this);
+                    this.global().ensure_indexeddb_factory(cx).unregister_indexeddb_transaction(&this);
                 }
             }));
     }
@@ -657,7 +657,7 @@ impl IDBTransaction {
                     //  Step 5.1: If transaction is an upgrade transaction, then let request be the request
                     // associated with transaction and set request’s transaction to null.
                     this.global()
-                        .get_indexeddb(cx)
+                        .ensure_indexeddb_factory(cx)
                         .clear_open_request_transaction_for_txn(&this);
                     let origin = this.global().origin().immutable().clone();
                     let db_name = String::from(this.db.get_name());
@@ -673,7 +673,7 @@ impl IDBTransaction {
                 }
                 this.notify_backend_transaction_finished();
                 if this.registered_in_global.get() {
-                    this.global().get_indexeddb(cx).unregister_indexeddb_transaction(&this);
+                    this.global().ensure_indexeddb_factory(cx).unregister_indexeddb_transaction(&this);
                 }
             }),
         );

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -1480,7 +1480,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     /// <https://w3c.github.io/IndexedDB/#factory-interface>
     fn IndexedDB(&self, cx: &mut JSContext) -> DomRoot<IDBFactory> {
-        self.upcast::<GlobalScope>().get_indexeddb(cx)
+        self.upcast::<GlobalScope>().ensure_indexeddb_factory(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-window-customelements>
@@ -2471,9 +2471,18 @@ impl Window {
         if let Some(performance) = self.performance.get() {
             performance.clear_and_disable_performance_entry_buffer();
         }
+
         self.as_global_scope()
             .task_manager()
             .cancel_all_tasks_and_ignore_future_tasks();
+
+        // From <https://w3c.github.io/IndexedDB/#database-connection>
+        // > The connection can be closed through several means. If the execution context where
+        // > the connection was created is destroyed (for example due to the user navigating away
+        // > from that page), the connection is closed.
+        if let Some(factory) = self.upcast::<GlobalScope>().indexeddb_factory() {
+            factory.abort_pending_upgrades_and_close_databases();
+        }
 
         // Callbacks may contain `Trusted` references, which are rooted and would
         // prevent the window from being GCed.

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -704,7 +704,7 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
 
     /// <https://w3c.github.io/IndexedDB/#factory-interface>
     fn IndexedDB(&self, cx: &mut JSContext) -> DomRoot<IDBFactory> {
-        self.upcast::<GlobalScope>().get_indexeddb(cx)
+        self.upcast::<GlobalScope>().ensure_indexeddb_factory(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-workerglobalscope-location>
@@ -1083,8 +1083,13 @@ impl WorkerGlobalScope {
         self.upcast::<GlobalScope>()
             .task_manager()
             .cancel_all_tasks_and_ignore_future_tasks();
-        if let Some(factory) = self.upcast::<GlobalScope>().get_existing_indexeddb() {
-            factory.abort_pending_upgrades();
+
+        // From <https://w3c.github.io/IndexedDB/#database-connection>
+        // > The connection can be closed through several means. If the execution context where
+        // > the connection was created is destroyed (for example due to the user navigating away
+        // > from that page), the connection is closed.
+        if let Some(factory) = self.upcast::<GlobalScope>().indexeddb_factory() {
+            factory.abort_pending_upgrades_and_close_databases();
         }
     }
 

--- a/components/script/microtask.rs
+++ b/components/script/microtask.rs
@@ -161,7 +161,9 @@ impl MicrotaskQueue {
         // “These steps are invoked by [HTML]. They ensure that transactions created by a script call
         // to transaction() are deactivated once the task that invoked the script has completed.”
         for global in globalscopes.iter() {
-            let _ = global.get_indexeddb(cx).cleanup_indexeddb_transactions(cx);
+            if let Some(factory) = global.indexeddb_factory() {
+                let _ = factory.cleanup_indexeddb_transactions(cx);
+            }
         }
 
         // TODO: Step 6. Perform ClearKeptObjects().


### PR DESCRIPTION
When tearing down a `Document` (when it's garbage collected), close any
open databases and ensure all upgrade transactions are aborted. The
second thing should likely happen as part of database closing, but this
is a transitional step toward matching the specification more closely.
This is important, because when running the IndexedDB test suite
lingering open connections on the backend can interfere with other
tests. Also, not doing this essentially leaks open connections.

Testing: This fixes flakiness when running the IndexedDB suite locally for me.
