### PR TITLE
layout: Fix baseline alignment of horizontal text in column flex container

### DIFF
--- a/components/layout/flexbox/geom.rs
+++ b/components/layout/flexbox/geom.rs
@@ -64,6 +64,13 @@ impl<T> FlexRelativeSides<T> {
             cross: self.cross_start + self.cross_end,
         }
     }
+
+    pub fn cross_sum(self) -> T::Output
+    where
+        T: std::ops::Add,
+    {
+        self.cross_start + self.cross_end
+    }
 }
 
 /// One of the two bits set by the `flex-direction` property

--- a/components/layout/flexbox/layout.rs
+++ b/components/layout/flexbox/layout.rs
@@ -14,7 +14,7 @@ use rayon::iter::{
 };
 use style::Zero;
 use style::computed_values::position::T as Position;
-use style::logical_geometry::Direction;
+use style::logical_geometry::{Direction, WritingMode};
 use style::properties::ComputedValues;
 use style::properties::longhands::align_items::computed_value::T as AlignItems;
 use style::properties::longhands::box_sizing::computed_value::T as BoxSizing;
@@ -153,12 +153,16 @@ struct FlexLineItem<'a> {
 }
 
 impl FlexLineItem<'_> {
-    fn get_or_synthesize_baseline_with_cross_size(&self, cross_size: Au) -> Au {
+    fn get_or_synthesize_baseline_with_cross_size(
+        &self,
+        cross_size: Au,
+        flex_container_config: &FlexContainerConfig,
+    ) -> Au {
         self.layout_result
             .flex_alignment_baseline_relative_to_margin_box
             .unwrap_or_else(|| {
                 self.item
-                    .synthesized_baseline_relative_to_margin_box(cross_size)
+                    .synthesized_baseline_relative_to_margin_box(cross_size, flex_container_config)
             })
     }
 
@@ -1496,6 +1500,7 @@ impl InitialFlexLineLayout<'_> {
             ) {
                 let baseline = item.get_or_synthesize_baseline_with_cross_size(
                     item.layout_result.hypothetical_cross_size,
+                    &flex_context.config,
                 );
                 let hypothetical_margin_box_cross_size =
                     item.layout_result.hypothetical_cross_size + item.item.pbm_auto_is_zero.cross;
@@ -1615,7 +1620,8 @@ impl InitialFlexLineLayout<'_> {
                         .layout(item.used_main_size, flex_context, Some(used_cross_size));
             }
 
-            let baseline = item.get_or_synthesize_baseline_with_cross_size(used_cross_size);
+            let baseline = item
+                .get_or_synthesize_baseline_with_cross_size(used_cross_size, &flex_context.config);
             if matches!(
                 item.item.align_self.0.value(),
                 AlignFlags::BASELINE | AlignFlags::LAST_BASELINE
@@ -1950,16 +1956,77 @@ impl FlexItem<'_> {
         }
     }
 
-    fn synthesized_baseline_relative_to_margin_box(&self, content_size: Au) -> Au {
-        // If the item does not have a baseline in the necessary axis,
-        // then one is synthesized from the flex item’s border box.
+    /// Returns the distance from the baseline relative to the cross-start edge of the margin box
+    /// along the cross axis.
+    fn synthesized_baseline_relative_to_margin_box(
+        &self,
+        content_size: Au,
+        config: &FlexContainerConfig,
+    ) -> Au {
+        let own_writing_mode = self.box_.style().writing_mode;
         // https://drafts.csswg.org/css-flexbox/#valdef-align-items-baseline
-        content_size +
-            self.margin.cross_start.auto_is(Au::zero) +
-            self.padding.cross_start +
-            self.border.cross_start +
-            self.border.cross_end +
-            self.padding.cross_end
+        // > If the item does not have a baseline in the necessary axis,
+        // > then one is synthesized from the flex item’s border box.
+        // Note: This is the case when this function is called.
+
+        // https://drafts.csswg.org/css-align-3/#synthesize-baseline
+        // > To synthesize baselines from a rectangle (or two parallel lines),
+        // > synthesize the alphabetic baseline from the line-under.
+        let distance_from_cross_start_to_line_under = |writing_mode: WritingMode| -> Au {
+            // The different positions for line-under depending on the writing mode are defined
+            // in https://drafts.csswg.org/css-writing-modes-4/#logical-to-physical.
+            // FIXME: This needs to handle "writing-mode: sideways-lr" once that is
+            // enabled in stylo.
+            let line_under_edge_is_on_same_side_as_cross_start = (writing_mode.is_horizontal() &&
+                config.flex_wrap_is_reversed) ||
+                (writing_mode.is_vertical_lr() != config.flex_wrap_is_reversed);
+            if line_under_edge_is_on_same_side_as_cross_start {
+                // line-under edge is the bottom border edge and cross axis goes bottom->top
+                // OR
+                // line-under edge is the left border edge and cross axis goes left->right
+                // OR
+                // line-under edge is the right border edge and cross axis goes right->left
+                self.margin.cross_start.auto_is(Au::zero)
+            } else {
+                // line-under edge is the bottom border edge and cross axis goes top->bottom
+                // OR
+                // line-under edge is the right border edge and cross axis goes left->right
+                // OR
+                // line-under edge is the left border edge and cross axis goes right->left
+                content_size +
+                    self.margin.cross_start.auto_is(Au::zero) +
+                    self.padding.cross_sum() +
+                    self.border.cross_sum()
+            }
+        };
+
+        // > In general, the writing mode of the box, shape, or other object being aligned is used
+        // > to determine the line-under and line-over edges for synthesis.
+        // > However, when that writing mode’s block flow direction is parallel to the axis of the
+        // > alignment context, an axis-compatible writing mode must be assumed:
+        // > * If the box establishing the alignment context has a block flow direction that is orthogonal
+        // >   to the axis of the alignment context, use its writing mode.
+        // > * Otherwise:
+        // >   * If the box’s own writing mode is vertical, assume horizontal-tb.
+        // >   * If the box’s own writing mode is horizontal, assume vertical-lr if direction is ltr
+        // >     and vertical-rl if direction is rtl.
+        let block_flow_direction_is_orthogonal_to_main_axis = |writing_mode: WritingMode| {
+            writing_mode.is_vertical() != (config.flex_axis == FlexAxis::Row)
+        };
+        if block_flow_direction_is_orthogonal_to_main_axis(own_writing_mode) {
+            distance_from_cross_start_to_line_under(own_writing_mode)
+        } else if block_flow_direction_is_orthogonal_to_main_axis(config.writing_mode) {
+            distance_from_cross_start_to_line_under(config.writing_mode)
+        } else if own_writing_mode.is_vertical() {
+            distance_from_cross_start_to_line_under(WritingMode::WRITING_MODE_HORIZONTAL_TB)
+        } else {
+            let used_writing_mode = match own_writing_mode.is_bidi_ltr() {
+                true => WritingMode::WRITING_MODE_VERTICAL_LR,
+                false => WritingMode::WRITING_MODE_VERTICAL_RL,
+            };
+
+            distance_from_cross_start_to_line_under(used_writing_mode)
+        }
     }
 
     fn subtree_size(&self) -> usize {

--- a/tests/wpt/meta/css/css-flexbox/align-baseline.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/align-baseline.html.ini
@@ -1,2 +1,0 @@
-[align-baseline.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/align-items-baseline-column-vert-lr-items.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/align-items-baseline-column-vert-lr-items.html.ini
@@ -1,0 +1,3 @@
+[align-items-baseline-column-vert-lr-items.html]
+  [#target > div 2]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-align-self-vert-001.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-align-self-vert-001.xhtml.ini
@@ -1,2 +1,0 @@
-[flexbox-align-self-vert-001.xhtml]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-align-self-vert-003.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-align-self-vert-003.xhtml.ini
@@ -1,2 +1,0 @@
-[flexbox-align-self-vert-003.xhtml]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-align-self-vert-004.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-align-self-vert-004.xhtml.ini
@@ -1,2 +1,0 @@
-[flexbox-align-self-vert-004.xhtml]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-baseline-align-self-baseline-vert-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-baseline-align-self-baseline-vert-001.html.ini
@@ -1,2 +1,0 @@
-[flexbox-baseline-align-self-baseline-vert-001.html]
-  expected: FAIL

--- a/tests/wpt/tests/css/css-flexbox/align-self-baseline-with-flex-wrap.html
+++ b/tests/wpt/tests/css/css-flexbox/align-self-baseline-with-flex-wrap.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<head>
+    <link rel="help" href="https://drafts.csswg.org/css-align-3/#synthesize-baseline">
+    <link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#logical-to-physical">
+    <link rel="author" href="mailto:simonwuelker@arcor.de" title="Simon Wülker">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/check-layout-th.js"></script>
+    <style>
+        .box {
+            display: flex;
+            outline: 1px solid;
+            position: relative;
+        }
+
+        .row {
+            width: 20px;
+            height: 50px;
+            flex-direction: row;
+
+            .big {
+                width: 10px;
+                height: 30px;
+                margin-top: 2px;
+                margin-bottom: 5px;
+            }
+        }
+
+        .column {
+            flex-direction: column;
+            width: 50px;
+            height: 20px;
+
+            .big {
+                width: 30px;
+                height: 10px;
+                margin-left: 2px;
+                margin-right: 5px;
+            }
+        }
+
+        .reverse {
+            flex-wrap: wrap-reverse;
+        }
+
+        .box span {
+            outline: 1px solid;
+            align-self: baseline;
+        }
+
+        .rtl {
+            direction: rtl;
+        }
+
+        .small {
+            width: 10px;
+            height: 10px;
+            background-color: blue;
+        }
+
+        .big {
+            background-color: blueviolet;
+        }
+
+        th, td {
+            border: 1px solid black;
+            padding: 5px;
+            text-align: center;
+            vertical-align: middle;
+        }
+        div {
+            margin-inline: auto;
+        }
+    </style>
+</head>
+<body onload="checkLayout('.box > span')">
+    <table>
+        <thead>
+            <tr>
+                <th></th>
+                <th><pre>flex-direction: row</pre></th>
+                <th><pre>flex-direction: row-reverse</pre></th>
+                <th><pre>flex-direction: column</pre></th>
+                <th><pre>flex-direction: column-reverse</pre></th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <th><pre>direction=ltr</pre></th>
+                <td>
+                    <div class="box row">
+                        <span class="small" data-offset-x="0" data-offset-y="22"></span>
+                        <span class="big" data-offset-x="10" data-offset-y="2"></span>
+                    </div>
+                </td>
+                <td>
+                    <div class="box row reverse">
+                        <span class="small" data-offset-x="0" data-offset-y="35"></span>
+                        <span class="big" data-offset-x="10" data-offset-y="15"></span>
+                    </div>
+                </td>
+                <td>
+                    <div class="box column">
+                        <span class="small" data-offset-x="2" data-offset-y="0"></span>
+                        <span class="big" data-offset-x="2" data-offset-y="10"></span>
+                    </div>
+                </td>
+                <td>
+                    <div class="box column reverse">
+                        <span class="small" data-offset-x="15" data-offset-y="0"></span>
+                        <span class="big" data-offset-x="15" data-offset-y="10"></span>
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <th>
+                    <pre>direction=rtl</pre>
+                </th>
+                <td>
+                    <div class="box rtl row">
+                        <span class="small" data-offset-x="10" data-offset-y="22"></span>
+                        <span class="big" data-offset-x="0" data-offset-y="2"></span>
+                    </div>
+                </td>
+                <td>
+                    <div class="box rtl row reverse">
+                        <span class="small" data-offset-x="10" data-offset-y="35"></span>
+                        <span class="big" data-offset-x="0" data-offset-y="15"></span>
+                    </div>
+                </td>
+                <td>
+                    <div class="box rtl column">
+                        <span class="small" data-offset-x="15" data-offset-y="0"></span>
+                        <span class="big" data-offset-x="15" data-offset-y="10"></span>
+                    </div>
+                </td>
+                <td>
+                    <div class="box rtl column reverse">
+                        <span class="small" data-offset-x="2" data-offset-y="0"></span>
+                        <span class="big" data-offset-x="2" data-offset-y="10"></span>
+                    </div>
+                </td>
+            </tr>
+        </tbody>
+    </table>


### PR DESCRIPTION
When flex items have no natural baseline (such as text items in a container with `flex-direction: column`) then we must [synthesize](https://drafts.csswg.org/css-align-3/#synthesize-baseline) one from the items border box. In that case the baseline is given by the [line-under](https://drafts.csswg.org/css-writing-modes-4/#line-under) border edge. So far we've been assuming that the line-under edge is always the cross-end edge of the flex item. But in reality, it depends on the flex axis and the writing mode of the item and its container. In particular, the current code incorrectly aligns items by their right border edge for `writing-mode: initial` and `flex-direction: column` (the baseline should be the left border edge). 

This change instead follows the algorithm from the specification for computing a synthetic baseline.

Testing: New tests start to pass.  `css/css-flexbox/align-items-baseline-column-vert-lr-items.html`regresses - this test uses baselines from vertical text, but we don't support vertical writing modes yet. I've also added a new test as the interaction between `flex-direction: row-reverse` and `direction: rtl` was not covered by WPT.

