### PR TITLE
fonts: Apply Harfbuzz features globally when shaping

### DIFF
--- a/components/fonts/shapers/harfbuzz.rs
+++ b/components/fonts/shapers/harfbuzz.rs
@@ -17,15 +17,14 @@ use harfbuzz_sys::{
     HB_MEMORY_MODE_READONLY, HB_OT_LAYOUT_BASELINE_TAG_HANGING,
     HB_OT_LAYOUT_BASELINE_TAG_IDEO_EMBOX_BOTTOM_OR_LEFT, HB_OT_LAYOUT_BASELINE_TAG_ROMAN,
     hb_blob_create, hb_blob_t, hb_bool_t, hb_buffer_add_utf8, hb_buffer_create, hb_buffer_destroy,
-    hb_buffer_get_glyph_infos, hb_buffer_get_glyph_positions, hb_buffer_get_length,
-    hb_buffer_set_cluster_level, hb_buffer_set_direction, hb_buffer_set_language,
-    hb_buffer_set_script, hb_buffer_t, hb_codepoint_t, hb_face_create_for_tables, hb_face_destroy,
-    hb_face_t, hb_feature_t, hb_font_create, hb_font_create_sub_font, hb_font_destroy,
-    hb_font_funcs_create, hb_font_funcs_set_glyph_h_advance_func,
-    hb_font_funcs_set_nominal_glyph_func, hb_font_funcs_t, hb_font_set_funcs, hb_font_set_ppem,
-    hb_font_set_scale, hb_font_set_variations, hb_font_t, hb_glyph_info_t, hb_glyph_position_t,
-    hb_language_from_string, hb_ot_layout_get_baseline, hb_position_t, hb_script_from_iso15924_tag,
-    hb_shape, hb_tag_t, hb_variation_t,
+    hb_buffer_get_glyph_infos, hb_buffer_get_glyph_positions, hb_buffer_set_cluster_level,
+    hb_buffer_set_direction, hb_buffer_set_language, hb_buffer_set_script, hb_buffer_t,
+    hb_codepoint_t, hb_face_create_for_tables, hb_face_destroy, hb_face_t, hb_feature_t,
+    hb_font_create, hb_font_create_sub_font, hb_font_destroy, hb_font_funcs_create,
+    hb_font_funcs_set_glyph_h_advance_func, hb_font_funcs_set_nominal_glyph_func, hb_font_funcs_t,
+    hb_font_set_funcs, hb_font_set_ppem, hb_font_set_scale, hb_font_set_variations, hb_font_t,
+    hb_glyph_info_t, hb_glyph_position_t, hb_language_from_string, hb_ot_layout_get_baseline,
+    hb_position_t, hb_script_from_iso15924_tag, hb_shape, hb_tag_t, hb_variation_t,
 };
 use num_traits::Zero;
 use read_fonts::types::Tag;
@@ -292,8 +291,8 @@ impl Shaper {
                 .map(|(tag, value)| hb_feature_t {
                     tag: u32::from_be_bytes(tag.to_be_bytes()),
                     value: *value,
-                    start: 0,
-                    end: hb_buffer_get_length(hb_buffer),
+                    start: 0,      // HB_FEATURE_GLOBAL_START
+                    end: u32::MAX, // HB_FEATURE_GLOBAL_END
                 })
                 .collect();
             hb_shape(


### PR DESCRIPTION
`hb_feature_t` takes a range of clusters via a `start` and `end` field.
Since UTF-8 text is added to the `hb_buffer_t`, each code unit (UTF-8)
byte is an input cluster. `hb_buffer_get_length` returns the number of
*items* in the buffer which pre-shaping is the number of Unicode code
units. This means that features were not covering the entire run being
shaped. Instead of using an explicit end offset use `u32::MAX` which is
equivalent to the unexposed `HB_FEATURE_GLOBAL_END` constant. This
always covers the entire run and allows Harfbuzz to mark the feature as
global.

Testing: This does change behavior, but will be tested by the changes
in #46829, which would otherwise fail 4 tests without this.
