### PR TITLE
android: Remove View-based Material library

### DIFF
--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -145,7 +145,6 @@ dependencies {
         implementation(project(":servoview"))
     }
     implementation("androidx.activity:activity-compose:1.13.0")
-    implementation("com.google.android.material:material:1.14.0")
     implementation("androidx.compose.material3.adaptive:adaptive:1.2.0")
     implementation("androidx.compose.material3:material3:1.4.0")
     implementation("androidx.preference:preference-ktx:1.2.1")

--- a/support/android/apk/servoapp/src/main/res/values/styles.xml
+++ b/support/android/apk/servoapp/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.Material3.Light.NoActionBar">
+    <style name="AppTheme" parent="android:Theme.Material.Light.NoActionBar">
         <item name="android:statusBarColor">#212121</item>
     </style>
 


### PR DESCRIPTION
Since the app is fully Compose UI based, we don't need the View-based Material library any more.

The only change is the theme that we're using. I chose this theme based on what [one of the many Compose UI sample apps used](https://github.com/android/compose-samples/blob/main/Reply/app/src/main/res/values/themes.xml).

Testing: There are no automated tests for Android.