### PR TITLE
base: Rework UTF-8/16/32 offset/length wrapper types

### DIFF
--- a/components/layout/construct_modern.rs
+++ b/components/layout/construct_modern.rs
@@ -9,7 +9,7 @@ use std::ops::Range;
 use std::sync::OnceLock;
 
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use servo_base::text::Utf32CodeUnitLength;
+use servo_base::text::Utf32CodeUnits;
 use style::selector_parser::PseudoElement;
 
 use crate::PropagatedBoxTreeData;
@@ -181,7 +181,7 @@ impl<'dom> ModernContainerJob<'dom> {
 struct ModernContainerTextRun<'dom> {
     info: NodeAndStyleInfo<'dom>,
     text: Cow<'dom, str>,
-    document_selection_range: Option<Range<Utf32CodeUnitLength>>,
+    document_selection_range: Option<Range<Utf32CodeUnits>>,
     style_from_display_contents: Option<SharedInlineStyles>,
 }
 
@@ -214,7 +214,7 @@ impl<'dom> TraversalHandler<'dom> for ModernContainerBuilder<'_, 'dom> {
         &mut self,
         info: &NodeAndStyleInfo<'dom>,
         text: Cow<'dom, str>,
-        document_selection_range: Option<Range<Utf32CodeUnitLength>>,
+        document_selection_range: Option<Range<Utf32CodeUnits>>,
     ) {
         self.contiguous_text_runs.push(ModernContainerTextRun {
             info: info.clone(),

--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -10,7 +10,7 @@ use layout_api::{
 };
 use script::layout_dom::ServoLayoutNode;
 use servo_arc::Arc as ServoArc;
-use servo_base::text::Utf32CodeUnitLength;
+use servo_base::text::Utf32CodeUnits;
 use style::dom::NodeInfo;
 use style::properties::ComputedValues;
 use style::selector_parser::PseudoElement;
@@ -91,7 +91,7 @@ pub(super) trait TraversalHandler<'dom> {
         &mut self,
         info: &NodeAndStyleInfo<'dom>,
         text: Cow<'dom, str>,
-        document_selection: Option<Range<Utf32CodeUnitLength>>,
+        document_selection: Option<Range<Utf32CodeUnits>>,
     );
 
     /// Or pseudo-element

--- a/components/layout/flow/construct.rs
+++ b/components/layout/flow/construct.rs
@@ -8,7 +8,7 @@ use std::ops::Range;
 use layout_api::LayoutNode;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use servo_arc::Arc;
-use servo_base::text::Utf32CodeUnitLength;
+use servo_base::text::Utf32CodeUnits;
 use style::properties::ComputedValues;
 use style::properties::longhands::list_style_position::computed_value::T as ListStylePosition;
 use style::selector_parser::PseudoElement;
@@ -436,7 +436,7 @@ impl<'dom> TraversalHandler<'dom> for BlockContainerBuilder<'dom, '_> {
         &mut self,
         info: &NodeAndStyleInfo<'dom>,
         text: Cow<'dom, str>,
-        document_selection_range: Option<Range<Utf32CodeUnitLength>>,
+        document_selection_range: Option<Range<Utf32CodeUnits>>,
     ) {
         if text.is_empty() {
             return;

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -10,7 +10,7 @@ use std::ops::{ControlFlow, Range};
 use icu_properties::BidiClass;
 use icu_segmenter::WordSegmenter;
 use layout_api::{LayoutNode, SharedSelection};
-use servo_base::text::{Utf8CodeUnitLength, Utf32CodeUnitLength, utf8_offset_to_utf32_offset};
+use servo_base::text::Utf32CodeUnits;
 use style::computed_values::_webkit_text_security::T as WebKitTextSecurity;
 use style::computed_values::direction::T as Direction;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
@@ -310,7 +310,7 @@ impl InlineFormattingContextBuilder {
         info: &NodeAndStyleInfo<'dom>,
         container_info: &NodeAndStyleInfo<'dom>,
         layout_context: &LayoutContext,
-        document_selection: Option<Range<Utf32CodeUnitLength>>,
+        document_selection: Option<Range<Utf32CodeUnits>>,
     ) -> bool {
         if self.has_processed_first_letter || !container_info.pseudo_element_chain().is_empty() {
             self.push_text(text, info, document_selection);
@@ -329,7 +329,7 @@ impl InlineFormattingContextBuilder {
             return false;
         }
 
-        let intersect_ranges = |a: Range<Utf32CodeUnitLength>, b: Range<Utf32CodeUnitLength>| {
+        let intersect_ranges = |a: Range<Utf32CodeUnits>, b: Range<Utf32CodeUnits>| {
             let start = a.start.max(b.start);
             let end = b.end.min(b.end);
             if start < end { Some(start..end) } else { None }
@@ -337,15 +337,15 @@ impl InlineFormattingContextBuilder {
 
         // Push any leading white space first.
         let first_letter_range_u32 = LazyCell::new(|| {
-            utf8_offset_to_utf32_offset(&text, Utf8CodeUnitLength(first_letter_range.start))..
-                utf8_offset_to_utf32_offset(&text, Utf8CodeUnitLength(first_letter_range.end))
+            Utf32CodeUnits::length_of(&text[..first_letter_range.start])..
+                Utf32CodeUnits::length_of(&text[..first_letter_range.end])
         });
         if first_letter_range.start != 0 {
             let leading_whitespace_range = 0..first_letter_range.start;
             let leading_whitespace_selection_range =
                 document_selection.clone().and_then(|document_selection| {
                     let leading_whitespace_range_u32 =
-                        Utf32CodeUnitLength::zero()..first_letter_range_u32.start;
+                        Utf32CodeUnits::zero()..first_letter_range_u32.start;
                     intersect_ranges(document_selection, leading_whitespace_range_u32)
                 });
 
@@ -402,7 +402,7 @@ impl InlineFormattingContextBuilder {
         &mut self,
         text: Cow<'dom, str>,
         info: &NodeAndStyleInfo<'dom>,
-        document_selection: Option<Range<Utf32CodeUnitLength>>,
+        document_selection: Option<Range<Utf32CodeUnits>>,
     ) {
         let white_space_collapse = info.style.clone_white_space_collapse();
         let collapsed = WhitespaceCollapse::new(
@@ -530,7 +530,7 @@ impl InlineFormattingContextBuilder {
     fn try_to_push_text_range_to_previous_text_run(
         &mut self,
         info: &NodeAndStyleInfo,
-        new_text_selection: &Option<Range<Utf32CodeUnitLength>>,
+        new_text_selection: &Option<Range<Utf32CodeUnits>>,
         new_range: &Range<usize>,
         new_character_range: &Range<usize>,
     ) -> ControlFlow<()> {
@@ -561,9 +561,9 @@ impl InlineFormattingContextBuilder {
                 }
             } else {
                 // If only the new part of the text run has a selection, we can use it directly.
-                text_run.document_selection = Utf32CodeUnitLength(existing_characters) +
+                text_run.document_selection = Utf32CodeUnits(existing_characters) +
                     next_text_selection.start..
-                    Utf32CodeUnitLength(existing_characters) + next_text_selection.end;
+                    Utf32CodeUnits(existing_characters) + next_text_selection.end;
             }
         }
 

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -19,7 +19,7 @@ use layout_api::ScriptSelection;
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use servo_arc::Arc as ServoArc;
-use servo_base::text::{Utf32CodeUnitLength, is_bidi_control};
+use servo_base::text::{Utf32CodeUnits, is_bidi_control};
 use style::Zero;
 use style::computed_values::font_kerning::T as FontKerning;
 use style::computed_values::font_variant_position::T as FontVariantPosition;
@@ -464,7 +464,7 @@ pub(crate) struct TextRun {
     pub character_range: Range<usize>,
 
     /// The range of `char` characters in this `TextRun` that overlap the Document’s selection
-    pub document_selection: Range<Utf32CodeUnitLength>,
+    pub document_selection: Range<Utf32CodeUnits>,
 
     /// The [`TextRunItem`]s of this text run. This is produced by segmenting the incoming text
     /// by things such as font and script as well as separating out hard line breaks.
@@ -478,7 +478,7 @@ impl TextRun {
         inline_styles: SharedInlineStyles,
         text_range: Range<usize>,
         character_range: Range<usize>,
-        document_selection: Range<Utf32CodeUnitLength>,
+        document_selection: Range<Utf32CodeUnits>,
         old_text_run: Option<ArcRefCell<TextRun>>,
     ) -> Self {
         // If there was a previous box tree layout of this text run, try to preserve the old shaped text.

--- a/components/layout/table/construct.rs
+++ b/components/layout/table/construct.rs
@@ -10,7 +10,7 @@ use atomic_refcell::AtomicRef;
 use layout_api::LayoutNode;
 use log::warn;
 use servo_arc::Arc;
-use servo_base::text::Utf32CodeUnitLength;
+use servo_base::text::Utf32CodeUnits;
 use style::properties::ComputedValues;
 use style::properties::style_structs::Font;
 use style::selector_parser::PseudoElement;
@@ -55,7 +55,7 @@ pub(crate) enum AnonymousTableContent<'dom> {
     Text(
         NodeAndStyleInfo<'dom>,
         Cow<'dom, str>,
-        Option<Range<Utf32CodeUnitLength>>,
+        Option<Range<Utf32CodeUnits>>,
     ),
     EnterDisplayContents(SharedInlineStyles),
     LeaveDisplayContents,
@@ -785,7 +785,7 @@ impl<'dom> TraversalHandler<'dom> for TableBuilderTraversal<'_, 'dom> {
         &mut self,
         info: &NodeAndStyleInfo<'dom>,
         text: Cow<'dom, str>,
-        document_selection_range: Option<Range<Utf32CodeUnitLength>>,
+        document_selection_range: Option<Range<Utf32CodeUnits>>,
     ) {
         self.current_anonymous_row_content
             .push(AnonymousTableContent::Text(
@@ -1080,7 +1080,7 @@ impl<'dom> TraversalHandler<'dom> for TableRowGroupBuilder<'_, '_, 'dom, '_> {
         &mut self,
         info: &NodeAndStyleInfo<'dom>,
         text: Cow<'dom, str>,
-        document_selection_range: Option<Range<Utf32CodeUnitLength>>,
+        document_selection_range: Option<Range<Utf32CodeUnits>>,
     ) {
         self.current_anonymous_row_content
             .push(AnonymousTableContent::Text(
@@ -1247,7 +1247,7 @@ impl<'dom> TraversalHandler<'dom> for TableRowBuilder<'_, '_, 'dom, '_> {
         &mut self,
         info: &NodeAndStyleInfo<'dom>,
         text: Cow<'dom, str>,
-        document_selection_range: Option<Range<Utf32CodeUnitLength>>,
+        document_selection_range: Option<Range<Utf32CodeUnits>>,
     ) {
         self.current_anonymous_cell_content
             .push(AnonymousTableContent::Text(
@@ -1366,7 +1366,7 @@ impl<'dom> TraversalHandler<'dom> for TableColumnGroupBuilder {
         &mut self,
         _info: &NodeAndStyleInfo<'dom>,
         _text: Cow<'dom, str>,
-        _document_selection_range: Option<Range<Utf32CodeUnitLength>>,
+        _document_selection_range: Option<Range<Utf32CodeUnits>>,
     ) {
     }
     fn enter_display_contents(&mut self, _: SharedInlineStyles) {}

--- a/components/script/dom/characterdata/characterdata.rs
+++ b/components/script/dom/characterdata/characterdata.rs
@@ -9,6 +9,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::{DomRefCell, Ref};
 use script_bindings::codegen::InheritTypes::{CharacterDataTypeId, NodeTypeId, TextTypeId};
+use servo_base::text::Utf16CodeUnits;
 
 use crate::dom::bindings::codegen::Bindings::CharacterDataBinding::CharacterDataMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::Node_Binding::NodeMethods;
@@ -113,7 +114,7 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
     fn SetData(&self, cx: &mut JSContext, data: DOMString) {
         self.queue_mutation_record(cx);
         let old_length = self.Length();
-        let new_length = data.str().encode_utf16().count() as u32;
+        let new_length = Utf16CodeUnits::length_of(&data.str()).0 as u32;
         *self.data.safe_borrow_mut(cx.no_gc()) = String::from(data.str());
         self.content_changed(cx);
 
@@ -125,7 +126,7 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
 
     /// <https://dom.spec.whatwg.org/#dom-characterdata-length>
     fn Length(&self) -> u32 {
-        self.data.borrow().encode_utf16().count() as u32
+        Utf16CodeUnits::length_of(&self.data.borrow()).0 as u32
     }
 
     /// <https://dom.spec.whatwg.org/#dom-characterdata-substringdata>
@@ -266,7 +267,7 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
                 node,
                 offset,
                 count,
-                arg.str().encode_utf16().count() as u32,
+                Utf16CodeUnits::length_of(&arg.str()).0 as u32,
             );
         }
 

--- a/components/script/dom/html/form_controls/htmlinputelement.rs
+++ b/components/script/dom/html/form_controls/htmlinputelement.rs
@@ -23,7 +23,7 @@ use num_traits::ToPrimitive;
 use script_bindings::cell::{DomRefCell, Ref};
 use script_bindings::domstring::parse_floating_point_number;
 use servo_base::generic_channel::GenericSender;
-use servo_base::text::Utf16CodeUnitLength;
+use servo_base::text::Utf16CodeUnits;
 use style::attr::AttrValue;
 use style::str::split_commas;
 use stylo_atoms::Atom;
@@ -757,7 +757,7 @@ impl HTMLInputElement {
         }
 
         let mut failed_flags = ValidationFlags::empty();
-        let Utf16CodeUnitLength(value_len) = textinput.len_utf16();
+        let Utf16CodeUnits(value_len) = textinput.len_utf16();
         let min_length = self.MinLength();
         let max_length = self.MaxLength();
 
@@ -1464,7 +1464,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionstart>
     fn SetSelectionStart(&self, _cx: &mut JSContext, start: Option<u32>) -> ErrorResult {
         self.selection()
-            .set_dom_start(start.map(Utf16CodeUnitLength::from))
+            .set_dom_start(start.map(Utf16CodeUnits::from))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionend>
@@ -1474,8 +1474,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionend>
     fn SetSelectionEnd(&self, _cx: &mut JSContext, end: Option<u32>) -> ErrorResult {
-        self.selection()
-            .set_dom_end(end.map(Utf16CodeUnitLength::from))
+        self.selection().set_dom_end(end.map(Utf16CodeUnits::from))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectiondirection>
@@ -1495,8 +1494,8 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-setselectionrange>
     fn SetSelectionRange(&self, start: u32, end: u32, direction: Option<DOMString>) -> ErrorResult {
         self.selection().set_dom_range(
-            Utf16CodeUnitLength::from(start),
-            Utf16CodeUnitLength::from(end),
+            Utf16CodeUnits::from(start),
+            Utf16CodeUnits::from(end),
             direction,
         )
     }
@@ -1517,8 +1516,8 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
     ) -> ErrorResult {
         self.selection().set_dom_range_text(
             replacement,
-            Some(Utf16CodeUnitLength::from(start)),
-            Some(Utf16CodeUnitLength::from(end)),
+            Some(Utf16CodeUnits::from(start)),
+            Some(Utf16CodeUnits::from(end)),
             selection_mode,
         )
     }
@@ -2126,12 +2125,10 @@ impl VirtualMethods for HTMLInputElement {
 
                         // Set or remove the length restrictions depending on whether they apply
                         if self.does_minmaxlength_apply() {
-                            textinput.set_min_length(
-                                self.MinLength().to_usize().map(Utf16CodeUnitLength),
-                            );
-                            textinput.set_max_length(
-                                self.MaxLength().to_usize().map(Utf16CodeUnitLength),
-                            );
+                            textinput
+                                .set_min_length(self.MinLength().to_usize().map(Utf16CodeUnits));
+                            textinput
+                                .set_max_length(self.MaxLength().to_usize().map(Utf16CodeUnits));
                         } else {
                             textinput.set_min_length(None);
                             textinput.set_max_length(None);
@@ -2177,7 +2174,7 @@ impl VirtualMethods for HTMLInputElement {
                     if value < 0 {
                         textinput.set_max_length(None);
                     } else {
-                        textinput.set_max_length(Some(Utf16CodeUnitLength(value as usize)))
+                        textinput.set_max_length(Some(Utf16CodeUnits(value as usize)))
                     }
                 },
                 _ => panic!("Expected an AttrValue::Int"),
@@ -2189,7 +2186,7 @@ impl VirtualMethods for HTMLInputElement {
                     if value < 0 {
                         textinput.set_min_length(None);
                     } else {
-                        textinput.set_min_length(Some(Utf16CodeUnitLength(value as usize)))
+                        textinput.set_min_length(Some(Utf16CodeUnits(value as usize)))
                     }
                 },
                 _ => panic!("Expected an AttrValue::Int"),

--- a/components/script/dom/html/form_controls/text_control.rs
+++ b/components/script/dom/html/form_controls/text_control.rs
@@ -10,7 +10,7 @@
 use std::cell::Ref;
 
 use script_bindings::cell::DomRefCell;
-use servo_base::text::Utf16CodeUnitLength;
+use servo_base::text::Utf16CodeUnits;
 
 use crate::dom::bindings::codegen::Bindings::HTMLFormElementBinding::SelectionMode;
 use crate::dom::bindings::conversions::DerivedFrom;
@@ -63,15 +63,15 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
 
         // Step 2 : Set the selection range with 0 and infinity.
         self.set_range(
-            Some(Utf16CodeUnitLength::zero()),
-            Some(Utf16CodeUnitLength(usize::MAX)),
+            Some(Utf16CodeUnits::zero()),
+            Some(Utf16CodeUnits(usize::MAX)),
             None,
             None,
         );
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionstart
-    pub(crate) fn dom_start(&self) -> Option<Utf16CodeUnitLength> {
+    pub(crate) fn dom_start(&self) -> Option<Utf16CodeUnits> {
         // Step 1
         if !self.element.selection_api_applies() {
             return None;
@@ -82,7 +82,7 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionstart
-    pub(crate) fn set_dom_start(&self, start: Option<Utf16CodeUnitLength>) -> ErrorResult {
+    pub(crate) fn set_dom_start(&self, start: Option<Utf16CodeUnits>) -> ErrorResult {
         // Step 1: If this element is an input element, and selectionStart does not apply
         // to this element, throw an "InvalidStateError" DOMException.
         if !self.element.selection_api_applies() {
@@ -105,7 +105,7 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionend
-    pub(crate) fn dom_end(&self) -> Option<Utf16CodeUnitLength> {
+    pub(crate) fn dom_end(&self) -> Option<Utf16CodeUnits> {
         // Step 1: If this element is an input element, and selectionEnd does not apply to
         // this element, return null.
         if !self.element.selection_api_applies() {
@@ -120,7 +120,7 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionend
-    pub(crate) fn set_dom_end(&self, end: Option<Utf16CodeUnitLength>) -> ErrorResult {
+    pub(crate) fn set_dom_end(&self, end: Option<Utf16CodeUnits>) -> ErrorResult {
         // Step 1: If this element is an input element, and selectionEnd does not apply to
         // this element, throw an "InvalidStateError" DOMException.
         if !self.element.selection_api_applies() {
@@ -164,8 +164,8 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
     // https://html.spec.whatwg.org/multipage/#dom-textarea/input-setselectionrange
     pub(crate) fn set_dom_range(
         &self,
-        start: Utf16CodeUnitLength,
-        end: Utf16CodeUnitLength,
+        start: Utf16CodeUnits,
+        end: Utf16CodeUnits,
         direction: Option<DOMString>,
     ) -> ErrorResult {
         // Step 1
@@ -187,8 +187,8 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
     pub(crate) fn set_dom_range_text(
         &self,
         replacement: DOMString,
-        start: Option<Utf16CodeUnitLength>,
-        end: Option<Utf16CodeUnitLength>,
+        start: Option<Utf16CodeUnits>,
+        end: Option<Utf16CodeUnits>,
         selection_mode: SelectionMode,
     ) -> ErrorResult {
         // Step 1: If this element is an input element, and setRangeText() does not apply
@@ -303,8 +303,7 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
                 // start. (This snaps the start of the selection to the start of the new
                 // text if it was in the middle of the text that it replaced.)
                 if selection_start > end {
-                    selection_start =
-                        Utf16CodeUnitLength::from((selection_start.0 as isize) + delta);
+                    selection_start = Utf16CodeUnits::from((selection_start.0 as isize) + delta);
                 } else if selection_start > start {
                     selection_start = start;
                 }
@@ -316,7 +315,7 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
                 // end. (This snaps the end of the selection to the end of the new text if
                 // it was in the middle of the text that it replaced.)
                 if selection_end > end {
-                    selection_end = Utf16CodeUnitLength::from((selection_end.0 as isize) + delta);
+                    selection_end = Utf16CodeUnits::from((selection_end.0 as isize) + delta);
                 } else if selection_end > start {
                     selection_end = new_end;
                 }
@@ -333,11 +332,11 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
         Ok(())
     }
 
-    fn start(&self) -> Utf16CodeUnitLength {
+    fn start(&self) -> Utf16CodeUnits {
         self.textinput.borrow().selection_start_utf16()
     }
 
-    fn end(&self) -> Utf16CodeUnitLength {
+    fn end(&self) -> Utf16CodeUnits {
         self.textinput.borrow().selection_end_utf16()
     }
 
@@ -348,8 +347,8 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
     /// <https://html.spec.whatwg.org/multipage/#set-the-selection-range>
     fn set_range(
         &self,
-        start: Option<Utf16CodeUnitLength>,
-        end: Option<Utf16CodeUnitLength>,
+        start: Option<Utf16CodeUnits>,
+        end: Option<Utf16CodeUnits>,
         direction: Option<SelectionDirection>,
         original_selection_state: Option<SelectionState>,
     ) {

--- a/components/script/dom/html/form_controls/text_input.rs
+++ b/components/script/dom/html/form_controls/text_input.rs
@@ -16,7 +16,7 @@ use script_bindings::match_domstring_ascii;
 use script_bindings::trace::CustomTraceable;
 use servo_base::generic_channel::GenericCallback;
 use servo_base::id::WebViewId;
-use servo_base::text::{Utf8CodeUnitLength, Utf16CodeUnitLength};
+use servo_base::text::{Utf8CodeUnits, Utf16CodeUnits};
 use servo_base::{Rope, RopeIndex, RopeMovement, RopeSlice};
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
@@ -154,8 +154,8 @@ pub struct TextInput<T: ClipboardProvider> {
     /// The maximum number of UTF-16 code units this text input is allowed to hold.
     ///
     /// <https://html.spec.whatwg.org/multipage/#attr-fe-maxlength>
-    max_length: Option<Utf16CodeUnitLength>,
-    min_length: Option<Utf16CodeUnitLength>,
+    max_length: Option<Utf16CodeUnits>,
+    min_length: Option<Utf16CodeUnits>,
 
     /// Was last change made by set_content?
     was_last_change_by_set_content: bool,
@@ -271,15 +271,15 @@ pub(crate) const CMD_OR_CONTROL: Modifiers = Modifiers::CONTROL;
 /// The length in bytes of the first n code units in a string when encoded in UTF-16.
 ///
 /// If the string is fewer than n code units, returns the length of the whole string.
-fn len_of_first_n_code_units(text: &DOMString, n: Utf16CodeUnitLength) -> Utf8CodeUnitLength {
-    let mut utf8_len = Utf8CodeUnitLength::zero();
-    let mut utf16_len = Utf16CodeUnitLength::zero();
+fn len_of_first_n_code_units(text: &DOMString, n: Utf16CodeUnits) -> Utf8CodeUnits {
+    let mut utf8_len = Utf8CodeUnits::zero();
+    let mut utf16_len = Utf16CodeUnits::zero();
     for c in text.str().chars() {
-        utf16_len += Utf16CodeUnitLength(c.len_utf16());
+        utf16_len += Utf16CodeUnits(c.len_utf16());
         if utf16_len > n {
             break;
         }
-        utf8_len += Utf8CodeUnitLength(c.len_utf8());
+        utf8_len += Utf8CodeUnits(c.len_utf8());
     }
     utf8_len
 }
@@ -319,11 +319,11 @@ impl<T: ClipboardProvider> TextInput<T> {
         self.selection_direction
     }
 
-    pub fn set_max_length(&mut self, length: Option<Utf16CodeUnitLength>) {
+    pub fn set_max_length(&mut self, length: Option<Utf16CodeUnits>) {
         self.max_length = length;
     }
 
-    pub fn set_min_length(&mut self, length: Option<Utf16CodeUnitLength>) {
+    pub fn set_min_length(&mut self, length: Option<Utf16CodeUnits>) {
         self.min_length = length;
     }
 
@@ -377,12 +377,12 @@ impl<T: ClipboardProvider> TextInput<T> {
         }
     }
 
-    pub(crate) fn selection_start_utf16(&self) -> Utf16CodeUnitLength {
+    pub(crate) fn selection_start_utf16(&self) -> Utf16CodeUnits {
         self.rope.index_to_utf16_offset(self.selection_start())
     }
 
     /// The byte offset of the selection_start()
-    fn selection_start_offset(&self) -> Utf8CodeUnitLength {
+    fn selection_start_offset(&self) -> Utf8CodeUnits {
         self.rope.index_to_utf8_offset(self.selection_start())
     }
 
@@ -395,12 +395,12 @@ impl<T: ClipboardProvider> TextInput<T> {
         }
     }
 
-    pub(crate) fn selection_end_utf16(&self) -> Utf16CodeUnitLength {
+    pub(crate) fn selection_end_utf16(&self) -> Utf16CodeUnits {
         self.rope.index_to_utf16_offset(self.selection_end())
     }
 
     /// The byte offset of the selection_end()
-    pub fn selection_end_offset(&self) -> Utf8CodeUnitLength {
+    pub fn selection_end_offset(&self) -> Utf8CodeUnits {
         self.rope.index_to_utf8_offset(self.selection_end())
     }
 
@@ -415,7 +415,7 @@ impl<T: ClipboardProvider> TextInput<T> {
     /// Return the selection range as byte offsets from the start of the content.
     ///
     /// If there is no selection, returns an empty range at the edit point.
-    pub(crate) fn sorted_selection_offsets_range(&self) -> Range<Utf8CodeUnitLength> {
+    pub(crate) fn sorted_selection_offsets_range(&self) -> Range<Utf8CodeUnits> {
         self.selection_start_offset()..self.selection_end_offset()
     }
 
@@ -472,8 +472,8 @@ impl<T: ClipboardProvider> TextInput<T> {
     }
 
     /// The length of the selected text in UTF-16 code units.
-    fn selection_utf16_len(&self) -> Utf16CodeUnitLength {
-        Utf16CodeUnitLength(
+    fn selection_utf16_len(&self) -> Utf16CodeUnits {
+        Utf16CodeUnits(
             self.selection_slice()
                 .chars()
                 .map(char::len_utf16)
@@ -490,7 +490,7 @@ impl<T: ClipboardProvider> TextInput<T> {
                 self.len_utf16().saturating_sub(self.selection_utf16_len());
             let utf16_length_that_can_be_inserted =
                 max_length.saturating_sub(utf16_length_without_selection);
-            let Utf8CodeUnitLength(last_char_index) =
+            let Utf8CodeUnits(last_char_index) =
                 len_of_first_n_code_units(insert, utf16_length_that_can_be_inserted);
             &insert.str()[..last_char_index]
         } else {
@@ -982,7 +982,7 @@ impl<T: ClipboardProvider> TextInput<T> {
     }
 
     /// The total number of code units required to encode the content in utf16.
-    pub(crate) fn len_utf16(&self) -> Utf16CodeUnitLength {
+    pub(crate) fn len_utf16(&self) -> Utf16CodeUnits {
         self.rope.len_utf16()
     }
 
@@ -1015,8 +1015,8 @@ impl<T: ClipboardProvider> TextInput<T> {
 
     pub fn set_selection_range_utf16(
         &mut self,
-        start: Utf16CodeUnitLength,
-        end: Utf16CodeUnitLength,
+        start: Utf16CodeUnits,
+        end: Utf16CodeUnits,
         direction: SelectionDirection,
     ) {
         self.set_selection_range_utf8(
@@ -1028,8 +1028,8 @@ impl<T: ClipboardProvider> TextInput<T> {
 
     pub fn set_selection_range_utf8(
         &mut self,
-        mut start: Utf8CodeUnitLength,
-        mut end: Utf8CodeUnitLength,
+        mut start: Utf8CodeUnits,
+        mut end: Utf8CodeUnits,
         direction: SelectionDirection,
     ) {
         let text_end = self.get_content().len_utf8();

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -13,7 +13,7 @@ use js::context::JSContext;
 use js::rust::HandleObject;
 use layout_api::{ScriptSelection, SharedSelection};
 use script_bindings::cell::DomRefCell;
-use servo_base::text::Utf16CodeUnitLength;
+use servo_base::text::Utf16CodeUnits;
 use style::attr::AttrValue;
 use stylo_dom::ElementState;
 
@@ -475,7 +475,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionstart>
     fn SetSelectionStart(&self, _cx: &mut JSContext, start: Option<u32>) -> ErrorResult {
         self.selection()
-            .set_dom_start(start.map(Utf16CodeUnitLength::from))
+            .set_dom_start(start.map(Utf16CodeUnits::from))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionend>
@@ -485,8 +485,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionend>
     fn SetSelectionEnd(&self, _cx: &mut JSContext, end: Option<u32>) -> ErrorResult {
-        self.selection()
-            .set_dom_end(end.map(Utf16CodeUnitLength::from))
+        self.selection().set_dom_end(end.map(Utf16CodeUnits::from))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectiondirection>
@@ -506,8 +505,8 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-setselectionrange>
     fn SetSelectionRange(&self, start: u32, end: u32, direction: Option<DOMString>) -> ErrorResult {
         self.selection().set_dom_range(
-            Utf16CodeUnitLength::from(start),
-            Utf16CodeUnitLength::from(end),
+            Utf16CodeUnits::from(start),
+            Utf16CodeUnits::from(end),
             direction,
         )
     }
@@ -528,8 +527,8 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
     ) -> ErrorResult {
         self.selection().set_dom_range_text(
             replacement,
-            Some(Utf16CodeUnitLength::from(start)),
-            Some(Utf16CodeUnitLength::from(end)),
+            Some(Utf16CodeUnits::from(start)),
+            Some(Utf16CodeUnits::from(end)),
             selection_mode,
         )
     }
@@ -651,7 +650,7 @@ impl VirtualMethods for HTMLTextAreaElement {
                     if value < 0 {
                         textinput.set_max_length(None);
                     } else {
-                        textinput.set_max_length(Some(Utf16CodeUnitLength(value as usize)))
+                        textinput.set_max_length(Some(Utf16CodeUnits(value as usize)))
                     }
                 },
                 _ => panic!("Expected an AttrValue::Int"),
@@ -663,7 +662,7 @@ impl VirtualMethods for HTMLTextAreaElement {
                     if value < 0 {
                         textinput.set_min_length(None);
                     } else {
-                        textinput.set_min_length(Some(Utf16CodeUnitLength(value as usize)))
+                        textinput.set_min_length(Some(Utf16CodeUnits(value as usize)))
                     }
                 },
                 _ => panic!("Expected an AttrValue::Int"),
@@ -903,7 +902,7 @@ impl Validatable for HTMLTextAreaElement {
         let mut failed_flags = ValidationFlags::empty();
 
         let textinput = self.textinput.borrow();
-        let Utf16CodeUnitLength(value_len) = textinput.len_utf16();
+        let Utf16CodeUnits(value_len) = textinput.len_utf16();
         let last_edit_by_user = !textinput.was_last_change_by_set_content();
         let value_dirty = self.value_dirty.get();
 

--- a/components/script/dom/node/layout_dom.rs
+++ b/components/script/dom/node/layout_dom.rs
@@ -17,7 +17,7 @@ use script_bindings::codegen::InheritTypes::{
     ElementTypeId, HTMLElementTypeId, SVGElementTypeId, SVGGraphicsElementTypeId,
 };
 use servo_base::id::{BrowsingContextId, PipelineId};
-use servo_base::text::{Utf32CodeUnitLength, utf16_offset_to_utf32_offset};
+use servo_base::text::Utf32CodeUnits;
 use servo_url::ServoUrl;
 use style::dom::OpaqueNode;
 use style::selector_parser::PseudoElement;
@@ -250,7 +250,7 @@ impl<'dom> LayoutDom<'dom, Node> {
     }
 
     #[expect(unsafe_code)]
-    pub(crate) fn document_selection_in_text_node(&self) -> Option<Range<Utf32CodeUnitLength>> {
+    pub(crate) fn document_selection_in_text_node(&self) -> Option<Range<Utf32CodeUnits>> {
         let unsafe_self = self.unsafe_get();
         if !unsafe_self.get_flag(NodeFlags::OVERLAPS_DOCUMENT_SELECTION) {
             return None;
@@ -273,15 +273,15 @@ impl<'dom> LayoutDom<'dom, Node> {
         let is_end_node = unsafe { range_end.node().to_layout() } == *self;
 
         let start_offset = if is_start_node {
-            utf16_offset_to_utf32_offset(text, range_start.offset().into())
+            range_start.offset().to_utf32_code_units_in(text)
         } else {
-            Utf32CodeUnitLength(0)
+            Utf32CodeUnits(0)
         };
 
         let end_offset = if is_end_node {
-            utf16_offset_to_utf32_offset(text, range_end.offset().into())
+            range_end.offset().to_utf32_code_units_in(text)
         } else {
-            Utf32CodeUnitLength(text.chars().count())
+            Utf32CodeUnits::length_of(text)
         };
 
         Some(start_offset..end_offset)

--- a/components/script/dom/range/abstractrange.rs
+++ b/components/script/dom/range/abstractrange.rs
@@ -8,6 +8,7 @@ use std::cmp::{Ord, Ordering, PartialEq, PartialOrd};
 use deny_public_fields::DenyPublicFields;
 use dom_struct::dom_struct;
 use script_bindings::reflector::Reflector;
+use servo_base::text::Utf16CodeUnits;
 
 use crate::dom::bindings::codegen::Bindings::AbstractRangeBinding::AbstractRangeMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::{NodeConstants, NodeMethods};
@@ -97,8 +98,8 @@ impl BoundaryPoint {
         self.set_offset(offset);
     }
 
-    pub(crate) fn offset(&self) -> u32 {
-        self.offset.get()
+    pub(crate) fn offset(&self) -> Utf16CodeUnits {
+        Utf16CodeUnits::from(self.offset.get())
     }
 
     pub(crate) fn set_offset(&self, offset: u32) {

--- a/components/script/layout_dom/servo_layout_node.rs
+++ b/components/script/layout_dom/servo_layout_node.rs
@@ -17,7 +17,7 @@ use net_traits::image_cache::Image;
 use pixels::ImageMetadata;
 use servo_arc::Arc;
 use servo_base::id::{BrowsingContextId, PipelineId};
-use servo_base::text::Utf32CodeUnitLength;
+use servo_base::text::Utf32CodeUnits;
 use servo_url::ServoUrl;
 use style;
 use style::context::SharedStyleContext;
@@ -248,7 +248,7 @@ impl<'dom> LayoutNode<'dom> for ServoLayoutNode<'dom> {
         self.node.text_content()
     }
 
-    fn document_selection_in_text_node(&self) -> Option<Range<Utf32CodeUnitLength>> {
+    fn document_selection_in_text_node(&self) -> Option<Range<Utf32CodeUnits>> {
         self.node.document_selection_in_text_node()
     }
 

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -22,7 +22,7 @@ use js::rust::{Runtime, Trace};
 use malloc_size_of::MallocSizeOfOps;
 use num_traits::{ToPrimitive, Zero};
 use regex::Regex;
-use servo_base::text::{Utf8CodeUnitLength, Utf16CodeUnitLength};
+use servo_base::text::{Utf8CodeUnits, Utf16CodeUnits};
 use style::Atom;
 use style::str::HTML_SPACE_CHARACTERS;
 use zeroize::Zeroize;
@@ -411,20 +411,20 @@ impl DOMString {
 
     /// The length of this string in UTF-8 code units, each one being one byte in size.
     /// This method is the same as [`DOMString::len`], but the result is wrapped in a
-    /// `Utf8CodeUnitLength` to be used in code that mixes different kinds of offsets.
+    /// `Utf8CodeUnits` to be used in code that mixes different kinds of offsets.
     ///
     /// Note: This is different than the number of Unicode characters (or code points). A
     /// character may require multiple UTF-8 code units.
-    pub fn len_utf8(&self) -> Utf8CodeUnitLength {
-        Utf8CodeUnitLength(self.len())
+    pub fn len_utf8(&self) -> Utf8CodeUnits {
+        Utf8CodeUnits(self.len())
     }
 
     /// The length of this string in UTF-16 code units, each one being one two bytes in size.
     ///
     /// Note: This is different than the number of Unicode characters (or code points). A
     /// character may require multiple UTF-16 code units.
-    pub fn len_utf16(&self) -> Utf16CodeUnitLength {
-        Utf16CodeUnitLength(self.str().chars().map(char::len_utf16).sum())
+    pub fn len_utf16(&self) -> Utf16CodeUnits {
+        Utf16CodeUnits(self.str().chars().map(char::len_utf16).sum())
     }
 
     pub fn make_ascii_lowercase(&mut self) {

--- a/components/script_bindings/trace.rs
+++ b/components/script_bindings/trace.rs
@@ -20,7 +20,7 @@ use js::jsapi::{GCTraceKindToAscii, Heap, JSObject, JSTracer, TraceKind};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use parking_lot::RwLock;
 use servo_arc::Arc as ServoArc;
-use servo_base::text::{Utf8CodeUnitLength, Utf16CodeUnitLength};
+use servo_base::text::{Utf8CodeUnits, Utf16CodeUnits};
 use smallvec::SmallVec;
 use style::author_styles::AuthorStyles;
 use style::stylesheet_set::{AuthorStylesheetSet, DocumentStylesheetSet};
@@ -425,12 +425,12 @@ impl<T: MallocSizeOf> MallocSizeOf for NoTrace<T> {
     }
 }
 
-unsafe impl CustomTraceable for Utf8CodeUnitLength {
+unsafe impl CustomTraceable for Utf8CodeUnits {
     #[inline]
     unsafe fn trace(&self, _: *mut JSTracer) {}
 }
 
-unsafe impl CustomTraceable for Utf16CodeUnitLength {
+unsafe impl CustomTraceable for Utf16CodeUnits {
     #[inline]
     unsafe fn trace(&self, _: *mut JSTracer) {}
 }

--- a/components/shared/base/rope.rs
+++ b/components/shared/base/rope.rs
@@ -9,7 +9,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use rayon::iter::Either;
 use unicode_segmentation::UnicodeSegmentation;
 
-use crate::text::{Utf8CodeUnitLength, Utf16CodeUnitLength};
+use crate::text::{Utf8CodeUnits, Utf16CodeUnits};
 
 fn contents_vec(contents: impl Into<String>) -> Vec<String> {
     let mut contents: Vec<_> = contents
@@ -153,8 +153,8 @@ impl Rope {
     }
 
     /// The total number of code units required to encode the content in utf16.
-    pub fn len_utf16(&self) -> Utf16CodeUnitLength {
-        Utf16CodeUnitLength(self.chars().map(char::len_utf16).sum())
+    pub fn len_utf16(&self) -> Utf16CodeUnits {
+        Utf16CodeUnits(self.chars().map(char::len_utf16).sum())
     }
 
     fn line(&self, index: usize) -> &str {
@@ -315,9 +315,9 @@ impl Rope {
     }
 
     /// Convert a [`RopeIndex`] into a byte offset from the start of the content.
-    pub fn index_to_utf8_offset(&self, rope_index: RopeIndex) -> Utf8CodeUnitLength {
+    pub fn index_to_utf8_offset(&self, rope_index: RopeIndex) -> Utf8CodeUnits {
         let rope_index = self.normalize_index(rope_index);
-        Utf8CodeUnitLength(
+        Utf8CodeUnits(
             self.lines
                 .iter()
                 .take(rope_index.line)
@@ -327,12 +327,12 @@ impl Rope {
         )
     }
 
-    pub fn index_to_utf16_offset(&self, rope_index: RopeIndex) -> Utf16CodeUnitLength {
+    pub fn index_to_utf16_offset(&self, rope_index: RopeIndex) -> Utf16CodeUnits {
         let rope_index = self.normalize_index(rope_index);
         let final_line = self.line(rope_index.line);
 
         // The offset might be past the end of the line due to being an exclusive offset.
-        let final_line_offset = Utf16CodeUnitLength(
+        let final_line_offset = Utf16CodeUnits(
             final_line[0..rope_index.code_point]
                 .chars()
                 .map(char::len_utf16)
@@ -342,8 +342,8 @@ impl Rope {
         self.lines
             .iter()
             .take(rope_index.line)
-            .map(|line| Utf16CodeUnitLength(line.chars().map(char::len_utf16).sum()))
-            .sum::<Utf16CodeUnitLength>() +
+            .map(|line| Utf16CodeUnits(line.chars().map(char::len_utf16).sum()))
+            .sum::<Utf16CodeUnits>() +
             final_line_offset
     }
 
@@ -363,7 +363,7 @@ impl Rope {
     }
 
     /// Convert a byte offset from the start of the content into a [`RopeIndex`].
-    pub fn utf8_offset_to_rope_index(&self, utf8_offset: Utf8CodeUnitLength) -> RopeIndex {
+    pub fn utf8_offset_to_rope_index(&self, utf8_offset: Utf8CodeUnits) -> RopeIndex {
         let mut current_utf8_offset = utf8_offset.0;
         for (line_index, line) in self.lines.iter().enumerate() {
             if current_utf8_offset == 0 || current_utf8_offset < line.len() {
@@ -374,20 +374,17 @@ impl Rope {
         self.last_index()
     }
 
-    pub fn utf16_offset_to_utf8_offset(
-        &self,
-        utf16_offset: Utf16CodeUnitLength,
-    ) -> Utf8CodeUnitLength {
-        let mut current_utf16_offset = Utf16CodeUnitLength::zero();
-        let mut current_utf8_offset = Utf8CodeUnitLength::zero();
+    pub fn utf16_offset_to_utf8_offset(&self, utf16_offset: Utf16CodeUnits) -> Utf8CodeUnits {
+        let mut current_utf16_offset = Utf16CodeUnits::zero();
+        let mut current_utf8_offset = Utf8CodeUnits::zero();
 
         for character in self.chars() {
             let utf16_length = character.len_utf16();
-            if current_utf16_offset + Utf16CodeUnitLength(utf16_length) > utf16_offset {
+            if current_utf16_offset + Utf16CodeUnits(utf16_length) > utf16_offset {
                 return current_utf8_offset;
             }
-            current_utf8_offset += Utf8CodeUnitLength(character.len_utf8());
-            current_utf16_offset += Utf16CodeUnitLength(utf16_length);
+            current_utf8_offset += Utf8CodeUnits(character.len_utf8());
+            current_utf16_offset += Utf16CodeUnits(utf16_length);
         }
         current_utf8_offset
     }
@@ -454,7 +451,7 @@ pub struct RopeIndex {
     /// The index of the code point on the [`RopeIndex`]'s line in UTF-8 code
     /// points.
     ///
-    /// Note: This is not a `Utf8CodeUnitLength` in order to avoid continually having
+    /// Note: This is not a `Utf8CodeUnits` in order to avoid continually having
     /// to unpack the inner value.
     pub code_point: usize,
 }
@@ -635,42 +632,42 @@ fn test_rope_index_conversion_to_utf8_offset() {
     let rope = Rope::new("A\nBB\nCCC\nDDDD");
     assert_eq!(
         rope.index_to_utf8_offset(RopeIndex::new(0, 0)),
-        Utf8CodeUnitLength(0),
+        Utf8CodeUnits(0),
     );
     assert_eq!(
         rope.index_to_utf8_offset(RopeIndex::new(0, 1)),
-        Utf8CodeUnitLength(1),
+        Utf8CodeUnits(1),
     );
     assert_eq!(
         rope.index_to_utf8_offset(RopeIndex::new(0, 10)),
-        Utf8CodeUnitLength(1),
+        Utf8CodeUnits(1),
         "RopeIndex with offset past the end of the line should return final offset in line",
     );
     assert_eq!(
         rope.index_to_utf8_offset(RopeIndex::new(1, 0)),
-        Utf8CodeUnitLength(2),
+        Utf8CodeUnits(2),
     );
     assert_eq!(
         rope.index_to_utf8_offset(RopeIndex::new(1, 2)),
-        Utf8CodeUnitLength(4),
+        Utf8CodeUnits(4),
     );
 
     assert_eq!(
         rope.index_to_utf8_offset(RopeIndex::new(3, 0)),
-        Utf8CodeUnitLength(9),
+        Utf8CodeUnits(9),
     );
     assert_eq!(
         rope.index_to_utf8_offset(RopeIndex::new(3, 3)),
-        Utf8CodeUnitLength(12),
+        Utf8CodeUnits(12),
     );
     assert_eq!(
         rope.index_to_utf8_offset(RopeIndex::new(3, 4)),
-        Utf8CodeUnitLength(13),
+        Utf8CodeUnits(13),
         "There should be no newline at the end of the TextInput",
     );
     assert_eq!(
         rope.index_to_utf8_offset(RopeIndex::new(3, 40)),
-        Utf8CodeUnitLength(13),
+        Utf8CodeUnits(13),
         "There should be no newline at the end of the TextInput",
     );
 }
@@ -680,34 +677,34 @@ fn test_rope_index_conversion_to_utf16_offset() {
     let rope = Rope::new("A\nBB\nCCC\n家家");
     assert_eq!(
         rope.index_to_utf16_offset(RopeIndex::new(0, 0)),
-        Utf16CodeUnitLength(0),
+        Utf16CodeUnits(0),
     );
     assert_eq!(
         rope.index_to_utf16_offset(RopeIndex::new(0, 1)),
-        Utf16CodeUnitLength(1),
+        Utf16CodeUnits(1),
     );
     assert_eq!(
         rope.index_to_utf16_offset(RopeIndex::new(0, 10)),
-        Utf16CodeUnitLength(1),
+        Utf16CodeUnits(1),
         "RopeIndex with offset past the end of the line should return final offset in line",
     );
     assert_eq!(
         rope.index_to_utf16_offset(RopeIndex::new(3, 0)),
-        Utf16CodeUnitLength(9),
+        Utf16CodeUnits(9),
     );
 
     assert_eq!(
         rope.index_to_utf16_offset(RopeIndex::new(3, 3)),
-        Utf16CodeUnitLength(10),
+        Utf16CodeUnits(10),
         "3 code unit UTF-8 encodede character"
     );
     assert_eq!(
         rope.index_to_utf16_offset(RopeIndex::new(3, 6)),
-        Utf16CodeUnitLength(11),
+        Utf16CodeUnits(11),
     );
     assert_eq!(
         rope.index_to_utf16_offset(RopeIndex::new(3, 20)),
-        Utf16CodeUnitLength(11),
+        Utf16CodeUnits(11),
     );
 }
 
@@ -715,35 +712,35 @@ fn test_rope_index_conversion_to_utf16_offset() {
 fn test_utf16_offset_to_utf8_offset() {
     let rope = Rope::new("A\nBB\nCCC\n家家");
     assert_eq!(
-        rope.utf16_offset_to_utf8_offset(Utf16CodeUnitLength(0)),
-        Utf8CodeUnitLength(0),
+        rope.utf16_offset_to_utf8_offset(Utf16CodeUnits(0)),
+        Utf8CodeUnits(0),
     );
     assert_eq!(
-        rope.utf16_offset_to_utf8_offset(Utf16CodeUnitLength(1)),
-        Utf8CodeUnitLength(1),
+        rope.utf16_offset_to_utf8_offset(Utf16CodeUnits(1)),
+        Utf8CodeUnits(1),
     );
     assert_eq!(
-        rope.utf16_offset_to_utf8_offset(Utf16CodeUnitLength(2)),
-        Utf8CodeUnitLength(2),
+        rope.utf16_offset_to_utf8_offset(Utf16CodeUnits(2)),
+        Utf8CodeUnits(2),
         "Offset past the end of the line",
     );
     assert_eq!(
-        rope.utf16_offset_to_utf8_offset(Utf16CodeUnitLength(9)),
-        Utf8CodeUnitLength(9),
+        rope.utf16_offset_to_utf8_offset(Utf16CodeUnits(9)),
+        Utf8CodeUnits(9),
     );
 
     assert_eq!(
-        rope.utf16_offset_to_utf8_offset(Utf16CodeUnitLength(10)),
-        Utf8CodeUnitLength(12),
+        rope.utf16_offset_to_utf8_offset(Utf16CodeUnits(10)),
+        Utf8CodeUnits(12),
         "3 code unit UTF-8 encodede character"
     );
     assert_eq!(
-        rope.utf16_offset_to_utf8_offset(Utf16CodeUnitLength(11)),
-        Utf8CodeUnitLength(15),
+        rope.utf16_offset_to_utf8_offset(Utf16CodeUnits(11)),
+        Utf8CodeUnits(15),
     );
     assert_eq!(
-        rope.utf16_offset_to_utf8_offset(Utf16CodeUnitLength(300)),
-        Utf8CodeUnitLength(15),
+        rope.utf16_offset_to_utf8_offset(Utf16CodeUnits(300)),
+        Utf8CodeUnits(15),
     );
 }
 
@@ -823,11 +820,8 @@ fn test_rope_index_intersects_character() {
     let rope = Rope::new("񉡚");
     let rope_index = RopeIndex::new(0, 1);
     assert_eq!(rope.normalize_index(rope_index), RopeIndex::new(0, 4));
-    assert_eq!(
-        rope.index_to_utf16_offset(rope_index),
-        Utf16CodeUnitLength(2)
-    );
-    assert_eq!(rope.index_to_utf8_offset(rope_index), Utf8CodeUnitLength(4));
+    assert_eq!(rope.index_to_utf16_offset(rope_index), Utf16CodeUnits(2));
+    assert_eq!(rope.index_to_utf8_offset(rope_index), Utf8CodeUnits(4));
 
     let rope = Rope::new("abc\ndef");
     assert_eq!(

--- a/components/shared/base/text.rs
+++ b/components/shared/base/text.rs
@@ -50,11 +50,8 @@ pub fn is_cjk(codepoint: char) -> bool {
 }
 
 macro_rules! unicode_length_type {
-    ($type_name:ident) => {
-        /// A length in code units of the given text encoding. For instance, `Utf8CodeUnitLength`
-        /// is a length in UTF-8 code units (one byte each). `Utf16CodeUnitLength` is a length in
-        /// UTF-16 code units (two bytes each). This type is used to more reliable work with
-        /// lengths in different encodings.
+    ($( #[$doc:meta] )+ $type_name:ident) => {
+        $( #[$doc] )+
         #[derive(Clone, Copy, Debug, Default, Eq, MallocSizeOf, Ord, PartialEq, PartialOrd)]
         pub struct $type_name(pub usize);
 
@@ -118,42 +115,79 @@ macro_rules! unicode_length_type {
     };
 }
 
-// Note: counting UTF-32 code units is the same as counting code points or scalar values /
-// `char`.
-unicode_length_type!(Utf32CodeUnitLength);
-unicode_length_type!(Utf8CodeUnitLength);
-unicode_length_type!(Utf16CodeUnitLength);
-
-pub fn utf16_offset_to_utf32_offset(
-    string: &str,
-    utf16_offset: Utf16CodeUnitLength,
-) -> Utf32CodeUnitLength {
-    let mut current_utf16_offset = Utf16CodeUnitLength(0);
-    let mut current_utf32_offset = Utf32CodeUnitLength(0);
-    for character in string.chars() {
-        if current_utf16_offset >= utf16_offset {
-            break;
-        }
-        current_utf16_offset.0 += character.len_utf16();
-        current_utf32_offset.0 += 1;
-    }
-    current_utf32_offset
+unicode_length_type! {
+    /// A length or offset counted in 8-bit code units (bytes) in an UTF-8 string.
+    /// This type is used to more reliable work with lengths or offsets in different encodings.
+    Utf8CodeUnits
 }
 
-pub fn utf8_offset_to_utf32_offset(
-    string: &str,
-    utf8_offset: Utf8CodeUnitLength,
-) -> Utf32CodeUnitLength {
-    let mut current_utf8_offset = Utf8CodeUnitLength(0);
-    let mut current_utf32_offset = Utf32CodeUnitLength(0);
-    for character in string.chars() {
-        if current_utf8_offset >= utf8_offset {
-            break;
-        }
-        current_utf8_offset.0 += character.len_utf8();
-        current_utf32_offset.0 += 1;
+unicode_length_type! {
+    /// A length or offset counted in 16-bit code units in an UTF-16 string.
+    /// This type is used to more reliable work with lengths or offsets in different encodings.
+    Utf16CodeUnits
+}
+
+unicode_length_type! {
+    /// A length or offset counted in 32-bit code units in UTF-32.
+    /// This is the same as counting Rust `char`s, Unicode scalar values, or Unicode code points.
+    /// This type is used to more reliable work with lengths or offsets in different encodings.
+    Utf32CodeUnits
+}
+
+impl Utf16CodeUnits {
+    pub fn length_of(string: &str) -> Self {
+        Self(string.bytes().map(len_utf16_for_utf8_byte).sum())
+
+        // TODO: after upgrading to a Rust version (1.99?) that includes that PR,
+        // replace the above with:
+
+        // // `EncodeUtf16::count` is optimized in https://github.com/rust-lang/rust/pull/159467
+        // Self(string.encode_utf16().count())
     }
-    current_utf32_offset
+
+    pub fn to_utf32_code_units_in(self, string: &str) -> Utf32CodeUnits {
+        let mut current_utf16_offset = Utf16CodeUnits(0);
+        let mut current_utf32_offset = Utf32CodeUnits(0);
+        for utf8_byte in string.bytes() {
+            if current_utf16_offset >= self {
+                break;
+            }
+            let len_utf16 = len_utf16_for_utf8_byte(utf8_byte);
+            current_utf16_offset.0 += len_utf16;
+            // `len_utf16 != 0` means this byte is the first byte of the UTF-8 byte sequence
+            // for one `char` /  UTF-32 code unit
+            current_utf32_offset.0 += (len_utf16 != 0) as usize;
+        }
+        current_utf32_offset
+    }
+}
+
+fn len_utf16_for_utf8_byte(byte: u8) -> usize {
+    if byte < 0b1000_0000 {
+        // 0b0xxx_xxxx: ASCII-compatible U+0000 to U+007F
+        1
+    } else if byte < 0b1100_0000 {
+        // 0b10xx_xxxx: UTF-8 continuation byte, already accounted for by its non-continuation byte
+        0
+    } else if byte < 0b1111_0000 {
+        // 0b110x_xxxx: start of a 2-byte UTF-8 sequence for U+0080 to U+07FF
+        // 0b1110_xxxx: start of a 3-byte UTF-8 sequence for U+0800 to U+FFFF
+        1
+    } else {
+        // 0b1111_0xxx: start of a 4-byte UTF-8 sequence for U+010000 to U+10FFFF
+        // This is exactly the range encoded as a surrogate pair in UTF-16
+        //
+        // 0b1111_1xxx: would fall here but never occurs in valid UTF-8
+        2
+    }
+}
+
+impl Utf32CodeUnits {
+    pub fn length_of(string: &str) -> Self {
+        // `std::str::Chars::count` is optimized in:
+        // https://github.com/rust-lang/rust/blob/main/library/core/src/str/count.rs
+        Self(string.chars().count())
+    }
 }
 
 #[cfg(test)]
@@ -177,5 +211,62 @@ mod test {
         assert_eq!(is_cjk('a'), false);
         assert_eq!(is_cjk('🙂'), false);
         assert_eq!(is_cjk('©'), false);
+    }
+
+    #[test]
+    fn test_utf16_length() {
+        assert_eq!(Utf16CodeUnits::length_of(""), Utf16CodeUnits(0));
+        assert_eq!(Utf16CodeUnits::length_of("a"), Utf16CodeUnits(1));
+        assert_eq!(Utf16CodeUnits::length_of("é"), Utf16CodeUnits(1));
+        assert_eq!(Utf16CodeUnits::length_of("字"), Utf16CodeUnits(1));
+        assert_eq!(Utf16CodeUnits::length_of("\u{1F4A9}"), Utf16CodeUnits(2));
+        assert_eq!(
+            Utf16CodeUnits::length_of("\u{1F4A9}字éa"),
+            Utf16CodeUnits(5)
+        );
+    }
+
+    #[test]
+    fn test_utf16_to_utf32() {
+        let s = "aé字\u{1F4A9}";
+        assert_eq!(
+            Utf16CodeUnits(0).to_utf32_code_units_in(s),
+            Utf32CodeUnits(0)
+        );
+        assert_eq!(
+            Utf16CodeUnits(1).to_utf32_code_units_in(s),
+            Utf32CodeUnits(1)
+        );
+        assert_eq!(
+            Utf16CodeUnits(2).to_utf32_code_units_in(s),
+            Utf32CodeUnits(2)
+        );
+        assert_eq!(
+            Utf16CodeUnits(3).to_utf32_code_units_in(s),
+            Utf32CodeUnits(3)
+        );
+
+        // This 16-bit offset splits the would-be surrogate pair. We return the 32-bit position
+        // after the whole pair. Should this be an error instead?
+        assert_eq!(
+            Utf16CodeUnits(4).to_utf32_code_units_in(s),
+            Utf32CodeUnits(4)
+        );
+
+        assert_eq!(
+            Utf16CodeUnits(5).to_utf32_code_units_in(s),
+            Utf32CodeUnits(4)
+        );
+
+        // This 16-bit offset is out of bounds. We clamp to the nearest valid 32-bit offset,
+        // a.k.a the UTF-32 length. Should this be an error instead?
+        assert_eq!(
+            Utf16CodeUnits(6).to_utf32_code_units_in(s),
+            Utf32CodeUnits(4)
+        );
+        assert_eq!(
+            Utf16CodeUnits(7).to_utf32_code_units_in(s),
+            Utf32CodeUnits(4)
+        );
     }
 }

--- a/components/shared/layout/layout_node.rs
+++ b/components/shared/layout/layout_node.rs
@@ -13,7 +13,7 @@ use net_traits::image_cache::Image;
 use pixels::ImageMetadata;
 use servo_arc::Arc;
 use servo_base::id::{BrowsingContextId, PipelineId};
-use servo_base::text::Utf32CodeUnitLength;
+use servo_base::text::Utf32CodeUnits;
 use servo_url::ServoUrl;
 use style::context::SharedStyleContext;
 use style::dom::{NodeInfo, OpaqueNode, TNode};
@@ -174,7 +174,7 @@ pub trait LayoutNode<'dom>: Copy + Debug + NodeInfo + Send + Sync {
     /// For a text node, returns which range of this text is part of the document selection
     ///
     /// Returned offsets are counted in `char`s in the `self.text_content()` string.
-    fn document_selection_in_text_node(&self) -> Option<Range<Utf32CodeUnitLength>>;
+    fn document_selection_in_text_node(&self) -> Option<Range<Utf32CodeUnits>>;
 
     /// If this node manages a selection, this returns the shared selection for the node.
     fn selection(&self) -> Option<SharedSelection>;

--- a/tests/unit/script/textinput.rs
+++ b/tests/unit/script/textinput.rs
@@ -12,7 +12,7 @@ use script::test::DOMString;
 use script::test::text_input::{
     ClipboardProvider, Direction, Lines, SelectionDirection, TextInput,
 };
-use servo_base::text::{Utf8CodeUnitLength, Utf16CodeUnitLength};
+use servo_base::text::{Utf8CodeUnits, Utf16CodeUnits};
 use servo_base::{RopeIndex, RopeMovement};
 
 pub struct DummyClipboardContext {
@@ -48,7 +48,7 @@ fn test_set_content_ignores_max_length() {
         DummyClipboardContext::new(""),
     );
 
-    textinput.set_max_length(Some(Utf16CodeUnitLength::one()));
+    textinput.set_max_length(Some(Utf16CodeUnits::one()));
     textinput.set_content(DOMString::from("mozilla rocks"));
     assert_eq!(textinput.get_content(), DOMString::from("mozilla rocks"));
 }
@@ -61,7 +61,7 @@ fn test_textinput_when_inserting_multiple_lines_over_a_selection_respects_max_le
         DummyClipboardContext::new(""),
     );
 
-    textinput.set_max_length(Some(Utf16CodeUnitLength(17)));
+    textinput.set_max_length(Some(Utf16CodeUnits(17)));
     textinput.modify_edit_point(1, RopeMovement::Grapheme);
     textinput.modify_selection(3, RopeMovement::Grapheme);
     textinput.modify_selection(1, RopeMovement::Line);
@@ -82,7 +82,7 @@ fn test_textinput_when_inserting_multiple_lines_still_respects_max_length() {
         DummyClipboardContext::new(""),
     );
 
-    textinput.set_max_length(Some(Utf16CodeUnitLength(17)));
+    textinput.set_max_length(Some(Utf16CodeUnits(17)));
     textinput.modify_edit_point(1, RopeMovement::Line);
     textinput.insert("cruel\nterrible");
     assert_eq!(textinput.get_content(), "hello\ncruel\nworld");
@@ -97,7 +97,7 @@ fn test_textinput_when_content_is_already_longer_than_max_length_and_theres_no_s
         DummyClipboardContext::new(""),
     );
 
-    textinput.set_max_length(Some(Utf16CodeUnitLength::one()));
+    textinput.set_max_length(Some(Utf16CodeUnits::one()));
     textinput.insert('a');
     assert_eq!(textinput.get_content(), "abc");
 }
@@ -111,7 +111,7 @@ fn test_multi_line_textinput_with_maxlength_doesnt_allow_appending_characters_wh
         DummyClipboardContext::new(""),
     );
 
-    textinput.set_max_length(Some(Utf16CodeUnitLength(5)));
+    textinput.set_max_length(Some(Utf16CodeUnits(5)));
     textinput.insert('a');
     assert_eq!(textinput.get_content(), "abc\nd");
 }
@@ -125,7 +125,7 @@ fn test_single_line_textinput_with_max_length_doesnt_allow_appending_characters_
         DummyClipboardContext::new(""),
     );
 
-    textinput.set_max_length(Some(Utf16CodeUnitLength(5)));
+    textinput.set_max_length(Some(Utf16CodeUnits(5)));
     textinput.modify_edit_point(1, RopeMovement::Grapheme);
     textinput.modify_selection(3, RopeMovement::Grapheme);
 
@@ -145,7 +145,7 @@ fn test_single_line_textinput_with_max_length_allows_deletion_when_replacing_a_s
         DummyClipboardContext::new(""),
     );
 
-    textinput.set_max_length(Some(Utf16CodeUnitLength(1)));
+    textinput.set_max_length(Some(Utf16CodeUnits(1)));
     textinput.modify_edit_point(1, RopeMovement::Grapheme);
     textinput.modify_selection(2, RopeMovement::Grapheme);
 
@@ -165,7 +165,7 @@ fn test_single_line_textinput_with_max_length_multibyte() {
         DummyClipboardContext::new(""),
     );
 
-    textinput.set_max_length(Some(Utf16CodeUnitLength(2)));
+    textinput.set_max_length(Some(Utf16CodeUnits(2)));
     textinput.insert('á');
     assert_eq!(textinput.get_content(), "á");
     textinput.insert('é');
@@ -182,7 +182,7 @@ fn test_single_line_textinput_with_max_length_multi_code_unit() {
         DummyClipboardContext::new(""),
     );
 
-    textinput.set_max_length(Some(Utf16CodeUnitLength(3)));
+    textinput.set_max_length(Some(Utf16CodeUnits(3)));
     textinput.insert('\u{10437}');
     assert_eq!(textinput.get_content(), "\u{10437}");
     textinput.insert('\u{10437}');
@@ -201,7 +201,7 @@ fn test_single_line_textinput_with_max_length_inside_char() {
         DummyClipboardContext::new(""),
     );
 
-    textinput.set_max_length(Some(Utf16CodeUnitLength::one()));
+    textinput.set_max_length(Some(Utf16CodeUnits::one()));
     textinput.insert('x');
     assert_eq!(textinput.get_content(), "\u{10437}");
 }
@@ -215,7 +215,7 @@ fn test_single_line_textinput_with_max_length_doesnt_allow_appending_characters_
         DummyClipboardContext::new(""),
     );
 
-    textinput.set_max_length(Some(Utf16CodeUnitLength::one()));
+    textinput.set_max_length(Some(Utf16CodeUnits::one()));
     textinput.insert('b');
     assert_eq!(textinput.get_content(), "a");
 }
@@ -243,8 +243,8 @@ fn test_textinput_delete_char() {
 
     let mut textinput = text_input(Lines::Single, "abcdefg");
     textinput.set_selection_range_utf8(
-        Utf8CodeUnitLength(2),
-        Utf8CodeUnitLength(2),
+        Utf8CodeUnits(2),
+        Utf8CodeUnits(2),
         SelectionDirection::None,
     );
     textinput.delete_unit_or_selection(RopeMovement::Grapheme, Direction::Backward);
@@ -574,8 +574,8 @@ fn test_textinput_cursor_position_correct_after_clearing_selection() {
 fn test_textinput_set_selection_with_direction() {
     let mut textinput = text_input(Lines::Single, "abcdef");
     textinput.set_selection_range_utf8(
-        Utf8CodeUnitLength(2),
-        Utf8CodeUnitLength(6),
+        Utf8CodeUnits(2),
+        Utf8CodeUnits(6),
         SelectionDirection::Forward,
     );
     assert_eq!(textinput.edit_point(), RopeIndex::new(0, 6));
@@ -584,8 +584,8 @@ fn test_textinput_set_selection_with_direction() {
     assert_eq!(textinput.selection_origin().unwrap(), RopeIndex::new(0, 2));
 
     textinput.set_selection_range_utf8(
-        Utf8CodeUnitLength(2),
-        Utf8CodeUnitLength(6),
+        Utf8CodeUnits(2),
+        Utf8CodeUnits(6),
         SelectionDirection::Backward,
     );
     assert_eq!(textinput.edit_point(), RopeIndex::new(0, 2));
@@ -598,8 +598,8 @@ fn test_textinput_set_selection_with_direction() {
 
     textinput = text_input(Lines::Multiple, "\n\n");
     textinput.set_selection_range_utf8(
-        Utf8CodeUnitLength(0),
-        Utf8CodeUnitLength(1),
+        Utf8CodeUnits(0),
+        Utf8CodeUnits(1),
         SelectionDirection::Forward,
     );
     assert_eq!(textinput.edit_point(), RopeIndex::new(1, 0));
@@ -609,8 +609,8 @@ fn test_textinput_set_selection_with_direction() {
 
     textinput = text_input(Lines::Multiple, "\n");
     textinput.set_selection_range_utf8(
-        Utf8CodeUnitLength(0),
-        Utf8CodeUnitLength(1),
+        Utf8CodeUnits(0),
+        Utf8CodeUnits(1),
         SelectionDirection::Forward,
     );
 
@@ -632,8 +632,8 @@ fn test_selection_bounds() {
     assert_eq!(RopeIndex::new(0, 0), textinput.selection_end());
 
     textinput.set_selection_range_utf8(
-        Utf8CodeUnitLength(2),
-        Utf8CodeUnitLength(5),
+        Utf8CodeUnits(2),
+        Utf8CodeUnits(5),
         SelectionDirection::Forward,
     );
     assert_eq!(
@@ -644,8 +644,8 @@ fn test_selection_bounds() {
     assert_eq!(RopeIndex::new(0, 5), textinput.selection_end());
 
     textinput.set_selection_range_utf8(
-        Utf8CodeUnitLength(3),
-        Utf8CodeUnitLength(6),
+        Utf8CodeUnits(3),
+        Utf8CodeUnits(6),
         SelectionDirection::Backward,
     );
     assert_eq!(
@@ -657,8 +657,8 @@ fn test_selection_bounds() {
 
     textinput = text_input(Lines::Multiple, "\n\n");
     textinput.set_selection_range_utf8(
-        Utf8CodeUnitLength(0),
-        Utf8CodeUnitLength(1),
+        Utf8CodeUnits(0),
+        Utf8CodeUnits(1),
         SelectionDirection::Forward,
     );
     assert_eq!(
@@ -673,8 +673,8 @@ fn test_selection_bounds() {
 fn test_select_all() {
     let mut textinput = text_input(Lines::Single, "abc");
     textinput.set_selection_range_utf8(
-        Utf8CodeUnitLength(2),
-        Utf8CodeUnitLength(3),
+        Utf8CodeUnits(2),
+        Utf8CodeUnits(3),
         SelectionDirection::Backward,
     );
     textinput.select_all();


### PR DESCRIPTION
* Rename `Utf*CodeUnitLength` to `Utf*CodeUnits` since it can be used for offsets as well as lengths
* Move free function conversions to methods
* Optimize conversions by matching UTF-8 bit patterns instead of decoding UTF-8 to `char`s.

Following up on https://github.com/servo/servo/pull/46698

Testing: expecting no change to existing tests

