### PR TITLE
layout: Accessibility code cleanups

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -180,7 +180,9 @@ impl AccessibilityTree {
 
         // FIXME: This assumes any local subtree damage always propagates up to the root. This is
         // currently true, but we might be able to improve at stopping propagation.
-        self.resolve_local_damage_for_node_and_subtree(self.assert_root_node(), &mut update);
+        self.assert_root_node()
+            .borrow_mut()
+            .resolve_local_damage_for_node_and_subtree(&mut update);
 
         update.finalize(self)
     }
@@ -220,10 +222,11 @@ impl AccessibilityTree {
                 // when it's added to its parent node.
                 continue;
             };
-            self.update_node_and_descendants_from_dom_node(
+            node.borrow_mut().update_node_from_dom_node(
                 node.clone(),
                 &dom_node,
                 dom_node_damage,
+                self,
                 update,
             );
         }
@@ -240,10 +243,12 @@ impl AccessibilityTree {
             }
             let node = self.assert_node_for_id(&node_id);
 
-            let mut parent_node = node.borrow().parent();
-            while let Some(node) = parent_node {
-                let node = node.borrow();
-                let existing_damage = update.unresolved_local_damage.entry(node.id).or_default();
+            for ancestor in node.borrow().ancestors() {
+                let ancestor = ancestor.borrow();
+                let existing_damage = update
+                    .unresolved_local_damage
+                    .entry(ancestor.id)
+                    .or_default();
 
                 // If we encounter a node which already has `SubtreeChanged` damage, we know that
                 // all of its ancestors have it too, so we can bail out early from our ancestor walk
@@ -252,77 +257,8 @@ impl AccessibilityTree {
                 }
 
                 existing_damage.insert(LocalAccessibilityDamage::SubtreeChanged);
-                parent_node = node.parent();
             }
         }
-    }
-
-    /// Update the given AccessibilityNode from its corresponding DOM node and
-    /// ['AccessibilityDamage'].
-    /// If it has new children, those will be recursively populated here.
-    // Any changed nodes will be added to the given [`AccessibilityUpdate`].
-    fn update_node_and_descendants_from_dom_node(
-        &mut self,
-        node: ArcRefCell<AccessibilityNode>,
-        dom_node: &ServoLayoutNode<'_>,
-        dom_damage: AccessibilityDamage,
-        update: &mut AccessibilityUpdate,
-    ) -> LocalAccessibilityDamage {
-        update.counters.update_node_and_descendants_from_dom_node += 1;
-
-        let weak_node = node.downgrade();
-        let mut node = node.borrow_mut();
-        let mut local_damage = LocalAccessibilityDamage::empty();
-
-        local_damage.insert(node.update_node_from_dom_node(dom_node, dom_damage));
-        local_damage.insert(
-            node.update_descendants_from_dom_node(weak_node, dom_node, dom_damage, self, update),
-        );
-
-        if node.updated {
-            update.add(&mut node);
-        }
-
-        if !local_damage.is_empty() {
-            update
-                .unresolved_local_damage
-                .entry(node.id)
-                .or_default()
-                .insert(local_damage);
-        }
-
-        local_damage
-    }
-
-    /// Update the given node and, where necessary, its descendants, based on damage propagated
-    /// within the accessibility as a result of changes made based on DOM tree changes.
-    /// For example, if a node's descendants changed as a result of the DOM tree changing, its
-    /// computed text may also have changed, so it would have had
-    /// [`LocalAccessibilityDamage::SubtreeChanged`] set when changes from the DOM tree were
-    /// applied. That damage is resolved here.
-    fn resolve_local_damage_for_node_and_subtree(
-        &mut self,
-        node: ArcRefCell<AccessibilityNode>,
-        update: &mut AccessibilityUpdate,
-    ) {
-        let mut node = node.borrow_mut();
-        let Some(&local_damage) = update.unresolved_local_damage.get(&node.id) else {
-            return;
-        };
-
-        node.update_node_local(local_damage, update);
-
-        if local_damage.contains(LocalAccessibilityDamage::SubtreeChanged) {
-            for child in node.children() {
-                self.resolve_local_damage_for_node_and_subtree(child.clone(), update);
-            }
-        }
-
-        if node.updated {
-            update.add(&mut node);
-        }
-
-        update.unresolved_local_damage.remove(&node.id);
     }
 
     fn get_or_create_node(
@@ -508,7 +444,7 @@ impl AccessibilityTree {
             // assert_node_for_id() here double-checks that the node hasn't been incorrectly evicted
             // from the map while it's still retained as a child node.
             let weak_node = Some(self.assert_node_for_id(&node.id).downgrade());
-            nodes.extend(node.children().iter().cloned().zip(repeat(weak_node)));
+            nodes.extend(node.children().cloned().zip(repeat(weak_node)));
         }
 
         // If this fails, then the tree has orphaned nodes (a leak).
@@ -540,6 +476,41 @@ fn role_from_dom_node(dom_node: &ServoLayoutNode<'_>) -> Role {
     }
 }
 
+struct AccessibilityNodeIterator<I>
+where
+    I: Fn(&AccessibilityNode) -> Option<ArcRefCell<AccessibilityNode>>,
+{
+    next_value: Option<ArcRefCell<AccessibilityNode>>,
+    next_fn: I,
+}
+
+impl<I> AccessibilityNodeIterator<I>
+where
+    I: Fn(&AccessibilityNode) -> Option<ArcRefCell<AccessibilityNode>>,
+{
+    fn new(next_value: Option<ArcRefCell<AccessibilityNode>>, next_fn: I) -> Self {
+        AccessibilityNodeIterator {
+            next_value,
+            next_fn,
+        }
+    }
+}
+
+impl<I> Iterator for AccessibilityNodeIterator<I>
+where
+    I: Fn(&AccessibilityNode) -> Option<ArcRefCell<AccessibilityNode>>,
+{
+    type Item = ArcRefCell<AccessibilityNode>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next_value = self.next_value.take();
+        self.next_value = next_value
+            .as_ref()
+            .and_then(|node| (self.next_fn)(&node.borrow()));
+        next_value
+    }
+}
+
 impl AccessibilityNode {
     fn new(id: NodeId) -> Self {
         Self::new_with_role(id, Role::Unknown)
@@ -556,11 +527,75 @@ impl AccessibilityNode {
         }
     }
 
+    /// Update the given node and, where necessary, its descendants, based on damage propagated
+    /// within the accessibility as a result of changes made based on DOM tree changes.
+    /// For example, if a node's descendants changed as a result of the DOM tree changing, its
+    /// computed text may also have changed, so it would have had
+    /// [`LocalAccessibilityDamage::SubtreeChanged`] set when changes from the DOM tree were
+    /// applied. That damage is resolved here.
+    fn resolve_local_damage_for_node_and_subtree(&mut self, update: &mut AccessibilityUpdate) {
+        let Some(&local_damage) = update.unresolved_local_damage.get(&self.id) else {
+            return;
+        };
+
+        self.update_node_local(local_damage, update);
+
+        if local_damage.contains(LocalAccessibilityDamage::SubtreeChanged) {
+            for child in self.children() {
+                child
+                    .borrow_mut()
+                    .resolve_local_damage_for_node_and_subtree(update);
+            }
+        }
+
+        if self.updated {
+            update.add(self);
+        }
+
+        update.unresolved_local_damage.remove(&self.id);
+    }
+
+    /// Update the given AccessibilityNode from its corresponding DOM node and
+    /// ['AccessibilityDamage'].
+    /// If it has new children, those will be recursively populated here.
+    // Any changed nodes will be added to the given [`AccessibilityUpdate`].
+    fn update_node_from_dom_node<'dom>(
+        &mut self,
+        ref_self: ArcRefCell<Self>,
+        dom_node: &ServoLayoutNode<'dom>,
+        dom_damage: AccessibilityDamage,
+        tree: &mut AccessibilityTree,
+        update: &mut AccessibilityUpdate,
+    ) -> LocalAccessibilityDamage {
+        update.counters.update_node_and_descendants_from_dom_node += 1;
+
+        let mut local_damage = LocalAccessibilityDamage::empty();
+
+        local_damage.insert(self.update_properties_from_dom_node(dom_node, dom_damage));
+        local_damage.insert(
+            self.update_children_from_dom_node(ref_self, dom_node, dom_damage, tree, update),
+        );
+
+        if self.updated {
+            update.add(self);
+        }
+
+        if !local_damage.is_empty() {
+            update
+                .unresolved_local_damage
+                .entry(self.id)
+                .or_default()
+                .insert(local_damage);
+        }
+
+        local_damage
+    }
+
     /// Update this node's [`Self::children`] from its corresponding DOM node. If any children are
     /// newly added to the tree, populate them and recursively populate their children.
-    fn update_descendants_from_dom_node<'dom>(
+    fn update_children_from_dom_node<'dom>(
         &mut self,
-        weak_self: WeakRefCell<Self>,
+        ref_self: ArcRefCell<AccessibilityNode>,
         dom_node: &ServoLayoutNode<'dom>,
         dom_damage: AccessibilityDamage,
         tree: &mut AccessibilityTree,
@@ -574,7 +609,8 @@ impl AccessibilityNode {
         let mut old_child_ids = self.child_ids().iter().peekable();
         let mut unchanged_count = 0usize;
 
-        // For the first `unchanged_count` children, no action is necessary.
+        // Iterate over existing children and DOM children while they match. No action is necessary
+        // for these nodes.
         while let Some(&old_id) = old_child_ids.peek() &&
             let Some(dom_child) = remaining_dom_children.peek()
         {
@@ -587,7 +623,7 @@ impl AccessibilityNode {
             }
         }
 
-        // If we iterated over all the dom children without finding any changes, we're done.
+        // If we iterated over all the DOM children without finding any changes, we're done.
         if old_child_ids.peek().is_none() && remaining_dom_children.peek().is_none() {
             return LocalAccessibilityDamage::empty();
         }
@@ -602,13 +638,17 @@ impl AccessibilityNode {
         // Then, (re-)add all the remaining DOM children. Note that this means that some children
         // may end up being "Moved" even though they haven't changed parents, and may even be in the
         // same position as previously.
+        let weak_self = ref_self.downgrade();
         for dom_child in remaining_dom_children {
             let (new_id, new_child) = tree.get_or_create_node(&dom_child, update);
+            let strong_child = new_child.clone();
+            let mut new_child = new_child.borrow_mut();
             if update.is_new(&new_id) {
-                tree.update_node_and_descendants_from_dom_node(
-                    new_child.clone(),
+                new_child.update_node_from_dom_node(
+                    strong_child.clone(),
                     &dom_child,
                     AccessibilityDamage::Rebuild,
+                    tree,
                     update,
                 );
             } else {
@@ -616,10 +656,9 @@ impl AccessibilityNode {
             }
 
             // Update self.child_nodes in place.
-            self.child_nodes.push(new_child.clone());
+            self.child_nodes.push(strong_child.clone());
             new_child_ids.push(new_id);
 
-            let mut new_child = new_child.borrow_mut();
             new_child.parent_node = Some(weak_self.clone());
         }
 
@@ -632,7 +671,7 @@ impl AccessibilityNode {
     }
 
     /// Update this node's properties from its corresponding DOM node.
-    fn update_node_from_dom_node(
+    fn update_properties_from_dom_node(
         &mut self,
         dom_node: &ServoLayoutNode<'_>,
         dom_damage: AccessibilityDamage,
@@ -681,7 +720,7 @@ impl AccessibilityNode {
         if !NAME_FROM_CONTENTS_ROLES.contains(&self.role()) {
             return None;
         }
-        let mut children = VecDeque::from_iter(self.children().iter().cloned());
+        let mut children = VecDeque::from_iter(self.children().cloned());
         let mut text = String::new();
         while let Some(child) = children.pop_front() {
             let child = child.borrow();
@@ -692,7 +731,7 @@ impl AccessibilityNode {
                     }
                 },
                 _ => {
-                    for node in child.children().iter().rev() {
+                    for node in child.children().rev() {
                         children.push_front(node.clone());
                     }
                 },
@@ -702,7 +741,7 @@ impl AccessibilityNode {
     }
 
     fn print(&self, print_tree: &mut PrintTree) {
-        if self.children().is_empty() {
+        if self.child_nodes.is_empty() {
             print_tree.add_item(format!("{self:?}"));
             return;
         }
@@ -721,8 +760,12 @@ impl AccessibilityNode {
 
     // TODO: use macros to generate getter/setter methods.
 
-    fn children(&self) -> &Vec<ArcRefCell<AccessibilityNode>> {
-        &self.child_nodes
+    fn children(&self) -> impl DoubleEndedIterator<Item = &ArcRefCell<AccessibilityNode>> {
+        self.child_nodes.iter()
+    }
+
+    fn ancestors(&self) -> impl Iterator<Item = ArcRefCell<AccessibilityNode>> {
+        AccessibilityNodeIterator::new(self.parent(), |node| node.parent_node.clone()?.upgrade())
     }
 
     fn child_ids(&self) -> &[NodeId] {
@@ -804,11 +847,7 @@ impl AccessibilityNode {
             );
         }
 
-        let children_ids: Vec<_> = self
-            .children()
-            .iter()
-            .map(|child| child.borrow().id)
-            .collect();
+        let children_ids: Vec<_> = self.children().map(|child| child.borrow().id).collect();
         assert_eq!(
             children_ids,
             self.child_ids(),

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -56,8 +56,8 @@ struct AccessibilityUpdate {
 
 #[derive(Debug, Default)]
 pub struct UpdateCounters {
-    pub update_node_and_descendants_from_dom_node: u32,
-    pub update_node_local: u32,
+    pub nodes_updated_from_dom: u32,
+    pub nodes_updated_from_tree: u32,
     pub nodes_in_tree_update: u32,
 }
 
@@ -209,8 +209,8 @@ impl AccessibilityTree {
     }
 
     /// For each DOM node in `damage_from_dom`, update the corresponding accessibility node based on
-    /// its `AccessibilityDamage`. If any [`LocalDamage`] results from the update, propagate
-    /// [`LocalDamage::SUBTREE_CHANGED`] to its ancestors.
+    /// its `AccessibilityDamage`. If any [`LocalAccessibilityDamage`] results from the update,
+    /// propagate [`LocalAccessibilityDamage::SubtreeChanged`] to its ancestors.
     fn apply_changes_from_dom_tree<'dom>(
         &mut self,
         mut damage_from_dom: VecDeque<(ServoLayoutNode<'dom>, AccessibilityDamage)>,
@@ -222,20 +222,21 @@ impl AccessibilityTree {
                 // when it's added to its parent node.
                 continue;
             };
-            node.borrow_mut().update_node_from_dom_node(
-                node.clone(),
-                &dom_node,
-                dom_node_damage,
-                self,
-                update,
-            );
+            node.borrow_mut()
+                .update_node_and_populate_new_descendants_from_dom_node(
+                    node.clone(),
+                    &dom_node,
+                    dom_node_damage,
+                    self,
+                    update,
+                );
         }
 
         self.propagate_subtree_damage_to_ancestors(update);
     }
 
     /// After applying changes from the DOM tree, mark the ancestors of any changed nodes with
-    /// [`LocalDamage::SubtreeChanged`].
+    /// [`LocalAccessibilityDamage::SubtreeChanged`].
     fn propagate_subtree_damage_to_ancestors(&mut self, update: &mut AccessibilityUpdate) {
         for (node_id, damage) in update.unresolved_local_damage.clone() {
             if damage.is_empty() {
@@ -267,10 +268,10 @@ impl AccessibilityTree {
         update: &mut AccessibilityUpdate,
     ) -> (NodeId, ArcRefCell<AccessibilityNode>) {
         let id = self.get_or_create_id_for_opaque(dom_node.opaque());
-        let node = self.get_or_create_node_with_id(id, update);
+        let node_ref = self.get_or_create_node_with_id(id, update);
 
-        {
-            let mut node = node.borrow_mut();
+        if update.is_new(&id) {
+            let mut node = node_ref.borrow_mut();
             node.opaque_node = Some(dom_node.opaque());
             if let Some(dom_element) = dom_node.as_element() {
                 let local_name = dom_element.local_name().to_ascii_lowercase();
@@ -278,7 +279,7 @@ impl AccessibilityTree {
             }
         }
 
-        (id, node)
+        (id, node_ref)
     }
 
     fn get_or_create_node_with_id(
@@ -555,11 +556,11 @@ impl AccessibilityNode {
         update.unresolved_local_damage.remove(&self.id);
     }
 
-    /// Update the given AccessibilityNode from its corresponding DOM node and
-    /// ['AccessibilityDamage'].
+    /// Update the given [`AccessibilityNode`] from its corresponding DOM node and
+    /// [`AccessibilityDamage`].
     /// If it has new children, those will be recursively populated here.
     // Any changed nodes will be added to the given [`AccessibilityUpdate`].
-    fn update_node_from_dom_node<'dom>(
+    fn update_node_and_populate_new_descendants_from_dom_node<'dom>(
         &mut self,
         ref_self: ArcRefCell<Self>,
         dom_node: &ServoLayoutNode<'dom>,
@@ -567,13 +568,15 @@ impl AccessibilityNode {
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate,
     ) -> LocalAccessibilityDamage {
-        update.counters.update_node_and_descendants_from_dom_node += 1;
+        update.counters.nodes_updated_from_dom += 1;
 
         let mut local_damage = LocalAccessibilityDamage::empty();
 
         local_damage.insert(self.update_properties_from_dom_node(dom_node, dom_damage));
         local_damage.insert(
-            self.update_children_from_dom_node(ref_self, dom_node, dom_damage, tree, update),
+            self.update_children_and_populate_new_descendants_from_dom_node(
+                ref_self, dom_node, dom_damage, tree, update,
+            ),
         );
 
         if self.updated {
@@ -593,7 +596,7 @@ impl AccessibilityNode {
 
     /// Update this node's [`Self::children`] from its corresponding DOM node. If any children are
     /// newly added to the tree, populate them and recursively populate their children.
-    fn update_children_from_dom_node<'dom>(
+    fn update_children_and_populate_new_descendants_from_dom_node<'dom>(
         &mut self,
         ref_self: ArcRefCell<AccessibilityNode>,
         dom_node: &ServoLayoutNode<'dom>,
@@ -640,26 +643,26 @@ impl AccessibilityNode {
         // same position as previously.
         let weak_self = ref_self.downgrade();
         for dom_child in remaining_dom_children {
-            let (new_id, new_child) = tree.get_or_create_node(&dom_child, update);
-            let strong_child = new_child.clone();
-            let mut new_child = new_child.borrow_mut();
-            if update.is_new(&new_id) {
-                new_child.update_node_from_dom_node(
-                    strong_child.clone(),
+            let (child_id, child_ref) = tree.get_or_create_node(&dom_child, update);
+
+            // Update self.child_nodes in place.
+            self.child_nodes.push(child_ref.clone());
+            new_child_ids.push(child_id);
+
+            let mut child = child_ref.borrow_mut();
+            child.parent_node = Some(weak_self.clone());
+
+            if update.is_new(&child_id) {
+                child.update_node_and_populate_new_descendants_from_dom_node(
+                    child_ref.clone(),
                     &dom_child,
                     AccessibilityDamage::Rebuild,
                     tree,
                     update,
                 );
             } else {
-                update.set_tree_state_change(new_id, TreeChange::PendingMove);
+                update.set_tree_state_change(child_id, TreeChange::PendingMove);
             }
-
-            // Update self.child_nodes in place.
-            self.child_nodes.push(strong_child.clone());
-            new_child_ids.push(new_id);
-
-            new_child.parent_node = Some(weak_self.clone());
         }
 
         // We can't update the AccessKit node's `children` in place, so we build up the full list
@@ -700,7 +703,7 @@ impl AccessibilityNode {
         local_damage: LocalAccessibilityDamage,
         update: &mut AccessibilityUpdate,
     ) -> LocalAccessibilityDamage {
-        update.counters.update_node_local += 1;
+        update.counters.nodes_updated_from_tree += 1;
 
         let mut new_damage = LocalAccessibilityDamage::empty();
         if local_damage.contains(LocalAccessibilityDamage::SubtreeChanged) ||

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -960,9 +960,8 @@ impl LayoutThread {
                 ));
         }
 
-        reflow_statistics.nodes_updated_from_dom =
-            counters.update_node_and_descendants_from_dom_node;
-        reflow_statistics.nodes_updated_from_tree = counters.update_node_local;
+        reflow_statistics.nodes_updated_from_dom = counters.nodes_updated_from_dom;
+        reflow_statistics.nodes_updated_from_tree = counters.nodes_updated_from_tree;
         reflow_statistics.nodes_in_tree_update = counters.nodes_in_tree_update;
 
         self.needs_accessibility_update.set(false);

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -398,38 +398,38 @@ fn test_accessibility_text_change() {
 #[test]
 fn test_accessibility_partial_subtree_move_and_delete() {
     let url = "data:text/html,<!DOCTYPE html>\
-               <div id='div1'>\
-                 <div id='div2'>\
+               <header id='header'>\
+                 <div id='div'>\
                    <h1 id='h1'>This is an h1</h1>\
                    <p id='p'>This is a paragraph</p>\
                  </div>\
-               </div>\
-               <div id='div3'><h2 id='h2'>This is an h2</h2></div>";
+               </header>\
+               <article id='article'><h2 id='h2'>This is an h2</h2></article>";
     let (servo_test, delegate, webview, mut tree) = build_webview_and_tree(url);
 
     let root = assert_tree_structure_and_get_root_web_area(&tree);
     let children: Vec<accesskit_consumer::Node> = root.children().collect();
     assert_eq!(children.len(), 2);
-    let div1 = children[0];
-    assert_eq!(div1.role(), Role::GenericContainer);
-    let h1 = find_all_matching_nodes(div1, |node| node.role() == Role::Heading)[0];
+    let header = children[0];
+    assert_eq!(header.role(), Role::Banner);
+    let h1 = find_all_matching_nodes(header, |node| node.role() == Role::Heading)[0];
     assert_eq!(h1.label(), Some("This is an h1".to_owned()));
-    let _p = find_all_matching_nodes(div1, |node| node.role() == Role::Paragraph)
+    let _p = find_all_matching_nodes(header, |node| node.role() == Role::Paragraph)
         .pop()
         .expect("Should be exactly one Paragraph node");
 
-    let div2 = children[1];
-    assert_eq!(div2.role(), Role::GenericContainer);
-    let h2 = find_all_matching_nodes(div2, |node| node.role() == Role::Heading)[0];
+    let article = children[1];
+    assert_eq!(article.role(), Role::Article);
+    let h2 = find_all_matching_nodes(article, |node| node.role() == Role::Heading)[0];
     assert_eq!(h2.label(), Some("This is an h2".to_owned()));
 
     let _ = evaluate_javascript(
         &servo_test,
         webview.clone(),
-        "div3.moveBefore(div2, h2);\
-         div3.moveBefore(h1, div2);\
+        "article.moveBefore(div, h2);\
+         article.moveBefore(h1, div);\
          p.remove();\
-         div1.remove();",
+         header.remove();",
     );
     let mut updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
     assert_eq!(updates.len(), 1);
@@ -438,15 +438,15 @@ fn test_accessibility_partial_subtree_move_and_delete() {
     let root = assert_tree_structure_and_get_root_web_area(&tree);
     let children: Vec<accesskit_consumer::Node> = root.children().collect();
     assert_eq!(children.len(), 1);
-    let div2 = children[0];
-    assert_eq!(div2.role(), Role::GenericContainer);
-    let children: Vec<accesskit_consumer::Node> = div2.children().collect();
+    let article = children[0];
+    assert_eq!(article.role(), Role::Article);
+    let children: Vec<accesskit_consumer::Node> = article.children().collect();
     assert_eq!(children.len(), 3);
     let h1 = children[0];
     assert_eq!(h1.role(), Role::Heading);
     assert_eq!(h1.label(), Some("This is an h1".to_owned()));
-    let div2 = children[1];
-    assert_eq!(div2.role(), Role::GenericContainer);
+    let div = children[1];
+    assert_eq!(div.role(), Role::GenericContainer);
     let h2 = children[2];
     assert_eq!(h2.role(), Role::Heading);
     assert_eq!(h2.label(), Some("This is an h2".to_owned()));


### PR DESCRIPTION
- Move `resolve_local_damage_for_node_and_subtree()` and `update_node_and_descendants_from_dom_node()` on to `AccessibilityNode`;
- Rename `update_node_from_dom_node()` to `update_properties_from_dom_node()`;
- Rename `update_node_and_descendants_from_dom_node()` to `update_node_and_populate_new_descendants_from_dom_node()`;
- Rename `update_descendants_from_dom_node()` to `update_children_and_populate_new_descendants_from_dom_node()`, and change the `weak_self` argument to be an `ArcRefCell`, only downgrading if necessary;
- Add an `ancestors()` iterator on `AccessibilityNode`;
- Make `AccessibilityNode::children()` return an Iterator;
- Make `test_accessibility_partial_subtree_move_and_delete()` less confusing by using more different types of elements;
- Rename the counters in `UpdateCounters` to match their corresponding values in `ReflowStatistics` and `ServoTestUtils`.

Testing: No behaviour changes.
Fixes: part of #4344