### PR TITLE
script: remove rooted variant of `MessageSource`

### DIFF
--- a/components/script/dom/serviceworker/extendablemessageevent.rs
+++ b/components/script/dom/serviceworker/extendablemessageevent.rs
@@ -32,60 +32,39 @@ use crate::dom::serviceworkerglobalscope::ServiceWorkerGlobalScope;
 /// <https://w3c.github.io/ServiceWorker/#dom-extendablemessageevent-source>
 #[derive(JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
-enum MessageSourceUnrooted {
+enum MessageSource {
     Client(Dom<Client>),
     ServiceWorker(Dom<ServiceWorker>),
     MessagePort(Dom<MessagePort>),
-}
-
-impl MessageSourceUnrooted {
-    fn root(&self) -> MessageSource {
-        match self {
-            MessageSourceUnrooted::Client(client) => {
-                MessageSource::Client(DomRoot::from_ref(client))
-            },
-            MessageSourceUnrooted::ServiceWorker(sw) => {
-                MessageSource::ServiceWorker(DomRoot::from_ref(sw))
-            },
-            MessageSourceUnrooted::MessagePort(port) => {
-                MessageSource::MessagePort(DomRoot::from_ref(port))
-            },
-        }
-    }
-}
-
-#[derive(JSTraceable, MallocSizeOf)]
-pub(crate) enum MessageSource {
-    Client(DomRoot<Client>),
-    ServiceWorker(DomRoot<ServiceWorker>),
-    MessagePort(DomRoot<MessagePort>),
 }
 
 impl From<&ClientOrServiceWorkerOrMessagePort> for MessageSource {
     fn from(value: &ClientOrServiceWorkerOrMessagePort) -> Self {
         match value {
             ClientOrServiceWorkerOrMessagePort::Client(client) => {
-                MessageSource::Client(DomRoot::from_ref(client))
+                MessageSource::Client(Dom::from_ref(client))
             },
             ClientOrServiceWorkerOrMessagePort::ServiceWorker(sw) => {
-                MessageSource::ServiceWorker(DomRoot::from_ref(sw))
+                MessageSource::ServiceWorker(Dom::from_ref(sw))
             },
             ClientOrServiceWorkerOrMessagePort::MessagePort(port) => {
-                MessageSource::MessagePort(DomRoot::from_ref(port))
+                MessageSource::MessagePort(Dom::from_ref(port))
             },
         }
     }
 }
 
-impl From<MessageSource> for ClientOrServiceWorkerOrMessagePort {
-    fn from(value: MessageSource) -> Self {
+impl From<&MessageSource> for ClientOrServiceWorkerOrMessagePort {
+    fn from(value: &MessageSource) -> Self {
         match value {
-            MessageSource::Client(client) => ClientOrServiceWorkerOrMessagePort::Client(client),
+            MessageSource::Client(client) => {
+                ClientOrServiceWorkerOrMessagePort::Client(DomRoot::from_ref(client))
+            },
             MessageSource::ServiceWorker(sw) => {
-                ClientOrServiceWorkerOrMessagePort::ServiceWorker(sw)
+                ClientOrServiceWorkerOrMessagePort::ServiceWorker(DomRoot::from_ref(sw))
             },
             MessageSource::MessagePort(port) => {
-                ClientOrServiceWorkerOrMessagePort::MessagePort(port)
+                ClientOrServiceWorkerOrMessagePort::MessagePort(DomRoot::from_ref(port))
             },
         }
     }
@@ -104,7 +83,7 @@ pub(crate) struct ExtendableMessageEvent {
     /// <https://w3c.github.io/ServiceWorker/#dom-extendablemessageevent-lasteventid>
     lastEventId: DOMString,
     /// <https://w3c.github.io/ServiceWorker/#dom-extendablemessageevent-source>
-    source: Option<MessageSourceUnrooted>,
+    source: Option<MessageSource>,
     /// <https://w3c.github.io/ServiceWorker/#dom-extendablemessageevent-ports>
     ports: Vec<Dom<MessagePort>>,
     #[ignore_malloc_size_of = "mozjs"]
@@ -116,7 +95,7 @@ impl ExtendableMessageEvent {
     pub(crate) fn new_inherited(
         origin: DOMString,
         lastEventId: DOMString,
-        source: Option<MessageSource>,
+        source: Option<&ClientOrServiceWorkerOrMessagePort>,
         ports: Vec<DomRoot<MessagePort>>,
     ) -> ExtendableMessageEvent {
         ExtendableMessageEvent {
@@ -124,15 +103,7 @@ impl ExtendableMessageEvent {
             data: Heap::default(),
             origin,
             lastEventId,
-            source: source.map(|source| match source {
-                MessageSource::Client(client) => MessageSourceUnrooted::Client(client.as_traced()),
-                MessageSource::ServiceWorker(sw) => {
-                    MessageSourceUnrooted::ServiceWorker(sw.as_traced())
-                },
-                MessageSource::MessagePort(port) => {
-                    MessageSourceUnrooted::MessagePort(port.as_traced())
-                },
-            }),
+            source: source.map(Into::into),
             ports: ports
                 .into_iter()
                 .map(|port| Dom::from_ref(&*port))
@@ -151,7 +122,7 @@ impl ExtendableMessageEvent {
         data: HandleValue,
         origin: DOMString,
         lastEventId: DOMString,
-        source: Option<MessageSource>,
+        source: Option<&ClientOrServiceWorkerOrMessagePort>,
         ports: Vec<DomRoot<MessagePort>>,
     ) -> DomRoot<ExtendableMessageEvent> {
         Self::new_with_proto(
@@ -180,7 +151,7 @@ impl ExtendableMessageEvent {
         data: HandleValue,
         origin: DOMString,
         lastEventId: DOMString,
-        source: Option<MessageSource>,
+        source: Option<&ClientOrServiceWorkerOrMessagePort>,
         ports: Vec<DomRoot<MessagePort>>,
     ) -> DomRoot<ExtendableMessageEvent> {
         let ev = Box::new(ExtendableMessageEvent::new_inherited(
@@ -204,7 +175,7 @@ impl ExtendableMessageEvent {
         target: &EventTarget,
         scope: &GlobalScope,
         message: HandleValue,
-        source: Option<MessageSource>,
+        source: Option<&ClientOrServiceWorkerOrMessagePort>,
         ports: Vec<DomRoot<MessagePort>>,
     ) {
         let Extendablemessageevent = ExtendableMessageEvent::new(
@@ -259,9 +230,7 @@ impl ExtendableMessageEventMethods<crate::DomTypeHolder> for ExtendableMessageEv
             init.data.handle(),
             init.origin.clone(),
             init.lastEventId.clone(),
-            init.source
-                .as_ref()
-                .and_then(|s| s.as_ref().map(|s| s.into())),
+            init.source.as_ref().and_then(Option::as_ref),
             vec![],
         );
         Ok(ev)
@@ -289,10 +258,7 @@ impl ExtendableMessageEventMethods<crate::DomTypeHolder> for ExtendableMessageEv
 
     /// <https://w3c.github.io/ServiceWorker/#dom-extendablemessageevent-source>
     fn GetSource(&self) -> Option<ClientOrServiceWorkerOrMessagePort> {
-        self.source
-            .as_ref()
-            .map(|source| source.root())
-            .map(|s| s.into())
+        self.source.as_ref().map(Into::into)
     }
 
     /// <https://w3c.github.io/ServiceWorker/#extendablemessage-event-ports>

--- a/components/script/dom/serviceworker/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworker/serviceworkerglobalscope.rs
@@ -37,6 +37,7 @@ use crate::dom::bindings::codegen::Bindings::ClientBinding::FrameType;
 use crate::dom::bindings::codegen::Bindings::ServiceWorkerGlobalScopeBinding;
 use crate::dom::bindings::codegen::Bindings::ServiceWorkerGlobalScopeBinding::ServiceWorkerGlobalScopeMethods;
 use crate::dom::bindings::codegen::Bindings::WorkerBinding::WorkerType;
+use crate::dom::bindings::codegen::UnionTypes::ClientOrServiceWorkerOrMessagePort;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
@@ -50,7 +51,7 @@ use crate::dom::dedicatedworkerglobalscope::AutoWorkerReset;
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::extendableevent::ExtendableEvent;
-use crate::dom::extendablemessageevent::{ExtendableMessageEvent, MessageSource};
+use crate::dom::extendablemessageevent::ExtendableMessageEvent;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::globalscope::script_execution::{ErrorReporting, RethrowErrors};
 #[cfg(feature = "webgpu")]
@@ -551,7 +552,7 @@ impl ServiceWorkerGlobalScope {
                         target,
                         scope.upcast(),
                         message.handle(),
-                        Some(MessageSource::Client(client)),
+                        Some(&ClientOrServiceWorkerOrMessagePort::Client(client)),
                         ports,
                     );
                 } else {


### PR DESCRIPTION
We already have a rooted variant of `MessageSourceUnrooted`, `ClientOrServiceWorkerOrMessagePort` from bindings, we can use that one instead of `MessageSource`.

Testing: It compiles
