### PR TITLE
script: Remove temporary root in `fn is_element_in_view`

### DIFF
--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -2038,7 +2038,7 @@ pub(crate) fn handle_element_click(
 fn is_element_in_view(element: &Element, paint_tree: &[DomRoot<Element>]) -> bool {
     // An element is in view if it is a member of its own pointer-interactable paint tree,
     // given the pretense that its pointer events are not disabled.
-    if !paint_tree.contains(&DomRoot::from_ref(element)) {
+    if !paint_tree.iter().any(|e| std::ptr::eq(&**e, element)) {
         return false;
     }
     use style::computed_values::pointer_events::T as PointerEvents;

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -2038,7 +2038,7 @@ pub(crate) fn handle_element_click(
 fn is_element_in_view(element: &Element, paint_tree: &[DomRoot<Element>]) -> bool {
     // An element is in view if it is a member of its own pointer-interactable paint tree,
     // given the pretense that its pointer events are not disabled.
-    if !paint_tree.iter().any(|e| std::ptr::eq(&**e, element)) {
+    if !paint_tree.iter().any(|e| &**e == element) {
         return false;
     }
     use style::computed_values::pointer_events::T as PointerEvents;


### PR DESCRIPTION
We were creating a temporary root for comparison.
We could just compare raw pointers instead.
But we will just rely on PartialEq trait https://github.com/servo/servo/pull/46678#issuecomment-5031476106 so that we may optimize in one place in future.

Testing: It compiles. 
Part of #34464