### PR TITLE
script: Implement async FileSystemFileEntry.file() success callback

### DIFF
--- a/components/script/dom/datatransfer/datatransferitem.rs
+++ b/components/script/dom/datatransfer/datatransferitem.rs
@@ -130,9 +130,10 @@ impl DataTransferItemMethods<crate::DomTypeHolder> for DataTransferItem {
                 .task_manager()
                 .dom_manipulation_task_source()
                 .queue(task!(invoke_callback: move |cx| {
-                    let maybe_index = this.root().pending_callbacks.borrow().iter().position(|val| val.id == id);
+                    let this = this.root();
+                    let maybe_index = this.pending_callbacks.borrow().iter().position(|val| val.id == id);
                     if let Some(index) = maybe_index {
-                        let callback = this.root().pending_callbacks.borrow_mut().swap_remove(index).callback;
+                        let callback = this.pending_callbacks.safe_borrow_mut(cx.no_gc()).swap_remove(index).callback;
                         let _ = callback.Call__(cx, DOMString::from(string), ExceptionHandling::Report);
                     }
                 }));

--- a/components/script/dom/filesystem/filesystemfileentry.rs
+++ b/components/script/dom/filesystem/filesystemfileentry.rs
@@ -104,7 +104,7 @@ impl FileSystemFileEntryMethods<crate::DomTypeHolder> for FileSystemFileEntry {
                 if let Some(index) = maybe_index {
                     let callback = this
                         .pending_callbacks
-                        .borrow_mut()
+                        .safe_borrow_mut(cx.no_gc())
                         .swap_remove(index)
                         .callback;
                     let file = DomRoot::from_ref(&*this.file);

--- a/components/script/dom/filesystem/filesystemfileentry.rs
+++ b/components/script/dom/filesystem/filesystemfileentry.rs
@@ -2,16 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::cell::Cell;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
+use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::reflect_dom_object_with_cx;
 
+use crate::dom::bindings::callback::ExceptionHandling;
 use crate::dom::bindings::codegen::Bindings::FileSystemEntryBinding::ErrorCallback;
 use crate::dom::bindings::codegen::Bindings::FileSystemFileEntryBinding::{
     FileCallback, FileSystemFileEntryMethods,
 };
+use crate::dom::bindings::refcounted::Trusted;
+use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
 use crate::dom::file::File;
@@ -23,6 +28,15 @@ use crate::dom::globalscope::GlobalScope;
 pub(crate) struct FileSystemFileEntry {
     filesystementry: FileSystemEntry,
     file: Dom<File>,
+    pending_callbacks: DomRefCell<Vec<PendingFileCallback>>,
+    next_callback: Cell<usize>,
+}
+
+#[derive(JSTraceable, MallocSizeOf)]
+struct PendingFileCallback {
+    id: usize,
+    #[conditional_malloc_size_of]
+    callback: Rc<FileCallback>,
 }
 
 impl FileSystemFileEntry {
@@ -30,6 +44,8 @@ impl FileSystemFileEntry {
         FileSystemFileEntry {
             filesystementry: FileSystemEntry::new_inherited(name, full_path, true),
             file: Dom::from_ref(file),
+            pending_callbacks: Default::default(),
+            next_callback: Cell::new(0),
         }
     }
 
@@ -54,12 +70,46 @@ impl FileSystemFileEntry {
 
 impl FileSystemFileEntryMethods<crate::DomTypeHolder> for FileSystemFileEntry {
     /// <https://wicg.github.io/entries-api/#dom-filesystemfileentry-file>
-    fn File(
-        &self,
-        _success_callback: Rc<FileCallback>,
-        _error_callback: Option<Rc<ErrorCallback>>,
-    ) {
-        // TODO: Implement per spec 7.4. No need to hook embedder here.
-        // It is done at `filesystementry`.
+    fn File(&self, success_callback: Rc<FileCallback>, _error_callback: Option<Rc<ErrorCallback>>) {
+        // Per spec 7.4: in parallel,
+        // 1. (TODO) Evaluate path
+        // 2-3. (TODO) errorCallback
+
+        // Note: Step 1 - 3 is meant to re-check if file exists on OS filesystem.
+        // It is unreachable for now, as the file data is already
+        // stored in-memory on this entry as `File` (set by webkitGetAsEntry).
+
+        // 4. on success, queue a task to invoke successCallback
+        // with a new `File` object representing item and "report".
+
+        let id = self.next_callback.get();
+        let pending_callback = PendingFileCallback {
+            id,
+            callback: success_callback,
+        };
+        self.pending_callbacks.borrow_mut().push(pending_callback);
+        self.next_callback.set(id + 1);
+
+        let this = Trusted::new(self);
+        self.global()
+            .task_manager()
+            .dom_manipulation_task_source()
+            .queue(task!(invoke_file_callback: move |cx| {
+                let this = this.root();
+                let maybe_index = this
+                    .pending_callbacks
+                    .borrow()
+                    .iter()
+                    .position(|val| val.id == id);
+                if let Some(index) = maybe_index {
+                    let callback = this
+                        .pending_callbacks
+                        .borrow_mut()
+                        .swap_remove(index)
+                        .callback;
+                    let file = DomRoot::from_ref(&*this.file);
+                    let _ = callback.Call__(cx, &file, ExceptionHandling::Report);
+                }
+            }));
     }
 }

--- a/powershell_webdriver/click.ps1
+++ b/powershell_webdriver/click.ps1
@@ -1,6 +1,0 @@
-$body = '{}'
-$response_load = Invoke-RestMethod -Method Post `
-                              -Uri "http://127.0.0.1:7000/session/${SESSIONID}/element/${elementID}/click" `
-                              -Body $body `
-                              -ContentType "application/json" `
-                              -Verbose

--- a/powershell_webdriver/click.ps1
+++ b/powershell_webdriver/click.ps1
@@ -1,0 +1,6 @@
+$body = '{}'
+$response_load = Invoke-RestMethod -Method Post `
+                              -Uri "http://127.0.0.1:7000/session/${SESSIONID}/element/${elementID}/click" `
+                              -Body $body `
+                              -ContentType "application/json" `
+                              -Verbose

--- a/tests/wpt/tests/entries-api/webkitGetAsEntry.html
+++ b/tests/wpt/tests/entries-api/webkitGetAsEntry.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Entries API: DataTransferItem.webkitGetAsEntry() with script-created DataTransfer</title>
+<link rel=help href="https://wicg.github.io/entries-api/#dom-datatransferitem-webkitgetasentry">
+<link rel="author" title="Euclid Ye" href="mailto:yezhizhenjiakang@gmail.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+test(t => {
+  const dt = new DataTransfer();
+  dt.items.add('hello', 'text/plain');
+  const item = dt.items[0];
+  assert_equals(item.kind, 'string');
+  assert_equals(item.webkitGetAsEntry(), null,
+    'webkitGetAsEntry() should return null for non-File items');
+}, 'webkitGetAsEntry() returns null for text items');
+
+test(t => {
+  const file = new File(['hello world'], 'test.txt', { type: 'text/plain' });
+  const dt = new DataTransfer();
+  dt.items.add(file);
+
+  const item = dt.items[0];
+  assert_equals(item.kind, 'file');
+
+  const entry = item.webkitGetAsEntry();
+  assert_not_equals(entry, null);
+  assert_true(entry.isFile);
+  assert_false(entry.isDirectory);
+  assert_equals(entry.name, 'test.txt');
+  assert_equals(entry.fullPath, '/test.txt');
+  assert_true(entry.filesystem instanceof FileSystem);
+  assert_true(entry.filesystem.root.isDirectory);
+}, 'webkitGetAsEntry() returns FileSystemFileEntry with correct attributes');
+
+async_test(t => {
+  const file = new File(['hello world'], 'test.txt', { type: 'text/plain' });
+  const dt = new DataTransfer();
+  dt.items.add(file);
+
+  const entry = dt.items[0].webkitGetAsEntry();
+
+  entry.file(
+    t.step_func_done(f => {
+      assert_class_string(f, 'File');
+      assert_equals(f.name, 'test.txt');
+      assert_equals(f.size, 11);
+    }),
+    t.unreached_func('file() should not invoke the error callback')
+  );
+}, 'FileSystemFileEntry.file() invokes callback with a File');
+</script>


### PR DESCRIPTION
The impl mimics https://github.com/servo/servo/blob/711b48d8755e827ffd216d0e0132dc3d6f34093a/components/script/dom/datatransfer/datatransferitem.rs#L107

Testing: Added an automated test unlike those existing manual ones. The major difference is, it does not require OS drag-and-drop support, but still tests the full DnD script path programatically.

Part of #45653
