### PR TITLE
android: Remove empty `AndroidManifest`

### DIFF
--- a/support/android/apk/servoview/src/main/AndroidManifest.xml
+++ b/support/android/apk/servoview/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" />


### PR DESCRIPTION
The Android Gradle Plugin used to require that all Android modules have an `AndroidManifest.xml` file, but that hasn't been a requirement for several versions now. If it's effectively empty, it can just be deleted.

Testing: There are no automated tests for Android.