### PR TITLE
Script: Create SVG Rendering Engine — Phase 1 (Scaffolding)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8311,6 +8311,7 @@ dependencies = [
  "bitflags 2.13.0",
  "data-url",
  "euclid",
+ "html5ever",
  "icu_locid",
  "icu_properties",
  "icu_segmenter",
@@ -8349,6 +8350,7 @@ dependencies = [
  "stylo",
  "stylo_atoms",
  "stylo_traits",
+ "svg_engine",
  "taffy",
  "tracing",
  "unicode-bidi",
@@ -10036,6 +10038,14 @@ dependencies = [
  "winapi",
  "wio",
  "x11-dl",
+]
+
+[[package]]
+name = "svg_engine"
+version = "0.4.0"
+dependencies = [
+ "malloc_size_of_derive",
+ "servo-malloc-size-of",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "components/media/examples",
+    "components/svg_engine",
     "components/xpath",
     "ffi/capi",
     "ports/servoshell",
@@ -359,6 +360,7 @@ servo-tracing = { version = "=0.4.0", path = "components/servo_tracing" }
 servo-url = { version = "=0.4.0", path = "components/url" }
 servo-wakelock = { version = "=0.4.0", path = "components/wakelock" }
 servo-webvtt = { version = "=0.4.0", path = "components/webvtt" }
+svg_engine = { version = "=0.4.0", path = "components/svg_engine" }
 storage = { package = "servo-storage", version = "=0.4.0", path = "components/storage" }
 storage_traits = { package = "servo-storage-traits", version = "=0.4.0", path = "components/shared/storage" }
 timers = { package = "servo-timers", version = "=0.4.0", path = "components/timers" }

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -17,6 +17,7 @@ doctest = false
 
 [features]
 tracing = ["dep:tracing"]
+svg-engine = ["dep:svg_engine", "dep:html5ever"]
 
 [dependencies]
 accesskit = { workspace = true }
@@ -28,6 +29,7 @@ embedder_traits = { workspace = true }
 euclid = { workspace = true }
 fonts = { workspace = true }
 fonts_traits = { workspace = true }
+html5ever = { workspace = true, optional = true }
 icu_locid = { workspace = true }
 icu_properties = { workspace = true, features = ["compiled_data"] }
 icu_segmenter = { workspace = true }
@@ -62,6 +64,7 @@ strum = { workspace = true }
 stylo = { workspace = true }
 stylo_atoms = { workspace = true }
 stylo_traits = { workspace = true }
+svg_engine = { workspace = true, optional = true }
 taffy = { workspace = true }
 tracing = { workspace = true, optional = true }
 unicode-bidi = { workspace = true }

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -8,9 +8,11 @@ use std::sync::Arc;
 use embedder_traits::UntrustedNodeAddress;
 use euclid::Size2D;
 use fonts::FontContext;
+#[cfg(not(feature = "svg-engine"))]
+use layout_api::LayoutNode;
 use layout_api::{
-    AnimatingImages, IFrameSizes, LayoutImageDestination, LayoutNode, PendingImage,
-    PendingImageState, PendingRasterizationImage,
+    AnimatingImages, IFrameSizes, LayoutImageDestination, PendingImage, PendingImageState,
+    PendingRasterizationImage,
 };
 use net_traits::image_cache::{
     Image as CachedImage, ImageCache, ImageCacheResult, ImageOrMetadataAvailable, PendingImageId,
@@ -18,6 +20,7 @@ use net_traits::image_cache::{
 use net_traits::request::InternalRequest;
 use parking_lot::{Mutex, RwLock};
 use pixels::RasterImage;
+#[cfg(not(feature = "svg-engine"))]
 use script::layout_dom::ServoLayoutNode;
 use servo_base::id::PainterId;
 use servo_url::{ImmutableOrigin, ServoUrl};
@@ -272,6 +275,7 @@ impl ImageResolver {
         result
     }
 
+    #[cfg(not(feature = "svg-engine"))]
     pub(crate) fn queue_svg_element_for_serialization(&self, element: ServoLayoutNode<'_>) {
         self.pending_svg_elements_for_serialization
             .lock()

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -785,6 +785,14 @@ impl PaintTraversalHandler for DisplayListBuilder<'_> {
             .to_webrender();
         let common = self.common_properties(state, clip, &style);
 
+        #[cfg(feature = "svg-engine")]
+        if let Some(ref svg_tree) = fragment.svg_render_tree {
+            use svg_engine::render_svg_tree;
+            // TODO: call with origin, size, spatial_id, clip_chain_id, and self.wr()
+            render_svg_tree(svg_tree);
+            return;
+        }
+
         if let Some(image_key) = fragment.image_key {
             self.wr().push_image(
                 &common,

--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -139,6 +139,18 @@ fn traverse_element<'dom>(
     let style = element.style(&context.style_context);
     let info = NodeAndStyleInfo::new(element, style);
 
+    #[cfg(feature = "svg-engine")]
+    if let Some(el) = element.as_element() {
+        if el.is_svg_element() &&
+            !matches!(
+                element.type_id(),
+                Some(LayoutNodeType::Element(LayoutElementType::SVGSVGElement))
+            )
+        {
+            return;
+        }
+    }
+
     match Display::from(info.style.get_box().display) {
         Display::None => {},
         Display::Contents => {

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -15,6 +15,8 @@ use servo_base::print_tree::PrintTree;
 use servo_url::ServoUrl;
 use style::Zero;
 use style_traits::CSSPixel;
+#[cfg(feature = "svg-engine")]
+use svg_engine::render_tree::SvgRenderTree;
 use webrender_api::{FontInstanceKey, ImageKey};
 
 use super::{
@@ -112,6 +114,9 @@ pub(crate) struct ImageFragment {
     pub image_key: Option<ImageKey>,
     pub showing_broken_image_icon: bool,
     pub url: Option<ServoUrl>,
+    #[cfg(feature = "svg-engine")]
+    #[conditional_malloc_size_of]
+    pub svg_render_tree: Option<Arc<SvgRenderTree>>,
 }
 
 #[derive(MallocSizeOf)]

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -31,6 +31,8 @@ mod quotes;
 mod replaced;
 mod sizing;
 mod style_ext;
+#[cfg(feature = "svg-engine")]
+pub mod svg;
 pub mod table;
 mod traversal;
 

--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -4,7 +4,9 @@
 
 use std::sync::Arc;
 
-use app_units::{Au, MAX_AU};
+use app_units::Au;
+#[cfg(not(feature = "svg-engine"))]
+use app_units::MAX_AU;
 use data_url::DataUrl;
 use embedder_traits::ViewportDetails;
 use euclid::{Scale, Size2D};
@@ -31,6 +33,8 @@ use style::values::CSSFloat;
 use style::values::computed::image::Image as ComputedImage;
 use style::values::computed::{Content, Context, ToComputedValue};
 use style::values::generics::counters::{GenericContentItem, GenericContentItems};
+#[cfg(feature = "svg-engine")]
+use svg_engine::render_tree::SvgRenderTree;
 use url::Url;
 use web_atoms::local_name;
 use webrender_api::ImageKey;
@@ -151,6 +155,9 @@ pub(crate) enum ReplacedContentKind {
     SVGElement {
         vector_image: Option<VectorImage>,
         has_viewbox: bool,
+        #[cfg(feature = "svg-engine")]
+        #[conditional_malloc_size_of]
+        render_tree: Option<Arc<SvgRenderTree>>,
     },
     Audio,
 }
@@ -283,47 +290,65 @@ impl ReplacedContents {
             ratio,
         };
 
-        let svg_source = match svg_data.source {
-            None => {
-                // The SVGSVGElement is not yet serialized, so we add it to a list
-                // and hand it over to script to peform the serialization.
+        #[cfg(feature = "svg-engine")]
+        {
+            let render_tree = crate::svg::build_svg_render_tree(node, context);
+            return (
+                ReplacedContentKind::SVGElement {
+                    vector_image: None,
+                    has_viewbox: svg_data.view_box.is_some(),
+                    render_tree,
+                },
+                natural_size,
+            );
+        }
+
+        #[cfg(not(feature = "svg-engine"))]
+        {
+            let svg_source = match svg_data.source {
+                None => {
+                    // The SVGSVGElement is not yet serialized, so we add it to a list
+                    // and hand it over to script to peform the serialization.
+                    context
+                        .image_resolver
+                        .queue_svg_element_for_serialization(node);
+                    None
+                },
+                // If `svg_source_result` is `Err()`, it means that the previous attempt
+                // had errored, then don't attempt to serialize again.
+                Some(svg_source_result) => svg_source_result.ok(),
+            };
+
+            let cached_image = svg_source.and_then(|svg_source| {
                 context
                     .image_resolver
-                    .queue_svg_element_for_serialization(node);
-                None
-            },
-            // If `svg_source_result` is `Err()`, it means that the previous attempt
-            // had errored, then don't attempt to serialize again.
-            Some(svg_source_result) => svg_source_result.ok(),
-        };
+                    .get_cached_image_for_url(
+                        node.opaque(),
+                        svg_source,
+                        LayoutImageDestination::BoxTreeConstruction,
+                        InternalRequest::Yes,
+                    )
+                    .ok()
+            });
 
-        let cached_image = svg_source.and_then(|svg_source| {
-            context
-                .image_resolver
-                .get_cached_image_for_url(
-                    node.opaque(),
-                    svg_source,
-                    LayoutImageDestination::BoxTreeConstruction,
-                    InternalRequest::Yes,
-                )
-                .ok()
-        });
+            let vector_image = cached_image.map(|image| match image {
+                Image::Vector(mut vector_image) => {
+                    vector_image.svg_id = Some(svg_data.svg_id);
+                    vector_image
+                },
+                _ => unreachable!("SVG element can't contain a raster image."),
+            });
 
-        let vector_image = cached_image.map(|image| match image {
-            Image::Vector(mut vector_image) => {
-                vector_image.svg_id = Some(svg_data.svg_id);
-                vector_image
-            },
-            _ => unreachable!("SVG element can't contain a raster image."),
-        });
-
-        (
-            ReplacedContentKind::SVGElement {
-                vector_image,
-                has_viewbox: svg_data.view_box.is_some(),
-            },
-            natural_size,
-        )
+            (
+                ReplacedContentKind::SVGElement {
+                    vector_image,
+                    has_viewbox: svg_data.view_box.is_some(),
+                    #[cfg(feature = "svg-engine")]
+                    render_tree: None,
+                },
+                natural_size,
+            )
+        }
     }
 
     fn from_content_property(node: ServoLayoutNode<'_>, context: &LayoutContext) -> Option<Self> {
@@ -537,6 +562,8 @@ impl ReplacedContents {
                         image_key: Some(image_key),
                         showing_broken_image_icon: image_info.showing_broken_image_icon,
                         url: image_info.url.clone(),
+                        #[cfg(feature = "svg-engine")]
+                        svg_render_tree: None,
                     }))
                 })
                 .into_iter()
@@ -548,6 +575,8 @@ impl ReplacedContents {
                     image_key: video_info.image_key,
                     showing_broken_image_icon: false,
                     url: None,
+                    #[cfg(feature = "svg-engine")]
+                    svg_render_tree: None,
                 }))]
             },
             ReplacedContentKind::IFrame(iframe) => {
@@ -588,8 +617,29 @@ impl ReplacedContents {
                     image_key: Some(image_key),
                     showing_broken_image_icon: false,
                     url: None,
+                    #[cfg(feature = "svg-engine")]
+                    svg_render_tree: None,
                 }))]
             },
+            #[cfg(feature = "svg-engine")]
+            ReplacedContentKind::SVGElement { .. } => {
+                if let ReplacedContentKind::SVGElement {
+                    render_tree: Some(tree),
+                    ..
+                } = &self.kind
+                {
+                    return vec![Fragment::Image(Arc::new(ImageFragment {
+                        base,
+                        clip,
+                        image_key: None,
+                        showing_broken_image_icon: false,
+                        url: None,
+                        svg_render_tree: Some(tree.clone()),
+                    }))];
+                }
+                return vec![];
+            },
+            #[cfg(not(feature = "svg-engine"))]
             ReplacedContentKind::SVGElement {
                 vector_image,
                 has_viewbox,
@@ -640,6 +690,8 @@ impl ReplacedContents {
                             image_key: Some(image_key),
                             showing_broken_image_icon: false,
                             url: None,
+                            #[cfg(feature = "svg-engine")]
+                            svg_render_tree: None,
                         }))
                     })
                     .into_iter()

--- a/components/layout/svg/builder.rs
+++ b/components/layout/svg/builder.rs
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::sync::Arc;
+
+use html5ever::local_name;
+use layout_api::{LayoutElement, LayoutNode};
+use script::layout_dom::{ServoLayoutElement, ServoLayoutNode};
+use svg_engine::render_tree::*;
+use svg_engine::shapes::Shape;
+use web_atoms::ns;
+
+use crate::context::LayoutContext;
+
+pub(crate) struct SvgRenderTreeBuilder<'dom, 'a> {
+    root_node: ServoLayoutNode<'dom>,
+    _context: &'a LayoutContext<'a>,
+    // TODO: css_rules
+}
+
+impl<'dom, 'a> SvgRenderTreeBuilder<'dom, 'a> {
+    pub(crate) fn new(node: ServoLayoutNode<'dom>, context: &'a LayoutContext<'a>) -> Self {
+        SvgRenderTreeBuilder {
+            root_node: node,
+            _context: context,
+        }
+    }
+
+    pub(crate) fn build(self) -> Option<Arc<SvgRenderTree>> {
+        let root = self.build_render_node(self.root_node)?;
+        // TODO: extract viewport info, gradients, clip_paths, patterns, masks, filters
+
+        let tree = SvgRenderTree {
+            root,
+            // TODO: viewport, gradients, clip_paths, patterns, masks, filters
+        };
+
+        Some(Arc::new(tree))
+    }
+
+    fn build_render_node(&self, node: ServoLayoutNode<'dom>) -> Option<SvgRenderNode> {
+        let element = node.as_element()?;
+        let tag = build_tag(node)?;
+        let id = extract_id(&element);
+        // TODO: implement style from computed values + presentation attributes
+
+        let children: Vec<SvgRenderNode> = node
+            .dom_children()
+            .filter_map(|child| self.build_render_node(child))
+            .collect();
+
+        Some(SvgRenderNode {
+            id,
+            tag,
+            // TODO: style, transforms
+            children,
+        })
+    }
+}
+
+// ======================= Tag Dispatch =======================
+
+fn build_tag(node: ServoLayoutNode) -> Option<SvgTag> {
+    let element = node.as_element()?;
+    let tag = element.local_name().as_ref();
+    match tag {
+        "svg" => Some(SvgTag::Container(Container::Svg)),
+        "g" => Some(SvgTag::Container(Container::Group)),
+        // TODO: defs, use, symbol, image, text, tspan
+        _ => build_shape(tag).map(SvgTag::Shape),
+    }
+}
+
+fn build_shape(tag_name: &str) -> Option<Shape> {
+    use svg_engine::shapes::*;
+    match tag_name {
+        // TODO: Parse Geometry for each shape type
+        "rect" => Some(Shape::Rect(Rectangle {})),
+        "circle" => Some(Shape::Circle(Circle {})),
+        "ellipse" => Some(Shape::Ellipse(Ellipse {})),
+        "line" => Some(Shape::Line(Line {})),
+        "polyline" => Some(Shape::Polyline(Polyline {})),
+        "polygon" => Some(Shape::Polygon(Polygon {})),
+        "path" => Some(Shape::Path(Path {})),
+        _ => None,
+    }
+}
+
+// ======================= Helpers =======================
+
+fn extract_id(element: &ServoLayoutElement) -> Option<String> {
+    element
+        .attribute_as_str(&ns!(), &local_name!("id"))
+        .map(|s| s.to_string())
+}

--- a/components/layout/svg/mod.rs
+++ b/components/layout/svg/mod.rs
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+pub(crate) mod builder;
+use std::sync::Arc;
+
+use script::layout_dom::ServoLayoutNode;
+use svg_engine::render_tree::SvgRenderTree;
+
+use crate::context::LayoutContext;
+
+pub(crate) fn build_svg_render_tree<'dom>(
+    node: ServoLayoutNode<'dom>,
+    context: &LayoutContext,
+) -> Option<Arc<SvgRenderTree>> {
+    builder::SvgRenderTreeBuilder::new(node, context).build()
+}

--- a/components/script/layout_dom/servo_layout_element.rs
+++ b/components/script/layout_dom/servo_layout_element.rs
@@ -55,6 +55,11 @@ impl<'dom> ServoLayoutElement<'dom> {
         self.element.is_html_element()
     }
 
+    /// Returns true if this element is in the SVG namespace.
+    pub fn is_svg_element(&self) -> bool {
+        *self.element.namespace() == ns!(svg)
+    }
+
     /// The shadow root that this [`ServoLayoutElement`] is a host of, if it has one.
     ///
     /// Note: This should *not* be exposed to layout as it allows access to an ancestor element.

--- a/components/svg_engine/Cargo.toml
+++ b/components/svg_engine/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "svg_engine"
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+description.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+malloc_size_of = { workspace = true }
+malloc_size_of_derive = { workspace = true }

--- a/components/svg_engine/src/lib.rs
+++ b/components/svg_engine/src/lib.rs
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+pub mod render_tree;
+pub mod shapes;
+
+mod renderer;
+mod traversal;
+
+pub use render_tree::SvgTag;
+pub use traversal::render_svg_tree;

--- a/components/svg_engine/src/render_tree.rs
+++ b/components/svg_engine/src/render_tree.rs
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use malloc_size_of_derive::MallocSizeOf;
+
+use crate::shapes::Shape;
+
+#[derive(Debug, MallocSizeOf)]
+pub struct SvgRenderTree {
+    pub root: SvgRenderNode,
+    // pub viewport: ViewportInfo,
+    // pub gradients: HashMap<String, GradientDef>,
+    // pub clip_paths: HashMap<String, ClipPathDef>,
+    // pub patterns: HashMap<String, PatternDef>,
+    // pub masks: HashMap<String, MaskDef>,
+    // pub filters: HashMap<String, FilterDef>,
+}
+
+#[derive(Debug, MallocSizeOf)]
+pub struct SvgRenderNode {
+    pub id: Option<String>,
+    pub tag: SvgTag,
+    // pub style: NodeStyle,
+    // pub transforms: Vec<TransformOp>,
+    pub children: Vec<SvgRenderNode>,
+}
+
+#[derive(Debug, MallocSizeOf)]
+pub enum SvgTag {
+    Shape(Shape),
+    Container(Container),
+    // TODO: Text, Image
+}
+
+#[derive(Debug, MallocSizeOf)]
+pub enum Container {
+    Group,
+    Svg,
+    // TODO: Defs, Symbol, Use
+}

--- a/components/svg_engine/src/renderer/circle.rs
+++ b/components/svg_engine/src/renderer/circle.rs
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::renderer::Render;
+use crate::shapes::Circle;
+
+impl Render for Circle {
+    fn render(&self) {
+        eprintln!("  circle");
+    }
+}

--- a/components/svg_engine/src/renderer/ellipse.rs
+++ b/components/svg_engine/src/renderer/ellipse.rs
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::renderer::Render;
+use crate::shapes::Ellipse;
+
+impl Render for Ellipse {
+    fn render(&self) {
+        eprintln!("  ellipse");
+    }
+}

--- a/components/svg_engine/src/renderer/line.rs
+++ b/components/svg_engine/src/renderer/line.rs
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::renderer::Render;
+use crate::shapes::Line;
+
+impl Render for Line {
+    fn render(&self) {
+        eprintln!("  line");
+    }
+}

--- a/components/svg_engine/src/renderer/mod.rs
+++ b/components/svg_engine/src/renderer/mod.rs
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+pub(crate) mod circle;
+pub(crate) mod ellipse;
+pub(crate) mod line;
+pub(crate) mod path;
+pub(crate) mod polygon;
+pub(crate) mod polyline;
+pub(crate) mod rect;
+pub(crate) mod render_trait;
+
+pub(crate) use render_trait::Render;

--- a/components/svg_engine/src/renderer/path.rs
+++ b/components/svg_engine/src/renderer/path.rs
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::renderer::Render;
+use crate::shapes::Path;
+
+impl Render for Path {
+    fn render(&self) {
+        eprintln!("  path");
+    }
+}

--- a/components/svg_engine/src/renderer/polygon.rs
+++ b/components/svg_engine/src/renderer/polygon.rs
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::renderer::Render;
+use crate::shapes::Polygon;
+
+impl Render for Polygon {
+    fn render(&self) {
+        eprintln!("  polygon");
+    }
+}

--- a/components/svg_engine/src/renderer/polyline.rs
+++ b/components/svg_engine/src/renderer/polyline.rs
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::renderer::Render;
+use crate::shapes::Polyline;
+
+impl Render for Polyline {
+    fn render(&self) {
+        eprintln!("  polyline");
+    }
+}

--- a/components/svg_engine/src/renderer/rect.rs
+++ b/components/svg_engine/src/renderer/rect.rs
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::renderer::Render;
+use crate::shapes::Rectangle;
+
+impl Render for Rectangle {
+    fn render(&self) {
+        eprintln!("  rect");
+    }
+}

--- a/components/svg_engine/src/renderer/render_trait.rs
+++ b/components/svg_engine/src/renderer/render_trait.rs
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::shapes::Shape;
+
+pub(crate) trait Render {
+    fn render(&self);
+}
+
+impl Render for Shape {
+    fn render(&self) {
+        match self {
+            Shape::Rect(r) => r.render(),
+            Shape::Circle(c) => c.render(),
+            Shape::Ellipse(e) => e.render(),
+            Shape::Line(l) => l.render(),
+            Shape::Polyline(p) => p.render(),
+            Shape::Polygon(p) => p.render(),
+            Shape::Path(p) => p.render(),
+        }
+    }
+}

--- a/components/svg_engine/src/shapes/circle.rs
+++ b/components/svg_engine/src/shapes/circle.rs
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use malloc_size_of_derive::MallocSizeOf;
+
+#[derive(Debug, MallocSizeOf)]
+pub struct Circle {
+    // TODO: cx, cy, r
+}

--- a/components/svg_engine/src/shapes/ellipse.rs
+++ b/components/svg_engine/src/shapes/ellipse.rs
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use malloc_size_of_derive::MallocSizeOf;
+
+#[derive(Debug, MallocSizeOf)]
+pub struct Ellipse {
+    // TODO: cx, cy, rx, ry
+}

--- a/components/svg_engine/src/shapes/line.rs
+++ b/components/svg_engine/src/shapes/line.rs
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use malloc_size_of_derive::MallocSizeOf;
+
+#[derive(Debug, MallocSizeOf)]
+pub struct Line {
+    // TODO: x1, y1, x2, y2
+}

--- a/components/svg_engine/src/shapes/mod.rs
+++ b/components/svg_engine/src/shapes/mod.rs
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+pub(crate) mod circle;
+pub(crate) mod ellipse;
+pub(crate) mod line;
+pub(crate) mod path;
+pub(crate) mod polygon;
+pub(crate) mod polyline;
+pub(crate) mod rectangle;
+
+use malloc_size_of_derive::MallocSizeOf;
+
+pub use self::circle::Circle;
+pub use self::ellipse::Ellipse;
+pub use self::line::Line;
+pub use self::path::Path;
+pub use self::polygon::Polygon;
+pub use self::polyline::Polyline;
+pub use self::rectangle::Rectangle;
+
+#[derive(Debug, MallocSizeOf)]
+pub enum Shape {
+    Rect(Rectangle),
+    Circle(Circle),
+    Ellipse(Ellipse),
+    Line(Line),
+    Polyline(Polyline),
+    Polygon(Polygon),
+    Path(Path),
+}

--- a/components/svg_engine/src/shapes/path.rs
+++ b/components/svg_engine/src/shapes/path.rs
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use malloc_size_of_derive::MallocSizeOf;
+
+#[derive(Debug, MallocSizeOf)]
+pub struct Path {
+    // TODO: path: BezPath
+}

--- a/components/svg_engine/src/shapes/polygon.rs
+++ b/components/svg_engine/src/shapes/polygon.rs
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use malloc_size_of_derive::MallocSizeOf;
+
+#[derive(Debug, MallocSizeOf)]
+pub struct Polygon {
+    // TODO: points: Vec<Point>
+}

--- a/components/svg_engine/src/shapes/polyline.rs
+++ b/components/svg_engine/src/shapes/polyline.rs
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use malloc_size_of_derive::MallocSizeOf;
+
+#[derive(Debug, MallocSizeOf)]
+pub struct Polyline {
+    // TODO: points: Vec<Point>
+}

--- a/components/svg_engine/src/shapes/rectangle.rs
+++ b/components/svg_engine/src/shapes/rectangle.rs
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use malloc_size_of_derive::MallocSizeOf;
+
+#[derive(Debug, MallocSizeOf)]
+pub struct Rectangle {
+    // TODO: x, y, width, height, rx, ry
+}

--- a/components/svg_engine/src/traversal.rs
+++ b/components/svg_engine/src/traversal.rs
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::render_tree::*;
+use crate::renderer::Render;
+
+pub fn render_svg_tree(
+    tree: &SvgRenderTree,
+    // TODO: svg_origin, svg_size, spatial_id, clip_chain_id, wr
+) {
+    // TODO: implement viewport clip + viewBox reference frame
+    render_node(&tree.root);
+    // TODO: pop viewBox reference frame
+}
+
+fn render_node(
+    node: &SvgRenderNode,
+    // TODO: svg_origin, spatial_id, clip_chain_id, wr, providers, parent_scale
+) {
+    eprintln!("▼ node enter: id={:?}", node.id);
+
+    // TODO: skip if display:none
+    // TODO: apply transforms, clip-path, mask, filter
+
+    emit_element(node);
+    recurse_children(node);
+
+    // TODO: pop transform reference frames
+
+    eprintln!("▲ node exit:  id={:?}", node.id);
+}
+
+fn emit_element(
+    node: &SvgRenderNode,
+    // TODO: cur_origin, cur_spatial_id, clip_chain, accumulated_scale, wr, params
+) {
+    match &node.tag {
+        SvgTag::Shape(shape) => shape.render(),
+        SvgTag::Container(_) => {},
+        // TODO: Text, Image
+    }
+}
+
+fn recurse_children(
+    node: &SvgRenderNode,
+    // TODO: cur_origin, cur_spatial_id, clip_chain, providers, accumulated_scale, wr
+) {
+    for child in &node.children {
+        render_node(child);
+    }
+}


### PR DESCRIPTION
Introduces Phase 1 of a native SVG rendering engine behind a `svg-engine` feature flag.
To keep this initial PR simple and strictly focused on structural plumbing, it intentionally omits visual rendering and instead delivers:
- **Core Architecture:** Implements the foundational data structures and integration layers.
- **Temporary Verification:** Prints log messages with the shape names to confirm successful data traversal without rendering output.

- **Integration layer** — `layout/svg/builder.rs`
  - `SvgRenderTreeBuilder::build()`
  - Input: `ServoLayoutNode` (the `<svg>` element)
  - Process: walks the SVG subtree, dispatches tag names to `Shape` or `Container`
  - Output: `SvgRenderTree`
   > Next: will create remaining types (text, image, ues, …) extract geometry, style, and presentation attributes

- **Traversal** — `svg_engine/src/traversal.rs`
  - `render_svg_tree()` → `render_node()` → `emit_element()`
  - Input: `&SvgRenderTree`
  - Process: depth-first walk, calls `Render::render()` at each node
   > Next: will apply clips, transforms, masks, and filters

- **Render dispatch** — `svg_engine/src/renderer/`
  - `Render::render()` per shape type
  - Input: individual shape (`Circle`, `Rect`, `Path`, …)
  - Process: dispatches via Render trait — Circle::render(), Rect::render(), …etc
  - Output: currently `eprintln!` to log the shape name
   > Next: will emit WebRender display items



### Data model
```
SvgRenderTree
└── root: SvgRenderNode
          ├── id: Option<String>
          ├── tag: SvgTag
          │   ├── Shape(Shape)                   -> Rectangle | Circle | Ellipse | Line | Path | Polygon | Polyline
          │   └── Container(Container)           -> Svg | Group
          └── children: Vec<SvgRenderNod
```

> This hirarchey will expand in future PRs with text, image, style, and resource nodes (gradients, patterns, clip-paths, masks, filters).

### Testing
> Add `features = ["svg-engine"]` to the `layout` dependency in `components/servo/Cargo.toml`
> ```toml
> layout = { workspace = true, features = ["svg-engine"] }
> ```


