### PR TITLE
script: Use AtomicRefCell for text node contents.

### DIFF
--- a/components/layout/construct_modern.rs
+++ b/components/layout/construct_modern.rs
@@ -4,7 +4,6 @@
 
 //! Layout construction code that is shared between modern layout modes (Flexbox and CSS Grid)
 
-use std::borrow::Cow;
 use std::sync::OnceLock;
 
 use layout_api::LayoutNode;
@@ -14,7 +13,7 @@ use style::selector_parser::PseudoElement;
 use crate::PropagatedBoxTreeData;
 use crate::context::LayoutContext;
 use crate::dom::{BoxSlot, LayoutBox, NodeExt};
-use crate::dom_traversal::{Contents, NodeAndStyleInfo, TraversalHandler};
+use crate::dom_traversal::{BoxTreeString, Contents, NodeAndStyleInfo, TraversalHandler};
 use crate::flow::inline::SharedInlineStyles;
 use crate::flow::inline::construct::InlineFormattingContextBuilder;
 use crate::flow::{BlockContainer, BlockFormattingContext};
@@ -179,7 +178,7 @@ impl<'dom> ModernContainerJob<'dom> {
 
 struct ModernContainerTextRun<'dom> {
     info: NodeAndStyleInfo<'dom>,
-    text: Cow<'dom, str>,
+    text: BoxTreeString<'dom>,
     style_from_display_contents: Option<SharedInlineStyles>,
 }
 
@@ -208,7 +207,7 @@ pub(crate) struct ModernItem<'dom> {
 }
 
 impl<'dom> TraversalHandler<'dom> for ModernContainerBuilder<'_, 'dom> {
-    fn handle_text(&mut self, info: &NodeAndStyleInfo<'dom>, text: Cow<'dom, str>) {
+    fn handle_text(&mut self, info: &NodeAndStyleInfo<'dom>, text: BoxTreeString<'dom>) {
         self.contiguous_text_runs.push(ModernContainerTextRun {
             info: info.clone(),
             text,

--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -3,7 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::borrow::Cow;
+use std::ops::Deref;
 
+use atomic_refcell::AtomicRef;
 use layout_api::{
     LayoutElement, LayoutElementType, LayoutNode, LayoutNodeType, PseudoElementChain,
 };
@@ -84,8 +86,44 @@ pub(super) enum PseudoElementContentItem {
     Replaced(ReplacedContents),
 }
 
+/// A piece of text.
+pub(crate) enum BoxTreeString<'a> {
+    /// Text borrowed in its entirety from a DOM node.
+    Ref(AtomicRef<'a, str>),
+    /// Text that exists independent of a particular DOM node.
+    Cow(Cow<'a, str>),
+}
+
+impl<'a> From<AtomicRef<'a, str>> for BoxTreeString<'a> {
+    fn from(text: AtomicRef<'a, str>) -> BoxTreeString<'a> {
+        BoxTreeString::Ref(text)
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for BoxTreeString<'a> {
+    fn from(text: Cow<'a, str>) -> BoxTreeString<'a> {
+        BoxTreeString::Cow(text)
+    }
+}
+
+impl From<String> for BoxTreeString<'_> {
+    fn from(text: String) -> BoxTreeString<'static> {
+        BoxTreeString::Cow(text.into())
+    }
+}
+
+impl Deref for BoxTreeString<'_> {
+    type Target = str;
+    fn deref(&self) -> &str {
+        match self {
+            Self::Ref(ref_) => ref_,
+            Self::Cow(cow) => cow,
+        }
+    }
+}
+
 pub(super) trait TraversalHandler<'dom> {
-    fn handle_text(&mut self, info: &NodeAndStyleInfo<'dom>, text: Cow<'dom, str>);
+    fn handle_text(&mut self, info: &NodeAndStyleInfo<'dom>, text: BoxTreeString<'dom>);
 
     /// Or pseudo-element
     fn handle_element(
@@ -120,7 +158,7 @@ fn traverse_children_of<'dom>(
     for child in parent_element_info.node.flat_tree_children() {
         if child.is_text_node() {
             let info = NodeAndStyleInfo::new(child, child.style(&context.style_context));
-            handler.handle_text(&info, child.text_content());
+            handler.handle_text(&info, child.text_content().into());
         } else if child.is_element() {
             traverse_element(child, context, handler);
         }

--- a/components/layout/flow/construct.rs
+++ b/components/layout/flow/construct.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::borrow::Cow;
-
 use layout_api::LayoutNode;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use servo_arc::Arc;
@@ -22,7 +20,8 @@ use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::dom::{BoxSlot, LayoutBox, NodeExt};
 use crate::dom_traversal::{
-    Contents, NodeAndStyleInfo, NonReplacedContents, PseudoElementContentItem, TraversalHandler,
+    BoxTreeString, Contents, NodeAndStyleInfo, NonReplacedContents, PseudoElementContentItem,
+    TraversalHandler,
 };
 use crate::flow::float::FloatBox;
 use crate::flow::same_formatting_context_block::SameFormattingContextBlock;
@@ -428,7 +427,7 @@ impl<'dom> TraversalHandler<'dom> for BlockContainerBuilder<'dom, '_> {
         }
     }
 
-    fn handle_text(&mut self, info: &NodeAndStyleInfo<'dom>, text: Cow<'dom, str>) {
+    fn handle_text(&mut self, info: &NodeAndStyleInfo<'dom>, text: BoxTreeString<'dom>) {
         if text.is_empty() {
             return;
         }

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -28,7 +28,7 @@ use super::{
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::dom::{LayoutBox, NodeExt};
-use crate::dom_traversal::NodeAndStyleInfo;
+use crate::dom_traversal::{BoxTreeString, NodeAndStyleInfo};
 use crate::flow::BlockLevelBox;
 use crate::flow::float::FloatBox;
 use crate::formatting_contexts::IndependentFormattingContext;
@@ -306,7 +306,7 @@ impl InlineFormattingContextBuilder {
     /// Note that this should only be used when processing text in block containers.
     pub(crate) fn push_text_with_possible_first_letter<'dom>(
         &mut self,
-        text: Cow<'dom, str>,
+        text: BoxTreeString<'dom>,
         info: &NodeAndStyleInfo<'dom>,
         container_info: &NodeAndStyleInfo<'dom>,
         layout_context: &LayoutContext,
@@ -350,7 +350,7 @@ impl InlineFormattingContextBuilder {
                 });
 
             self.push_text(
-                Cow::Borrowed(&text[leading_whitespace_range]),
+                Cow::Borrowed(&text[leading_whitespace_range]).into(),
                 info,
                 leading_whitespace_selection_range,
             );
@@ -375,7 +375,7 @@ impl InlineFormattingContextBuilder {
                 )
             });
         self.push_text(
-            first_letter_text,
+            first_letter_text.into(),
             &first_letter_info,
             first_letter_selection_range,
         );
@@ -390,7 +390,7 @@ impl InlineFormattingContextBuilder {
             })
         });
         self.push_text(
-            Cow::Borrowed(&text[first_letter_range.end..]),
+            Cow::Borrowed(&text[first_letter_range.end..]).into(),
             info,
             remaining_selection_range,
         );
@@ -400,7 +400,7 @@ impl InlineFormattingContextBuilder {
 
     pub(crate) fn push_text<'dom>(
         &mut self,
-        text: Cow<'dom, str>,
+        text: BoxTreeString<'dom>,
         info: &NodeAndStyleInfo<'dom>,
         document_selection: Option<Range<Utf32CodeUnits>>,
     ) {

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -4,6 +4,7 @@
 
 //! Utilities for querying the layout, as needed by layout.
 use std::cell::LazyCell;
+use std::ops::Deref;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -1181,7 +1182,9 @@ fn rendered_text_collection_steps(
             } else {
                 // If we don't have a parent element then there's no style data available,
                 // in this (pretty unlikely) case we just return the Text fragment as is.
-                items.push(InnerOrOuterTextItem::Text(node.text_content().into()));
+                items.push(InnerOrOuterTextItem::Text(
+                    node.text_content().deref().into(),
+                ));
             }
         },
         Some(LayoutNodeType::Element(LayoutElementType::HTMLBRElement)) => {

--- a/components/layout/table/construct.rs
+++ b/components/layout/table/construct.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::borrow::Cow;
 use std::iter::repeat_n;
 
 use atomic_refcell::AtomicRef;
@@ -21,7 +20,9 @@ use super::{
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::dom::{BoxSlot, LayoutBox, NodeExt};
-use crate::dom_traversal::{Contents, NodeAndStyleInfo, NonReplacedContents, TraversalHandler};
+use crate::dom_traversal::{
+    BoxTreeString, Contents, NodeAndStyleInfo, NonReplacedContents, TraversalHandler,
+};
 use crate::flow::inline::SharedInlineStyles;
 use crate::flow::{BlockContainerBuilder, BlockFormattingContext};
 use crate::formatting_contexts::{
@@ -50,7 +51,7 @@ impl ResolvedSlotAndLocation<'_> {
 }
 
 pub(crate) enum AnonymousTableContent<'dom> {
-    Text(NodeAndStyleInfo<'dom>, Cow<'dom, str>),
+    Text(NodeAndStyleInfo<'dom>, BoxTreeString<'dom>),
     EnterDisplayContents(SharedInlineStyles),
     LeaveDisplayContents,
     Element {
@@ -775,7 +776,7 @@ impl<'style, 'dom> TableBuilderTraversal<'style, 'dom> {
 }
 
 impl<'dom> TraversalHandler<'dom> for TableBuilderTraversal<'_, 'dom> {
-    fn handle_text(&mut self, info: &NodeAndStyleInfo<'dom>, text: Cow<'dom, str>) {
+    fn handle_text(&mut self, info: &NodeAndStyleInfo<'dom>, text: BoxTreeString<'dom>) {
         self.current_anonymous_row_content
             .push(AnonymousTableContent::Text(info.clone(), text));
     }
@@ -1061,7 +1062,7 @@ impl<'style, 'builder, 'dom, 'a> TableRowGroupBuilder<'style, 'builder, 'dom, 'a
 }
 
 impl<'dom> TraversalHandler<'dom> for TableRowGroupBuilder<'_, '_, 'dom, '_> {
-    fn handle_text(&mut self, info: &NodeAndStyleInfo<'dom>, text: Cow<'dom, str>) {
+    fn handle_text(&mut self, info: &NodeAndStyleInfo<'dom>, text: BoxTreeString<'dom>) {
         self.current_anonymous_row_content
             .push(AnonymousTableContent::Text(info.clone(), text));
     }
@@ -1219,7 +1220,7 @@ impl<'style, 'builder, 'dom, 'a> TableRowBuilder<'style, 'builder, 'dom, 'a> {
 }
 
 impl<'dom> TraversalHandler<'dom> for TableRowBuilder<'_, '_, 'dom, '_> {
-    fn handle_text(&mut self, info: &NodeAndStyleInfo<'dom>, text: Cow<'dom, str>) {
+    fn handle_text(&mut self, info: &NodeAndStyleInfo<'dom>, text: BoxTreeString<'dom>) {
         self.current_anonymous_cell_content
             .push(AnonymousTableContent::Text(info.clone(), text));
     }
@@ -1329,7 +1330,7 @@ struct TableColumnGroupBuilder {
 }
 
 impl<'dom> TraversalHandler<'dom> for TableColumnGroupBuilder {
-    fn handle_text(&mut self, _info: &NodeAndStyleInfo<'dom>, _text: Cow<'dom, str>) {}
+    fn handle_text(&mut self, _info: &NodeAndStyleInfo<'dom>, _text: BoxTreeString<'dom>) {}
     fn enter_display_contents(&mut self, _: SharedInlineStyles) {}
     fn leave_display_contents(&mut self) {}
     fn handle_element(

--- a/components/script/dom/bindings/cell.rs
+++ b/components/script/dom/bindings/cell.rs
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::ops::{Deref, DerefMut};
+
+use atomic_refcell::{AtomicRefCell, AtomicRefMut};
+use js::context::NoGC;
+
+/// A borrowed mutable reference to the contents of an AtomicRefCell,
+/// anchored to the lifetime of a [NoGC] token.
+pub(crate) struct AtomicRefMutNoGC<'a, T> {
+    ref_mut: AtomicRefMut<'a, T>,
+    _anchor: &'a NoGC,
+}
+
+pub(crate) trait AtomicSafeBorrowMut {
+    type Target;
+
+    /// A version of [DomRefCell::safe_borrow_mut] for [AtomicRefCell].
+    /// The resulting borrowed mutable reference statically guarantees
+    /// that no garbage collection can occur while the borrow is live.
+    fn safe_borrow_mut<'a: 'b, 'b>(&'a self, no_gc: &'b NoGC)
+    -> AtomicRefMutNoGC<'b, Self::Target>;
+}
+
+impl<T> AtomicSafeBorrowMut for AtomicRefCell<T> {
+    type Target = T;
+    fn safe_borrow_mut<'a: 'b, 'b>(
+        &'a self,
+        no_gc: &'b NoGC,
+    ) -> AtomicRefMutNoGC<'b, Self::Target> {
+        AtomicRefMutNoGC {
+            ref_mut: self.borrow_mut(),
+            _anchor: no_gc,
+        }
+    }
+}
+
+impl<'a, T> Deref for AtomicRefMutNoGC<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.ref_mut
+    }
+}
+
+impl<'a, T> DerefMut for AtomicRefMutNoGC<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.ref_mut
+    }
+}

--- a/components/script/dom/bindings/mod.rs
+++ b/components/script/dom/bindings/mod.rs
@@ -135,6 +135,7 @@
 #![deny(non_snake_case)]
 
 pub(crate) mod buffer_source;
+pub(crate) mod cell;
 pub(crate) mod constructor;
 pub(crate) mod conversions;
 pub(crate) mod domname;

--- a/components/script/dom/characterdata/characterdata.rs
+++ b/components/script/dom/characterdata/characterdata.rs
@@ -5,12 +5,13 @@
 //! DOM bindings for `CharacterData`.
 use std::cell::LazyCell;
 
+use atomic_refcell::{AtomicRef, AtomicRefCell};
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::cell::{DomRefCell, Ref};
 use script_bindings::codegen::InheritTypes::{CharacterDataTypeId, NodeTypeId, TextTypeId};
 use servo_base::text::Utf16CodeUnits;
 
+use crate::dom::bindings::cell::AtomicSafeBorrowMut;
 use crate::dom::bindings::codegen::Bindings::CharacterDataBinding::CharacterDataMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::Node_Binding::NodeMethods;
 use crate::dom::bindings::codegen::Bindings::ProcessingInstructionBinding::ProcessingInstructionMethods;
@@ -33,14 +34,15 @@ use crate::dom::text::Text;
 #[dom_struct]
 pub(crate) struct CharacterData {
     node: Node,
-    data: DomRefCell<String>,
+    #[no_trace]
+    data: AtomicRefCell<String>,
 }
 
 impl CharacterData {
     pub(crate) fn new_inherited(data: DOMString, document: &Document) -> CharacterData {
         CharacterData {
             node: Node::new_inherited(document),
-            data: DomRefCell::new(String::from(data)),
+            data: AtomicRefCell::new(String::from(data)),
         }
     }
 
@@ -69,7 +71,7 @@ impl CharacterData {
     }
 
     #[inline]
-    pub(crate) fn data(&self) -> Ref<'_, String> {
+    pub(crate) fn data(&self) -> AtomicRef<'_, String> {
         self.data.borrow()
     }
 
@@ -318,10 +320,9 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
 }
 
 impl<'dom> LayoutDom<'dom, CharacterData> {
-    #[expect(unsafe_code)]
     #[inline]
-    pub(crate) fn data_for_layout(self) -> &'dom str {
-        unsafe { self.unsafe_get().data.borrow_for_layout() }
+    pub(crate) fn data_for_layout(self) -> AtomicRef<'dom, str> {
+        AtomicRef::map(self.unsafe_get().data.borrow(), |data| &**data)
     }
 }
 

--- a/components/script/dom/execcommand/contenteditable/text.rs
+++ b/components/script/dom/execcommand/contenteditable/text.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use atomic_refcell::AtomicRef;
 use js::context::NoGC;
-use script_bindings::cell::Ref;
 use script_bindings::inheritance::Castable;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 
@@ -18,7 +18,7 @@ use crate::dom::text::Text;
 
 impl Text {
     /// <https://dom.spec.whatwg.org/#concept-cd-data>
-    pub(crate) fn data(&self) -> Ref<'_, String> {
+    pub(crate) fn data(&self) -> AtomicRef<'_, String> {
         self.upcast::<CharacterData>().data()
     }
 

--- a/components/script/dom/node/layout_dom.rs
+++ b/components/script/dom/node/layout_dom.rs
@@ -4,9 +4,9 @@
 
 //! Methods for layout of node
 
-use std::borrow::Cow;
 use std::ops::Range;
 
+use atomic_refcell::AtomicRef;
 use layout_api::{
     GenericLayoutData, HTMLCanvasData, HTMLMediaData, LayoutElementType, LayoutNodeType,
     SVGElementData, SharedSelection,
@@ -241,12 +241,11 @@ impl<'dom> LayoutDom<'dom, Node> {
         self.is_single_line_text_inner_editor() || is_single_line_text_inner_placeholder
     }
 
-    pub(crate) fn text_content(self) -> Cow<'dom, str> {
+    pub(crate) fn text_content(self) -> AtomicRef<'dom, str> {
         self.downcast::<Text>()
             .expect("Called LayoutDom::text_content on non-Text node!")
             .upcast()
             .data_for_layout()
-            .into()
     }
 
     #[expect(unsafe_code)]
@@ -273,15 +272,15 @@ impl<'dom> LayoutDom<'dom, Node> {
         let is_end_node = unsafe { range_end.node().to_layout() } == *self;
 
         let start_offset = if is_start_node {
-            range_start.offset().to_utf32_code_units_in(text)
+            range_start.offset().to_utf32_code_units_in(&text)
         } else {
             Utf32CodeUnits(0)
         };
 
         let end_offset = if is_end_node {
-            range_end.offset().to_utf32_code_units_in(text)
+            range_end.offset().to_utf32_code_units_in(&text)
         } else {
-            Utf32CodeUnits::length_of(text)
+            Utf32CodeUnits::length_of(&text)
         };
 
         Some(start_offset..end_offset)

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -177,7 +177,7 @@ impl fmt::Debug for Node {
         if let Some(element) = self.downcast::<Element>() {
             element.fmt(f)
         } else if let Some(character_data) = self.downcast::<CharacterData>() {
-            write!(f, "[Text({})]", character_data.data())
+            write!(f, "[Text({})]", &*character_data.data())
         } else {
             write!(f, "[Node({:?})]", self.type_id())
         }

--- a/components/script/layout_dom/servo_layout_node.rs
+++ b/components/script/layout_dom/servo_layout_node.rs
@@ -5,10 +5,10 @@
 #![expect(unsafe_code)]
 #![deny(missing_docs)]
 
-use std::borrow::Cow;
 use std::fmt;
 use std::ops::Range;
 
+use atomic_refcell::AtomicRef;
 use layout_api::{
     GenericLayoutData, HTMLCanvasData, HTMLMediaData, LayoutDataTrait, LayoutElement, LayoutNode,
     LayoutNodeType, PseudoElementChain, SVGElementData, SharedSelection, TrustedNodeAddress,
@@ -244,7 +244,7 @@ impl<'dom> LayoutNode<'dom> for ServoLayoutNode<'dom> {
             .filter(|element| element.is_html_element())
     }
 
-    fn text_content(self) -> Cow<'dom, str> {
+    fn text_content(self) -> AtomicRef<'dom, str> {
         self.node.text_content()
     }
 

--- a/components/shared/layout/layout_node.rs
+++ b/components/shared/layout/layout_node.rs
@@ -5,10 +5,10 @@
 #![expect(unsafe_code)]
 #![deny(missing_docs)]
 
-use std::borrow::Cow;
 use std::fmt::Debug;
 use std::ops::Range;
 
+use atomic_refcell::AtomicRef;
 use net_traits::image_cache::Image;
 use pixels::ImageMetadata;
 use servo_arc::Arc;
@@ -169,7 +169,7 @@ pub trait LayoutNode<'dom>: Copy + Debug + NodeInfo + Send + Sync {
     /// # Panics
     ///
     /// This method will panic if called on a node that is not a DOM text node.
-    fn text_content(self) -> Cow<'dom, str>;
+    fn text_content(self) -> AtomicRef<'dom, str>;
 
     /// For a text node, returns which range of this text is part of the document selection
     ///


### PR DESCRIPTION
The actual change here in the CharacterData code removes a use of unsafe, but the AtomicRef type that we now return ends up propagating throughout the layout code that interacts with text. The actual changes are mechanical, just more infectious than I originally anticipated. We're now working _with_ Rust's type system instead of around it.

Testing: Existing tests suffice.
Fixes: part of #46049
