### PR TITLE
android: Remove native symbols if no corresponding implementation

### DIFF
--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.java
@@ -22,12 +22,6 @@ class JNIServo {
 
     native void init(Context context, ServoOptions options, Callbacks callbacks, Surface surface);
 
-    native void deinit();
-
-    native void requestShutdown();
-
-    native void setBatchMode(boolean mode);
-
     native void performUpdates();
 
     native void resize(ServoCoordinates coords);
@@ -79,8 +73,6 @@ class JNIServo {
         String url;
         ServoCoordinates coordinates;
         float density = 1;
-        boolean enableSubpixelTextAntialiasing = true;
-        long VRExternalContext = 0;
         String logStr;
         String gstDebugStr;
         boolean enableLogs = false;

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.java
@@ -41,10 +41,6 @@ public class Servo {
         runCallback.inGLThread(() -> jni.performUpdates());
     }
 
-    public void setBatchMode(boolean mode) {
-        runCallback.inGLThread(() -> jni.setBatchMode(mode));
-    }
-
     public void resize(ServoCoordinates coords) {
         runCallback.inGLThread(() -> jni.resize(coords));
     }

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
@@ -217,7 +217,6 @@ public class ServoView extends SurfaceView
             options.url = servoView.initialUri;
             options.coordinates = coords;
             options.enableLogs = true;
-            options.enableSubpixelTextAntialiasing = true;
             options.experimentalMode = servoView.experimentalMode;
 
             DisplayMetrics metrics = context.getResources().getDisplayMetrics();


### PR DESCRIPTION
Invoking `deinit`, `requestShutdown`, or `setBatchMode` will cause the exception `UnsatisfiedLinkError` to be thrown as there are no corresponding native implementations of these functions.

Setting `enableSubpixelTextAntialiasing` or `VRExternalContext` will just cause no-ops as there are no corresponding native references to these fields.

Testing: There are no automated tests for Android.