### PR TITLE
image-rs: Remove unneeded `avif` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4468,7 +4468,6 @@ dependencies = [
  "png",
  "ravif",
  "rayon",
- "rgb",
  "tiff",
  "zune-core",
  "zune-jpeg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "ht
 icu_locid = "1.5.0"
 icu_properties = "1.5.0"
 icu_segmenter = "1.5.0"
-image = { version = "0.25", default-features = false, features = ["avif", "bmp", "gif", "ico", "jpeg", "png", "rayon", "webp"] }
+image = { version = "0.25", default-features = false, features = ["bmp", "gif", "ico", "jpeg", "png", "rayon", "webp"] }
 imsz = "0.4"
 indexmap = { version = "2.14.0", features = ["std"] }
 inventory = "0.3.24"

--- a/deny.toml
+++ b/deny.toml
@@ -80,11 +80,7 @@ allow = [
 confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
-exceptions = [
-    # rav1e depends on libfuzzer-sys when cfg(fuzzing) is true, which it isn't for servo builds.
-    # cargo-deny is being run with --all-features, so we need to explicitly make an exception here.
-    { allow = ["NCSA"], crate = "libfuzzer-sys" },
-]
+exceptions = []
 
 
 # This section is considered when running `cargo deny check bans`.
@@ -200,7 +196,6 @@ skip = [
     "fearless_simd",
 
     # Duplicated by resvg/image
-    "pastey",
     "roxmltree",
     "tiny-skia",
     "tiny-skia-path",


### PR DESCRIPTION
We currently don't support AV1, so no need to enable the feature.
I did not measure binary size savings.

Testing: It compiles

Edit: Post-merge bencher.dev shows ~1.4 MB binary size savings.

