### PR TITLE
Make sure virtual keyboard is hidden when <input type=text> and <textarea> is no longer focused on OHOS

### DIFF
--- a/components/script/dom/html/form_controls/htmlinputelement.rs
+++ b/components/script/dom/html/form_controls/htmlinputelement.rs
@@ -2271,15 +2271,9 @@ impl VirtualMethods for HTMLInputElement {
 
     fn unbind_from_tree(&self, cx: &mut JSContext, context: &UnbindContext) {
         // We make sure that when currently focused input element is removed, keyboard is hidden
-        let doc = self.owner_document();
-        if doc
-            .focus_handler()
-            .focused_area()
-            .element()
-            .is_some_and(|e| e == self.upcast::<Element>())
-        {
-            doc.embedder_controls().hide_embedder_control(self.upcast());
-        }
+        self.owner_document()
+            .embedder_controls()
+            .hide_embedder_control(self.upcast());
 
         let form_owner = self.form_owner();
         self.super_type().unwrap().unbind_from_tree(cx, context);

--- a/components/script/dom/html/form_controls/htmlinputelement.rs
+++ b/components/script/dom/html/form_controls/htmlinputelement.rs
@@ -2270,7 +2270,7 @@ impl VirtualMethods for HTMLInputElement {
     }
 
     fn unbind_from_tree(&self, cx: &mut JSContext, context: &UnbindContext) {
-        // We make sure that when currently focused input element is removed, keyboard is hidden
+        // Always attempt to hide IME when unbinding input elements from the tree.
         self.owner_document()
             .embedder_controls()
             .hide_embedder_control(self.upcast());

--- a/components/script/dom/html/form_controls/htmlinputelement.rs
+++ b/components/script/dom/html/form_controls/htmlinputelement.rs
@@ -2270,6 +2270,17 @@ impl VirtualMethods for HTMLInputElement {
     }
 
     fn unbind_from_tree(&self, cx: &mut JSContext, context: &UnbindContext) {
+        // We make sure that when currently focused input element is removed, keyboard is hidden
+        let doc = self.owner_document();
+        if doc
+            .focus_handler()
+            .focused_area()
+            .element()
+            .is_some_and(|e| e == self.upcast::<Element>())
+        {
+            doc.embedder_controls().hide_embedder_control(self.upcast());
+        }
+
         let form_owner = self.form_owner();
         self.super_type().unwrap().unbind_from_tree(cx, context);
 

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -732,7 +732,7 @@ impl VirtualMethods for HTMLTextAreaElement {
     }
 
     fn unbind_from_tree(&self, cx: &mut JSContext, context: &UnbindContext) {
-        // We make sure that when currently focused textarea element is removed, keyboard is hidden
+        // Always attempt to hide IME when unbinding input elements from the tree.
         self.owner_document()
             .embedder_controls()
             .hide_embedder_control(self.upcast());

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -733,15 +733,9 @@ impl VirtualMethods for HTMLTextAreaElement {
 
     fn unbind_from_tree(&self, cx: &mut JSContext, context: &UnbindContext) {
         // We make sure that when currently focused textarea element is removed, keyboard is hidden
-        let doc = self.owner_document();
-        if doc
-            .focus_handler()
-            .focused_area()
-            .element()
-            .is_some_and(|e| e == self.upcast::<Element>())
-        {
-            doc.embedder_controls().hide_embedder_control(self.upcast());
-        }
+        self.owner_document()
+            .embedder_controls()
+            .hide_embedder_control(self.upcast());
 
         self.super_type().unwrap().unbind_from_tree(cx, context);
 

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -732,6 +732,17 @@ impl VirtualMethods for HTMLTextAreaElement {
     }
 
     fn unbind_from_tree(&self, cx: &mut JSContext, context: &UnbindContext) {
+        // We make sure that when currently focused textarea element is removed, keyboard is hidden
+        let doc = self.owner_document();
+        if doc
+            .focus_handler()
+            .focused_area()
+            .element()
+            .is_some_and(|e| e == self.upcast::<Element>())
+        {
+            doc.embedder_controls().hide_embedder_control(self.upcast());
+        }
+
         self.super_type().unwrap().unbind_from_tree(cx, context);
 
         let node = self.upcast::<Node>();

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -655,8 +655,9 @@ impl App {
     pub fn ime_dismissed(&self) {
         if let Some(webview) = self.active_or_newest_webview() {
             webview.notify_input_event(InputEvent::Ime(ImeEvent::Dismissed));
-            self.spin_event_loop();
         }
+        self.host.on_ime_hide();
+        self.spin_event_loop();
     }
 
     pub fn notify_vsync(&self) {

--- a/ports/servoshell/egl/ohos/mod.rs
+++ b/ports/servoshell/egl/ohos/mod.rs
@@ -76,7 +76,7 @@ use napi_ohos::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallM
 use napi_ohos::{Env, JsString, JsValue};
 use ohos_abilitykit_sys::runtime::application_context;
 use ohos_ime::{
-    AttachOptions, CreateImeProxyError, CreateTextEditorProxyError, Ime, ImeProxy,
+    AttachOptions, CreateImeProxyError, CreateTextEditorProxyError, Ime, ImeProxy, KeyboardStatus,
     RawTextEditorProxy,
 };
 use ohos_ime_sys::types::InputMethod_EnterKeyType;
@@ -345,6 +345,7 @@ pub(super) enum ServoAction {
     ImeDeleteForward(usize),
     ImeDeleteBackward(usize),
     ImeSendEnter,
+    ImeDismiss,
     Vsync,
     Resize {
         width: i32,
@@ -382,6 +383,7 @@ impl std::fmt::Debug for ServoAction {
                 f.debug_tuple("ImeDeleteBackward").field(arg0).finish()
             },
             Self::ImeSendEnter => write!(f, "ImeSendEnter"),
+            Self::ImeDismiss => write!(f, "ImeDismiss"),
             Self::Vsync => write!(f, "Vsync"),
             Self::Resize { width, height } => f
                 .debug_struct("Resize")
@@ -451,7 +453,11 @@ impl ServoAction {
             ImeSendEnter => {
                 servo.key_down(Key::Named(NamedKey::Enter));
                 servo.key_up(Key::Named(NamedKey::Enter));
+                servo.ime_dismissed();
             },
+            ImeDismiss => {
+                servo.ime_dismissed();
+            }
             Vsync => {
                 servo.notify_vsync();
             },
@@ -1104,6 +1110,15 @@ impl Ime for ServoIme {
 
     fn send_enter_key(&self, _enter_key: InputMethod_EnterKeyType) {
         call(ServoAction::ImeSendEnter).unwrap()
+    }
+
+    fn keyboard_status_changed(&self, status: KeyboardStatus) {
+        match status {
+            KeyboardStatus::Hidden => {
+                call(ServoAction::ImeDismiss).unwrap()
+            },
+            _ => (),
+        }
     }
 }
 

--- a/ports/servoshell/egl/ohos/mod.rs
+++ b/ports/servoshell/egl/ohos/mod.rs
@@ -457,7 +457,7 @@ impl ServoAction {
             },
             ImeDismiss => {
                 servo.ime_dismissed();
-            }
+            },
             Vsync => {
                 servo.notify_vsync();
             },
@@ -1114,9 +1114,7 @@ impl Ime for ServoIme {
 
     fn keyboard_status_changed(&self, status: KeyboardStatus) {
         match status {
-            KeyboardStatus::Hidden => {
-                call(ServoAction::ImeDismiss).unwrap()
-            },
+            KeyboardStatus::Hidden => call(ServoAction::ImeDismiss).unwrap(),
             _ => (),
         }
     }


### PR DESCRIPTION
Fixing 2 issues related to text input on OHOS:
1. When  `<input type=text>` or `<textarea>` is currently focused and was removed from the page, virtual keyboard is not automatically hidden. 
2. Pressing "done"/"enter" in virtual keyboard does not automatically hides it.

Testing: Manually tested by checking virtual keyboard behaviour when `<textarea>` is removed by a script.