### PR TITLE
android: Move dependencies to version catalog

### DIFF
--- a/support/android/apk/gradle/libs.versions.toml
+++ b/support/android/apk/gradle/libs.versions.toml
@@ -1,0 +1,5 @@
+[libraries]
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.13.0" }
+androidx-material3-compose = { module = "androidx.compose.material3:material3", version = "1.4.0" }
+androidx-material3-compose-adaptive = { module = "androidx.compose.material3.adaptive:adaptive", version = "1.2.0" }
+androidx-preference = { module = "androidx.preference:preference-ktx", version = "1.2.1" }

--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -144,8 +144,8 @@ dependencies {
     } else {
         implementation(project(":servoview"))
     }
-    implementation("androidx.activity:activity-compose:1.13.0")
-    implementation("androidx.compose.material3.adaptive:adaptive:1.2.0")
-    implementation("androidx.compose.material3:material3:1.4.0")
-    implementation("androidx.preference:preference-ktx:1.2.1")
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.material3.compose)
+    implementation(libs.androidx.material3.compose.adaptive)
+    implementation(libs.androidx.preference)
 }


### PR DESCRIPTION
The benefit of version catalogs at the moment is marginal, but as the dependencies grow (and perhaps grows to `servoview`), it can come in handy to have a SSOT for dependencies and their versions.

Testing: There are no automated tests for Android.
