### PR TITLE
font: Expose `ShapedTextSliceType` to clarify different `ShapedTextSlice`s

### DIFF
--- a/components/fonts/glyph.rs
+++ b/components/fonts/glyph.rs
@@ -545,6 +545,18 @@ impl fmt::Debug for ShapedText {
     }
 }
 
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+pub enum ShapedTextSliceType {
+    /// A [`ShapedTextSlice`] that is a word that is not followed by white space.
+    Word,
+    /// A [`ShapedTextSlice`] composed of only white space glyphs.
+    WhiteSpace,
+    /// A [`ShapedTextSlice`] that is a word that ends with a white space glyphs.
+    /// Typically whitespace glyphs are placed in a separate slice, but that may not be
+    /// the case with `white-space: break-spaces`.
+    WordAndWhiteSpace,
+}
+
 /// A slice of a [`ShapedText`] which allows having different views into a shaped
 /// text run. This is used for splitting up shaped text during layout, without
 /// duplicating the entire run.
@@ -567,13 +579,8 @@ pub struct ShapedTextSlice {
     /// <https://drafts.csswg.org/css-text/#word-separator>.
     total_word_separators: usize,
 
-    /// Whether or not this [`ShapedTextSlice`] is entirely whitespace.
-    is_whitespace: bool,
-
-    /// Whether or not this [`ShapedTextSlice`] ends with whitespace glyphs.
-    /// Typically whitespace glyphs are placed in a separate slice,
-    /// but that may not be the case with `white-space: break-spaces`.
-    ends_with_whitespace: bool,
+    /// The [`ShapedTextSliceType`] of this [`ShapedTextSlice`].
+    slice_type: ShapedTextSliceType,
 }
 
 impl ShapedTextSlice {
@@ -606,13 +613,16 @@ impl ShapedTextSlice {
     /// Whether or not this [`ShapedTextSlice`] is entirely whitespace.
     #[inline]
     pub fn is_whitespace(&self) -> bool {
-        self.is_whitespace
+        matches!(self.slice_type, ShapedTextSliceType::WhiteSpace)
     }
 
     /// Whether or not this [`ShapedTextSlice`] ends with whitespace.
     #[inline]
     pub fn ends_with_whitespace(&self) -> bool {
-        self.ends_with_whitespace
+        match self.slice_type {
+            ShapedTextSliceType::Word => false,
+            ShapedTextSliceType::WhiteSpace | ShapedTextSliceType::WordAndWhiteSpace => true,
+        }
     }
 
     /// An iterator over the glyphs represented by this [`ShapedTextSlice`].
@@ -650,8 +660,7 @@ impl ShapedTextSlicer {
     pub fn slice_until_character_offset(
         &mut self,
         desired_character_offset: usize,
-        is_whitespace: bool,
-        ends_with_whitespace: bool,
+        slice_type: ShapedTextSliceType,
     ) -> Option<Arc<ShapedTextSlice>> {
         let mut glyph_count = 0;
         let mut total_word_separators = 0;
@@ -721,9 +730,8 @@ impl ShapedTextSlicer {
             glyph_range,
             total_advance,
             character_count: self.current_character_offset - original_character_offset,
-            is_whitespace,
-            ends_with_whitespace,
             total_word_separators,
+            slice_type,
         }))
     }
 }

--- a/components/fonts/lib.rs
+++ b/components/fonts/lib.rs
@@ -28,7 +28,7 @@ pub use font_context::{
 pub use font_store::FontTemplates;
 pub use fonts_traits::*;
 pub(crate) use glyph::*;
-pub use glyph::{GlyphInfo, ShapedText, ShapedTextSlice, ShapedTextSlicer};
+pub use glyph::{GlyphInfo, ShapedText, ShapedTextSlice, ShapedTextSliceType, ShapedTextSlicer};
 use icu_locid::subtags::Language;
 pub use platform::font_list::fallback_font_families;
 pub(crate) use shapers::*;

--- a/components/layout/flow/inline/shaping_queue.rs
+++ b/components/layout/flow/inline/shaping_queue.rs
@@ -5,7 +5,7 @@
 use std::ops::Range;
 use std::sync::Arc;
 
-use fonts::{ShapedText, ShapedTextSlice, ShapedTextSlicer, ShapingOptions};
+use fonts::{ShapedText, ShapedTextSlice, ShapedTextSliceType, ShapedTextSlicer, ShapingOptions};
 use icu_segmenter::LineBreakOptions;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::computed_values::word_break::T as WordBreak;
@@ -125,7 +125,7 @@ impl BatchSlicer<'_> {
             let mut whitespace = slice.end..slice.end;
             let rev_char_indices = word.char_indices().rev().peekable();
 
-            let mut non_whitespace_slice_ends_with_whitespace = false;
+            let mut slice_type = ShapedTextSliceType::Word;
             let mut ends_with_whitespace = false;
             if let Some((first_white_space_index, first_white_space_character)) = rev_char_indices
                 .take_while(|&(_, character)| char_is_whitespace(character))
@@ -143,7 +143,7 @@ impl BatchSlicer<'_> {
                     !can_break_anywhere
                 {
                     whitespace.start += first_white_space_character.len_utf8();
-                    non_whitespace_slice_ends_with_whitespace = true;
+                    slice_type = ShapedTextSliceType::WordAndWhiteSpace;
                 }
 
                 slice.end = whitespace.start;
@@ -165,11 +165,10 @@ impl BatchSlicer<'_> {
             // Push the non-whitespace part of the range.
             if !slice.is_empty() {
                 current_character_offset += self.text[slice].chars().count();
-                maybe_push_run(self.slicer.slice_until_character_offset(
-                    current_character_offset,
-                    false, /* is_whitespace */
-                    non_whitespace_slice_ends_with_whitespace,
-                ));
+                maybe_push_run(
+                    self.slicer
+                        .slice_until_character_offset(current_character_offset, slice_type),
+                );
             }
 
             if whitespace.is_empty() {
@@ -183,8 +182,7 @@ impl BatchSlicer<'_> {
                     current_character_offset += 1;
                     maybe_push_run(self.slicer.slice_until_character_offset(
                         current_character_offset,
-                        true, /* is_whitespace */
-                        true, /* ends_with_whitespace */
+                        ShapedTextSliceType::WhiteSpace,
                     ));
                 }
                 continue;
@@ -193,8 +191,7 @@ impl BatchSlicer<'_> {
             current_character_offset += self.text[whitespace].chars().count();
             maybe_push_run(self.slicer.slice_until_character_offset(
                 current_character_offset,
-                true, /* is_whitespace */
-                true, /* ends_with_whitespace */
+                ShapedTextSliceType::WhiteSpace,
             ));
         }
 


### PR DESCRIPTION
Instead of using two boolean fields that could encode unreachable
behavior, this change makes it so that the `ShapedTextSlice` holds a
type. This type more clearly defines the kinds of `ShapedTextSlice`s
making it easier to read what's happening as they are created and
simplifying the constructor.

Testing: This does not change behavior, so should be covered by existing tests.
