### PR TITLE
script: Restrict borrow scope in XRTest::DisconnectAllDevices

### DIFF
--- a/components/script/dom/webxr/xrtest.rs
+++ b/components/script/dom/webxr/xrtest.rs
@@ -191,38 +191,46 @@ impl XRTestMethods<crate::DomTypeHolder> for XRTest {
     fn DisconnectAllDevices(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
         // XXXManishearth implement device disconnection and session ending
         let p = Promise::new_in_realm(cx);
-        let mut devices = self.devices_connected.borrow_mut();
-        if devices.is_empty() {
+
+        // restrict borrow scope prior to p.resolve_native(), which can GC
+        let is_empty = self.devices_connected.borrow().is_empty();
+        if is_empty {
             p.resolve_native(cx, &());
-        } else {
-            let mut len = devices.len();
+            return p;
+        }
 
-            let rooted_devices: Vec<_> = devices.iter().map(|x| DomRoot::from_ref(&**x)).collect();
-            devices.clear();
-
-            let mut trusted = Some(TrustedPromise::new(p.clone()));
-            let global = self.global();
-            let task_source = global
-                .task_manager()
-                .dom_manipulation_task_source()
-                .to_sendable();
-
-            let callback =
-                ProfileGenericCallback::new(global.time_profiler_chan().clone(), move |_| {
-                    len -= 1;
-                    if len == 0 {
-                        let trusted = trusted
-                            .take()
-                            .expect("DisconnectAllDevices disconnected more devices than expected");
-                        task_source.queue(trusted.resolve_task(()));
-                    }
-                })
-                .expect("Could not create callback");
-
-            for device in rooted_devices {
-                device.disconnect(callback.clone());
-            }
+        // Collect rooted devices in immutable borrow
+        // and clear connected devices with mutable borrow
+        // so neither spans a GC-capable call.
+        let rooted_devices: Vec<_> = {
+            let devices = self.devices_connected.borrow();
+            devices.iter().map(|x| DomRoot::from_ref(&**x)).collect()
         };
+        self.devices_connected.borrow_mut().clear();
+
+        let mut len = rooted_devices.len();
+        let mut trusted = Some(TrustedPromise::new(p.clone()));
+        let global = self.global();
+        let task_source = global
+            .task_manager()
+            .dom_manipulation_task_source()
+            .to_sendable();
+
+        let callback =
+            ProfileGenericCallback::new(global.time_profiler_chan().clone(), move |_| {
+                len -= 1;
+                if len == 0 {
+                    let trusted = trusted
+                        .take()
+                        .expect("DisconnectAllDevices disconnected more devices than expected");
+                    task_source.queue(trusted.resolve_task(()));
+                }
+            })
+            .expect("Could not create callback");
+
+        for device in rooted_devices {
+            device.disconnect(callback.clone());
+        }
         p
     }
 }

--- a/components/script/dom/webxr/xrtest.rs
+++ b/components/script/dom/webxr/xrtest.rs
@@ -206,7 +206,7 @@ impl XRTestMethods<crate::DomTypeHolder> for XRTest {
             let devices = self.devices_connected.borrow();
             devices.iter().map(|x| DomRoot::from_ref(&**x)).collect()
         };
-        self.devices_connected.borrow_mut().clear();
+        self.devices_connected.safe_borrow_mut(cx).clear();
 
         let mut len = rooted_devices.len();
         let mut trusted = Some(TrustedPromise::new(p.clone()));


### PR DESCRIPTION
Avoid holding a mutable borrow of `devices_connected` while `p.resolve_native` is called, which can trigger GC and panic if the RefCell is borrowed. Evaluates the conditional with an immutable borrow prior to calling the `p.resolve_native`.

Tested by building with `debug-mozjs flag` and running the GC flags with the respective XRTest.

`.\mach build --debug-mozjs`
`.\mach test-wpt /webxr/xrDevice_isSessionSupported_inline.https.html --pref js_mem_gc_zeal_level=2 --pref js_mem_gc_zeal_frequency=1 --timeout-multiplier=20`

Fixes: #46714
