### PR TITLE
canvas: Adjust memory pressure heuristic

### DIFF
--- a/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
@@ -46,8 +46,22 @@ pub(crate) struct CanvasRenderingContext2D {
 
 impl CanvasRenderingContext2D {
     const RGBA8_BYTES_PER_PIXEL: usize = 4;
-    /// We have two bitmap buffers one in Canvas Paint Thread and one for WebRender
-    const ASSOCIATED_MEMORY_BUFFER_COUNT: usize = 2;
+    /// Ideally this would be two bitmap buffers, unfortunately we currently have ~4 copies
+    /// which are all retained until GC:
+    ///
+    /// 1. The draw target's backing bitmap in the canvas paint thread
+    ///    (`CanvasData::draw_target`, e.g. `pixmap` in `VelloCPUDrawTarget`).
+    /// 2. Additional backend resources (estimated 1 bitmap, actually depends on backend):
+    ///    e.g. `ctx` and `resources` in `VelloCPUDrawTarget` for vello_cpu.
+    ///    TODO: #46785 tracks getting accurate statistics from the backend.
+    /// 3. `CachedImageData::Raw` in WebRender (cpu memory copy).
+    /// 4. GPU memory in webrender / driver (also lives in RAM on unified memory systems).
+    ///
+    /// This metric is only used to inform the GC about memory pressure, so it doesn't need to
+    /// be completely accurate, but undercounting may delay GCs and hence increase memory usage.
+    /// On mobile devices this slightly undercounts (usually unified memory), on desktop this
+    /// slightly overcounts, since GPU memory is separate.
+    const ASSOCIATED_MEMORY_BUFFER_COUNT: usize = 4;
 
     fn associated_memory_size(size: Size2D<u64>) -> usize {
         (size.width as usize)

--- a/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
@@ -51,7 +51,7 @@ impl CanvasRenderingContext2D {
     ///
     /// 1. The draw target's backing bitmap in the canvas paint thread
     ///    (`CanvasData::draw_target`, e.g. `pixmap` in `VelloCPUDrawTarget`).
-    /// 2. Additional backend resources (estimated 1 bitmap, actually depends on backend):
+    /// 2. Additional backend resources (approximated with 1 bitmap buffer, actually depends on backend):
     ///    e.g. `ctx` and `resources` in `VelloCPUDrawTarget` for vello_cpu.
     ///    TODO: #46785 tracks getting accurate statistics from the backend.
     /// 3. `CachedImageData::Raw` in WebRender (cpu memory copy).


### PR DESCRIPTION
With the testcase from #45199 memory usage grew to 1.7 GiB before stabilizing. With this patch it stopped at around 1GiB (due to more frequent GCs).
We probably should be able to remove at least one of the copies in memory, but thats a bit more effort than making the memory pressure more accurate.

Testing: We don't have any tests for GC behavior / memory usage.
