### PR TITLE
script: Use AtomicRefCell for CustomStateSet internal set.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9063,6 +9063,7 @@ dependencies = [
 name = "servo-script-bindings"
 version = "0.4.0"
 dependencies = [
+ "atomic_refcell",
  "bitflags 2.13.0",
  "crossbeam-channel",
  "encoding_rs",

--- a/components/script/dom/customstateset.rs
+++ b/components/script/dom/customstateset.rs
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use atomic_refcell::{AtomicRef, AtomicRefCell};
 use dom_struct::dom_struct;
 use indexmap::IndexSet;
 use js::context::JSContext;
-use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::ElementInternalsBinding::CustomStateSetMethods;
 use script_bindings::like::Setlike;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use script_bindings::root::{Dom, DomRoot};
 use script_bindings::str::DOMString;
-use script_bindings::trace::CustomTraceable;
 
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::html::htmlelement::HTMLElement;
@@ -22,7 +21,8 @@ use crate::dom::window::Window;
 #[dom_struct]
 pub(crate) struct CustomStateSet {
     reflector: Reflector,
-    internal: DomRefCell<IndexSet<DOMString>>,
+    #[no_trace]
+    internal: AtomicRefCell<IndexSet<DOMString>>,
     owner_element: Dom<HTMLElement>,
 }
 
@@ -30,7 +30,7 @@ impl CustomStateSet {
     fn new_inherited(element: &HTMLElement) -> Self {
         Self {
             reflector: Reflector::new(),
-            internal: DomRefCell::new(Default::default()),
+            internal: Default::default(),
             owner_element: Dom::from_ref(element),
         }
     }
@@ -39,12 +39,8 @@ impl CustomStateSet {
         reflect_dom_object_with_cx(Box::new(Self::new_inherited(element)), window, cx)
     }
 
-    /// Returns a borrowed version of the set without the usual Ref wrapper.
-    /// Mutating the underlying refcell while this value is active is
-    /// undefined behaviour.
-    #[expect(unsafe_code)]
-    pub(crate) unsafe fn set_for_layout(&self) -> &IndexSet<DOMString> {
-        unsafe { self.internal.borrow_for_layout() }
+    pub(crate) fn set_for_layout(&self) -> AtomicRef<'_, IndexSet<DOMString>> {
+        self.internal.borrow()
     }
 
     fn states_did_change(&self) {

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -1676,7 +1676,7 @@ impl<'dom> LayoutDom<'dom, Element> {
 
         let element_internals: LayoutDom<'_, _> = unsafe { element_internals.to_layout() };
         if let Some(states) = element_internals.unsafe_get().custom_states_for_layout() {
-            for state in unsafe { states.unsafe_get().set_for_layout().iter() } {
+            for state in states.unsafe_get().set_for_layout().iter() {
                 // FIXME: This creates new atoms whenever it is called, which is not optimal.
                 callback(&AtomIdent::from(&*state.str()));
             }

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -20,6 +20,7 @@ name = "script_bindings"
 path = "lib.rs"
 
 [dependencies]
+atomic_refcell = { workspace = true }
 bitflags = { workspace = true }
 crossbeam-channel = { workspace = true }
 deny_public_fields = { workspace = true }

--- a/components/script_bindings/like.rs
+++ b/components/script_bindings/like.rs
@@ -6,6 +6,7 @@
 
 use std::hash::Hash;
 
+use atomic_refcell::AtomicRefCell;
 use indexmap::{IndexMap, IndexSet};
 use js::context::JSContext;
 use js::conversions::ToJSValConvertible;
@@ -162,6 +163,43 @@ where
 }
 
 impl<K> Setlike for DomRefCell<IndexSet<K>>
+where
+    K: ToJSValConvertible + Eq + PartialEq + Hash + Clone,
+{
+    type Key = K;
+
+    #[inline(always)]
+    fn get_index(&self, _cx: &mut JSContext, index: u32) -> Option<Self::Key> {
+        self.borrow().get_index(index as usize).cloned()
+    }
+
+    #[inline(always)]
+    fn size(&self, _cx: &mut JSContext) -> u32 {
+        self.borrow().len() as u32
+    }
+
+    #[inline(always)]
+    fn add(&self, _cx: &mut JSContext, key: Self::Key) {
+        self.borrow_mut().insert(key);
+    }
+
+    #[inline(always)]
+    fn has(&self, _cx: &mut JSContext, key: Self::Key) -> bool {
+        self.borrow().contains(&key)
+    }
+
+    #[inline(always)]
+    fn clear(&self, _cx: &mut JSContext) {
+        self.borrow_mut().clear()
+    }
+
+    #[inline(always)]
+    fn delete(&self, _cx: &mut JSContext, key: Self::Key) -> bool {
+        self.borrow_mut().shift_remove(&key)
+    }
+}
+
+impl<K> Setlike for AtomicRefCell<IndexSet<K>>
 where
     K: ToJSValConvertible + Eq + PartialEq + Hash + Clone,
 {


### PR DESCRIPTION
This removes some unsafe code by replacing a type that really shouldn't be shared between threads with one that is intended for that purpose.

Testing: Existing tests suffice.
Fixes: part of #46049
