### PR TITLE
script: Don't store rooted values inside `ElementsFilter` and microtasks

### DIFF
--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -367,8 +367,9 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-form-elements>
     fn Elements(&self, cx: &mut JSContext) -> DomRoot<HTMLFormControlsCollection> {
         #[derive(JSTraceable, MallocSizeOf)]
+        #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
         struct ElementsFilter {
-            form: DomRoot<HTMLFormElement>,
+            form: Dom<HTMLFormElement>,
         }
         impl CollectionFilter for ElementsFilter {
             fn filter<'a>(&self, elem: &'a Element, _root: &'a Node) -> bool {
@@ -417,18 +418,21 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
                     _ => return false,
                 };
 
-                match form_owner {
-                    Some(form_owner) => form_owner == self.form,
-                    None => false,
-                }
+                form_owner
+                    .as_deref()
+                    .is_some_and(|form_owner| self.form == form_owner)
             }
         }
         DomRoot::from_ref(self.elements.init_once(|| {
-            let filter = Box::new(ElementsFilter {
-                form: DomRoot::from_ref(self),
-            });
             let window = self.owner_window();
-            HTMLFormControlsCollection::new(cx, &window, self, filter)
+            HTMLFormControlsCollection::new(
+                cx,
+                &window,
+                self,
+                Box::new(ElementsFilter {
+                    form: Dom::from_ref(self),
+                }),
+            )
         }))
     }
 

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -51,7 +51,7 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
 use crate::dom::bindings::reflector::DomGlobal;
-use crate::dom::bindings::root::{DomRoot, LayoutDom, MutNullableDom, ToLayoutOptional};
+use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, MutNullableDom, ToLayoutOptional};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::csp::{GlobalCspReporting, Violation};
 use crate::dom::document::Document;
@@ -1221,7 +1221,7 @@ impl HTMLImageElement {
         // Step 8. Queue a microtask to perform the rest of this algorithm, allowing the task that
         // invoked this algorithm to continue.
         let task = ImageElementMicrotask::UpdateImageData {
-            elem: DomRoot::from_ref(self),
+            elem: Dom::from_ref(self),
             generation: self.generation.get(),
         };
 
@@ -1232,7 +1232,7 @@ impl HTMLImageElement {
     pub(crate) fn react_to_environment_changes(&self, cx: &JSContext) {
         // Step 1. Await a stable state.
         let task = ImageElementMicrotask::EnvironmentChanges {
-            elem: DomRoot::from_ref(self),
+            elem: Dom::from_ref(self),
             generation: self.generation.get(),
         };
 
@@ -1631,15 +1631,15 @@ impl HTMLImageElement {
 #[derive(JSTraceable, MallocSizeOf)]
 pub(crate) enum ImageElementMicrotask {
     UpdateImageData {
-        elem: DomRoot<HTMLImageElement>,
+        elem: Dom<HTMLImageElement>,
         generation: u32,
     },
     EnvironmentChanges {
-        elem: DomRoot<HTMLImageElement>,
+        elem: Dom<HTMLImageElement>,
         generation: u32,
     },
     Decode {
-        elem: DomRoot<HTMLImageElement>,
+        elem: Dom<HTMLImageElement>,
         #[conditional_malloc_size_of]
         promise: Rc<Promise>,
     },
@@ -1940,7 +1940,7 @@ impl HTMLImageElementMethods<crate::DomTypeHolder> for HTMLImageElement {
 
         // Step 2. Queue a microtask to perform the following steps:
         let task = ImageElementMicrotask::Decode {
-            elem: DomRoot::from_ref(self),
+            elem: Dom::from_ref(self),
             promise: promise.clone(),
         };
 

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -1080,7 +1080,7 @@ impl HTMLMediaElement {
         // changed, which is why we need to pass the base URL in the task
         // right here.
         let task = MediaElementMicrotask::ResourceSelection {
-            elem: DomRoot::from_ref(self),
+            elem: Dom::from_ref(self),
             generation_id: self.generation_id.get(),
             base_url: self.owner_document().base_url(),
         };
@@ -1308,7 +1308,7 @@ impl HTMLMediaElement {
 
         // Step 9.children.11. Await a stable state.
         let task = MediaElementMicrotask::SelectNextSourceChild {
-            elem: DomRoot::from_ref(self),
+            elem: Dom::from_ref(self),
             generation_id: self.generation_id.get(),
         };
 
@@ -1911,7 +1911,7 @@ impl HTMLMediaElement {
 
         // Step 9.children.23. Await a stable state.
         let task = MediaElementMicrotask::SelectNextSourceChildAfterWait {
-            elem: DomRoot::from_ref(self),
+            elem: Dom::from_ref(self),
             generation_id: self.generation_id.get(),
         };
 
@@ -2778,7 +2778,7 @@ impl HTMLMediaElement {
         // <https://html.spec.whatwg.org/multipage/#dom-media-seek>
         // Step 13. Await a stable state.
         let task = MediaElementMicrotask::Seeked {
-            elem: DomRoot::from_ref(self),
+            elem: Dom::from_ref(self),
             generation_id: self.generation_id.get(),
         };
 
@@ -3545,7 +3545,7 @@ impl VirtualMethods for HTMLMediaElement {
         // (Steps in the synchronous section are marked with ⌛.)
         if context.tree_connected {
             let task = MediaElementMicrotask::PauseIfNotInDocument {
-                elem: DomRoot::from_ref(self),
+                elem: Dom::from_ref(self),
             };
             ScriptThread::await_stable_state(cx, Box::new(task));
         }
@@ -3573,24 +3573,24 @@ impl VirtualMethods for HTMLMediaElement {
 #[derive(JSTraceable, MallocSizeOf)]
 pub(crate) enum MediaElementMicrotask {
     ResourceSelection {
-        elem: DomRoot<HTMLMediaElement>,
+        elem: Dom<HTMLMediaElement>,
         generation_id: u32,
         #[no_trace]
         base_url: ServoUrl,
     },
     PauseIfNotInDocument {
-        elem: DomRoot<HTMLMediaElement>,
+        elem: Dom<HTMLMediaElement>,
     },
     Seeked {
-        elem: DomRoot<HTMLMediaElement>,
+        elem: Dom<HTMLMediaElement>,
         generation_id: u32,
     },
     SelectNextSourceChild {
-        elem: DomRoot<HTMLMediaElement>,
+        elem: Dom<HTMLMediaElement>,
         generation_id: u32,
     },
     SelectNextSourceChildAfterWait {
-        elem: DomRoot<HTMLMediaElement>,
+        elem: Dom<HTMLMediaElement>,
         generation_id: u32,
     },
 }

--- a/components/script/dom/html/htmltrackelement.rs
+++ b/components/script/dom/html/htmltrackelement.rs
@@ -159,7 +159,7 @@ impl HTMLTrackElement {
         // crossorigin content attribute. Otherwise, let corsAttributeState be No CORS.
         let cors_attribute_state = cors_setting_for_element(&parent);
         let task = TrackElementMicrotask::ProcessingModel {
-            elem: DomRoot::from_ref(self),
+            elem: Dom::from_ref(self),
             cors_attribute_state,
             url,
         };
@@ -349,7 +349,7 @@ impl VirtualMethods for HTMLTrackElement {
 #[derive(JSTraceable, MallocSizeOf)]
 pub(crate) enum TrackElementMicrotask {
     ProcessingModel {
-        elem: DomRoot<HTMLTrackElement>,
+        elem: Dom<HTMLTrackElement>,
         #[no_trace]
         cors_attribute_state: Option<CorsSettings>,
         #[no_trace]

--- a/components/script/dom/promise/promise.rs
+++ b/components/script/dom/promise/promise.rs
@@ -41,7 +41,7 @@ use crate::DomTypeHolder;
 use crate::dom::bindings::conversions::root_from_object;
 use crate::dom::bindings::error::{Error, ErrorToJsval};
 use crate::dom::bindings::reflector::DomGlobal;
-use crate::dom::bindings::root::{AsHandleValue, DomRoot};
+use crate::dom::bindings::root::{AsHandleValue, Dom};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::microtask::MicrotaskRunnable;
@@ -486,8 +486,9 @@ impl Callback for WaitForAllRejectionHandler {
 /// The microtask for performing successSteps given « » in
 /// <https://webidl.spec.whatwg.org/#wait-for-all>.
 #[derive(JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct WaitForAllSuccessStepsMicrotask {
-    global: DomRoot<GlobalScope>,
+    global: Dom<GlobalScope>,
 
     #[ignore_malloc_size_of = "Closure is hard"]
     #[no_trace]
@@ -535,7 +536,7 @@ fn wait_for_all(
         global.enqueue_microtask(
             cx,
             Box::new(WaitForAllSuccessStepsMicrotask {
-                global: DomRoot::from_ref(global),
+                global: Dom::from_ref(global),
                 success_steps,
             }),
         );


### PR DESCRIPTION

Testing: It compiles
Part of #39139
