### PR TITLE
script: Make gamepad attribute optional in GamepadEvent

### DIFF
--- a/components/script/dom/gamepad/gamepadevent.rs
+++ b/components/script/dom/gamepad/gamepadevent.rs
@@ -10,9 +10,9 @@ use stylo_atoms::Atom;
 
 use super::gamepad::Gamepad;
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
-use crate::dom::bindings::codegen::Bindings::GamepadEventBinding;
-use crate::dom::bindings::codegen::Bindings::GamepadEventBinding::GamepadEventMethods;
-use crate::dom::bindings::error::Fallible;
+use crate::dom::bindings::codegen::Bindings::GamepadEventBinding::{
+    GamepadEventInit, GamepadEventMethods,
+};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
@@ -22,7 +22,7 @@ use crate::dom::window::Window;
 #[dom_struct]
 pub(crate) struct GamepadEvent {
     event: Event,
-    gamepad: Dom<Gamepad>,
+    gamepad: Option<Dom<Gamepad>>,
 }
 
 pub(crate) enum GamepadEventType {
@@ -31,10 +31,10 @@ pub(crate) enum GamepadEventType {
 }
 
 impl GamepadEvent {
-    fn new_inherited(gamepad: &Gamepad) -> GamepadEvent {
+    fn new_inherited(gamepad: Option<&Gamepad>) -> GamepadEvent {
         GamepadEvent {
             event: Event::new_inherited(),
-            gamepad: Dom::from_ref(gamepad),
+            gamepad: gamepad.map(Dom::from_ref),
         }
     }
 
@@ -44,7 +44,7 @@ impl GamepadEvent {
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
-        gamepad: &Gamepad,
+        gamepad: Option<&Gamepad>,
     ) -> DomRoot<GamepadEvent> {
         Self::new_with_proto(cx, window, None, type_, bubbles, cancelable, gamepad)
     }
@@ -56,7 +56,7 @@ impl GamepadEvent {
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
-        gamepad: &Gamepad,
+        gamepad: Option<&Gamepad>,
     ) -> DomRoot<GamepadEvent> {
         let ev = reflect_dom_object_with_proto(
             cx,
@@ -82,7 +82,7 @@ impl GamepadEvent {
             GamepadEventType::Disconnected => "gamepaddisconnected",
         };
 
-        GamepadEvent::new(cx, window, name.into(), false, false, gamepad)
+        GamepadEvent::new(cx, window, name.into(), false, false, Some(gamepad))
     }
 }
 
@@ -93,22 +93,22 @@ impl GamepadEventMethods<crate::DomTypeHolder> for GamepadEvent {
         window: &Window,
         proto: Option<HandleObject>,
         type_: DOMString,
-        init: &GamepadEventBinding::GamepadEventInit,
-    ) -> Fallible<DomRoot<GamepadEvent>> {
-        Ok(GamepadEvent::new_with_proto(
+        init: &GamepadEventInit,
+    ) -> DomRoot<GamepadEvent> {
+        GamepadEvent::new_with_proto(
             cx,
             window,
             proto,
             Atom::from(type_),
             init.parent.bubbles,
             init.parent.cancelable,
-            &init.gamepad,
-        ))
+            init.gamepad.as_deref(),
+        )
     }
 
     /// <https://w3c.github.io/gamepad/#gamepadevent-interface>
-    fn Gamepad(&self) -> DomRoot<Gamepad> {
-        DomRoot::from_ref(&*self.gamepad)
+    fn GetGamepad(&self) -> Option<DomRoot<Gamepad>> {
+        self.gamepad.as_deref().map(DomRoot::from_ref)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-event-istrusted>

--- a/components/script_bindings/webidls/GamepadEvent.webidl
+++ b/components/script_bindings/webidls/GamepadEvent.webidl
@@ -7,10 +7,14 @@
 // https://w3c.github.io/gamepad/#gamepadevent-interface
 [Exposed=Window, Pref="dom_gamepad_enabled"]
 interface GamepadEvent : Event {
-  [Throws] constructor(DOMString type, GamepadEventInit eventInitDict);
-  readonly attribute Gamepad gamepad;
+  constructor(DOMString type, optional GamepadEventInit eventInitDict = {});
+
+  // Gamepad attribute is required in the original idl but it is practically
+  // impossible to keep it so because GamepadEventInit.gamepad can be null.
+  // Discussed in: https://github.com/w3c/gamepad/pull/217
+  [SameObject] readonly attribute Gamepad? gamepad;
 };
 
 dictionary GamepadEventInit : EventInit {
-  required Gamepad gamepad;
+  Gamepad? gamepad = null;
 };

--- a/tests/wpt/meta/dom/events/Event-timestamp-high-resolution.https.html.ini
+++ b/tests/wpt/meta/dom/events/Event-timestamp-high-resolution.https.html.ini
@@ -1,3 +1,0 @@
-[Event-timestamp-high-resolution.https.html]
-  [Constructed GamepadEvent timestamp should be high resolution and have the same time origin as performance.now()]
-    expected: FAIL

--- a/tests/wpt/meta/gamepad/idlharness.window.js.ini
+++ b/tests/wpt/meta/gamepad/idlharness.window.js.ini
@@ -1,15 +1,3 @@
 [idlharness.window.html]
-  [GamepadEvent must be primary interface of new GamepadEvent("gamepad")]
-    expected: FAIL
-
-  [Stringification of new GamepadEvent("gamepad")]
-    expected: FAIL
-
-  [GamepadEvent interface: new GamepadEvent("gamepad") must inherit property "gamepad" with the proper type]
-    expected: FAIL
-
   [Gamepad interface: attribute touches]
-    expected: FAIL
-
-  [GamepadEvent interface object length]
     expected: FAIL


### PR DESCRIPTION
This change makes GamepadEvent's gamepad attribute optional to conform with the latest [Gamepad API](https://w3c.github.io/gamepad/#gamepadevent-interface). 

There is one minor issue, even though GamepadEvent can be instantiated without a gamepad (see GamepadEventInit), gamepad attribute under GamepadEvent is still required. I couldn't find a way to implement it this way, so made the latter optional as well. This is discussed [here](https://github.com/w3c/gamepad/pull/217). Firefox also makes it [optional](https://searchfox.org/firefox-main/source/dom/webidl/GamepadEvent.webidl).

Testing: Failing GamepadEvent related wpt tests under wpt/tests/gamepad are now passing
