### PR TITLE
android: Remove theoretical origin customisation

### DIFF
--- a/ports/servoshell/egl/android/mod.rs
+++ b/ports/servoshell/egl/android/mod.rs
@@ -904,13 +904,10 @@ fn jni_coordinate_to_rust_viewport_rect<'local>(
     env: &mut Env<'local>,
     obj: &JObject<'local>,
 ) -> Result<Rect<i32, DevicePixel>, Error> {
-    let x = env.get_field(obj, jni_str!("x"), jni_sig!("I"))?.i()?;
-    let y = env.get_field(obj, jni_str!("y"), jni_sig!("I"))?.i()?;
-
     let width = env.get_field(obj, jni_str!("width"), jni_sig!("I"))?.i()?;
     let height = env.get_field(obj, jni_str!("height"), jni_sig!("I"))?.i()?;
 
-    Ok(Rect::new(Point2D::new(x, y), Size2D::new(width, height)))
+    Ok(Rect::new(Point2D::origin(), Size2D::new(width, height)))
 }
 
 fn get_field_as_string<'local>(

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.java
@@ -88,8 +88,6 @@ class JNIServo {
     }
 
     static class ServoCoordinates {
-        int x = 0;
-        int y = 0;
         int width = 0;
         int height = 0;
     }


### PR DESCRIPTION
We never customise the `x` and `y` coordinates, so they have always been 0. I tried seeing what would happen if we _did_ customise these values, and seemingly nothing changed. Following the references of `jni_coordinate_to_rust_viewport_rect` seemed to confirm that only the `size` property was ever referenced, never the `origin`.

Testing: There are no automated tests for Android.