### PR TITLE
script: Implement inserttext command

### DIFF
--- a/components/script/dom/execcommand/basecommand.rs
+++ b/components/script/dom/execcommand/basecommand.rs
@@ -33,6 +33,7 @@ use crate::dom::execcommand::commands::hilitecolor::execute_hilitecolor_command;
 use crate::dom::execcommand::commands::inserthorizontalrule::execute_insert_horizontal_rule_command;
 use crate::dom::execcommand::commands::insertimage::execute_insert_image_command;
 use crate::dom::execcommand::commands::insertparagraph::execute_insert_paragraph_command;
+use crate::dom::execcommand::commands::inserttext::execute_insert_text_command;
 use crate::dom::execcommand::commands::italic::execute_italic_command;
 use crate::dom::execcommand::commands::removeformat::execute_removeformat_command;
 use crate::dom::execcommand::commands::strikethrough::execute_strikethrough_command;
@@ -553,7 +554,7 @@ impl CommandName {
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#record-current-overrides>
-    fn record_current_overrides(document: &Document) -> Vec<RecordedStateOfCommand> {
+    pub(crate) fn record_current_overrides(document: &Document) -> Vec<RecordedStateOfCommand> {
         // Step 1. Let overrides be a list of (string, string or boolean) ordered pairs, initially empty.
         let mut overrides = vec![];
         // Step 2. If there is a value override for "createLink",
@@ -754,6 +755,7 @@ impl CommandName {
             CommandName::InsertParagraph => {
                 execute_insert_paragraph_command(cx, document, selection)
             },
+            CommandName::InsertText => execute_insert_text_command(cx, document, selection, value),
             CommandName::Italic => execute_italic_command(cx, document, selection),
             CommandName::RemoveFormat => execute_removeformat_command(cx, document, selection),
             CommandName::Strikethrough => execute_strikethrough_command(cx, document, selection),

--- a/components/script/dom/execcommand/commands/inserttext.rs
+++ b/components/script/dom/execcommand/commands/inserttext.rs
@@ -1,0 +1,186 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use js::context::JSContext;
+use script_bindings::codegen::GenericBindings::CharacterDataBinding::CharacterDataMethods;
+use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
+use script_bindings::codegen::GenericBindings::SelectionBinding::SelectionMethods;
+use script_bindings::inheritance::Castable;
+
+use crate::dom::Node;
+use crate::dom::bindings::codegen::Bindings::RangeBinding::RangeMethods;
+use crate::dom::bindings::str::DOMString;
+use crate::dom::characterdata::CharacterData;
+use crate::dom::document::Document;
+use crate::dom::execcommand::basecommand::CommandName;
+use crate::dom::execcommand::commands::insertparagraph::execute_insert_paragraph_command;
+use crate::dom::execcommand::contenteditable::selection::SelectionDeletionStripWrappers;
+use crate::dom::selection::Selection;
+use crate::dom::text::Text;
+
+/// <https://w3c.github.io/editing/docs/execCommand/#the-inserttext-command>
+pub(crate) fn execute_insert_text_command(
+    cx: &mut JSContext,
+    document: &Document,
+    selection: &Selection,
+    value: DOMString,
+) -> bool {
+    // Step 1. Delete the selection, with strip wrappers false.
+    selection.delete_the_selection(
+        cx,
+        document,
+        Default::default(),
+        SelectionDeletionStripWrappers::NoStrip,
+        Default::default(),
+    );
+
+    // Step 2. If the active range's start node is neither editable nor an editing host, return true.
+    let mut active_range = selection
+        .active_range()
+        .expect("Must always have an active range.");
+    if !active_range.start_container().is_editable_or_editing_host() {
+        return true;
+    }
+
+    // Step 3. If value's length is greater than one:
+    if value.len() > 1 {
+        // Step 3.1. For each code unit el in value, take the action for the insertText command, with value equal to el.
+        for el in value.str().chars() {
+            execute_insert_text_command(cx, document, selection, DOMString::from(el.to_string()));
+        }
+
+        // Step 3.2. Return true.
+        return true;
+    }
+
+    // Step 4. If value is the empty string, return true.
+    if value.is_empty() {
+        return true;
+    }
+
+    // Step 5. If value is a newline (U+000A), take the action for the insertParagraph command and return true.
+    if value == "\n" {
+        execute_insert_paragraph_command(cx, document, selection);
+        return true;
+    }
+
+    // Step 6. Let node and offset be the active range's start node and offset.
+    let mut node = active_range.start_container();
+    let mut offset = active_range.start_offset();
+
+    // Step 7. If node has a child whose index is offset − 1, and that child is a Text node, set node to that child, then set offset to node's length.
+    if offset > 0 &&
+        let Some(child) = node.children().nth((offset - 1) as usize) &&
+        child.is::<Text>()
+    {
+        node = child;
+        offset = node.len();
+    }
+
+    // Step 8. If node has a child whose index is offset, and that child is a Text node, set node to that child, then set offset to zero.
+    if let Some(child) = node.children().nth((offset) as usize) &&
+        child.is::<Text>()
+    {
+        node = child;
+        offset = 0;
+    }
+
+    // Step 9. Record current overrides, and let overrides be the result.
+    let overrides = CommandName::record_current_overrides(document);
+
+    // Step 10. Call collapse(node, offset) on the context object's selection.
+    if selection.Collapse(cx, Some(&node), offset).is_err() {
+        unreachable!("Must always be able to collapse the selection");
+    }
+
+    // Step 11. Canonicalize whitespace at (node, offset).
+    node.canonicalize_whitespace(cx, offset, Default::default());
+
+    // Step 12. Let (node, offset) be the active range's start.
+    active_range = selection
+        .active_range()
+        .expect("Must always have an active range.");
+    node = active_range.start_container();
+    offset = active_range.start_offset();
+
+    // Step 13. If node is a Text node:
+    if let Some(node_as_text) = node.downcast::<Text>() {
+        // Step 13.1. Call insertData(offset, value) on node.
+        if node_as_text
+            .upcast::<CharacterData>()
+            .InsertData(cx, offset, value.clone())
+            .is_err()
+        {
+            unreachable!("Must always be able to insert");
+        }
+
+        // Step 13.2. Call collapse(node, offset) on the context object's selection.
+        if selection.Collapse(cx, Some(&node), offset).is_err() {
+            unreachable!("Must always be able to collapse the selection.");
+        }
+
+        // Step 13.3. Call extend(node, offset + 1) on the context object's selection.
+        if selection.Extend(cx, &node, offset + 1).is_err() {
+            unreachable!("Must always be able to extend the selection");
+        }
+
+        active_range = selection
+            .active_range()
+            .expect("Must always have an active range.");
+    }
+    // Step 14. Otherwise:
+    else {
+        // Step 14.1. If node has only one child, which is a collapsed line break, remove its child from it.
+        // TODO: Implement this.
+
+        // Step 14.2. Let text be the result of calling createTextNode(value) on the context object.
+        let text = document.CreateTextNode(cx, value.clone());
+        let text = text.upcast::<Node>();
+
+        // Step 14.3. Call insertNode(text) on the active range.
+        if active_range.InsertNode(cx, text).is_err() {
+            unreachable!("Must always be able to insert");
+        }
+
+        // Step 14.4. Call collapse(text, 0) on the context object's selection.
+        if selection.Collapse(cx, Some(text), 0).is_err() {
+            unreachable!("Must always be able to collapse the selection");
+        }
+
+        // Step 14.5. Call extend(text, 1) on the context object's selection.
+        if selection.Extend(cx, text, 1).is_err() {
+            unreachable!("Must always be able to extend the selection");
+        }
+
+        active_range = selection
+            .active_range()
+            .expect("Must always have an active range.");
+    }
+
+    // Step 15. Restore states and values from overrides.
+    active_range.restore_states_and_values(cx, selection, document, overrides);
+
+    // Step 16. Canonicalize whitespace at the active range's start, with fix collapsed space false.
+    active_range
+        .start_container()
+        .canonicalize_whitespace(cx, active_range.start_offset(), false);
+
+    // Step 17. Canonicalize whitespace at the active range's end, with fix collapsed space false.
+    active_range
+        .end_container()
+        .canonicalize_whitespace(cx, active_range.end_offset(), false);
+
+    // Step 18. If value is a space character, autolink the active range's start.
+    if value == " " {
+        // TODO: Implement autolink.
+    }
+
+    // Step 19. Call collapseToEnd() on the context object's selection.
+    if selection.CollapseToEnd(cx).is_err() {
+        unreachable!("Must always be able to CollapseToEnd here.");
+    }
+
+    // Step 20. Return true.
+    true
+}

--- a/components/script/dom/execcommand/commands/mod.rs
+++ b/components/script/dom/execcommand/commands/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod hilitecolor;
 pub(crate) mod inserthorizontalrule;
 pub(crate) mod insertimage;
 pub(crate) mod insertparagraph;
+pub(crate) mod inserttext;
 pub(crate) mod italic;
 pub(crate) mod removeformat;
 pub(crate) mod strikethrough;

--- a/components/script/dom/execcommand/execcommands.rs
+++ b/components/script/dom/execcommand/execcommands.rs
@@ -133,6 +133,7 @@ impl Document {
             "inserthorizontalrule" => CommandName::InsertHorizontalRule,
             "insertimage" => CommandName::InsertImage,
             "insertparagraph" => CommandName::InsertParagraph,
+            "inserttext" => CommandName::InsertText,
             "italic" => CommandName::Italic,
             "removeformat" => CommandName::RemoveFormat,
             "strikethrough" => CommandName::Strikethrough,

--- a/tests/wpt/meta/editing/event.html.ini
+++ b/tests/wpt/meta/editing/event.html.ini
@@ -80,15 +80,6 @@
   [Command insertOrderedList, value "quasit": input event]
     expected: FAIL
 
-  [Command insertText, value "": input event]
-    expected: FAIL
-
-  [Command insertText, value "quasit": input event]
-    expected: FAIL
-
-  [Command insertText, value "abc": input event]
-    expected: FAIL
-
   [Command insertUnorderedList, value "": input event]
     expected: FAIL
 

--- a/tests/wpt/meta/editing/other/delete-without-unwrapping-first-line-of-child-block.html.ini
+++ b/tests/wpt/meta/editing/other/delete-without-unwrapping-first-line-of-child-block.html.ini
@@ -219,13 +219,7 @@
   [document.execCommand("delete") at <br><br><div id="child">[\]def<br>ghi</div>]
     expected: FAIL
 
-  [document.execCommand("delete") at <br><div id="child">[\]def<br>ghi</div>]
-    expected: FAIL
-
   [document.execCommand("delete") at <b>abc<br><br></b></b><div id="child">[\]def<br>ghi</div>]
-    expected: FAIL
-
-  [document.execCommand("delete") at <b><br></b><div id="child">[\]def<br>ghi</div>]
     expected: FAIL
 
 

--- a/tests/wpt/meta/editing/other/editable-state-and-focus-in-assigned-slot-dom.tentative.html.ini
+++ b/tests/wpt/meta/editing/other/editable-state-and-focus-in-assigned-slot-dom.tentative.html.ini
@@ -1,3 +1,0 @@
-[editable-state-and-focus-in-assigned-slot-dom.tentative.html]
-  [Testing editable state and focus in slotted editable element]
-    expected: FAIL

--- a/tests/wpt/meta/editing/other/editing-around-select-element.tentative.html.ini
+++ b/tests/wpt/meta/editing/other/editing-around-select-element.tentative.html.ini
@@ -1,4 +1,5 @@
 [editing-around-select-element.tentative.html?insertText]
+  expected: TIMEOUT
   [execCommand(insertText, false, "XYZ") in <div contenteditable><p>abc</p>{<select><option>def</option><option>ghi</option></select>}<p>jkl</p></div>: <select> element itself should be removable]
     expected: FAIL
 

--- a/tests/wpt/meta/editing/other/editing-div-outside-body.html.ini
+++ b/tests/wpt/meta/editing/other/editing-div-outside-body.html.ini
@@ -1,7 +1,4 @@
 [editing-div-outside-body.html?nothing]
-  [Test for execCommand("insertText", false, "abc") in "<div>[\]<br></div>"]
-    expected: FAIL
-
   [Test for execCommand("insertLineBreak", false, undefined) in "<div>ab[\]c</div>"]
     expected: FAIL
 
@@ -10,9 +7,6 @@
 
 
 [editing-div-outside-body.html?html]
-  [Test for execCommand("insertText", false, "abc") in "<div>[\]<br></div>"]
-    expected: FAIL
-
   [Test for execCommand("insertLineBreak", false, undefined) in "<div>ab[\]c</div>"]
     expected: FAIL
 
@@ -21,9 +15,6 @@
 
 
 [editing-div-outside-body.html?body]
-  [Test for execCommand("insertText", false, "abc") in "<div>[\]<br></div>"]
-    expected: FAIL
-
   [Test for execCommand("insertLineBreak", false, undefined) in "<div>ab[\]c</div>"]
     expected: FAIL
 
@@ -32,9 +23,6 @@
 
 
 [editing-div-outside-body.html?designMode]
-  [Test for execCommand("insertText", false, "abc") in "<div>[\]<br></div>"]
-    expected: FAIL
-
   [Test for execCommand("insertLineBreak", false, undefined) in "<div>ab[\]c</div>"]
     expected: FAIL
 
@@ -43,9 +31,6 @@
 
 
 [editing-div-outside-body.html?div-in-body]
-  [Test for execCommand("insertText", false, "abc") in "<div>[\]<br></div>"]
-    expected: FAIL
-
   [Test for execCommand("insertLineBreak", false, undefined) in "<div>ab[\]c</div>"]
     expected: FAIL
 

--- a/tests/wpt/meta/editing/other/exec-command-with-text-editor.tentative.html.ini
+++ b/tests/wpt/meta/editing/other/exec-command-with-text-editor.tentative.html.ini
@@ -71,13 +71,7 @@
   [In <input type="password">, execCommand("inserthtml", false, <b>inserted</b>), a[b\]c): The command should be enabled]
     expected: FAIL
 
-  [In <input type="password">, execCommand("inserttext", false, **inserted**), a[b\]c): The command should be supported]
-    expected: FAIL
-
   [In <input type="password">, execCommand("inserttext", false, **inserted**), a[b\]c): The command should be enabled]
-    expected: FAIL
-
-  [In <input type="password">, execCommand("inserttext", false, ), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <input type="password">, execCommand("inserttext", false, ), a[b\]c): The command should be enabled]
@@ -167,13 +161,7 @@
   [In <input type="password"> in contenteditable, execCommand("inserthtml", false, <b>inserted</b>), a[b\]c): The command should be enabled]
     expected: FAIL
 
-  [In <input type="password"> in contenteditable, execCommand("inserttext", false, **inserted**), a[b\]c): The command should be supported]
-    expected: FAIL
-
   [In <input type="password"> in contenteditable, execCommand("inserttext", false, **inserted**), a[b\]c): The command should be enabled]
-    expected: FAIL
-
-  [In <input type="password"> in contenteditable, execCommand("inserttext", false, ), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <input type="password"> in contenteditable, execCommand("inserttext", false, ), a[b\]c): The command should be enabled]
@@ -482,6 +470,30 @@
   [In <input type="password">, execCommand("forwarddelete", false, null), a[\]bc): input.target should be [object HTMLInputElement\]]
     expected: FAIL
 
+  [In <input type="password">, execCommand("inserttext", false, **inserted**), a[b\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <input type="password">, execCommand("inserttext", false, **inserted**), a[b\]c): <input>.value should be "a**inserted**[\]c"]
+    expected: FAIL
+
+  [In <input type="password">, execCommand("inserttext", false, **inserted**), a[b\]c): input.inputType should be insertText]
+    expected: FAIL
+
+  [In <input type="password">, execCommand("inserttext", false, **inserted**), a[b\]c): input.target should be [object HTMLInputElement\]]
+    expected: FAIL
+
+  [In <input type="password">, execCommand("inserttext", false, ), a[b\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <input type="password">, execCommand("inserttext", false, ), a[b\]c): <input>.value should be "a[\]c"]
+    expected: FAIL
+
+  [In <input type="password">, execCommand("inserttext", false, ), a[b\]c): input.inputType should be insertText]
+    expected: FAIL
+
+  [In <input type="password">, execCommand("inserttext", false, ), a[b\]c): input.target should be [object HTMLInputElement\]]
+    expected: FAIL
+
   [In <input type="password"> in contenteditable, execCommand("forwarddelete", false, null), a[b\]c): <input>.value should be "a[\]c"]
     expected: FAIL
 
@@ -498,6 +510,30 @@
     expected: FAIL
 
   [In <input type="password"> in contenteditable, execCommand("forwarddelete", false, null), a[\]bc): input.target should be [object HTMLInputElement\]]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("inserttext", false, **inserted**), a[b\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("inserttext", false, **inserted**), a[b\]c): <input>.value should be "a**inserted**[\]c"]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("inserttext", false, **inserted**), a[b\]c): input.inputType should be insertText]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("inserttext", false, **inserted**), a[b\]c): input.target should be [object HTMLInputElement\]]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("inserttext", false, ), a[b\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("inserttext", false, ), a[b\]c): <input>.value should be "a[\]c"]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("inserttext", false, ), a[b\]c): input.inputType should be insertText]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("inserttext", false, ), a[b\]c): input.target should be [object HTMLInputElement\]]
     expected: FAIL
 
 
@@ -574,13 +610,7 @@
   [In <input type="text">, execCommand("inserthtml", false, <b>inserted</b>), a[b\]c): The command should be enabled]
     expected: FAIL
 
-  [In <input type="text">, execCommand("inserttext", false, **inserted**), a[b\]c): The command should be supported]
-    expected: FAIL
-
   [In <input type="text">, execCommand("inserttext", false, **inserted**), a[b\]c): The command should be enabled]
-    expected: FAIL
-
-  [In <input type="text">, execCommand("inserttext", false, ), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <input type="text">, execCommand("inserttext", false, ), a[b\]c): The command should be enabled]
@@ -670,13 +700,7 @@
   [In <input type="text"> in contenteditable, execCommand("inserthtml", false, <b>inserted</b>), a[b\]c): The command should be enabled]
     expected: FAIL
 
-  [In <input type="text"> in contenteditable, execCommand("inserttext", false, **inserted**), a[b\]c): The command should be supported]
-    expected: FAIL
-
   [In <input type="text"> in contenteditable, execCommand("inserttext", false, **inserted**), a[b\]c): The command should be enabled]
-    expected: FAIL
-
-  [In <input type="text"> in contenteditable, execCommand("inserttext", false, ), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <input type="text"> in contenteditable, execCommand("inserttext", false, ), a[b\]c): The command should be enabled]
@@ -985,6 +1009,30 @@
   [In <input type="text">, execCommand("forwarddelete", false, null), a[\]bc): input.target should be [object HTMLInputElement\]]
     expected: FAIL
 
+  [In <input type="text">, execCommand("inserttext", false, **inserted**), a[b\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <input type="text">, execCommand("inserttext", false, **inserted**), a[b\]c): <input>.value should be "a**inserted**[\]c"]
+    expected: FAIL
+
+  [In <input type="text">, execCommand("inserttext", false, **inserted**), a[b\]c): input.inputType should be insertText]
+    expected: FAIL
+
+  [In <input type="text">, execCommand("inserttext", false, **inserted**), a[b\]c): input.target should be [object HTMLInputElement\]]
+    expected: FAIL
+
+  [In <input type="text">, execCommand("inserttext", false, ), a[b\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <input type="text">, execCommand("inserttext", false, ), a[b\]c): <input>.value should be "a[\]c"]
+    expected: FAIL
+
+  [In <input type="text">, execCommand("inserttext", false, ), a[b\]c): input.inputType should be insertText]
+    expected: FAIL
+
+  [In <input type="text">, execCommand("inserttext", false, ), a[b\]c): input.target should be [object HTMLInputElement\]]
+    expected: FAIL
+
   [In <input type="text"> in contenteditable, execCommand("forwarddelete", false, null), a[b\]c): <input>.value should be "a[\]c"]
     expected: FAIL
 
@@ -1001,6 +1049,30 @@
     expected: FAIL
 
   [In <input type="text"> in contenteditable, execCommand("forwarddelete", false, null), a[\]bc): input.target should be [object HTMLInputElement\]]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("inserttext", false, **inserted**), a[b\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("inserttext", false, **inserted**), a[b\]c): <input>.value should be "a**inserted**[\]c"]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("inserttext", false, **inserted**), a[b\]c): input.inputType should be insertText]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("inserttext", false, **inserted**), a[b\]c): input.target should be [object HTMLInputElement\]]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("inserttext", false, ), a[b\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("inserttext", false, ), a[b\]c): <input>.value should be "a[\]c"]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("inserttext", false, ), a[b\]c): input.inputType should be insertText]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("inserttext", false, ), a[b\]c): input.target should be [object HTMLInputElement\]]
     expected: FAIL
 
 
@@ -1077,13 +1149,7 @@
   [In <textarea>, execCommand("inserthtml", false, <b>inserted</b>), a[b\]c): The command should be enabled]
     expected: FAIL
 
-  [In <textarea>, execCommand("inserttext", false, **inserted**), a[b\]c): The command should be supported]
-    expected: FAIL
-
   [In <textarea>, execCommand("inserttext", false, **inserted**), a[b\]c): The command should be enabled]
-    expected: FAIL
-
-  [In <textarea>, execCommand("inserttext", false, ), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <textarea>, execCommand("inserttext", false, ), a[b\]c): The command should be enabled]
@@ -1179,13 +1245,7 @@
   [In <textarea> in contenteditable, execCommand("inserthtml", false, <b>inserted</b>), a[b\]c): The command should be enabled]
     expected: FAIL
 
-  [In <textarea> in contenteditable, execCommand("inserttext", false, **inserted**), a[b\]c): The command should be supported]
-    expected: FAIL
-
   [In <textarea> in contenteditable, execCommand("inserttext", false, **inserted**), a[b\]c): The command should be enabled]
-    expected: FAIL
-
-  [In <textarea> in contenteditable, execCommand("inserttext", false, ), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <textarea> in contenteditable, execCommand("inserttext", false, ), a[b\]c): The command should be enabled]
@@ -1524,6 +1584,30 @@
   [In <textarea>, execCommand("forwarddelete", false, null), a[\]bc): input.target should be [object HTMLTextAreaElement\]]
     expected: FAIL
 
+  [In <textarea>, execCommand("inserttext", false, **inserted**), a[b\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <textarea>, execCommand("inserttext", false, **inserted**), a[b\]c): <textarea>.value should be "a**inserted**[\]c"]
+    expected: FAIL
+
+  [In <textarea>, execCommand("inserttext", false, **inserted**), a[b\]c): input.inputType should be insertText]
+    expected: FAIL
+
+  [In <textarea>, execCommand("inserttext", false, **inserted**), a[b\]c): input.target should be [object HTMLTextAreaElement\]]
+    expected: FAIL
+
+  [In <textarea>, execCommand("inserttext", false, ), a[b\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <textarea>, execCommand("inserttext", false, ), a[b\]c): <textarea>.value should be "a[\]c"]
+    expected: FAIL
+
+  [In <textarea>, execCommand("inserttext", false, ), a[b\]c): input.inputType should be insertText]
+    expected: FAIL
+
+  [In <textarea>, execCommand("inserttext", false, ), a[b\]c): input.target should be [object HTMLTextAreaElement\]]
+    expected: FAIL
+
   [In <textarea> in contenteditable, execCommand("forwarddelete", false, null), a[b\]c): <textarea>.value should be "a[\]c"]
     expected: FAIL
 
@@ -1540,4 +1624,28 @@
     expected: FAIL
 
   [In <textarea> in contenteditable, execCommand("forwarddelete", false, null), a[\]bc): input.target should be [object HTMLTextAreaElement\]]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("inserttext", false, **inserted**), a[b\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("inserttext", false, **inserted**), a[b\]c): <textarea>.value should be "a**inserted**[\]c"]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("inserttext", false, **inserted**), a[b\]c): input.inputType should be insertText]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("inserttext", false, **inserted**), a[b\]c): input.target should be [object HTMLTextAreaElement\]]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("inserttext", false, ), a[b\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("inserttext", false, ), a[b\]c): <textarea>.value should be "a[\]c"]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("inserttext", false, ), a[b\]c): input.inputType should be insertText]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("inserttext", false, ), a[b\]c): input.target should be [object HTMLTextAreaElement\]]
     expected: FAIL

--- a/tests/wpt/meta/editing/other/inline-editing-host-has-placeholder-with-after-pseudo-element.html.ini
+++ b/tests/wpt/meta/editing/other/inline-editing-host-has-placeholder-with-after-pseudo-element.html.ini
@@ -1,3 +1,4 @@
 [inline-editing-host-has-placeholder-with-after-pseudo-element.html]
+  expected: TIMEOUT
   [The editing host should have inserted text]
     expected: FAIL

--- a/tests/wpt/meta/editing/other/inline-editing-host-has-placeholder-with-before-pseudo-element.html.ini
+++ b/tests/wpt/meta/editing/other/inline-editing-host-has-placeholder-with-before-pseudo-element.html.ini
@@ -1,3 +1,4 @@
 [inline-editing-host-has-placeholder-with-before-pseudo-element.html]
+  expected: TIMEOUT
   [The editing host should have inserted text]
     expected: FAIL

--- a/tests/wpt/meta/editing/other/insertlinebreak-with-white-space-style.tentative.html.ini
+++ b/tests/wpt/meta/editing/other/insertlinebreak-with-white-space-style.tentative.html.ini
@@ -1,4 +1,5 @@
 [insertlinebreak-with-white-space-style.tentative.html?pre]
+  expected: CRASH
   [<div contenteditable style="white-space:pre; display:block">abc[\]</div> (defaultparagraphseparator: div)]
     expected: FAIL
 
@@ -415,6 +416,7 @@
 
 
 [insertlinebreak-with-white-space-style.tentative.html?pre-line]
+  expected: CRASH
   [<div contenteditable style="white-space:pre-line; display:block">abc[\]</div> (defaultparagraphseparator: div)]
     expected: FAIL
 
@@ -831,6 +833,7 @@
 
 
 [insertlinebreak-with-white-space-style.tentative.html?pre-wrap]
+  expected: CRASH
   [<div contenteditable style="white-space:pre-wrap; display:block">abc[\]</div> (defaultparagraphseparator: div)]
     expected: FAIL
 
@@ -1247,6 +1250,7 @@
 
 
 [insertlinebreak-with-white-space-style.tentative.html?nowrap]
+  expected: CRASH
   [<div contenteditable style="white-space:nowrap; display:block">abc[\]</div> (defaultparagraphseparator: div)]
     expected: FAIL
 

--- a/tests/wpt/meta/editing/other/insertparagraph-in-editing-host-cannot-have-div.tentative.html.ini
+++ b/tests/wpt/meta/editing/other/insertparagraph-in-editing-host-cannot-have-div.tentative.html.ini
@@ -37,9 +37,6 @@
   [<span contenteditable style="display:block; white-space:pre-wrap"><span style="display:block;white-space:normal">a[\]b</span></span>]
     expected: FAIL
 
-  [<span contenteditable style="display:block; white-space:pre-wrap"><div>a[\]b</div></span>]
-    expected: FAIL
-
   [<span contenteditable style="display:block; white-space:pre-wrap"><div style="display:inline">a[\]b</div></span>]
     expected: FAIL
 
@@ -92,9 +89,6 @@
   [<span contenteditable style="display:inline-block; white-space:pre-line"><span style="display:block;white-space:normal">a[\]b</span></span>]
     expected: FAIL
 
-  [<span contenteditable style="display:inline-block; white-space:pre-line"><div>a[\]b</div></span>]
-    expected: FAIL
-
   [<span contenteditable style="display:inline-block; white-space:pre-line"><div style="display:inline">a[\]b</div></span>]
     expected: FAIL
 
@@ -116,9 +110,6 @@
     expected: FAIL
 
   [<p contenteditable style="display:block; white-space:normal"><span style="display:block;white-space:normal">a[\]b</span></p>]
-    expected: FAIL
-
-  [<p contenteditable style="display:block; white-space:normal"><div>a[\]b</div></p>]
     expected: FAIL
 
   [<p contenteditable style="display:block; white-space:normal"><div style="display:inline">a[\]b</div></p>]
@@ -173,9 +164,6 @@
   [<p contenteditable style="display:inline; white-space:pre-line"><span style="display:block;white-space:normal">a[\]b</span></p>]
     expected: FAIL
 
-  [<p contenteditable style="display:inline; white-space:pre-line"><div>a[\]b</div></p>]
-    expected: FAIL
-
   [<p contenteditable style="display:inline; white-space:pre-line"><div style="display:inline">a[\]b</div></p>]
     expected: FAIL
 
@@ -223,9 +211,6 @@
     expected: FAIL
 
   [<p contenteditable style="display:inline-block; white-space:normal"><span style="display:block;white-space:normal">a[\]b</span></p>]
-    expected: FAIL
-
-  [<p contenteditable style="display:inline-block; white-space:normal"><div>a[\]b</div></p>]
     expected: FAIL
 
   [<p contenteditable style="display:inline-block; white-space:normal"><div style="display:inline">a[\]b</div></p>]
@@ -277,9 +262,6 @@
   [<span contenteditable style="display:inline-block; white-space:pre"><span style="display:block;white-space:normal">a[\]b</span></span>]
     expected: FAIL
 
-  [<span contenteditable style="display:inline-block; white-space:pre"><div>a[\]b</div></span>]
-    expected: FAIL
-
   [<span contenteditable style="display:inline-block; white-space:pre"><div style="display:inline">a[\]b</div></span>]
     expected: FAIL
 
@@ -306,9 +288,6 @@
   [<span contenteditable style="display:inline; white-space:pre-line"><span style="display:block;white-space:normal">a[\]b</span></span>]
     expected: FAIL
 
-  [<span contenteditable style="display:inline; white-space:pre-line"><div>a[\]b</div></span>]
-    expected: FAIL
-
   [<span contenteditable style="display:inline; white-space:pre-line"><div style="display:inline">a[\]b</div></span>]
     expected: FAIL
 
@@ -333,9 +312,6 @@
     expected: FAIL
 
   [<p contenteditable style="display:block; white-space:pre-wrap"><span style="display:block;white-space:normal">a[\]b</span></p>]
-    expected: FAIL
-
-  [<p contenteditable style="display:block; white-space:pre-wrap"><div>a[\]b</div></p>]
     expected: FAIL
 
   [<p contenteditable style="display:block; white-space:pre-wrap"><div style="display:inline">a[\]b</div></p>]
@@ -384,9 +360,6 @@
   [<p contenteditable style="display:inline; white-space:normal"><span style="display:block;white-space:normal">a[\]b</span></p>]
     expected: FAIL
 
-  [<p contenteditable style="display:inline; white-space:normal"><div>a[\]b</div></p>]
-    expected: FAIL
-
   [<p contenteditable style="display:inline; white-space:normal"><div style="display:inline">a[\]b</div></p>]
     expected: FAIL
 
@@ -413,9 +386,6 @@
   [<p contenteditable style="display:inline-block; white-space:pre-wrap"><span style="display:block;white-space:normal">a[\]b</span></p>]
     expected: FAIL
 
-  [<p contenteditable style="display:inline-block; white-space:pre-wrap"><div>a[\]b</div></p>]
-    expected: FAIL
-
   [<p contenteditable style="display:inline-block; white-space:pre-wrap"><div style="display:inline">a[\]b</div></p>]
     expected: FAIL
 
@@ -437,9 +407,6 @@
     expected: FAIL
 
   [<span contenteditable style="display:inline-block; white-space:normal"><span style="display:block;white-space:normal">a[\]b</span></span>]
-    expected: FAIL
-
-  [<span contenteditable style="display:inline-block; white-space:normal"><div>a[\]b</div></span>]
     expected: FAIL
 
   [<span contenteditable style="display:inline-block; white-space:normal"><div style="display:inline">a[\]b</div></span>]
@@ -466,9 +433,6 @@
     expected: FAIL
 
   [<p contenteditable style="display:inline; white-space:pre"><span style="display:block;white-space:normal">a[\]b</span></p>]
-    expected: FAIL
-
-  [<p contenteditable style="display:inline; white-space:pre"><div>a[\]b</div></p>]
     expected: FAIL
 
   [<p contenteditable style="display:inline; white-space:pre"><div style="display:inline">a[\]b</div></p>]
@@ -523,9 +487,6 @@
   [<p contenteditable style="display:inline-block; white-space:pre-line"><span style="display:block;white-space:normal">a[\]b</span></p>]
     expected: FAIL
 
-  [<p contenteditable style="display:inline-block; white-space:pre-line"><div>a[\]b</div></p>]
-    expected: FAIL
-
   [<p contenteditable style="display:inline-block; white-space:pre-line"><div style="display:inline">a[\]b</div></p>]
     expected: FAIL
 
@@ -552,9 +513,6 @@
   [<span contenteditable style="display:inline-block; white-space:pre-wrap"><span style="display:block;white-space:normal">a[\]b</span></span>]
     expected: FAIL
 
-  [<span contenteditable style="display:inline-block; white-space:pre-wrap"><div>a[\]b</div></span>]
-    expected: FAIL
-
   [<span contenteditable style="display:inline-block; white-space:pre-wrap"><div style="display:inline">a[\]b</div></span>]
     expected: FAIL
 
@@ -579,9 +537,6 @@
     expected: FAIL
 
   [<p contenteditable style="display:block; white-space:pre"><span style="display:block;white-space:normal">a[\]b</span></p>]
-    expected: FAIL
-
-  [<p contenteditable style="display:block; white-space:pre"><div>a[\]b</div></p>]
     expected: FAIL
 
   [<p contenteditable style="display:block; white-space:pre"><div style="display:inline">a[\]b</div></p>]
@@ -636,9 +591,6 @@
   [<span contenteditable style="display:block; white-space:pre"><span style="display:block;white-space:normal">a[\]b</span></span>]
     expected: FAIL
 
-  [<span contenteditable style="display:block; white-space:pre"><div>a[\]b</div></span>]
-    expected: FAIL
-
   [<span contenteditable style="display:block; white-space:pre"><div style="display:inline">a[\]b</div></span>]
     expected: FAIL
 
@@ -660,9 +612,6 @@
     expected: FAIL
 
   [<span contenteditable style="display:block; white-space:normal"><span style="display:block;white-space:normal">a[\]b</span></span>]
-    expected: FAIL
-
-  [<span contenteditable style="display:block; white-space:normal"><div>a[\]b</div></span>]
     expected: FAIL
 
   [<span contenteditable style="display:block; white-space:normal"><div style="display:inline">a[\]b</div></span>]
@@ -717,9 +666,6 @@
   [<span contenteditable style="display:inline; white-space:pre"><span style="display:block;white-space:normal">a[\]b</span></span>]
     expected: FAIL
 
-  [<span contenteditable style="display:inline; white-space:pre"><div>a[\]b</div></span>]
-    expected: FAIL
-
   [<span contenteditable style="display:inline; white-space:pre"><div style="display:inline">a[\]b</div></span>]
     expected: FAIL
 
@@ -770,9 +716,6 @@
     expected: FAIL
 
   [<p contenteditable style="display:block; white-space:pre-line"><span style="display:block;white-space:normal">a[\]b</span></p>]
-    expected: FAIL
-
-  [<p contenteditable style="display:block; white-space:pre-line"><div>a[\]b</div></p>]
     expected: FAIL
 
   [<p contenteditable style="display:block; white-space:pre-line"><div style="display:inline">a[\]b</div></p>]
@@ -848,9 +791,6 @@
     expected: FAIL
 
   [<span contenteditable style="display:block; white-space:pre-line"><span style="display:block;white-space:normal">a[\]b</span></span>]
-    expected: FAIL
-
-  [<span contenteditable style="display:block; white-space:pre-line"><div>a[\]b</div></span>]
     expected: FAIL
 
   [<span contenteditable style="display:block; white-space:pre-line"><div style="display:inline">a[\]b</div></span>]
@@ -931,9 +871,6 @@
   [<span contenteditable style="display:inline; white-space:pre-wrap"><span style="display:block;white-space:normal">a[\]b</span></span>]
     expected: FAIL
 
-  [<span contenteditable style="display:inline; white-space:pre-wrap"><div>a[\]b</div></span>]
-    expected: FAIL
-
   [<span contenteditable style="display:inline; white-space:pre-wrap"><div style="display:inline">a[\]b</div></span>]
     expected: FAIL
 
@@ -984,9 +921,6 @@
     expected: FAIL
 
   [<p contenteditable style="display:inline; white-space:pre-wrap"><span style="display:block;white-space:normal">a[\]b</span></p>]
-    expected: FAIL
-
-  [<p contenteditable style="display:inline; white-space:pre-wrap"><div>a[\]b</div></p>]
     expected: FAIL
 
   [<p contenteditable style="display:inline; white-space:pre-wrap"><div style="display:inline">a[\]b</div></p>]
@@ -1064,9 +998,6 @@
   [<span contenteditable style="display:inline; white-space:normal"><span style="display:block;white-space:normal">a[\]b</span></span>]
     expected: FAIL
 
-  [<span contenteditable style="display:inline; white-space:normal"><div>a[\]b</div></span>]
-    expected: FAIL
-
   [<span contenteditable style="display:inline; white-space:normal"><div style="display:inline">a[\]b</div></span>]
     expected: FAIL
 
@@ -1140,9 +1071,6 @@
     expected: FAIL
 
   [<p contenteditable style="display:inline-block; white-space:pre"><span style="display:block;white-space:normal">a[\]b</span></p>]
-    expected: FAIL
-
-  [<p contenteditable style="display:inline-block; white-space:pre"><div>a[\]b</div></p>]
     expected: FAIL
 
   [<p contenteditable style="display:inline-block; white-space:pre"><div style="display:inline">a[\]b</div></p>]

--- a/tests/wpt/meta/editing/other/insertparagraph-with-white-space-style.tentative.html.ini
+++ b/tests/wpt/meta/editing/other/insertparagraph-with-white-space-style.tentative.html.ini
@@ -2,6 +2,7 @@
   expected: CRASH
 
 [insertparagraph-with-white-space-style.tentative.html?white-space=pre-wrap&command=insertText]
+  expected: CRASH
   [<div contenteditable style="white-space:pre-wrap; display:block">abc[\]</div> (defaultParagraphSeparator: div)]
     expected: FAIL
 
@@ -421,6 +422,7 @@
   expected: CRASH
 
 [insertparagraph-with-white-space-style.tentative.html?white-space=pre-line&command=insertText]
+  expected: CRASH
   [<div contenteditable style="white-space:pre-line; display:block">abc[\]</div> (defaultParagraphSeparator: div)]
     expected: FAIL
 
@@ -837,6 +839,7 @@
 
 
 [insertparagraph-with-white-space-style.tentative.html?white-space=pre&command=insertText]
+  expected: CRASH
   [<div contenteditable style="white-space:pre; display:block">abc[\]</div> (defaultParagraphSeparator: div)]
     expected: FAIL
 
@@ -1253,6 +1256,7 @@
 
 
 [insertparagraph-with-white-space-style.tentative.html?white-space=nowrap&command=insertText]
+  expected: CRASH
   [<div contenteditable style="white-space:nowrap; display:block">abc[\]</div> (defaultParagraphSeparator: div)]
     expected: FAIL
 

--- a/tests/wpt/meta/editing/other/link-boundaries-insertion.html.ini
+++ b/tests/wpt/meta/editing/other/link-boundaries-insertion.html.ini
@@ -1,6 +1,0 @@
-[link-boundaries-insertion.html]
-  [Insert text into the selection at the end of a link]
-    expected: FAIL
-
-  [Insert text into the selection at the beginning of a link]
-    expected: FAIL

--- a/tests/wpt/meta/editing/other/recursive-exec-command-calls.tentative.html.ini
+++ b/tests/wpt/meta/editing/other/recursive-exec-command-calls.tentative.html.ini
@@ -1,3 +1,4 @@
 [recursive-exec-command-calls.tentative.html]
+  expected: ERROR
   [Recursive `Document.execCommand()` shouldn't be supported]
     expected: FAIL

--- a/tests/wpt/meta/editing/other/restoration.html.ini
+++ b/tests/wpt/meta/editing/other/restoration.html.ini
@@ -1,26 +1,8 @@
 [restoration.html]
-  [insertparagraph  starting bold]
-    expected: FAIL
-
-  [insertparagraph  starting not bold]
-    expected: FAIL
-
   [insertlinebreak  starting bold]
     expected: FAIL
 
   [insertlinebreak  starting not bold]
-    expected: FAIL
-
-  [delete  starting bold]
-    expected: FAIL
-
-  [delete  starting not bold]
-    expected: FAIL
-
-  [forwarddelete  starting bold]
-    expected: FAIL
-
-  [forwarddelete  starting not bold]
     expected: FAIL
 
   [insertorderedlist  starting bold]
@@ -81,22 +63,4 @@
     expected: FAIL
 
   [formatblock blockquote starting not bold]
-    expected: FAIL
-
-  [inserthorizontalrule  starting bold]
-    expected: FAIL
-
-  [inserthorizontalrule  starting not bold]
-    expected: FAIL
-
-  [insertimage a starting bold]
-    expected: FAIL
-
-  [insertimage a starting not bold]
-    expected: FAIL
-
-  [inserttext bar starting bold]
-    expected: FAIL
-
-  [inserttext bar starting not bold]
     expected: FAIL

--- a/tests/wpt/meta/editing/plaintext-only/insertText.html.ini
+++ b/tests/wpt/meta/editing/plaintext-only/insertText.html.ini
@@ -11,55 +11,28 @@
   [Typing "a" when {}<br>]
     expected: FAIL
 
-  [execCommand("insertText", false, "a") when A[\]B]
-    expected: FAIL
-
   [Typing "a" when A[\]B]
-    expected: FAIL
-
-  [execCommand("insertText", false, "a") when <b>A[\]B</b>]
     expected: FAIL
 
   [Typing "a" when <b>A[\]B</b>]
     expected: FAIL
 
-  [execCommand("insertText", false, " ") when A[\]B]
-    expected: FAIL
-
   [Typing " " when A[\]B]
-    expected: FAIL
-
-  [execCommand("insertText", false, " ") when <b>A[\]B</b>]
     expected: FAIL
 
   [Typing " " when <b>A[\]B</b>]
     expected: FAIL
 
-  [execCommand("insertText", false, "  ") when <b>A[\]B</b>]
-    expected: FAIL
-
   [Typing "  " when <b>A[\]B</b>]
-    expected: FAIL
-
-  [execCommand("insertText", false, "  ") when <p style="white-space:normal">A[\]B</p>]
     expected: FAIL
 
   [Typing "  " when <p style="white-space:normal">A[\]B</p>]
     expected: FAIL
 
-  [execCommand("insertText", false, "  ") when <p style="white-space:pre">A[\]B</p>]
-    expected: FAIL
-
   [Typing "  " when <p style="white-space:pre">A[\]B</p>]
     expected: FAIL
 
-  [execCommand("insertText", false, "  ") when <p style="white-space:pre-line">A[\]B</p>]
-    expected: FAIL
-
   [Typing "  " when <p style="white-space:pre-line">A[\]B</p>]
-    expected: FAIL
-
-  [execCommand("insertText", false, "  ") when <p style="white-space:pre-wrap">A[\]B</p>]
     expected: FAIL
 
   [Typing "  " when <p style="white-space:pre-wrap">A[\]B</p>]
@@ -141,9 +114,6 @@
     expected: FAIL
 
   [Typing "a" when <p><b>A[\]</b></b> and execCommand("insertParagraph") and move caret to the preceding paragraph temporarily]
-    expected: FAIL
-
-  [execCommand("insertText", false, "b") when a[\]<br>]
     expected: FAIL
 
   [Typing "b" when a[\]<br>]
@@ -169,55 +139,28 @@
   [Typing "a" when [\]\\n]
     expected: FAIL
 
-  [execCommand("insertText", false, "a") when A[\]B]
-    expected: FAIL
-
   [Typing "a" when A[\]B]
-    expected: FAIL
-
-  [execCommand("insertText", false, "a") when <b>A[\]B</b>]
     expected: FAIL
 
   [Typing "a" when <b>A[\]B</b>]
     expected: FAIL
 
-  [execCommand("insertText", false, " ") when A[\]B]
-    expected: FAIL
-
   [Typing " " when A[\]B]
-    expected: FAIL
-
-  [execCommand("insertText", false, " ") when <b>A[\]B</b>]
     expected: FAIL
 
   [Typing " " when <b>A[\]B</b>]
     expected: FAIL
 
-  [execCommand("insertText", false, "  ") when <b>A[\]B</b>]
-    expected: FAIL
-
   [Typing "  " when <b>A[\]B</b>]
-    expected: FAIL
-
-  [execCommand("insertText", false, "  ") when <p style="white-space:normal">A[\]B</p>]
     expected: FAIL
 
   [Typing "  " when <p style="white-space:normal">A[\]B</p>]
     expected: FAIL
 
-  [execCommand("insertText", false, "  ") when <p style="white-space:pre">A[\]B</p>]
-    expected: FAIL
-
   [Typing "  " when <p style="white-space:pre">A[\]B</p>]
     expected: FAIL
 
-  [execCommand("insertText", false, "  ") when <p style="white-space:pre-line">A[\]B</p>]
-    expected: FAIL
-
   [Typing "  " when <p style="white-space:pre-line">A[\]B</p>]
-    expected: FAIL
-
-  [execCommand("insertText", false, "  ") when <p style="white-space:pre-wrap">A[\]B</p>]
     expected: FAIL
 
   [Typing "  " when <p style="white-space:pre-wrap">A[\]B</p>]
@@ -301,13 +244,7 @@
   [Typing "a" when <p><b>A[\]</b></b> and execCommand("insertParagraph") and move caret to the preceding paragraph temporarily]
     expected: FAIL
 
-  [execCommand("insertText", false, "b") when a[\]<br>]
-    expected: FAIL
-
   [Typing "b" when a[\]<br>]
-    expected: FAIL
-
-  [execCommand("insertText", false, "b") when a[\]\\n]
     expected: FAIL
 
   [Typing "b" when a[\]\\n]
@@ -333,55 +270,28 @@
   [Typing "a" when [\]\\n]
     expected: FAIL
 
-  [execCommand("insertText", false, "a") when A[\]B]
-    expected: FAIL
-
   [Typing "a" when A[\]B]
-    expected: FAIL
-
-  [execCommand("insertText", false, "a") when <b>A[\]B</b>]
     expected: FAIL
 
   [Typing "a" when <b>A[\]B</b>]
     expected: FAIL
 
-  [execCommand("insertText", false, " ") when A[\]B]
-    expected: FAIL
-
   [Typing " " when A[\]B]
-    expected: FAIL
-
-  [execCommand("insertText", false, " ") when <b>A[\]B</b>]
     expected: FAIL
 
   [Typing " " when <b>A[\]B</b>]
     expected: FAIL
 
-  [execCommand("insertText", false, "  ") when <b>A[\]B</b>]
-    expected: FAIL
-
   [Typing "  " when <b>A[\]B</b>]
-    expected: FAIL
-
-  [execCommand("insertText", false, "  ") when <p style="white-space:normal">A[\]B</p>]
     expected: FAIL
 
   [Typing "  " when <p style="white-space:normal">A[\]B</p>]
     expected: FAIL
 
-  [execCommand("insertText", false, "  ") when <p style="white-space:pre">A[\]B</p>]
-    expected: FAIL
-
   [Typing "  " when <p style="white-space:pre">A[\]B</p>]
     expected: FAIL
 
-  [execCommand("insertText", false, "  ") when <p style="white-space:pre-line">A[\]B</p>]
-    expected: FAIL
-
   [Typing "  " when <p style="white-space:pre-line">A[\]B</p>]
-    expected: FAIL
-
-  [execCommand("insertText", false, "  ") when <p style="white-space:pre-wrap">A[\]B</p>]
     expected: FAIL
 
   [Typing "  " when <p style="white-space:pre-wrap">A[\]B</p>]
@@ -465,13 +375,7 @@
   [Typing "a" when <p><b>A[\]</b></b> and execCommand("insertParagraph") and move caret to the preceding paragraph temporarily]
     expected: FAIL
 
-  [execCommand("insertText", false, "b") when a[\]<br>]
-    expected: FAIL
-
   [Typing "b" when a[\]<br>]
-    expected: FAIL
-
-  [execCommand("insertText", false, "b") when a[\]\\n]
     expected: FAIL
 
   [Typing "b" when a[\]\\n]
@@ -497,55 +401,28 @@
   [Typing "a" when [\]\\n]
     expected: FAIL
 
-  [execCommand("insertText", false, "a") when A[\]B]
-    expected: FAIL
-
   [Typing "a" when A[\]B]
-    expected: FAIL
-
-  [execCommand("insertText", false, "a") when <b>A[\]B</b>]
     expected: FAIL
 
   [Typing "a" when <b>A[\]B</b>]
     expected: FAIL
 
-  [execCommand("insertText", false, " ") when A[\]B]
-    expected: FAIL
-
   [Typing " " when A[\]B]
-    expected: FAIL
-
-  [execCommand("insertText", false, " ") when <b>A[\]B</b>]
     expected: FAIL
 
   [Typing " " when <b>A[\]B</b>]
     expected: FAIL
 
-  [execCommand("insertText", false, "  ") when <b>A[\]B</b>]
-    expected: FAIL
-
   [Typing "  " when <b>A[\]B</b>]
-    expected: FAIL
-
-  [execCommand("insertText", false, "  ") when <p style="white-space:normal">A[\]B</p>]
     expected: FAIL
 
   [Typing "  " when <p style="white-space:normal">A[\]B</p>]
     expected: FAIL
 
-  [execCommand("insertText", false, "  ") when <p style="white-space:pre">A[\]B</p>]
-    expected: FAIL
-
   [Typing "  " when <p style="white-space:pre">A[\]B</p>]
     expected: FAIL
 
-  [execCommand("insertText", false, "  ") when <p style="white-space:pre-line">A[\]B</p>]
-    expected: FAIL
-
   [Typing "  " when <p style="white-space:pre-line">A[\]B</p>]
-    expected: FAIL
-
-  [execCommand("insertText", false, "  ") when <p style="white-space:pre-wrap">A[\]B</p>]
     expected: FAIL
 
   [Typing "  " when <p style="white-space:pre-wrap">A[\]B</p>]
@@ -629,13 +506,7 @@
   [Typing "a" when <p><b>A[\]</b></b> and execCommand("insertParagraph") and move caret to the preceding paragraph temporarily]
     expected: FAIL
 
-  [execCommand("insertText", false, "b") when a[\]<br>]
-    expected: FAIL
-
   [Typing "b" when a[\]<br>]
-    expected: FAIL
-
-  [execCommand("insertText", false, "b") when a[\]\\n]
     expected: FAIL
 
   [Typing "b" when a[\]\\n]

--- a/tests/wpt/meta/editing/run/forecolor.html.ini
+++ b/tests/wpt/meta/editing/run/forecolor.html.ini
@@ -450,16 +450,7 @@
   [[["styleWithCSS","false"\],["foreColor","#ff0000"\]\] "<font size=\\"7\\" face=monospace>[abc\]</font>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","true"\],["foreColor","#0000FF"\],["styleWithCSS","false"\],["insertText","b"\]\] "a[\]c": execCommand("insertText", false, "b") return value]
-    expected: FAIL
-
-  [[["styleWithCSS","true"\],["foreColor","#0000FF"\],["styleWithCSS","false"\],["insertText","b"\]\] "a[\]c" compare innerHTML]
-    expected: FAIL
-
   [[["styleWithCSS","true"\],["foreColor","rgb(0, 0, 255)"\],["styleWithCSS","false"\],["insertText","b"\]\] "a[\]c": execCommand("foreColor", false, "rgb(0, 0, 255)") return value]
-    expected: FAIL
-
-  [[["styleWithCSS","true"\],["foreColor","rgb(0, 0, 255)"\],["styleWithCSS","false"\],["insertText","b"\]\] "a[\]c": execCommand("insertText", false, "b") return value]
     expected: FAIL
 
   [[["styleWithCSS","true"\],["foreColor","rgb(0, 0, 255)"\],["styleWithCSS","false"\],["insertText","b"\]\] "a[\]c" compare innerHTML]
@@ -468,31 +459,16 @@
   [[["styleWithCSS","true"\],["foreColor","rgba(0, 0, 255, 0.5)"\],["styleWithCSS","false"\],["insertText","b"\]\] "a[\]c": execCommand("foreColor", false, "rgba(0, 0, 255, 0.5)") return value]
     expected: FAIL
 
-  [[["styleWithCSS","true"\],["foreColor","rgba(0, 0, 255, 0.5)"\],["styleWithCSS","false"\],["insertText","b"\]\] "a[\]c": execCommand("insertText", false, "b") return value]
-    expected: FAIL
-
   [[["styleWithCSS","true"\],["foreColor","rgba(0, 0, 255, 0.5)"\],["styleWithCSS","false"\],["insertText","b"\]\] "a[\]c" compare innerHTML]
     expected: FAIL
 
   [[["styleWithCSS","true"\],["foreColor","transparent"\],["styleWithCSS","false"\],["insertText","b"\]\] "a[\]c": execCommand("foreColor", false, "transparent") return value]
     expected: FAIL
 
-  [[["styleWithCSS","true"\],["foreColor","transparent"\],["styleWithCSS","false"\],["insertText","b"\]\] "a[\]c": execCommand("insertText", false, "b") return value]
-    expected: FAIL
-
   [[["styleWithCSS","true"\],["foreColor","transparent"\],["styleWithCSS","false"\],["insertText","b"\]\] "a[\]c" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["foreColor","#0000FF"\],["styleWithCSS","true"\],["insertText","b"\]\] "a[\]c": execCommand("insertText", false, "b") return value]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["foreColor","#0000FF"\],["styleWithCSS","true"\],["insertText","b"\]\] "a[\]c" compare innerHTML]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["foreColor","rgb(0, 0, 255)"\],["styleWithCSS","true"\],["insertText","b"\]\] "a[\]c": execCommand("foreColor", false, "rgb(0, 0, 255)") return value]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["foreColor","rgb(0, 0, 255)"\],["styleWithCSS","true"\],["insertText","b"\]\] "a[\]c": execCommand("insertText", false, "b") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["foreColor","rgb(0, 0, 255)"\],["styleWithCSS","true"\],["insertText","b"\]\] "a[\]c" compare innerHTML]
@@ -501,16 +477,10 @@
   [[["styleWithCSS","false"\],["foreColor","rgba(0, 0, 255, 0.5)"\],["styleWithCSS","true"\],["insertText","b"\]\] "a[\]c": execCommand("foreColor", false, "rgba(0, 0, 255, 0.5)") return value]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["foreColor","rgba(0, 0, 255, 0.5)"\],["styleWithCSS","true"\],["insertText","b"\]\] "a[\]c": execCommand("insertText", false, "b") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["foreColor","rgba(0, 0, 255, 0.5)"\],["styleWithCSS","true"\],["insertText","b"\]\] "a[\]c" compare innerHTML]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["foreColor","transparent"\],["styleWithCSS","true"\],["insertText","b"\]\] "a[\]c": execCommand("foreColor", false, "transparent") return value]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["foreColor","transparent"\],["styleWithCSS","true"\],["insertText","b"\]\] "a[\]c": execCommand("insertText", false, "b") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["foreColor","transparent"\],["styleWithCSS","true"\],["insertText","b"\]\] "a[\]c" compare innerHTML]

--- a/tests/wpt/meta/editing/run/insertorderedlist.html.ini
+++ b/tests/wpt/meta/editing/run/insertorderedlist.html.ini
@@ -539,9 +539,6 @@
   [[["insertorderedlist",""\],["inserttext","abc"\]\] "{}": execCommand("insertorderedlist", false, "") return value]
     expected: FAIL
 
-  [[["insertorderedlist",""\],["inserttext","abc"\]\] "{}": execCommand("inserttext", false, "abc") return value]
-    expected: FAIL
-
   [[["insertorderedlist",""\],["inserttext","abc"\]\] "{}" compare innerHTML]
     expected: FAIL
 
@@ -555,9 +552,6 @@
     expected: FAIL
 
   [[["insertorderedlist",""\],["inserttext","abc"\]\] "<div>{}</div>": execCommand("insertorderedlist", false, "") return value]
-    expected: FAIL
-
-  [[["insertorderedlist",""\],["inserttext","abc"\]\] "<div>{}</div>": execCommand("inserttext", false, "abc") return value]
     expected: FAIL
 
   [[["insertorderedlist",""\],["inserttext","abc"\]\] "<div>{}</div>" compare innerHTML]
@@ -575,9 +569,6 @@
   [[["insertorderedlist",""\],["inserttext","abc"\]\] "<div>{}<br></div>": execCommand("insertorderedlist", false, "") return value]
     expected: FAIL
 
-  [[["insertorderedlist",""\],["inserttext","abc"\]\] "<div>{}<br></div>": execCommand("inserttext", false, "abc") return value]
-    expected: FAIL
-
   [[["insertorderedlist",""\],["inserttext","abc"\]\] "<div>{}<br></div>" compare innerHTML]
     expected: FAIL
 
@@ -593,9 +584,6 @@
   [[["insertorderedlist",""\],["inserttext","abc"\]\] "<p>{}</p>": execCommand("insertorderedlist", false, "") return value]
     expected: FAIL
 
-  [[["insertorderedlist",""\],["inserttext","abc"\]\] "<p>{}</p>": execCommand("inserttext", false, "abc") return value]
-    expected: FAIL
-
   [[["insertorderedlist",""\],["inserttext","abc"\]\] "<p>{}</p>" compare innerHTML]
     expected: FAIL
 
@@ -609,9 +597,6 @@
     expected: FAIL
 
   [[["insertorderedlist",""\],["inserttext","abc"\]\] "<p>{}<br></p>": execCommand("insertorderedlist", false, "") return value]
-    expected: FAIL
-
-  [[["insertorderedlist",""\],["inserttext","abc"\]\] "<p>{}<br></p>": execCommand("inserttext", false, "abc") return value]
     expected: FAIL
 
   [[["insertorderedlist",""\],["inserttext","abc"\]\] "<p>{}<br></p>" compare innerHTML]

--- a/tests/wpt/meta/editing/run/insertparagraph.html.ini
+++ b/tests/wpt/meta/editing/run/insertparagraph.html.ini
@@ -519,37 +519,19 @@
   [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "<div>abc</div><p>[def\]</p>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\],["inserttext","d"\]\] "<div>abc</div><div>[def\]</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["insertparagraph",""\],["inserttext","d"\]\] "<div>abc</div><div>[def\]</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\],["inserttext","d"\]\] "<div>abc</div><p>[def\]</p>": execCommand("inserttext", false, "d") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["insertparagraph",""\],["inserttext","d"\]\] "<div>abc</div><p>[def\]</p>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\],["inserttext","d"\]\] "<ol><li>[abc\]</li></ol>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["insertparagraph",""\],["inserttext","d"\]\] "<ol><li>[abc\]</li></ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\],["inserttext","d"\]\] "<ol><li>abc</li><li>[def\]</li></ol>": execCommand("inserttext", false, "d") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["insertparagraph",""\],["inserttext","d"\]\] "<ol><li>abc</li><li>[def\]</li></ol>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\],["inserttext","d"\]\] "<ol><li>abc</li><li>[def\]</li><li>ghi</li></ol>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["insertparagraph",""\],["inserttext","d"\]\] "<ol><li>abc</li><li>[def\]</li><li>ghi</li></ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\],["inserttext","a"\]\] "<ol><li>[abc\]</li><li>def</li></ol>": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["insertparagraph",""\],["inserttext","a"\]\] "<ol><li>[abc\]</li><li>def</li></ol>" compare innerHTML]
@@ -559,9 +541,6 @@
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "<h3>[abc\]</h3>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\],["inserttext","a"\]\] "<h3>[abc\]</h3>": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["insertparagraph",""\],["inserttext","a"\]\] "<h3>[abc\]</h3>" compare innerHTML]

--- a/tests/wpt/meta/editing/run/inserttext.html.ini
+++ b/tests/wpt/meta/editing/run/inserttext.html.ini
@@ -1,891 +1,295 @@
 [inserttext.html?2001-last]
-  [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<font color=blue><a href=http://www.google.com>bar\]</a></font>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<font color=blue><a href=http://www.google.com>bar\]</a></font>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<font color=blue><a href=http://www.google.com>bar\]</a></font>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<font color=blue><a href=http://www.google.com>bar\]</a></font>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<a href=http://www.google.com><font color=brown>bar\]</font></a>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<a href=http://www.google.com><font color=brown>bar\]</font></a>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<a href=http://www.google.com><font color=brown>bar\]</font></a>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<a href=http://www.google.com><font color=brown>bar\]</font></a>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<font color=brown><a href=http://www.google.com>bar\]</a></font>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<font color=brown><a href=http://www.google.com>bar\]</a></font>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<font color=brown><a href=http://www.google.com>bar\]</a></font>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<font color=brown><a href=http://www.google.com>bar\]</a></font>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<a href=http://www.google.com><font color=black>bar\]</font></a>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<a href=http://www.google.com><font color=black>bar\]</font></a>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<a href=http://www.google.com><font color=black>bar\]</font></a>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<a href=http://www.google.com><font color=black>bar\]</font></a>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<a href=http://www.google.com><u>bar\]</u></a>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<a href=http://www.google.com><u>bar\]</u></a>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<a href=http://www.google.com><u>bar\]</u></a>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<a href=http://www.google.com><u>bar\]</u></a>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<u><a href=http://www.google.com>bar\]</a></u>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<u><a href=http://www.google.com>bar\]</a></u>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<u><a href=http://www.google.com>bar\]</a></u>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<u><a href=http://www.google.com>bar\]</a></u>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<sub><font size=2>bar\]</font></sub>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<sub><font size=2>bar\]</font></sub>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<sub><font size=2>bar\]</font></sub>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<sub><font size=2>bar\]</font></sub>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<font size=2><sub>bar\]</sub></font>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<font size=2><sub>bar\]</sub></font>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<font size=2><sub>bar\]</sub></font>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<font size=2><sub>bar\]</sub></font>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<sub><font size=3>bar\]</font></sub>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<sub><font size=3>bar\]</font></sub>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<sub><font size=3>bar\]</font></sub>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<sub><font size=3>bar\]</font></sub>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<font size=3><sub>bar\]</sub></font>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<font size=3><sub>bar\]</sub></font>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<font size=3><sub>bar\]</sub></font>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<font size=3><sub>bar\]</sub></font>baz" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","a"\]\] "foo<b>[bar</b>baz\]": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["inserttext","a"\]\] "foo<b>[bar</b>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","a"\]\] "foo<i>[bar</i>baz\]": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["inserttext","a"\]\] "foo<i>[bar</i>baz\]" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","a"\]\] "foo<s>[bar</s>baz\]": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["inserttext","a"\]\] "foo<s>[bar</s>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","a"\]\] "foo<sub>[bar</sub>baz\]": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["inserttext","a"\]\] "foo<sub>[bar</sub>baz\]" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","a"\]\] "foo<sup>[bar</sup>baz\]": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["inserttext","a"\]\] "foo<sup>[bar</sup>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","a"\]\] "foo<u>[bar</u>baz\]": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["inserttext","a"\]\] "foo<u>[bar</u>baz\]" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","a"\]\] "foo<a href=http://www.google.com>[bar</a>baz\]": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["inserttext","a"\]\] "foo<a href=http://www.google.com>[bar</a>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","a"\]\] "foo<font face=sans-serif>[bar</font>baz\]": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["inserttext","a"\]\] "foo<font face=sans-serif>[bar</font>baz\]" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","a"\]\] "foo<font size=4>[bar</font>baz\]": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["inserttext","a"\]\] "foo<font size=4>[bar</font>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","a"\]\] "foo<font color=#0000FF>[bar</font>baz\]": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["inserttext","a"\]\] "foo<font color=#0000FF>[bar</font>baz\]" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","a"\]\] "foo<span style=background-color:#00FFFF>[bar</span>baz\]": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["inserttext","a"\]\] "foo<span style=background-color:#00FFFF>[bar</span>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","a"\]\] "foo<a href=http://www.google.com><font color=blue>[bar</font></a>baz\]": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["inserttext","a"\]\] "foo<a href=http://www.google.com><font color=blue>[bar</font></a>baz\]" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","a"\]\] "foo<font color=blue><a href=http://www.google.com>[bar</a></font>baz\]": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["inserttext","a"\]\] "foo<font color=blue><a href=http://www.google.com>[bar</a></font>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","a"\]\] "foo<a href=http://www.google.com><font color=brown>[bar</font></a>baz\]": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["inserttext","a"\]\] "foo<a href=http://www.google.com><font color=brown>[bar</font></a>baz\]" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","a"\]\] "foo<font color=brown><a href=http://www.google.com>[bar</a></font>baz\]": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["inserttext","a"\]\] "foo<font color=brown><a href=http://www.google.com>[bar</a></font>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","a"\]\] "foo<a href=http://www.google.com><font color=black>[bar</font></a>baz\]": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["inserttext","a"\]\] "foo<a href=http://www.google.com><font color=black>[bar</font></a>baz\]" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","a"\]\] "foo<a href=http://www.google.com><u>[bar</u></a>baz\]": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["inserttext","a"\]\] "foo<a href=http://www.google.com><u>[bar</u></a>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","a"\]\] "foo<u><a href=http://www.google.com>[bar</a></u>baz\]": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["inserttext","a"\]\] "foo<u><a href=http://www.google.com>[bar</a></u>baz\]" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","a"\]\] "foo<sub><font size=2>[bar</font></sub>baz\]": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["inserttext","a"\]\] "foo<sub><font size=2>[bar</font></sub>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","a"\]\] "foo<font size=2><sub>[bar</sub></font>baz\]": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["inserttext","a"\]\] "foo<font size=2><sub>[bar</sub></font>baz\]" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","a"\]\] "foo<sub><font size=3>[bar</font></sub>baz\]": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["inserttext","a"\]\] "foo<sub><font size=3>[bar</font></sub>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","a"\]\] "foo<font size=3><sub>[bar</sub></font>baz\]": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["inserttext","a"\]\] "foo<font size=3><sub>[bar</sub></font>baz\]" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","a"\]\] "<blockquote><font color=blue>[foo\]</font></blockquote>": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["inserttext","a"\]\] "<blockquote><font color=blue>[foo\]</font></blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div>[\] abc</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div>[\] abc</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div> [\]abc</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div> [\]abc</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div>[\]  abc</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div>[\]  abc</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div> [\] abc</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div> [\] abc</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div>  [\]abc</div>": execCommand("inserttext", false, " ") return value]
     expected: FAIL
 
   [[["inserttext"," "\]\] "<div>  [\]abc</div>" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext"," "\]\] "<div>abc[\] </div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
   [[["inserttext"," "\]\] "<div>abc[\] </div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div>abc [\]</div>": execCommand("inserttext", false, " ") return value]
     expected: FAIL
 
   [[["inserttext"," "\]\] "<div>abc [\]</div>" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext"," "\]\] "<div>abc[\]  </div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
   [[["inserttext"," "\]\] "<div>abc[\]  </div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div>abc [\] </div>": execCommand("inserttext", false, " ") return value]
     expected: FAIL
 
   [[["inserttext"," "\]\] "<div>abc [\] </div>" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext"," "\]\] "<div>abc  [\]</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
   [[["inserttext"," "\]\] "<div>abc  [\]</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","a"\]\] "<br>{}": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["inserttext","a"\]\] "<br>{}" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","d"\]\] "abc<br>{}": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
   [[["inserttext","d"\]\] "abc<br>{}" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","d"\]\] "abc<br>{}<br>": execCommand("inserttext", false, "d") return value]
     expected: FAIL
 
   [[["inserttext","d"\]\] "abc<br>{}<br>" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","d"\]\] "<span contenteditable=false>abc</span><br>{}": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
   [[["inserttext","d"\]\] "<span contenteditable=false>abc</span><br>{}" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","a"\]\] "<div contenteditable=false><span contenteditable><br>{}</span></div>": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["inserttext","a"\]\] "<div contenteditable=false><span contenteditable><br>{}</span></div>" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","d"\]\] "<div contenteditable=false><span contenteditable>abc<br>{}</span></div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
   [[["inserttext","d"\]\] "<div contenteditable=false><span contenteditable>abc<br>{}</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","    "\]\] "<div style=white-space:pre>foo[\]bar</div>": execCommand("inserttext", false, "    ") return value]
-    expected: FAIL
-
-  [[["inserttext","    "\]\] "<div style=white-space:pre>foo[\]bar</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","    "\]\] "<div style=white-space:pre>foo[\]</div>": execCommand("inserttext", false, "    ") return value]
-    expected: FAIL
-
-  [[["inserttext","    "\]\] "<div style=white-space:pre>foo[\]</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","    "\]\] "<div style=white-space:pre-wrap>foo[\]bar</div>": execCommand("inserttext", false, "    ") return value]
-    expected: FAIL
-
-  [[["inserttext","    "\]\] "<div style=white-space:pre-wrap>foo[\]bar</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","    "\]\] "<div style=white-space:pre-wrap>foo[\]</div>": execCommand("inserttext", false, "    ") return value]
-    expected: FAIL
-
-  [[["inserttext","    "\]\] "<div style=white-space:pre-wrap>foo[\]</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","    "\]\] "<div style=white-space:pre-line>foo[\]bar</div>": execCommand("inserttext", false, "    ") return value]
     expected: FAIL
 
   [[["inserttext","    "\]\] "<div style=white-space:pre-line>foo[\]bar</div>" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","    "\]\] "<div style=white-space:pre-line>foo[\]</div>": execCommand("inserttext", false, "    ") return value]
-    expected: FAIL
-
   [[["inserttext","    "\]\] "<div style=white-space:pre-line>foo[\]</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","    "\]\] "<div style=white-space:nowrap>foo[\]bar</div>": execCommand("inserttext", false, "    ") return value]
     expected: FAIL
 
   [[["inserttext","    "\]\] "<div style=white-space:nowrap>foo[\]bar</div>" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","    "\]\] "<div style=white-space:nowrap>foo[\]</div>": execCommand("inserttext", false, "    ") return value]
-    expected: FAIL
-
   [[["inserttext","    "\]\] "<div style=white-space:nowrap>foo[\]</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","b"\]\] "<p>a<br>{}<span></span></p>": execCommand("inserttext", false, "b") return value]
     expected: FAIL
 
   [[["inserttext","b"\]\] "<p>a<br>{}<span></span></p>" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","b"\]\] "<p style=\\"white-space:pre-wrap\\">a<br>{}<span style=\\"padding:1px\\"></span></p>": execCommand("inserttext", false, "b") return value]
-    expected: FAIL
-
-  [[["inserttext","b"\]\] "<p style=\\"white-space:pre-wrap\\">a<br>{}<span style=\\"padding:1px\\"></span></p>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","b"\]\] "<div style=\\"white-space:pre-wrap\\">a<br>{}<span style=\\"padding:1px\\"></span><p>c</p></div>": execCommand("inserttext", false, "b") return value]
-    expected: FAIL
-
-  [[["inserttext","b"\]\] "<div style=\\"white-space:pre-wrap\\">a<br>{}<span style=\\"padding:1px\\"></span><p>c</p></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","b"\]\] "<div>a<br>{}<span></span><p>c</p></div>": execCommand("inserttext", false, "b") return value]
-    expected: FAIL
-
   [[["inserttext","b"\]\] "<div>a<br>{}<span></span><p>c</p></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","d"\]\] "<div>abc{</div><div>}efg</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\]\] "<div>abc{</div><div>}efg</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i>def</i></b>}ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i>def</i></b>}ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i>def</i></b>}ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def\]</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def\]</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def\]</i></b>ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i>def\]</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i>def\]</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i>def\]</i></b>ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def</i></b>\]ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def</i></b>\]ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def</i></b>\]ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc<b><i>[def</i></b>g\]hi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc<b><i>[def</i></b>g\]hi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc<b><i>[def</i></b>g\]hi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc<b><i>[def</i></b>g\]hi</div>": execCommand("inserttext", false, "g") return value]
     expected: FAIL
 
   [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc<b><i>[def</i></b>g\]hi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc[<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc[<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc[<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc[<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
   [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc[<b><i>def</i></b>g\]hi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc{<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc{<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc{<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc{<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "g") return value]
     expected: FAIL
 
   [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc{<b><i>def</i></b>g\]hi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
   [[["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">de\]f</i></b>ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def\]</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def\]</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def\]</i></b>ghi</div>": execCommand("inserttext", false, "f") return value]
     expected: FAIL
 
   [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def\]</i></b>ghi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
   [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "f") return value]
     expected: FAIL
 
   [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "c") return value]
-    expected: FAIL
-
-  [[["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
   [[["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div>{abc</div><div>def</div>}": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div>{abc</div><div>def</div>}": execCommand("inserttext", false, "h") return value]
     expected: FAIL
 
   [[["inserttext","g"\],["inserttext","h"\]\] "<div>{abc</div><div>def</div>}" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div>abc</div><div>{def</div>}": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div>abc</div><div>{def</div>}": execCommand("inserttext", false, "h") return value]
-    expected: FAIL
-
   [[["inserttext","g"\],["inserttext","h"\]\] "<div>abc</div><div>{def</div>}" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span>{abc</span><span>def</span>}</div>": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span>{abc</span><span>def</span>}</div>": execCommand("inserttext", false, "h") return value]
     expected: FAIL
 
   [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span>{abc</span><span>def</span>}</div>" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span>abc</span><span>{def</span>}</div>": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span>abc</span><span>{def</span>}</div>": execCommand("inserttext", false, "h") return value]
-    expected: FAIL
-
   [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span>abc</span><span>{def</span>}</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span>{abc</span><span>def</span>}</div>": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span>{abc</span><span>def</span>}</div>": execCommand("inserttext", false, "h") return value]
     expected: FAIL
 
   [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span>{abc</span><span>def</span>}</div>" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span>abc</span><span>{def</span>}</div>": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span>abc</span><span>{def</span>}</div>": execCommand("inserttext", false, "h") return value]
-    expected: FAIL
-
   [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span>abc</span><span>{def</span>}</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div><b>{abc</b></div><div>def</div>}": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div><b>{abc</b></div><div>def</div>}": execCommand("inserttext", false, "h") return value]
     expected: FAIL
 
   [[["inserttext","g"\],["inserttext","h"\]\] "<div><b>{abc</b></div><div>def</div>}" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div>abc</div><div><b>{def</b></div>}": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div>abc</div><div><b>{def</b></div>}": execCommand("inserttext", false, "h") return value]
-    expected: FAIL
-
   [[["inserttext","g"\],["inserttext","h"\]\] "<div>abc</div><div><b>{def</b></div>}" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span><b>{abc</b></span><span>def</span>}</div>": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span><b>{abc</b></span><span>def</span>}</div>": execCommand("inserttext", false, "h") return value]
     expected: FAIL
 
   [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span><b>{abc</b></span><span>def</span>}</div>" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span>abc</span><span><b>{def</b></span>}</div>": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span>abc</span><span><b>{def</b></span>}</div>": execCommand("inserttext", false, "h") return value]
-    expected: FAIL
-
   [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span>abc</span><span><b>{def</b></span>}</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span><b>{abc</b></span><span>def</span>}</div>": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span><b>{abc</b></span><span>def</span>}</div>": execCommand("inserttext", false, "h") return value]
     expected: FAIL
 
   [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span><b>{abc</b></span><span>def</span>}</div>" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span>abc</span><span><b>{def</b></span>}</div>": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span>abc</span><span><b>{def</b></span>}</div>": execCommand("inserttext", false, "h") return value]
-    expected: FAIL
-
   [[["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span>abc</span><span><b>{def</b></span>}</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","B"\]\] "<table><tr><td>a<td><b>[b</b><td><b>c</b><td><b>d\]</b><td>e</table>": execCommand("inserttext", false, "B") return value]
     expected: FAIL
 
   [[["inserttext","B"\]\] "<table><tr><td>a<td><b>[b</b><td><b>c</b><td><b>d\]</b><td>e</table>" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","B"\]\] "<table><tr><th>a<th><b>[b</b><th><b>c</b><th><b>d\]</b><th>e</table>": execCommand("inserttext", false, "B") return value]
-    expected: FAIL
-
   [[["inserttext","B"\]\] "<table><tr><th>a<th><b>[b</b><th><b>c</b><th><b>d\]</b><th>e</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:flex><span>[\]abc</span><span>def</span></div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:flex><span>[\]abc</span><span>def</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:inline-flex><span>[\]abc</span><span>def</span></div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:inline-flex><span>[\]abc</span><span>def</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:flex><span>abc[\]</span><span>def</span></div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:flex><span>abc[\]</span><span>def</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:inline-flex><span>abc[\]</span><span>def</span></div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:inline-flex><span>abc[\]</span><span>def</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:flex><span>abc</span><span>[\]def</span></div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:flex><span>abc</span><span>[\]def</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:inline-flex><span>abc</span><span>[\]def</span></div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:inline-flex><span>abc</span><span>[\]def</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:flex><span>abc</span><span>def[\]</span></div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:flex><span>abc</span><span>def[\]</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:inline-flex><span>abc</span><span>def[\]</span></div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:inline-flex><span>abc</span><span>def[\]</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:grid><span>[\]abc</span><span>def</span></div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:grid><span>[\]abc</span><span>def</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:inline-grid><span>[\]abc</span><span>def</span></div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:inline-grid><span>[\]abc</span><span>def</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:grid><span>abc[\]</span><span>def</span></div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:grid><span>abc[\]</span><span>def</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:inline-grid><span>abc[\]</span><span>def</span></div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:inline-grid><span>abc[\]</span><span>def</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:grid><span>abc</span><span>[\]def</span></div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:grid><span>abc</span><span>[\]def</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:inline-grid><span>abc</span><span>[\]def</span></div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:inline-grid><span>abc</span><span>[\]def</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:grid><span>abc</span><span>def[\]</span></div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:grid><span>abc</span><span>def[\]</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:inline-grid><span>abc</span><span>def[\]</span></div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=display:inline-grid><span>abc</span><span>def[\]</span></div>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<font color=blue><a href=http://www.google.com>bar\]</a></font>baz" queryCommandState("stylewithcss") before]
     expected: FAIL
 
-  [[["inserttext","X"\]\] "<div style=white-space:pre>abc[\]\\n</div>": execCommand("inserttext", false, "X") return value]
-    expected: FAIL
-
-  [[["inserttext","X"\]\] "<div style=white-space:pre>abc[\]\\n</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","X"\],["inserttext","Y"\]\] "<div style=white-space:pre>abc[\]\\n</div>": execCommand("inserttext", false, "X") return value]
-    expected: FAIL
-
-  [[["inserttext","X"\],["inserttext","Y"\]\] "<div style=white-space:pre>abc[\]\\n</div>": execCommand("inserttext", false, "Y") return value]
-    expected: FAIL
-
-  [[["inserttext","X"\],["inserttext","Y"\]\] "<div style=white-space:pre>abc[\]\\n</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","X"\]\] "<div style=white-space:pre-line>abc[\]\\n</div>": execCommand("inserttext", false, "X") return value]
-    expected: FAIL
-
-  [[["inserttext","X"\]\] "<div style=white-space:pre-line>abc[\]\\n</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","X"\],["inserttext","Y"\]\] "<div style=white-space:pre-line>abc[\]\\n</div>": execCommand("inserttext", false, "X") return value]
-    expected: FAIL
-
-  [[["inserttext","X"\],["inserttext","Y"\]\] "<div style=white-space:pre-line>abc[\]\\n</div>": execCommand("inserttext", false, "Y") return value]
-    expected: FAIL
-
-  [[["inserttext","X"\],["inserttext","Y"\]\] "<div style=white-space:pre-line>abc[\]\\n</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","X"\]\] "<div style=white-space:pre>abc [\]\\n</div>": execCommand("inserttext", false, "X") return value]
-    expected: FAIL
-
-  [[["inserttext","X"\]\] "<div style=white-space:pre>abc [\]\\n</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","X"\],["inserttext","Y"\]\] "<div style=white-space:pre>abc [\]\\n</div>": execCommand("inserttext", false, "X") return value]
-    expected: FAIL
-
-  [[["inserttext","X"\],["inserttext","Y"\]\] "<div style=white-space:pre>abc [\]\\n</div>": execCommand("inserttext", false, "Y") return value]
-    expected: FAIL
-
-  [[["inserttext","X"\],["inserttext","Y"\]\] "<div style=white-space:pre>abc [\]\\n</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","X"\]\] "<div style=white-space:pre-line>abc [\]\\n</div>": execCommand("inserttext", false, "X") return value]
-    expected: FAIL
-
   [[["inserttext","X"\]\] "<div style=white-space:pre-line>abc [\]\\n</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","X"\],["inserttext","Y"\]\] "<div style=white-space:pre-line>abc [\]\\n</div>": execCommand("inserttext", false, "X") return value]
-    expected: FAIL
-
-  [[["inserttext","X"\],["inserttext","Y"\]\] "<div style=white-space:pre-line>abc [\]\\n</div>": execCommand("inserttext", false, "Y") return value]
     expected: FAIL
 
   [[["inserttext","X"\],["inserttext","Y"\]\] "<div style=white-space:pre-line>abc [\]\\n</div>" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext","X"\]\] "<div style=white-space:pre>[\]\\n</div>": execCommand("inserttext", false, "X") return value]
-    expected: FAIL
-
   [[["inserttext","X"\]\] "<div style=white-space:pre>[\]\\n</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","X"\]\] "<div style=white-space:pre-line>[\]\\n</div>": execCommand("inserttext", false, "X") return value]
     expected: FAIL
 
   [[["inserttext","X"\]\] "<div style=white-space:pre-line>[\]\\n</div>" compare innerHTML]
     expected: FAIL
 
+  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i>def</i></b>}ghi</div>" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def\]</i></b>ghi</div>" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i>def\]</i></b>ghi</div>" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def</i></b>\]ghi</div>" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i>de\]f</i></b>ghi</div>" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<b><i>de\]f</i></b>ghi</div>" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<s></s><b><i>de\]f</i></b>ghi</div>" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<s></s><b><i>de\]f</i></b>ghi</div>" compare innerHTML]
+    expected: FAIL
+
 
 [inserttext.html?1001-2000]
+  expected: CRASH
   [[["inserttext"," "\]\] "<b>a</b><i>@</i><u>b</u>{}": execCommand("inserttext", false, " ") return value]
     expected: FAIL
 
@@ -1416,650 +820,65 @@
 
 
 [inserttext.html?1-1000]
-  [[["inserttext","a"\]\] "foo[bar\]baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["inserttext","a"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext",""\]\] "foo[bar\]baz": execCommand("inserttext", false, "") return value]
-    expected: FAIL
-
-  [[["inserttext",""\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","\\t"\]\] "foo[\]bar": execCommand("inserttext", false, "\\t") return value]
-    expected: FAIL
-
-  [[["inserttext","\\t"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","&"\]\] "foo[\]bar": execCommand("inserttext", false, "&") return value]
-    expected: FAIL
-
-  [[["inserttext","&"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["inserttext","\\n"\]\] "foo[\]bar": execCommand("inserttext", false, "\\n") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["inserttext","\\n"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","p"\],["inserttext","\\n"\]\] "foo[\]bar": execCommand("inserttext", false, "\\n") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","p"\],["inserttext","\\n"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["inserttext","abc\\ndef"\]\] "foo[\]bar": execCommand("inserttext", false, "abc\\ndef") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["inserttext","abc\\ndef"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","p"\],["inserttext","abc\\ndef"\]\] "foo[\]bar": execCommand("inserttext", false, "abc\\ndef") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","p"\],["inserttext","abc\\ndef"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","\\u0007"\]\] "foo[\]bar": execCommand("inserttext", false, "\\x07") return value]
-    expected: FAIL
-
-  [[["inserttext","\\u0007"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","<b>hi</b>"\]\] "foo[\]bar": execCommand("inserttext", false, "<b>hi</b>") return value]
-    expected: FAIL
-
-  [[["inserttext","<b>hi</b>"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","<"\]\] "foo[\]bar": execCommand("inserttext", false, "<") return value]
-    expected: FAIL
-
-  [[["inserttext","<"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext","&amp;"\]\] "foo[\]bar": execCommand("inserttext", false, "&amp;") return value]
-    expected: FAIL
-
-  [[["inserttext","&amp;"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo[\]bar": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo [\]bar": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo [\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo[\] bar": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo[\] bar" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo &nbsp;[\]bar": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo &nbsp;[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo [\]&nbsp;bar": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo [\]&nbsp;bar" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo[\] &nbsp;bar": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo[\] &nbsp;bar" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo&nbsp; [\]bar": execCommand("inserttext", false, " ") return value]
     expected: FAIL
 
   [[["inserttext"," "\]\] "foo&nbsp; [\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext"," "\]\] "foo&nbsp;[\] bar": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo&nbsp;[\] bar" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo[\]&nbsp; bar": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo[\]&nbsp; bar" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo&nbsp;&nbsp;[\]bar": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
   [[["inserttext"," "\]\] "foo&nbsp;&nbsp;[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo&nbsp;[\]&nbsp;bar": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo&nbsp;[\]&nbsp;bar" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo[\]&nbsp;&nbsp;bar": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo[\]&nbsp;&nbsp;bar" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo [\]&nbsp;        bar": execCommand("inserttext", false, " ") return value]
     expected: FAIL
 
   [[["inserttext"," "\]\] "foo [\]&nbsp;        bar" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext"," "\]\] "foo  [\]bar": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
   [[["inserttext"," "\]\] "foo  [\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo [\]&nbsp;&nbsp; &nbsp; bar": execCommand("inserttext", false, " ") return value]
     expected: FAIL
 
   [[["inserttext"," "\]\] "foo [\]&nbsp;&nbsp; &nbsp; bar" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext"," "\]\] "[\]foo": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "[\]foo" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "{}foo": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "{}foo" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo[\]": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo[\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo{}": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo{}" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo&nbsp;[\]": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo&nbsp;[\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo&nbsp;{}": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo&nbsp;{}" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo&nbsp;&nbsp;[\]": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo&nbsp;&nbsp;[\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo&nbsp;&nbsp;{}": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo&nbsp;&nbsp;{}" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<b>foo[\]</b>bar": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<b>foo[\]</b>bar" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo[\]<b>bar</b>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo[\]<b>bar</b>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo[\] ": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
   [[["inserttext"," "\]\] "foo[\] " compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] " foo   [\]   ": execCommand("inserttext", false, " ") return value]
     expected: FAIL
 
   [[["inserttext"," "\]\] " foo   [\]   " compare innerHTML]
     expected: FAIL
 
-  [[["inserttext"," "\]\] "foo[\]<span> </span>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
   [[["inserttext"," "\]\] "foo[\]<span> </span>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "foo[\]<span> </span> ": execCommand("inserttext", false, " ") return value]
     expected: FAIL
 
   [[["inserttext"," "\]\] "foo[\]<span> </span> " compare innerHTML]
     expected: FAIL
 
-  [[["inserttext"," "\]\] " [\]foo": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] " [\]foo" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "   [\]   foo ": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
   [[["inserttext"," "\]\] "   [\]   foo " compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<span> </span>[\]foo": execCommand("inserttext", false, " ") return value]
     expected: FAIL
 
   [[["inserttext"," "\]\] "<span> </span>[\]foo" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext"," "\]\] " <span> </span>[\]foo": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
   [[["inserttext"," "\]\] " <span> </span>[\]foo" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "{}<br>": execCommand("inserttext", false, " ") return value]
     expected: FAIL
 
   [[["inserttext"," "\]\] "{}<br>" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext"," "\]\] "<p>{}<br>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
   [[["inserttext"," "\]\] "<p>{}<br>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<p>foo[\]<p>bar": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<p>foo[\]<p>bar" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<p>foo&nbsp;[\]<p>bar": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<p>foo&nbsp;[\]<p>bar" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<p>foo[\]<p>&nbsp;bar": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<p>foo[\]<p>&nbsp;bar" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<pre>foo[\]bar</pre>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<pre>foo[\]bar</pre>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<pre>foo [\]bar</pre>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<pre>foo [\]bar</pre>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<pre>foo[\] bar</pre>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<pre>foo[\] bar</pre>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<pre>foo &nbsp;[\]bar</pre>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<pre>foo &nbsp;[\]bar</pre>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<pre>[\]foo</pre>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<pre>[\]foo</pre>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<pre>foo[\]</pre>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<pre>foo[\]</pre>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<pre>foo&nbsp;[\]</pre>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<pre>foo&nbsp;[\]</pre>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<pre> foo   [\]   </pre>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<pre> foo   [\]   </pre>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre>foo[\]bar</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre>foo[\]bar</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre>foo [\]bar</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre>foo [\]bar</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre>foo[\] bar</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre>foo[\] bar</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre>foo &nbsp;[\]bar</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre>foo &nbsp;[\]bar</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre>[\]foo</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre>[\]foo</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre>foo[\]</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre>foo[\]</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre>foo&nbsp;[\]</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre>foo&nbsp;[\]</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre> foo   [\]   </div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre> foo   [\]   </div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-wrap>foo[\]bar</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-wrap>foo[\]bar</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-wrap>foo [\]bar</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-wrap>foo [\]bar</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-wrap>foo[\] bar</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-wrap>foo[\] bar</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-wrap>foo &nbsp;[\]bar</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-wrap>foo &nbsp;[\]bar</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-wrap>[\]foo</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-wrap>[\]foo</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-wrap>foo[\]</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-wrap>foo[\]</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-wrap>foo&nbsp;[\]</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-wrap>foo&nbsp;[\]</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-wrap> foo   [\]   </div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-wrap> foo   [\]   </div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-line>foo[\]bar</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-line>foo[\]bar</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-line>foo [\]bar</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-line>foo [\]bar</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-line>foo[\] bar</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-line>foo[\] bar</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-line>foo &nbsp;[\]bar</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-line>foo &nbsp;[\]bar</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-line>[\]foo</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-line>[\]foo</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-line>foo[\]</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-line>foo[\]</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-line>foo&nbsp;[\]</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-line>foo&nbsp;[\]</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:pre-line> foo   [\]   </div>": execCommand("inserttext", false, " ") return value]
     expected: FAIL
 
   [[["inserttext"," "\]\] "<div style=white-space:pre-line> foo   [\]   </div>" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext"," "\]\] "<div style=white-space:nowrap>foo[\]bar</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:nowrap>foo[\]bar</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:nowrap>foo [\]bar</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:nowrap>foo [\]bar</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:nowrap>foo[\] bar</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:nowrap>foo[\] bar</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:nowrap>foo &nbsp;[\]bar</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:nowrap>foo &nbsp;[\]bar</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:nowrap>[\]foo</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:nowrap>[\]foo</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:nowrap>foo[\]</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:nowrap>foo[\]</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:nowrap>foo&nbsp;[\]</div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:nowrap>foo&nbsp;[\]</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<div style=white-space:nowrap> foo   [\]   </div>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
   [[["inserttext"," "\]\] "<div style=white-space:nowrap> foo   [\]   </div>" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "http://a[\]": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "http://a[\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "ftp://a[\]": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "ftp://a[\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "quasit://a[\]": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "quasit://a[\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] ".x-++-.://a[\]": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] ".x-++-.://a[\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "(http://a)[\]": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "(http://a)[\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "&lt;http://a>[\]": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "&lt;http://a>[\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "http://a![\]": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "http://a![\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "!\\"#$%&amp;'()*+,-./:;&lt;=>?^_`|~http://a!\\"#$%&amp;'()*+,-./:;&lt;=>?^_`|~[\]": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "!\\"#$%&amp;'()*+,-./:;&lt;=>?^_`|~http://a!\\"#$%&amp;'()*+,-./:;&lt;=>?^_`|~[\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "http://a!\\"'(),-.:;&lt;>`[\]": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "http://a!\\"'(),-.:;&lt;>`[\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "http://a#$%&amp;*+/=?^_|~[\]": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "http://a#$%&amp;*+/=?^_|~[\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "mailto:a[\]": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "mailto:a[\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "a@b[\]": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "a@b[\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "a@[\]": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "a@[\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "@b[\]": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "@b[\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "#@x[\]": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "#@x[\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "a@.[\]": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "a@.[\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "!\\"#$%&amp;'()*+,-./:;&lt;=>?^_`|~a@b!\\"#$%&amp;'()*+,-./:;&lt;=>?^_`|~[\]": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "!\\"#$%&amp;'()*+,-./:;&lt;=>?^_`|~a@b!\\"#$%&amp;'()*+,-./:;&lt;=>?^_`|~[\]" compare innerHTML]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<b>a@b</b>{}": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\]\] "<b>a@b</b>{}" compare innerHTML]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/insertunorderedlist.html.ini
+++ b/tests/wpt/meta/editing/run/insertunorderedlist.html.ini
@@ -590,9 +590,6 @@
   [[["insertunorderedlist",""\],["inserttext","abc"\]\] "{}": execCommand("insertunorderedlist", false, "") return value]
     expected: FAIL
 
-  [[["insertunorderedlist",""\],["inserttext","abc"\]\] "{}": execCommand("inserttext", false, "abc") return value]
-    expected: FAIL
-
   [[["insertunorderedlist",""\],["inserttext","abc"\]\] "{}" compare innerHTML]
     expected: FAIL
 
@@ -608,9 +605,6 @@
   [[["insertunorderedlist",""\],["inserttext","abc"\]\] "<div>{}</div>": execCommand("insertunorderedlist", false, "") return value]
     expected: FAIL
 
-  [[["insertunorderedlist",""\],["inserttext","abc"\]\] "<div>{}</div>": execCommand("inserttext", false, "abc") return value]
-    expected: FAIL
-
   [[["insertunorderedlist",""\],["inserttext","abc"\]\] "<div>{}</div>" compare innerHTML]
     expected: FAIL
 
@@ -624,9 +618,6 @@
     expected: FAIL
 
   [[["insertunorderedlist",""\],["inserttext","abc"\]\] "<div>{}<br></div>": execCommand("insertunorderedlist", false, "") return value]
-    expected: FAIL
-
-  [[["insertunorderedlist",""\],["inserttext","abc"\]\] "<div>{}<br></div>": execCommand("inserttext", false, "abc") return value]
     expected: FAIL
 
   [[["insertunorderedlist",""\],["inserttext","abc"\]\] "<div>{}<br></div>" compare innerHTML]
@@ -649,9 +640,6 @@
   [[["insertunorderedlist",""\],["inserttext","abc"\]\] "<p>{}</p>": execCommand("insertunorderedlist", false, "") return value]
     expected: FAIL
 
-  [[["insertunorderedlist",""\],["inserttext","abc"\]\] "<p>{}</p>": execCommand("inserttext", false, "abc") return value]
-    expected: FAIL
-
   [[["insertunorderedlist",""\],["inserttext","abc"\]\] "<p>{}</p>" compare innerHTML]
     expected: FAIL
 
@@ -665,9 +653,6 @@
     expected: FAIL
 
   [[["insertunorderedlist",""\],["inserttext","abc"\]\] "<p>{}<br></p>": execCommand("insertunorderedlist", false, "") return value]
-    expected: FAIL
-
-  [[["insertunorderedlist",""\],["inserttext","abc"\]\] "<p>{}<br></p>": execCommand("inserttext", false, "abc") return value]
     expected: FAIL
 
   [[["insertunorderedlist",""\],["inserttext","abc"\]\] "<p>{}<br></p>" compare innerHTML]

--- a/tests/wpt/meta/editing/run/multitest.html.ini
+++ b/tests/wpt/meta/editing/run/multitest.html.ini
@@ -5,19 +5,7 @@
   [[["forecolor","#0000FF"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
     expected: FAIL
 
-  [[["forecolor","#0000FF"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["forecolor","#0000FF"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["hilitecolor","#00FFFF"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["hilitecolor","#00FFFF"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["hilitecolor","#00FFFF"\],["delete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["hilitecolor","#00FFFF"\],["delete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -35,16 +23,10 @@
   [[["hilitecolor","#00FFFF"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("formatblock", false, "<div>") return value]
     expected: FAIL
 
-  [[["hilitecolor","#00FFFF"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["hilitecolor","#00FFFF"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["hilitecolor","#00FFFF"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("formatblock") after]
-    expected: FAIL
-
-  [[["hilitecolor","#00FFFF"\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["hilitecolor","#00FFFF"\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -59,16 +41,7 @@
   [[["hilitecolor","#00FFFF"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("indent", false, "") return value]
     expected: FAIL
 
-  [[["hilitecolor","#00FFFF"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["hilitecolor","#00FFFF"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["hilitecolor","#00FFFF"\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["hilitecolor","#00FFFF"\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["hilitecolor","#00FFFF"\],["inserthtml","ab<b>c</b>d"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
@@ -80,16 +53,7 @@
   [[["hilitecolor","#00FFFF"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
     expected: FAIL
 
-  [[["hilitecolor","#00FFFF"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["hilitecolor","#00FFFF"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["hilitecolor","#00FFFF"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["hilitecolor","#00FFFF"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["hilitecolor","#00FFFF"\],["insertlinebreak",""\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
@@ -99,9 +63,6 @@
     expected: FAIL
 
   [[["hilitecolor","#00FFFF"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
-  [[["hilitecolor","#00FFFF"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["hilitecolor","#00FFFF"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -119,9 +80,6 @@
   [[["hilitecolor","#00FFFF"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertorderedlist", false, "") return value]
     expected: FAIL
 
-  [[["hilitecolor","#00FFFF"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["hilitecolor","#00FFFF"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -129,9 +87,6 @@
     expected: FAIL
 
   [[["hilitecolor","#00FFFF"\],["insertparagraph",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["hilitecolor","#00FFFF"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["hilitecolor","#00FFFF"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -147,9 +102,6 @@
     expected: FAIL
 
   [[["hilitecolor","#00FFFF"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertunorderedlist", false, "") return value]
-    expected: FAIL
-
-  [[["hilitecolor","#00FFFF"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["hilitecolor","#00FFFF"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -174,9 +126,6 @@
     expected: FAIL
 
   [[["hilitecolor","#00FFFF"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifycenter", false, "") return value]
-    expected: FAIL
-
-  [[["hilitecolor","#00FFFF"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["hilitecolor","#00FFFF"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -209,9 +158,6 @@
   [[["hilitecolor","#00FFFF"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyfull", false, "") return value]
     expected: FAIL
 
-  [[["hilitecolor","#00FFFF"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["hilitecolor","#00FFFF"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -240,12 +186,6 @@
     expected: FAIL
 
   [[["hilitecolor","#00FFFF"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyleft", false, "") return value]
-    expected: FAIL
-
-  [[["hilitecolor","#00FFFF"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["hilitecolor","#00FFFF"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["hilitecolor","#00FFFF"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("justifyleft") before]
@@ -278,9 +218,6 @@
   [[["hilitecolor","#00FFFF"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyright", false, "") return value]
     expected: FAIL
 
-  [[["hilitecolor","#00FFFF"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["hilitecolor","#00FFFF"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -299,31 +236,10 @@
   [[["hilitecolor","#00FFFF"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
     expected: FAIL
 
-  [[["hilitecolor","#00FFFF"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["hilitecolor","#00FFFF"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["superscript",""\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["superscript",""\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["subscript",""\],["superscript",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["subscript",""\],["superscript",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["forecolor","#0000FF"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["createlink","http://www.google.com/"\],["forecolor","#0000FF"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forecolor","#0000FF"\],["createlink","http://www.google.com/"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["forecolor","#0000FF"\],["createlink","http://www.google.com/"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -332,31 +248,10 @@
   [[["createlink","http://www.google.com/"\],["forecolor","blue"\],["inserttext","a"\]\] "foo[\]bar": execCommand("forecolor", false, "blue") return value]
     expected: FAIL
 
-  [[["createlink","http://www.google.com/"\],["forecolor","blue"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["forecolor","blue"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["forecolor","blue"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("forecolor") after]
-    expected: FAIL
-
   [[["forecolor","blue"\],["createlink","http://www.google.com/"\],["inserttext","a"\]\] "foo[\]bar": execCommand("forecolor", false, "blue") return value]
     expected: FAIL
 
-  [[["forecolor","blue"\],["createlink","http://www.google.com/"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["forecolor","blue"\],["createlink","http://www.google.com/"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forecolor","blue"\],["createlink","http://www.google.com/"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("forecolor") after]
-    expected: FAIL
-
   [[["createlink","http://www.google.com/"\],["forecolor","brown"\],["inserttext","a"\]\] "foo[\]bar": execCommand("forecolor", false, "brown") return value]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["forecolor","brown"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["createlink","http://www.google.com/"\],["forecolor","brown"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -368,9 +263,6 @@
   [[["forecolor","brown"\],["createlink","http://www.google.com/"\],["inserttext","a"\]\] "foo[\]bar": execCommand("forecolor", false, "brown") return value]
     expected: FAIL
 
-  [[["forecolor","brown"\],["createlink","http://www.google.com/"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["forecolor","brown"\],["createlink","http://www.google.com/"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -380,66 +272,30 @@
   [[["createlink","http://www.google.com/"\],["forecolor","black"\],["inserttext","a"\]\] "foo[\]bar": execCommand("forecolor", false, "black") return value]
     expected: FAIL
 
-  [[["createlink","http://www.google.com/"\],["forecolor","black"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["createlink","http://www.google.com/"\],["forecolor","black"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["forecolor","black"\],["createlink","http://www.google.com/"\],["inserttext","a"\]\] "foo[\]bar": execCommand("forecolor", false, "black") return value]
     expected: FAIL
 
-  [[["forecolor","black"\],["createlink","http://www.google.com/"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["forecolor","black"\],["createlink","http://www.google.com/"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["underline",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["underline",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\],["createlink","http://www.google.com/"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["underline",""\],["createlink","http://www.google.com/"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["underline","","first application"\],["underline","","second application"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["underline","","first application"\],["underline","","second application"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["underline","","first application"\],["underline","","second application"\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["underline","","first application"\],["underline","","second application"\],["createlink","http://www.google.com/"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["underline","","first application"\],["underline","","second application"\],["createlink","http://www.google.com/"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["underline","","first application"\],["underline","","second application"\],["createlink","http://www.google.com/"\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("underline") after]
     expected: FAIL
 
   [[["superscript",""\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("superscript") after]
     expected: FAIL
 
-  [[["subscript",""\],["superscript",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("subscript") after]
+  [[["superscript",""\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("subscript") after]
+    expected: FAIL
+
+  [[["createlink","http://www.google.com/"\],["forecolor","black"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("forecolor") after]
+    expected: FAIL
+
+  [[["forecolor","black"\],["createlink","http://www.google.com/"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("forecolor") after]
     expected: FAIL
 
 
 [multitest.html?1-1000]
-  [[["bold",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["bold",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["bold",""\],["delete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["bold",""\],["delete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -457,16 +313,10 @@
   [[["bold",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("formatblock", false, "<div>") return value]
     expected: FAIL
 
-  [[["bold",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["bold",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["bold",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("formatblock") after]
-    expected: FAIL
-
-  [[["bold",""\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["bold",""\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -481,13 +331,7 @@
   [[["bold",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("indent", false, "") return value]
     expected: FAIL
 
-  [[["bold",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["bold",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["bold",""\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["bold",""\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -502,13 +346,7 @@
   [[["bold",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
     expected: FAIL
 
-  [[["bold",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["bold",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["bold",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["bold",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -521,9 +359,6 @@
     expected: FAIL
 
   [[["bold",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
-  [[["bold",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["bold",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -541,9 +376,6 @@
   [[["bold",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertorderedlist", false, "") return value]
     expected: FAIL
 
-  [[["bold",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["bold",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -551,9 +383,6 @@
     expected: FAIL
 
   [[["bold",""\],["insertparagraph",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["bold",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["bold",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -569,9 +398,6 @@
     expected: FAIL
 
   [[["bold",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertunorderedlist", false, "") return value]
-    expected: FAIL
-
-  [[["bold",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["bold",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -596,9 +422,6 @@
     expected: FAIL
 
   [[["bold",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifycenter", false, "") return value]
-    expected: FAIL
-
-  [[["bold",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["bold",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -631,9 +454,6 @@
   [[["bold",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyfull", false, "") return value]
     expected: FAIL
 
-  [[["bold",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["bold",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -662,9 +482,6 @@
     expected: FAIL
 
   [[["bold",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyleft", false, "") return value]
-    expected: FAIL
-
-  [[["bold",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["bold",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -700,9 +517,6 @@
   [[["bold",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyright", false, "") return value]
     expected: FAIL
 
-  [[["bold",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["bold",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -721,19 +535,10 @@
   [[["bold",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
     expected: FAIL
 
-  [[["bold",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["bold",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["italic",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["italic",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["delete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["italic",""\],["delete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -751,16 +556,10 @@
   [[["italic",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("formatblock", false, "<div>") return value]
     expected: FAIL
 
-  [[["italic",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["italic",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["italic",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("formatblock") after]
-    expected: FAIL
-
-  [[["italic",""\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["italic",""\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -775,13 +574,7 @@
   [[["italic",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("indent", false, "") return value]
     expected: FAIL
 
-  [[["italic",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["italic",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["italic",""\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -796,13 +589,7 @@
   [[["italic",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
     expected: FAIL
 
-  [[["italic",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["italic",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["italic",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -815,9 +602,6 @@
     expected: FAIL
 
   [[["italic",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
-  [[["italic",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["italic",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -835,9 +619,6 @@
   [[["italic",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertorderedlist", false, "") return value]
     expected: FAIL
 
-  [[["italic",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["italic",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -847,9 +628,6 @@
 
 [multitest.html?1001-2000]
   [[["italic",""\],["insertparagraph",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["italic",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -865,9 +643,6 @@
     expected: FAIL
 
   [[["italic",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertunorderedlist", false, "") return value]
-    expected: FAIL
-
-  [[["italic",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["italic",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -892,9 +667,6 @@
     expected: FAIL
 
   [[["italic",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifycenter", false, "") return value]
-    expected: FAIL
-
-  [[["italic",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["italic",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -927,9 +699,6 @@
   [[["italic",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyfull", false, "") return value]
     expected: FAIL
 
-  [[["italic",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["italic",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -958,9 +727,6 @@
     expected: FAIL
 
   [[["italic",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyleft", false, "") return value]
-    expected: FAIL
-
-  [[["italic",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["italic",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -996,9 +762,6 @@
   [[["italic",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyright", false, "") return value]
     expected: FAIL
 
-  [[["italic",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["italic",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -1017,19 +780,10 @@
   [[["italic",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
     expected: FAIL
 
-  [[["italic",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["italic",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["strikethrough",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["strikethrough",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["strikethrough",""\],["delete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["strikethrough",""\],["delete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1047,16 +801,10 @@
   [[["strikethrough",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("formatblock", false, "<div>") return value]
     expected: FAIL
 
-  [[["strikethrough",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["strikethrough",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["strikethrough",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("formatblock") after]
-    expected: FAIL
-
-  [[["strikethrough",""\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["strikethrough",""\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1071,13 +819,7 @@
   [[["strikethrough",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("indent", false, "") return value]
     expected: FAIL
 
-  [[["strikethrough",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["strikethrough",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["strikethrough",""\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["strikethrough",""\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1092,13 +834,7 @@
   [[["strikethrough",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
     expected: FAIL
 
-  [[["strikethrough",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["strikethrough",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["strikethrough",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["strikethrough",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1111,9 +847,6 @@
     expected: FAIL
 
   [[["strikethrough",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
-  [[["strikethrough",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["strikethrough",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1131,9 +864,6 @@
   [[["strikethrough",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertorderedlist", false, "") return value]
     expected: FAIL
 
-  [[["strikethrough",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["strikethrough",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -1141,9 +871,6 @@
     expected: FAIL
 
   [[["strikethrough",""\],["insertparagraph",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["strikethrough",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["strikethrough",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1159,9 +886,6 @@
     expected: FAIL
 
   [[["strikethrough",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertunorderedlist", false, "") return value]
-    expected: FAIL
-
-  [[["strikethrough",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["strikethrough",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1186,9 +910,6 @@
     expected: FAIL
 
   [[["strikethrough",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifycenter", false, "") return value]
-    expected: FAIL
-
-  [[["strikethrough",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["strikethrough",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1221,9 +942,6 @@
   [[["strikethrough",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyfull", false, "") return value]
     expected: FAIL
 
-  [[["strikethrough",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["strikethrough",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -1252,9 +970,6 @@
     expected: FAIL
 
   [[["strikethrough",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyleft", false, "") return value]
-    expected: FAIL
-
-  [[["strikethrough",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["strikethrough",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1290,9 +1005,6 @@
   [[["strikethrough",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyright", false, "") return value]
     expected: FAIL
 
-  [[["strikethrough",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["strikethrough",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -1311,19 +1023,7 @@
   [[["strikethrough",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
     expected: FAIL
 
-  [[["strikethrough",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["strikethrough",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["subscript",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["subscript",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["subscript",""\],["delete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["subscript",""\],["delete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1341,17 +1041,11 @@
   [[["subscript",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("formatblock", false, "<div>") return value]
     expected: FAIL
 
-  [[["subscript",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["subscript",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
 
 [multitest.html?6001-7000]
-  [[["fontsize","4"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -1362,9 +1056,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1382,9 +1073,6 @@
   [[["fontsize","4"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertorderedlist", false, "") return value]
     expected: FAIL
 
-  [[["fontsize","4"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -1392,9 +1080,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["insertparagraph",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1410,9 +1095,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertunorderedlist", false, "") return value]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1437,9 +1119,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifycenter", false, "") return value]
-    expected: FAIL
-
-  [[["fontsize","4"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1472,9 +1151,6 @@
   [[["fontsize","4"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyfull", false, "") return value]
     expected: FAIL
 
-  [[["fontsize","4"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -1503,9 +1179,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyleft", false, "") return value]
-    expected: FAIL
-
-  [[["fontsize","4"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1541,9 +1214,6 @@
   [[["fontsize","4"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyright", false, "") return value]
     expected: FAIL
 
-  [[["fontsize","4"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -1562,19 +1232,10 @@
   [[["fontsize","4"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
     expected: FAIL
 
-  [[["fontsize","4"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["forecolor","#0000FF"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["forecolor","#0000FF"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forecolor","#0000FF"\],["delete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["forecolor","#0000FF"\],["delete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1592,16 +1253,10 @@
   [[["forecolor","#0000FF"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("formatblock", false, "<div>") return value]
     expected: FAIL
 
-  [[["forecolor","#0000FF"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["forecolor","#0000FF"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["forecolor","#0000FF"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("formatblock") after]
-    expected: FAIL
-
-  [[["forecolor","#0000FF"\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["forecolor","#0000FF"\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1616,13 +1271,7 @@
   [[["forecolor","#0000FF"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("indent", false, "") return value]
     expected: FAIL
 
-  [[["forecolor","#0000FF"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["forecolor","#0000FF"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forecolor","#0000FF"\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["forecolor","#0000FF"\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1637,13 +1286,7 @@
   [[["forecolor","#0000FF"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
     expected: FAIL
 
-  [[["forecolor","#0000FF"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["forecolor","#0000FF"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forecolor","#0000FF"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["forecolor","#0000FF"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1656,9 +1299,6 @@
     expected: FAIL
 
   [[["forecolor","#0000FF"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
-  [[["forecolor","#0000FF"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["forecolor","#0000FF"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1676,9 +1316,6 @@
   [[["forecolor","#0000FF"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertorderedlist", false, "") return value]
     expected: FAIL
 
-  [[["forecolor","#0000FF"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["forecolor","#0000FF"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -1686,9 +1323,6 @@
     expected: FAIL
 
   [[["forecolor","#0000FF"\],["insertparagraph",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forecolor","#0000FF"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["forecolor","#0000FF"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1704,9 +1338,6 @@
     expected: FAIL
 
   [[["forecolor","#0000FF"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertunorderedlist", false, "") return value]
-    expected: FAIL
-
-  [[["forecolor","#0000FF"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["forecolor","#0000FF"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1731,9 +1362,6 @@
     expected: FAIL
 
   [[["forecolor","#0000FF"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifycenter", false, "") return value]
-    expected: FAIL
-
-  [[["forecolor","#0000FF"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["forecolor","#0000FF"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1766,9 +1394,6 @@
   [[["forecolor","#0000FF"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyfull", false, "") return value]
     expected: FAIL
 
-  [[["forecolor","#0000FF"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["forecolor","#0000FF"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -1797,9 +1422,6 @@
     expected: FAIL
 
   [[["forecolor","#0000FF"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyleft", false, "") return value]
-    expected: FAIL
-
-  [[["forecolor","#0000FF"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["forecolor","#0000FF"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1835,9 +1457,6 @@
   [[["forecolor","#0000FF"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyright", false, "") return value]
     expected: FAIL
 
-  [[["forecolor","#0000FF"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["forecolor","#0000FF"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -1848,6 +1467,36 @@
     expected: FAIL
 
   [[["forecolor","#0000FF"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyright") after]
+    expected: FAIL
+
+  [[["fontsize","4"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
+    expected: FAIL
+
+  [[["fontsize","4"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
+    expected: FAIL
+
+  [[["fontsize","4"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
+    expected: FAIL
+
+  [[["fontsize","4"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
+    expected: FAIL
+
+  [[["fontsize","4"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
+    expected: FAIL
+
+  [[["fontsize","4"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
+    expected: FAIL
+
+  [[["fontsize","4"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
+    expected: FAIL
+
+  [[["fontsize","4"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
+    expected: FAIL
+
+  [[["fontsize","4"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
+    expected: FAIL
+
+  [[["fontsize","4"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
 
@@ -1868,12 +1517,6 @@
     expected: FAIL
 
   [[["createlink","http://www.google.com/"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyleft", false, "") return value]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["createlink","http://www.google.com/"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("justifyleft") before]
@@ -1906,9 +1549,6 @@
   [[["createlink","http://www.google.com/"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyright", false, "") return value]
     expected: FAIL
 
-  [[["createlink","http://www.google.com/"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["createlink","http://www.google.com/"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -1927,19 +1567,7 @@
   [[["createlink","http://www.google.com/"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
     expected: FAIL
 
-  [[["createlink","http://www.google.com/"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontname","sans-serif"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["fontname","sans-serif"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontname","sans-serif"\],["delete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["fontname","sans-serif"\],["delete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1957,16 +1585,10 @@
   [[["fontname","sans-serif"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("formatblock", false, "<div>") return value]
     expected: FAIL
 
-  [[["fontname","sans-serif"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["fontname","sans-serif"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["fontname","sans-serif"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("formatblock") after]
-    expected: FAIL
-
-  [[["fontname","sans-serif"\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["fontname","sans-serif"\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1981,13 +1603,7 @@
   [[["fontname","sans-serif"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("indent", false, "") return value]
     expected: FAIL
 
-  [[["fontname","sans-serif"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["fontname","sans-serif"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontname","sans-serif"\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["fontname","sans-serif"\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -2002,13 +1618,7 @@
   [[["fontname","sans-serif"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
     expected: FAIL
 
-  [[["fontname","sans-serif"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["fontname","sans-serif"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontname","sans-serif"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["fontname","sans-serif"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -2021,9 +1631,6 @@
     expected: FAIL
 
   [[["fontname","sans-serif"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
-  [[["fontname","sans-serif"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["fontname","sans-serif"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -2041,9 +1648,6 @@
   [[["fontname","sans-serif"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertorderedlist", false, "") return value]
     expected: FAIL
 
-  [[["fontname","sans-serif"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["fontname","sans-serif"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -2051,9 +1655,6 @@
     expected: FAIL
 
   [[["fontname","sans-serif"\],["insertparagraph",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontname","sans-serif"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["fontname","sans-serif"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -2069,9 +1670,6 @@
     expected: FAIL
 
   [[["fontname","sans-serif"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertunorderedlist", false, "") return value]
-    expected: FAIL
-
-  [[["fontname","sans-serif"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["fontname","sans-serif"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -2096,9 +1694,6 @@
     expected: FAIL
 
   [[["fontname","sans-serif"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifycenter", false, "") return value]
-    expected: FAIL
-
-  [[["fontname","sans-serif"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["fontname","sans-serif"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -2131,9 +1726,6 @@
   [[["fontname","sans-serif"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyfull", false, "") return value]
     expected: FAIL
 
-  [[["fontname","sans-serif"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["fontname","sans-serif"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -2162,9 +1754,6 @@
     expected: FAIL
 
   [[["fontname","sans-serif"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyleft", false, "") return value]
-    expected: FAIL
-
-  [[["fontname","sans-serif"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["fontname","sans-serif"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -2200,9 +1789,6 @@
   [[["fontname","sans-serif"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyright", false, "") return value]
     expected: FAIL
 
-  [[["fontname","sans-serif"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["fontname","sans-serif"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -2221,19 +1807,10 @@
   [[["fontname","sans-serif"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
     expected: FAIL
 
-  [[["fontname","sans-serif"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["fontname","sans-serif"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontsize","4"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","4"\],["delete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["delete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -2251,16 +1828,10 @@
   [[["fontsize","4"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("formatblock", false, "<div>") return value]
     expected: FAIL
 
-  [[["fontsize","4"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["fontsize","4"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("formatblock") after]
-    expected: FAIL
-
-  [[["fontsize","4"\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -2275,13 +1846,7 @@
   [[["fontsize","4"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("indent", false, "") return value]
     expected: FAIL
 
-  [[["fontsize","4"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","4"\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -2296,10 +1861,28 @@
   [[["fontsize","4"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
     expected: FAIL
 
-  [[["fontsize","4"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
+  [[["fontsize","4"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontsize","4"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
+  [[["fontsize","4"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
+    expected: FAIL
+
+  [[["fontsize","4"\],["delete",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
+    expected: FAIL
+
+  [[["fontsize","4"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
+    expected: FAIL
+
+  [[["fontsize","4"\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
+    expected: FAIL
+
+  [[["fontsize","4"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
+    expected: FAIL
+
+  [[["fontsize","4"\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
+    expected: FAIL
+
+  [[["fontsize","4"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
 
@@ -2308,9 +1891,6 @@
     expected: FAIL
 
   [[["subscript",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("formatblock") after]
-    expected: FAIL
-
-  [[["subscript",""\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["subscript",""\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -2325,16 +1905,7 @@
   [[["subscript",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("indent", false, "") return value]
     expected: FAIL
 
-  [[["subscript",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["subscript",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["subscript",""\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["subscript",""\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["subscript",""\],["inserthtml","ab<b>c</b>d"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
@@ -2346,16 +1917,7 @@
   [[["subscript",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
     expected: FAIL
 
-  [[["subscript",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["subscript",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["subscript",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["subscript",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["subscript",""\],["insertlinebreak",""\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
@@ -2365,9 +1927,6 @@
     expected: FAIL
 
   [[["subscript",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
-  [[["subscript",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["subscript",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -2385,9 +1944,6 @@
   [[["subscript",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertorderedlist", false, "") return value]
     expected: FAIL
 
-  [[["subscript",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["subscript",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -2395,9 +1951,6 @@
     expected: FAIL
 
   [[["subscript",""\],["insertparagraph",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["subscript",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["subscript",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -2413,9 +1966,6 @@
     expected: FAIL
 
   [[["subscript",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertunorderedlist", false, "") return value]
-    expected: FAIL
-
-  [[["subscript",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["subscript",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -2440,9 +1990,6 @@
     expected: FAIL
 
   [[["subscript",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifycenter", false, "") return value]
-    expected: FAIL
-
-  [[["subscript",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["subscript",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -2475,9 +2022,6 @@
   [[["subscript",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyfull", false, "") return value]
     expected: FAIL
 
-  [[["subscript",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["subscript",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -2506,12 +2050,6 @@
     expected: FAIL
 
   [[["subscript",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyleft", false, "") return value]
-    expected: FAIL
-
-  [[["subscript",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["subscript",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["subscript",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("justifyleft") before]
@@ -2544,9 +2082,6 @@
   [[["subscript",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyright", false, "") return value]
     expected: FAIL
 
-  [[["subscript",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["subscript",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -2565,21 +2100,6 @@
   [[["subscript",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
     expected: FAIL
 
-  [[["subscript",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["subscript",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["superscript",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["superscript",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["superscript",""\],["delete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["superscript",""\],["delete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -2595,16 +2115,10 @@
   [[["superscript",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("formatblock", false, "<div>") return value]
     expected: FAIL
 
-  [[["superscript",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["superscript",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["superscript",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("formatblock") after]
-    expected: FAIL
-
-  [[["superscript",""\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["superscript",""\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -2619,16 +2133,7 @@
   [[["superscript",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("indent", false, "") return value]
     expected: FAIL
 
-  [[["superscript",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["superscript",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["superscript",""\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["superscript",""\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["superscript",""\],["inserthtml","ab<b>c</b>d"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
@@ -2640,16 +2145,7 @@
   [[["superscript",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
     expected: FAIL
 
-  [[["superscript",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["superscript",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["superscript",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["superscript",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["superscript",""\],["insertlinebreak",""\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
@@ -2659,9 +2155,6 @@
     expected: FAIL
 
   [[["superscript",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
-  [[["superscript",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["superscript",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -2679,9 +2172,6 @@
   [[["superscript",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertorderedlist", false, "") return value]
     expected: FAIL
 
-  [[["superscript",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["superscript",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -2689,9 +2179,6 @@
     expected: FAIL
 
   [[["superscript",""\],["insertparagraph",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["superscript",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["superscript",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -2709,9 +2196,6 @@
   [[["superscript",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertunorderedlist", false, "") return value]
     expected: FAIL
 
-  [[["superscript",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["superscript",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -2720,25 +2204,13 @@
 
 
 [multitest.html?8001-9000]
-  [[["subscript",""\],["fontsize","2"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["subscript",""\],["fontsize","2"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","2"\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["fontsize","2"\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["subscript",""\],["fontsize","3"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["subscript",""\],["fontsize","3"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","3"\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["fontsize","3"\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -2748,9 +2220,6 @@
     expected: FAIL
 
   [[["hilitecolor","aqua"\],["backcolor","tan"\],["inserttext","a"\]\] "foo[\]bar": execCommand("backcolor", false, "tan") return value]
-    expected: FAIL
-
-  [[["hilitecolor","aqua"\],["backcolor","tan"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["hilitecolor","aqua"\],["backcolor","tan"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -2768,9 +2237,6 @@
   [[["backcolor","tan"\],["hilitecolor","aqua"\],["inserttext","a"\]\] "foo[\]bar": execCommand("hilitecolor", false, "aqua") return value]
     expected: FAIL
 
-  [[["backcolor","tan"\],["hilitecolor","aqua"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["backcolor","tan"\],["hilitecolor","aqua"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -2780,891 +2246,330 @@
   [[["backcolor","tan"\],["hilitecolor","aqua"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("hilitecolor") after]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "foo<b>[bar\]</b>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "foo<b>[bar\]</b>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "foo<i>[bar\]</i>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "foo<i>[bar\]</i>baz" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "foo<s>[bar\]</s>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "foo<s>[bar\]</s>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "foo<sub>[bar\]</sub>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "foo<sub>[bar\]</sub>baz" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "foo<sup>[bar\]</sup>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "foo<sup>[bar\]</sup>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "foo<u>[bar\]</u>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "foo<u>[bar\]</u>baz" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "foo<a href=http://www.google.com>[bar\]</a>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "foo<a href=http://www.google.com>[bar\]</a>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "foo<font face=sans-serif>[bar\]</font>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "foo<font face=sans-serif>[bar\]</font>baz" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "foo<font size=4>[bar\]</font>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "foo<font size=4>[bar\]</font>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "foo<font color=#0000FF>[bar\]</font>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "foo<font color=#0000FF>[bar\]</font>baz" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "foo<span style=background-color:#00FFFF>[bar\]</span>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "foo<span style=background-color:#00FFFF>[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "foo<a href=http://www.google.com><font color=blue>[bar\]</font></a>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "foo<a href=http://www.google.com><font color=blue>[bar\]</font></a>baz" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "foo<font color=blue><a href=http://www.google.com>[bar\]</a></font>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "foo<font color=blue><a href=http://www.google.com>[bar\]</a></font>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "foo<a href=http://www.google.com><font color=brown>[bar\]</font></a>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "foo<a href=http://www.google.com><font color=brown>[bar\]</font></a>baz" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "foo<font color=brown><a href=http://www.google.com>[bar\]</a></font>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "foo<font color=brown><a href=http://www.google.com>[bar\]</a></font>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "foo<a href=http://www.google.com><font color=black>[bar\]</font></a>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "foo<a href=http://www.google.com><font color=black>[bar\]</font></a>baz" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "foo<a href=http://www.google.com><u>[bar\]</u></a>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "foo<a href=http://www.google.com><u>[bar\]</u></a>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "foo<u><a href=http://www.google.com>[bar\]</a></u>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "foo<u><a href=http://www.google.com>[bar\]</a></u>baz" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "foo<sub><font size=2>[bar\]</font></sub>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "foo<sub><font size=2>[bar\]</font></sub>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "foo<font size=2><sub>[bar\]</sub></font>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "foo<font size=2><sub>[bar\]</sub></font>baz" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "foo<sub><font size=3>[bar\]</font></sub>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "foo<sub><font size=3>[bar\]</font></sub>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "foo<font size=3><sub>[bar\]</sub></font>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "foo<font size=3><sub>[bar\]</sub></font>baz" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "[foo<b>bar\]</b>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "[foo<b>bar\]</b>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "[foo<i>bar\]</i>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "[foo<i>bar\]</i>baz" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "[foo<s>bar\]</s>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "[foo<s>bar\]</s>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "[foo<sub>bar\]</sub>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "[foo<sub>bar\]</sub>baz" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "[foo<sup>bar\]</sup>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "[foo<sup>bar\]</sup>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "[foo<u>bar\]</u>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "[foo<u>bar\]</u>baz" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "[foo<a href=http://www.google.com>bar\]</a>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "[foo<a href=http://www.google.com>bar\]</a>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "[foo<font face=sans-serif>bar\]</font>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "[foo<font face=sans-serif>bar\]</font>baz" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "[foo<font size=4>bar\]</font>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "[foo<font size=4>bar\]</font>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "[foo<font color=#0000FF>bar\]</font>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "[foo<font color=#0000FF>bar\]</font>baz" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "[foo<span style=background-color:#00FFFF>bar\]</span>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "[foo<span style=background-color:#00FFFF>bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "[foo<a href=http://www.google.com><font color=blue>bar\]</font></a>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "[foo<a href=http://www.google.com><font color=blue>bar\]</font></a>baz" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "[foo<font color=blue><a href=http://www.google.com>bar\]</a></font>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "[foo<font color=blue><a href=http://www.google.com>bar\]</a></font>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "[foo<a href=http://www.google.com><font color=brown>bar\]</font></a>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "[foo<a href=http://www.google.com><font color=brown>bar\]</font></a>baz" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "[foo<font color=brown><a href=http://www.google.com>bar\]</a></font>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "[foo<font color=brown><a href=http://www.google.com>bar\]</a></font>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "[foo<a href=http://www.google.com><font color=black>bar\]</font></a>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "[foo<a href=http://www.google.com><font color=black>bar\]</font></a>baz" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "[foo<a href=http://www.google.com><u>bar\]</u></a>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "[foo<a href=http://www.google.com><u>bar\]</u></a>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "[foo<u><a href=http://www.google.com>bar\]</a></u>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "[foo<u><a href=http://www.google.com>bar\]</a></u>baz" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "[foo<sub><font size=2>bar\]</font></sub>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "[foo<sub><font size=2>bar\]</font></sub>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "[foo<font size=2><sub>bar\]</sub></font>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "[foo<font size=2><sub>bar\]</sub></font>baz" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "[foo<sub><font size=3>bar\]</font></sub>baz": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "[foo<sub><font size=3>bar\]</font></sub>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "[foo<font size=3><sub>bar\]</sub></font>baz": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "[foo<font size=3><sub>bar\]</sub></font>baz" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "foo<b>[bar</b>baz\]": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "foo<b>[bar</b>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "foo<i>[bar</i>baz\]": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "foo<i>[bar</i>baz\]" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "foo<s>[bar</s>baz\]": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "foo<s>[bar</s>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "foo<sub>[bar</sub>baz\]": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "foo<sub>[bar</sub>baz\]" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "foo<sup>[bar</sup>baz\]": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "foo<sup>[bar</sup>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "foo<u>[bar</u>baz\]": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "foo<u>[bar</u>baz\]" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "foo<a href=http://www.google.com>[bar</a>baz\]": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "foo<a href=http://www.google.com>[bar</a>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "foo<font face=sans-serif>[bar</font>baz\]": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "foo<font face=sans-serif>[bar</font>baz\]" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "foo<font size=4>[bar</font>baz\]": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "foo<font size=4>[bar</font>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "foo<font color=#0000FF>[bar</font>baz\]": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "foo<font color=#0000FF>[bar</font>baz\]" compare innerHTML]
     expected: FAIL
 
+  [[["subscript",""\],["fontsize","2"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
+    expected: FAIL
+
+  [[["fontsize","2"\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
+    expected: FAIL
+
+  [[["subscript",""\],["fontsize","3"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
+    expected: FAIL
+
+  [[["fontsize","3"\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
+    expected: FAIL
+
 
 [multitest.html?9001-last]
-  [[["delete",""\],["inserttext","a"\]\] "foo<span style=background-color:#00FFFF>[bar</span>baz\]": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "foo<span style=background-color:#00FFFF>[bar</span>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "foo<a href=http://www.google.com><font color=blue>[bar</font></a>baz\]": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "foo<a href=http://www.google.com><font color=blue>[bar</font></a>baz\]" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "foo<font color=blue><a href=http://www.google.com>[bar</a></font>baz\]": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "foo<font color=blue><a href=http://www.google.com>[bar</a></font>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "foo<a href=http://www.google.com><font color=brown>[bar</font></a>baz\]": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "foo<a href=http://www.google.com><font color=brown>[bar</font></a>baz\]" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "foo<font color=brown><a href=http://www.google.com>[bar</a></font>baz\]": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "foo<font color=brown><a href=http://www.google.com>[bar</a></font>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "foo<a href=http://www.google.com><font color=black>[bar</font></a>baz\]": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "foo<a href=http://www.google.com><font color=black>[bar</font></a>baz\]" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "foo<a href=http://www.google.com><u>[bar</u></a>baz\]": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "foo<a href=http://www.google.com><u>[bar</u></a>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "foo<u><a href=http://www.google.com>[bar</a></u>baz\]": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "foo<u><a href=http://www.google.com>[bar</a></u>baz\]" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "foo<sub><font size=2>[bar</font></sub>baz\]": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "foo<sub><font size=2>[bar</font></sub>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "foo<font size=2><sub>[bar</sub></font>baz\]": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "foo<font size=2><sub>[bar</sub></font>baz\]" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "foo<sub><font size=3>[bar</font></sub>baz\]": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "foo<sub><font size=3>[bar</font></sub>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","a"\]\] "foo<font size=3><sub>[bar</sub></font>baz\]": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","a"\]\] "foo<font size=3><sub>[bar</sub></font>baz\]" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","a"\]\] "<blockquote><font color=blue>[foo\]</font></blockquote>": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","a"\]\] "<blockquote><font color=blue>[foo\]</font></blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["delete",""\],["inserttext","a"\]\] "<div><b>[abc\]</b></div>": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["delete",""\],["inserttext","a"\]\] "<div><b>[abc\]</b></div>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["delete",""\],["inserttext","d"\]\] "<div>abc<b>[def\]</b></div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["delete",""\],["inserttext","d"\]\] "<div>abc<b>[def\]</b></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["delete",""\],["insertparagraph",""\],["inserttext","a"\]\] "<div><b>[abc\]</b></div>": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["delete",""\],["insertparagraph",""\],["inserttext","a"\]\] "<div><b>[abc\]</b></div>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["delete",""\],["insertparagraph",""\],["inserttext","d"\]\] "<div>abc<b>[def\]</b></div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["delete",""\],["insertparagraph",""\],["inserttext","d"\]\] "<div>abc<b>[def\]</b></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["insertparagraph",""\],["inserttext","a"\]\] "<div><b>[abc\]</b></div>": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["insertparagraph",""\],["inserttext","a"\]\] "<div><b>[abc\]</b></div>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["insertparagraph",""\],["inserttext","d"\]\] "<div>abc<b>[def\]</b></div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["insertparagraph",""\],["inserttext","d"\]\] "<div>abc<b>[def\]</b></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["bold",""\],["inserttext","d"\]\] "<div><b>abc[\]<br></b></div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["bold",""\],["inserttext","d"\]\] "<div><b>abc[\]<br></b></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["bold",""\],["inserttext","d"\]\] "<div><i><b>abc[\]<br></b></i></div>": execCommand("inserttext", false, "d") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["bold",""\],["inserttext","d"\]\] "<div><i><b>abc[\]<br></b></i></div>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["bold",""\],["inserttext","d"\]\] "<div><i><b>abc[\]</b><br></i></div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["bold",""\],["inserttext","d"\]\] "<div><i><b>abc[\]</b><br></i></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["bold",""\],["inserttext","d"\]\] "<div><b><i>abc[\]<br></i></b></div>": execCommand("inserttext", false, "d") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["bold",""\],["inserttext","d"\]\] "<div><b><i>abc[\]<br></i></b></div>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["bold",""\],["inserttext","d"\]\] "<div><b><i>abc[\]</i><br></b></div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["bold",""\],["inserttext","d"\]\] "<div><b><i>abc[\]</i><br></b></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["bold",""\],["inserttext","d"\]\] "<div><b><i>abc[\]<br></i><br></b></div>": execCommand("inserttext", false, "d") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["bold",""\],["inserttext","d"\]\] "<div><b><i>abc[\]<br></i><br></b></div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc<b>[def</b>\]ghi": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc<b>[def</b>\]ghi": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc<b>[def</b>\]ghi": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
   [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc<b>[def</b>\]ghi" compare innerHTML]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc[<b>def\]</b>ghi": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc[<b>def\]</b>ghi": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc[<b>def\]</b>ghi": execCommand("inserttext", false, "f") return value]
     expected: FAIL
 
   [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc[<b>def\]</b>ghi" compare innerHTML]
     expected: FAIL
 
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc<b>[def\]</b>ghi": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc<b>[def\]</b>ghi": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc<b>[def\]</b>ghi": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
   [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc<b>[def\]</b>ghi" compare innerHTML]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc<b>{def}</b>ghi": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc<b>{def}</b>ghi": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc<b>{def}</b>ghi": execCommand("inserttext", false, "f") return value]
     expected: FAIL
 
   [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc<b>{def}</b>ghi" compare innerHTML]
     expected: FAIL
 
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc{<b>def</b>}ghi": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc{<b>def</b>}ghi": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc{<b>def</b>}ghi": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
   [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc{<b>def</b>}ghi" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i>def</i></b>}ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i>def</i></b>}ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i>def</i></b>}ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i>def</i></b>}ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i>def</i></b>}ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i>def</i></b>}ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def\]</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def\]</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def\]</i></b>ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def\]</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def\]</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def\]</i></b>ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i>def\]</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i>def\]</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i>def\]</i></b>ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i>def\]</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i>def\]</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i>def\]</i></b>ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def</i></b>\]ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def</i></b>\]ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def</i></b>\]ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def</i></b>\]ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def</i></b>\]ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def</i></b>\]ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc<b><i>[def</i></b>g\]hi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc<b><i>[def</i></b>g\]hi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc<b><i>[def</i></b>g\]hi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc<b><i>[def</i></b>g\]hi</div>": execCommand("inserttext", false, "g") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc<b><i>[def</i></b>g\]hi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc<b><i>[def</i></b>g\]hi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc<b><i>[def</i></b>g\]hi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc<b><i>[def</i></b>g\]hi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc<b><i>[def</i></b>g\]hi</div>": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
   [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc<b><i>[def</i></b>g\]hi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc[<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc[<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc[<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc[<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "g") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc[<b><i>def</i></b>g\]hi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc[<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc[<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc[<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc[<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
   [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc[<b><i>def</i></b>g\]hi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc{<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc{<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc{<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc{<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "g") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc{<b><i>def</i></b>g\]hi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc{<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc{<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc{<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc{<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
   [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc{<b><i>def</i></b>g\]hi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i>def</i></b>}ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i>def</i></b>}ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i>def</i></b>}ghi</div>": execCommand("inserttext", false, "f") return value]
     expected: FAIL
 
   [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i>def</i></b>}ghi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def\]</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def\]</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def\]</i></b>ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
   [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def\]</i></b>ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i>def\]</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i>def\]</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i>def\]</i></b>ghi</div>": execCommand("inserttext", false, "f") return value]
     expected: FAIL
 
   [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i>def\]</i></b>ghi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def</i></b>\]ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def</i></b>\]ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def</i></b>\]ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
   [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def</i></b>\]ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc<b><i>[def</i></b>g\]hi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc<b><i>[def</i></b>g\]hi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc<b><i>[def</i></b>g\]hi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc<b><i>[def</i></b>g\]hi</div>": execCommand("inserttext", false, "g") return value]
     expected: FAIL
 
   [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc<b><i>[def</i></b>g\]hi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc[<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc[<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc[<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc[<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
   [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc[<b><i>def</i></b>g\]hi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc{<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc{<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc{<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc{<b><i>def</i></b>g\]hi</div>": execCommand("inserttext", false, "g") return value]
     expected: FAIL
 
   [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\],["inserttext","g"\]\] "<div>abc{<b><i>def</i></b>g\]hi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">de\]f</i></b>ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
     expected: FAIL
 
   [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">de\]f</i></b>ghi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def\]</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def\]</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def\]</i></b>ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def\]</i></b>ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def\]</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def\]</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def\]</i></b>ghi</div>": execCommand("inserttext", false, "f") return value]
     expected: FAIL
 
   [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def\]</i></b>ghi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "f") return value]
     expected: FAIL
 
   [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
   [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
     expected: FAIL
 
   [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">de\]f</i></b>ghi</div>" compare innerHTML]
@@ -3673,127 +2578,31 @@
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">de\]f</i></b>ghi</div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">de\]f</i></b>ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def\]</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def\]</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def\]</i></b>ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def\]</i></b>ghi</div>" compare innerHTML]
     expected: FAIL
 
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def\]</i></b>ghi</div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def\]</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def\]</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def\]</i></b>ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def\]</i></b>ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>" compare innerHTML]
     expected: FAIL
 
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>" compare innerHTML]
     expected: FAIL
 
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("inserttext", false, "f") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "c") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["forwarddelete",""\],["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "c") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
   [[["forwarddelete",""\],["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "c") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
     expected: FAIL
 
   [[["insertparagraph",""\],["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>" compare innerHTML]
@@ -3802,58 +2611,19 @@
   [[["insertlinebreak",""\],["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
-  [[["insertlinebreak",""\],["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "c") return value]
-    expected: FAIL
-
-  [[["insertlinebreak",""\],["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertlinebreak",""\],["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\],["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i>de\]f</i></b>ghi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
   [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i>de\]f</i></b>ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<b><i>de\]f</i></b>ghi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
   [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<b><i>de\]f</i></b>ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
     expected: FAIL
 
   [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i>de\]f</i></b>ghi</div>" compare innerHTML]
@@ -3862,19 +2632,7 @@
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i>de\]f</i></b>ghi</div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i>de\]f</i></b>ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
     expected: FAIL
 
   [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<b><i>de\]f</i></b>ghi</div>" compare innerHTML]
@@ -3883,55 +2641,19 @@
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<b><i>de\]f</i></b>ghi</div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<b><i>de\]f</i></b>ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<s></s><b><i>de\]f</i></b>ghi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
   [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<s></s><b><i>de\]f</i></b>ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<s></s><b><i>de\]f</i></b>ghi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
   [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<s></s><b><i>de\]f</i></b>ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
     expected: FAIL
 
   [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<s></s><b><i>de\]f</i></b>ghi</div>" compare innerHTML]
@@ -3940,19 +2662,7 @@
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<s></s><b><i>de\]f</i></b>ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
     expected: FAIL
 
   [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<s></s><b><i>de\]f</i></b>ghi</div>" compare innerHTML]
@@ -3961,475 +2671,196 @@
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("inserttext", false, "e") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<s></s><b><i>de\]f</i></b>ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\],["insertText","a"\]\] "<font size=7>{}<br></font>": execCommand("insertText", false, "a") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\],["insertText","a"\]\] "<font size=7>{}<br></font>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["italic",""\],["insertText","a"\]\] "<span style=font-weight:bold>{}<br></span></b>": execCommand("insertText", false, "a") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["italic",""\],["insertText","a"\]\] "<span style=font-weight:bold>{}<br></span></b>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontSize","4"\],["backColor","#00dddd"\],["insertText","d"\]\] "abc[\]ef": execCommand("insertText", false, "d") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontSize","4"\],["backColor","#00dddd"\],["insertText","d"\]\] "abc[\]ef" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["foreColor","#ff0000"\],["backColor","#00dddd"\],["insertText","d"\]\] "abc[\]ef": execCommand("insertText", false, "d") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["foreColor","#ff0000"\],["backColor","#00dddd"\],["insertText","d"\]\] "abc[\]ef" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontName","monospace"\],["backColor","#00dddd"\],["insertText","d"\]\] "abc[\]ef": execCommand("insertText", false, "d") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontName","monospace"\],["backColor","#00dddd"\],["insertText","d"\]\] "abc[\]ef" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["backColor","#00dddd"\],["fontSize","4"\],["insertText","d"\]\] "abc[\]ef": execCommand("insertText", false, "d") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["backColor","#00dddd"\],["fontSize","4"\],["insertText","d"\]\] "abc[\]ef" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["backColor","#00dddd"\],["foreColor","#ff0000"\],["insertText","d"\]\] "abc[\]ef": execCommand("insertText", false, "d") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["backColor","#00dddd"\],["foreColor","#ff0000"\],["insertText","d"\]\] "abc[\]ef" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["backColor","#00dddd"\],["fontName","monospace"\],["insertText","d"\]\] "abc[\]ef": execCommand("insertText", false, "d") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["backColor","#00dddd"\],["fontName","monospace"\],["insertText","d"\]\] "abc[\]ef" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontName","monospace"\],["foreColor","#ff0000"\],["fontSize","7"\],["backColor","#00dddd"\],["insertText","d"\]\] "abc[\]ef": execCommand("insertText", false, "d") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontName","monospace"\],["foreColor","#ff0000"\],["fontSize","7"\],["backColor","#00dddd"\],["insertText","d"\]\] "abc[\]ef" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["delete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo</span></p><p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span></p>": execCommand("insertText", false, "A") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["delete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo</span></p><p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span></p>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["delete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo</span><br></p><p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span></p>": execCommand("insertText", false, "A") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["delete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo</span><br></p><p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span></p>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["delete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo<br></span></p><p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span></p>": execCommand("insertText", false, "A") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["delete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo<br></span></p><p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span></p>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["delete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo</span></p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span>": execCommand("insertText", false, "A") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["delete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo</span></p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["delete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo</span><br></p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span>": execCommand("insertText", false, "A") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["delete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo</span><br></p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["delete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo<br></span></p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span>": execCommand("insertText", false, "A") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["delete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo<br></span></p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["delete",""\],["insertText","A"\]\] "<span style=\\"color:rgb(0, 0, 255)\\">foo</span><br><p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span></p>": execCommand("insertText", false, "A") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["delete",""\],["insertText","A"\]\] "<span style=\\"color:rgb(0, 0, 255)\\">foo</span><br><p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span></p>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["delete",""\],["insertText","A"\]\] "<span style=\\"color:rgb(0, 0, 255)\\">foo<br></span><p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span></p>": execCommand("insertText", false, "A") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["delete",""\],["insertText","A"\]\] "<span style=\\"color:rgb(0, 0, 255)\\">foo<br></span><p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span></p>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["forwarddelete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo[\]</span></p><p><span style=\\"color:rgb(255, 0, 0)\\">bar</span></p>": execCommand("insertText", false, "A") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["forwarddelete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo[\]</span></p><p><span style=\\"color:rgb(255, 0, 0)\\">bar</span></p>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["forwarddelete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo[\]</span><br></p><p><span style=\\"color:rgb(255, 0, 0)\\">bar</span></p>": execCommand("insertText", false, "A") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["forwarddelete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo[\]</span><br></p><p><span style=\\"color:rgb(255, 0, 0)\\">bar</span></p>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["forwarddelete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo[\]<br></span></p><p><span style=\\"color:rgb(255, 0, 0)\\">bar</span></p>": execCommand("insertText", false, "A") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["forwarddelete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo[\]<br></span></p><p><span style=\\"color:rgb(255, 0, 0)\\">bar</span></p>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["forwarddelete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo[\]</span></p><span style=\\"color:rgb(255, 0, 0)\\">bar</span>": execCommand("insertText", false, "A") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["forwarddelete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo[\]</span></p><span style=\\"color:rgb(255, 0, 0)\\">bar</span>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["forwarddelete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo[\]</span><br></p><span style=\\"color:rgb(255, 0, 0)\\">bar</span>": execCommand("insertText", false, "A") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["forwarddelete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo[\]</span><br></p><span style=\\"color:rgb(255, 0, 0)\\">bar</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["forwarddelete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo[\]<br></span></p><span style=\\"color:rgb(255, 0, 0)\\">bar</span>": execCommand("insertText", false, "A") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["forwarddelete",""\],["insertText","A"\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo[\]<br></span></p><span style=\\"color:rgb(255, 0, 0)\\">bar</span>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["forwarddelete",""\],["insertText","A"\]\] "<span style=\\"color:rgb(0, 0, 255)\\">foo[\]</span><br><p><span style=\\"color:rgb(255, 0, 0)\\">bar</span></p>": execCommand("insertText", false, "A") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["forwarddelete",""\],["insertText","A"\]\] "<span style=\\"color:rgb(0, 0, 255)\\">foo[\]</span><br><p><span style=\\"color:rgb(255, 0, 0)\\">bar</span></p>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["forwarddelete",""\],["insertText","A"\]\] "<span style=\\"color:rgb(0, 0, 255)\\">foo[\]<br></span><p><span style=\\"color:rgb(255, 0, 0)\\">bar</span></p>": execCommand("insertText", false, "A") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["forwarddelete",""\],["insertText","A"\]\] "<span style=\\"color:rgb(0, 0, 255)\\">foo[\]<br></span><p><span style=\\"color:rgb(255, 0, 0)\\">bar</span></p>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "a[\]c": execCommand("insertText", false, "b") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "a[\]c" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["italic",""\],["bold",""\],["insertText","b"\]\] "a[\]c": execCommand("insertText", false, "b") return value]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["italic",""\],["bold",""\],["insertText","b"\]\] "a[\]c" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "<b>a[\]</b>c": execCommand("insertText", false, "b") return value]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "<b>a[\]</b>c" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "<i>a[\]</i>c": execCommand("insertText", false, "b") return value]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "<i>a[\]</i>c" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "a[\]<b>c</b>": execCommand("insertText", false, "b") return value]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "a[\]<b>c</b>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "a[\]<i>c</i>": execCommand("insertText", false, "b") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "a[\]<i>c</i>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["foreColor","#ff0000"\],["bold",""\],["insertText","b"\]\] "a[\]c": execCommand("insertText", false, "b") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["foreColor","#ff0000"\],["bold",""\],["insertText","b"\]\] "a[\]c" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["bold",""\],["foreColor","#ff0000"\],["insertText","b"\]\] "a[\]c": execCommand("insertText", false, "b") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["bold",""\],["foreColor","#ff0000"\],["insertText","b"\]\] "a[\]c" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["fontName","monospace"\],["bold",""\],["insertText","b"\]\] "a[\]c": execCommand("insertText", false, "b") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["fontName","monospace"\],["bold",""\],["insertText","b"\]\] "a[\]c" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["bold",""\],["fontName","monospace"\],["insertText","b"\]\] "a[\]c": execCommand("insertText", false, "b") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["bold",""\],["fontName","monospace"\],["insertText","b"\]\] "a[\]c" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["fontSize","5"\],["bold",""\],["insertText","b"\]\] "a[\]c": execCommand("insertText", false, "b") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["fontSize","5"\],["bold",""\],["insertText","b"\]\] "a[\]c" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["bold",""\],["fontSize","5"\],["insertText","b"\]\] "a[\]c": execCommand("insertText", false, "b") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["bold",""\],["fontSize","5"\],["insertText","b"\]\] "a[\]c" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["foreColor","#ff0000"\],["bold",""\],["fontSize","5"\],["fontName","monospace"\],["insertText","b"\]\] "a[\]c": execCommand("insertText", false, "b") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["foreColor","#ff0000"\],["bold",""\],["fontSize","5"\],["fontName","monospace"\],["insertText","b"\]\] "a[\]c" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["delete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\">a</font></p><p>[\]c</p>": execCommand("insertText", false, "b") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["delete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\">a</font></p><p>[\]c</p>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["delete",""\],["fontSize","5"\],["foreColor","#ff0000"\],["insertText","b"\]\] "<p><font size=\\"5\\" color=\\"#ff0000\\">a</font></p><p>[\]c</p>": execCommand("insertText", false, "b") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["delete",""\],["fontSize","5"\],["foreColor","#ff0000"\],["insertText","b"\]\] "<p><font size=\\"5\\" color=\\"#ff0000\\">a</font></p><p>[\]c</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["delete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\"><b>a</b></font></p><p>[\]c</p>": execCommand("insertText", false, "b") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["delete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\"><b>a</b></font></p><p>[\]c</p>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["delete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\"><b>a</b></font></p><p><i>[\]c</i></p>": execCommand("insertText", false, "b") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["delete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\"><b>a</b></font></p><p><i>[\]c</i></p>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["forwardDelete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\">a[\]</font></p><p>c</p>": execCommand("insertText", false, "b") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["forwardDelete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\">a[\]</font></p><p>c</p>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["forwardDelete",""\],["fontSize","5"\],["foreColor","#ff0000"\],["insertText","b"\]\] "<p><font size=\\"5\\" color=\\"#ff0000\\">a[\]</font></p><p>c</p>": execCommand("insertText", false, "b") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["forwardDelete",""\],["fontSize","5"\],["foreColor","#ff0000"\],["insertText","b"\]\] "<p><font size=\\"5\\" color=\\"#ff0000\\">a[\]</font></p><p>c</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["forwardDelete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\"><b>a[\]</b></font></p><p>c</p>": execCommand("insertText", false, "b") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["forwardDelete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\"><b>a[\]</b></font></p><p>c</p>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["forwardDelete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\"><b>a[\]</b></font></p><p><i>c</i></p>": execCommand("insertText", false, "b") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["forwardDelete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\"><b>a[\]</b></font></p><p><i>c</i></p>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div>{abc</div><div>def</div>}": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div>{abc</div><div>def</div>}": execCommand("inserttext", false, "h") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div>{abc</div><div>def</div>}" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div>abc</div><div>{def</div>}": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div>abc</div><div>{def</div>}": execCommand("inserttext", false, "h") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div>abc</div><div>{def</div>}" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span>{abc</span><span>def</span>}</div>": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span>{abc</span><span>def</span>}</div>": execCommand("inserttext", false, "h") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span>{abc</span><span>def</span>}</div>" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span>abc</span><span>{def</span>}</div>": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span>abc</span><span>{def</span>}</div>": execCommand("inserttext", false, "h") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span>abc</span><span>{def</span>}</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span>{abc</span><span>def</span>}</div>": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span>{abc</span><span>def</span>}</div>": execCommand("inserttext", false, "h") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span>{abc</span><span>def</span>}</div>" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span>abc</span><span>{def</span>}</div>": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span>abc</span><span>{def</span>}</div>": execCommand("inserttext", false, "h") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span>abc</span><span>{def</span>}</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div><b>{abc</b></div><div>def</div>}": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div><b>{abc</b></div><div>def</div>}": execCommand("inserttext", false, "h") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div><b>{abc</b></div><div>def</div>}" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div>abc</div><div><b>{def</b></div>}": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div>abc</div><div><b>{def</b></div>}": execCommand("inserttext", false, "h") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div>abc</div><div><b>{def</b></div>}" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span><b>{abc</b></span><span>def</span>}</div>": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span><b>{abc</b></span><span>def</span>}</div>": execCommand("inserttext", false, "h") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span><b>{abc</b></span><span>def</span>}</div>" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span>abc</span><span><b>{def</b></span>}</div>": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span>abc</span><span><b>{def</b></span>}</div>": execCommand("inserttext", false, "h") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:flex><span>abc</span><span><b>{def</b></span>}</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span><b>{abc</b></span><span>def</span>}</div>": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span><b>{abc</b></span><span>def</span>}</div>": execCommand("inserttext", false, "h") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span><b>{abc</b></span><span>def</span>}</div>" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span>abc</span><span><b>{def</b></span>}</div>": execCommand("inserttext", false, "g") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span>abc</span><span><b>{def</b></span>}</div>": execCommand("inserttext", false, "h") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","g"\],["inserttext","h"\]\] "<div style=display:grid><span>abc</span><span><b>{def</b></span>}</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","Y"\]\] "<b>X[\]<span contenteditable=false>abc</span></b><i>def</i>": execCommand("inserttext", false, "Y") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","Y"\]\] "<b>X[\]<span contenteditable=false>abc</span></b><i>def</i>" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","Y"\]\] "<b><span contenteditable=false>abc</span>X[\]</b><i>def</i>": execCommand("inserttext", false, "Y") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","Y"\]\] "<b><span contenteditable=false>abc</span>X[\]</b><i>def</i>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","Y"\]\] "<b>[\]X<span contenteditable=false>abc</span></b><i>def</i>": execCommand("inserttext", false, "Y") return value]
     expected: FAIL
 
   [[["forwarddelete",""\],["inserttext","Y"\]\] "<b>[\]X<span contenteditable=false>abc</span></b><i>def</i>" compare innerHTML]
     expected: FAIL
 
-  [[["forwarddelete",""\],["inserttext","Y"\]\] "<b><span contenteditable=false>abc</span>[\]X</b><i>def</i>": execCommand("inserttext", false, "Y") return value]
-    expected: FAIL
-
   [[["forwarddelete",""\],["inserttext","Y"\]\] "<b><span contenteditable=false>abc</span>[\]X</b><i>def</i>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","B"\]\] "<table><tr><td>a<td><b>[b</b><td><b>c</b><td><b>d\]</b><td>e</table>": execCommand("inserttext", false, "B") return value]
     expected: FAIL
 
   [[["delete",""\],["inserttext","B"\]\] "<table><tr><td>a<td><b>[b</b><td><b>c</b><td><b>d\]</b><td>e</table>" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\],["inserttext","B"\]\] "<table><tr><th>a<th><b>[b</b><th><b>c</b><th><b>d\]</b><th>e</table>": execCommand("inserttext", false, "B") return value]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","B"\]\] "<table><tr><th>a<th><b>[b</b><th><b>c</b><th><b>d\]</b><th>e</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","B"\]\] "<table><tr><td>a<td><b>[b</b><td><b>c</b><td><b>d\]</b><td>e</table>": execCommand("inserttext", false, "B") return value]
     expected: FAIL
 
   [[["forwarddelete",""\],["inserttext","B"\]\] "<table><tr><td>a<td><b>[b</b><td><b>c</b><td><b>d\]</b><td>e</table>" compare innerHTML]
     expected: FAIL
 
-  [[["forwarddelete",""\],["inserttext","B"\]\] "<table><tr><th>a<th><b>[b</b><th><b>c</b><th><b>d\]</b><th>e</table>": execCommand("inserttext", false, "B") return value]
-    expected: FAIL
-
   [[["forwarddelete",""\],["inserttext","B"\]\] "<table><tr><th>a<th><b>[b</b><th><b>c</b><th><b>d\]</b><th>e</table>" compare innerHTML]
     expected: FAIL
 
-  [[["inserttext"," "\],["bold",""\],["inserttext","d"\]\] "<p><b>abc[\]</b></p>": execCommand("inserttext", false, " ") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\],["bold",""\],["inserttext","d"\]\] "<p><b>abc[\]</b></p>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["inserttext"," "\],["bold",""\],["inserttext","d"\]\] "<p><b>abc[\]</b></p>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\]\] "<p>abc<br> </p> <p>{}<br></p>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\]\] "<p>abc<br> </p> <p>{}<br></p>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\]\] "<div style=white-space:pre><p>abc</p> <p>{}<br></p></div>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
-  [[["delete",""\],["inserttext","d"\]\] "<div style=white-space:pre><p>abc</p> <p>{}<br></p></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\]\] "<p>abc[\]<br> </p> <p><br></p>": execCommand("inserttext", false, "d") return value]
-    expected: FAIL
-
   [[["forwarddelete",""\],["inserttext","d"\]\] "<p>abc[\]<br> </p> <p><br></p>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\],["inserttext","d"\]\] "<div style=white-space:pre><p>abc[\]</p> <p><br></p></div>": execCommand("inserttext", false, "d") return value]
     expected: FAIL
 
   [[["forwarddelete",""\],["inserttext","d"\]\] "<div style=white-space:pre><p>abc[\]</p> <p><br></p></div>" compare innerHTML]
@@ -4465,6 +2896,9 @@
   [[["forwarddelete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def</i></b>\]ghi</div>" compare innerHTML]
     expected: FAIL
 
+  [[["stylewithcss","false"\],["fontsize","4"\],["insertText","a"\]\] "<font size=7>{}<br></font>" queryCommandValue("fontsize") after]
+    expected: FAIL
+
 
 [multitest.html?3001-4000]
   [[["superscript",""\],["justifycenter",""\]\] "foo[\]bar": execCommand("justifycenter", false, "") return value]
@@ -4483,9 +2917,6 @@
     expected: FAIL
 
   [[["superscript",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifycenter", false, "") return value]
-    expected: FAIL
-
-  [[["superscript",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["superscript",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -4518,9 +2949,6 @@
   [[["superscript",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyfull", false, "") return value]
     expected: FAIL
 
-  [[["superscript",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["superscript",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -4549,12 +2977,6 @@
     expected: FAIL
 
   [[["superscript",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyleft", false, "") return value]
-    expected: FAIL
-
-  [[["superscript",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["superscript",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["superscript",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("justifyleft") before]
@@ -4587,9 +3009,6 @@
   [[["superscript",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyright", false, "") return value]
     expected: FAIL
 
-  [[["superscript",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["superscript",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -4608,19 +3027,7 @@
   [[["superscript",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
     expected: FAIL
 
-  [[["superscript",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["superscript",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["underline",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\],["delete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["underline",""\],["delete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -4638,16 +3045,10 @@
   [[["underline",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("formatblock", false, "<div>") return value]
     expected: FAIL
 
-  [[["underline",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["underline",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["underline",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("formatblock") after]
-    expected: FAIL
-
-  [[["underline",""\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["underline",""\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -4662,13 +3063,7 @@
   [[["underline",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("indent", false, "") return value]
     expected: FAIL
 
-  [[["underline",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["underline",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["underline",""\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -4683,13 +3078,7 @@
   [[["underline",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
     expected: FAIL
 
-  [[["underline",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["underline",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["underline",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -4702,9 +3091,6 @@
     expected: FAIL
 
   [[["underline",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
-  [[["underline",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["underline",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -4722,9 +3108,6 @@
   [[["underline",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertorderedlist", false, "") return value]
     expected: FAIL
 
-  [[["underline",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["underline",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -4732,9 +3115,6 @@
     expected: FAIL
 
   [[["underline",""\],["insertparagraph",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["underline",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -4750,9 +3130,6 @@
     expected: FAIL
 
   [[["underline",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertunorderedlist", false, "") return value]
-    expected: FAIL
-
-  [[["underline",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["underline",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -4777,9 +3154,6 @@
     expected: FAIL
 
   [[["underline",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifycenter", false, "") return value]
-    expected: FAIL
-
-  [[["underline",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["underline",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -4812,9 +3186,6 @@
   [[["underline",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyfull", false, "") return value]
     expected: FAIL
 
-  [[["underline",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["underline",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -4843,9 +3214,6 @@
     expected: FAIL
 
   [[["underline",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyleft", false, "") return value]
-    expected: FAIL
-
-  [[["underline",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["underline",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -4881,9 +3249,6 @@
   [[["underline",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyright", false, "") return value]
     expected: FAIL
 
-  [[["underline",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["underline",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -4902,22 +3267,13 @@
   [[["underline",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
     expected: FAIL
 
-  [[["underline",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["underline",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["backcolor","#00FFFF"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["delete",""\]\] "foo[\]bar" queryCommandValue("backcolor") after]
-    expected: FAIL
-
-  [[["backcolor","#00FFFF"\],["delete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["delete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -4938,16 +3294,10 @@
   [[["backcolor","#00FFFF"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("formatblock", false, "<div>") return value]
     expected: FAIL
 
-  [[["backcolor","#00FFFF"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["backcolor","#00FFFF"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("formatblock") after]
-    expected: FAIL
-
-  [[["backcolor","#00FFFF"\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -4962,23 +3312,26 @@
   [[["backcolor","#00FFFF"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("indent", false, "") return value]
     expected: FAIL
 
-  [[["backcolor","#00FFFF"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["backcolor","#00FFFF"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["backcolor","#00FFFF"\],["forwarddelete",""\]\] "foo[\]bar" queryCommandValue("backcolor") after]
+  [[["backcolor","#00FFFF"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("backcolor") after]
+    expected: FAIL
+
+  [[["backcolor","#00FFFF"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("backcolor") after]
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("backcolor") after]
     expected: FAIL
 
-
-[multitest.html?4001-5000]
-  [[["backcolor","#00FFFF"\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
+  [[["backcolor","#00FFFF"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("backcolor") after]
     expected: FAIL
 
+  [[["backcolor","#00FFFF"\],["forwarddelete",""\]\] "foo[\]bar" queryCommandValue("backcolor") after]
+    expected: FAIL
+
+
+[multitest.html?4001-5000]
   [[["backcolor","#00FFFF"\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -4991,13 +3344,7 @@
   [[["backcolor","#00FFFF"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
     expected: FAIL
 
-  [[["backcolor","#00FFFF"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["backcolor","#00FFFF"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["backcolor","#00FFFF"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -5010,9 +3357,6 @@
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
-  [[["backcolor","#00FFFF"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -5030,9 +3374,6 @@
   [[["backcolor","#00FFFF"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertorderedlist", false, "") return value]
     expected: FAIL
 
-  [[["backcolor","#00FFFF"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["backcolor","#00FFFF"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -5040,9 +3381,6 @@
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["insertparagraph",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["backcolor","#00FFFF"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -5058,9 +3396,6 @@
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertunorderedlist", false, "") return value]
-    expected: FAIL
-
-  [[["backcolor","#00FFFF"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -5085,9 +3420,6 @@
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifycenter", false, "") return value]
-    expected: FAIL
-
-  [[["backcolor","#00FFFF"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -5120,9 +3452,6 @@
   [[["backcolor","#00FFFF"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyfull", false, "") return value]
     expected: FAIL
 
-  [[["backcolor","#00FFFF"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["backcolor","#00FFFF"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -5151,9 +3480,6 @@
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyleft", false, "") return value]
-    expected: FAIL
-
-  [[["backcolor","#00FFFF"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -5189,9 +3515,6 @@
   [[["backcolor","#00FFFF"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyright", false, "") return value]
     expected: FAIL
 
-  [[["backcolor","#00FFFF"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["backcolor","#00FFFF"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -5210,19 +3533,7 @@
   [[["backcolor","#00FFFF"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
     expected: FAIL
 
-  [[["backcolor","#00FFFF"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["backcolor","#00FFFF"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["delete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["createlink","http://www.google.com/"\],["delete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -5240,16 +3551,10 @@
   [[["createlink","http://www.google.com/"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("formatblock", false, "<div>") return value]
     expected: FAIL
 
-  [[["createlink","http://www.google.com/"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["createlink","http://www.google.com/"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["createlink","http://www.google.com/"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("formatblock") after]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["createlink","http://www.google.com/"\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -5264,16 +3569,7 @@
   [[["createlink","http://www.google.com/"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("indent", false, "") return value]
     expected: FAIL
 
-  [[["createlink","http://www.google.com/"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["createlink","http://www.google.com/"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["createlink","http://www.google.com/"\],["inserthtml","ab<b>c</b>d"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
@@ -5285,16 +3581,7 @@
   [[["createlink","http://www.google.com/"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
     expected: FAIL
 
-  [[["createlink","http://www.google.com/"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["createlink","http://www.google.com/"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["createlink","http://www.google.com/"\],["insertlinebreak",""\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
@@ -5304,9 +3591,6 @@
     expected: FAIL
 
   [[["createlink","http://www.google.com/"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["createlink","http://www.google.com/"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -5324,9 +3608,6 @@
   [[["createlink","http://www.google.com/"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertorderedlist", false, "") return value]
     expected: FAIL
 
-  [[["createlink","http://www.google.com/"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["createlink","http://www.google.com/"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -5334,9 +3615,6 @@
     expected: FAIL
 
   [[["createlink","http://www.google.com/"\],["insertparagraph",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["createlink","http://www.google.com/"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -5352,9 +3630,6 @@
     expected: FAIL
 
   [[["createlink","http://www.google.com/"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertunorderedlist", false, "") return value]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["createlink","http://www.google.com/"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -5379,9 +3654,6 @@
     expected: FAIL
 
   [[["createlink","http://www.google.com/"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifycenter", false, "") return value]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["createlink","http://www.google.com/"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -5414,9 +3686,6 @@
   [[["createlink","http://www.google.com/"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyfull", false, "") return value]
     expected: FAIL
 
-  [[["createlink","http://www.google.com/"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
-    expected: FAIL
-
   [[["createlink","http://www.google.com/"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -5445,4 +3714,31 @@
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("backcolor") after]
+    expected: FAIL
+
+  [[["backcolor","#00FFFF"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("backcolor") after]
+    expected: FAIL
+
+  [[["backcolor","#00FFFF"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("backcolor") after]
+    expected: FAIL
+
+  [[["backcolor","#00FFFF"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("backcolor") after]
+    expected: FAIL
+
+  [[["backcolor","#00FFFF"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("backcolor") after]
+    expected: FAIL
+
+  [[["backcolor","#00FFFF"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("backcolor") after]
+    expected: FAIL
+
+  [[["backcolor","#00FFFF"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("backcolor") after]
+    expected: FAIL
+
+  [[["backcolor","#00FFFF"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("backcolor") after]
+    expected: FAIL
+
+  [[["backcolor","#00FFFF"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("backcolor") after]
+    expected: FAIL
+
+  [[["backcolor","#00FFFF"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("backcolor") after]
     expected: FAIL

--- a/tests/wpt/meta/editing/whitespaces/chrome-compat/inserttext.tentative.html.ini
+++ b/tests/wpt/meta/editing/whitespaces/chrome-compat/inserttext.tentative.html.ini
@@ -1,4 +1,5 @@
 [inserttext.tentative.html]
+  expected: CRASH
   [execCommand("inserttext", false, " ") at "a[\]b"]
     expected: FAIL
 

--- a/tests/wpt/meta/editing/whitespaces/inserttext-at-end-of-block-when-br-always-block.html.ini
+++ b/tests/wpt/meta/editing/whitespaces/inserttext-at-end-of-block-when-br-always-block.html.ini
@@ -1,3 +1,0 @@
-[inserttext-at-end-of-block-when-br-always-block.html]
-  [Inserting white-space and a character at block end should keep the white-space even before block <br> element]
-    expected: FAIL


### PR DESCRIPTION
This implements the inserttext editing command.

Testing: A bunch of new passes. Also some new crashes and timeouts, but I haven't yet had the time to debug those and this has been sitting on my harddrive for a while now, so I thought I'd just open the PR.
(I also assume that debugging test failures will get easier overall once more of these commands are implemented, since there'll be less noise due to missing commands and one could probably cross-reference between multiple commands with similar failures... but maybe that's just wishful thinking to justify being lazy right now.)