### PR TITLE
ci: Add support for nightly arm64 linux builds

### DIFF
--- a/.github/workflows/dispatch-workflow.yml
+++ b/.github/workflows/dispatch-workflow.yml
@@ -105,6 +105,24 @@ jobs:
       coverage: ${{ inputs.coverage }}
       capi: ${{ inputs.capi }}
 
+  linux-arm64:
+    if: ${{ inputs.workflow == 'linux-arm64' }}
+    name: Linux (arm64)
+    uses: ./.github/workflows/linux-arm64.yml
+    secrets: inherit
+    with:
+      profile: ${{ inputs.profile }}
+      build-args: ${{ inputs.build-args }}
+      wpt: ${{ inputs.wpt }}
+      number-of-wpt-chunks: ${{ inputs.number-of-wpt-chunks }}
+      unit-tests: ${{ inputs.unit-tests }}
+      devtools-tests: ${{ inputs.devtools-tests }}
+      build-libservo: ${{ inputs.build-libservo }}
+      wpt-args: ${{ inputs.wpt-args }}
+      bencher: ${{ inputs.bencher }}
+      coverage: ${{ inputs.coverage }}
+      capi: ${{ inputs.capi }}
+
   lint:
     if: ${{ inputs.workflow == 'lint' }}
     name: Lint

--- a/.github/workflows/linux-arm64.yml
+++ b/.github/workflows/linux-arm64.yml
@@ -1,0 +1,132 @@
+name: Linux Arm64
+on:
+  workflow_call:
+    outputs:
+      artifact_ids:
+        value: ${{ jobs.linux-arm64.outputs.artifact_ids }}
+        description: Comma-separated list of artifact IDs for the release artifacts
+    inputs:
+      profile:
+        required: false
+        default: "checked-release"
+        type: string
+      build-args:
+        default: ""
+        required: false
+        type: string
+      wpt-args:
+        default: ""
+        required: false
+        type: string
+      wpt-sync-from-upstream:
+        required: false
+        default: false
+        type: boolean
+      wpt:
+        required: false
+        type: boolean
+      number-of-wpt-chunks:
+        default: 20
+        required: false
+        type: number
+      unit-tests:
+        required: false
+        default: false
+        type: boolean
+      devtools-tests:
+        required: false
+        default: false
+        type: boolean
+      build-libservo:
+        required: false
+        default: false
+        type: boolean
+      force-github-hosted-runner:
+        required: false
+        type: boolean
+        default: false
+      bencher:
+        required: false
+        default: false
+        type: boolean
+      coverage:
+        required: false
+        default: false
+        type: boolean
+      capi:
+        required: false
+        default: false
+        type: boolean
+
+  workflow_dispatch:
+    inputs:
+      profile:
+        required: false
+        default: "checked-release"
+        type: choice
+        options: ["checked-release", "release", "debug", "production"]
+      wpt-args:
+        default: ""
+        required: false
+        type: string
+      wpt-sync-from-upstream:
+        default: false
+        required: false
+        type: boolean
+      wpt:
+        required: false
+        type: boolean
+      number-of-wpt-chunks:
+        default: 20
+        required: false
+        type: number
+      unit-tests:
+        required: false
+        default: false
+        type: boolean
+      devtools-tests:
+        required: false
+        default: false
+        type: boolean
+      build-libservo:
+        required: false
+        default: false
+        type: boolean
+      force-github-hosted-runner:
+        required: false
+        type: boolean
+        default: false
+      bencher:
+        required: false
+        default: false
+        type: boolean
+      capi:
+        required: false
+        default: false
+        type: boolean
+
+env:
+  RUST_BACKTRACE: 1
+  SHELL: /bin/bash
+
+jobs:
+  linux-arm64:
+    name: Call common linux workflow for arm64
+    uses: ./.github/workflows/linux-common.yml
+    secrets: inherit
+    with:
+      arch: arm64
+      github-runner-label: ubuntu-22.04-arm
+      uploaded-artifact-name: ${{ inputs.profile }}-binary-linux-arm64
+      profile: ${{ inputs.profile }}
+      build-args: ${{ inputs.build-args }}
+      wpt: ${{ inputs.wpt }}
+      number-of-wpt-chunks: ${{ inputs.number-of-wpt-chunks }}
+      unit-tests: ${{ inputs.unit-tests }}
+      devtools-tests: ${{ inputs.devtools-tests }}
+      build-libservo: ${{ inputs.build-libservo }}
+      wpt-args: ${{ inputs.wpt-args }}
+      bencher: ${{ inputs.bencher }}
+      coverage: ${{ inputs.coverage }}
+      capi: ${{ inputs.capi }}
+

--- a/.github/workflows/linux-common.yml
+++ b/.github/workflows/linux-common.yml
@@ -1,0 +1,263 @@
+name: Linux Common
+on:
+  workflow_call:
+    outputs:
+      artifact_ids:
+        value: ${{ jobs.build.outputs.artifact_ids }}
+        description: Comma-separated list of artifact IDs for the release artifacts
+    inputs:
+      arch:
+        required: true
+        type: string
+      github-runner-label:
+        required: true
+        type: string
+      uploaded-artifact-name:
+        required: true
+        type: string
+      profile:
+        required: false
+        default: "checked-release"
+        type: string
+      build-args:
+        default: ""
+        required: false
+        type: string
+      wpt-args:
+        default: ""
+        required: false
+        type: string
+      wpt-sync-from-upstream:
+        required: false
+        default: false
+        type: boolean
+      wpt:
+        required: false
+        type: boolean
+      number-of-wpt-chunks:
+        default: 20
+        required: false
+        type: number
+      unit-tests:
+        required: false
+        default: false
+        type: boolean
+      devtools-tests:
+        required: false
+        default: false
+        type: boolean
+      build-libservo:
+        required: false
+        default: false
+        type: boolean
+      force-github-hosted-runner:
+        required: false
+        type: boolean
+        default: false
+      bencher:
+        required: false
+        default: false
+        type: boolean
+      coverage:
+        required: false
+        default: false
+        type: boolean
+      capi:
+        required: false
+        default: false
+        type: boolean
+
+env:
+  RUST_BACKTRACE: 1
+  SHELL: /bin/bash
+
+jobs:
+  runner-select:
+    runs-on: ubuntu-24.04
+    outputs:
+      unique-id: ${{ steps.select.outputs.unique-id }}
+      selected-runner-label: ${{ steps.select.outputs.selected-runner-label }}
+      runner-type-label: ${{ steps.select.outputs.runner-type-label }}
+      is-self-hosted: ${{ steps.select.outputs.is-self-hosted }}
+    steps:
+      - name: Runner select
+        id: select
+        uses: servo/ci-runners/actions/runner-select@a05e7e830e3f4d4c71bdc5a38f003f052b72668c
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
+          github-hosted-runner-label: ${{ inputs.github-runner-label }}
+          self-hosted-image-name: servo-ubuntu2204
+          # You can disable self-hosted runners globally by creating a repository variable named
+          # NO_SELF_HOSTED_RUNNERS with any non-empty value.
+          # <https://github.com/servo/servo/settings/variables/actions>
+          NO_SELF_HOSTED_RUNNERS: ${{ vars.NO_SELF_HOSTED_RUNNERS }}
+          # Any other boolean conditions that disable self-hosted runners go here.
+          force-github-hosted-runner: ${{ inputs.force-github-hosted-runner }}
+
+  build:
+    needs:
+      - runner-select
+    name: Linux Build (${{ inputs.arch }}) [${{ needs.runner-select.outputs.unique-id }}]
+    runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
+    outputs:
+      artifact_ids: ${{ steps.artifact_ids.outputs.artifact_ids }}
+    steps:
+      - uses: servo/ci-runners/actions/checkout@a05e7e830e3f4d4c71bdc5a38f003f052b72668c
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        if: ${{ runner.environment != 'self-hosted' }}
+        with:
+          tool-cache: false
+          large-packages: false
+          swap-storage: false
+      - name: Set LIBCLANG_PATH env # needed for bindgen in mozangle
+        if: ${{ runner.environment != 'self-hosted' }}
+        run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV
+      - name: Setup Python
+        if: ${{ runner.environment != 'self-hosted' }}
+        uses: ./.github/actions/setup-python
+      - name: Change Mirror Priorities
+        if: ${{ runner.environment != 'self-hosted' }}
+        uses: ./.github/actions/apt-mirrors
+      - name: Install cargo nextest
+        if: ${{ inputs.unit-tests }}
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.140
+      - name: Bootstrap dependencies
+        if: ${{ runner.environment != 'self-hosted' }}
+        timeout-minutes: 30
+        run: |
+          sudo apt update
+          echo "wireshark-common wireshark-common/install-setuid boolean true" | sudo debconf-set-selections
+          sudo apt install -qy tshark shellcheck
+          ./mach bootstrap --yes --skip-lints --skip-nextest
+
+      # Always install crown, even on self-hosted runners, because it is tightly
+      # coupled to the rustc version, and we may have the wrong version if the
+      # commit we are building uses a different rustc version.
+      - name: Install crown
+        run: cargo install --path support/crown
+
+      - name: Build (${{ inputs.profile }})
+        env:
+          RUSTFLAGS: ${{ inputs.profile == 'checked-release' && '-D warnings' || '' }}
+        run: |
+          ./mach build --use-crown --locked --profile ${{ inputs.profile }} ${{ inputs.build-args }}
+          mv target/cargo-timings target/cargo-timings-linux
+      - name: Smoketest
+        run: xvfb-run ./mach smoketest --profile ${{ inputs.profile  }}
+      - name: Script tests
+        run: ./mach test-scripts
+      - name: Unit tests
+        id: run_unit_tests
+        if: ${{ inputs.unit-tests }}
+        env:
+          NEXTEST_RETRIES: 2 # https://github.com/servo/servo/issues/30683
+          LANG: en-US
+        run: |
+          ./mach test-unit --profile ${{ inputs.profile }} --nextest-profile ci
+          ./mach test-unit --profile ${{ inputs.profile }} --doc
+      # We upload the test-results to Codecov to help us identify flaky unit-tests.
+      - name: Upload test results to Codecov
+        # Upload test results to Codecov, also for failed unit-tests, but only
+        # if unit-tests were supposed to run, and not if they were skipped (e.g., due
+        # to an earlier failure).
+        if: ${{ !cancelled() && steps.run_unit_tests.conclusion != 'skipped' }}
+        uses: codecov/codecov-action@v6
+        with:
+          report_type: test_results
+          files: target/nextest/ci/junit.xml
+          disable_search: true
+          flags: unittests,unittests-linux,unittests-linux-${{ inputs.profile }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Devtools tests
+        if: ${{ inputs.devtools-tests }}
+        run: ./mach test-devtools --profile ${{ inputs.profile }}
+      - name: Archive build timing
+        uses: actions/upload-artifact@v7
+        with:
+          name: cargo-timings-linux-${{ inputs.profile }}
+          # Using a wildcard here ensures that the archive includes the path.
+          path: target/cargo-timings-*
+          if-no-files-found: error
+      - name: Build mach package
+        run: ./mach package --profile ${{ inputs.profile }}
+      - name: Upload artifact for mach package
+        uses: actions/upload-artifact@v7
+        id: upload-tarball
+        with:
+          name: ${{ inputs.uploaded-artifact-name }}
+          path: target/${{ inputs.profile }}/servo-tech-demo.tar.gz
+          if-no-files-found: error
+      - name: Collect artifact IDs needed by the release workflow
+        id: artifact_ids
+        shell: bash
+        run: |
+          echo "artifact_ids=${{steps.upload-tarball.outputs.artifact-id}}" >> $GITHUB_OUTPUT
+
+  build-libservo:
+    if: ${{ inputs.build-libservo }}
+    name: Build libservo and MSRV check (${{ inputs.arch }})
+    runs-on: ${{ inputs.github-runner-label }}
+    steps:
+      - uses: servo/ci-runners/actions/checkout@a05e7e830e3f4d4c71bdc5a38f003f052b72668c
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        if: ${{ runner.environment != 'self-hosted' }}
+        with:
+          tool-cache: false
+          large-packages: false
+          swap-storage: false
+      - name: Set LIBCLANG_PATH env # needed for bindgen in mozangle
+        run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
+      - name: Determine MSRV
+        id: msrv
+        uses: ./.github/actions/parse_msrv
+      - name: Install MSRV
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.rust_version }}
+      # We can remove this after upgrading to Rust 1.90, but for now
+      # installing lld is the easiest way to get it in path.
+      - name: install lld
+        run: sudo apt-get install -y lld
+      - name: Compile libservo with MSRV
+        env:
+          # lld seems to use less memory and prevents OOM errors during linking.
+          # We can remove this after upgrading to Rust 1.90, where lld will be the default.
+          RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
+          LLVM_OBJDUMP: llvm-objdump-14
+        run: |
+          cargo +${{ steps.msrv.outputs.rust_version }} build -p servo --locked
+
+  capi:
+    if: ${{ inputs.capi }}
+    name: Build and test Servo's C API (${{ inputs.arch }})
+    runs-on: ${{ inputs.github-runner-label }}
+    steps:
+      - uses: servo/ci-runners/actions/checkout@a05e7e830e3f4d4c71bdc5a38f003f052b72668c
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          large-packages: false
+          swap-storage: false
+      - name: Set LIBCLANG_PATH env # needed for bindgen in mozangle
+        run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
+      - name: Change Mirror Priorities
+        uses: ./.github/actions/apt-mirrors
+      - name: Install EGL library and headers
+        run: |
+          sudo apt update
+          sudo apt install -y libegl1-mesa-dev libegl-dev
+      - name: Install cargo-c # required by servo-capi-tests's build.rs
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-c@0.10.23
+      - name: Build and test servo-capi-tests
+        run: cargo test -p servo-capi-tests --locked

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     outputs:
       artifact_ids:
-        value: ${{ jobs.build.outputs.artifact_ids }}
+        value: ${{ jobs.common.outputs.artifact_ids }}
         description: Comma-separated list of artifact IDs for the release artifacts
     inputs:
       profile:
@@ -57,6 +57,7 @@ on:
         required: false
         default: false
         type: boolean
+
   workflow_dispatch:
     inputs:
       profile:
@@ -109,151 +110,51 @@ env:
   SHELL: /bin/bash
 
 jobs:
-  # Runs the underlying job (“workload”) on a self-hosted runner if available,
-  # with the help of a `runner-select` job and a `runner-timeout` job.
-  runner-select:
-    runs-on: ubuntu-24.04
-    outputs:
-      unique-id: ${{ steps.select.outputs.unique-id }}
-      selected-runner-label: ${{ steps.select.outputs.selected-runner-label }}
-      runner-type-label: ${{ steps.select.outputs.runner-type-label }}
-      is-self-hosted: ${{ steps.select.outputs.is-self-hosted }}
-    steps:
-      - name: Runner select
-        id: select
-        uses: servo/ci-runners/actions/runner-select@a05e7e830e3f4d4c71bdc5a38f003f052b72668c
-        with:
-          GITHUB_TOKEN: ${{ github.token }}
-          # Before updating the GH action runner image for the nightly job, ensure
-          # that the system has a glibc version that is compatible with the one
-          # used by the wpt.fyi runners.
-          github-hosted-runner-label: ubuntu-22.04
-          self-hosted-image-name: servo-ubuntu2204
-          # You can disable self-hosted runners globally by creating a repository variable named
-          # NO_SELF_HOSTED_RUNNERS with any non-empty value.
-          # <https://github.com/servo/servo/settings/variables/actions>
-          NO_SELF_HOSTED_RUNNERS: ${{ vars.NO_SELF_HOSTED_RUNNERS }}
-          # Any other boolean conditions that disable self-hosted runners go here.
-          force-github-hosted-runner: ${{ inputs.force-github-hosted-runner }}
-
-  build:
-    needs:
-      - runner-select
-    name: Linux Build [${{ needs.runner-select.outputs.unique-id }}]
-    runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
-    outputs:
-      artifact_ids: ${{ steps.artifact_ids.outputs.artifact_ids }}
-    steps:
-      - uses: servo/ci-runners/actions/checkout@a05e7e830e3f4d4c71bdc5a38f003f052b72668c
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        if: ${{ runner.environment != 'self-hosted' }}
-        with:
-          tool-cache: false
-          large-packages: false
-          swap-storage: false
-      - name: Set LIBCLANG_PATH env # needed for bindgen in mozangle
-        if: ${{ runner.environment != 'self-hosted' }}
-        run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV
-      - name: Setup Python
-        if: ${{ runner.environment != 'self-hosted' }}
-        uses: ./.github/actions/setup-python
-      - name: Change Mirror Priorities
-        if: ${{ runner.environment != 'self-hosted' }}
-        uses: ./.github/actions/apt-mirrors
-      - name: Install cargo nextest
-        if: ${{ inputs.unit-tests }}
-        uses: taiki-e/install-action@v2
-        with:
-          tool: nextest@0.9.140
-      - name: Bootstrap dependencies
-        if: ${{ runner.environment != 'self-hosted' }}
-        timeout-minutes: 30
-        run: |
-          sudo apt update
-          echo "wireshark-common wireshark-common/install-setuid boolean true" | sudo debconf-set-selections
-          sudo apt install -qy tshark shellcheck
-          ./mach bootstrap --yes --skip-lints --skip-nextest
-
-      # Always install crown, even on self-hosted runners, because it is tightly
-      # coupled to the rustc version, and we may have the wrong version if the
-      # commit we are building uses a different rustc version.
-      - name: Install crown
-        run: cargo install --path support/crown
-
-      - name: Build (${{ inputs.profile }})
-        env:
-          RUSTFLAGS: ${{ inputs.profile == 'checked-release' && '-D warnings' || '' }}
-        run: |
-          ./mach build --use-crown --locked --profile ${{ inputs.profile }} ${{ inputs.build-args }}
-          mv target/cargo-timings target/cargo-timings-linux
-      - name: Smoketest
-        run: xvfb-run ./mach smoketest --profile ${{ inputs.profile  }}
-      - name: Script tests
-        run: ./mach test-scripts
-      - name: Unit tests
-        id: run_unit_tests
-        if: ${{ inputs.unit-tests }}
-        env:
-          NEXTEST_RETRIES: 2 # https://github.com/servo/servo/issues/30683
-          LANG: en-US
-        run: |
-          ./mach test-unit --profile ${{ inputs.profile }} --nextest-profile ci
-          ./mach test-unit --profile ${{ inputs.profile }} --doc
-      # We upload the test-results to Codecov to help us identify flaky unit-tests.
-      - name: Upload test results to Codecov
-        # Upload test results to Codecov, also for failed unit-tests, but only
-        # if unit-tests were supposed to run, and not if they were skipped (e.g., due
-        # to an earlier failure).
-        if: ${{ !cancelled() && steps.run_unit_tests.conclusion != 'skipped' }}
-        uses: codecov/codecov-action@v6
-        with:
-          report_type: test_results
-          files: target/nextest/ci/junit.xml
-          disable_search: true
-          flags: unittests,unittests-linux,unittests-linux-${{ inputs.profile }}
-          token: ${{ secrets.CODECOV_TOKEN }}
-      - name: Devtools tests
-        if: ${{ inputs.devtools-tests }}
-        run: ./mach test-devtools --profile ${{ inputs.profile }}
-      - name: Archive build timing
-        uses: actions/upload-artifact@v7
-        with:
-          name: cargo-timings-linux-${{ inputs.profile }}
-          # Using a wildcard here ensures that the archive includes the path.
-          path: target/cargo-timings-*
-          if-no-files-found: error
-      - name: Build mach package
-        run: ./mach package --profile ${{ inputs.profile }}
-      - name: Upload artifact for mach package
-        uses: actions/upload-artifact@v7
-        id: upload-tarball
-        with:
-          name: ${{ inputs.profile }}-binary-linux
-          path: target/${{ inputs.profile }}/servo-tech-demo.tar.gz
-          if-no-files-found: error
-      - name: Collect artifact IDs needed by the release workflow
-        id: artifact_ids
-        shell: bash
-        run: |
-          echo "artifact_ids=${{steps.upload-tarball.outputs.artifact-id}}" >> $GITHUB_OUTPUT
+  common:
+    name: Call common Linux workflow for x86_64
+    uses: ./.github/workflows/linux-common.yml
+    secrets: inherit
+    with:
+      arch: x86_64
+      # Before updating the GH action runner image for the nightly job, ensure
+      # that the system has a glibc version that is compatible with the one
+      # used by the wpt.fyi runners.
+      github-runner-label: ubuntu-22.04
+      uploaded-artifact-name: ${{ inputs.profile }}-binary-linux
+      profile: ${{ inputs.profile }}
+      build-args: ${{ inputs.build-args }}
+      wpt: ${{ inputs.wpt }}
+      number-of-wpt-chunks: ${{ inputs.number-of-wpt-chunks }}
+      unit-tests: ${{ inputs.unit-tests }}
+      devtools-tests: ${{ inputs.devtools-tests }}
+      build-libservo: ${{ inputs.build-libservo }}
+      wpt-args: ${{ inputs.wpt-args }}
+      bencher: ${{ inputs.bencher }}
+      coverage: ${{ inputs.coverage }}
+      capi: ${{ inputs.capi }}
 
   wpt-2020:
     if: ${{ inputs.wpt }}
     name: Linux WPT
-    needs: ["build"]
+    needs: ["common"]
     uses: ./.github/workflows/linux-wpt.yml
     with:
       wpt-args: ${{ inputs.wpt-args }}
       profile: ${{ inputs.profile }}
       wpt-sync-from-upstream: ${{ inputs.wpt-sync-from-upstream }}
-      number-of-wpt-chunks: ${{ inputs. number-of-wpt-chunks }}
+      number-of-wpt-chunks: ${{ inputs.number-of-wpt-chunks }}
       binary-path: servo/servoshell
     secrets: inherit
 
   bencher:
-    needs: ["build"]
-    if: ${{ inputs.bencher && inputs.profile != 'debug' && github.event_name != 'workflow_dispatch' && github.event_name != 'merge_group' }}
+    needs: ["common"]
+    if: >-
+      ${{
+          inputs.bencher &&
+          inputs.profile != 'debug' &&
+          github.event_name != 'workflow_dispatch' &&
+          github.event_name != 'merge_group'
+      }}
     uses: ./.github/workflows/bencher.yml
     with:
       target: "linux"
@@ -265,72 +166,6 @@ jobs:
       speedometer: ${{ inputs.profile == 'release' }}
       dromaeo: ${{ inputs.profile == 'release' }}
     secrets: inherit
-
-  build-libservo:
-    if: ${{ inputs.build-libservo }}
-    name: Build libservo and MSRV check
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: servo/ci-runners/actions/checkout@a05e7e830e3f4d4c71bdc5a38f003f052b72668c
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        if: ${{ runner.environment != 'self-hosted' }}
-        with:
-          tool-cache: false
-          large-packages: false
-          swap-storage: false
-      - name: Set LIBCLANG_PATH env # needed for bindgen in mozangle
-        run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV
-      - name: Setup Python
-        uses: ./.github/actions/setup-python
-      - name: Determine MSRV
-        id: msrv
-        uses: ./.github/actions/parse_msrv
-      - name: Install MSRV
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ steps.msrv.outputs.rust_version }}
-      # We can remove this after upgrading to Rust 1.90, but for now
-      # installing lld is the easiest way to get it in path.
-      - name: install lld
-        run: sudo apt-get install -y lld
-      - name: Compile libservo with MSRV
-        env:
-          # lld seems to use less memory and prevents OOM errors during linking.
-          # We can remove this after upgrading to Rust 1.90, where lld will be the default.
-          RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
-          LLVM_OBJDUMP: llvm-objdump-14
-        run: |
-          cargo +${{ steps.msrv.outputs.rust_version }} build -p servo --locked
-
-  capi:
-    if: ${{ inputs.capi }}
-    name: Build and test Servo's C API
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: servo/ci-runners/actions/checkout@a05e7e830e3f4d4c71bdc5a38f003f052b72668c
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          large-packages: false
-          swap-storage: false
-      - name: Set LIBCLANG_PATH env # needed for bindgen in mozangle
-        run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV
-      - name: Setup Python
-        uses: ./.github/actions/setup-python
-      - name: Change Mirror Priorities
-        uses: ./.github/actions/apt-mirrors
-      - name: Install EGL library and headers
-        run: |
-          sudo apt update
-          sudo apt install -y libegl1-mesa-dev libegl-dev
-      - name: Install cargo-c # required by servo-capi-tests's build.rs
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-c@0.10.23
-      - name: Build and test servo-capi-tests
-        run: cargo test -p servo-capi-tests --locked
 
   # Runs the underlying job (“workload”) on a self-hosted runner if available.
   runner-select-coverage:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,7 @@ jobs:
       # any of the build jobs failed.
       - build-android
       - build-linux
+      - build-linux-arm64
       - build-mac
       - build-mac-arm64
       - build-ohos
@@ -221,6 +222,7 @@ jobs:
       - build-mac
       - build-mac-arm64
       - build-linux
+      - build-linux-arm64
       - build-android
       - build-ohos
     strategy: &upload-artifacts-strategy
@@ -235,6 +237,8 @@ jobs:
             artifact_platform: mac-arm64
           - artifact_ids: ${{ needs.build-linux.outputs.artifact_ids }}
             artifact_platform: linux
+          - artifact_ids: ${{ needs.build-linux-arm64.outputs.artifact_ids }}
+            artifact_platform: linux-arm64
           - artifact_ids: ${{ needs.build-android.outputs.artifact_ids }}
             artifact_platform: android
           - artifact_ids: ${{ needs.build-ohos.outputs.artifact_ids }}
@@ -324,6 +328,15 @@ jobs:
     if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
     name: Build production release (Linux)
     uses: ./.github/workflows/linux.yml
+    with:
+      profile: "production"
+      force-github-hosted-runner: true  # <https://github.com/servo/servo/issues/33296>
+
+  build-linux-arm64:
+    # This job is only useful when run on upstream servo.
+    if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
+    name: Build production release (Linux Arm64)
+    uses: ./.github/workflows/linux-arm64.yml
     with:
       profile: "production"
       force-github-hosted-runner: true  # <https://github.com/servo/servo/issues/33296>

--- a/components/background_hang_monitor/sampler.rs
+++ b/components/background_hang_monitor/sampler.rs
@@ -39,7 +39,14 @@ impl Default for NativeStack {
 }
 
 impl NativeStack {
-    #[cfg_attr(any(target_os = "windows", target_env = "ohos"), expect(dead_code))]
+    #[cfg_attr(
+        any(
+            target_os = "windows",
+            target_env = "ohos",
+            all(target_os = "linux", target_arch = "aarch64")
+        ),
+        expect(dead_code)
+    )]
     pub fn process_register(
         &mut self,
         instruction_ptr: *mut std::ffi::c_void,

--- a/etc/ci/upload_nightly.py
+++ b/etc/ci/upload_nightly.py
@@ -46,6 +46,8 @@ def map_platform(platform: str) -> str:
         return "aarch64-android"
     elif platform == "linux":
         return "x86_64-linux-gnu"
+    elif platform == "linux-arm64":
+        return "aarch64-linux-gnu"
     elif platform == "windows-msvc":
         return "x86_64-windows-msvc"
     elif platform == "mac":

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -23,6 +23,7 @@ from enum import Enum
 
 class Workflow(str, Enum):
     LINUX = "linux"
+    LINUX_ARM = "linux-arm64"
     MACOS = "macos"
     MACOS_ARM = "macos-arm64"
     WINDOWS = "windows"
@@ -71,6 +72,8 @@ class JobConfig(object):
     def update_name(self) -> None:
         if self.workflow is Workflow.LINUX:
             self.name = "Linux"
+        elif self.workflow is Workflow.LINUX_ARM:
+            self.name = "Linux Arm64"
         elif self.workflow is Workflow.MACOS:
             self.name = "MacOS"
         elif self.workflow is Workflow.MACOS_ARM:
@@ -107,7 +110,9 @@ class JobConfig(object):
 def handle_preset(s: str) -> Optional[JobConfig]:
     s = s.lower()
 
-    if any(word in s for word in ["linux"]):
+    if any(word in s for word in ["linux-arm", "linux-arm64"]):
+        return JobConfig("Linux Arm64", Workflow.LINUX_ARM)
+    elif any(word in s for word in ["linux"]):
         return JobConfig("Linux", Workflow.LINUX)
     elif any(word in s for word in ["mac-arm", "macos-arm", "mac-arm64", "macos-arm64"]):
         return JobConfig("MacOS Arm64", Workflow.MACOS_ARM)


### PR DESCRIPTION
The common jobs for both x86_64 and arm64 are extracted into a callable workflow `linux-common.yml`.

Only nightly builds are enabled in this patch to avoid introducing a bottleneck in the merge queue on the availability of arm64 runners. However, it should be possible to trigger the arm64 job using a try label.

Fixes: #35023
Testing: Validated the CI logic on personal fork. The build artifacts have not been validated manually yet, although one of the fork runs ran the unit tests for arm64 build without issues.