### PR TITLE
net: Allow starting the `FetchThread` asynchronously

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -125,7 +125,7 @@ use log::{debug, error, info, trace, warn};
 use media::WindowGLContext;
 use net::image_cache::ImageCacheFactoryImpl;
 use net_traits::pub_domains::registered_domain_name;
-use net_traits::{self, AsyncRuntime, ResourceThreads, exit_fetch_thread, start_fetch_thread};
+use net_traits::{self, AsyncRuntime, FetchThread, ResourceThreads};
 use paint_api::{
     PaintMessage, PaintProxy, PinchZoomInfos, PipelineExitSource, SendableFrameTree,
     WebRenderExternalImageIdManager,
@@ -772,11 +772,6 @@ where
 
     /// The main event loop for the constellation.
     fn run(&mut self) {
-        // Start a fetch thread.
-        // In single-process mode this will be the global fetch thread;
-        // in multi-process mode this will be used only by the canvas paint thread.
-        let join_handle = start_fetch_thread();
-
         while !self.shutting_down || !self.pipelines.is_empty() {
             // Randomly close a pipeline if --random-pipeline-closure-probability is set
             // This is for testing the hardening of the constellation.
@@ -790,11 +785,8 @@ where
             StyleThreadPool::shutdown();
         }
 
-        // Shut down the fetch thread started above.
-        exit_fetch_thread();
-        join_handle
-            .join()
-            .expect("Failed to join on the fetch thread in the constellation");
+        // Shut down the `FetchThread` if it has been started at any time.
+        FetchThread::exit();
 
         // Note: the last thing the constellation does, is asking the embedder to
         // shut down. This helps ensure we've shut down all our internal threads before

--- a/components/fonts/tests/font_context.rs
+++ b/components/fonts/tests/font_context.rs
@@ -9,8 +9,8 @@ mod font_context {
     use std::collections::HashMap;
     use std::ffi::OsStr;
     use std::path::PathBuf;
+    use std::sync::Arc;
     use std::sync::atomic::{AtomicI32, Ordering};
-    use std::sync::{Arc, Once};
     use std::thread;
 
     use app_units::Au;
@@ -22,7 +22,7 @@ mod font_context {
         SystemFontServiceProxySender, fallback_font_families,
     };
     use icu_locid::subtags::Language;
-    use net_traits::{ResourceThreads, start_fetch_thread};
+    use net_traits::ResourceThreads;
     use paint_api::CrossProcessPaintApi;
     use parking_lot::Mutex;
     use servo_arc::Arc as ServoArc;
@@ -38,8 +38,6 @@ mod font_context {
     use stylo_atoms::Atom;
     use webrender_api::{FontInstanceKey, FontKey, IdNamespace};
 
-    static INIT: Once = Once::new();
-
     struct TestContext {
         context: FontContext,
         system_font_service: Arc<MockSystemFontService>,
@@ -54,9 +52,6 @@ mod font_context {
             let mock_paint_api = CrossProcessPaintApi::dummy();
 
             let proxy_clone = Arc::new(system_font_service_proxy.to_sender().to_proxy());
-            INIT.call_once(|| {
-                start_fetch_thread();
-            });
             Self {
                 context: FontContext::new(proxy_clone, mock_paint_api, mock_resource_threads),
                 system_font_service,

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -32,7 +32,7 @@ use net::embedder::NetToEmbedderMsg;
 use net::image_cache::ImageCacheFactoryImpl;
 use net::protocols::ProtocolRegistry;
 use net::resource_thread::new_resource_threads;
-use net_traits::{ResourceThreads, exit_fetch_thread, start_fetch_thread};
+use net_traits::{FetchThread, ResourceThreads};
 use paint::{InitialPaintState, Paint};
 pub use paint_api::rendering_context::RenderingContext;
 use paint_api::{CrossProcessPaintApi, PaintMessage, PaintProxy};
@@ -1319,9 +1319,6 @@ pub fn run_content_process(token: String) {
         UnprivilegedContent::ScriptEventLoop(new_event_loop_info) => {
             media_platform::init();
 
-            // Start the fetch thread for this content process.
-            let fetch_thread_join_handle = start_fetch_thread();
-
             set_logger(
                 new_event_loop_info
                     .initial_script_state
@@ -1357,11 +1354,8 @@ pub fn run_content_process(token: String) {
 
             StyleThreadPool::shutdown();
 
-            // Shut down the fetch thread started above.
-            exit_fetch_thread();
-            fetch_thread_join_handle
-                .join()
-                .expect("Failed to join on the fetch thread in the constellation");
+            // Shut down the `FetchThread` if it had been started in the course of execution.
+            FetchThread::exit();
         },
         UnprivilegedContent::ServiceWorker(content) => {
             content.start::<ServiceWorkerManager>();

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -880,7 +880,7 @@ impl FetchThread {
             .expect("Thread spawning failed");
         FetchThreadHandle {
             sender,
-            join_handle,
+            join_handle: RwLock::new(Some(join_handle)),
         }
     }
 
@@ -954,20 +954,18 @@ impl FetchThread {
         response_init: Option<ResponseInit>,
         callback: BoxedFetchCallback,
     ) {
-        let _ = FETCH_THREAD
-            .read()
-            .get_or_init(FetchThread::spawn)
-            .sender
-            .send(ToFetchThreadMessage::StartFetch(
+        let _ = FETCH_THREAD.get_or_init(FetchThread::spawn).sender.send(
+            ToFetchThreadMessage::StartFetch(
                 request,
                 response_init,
                 callback,
                 core_resource_thread.clone(),
-            ));
+            ),
+        );
     }
 
     fn cancel_async_fetch(request_ids: Vec<RequestId>, core_resource_thread: &CoreResourceThread) {
-        if let Some(fetch_thread) = FETCH_THREAD.read().get() {
+        if let Some(fetch_thread) = FETCH_THREAD.get() {
             let _ = fetch_thread.sender.send(ToFetchThreadMessage::Cancel(
                 request_ids,
                 core_resource_thread.clone(),
@@ -977,23 +975,24 @@ impl FetchThread {
 
     /// If the `FetchThread` is running, send the exit message and wait for it to exit.
     pub fn exit() {
-        let Some(fetch_thread) = FETCH_THREAD.write().take() else {
+        let Some(fetch_thread) = FETCH_THREAD.get() else {
             return;
         };
         let _ = fetch_thread.sender.send(ToFetchThreadMessage::Exit);
-        fetch_thread
-            .join_handle
-            .join()
-            .expect("Failed to join on the FetchThread join handle.");
+        if let Some(join_handle) = fetch_thread.join_handle.write().take() {
+            join_handle
+                .join()
+                .expect("Failed to join on the FetchThread join handle.");
+        }
     }
 }
 
 struct FetchThreadHandle {
     sender: Sender<ToFetchThreadMessage>,
-    join_handle: JoinHandle<()>,
+    join_handle: RwLock<Option<JoinHandle<()>>>,
 }
 
-static FETCH_THREAD: RwLock<OnceLock<FetchThreadHandle>> = RwLock::new(OnceLock::new());
+static FETCH_THREAD: OnceLock<FetchThreadHandle> = OnceLock::new();
 
 /// Instruct the fetch thread to start a new asynchronous fetch request.
 pub fn fetch_async(

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -20,6 +20,7 @@ use ipc_channel::router::ROUTER;
 use malloc_size_of::malloc_size_of_is_0;
 use malloc_size_of_derive::MallocSizeOf;
 use mime::Mime;
+use parking_lot::RwLock;
 use profile_traits::mem::ReportsChan;
 use rand::{Rng, rng};
 use request::RequestId;
@@ -840,7 +841,7 @@ pub type BoxedFetchCallback = Box<dyn FnMut(FetchResponseMsg) + Send + 'static>;
 /// A thread to handle fetches in a Servo process. This thread is responsible for
 /// listening for new fetch requests as well as updates on those operations and forwarding
 /// them to crossbeam channels.
-struct FetchThread {
+pub struct FetchThread {
     /// A list of active fetches. A fetch is no longer active once the
     /// [`FetchResponseMsg::ProcessResponseEOF`] is received.
     active_fetches: FxHashMap<RequestId, BoxedFetchCallback>,
@@ -854,7 +855,7 @@ struct FetchThread {
 }
 
 impl FetchThread {
-    fn spawn() -> (Sender<ToFetchThreadMessage>, JoinHandle<()>) {
+    fn spawn() -> FetchThreadHandle {
         let (sender, receiver) = unbounded();
         let (to_fetch_sender, from_fetch_sender) = ipc::channel().unwrap();
 
@@ -877,7 +878,10 @@ impl FetchThread {
                 fetch_thread.run();
             })
             .expect("Thread spawning failed");
-        (sender, join_handle)
+        FetchThreadHandle {
+            sender,
+            join_handle,
+        }
     }
 
     fn run(&mut self) {
@@ -943,59 +947,68 @@ impl FetchThread {
             }
         }
     }
+
+    fn fetch_async(
+        core_resource_thread: &CoreResourceThread,
+        request: RequestBuilder,
+        response_init: Option<ResponseInit>,
+        callback: BoxedFetchCallback,
+    ) {
+        let _ = FETCH_THREAD
+            .read()
+            .get_or_init(FetchThread::spawn)
+            .sender
+            .send(ToFetchThreadMessage::StartFetch(
+                request,
+                response_init,
+                callback,
+                core_resource_thread.clone(),
+            ));
+    }
+
+    fn cancel_async_fetch(request_ids: Vec<RequestId>, core_resource_thread: &CoreResourceThread) {
+        if let Some(fetch_thread) = FETCH_THREAD.read().get() {
+            let _ = fetch_thread.sender.send(ToFetchThreadMessage::Cancel(
+                request_ids,
+                core_resource_thread.clone(),
+            ));
+        }
+    }
+
+    /// If the `FetchThread` is running, send the exit message and wait for it to exit.
+    pub fn exit() {
+        let Some(fetch_thread) = FETCH_THREAD.write().take() else {
+            return;
+        };
+        let _ = fetch_thread.sender.send(ToFetchThreadMessage::Exit);
+        fetch_thread
+            .join_handle
+            .join()
+            .expect("Failed to join on the FetchThread join handle.");
+    }
 }
 
-static FETCH_THREAD: OnceLock<Sender<ToFetchThreadMessage>> = OnceLock::new();
-
-/// Start the fetch thread,
-/// and returns the join handle to the background thread.
-pub fn start_fetch_thread() -> JoinHandle<()> {
-    let (sender, join_handle) = FetchThread::spawn();
-    FETCH_THREAD
-        .set(sender)
-        .expect("Fetch thread should be set only once on start-up");
-    join_handle
+struct FetchThreadHandle {
+    sender: Sender<ToFetchThreadMessage>,
+    join_handle: JoinHandle<()>,
 }
 
-/// Send the exit message to the background thread,
-/// after which the caller can,
-/// and should,
-/// join on the thread.
-pub fn exit_fetch_thread() {
-    let _ = FETCH_THREAD
-        .get()
-        .expect("Fetch thread should always be initialized on start-up")
-        .send(ToFetchThreadMessage::Exit);
-}
+static FETCH_THREAD: RwLock<OnceLock<FetchThreadHandle>> = RwLock::new(OnceLock::new());
 
-/// Instruct the resource thread to make a new fetch request.
+/// Instruct the fetch thread to start a new asynchronous fetch request.
 pub fn fetch_async(
     core_resource_thread: &CoreResourceThread,
     request: RequestBuilder,
     response_init: Option<ResponseInit>,
     callback: BoxedFetchCallback,
 ) {
-    let _ = FETCH_THREAD
-        .get()
-        .expect("Fetch thread should always be initialized on start-up")
-        .send(ToFetchThreadMessage::StartFetch(
-            request,
-            response_init,
-            callback,
-            core_resource_thread.clone(),
-        ));
+    FetchThread::fetch_async(core_resource_thread, request, response_init, callback);
 }
 
 /// Instruct the resource thread to cancel an existing request. Does nothing if the
 /// request has already completed or has not been fetched yet.
 pub fn cancel_async_fetch(request_ids: Vec<RequestId>, core_resource_thread: &CoreResourceThread) {
-    let _ = FETCH_THREAD
-        .get()
-        .expect("Fetch thread should always be initialized on start-up")
-        .send(ToFetchThreadMessage::Cancel(
-            request_ids,
-            core_resource_thread.clone(),
-        ));
+    FetchThread::cancel_async_fetch(request_ids, core_resource_thread);
 }
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]


### PR DESCRIPTION
This change simplifies the way that the `FetchThread` is initialized
while still allowing shutdown to wait for the call to `join`.

Testing: This should not change behavior so is covered by existing tests.
