### PR TITLE
script: Implement `safe_to_jsval` for more types

### DIFF
--- a/components/dom_struct/domobject.rs
+++ b/components/dom_struct/domobject.rs
@@ -45,6 +45,11 @@ pub(crate) fn expand_dom_object(
                 let object = crate::DomObject::reflector(self).get_jsobject();
                 object.to_jsval(cx, rval)
             }
+
+            fn safe_to_jsval(&self, cx: &mut js::context::JSContext, rval: js::rust::MutableHandleValue) {
+                let object = crate::DomObject::reflector(self).get_jsobject();
+                js::conversions::ToJSValConvertible::safe_to_jsval(&*object, cx, rval);
+            }
         }
 
         impl #impl_generics crate::DomObject for #name #ty_generics #where_clause {

--- a/components/dom_struct/lib.rs
+++ b/components/dom_struct/lib.rs
@@ -131,6 +131,15 @@ fn test_valid_dom_struct_generation() {
                 let object = crate::DomObject::reflector(self).get_jsobject();
                 object.to_jsval(cx, rval)
             }
+
+            fn safe_to_jsval(
+                &self,
+                cx: &mut js::context::JSContext,
+                rval: js::rust::MutableHandleValue,
+            ) {
+                let object = crate::DomObject::reflector(self).get_jsobject();
+                js::conversions::ToJSValConvertible::safe_to_jsval(&*object, cx, rval);
+            }
         }
         impl crate::DomObject for DomElement {
             type ReflectorType = crate::AssociatedMemory;

--- a/components/script/dom/webxr/xrhand.rs
+++ b/components/script/dom/webxr/xrhand.rs
@@ -4,13 +4,10 @@
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use js::jsapi::JSContext as RawJSContext;
-use js::rust::MutableHandleValue;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webxr_api::{FingerJoint, Hand, Joint};
 
 use crate::dom::bindings::codegen::Bindings::XRHandBinding::{XRHandJoint, XRHandMethods};
-use crate::dom::bindings::conversions::ToJSValConvertible;
 use crate::dom::bindings::iterable::Iterable;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::globalscope::GlobalScope;
@@ -161,30 +158,19 @@ impl XRHandMethods<crate::DomTypeHolder> for XRHand {
     }
 }
 
-/// A wrapper to work around a crown error—Root<T> has a crown annotation on it that is not present
-/// on the Iterable::Value associated type. The absence is harmless in this case.
-pub(crate) struct ValueWrapper(pub DomRoot<XRJointSpace>);
-
-impl ToJSValConvertible for ValueWrapper {
-    #[expect(unsafe_code)]
-    unsafe fn to_jsval(&self, cx: *mut RawJSContext, rval: MutableHandleValue) {
-        unsafe { self.0.to_jsval(cx, rval) }
-    }
-}
-
 impl Iterable for XRHand {
     type Key = XRHandJoint;
-    type Value = ValueWrapper;
+    type Value = DomRoot<XRJointSpace>;
 
     fn get_iterable_length(&self, _cx: &mut JSContext) -> u32 {
         JOINT_SPACE_MAP.len() as u32
     }
 
-    fn get_value_at_index(&self, _cx: &mut JSContext, n: u32) -> ValueWrapper {
+    fn get_value_at_index(&self, _cx: &mut JSContext, n: u32) -> DomRoot<XRJointSpace> {
         let joint = JOINT_SPACE_MAP[n as usize].1;
         self.spaces
             .get(joint)
-            .map(|j| ValueWrapper(DomRoot::from_ref(&**j)))
+            .map(|j| DomRoot::from_ref(&**j))
             .expect("Failed to get joint pose")
     }
 

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -1516,7 +1516,7 @@ def wrapForType(jsvalRef: str, result: str = 'result', successCode: str = 'true'
       * 'successCode': the code to run once we have done the conversion.
       * 'pre': code to run before the conversion if rooting is necessary
     """
-    wrap = f"{pre}\n({result}).to_jsval(cx.raw_cx(), {jsvalRef});"
+    wrap = f"{pre}\n({result}).safe_to_jsval(cx, {jsvalRef});"
     if successCode:
         wrap += f"\n{successCode}"
     return wrap
@@ -5434,6 +5434,10 @@ impl ToJSValConvertible for super::{ident} {{
     unsafe fn to_jsval(&self, cx: *mut RawJSContext, rval: MutableHandleValue) {{
         pairs[*self as usize].0.to_jsval(cx, rval);
     }}
+
+    fn safe_to_jsval(&self, cx: &mut JSContext, rval: MutableHandleValue) {{
+        pairs[*self as usize].0.safe_to_jsval(cx, rval);
+    }}
 }}
 
 impl FromJSValConvertible for super::{ident} {{
@@ -5630,7 +5634,7 @@ impl{self.generic} Clone for {self.type}{self.genericSuffix} {{
             for (v, wrapper) in templateVars
         ]
         enumConversions = [
-            f"            {self.type}::{v['name']}(ref inner) => inner.to_jsval(cx, rval),"
+            f"            {self.type}::{v['name']}(ref inner) => inner.safe_to_jsval(cx, rval),"
             for (v, _) in templateVars
         ]
         joinedEnumValues = "\n".join(enumValues)
@@ -5644,7 +5648,14 @@ pub enum {self.type}{self.generic} {{
 }}
 
 impl{self.generic} ToJSValConvertible for {self.type}{self.genericSuffix} {{
-    unsafe fn to_jsval(&self, cx: *mut RawJSContext, rval: MutableHandleValue) {{
+    unsafe fn to_jsval(&self, _cx: *mut RawJSContext, rval: MutableHandleValue) {{
+        // TODO: https://github.com/servo/mozjs/issues/764
+        // This is needed until the `RawJSContext` version is removed from the trait.
+        let mut cx = crate::script_runtime::temp_cx();
+        self.safe_to_jsval(&mut cx, rval);
+    }}
+
+    fn safe_to_jsval(&self, cx: &mut JSContext, rval: MutableHandleValue) {{
         match *self {{
 {joinedEnumConversions}
         }}
@@ -8650,6 +8661,10 @@ impl<D: DomTypes> ToJSValConvertible for {type} {{
     unsafe fn to_jsval(&self, cx: *mut RawJSContext, rval: MutableHandleValue) {{
         self.callback().to_jsval(cx, rval);
     }}
+
+    fn safe_to_jsval(&self, cx: &mut JSContext, rval: MutableHandleValue) {{
+        self.callback().safe_to_jsval(cx, rval);
+    }}
 }}
 """)
         CGGeneric.__init__(self, impl)
@@ -9084,8 +9099,8 @@ class CGIterableMethodGenerator(CGGeneric):
                 // https://heycam.github.io/webidl/#es-forEach
                 let mut i = 0;
                 while i < (*this).get_iterable_length(cx) {
-                  (*this).get_value_at_index(cx, i).to_jsval(cx.raw_cx(), call_arg1.handle_mut());
-                  (*this).get_key_at_index(cx, i).to_jsval(cx.raw_cx(), call_arg2.handle_mut());
+                  (*this).get_value_at_index(cx, i).safe_to_jsval(cx, call_arg1.handle_mut());
+                  (*this).get_key_at_index(cx, i).safe_to_jsval(cx, call_arg2.handle_mut());
                   call_args.set_index(0, call_arg1.handle().get());
                   call_args.set_index(1, call_arg2.handle().get());
                   let call_args_handle = HandleValueArray::from(&call_args);

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -11,13 +11,11 @@ use js::error::throw_type_error;
 use js::glue::{
     GetProxyHandlerExtra, GetProxyReservedSlot, IsProxyHandlerFamily, IsWrapper, JS_GetReservedSlot,
 };
-use js::jsapi::{
-    Heap, IsWindowProxy, JS_DeprecatedStringHasLatin1Chars, JS_NewStringCopyN, JSContext, JSObject,
-};
+use js::jsapi::{Heap, IsWindowProxy, JS_DeprecatedStringHasLatin1Chars, JSContext, JSObject};
 use js::jsval::{ObjectValue, StringValue, UndefinedValue};
 use js::rust::wrappers2::{
     IsArrayObject, JS_GetLatin1StringCharsAndLength, JS_GetTwoByteStringCharsAndLength,
-    UnwrapObjectDynamic,
+    JS_NewStringCopyN, UnwrapObjectDynamic,
 };
 use js::rust::{
     HandleId, HandleValue, MutableHandleValue, ToString, get_object_class, is_dom_class,
@@ -65,6 +63,10 @@ pub trait DerivedFrom<T: Castable>: Castable {}
 impl ToJSValConvertible for USVString {
     unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
         self.0.to_jsval(cx, rval);
+    }
+
+    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, rval: MutableHandleValue) {
+        ToJSValConvertible::safe_to_jsval(&self.0, cx, rval);
     }
 }
 
@@ -120,16 +122,25 @@ impl FromJSValConvertible for USVString {
 
 // http://heycam.github.io/webidl/#es-ByteString
 impl ToJSValConvertible for ByteString {
-    unsafe fn to_jsval(&self, cx: *mut JSContext, mut rval: MutableHandleValue) {
-        let jsstr = JS_NewStringCopyN(
-            cx,
-            self.as_ptr() as *const libc::c_char,
-            self.len() as libc::size_t,
-        );
+    unsafe fn to_jsval(&self, _cx: *mut JSContext, rval: MutableHandleValue) {
+        // TODO: https://github.com/servo/mozjs/issues/764
+        // This is needed until the `RawJSContext` version is removed from the trait.
+        let mut cx = unsafe { crate::script_runtime::temp_cx() };
+        ToJSValConvertible::safe_to_jsval(self, &mut cx, rval);
+    }
+
+    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
+        let jsstr = unsafe {
+            JS_NewStringCopyN(
+                cx,
+                self.as_ptr() as *const libc::c_char,
+                self.len() as libc::size_t,
+            )
+        };
         if jsstr.is_null() {
             panic!("JS_NewStringCopyN failed");
         }
-        rval.set(StringValue(&*jsstr));
+        unsafe { rval.set(StringValue(&*jsstr)) };
     }
 }
 
@@ -184,6 +195,13 @@ impl<T> ToJSValConvertible for Reflector<T> {
         rval.set(ObjectValue(obj));
         maybe_wrap_value(cx, rval);
     }
+
+    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
+        let obj = self.get_jsobject().get();
+        assert!(!obj.is_null());
+        rval.set(ObjectValue(obj));
+        unsafe { maybe_wrap_value(cx.raw_cx(), rval) };
+    }
 }
 
 impl<T: DomObject + IDLInterface> FromJSValConvertible for DomRoot<T> {
@@ -204,6 +222,10 @@ impl<T: DomObject + IDLInterface> FromJSValConvertible for DomRoot<T> {
 impl<T: DomObject> ToJSValConvertible for DomRoot<T> {
     unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
         self.reflector().to_jsval(cx, rval);
+    }
+
+    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, rval: MutableHandleValue) {
+        ToJSValConvertible::safe_to_jsval(&self.reflector(), cx, rval);
     }
 }
 
@@ -409,6 +431,12 @@ impl<T: Float + ToJSValConvertible> ToJSValConvertible for Finite<T> {
         let value = **self;
         value.to_jsval(cx, rval);
     }
+
+    #[inline]
+    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, rval: MutableHandleValue) {
+        let value = **self;
+        value.safe_to_jsval(cx, rval);
+    }
 }
 
 impl<T: Float + FromJSValConvertible<Config = ()>> FromJSValConvertible for Finite<T> {
@@ -504,6 +532,12 @@ impl<T: ToJSValConvertible + JSTraceable> ToJSValConvertible for RootedTraceable
     unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
         let value = &**self;
         value.to_jsval(cx, rval);
+    }
+
+    #[inline]
+    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, rval: MutableHandleValue) {
+        let value = &**self;
+        value.safe_to_jsval(cx, rval);
     }
 }
 

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -767,12 +767,17 @@ impl Extend<char> for DOMString {
 }
 
 impl ToJSValConvertible for DOMString {
-    unsafe fn to_jsval(&self, cx: *mut RawJSContext, mut rval: MutableHandleValue) {
+    unsafe fn to_jsval(&self, _cx: *mut RawJSContext, rval: MutableHandleValue) {
+        // TODO: https://github.com/servo/mozjs/issues/764
+        // This is needed until the `RawJSContext` version is removed from the trait.
+        let mut cx = unsafe { crate::script_runtime::temp_cx() };
+        ToJSValConvertible::safe_to_jsval(self, &mut cx, rval);
+    }
+
+    fn safe_to_jsval(&self, cx: &mut JSContext, mut rval: MutableHandleValue) {
         let val = self.0.borrow();
         match *val {
-            DOMStringType::Rust(ref s) => unsafe {
-                s.to_jsval(cx, rval);
-            },
+            DOMStringType::Rust(ref s) => s.safe_to_jsval(cx, rval),
             DOMStringType::JSString(ref rooted_traceable_box) => unsafe {
                 rval.set(StringValue(&*rooted_traceable_box.get()));
             },
@@ -785,7 +790,7 @@ impl ToJSValConvertible for DOMString {
 
                 String::from_utf8(v)
                     .expect("Error in constructin test string")
-                    .to_jsval(cx, rval);
+                    .safe_to_jsval(cx, rval);
             },
         };
     }


### PR DESCRIPTION
Other than to have safer implementations, this is needed to complete migration to mozjs's safe bindings.

Testing: It compiles
Part of #40600 
