### PR TITLE
layout: Use a total order comparator when distributing extra space to rowspans

### DIFF
--- a/components/layout/table/layout.rs
+++ b/components/layout/table/layout.rs
@@ -3060,8 +3060,11 @@ impl RowspanToDistribute<'_> {
         self.coordinates.y..self.coordinates.y + self.cell.rowspan
     }
 
+    /// Returns true if other is a proper subset of [`self`].
     fn fully_encloses(&self, other: &RowspanToDistribute) -> bool {
-        other.coordinates.y > self.coordinates.y && other.range().end < self.range().end
+        self.range() != other.range() &&
+            other.coordinates.y >= self.coordinates.y &&
+            other.range().end <= self.range().end
     }
 }
 

--- a/tests/wpt/tests/css/css-tables/crashtests/row-size-distribution-rowspan-sorting.html
+++ b/tests/wpt/tests/css/css-tables/crashtests/row-size-distribution-rowspan-sorting.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/46806">
+<table>
+    <tr>
+        <td rowspan=6></td>
+        <td rowspan=2></td>
+        <td rowspan=4></td>
+        <td rowspan=4></td>
+        <td rowspan=2></td>
+    </tr>
+    <tr>
+        <td rowspan=2></td>
+        <td rowspan=2></td>
+    </tr>
+    <tr>
+        <td rowspan=2>XXXX</td>
+        <td rowspan=2></td>
+    </tr>
+    <tr></tr>
+    <tr>
+        <td rowspan=6></td>
+        <td rowspan=2></td>
+    </tr>
+    <tr>
+        <td rowspan=4></td>
+        <td rowspan=4></td>
+        <td rowspan=2></td>
+    </tr>
+    <tr>
+        <td rowspan=2></td>
+        <td rowspan=2></td>
+        <td rowspan=2></td>
+        <td rowspan=2></td>
+        <td rowspan=2></td>
+        <td rowspan=2></td>
+        <td rowspan=2></td>
+    </tr>
+    <tr></tr>
+</table>


### PR DESCRIPTION
Extra space is distributed to rowspans in an order determined by the
specification. The sorting that was used to determine this order wasn't
total which meant that you could have a situation where:

 - rowspan_a == rowspan_b
 - rowspan_a > rowspan_c
 - rowspan_c > rowspan_b

This change makes the sorting total by properly ordering ranges even
when one side of their ranges overlap. The test included here
unfortunately has to be a bit noisy because the standard library only
detects a non-total ordering under a specific set and distribution of
elements.

Testing: This change includes a WPT crashtest.
Fixes: #46806.
