### PR TITLE
Fix adopted stylesheet borrow hazard

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -6667,12 +6667,11 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     fn SetAdoptedStyleSheets(&self, cx: &mut JSContext, val: HandleValue) -> ErrorResult {
         let result = DocumentOrShadowRoot::set_adopted_stylesheet_from_jsval(
             cx,
-            self.adopted_stylesheets.borrow_mut().as_mut(),
+            &self.adopted_stylesheets,
             val,
             &StyleSheetListOwner::Document(Dom::from_ref(self)),
         );
 
-        // If update is successful, clear the FrozenArray cache.
         if result.is_ok() {
             self.adopted_stylesheets_frozen_types.clear()
         }

--- a/components/script/dom/document/documentorshadowroot.rs
+++ b/components/script/dom/document/documentorshadowroot.rs
@@ -10,6 +10,7 @@ use embedder_traits::UntrustedNodeAddress;
 use js::context::JSContext;
 use js::conversions::FromJSValConvertible;
 use js::rust::HandleValue;
+use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
 use script_bindings::codegen::GenericBindings::ShadowRootBinding::ShadowRootMethods;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
@@ -442,7 +443,7 @@ impl DocumentOrShadowRoot {
     /// values to the inner [DocumentOrShadowRoot::set_adopted_stylesheet].
     pub(crate) fn set_adopted_stylesheet_from_jsval(
         cx: &mut JSContext,
-        adopted_stylesheets: &mut Vec<Dom<CSSStyleSheet>>,
+        adopted_stylesheets: &DomRefCell<Vec<Dom<CSSStyleSheet>>>,
         incoming_value: HandleValue,
         owner: &StyleSheetListOwner,
     ) -> ErrorResult {
@@ -454,11 +455,8 @@ impl DocumentOrShadowRoot {
             ConversionResult::Success(stylesheets) => {
                 rooted_vec!(let stylesheets <- stylesheets.iter().map(|s| s.as_traced()));
 
-                DocumentOrShadowRoot::set_adopted_stylesheet(
-                    adopted_stylesheets,
-                    &stylesheets,
-                    owner,
-                )
+                let mut sheets = adopted_stylesheets.safe_borrow_mut(cx);
+                DocumentOrShadowRoot::set_adopted_stylesheet(sheets.as_mut(), &stylesheets, owner)
             },
             ConversionResult::Failure(msg) => Err(Error::Type(msg.into_owned())),
         }

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -588,12 +588,11 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     fn SetAdoptedStyleSheets(&self, cx: &mut JSContext, val: HandleValue) -> ErrorResult {
         let result = DocumentOrShadowRoot::set_adopted_stylesheet_from_jsval(
             cx,
-            self.adopted_stylesheets.borrow_mut().as_mut(),
+            &self.adopted_stylesheets,
             val,
             &StyleSheetListOwner::ShadowRoot(Dom::from_ref(self)),
         );
 
-        // If update is successful, clear the FrozenArray cache.
         if result.is_ok() {
             self.adopted_stylesheets_frozen_types.clear();
         }


### PR DESCRIPTION
This avoids holding a mutable borrow while reading adoptedStyleSheets from JS, preventing a GC-time panic, and adds a regression crash test.

Testing: Tested with `./mach test-wpt /_mozilla/mozilla/css/adoptedstylesheets-borrow-hazard-crash.html --pref dom_adoptedstylesheet_enabled --test-types crashtest` and `./mach test-tidy`

Fixes: #46369 
