### PR TITLE
script: Use NoGC for note_dirty_descendants

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -1166,9 +1166,9 @@ impl Document {
         self.encoding.set(encoding);
     }
 
-    pub(crate) fn content_and_heritage_changed(&self, node: &Node) {
+    pub(crate) fn content_and_heritage_changed(&self, no_gc: &NoGC, node: &Node) {
         if node.is_connected() {
-            node.note_dirty_descendants();
+            node.note_dirty_descendants(no_gc);
         }
 
         // FIXME(emilio): This is very inefficient, ideally the flag above would
@@ -4570,7 +4570,10 @@ impl Document {
         self.name_map.get_all(cx.no_gc(), self.upcast(), name)
     }
 
-    pub(crate) fn drain_pending_restyles(&self) -> Vec<(TrustedNodeAddress, PendingRestyle)> {
+    pub(crate) fn drain_pending_restyles(
+        &self,
+        no_gc: &NoGC,
+    ) -> Vec<(TrustedNodeAddress, PendingRestyle)> {
         self.pending_restyles
             .borrow_mut()
             .drain()
@@ -4579,7 +4582,7 @@ impl Document {
                 if !node.get_flag(NodeFlags::IS_CONNECTED) {
                     return None;
                 }
-                node.note_dirty_descendants();
+                node.note_dirty_descendants(no_gc);
                 Some((node.to_trusted_node_address(), restyle.0))
             })
             .collect()

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -4318,7 +4318,7 @@ impl VirtualMethods for Node {
             weak_ranges.drain_to_parent(old_parent, context.index(), self);
         }
 
-        self.owner_doc()
+        self.owner_doc_unrooted(cx.no_gc())
             .content_and_heritage_changed(cx.no_gc(), self);
     }
 

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -512,7 +512,7 @@ impl Node {
     /// Fails unless `child` is a child of this node.
     fn remove_child(&self, cx: &mut JSContext, child: &Node, cached_index: Option<u32>) {
         assert!(child.parent_node.get().as_deref() == Some(self));
-        self.note_dirty_descendants();
+        self.note_dirty_descendants(cx.no_gc());
         self.add_pending_accessibility_damage(AccessibilityDamage::Children);
 
         let prev_sibling = child.GetPreviousSibling();
@@ -556,7 +556,7 @@ impl Node {
     fn move_child(&self, cx: &mut JSContext, child: &Node) {
         assert!(child.parent_node.get().as_deref() == Some(self));
         self.dirty(NodeDamage::ContentOrHeritage);
-        self.note_dirty_descendants();
+        self.note_dirty_descendants(cx.no_gc());
         self.add_pending_accessibility_damage(AccessibilityDamage::Children);
 
         child.prev_sibling.set(None);
@@ -872,8 +872,9 @@ impl Node {
     }
 
     // FIXME(emilio): This and the function below should move to Element.
-    pub(crate) fn note_dirty_descendants(&self) {
-        self.owner_doc().note_node_with_dirty_descendants(self);
+    pub(crate) fn note_dirty_descendants(&self, no_gc: &NoGC) {
+        self.owner_doc_unrooted(no_gc)
+            .note_node_with_dirty_descendants(self);
     }
 
     pub(crate) fn has_dirty_descendants(&self) -> bool {
@@ -1715,6 +1716,10 @@ impl Node {
 
     pub(crate) fn owner_doc(&self) -> DomRoot<Document> {
         self.owner_doc.get().unwrap()
+    }
+
+    pub(crate) fn owner_doc_unrooted<'a>(&self, no_gc: &'a NoGC) -> UnrootedDom<'a, Document> {
+        self.owner_doc.get_unrooted(no_gc).unwrap()
     }
 
     pub(crate) fn set_owner_doc(&self, document: &Document) {
@@ -4275,7 +4280,8 @@ impl VirtualMethods for Node {
             list.as_children_list().children_changed(mutation);
         }
 
-        self.owner_doc().content_and_heritage_changed(self);
+        self.owner_doc_unrooted(cx.no_gc())
+            .content_and_heritage_changed(cx.no_gc(), self);
     }
 
     // This handles the ranges mentioned in steps 2-3 when removing a node.
@@ -4312,7 +4318,8 @@ impl VirtualMethods for Node {
             weak_ranges.drain_to_parent(old_parent, context.index(), self);
         }
 
-        self.owner_doc().content_and_heritage_changed(self);
+        self.owner_doc()
+            .content_and_heritage_changed(cx.no_gc(), self);
     }
 
     fn handle_event(&self, cx: &mut JSContext, event: &Event) {

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -2672,7 +2672,7 @@ impl Window {
             }
 
             let stylesheets_changed = document.flush_stylesheets_for_reflow();
-            let pending_restyles = document.drain_pending_restyles();
+            let pending_restyles = document.drain_pending_restyles(cx.no_gc());
             let dirty_root = document
                 .take_dirty_root()
                 .filter(|_| !stylesheets_changed)


### PR DESCRIPTION
Use no_gc for note_dirty_descendants. This should take 0.4% runtime cost away from script in a small slice.

Testing: *Describe the new automated tests that cover this change or explain why it doesn't require tests.*
Fixes: *Link to an issue this pull request fixes or remove this line if there is no issue.*
