### PR TITLE
android: Fix enablement of log filter groups

### DIFF
--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
@@ -212,6 +212,7 @@ public class ServoView extends SurfaceView
             options.args = servoView.servoArgs;
             options.url = servoView.initialUri;
             options.coordinates = coords;
+            options.logStr = servoLog;
             options.enableLogs = true;
             options.experimentalMode = servoView.experimentalMode;
 


### PR DESCRIPTION
Manually validated by setting `servoLog` to `"paint::touch"` and observing that new logs relating to `paint::touch` are displayed.

Testing: There are no automated tests for Android.
Fixes: https://github.com/servo/servo/issues/41781