### PR TITLE
script: Implement `Animation.effect`, `AnimationEffect.getTiming()`, `AnimationEffect.getComputedTiming()` and `AnimationEffect.updateTiming()`

### DIFF
--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -1320,6 +1320,18 @@ impl<T: stylo_malloc_size_of::MallocSizeOf, const FRACTION_BITS: u16> MallocSize
     }
 }
 
+impl<Integer, Number, LinearStops> MallocSizeOf
+    for style::values::generics::easing::TimingFunction<Integer, Number, LinearStops>
+where
+    Integer: stylo_malloc_size_of::MallocSizeOf,
+    Number: stylo_malloc_size_of::MallocSizeOf,
+    LinearStops: stylo_malloc_size_of::MallocSizeOf,
+{
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        <Self as stylo_malloc_size_of::MallocSizeOf>::size_of(self, ops)
+    }
+}
+
 malloc_size_of_is_stylo_malloc_size_of!(style::properties::PropertyId);
 malloc_size_of_is_stylo_malloc_size_of!(style::animation::DocumentAnimationSet);
 malloc_size_of_is_stylo_malloc_size_of!(style::attr::AttrIdentifier);

--- a/components/script/dom/animations/animation.rs
+++ b/components/script/dom/animations/animation.rs
@@ -73,6 +73,8 @@ impl AnimationMethods<crate::DomTypeHolder> for Animation {
         _object: Option<HandleObject>,
         effect: Option<&AnimationEffect>,
     ) -> DomRoot<Self> {
+        let document = window.Document();
+
         // Step 1. Let animation be a new Animation object.
         let animation = Animation::new(cx, window.upcast());
 
@@ -80,7 +82,7 @@ impl AnimationMethods<crate::DomTypeHolder> for Animation {
         // as the new timeline; or, if the timeline argument is missing, passing the default document
         // timeline of the Document associated with the Window that is the current global object.
         // TODO: We don't suppor the timeline argument yet.
-        animation.set_the_timeline(window.Document().Timeline().upcast());
+        animation.set_the_timeline(document.Timeline().upcast());
 
         // Step 3. Run the procedure to set the associated effect of an animation on animation passing
         // source as the new effect.

--- a/components/script/dom/animations/animation.rs
+++ b/components/script/dom/animations/animation.rs
@@ -90,4 +90,16 @@ impl AnimationMethods<crate::DomTypeHolder> for Animation {
 
         animation
     }
+
+    /// <https://drafts.csswg.org/web-animations-1/#dom-animation-effect>
+    fn GetEffect(&self) -> Option<DomRoot<AnimationEffect>> {
+        self.associated_effect.get()
+    }
+
+    /// <https://drafts.csswg.org/web-animations-1/#dom-animation-effect>
+    fn SetEffect(&self, effect: Option<&AnimationEffect>) {
+        // > Setting this attribute updates the object’s associated effect using
+        //> the procedure to set the associated effect of an animation.
+        self.set_the_associated_effect(effect);
+    }
 }

--- a/components/script/dom/animations/animationeffect.rs
+++ b/components/script/dom/animations/animationeffect.rs
@@ -6,7 +6,8 @@ use cssparser::{Parser, ParserInput};
 use dom_struct::dom_struct;
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::AnimationEffectBinding::{
-    AnimationEffectMethods, EffectTiming, FillMode, OptionalEffectTiming, PlaybackDirection,
+    AnimationEffectMethods, ComputedEffectTiming, EffectTiming, FillMode, OptionalEffectTiming,
+    PlaybackDirection,
 };
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::error::{Error, Fallible};
@@ -236,6 +237,31 @@ impl AnimationEffectMethods<crate::DomTypeHolder> for AnimationEffect {
         }
     }
 
+    /// <https://drafts.csswg.org/web-animations-1/#dom-animationeffect-getcomputedtiming>
+    fn GetComputedTiming(&self) -> ComputedEffectTiming {
+        let specified_timing_properties = self.specified_timing_properties.borrow();
+        let computed_fill_mode = if specified_timing_properties.fill_mode == FillMode::Auto {
+            FillMode::None
+        } else {
+            specified_timing_properties.fill_mode
+        };
+        ComputedEffectTiming {
+            delay: specified_timing_properties.start_delay,
+            direction: specified_timing_properties.playback_direction,
+            duration: specified_timing_properties
+                .iteration_duration
+                .computed_value(),
+            easing: specified_timing_properties
+                .easing_function
+                .to_css_string()
+                .into(),
+            endDelay: specified_timing_properties.end_delay,
+            fill: computed_fill_mode,
+            iterationStart: specified_timing_properties.iteration_start,
+            iterations: specified_timing_properties.iteration_count,
+        }
+    }
+
     /// <https://drafts.csswg.org/web-animations-1/#dom-animationeffect-updatetiming>
     fn UpdateTiming(&self, timing: &OptionalEffectTiming) -> Fallible<()> {
         // > Updates the specified timing properties of this animation effect by performing the procedure
@@ -248,6 +274,15 @@ impl AnimationEffectMethods<crate::DomTypeHolder> for AnimationEffect {
 enum IterationDurationOrAuto {
     Duration(f64),
     Auto,
+}
+
+impl IterationDurationOrAuto {
+    fn computed_value(&self) -> f64 {
+        match self {
+            IterationDurationOrAuto::Auto => 0.0,
+            IterationDurationOrAuto::Duration(double) => double,
+        }
+    }
 }
 
 impl From<IterationDurationOrAuto> for UnrestrictedDoubleOrString {

--- a/components/script/dom/animations/animationeffect.rs
+++ b/components/script/dom/animations/animationeffect.rs
@@ -239,26 +239,47 @@ impl AnimationEffectMethods<crate::DomTypeHolder> for AnimationEffect {
 
     /// <https://drafts.csswg.org/web-animations-1/#dom-animationeffect-getcomputedtiming>
     fn GetComputedTiming(&self) -> ComputedEffectTiming {
+        // > Returns the calculated timing properties for this animation effect.
         let specified_timing_properties = self.specified_timing_properties.borrow();
+
+        // > while getTiming() can return the string auto, getComputedTiming() must return a number
+        // > corresponding to the calculated value of the iteration duration as defined in the description
+        // > of the duration member of the EffectTiming interface.
+        // > In this level of the specification, that simply means that an auto value is replaced by zero.
+        let computed_duration = specified_timing_properties
+            .iteration_duration
+            .computed_value();
+
+        // > likewise, while getTiming() can return the string auto, getComputedTiming() must return the
+        // > specific FillMode used for timing calculations as defined in the description of the fill
+        // > member of the EffectTiming interface.
+        // > In this level of the specification, that simply means that an auto value is replaced by the none FillMode.
         let computed_fill_mode = if specified_timing_properties.fill_mode == FillMode::Auto {
             FillMode::None
         } else {
             specified_timing_properties.fill_mode
         };
+
         ComputedEffectTiming {
-            delay: specified_timing_properties.start_delay,
-            direction: specified_timing_properties.playback_direction,
-            duration: specified_timing_properties
-                .iteration_duration
-                .computed_value(),
-            easing: specified_timing_properties
-                .easing_function
-                .to_css_string()
-                .into(),
-            endDelay: specified_timing_properties.end_delay,
-            fill: computed_fill_mode,
-            iterationStart: specified_timing_properties.iteration_start,
-            iterations: specified_timing_properties.iteration_count,
+            parent: EffectTiming {
+                delay: specified_timing_properties.start_delay,
+                direction: specified_timing_properties.playback_direction,
+                duration: UnrestrictedDoubleOrString::UnrestrictedDouble(computed_duration),
+                easing: specified_timing_properties
+                    .easing_function
+                    .to_css_string()
+                    .into(),
+                endDelay: specified_timing_properties.end_delay,
+                fill: computed_fill_mode,
+                iterationStart: specified_timing_properties.iteration_start,
+                iterations: specified_timing_properties.iteration_count,
+            },
+            // FIXME: These are just placeholder values
+            endTime: None,
+            activeDuration: None,
+            localTime: None,
+            progress: None,
+            currentIteration: None,
         }
     }
 
@@ -280,7 +301,7 @@ impl IterationDurationOrAuto {
     fn computed_value(&self) -> f64 {
         match self {
             IterationDurationOrAuto::Auto => 0.0,
-            IterationDurationOrAuto::Duration(double) => double,
+            IterationDurationOrAuto::Duration(double) => *double,
         }
     }
 }

--- a/components/script/dom/animations/animationeffect.rs
+++ b/components/script/dom/animations/animationeffect.rs
@@ -2,19 +2,261 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use cssparser::{Parser, ParserInput};
 use dom_struct::dom_struct;
+use script_bindings::cell::DomRefCell;
+use script_bindings::codegen::GenericBindings::AnimationEffectBinding::{
+    AnimationEffectMethods, EffectTiming, FillMode, OptionalEffectTiming, PlaybackDirection,
+};
+use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
+use script_bindings::error::{Error, Fallible};
+use script_bindings::num::Finite;
 use script_bindings::reflector::Reflector;
+use script_bindings::root::Dom;
+use style::parser::Parse;
+use style::stylesheets::CssRuleType;
+use style::values::generics::easing::TimingKeyword;
+use style::values::specified::TimingFunction;
+use style_traits::{ParsingMode, ToCss};
+
+use crate::css::parser_context_for_document;
+use crate::dom::Window;
+use crate::dom::bindings::codegen::UnionTypes::UnrestrictedDoubleOrString;
 
 /// <https://drafts.csswg.org/web-animations-1/#animationeffect>
 #[dom_struct]
 pub(crate) struct AnimationEffect {
     reflector: Reflector,
+
+    /// The window that this `AnimationEffect` was constructed in.
+    window: Dom<Window>,
+
+    specified_timing_properties: DomRefCell<SpecifiedTimingProperties>,
+}
+
+#[derive(Clone, JSTraceable, MallocSizeOf)]
+struct SpecifiedTimingProperties {
+    /// <https://drafts.csswg.org/web-animations-1/#start-delay>
+    start_delay: Finite<f64>,
+
+    /// <https://drafts.csswg.org/web-animations-1/#end-delay>
+    end_delay: Finite<f64>,
+
+    /// <https://drafts.csswg.org/web-animations-1/#fill-mode>
+    fill_mode: FillMode,
+
+    /// <https://drafts.csswg.org/web-animations-1/#iteration-count>
+    iteration_count: f64,
+
+    /// <https://drafts.csswg.org/web-animations-1/#iteration-start>
+    iteration_start: Finite<f64>,
+
+    /// <https://drafts.csswg.org/web-animations-1/#iteration-duration>
+    iteration_duration: IterationDurationOrAuto,
+
+    /// <https://drafts.csswg.org/web-animations-1/#playback-direction>
+    playback_direction: PlaybackDirection,
+
+    /// <https://drafts.csswg.org/css-easing-2/#easing-function>
+    #[no_trace]
+    easing_function: TimingFunction,
 }
 
 impl AnimationEffect {
-    pub(crate) fn new_inherited() -> Self {
+    pub(crate) fn new_inherited(window: &Window) -> Self {
         Self {
             reflector: Reflector::new(),
+            window: Dom::from_ref(window),
+
+            // The default values of the timing properties specified here don't matter.
+            // There is no way to construct a AnimationEffect without subsequently initializing them,
+            // even if they're not passed to the constructor.
+            specified_timing_properties: DomRefCell::new(SpecifiedTimingProperties {
+                start_delay: Default::default(),
+                end_delay: Default::default(),
+                fill_mode: FillMode::None,
+                iteration_count: Default::default(),
+                iteration_start: Default::default(),
+                iteration_duration: IterationDurationOrAuto::Auto,
+                playback_direction: PlaybackDirection::Normal,
+                easing_function: TimingFunction::Keyword(TimingKeyword::Linear),
+            }),
+        }
+    }
+
+    pub(crate) fn window(&self) -> &Window {
+        &self.window
+    }
+
+    /// <https://drafts.csswg.org/web-animations-1/#update-the-timing-properties-of-an-animation-effect>
+    pub(crate) fn update_the_timing_properties(
+        &self,
+        input: &OptionalEffectTiming,
+    ) -> Fallible<()> {
+        // Step 1. If the iterationStart member of input exists and is less than zero,
+        // throw a TypeError and abort this procedure.
+        if input
+            .iterationStart
+            .is_some_and(|iteration_start| *iteration_start < 0.0)
+        {
+            return Err(Error::Type(
+                c"Negative values for iterationStart are not allowed".to_owned(),
+            ));
+        }
+
+        // Step 2. If the iterations member of input exists, and is less than zero or is the value NaN,
+        // throw a TypeError and abort this procedure.
+        if input
+            .iterations
+            .is_some_and(|iterations| iterations < 0.0 || iterations.is_nan())
+        {
+            return Err(Error::Type(
+                c"\"iterations\" must be a positive number".to_owned(),
+            ));
+        }
+
+        // Step 3. If the duration member of input exists, and is less than zero or is the value NaN,
+        // throw a TypeError and abort this procedure.
+        //
+        // Note: "auto" values are treated as zero: https://drafts.csswg.org/web-animations-1/#dom-animationeffect-updatetiming
+        // > In this level of this specification, the string value auto is treated as the value zero
+        // > for the purpose of timing model calculations and for the result of the duration member returned
+        // > from getComputedTiming(). If the author specifies the auto value, user agents must, however,
+        // > return auto for the duration member returned from getTiming().
+        //
+        // Note: It is unspecified how non-"auto" strings should be treated. We choose to throw a TypeError.
+        //       See also https://github.com/w3c/csswg-drafts/issues/14206
+        let Ok(duration) = input
+            .duration
+            .as_ref()
+            .map(|duration| match duration {
+                UnrestrictedDoubleOrString::UnrestrictedDouble(double) => {
+                    if *double < 0.0 || double.is_nan() {
+                        Err(())
+                    } else {
+                        Ok(IterationDurationOrAuto::Duration(*double))
+                    }
+                },
+                UnrestrictedDoubleOrString::String(string) => {
+                    if string == "auto" {
+                        Ok(IterationDurationOrAuto::Auto)
+                    } else {
+                        Err(())
+                    }
+                },
+            })
+            .transpose()
+        else {
+            return Err(Error::Type(
+                c"\"duration\" must be a positive number".to_owned(),
+            ));
+        };
+
+        // Step 4. If the easing member of input exists but cannot be parsed using the <easing-function> production [CSS-EASING-1],
+        // throw a TypeError and abort this procedure.
+        let easing = input.easing.as_ref().and_then(|easing| {
+            let easing = easing.str();
+            let mut parser_input = ParserInput::new(&easing);
+            let mut parser = Parser::new(&mut parser_input);
+
+            // None of these values should matter
+            let document = self.window.Document();
+            let urlextradata = document.url().into_url().into();
+            let parser_context = parser_context_for_document(
+                &document,
+                CssRuleType::Style,
+                ParsingMode::DEFAULT,
+                &urlextradata,
+            );
+            TimingFunction::parse(&parser_context, &mut parser).ok()
+        });
+
+        // Step 5. Assign each member that exists in input to the corresponding timing property of effect as follows:
+        // delay → start delay
+        let mut specified_timing_properties = self.specified_timing_properties.borrow_mut();
+        if let Some(start_delay) = input.delay {
+            specified_timing_properties.start_delay = start_delay;
+        }
+
+        // endDelay → end delay
+        if let Some(end_delay) = input.endDelay {
+            specified_timing_properties.end_delay = end_delay;
+        }
+
+        // fill → fill mode
+        if let Some(fill) = input.fill {
+            specified_timing_properties.fill_mode = fill;
+        }
+
+        // iterationStart → iteration start
+        if let Some(iteration_start) = input.iterationStart {
+            specified_timing_properties.iteration_start = iteration_start;
+        }
+
+        // iterations → iteration count
+        if let Some(iterations) = input.iterations {
+            specified_timing_properties.iteration_count = iterations;
+        }
+
+        // duration → iteration duration
+        if let Some(duration) = duration {
+            specified_timing_properties.iteration_duration = duration;
+        }
+
+        // direction → playback direction
+        if let Some(direction) = input.direction {
+            specified_timing_properties.playback_direction = direction;
+        }
+
+        // easing → easing function
+        if let Some(easing) = easing {
+            specified_timing_properties.easing_function = easing;
+        }
+        Ok(())
+    }
+}
+
+impl AnimationEffectMethods<crate::DomTypeHolder> for AnimationEffect {
+    /// <https://drafts.csswg.org/web-animations-1/#dom-animationeffect-gettiming>
+    fn GetTiming(&self) -> EffectTiming {
+        // > Returns the specified timing properties for this animation effect.
+        let specified_timing_properties = self.specified_timing_properties.borrow();
+        EffectTiming {
+            delay: specified_timing_properties.start_delay,
+            direction: specified_timing_properties.playback_direction,
+            duration: specified_timing_properties.iteration_duration.into(),
+            easing: specified_timing_properties
+                .easing_function
+                .to_css_string()
+                .into(),
+            endDelay: specified_timing_properties.end_delay,
+            fill: specified_timing_properties.fill_mode,
+            iterationStart: specified_timing_properties.iteration_start,
+            iterations: specified_timing_properties.iteration_count,
+        }
+    }
+
+    /// <https://drafts.csswg.org/web-animations-1/#dom-animationeffect-updatetiming>
+    fn UpdateTiming(&self, timing: &OptionalEffectTiming) -> Fallible<()> {
+        // > Updates the specified timing properties of this animation effect by performing the procedure
+        // > to update the timing properties of an animation effect passing the timing parameter as input.
+        self.update_the_timing_properties(timing)
+    }
+}
+
+#[derive(Clone, Copy, Debug, JSTraceable, MallocSizeOf)]
+enum IterationDurationOrAuto {
+    Duration(f64),
+    Auto,
+}
+
+impl From<IterationDurationOrAuto> for UnrestrictedDoubleOrString {
+    fn from(value: IterationDurationOrAuto) -> Self {
+        match value {
+            IterationDurationOrAuto::Auto => UnrestrictedDoubleOrString::String("auto".into()),
+            IterationDurationOrAuto::Duration(double) => {
+                UnrestrictedDoubleOrString::UnrestrictedDouble(double)
+            },
         }
     }
 }

--- a/components/script/dom/animations/animationeffect.rs
+++ b/components/script/dom/animations/animationeffect.rs
@@ -155,22 +155,31 @@ impl AnimationEffect {
 
         // Step 4. If the easing member of input exists but cannot be parsed using the <easing-function> production [CSS-EASING-1],
         // throw a TypeError and abort this procedure.
-        let easing = input.easing.as_ref().and_then(|easing| {
-            let easing = easing.str();
-            let mut parser_input = ParserInput::new(&easing);
-            let mut parser = Parser::new(&mut parser_input);
+        let Ok(easing) = input
+            .easing
+            .as_ref()
+            .map(|easing| {
+                let easing = easing.str();
+                let mut parser_input = ParserInput::new(&easing);
+                let mut parser = Parser::new(&mut parser_input);
 
-            // None of these values should matter
-            let document = self.window.Document();
-            let urlextradata = document.url().into_url().into();
-            let parser_context = parser_context_for_document(
-                &document,
-                CssRuleType::Style,
-                ParsingMode::DEFAULT,
-                &urlextradata,
-            );
-            TimingFunction::parse(&parser_context, &mut parser).ok()
-        });
+                // None of these values should matter
+                let document = self.window.Document();
+                let urlextradata = document.url().into_url().into();
+                let parser_context = parser_context_for_document(
+                    &document,
+                    CssRuleType::Style,
+                    ParsingMode::DEFAULT,
+                    &urlextradata,
+                );
+                TimingFunction::parse(&parser_context, &mut parser).map_err(|_| ())
+            })
+            .transpose()
+        else {
+            return Err(Error::Type(
+                c"\"easing\" is not a valid timing function".to_owned(),
+            ));
+        };
 
         // Step 5. Assign each member that exists in input to the corresponding timing property of effect as follows:
         // delay → start delay

--- a/components/script/dom/animations/keyframeeffect.rs
+++ b/components/script/dom/animations/keyframeeffect.rs
@@ -29,9 +29,10 @@ use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::codegen::GenericUnionTypes::UnrestrictedDoubleOrKeyframeEffectOptions;
 use script_bindings::conversions::StringificationBehavior;
 use script_bindings::error::{Error, Fallible};
+use script_bindings::inheritance::Castable;
 use script_bindings::num::Finite;
 use script_bindings::reflector::reflect_dom_object_with_proto;
-use script_bindings::root::{Dom, DomRoot};
+use script_bindings::root::DomRoot;
 use script_bindings::str::DOMString;
 use style::parser::ParserContext;
 use style::properties::generated::PropertyDeclaration;
@@ -57,9 +58,6 @@ use crate::dom::window::Window;
 pub(crate) struct KeyframeEffect {
     animationeffect: AnimationEffect,
 
-    /// The window that this keyframe was constructed in
-    window: Dom<Window>,
-
     /// <https://drafts.csswg.org/web-animations-1/#effect-target-target-element>
     // FIXME: Store a target pseudo-selector
     // to fully match the concept of the effect target
@@ -75,8 +73,7 @@ pub(crate) struct KeyframeEffect {
 impl KeyframeEffect {
     pub(crate) fn new_inherited(window: &Window) -> Self {
         Self {
-            window: Dom::from_ref(window),
-            animationeffect: AnimationEffect::new_inherited(),
+            animationeffect: AnimationEffect::new_inherited(window),
             target_element: Default::default(),
             keyframes: Default::default(),
         }
@@ -142,7 +139,7 @@ impl KeyframeEffectMethods<crate::DomTypeHolder> for KeyframeEffect {
         cx: &mut JSContext,
         result: &mut RootedVec<'_, Box<Heap<*mut JSObject>>>,
     ) -> Fallible<()> {
-        let mut layout = self.window.layout_mut();
+        let mut layout = self.upcast::<AnimationEffect>().window().layout_mut();
         let stylist = layout.stylist_mut();
 
         // Step 1. Let result be an empty sequence of objects.
@@ -244,7 +241,7 @@ impl KeyframeEffectMethods<crate::DomTypeHolder> for KeyframeEffect {
         // > This effect’s set of keyframes is replaced with the result of performing the procedure to
         // > process a keyframes argument. If that procedure throws an exception, this effect’s
         // > keyframes are not modified.
-        let document = self.window.Document();
+        let document = self.upcast::<AnimationEffect>().window().Document();
         let Ok(keyframes) = process_a_keyframes_argument(cx, &document, keyframes) else {
             return;
         };

--- a/components/script_bindings/webidls/Animation.webidl
+++ b/components/script_bindings/webidls/Animation.webidl
@@ -9,7 +9,7 @@ interface Animation : EventTarget {
   constructor(optional AnimationEffect? effect = null/*,
               optional AnimationTimeline? timeline */);
   //          attribute DOMString                id;
-            attribute AnimationEffect?         effect;
+              attribute AnimationEffect?         effect;
   //          attribute AnimationTimeline?       timeline;
   //          attribute double?                  startTime;
   //          attribute double?                  currentTime;

--- a/components/script_bindings/webidls/Animation.webidl
+++ b/components/script_bindings/webidls/Animation.webidl
@@ -9,7 +9,7 @@ interface Animation : EventTarget {
   constructor(optional AnimationEffect? effect = null/*,
               optional AnimationTimeline? timeline */);
   //          attribute DOMString                id;
-  //          attribute AnimationEffect?         effect;
+            attribute AnimationEffect?         effect;
   //          attribute AnimationTimeline?       timeline;
   //          attribute double?                  startTime;
   //          attribute double?                  currentTime;

--- a/components/script_bindings/webidls/AnimationEffect.webidl
+++ b/components/script_bindings/webidls/AnimationEffect.webidl
@@ -5,9 +5,9 @@
 // https://drafts.csswg.org/web-animations-1/#animationeffect
 [Exposed=Window, Pref="dom_web_animations_enabled"]
 interface AnimationEffect {
-//     EffectTiming         getTiming();
+     EffectTiming         getTiming();
 //     ComputedEffectTiming getComputedTiming();
-//     undefined            updateTiming(optional OptionalEffectTiming timing = {});
+     [Throws] undefined            updateTiming(optional OptionalEffectTiming timing = {});
 };
 
 // https://drafts.csswg.org/web-animations-1/#the-effecttiming-dictionaries

--- a/components/script_bindings/webidls/AnimationEffect.webidl
+++ b/components/script_bindings/webidls/AnimationEffect.webidl
@@ -6,7 +6,7 @@
 [Exposed=Window, Pref="dom_web_animations_enabled"]
 interface AnimationEffect {
      EffectTiming         getTiming();
-//     ComputedEffectTiming getComputedTiming();
+     ComputedEffectTiming getComputedTiming();
      [Throws] undefined            updateTiming(optional OptionalEffectTiming timing = {});
 };
 
@@ -38,3 +38,12 @@ enum FillMode { "none", "forwards", "backwards", "both", "auto" };
 
 // https://drafts.csswg.org/web-animations-1/#the-playbackdirection-enumeration
 enum PlaybackDirection { "normal", "reverse", "alternate", "alternate-reverse" };
+
+// https://drafts.csswg.org/web-animations-1/#the-computedeffecttiming-dictionary
+dictionary ComputedEffectTiming : EffectTiming {
+  unrestricted double  endTime;
+  unrestricted double  activeDuration;
+  double?              localTime;
+  double?              progress;
+  unrestricted double? currentIteration;
+};

--- a/tests/wpt/meta/web-animations/interfaces/Animatable/animate.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animatable/animate.html.ini
@@ -1,10 +1,4 @@
 [animate.html]
-  [Element.animate() creates an Animation object with a KeyframeEffect]
-    expected: FAIL
-
-  [Element.animate() creates an Animation object with a KeyframeEffect that is created in the relevant realm of the target element]
-    expected: FAIL
-
   [Element.animate() accepts a one property two value property-indexed keyframes specification]
     expected: FAIL
 
@@ -122,30 +116,6 @@
   [Element.animate() accepts a property-indexed keyframe with a single-element composite array]
     expected: FAIL
 
-  [Element.animate() accepts a one property one keyframe sequence]
-    expected: FAIL
-
-  [Element.animate() accepts a one property two keyframe sequence]
-    expected: FAIL
-
-  [Element.animate() accepts a two property two keyframe sequence]
-    expected: FAIL
-
-  [Element.animate() accepts a one shorthand property two keyframe sequence]
-    expected: FAIL
-
-  [Element.animate() accepts a two property (a shorthand and one of its component longhands) two keyframe sequence]
-    expected: FAIL
-
-  [Element.animate() accepts a two property keyframe sequence where one property is missing from the first keyframe]
-    expected: FAIL
-
-  [Element.animate() accepts a two property keyframe sequence where one property is missing from the last keyframe]
-    expected: FAIL
-
-  [Element.animate() accepts a one property two keyframe sequence that needs to stringify its values]
-    expected: FAIL
-
   [Element.animate() accepts a keyframe sequence with a CSS variable reference]
     expected: FAIL
 
@@ -155,22 +125,10 @@
   [Element.animate() accepts a keyframe sequence with a CSS variable as its property]
     expected: FAIL
 
-  [Element.animate() accepts a keyframe sequence with duplicate values for a given interior offset]
-    expected: FAIL
-
-  [Element.animate() accepts a keyframe sequence with duplicate values for offsets 0 and 1]
-    expected: FAIL
-
-  [Element.animate() accepts a two property four keyframe sequence]
-    expected: FAIL
-
   [Element.animate() accepts a single keyframe sequence with omitted offset]
     expected: FAIL
 
   [Element.animate() accepts a single keyframe sequence with null offset]
-    expected: FAIL
-
-  [Element.animate() accepts a single keyframe sequence with string offset]
     expected: FAIL
 
   [Element.animate() accepts a single keyframe sequence with a single calc() offset]
@@ -189,9 +147,6 @@
     expected: FAIL
 
   [Element.animate() accepts a keyframe sequence with different easing values, but the same easing value for a given offset]
-    expected: FAIL
-
-  [Element.animate() accepts a keyframe sequence with different composite values, but the same composite value for a given offset]
     expected: FAIL
 
   [Element.animate() does not accept keyframes with an out-of-bounded positive offset]
@@ -246,9 +201,6 @@
     expected: FAIL
 
   [Element.animate() accepts an absent options argument]
-    expected: FAIL
-
-  [Element.animate() accepts a duration of 'auto' using a dictionary object]
     expected: FAIL
 
   [Element.animate() does not accept invalid duration value: -1]

--- a/tests/wpt/meta/web-animations/interfaces/Animation/effect.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animation/effect.html.ini
@@ -1,6 +1,3 @@
 [effect.html]
-  [effect is set correctly.]
-    expected: FAIL
-
   [Clearing and setting Animation.effect should update the computed style of the target element]
     expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/Animation/style-change-events.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/Animation/style-change-events.html.ini
@@ -4,3 +4,6 @@
 
   [Animation.Animation constructor produces expected style change events]
     expected: FAIL
+
+  [Animation.effect produces expected style change events]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/AnimationEffect/updateTiming.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/AnimationEffect/updateTiming.html.ini
@@ -1,10 +1,4 @@
 [updateTiming.html]
-  [Allows setting the delay to a positive number]
-    expected: FAIL
-
-  [Allows setting the delay to a negative number]
-    expected: FAIL
-
   [Allows setting the delay of an animation in progress: positive delay that causes the animation to be no longer in-effect]
     expected: FAIL
 
@@ -12,24 +6,6 @@
     expected: FAIL
 
   [Allows setting the delay of an animation in progress: large negative delay that causes the animation to be finished]
-    expected: FAIL
-
-  [Allows setting the endDelay to a positive number]
-    expected: FAIL
-
-  [Allows setting the endDelay to a negative number]
-    expected: FAIL
-
-  [Allows setting the fill to 'none']
-    expected: FAIL
-
-  [Allows setting the fill to 'forwards']
-    expected: FAIL
-
-  [Allows setting the fill to 'backwards']
-    expected: FAIL
-
-  [Allows setting the fill to 'both']
     expected: FAIL
 
   [Allows setting the iterationStart of an animation in progress: backwards-filling]
@@ -41,22 +17,7 @@
   [Allows setting the iterationStart of an animation in progress: forwards-filling]
     expected: FAIL
 
-  [Allows setting iterations to a double value]
-    expected: FAIL
-
-  [Allows setting iterations to infinity]
-    expected: FAIL
-
   [Allows setting the iterations of an animation in progress]
-    expected: FAIL
-
-  [Allows setting the duration to 123.45]
-    expected: FAIL
-
-  [Allows setting the duration to auto]
-    expected: FAIL
-
-  [Allows setting the duration to Infinity]
     expected: FAIL
 
   [Throws when setting invalid duration: -1]
@@ -78,9 +39,6 @@
     expected: FAIL
 
   [Allows setting the duration of an animation in progress such that the the start and current time do not change]
-    expected: FAIL
-
-  [Allows setting the direction to each of the possible keywords]
     expected: FAIL
 
   [Allows setting the direction of an animation in progress from 'normal' to 'reverse']
@@ -138,30 +96,6 @@
     expected: FAIL
 
   [Allows setting the easing to a easing function which produces values less than 1]
-    expected: FAIL
-
-  [Updates the specified value when setting the easing to 'ease']
-    expected: FAIL
-
-  [Updates the specified value when setting the easing to 'linear']
-    expected: FAIL
-
-  [Updates the specified value when setting the easing to 'ease-in']
-    expected: FAIL
-
-  [Updates the specified value when setting the easing to 'ease-out']
-    expected: FAIL
-
-  [Updates the specified value when setting the easing to 'ease-in-out']
-    expected: FAIL
-
-  [Updates the specified value when setting the easing to 'cubic-bezier(0.1, 5, 0.23, 0)']
-    expected: FAIL
-
-  [Updates the specified value when setting the easing to 'steps(3, start)']
-    expected: FAIL
-
-  [Updates the specified value when setting the easing to 'steps(3)']
     expected: FAIL
 
   [Allows setting the easing of an animation in progress]

--- a/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/composite.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/composite.html.ini
@@ -2,9 +2,6 @@
   [Default value]
     expected: FAIL
 
-  [Change composite value]
-    expected: FAIL
-
   [Unspecified keyframe composite value when setting effect composite]
     expected: FAIL
 

--- a/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/style-change-events.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/style-change-events.html.ini
@@ -13,3 +13,12 @@
 
   [KeyframeEffect.getKeyframes does NOT trigger a style change event]
     expected: FAIL
+
+  [KeyframeEffect.getTiming does NOT trigger a style change event]
+    expected: FAIL
+
+  [KeyframeEffect.getComputedTiming does NOT trigger a style change event]
+    expected: FAIL
+
+  [KeyframeEffect.updateTiming does NOT trigger a style change event]
+    expected: FAIL

--- a/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/target.html.ini
+++ b/tests/wpt/meta/web-animations/interfaces/KeyframeEffect/target.html.ini
@@ -11,9 +11,6 @@
   [Test setting target from a valid target to another target]
     expected: FAIL
 
-  [Target element can be set to a foreign element]
-    expected: FAIL
-
   [Change target from null to an existing pseudoElement setting target first.]
     expected: FAIL
 


### PR DESCRIPTION
This is the next set of changes that bring us closer to supporting `Element.animate` and can be tested in isolation. 

Testing: New tests start to pass.
Part of https://github.com/servo/servo/issues/36950