### PR TITLE
script: Move more files to script_webgpu crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9127,6 +9127,7 @@ dependencies = [
 name = "servo-script-webgpu"
 version = "0.4.0"
 dependencies = [
+ "log",
  "malloc_size_of_derive",
  "mozjs",
  "servo-deny-public-fields",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9136,6 +9136,7 @@ dependencies = [
  "servo-malloc-size-of",
  "servo-script-bindings",
  "servo-webgpu-traits",
+ "wgpu-core 30.0.0",
 ]
 
 [[package]]

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -11,6 +11,7 @@ use js::context::{JSContext, NoGC};
 use js::realm::CurrentRealm;
 use js::typedarray::HeapArrayBuffer;
 use script_bindings::cell::DomRefCell;
+use script_bindings::codegen::GenericBindings::WebGPUBinding::GPUMapModeConstants;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use script_bindings::trace::RootedTraceableBox;
 use servo_base::generic_channel::GenericSharedMemory;
@@ -21,8 +22,8 @@ use wgpu_core::resource::BufferAccessError;
 use crate::conversions::Convert;
 use crate::dom::bindings::buffer_source::DataBlock;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
-    GPUBufferDescriptor, GPUBufferMapState, GPUBufferMethods, GPUFlagsConstant,
-    GPUMapModeConstants, GPUMapModeFlags, GPUSize64,
+    GPUBufferDescriptor, GPUBufferMapState, GPUBufferMethods, GPUFlagsConstant, GPUMapModeFlags,
+    GPUSize64,
 };
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::DomGlobal;

--- a/components/script/dom/webgpu/gpucanvascontext.rs
+++ b/components/script/dom/webgpu/gpucanvascontext.rs
@@ -11,7 +11,9 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use pixels::Snapshot;
 use script_bindings::cformat;
-use script_bindings::codegen::GenericBindings::WebGPUBinding::GPUTextureFormat;
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{
+    GPUTextureFormat, GPUTextureUsageConstants,
+};
 use script_bindings::reflector::{Reflector, reflect_weak_referenceable_dom_object};
 use servo_base::{Epoch, generic_channel};
 use webgpu_traits::{
@@ -28,7 +30,7 @@ use crate::dom::bindings::codegen::Bindings::GPUCanvasContextBinding::GPUCanvasC
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUTexture_Binding::GPUTextureMethods;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUCanvasAlphaMode, GPUCanvasConfiguration, GPUDeviceMethods, GPUExtent3D, GPUExtent3DDict,
-    GPUObjectDescriptorBase, GPUTextureDescriptor, GPUTextureDimension, GPUTextureUsageConstants,
+    GPUObjectDescriptorBase, GPUTextureDescriptor, GPUTextureDimension,
 };
 use crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas as RootedHTMLCanvasElementOrOffscreenCanvas;
 use crate::dom::bindings::error::{Error, Fallible};

--- a/components/script/dom/webgpu/mod.rs
+++ b/components/script/dom/webgpu/mod.rs
@@ -41,7 +41,9 @@ pub(crate) mod gpudevicelostinfo {
 pub(crate) mod gpuerror;
 pub(crate) mod gpuexternaltexture;
 pub(crate) mod gpuinternalerror;
-pub(crate) mod gpumapmode;
+pub(crate) mod gpumapmode {
+    pub(crate) type GPUMapMode = script_webgpu::gpumapmode::GPUMapMode<crate::DomTypeHolder>;
+}
 pub(crate) mod gpuoutofmemoryerror;
 pub(crate) mod gpupipelineerror;
 #[expect(dead_code)]

--- a/components/script/dom/webgpu/mod.rs
+++ b/components/script/dom/webgpu/mod.rs
@@ -17,7 +17,10 @@ pub(crate) mod gpubufferusage {
 }
 pub(crate) mod gpucanvascontext;
 pub(crate) mod gpucolorwrite;
-pub(crate) mod gpucommandbuffer;
+pub(crate) mod gpucommandbuffer {
+    pub(crate) type GPUCommandBuffer =
+        script_webgpu::gpucommandbuffer::GPUCommandBuffer<crate::DomTypeHolder>;
+}
 pub(crate) mod gpucommandencoder;
 pub(crate) mod gpucompilationinfo {
     pub(crate) type GPUCompilationInfo =

--- a/components/script/dom/webgpu/mod.rs
+++ b/components/script/dom/webgpu/mod.rs
@@ -59,7 +59,10 @@ pub(crate) mod gpurenderpassencoder;
 pub(crate) mod gpurenderpipeline;
 pub(crate) mod gpusampler;
 pub(crate) mod gpushadermodule;
-pub(crate) mod gpushaderstage;
+pub(crate) mod gpushaderstage {
+    pub(crate) type GPUShaderStage =
+        script_webgpu::gpushaderstage::GPUShaderStage<crate::DomTypeHolder>;
+}
 pub(crate) mod gpusupportedfeatures;
 pub(crate) mod gpusupportedlimits;
 pub(crate) mod gputexture;

--- a/components/script/dom/webgpu/mod.rs
+++ b/components/script/dom/webgpu/mod.rs
@@ -66,7 +66,10 @@ pub(crate) mod gpushaderstage {
 pub(crate) mod gpusupportedfeatures;
 pub(crate) mod gpusupportedlimits;
 pub(crate) mod gputexture;
-pub(crate) mod gputextureusage;
+pub(crate) mod gputextureusage {
+    pub(crate) type GPUTextureUsage =
+        script_webgpu::gputextureusage::GPUTextureUsage<crate::DomTypeHolder>;
+}
 pub(crate) mod gputextureview;
 pub(crate) mod gpuuncapturederrorevent;
 pub(crate) mod gpuvalidationerror;

--- a/components/script/dom/webgpu/mod.rs
+++ b/components/script/dom/webgpu/mod.rs
@@ -50,7 +50,10 @@ pub(crate) mod gpupipelineerror;
 pub(crate) mod gpupipelinelayout;
 pub(crate) mod gpuqueryset;
 pub(crate) mod gpuqueue;
-pub(crate) mod gpurenderbundle;
+pub(crate) mod gpurenderbundle {
+    pub(crate) type GPURenderBundle =
+        script_webgpu::gpurenderbundle::GPURenderBundle<crate::DomTypeHolder>;
+}
 pub(crate) mod gpurenderbundleencoder;
 pub(crate) mod gpurenderpassencoder;
 pub(crate) mod gpurenderpipeline;

--- a/components/script/dom/webgpu/mod.rs
+++ b/components/script/dom/webgpu/mod.rs
@@ -73,6 +73,7 @@ pub(crate) mod gputextureusage {
 pub(crate) mod gputextureview;
 pub(crate) mod gpuuncapturederrorevent;
 pub(crate) mod gpuvalidationerror;
-#[expect(dead_code)]
-pub(crate) mod identityhub;
+pub(crate) mod identityhub {
+    pub(crate) type IdentityHub = script_webgpu::identityhub::IdentityHub;
+}
 pub(crate) mod wgsllanguagefeatures;

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1699,5 +1699,6 @@ Unions = {
 
 SubCrates = {
     'script_webgpu': ['GPUAdapterInfo', 'GPUBufferUsage', 'GPUCommandBuffer',
-    'GPUCompilationInfo', 'GPUCompilationMessage', 'GPUDeviceLostInfo', 'GPUMapMode', 'GPURenderBundle', 'GPUShaderStage'],
+    'GPUCompilationInfo', 'GPUCompilationMessage', 'GPUDeviceLostInfo', 'GPUMapMode', 'GPURenderBundle', 'GPUShaderStage',
+    'GPUTextureUsage',],
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1699,5 +1699,5 @@ Unions = {
 
 SubCrates = {
     'script_webgpu': ['GPUAdapterInfo', 'GPUBufferUsage', 'GPUCommandBuffer',
-    'GPUCompilationInfo', 'GPUCompilationMessage', 'GPUDeviceLostInfo', 'GPUMapMode', 'GPURenderBundle'],
+    'GPUCompilationInfo', 'GPUCompilationMessage', 'GPUDeviceLostInfo', 'GPUMapMode', 'GPURenderBundle', 'GPUShaderStage'],
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1698,5 +1698,5 @@ Unions = {
 }
 
 SubCrates = {
-    'script_webgpu': ['GPUAdapterInfo', 'GPUBufferUsage', 'GPUCompilationInfo', 'GPUCompilationMessage', 'GPUDeviceLostInfo',],
+    'script_webgpu': ['GPUAdapterInfo', 'GPUBufferUsage', 'GPUCommandBuffer', 'GPUCompilationInfo', 'GPUCompilationMessage', 'GPUDeviceLostInfo',],
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1698,5 +1698,6 @@ Unions = {
 }
 
 SubCrates = {
-    'script_webgpu': ['GPUAdapterInfo', 'GPUBufferUsage', 'GPUCommandBuffer', 'GPUCompilationInfo', 'GPUCompilationMessage', 'GPUDeviceLostInfo',],
+    'script_webgpu': ['GPUAdapterInfo', 'GPUBufferUsage', 'GPUCommandBuffer',
+    'GPUCompilationInfo', 'GPUCompilationMessage', 'GPUDeviceLostInfo', 'GPUMapMode'],
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1699,5 +1699,5 @@ Unions = {
 
 SubCrates = {
     'script_webgpu': ['GPUAdapterInfo', 'GPUBufferUsage', 'GPUCommandBuffer',
-    'GPUCompilationInfo', 'GPUCompilationMessage', 'GPUDeviceLostInfo', 'GPUMapMode'],
+    'GPUCompilationInfo', 'GPUCompilationMessage', 'GPUDeviceLostInfo', 'GPUMapMode', 'GPURenderBundle'],
 }

--- a/components/script_webgpu/Cargo.toml
+++ b/components/script_webgpu/Cargo.toml
@@ -27,3 +27,4 @@ script_bindings = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 webgpu_traits = { workspace = true }
+wgpu-core = { workspace = true }

--- a/components/script_webgpu/Cargo.toml
+++ b/components/script_webgpu/Cargo.toml
@@ -21,6 +21,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(crown)'] }
 deny_public_fields = { workspace = true }
 dom_struct = { workspace = true }
 js = { workspace = true }
+log = { workspace = true }
 jstraceable_derive = { workspace = true }
 script_bindings = { workspace = true }
 malloc_size_of = { workspace = true }

--- a/components/script_webgpu/gpucommandbuffer.rs
+++ b/components/script_webgpu/gpucommandbuffer.rs
@@ -2,16 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::marker::PhantomData;
+
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
+use jstraceable_derive::JSTraceable;
+use log::warn;
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{
+    GPUCommandBufferMethods, GPUCommandBufferWrap,
+};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_wrap};
 use webgpu_traits::{WebGPU, WebGPUCommandBuffer, WebGPURequest};
 
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUCommandBufferMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::USVString;
-use crate::dom::globalscope::GlobalScope;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUCommandBuffer {
@@ -37,13 +44,18 @@ impl Drop for DroppableGPUCommandBuffer {
 }
 
 #[dom_struct]
-pub(crate) struct GPUCommandBuffer {
+pub struct GPUCommandBuffer<D: DomTypes> {
     reflector_: Reflector,
     label: DomRefCell<USVString>,
     droppable: DroppableGPUCommandBuffer,
+    #[no_trace = "PhantomData does not exist"]
+    phantom: PhantomData<D>,
 }
 
-impl GPUCommandBuffer {
+impl<D> GPUCommandBuffer<D>
+where
+    D: DomTypes<GPUCommandBuffer = GPUCommandBuffer<D>>,
+{
     fn new_inherited(
         channel: WebGPU,
         command_buffer: WebGPUCommandBuffer,
@@ -56,17 +68,18 @@ impl GPUCommandBuffer {
                 channel,
                 command_buffer,
             },
+            phantom: PhantomData,
         }
     }
 
-    pub(crate) fn new(
+    pub fn new(
         cx: &mut JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         channel: WebGPU,
         command_buffer: WebGPUCommandBuffer,
         label: USVString,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object_with_wrap::<D, _, _>(
             Box::new(GPUCommandBuffer::new_inherited(
                 channel,
                 command_buffer,
@@ -74,17 +87,18 @@ impl GPUCommandBuffer {
             )),
             global,
             cx,
+            GPUCommandBufferWrap::<D>,
         )
     }
 }
 
-impl GPUCommandBuffer {
-    pub(crate) fn id(&self) -> WebGPUCommandBuffer {
+impl<D: DomTypes> GPUCommandBuffer<D> {
+    pub fn id(&self) -> WebGPUCommandBuffer {
         self.droppable.command_buffer
     }
 }
 
-impl GPUCommandBufferMethods<crate::DomTypeHolder> for GPUCommandBuffer {
+impl<D: DomTypes> GPUCommandBufferMethods<D> for GPUCommandBuffer<D> {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()

--- a/components/script_webgpu/gpumapmode.rs
+++ b/components/script_webgpu/gpumapmode.rs
@@ -2,10 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::marker::PhantomData;
+
 use dom_struct::dom_struct;
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
 use script_bindings::reflector::Reflector;
 
+use crate::JSTraceable;
+
 #[dom_struct]
-pub(crate) struct GPUMapMode {
+pub struct GPUMapMode<D: DomTypes> {
     reflector_: Reflector,
+    #[no_trace = "PhantomData does not exist"]
+    phantom: PhantomData<D>,
 }

--- a/components/script_webgpu/gpurenderbundle.rs
+++ b/components/script_webgpu/gpurenderbundle.rs
@@ -2,16 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::marker::PhantomData;
+
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
+use jstraceable_derive::JSTraceable;
+use log::warn;
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{
+    GPURenderBundleMethods, GPURenderBundleWrap,
+};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_wrap};
 use webgpu_traits::{WebGPU, WebGPUDevice, WebGPURenderBundle, WebGPURequest};
 
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPURenderBundleMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::USVString;
-use crate::dom::globalscope::GlobalScope;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPURenderBundle {
@@ -37,15 +44,20 @@ impl Drop for DroppableGPURenderBundle {
 }
 
 #[dom_struct]
-pub(crate) struct GPURenderBundle {
+pub struct GPURenderBundle<D: DomTypes> {
     reflector_: Reflector,
     #[no_trace]
     device: WebGPUDevice,
     label: DomRefCell<USVString>,
     droppable: DroppableGPURenderBundle,
+    #[no_trace = "PhantomData does not exist"]
+    phantom: PhantomData<D>,
 }
 
-impl GPURenderBundle {
+impl<D> GPURenderBundle<D>
+where
+    D: DomTypes<GPURenderBundle = GPURenderBundle<D>>,
+{
     fn new_inherited(
         render_bundle: WebGPURenderBundle,
         device: WebGPUDevice,
@@ -60,18 +72,19 @@ impl GPURenderBundle {
                 channel,
                 render_bundle,
             },
+            phantom: PhantomData,
         }
     }
 
-    pub(crate) fn new(
+    pub fn new(
         cx: &mut JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         render_bundle: WebGPURenderBundle,
         device: WebGPUDevice,
         channel: WebGPU,
         label: USVString,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object_with_wrap::<D, _, _>(
             Box::new(GPURenderBundle::new_inherited(
                 render_bundle,
                 device,
@@ -80,17 +93,18 @@ impl GPURenderBundle {
             )),
             global,
             cx,
+            GPURenderBundleWrap::<D>,
         )
     }
 }
 
-impl GPURenderBundle {
-    pub(crate) fn id(&self) -> WebGPURenderBundle {
+impl<D: DomTypes> GPURenderBundle<D> {
+    pub fn id(&self) -> WebGPURenderBundle {
         self.droppable.render_bundle
     }
 }
 
-impl GPURenderBundleMethods<crate::DomTypeHolder> for GPURenderBundle {
+impl<D: DomTypes> GPURenderBundleMethods<D> for GPURenderBundle<D> {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()

--- a/components/script_webgpu/gpushaderstage.rs
+++ b/components/script_webgpu/gpushaderstage.rs
@@ -2,10 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::marker::PhantomData;
+
 use dom_struct::dom_struct;
+use jstraceable_derive::JSTraceable;
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
 use script_bindings::reflector::Reflector;
 
 #[dom_struct]
-pub(crate) struct GPUShaderStage {
+pub struct GPUShaderStage<D: DomTypes> {
     reflector_: Reflector,
+    #[no_trace = "PhantomData does not exist"]
+    phantom: PhantomData<D>,
 }

--- a/components/script_webgpu/gputextureusage.rs
+++ b/components/script_webgpu/gputextureusage.rs
@@ -2,10 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::marker::PhantomData;
+
 use dom_struct::dom_struct;
+use jstraceable_derive::JSTraceable;
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
 use script_bindings::reflector::Reflector;
 
 #[dom_struct]
-pub(crate) struct GPUTextureUsage {
+pub struct GPUTextureUsage<D: DomTypes> {
     reflector_: Reflector,
+    #[no_trace = "PhantomData does not exist"]
+    phantom: PhantomData<D>,
 }

--- a/components/script_webgpu/identityhub.rs
+++ b/components/script_webgpu/identityhub.rs
@@ -17,7 +17,7 @@ use wgpu_core::id::{
 use wgpu_core::identity::IdentityManager;
 
 #[derive(Debug)]
-pub(crate) struct IdentityHub {
+pub struct IdentityHub {
     adapters: IdentityManager<Adapter>,
     devices: IdentityManager<Device>,
     queues: IdentityManager<Queue>,
@@ -70,171 +70,176 @@ impl Default for IdentityHub {
 }
 
 impl IdentityHub {
-    pub(crate) fn create_device_id(&self) -> DeviceId {
+    pub fn create_device_id(&self) -> DeviceId {
         self.devices.process()
     }
 
-    pub(crate) fn free_device_id(&self, id: DeviceId) {
+    pub fn free_device_id(&self, id: DeviceId) {
         self.devices.free(id);
     }
 
-    pub(crate) fn create_queue_id(&self) -> QueueId {
+    pub fn create_queue_id(&self) -> QueueId {
         self.queues.process()
     }
 
-    pub(crate) fn free_queue_id(&self, id: QueueId) {
+    #[expect(unused)]
+    fn free_queue_id(&self, id: QueueId) {
         self.queues.free(id);
     }
 
-    pub(crate) fn create_adapter_id(&self) -> AdapterId {
+    pub fn create_adapter_id(&self) -> AdapterId {
         self.adapters.process()
     }
 
-    pub(crate) fn free_adapter_id(&self, id: AdapterId) {
+    pub fn free_adapter_id(&self, id: AdapterId) {
         self.adapters.free(id);
     }
 
-    pub(crate) fn create_buffer_id(&self) -> BufferId {
+    pub fn create_buffer_id(&self) -> BufferId {
         self.buffers.process()
     }
 
-    pub(crate) fn free_buffer_id(&self, id: BufferId) {
+    pub fn free_buffer_id(&self, id: BufferId) {
         self.buffers.free(id);
     }
 
-    pub(crate) fn create_bind_group_id(&self) -> BindGroupId {
+    pub fn create_bind_group_id(&self) -> BindGroupId {
         self.bind_groups.process()
     }
 
-    pub(crate) fn free_bind_group_id(&self, id: BindGroupId) {
+    pub fn free_bind_group_id(&self, id: BindGroupId) {
         self.bind_groups.free(id);
     }
 
-    pub(crate) fn create_bind_group_layout_id(&self) -> BindGroupLayoutId {
+    pub fn create_bind_group_layout_id(&self) -> BindGroupLayoutId {
         self.bind_group_layouts.process()
     }
 
-    pub(crate) fn free_bind_group_layout_id(&self, id: BindGroupLayoutId) {
+    pub fn free_bind_group_layout_id(&self, id: BindGroupLayoutId) {
         self.bind_group_layouts.free(id);
     }
 
-    pub(crate) fn create_compute_pipeline_id(&self) -> ComputePipelineId {
+    pub fn create_compute_pipeline_id(&self) -> ComputePipelineId {
         self.compute_pipelines.process()
     }
 
-    pub(crate) fn free_compute_pipeline_id(&self, id: ComputePipelineId) {
+    pub fn free_compute_pipeline_id(&self, id: ComputePipelineId) {
         self.compute_pipelines.free(id);
     }
 
-    pub(crate) fn create_pipeline_layout_id(&self) -> PipelineLayoutId {
+    pub fn create_pipeline_layout_id(&self) -> PipelineLayoutId {
         self.pipeline_layouts.process()
     }
 
-    pub(crate) fn free_pipeline_layout_id(&self, id: PipelineLayoutId) {
+    pub fn free_pipeline_layout_id(&self, id: PipelineLayoutId) {
         self.pipeline_layouts.free(id);
     }
 
-    pub(crate) fn create_shader_module_id(&self) -> ShaderModuleId {
+    pub fn create_shader_module_id(&self) -> ShaderModuleId {
         self.shader_modules.process()
     }
 
-    pub(crate) fn free_shader_module_id(&self, id: ShaderModuleId) {
+    pub fn free_shader_module_id(&self, id: ShaderModuleId) {
         self.shader_modules.free(id);
     }
 
-    pub(crate) fn create_command_encoder_id(&self) -> CommandEncoderId {
+    pub fn create_command_encoder_id(&self) -> CommandEncoderId {
         self.command_encoders.process()
     }
 
-    pub(crate) fn free_command_encoder_id(&self, id: CommandEncoderId) {
+    #[expect(unused)]
+    fn free_command_encoder_id(&self, id: CommandEncoderId) {
         self.command_encoders.free(id);
     }
 
-    pub(crate) fn create_command_buffer_id(&self) -> CommandBufferId {
+    pub fn create_command_buffer_id(&self) -> CommandBufferId {
         self.command_buffers.process()
     }
 
-    pub(crate) fn free_command_buffer_id(&self, id: CommandBufferId) {
+    pub fn free_command_buffer_id(&self, id: CommandBufferId) {
         self.command_buffers.free(id);
     }
 
-    pub(crate) fn create_sampler_id(&self) -> SamplerId {
+    pub fn create_sampler_id(&self) -> SamplerId {
         self.samplers.process()
     }
 
-    pub(crate) fn free_sampler_id(&self, id: SamplerId) {
+    pub fn free_sampler_id(&self, id: SamplerId) {
         self.samplers.free(id);
     }
 
-    pub(crate) fn create_render_pipeline_id(&self) -> RenderPipelineId {
+    pub fn create_render_pipeline_id(&self) -> RenderPipelineId {
         self.render_pipelines.process()
     }
 
-    pub(crate) fn free_render_pipeline_id(&self, id: RenderPipelineId) {
+    pub fn free_render_pipeline_id(&self, id: RenderPipelineId) {
         self.render_pipelines.free(id);
     }
 
-    pub(crate) fn create_texture_id(&self) -> TextureId {
+    pub fn create_texture_id(&self) -> TextureId {
         self.textures.process()
     }
 
-    pub(crate) fn free_texture_id(&self, id: TextureId) {
+    pub fn free_texture_id(&self, id: TextureId) {
         self.textures.free(id);
     }
 
-    pub(crate) fn create_texture_view_id(&self) -> TextureViewId {
+    pub fn create_texture_view_id(&self) -> TextureViewId {
         self.texture_views.process()
     }
 
-    pub(crate) fn free_texture_view_id(&self, id: TextureViewId) {
+    pub fn free_texture_view_id(&self, id: TextureViewId) {
         self.texture_views.free(id);
     }
 
-    pub(crate) fn create_render_bundle_id(&self) -> RenderBundleId {
+    pub fn create_render_bundle_id(&self) -> RenderBundleId {
         self.render_bundles.process()
     }
 
-    pub(crate) fn free_render_bundle_id(&self, id: RenderBundleId) {
+    pub fn free_render_bundle_id(&self, id: RenderBundleId) {
         self.render_bundles.free(id);
     }
 
-    pub(crate) fn create_compute_pass_id(&self) -> ComputePassId {
+    pub fn create_compute_pass_id(&self) -> ComputePassId {
         self.compute_passes.process()
     }
 
-    pub(crate) fn free_compute_pass_id(&self, id: ComputePassId) {
+    pub fn free_compute_pass_id(&self, id: ComputePassId) {
         self.compute_passes.free(id);
     }
 
-    pub(crate) fn create_render_pass_id(&self) -> RenderPassId {
+    pub fn create_render_pass_id(&self) -> RenderPassId {
         self.render_passes.process()
     }
 
-    pub(crate) fn free_render_pass_id(&self, id: RenderPassId) {
+    pub fn free_render_pass_id(&self, id: RenderPassId) {
         self.render_passes.free(id);
     }
 
-    pub(crate) fn create_query_set_id(&self) -> QuerySetId {
+    pub fn create_query_set_id(&self) -> QuerySetId {
         self.query_sets.process()
     }
 
-    pub(crate) fn free_query_set_id(&self, id: QuerySetId) {
+    #[expect(unused)]
+    fn free_query_set_id(&self, id: QuerySetId) {
         self.query_sets.free(id);
     }
 
-    pub(crate) fn create_external_texture_id(&self) -> ExternalTextureId {
+    pub fn create_external_texture_id(&self) -> ExternalTextureId {
         self.external_textures.process()
     }
 
-    pub(crate) fn free_external_texture_id(&self, id: ExternalTextureId) {
+    #[expect(unused)]
+    fn free_external_texture_id(&self, id: ExternalTextureId) {
         self.external_textures.free(id);
     }
 
-    pub(crate) fn create_render_bundle_encoder_id(&self) -> RenderBundleEncoderId {
+    pub fn create_render_bundle_encoder_id(&self) -> RenderBundleEncoderId {
         self.render_bundle_encoders.process()
     }
 
-    pub(crate) fn free_render_bundle_encoder_id(&self, id: RenderBundleEncoderId) {
+    #[expect(unused)]
+    fn free_render_bundle_encoder_id(&self, id: RenderBundleEncoderId) {
         self.render_bundle_encoders.free(id);
     }
 }

--- a/components/script_webgpu/lib.rs
+++ b/components/script_webgpu/lib.rs
@@ -12,6 +12,7 @@ pub mod gpucommandbuffer;
 pub mod gpucompilationinfo;
 pub mod gpucompilationmessage;
 pub mod gpudevicelostinfo;
+pub mod gpumapmode;
 
 pub(crate) use js::gc::Traceable as JSTraceable;
 pub(crate) use jstraceable_derive::JSTraceable;
@@ -49,6 +50,7 @@ pub(crate) mod codegen {
         use crate::gpucompilationinfo::GPUCompilationInfo;
         use crate::gpucompilationmessage::GPUCompilationMessage;
         use crate::gpudevicelostinfo::GPUDeviceLostInfo;
+        use crate::gpumapmode::GPUMapMode;
         include!(concat!(
             env!("OUT_DIR"),
             "/ConcreteBindings/WebGPUBinding.rs"

--- a/components/script_webgpu/lib.rs
+++ b/components/script_webgpu/lib.rs
@@ -16,6 +16,7 @@ pub mod gpumapmode;
 pub mod gpurenderbundle;
 pub mod gpushaderstage;
 pub mod gputextureusage;
+pub mod identityhub;
 
 pub(crate) use js::gc::Traceable as JSTraceable;
 pub(crate) use jstraceable_derive::JSTraceable;

--- a/components/script_webgpu/lib.rs
+++ b/components/script_webgpu/lib.rs
@@ -13,6 +13,7 @@ pub mod gpucompilationinfo;
 pub mod gpucompilationmessage;
 pub mod gpudevicelostinfo;
 pub mod gpumapmode;
+pub mod gpurenderbundle;
 
 pub(crate) use js::gc::Traceable as JSTraceable;
 pub(crate) use jstraceable_derive::JSTraceable;
@@ -51,6 +52,7 @@ pub(crate) mod codegen {
         use crate::gpucompilationmessage::GPUCompilationMessage;
         use crate::gpudevicelostinfo::GPUDeviceLostInfo;
         use crate::gpumapmode::GPUMapMode;
+        use crate::gpurenderbundle::GPURenderBundle;
         include!(concat!(
             env!("OUT_DIR"),
             "/ConcreteBindings/WebGPUBinding.rs"

--- a/components/script_webgpu/lib.rs
+++ b/components/script_webgpu/lib.rs
@@ -15,6 +15,7 @@ pub mod gpudevicelostinfo;
 pub mod gpumapmode;
 pub mod gpurenderbundle;
 pub mod gpushaderstage;
+pub mod gputextureusage;
 
 pub(crate) use js::gc::Traceable as JSTraceable;
 pub(crate) use jstraceable_derive::JSTraceable;
@@ -55,6 +56,7 @@ pub(crate) mod codegen {
         use crate::gpumapmode::GPUMapMode;
         use crate::gpurenderbundle::GPURenderBundle;
         use crate::gpushaderstage::GPUShaderStage;
+        use crate::gputextureusage::GPUTextureUsage;
         include!(concat!(
             env!("OUT_DIR"),
             "/ConcreteBindings/WebGPUBinding.rs"

--- a/components/script_webgpu/lib.rs
+++ b/components/script_webgpu/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod gpuadapterinfo;
 pub mod gpubufferusage;
+pub mod gpucommandbuffer;
 pub mod gpucompilationinfo;
 pub mod gpucompilationmessage;
 pub mod gpudevicelostinfo;
@@ -44,6 +45,7 @@ pub(crate) mod codegen {
 
         use crate::gpuadapterinfo::GPUAdapterInfo;
         use crate::gpubufferusage::GPUBufferUsage;
+        use crate::gpucommandbuffer::GPUCommandBuffer;
         use crate::gpucompilationinfo::GPUCompilationInfo;
         use crate::gpucompilationmessage::GPUCompilationMessage;
         use crate::gpudevicelostinfo::GPUDeviceLostInfo;

--- a/components/script_webgpu/lib.rs
+++ b/components/script_webgpu/lib.rs
@@ -14,6 +14,7 @@ pub mod gpucompilationmessage;
 pub mod gpudevicelostinfo;
 pub mod gpumapmode;
 pub mod gpurenderbundle;
+pub mod gpushaderstage;
 
 pub(crate) use js::gc::Traceable as JSTraceable;
 pub(crate) use jstraceable_derive::JSTraceable;
@@ -53,6 +54,7 @@ pub(crate) mod codegen {
         use crate::gpudevicelostinfo::GPUDeviceLostInfo;
         use crate::gpumapmode::GPUMapMode;
         use crate::gpurenderbundle::GPURenderBundle;
+        use crate::gpushaderstage::GPUShaderStage;
         include!(concat!(
             env!("OUT_DIR"),
             "/ConcreteBindings/WebGPUBinding.rs"


### PR DESCRIPTION
This moves the following files to script_webgpu crate:
- GPUCommandBuffer
- GPUMapMode
- GPURenderBundle
- GPUShaderStage
- GPUTextureUsage
- IdentityHub

All these changes follow the same scheme and use D: DomTypes when necessary. Currently there are a couple of types which do not need this restriction but are still generic over DomTypes 
because the codegen needs the parameter. 

Testing: This is just a refactor so compilation is the test.
