### PR TITLE
ci: Pass the 'force-github-hosted-runner' to common linux workflow.

### DIFF
--- a/.github/workflows/linux-arm64.yml
+++ b/.github/workflows/linux-arm64.yml
@@ -117,6 +117,8 @@ jobs:
     with:
       arch: arm64
       github-runner-label: ubuntu-22.04-arm
+      self-hosted-image-name: "" # We don't have any self-hosted arm64 runners.
+      force-github-hosted-runner: true
       uploaded-artifact-name: ${{ inputs.profile }}-binary-linux-arm64
       profile: ${{ inputs.profile }}
       build-args: ${{ inputs.build-args }}

--- a/.github/workflows/linux-common.yml
+++ b/.github/workflows/linux-common.yml
@@ -15,6 +15,9 @@ on:
       uploaded-artifact-name:
         required: true
         type: string
+      self-hosted-image-name:
+        required: true
+        type: string
       profile:
         required: false
         default: "checked-release"
@@ -86,7 +89,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ github.token }}
           github-hosted-runner-label: ${{ inputs.github-runner-label }}
-          self-hosted-image-name: servo-ubuntu2204
+          self-hosted-image-name: ${{ inputs.self-hosted-image-name }}
           # You can disable self-hosted runners globally by creating a repository variable named
           # NO_SELF_HOSTED_RUNNERS with any non-empty value.
           # <https://github.com/servo/servo/settings/variables/actions>

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -119,8 +119,10 @@ jobs:
       # Before updating the GH action runner image for the nightly job, ensure
       # that the system has a glibc version that is compatible with the one
       # used by the wpt.fyi runners.
-      github-runner-label: ubuntu-22.04
       uploaded-artifact-name: ${{ inputs.profile }}-binary-linux
+      github-runner-label: ubuntu-22.04
+      self-hosted-image-name: servo-ubuntu2204
+      force-github-hosted-runner: ${{ inputs.force-github-hosted-runner }}
       profile: ${{ inputs.profile }}
       build-args: ${{ inputs.build-args }}
       wpt: ${{ inputs.wpt }}


### PR DESCRIPTION
This was missed in #46760 and was not caught in the fork runs as forks can't use the self-hosted runners. In `servo/servo` repo, the bug caused nightly build job to run with self-hosted x84_64 runners even for arm64 builds.

https://github.com/servo/servo/actions/runs/30311263496/job/90127199930

This patch fixes the bug by passing along the `force-github-hosted-runner` from release.yml. It also makes `self-hosted-runner-image` a required parameter to force the caller to pass it explicitly and avoid silently using the wrong runner. Perhaps we could also pass the `--target` explictly to the `./mach build` but that is left for a future patch.

Testing: Not tested as the self-hosted runners are available only for 'servo/servo'

