### PR TITLE
 layout: Allow shaping across inline box boundaries

### DIFF
--- a/components/fonts/glyph.rs
+++ b/components/fonts/glyph.rs
@@ -348,6 +348,11 @@ impl ShapedText {
         self.glyphs.len()
     }
 
+    /// Get the number of characters that were shaped to produce this [`ShapedText`].
+    pub fn character_count(&self) -> usize {
+        self.character_count
+    }
+
     /// Adds glyph that corresponds to a single character (as far we know) in the originating string.
     #[inline]
     pub(crate) fn add_glyph(&mut self, character: char, glyph: &ShapedGlyph) {
@@ -572,12 +577,6 @@ pub struct ShapedTextSlice {
 }
 
 impl ShapedTextSlice {
-    /// Return the [`ShapedText`] that backs this [`ShapedTextSlice`].
-    #[inline]
-    pub fn shaped_text(&self) -> Arc<ShapedText> {
-        self.shaped_text.clone()
-    }
-
     /// Return the number of glyphs represented by this [`ShapedTextSlice`].
     #[inline]
     pub fn glyph_count(&self) -> usize {
@@ -625,6 +624,7 @@ impl ShapedTextSlice {
 /// A data structure used to efficiently slice up a [`ShapedText`] into [`ShapedTextSlice`]s.
 pub struct ShapedTextSlicer {
     current_glyph_offset: usize,
+    current_character_offset: usize,
     shaped_text: Arc<ShapedText>,
 }
 
@@ -638,24 +638,29 @@ impl ShapedTextSlicer {
 
         Self {
             current_glyph_offset,
+            current_character_offset: 0,
             shaped_text,
         }
     }
 
-    /// Given a desired character count, consume that number of characters worth
-    /// of glyphs from the [`ShapedText`] of this [`ShapedTextSlicer`]. In addition,
-    /// tag the resulting [`ShapedTextSlice`] with the given whitespace-related
-    /// properties.
-    pub fn slice_for_character_count(
+    /// Given a desired character offset, consume glyphs until that character offset
+    /// is reached (inclusive of glyphs that come from zero characters). Return those
+    /// glyphs as a [`ShapedTextSlice`] tagged with the given whitespace-related
+    /// properties. Returns `None` if the resulting slice would not hold any glyphs.
+    pub fn slice_until_character_offset(
         &mut self,
-        desired_character_count: usize,
+        desired_character_offset: usize,
         is_whitespace: bool,
         ends_with_whitespace: bool,
-    ) -> Arc<ShapedTextSlice> {
+    ) -> Option<Arc<ShapedTextSlice>> {
         let mut glyph_count = 0;
-        let mut character_count = 0;
         let mut total_word_separators = 0;
         let mut total_advance = Au::zero();
+        let original_character_offset = self.current_character_offset;
+
+        if self.current_character_offset >= desired_character_offset {
+            return None;
+        }
 
         // In `ShapedText` glyphs are stored in physical left-to-right order, which means that the
         // indices of the characters that they represent might decrease. Since we want to consume
@@ -675,17 +680,16 @@ impl ShapedTextSlicer {
         };
 
         for glyph in iterator {
-            // When one character produces multiple glyphs, only the first glyph has a character
-            // count of one and the rest have a character count of 0. This checks the potential
-            // total before accumulating a glyph, which allows merging glyphs with a 0 character
-            // count into the slice with the first glyph.
-            let glyph_character_count = glyph.character_count();
-            if character_count + glyph_character_count > desired_character_count {
+            // When glyphs span two character slices, prioritize the first slice and also
+            // ensure that glyphs that span zero characters are also included there.
+            if self.current_character_offset >= desired_character_offset &&
+                glyph.character_count() > 0
+            {
                 break;
             }
 
             glyph_count += 1;
-            character_count += glyph_character_count;
+            self.current_character_offset += glyph.character_count();
             total_advance += glyph.advance();
             if glyph.char_is_word_separator() {
                 total_word_separators += 1;
@@ -707,15 +711,19 @@ impl ShapedTextSlicer {
             )
         };
 
+        if glyph_count == 0 {
+            return None;
+        }
+
         self.current_glyph_offset = new_glyph_offset;
-        Arc::new(ShapedTextSlice {
+        Some(Arc::new(ShapedTextSlice {
             shaped_text: self.shaped_text.clone(),
             glyph_range,
             total_advance,
-            character_count,
+            character_count: self.current_character_offset - original_character_offset,
             is_whitespace,
             ends_with_whitespace,
             total_word_separators,
-        })
+        }))
     }
 }

--- a/components/layout/flow/inline/inline_box.rs
+++ b/components/layout/flow/inline/inline_box.rs
@@ -10,9 +10,13 @@ use layout_api::LayoutNode;
 use malloc_size_of_derive::MallocSizeOf;
 use script::layout_dom::ServoLayoutNode;
 use servo_arc::Arc as ServoArc;
+use style::Zero;
+use style::computed_values::alignment_baseline::T as AlignmentBaseline;
+use style::computed_values::baseline_source::T as BaselineSource;
 use style::computed_values::box_decoration_break::T as BoxDecorationBreak;
 use style::context::SharedStyleContext;
 use style::properties::ComputedValues;
+use style::values::computed::{BaselineShift, LengthPercentage};
 
 use super::{
     InlineContainerState, InlineContainerStateFlags, SharedInlineStyles,
@@ -24,7 +28,7 @@ use crate::context::LayoutContext;
 use crate::dom_traversal::NodeAndStyleInfo;
 use crate::fragment_tree::BaseFragmentInfo;
 use crate::layout_box_base::LayoutBoxBase;
-use crate::style_ext::{LayoutStyle, PaddingBorderMargin};
+use crate::style_ext::{ComputedValuesExt, LayoutStyle, PaddingBorderMargin};
 
 #[derive(Debug, MallocSizeOf)]
 pub(crate) struct InlineBox {
@@ -37,16 +41,24 @@ pub(crate) struct InlineBox {
     /// The index of the default font in the [`super::InlineFormattingContext`]'s font metrics store.
     /// This is initialized during IFC shaping.
     pub default_font: Option<FontRef>,
+    /// Whether or not this [`InlineBox`] breaks shaping at the start.
+    pub breaks_shaping_at_start: bool,
+    /// Whether or not this [`InlineBox`] breaks shaping at the end.
+    pub breaks_shaping_at_end: bool,
 }
 
 impl InlineBox {
     pub(crate) fn new(info: &NodeAndStyleInfo, context: &LayoutContext) -> Self {
+        let (breaks_shaping_at_start, breaks_shaping_at_end) =
+            inline_box_style_breaks_shaping(&info.style);
         Self {
             base: LayoutBoxBase::new(info.into(), info.style.clone()),
             shared_inline_styles: SharedInlineStyles::from_info_and_context(info, context),
             // This will be assigned later, when the box is actually added to the IFC.
             identifier: InlineBoxIdentifier::default(),
             default_font: None,
+            breaks_shaping_at_start,
+            breaks_shaping_at_end,
         }
     }
 
@@ -61,6 +73,9 @@ impl InlineBox {
         node: &ServoLayoutNode,
         new_style: &ServoArc<ComputedValues>,
     ) {
+        (self.breaks_shaping_at_start, self.breaks_shaping_at_end) =
+            inline_box_style_breaks_shaping(new_style);
+
         self.base.repair_style(new_style);
         *self.shared_inline_styles.style.borrow_mut() = new_style.clone();
         *self.shared_inline_styles.selected.borrow_mut() = node.selected_style(context);
@@ -255,4 +270,48 @@ impl InlineBoxContainerState {
     pub(super) fn should_clone_pbm(&self) -> bool {
         self.base.style.get_border().box_decoration_break == BoxDecorationBreak::Clone
     }
+}
+
+/// Whether or not an inline box style breaks shaping at the start and end.
+/// The return value is `(breaks_shaping_at_start, breaks_shaping_at_end)`.
+///
+/// From <https://drafts.csswg.org/css-text/#boundary-shaping>
+/// > Text shaping must be broken at inline box boundaries when any of the
+/// > following are true for any box whose boundary separates the two typographic
+/// > character units:
+/// > - Any of margin/border/padding separating the two typographic character units
+/// >   in the inline axis is non-zero.
+/// > - `vertical-align` is not `baseline`.
+/// > - The boundary is a bidi isolation boundary.
+fn inline_box_style_breaks_shaping(style: &ComputedValues) -> (bool, bool) {
+    // Note: These steps are reordered for performance reasons and bidi isolation is handled
+    // intrinsically by the fact that bidi isolation inserts bidi characters into the inline
+    // formatting context text content. This leads to non-contiguous character offsets between
+    // shaping queue entries.
+    if style.clone_baseline_shift() != BaselineShift::zero() ||
+        style.clone_baseline_source() != BaselineSource::Auto ||
+        style.clone_alignment_baseline() != AlignmentBaseline::Baseline
+    {
+        return (true, true);
+    }
+
+    let layout_style = LayoutStyle::Default(style);
+    let border_widths = layout_style.border_width(style.writing_mode);
+    let padding = layout_style.padding(style.writing_mode);
+    let margin = style.margin(style.writing_mode);
+
+    (
+        !border_widths.inline_start.is_zero() ||
+            !padding.inline_start.is_zero() ||
+            !margin
+                .inline_start
+                .non_auto()
+                .is_none_or(LengthPercentage::is_zero),
+        !border_widths.inline_end.is_zero() ||
+            !padding.inline_end.is_zero() ||
+            !margin
+                .inline_end
+                .non_auto()
+                .is_none_or(LengthPercentage::is_zero),
+    )
 }

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -72,6 +72,7 @@ pub mod construct;
 pub mod inline_box;
 pub mod line;
 mod line_breaker;
+mod shaping_queue;
 pub mod text_run;
 
 use std::cell::{Cell, OnceCell};
@@ -94,7 +95,6 @@ use line::{
     AbsolutelyPositionedLineItem, AtomicLineItem, FloatLineItem, LineItem, LineItemLayout,
     TextRunLineItem,
 };
-use line_breaker::LineBreaker;
 use malloc_size_of_derive::MallocSizeOf;
 use script::layout_dom::ServoLayoutNode;
 use servo_arc::Arc as ServoArc;
@@ -123,6 +123,7 @@ use crate::dom::WeakLayoutBox;
 use crate::dom_traversal::NodeAndStyleInfo;
 use crate::flow::float::{FloatBox, SequentialLayoutState};
 use crate::flow::inline::line::TextRunOffsets;
+use crate::flow::inline::shaping_queue::ShapingQueue;
 use crate::flow::inline::text_run::{FontAndScriptInfo, TextRunItem, TextRunSegment};
 use crate::flow::{
     BlockLevelBox, CollapsibleWithParentStartMargin, FloatSide, PlacementState,
@@ -1981,16 +1982,19 @@ impl InlineFormattingContext {
             })
         };
 
-        let mut new_linebreaker = LineBreaker::new(text_content.as_str(), options);
+        let mut shaping_queue = ShapingQueue::new(&text_content, options);
         for item in &mut builder.inline_items {
             match item {
                 InlineItem::TextRun(text_run) => {
-                    text_run.borrow_mut().segment_and_shape(
+                    let shaping_queue_entries = text_run.borrow_mut().segment(
+                        text_run.clone(),
                         &text_content,
                         layout_context,
-                        &mut new_linebreaker,
                         &bidi_levels,
                     );
+                    for entry in shaping_queue_entries.into_iter() {
+                        shaping_queue.push(entry);
+                    }
                 },
                 InlineItem::StartInlineBox(inline_box) => {
                     let inline_box = &mut *inline_box.borrow_mut();
@@ -2000,16 +2004,27 @@ impl InlineFormattingContext {
                     ) {
                         inline_box.default_font = Some(font);
                     }
+
+                    if inline_box.breaks_shaping_at_start {
+                        shaping_queue.flush();
+                    }
                 },
                 InlineItem::Atomic(_, index_in_text, bidi_level) => {
+                    shaping_queue.flush();
                     *bidi_level = bidi_levels.level(*index_in_text);
+                },
+                InlineItem::EndInlineBox(inline_box) => {
+                    if inline_box.borrow().breaks_shaping_at_end {
+                        shaping_queue.flush();
+                    }
                 },
                 InlineItem::OutOfFlowAbsolutelyPositionedBox(..) |
                 InlineItem::OutOfFlowFloatBox(_) |
-                InlineItem::EndInlineBox(..) |
                 InlineItem::BlockLevel { .. } => {},
             }
         }
+
+        shaping_queue.flush();
 
         let default_font = get_font_for_first_font_for_style(
             &shared_inline_styles.style.borrow(),

--- a/components/layout/flow/inline/shaping_queue.rs
+++ b/components/layout/flow/inline/shaping_queue.rs
@@ -1,0 +1,370 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::ops::Range;
+use std::sync::Arc;
+
+use fonts::{ShapedText, ShapedTextSlice, ShapedTextSlicer, ShapingOptions};
+use icu_segmenter::LineBreakOptions;
+use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
+use style::computed_values::word_break::T as WordBreak;
+use style::properties::ComputedValues;
+use style::str::char_is_whitespace;
+use style::values::computed::OverflowWrap;
+use unicode_script::Script;
+
+use crate::ArcRefCell;
+use crate::flow::inline::line_breaker::LineBreaker;
+use crate::flow::inline::text_run::{FontAndScriptInfo, TextRun, TextRunItem, script_is_specific};
+
+/// An entry on the shaping queue that represents text that needs to be shaped.
+/// This contains a lot of duplicated data from `TextRunSegment` so that
+/// it can outlive a mutable borrow on the owning `TextRun`.
+pub(crate) struct ShapingQueueText {
+    info: FontAndScriptInfo,
+    byte_range: Range<usize>,
+    character_range: Range<usize>,
+    text_run: ArcRefCell<TextRun>,
+    index_in_text_run: usize,
+    old_shaped_text: Option<Arc<ShapedText>>,
+}
+
+/// A new entry for the [`ShapingQueue`].
+pub(crate) enum ShapingQueueEntry {
+    PreservedTabOrNewline,
+    Text(ShapingQueueText),
+}
+
+impl ShapingQueueEntry {
+    pub(crate) fn new(
+        text_run: ArcRefCell<TextRun>,
+        text_run_item: &TextRunItem,
+        index_in_text_run: usize,
+        old_text_run_line_item: Option<TextRunItem>,
+    ) -> Self {
+        let text_segment = match text_run_item {
+            TextRunItem::LineBreak { .. } | TextRunItem::Tab { .. } => {
+                return Self::PreservedTabOrNewline;
+            },
+            TextRunItem::TextSegment(text_run_segment) => text_run_segment,
+        };
+
+        let old_shaped_text = old_text_run_line_item.and_then(|old_text_run_line_item| {
+            let TextRunItem::TextSegment(old_text_segment) = old_text_run_line_item else {
+                return None;
+            };
+            if !text_segment.is_compatible_with_old_shaping_result(&old_text_segment) {
+                return None;
+            }
+            old_text_segment.shaped_text
+        });
+
+        Self::Text(ShapingQueueText {
+            info: text_segment.info.clone(),
+            byte_range: text_segment.byte_range.clone(),
+            character_range: text_segment.character_range.clone(),
+            text_run,
+            index_in_text_run,
+            old_shaped_text,
+        })
+    }
+}
+
+struct BatchSlicer<'a> {
+    slicer: ShapedTextSlicer,
+    text: &'a str,
+    line_breaker: &'a mut LineBreaker,
+    character_offset_origin: usize,
+}
+
+impl BatchSlicer<'_> {
+    fn slice_shaped_text_at_line_break_opportunities(
+        &mut self,
+        segment: &ShapingQueueText,
+        parent_style: &ComputedValues,
+    ) -> (Vec<Arc<ShapedTextSlice>>, bool) {
+        // Gather the linebreaks that apply to this segment from the inline formatting context's collection
+        // of line breaks. Also add a simulated break at the end of the segment in order to ensure the final
+        // piece of text is processed.
+        let range = segment.byte_range.clone();
+        let linebreaks = self
+            .line_breaker
+            .advance_to_linebreaks_in_range(segment.byte_range.clone());
+        let linebreak_iter = linebreaks.iter().chain(std::iter::once(&range.end));
+
+        let mut break_at_start = false;
+
+        let text_style = parent_style.get_inherited_text();
+        let can_break_anywhere = text_style.word_break == WordBreak::BreakAll ||
+            text_style.overflow_wrap == OverflowWrap::Anywhere ||
+            text_style.overflow_wrap == OverflowWrap::BreakWord;
+
+        let mut last_slice = segment.byte_range.start..segment.byte_range.start;
+        let mut current_character_offset =
+            segment.character_range.start - self.character_offset_origin;
+
+        let mut runs = Vec::with_capacity(linebreaks.len());
+        let mut maybe_push_run = |run: Option<Arc<ShapedTextSlice>>| {
+            if let Some(run) = run {
+                runs.push(run);
+            }
+        };
+
+        for break_index in linebreak_iter {
+            if *break_index == segment.byte_range.start {
+                break_at_start = true;
+                continue;
+            }
+
+            // Extend the slice to the next UAX#14 line break opportunity.
+            let mut slice = last_slice.end..*break_index;
+            let word = &self.text[slice.clone()];
+
+            // Split off any trailing whitespace into a separate glyph run.
+            let mut whitespace = slice.end..slice.end;
+            let rev_char_indices = word.char_indices().rev().peekable();
+
+            let mut non_whitespace_slice_ends_with_whitespace = false;
+            let mut ends_with_whitespace = false;
+            if let Some((first_white_space_index, first_white_space_character)) = rev_char_indices
+                .take_while(|&(_, character)| char_is_whitespace(character))
+                .last()
+            {
+                ends_with_whitespace = true;
+                whitespace.start = slice.start + first_white_space_index;
+
+                // If line breaking for a piece of text that has `white-space-collapse:
+                // break-spaces` there is a line break opportunity *after* every preserved space,
+                // but not before. This means that we should not split off the first whitespace.
+                //
+                // An exception to this is if the style tells us that we can break in the middle of words.
+                if text_style.white_space_collapse == WhiteSpaceCollapse::BreakSpaces &&
+                    !can_break_anywhere
+                {
+                    whitespace.start += first_white_space_character.len_utf8();
+                    non_whitespace_slice_ends_with_whitespace = true;
+                }
+
+                slice.end = whitespace.start;
+            }
+
+            // If there's no whitespace and `word-break` is set to `keep-all`, try increasing the slice.
+            // TODO: This should only happen for CJK text.
+            if !ends_with_whitespace &&
+                *break_index != segment.byte_range.end &&
+                text_style.word_break == WordBreak::KeepAll &&
+                !can_break_anywhere
+            {
+                continue;
+            }
+
+            // Only advance the last slice if we are not going to try to expand the slice.
+            last_slice = slice.start..*break_index;
+
+            // Push the non-whitespace part of the range.
+            if !slice.is_empty() {
+                current_character_offset += self.text[slice].chars().count();
+                maybe_push_run(self.slicer.slice_until_character_offset(
+                    current_character_offset,
+                    false, /* is_whitespace */
+                    non_whitespace_slice_ends_with_whitespace,
+                ));
+            }
+
+            if whitespace.is_empty() {
+                continue;
+            }
+
+            // If `white-space-collapse: break-spaces` is active, insert a line breaking opportunity
+            // between each white space character in the white space that we trimmed off.
+            if text_style.white_space_collapse == WhiteSpaceCollapse::BreakSpaces {
+                for _ in self.text[whitespace].chars() {
+                    current_character_offset += 1;
+                    maybe_push_run(self.slicer.slice_until_character_offset(
+                        current_character_offset,
+                        true, /* is_whitespace */
+                        true, /* ends_with_whitespace */
+                    ));
+                }
+                continue;
+            }
+
+            current_character_offset += self.text[whitespace].chars().count();
+            maybe_push_run(self.slicer.slice_until_character_offset(
+                current_character_offset,
+                true, /* is_whitespace */
+                true, /* ends_with_whitespace */
+            ));
+        }
+
+        (runs, break_at_start)
+    }
+}
+
+/// The [`ShapingQueue`] is responsible for shaping text during inline formatting context
+/// construction. It allows for shaping text across inline box boundaries. When pushing
+/// items to the queue, if the items are compatible pieces of text that can be shaped
+/// together, they are accumulated. The queue may be flushed in the given situations:
+///
+/// - An incompatible piece of text (different fonts or certain style properties) is
+///   pushed to the queue.
+/// - A preserved newline or tab is pushed to the queue.
+/// - An inline box breaks shaping via padding, border, margins or a non-`baseline`
+///   `vertical-align` property.
+/// - Atomic content in the inline formatting context
+///
+/// Upon flushing, the [`ShapingQueue`] will shape any pending text and assign the
+/// resulting [`ShapedTextSlice`]s to the originating [`TextRun`]s.
+pub(crate) struct ShapingQueue<'a> {
+    /// The queue of items in the current batch that will be shaped together.
+    queue: Vec<ShapingQueueText>,
+    /// The text that will be used for shaping.
+    text: &'a str,
+    /// The line breaker that will be used to slice shaping results across on line break boundaries.
+    line_breaker: LineBreaker,
+    /// The byte range of the text to shape in [`Self::text`] for the current batch.
+    /// Only contiguous ranges can be shaped together.
+    byte_range: Range<usize>,
+    /// The character range of the text to shape in [`Self::text`] for the current batch.
+    /// Only contiguous ranges can be shaped together.
+    character_range: Range<usize>,
+    /// The resolved script for the current batch. This is used to gradually turn non-specific
+    /// scripts into a resolved value for shaping.
+    resolved_script: Option<Script>,
+}
+
+impl<'a> ShapingQueue<'a> {
+    pub(crate) fn new(text: &'a str, line_break_options: LineBreakOptions) -> Self {
+        Self {
+            queue: Default::default(),
+            text,
+            line_breaker: LineBreaker::new(text, line_break_options),
+            byte_range: Default::default(),
+            character_range: Default::default(),
+            resolved_script: None,
+        }
+    }
+
+    fn compatible_old_shaping_result(&self, character_count: usize) -> Option<Arc<ShapedText>> {
+        let old_shaped_text = self.queue.first()?.old_shaped_text.as_ref()?;
+        if old_shaped_text.character_count() != character_count {
+            return None;
+        }
+
+        if !self.queue.iter().all(|entry| {
+            entry
+                .old_shaped_text
+                .as_ref()
+                .is_some_and(|entry_old_shaped_text| {
+                    Arc::ptr_eq(old_shaped_text, entry_old_shaped_text)
+                })
+        }) {
+            return None;
+        }
+        Some(old_shaped_text.clone())
+    }
+
+    fn shape_batch(&self) -> Option<Arc<ShapedText>> {
+        let first = self.queue.first()?;
+
+        let character_count = self.character_range.end - self.character_range.start;
+        if let Some(old_shaping_result) = self.compatible_old_shaping_result(character_count) {
+            return Some(old_shaping_result);
+        };
+
+        let mut options: ShapingOptions = (&first.info).into();
+        options.script = self.resolved_script.unwrap_or(first.info.script);
+
+        let font = &first.info.font_info.font;
+        Some(font.shape_text(&self.text[self.byte_range.clone()], &options))
+    }
+
+    /// Flush this [`ShapingQueue`]. If any content had been collected up to this point,
+    /// it will be shaped and the resulting [`ShapedTextSlice`]s will be assigned to their
+    /// originating [`TextRun`]s.
+    pub(crate) fn flush(&mut self) {
+        let Some(shaped_text) = self.shape_batch() else {
+            return;
+        };
+
+        let mut slicer = BatchSlicer {
+            slicer: ShapedTextSlicer::new(shaped_text.clone()),
+            text: self.text,
+            line_breaker: &mut self.line_breaker,
+            character_offset_origin: self.character_range.start,
+        };
+
+        for entry in self.queue.drain(..) {
+            let mut text_run = entry.text_run.borrow_mut();
+            let style = text_run.inline_styles.style.borrow().clone();
+            let (runs, break_at_start) =
+                slicer.slice_shaped_text_at_line_break_opportunities(&entry, &style);
+
+            if let TextRunItem::TextSegment(text_segment) =
+                &mut text_run.items[entry.index_in_text_run]
+            {
+                text_segment.shaped_text = Some(shaped_text.clone());
+                text_segment.runs = runs;
+                text_segment.break_at_start = break_at_start;
+            }
+        }
+    }
+
+    fn compatible_with_batch(&self, text: &ShapingQueueText) -> bool {
+        // If the queue is empty, we can always add new text to the batch.
+        let Some(last) = self.queue.last() else {
+            return true;
+        };
+
+        // The new text is only compatible with the current batch if their character and
+        // text byte boundaries are contiguous.
+        if last.character_range.end != text.character_range.start ||
+            last.byte_range.end != text.byte_range.start
+        {
+            return false;
+        }
+
+        // The `FontInfo`s of the batch and the new text need to match exactly to shape
+        // together.
+        if !Arc::ptr_eq(&last.info.font_info, &text.info.font_info) &&
+            *last.info.font_info != *text.info.font_info
+        {
+            return false;
+        }
+
+        // Any resolved `Script` has to be compatible with any new specific `Script`.
+        !script_is_specific(text.info.script) ||
+            self.resolved_script
+                .is_none_or(|resolved_script| resolved_script == text.info.script)
+    }
+
+    fn push_text(&mut self, text: ShapingQueueText) {
+        if !self.compatible_with_batch(&text) {
+            self.flush();
+        }
+
+        if self.queue.is_empty() {
+            self.character_range = text.character_range.clone();
+            self.byte_range = text.byte_range.clone();
+            self.resolved_script = None;
+        } else {
+            self.character_range.end = text.character_range.end;
+            self.byte_range.end = text.byte_range.end;
+        }
+        if self.resolved_script.is_none() && script_is_specific(text.info.script) {
+            self.resolved_script = Some(text.info.script);
+        }
+
+        self.queue.push(text);
+    }
+
+    /// Push a new [`ShapingQueueEntry`] on to this [`ShapingQueue`], maybe flushing
+    /// previously collected entries.
+    pub(crate) fn push(&mut self, entry: ShapingQueueEntry) {
+        match entry {
+            ShapingQueueEntry::PreservedTabOrNewline => self.flush(),
+            ShapingQueueEntry::Text(shaping_queue_text) => self.push_text(shaping_queue_text),
+        }
+    }
+}

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -10,8 +10,8 @@ use app_units::Au;
 use atomic_refcell::AtomicRefCell;
 use fonts::font_feature_values::ResolvedFontVariantAlternates;
 use fonts::{
-    ByteIndex, FontContext, FontRef, ShapedTextSlice, ShapedTextSlicer, ShapingFlags,
-    ShapingOptions, TextByteRange,
+    ByteIndex, FontContext, FontRef, ShapedText, ShapedTextSlice, ShapingFlags, ShapingOptions,
+    TextByteRange,
 };
 use icu_locid::subtags::Language;
 use icu_properties::{self, LineBreak};
@@ -20,28 +20,26 @@ use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use servo_arc::Arc as ServoArc;
 use servo_base::text::{Utf32CodeUnits, is_bidi_control};
+use smallvec::SmallVec;
 use style::Zero;
 use style::computed_values::font_kerning::T as FontKerning;
 use style::computed_values::font_variant_position::T as FontVariantPosition;
 use style::computed_values::text_rendering::T as TextRendering;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
-use style::computed_values::word_break::T as WordBreak;
 use style::font_face::FontLanguageOverride;
 use style::properties::ComputedValues;
-use style::str::char_is_whitespace;
 use style::values::computed::{
     FontFeatureSettings, FontVariantEastAsian, FontVariantLigatures, FontVariantNumeric,
-    OverflowWrap,
 };
 use unicode_bidi::Level;
 use unicode_script::Script;
 
-use super::line_breaker::LineBreaker;
 use super::{InlineFormattingContextLayout, SharedInlineStyles};
 use crate::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::dom::WeakLayoutBox;
 use crate::flow::inline::line::TextRunOffsets;
+use crate::flow::inline::shaping_queue::ShapingQueueEntry;
 use crate::flow::inline::{BidiLevels, LineBlockSizes, LineItem, SegmentContentFlags};
 use crate::fragment_tree::BaseFragmentInfo;
 
@@ -200,6 +198,11 @@ pub(crate) struct TextRunSegment {
     /// The shaped runs within this segment.
     #[conditional_malloc_size_of]
     pub runs: Vec<Arc<ShapedTextSlice>>,
+
+    /// The shaped text that was used to produce this segment. [`Self::runs`] are slices
+    /// of this shaped text.
+    #[conditional_malloc_size_of]
+    pub shaped_text: Option<Arc<ShapedText>>,
 }
 
 impl TextRunSegment {
@@ -214,6 +217,7 @@ impl TextRunSegment {
             character_range,
             runs: Vec::new(),
             break_at_start: false,
+            shaped_text: None,
         }
     }
 
@@ -300,140 +304,7 @@ impl TextRunSegment {
         }
     }
 
-    /// Shape the text of this [`TextRunSegment`], first finding "words" for the shaper by processing
-    /// the linebreaks found in the owning [`super::InlineFormattingContext`]. Linebreaks are filtered,
-    /// based on the style of the parent inline box.
-    fn shape_text(
-        &mut self,
-        parent_style: &ComputedValues,
-        formatting_context_text: &str,
-        linebreaker: &mut LineBreaker,
-        old_text_run_item: Option<TextRunItem>,
-    ) {
-        // Gather the linebreaks that apply to this segment from the inline formatting context's collection
-        // of line breaks. Also add a simulated break at the end of the segment in order to ensure the final
-        // piece of text is processed.
-        let range = self.byte_range.clone();
-        let linebreaks = linebreaker.advance_to_linebreaks_in_range(self.byte_range.clone());
-        let linebreak_iter = linebreaks.iter().chain(std::iter::once(&range.end));
-
-        let options: ShapingOptions = (&self.info).into();
-        let shaped_text = old_text_run_item
-            .and_then(|old_text_run_item| {
-                let TextRunItem::TextSegment(old_text_segment) = old_text_run_item else {
-                    return None;
-                };
-                if !self.is_compatible_with_old_shaping_result(&old_text_segment) {
-                    return None;
-                }
-                Some(old_text_segment.runs.first()?.shaped_text())
-            })
-            .unwrap_or_else(|| {
-                self.info
-                    .font_info
-                    .font
-                    .shape_text(&formatting_context_text[range.clone()], &options)
-            });
-
-        let mut shaped_text_slicer = ShapedTextSlicer::new(shaped_text);
-
-        self.runs.clear();
-        self.runs.reserve(linebreaks.len());
-        self.break_at_start = false;
-
-        let text_style = parent_style.get_inherited_text().clone();
-        let can_break_anywhere = text_style.word_break == WordBreak::BreakAll ||
-            text_style.overflow_wrap == OverflowWrap::Anywhere ||
-            text_style.overflow_wrap == OverflowWrap::BreakWord;
-
-        let mut last_slice = self.byte_range.start..self.byte_range.start;
-        for break_index in linebreak_iter {
-            if *break_index == self.byte_range.start {
-                self.break_at_start = true;
-                continue;
-            }
-
-            // Extend the slice to the next UAX#14 line break opportunity.
-            let mut slice = last_slice.end..*break_index;
-            let word = &formatting_context_text[slice.clone()];
-
-            // Split off any trailing whitespace into a separate glyph run.
-            let mut whitespace = slice.end..slice.end;
-            let rev_char_indices = word.char_indices().rev().peekable();
-
-            let mut non_whitespace_slice_ends_with_whitespace = false;
-            let mut ends_with_whitespace = false;
-            if let Some((first_white_space_index, first_white_space_character)) = rev_char_indices
-                .take_while(|&(_, character)| char_is_whitespace(character))
-                .last()
-            {
-                ends_with_whitespace = true;
-                whitespace.start = slice.start + first_white_space_index;
-
-                // If line breaking for a piece of text that has `white-space-collapse:
-                // break-spaces` there is a line break opportunity *after* every preserved space,
-                // but not before. This means that we should not split off the first whitespace.
-                //
-                // An exception to this is if the style tells us that we can break in the middle of words.
-                if text_style.white_space_collapse == WhiteSpaceCollapse::BreakSpaces &&
-                    !can_break_anywhere
-                {
-                    whitespace.start += first_white_space_character.len_utf8();
-                    non_whitespace_slice_ends_with_whitespace = true;
-                }
-
-                slice.end = whitespace.start;
-            }
-
-            // If there's no whitespace and `word-break` is set to `keep-all`, try increasing the slice.
-            // TODO: This should only happen for CJK text.
-            if !ends_with_whitespace &&
-                *break_index != self.byte_range.end &&
-                text_style.word_break == WordBreak::KeepAll &&
-                !can_break_anywhere
-            {
-                continue;
-            }
-
-            // Only advance the last slice if we are not going to try to expand the slice.
-            last_slice = slice.start..*break_index;
-
-            // Push the non-whitespace part of the range.
-            if !slice.is_empty() {
-                let character_count = formatting_context_text[slice].chars().count();
-                self.runs.push(shaped_text_slicer.slice_for_character_count(
-                    character_count,
-                    false, /* is_whitespace */
-                    non_whitespace_slice_ends_with_whitespace,
-                ));
-            }
-
-            if whitespace.is_empty() {
-                continue;
-            }
-
-            // If `white-space-collapse: break-spaces` is active, insert a line breaking opportunity
-            // between each white space character in the white space that we trimmed off.
-            if text_style.white_space_collapse == WhiteSpaceCollapse::BreakSpaces {
-                for _ in formatting_context_text[whitespace].chars() {
-                    self.runs.push(shaped_text_slicer.slice_for_character_count(
-                        1, true, /* is_whitespace */
-                        true, /* ends_with_whitespace */
-                    ));
-                }
-                continue;
-            }
-
-            let character_count = formatting_context_text[whitespace].chars().count();
-            self.runs.push(shaped_text_slicer.slice_for_character_count(
-                character_count,
-                true, /* is_whitespace */
-                true, /* ends_with_whitespace */
-            ));
-        }
-    }
-
-    fn is_compatible_with_old_shaping_result(&self, old_segment: &Self) -> bool {
+    pub(crate) fn is_compatible_with_old_shaping_result(&self, old_segment: &Self) -> bool {
         old_segment.info == self.info && self.byte_range == old_segment.byte_range
     }
 }
@@ -513,13 +384,13 @@ impl TextRun {
         }
     }
 
-    pub(super) fn segment_and_shape(
+    pub(super) fn segment(
         &mut self,
+        self_arc_ref_cell: ArcRefCell<TextRun>,
         formatting_context_text: &str,
         layout_context: &LayoutContext,
-        linebreaker: &mut LineBreaker,
         bidi_levels: &BidiLevels,
-    ) {
+    ) -> SmallVec<[ShapingQueueEntry; 1]> {
         let parent_style = self.inline_styles.style.borrow().clone();
         let items = self.segment_text_by_font(
             layout_context,
@@ -531,17 +402,20 @@ impl TextRun {
         // If a previous box tree layout seeded this [`TextRun`] with old shaping results, use those
         // to try to prevent re-shaping.
         let mut old_text_run_items = std::mem::replace(&mut self.items, items).into_iter();
-        for item in self.items.iter_mut() {
-            let old_text_run_item = old_text_run_items.next();
-            if let TextRunItem::TextSegment(text_segment) = item {
-                text_segment.shape_text(
-                    &parent_style,
-                    formatting_context_text,
-                    linebreaker,
+
+        self.items
+            .iter()
+            .enumerate()
+            .map(move |(index, text_run_item)| {
+                let old_text_run_item = old_text_run_items.next();
+                ShapingQueueEntry::new(
+                    self_arc_ref_cell.clone(),
+                    text_run_item,
+                    index,
                     old_text_run_item,
-                );
-            }
-        }
+                )
+            })
+            .collect()
     }
 
     /// Take the [`TextRun`]'s text and turn it into [`TextRunSegment`]s. Each segment has a matched
@@ -852,6 +726,6 @@ where
     }
 }
 
-fn script_is_specific(script: Script) -> bool {
+pub(crate) fn script_is_specific(script: Script) -> bool {
     script != Script::Common && script != Script::Inherited
 }

--- a/tests/wpt/meta/css/css-display/display-inline-dynamic-001.html.ini
+++ b/tests/wpt/meta/css/css-display/display-inline-dynamic-001.html.ini
@@ -1,2 +1,0 @@
-[display-inline-dynamic-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-features-across-space-1.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-features-across-space-1.html.ini
@@ -1,2 +1,0 @@
-[font-features-across-space-1.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-features-across-space-2.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-features-across-space-2.html.ini
@@ -1,2 +1,0 @@
-[font-features-across-space-2.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-features-across-space-3.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-features-across-space-3.html.ini
@@ -1,2 +1,0 @@
-[font-features-across-space-3.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text-decor/text-emphasis-punctuation-2.html.ini
+++ b/tests/wpt/meta/css/css-text-decor/text-emphasis-punctuation-2.html.ini
@@ -1,2 +1,0 @@
-[text-emphasis-punctuation-2.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/boundary-shaping/boundary-shaping-001.html.ini
+++ b/tests/wpt/meta/css/css-text/boundary-shaping/boundary-shaping-001.html.ini
@@ -1,2 +1,0 @@
-[boundary-shaping-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/boundary-shaping/boundary-shaping-003.html.ini
+++ b/tests/wpt/meta/css/css-text/boundary-shaping/boundary-shaping-003.html.ini
@@ -1,2 +1,0 @@
-[boundary-shaping-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/boundary-shaping/boundary-shaping-004.html.ini
+++ b/tests/wpt/meta/css/css-text/boundary-shaping/boundary-shaping-004.html.ini
@@ -1,2 +1,0 @@
-[boundary-shaping-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/boundary-shaping/boundary-shaping-005.html.ini
+++ b/tests/wpt/meta/css/css-text/boundary-shaping/boundary-shaping-005.html.ini
@@ -1,2 +1,0 @@
-[boundary-shaping-005.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/boundary-shaping/boundary-shaping-010.html.ini
+++ b/tests/wpt/meta/css/css-text/boundary-shaping/boundary-shaping-010.html.ini
@@ -1,2 +1,0 @@
-[boundary-shaping-010.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/letter-spacing/letter-spacing-ligatures-005.html.ini
+++ b/tests/wpt/meta/css/css-text/letter-spacing/letter-spacing-ligatures-005.html.ini
@@ -1,2 +1,0 @@
-[letter-spacing-ligatures-005.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-000.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-000.html.ini
@@ -1,2 +1,0 @@
-[shaping-000.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-001.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-001.html.ini
@@ -1,2 +1,0 @@
-[shaping-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-004.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-004.html.ini
@@ -1,2 +1,0 @@
-[shaping-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-005.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-005.html.ini
@@ -1,2 +1,0 @@
-[shaping-005.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-006.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-006.html.ini
@@ -1,2 +1,0 @@
-[shaping-006.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-007.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-007.html.ini
@@ -1,2 +1,0 @@
-[shaping-007.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-014.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-014.html.ini
@@ -1,2 +1,0 @@
-[shaping-014.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-016.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-016.html.ini
@@ -1,2 +1,0 @@
-[shaping-016.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-020.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-020.html.ini
@@ -1,2 +1,0 @@
-[shaping-020.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-022.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-022.html.ini
@@ -1,2 +1,0 @@
-[shaping-022.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-023.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-023.html.ini
@@ -1,2 +1,0 @@
-[shaping-023.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-025.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-025.html.ini
@@ -1,2 +1,0 @@
-[shaping-025.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping_lig-000.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping_lig-000.html.ini
@@ -1,2 +1,0 @@
-[shaping_lig-000.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/text-transform/text-transform-shaping-001.html.ini
+++ b/tests/wpt/meta/css/css-text/text-transform/text-transform-shaping-001.html.ini
@@ -1,2 +1,0 @@
-[text-transform-shaping-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/text-transform/text-transform-shaping-002.html.ini
+++ b/tests/wpt/meta/css/css-text/text-transform/text-transform-shaping-002.html.ini
@@ -1,2 +1,0 @@
-[text-transform-shaping-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/text-transform/text-transform-shaping-003.html.ini
+++ b/tests/wpt/meta/css/css-text/text-transform/text-transform-shaping-003.html.ini
@@ -1,2 +1,0 @@
-[text-transform-shaping-003.html]
-  expected: FAIL


### PR DESCRIPTION
Allow shaping across inline box boundaries by collecting text to shape during
inline formatting context construction in a `ShapingQueue`. The `ShapingQueue`
is responsible for shaping all text as well as placing it into its originating
`TextRun`. The queue is flushed when an incompatible piece of text (using CSS
specification rules) is pushed.

Testing: This causes a good number of WPT tests to start to pass.
Fixes: #35397.
