### PR TITLE
script: Reduce GC-rooting in `NodeList`

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -4132,15 +4132,18 @@ impl Document {
         self.count_node_list(|n| Document::is_element_in_get_by_name(n, name))
     }
 
-    pub(crate) fn nth_element_by_name(
+    pub(crate) fn nth_element_by_name<'a>(
         &self,
+        no_gc: &'a NoGC,
         index: u32,
         name: &DOMString,
-    ) -> Option<DomRoot<Node>> {
+    ) -> Option<UnrootedDom<'a, Node>> {
         if name.is_empty() {
             return None;
         }
-        self.nth_in_node_list(index, |n| Document::is_element_in_get_by_name(n, name))
+        self.nth_in_node_list(no_gc, index, |n| {
+            Document::is_element_in_get_by_name(n, name)
+        })
     }
 
     // Note that document.getByName does not match on the same conditions
@@ -4166,19 +4169,17 @@ impl Document {
             .count() as u32
     }
 
-    fn nth_in_node_list<F: Fn(&Node) -> bool>(
+    fn nth_in_node_list<'a, F: Fn(&Node) -> bool>(
         &self,
+        no_gc: &'a NoGC,
         index: u32,
         callback: F,
-    ) -> Option<DomRoot<Node>> {
-        let doc = self.GetDocumentElement();
-        let maybe_node = doc.as_deref().map(Castable::upcast::<Node>);
-        maybe_node
-            .iter()
-            .flat_map(|node| node.traverse_preorder(ShadowIncluding::No))
+    ) -> Option<UnrootedDom<'a, Node>> {
+        let doc = self.get_document_element_unrooted(no_gc)?;
+        doc.upcast::<Node>()
+            .traverse_preorder_non_rooting(no_gc, ShadowIncluding::No)
             .filter(|node| callback(node))
             .nth(index as usize)
-            .map(|n| DomRoot::from_ref(&*n))
     }
 
     fn get_html_element(&self) -> Option<DomRoot<HTMLHtmlElement>> {

--- a/components/script/dom/form/radionodelist.rs
+++ b/components/script/dom/form/radionodelist.rs
@@ -143,7 +143,7 @@ impl RadioNodeListMethods<crate::DomTypeHolder> for RadioNodeList {
     // https://github.com/servo/servo/issues/5875
     //
     /// <https://dom.spec.whatwg.org/#dom-nodelist-item>
-    fn IndexedGetter(&self, no_gc: &NoGC, index: u32) -> Option<DomRoot<Node>> {
-        self.node_list.IndexedGetter(no_gc, index)
+    fn IndexedGetter(&self, cx: &NoGC, index: u32) -> Option<DomRoot<Node>> {
+        self.node_list.IndexedGetter(cx, index)
     }
 }

--- a/components/script/dom/form/radionodelist.rs
+++ b/components/script/dom/form/radionodelist.rs
@@ -85,9 +85,9 @@ impl RadioNodeListMethods<crate::DomTypeHolder> for RadioNodeList {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-radionodelist-value>
-    fn Value(&self) -> DOMString {
+    fn Value(&self, cx: &JSContext) -> DOMString {
         self.upcast::<NodeList>()
-            .iter()
+            .iter(cx)
             .find_map(|node| {
                 // Step 1
                 node.downcast::<HTMLInputElement>().and_then(|input| {
@@ -110,7 +110,12 @@ impl RadioNodeListMethods<crate::DomTypeHolder> for RadioNodeList {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-radionodelist-value>
     fn SetValue(&self, cx: &mut JSContext, value: DOMString) {
-        for node in self.upcast::<NodeList>().iter() {
+        let node_list = self.upcast::<NodeList>();
+        // Inlining `node_list.iter()` so `cx` doesn’t stay borrowed
+        for index in 0..node_list.Length() {
+            let Some(node) = node_list.Item(cx, index) else {
+                continue;
+            };
             // Step 1
             if let Some(input) = node.downcast::<HTMLInputElement>() {
                 match *input.input_type() {
@@ -138,7 +143,7 @@ impl RadioNodeListMethods<crate::DomTypeHolder> for RadioNodeList {
     // https://github.com/servo/servo/issues/5875
     //
     /// <https://dom.spec.whatwg.org/#dom-nodelist-item>
-    fn IndexedGetter(&self, index: u32) -> Option<DomRoot<Node>> {
-        self.node_list.IndexedGetter(index)
+    fn IndexedGetter(&self, cx: &JSContext, index: u32) -> Option<DomRoot<Node>> {
+        self.node_list.IndexedGetter(cx, index)
     }
 }

--- a/components/script/dom/form/radionodelist.rs
+++ b/components/script/dom/form/radionodelist.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::reflector::reflect_dom_object_with_cx;
 use script_bindings::root::DomRoot;
 use stylo_atoms::Atom;
@@ -85,9 +85,9 @@ impl RadioNodeListMethods<crate::DomTypeHolder> for RadioNodeList {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-radionodelist-value>
-    fn Value(&self, cx: &JSContext) -> DOMString {
+    fn Value(&self, no_gc: &NoGC) -> DOMString {
         self.upcast::<NodeList>()
-            .iter(cx)
+            .iter(no_gc)
             .find_map(|node| {
                 // Step 1
                 node.downcast::<HTMLInputElement>().and_then(|input| {
@@ -143,7 +143,7 @@ impl RadioNodeListMethods<crate::DomTypeHolder> for RadioNodeList {
     // https://github.com/servo/servo/issues/5875
     //
     /// <https://dom.spec.whatwg.org/#dom-nodelist-item>
-    fn IndexedGetter(&self, cx: &JSContext, index: u32) -> Option<DomRoot<Node>> {
-        self.node_list.IndexedGetter(cx, index)
+    fn IndexedGetter(&self, no_gc: &NoGC, index: u32) -> Option<DomRoot<Node>> {
+        self.node_list.IndexedGetter(no_gc, index)
     }
 }

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -7,13 +7,14 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, QualName, local_name, ns};
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::rust::HandleObject;
 use layout_api::{QueryMsg, ScrollContainerQueryFlags, ScrollContainerResponse};
 use rustc_hash::FxHashSet;
 use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
 use script_bindings::codegen::GenericBindings::ElementBinding::ScrollLogicalPosition;
 use script_bindings::codegen::GenericBindings::WindowBinding::ScrollBehavior;
+use script_bindings::dom::UnrootedDom;
 use style::attr::AttrValue;
 use stylo_dom::ElementState;
 
@@ -925,7 +926,11 @@ impl HTMLElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-lfe-labels
     // This gets the nth label in tree order.
-    pub(crate) fn label_at(&self, index: u32) -> Option<DomRoot<Node>> {
+    pub(crate) fn label_at<'a>(
+        &self,
+        no_gc: &'a NoGC,
+        index: u32,
+    ) -> Option<UnrootedDom<'a, Node>> {
         let element = self.as_element();
 
         // Traverse entire tree for <label> elements that have
@@ -941,14 +946,14 @@ impl HTMLElement {
         let root_element = element.root_element();
         let root_node = root_element.upcast::<Node>();
         root_node
-            .traverse_preorder(ShadowIncluding::No)
-            .filter_map(DomRoot::downcast::<HTMLLabelElement>)
+            .traverse_preorder_non_rooting(no_gc, ShadowIncluding::No)
+            .filter_map(UnrootedDom::downcast::<HTMLLabelElement>)
             .filter(|elem| match elem.GetControl() {
                 Some(control) => &*control == self,
                 _ => false,
             })
             .nth(index as usize)
-            .map(|n| DomRoot::from_ref(n.upcast::<Node>()))
+            .map(UnrootedDom::upcast)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-lfe-labels

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -19,6 +19,7 @@ use rand::random;
 use rustc_hash::FxBuildHasher;
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::DocumentFragmentBinding::DocumentFragmentMethods;
+use script_bindings::dom::UnrootedDom;
 use script_bindings::match_domstring_ascii;
 use script_bindings::reflector::DomObject;
 use servo_constellation_traits::{LoadData, LoadOrigin, NavigationHistoryBehavior};
@@ -186,18 +187,19 @@ impl HTMLFormElement {
         false
     }
 
-    pub(crate) fn nth_for_radio_list(
+    pub(crate) fn nth_for_radio_list<'a>(
         &self,
+        no_gc: &'a NoGC,
         index: u32,
         mode: RadioListMode,
         name: &Atom,
-    ) -> Option<DomRoot<Node>> {
+    ) -> Option<UnrootedDom<'a, Node>> {
         self.controls
             .borrow()
             .iter()
             .filter(|n| HTMLFormElement::filter_for_radio_list(mode, n, name))
             .nth(index as usize)
-            .map(|n| DomRoot::from_ref(n.upcast::<Node>()))
+            .map(|n| UnrootedDom::upcast(UnrootedDom::from_dom(n.clone(), no_gc)))
     }
 
     pub(crate) fn count_for_radio_list(&self, mode: RadioListMode, name: &Atom) -> u32 {

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -483,7 +483,7 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
 
         // Step 5
         // candidates_length is 1, so we can unwrap item 0
-        let element_node = candidates.upcast::<NodeList>().Item(0).unwrap();
+        let element_node = candidates.upcast::<NodeList>().Item(cx, 0).unwrap();
         past_names_map.insert(
             name,
             (

--- a/components/script/dom/node/nodelist.rs
+++ b/components/script/dom/node/nodelist.rs
@@ -128,12 +128,12 @@ impl NodeListMethods<crate::DomTypeHolder> for NodeList {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-nodelist-item>
-    fn Item(&self, cx: &JSContext, index: u32) -> Option<DomRoot<Node>> {
+    fn Item(&self, no_gc: &NoGC, index: u32) -> Option<DomRoot<Node>> {
         match self.list_type {
             NodeListType::Simple(ref elems) => elems
                 .get(index as usize)
                 .map(|node| DomRoot::from_ref(&**node)),
-            NodeListType::Children(ref list) => list.item(index, cx),
+            NodeListType::Children(ref list) => list.item(index, no_gc),
             NodeListType::Labels(ref list) => list.item(index),
             NodeListType::Radio(ref list) => list.item(index),
             NodeListType::ElementsByName(ref list) => list.item(index),
@@ -141,8 +141,8 @@ impl NodeListMethods<crate::DomTypeHolder> for NodeList {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-nodelist-item>
-    fn IndexedGetter(&self, cx: &JSContext, index: u32) -> Option<DomRoot<Node>> {
-        self.Item(cx, index)
+    fn IndexedGetter(&self, no_gc: &NoGC, index: u32) -> Option<DomRoot<Node>> {
+        self.Item(no_gc, index)
     }
 }
 
@@ -155,14 +155,11 @@ impl NodeList {
         }
     }
 
-    pub(crate) fn iter<'a>(
-        &'a self,
-        cx: &'a JSContext,
-    ) -> impl Iterator<Item = DomRoot<Node>> + 'a {
+    pub(crate) fn iter<'a>(&'a self, no_gc: &'a NoGC) -> impl Iterator<Item = DomRoot<Node>> + 'a {
         let len = self.Length();
         // There is room for optimization here in non-simple cases,
         // as calling Item repeatedly on a live list can involve redundant work.
-        (0..len).flat_map(move |i| self.Item(cx, i))
+        (0..len).flat_map(move |i| self.Item(no_gc, i))
     }
 }
 

--- a/components/script/dom/node/nodelist.rs
+++ b/components/script/dom/node/nodelist.rs
@@ -6,6 +6,7 @@ use std::cell::RefCell;
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
+use script_bindings::dom::UnrootedDom;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use stylo_atoms::Atom;
 
@@ -129,15 +130,8 @@ impl NodeListMethods<crate::DomTypeHolder> for NodeList {
 
     /// <https://dom.spec.whatwg.org/#dom-nodelist-item>
     fn Item(&self, no_gc: &NoGC, index: u32) -> Option<DomRoot<Node>> {
-        match self.list_type {
-            NodeListType::Simple(ref elems) => elems
-                .get(index as usize)
-                .map(|node| DomRoot::from_ref(&**node)),
-            NodeListType::Children(ref list) => list.item(index, no_gc),
-            NodeListType::Labels(ref list) => list.item(index),
-            NodeListType::Radio(ref list) => list.item(index),
-            NodeListType::ElementsByName(ref list) => list.item(index),
-        }
+        self.item_unrooted(no_gc, index)
+            .map(|item| item.as_rooted())
     }
 
     /// <https://dom.spec.whatwg.org/#dom-nodelist-item>
@@ -155,11 +149,30 @@ impl NodeList {
         }
     }
 
-    pub(crate) fn iter<'a>(&'a self, no_gc: &'a NoGC) -> impl Iterator<Item = DomRoot<Node>> + 'a {
+    pub(crate) fn item_unrooted<'a>(
+        &self,
+        no_gc: &'a NoGC,
+        index: u32,
+    ) -> Option<UnrootedDom<'a, Node>> {
+        match self.list_type {
+            NodeListType::Simple(ref elems) => elems
+                .get(index as usize)
+                .map(|node| UnrootedDom::from_dom(node.clone(), no_gc)),
+            NodeListType::Children(ref list) => list.item(no_gc, index),
+            NodeListType::Labels(ref list) => list.item(no_gc, index),
+            NodeListType::Radio(ref list) => list.item(no_gc, index),
+            NodeListType::ElementsByName(ref list) => list.item(no_gc, index),
+        }
+    }
+
+    pub(crate) fn iter<'a>(
+        &'a self,
+        no_gc: &'a NoGC,
+    ) -> impl Iterator<Item = UnrootedDom<'a, Node>> {
         let len = self.Length();
         // There is room for optimization here in non-simple cases,
         // as calling Item repeatedly on a live list can involve redundant work.
-        (0..len).flat_map(move |i| self.Item(no_gc, i))
+        (0..len).flat_map(move |i| self.item_unrooted(no_gc, i))
     }
 }
 
@@ -182,7 +195,7 @@ impl ChildrenList {
         self.node.children_count()
     }
 
-    pub(crate) fn item(&self, index: u32, no_gc: &NoGC) -> Option<DomRoot<Node>> {
+    pub(crate) fn item<'a>(&self, no_gc: &'a NoGC, index: u32) -> Option<UnrootedDom<'a, Node>> {
         self.cached_children
             .borrow_mut()
             .get_or_insert_with(|| {
@@ -192,7 +205,7 @@ impl ChildrenList {
                     .collect()
             })
             .get(index as usize)
-            .map(|child| DomRoot::from_ref(&**child))
+            .map(|child| UnrootedDom::from_dom(child.clone(), no_gc))
     }
 
     pub(crate) fn children_changed(&self, mutation: &ChildrenMutation) {
@@ -232,8 +245,8 @@ impl LabelsList {
         self.element.labels_count()
     }
 
-    pub(crate) fn item(&self, index: u32) -> Option<DomRoot<Node>> {
-        self.element.label_at(index)
+    pub(crate) fn item<'a>(&self, no_gc: &'a NoGC, index: u32) -> Option<UnrootedDom<'a, Node>> {
+        self.element.label_at(no_gc, index)
     }
 }
 
@@ -270,8 +283,9 @@ impl RadioList {
         self.form.count_for_radio_list(self.mode, &self.name)
     }
 
-    pub(crate) fn item(&self, index: u32) -> Option<DomRoot<Node>> {
-        self.form.nth_for_radio_list(index, self.mode, &self.name)
+    pub(crate) fn item<'a>(&self, no_gc: &'a NoGC, index: u32) -> Option<UnrootedDom<'a, Node>> {
+        self.form
+            .nth_for_radio_list(no_gc, index, self.mode, &self.name)
     }
 }
 
@@ -294,9 +308,7 @@ impl ElementsByNameList {
         self.document.elements_by_name_count(&self.name)
     }
 
-    pub(crate) fn item(&self, index: u32) -> Option<DomRoot<Node>> {
-        self.document
-            .nth_element_by_name(index, &self.name)
-            .map(|n| DomRoot::from_ref(&*n))
+    pub(crate) fn item<'a>(&self, no_gc: &'a NoGC, index: u32) -> Option<UnrootedDom<'a, Node>> {
+        self.document.nth_element_by_name(no_gc, index, &self.name)
     }
 }

--- a/components/script/dom/node/nodelist.rs
+++ b/components/script/dom/node/nodelist.rs
@@ -5,7 +5,7 @@
 use std::cell::RefCell;
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use stylo_atoms::Atom;
 
@@ -128,12 +128,12 @@ impl NodeListMethods<crate::DomTypeHolder> for NodeList {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-nodelist-item>
-    fn Item(&self, index: u32) -> Option<DomRoot<Node>> {
+    fn Item(&self, cx: &JSContext, index: u32) -> Option<DomRoot<Node>> {
         match self.list_type {
             NodeListType::Simple(ref elems) => elems
                 .get(index as usize)
                 .map(|node| DomRoot::from_ref(&**node)),
-            NodeListType::Children(ref list) => list.item(index),
+            NodeListType::Children(ref list) => list.item(index, cx),
             NodeListType::Labels(ref list) => list.item(index),
             NodeListType::Radio(ref list) => list.item(index),
             NodeListType::ElementsByName(ref list) => list.item(index),
@@ -141,8 +141,8 @@ impl NodeListMethods<crate::DomTypeHolder> for NodeList {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-nodelist-item>
-    fn IndexedGetter(&self, index: u32) -> Option<DomRoot<Node>> {
-        self.Item(index)
+    fn IndexedGetter(&self, cx: &JSContext, index: u32) -> Option<DomRoot<Node>> {
+        self.Item(cx, index)
     }
 }
 
@@ -155,11 +155,14 @@ impl NodeList {
         }
     }
 
-    pub(crate) fn iter(&self) -> impl Iterator<Item = DomRoot<Node>> + '_ {
+    pub(crate) fn iter<'a>(
+        &'a self,
+        cx: &'a JSContext,
+    ) -> impl Iterator<Item = DomRoot<Node>> + 'a {
         let len = self.Length();
         // There is room for optimization here in non-simple cases,
         // as calling Item repeatedly on a live list can involve redundant work.
-        (0..len).flat_map(move |i| self.Item(i))
+        (0..len).flat_map(move |i| self.Item(cx, i))
     }
 }
 
@@ -182,13 +185,13 @@ impl ChildrenList {
         self.node.children_count()
     }
 
-    pub(crate) fn item(&self, index: u32) -> Option<DomRoot<Node>> {
+    pub(crate) fn item(&self, index: u32, no_gc: &NoGC) -> Option<DomRoot<Node>> {
         self.cached_children
             .borrow_mut()
             .get_or_insert_with(|| {
                 self.node
-                    .children()
-                    .map(|child| Dom::from_ref(&*child))
+                    .children_unrooted(no_gc)
+                    .map(|child| (*child).clone())
                     .collect()
             })
             .get(index as usize)

--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -923,7 +923,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             },
             _ => {
                 // Steps 4-5.
-                let child = start_node.ChildNodes(cx).Item(start_offset);
+                let child = start_node.ChildNodes(cx).Item(cx, start_offset);
                 (child, DomRoot::from_ref(&*start_node))
             },
         };

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -284,13 +284,14 @@ pub(crate) fn find_node_by_unique_id_in_document(
 }
 
 /// <https://w3c.github.io/webdriver/#dfn-link-text-selector>
-fn matching_links(
-    links: &NodeList,
+fn matching_links<'a>(
+    cx: &'a JSContext,
+    links: &'a NodeList,
     link_text: String,
     partial: bool,
-) -> impl Iterator<Item = String> + '_ {
+) -> impl Iterator<Item = String> + 'a {
     links
-        .iter()
+        .iter(cx)
         .filter(move |node| {
             let content = node
                 .downcast::<HTMLElement>()
@@ -319,7 +320,7 @@ fn all_matching_links(
     root_node
         .query_selector_all(cx, DOMString::from("a"))
         .map_err(|_| ErrorStatus::InvalidSelector)
-        .map(|nodes| matching_links(&nodes, link_text, partial).collect())
+        .map(|nodes| matching_links(cx, &nodes, link_text, partial).collect())
 }
 
 #[expect(unsafe_code)]
@@ -797,7 +798,7 @@ pub(crate) fn handle_find_elements_css_selector(
                     .map_err(|_| ErrorStatus::InvalidSelector)
                     .map(|nodes| {
                         nodes
-                            .iter()
+                            .iter(cx)
                             .map(|x| x.upcast::<Node>().unique_id(pipeline))
                             .collect()
                     }),
@@ -945,7 +946,7 @@ pub(crate) fn handle_find_element_elements_css_selector(
                     .map_err(|_| ErrorStatus::InvalidSelector)
                     .map(|nodes| {
                         nodes
-                            .iter()
+                            .iter(cx)
                             .map(|x| x.upcast::<Node>().unique_id(pipeline))
                             .collect()
                     })
@@ -1036,7 +1037,7 @@ pub(crate) fn handle_find_shadow_elements_css_selector(
                     .map_err(|_| ErrorStatus::InvalidSelector)
                     .map(|nodes| {
                         nodes
-                            .iter()
+                            .iter(cx)
                             .map(|x| x.upcast::<Node>().unique_id(pipeline))
                             .collect()
                     })
@@ -1084,7 +1085,7 @@ pub(crate) fn handle_find_shadow_elements_tag_name(
                     .query_selector_all(cx, DOMString::from(selector))
                     .map(|nodes| {
                         nodes
-                            .iter()
+                            .iter(cx)
                             .map(|x| x.upcast::<Node>().unique_id(pipeline))
                             .collect()
                     })

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -285,7 +285,7 @@ pub(crate) fn find_node_by_unique_id_in_document(
 
 /// <https://w3c.github.io/webdriver/#dfn-link-text-selector>
 fn matching_links<'a>(
-    cx: &'a JSContext,
+    cx: &'a NoGC,
     links: &'a NodeList,
     link_text: String,
     partial: bool,

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -915,6 +915,10 @@ DOMInterfaces = {
     'cx': ['NextNode', 'PreviousNode'],
 },
 
+'NodeList': {
+    'cx_no_gc': ['Item', 'IndexedGetter'],
+},
+
 'Notification': {
     'cx': ['Actions', 'RequestPermission', 'Vibrate']
 },
@@ -977,7 +981,7 @@ DOMInterfaces = {
 
 'RadioNodeList': {
     'cx': ['SetValue'],
-    'cx_no_gc': ['Length'],
+    'cx_no_gc': ['Length', 'Value', 'IndexedGetter'],
 },
 
 'Range': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -916,7 +916,7 @@ DOMInterfaces = {
 },
 
 'NodeList': {
-    'cx_no_gc': ['Item', 'IndexedGetter'],
+    'no_gc': ['Item', 'IndexedGetter'],
 },
 
 'Notification': {
@@ -981,7 +981,8 @@ DOMInterfaces = {
 
 'RadioNodeList': {
     'cx': ['SetValue'],
-    'cx_no_gc': ['Length', 'Value', 'IndexedGetter'],
+    'cx_no_gc': ['Length'],
+    'no_gc': ['Value', 'IndexedGetter'],
 },
 
 'Range': {


### PR DESCRIPTION
Pass `&JsContext` in a few more places in order to use `*_no_gc` APIs. This is a follow-up to https://github.com/servo/servo/pull/44435

Testing: expecting no change to existing test results
