### PR TITLE
layout: Simplify the way that document selection is handled in traversals

### DIFF
--- a/components/layout/construct_modern.rs
+++ b/components/layout/construct_modern.rs
@@ -5,11 +5,10 @@
 //! Layout construction code that is shared between modern layout modes (Flexbox and CSS Grid)
 
 use std::borrow::Cow;
-use std::ops::Range;
 use std::sync::OnceLock;
 
+use layout_api::LayoutNode;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use servo_base::text::Utf32CodeUnits;
 use style::selector_parser::PseudoElement;
 
 use crate::PropagatedBoxTreeData;
@@ -85,7 +84,7 @@ impl<'dom> ModernContainerJob<'dom> {
                     inline_formatting_context_builder.push_text(
                         flex_text_run.text,
                         &flex_text_run.info,
-                        flex_text_run.document_selection_range,
+                        flex_text_run.info.node.document_selection_in_text_node(),
                     );
                 }
 
@@ -181,7 +180,6 @@ impl<'dom> ModernContainerJob<'dom> {
 struct ModernContainerTextRun<'dom> {
     info: NodeAndStyleInfo<'dom>,
     text: Cow<'dom, str>,
-    document_selection_range: Option<Range<Utf32CodeUnits>>,
     style_from_display_contents: Option<SharedInlineStyles>,
 }
 
@@ -210,16 +208,10 @@ pub(crate) struct ModernItem<'dom> {
 }
 
 impl<'dom> TraversalHandler<'dom> for ModernContainerBuilder<'_, 'dom> {
-    fn handle_text(
-        &mut self,
-        info: &NodeAndStyleInfo<'dom>,
-        text: Cow<'dom, str>,
-        document_selection_range: Option<Range<Utf32CodeUnits>>,
-    ) {
+    fn handle_text(&mut self, info: &NodeAndStyleInfo<'dom>, text: Cow<'dom, str>) {
         self.contiguous_text_runs.push(ModernContainerTextRun {
             info: info.clone(),
             text,
-            document_selection_range,
             style_from_display_contents: self.display_contents_shared_styles.last().cloned(),
         })
     }

--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -3,14 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::borrow::Cow;
-use std::ops::Range;
 
 use layout_api::{
     LayoutElement, LayoutElementType, LayoutNode, LayoutNodeType, PseudoElementChain,
 };
 use script::layout_dom::ServoLayoutNode;
 use servo_arc::Arc as ServoArc;
-use servo_base::text::Utf32CodeUnits;
 use style::dom::NodeInfo;
 use style::properties::ComputedValues;
 use style::selector_parser::PseudoElement;
@@ -87,12 +85,7 @@ pub(super) enum PseudoElementContentItem {
 }
 
 pub(super) trait TraversalHandler<'dom> {
-    fn handle_text(
-        &mut self,
-        info: &NodeAndStyleInfo<'dom>,
-        text: Cow<'dom, str>,
-        document_selection: Option<Range<Utf32CodeUnits>>,
-    );
+    fn handle_text(&mut self, info: &NodeAndStyleInfo<'dom>, text: Cow<'dom, str>);
 
     /// Or pseudo-element
     fn handle_element(
@@ -127,11 +120,7 @@ fn traverse_children_of<'dom>(
     for child in parent_element_info.node.flat_tree_children() {
         if child.is_text_node() {
             let info = NodeAndStyleInfo::new(child, child.style(&context.style_context));
-            handler.handle_text(
-                &info,
-                child.text_content(),
-                child.document_selection_in_text_node(),
-            );
+            handler.handle_text(&info, child.text_content());
         } else if child.is_element() {
             traverse_element(child, context, handler);
         }
@@ -227,9 +216,7 @@ fn traverse_pseudo_element_contents<'dom>(
     let mut anonymous_info = None;
     for item in items {
         match item {
-            PseudoElementContentItem::Text(text) => {
-                handler.handle_text(info, text.into(), None /* document_selection_range */)
-            },
+            PseudoElementContentItem::Text(text) => handler.handle_text(info, text.into()),
             PseudoElementContentItem::Replaced(contents) => {
                 let anonymous_info = anonymous_info.get_or_insert_with(|| {
                     info.with_pseudo_element(context, PseudoElement::ServoAnonymousBox)

--- a/components/layout/flow/construct.rs
+++ b/components/layout/flow/construct.rs
@@ -3,12 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::borrow::Cow;
-use std::ops::Range;
 
 use layout_api::LayoutNode;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use servo_arc::Arc;
-use servo_base::text::Utf32CodeUnits;
 use style::properties::ComputedValues;
 use style::properties::longhands::list_style_position::computed_value::T as ListStylePosition;
 use style::selector_parser::PseudoElement;
@@ -373,9 +371,7 @@ impl<'dom, 'style> BlockContainerBuilder<'dom, 'style> {
         // irrelevant boxes" and "Generate missing parents."
         for content in trailing_contents {
             match content {
-                AnonymousTableContent::Text(info, text, document_selection_range) => {
-                    self.handle_text(&info, text, document_selection_range)
-                },
+                AnonymousTableContent::Text(info, text) => self.handle_text(&info, text),
                 AnonymousTableContent::EnterDisplayContents(styles) => {
                     self.enter_display_contents(styles)
                 },
@@ -432,12 +428,7 @@ impl<'dom> TraversalHandler<'dom> for BlockContainerBuilder<'dom, '_> {
         }
     }
 
-    fn handle_text(
-        &mut self,
-        info: &NodeAndStyleInfo<'dom>,
-        text: Cow<'dom, str>,
-        document_selection_range: Option<Range<Utf32CodeUnits>>,
-    ) {
+    fn handle_text(&mut self, info: &NodeAndStyleInfo<'dom>, text: Cow<'dom, str>) {
         if text.is_empty() {
             return;
         }
@@ -447,11 +438,7 @@ impl<'dom> TraversalHandler<'dom> for BlockContainerBuilder<'dom, '_> {
         // whitespace to the table builder.
         if !self.anonymous_table_content.is_empty() && text.chars().all(char_is_whitespace) {
             self.anonymous_table_content
-                .push(AnonymousTableContent::Text(
-                    info.clone(),
-                    text,
-                    document_selection_range,
-                ));
+                .push(AnonymousTableContent::Text(info.clone(), text));
             return;
         } else {
             self.finish_anonymous_table_if_needed();
@@ -461,13 +448,7 @@ impl<'dom> TraversalHandler<'dom> for BlockContainerBuilder<'dom, '_> {
         self.inline_formatting_context_builder
             .as_mut()
             .expect("Should be guaranteed by line above")
-            .push_text_with_possible_first_letter(
-                text,
-                info,
-                self.info,
-                self.context,
-                document_selection_range,
-            );
+            .push_text_with_possible_first_letter(text, info, self.info, self.context);
     }
 
     fn enter_display_contents(&mut self, styles: SharedInlineStyles) {

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -310,8 +310,8 @@ impl InlineFormattingContextBuilder {
         info: &NodeAndStyleInfo<'dom>,
         container_info: &NodeAndStyleInfo<'dom>,
         layout_context: &LayoutContext,
-        document_selection: Option<Range<Utf32CodeUnits>>,
     ) -> bool {
+        let document_selection = info.node.document_selection_in_text_node();
         if self.has_processed_first_letter || !container_info.pseudo_element_chain().is_empty() {
             self.push_text(text, info, document_selection);
             return false;

--- a/components/layout/table/construct.rs
+++ b/components/layout/table/construct.rs
@@ -4,13 +4,11 @@
 
 use std::borrow::Cow;
 use std::iter::repeat_n;
-use std::ops::Range;
 
 use atomic_refcell::AtomicRef;
 use layout_api::LayoutNode;
 use log::warn;
 use servo_arc::Arc;
-use servo_base::text::Utf32CodeUnits;
 use style::properties::ComputedValues;
 use style::properties::style_structs::Font;
 use style::selector_parser::PseudoElement;
@@ -52,11 +50,7 @@ impl ResolvedSlotAndLocation<'_> {
 }
 
 pub(crate) enum AnonymousTableContent<'dom> {
-    Text(
-        NodeAndStyleInfo<'dom>,
-        Cow<'dom, str>,
-        Option<Range<Utf32CodeUnits>>,
-    ),
+    Text(NodeAndStyleInfo<'dom>, Cow<'dom, str>),
     EnterDisplayContents(SharedInlineStyles),
     LeaveDisplayContents,
     Element {
@@ -71,7 +65,7 @@ impl AnonymousTableContent<'_> {
     fn is_whitespace_only(&self) -> bool {
         match self {
             Self::Element { .. } => false,
-            Self::Text(_, text, _) => text.chars().all(char_is_whitespace),
+            Self::Text(_, text) => text.chars().all(char_is_whitespace),
             Self::EnterDisplayContents(_) | Self::LeaveDisplayContents => true,
         }
     }
@@ -738,8 +732,8 @@ impl<'style, 'dom> TableBuilderTraversal<'style, 'dom> {
                 } => {
                     row_builder.handle_element(&info, display, contents, box_slot);
                 },
-                AnonymousTableContent::Text(info, text, document_selection_range) => {
-                    row_builder.handle_text(&info, text, document_selection_range);
+                AnonymousTableContent::Text(info, text) => {
+                    row_builder.handle_text(&info, text);
                 },
                 AnonymousTableContent::EnterDisplayContents(ref styles) => {
                     row_builder.enter_display_contents(styles.clone());
@@ -781,18 +775,9 @@ impl<'style, 'dom> TableBuilderTraversal<'style, 'dom> {
 }
 
 impl<'dom> TraversalHandler<'dom> for TableBuilderTraversal<'_, 'dom> {
-    fn handle_text(
-        &mut self,
-        info: &NodeAndStyleInfo<'dom>,
-        text: Cow<'dom, str>,
-        document_selection_range: Option<Range<Utf32CodeUnits>>,
-    ) {
+    fn handle_text(&mut self, info: &NodeAndStyleInfo<'dom>, text: Cow<'dom, str>) {
         self.current_anonymous_row_content
-            .push(AnonymousTableContent::Text(
-                info.clone(),
-                text,
-                document_selection_range,
-            ));
+            .push(AnonymousTableContent::Text(info.clone(), text));
     }
 
     fn enter_display_contents(&mut self, styles: SharedInlineStyles) {
@@ -1042,8 +1027,8 @@ impl<'style, 'builder, 'dom, 'a> TableRowGroupBuilder<'style, 'builder, 'dom, 'a
                 } => {
                     row_builder.handle_element(&info, display, contents, box_slot);
                 },
-                AnonymousTableContent::Text(info, text, document_selection_range) => {
-                    row_builder.handle_text(&info, text, document_selection_range);
+                AnonymousTableContent::Text(info, text) => {
+                    row_builder.handle_text(&info, text);
                 },
                 AnonymousTableContent::EnterDisplayContents(ref styles) => {
                     row_builder.enter_display_contents(styles.clone());
@@ -1076,18 +1061,9 @@ impl<'style, 'builder, 'dom, 'a> TableRowGroupBuilder<'style, 'builder, 'dom, 'a
 }
 
 impl<'dom> TraversalHandler<'dom> for TableRowGroupBuilder<'_, '_, 'dom, '_> {
-    fn handle_text(
-        &mut self,
-        info: &NodeAndStyleInfo<'dom>,
-        text: Cow<'dom, str>,
-        document_selection_range: Option<Range<Utf32CodeUnits>>,
-    ) {
+    fn handle_text(&mut self, info: &NodeAndStyleInfo<'dom>, text: Cow<'dom, str>) {
         self.current_anonymous_row_content
-            .push(AnonymousTableContent::Text(
-                info.clone(),
-                text,
-                document_selection_range,
-            ));
+            .push(AnonymousTableContent::Text(info.clone(), text));
     }
 
     fn enter_display_contents(&mut self, styles: SharedInlineStyles) {
@@ -1202,8 +1178,8 @@ impl<'style, 'builder, 'dom, 'a> TableRowBuilder<'style, 'builder, 'dom, 'a> {
                 } => {
                     builder.handle_element(&info, display, contents, box_slot);
                 },
-                AnonymousTableContent::Text(info, text, document_selection_range) => {
-                    builder.handle_text(&info, text, document_selection_range);
+                AnonymousTableContent::Text(info, text) => {
+                    builder.handle_text(&info, text);
                 },
                 AnonymousTableContent::EnterDisplayContents(ref styles) => {
                     builder.enter_display_contents(styles.clone());
@@ -1243,18 +1219,9 @@ impl<'style, 'builder, 'dom, 'a> TableRowBuilder<'style, 'builder, 'dom, 'a> {
 }
 
 impl<'dom> TraversalHandler<'dom> for TableRowBuilder<'_, '_, 'dom, '_> {
-    fn handle_text(
-        &mut self,
-        info: &NodeAndStyleInfo<'dom>,
-        text: Cow<'dom, str>,
-        document_selection_range: Option<Range<Utf32CodeUnits>>,
-    ) {
+    fn handle_text(&mut self, info: &NodeAndStyleInfo<'dom>, text: Cow<'dom, str>) {
         self.current_anonymous_cell_content
-            .push(AnonymousTableContent::Text(
-                info.clone(),
-                text,
-                document_selection_range,
-            ));
+            .push(AnonymousTableContent::Text(info.clone(), text));
     }
 
     fn enter_display_contents(&mut self, styles: SharedInlineStyles) {
@@ -1362,13 +1329,7 @@ struct TableColumnGroupBuilder {
 }
 
 impl<'dom> TraversalHandler<'dom> for TableColumnGroupBuilder {
-    fn handle_text(
-        &mut self,
-        _info: &NodeAndStyleInfo<'dom>,
-        _text: Cow<'dom, str>,
-        _document_selection_range: Option<Range<Utf32CodeUnits>>,
-    ) {
-    }
+    fn handle_text(&mut self, _info: &NodeAndStyleInfo<'dom>, _text: Cow<'dom, str>) {}
     fn enter_display_contents(&mut self, _: SharedInlineStyles) {}
     fn leave_display_contents(&mut self) {}
     fn handle_element(

--- a/components/script/layout_dom/servo_layout_node.rs
+++ b/components/script/layout_dom/servo_layout_node.rs
@@ -249,6 +249,11 @@ impl<'dom> LayoutNode<'dom> for ServoLayoutNode<'dom> {
     }
 
     fn document_selection_in_text_node(&self) -> Option<Range<Utf32CodeUnits>> {
+        // Pseudo-elements do not ever have document selection.
+        if !self.pseudo_element_chain.is_empty() {
+            return None;
+        }
+
         self.node.document_selection_in_text_node()
     }
 


### PR DESCRIPTION
Instead of eagerly passing the document selection range in the DOM
traveral, only fetch it when necessary before pushing text into an
`InlineFormattingContextBuilder`. This greatly simplifies the traversal
handler signatures and makes the code more straight-foward in other
places as well (removing ~70 lines of code).

Testing: This should not change behavior so is covered by existing tests.
