### PR TITLE
ci: Fix ohos bencher error by reverting to `actions/checkout`

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -218,9 +218,16 @@ jobs:
           # to make sure we don't use a previous version if installation failed for some reason.
           hdc uninstall org.servo.servo
           hdc install -r servoshell-hos-signed.hap
-      - uses: servo/ci-runners/actions/checkout@a05e7e830e3f4d4c71bdc5a38f003f052b72668c
+      - uses: actions/checkout@v6
+        if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 0
+      - uses: actions/checkout@v6
+        if: github.event_name == 'pull_request_target'
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          allow-unsafe-pr-checkout: true
       - name: Setup Python
         uses: ./.github/actions/setup-python
       - name: Get model name


### PR DESCRIPTION
Error earlier was
```
Run servo/ci-runners/actions/checkout@a05e7e830e3f4d4c71bdc5a38f003f052b72668c
Run if [ 'push' == pull_request_target ]; then
commit=1d51def4cc6345919283f3aa857cddaa59021ceb
Run git fetch origin 1d51def4cc6345919283f3aa857cddaa59021ceb
fatal: not a git repository (or any of the parent directories): .git
Error: Process completed with exit code 128.
```

Testing: [Try](https://github.com/servo/servo/actions/runs/30141782360)
