### PR TITLE
android: Fix back navigation when `ServoView` displayed

### DIFF
--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
@@ -106,14 +106,20 @@ public class ServoView extends SurfaceView
     // View
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
-        mServo.onKeyDown(keyCode, event);
-        return true;
+        if (event.getKeyCode() != KeyEvent.KEYCODE_BACK) {
+            mServo.onKeyDown(keyCode, event);
+            return true;
+        }
+        return false;
     }
 
     @Override
     public boolean onKeyUp(int keyCode, KeyEvent event) {
-        mServo.onKeyUp(keyCode, event);
-        return true;
+        if (event.getKeyCode() != KeyEvent.KEYCODE_BACK) {
+            mServo.onKeyUp(keyCode, event);
+            return true;
+        }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Now when `ServoView` is displayed:

1. The app is exited if the page history is empty.
2. `ServoView` goes back a page if the page history isn't empty.

This is the logic that `MainActivity#onBackPressed()` codifies, but it was never perceivable due to `ServoView` consuming all the back events before it could get to `MainActivity#onBackPressed()`.

Testing: There are no automated tests for Android.
Fixes: https://github.com/servo/servo/issues/46764