### PR TITLE
net: Store original response for preload requests.

### DIFF
--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -27,7 +27,7 @@ use net_traits::response::{Response, ResponseInit};
 use net_traits::{
     AsyncRuntime, CookieAsyncResponse, CookieData, CookieSource, CoreResourceMsg,
     CoreResourceThread, CustomResponseMediator, DiscardFetch, FetchChannels, FetchTaskTarget,
-    ResourceFetchTiming, ResourceThreads, ResourceTimingType, WebSocketDomAction,
+    NetworkError, ResourceFetchTiming, ResourceThreads, ResourceTimingType, WebSocketDomAction,
     WebSocketNetworkEvent,
 };
 use parking_lot::{Mutex, RwLock};
@@ -646,9 +646,6 @@ impl ResourceChannelManager {
                 }
             },
             CoreResourceMsg::ToFileManager(msg) => self.resource_manager.filemanager.handle(msg),
-            CoreResourceMsg::StorePreloadedResponse(preload_id, response) => self
-                .resource_manager
-                .handle_preloaded_response(preload_id, response),
             CoreResourceMsg::TotalSizeOfInFlightKeepAliveRecords(pipeline_id, sender) => {
                 let total = self
                     .resource_manager
@@ -740,8 +737,23 @@ impl CoreResourceManager {
         }
     }
 
-    fn handle_preloaded_response(&self, preload_id: PreloadId, response: Response) {
-        let mut preloaded_resources = self.preloaded_resources.lock().unwrap();
+    fn handle_preloaded_response(
+        preloaded_resources: SharedPreloadedResources,
+        preload_id: PreloadId,
+        response: Response,
+    ) {
+        // https://html.spec.whatwg.org/multipage/#preload
+        // Step 11.1. If bodyBytes is a byte sequence, then set response's body to bodyBytes as a body.
+        // Step 11.2. Otherwise, set response to a network error.
+        let response = response
+            .get_network_error()
+            .map(|_| {
+                Response::network_error(NetworkError::ResourceLoadError("Failed to preload".into()))
+            })
+            .unwrap_or(response);
+        let mut preloaded_resources = preloaded_resources.lock().unwrap();
+        // Step 11.5. If entry's on response available is null, then set entry's response to response;
+        // otherwise call entry's on response available given response.
         if let Some(entry) = preloaded_resources.get_mut(&preload_id) {
             entry.with_response(response);
         }
@@ -837,7 +849,7 @@ impl CoreResourceManager {
                 websocket_chan: None,
                 ca_certificates,
                 ignore_certificate_errors,
-                preloaded_resources,
+                preloaded_resources: preloaded_resources.clone(),
                 in_flight_keep_alive_records,
             };
 
@@ -866,7 +878,11 @@ impl CoreResourceManager {
                     }
                 },
                 None => {
-                    fetch(request, &mut sender, &context).await;
+                    let preload_id = request.preload_id.clone();
+                    let response = fetch(request, &mut sender, &context).await;
+                    if let Some(preload_id) = preload_id {
+                        Self::handle_preloaded_response(preloaded_resources, preload_id, response);
+                    }
                 },
             };
 

--- a/components/script/dom/html/documentmetadata/htmllinkelement.rs
+++ b/components/script/dom/html/documentmetadata/htmllinkelement.rs
@@ -644,7 +644,6 @@ impl HTMLLinkElement {
         let fetch_context = LinkFetchContext {
             url,
             link: Some(Trusted::new(self)),
-            document: Trusted::new(&document),
             global: Trusted::new(&document.global()),
             type_: LinkFetchContextType::Prefetch,
             response_body: vec![],

--- a/components/script/dom/processingoptions.rs
+++ b/components/script/dom/processingoptions.rs
@@ -15,10 +15,7 @@ use net_traits::request::{
     CorsSettings, Destination, Initiator, PreloadId, PreloadKey, Referrer, RequestBuilder,
     RequestClient, RequestId,
 };
-use net_traits::response::{Response, ResponseBody};
-use net_traits::{
-    CoreResourceMsg, FetchMetadata, NetworkError, ReferrerPolicy, ResourceFetchTiming,
-};
+use net_traits::{FetchMetadata, NetworkError, ReferrerPolicy, ResourceFetchTiming};
 pub use nom_rfc8288::complete::LinkDataOwned as LinkHeader;
 use nom_rfc8288::complete::link_lenient as parse_link_header;
 use servo_base::id::WebViewId;
@@ -305,9 +302,8 @@ impl LinkProcessingOptions {
         let fetch_context = LinkFetchContext {
             url,
             link,
-            document: Trusted::new(document),
             global: Trusted::new(&document.global()),
-            type_: LinkFetchContextType::Preload(key.clone()),
+            type_: LinkFetchContextType::Preload,
             response_body: vec![],
         };
         document.insert_preloaded_resource(key, preload_id);
@@ -428,7 +424,7 @@ pub(crate) fn process_link_headers(
 #[strum(serialize_all = "lowercase")]
 pub(crate) enum LinkFetchContextType {
     Prefetch,
-    Preload(PreloadKey),
+    Preload,
 }
 
 impl From<LinkFetchContextType> for InitiatorType {
@@ -443,7 +439,6 @@ pub(crate) struct LinkFetchContext {
     pub(crate) link: Option<Trusted<HTMLLinkElement>>,
 
     pub(crate) global: Trusted<GlobalScope>,
-    pub(crate) document: Trusted<Document>,
 
     /// The url being prefetched
     pub(crate) url: ServoUrl,
@@ -472,7 +467,7 @@ impl FetchResponseListener for LinkFetchContext {
         _: RequestId,
         mut chunk: Vec<u8>,
     ) {
-        if matches!(self.type_, LinkFetchContextType::Preload(..)) {
+        if matches!(self.type_, LinkFetchContextType::Preload) {
             self.response_body.append(&mut chunk);
         }
     }
@@ -480,41 +475,12 @@ impl FetchResponseListener for LinkFetchContext {
     /// Step 7 of <https://html.spec.whatwg.org/multipage/#link-type-prefetch:fetch-and-process-the-linked-resource-2>
     /// and step 3.1 of <https://html.spec.whatwg.org/multipage/#link-type-preload:fetch-and-process-the-linked-resource-2>
     fn process_response_eof(
-        mut self,
+        self,
         cx: &mut js::context::JSContext,
         _: RequestId,
         response_result: Result<(), NetworkError>,
         timing: ResourceFetchTiming,
     ) {
-        // Steps for https://html.spec.whatwg.org/multipage/#preload
-        if let LinkFetchContextType::Preload(key) = &self.type_ {
-            let response = if response_result.is_ok() {
-                // Step 11.1. If bodyBytes is a byte sequence, then set response's body to bodyBytes as a body.
-                let response = Response::new(self.url.clone(), timing.clone());
-                *response.body.lock() = ResponseBody::Done(std::mem::take(&mut self.response_body));
-                response
-            } else {
-                // Step 11.2. Otherwise, set response to a network error.
-                Response::network_error(NetworkError::ResourceLoadError("Failed to preload".into()))
-            };
-            // Step 11.5. If entry's on response available is null, then set entry's response to response;
-            // otherwise call entry's on response available given response.
-            // Step 12. Let commit be the following steps given a Document document:
-            // Step 12.1. If entry's response is not null, then call reportTiming given document.
-            // Step 12.2. Set document's map of preloaded resources[key] to entry.
-            // Step 13. If options's document is null, then set options's on document ready to commit. Otherwise, call commit with options's document.
-            let document = self.document.root();
-            let document_preloaded_resources = document.preloaded_resources();
-            let Some(preload_id) = document_preloaded_resources.get(key) else {
-                unreachable!(
-                    "Must only be able to lookup preloaded resources if they already exist in document"
-                );
-            };
-            let _ = self.global.root().core_resource_thread().send(
-                CoreResourceMsg::StorePreloadedResponse(preload_id.clone(), response),
-            );
-        }
-
         submit_timing(cx, &self, &response_result, &timing);
 
         // Step 11.6. If processResponse is given, then call processResponse with response.

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -42,7 +42,7 @@ use crate::fetch::headers::determine_nosniff;
 use crate::filemanager_thread::FileManagerThreadMsg;
 use crate::http_status::HttpStatus;
 use crate::mime_classifier::{ApacheBugFlag, MimeClassifier};
-use crate::request::{PreloadId, Request, RequestBuilder};
+use crate::request::{Request, RequestBuilder};
 use crate::response::{Response, ResponseInit};
 
 pub mod blob_url_store;
@@ -777,7 +777,6 @@ pub enum CoreResourceMsg {
     NetworkMediator(IpcSender<CustomResponseMediator>, ImmutableOrigin),
     /// Message forwarded to file manager's handler
     ToFileManager(FileManagerThreadMsg),
-    StorePreloadedResponse(PreloadId, Response),
     TotalSizeOfInFlightKeepAliveRecords(PipelineId, GenericSender<u64>),
     /// Break the load handler loop, send a reply when done cleaning up local resources
     /// and exit

--- a/tests/wpt/meta/preload/preload-error.sub.html.ini
+++ b/tests/wpt/meta/preload/preload-error.sub.html.ini
@@ -11,17 +11,8 @@
   [CSP-error (fetch): main]
     expected: FAIL
 
-  [MIME-error (style): main]
-    expected: FAIL
-
   [MIME-blocked-nosniff (style): preload events]
     expected: FAIL
 
-  [MIME-blocked-nosniff (style): main]
-    expected: FAIL
-
-  [404 (style): main]
-    expected: FAIL
-
-  [404 (script): main]
+  [404 (image): main]
     expected: FAIL

--- a/tests/wpt/meta/preload/preload-with-type.html.ini
+++ b/tests/wpt/meta/preload/preload-with-type.html.ini
@@ -1,0 +1,3 @@
+[preload-with-type.html]
+  [Makes sure that preloaded resources with a type attribute trigger the onload event]
+    expected: FAIL


### PR DESCRIPTION
Previously we were synthesizing new Response objects from a subset of the response data in a successful preload, which meant that the actual request for the preloaded data would receive the response body but no data like HTTP headers. Many consumers were ok with this, but preloaded SVGs always failed to load because there was no Content-Type available. With this change, we now pass several new tests that relied on the missing data, but also fail a few tests that now behave differently because they see a real Content-Type value.

This fixes a number of broken images on the duckduckgo homepage.

Testing: New passing tests.
Fixes: #46621
