### PR TITLE
script: Replace raw pointer comparison with `==` for DOM identity comparison

### DIFF
--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -3143,10 +3143,8 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     fn RemoveAttributeNode(&self, cx: &mut JSContext, attr: &Attr) -> Fallible<DomRoot<Attr>> {
         // The attr parameter passed here is already a Dom<Attr> that is somewhere present in the DOM,
         // hence already materialized. That means that `as_attr()` will never fail.
-        self.remove_first_matching_attribute(cx, |a| {
-            a.as_attr().is_some_and(|a| std::ptr::eq(a, attr))
-        })
-        .ok_or(Error::NotFound(None))
+        self.remove_first_matching_attribute(cx, |a| a.as_attr().is_some_and(|a| a == attr))
+            .ok_or(Error::NotFound(None))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-hasattribute>

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -2129,7 +2129,7 @@ impl VirtualMethods for HTMLImageElement {
 
         // Step 1. If insertedNode's parent is a picture element, then, count this as a relevant
         // mutation for insertedNode.
-        if parent.is::<HTMLPictureElement>() && std::ptr::eq(&*parent, context.parent) {
+        if parent.is::<HTMLPictureElement>() && *parent == *context.parent {
             self.update_the_image_data(cx);
         }
     }

--- a/components/script/dom/html/htmlsourceelement.rs
+++ b/components/script/dom/html/htmlsourceelement.rs
@@ -154,7 +154,7 @@ impl VirtualMethods for HTMLSourceElement {
 
         // Step 2. If parent is a media element that has no src attribute and whose networkState has
         // the value NETWORK_EMPTY, then invoke that media element's resource selection algorithm.
-        if parent.is::<HTMLMediaElement>() && std::ptr::eq(&*parent, context.parent) {
+        if parent.is::<HTMLMediaElement>() && *parent == *context.parent {
             parent
                 .downcast::<HTMLMediaElement>()
                 .unwrap()
@@ -163,7 +163,7 @@ impl VirtualMethods for HTMLSourceElement {
 
         // Step 3. If parent is a picture element, then for each child of parent's children, if
         // child is an img element, then count this as a relevant mutation for child.
-        if parent.is::<HTMLPictureElement>() && std::ptr::eq(&*parent, context.parent) {
+        if parent.is::<HTMLPictureElement>() && *parent == *context.parent {
             let next_sibling_iterator = self.upcast::<Node>().following_siblings();
             HTMLSourceElement::iterate_next_html_image_element_siblings_with_cx(
                 cx,

--- a/components/script/dom/mutationobserver/mutationobserver.rs
+++ b/components/script/dom/mutationobserver/mutationobserver.rs
@@ -308,7 +308,7 @@ impl MutationObserverMethods<crate::DomTypeHolder> for MutationObserver {
         let add_new_observer = {
             let mut replaced = false;
             for registered in &mut *target.registered_mutation_observers_mut() {
-                if !std::ptr::eq(&*registered.observer, self) {
+                if registered.observer != self {
                     continue;
                 }
                 // TODO: remove matching transient registered observers

--- a/components/script/dom/range/abstractrange.rs
+++ b/components/script/dom/range/abstractrange.rs
@@ -134,7 +134,7 @@ pub(crate) fn bp_position(a_node: &Node, a_offset: u32, b_node: &Node, b_offset:
 
     // Step 2: If nodeA is nodeB, then return equal if offsetA is offsetB, before if
     // offsetA is less than offsetB, and after if offsetA is greater than offsetB.
-    if std::ptr::eq(a_node, b_node) {
+    if a_node == b_node {
         return a_offset.cmp(&b_offset);
     }
 

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -470,7 +470,7 @@ impl WebGLRenderingContext {
         let Some(context) = object.upcast().context() else {
             return Err(WebGLError::InvalidOperation);
         };
-        if !std::ptr::eq(self, &*context) {
+        if self != &*context {
             return Err(WebGLError::InvalidOperation);
         }
         Ok(())

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -3717,7 +3717,7 @@ impl Window {
             }
 
             let nodes = images.entry(id).or_default();
-            if !nodes.iter().any(|n| std::ptr::eq(&*(n.node), &*node)) {
+            if !nodes.iter().any(|n| *n.node == *node) {
                 nodes.push(PendingLayoutImageAncillaryData {
                     node: Dom::from_ref(&*node),
                     destination: image.destination,
@@ -3742,7 +3742,7 @@ impl Window {
             }
 
             let nodes = images.entry((image.id, image.size)).or_default();
-            if !nodes.iter().any(|n| std::ptr::eq(&**n, &*node)) {
+            if !nodes.iter().any(|n| **n == *node) {
                 nodes.push(Dom::from_ref(&*node));
             }
         }


### PR DESCRIPTION
As mentioned in https://github.com/servo/servo/pull/46678#issuecomment-5032596960, we should rely on `PartialEq` for all cases, so that we just need to optimize a single point.

Testing: This would be slightly slower because of
https://github.com/servo/servo/blob/fc340087b7411d5d736ad8705581baf16b567b1c/components/dom_struct/lib.rs#L154-L156, which then expands into multiple crates and call chain. But other behaviours should not change.

Part of #34464