### PR TITLE
script: replace deprecated as_slice method with as_slice_safe method

### DIFF
--- a/components/script/dom/bindings/serializable.rs
+++ b/components/script/dom/bindings/serializable.rs
@@ -5,7 +5,7 @@
 //! Trait representing the concept of [serializable objects]
 //! (<https://html.spec.whatwg.org/multipage/#serializable-objects>).
 
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use rustc_hash::FxHashMap;
 use script_bindings::reflector::DomObject;
 use script_bindings::structuredclone::MarkedAsSerializableInIdl;
@@ -53,7 +53,7 @@ where
     type Data;
 
     /// <https://html.spec.whatwg.org/multipage/#serialization-steps>
-    fn serialize(&self) -> Result<(NamespaceIndex<Self::Index>, Self::Data), ()>;
+    fn serialize(&self, no_gc: &NoGC) -> Result<(NamespaceIndex<Self::Index>, Self::Data), ()>;
     /// <https://html.spec.whatwg.org/multipage/#deserialization-steps>
     fn deserialize(
         cx: &mut JSContext,

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -8,7 +8,7 @@ use std::ffi::CStr;
 use std::os::raw;
 use std::ptr::{self, NonNull};
 
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::gc::RootedVec;
 use js::glue::{
     CopyJSStructuredCloneData, GetLengthOfJSStructuredCloneData, WriteBytesToJSStructuredCloneData,
@@ -202,13 +202,14 @@ unsafe fn read_object<T: Serializable>(
 }
 
 unsafe fn write_object<T: Serializable>(
+    no_gc: &NoGC,
     interface: SerializableInterface,
     owner: &GlobalScope,
     object: &T,
     w: *mut JSStructuredCloneWriter,
     sc_writer: &mut StructuredDataWriter,
 ) -> bool {
-    if let Ok((new_id, serialized)) = object.serialize() {
+    if let Ok((new_id, serialized)) = object.serialize(no_gc) {
         let objects = T::serialized_storage(StructuredData::Writer(sc_writer))
             .get_or_insert(FxHashMap::default());
         objects.insert(new_id, serialized);
@@ -283,7 +284,7 @@ unsafe fn try_serialize<T: Serializable + IDLInterface>(
 ) -> Result<bool, OperationError> {
     let object = unsafe { root_from_object::<T>(cx, *object) };
     if let Ok(obj) = object {
-        return unsafe { Ok(write_object(val, global, &*obj, w, writer)) };
+        return unsafe { Ok(write_object(cx.no_gc(), val, global, &*obj, w, writer)) };
     }
     Err(OperationError::InterfaceDoesNotMatch)
 }

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -17,7 +17,7 @@ use fonts::{
     ShapingOptions,
 };
 use icu_locid::subtags::Language;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use net_traits::image_cache::{ImageCache, ImageResponse};
 use net_traits::request::CorsSettings;
 use pixels::{Snapshot, SnapshotAlphaMode, SnapshotPixelFormat};
@@ -1904,12 +1904,14 @@ impl CanvasState {
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata
     pub(super) fn put_image_data(
         &self,
+        no_gc: &NoGC,
         canvas_size: Size2D<u32>,
         imagedata: &ImageData,
         dx: i32,
         dy: i32,
     ) {
         self.put_image_data_(
+            no_gc,
             canvas_size,
             imagedata,
             dx,
@@ -1925,6 +1927,7 @@ impl CanvasState {
     #[expect(clippy::too_many_arguments)]
     pub(super) fn put_image_data_(
         &self,
+        no_gc: &NoGC,
         canvas_size: Size2D<u32>,
         imagedata: &ImageData,
         dx: i32,
@@ -1973,7 +1976,8 @@ impl CanvasState {
         };
 
         // Step 7.
-        let snapshot = imagedata.get_snapshot_rect(Rect::new(src_rect.origin, dst_rect.size));
+        let snapshot =
+            imagedata.get_snapshot_rect(no_gc, Rect::new(src_rect.origin, dst_rect.size));
         // Flushing is not required for correctness, but optimization heuristics for heavy command.
         self.send_canvas_command_immediate(CanvasCommand::PutImageData(
             dst_rect,

--- a/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use pixels::Snapshot;
 use script_bindings::reflector::{AssociatedMemory, Reflector, reflect_dom_object_with_cx};
 use servo_base::{Epoch, generic_channel};
@@ -558,15 +558,16 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata>
-    fn PutImageData(&self, imagedata: &ImageData, dx: i32, dy: i32) {
+    fn PutImageData(&self, no_gc: &NoGC, imagedata: &ImageData, dx: i32, dy: i32) {
         self.canvas_state
-            .put_image_data(self.canvas.size(), imagedata, dx, dy);
+            .put_image_data(no_gc, self.canvas.size(), imagedata, dx, dy);
         self.mark_as_dirty();
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata
     fn PutImageData_(
         &self,
+        no_gc: &NoGC,
         imagedata: &ImageData,
         dx: i32,
         dy: i32,
@@ -576,6 +577,7 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
         dirty_height: i32,
     ) {
         self.canvas_state.put_image_data_(
+            no_gc,
             self.canvas.size(),
             imagedata,
             dx,

--- a/components/script/dom/canvas/2d/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/offscreencanvasrenderingcontext2d.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use pixels::Snapshot;
 use script_bindings::reflector::reflect_dom_object_with_cx;
 use servo_canvas_traits::canvas::CanvasCommand;
@@ -419,13 +419,14 @@ impl OffscreenCanvasRenderingContext2DMethods<crate::DomTypeHolder>
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata>
-    fn PutImageData(&self, imagedata: &ImageData, dx: i32, dy: i32) {
-        self.context.PutImageData(imagedata, dx, dy)
+    fn PutImageData(&self, no_gc: &NoGC, imagedata: &ImageData, dx: i32, dy: i32) {
+        self.context.PutImageData(no_gc, imagedata, dx, dy)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata
     fn PutImageData_(
         &self,
+        no_gc: &NoGC,
         imagedata: &ImageData,
         dx: i32,
         dy: i32,
@@ -435,6 +436,7 @@ impl OffscreenCanvasRenderingContext2DMethods<crate::DomTypeHolder>
         dirty_height: i32,
     ) {
         self.context.PutImageData_(
+            no_gc,
             imagedata,
             dx,
             dy,

--- a/components/script/dom/canvas/imagebitmap.rs
+++ b/components/script/dom/canvas/imagebitmap.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use euclid::default::{Point2D, Rect, Size2D};
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::realm::CurrentRealm;
 use pixels::{CorsStatus, Snapshot, SnapshotAlphaMode, SnapshotPixelFormat};
 use rustc_hash::FxHashMap;
@@ -573,7 +573,7 @@ impl ImageBitmap {
                     image_data.get_size().cast(),
                     SnapshotPixelFormat::RGBA,
                     alpha_mode,
-                    image_data.to_vec(),
+                    image_data.to_vec(realm.no_gc()),
                 );
 
                 // Step 6.3. Set imageBitmap's bitmap data to image's image data,
@@ -608,7 +608,7 @@ impl Serializable for ImageBitmap {
     type Data = SerializableImageBitmap;
 
     /// <https://html.spec.whatwg.org/multipage/#the-imagebitmap-interface:serialization-steps>
-    fn serialize(&self) -> Result<(ImageBitmapId, Self::Data), ()> {
+    fn serialize(&self, _no_gc: &NoGC) -> Result<(ImageBitmapId, Self::Data), ()> {
         // <https://html.spec.whatwg.org/multipage/#structuredserializeinternal>
         // Step 19.1. If value has a [[Detached]] internal slot whose value is
         // true, then throw a "DataCloneError" DOMException.

--- a/components/script/dom/canvas/imagedata.rs
+++ b/components/script/dom/canvas/imagedata.rs
@@ -7,7 +7,7 @@ use std::vec::Vec;
 
 use dom_struct::dom_struct;
 use euclid::default::{Rect, Size2D};
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::gc::CustomAutoRooterGuard;
 use js::jsapi::JSObject;
 use js::rust::HandleObject;
@@ -163,8 +163,8 @@ impl ImageData {
     }
 
     /// Nothing must change the array on the JS side while the slice is live.
-    #[expect(unsafe_code, deprecated)]
-    pub(crate) unsafe fn as_slice(&self) -> &[u8] {
+    #[expect(unsafe_code)]
+    pub(crate) unsafe fn as_slice(&self, no_gc: &NoGC) -> &[u8] {
         assert!(self.data.is_initialized());
         let internal_data = self
             .data
@@ -176,51 +176,55 @@ impl ImageData {
         // because the array may be manipulated from JS while the reference
         // is live.
         unsafe {
-            let ptr: *const [u8] = internal_data.as_slice() as *const _;
+            let ptr: *const [u8] = internal_data.as_slice_safe(no_gc) as *const _;
             &*ptr
         }
     }
 
     /// Nothing must change the array on the JS side while the slice is live.
     #[expect(unsafe_code)]
-    pub(crate) unsafe fn get_rect(&self, rect: Rect<u32>) -> Cow<'_, [u8]> {
-        pixels::rgba8_get_rect(unsafe { self.as_slice() }, self.get_size().to_u32(), rect)
+    pub(crate) unsafe fn get_rect(&self, no_gc: &NoGC, rect: Rect<u32>) -> Cow<'_, [u8]> {
+        pixels::rgba8_get_rect(
+            unsafe { self.as_slice(no_gc) },
+            self.get_size().to_u32(),
+            rect,
+        )
     }
 
     #[expect(unsafe_code)]
-    pub(crate) fn get_snapshot_rect(&self, rect: Rect<u32>) -> Snapshot {
+    pub(crate) fn get_snapshot_rect(&self, no_gc: &NoGC, rect: Rect<u32>) -> Snapshot {
         Snapshot::from_vec(
             rect.size,
             SnapshotPixelFormat::RGBA,
             SnapshotAlphaMode::Transparent {
                 premultiplied: false,
             },
-            unsafe { self.get_rect(rect).into_owned() },
+            unsafe { self.get_rect(no_gc, rect).into_owned() },
         )
     }
 
     #[expect(unsafe_code)]
-    pub(crate) fn get_snapshot(&self) -> Snapshot {
+    pub(crate) fn get_snapshot(&self, no_gc: &NoGC) -> Snapshot {
         Snapshot::from_vec(
             self.get_size(),
             SnapshotPixelFormat::RGBA,
             SnapshotAlphaMode::Transparent {
                 premultiplied: false,
             },
-            unsafe { self.as_slice().to_vec() },
+            unsafe { self.as_slice(no_gc).to_vec() },
         )
     }
 
     #[expect(unsafe_code)]
-    pub(crate) fn to_shared_memory(&self) -> GenericSharedMemory {
+    pub(crate) fn to_shared_memory(&self, no_gc: &NoGC) -> GenericSharedMemory {
         // This is safe because we copy the slice content
-        GenericSharedMemory::from_bytes(unsafe { self.as_slice() })
+        GenericSharedMemory::from_bytes(unsafe { self.as_slice(no_gc) })
     }
 
     #[expect(unsafe_code)]
-    pub(crate) fn to_vec(&self) -> Vec<u8> {
+    pub(crate) fn to_vec(&self, no_gc: &NoGC) -> Vec<u8> {
         // This is safe because we copy the slice content
-        unsafe { self.as_slice() }.to_vec()
+        unsafe { self.as_slice(no_gc) }.to_vec()
     }
 }
 
@@ -229,9 +233,9 @@ impl Serializable for ImageData {
     type Data = SerializableImageData;
 
     /// <https://html.spec.whatwg.org/multipage/#the-imagedata-interface:serializable-objects>
-    fn serialize(&self) -> Result<(ImageDataId, Self::Data), ()> {
+    fn serialize(&self, no_gc: &NoGC) -> Result<(ImageDataId, Self::Data), ()> {
         // Step 1 Set serialized.[[Data]] to the sub-serialization of the value of value's data attribute.
-        let data = self.to_vec();
+        let data = self.to_vec(no_gc);
 
         // Step 2 Set serialized.[[Width]] to the value of value's width attribute.
         // Step 3 Set serialized.[[Height]] to the value of value's height attribute.

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::rust::HandleObject;
 use rustc_hash::FxHashMap;
 use script_bindings::match_domstring_ascii;
@@ -253,7 +253,7 @@ impl Serializable for DOMException {
     type Data = DomException;
 
     /// <https://webidl.spec.whatwg.org/#idl-DOMException>
-    fn serialize(&self) -> Result<(DomExceptionId, Self::Data), ()> {
+    fn serialize(&self, _no_gc: &NoGC) -> Result<(DomExceptionId, Self::Data), ()> {
         let serialized = DomException {
             message: self.message.to_string(),
             name: self.name.to_string(),

--- a/components/script/dom/file/blob.rs
+++ b/components/script/dom/file/blob.rs
@@ -103,7 +103,7 @@ impl Serializable for Blob {
     type Data = BlobImpl;
 
     /// <https://w3c.github.io/FileAPI/#ref-for-serialization-steps>
-    fn serialize(&self) -> Result<(BlobId, BlobImpl), ()> {
+    fn serialize(&self, _no_gc: &NoGC) -> Result<(BlobId, BlobImpl), ()> {
         let blob_id = self.blob_id;
 
         // 1. Get a clone of the blob impl.

--- a/components/script/dom/file/file.rs
+++ b/components/script/dom/file/file.rs
@@ -7,7 +7,7 @@ use std::time::SystemTime;
 
 use dom_struct::dom_struct;
 use embedder_traits::SelectedFile;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::rust::HandleObject;
 use script_bindings::reflector::reflect_weak_referenceable_dom_object_with_proto;
 use servo_base::id::{FileId, FileIndex};
@@ -139,8 +139,8 @@ impl File {
         self.modified
     }
 
-    pub(crate) fn serialized_data(&self) -> Result<SerializableFile, ()> {
-        let (_, blob_impl) = self.upcast::<Blob>().serialize()?;
+    pub(crate) fn serialized_data(&self, no_gc: &NoGC) -> Result<SerializableFile, ()> {
+        let (_, blob_impl) = self.upcast::<Blob>().serialize(no_gc)?;
         Ok(SerializableFile {
             blob_impl,
             name: self.name.to_string(),
@@ -155,8 +155,8 @@ impl Serializable for File {
     type Data = SerializableFile;
 
     /// <https://html.spec.whatwg.org/multipage/#serialization-steps>
-    fn serialize(&self) -> Result<(FileId, SerializableFile), ()> {
-        Ok((FileId::new(), self.serialized_data()?))
+    fn serialize(&self, no_gc: &NoGC) -> Result<(FileId, SerializableFile), ()> {
+        Ok((FileId::new(), self.serialized_data(no_gc)?))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#deserialization-steps>

--- a/components/script/dom/file/filelist.rs
+++ b/components/script/dom/file/filelist.rs
@@ -5,7 +5,7 @@
 use std::slice::Iter;
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::id::{FileListId, FileListIndex};
 use servo_constellation_traits::SerializableFileList;
@@ -72,11 +72,11 @@ impl Serializable for FileList {
     type Data = SerializableFileList;
 
     /// <https://html.spec.whatwg.org/multipage/#serialization-steps>
-    fn serialize(&self) -> Result<(FileListId, SerializableFileList), ()> {
+    fn serialize(&self, no_gc: &NoGC) -> Result<(FileListId, SerializableFileList), ()> {
         let files = self
             .list
             .iter()
-            .map(|file| file.serialized_data())
+            .map(|file| file.serialized_data(no_gc))
             .collect::<Result<Vec<_>, _>>()?;
         Ok((FileListId::new(), SerializableFileList { files }))
     }

--- a/components/script/dom/geometry/dommatrix.rs
+++ b/components/script/dom/geometry/dommatrix.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use euclid::default::Transform3D;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::rust::{CustomAutoRooterGuard, HandleObject};
 use js::typedarray::{Float32Array, Float64Array};
 use rustc_hash::FxHashMap;
@@ -502,7 +502,7 @@ impl Serializable for DOMMatrix {
     type Index = DomMatrixIndex;
     type Data = DomMatrix;
 
-    fn serialize(&self) -> Result<(DomMatrixId, Self::Data), ()> {
+    fn serialize(&self, _no_gc: &NoGC) -> Result<(DomMatrixId, Self::Data), ()> {
         let serialized = if self.parent.is2D() {
             DomMatrix {
                 matrix: Transform3D::new(

--- a/components/script/dom/geometry/dommatrixreadonly.rs
+++ b/components/script/dom/geometry/dommatrixreadonly.rs
@@ -9,6 +9,7 @@ use cssparser::{Parser, ParserInput};
 use dom_struct::dom_struct;
 use euclid::Angle;
 use euclid::default::{Transform2D, Transform3D};
+use js::context::NoGC;
 use js::conversions::jsstr_to_string;
 use js::jsapi::JSObject;
 use js::jsval;
@@ -987,7 +988,7 @@ impl Serializable for DOMMatrixReadOnly {
     type Index = DomMatrixIndex;
     type Data = DomMatrix;
 
-    fn serialize(&self) -> Result<(DomMatrixId, Self::Data), ()> {
+    fn serialize(&self, _no_gc: &NoGC) -> Result<(DomMatrixId, Self::Data), ()> {
         let serialized = if self.is2D() {
             DomMatrix {
                 matrix: Transform3D::new(

--- a/components/script/dom/geometry/dompoint.rs
+++ b/components/script/dom/geometry/dompoint.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::rust::HandleObject;
 use rustc_hash::FxHashMap;
 use script_bindings::reflector::reflect_dom_object_with_proto;
@@ -133,7 +133,7 @@ impl Serializable for DOMPoint {
     type Index = DomPointIndex;
     type Data = DomPoint;
 
-    fn serialize(&self) -> Result<(DomPointId, Self::Data), ()> {
+    fn serialize(&self, _no_gc: &NoGC) -> Result<(DomPointId, Self::Data), ()> {
         let serialized = DomPoint {
             x: self.X(),
             y: self.Y(),

--- a/components/script/dom/geometry/dompointreadonly.rs
+++ b/components/script/dom/geometry/dompointreadonly.rs
@@ -5,7 +5,7 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::rust::HandleObject;
 use rustc_hash::FxHashMap;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
@@ -182,7 +182,7 @@ impl Serializable for DOMPointReadOnly {
     type Index = DomPointIndex;
     type Data = DomPoint;
 
-    fn serialize(&self) -> Result<(DomPointId, Self::Data), ()> {
+    fn serialize(&self, _no_gc: &NoGC) -> Result<(DomPointId, Self::Data), ()> {
         let serialized = DomPoint {
             x: self.x.get(),
             y: self.y.get(),

--- a/components/script/dom/geometry/domquad.rs
+++ b/components/script/dom/geometry/domquad.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::rust::HandleObject;
 use rustc_hash::FxHashMap;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
@@ -199,7 +199,7 @@ impl Serializable for DOMQuad {
     type Index = DomQuadIndex;
     type Data = DomQuad;
 
-    fn serialize(&self) -> Result<(DomQuadId, Self::Data), ()> {
+    fn serialize(&self, _no_gc: &NoGC) -> Result<(DomQuadId, Self::Data), ()> {
         let make_point = |src: &DOMPoint| -> DomPoint {
             DomPoint {
                 x: src.X(),

--- a/components/script/dom/geometry/domrect.rs
+++ b/components/script/dom/geometry/domrect.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::rust::HandleObject;
 use rustc_hash::FxHashMap;
 use script_bindings::reflector::{reflect_dom_object_with_cx, reflect_dom_object_with_proto};
@@ -131,7 +131,7 @@ impl Serializable for DOMRect {
     type Index = DomRectIndex;
     type Data = DomRect;
 
-    fn serialize(&self) -> Result<(DomRectId, Self::Data), ()> {
+    fn serialize(&self, _no_gc: &NoGC) -> Result<(DomRectId, Self::Data), ()> {
         let serialized = DomRect {
             x: self.X(),
             y: self.Y(),

--- a/components/script/dom/geometry/domrectreadonly.rs
+++ b/components/script/dom/geometry/domrectreadonly.rs
@@ -5,7 +5,7 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::rust::HandleObject;
 use rustc_hash::FxHashMap;
 use script_bindings::reflector::{
@@ -205,7 +205,7 @@ impl Serializable for DOMRectReadOnly {
     type Index = DomRectIndex;
     type Data = DomRect;
 
-    fn serialize(&self) -> Result<(DomRectId, Self::Data), ()> {
+    fn serialize(&self, _no_gc: &NoGC) -> Result<(DomRectId, Self::Data), ()> {
         let serialized = DomRect {
             x: self.X(),
             y: self.Y(),

--- a/components/script/dom/quotaexceedederror.rs
+++ b/components/script/dom/quotaexceedederror.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::gc::HandleObject;
 use rustc_hash::FxHashMap;
 use script_bindings::codegen::GenericBindings::QuotaExceededErrorBinding::{
@@ -124,8 +124,8 @@ impl Serializable for QuotaExceededError {
     type Data = SerializableQuotaExceededError;
 
     /// <https://webidl.spec.whatwg.org/#quotaexceedederror>
-    fn serialize(&self) -> Result<(QuotaExceededErrorId, Self::Data), ()> {
-        let (_, dom_exception) = self.dom_exception.serialize()?;
+    fn serialize(&self, no_gc: &NoGC) -> Result<(QuotaExceededErrorId, Self::Data), ()> {
+        let (_, dom_exception) = self.dom_exception.serialize(no_gc)?;
         let serialized = SerializableQuotaExceededError {
             dom_exception,
             quota: self.quota.as_deref().copied(),

--- a/components/script/dom/webcrypto/cryptokey.rs
+++ b/components/script/dom/webcrypto/cryptokey.rs
@@ -6,6 +6,7 @@ use std::cell::Cell;
 use std::str::FromStr;
 
 use dom_struct::dom_struct;
+use js::context::NoGC;
 use js::jsapi::{Heap, JSObject, Value};
 use js::rust::MutableHandleObject;
 use malloc_size_of::MallocSizeOf;
@@ -229,7 +230,7 @@ impl Serializable for CryptoKey {
     type Data = SerializableCryptoKey;
 
     /// <https://w3c.github.io/webcrypto/#cryptokey-interface-serializable>
-    fn serialize(&self) -> Result<(CryptoKeyId, Self::Data), ()> {
+    fn serialize(&self, _no_gc: &NoGC) -> Result<(CryptoKeyId, Self::Data), ()> {
         // Step 1. Set serialized.[[Type]] to the [[type]] internal slot of value.
         // Step 2. Set serialized.[[Extractable]] to the [[extractable]] internal slot of value.
         // Step 3. Set serialized.[[Algorithm]] to the sub-serialization of the [[algorithm]]

--- a/components/script/dom/webgl/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl/webgl2renderingcontext.rs
@@ -3412,7 +3412,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.6>
     fn TexImage2D___(
         &self,
-        _no_gc: &NoGC,
+        no_gc: &NoGC,
         target: u32,
         level: i32,
         internalformat: i32,
@@ -3457,7 +3457,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
 
         let unpacking_alignment = self.base.texture_unpacking_alignment();
 
-        let pixels = match self.base.get_image_pixels(source)? {
+        let pixels = match self.base.get_image_pixels(no_gc, source)? {
             Some(pixels) => pixels,
             None => return Ok(()),
         };

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -653,7 +653,11 @@ impl WebGLRenderingContext {
         )
     }
 
-    pub(crate) fn get_image_pixels(&self, source: TexImageSource) -> Fallible<Option<TexPixels>> {
+    pub(crate) fn get_image_pixels(
+        &self,
+        no_gc: &NoGC,
+        source: TexImageSource,
+    ) -> Fallible<Option<TexPixels>> {
         Ok(Some(match source {
             TexImageSource::ImageBitmap(bitmap) => {
                 if !bitmap.origin_is_clean() {
@@ -690,7 +694,7 @@ impl WebGLRenderingContext {
                     self.get_current_unpack_state(Alpha::NotPremultiplied);
 
                 TexPixels::new(
-                    image_data.to_shared_memory(),
+                    image_data.to_shared_memory(no_gc),
                     image_data.get_size(),
                     PixelFormat::RGBA8,
                     alpha_treatment,
@@ -4712,7 +4716,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
     fn TexImage2D_(
         &self,
-        _no_gc: &NoGC,
+        no_gc: &NoGC,
         target: u32,
         level: i32,
         internal_format: i32,
@@ -4725,7 +4729,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             return Ok(());
         }
 
-        let pixels = match self.get_image_pixels(source)? {
+        let pixels = match self.get_image_pixels(no_gc, source)? {
             Some(pixels) => pixels,
             None => return Ok(()),
         };
@@ -4889,7 +4893,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
     fn TexSubImage2D_(
         &self,
-        _no_gc: &NoGC,
+        no_gc: &NoGC,
         target: u32,
         level: i32,
         xoffset: i32,
@@ -4898,7 +4902,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         data_type: u32,
         source: TexImageSource,
     ) -> ErrorResult {
-        let pixels = match self.get_image_pixels(source)? {
+        let pixels = match self.get_image_pixels(no_gc, source)? {
             Some(pixels) => pixels,
             None => return Ok(()),
         };

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -289,7 +289,7 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
                         "ImageData is detached".to_string(),
                     )));
                 }
-                Some(data.get_snapshot())
+                Some(data.get_snapshot(cx.no_gc()))
             },
             GPUCopyExternalImageSource::HTMLImageElement(inner) => {
                 if inner.is_usable()? {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -99,6 +99,7 @@ DOMInterfaces = {
 
 'CanvasRenderingContext2D': {
     'cx': ['GetTransform', 'MeasureText', 'CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient', 'CreateImageData', 'GetImageData', 'CreateImageData_'],
+    'no_gc': ['PutImageData', 'PutImageData_']
 },
 
 'CharacterData': {
@@ -932,6 +933,7 @@ DOMInterfaces = {
 
 'OffscreenCanvasRenderingContext2D': {
     'cx': ['CreateImageData', 'CreateImageData_', 'GetImageData', 'GetTransform', 'MeasureText', 'CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient'],
+    'no_gc': ['PutImageData', 'PutImageData_']
 },
 
 'PaintRenderingContext2D': {


### PR DESCRIPTION
Replace deprecated `as_slice` method in ImageData with safe `as_slice_safe` method.

Testing: It compiles
Fixes: #46474
