### PR TITLE
Update rand crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4573,7 +4573,7 @@ dependencies = [
  "libc",
  "mio",
  "postcard",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rustc-hash 2.1.3",
  "serde_core",
  "tempfile",
@@ -6878,9 +6878,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -6889,9 +6889,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -6985,7 +6985,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",
@@ -10626,7 +10626,7 @@ dependencies = [
  "bytes",
  "chrono",
  "prost",
- "rand 0.8.6",
+ "rand 0.8.7",
  "thread-id",
  "tracing",
  "tracing-subscriber",
@@ -10682,7 +10682,7 @@ dependencies = [
  "http 1.4.2",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rustls",
  "rustls-pki-types",
  "sha1 0.10.6",


### PR DESCRIPTION
Update rand crates.

Testing: No tests for Cargo.lock update.

