### PR TITLE
ci: Enable `allow-unsafe-pr-checkout` for WPT runs

### DIFF
--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -92,6 +92,7 @@ jobs:
         if: github.event_name == 'pull_request_target'
         with:
           ref: refs/pull/${{ github.event.number }}/head
+          allow-unsafe-pr-checkout: true
       - uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.profile }}-binary-linux
@@ -176,6 +177,7 @@ jobs:
         if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream && github.event_name == 'pull_request_target' }}
         with:
           ref: refs/pull/${{ github.event.number }}/head
+          allow-unsafe-pr-checkout: true
       - uses: actions/download-artifact@v8
         if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream }}
         with:

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -38,6 +38,7 @@ jobs:
         if: github.event_name == 'pull_request_target'
         with:
           ref: refs/pull/${{ github.event.number }}/head
+          allow-unsafe-pr-checkout: true
       - uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.profile }}-binary-${{ env.NAME }}


### PR DESCRIPTION
This works around a new GitHub security requirement. We use
`pull_request_target` for try label jobs as they need access to the
following two secrets:

- `INTERMITTENT_TRACKER_DASHBOARD_SECRET`
- `GITHUB_TOKEN` (in order to make comments)

A future change should move these jobs to a different environment with
limited secret access.

Testing: There is unfortunately no way to run automated tests for CI changes yet.
