### PR TITLE
android: Replace `servo.properties` with version catalog

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -109,7 +109,7 @@ jobs:
         if: ${{ matrix.target == 'x86_64-linux-android' }}
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          # This should be kept in sync with the `minSdk` version in `servo.properties`.
+          # This should be kept in sync with the `android-sdk-min` version in `libs.versions.toml`.
           # DO NOT INCREASE THIS without prior discussion on zulip!
           api-level: 29
           arch: x86_64

--- a/python/servo/platform/build_target.py
+++ b/python/servo/platform/build_target.py
@@ -16,6 +16,7 @@ import platform
 import shutil
 import subprocess
 import sys
+import toml
 from enum import Enum
 
 from os import path
@@ -92,15 +93,7 @@ class AndroidTarget(CrossBuildTarget):
     def min_sdk() -> int:
         """Minimum supported Android API level"""
         version_catalog_file = path.join(util.SERVO_ROOT, "support", "android", "apk", "gradle", "libs.versions.toml")
-        with open(version_catalog_file, encoding="utf8") as version_catalog:
-            for line in version_catalog:
-                line = line.strip()
-                if line.startswith(("#", "[")) or line.strip() == "":
-                    continue
-                key, value = line.split("=", 1)
-                if key.strip() == "android-sdk-min":
-                    return int(value.strip(' "'))
-        raise Exception(f"`android.minSdk` is missing from {version_catalog_file}")
+        return int(toml.load(version_catalog_file)["versions"]["android-sdk-min"])
 
     def ndk_configuration(self) -> dict[str, str]:
         target = self.triple()

--- a/python/servo/platform/build_target.py
+++ b/python/servo/platform/build_target.py
@@ -89,21 +89,18 @@ class AndroidTarget(CrossBuildTarget):
     DEFAULT_TRIPLE = "aarch64-linux-android"
 
     @staticmethod
-    def min_sdk() -> str:
+    def min_sdk() -> int:
         """Minimum supported Android API level"""
-        properties_file = path.join(util.SERVO_ROOT, "support", "android", "apk", "servo.properties")
-        with open(properties_file, encoding="utf8") as properties:
-            for line in properties:
+        version_catalog_file = path.join(util.SERVO_ROOT, "support", "android", "apk", "gradle", "libs.versions.toml")
+        with open(version_catalog_file, encoding="utf8") as version_catalog:
+            for line in version_catalog:
                 line = line.strip()
-                if line.startswith("#") or line.strip() == "":
+                if line.startswith(("#", "[")) or line.strip() == "":
                     continue
                 key, value = line.split("=", 1)
-                if key.strip() == "android.minSdk":
-                    assert value.strip().isdigit(), (
-                        f"android.minSdk must be an integer but was {value}. Check {properties_file}."
-                    )
-                    return value.strip()
-        raise Exception(f"`android.minSdk` is missing from {properties_file}")
+                if key.strip() == "android-sdk-min":
+                    return int(value.strip(' "'))
+        raise Exception(f"`android.minSdk` is missing from {version_catalog_file}")
 
     def ndk_configuration(self) -> dict[str, str]:
         target = self.triple()

--- a/support/android/apk/buildSrc/src/main/kotlin/Interop.kt
+++ b/support/android/apk/buildSrc/src/main/kotlin/Interop.kt
@@ -52,17 +52,6 @@ fun getNDKAbi(arch: String): String {
     }
 }
 
-fun Project.getServoMinSdk(): Int {
-    val propertiesFile = File(project.rootDir, "servo.properties")
-    val properties = Properties()
-    propertiesFile.inputStream().use { instr ->
-        properties.load(instr)
-    }
-    val minSdk = properties.getProperty("android.minSdk")
-        ?: throw GradleException("`android.minSdk` is missing from ${propertiesFile.absolutePath}")
-    return minSdk.trim().toInt()
-}
-
 fun Project.getNdkDir(): String {
     // Read environment variable used in rust build system
     var ndkRoot = System.getenv("ANDROID_NDK_ROOT")

--- a/support/android/apk/gradle/libs.versions.toml
+++ b/support/android/apk/gradle/libs.versions.toml
@@ -1,5 +1,12 @@
 [versions]
 android-gradle-plugin = "9.2.1"
+# The `minSdk` configuration affects both the `NDK` version we require,
+# and the `minSdk` version for the gradle build.
+# This value should only be bumped if necessary, and after discussion
+# on zulip, since it directly affects the amount of people able to use
+# servo on android.
+# ATTENTION - READ THE COMMENT ABOVE, if the minSdk value below is changed.
+android-sdk-min = "29"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.13.0" }

--- a/support/android/apk/servo.properties
+++ b/support/android/apk/servo.properties
@@ -1,7 +1,0 @@
-# The `minSdk` configuration affects both the `NDK` version we require,
-# and the `minSdk` version for the gradle build.
-# This value should only be bumped if necessary, and after discussion
-# on zulip, since it directly affects the amount of people able to use
-# servo on android.
-# ATTENTION - READ THE COMMENT ABOVE, if the minSdk value below is changed.
-android.minSdk=29

--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         applicationId = "org.servo.servoshell"
-        minSdk = getServoMinSdk()
+        minSdk = libs.versions.android.sdk.min.get().toInt()
         targetSdk = 34
         versionCode = generatedVersionCode
         versionName = "0.4.0"

--- a/support/android/apk/servoview/build.gradle.kts
+++ b/support/android/apk/servoview/build.gradle.kts
@@ -13,7 +13,7 @@ android {
     ndkPath = getNdkDir()
 
     defaultConfig {
-        minSdk = getServoMinSdk()
+        minSdk = libs.versions.android.sdk.min.get().toInt()
     }
 
     lint {
@@ -145,7 +145,7 @@ project.afterEvaluate {
                 "NDK_LIBS_OUT=" + getJniLibsPath(debug, arch),
                 "NDK_DEBUG=" + if (debug) "1" else "0",
                 "APP_ABI=" + getNDKAbi(arch),
-                "APP_PLATFORM=android-" + getServoMinSdk(),
+                "APP_PLATFORM=android-" + libs.versions.android.sdk.min.get(),
                 "NDK_LOG=1",
                 "SERVO_TARGET_DIR=" + getNativeTargetDir(debug, arch)
             )


### PR DESCRIPTION
The min SDK for Android is often put in the version catalog, as it's where versions should go and it's built-in to Gradle. By putting the min SDK their, we can remove our bespoke solution.

Testing: There are no automated tests for Android.