### PR TITLE
script: Borrow hazard in Sanitizer::AllowElement

### DIFF
--- a/components/script/dom/security/sanitizer.rs
+++ b/components/script/dom/security/sanitizer.rs
@@ -780,18 +780,24 @@ impl SanitizerMethods<crate::DomTypeHolder> for Sanitizer {
 
     /// <https://wicg.github.io/sanitizer-api/#dom-sanitizer-allowelement>
     fn AllowElement(&self, cx: &mut JSContext, element: SanitizerElementWithAttributes) -> bool {
-        // Step 1. Let configuration be this’s configuration.
-        let mut configuration = self.configuration.borrow_mut();
+        let has_configuration_element = {
+            // Step 1. Let configuration be this’s configuration.
+            let configuration = self.configuration.borrow();
 
-        // Step 2. Assert: configuration is valid.
-        debug_assert!(configuration.is_valid());
+            // Step 2. Assert: configuration is valid.
+            debug_assert!(configuration.is_valid());
+
+            configuration.elements.is_some()
+        };
 
         // Step 3. Set element to the result of canonicalize a sanitizer element with attributes
         // with element.
         let mut element = element.canonicalize();
 
         // Step 4. If configuration["elements"] exists:
-        if configuration.elements.is_some() {
+        if has_configuration_element {
+            let mut configuration = self.configuration.safe_borrow_mut(cx);
+
             // Step 4.1. Set modified to the result of remove element from
             // configuration["replaceWithChildrenElements"].
             let modified = if let Some(replace_with_children_elements) =
@@ -952,6 +958,8 @@ impl SanitizerMethods<crate::DomTypeHolder> for Sanitizer {
                 // Step 5.1.2. Return false.
                 return false;
             }
+
+            let mut configuration = self.configuration.safe_borrow_mut(cx);
 
             // Step 5.2. Set modified to the result of remove element from
             // configuration["replaceWithChildrenElements"].

--- a/components/script/dom/security/sanitizer.rs
+++ b/components/script/dom/security/sanitizer.rs
@@ -780,24 +780,18 @@ impl SanitizerMethods<crate::DomTypeHolder> for Sanitizer {
 
     /// <https://wicg.github.io/sanitizer-api/#dom-sanitizer-allowelement>
     fn AllowElement(&self, cx: &mut JSContext, element: SanitizerElementWithAttributes) -> bool {
-        let has_configuration_element = {
-            // Step 1. Let configuration be this’s configuration.
-            let configuration = self.configuration.borrow();
+        // Step 1. Let configuration be this’s configuration.
+        let mut configuration = self.configuration.safe_borrow_mut(cx);
 
-            // Step 2. Assert: configuration is valid.
-            debug_assert!(configuration.is_valid());
-
-            configuration.elements.is_some()
-        };
+        // Step 2. Assert: configuration is valid.
+        debug_assert!(configuration.is_valid());
 
         // Step 3. Set element to the result of canonicalize a sanitizer element with attributes
         // with element.
         let mut element = element.canonicalize();
 
         // Step 4. If configuration["elements"] exists:
-        if has_configuration_element {
-            let mut configuration = self.configuration.safe_borrow_mut(cx);
-
+        if configuration.elements.is_some() {
             // Step 4.1. Set modified to the result of remove element from
             // configuration["replaceWithChildrenElements"].
             let modified = if let Some(replace_with_children_elements) =
@@ -945,6 +939,8 @@ impl SanitizerMethods<crate::DomTypeHolder> for Sanitizer {
             if element.attributes().is_some() ||
                 !element.remove_attributes().unwrap_or_default().is_empty()
             {
+                std::mem::drop(configuration);
+
                 // Step 5.1.1. The user agent may report a warning to the console that this
                 // operation is not supported.
                 Console::internal_warn(
@@ -958,8 +954,6 @@ impl SanitizerMethods<crate::DomTypeHolder> for Sanitizer {
                 // Step 5.1.2. Return false.
                 return false;
             }
-
-            let mut configuration = self.configuration.safe_borrow_mut(cx);
 
             // Step 5.2. Set modified to the result of remove element from
             // configuration["replaceWithChildrenElements"].


### PR DESCRIPTION
restrict mutable borrow scope exclude Console::internal_warn.

Testing: 
./mach build --debug-mozjs
./mach test-wpt /sanitizer-api/sanitizer-modifiers.html
19/19 passed

Fixes: https://github.com/servo/servo/issues/46702
