### PR TITLE
android: Add back icon in toolbar to settings and history

### DIFF
--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/HistoryActivity.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/HistoryActivity.kt
@@ -53,6 +53,11 @@ class HistoryActivity : ComponentActivity() {
                     @OptIn(ExperimentalMaterial3Api::class)
                     TopAppBar(
                         title = { Text(stringResource(R.string.history_title)) },
+                        navigationIcon = {
+                            IconButton(onClick = { finish() }) {
+                                Icon(painterResource(R.drawable.arrow_back), stringResource(R.string.back))
+                            }
+                        },
                         actions = {
                             IconButton(
                                 onClick = {

--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/SettingsActivity.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/SettingsActivity.kt
@@ -12,6 +12,8 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
@@ -23,6 +25,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
@@ -38,6 +41,11 @@ class SettingsActivity : ComponentActivity() {
                     @OptIn(ExperimentalMaterial3Api::class)
                     TopAppBar(
                         title = { Text(stringResource(R.string.settings_title)) },
+                        navigationIcon = {
+                            IconButton(onClick = { finish() }) {
+                                Icon(painterResource(R.drawable.arrow_back), stringResource(R.string.back))
+                            }
+                        },
                     )
                 },
             ) { innerPadding ->

--- a/support/android/apk/servoapp/src/main/res/values/strings.xml
+++ b/support/android/apk/servoapp/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
   <string name="app_name">Servo</string>
+  <string name="back">Back</string>
   <string name="media_channel_name">ServoMedia</string>
   <string name="media_channel_description">Notication channel for multimedia activity</string>
   <string name="history_back">Back</string>


### PR DESCRIPTION
Adds a back icon in the toolbar as is common for nested screens.

Here's what it looks lie for the settings screen (the history screen looks similar):

|Before|After|
|---|---|
|<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/07d29a32-6dc1-45ab-8e60-756f9556685e" />|<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/47c99c50-cef0-4cb5-881c-5c156803e783" />|

Testing: There are no automated tests for Android.