### PR TITLE
script: Avoid uncollectible cycles from IntersectionObserver.root

### DIFF
--- a/components/script/dom/intersectionobserver/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver/intersectionobserver.rs
@@ -53,8 +53,12 @@ pub(crate) enum UnrootedElementOrDocument {
 impl From<&ElementOrDocument> for UnrootedElementOrDocument {
     fn from(value: &ElementOrDocument) -> Self {
         match value {
-            ElementOrDocument::Document(d) => UnrootedElementOrDocument::Document(d.as_traced()),
-            ElementOrDocument::Element(e) => UnrootedElementOrDocument::Element(e.as_traced()),
+            ElementOrDocument::Document(document) => {
+                UnrootedElementOrDocument::Document(document.as_traced())
+            },
+            ElementOrDocument::Element(element) => {
+                UnrootedElementOrDocument::Element(element.as_traced())
+            },
         }
     }
 }
@@ -62,8 +66,12 @@ impl From<&ElementOrDocument> for UnrootedElementOrDocument {
 impl From<&UnrootedElementOrDocument> for ElementOrDocument {
     fn from(value: &UnrootedElementOrDocument) -> Self {
         match value {
-            UnrootedElementOrDocument::Document(d) => ElementOrDocument::Document(d.as_rooted()),
-            UnrootedElementOrDocument::Element(e) => ElementOrDocument::Element(e.as_rooted()),
+            UnrootedElementOrDocument::Document(document) => {
+                ElementOrDocument::Document(document.as_rooted())
+            },
+            UnrootedElementOrDocument::Element(element) => {
+                ElementOrDocument::Element(element.as_rooted())
+            },
         }
     }
 }
@@ -140,7 +148,7 @@ impl IntersectionObserver {
         Self {
             reflector_: Reflector::new(),
             owner_doc: window.Document().as_traced(),
-            root: root.as_ref().map(|r| r.into()),
+            root: root.as_ref().map(|root| root.into()),
             callback,
             queued_entries: Default::default(),
             observation_targets: Default::default(),
@@ -738,9 +746,7 @@ impl IntersectionObserverMethods<crate::DomTypeHolder> for IntersectionObserver 
     ///
     /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-root>
     fn GetRoot(&self) -> Option<ElementOrDocument> {
-        // Convert Dom<T> to DomRoot<T> for both (Document and Element) arms so the binding can
-        // return this attribute to JS.
-        self.root.as_ref().map(|r| r.into())
+        self.root.as_ref().map(|root| root.into())
     }
 
     /// > Offsets applied to the root intersection rectangle, effectively growing or

--- a/components/script/dom/intersectionobserver/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver/intersectionobserver.rs
@@ -43,11 +43,36 @@ use crate::dom::intersectionobserverentry::IntersectionObserverEntry;
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::window::Window;
 
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
+#[derive(JSTraceable, MallocSizeOf)]
+pub(crate) enum UnrootedElementOrDocument {
+    Element(Dom<Element>),
+    Document(Dom<Document>),
+}
+
+impl From<&ElementOrDocument> for UnrootedElementOrDocument {
+    fn from(value: &ElementOrDocument) -> Self {
+        match value {
+            ElementOrDocument::Document(d) => UnrootedElementOrDocument::Document(d.as_traced()),
+            ElementOrDocument::Element(e) => UnrootedElementOrDocument::Element(e.as_traced()),
+        }
+    }
+}
+
+impl From<&UnrootedElementOrDocument> for ElementOrDocument {
+    fn from(value: &UnrootedElementOrDocument) -> Self {
+        match value {
+            UnrootedElementOrDocument::Document(d) => ElementOrDocument::Document(d.as_rooted()),
+            UnrootedElementOrDocument::Element(e) => ElementOrDocument::Element(e.as_rooted()),
+        }
+    }
+}
+
 /// > The intersection root for an IntersectionObserver is the value of its root attribute if the attribute is non-null;
 /// > otherwise, it is the top-level browsing context’s document node, referred to as the implicit root.
 ///
 /// <https://w3c.github.io/IntersectionObserver/#intersectionobserver-intersection-root>
-pub type IntersectionRoot = Option<ElementOrDocument>;
+pub type IntersectionRoot = Option<UnrootedElementOrDocument>;
 
 /// The Intersection Observer interface
 ///
@@ -108,14 +133,14 @@ impl IntersectionObserver {
     fn new_inherited(
         window: &Window,
         callback: Rc<IntersectionObserverCallback>,
-        root: IntersectionRoot,
+        root: &Option<ElementOrDocument>,
         root_margin: IntersectionObserverMargin,
         scroll_margin: IntersectionObserverMargin,
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
             owner_doc: window.Document().as_traced(),
-            root,
+            root: root.as_ref().map(|r| r.into()),
             callback,
             queued_entries: Default::default(),
             observation_targets: Default::default(),
@@ -164,7 +189,7 @@ impl IntersectionObserver {
             Box::new(Self::new_inherited(
                 window,
                 callback,
-                init.root.clone(),
+                &init.root,
                 root_margin,
                 scroll_margin,
             )),
@@ -468,7 +493,7 @@ impl IntersectionObserver {
     // TODO: Currently we are unable to get the cross `ScriptThread` document.
     fn concrete_root(&self) -> Option<ElementOrDocument> {
         match &self.root {
-            Some(root) => Some(root.clone()),
+            Some(root) => Some(root.into()),
             None => self
                 .owner_doc
                 .window()
@@ -497,10 +522,12 @@ impl IntersectionObserver {
         // > If the intersection root is an Element, and target is not a descendant of
         // > the intersection root in the containing block chain, skip to step 11.
         match &self.root {
-            Some(ElementOrDocument::Document(document)) if document != &target.owner_document() => {
+            Some(UnrootedElementOrDocument::Document(document))
+                if document.as_rooted() != target.owner_document() =>
+            {
                 return IntersectionObservationOutput::default_skipped();
             },
-            Some(ElementOrDocument::Element(element)) => {
+            Some(UnrootedElementOrDocument::Element(element)) => {
                 // To ensure consistency, we also check for elements right now, but we can depend on the
                 // layout query later.
                 if element.owner_document() != target.owner_document() {
@@ -711,7 +738,9 @@ impl IntersectionObserverMethods<crate::DomTypeHolder> for IntersectionObserver 
     ///
     /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-root>
     fn GetRoot(&self) -> Option<ElementOrDocument> {
-        self.root.clone()
+        // Convert Dom<T> to DomRoot<T> for both (Document and Element) arms so the binding can
+        // return this attribute to JS.
+        self.root.as_ref().map(|r| r.into())
     }
 
     /// > Offsets applied to the root intersection rectangle, effectively growing or


### PR DESCRIPTION
Use an unrooted must_root enum with Dom<T> variants instead of the web IDL binding union for the root field. Dom edges are JSTraceable and traced with the observer, rather than DomRoot values that get registered in STACK_ROOTS and can leak via uncollectible cycles.


Testing:
```zsh
(servo) ➜  servo git:(io-el-or-doc-45630) git --no-pager log -n 1
commit 6cce6d1e1baa7e511fc2537769e12ac3ced0afbd (HEAD -> io-el-or-doc-45630, origin/io-el-or-doc-45630)
Author: apoorva <apoorvavpendse@gmail.com>
Date:   Thu Jul 23 10:17:09 2026 +0530

    script: Avoid uncollectible cycles from IntersectionObserver.root
    
    Use an unrooted enum with Dom<T> variants instead of the web IDL
    binding union for the root field. Dom edges are JSTraceable and
    traced with the observer, rather than DomRoot values that get
    registered in STACK_ROOTS and can leak via uncollectible cycles.
    
    Signed-off-by: apoorva <apoorvavpendse@gmail.com>
(servo) ➜  servo git:(io-el-or-doc-45630) ./mach test-tidy                                     
 ➤  Checking config file (./servo-tidy.toml)...
 ➤  Checking directories for correct file extensions...
 ➤  Checking files for tidiness...
 ➤  Checking type annotations in python files ...
 ➤  Skipping WPT lint checks, because no relevant files changed.
 ➤  Running `cargo-deny` checks...
 ➤  Checking co-authors ...
 ➤  Checking formatting of Rust files...
 ➤  Checking formatting of python files...
 ➤  Checking formatting of toml files...

 ✅ test-tidy reported no errors.
(servo) ➜  servo git:(io-el-or-doc-45630) ./mach build --use-crown
No build type specified so assuming `--dev`.
Building `debug` build with crown enabled.
   Compiling servo-script v0.4.0 (/Users/apoorva/Documents/programming/servo/components/script)
   Compiling servo-layout v0.4.0 (/Users/apoorva/Documents/programming/servo/components/layout)
   Compiling servo v0.4.0 (/Users/apoorva/Documents/programming/servo/components/servo)
   Compiling servoshell v0.4.0 (/Users/apoorva/Documents/programming/servo/ports/servoshell)
      Timing report saved to /Users/apoorva/Documents/programming/servo/target/cargo-timings/cargo-timing-20260723T045744901Z-0bfce867e997bfea.html
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 27.52s

 • GStreamer packaging is up-to-date
Succeeded in 0:00:27
(servo) ➜  servo git:(io-el-or-doc-45630) ./mach test-wpt tests/wpt/tests/intersection-observer
No build type specified so assuming `--dev`.
Running WPT tests with /Users/apoorva/Documents/programming/servo/target/debug/servoshell
Running 146 tests in web-platform-tests

Ran 146 tests finished in 26.2 seconds.
  • 146 ran as expected.
```

Fixes: #45630.

Discussion on Zulip realm: [#general > IntersectionObserver should not store a ElementOrDocument](https://servo.zulipchat.com/#narrow/channel/263398-general/topic/IntersectionObserver.20should.20not.20store.20a.20ElementOrDocument/with/609810962) 

*100% human-made* 🙂, unlike the previous #46561.