### PR TITLE
script: Account for nested rules when parsing selectors for CSSOM

### DIFF
--- a/components/script/dom/css/cssconditionrule.rs
+++ b/components/script/dom/css/cssconditionrule.rs
@@ -27,11 +27,12 @@ pub(crate) struct CSSConditionRule {
 
 impl CSSConditionRule {
     pub(crate) fn new_inherited(
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         rules: Arc<Locked<StyleCssRules>>,
     ) -> CSSConditionRule {
         CSSConditionRule {
-            css_grouping_rule: CSSGroupingRule::new_inherited(parent_stylesheet),
+            css_grouping_rule: CSSGroupingRule::new_inherited(parent_rule, parent_stylesheet),
             rules: RefCell::new(rules),
         }
     }

--- a/components/script/dom/css/cssfontfacerule.rs
+++ b/components/script/dom/css/cssfontfacerule.rs
@@ -15,6 +15,7 @@ use super::cssrule::{CSSRule, SpecificCSSRule};
 use super::cssstylesheet::CSSStyleSheet;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
+use crate::dom::cssgroupingrule::CSSGroupingRule;
 use crate::dom::window::Window;
 
 #[dom_struct]
@@ -27,11 +28,12 @@ pub(crate) struct CSSFontFaceRule {
 
 impl CSSFontFaceRule {
     fn new_inherited(
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         fontfacerule: Arc<Locked<FontFaceRule>>,
     ) -> CSSFontFaceRule {
         CSSFontFaceRule {
-            css_rule: CSSRule::new_inherited(parent_stylesheet),
+            css_rule: CSSRule::new_inherited(parent_rule, parent_stylesheet),
             font_face_rule: RefCell::new(fontfacerule),
         }
     }
@@ -39,11 +41,13 @@ impl CSSFontFaceRule {
     pub(crate) fn new(
         cx: &mut JSContext,
         window: &Window,
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         fontfacerule: Arc<Locked<FontFaceRule>>,
     ) -> DomRoot<CSSFontFaceRule> {
         reflect_dom_object_with_cx(
             Box::new(CSSFontFaceRule::new_inherited(
+                parent_rule,
                 parent_stylesheet,
                 fontfacerule,
             )),

--- a/components/script/dom/css/cssfontfeaturevaluesrule.rs
+++ b/components/script/dom/css/cssfontfeaturevaluesrule.rs
@@ -13,6 +13,7 @@ use super::cssrule::{CSSRule, SpecificCSSRule};
 use super::cssstylesheet::CSSStyleSheet;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
+use crate::dom::cssgroupingrule::CSSGroupingRule;
 use crate::dom::window::Window;
 
 #[dom_struct]
@@ -25,11 +26,12 @@ pub(crate) struct CSSFontFeatureValuesRule {
 
 impl CSSFontFeatureValuesRule {
     fn new_inherited(
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         font_feature_values_rule: Arc<FontFeatureValuesRule>,
     ) -> CSSFontFeatureValuesRule {
         CSSFontFeatureValuesRule {
-            css_rule: CSSRule::new_inherited(parent_stylesheet),
+            css_rule: CSSRule::new_inherited(parent_rule, parent_stylesheet),
             font_feature_values_rule,
         }
     }
@@ -37,11 +39,13 @@ impl CSSFontFeatureValuesRule {
     pub(crate) fn new(
         cx: &mut JSContext,
         window: &Window,
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         font_feature_values_rule: Arc<FontFeatureValuesRule>,
     ) -> DomRoot<CSSFontFeatureValuesRule> {
         reflect_dom_object_with_cx(
             Box::new(CSSFontFeatureValuesRule::new_inherited(
+                parent_rule,
                 parent_stylesheet,
                 font_feature_values_rule,
             )),

--- a/components/script/dom/css/cssgroupingrule.rs
+++ b/components/script/dom/css/cssgroupingrule.rs
@@ -6,7 +6,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use servo_arc::Arc;
 use style::shared_lock::{Locked, SharedRwLock, SharedRwLockReadGuard};
-use style::stylesheets::{CssRuleType, CssRuleTypes, CssRules};
+use style::stylesheets::CssRules;
 
 use super::cssconditionrule::CSSConditionRule;
 use super::csslayerblockrule::CSSLayerBlockRule;
@@ -28,9 +28,12 @@ pub(crate) struct CSSGroupingRule {
 }
 
 impl CSSGroupingRule {
-    pub(crate) fn new_inherited(parent_stylesheet: &CSSStyleSheet) -> CSSGroupingRule {
+    pub(crate) fn new_inherited(
+        parent_rule: Option<&CSSGroupingRule>,
+        parent_stylesheet: &CSSStyleSheet,
+    ) -> CSSGroupingRule {
         CSSGroupingRule {
-            css_rule: CSSRule::new_inherited(parent_stylesheet),
+            css_rule: CSSRule::new_inherited(parent_rule, parent_stylesheet),
             rule_list: MutNullableDom::new(None),
         }
     }
@@ -50,6 +53,7 @@ impl CSSGroupingRule {
             CSSRuleList::new(
                 cx,
                 self.global().as_window(),
+                Some(self),
                 parent_stylesheet,
                 RulesSource::Rules(rules),
             )
@@ -84,20 +88,7 @@ impl CSSGroupingRuleMethods<crate::DomTypeHolder> for CSSGroupingRule {
 
     /// <https://drafts.csswg.org/cssom/#dom-cssgroupingrule-insertrule>
     fn InsertRule(&self, cx: &mut JSContext, rule: DOMString, index: u32) -> Fallible<u32> {
-        // TODO: this should accumulate the rule types of all ancestors.
-        let rule_type = self.css_rule.as_specific().ty();
-        let containing_rule_types = CssRuleTypes::from(rule_type);
-        let parse_relative_rule_type = match rule_type {
-            CssRuleType::Style | CssRuleType::Scope => Some(rule_type),
-            _ => None,
-        };
-        self.rulelist(cx).insert_rule(
-            cx,
-            &rule,
-            index,
-            containing_rule_types,
-            parse_relative_rule_type,
-        )
+        self.rulelist(cx).insert_rule(cx, &rule, index)
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-cssgroupingrule-deleterule>

--- a/components/script/dom/css/cssimportrule.rs
+++ b/components/script/dom/css/cssimportrule.rs
@@ -18,6 +18,7 @@ use super::cssstylesheet::CSSStyleSheet;
 use crate::dom::bindings::codegen::Bindings::CSSImportRuleBinding::CSSImportRuleMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
+use crate::dom::cssgroupingrule::CSSGroupingRule;
 use crate::dom::window::Window;
 
 #[dom_struct]
@@ -30,11 +31,12 @@ pub(crate) struct CSSImportRule {
 
 impl CSSImportRule {
     fn new_inherited(
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         import_rule: Arc<Locked<ImportRule>>,
     ) -> Self {
         CSSImportRule {
-            css_rule: CSSRule::new_inherited(parent_stylesheet),
+            css_rule: CSSRule::new_inherited(parent_rule, parent_stylesheet),
             import_rule: RefCell::new(import_rule),
         }
     }
@@ -42,11 +44,16 @@ impl CSSImportRule {
     pub(crate) fn new(
         cx: &mut JSContext,
         window: &Window,
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         import_rule: Arc<Locked<ImportRule>>,
     ) -> DomRoot<Self> {
         reflect_dom_object_with_cx(
-            Box::new(Self::new_inherited(parent_stylesheet, import_rule)),
+            Box::new(Self::new_inherited(
+                parent_rule,
+                parent_stylesheet,
+                import_rule,
+            )),
             window,
             cx,
         )

--- a/components/script/dom/css/csskeyframerule.rs
+++ b/components/script/dom/css/csskeyframerule.rs
@@ -20,6 +20,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
+use crate::dom::cssgroupingrule::CSSGroupingRule;
 use crate::dom::window::Window;
 
 #[dom_struct]
@@ -33,11 +34,12 @@ pub(crate) struct CSSKeyframeRule {
 
 impl CSSKeyframeRule {
     fn new_inherited(
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         keyframerule: Arc<Locked<Keyframe>>,
     ) -> CSSKeyframeRule {
         CSSKeyframeRule {
-            css_rule: CSSRule::new_inherited(parent_stylesheet),
+            css_rule: CSSRule::new_inherited(parent_rule, parent_stylesheet),
             keyframe_rule: RefCell::new(keyframerule),
             style_declaration: Default::default(),
         }
@@ -46,11 +48,13 @@ impl CSSKeyframeRule {
     pub(crate) fn new(
         cx: &mut JSContext,
         window: &Window,
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         keyframerule: Arc<Locked<Keyframe>>,
     ) -> DomRoot<CSSKeyframeRule> {
         reflect_dom_object_with_cx(
             Box::new(CSSKeyframeRule::new_inherited(
+                parent_rule,
                 parent_stylesheet,
                 keyframerule,
             )),

--- a/components/script/dom/css/csskeyframesrule.rs
+++ b/components/script/dom/css/csskeyframesrule.rs
@@ -24,6 +24,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
+use crate::dom::cssgroupingrule::CSSGroupingRule;
 use crate::dom::window::Window;
 
 #[dom_struct]
@@ -37,11 +38,12 @@ pub(crate) struct CSSKeyframesRule {
 
 impl CSSKeyframesRule {
     fn new_inherited(
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         keyframesrule: Arc<Locked<KeyframesRule>>,
     ) -> CSSKeyframesRule {
         CSSKeyframesRule {
-            css_rule: CSSRule::new_inherited(parent_stylesheet),
+            css_rule: CSSRule::new_inherited(parent_rule, parent_stylesheet),
             keyframes_rule: RefCell::new(keyframesrule),
             rule_list: MutNullableDom::new(None),
         }
@@ -50,11 +52,13 @@ impl CSSKeyframesRule {
     pub(crate) fn new(
         cx: &mut JSContext,
         window: &Window,
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         keyframesrule: Arc<Locked<KeyframesRule>>,
     ) -> DomRoot<CSSKeyframesRule> {
         reflect_dom_object_with_cx(
             Box::new(CSSKeyframesRule::new_inherited(
+                parent_rule,
                 parent_stylesheet,
                 keyframesrule,
             )),
@@ -69,6 +73,7 @@ impl CSSKeyframesRule {
             CSSRuleList::new(
                 cx,
                 self.global().as_window(),
+                None,
                 parent_stylesheet,
                 RulesSource::Keyframes(self.keyframes_rule.borrow().clone()),
             )

--- a/components/script/dom/css/csslayerblockrule.rs
+++ b/components/script/dom/css/csslayerblockrule.rs
@@ -30,11 +30,12 @@ pub(crate) struct CSSLayerBlockRule {
 
 impl CSSLayerBlockRule {
     pub(crate) fn new_inherited(
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         layerblockrule: Arc<LayerBlockRule>,
     ) -> CSSLayerBlockRule {
         CSSLayerBlockRule {
-            css_grouping_rule: CSSGroupingRule::new_inherited(parent_stylesheet),
+            css_grouping_rule: CSSGroupingRule::new_inherited(parent_rule, parent_stylesheet),
             layer_block_rule: RefCell::new(layerblockrule),
         }
     }
@@ -42,11 +43,13 @@ impl CSSLayerBlockRule {
     pub(crate) fn new(
         cx: &mut JSContext,
         window: &Window,
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         layerblockrule: Arc<LayerBlockRule>,
     ) -> DomRoot<CSSLayerBlockRule> {
         reflect_dom_object_with_cx(
             Box::new(CSSLayerBlockRule::new_inherited(
+                parent_rule,
                 parent_stylesheet,
                 layerblockrule,
             )),

--- a/components/script/dom/css/csslayerstatementrule.rs
+++ b/components/script/dom/css/csslayerstatementrule.rs
@@ -19,6 +19,7 @@ use crate::dom::bindings::codegen::Bindings::CSSLayerStatementRuleBinding::CSSLa
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::utils::to_frozen_array;
+use crate::dom::types::CSSGroupingRule;
 use crate::dom::window::Window;
 
 #[dom_struct]
@@ -31,11 +32,12 @@ pub(crate) struct CSSLayerStatementRule {
 
 impl CSSLayerStatementRule {
     pub(crate) fn new_inherited(
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         layerstatementrule: Arc<LayerStatementRule>,
     ) -> CSSLayerStatementRule {
         CSSLayerStatementRule {
-            css_rule: CSSRule::new_inherited(parent_stylesheet),
+            css_rule: CSSRule::new_inherited(parent_rule, parent_stylesheet),
             layer_statement_rule: RefCell::new(layerstatementrule),
         }
     }
@@ -43,11 +45,13 @@ impl CSSLayerStatementRule {
     pub(crate) fn new(
         cx: &mut JSContext,
         window: &Window,
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         layerstatementrule: Arc<LayerStatementRule>,
     ) -> DomRoot<CSSLayerStatementRule> {
         reflect_dom_object_with_cx(
             Box::new(CSSLayerStatementRule::new_inherited(
+                parent_rule,
                 parent_stylesheet,
                 layerstatementrule,
             )),

--- a/components/script/dom/css/cssmediarule.rs
+++ b/components/script/dom/css/cssmediarule.rs
@@ -19,6 +19,7 @@ use crate::dom::bindings::codegen::Bindings::CSSMediaRuleBinding::CSSMediaRuleMe
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
+use crate::dom::css::cssgroupingrule::CSSGroupingRule;
 use crate::dom::medialist::MediaList;
 use crate::dom::window::Window;
 
@@ -32,10 +33,18 @@ pub(crate) struct CSSMediaRule {
 }
 
 impl CSSMediaRule {
-    fn new_inherited(parent_stylesheet: &CSSStyleSheet, mediarule: Arc<MediaRule>) -> CSSMediaRule {
+    fn new_inherited(
+        parent_rule: Option<&CSSGroupingRule>,
+        parent_stylesheet: &CSSStyleSheet,
+        mediarule: Arc<MediaRule>,
+    ) -> CSSMediaRule {
         let list = mediarule.rules.clone();
         CSSMediaRule {
-            css_condition_rule: CSSConditionRule::new_inherited(parent_stylesheet, list),
+            css_condition_rule: CSSConditionRule::new_inherited(
+                parent_rule,
+                parent_stylesheet,
+                list,
+            ),
             media_rule: RefCell::new(mediarule),
             media_list: MutNullableDom::new(None),
         }
@@ -44,11 +53,16 @@ impl CSSMediaRule {
     pub(crate) fn new(
         cx: &mut JSContext,
         window: &Window,
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         mediarule: Arc<MediaRule>,
     ) -> DomRoot<CSSMediaRule> {
         reflect_dom_object_with_cx(
-            Box::new(CSSMediaRule::new_inherited(parent_stylesheet, mediarule)),
+            Box::new(CSSMediaRule::new_inherited(
+                parent_rule,
+                parent_stylesheet,
+                mediarule,
+            )),
             window,
             cx,
         )

--- a/components/script/dom/css/cssnamespacerule.rs
+++ b/components/script/dom/css/cssnamespacerule.rs
@@ -16,6 +16,7 @@ use super::cssstylesheet::CSSStyleSheet;
 use crate::dom::bindings::codegen::Bindings::CSSNamespaceRuleBinding::CSSNamespaceRuleMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
+use crate::dom::cssgroupingrule::CSSGroupingRule;
 use crate::dom::window::Window;
 
 #[dom_struct]
@@ -28,11 +29,12 @@ pub(crate) struct CSSNamespaceRule {
 
 impl CSSNamespaceRule {
     fn new_inherited(
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         namespacerule: Arc<NamespaceRule>,
     ) -> CSSNamespaceRule {
         CSSNamespaceRule {
-            css_rule: CSSRule::new_inherited(parent_stylesheet),
+            css_rule: CSSRule::new_inherited(parent_rule, parent_stylesheet),
             namespace_rule: RefCell::new(namespacerule),
         }
     }
@@ -40,11 +42,13 @@ impl CSSNamespaceRule {
     pub(crate) fn new(
         cx: &mut JSContext,
         window: &Window,
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         namespacerule: Arc<NamespaceRule>,
     ) -> DomRoot<CSSNamespaceRule> {
         reflect_dom_object_with_cx(
             Box::new(CSSNamespaceRule::new_inherited(
+                parent_rule,
                 parent_stylesheet,
                 namespacerule,
             )),

--- a/components/script/dom/css/cssnesteddeclarations.rs
+++ b/components/script/dom/css/cssnesteddeclarations.rs
@@ -19,6 +19,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
+use crate::dom::cssgroupingrule::CSSGroupingRule;
 use crate::dom::window::Window;
 
 #[dom_struct]
@@ -32,11 +33,12 @@ pub(crate) struct CSSNestedDeclarations {
 
 impl CSSNestedDeclarations {
     pub(crate) fn new_inherited(
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         nesteddeclarationsrule: Arc<Locked<NestedDeclarationsRule>>,
     ) -> Self {
         Self {
-            css_rule: CSSRule::new_inherited(parent_stylesheet),
+            css_rule: CSSRule::new_inherited(parent_rule, parent_stylesheet),
             nesteddeclarationsrule: RefCell::new(nesteddeclarationsrule),
             style_declaration: Default::default(),
         }
@@ -45,11 +47,13 @@ impl CSSNestedDeclarations {
     pub(crate) fn new(
         cx: &mut JSContext,
         window: &Window,
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         nesteddeclarationsrule: Arc<Locked<NestedDeclarationsRule>>,
     ) -> DomRoot<Self> {
         reflect_dom_object_with_cx(
             Box::new(Self::new_inherited(
+                parent_rule,
                 parent_stylesheet,
                 nesteddeclarationsrule,
             )),

--- a/components/script/dom/css/csspropertyrule.rs
+++ b/components/script/dom/css/csspropertyrule.rs
@@ -17,6 +17,7 @@ use super::cssstylesheet::CSSStyleSheet;
 use crate::dom::bindings::codegen::Bindings::CSSPropertyRuleBinding::CSSPropertyRuleMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
+use crate::dom::css::cssgroupingrule::CSSGroupingRule;
 use crate::dom::window::Window;
 
 #[dom_struct]
@@ -28,9 +29,13 @@ pub(crate) struct CSSPropertyRule {
 }
 
 impl CSSPropertyRule {
-    fn new_inherited(parent_stylesheet: &CSSStyleSheet, property_rule: Arc<PropertyRule>) -> Self {
+    fn new_inherited(
+        parent_rule: Option<&CSSGroupingRule>,
+        parent_stylesheet: &CSSStyleSheet,
+        property_rule: Arc<PropertyRule>,
+    ) -> Self {
         CSSPropertyRule {
-            css_rule: CSSRule::new_inherited(parent_stylesheet),
+            css_rule: CSSRule::new_inherited(parent_rule, parent_stylesheet),
             property_rule: RefCell::new(property_rule),
         }
     }
@@ -38,11 +43,16 @@ impl CSSPropertyRule {
     pub(crate) fn new(
         cx: &mut JSContext,
         window: &Window,
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         property_rule: Arc<PropertyRule>,
     ) -> DomRoot<Self> {
         reflect_dom_object_with_cx(
-            Box::new(Self::new_inherited(parent_stylesheet, property_rule)),
+            Box::new(Self::new_inherited(
+                parent_rule,
+                parent_stylesheet,
+                property_rule,
+            )),
             window,
             cx,
         )

--- a/components/script/dom/css/cssrule.rs
+++ b/components/script/dom/css/cssrule.rs
@@ -28,11 +28,13 @@ use crate::dom::bindings::codegen::Bindings::CSSRuleBinding::CSSRuleMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
+use crate::dom::cssgroupingrule::CSSGroupingRule;
 use crate::dom::window::Window;
 
 #[dom_struct]
 pub(crate) struct CSSRule {
     reflector_: Reflector,
+    parent_rule: Option<Dom<CSSGroupingRule>>,
     parent_stylesheet: Dom<CSSStyleSheet>,
 
     /// Whether the parentStyleSheet attribute should return null.
@@ -42,9 +44,13 @@ pub(crate) struct CSSRule {
 }
 
 impl CSSRule {
-    pub(crate) fn new_inherited(parent_stylesheet: &CSSStyleSheet) -> CSSRule {
+    pub(crate) fn new_inherited(
+        parent_rule: Option<&CSSGroupingRule>,
+        parent_stylesheet: &CSSStyleSheet,
+    ) -> CSSRule {
         CSSRule {
             reflector_: Reflector::new(),
+            parent_rule: parent_rule.map(Dom::from_ref),
             parent_stylesheet: Dom::from_ref(parent_stylesheet),
             parent_stylesheet_removed: Cell::new(false),
         }
@@ -87,57 +93,102 @@ impl CSSRule {
     pub(crate) fn new_specific(
         cx: &mut JSContext,
         window: &Window,
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         rule: StyleCssRule,
     ) -> DomRoot<CSSRule> {
         // be sure to update the match in as_specific when this is updated
         match rule {
-            StyleCssRule::Import(s) => {
-                DomRoot::upcast(CSSImportRule::new(cx, window, parent_stylesheet, s))
-            },
-            StyleCssRule::Style(s) => {
-                DomRoot::upcast(CSSStyleRule::new(cx, window, parent_stylesheet, s))
-            },
-            StyleCssRule::FontFace(s) => {
-                DomRoot::upcast(CSSFontFaceRule::new(cx, window, parent_stylesheet, s))
-            },
+            StyleCssRule::Import(s) => DomRoot::upcast(CSSImportRule::new(
+                cx,
+                window,
+                parent_rule,
+                parent_stylesheet,
+                s,
+            )),
+            StyleCssRule::Style(s) => DomRoot::upcast(CSSStyleRule::new(
+                cx,
+                window,
+                parent_rule,
+                parent_stylesheet,
+                s,
+            )),
+            StyleCssRule::FontFace(s) => DomRoot::upcast(CSSFontFaceRule::new(
+                cx,
+                window,
+                parent_rule,
+                parent_stylesheet,
+                s,
+            )),
             StyleCssRule::FontFeatureValues(rule) => DomRoot::upcast(
-                CSSFontFeatureValuesRule::new(cx, window, parent_stylesheet, rule),
+                CSSFontFeatureValuesRule::new(cx, window, parent_rule, parent_stylesheet, rule),
             ),
             StyleCssRule::CounterStyle(_) => unimplemented!(),
-            StyleCssRule::Keyframes(s) => {
-                DomRoot::upcast(CSSKeyframesRule::new(cx, window, parent_stylesheet, s))
-            },
-            StyleCssRule::Media(s) => {
-                DomRoot::upcast(CSSMediaRule::new(cx, window, parent_stylesheet, s))
-            },
-            StyleCssRule::Namespace(s) => {
-                DomRoot::upcast(CSSNamespaceRule::new(cx, window, parent_stylesheet, s))
-            },
-            StyleCssRule::Supports(s) => {
-                DomRoot::upcast(CSSSupportsRule::new(cx, window, parent_stylesheet, s))
-            },
+            StyleCssRule::Keyframes(s) => DomRoot::upcast(CSSKeyframesRule::new(
+                cx,
+                window,
+                parent_rule,
+                parent_stylesheet,
+                s,
+            )),
+            StyleCssRule::Media(s) => DomRoot::upcast(CSSMediaRule::new(
+                cx,
+                window,
+                parent_rule,
+                parent_stylesheet,
+                s,
+            )),
+            StyleCssRule::Namespace(s) => DomRoot::upcast(CSSNamespaceRule::new(
+                cx,
+                window,
+                parent_rule,
+                parent_stylesheet,
+                s,
+            )),
+            StyleCssRule::Supports(s) => DomRoot::upcast(CSSSupportsRule::new(
+                cx,
+                window,
+                parent_rule,
+                parent_stylesheet,
+                s,
+            )),
             StyleCssRule::Page(_) => unreachable!(),
             StyleCssRule::Container(_) => unimplemented!(), // TODO
             StyleCssRule::Document(_) => unimplemented!(),  // TODO
-            StyleCssRule::LayerBlock(s) => {
-                DomRoot::upcast(CSSLayerBlockRule::new(cx, window, parent_stylesheet, s))
-            },
-            StyleCssRule::LayerStatement(s) => {
-                DomRoot::upcast(CSSLayerStatementRule::new(cx, window, parent_stylesheet, s))
-            },
+            StyleCssRule::LayerBlock(s) => DomRoot::upcast(CSSLayerBlockRule::new(
+                cx,
+                window,
+                parent_rule,
+                parent_stylesheet,
+                s,
+            )),
+            StyleCssRule::LayerStatement(s) => DomRoot::upcast(CSSLayerStatementRule::new(
+                cx,
+                window,
+                parent_rule,
+                parent_stylesheet,
+                s,
+            )),
             StyleCssRule::FontPaletteValues(_) => unimplemented!(), // TODO
-            StyleCssRule::Property(s) => {
-                DomRoot::upcast(CSSPropertyRule::new(cx, window, parent_stylesheet, s))
-            },
+            StyleCssRule::Property(s) => DomRoot::upcast(CSSPropertyRule::new(
+                cx,
+                window,
+                parent_rule,
+                parent_stylesheet,
+                s,
+            )),
             StyleCssRule::Margin(_) => unimplemented!(), // TODO
             StyleCssRule::Scope(_) => unimplemented!(),  // TODO
             StyleCssRule::StartingStyle(_) => unimplemented!(), // TODO
             StyleCssRule::PositionTry(_) => unimplemented!(), // TODO
             StyleCssRule::CustomMedia(_) => unimplemented!(), // TODO
-            StyleCssRule::NestedDeclarations(s) => {
-                DomRoot::upcast(CSSNestedDeclarations::new(cx, window, parent_stylesheet, s))
-            },
+            StyleCssRule::NestedDeclarations(s) => DomRoot::upcast(CSSNestedDeclarations::new(
+                cx,
+                window,
+                parent_rule,
+                parent_stylesheet,
+                s,
+            )),
             StyleCssRule::AppearanceBase(_) => unimplemented!(), // TODO
             StyleCssRule::ViewTransition(_) => unimplemented!(), // TODO
         }
@@ -158,12 +209,20 @@ impl CSSRule {
         self.as_specific().deparent_children();
     }
 
+    pub(crate) fn parent_rule(&self) -> Option<&CSSGroupingRule> {
+        self.parent_rule.as_deref()
+    }
+
     pub(crate) fn parent_stylesheet(&self) -> &CSSStyleSheet {
         &self.parent_stylesheet
     }
 
     pub(crate) fn shared_lock(&self) -> &SharedRwLock {
         self.parent_stylesheet.shared_lock()
+    }
+
+    pub(crate) fn rule_type(&self) -> CssRuleType {
+        self.as_specific().ty()
     }
 
     pub(crate) fn update_rule(&self, style_rule: &StyleCssRule, guard: &SharedRwLockReadGuard) {

--- a/components/script/dom/css/cssrulelist.rs
+++ b/components/script/dom/css/cssrulelist.rs
@@ -14,7 +14,7 @@ use script_bindings::str::DOMString;
 use servo_arc::Arc;
 use style::shared_lock::{Locked, SharedRwLockReadGuard};
 use style::stylesheets::{
-    AllowImportRules, CssRuleType, CssRuleTypes, CssRules, KeyframesRule, RulesMutateError,
+    AllowImportRules, CssRuleTypes, CssRules, KeyframesRule, RulesMutateError,
     StylesheetInDocument, StylesheetLoader as StyleStylesheetLoader,
 };
 
@@ -26,6 +26,7 @@ use crate::dom::bindings::codegen::Bindings::CSSRuleListBinding::CSSRuleListMeth
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
+use crate::dom::cssgroupingrule::CSSGroupingRule;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::window::Window;
 use crate::stylesheet_loader::ElementStylesheetLoader;
@@ -46,6 +47,7 @@ impl Convert<Error> for RulesMutateError {
 #[dom_struct]
 pub(crate) struct CSSRuleList {
     reflector_: Reflector,
+    created_by_rule: Option<Dom<CSSGroupingRule>>,
     parent_stylesheet: Dom<CSSStyleSheet>,
     #[ignore_malloc_size_of = "Stylo"]
     rules: RefCell<RulesSource>,
@@ -60,6 +62,7 @@ pub(crate) enum RulesSource {
 impl CSSRuleList {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new_inherited(
+        created_by_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         rules: RulesSource,
     ) -> CSSRuleList {
@@ -81,6 +84,7 @@ impl CSSRuleList {
 
         CSSRuleList {
             reflector_: Reflector::new(),
+            created_by_rule: created_by_rule.map(Dom::from_ref),
             parent_stylesheet: Dom::from_ref(parent_stylesheet),
             rules: RefCell::new(rules),
             dom_rules: DomRefCell::new(dom_rules),
@@ -90,11 +94,16 @@ impl CSSRuleList {
     pub(crate) fn new(
         cx: &mut JSContext,
         window: &Window,
+        created_by_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         rules: RulesSource,
     ) -> DomRoot<CSSRuleList> {
         reflect_dom_object_with_cx(
-            Box::new(CSSRuleList::new_inherited(parent_stylesheet, rules)),
+            Box::new(CSSRuleList::new_inherited(
+                created_by_rule,
+                parent_stylesheet,
+                rules,
+            )),
             window,
             cx,
         )
@@ -107,8 +116,6 @@ impl CSSRuleList {
         cx: &mut JSContext,
         rule: &DOMString,
         idx: u32,
-        containing_rule_types: CssRuleTypes,
-        parse_relative_rule_type: Option<CssRuleType>,
     ) -> Fallible<u32> {
         self.parent_stylesheet.will_modify();
         let css_rules = if let RulesSource::Rules(rules) = &*self.rules.borrow() {
@@ -134,6 +141,22 @@ impl CSSRuleList {
         } else {
             AllowImportRules::Yes
         };
+
+        let mut containing_rule_types = CssRuleTypes::default();
+        let mut current_rule = self
+            .created_by_rule
+            .as_ref()
+            .map(|rule| rule.upcast::<CSSRule>())
+            .map(DomRoot::from_ref);
+        while let Some(containing_rule) = current_rule {
+            containing_rule_types.insert(containing_rule.rule_type());
+
+            current_rule = containing_rule
+                .parent_rule()
+                .map(|rule| rule.upcast::<CSSRule>())
+                .map(DomRoot::from_ref);
+        }
+
         let new_rule = {
             let guard = parent_stylesheet.shared_lock.read();
             css_rules
@@ -144,7 +167,9 @@ impl CSSRuleList {
                     parent_stylesheet.contents(&guard),
                     index,
                     containing_rule_types,
-                    parse_relative_rule_type,
+                    self.created_by_rule
+                        .as_ref()
+                        .map(|rule| rule.upcast::<CSSRule>().rule_type()),
                     loader.as_ref().map(|l| l as &dyn StyleStylesheetLoader),
                     allow_import_rules,
                 )
@@ -160,7 +185,14 @@ impl CSSRuleList {
 
         let parent_stylesheet = &*self.parent_stylesheet;
         parent_stylesheet.will_modify();
-        let dom_rule = CSSRule::new_specific(cx, window, parent_stylesheet, new_rule);
+
+        let dom_rule = CSSRule::new_specific(
+            cx,
+            window,
+            self.created_by_rule.as_deref(),
+            parent_stylesheet,
+            new_rule,
+        );
         self.dom_rules
             .safe_borrow_mut(cx.no_gc())
             .insert(index, MutNullableDom::new(Some(&*dom_rule)));
@@ -226,6 +258,7 @@ impl CSSRuleList {
                         CSSRule::new_specific(
                             cx,
                             self.global().as_window(),
+                            self.created_by_rule.as_deref(),
                             parent_stylesheet,
                             rule,
                         )
@@ -238,6 +271,7 @@ impl CSSRuleList {
                         DomRoot::upcast(CSSKeyframeRule::new(
                             cx,
                             self.global().as_window(),
+                            self.created_by_rule.as_deref(),
                             parent_stylesheet,
                             rule,
                         ))

--- a/components/script/dom/css/cssstylerule.rs
+++ b/components/script/dom/css/cssstylerule.rs
@@ -15,7 +15,6 @@ use style::selector_parser::SelectorParser;
 use style::shared_lock::{Locked, SharedRwLockReadGuard, ToCssWithGuard};
 use style::stylesheets::{CssRuleType, CssRules, Origin, StyleRule, StylesheetInDocument};
 
-use super::cssgroupingrule::CSSGroupingRule;
 use super::cssrule::SpecificCSSRule;
 use super::cssstyledeclaration::{CSSModificationAccess, CSSStyleDeclaration, CSSStyleOwner};
 use super::cssstylesheet::CSSStyleSheet;
@@ -24,6 +23,8 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
+use crate::dom::cssgroupingrule::CSSGroupingRule;
+use crate::dom::types::CSSRule;
 use crate::dom::window::Window;
 
 #[dom_struct]
@@ -37,11 +38,12 @@ pub(crate) struct CSSStyleRule {
 
 impl CSSStyleRule {
     fn new_inherited(
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         stylerule: Arc<Locked<StyleRule>>,
     ) -> CSSStyleRule {
         CSSStyleRule {
-            css_grouping_rule: CSSGroupingRule::new_inherited(parent_stylesheet),
+            css_grouping_rule: CSSGroupingRule::new_inherited(parent_rule, parent_stylesheet),
             style_rule: RefCell::new(stylerule),
             style_declaration: Default::default(),
         }
@@ -50,11 +52,16 @@ impl CSSStyleRule {
     pub(crate) fn new(
         cx: &mut JSContext,
         window: &Window,
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         stylerule: Arc<Locked<StyleRule>>,
     ) -> DomRoot<CSSStyleRule> {
         reflect_dom_object_with_cx(
-            Box::new(CSSStyleRule::new_inherited(parent_stylesheet, stylerule)),
+            Box::new(CSSStyleRule::new_inherited(
+                parent_rule,
+                parent_stylesheet,
+                stylerule,
+            )),
             window,
             cx,
         )
@@ -162,9 +169,17 @@ impl CSSStyleRuleMethods<crate::DomTypeHolder> for CSSStyleRule {
             };
             let mut css_parser = CssParserInput::new(&value);
             let mut css_parser = CssParser::new(&mut css_parser);
-            // TODO: Maybe allow setting relative selectors from the OM, if we're in a nested style
-            // rule?
-            SelectorList::parse(&parser, &mut css_parser, ParseRelative::No)
+
+            let parse_relative = match self
+                .upcast::<CSSRule>()
+                .parent_rule()
+                .map(|parent| parent.upcast::<CSSRule>().rule_type())
+            {
+                Some(CssRuleType::Style) => ParseRelative::ForNesting,
+                Some(CssRuleType::Scope) => ParseRelative::ForScope,
+                _ => ParseRelative::No,
+            };
+            SelectorList::parse(&parser, &mut css_parser, parse_relative)
         }) else {
             return;
         };

--- a/components/script/dom/css/cssstylesheet.rs
+++ b/components/script/dom/css/cssstylesheet.rs
@@ -18,7 +18,7 @@ use servo_arc::Arc;
 use style::media_queries::MediaList as StyleMediaList;
 use style::shared_lock::{SharedRwLock, SharedRwLockReadGuard};
 use style::stylesheets::{
-    AllowImportRules, CssRuleTypes, Origin, Stylesheet as StyleStyleSheet, StylesheetContents,
+    AllowImportRules, Origin, Stylesheet as StyleStyleSheet, StylesheetContents,
     StylesheetInDocument, UrlExtraData,
 };
 
@@ -163,6 +163,7 @@ impl CSSStyleSheet {
             CSSRuleList::new(
                 cx,
                 self.global().as_window(),
+                None,
                 self,
                 RulesSource::Rules(rules),
             )
@@ -412,8 +413,7 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
             )));
         }
 
-        self.rulelist(cx)
-            .insert_rule(cx, &rule, index, CssRuleTypes::default(), None)
+        self.rulelist(cx).insert_rule(cx, &rule, index)
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-cssstylesheet-deleterule>

--- a/components/script/dom/css/csssupportsrule.rs
+++ b/components/script/dom/css/csssupportsrule.rs
@@ -17,6 +17,7 @@ use super::cssrule::SpecificCSSRule;
 use super::cssstylesheet::CSSStyleSheet;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
+use crate::dom::css::cssgroupingrule::CSSGroupingRule;
 use crate::dom::window::Window;
 
 #[dom_struct]
@@ -29,12 +30,17 @@ pub(crate) struct CSSSupportsRule {
 
 impl CSSSupportsRule {
     fn new_inherited(
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         supportsrule: Arc<SupportsRule>,
     ) -> CSSSupportsRule {
         let list = supportsrule.rules.clone();
         CSSSupportsRule {
-            css_condition_rule: CSSConditionRule::new_inherited(parent_stylesheet, list),
+            css_condition_rule: CSSConditionRule::new_inherited(
+                parent_rule,
+                parent_stylesheet,
+                list,
+            ),
             supports_rule: RefCell::new(supportsrule),
         }
     }
@@ -42,11 +48,13 @@ impl CSSSupportsRule {
     pub(crate) fn new(
         cx: &mut JSContext,
         window: &Window,
+        parent_rule: Option<&CSSGroupingRule>,
         parent_stylesheet: &CSSStyleSheet,
         supportsrule: Arc<SupportsRule>,
     ) -> DomRoot<CSSSupportsRule> {
         reflect_dom_object_with_cx(
             Box::new(CSSSupportsRule::new_inherited(
+                parent_rule,
                 parent_stylesheet,
                 supportsrule,
             )),

--- a/tests/wpt/meta/css/css-nesting/cssom.html.ini
+++ b/tests/wpt/meta/css/css-nesting/cssom.html.ini
@@ -1,6 +1,3 @@
 [cssom.html]
   [Simple CSSOM manipulation of subrules 7]
     expected: FAIL
-
-  [Manipulation of nested declarations through CSSOM]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-nesting/invalid-inner-rules.html.ini
+++ b/tests/wpt/meta/css/css-nesting/invalid-inner-rules.html.ini
@@ -1,3 +1,0 @@
-[invalid-inner-rules.html]
-  [Simple CSSOM manipulation of subrules 1]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-nesting/nested-declarations-cssom.html.ini
+++ b/tests/wpt/meta/css/css-nesting/nested-declarations-cssom.html.ini
@@ -1,3 +1,0 @@
-[nested-declarations-cssom.html]
-  [Inserting a CSSNestedDeclaration rule into nested group rule]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-nesting/nested-declarations-matching.html.ini
+++ b/tests/wpt/meta/css/css-nesting/nested-declarations-matching.html.ini
@@ -1,6 +1,3 @@
 [nested-declarations-matching.html]
   [Bare declartaion in nested grouping rule can match pseudo-element]
     expected: FAIL
-
-  [Nested declarations rule responds to parent selector text change]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-nesting/nested-rule-cssom-invalidation.html.ini
+++ b/tests/wpt/meta/css/css-nesting/nested-rule-cssom-invalidation.html.ini
@@ -1,3 +1,0 @@
-[nested-rule-cssom-invalidation.html]
-  [Nested rule responds to parent selector text change]
-    expected: FAIL


### PR DESCRIPTION
When parsing a CSS selector in methods like `CSSStyleRule::SetSelectorText` then stylo needs to know whether we're inside a nested rule or not. That decides whether a implicit `&` is added or not. So far we've simply been acting as if we're always parsing for a top-level rule.

Fixing this requires us to track the parent rule of each `CSSRule`. That modifies a lot of files but the changes themselves are simple.

Testing: New tests start to pass.