### PR TITLE
script: Implement a readonly version of `CSSFontFeatureValuesRule`

### DIFF
--- a/components/script/dom/css/cssfontfeaturevaluesmap.rs
+++ b/components/script/dom/css/cssfontfeaturevaluesmap.rs
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use dom_struct::dom_struct;
+use indexmap::IndexMap;
+use js::context::JSContext;
+use script_bindings::cell::DomRefCell;
+use script_bindings::like::Maplike;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use style::stylesheets::font_feature_values_rule::{
+    FFVDeclaration, PairValues, SingleValue, VectorValues,
+};
+
+use crate::dom::GlobalScope;
+use crate::dom::bindings::codegen::Bindings::CSSFontFeatureValuesRuleBinding::CSSFontFeatureValuesMapMethods;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::str::DOMString;
+use crate::maplike;
+
+/// <https://drafts.csswg.org/css-fonts/#cssfontfeaturevaluesmap>
+#[dom_struct]
+pub(crate) struct CSSFontFeatureValuesMap {
+    reflector: Reflector,
+    #[custom_trace]
+    internal: DomRefCell<IndexMap<DOMString, Vec<u32>>>,
+}
+
+impl CSSFontFeatureValuesMap {
+    fn new_inherited(map: IndexMap<DOMString, Vec<u32>>) -> CSSFontFeatureValuesMap {
+        CSSFontFeatureValuesMap {
+            reflector: Reflector::new(),
+            internal: DomRefCell::new(map),
+        }
+    }
+
+    pub(crate) fn new(
+        cx: &mut JSContext,
+        global: &GlobalScope,
+        map: IndexMap<DOMString, Vec<u32>>,
+    ) -> DomRoot<CSSFontFeatureValuesMap> {
+        reflect_dom_object_with_cx(
+            Box::new(CSSFontFeatureValuesMap::new_inherited(map)),
+            global,
+            cx,
+        )
+    }
+
+    pub(crate) fn build_from<DeclarationValue>(
+        cx: &mut JSContext,
+        global: &GlobalScope,
+        declarations: &[FFVDeclaration<DeclarationValue>],
+    ) -> DomRoot<Self>
+    where
+        DeclarationValue: AsValues,
+    {
+        let mut map = IndexMap::default();
+        for declaration in declarations {
+            map.insert(
+                declaration.name.to_string().into(),
+                declaration.value.as_vec(),
+            );
+        }
+        Self::new(cx, global, map)
+    }
+}
+
+impl Maplike for CSSFontFeatureValuesMap {
+    type Key = DOMString;
+    type Value = Vec<u32>;
+
+    maplike!(self, internal);
+}
+
+impl CSSFontFeatureValuesMapMethods<crate::DomTypeHolder> for CSSFontFeatureValuesMap {
+    fn Size(&self) -> u32 {
+        self.internal.borrow().len() as u32
+    }
+}
+
+/// A trait to generalize over [SingleValue], [PairValues] and [VectorValues`].
+pub(crate) trait AsValues {
+    fn as_vec(&self) -> Vec<u32>;
+}
+
+impl AsValues for SingleValue {
+    fn as_vec(&self) -> Vec<u32> {
+        vec![self.0]
+    }
+}
+
+impl AsValues for PairValues {
+    fn as_vec(&self) -> Vec<u32> {
+        let mut result = vec![self.0];
+        if let Some(second_value) = self.1 {
+            result.push(second_value);
+        }
+        result
+    }
+}
+
+impl AsValues for VectorValues {
+    fn as_vec(&self) -> Vec<u32> {
+        self.0.clone()
+    }
+}

--- a/components/script/dom/css/cssfontfeaturevaluesmap.rs
+++ b/components/script/dom/css/cssfontfeaturevaluesmap.rs
@@ -22,6 +22,9 @@ use crate::maplike;
 #[dom_struct]
 pub(crate) struct CSSFontFeatureValuesMap {
     reflector: Reflector,
+
+    /// The map from identifiers to font feature values, derived from a single block
+    /// of the `@font-feature-values` rule.
     #[custom_trace]
     internal: DomRefCell<IndexMap<DOMString, Vec<u32>>>,
 }
@@ -78,7 +81,7 @@ impl CSSFontFeatureValuesMapMethods<crate::DomTypeHolder> for CSSFontFeatureValu
     }
 }
 
-/// A trait to generalize over [SingleValue], [PairValues] and [VectorValues`].
+/// A trait to generalize over [SingleValue], [PairValues] and [VectorValues].
 pub(crate) trait AsValues {
     fn as_vec(&self) -> Vec<u32>;
 }

--- a/components/script/dom/css/cssfontfeaturevaluesrule.rs
+++ b/components/script/dom/css/cssfontfeaturevaluesrule.rs
@@ -4,24 +4,49 @@
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
+use script_bindings::dom::MutNullableDom;
 use script_bindings::reflector::reflect_dom_object_with_cx;
 use servo_arc::Arc;
 use style::shared_lock::ToCssWithGuard;
 use style::stylesheets::{CssRuleType, FontFeatureValuesRule};
+use style_traits::ToCss;
 
 use super::cssrule::{CSSRule, SpecificCSSRule};
 use super::cssstylesheet::CSSStyleSheet;
+use crate::dom::bindings::codegen::Bindings::CSSFontFeatureValuesRuleBinding::CSSFontFeatureValuesRuleMethods;
+use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
+use crate::dom::cssfontfeaturevaluesmap::CSSFontFeatureValuesMap;
 use crate::dom::cssgroupingrule::CSSGroupingRule;
 use crate::dom::window::Window;
 
 #[dom_struct]
 pub(crate) struct CSSFontFeatureValuesRule {
     css_rule: CSSRule,
+
+    /// A reference to the `@font-feature-values` rule as it is stored by stylo.
     #[no_trace]
     #[conditional_malloc_size_of]
     font_feature_values_rule: Arc<FontFeatureValuesRule>,
+
+    /// <https://drafts.csswg.org/css-fonts/#dom-cssfontfeaturevaluesrule-annotation>
+    annotation: MutNullableDom<CSSFontFeatureValuesMap>,
+
+    /// <https://drafts.csswg.org/css-fonts/#dom-cssfontfeaturevaluesrule-ornaments>
+    ornaments: MutNullableDom<CSSFontFeatureValuesMap>,
+
+    /// <https://drafts.csswg.org/css-fonts/#dom-cssfontfeaturevaluesrule-stylistic>
+    stylistic: MutNullableDom<CSSFontFeatureValuesMap>,
+
+    /// <https://drafts.csswg.org/css-fonts/#dom-cssfontfeaturevaluesrule-swash>
+    swash: MutNullableDom<CSSFontFeatureValuesMap>,
+
+    /// <https://drafts.csswg.org/css-fonts/#dom-cssfontfeaturevaluesrule-charactervariant>
+    character_variant: MutNullableDom<CSSFontFeatureValuesMap>,
+
+    /// <https://drafts.csswg.org/css-fonts/#dom-cssfontfeaturevaluesrule-styleset>
+    styleset: MutNullableDom<CSSFontFeatureValuesMap>,
 }
 
 impl CSSFontFeatureValuesRule {
@@ -33,6 +58,12 @@ impl CSSFontFeatureValuesRule {
         CSSFontFeatureValuesRule {
             css_rule: CSSRule::new_inherited(parent_rule, parent_stylesheet),
             font_feature_values_rule,
+            annotation: Default::default(),
+            ornaments: Default::default(),
+            stylistic: Default::default(),
+            swash: Default::default(),
+            character_variant: Default::default(),
+            styleset: Default::default(),
         }
     }
 
@@ -63,5 +94,83 @@ impl SpecificCSSRule for CSSFontFeatureValuesRule {
     fn get_css(&self) -> DOMString {
         let guard = self.css_rule.shared_lock().read();
         self.font_feature_values_rule.to_css_string(&guard).into()
+    }
+}
+
+impl CSSFontFeatureValuesRuleMethods<crate::DomTypeHolder> for CSSFontFeatureValuesRule {
+    /// <https://drafts.csswg.org/css-fonts/#dom-cssfontfeaturevaluesrule-fontfamily>
+    fn FontFamily(&self) -> DOMString {
+        self.font_feature_values_rule
+            .family_names
+            .to_css_string()
+            .into()
+    }
+
+    /// <https://drafts.csswg.org/css-fonts/#dom-cssfontfeaturevaluesrule-annotation>
+    fn Annotation(&self, cx: &mut JSContext) -> DomRoot<CSSFontFeatureValuesMap> {
+        self.annotation.or_init(|| {
+            let global = self.global();
+            CSSFontFeatureValuesMap::build_from(
+                cx,
+                &global,
+                &self.font_feature_values_rule.annotation,
+            )
+        })
+    }
+
+    /// <https://drafts.csswg.org/css-fonts/#dom-cssfontfeaturevaluesrule-ornaments>
+    fn Ornaments(&self, cx: &mut JSContext) -> DomRoot<CSSFontFeatureValuesMap> {
+        self.ornaments.or_init(|| {
+            let global = self.global();
+            CSSFontFeatureValuesMap::build_from(
+                cx,
+                &global,
+                &self.font_feature_values_rule.ornaments,
+            )
+        })
+    }
+
+    /// <https://drafts.csswg.org/css-fonts/#dom-cssfontfeaturevaluesrule-stylistic>
+    fn Stylistic(&self, cx: &mut JSContext) -> DomRoot<CSSFontFeatureValuesMap> {
+        self.stylistic.or_init(|| {
+            let global = self.global();
+            CSSFontFeatureValuesMap::build_from(
+                cx,
+                &global,
+                &self.font_feature_values_rule.stylistic,
+            )
+        })
+    }
+
+    /// <https://drafts.csswg.org/css-fonts/#dom-cssfontfeaturevaluesrule-swash>
+    fn Swash(&self, cx: &mut JSContext) -> DomRoot<CSSFontFeatureValuesMap> {
+        self.swash.or_init(|| {
+            let global = self.global();
+            CSSFontFeatureValuesMap::build_from(cx, &global, &self.font_feature_values_rule.swash)
+        })
+    }
+
+    /// <https://drafts.csswg.org/css-fonts/#dom-cssfontfeaturevaluesrule-charactervariant>
+    fn CharacterVariant(&self, cx: &mut JSContext) -> DomRoot<CSSFontFeatureValuesMap> {
+        self.character_variant.or_init(|| {
+            let global = self.global();
+            CSSFontFeatureValuesMap::build_from(
+                cx,
+                &global,
+                &self.font_feature_values_rule.character_variant,
+            )
+        })
+    }
+
+    /// <https://drafts.csswg.org/css-fonts/#dom-cssfontfeaturevaluesrule-styleset>
+    fn Styleset(&self, cx: &mut JSContext) -> DomRoot<CSSFontFeatureValuesMap> {
+        self.styleset.or_init(|| {
+            let global = self.global();
+            CSSFontFeatureValuesMap::build_from(
+                cx,
+                &global,
+                &self.font_feature_values_rule.styleset,
+            )
+        })
     }
 }

--- a/components/script/dom/css/mod.rs
+++ b/components/script/dom/css/mod.rs
@@ -6,6 +6,7 @@
 pub(crate) mod css;
 pub(crate) mod cssconditionrule;
 pub(crate) mod cssfontfacerule;
+pub(crate) mod cssfontfeaturevaluesmap;
 pub(crate) mod cssfontfeaturevaluesrule;
 pub(crate) mod cssgroupingrule;
 pub(crate) mod cssimportrule;

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -143,6 +143,10 @@ DOMInterfaces = {
     'cx': ['PaintWorklet'],
 },
 
+'CSSFontFeatureValuesRule': {
+    'cx': ['Annotation', 'Ornaments', 'Stylistic', 'Swash', 'CharacterVariant', 'Styleset', 'HistoricalForms'],
+},
+
 'CSSGroupingRule': {
     'cx': ['CssRules', 'InsertRule', 'DeleteRule'],
 },

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -114,9 +114,7 @@ pub(crate) mod module {
         define_guarded_properties, get_per_interface_object_handle, is_exposed_in,
     };
     pub(crate) use crate::iterable::{Iterable, IterableIterator, IteratorType};
-    #[cfg(feature = "testbinding")]
-    pub(crate) use crate::like::Maplike;
-    pub(crate) use crate::like::Setlike;
+    pub(crate) use crate::like::{Maplike, Setlike};
     pub(crate) use crate::mem::malloc_size_of_including_raw_self;
     pub(crate) use crate::namespace::NamespaceObjectClass;
     pub(crate) use crate::proxyhandler::{get_expando_object, set_property_descriptor};

--- a/components/script_bindings/webidls/CSSFontFeatureValuesRule.webidl
+++ b/components/script_bindings/webidls/CSSFontFeatureValuesRule.webidl
@@ -6,19 +6,23 @@
 
 [Exposed=Window]
 interface CSSFontFeatureValuesRule : CSSRule {
-  // attribute CSSOMString fontFamily;
-  // readonly attribute CSSFontFeatureValuesMap annotation;
-  // readonly attribute CSSFontFeatureValuesMap ornaments;
-  // readonly attribute CSSFontFeatureValuesMap stylistic;
-  // readonly attribute CSSFontFeatureValuesMap swash;
-  // readonly attribute CSSFontFeatureValuesMap characterVariant;
-  // readonly attribute CSSFontFeatureValuesMap styleset;
+  // FIXME: This attribute should not be readonly. But assigning to it is unspecified behaviour.
+  readonly attribute CSSOMString fontFamily;
+  readonly attribute CSSFontFeatureValuesMap annotation;
+  readonly attribute CSSFontFeatureValuesMap ornaments;
+  readonly attribute CSSFontFeatureValuesMap stylistic;
+  readonly attribute CSSFontFeatureValuesMap swash;
+  readonly attribute CSSFontFeatureValuesMap characterVariant;
+  readonly attribute CSSFontFeatureValuesMap styleset;
+
+  // Note: This attribute exists in IDL but it does not make sense
+  // and browsers don't support it: https://github.com/w3c/csswg-drafts/issues/13826
   // readonly attribute CSSFontFeatureValuesMap historicalForms;
 };
 
-// [Exposed=Window]
-// interface CSSFontFeatureValuesMap {
-//   maplike<CSSOMString, sequence<unsigned long>>;
-//   undefined set(CSSOMString featureValueName,
-//     (unsigned long or sequence<unsigned long>) values);
-// };
+[Exposed=Window]
+interface CSSFontFeatureValuesMap {
+  maplike<CSSOMString, sequence<unsigned long>>;
+  // undefined set(CSSOMString featureValueName,
+  //  (unsigned long or sequence<unsigned long>) values);
+};

--- a/components/script_bindings/webidls/CSSRule.webidl
+++ b/components/script_bindings/webidls/CSSRule.webidl
@@ -30,3 +30,8 @@ partial interface CSSRule {
 partial interface CSSRule {
     const unsigned short SUPPORTS_RULE = 12;
 };
+
+// https://drafts.csswg.org/css-fonts/#om-fontfeaturevalues
+partial interface CSSRule {
+    const unsigned short FONT_FEATURE_VALUES_RULE = 14;
+};

--- a/tests/wpt/meta/css/css-fonts/font-feature-values-map-live.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-feature-values-map-live.html.ini
@@ -1,6 +1,3 @@
 [font-feature-values-map-live.html]
   [Two retreived maps for CSSFontFeatureValuesRule.annotation should reflect the same values]
     expected: FAIL
-
-  [The second stylesheet should not be affected by modifications in the first]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/idlharness.html.ini
+++ b/tests/wpt/meta/css/css-fonts/idlharness.html.ini
@@ -5,49 +5,7 @@
   [CSSFontFaceRule interface: cssFontFaceRule must inherit property "style" with the proper type]
     expected: FAIL
 
-  [CSSRule interface: cssFontFaceRule must inherit property "FONT_FEATURE_VALUES_RULE" with the proper type]
-    expected: FAIL
-
   [CSSFontFeatureValuesRule interface: attribute fontFamily]
-    expected: FAIL
-
-  [CSSFontFeatureValuesRule interface: attribute annotation]
-    expected: FAIL
-
-  [CSSFontFeatureValuesRule interface: attribute ornaments]
-    expected: FAIL
-
-  [CSSFontFeatureValuesRule interface: attribute stylistic]
-    expected: FAIL
-
-  [CSSFontFeatureValuesRule interface: attribute swash]
-    expected: FAIL
-
-  [CSSFontFeatureValuesRule interface: attribute characterVariant]
-    expected: FAIL
-
-  [CSSFontFeatureValuesRule interface: attribute styleset]
-    expected: FAIL
-
-  [CSSFontFeatureValuesMap interface: existence and properties of interface object]
-    expected: FAIL
-
-  [CSSFontFeatureValuesMap interface object length]
-    expected: FAIL
-
-  [CSSFontFeatureValuesMap interface object name]
-    expected: FAIL
-
-  [CSSFontFeatureValuesMap interface: existence and properties of interface prototype object]
-    expected: FAIL
-
-  [CSSFontFeatureValuesMap interface: existence and properties of interface prototype object's "constructor" property]
-    expected: FAIL
-
-  [CSSFontFeatureValuesMap interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
-  [CSSFontFeatureValuesMap interface: operation set(CSSOMString, (unsigned long or sequence<unsigned long>))]
     expected: FAIL
 
   [CSSFontPaletteValuesRule interface: existence and properties of interface object]
@@ -78,18 +36,6 @@
     expected: FAIL
 
   [CSSFontPaletteValuesRule interface: attribute overrideColors]
-    expected: FAIL
-
-  [CSSRule interface: constant FONT_FEATURE_VALUES_RULE on interface object]
-    expected: FAIL
-
-  [CSSRule interface: constant FONT_FEATURE_VALUES_RULE on interface prototype object]
-    expected: FAIL
-
-  [CSSRule interface: cssRule must inherit property "FONT_FEATURE_VALUES_RULE" with the proper type]
-    expected: FAIL
-
-  [CSSFontFeatureValuesMap interface: maplike<CSSOMString, [object Object\]>]
     expected: FAIL
 
   [CSSFontFeatureValuesRule interface: attribute historicalForms]

--- a/tests/wpt/meta/css/css-values/tree-counting/sibling-function-descriptors.tentative.html.ini
+++ b/tests/wpt/meta/css/css-values/tree-counting/sibling-function-descriptors.tentative.html.ini
@@ -22,9 +22,3 @@
 
   [sibling-count() should not be allowed in @counter-style descriptors]
     expected: FAIL
-
-  [sibling-index() should not be allowed in @font-feature-values descriptors]
-    expected: FAIL
-
-  [sibling-count() should not be allowed in @font-feature-values descriptors]
-    expected: FAIL

--- a/tests/wpt/meta/css/cssom/CSSFontFeatureValuesRule.html.ini
+++ b/tests/wpt/meta/css/cssom/CSSFontFeatureValuesRule.html.ini
@@ -1,21 +1,6 @@
 [CSSFontFeatureValuesRule.html]
-  [CSSFontFeatureValuesRule is correctly parsed and accessible via CSSOM.]
-    expected: FAIL
-
   [CSSFontFeatureValuesMap entries are settable to single values.]
     expected: FAIL
 
-  [CSSFontFeatureValuesMap entries are settable to sequences of numbers.]
-    expected: FAIL
-
-  [New rules can be added.]
-    expected: FAIL
-
-  [Deleting single entries is possible.]
-    expected: FAIL
-
-  [Clearing all entries is possible.]
-    expected: FAIL
-
-  [Multiple rules for the same family are kept separate in CSSOM.]
+  [CSSFontFeatureValuesRule family is settable and readable.]
     expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14503,7 +14503,7 @@
      ]
     ],
     "interfaces.https.html": [
-     "8aeeed2ed1657c02068af282e1e424677f1a2190",
+     "dc8599403edd4ad6415b145562c1bf2f2bdd9026",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
@@ -53,6 +53,7 @@ test_interfaces([
   "CSS",
   "CSSConditionRule",
   "CSSFontFaceRule",
+  "CSSFontFeatureValuesMap",
   "CSSFontFeatureValuesRule",
   "CSSGroupingRule",
   "CSSImportRule",


### PR DESCRIPTION
So far the interface has been a complete stub, now we expose all the available info but don't allow modifying the underlying `@font-feature-values` rule yet.

Testing: New tests start to pass
