### PR TITLE
android: Let `Servo` and `ServoView` take any type of `Context`

### DIFF
--- a/ports/servoshell/egl/android/mod.rs
+++ b/ports/servoshell/egl/android/mod.rs
@@ -98,7 +98,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_version<'local>(
 pub extern "C" fn Java_org_servo_servoview_JNIServo_init<'local>(
     mut env: EnvUnowned<'local>,
     _: JClass<'local>,
-    activity: JObject<'local>,
+    context: JObject<'local>,
     opts: JObject<'local>,
     callbacks_obj: JObject<'local>,
     surface: JObject<'local>,
@@ -172,7 +172,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_init<'local>(
 
         crate::init_crypto();
 
-        if let Err(error) = set_default_config_dir(env, &activity) {
+        if let Err(error) = set_default_config_dir(env, &context) {
             error!("Failed to determine Android config directory: {error:?}");
         }
 
@@ -926,11 +926,11 @@ fn get_field_as_string<'local>(
 
 fn set_default_config_dir<'local>(
     env: &mut Env<'local>,
-    activity: &JObject<'local>,
+    context: &JObject<'local>,
 ) -> Result<(), Error> {
     let files_dir = env
         .call_method(
-            activity,
+            context,
             jni_str!("getFilesDir"),
             jni_sig!("()Ljava/io/File;"),
             &[],

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.java
@@ -5,7 +5,7 @@
 
 package org.servo.servoview;
 
-import android.app.Activity;
+import android.content.Context;
 import android.view.Surface;
 
 /**
@@ -20,7 +20,7 @@ class JNIServo {
 
     native String version();
 
-    native void init(Activity activity, ServoOptions options, Callbacks callbacks, Surface surface);
+    native void init(Context context, ServoOptions options, Callbacks callbacks, Surface surface);
 
     native void deinit();
 

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.java
@@ -5,7 +5,7 @@
 
 package org.servo.servoview;
 
-import android.app.Activity;
+import android.content.Context;
 import android.view.KeyEvent;
 import android.view.Surface;
 
@@ -23,14 +23,14 @@ public class Servo {
             ServoOptions options,
             RunCallback runCallback,
             Client client,
-            Activity activity,
+            Context context,
             Surface surface) {
 
         this.runCallback = runCallback;
 
         servoCallbacks = new Callbacks(client);
 
-        this.runCallback.inGLThread(() -> jni.init(activity, options, servoCallbacks, surface));
+        this.runCallback.inGLThread(() -> jni.init(context, options, servoCallbacks, surface));
     }
 
     public String version() {

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
@@ -5,7 +5,6 @@
 
 package org.servo.servoview;
 
-import android.app.Activity;
 import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
@@ -40,7 +39,7 @@ public class ServoView extends SurfaceView
     private String servoArgs;
     private String servoLog;
     private String initialUri;
-    private Activity activity;
+    private Context context;
 
     private boolean experimentalMode;
     private boolean paused = false;
@@ -56,7 +55,7 @@ public class ServoView extends SurfaceView
     }
 
     private void init(Context context) {
-        activity = (Activity) context;
+        this.context = context;
         setFocusable(true);
         setFocusableInTouchMode(true);
         setClickable(true);
@@ -64,7 +63,7 @@ public class ServoView extends SurfaceView
         view.add(this);
         addTouchables(view);
 
-        glThread = new GLThread(activity, this);
+        glThread = new GLThread(context, this);
         getHolder().addCallback(glThread);
         glThread.start();
     }
@@ -197,11 +196,11 @@ public class ServoView extends SurfaceView
     }
 
     class GLThread extends Thread implements SurfaceHolder.Callback {
-        private Activity activity;
+        private Context context;
         private ServoView servoView;
 
-        GLThread(Activity activity, ServoView servoView) {
-            this.activity = activity;
+        GLThread(Context context, ServoView servoView) {
+            this.context = context;
             this.servoView = servoView;
         }
 
@@ -221,11 +220,11 @@ public class ServoView extends SurfaceView
             options.enableSubpixelTextAntialiasing = true;
             options.experimentalMode = servoView.experimentalMode;
 
-            DisplayMetrics metrics = activity.getResources().getDisplayMetrics();
+            DisplayMetrics metrics = context.getResources().getDisplayMetrics();
             options.density = metrics.density;
             if (servoView.servo == null && !paused) {
                 servoView.servo = new Servo(
-                        options, servoView, client, activity, surface);
+                        options, servoView, client, context, surface);
             } else {
                 paused = false;
                 servoView.servo.resumePainting(surface, coords);


### PR DESCRIPTION
`Servo` and `ServoView` are needlessly restrictive, respectively requiring an `Activity` instance or a `Context` instance that crashes on cast if it's not an `Activity`. Both these classes only need a `Context`, regardless of whether that `Context` is an `Activity` or something else.

Testing: There are no automated tests for Android.