### PR TITLE
script: Fix borrow hazard when resolving XRSession end promises

### DIFF
--- a/components/script/dom/webxr/xrsession.rs
+++ b/components/script/dom/webxr/xrsession.rs
@@ -286,9 +286,10 @@ impl XRSession {
                 // Step 5: We currently do not have any such promises
                 // Step 6 is happening n the XR session
                 // https://immersive-web.github.io/webxr/#dom-xrsession-end step 3
-                for promise in self.end_promises.borrow_mut().drain(..) {
+                for promise in self.end_promises.borrow().iter() {
                     promise.resolve_native(cx, &());
                 }
+                self.end_promises.safe_borrow_mut(cx.no_gc()).clear();
                 // Step 7
                 let event = XRSessionEvent::new(
                     cx,


### PR DESCRIPTION
Before, end_promises was drained while holding a mutable borrow during resolve_native(). Rewrote to resolve each promise reading from an immutable borrow, and then clearing the list after.

Testing: 
`.\mach build -r` : to test if borrow fixed in compile-time
`.\mach test-wpt -r tests/wpt/tests/webxr/` : no change in test results, when comparing with main branch

Fixes #46715.
