### PR TITLE
ci: Disable choco / WiX installation on self-hosted runners

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -121,24 +121,9 @@ jobs:
         run: |
           echo CCACHE=ccache >> $GITHUB_ENV
 
-      - name: install choco
-        if: ${{ runner.environment == 'self-hosted' }}
-        # copied from https://chocolatey.org/install
-        run: |
-          Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
-          echo "C:\\ProgramData\\chocolatey\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      # To be removed once we update to WiX 7.
-      - name: Add WiX to PATH (self-hosted)
-        if: ${{ runner.environment == 'self-hosted' }}
-        run: |
-          choco install wixtoolset -y
-          echo "C:\\Program Files (x86)\\WiX Toolset v3.14\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-
       # Install missing tools in a GitHub-hosted runner.
       - name: Install Winget
-        # TODO: Re-enable this condition once WiX 7 is pre-installed on the self-hosted runners.
-        # if: ${{ runner.environment != 'self-hosted' }}
+        if: ${{ runner.environment != 'self-hosted' }}
         shell: powershell
         run: |
           Install-Module -Name Microsoft.WinGet.Client -Repository PSGallery -Force
@@ -147,8 +132,7 @@ jobs:
           # Authenticated requests have a higher rate limit.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install WiX
-        # TODO: Re-enable this condition once WiX 7 is pre-installed on the self-hosted runners.
-        # if: ${{ runner.environment != 'self-hosted' }}
+        if: ${{ runner.environment != 'self-hosted' }}
         shell: powershell
         run: |
           winget install --silent --exact WiXToolset.WiXCLI --version 7.0.0.0 --accept-source-agreements


### PR DESCRIPTION
The self-hosted CI runners are now detecting a double WiX installation.
This is a minimal attempt to fix that.

Testing: CI changes do not really have tests.
