### PR TITLE
layout: Avoid setting FragmentFlags for HTML elements on pseudo-elements

### DIFF
--- a/components/layout/fragment_tree/base_fragment.rs
+++ b/components/layout/fragment_tree/base_fragment.rs
@@ -182,19 +182,32 @@ impl From<ServoLayoutNode<'_>> for BaseFragmentInfo {
         let pseudo_element_chain = node.pseudo_element_chain();
         let mut flags = FragmentFlags::empty();
 
-        // Anonymous boxes should not have a tag, because they should not take part in hit testing.
-        //
-        // TODO(mrobinson): It seems that anonymous boxes should take part in hit testing in some
-        // cases, but currently this means that the order of hit test results isn't as expected for
-        // some WPT tests. This needs more investigation.
-        if matches!(
-            pseudo_element_chain.innermost(),
-            Some(PseudoElement::ServoAnonymousBox) |
-                Some(PseudoElement::ServoAnonymousTable) |
-                Some(PseudoElement::ServoAnonymousTableCell) |
-                Some(PseudoElement::ServoAnonymousTableRow)
-        ) {
-            return Self::anonymous();
+        if let Some(innermost_pseudo) = pseudo_element_chain.innermost() {
+            match innermost_pseudo {
+                // Anonymous boxes should not have a tag, because they should not take part in hit testing.
+                //
+                // TODO(mrobinson): It seems that anonymous boxes should take part in hit testing in some
+                // cases, but currently this means that the order of hit test results isn't as expected for
+                // some WPT tests. This needs more investigation.
+                PseudoElement::ServoAnonymousBox |
+                PseudoElement::ServoAnonymousTable |
+                PseudoElement::ServoAnonymousTableCell |
+                PseudoElement::ServoAnonymousTableRow => return Self::anonymous(),
+                // A `<br>` forces a new line using a `::before` pseudo-element. Both of them need to get
+                // this flag.
+                PseudoElement::Before
+                    if node
+                        .as_html_element()
+                        .is_some_and(|element| element.local_name() == &local_name!("br")) =>
+                {
+                    flags.insert(FragmentFlags::IS_BR_ELEMENT);
+                },
+                _ => {},
+            }
+            return Self {
+                tag: Some(node.into()),
+                flags,
+            };
         }
 
         if node.as_element().is_some_and(|element| element.is_root()) {
@@ -246,7 +259,8 @@ bitflags! {
     pub(crate) struct FragmentFlags: u16 {
         /// Whether or not the node that created this fragment is a `<body>` element on an HTML document.
         const IS_BODY_ELEMENT_OF_HTML_ELEMENT_ROOT = 1 << 0;
-        /// Whether or not the node that created this Fragment is a `<br>` element.
+        /// Whether or not the node that created this Fragment is a `<br>` element, or a `::before`
+        /// pseudo-element originated by `<br>`.
         const IS_BR_ELEMENT = 1 << 1;
         /// Whether or not the node that created this Fragment is a widget. Widgets behave similarly to
         /// replaced elements, e.g. they are atomic when inline-level, and their automatic inline size

--- a/tests/wpt/tests/css/css-backgrounds/background-color-body-propagation-010.html
+++ b/tests/wpt/tests/css/css-backgrounds/background-color-body-propagation-010.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Test: Do not propagate background from `body::before`</title>
+<link rel="author" href="mailto:obrufau@igalia.com" title="Oriol Brufau">
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#special-backgrounds">
+<link rel="help" href="https://github.com/servo/servo/issues/41084">
+<link rel="match" href="background-color-no-body-propagation-ref.html">
+<style>
+body::before {
+  content: "This text should have a green background.";
+  display: block;
+  background-color: green;
+}
+</style>

--- a/tests/wpt/tests/css/css-backgrounds/background-color-root-propagation-003.html
+++ b/tests/wpt/tests/css/css-backgrounds/background-color-root-propagation-003.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Test: Do not propagate background from `html::before`</title>
+<link rel="author" href="mailto:obrufau@igalia.com" title="Oriol Brufau">
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#special-backgrounds">
+<link rel="help" href="https://github.com/servo/servo/issues/41084">
+<link rel="match" href="background-color-no-body-propagation-ref.html">
+<style>
+html::before {
+  content: "This text should have a green background.";
+  display: block;
+  margin: 8px;
+  background-color: green;
+}
+</style>

--- a/tests/wpt/tests/html/rendering/widgets/button-layout/centering-004-ref.html
+++ b/tests/wpt/tests/html/rendering/widgets/button-layout/centering-004-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+button > div {
+  display: flow-root;
+  height: 200px;
+}
+</style>
+<button>
+  <div>ABC</div>
+</button>

--- a/tests/wpt/tests/html/rendering/widgets/button-layout/centering-004.html
+++ b/tests/wpt/tests/html/rendering/widgets/button-layout/centering-004.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>A ::before originated by a button doesn't center vertically</title>
+<link rel="author" href="mailto:obrufau@igalia.com" title="Oriol Brufau">
+<link rel="help" href="https://html.spec.whatwg.org/#button-layout">
+<link rel="help" href="https://github.com/servo/servo/issues/46639">
+<link rel="match" href="centering-004-ref.html">
+<style>
+button::before {
+  content: "ABC";
+  display: flow-root;
+  height: 200px;
+}
+</style>
+<button></button>


### PR DESCRIPTION
For example, a `::before` originated by a `<button>` was marked with `FragmentFlags::IS_BUTTON`, so its contents were wrongly centered vertically, as if it was another `<button>`.

Or a `::before` originated by the body element used to be marked with `FragmentFlags::IS_BODY_ELEMENT_OF_HTML_ELEMENT_ROOT`, so if the body propagated its background to the viewport, we would also avoid painting the background of that `::before`.

The exception is the `<br>` element. Layout logic expects the flag to appear both on the element itself, and on its `::before`.

Testing: Adding 3 new tests
Fixes: #41084
Fixes: #46639
