### PR TITLE
android: Remove usage of appcompat

### DIFF
--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -145,7 +145,6 @@ dependencies {
         implementation(project(":servoview"))
     }
     implementation("androidx.activity:activity-compose:1.13.0")
-    implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("com.google.android.material:material:1.14.0")
     implementation("androidx.compose.material3.adaptive:adaptive:1.2.0")
     implementation("androidx.compose.material3:material3:1.4.0")

--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
@@ -13,8 +13,8 @@ import android.system.ErrnoException
 import android.system.Os
 import android.util.Log
 import android.view.inputmethod.InputMethodManager
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -48,7 +48,7 @@ import kotlinx.coroutines.launch
 import org.servo.servoview.Servo
 import org.servo.servoview.ServoView
 
-class MainActivity : AppCompatActivity(), Servo.Client {
+class MainActivity : ComponentActivity(), Servo.Client {
     private lateinit var servoView: ServoView
 
     private val urlTextFieldState = TextFieldState()


### PR DESCRIPTION
The only usage of appcompat is via our inheritance of `AppCompatActivity`.

The class hierarchy of `AppCompatActivity` is `... > ComponentActivity > FragmentActivity > AppCompatActivity`.

The [docs of `FragmentActivity` says](https://developer.android.com/reference/androidx/fragment/app/FragmentActivity):

> Base class for activities that want to use the support-based [Fragments](https://developer.android.com/reference/androidx/fragment/app/Fragment).

We no longer use Fragments, so we don't care about its support.

The [docs of `AppCompatActivity` says](https://developer.android.com/reference/androidx/appcompat/app/AppCompatActivity):

> Base class for activities that wish to use some of the newer platform features on older Android devices. Some of these backported features include:
>
> - Using the action bar, including action items, navigation modes and more with the [setSupportActionBar](https://developer.android.com/reference/androidx/appcompat/app/AppCompatActivity#setSupportActionBar(androidx.appcompat.widget.Toolbar)) API.
> - Built-in switching between light and dark themes by using the [Theme.AppCompat.DayNight](https://developer.android.com/reference/androidx/appcompat/R.style#Theme_AppCompat_DayNight()) theme and [setDefaultNightMode](https://developer.android.com/reference/androidx/appcompat/app/AppCompatDelegate#setDefaultNightMode(int)) API.
> - Integration with DrawerLayout by using the [getDrawerToggleDelegate](https://developer.android.com/reference/androidx/appcompat/app/AppCompatActivity#getDrawerToggleDelegate()) API.

We also don't use or care about any of these features (these are all legacy ways of achieving things, and have been replaced with Compose UI equivalents).

Therefore, we can just directly depend on `ComponentActivity`.

Testing: There are no automated tests for Android.