### PR TITLE
android: Remove `GfxCallbacks` as never invoked

### DIFF
--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.java
@@ -97,10 +97,6 @@ public class JNIServo {
     public interface Callbacks {
         void wakeup();
 
-        void flush();
-
-        void makeCurrent();
-
         void onAlert(String message);
 
         void onLoadStarted();

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.java
@@ -22,20 +22,15 @@ public class Servo {
     public Servo(
             ServoOptions options,
             RunCallback runCallback,
-            GfxCallbacks gfxcb,
             Client client,
             Activity activity,
             Surface surface) {
 
         mRunCallback = runCallback;
 
-        mServoCallbacks = new Callbacks(client, gfxcb);
+        mServoCallbacks = new Callbacks(client);
 
         mRunCallback.inGLThread(() -> mJNI.init(activity, options, mServoCallbacks, surface));
-    }
-
-    public void resetGfxCallbacks(GfxCallbacks gfxcb) {
-        mServoCallbacks.resetGfxCallbacks(gfxcb);
     }
 
     public String version() {
@@ -174,40 +169,18 @@ public class Servo {
         void inUIThread(Runnable f);
     }
 
-    public interface GfxCallbacks {
-        void flushGLBuffers();
-
-        void makeCurrent();
-    }
-
     private class Callbacks implements JNIServo.Callbacks, Client {
 
-        private GfxCallbacks mGfxCb;
         Client mClient;
 
-        Callbacks(Client client, GfxCallbacks gfxcb) {
+        Callbacks(Client client) {
             mClient = client;
-            mGfxCb = gfxcb;
-        }
-
-        private void resetGfxCallbacks(GfxCallbacks gfxcb) {
-            mGfxCb = gfxcb;
         }
 
         public void wakeup() {
             if (!mSuspended) {
                 mRunCallback.inGLThread(() -> mJNI.performUpdates());
             }
-        }
-
-        public void flush() {
-            // Up to the callback to execute this in the right thread
-            mGfxCb.flushGLBuffers();
-        }
-
-        public void makeCurrent() {
-            // Up to the callback to execute this in the right thread
-            mGfxCb.makeCurrent();
         }
 
         public void onAlert(String message) {

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
@@ -23,14 +23,12 @@ import android.view.View;
 import org.servo.servoview.JNIServo.ServoCoordinates;
 import org.servo.servoview.JNIServo.ServoOptions;
 import org.servo.servoview.Servo.Client;
-import org.servo.servoview.Servo.GfxCallbacks;
 import org.servo.servoview.Servo.RunCallback;
 
 import java.util.ArrayList;
 
 public class ServoView extends SurfaceView
         implements
-        GfxCallbacks,
         RunCallback,
         Choreographer.FrameCallback {
     private static final String LOGTAG = "ServoView";
@@ -90,17 +88,6 @@ public class ServoView extends SurfaceView
     @Override
     public void inUIThread(Runnable r) {
         post(r);
-    }
-
-
-    // GfxCallbacks
-    @Override
-    public void flushGLBuffers() {
-    }
-
-
-    @Override
-    public void makeCurrent() {
     }
 
     // View
@@ -232,7 +219,7 @@ public class ServoView extends SurfaceView
             options.density = metrics.density;
             if (mServoView.mServo == null && !mPaused) {
                 mServoView.mServo = new Servo(
-                        options, mServoView, mServoView, mClient, mActivity, surface);
+                        options, mServoView, mClient, mActivity, surface);
             } else {
                 mPaused = false;
                 mServoView.mServo.resumePainting(surface, coords);


### PR DESCRIPTION
As of d7de206dbd459e8c8bf121f73755d12569c6cc55, these callbacks are never invoked, so these callbacks aren't listening to anything.

Testing: There are no automated tests for Android.