### PR TITLE
perf: add initial threadboost mechanism (for ohos).

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -380,6 +380,10 @@ pub struct Preferences {
     pub network_use_webpki_roots: bool,
     /// The maximum content size we will forward for preallocation, defaults to 5MB
     pub network_max_content_length: u64,
+    /// Experimental option. If enabled servo will attempt to optimize thread placement
+    /// and/or priority of critical servo threads to optimize performance.
+    #[doc(hidden)]
+    pub perf_thread_boost_enabled: bool,
     /// The length of the session history, in navigations, for each `WebView. Back-forward
     /// cache entries that are more than `session_history_max_length` steps in the future or
     /// `session_history_max_length` steps in the past will be discarded. Navigating forward
@@ -580,6 +584,7 @@ impl Preferences {
             network_local_directory_listing_enabled: true,
             network_use_webpki_roots: false,
             network_max_content_length: 5 * 1024 * 1024,
+            perf_thread_boost_enabled: true,
             session_history_max_length: 20,
             shell_background_color_rgba: [1.0, 1.0, 1.0, 1.0],
             log_filter: String::new(),

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -619,6 +619,7 @@ where
         thread::Builder::new()
             .name("Constellation".to_owned())
             .spawn(move || {
+                servo_base::threadboost::mark_thread_as_critical();
                 let (script_ipc_sender, script_ipc_receiver) =
                     generic_channel::channel().expect("ipc channel failure");
                 let script_receiver = script_ipc_receiver.route_preserving_errors();

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -508,6 +508,7 @@ impl ScriptThreadFactory for ScriptThread {
                 SCRIPT_THREAD_ROOT.with(|root| {
                     root.set(Some(Rc::as_ptr(&script_thread)));
                 });
+                servo_base::threadboost::mark_thread_as_critical();
                 let mut failsafe = ScriptMemoryFailsafe::new(&script_thread);
 
                 memory_profiler_sender.run_with_memory_reporting(

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -1002,6 +1002,10 @@ impl Servo {
             prefs::add_observer(Box::new(constellation_proxy.clone()));
         }
 
+        // Note: This marks the embedder thread as critical, we'll want to
+        // evaluate that in the future.
+        servo_base::threadboost::mark_thread_as_critical();
+
         Servo(Rc::new(ServoInner {
             delegate: RefCell::new(Rc::new(DefaultServoDelegate)),
             paint,

--- a/components/shared/base/lib.rs
+++ b/components/shared/base/lib.rs
@@ -15,6 +15,7 @@ pub mod id;
 pub mod print_tree;
 mod rope;
 pub mod text;
+pub mod threadboost;
 pub mod threadpool;
 mod unicode_block;
 

--- a/components/shared/base/threadboost.rs
+++ b/components/shared/base/threadboost.rs
@@ -17,6 +17,8 @@
 //! TODO: For mobile linux, the ohos implementation could be shared, however other APIs
 //!    like uclamp or enhanced thread priorities might work better there?
 
+use servo_config::pref;
+
 #[cfg(target_env = "ohos")]
 mod ohos {
     //! On `ohos` targets we only have the `OH_QoS_SetThreadQoS` API from qos/qos.h,
@@ -168,6 +170,9 @@ mod ohos {
 ///   if spawned after this call, so placement can be important.
 #[allow(unsafe_code)]
 pub fn mark_thread_as_critical() {
+    if !pref!(perf_thread_boost_enabled) {
+        return;
+    }
     #[cfg(target_env = "ohos")]
     ohos::mark_thread_as_critical()
 }

--- a/components/shared/base/threadboost.rs
+++ b/components/shared/base/threadboost.rs
@@ -170,9 +170,8 @@ mod ohos {
 ///   if spawned after this call, so placement can be important.
 #[allow(unsafe_code)]
 pub fn mark_thread_as_critical() {
-    if !pref!(perf_thread_boost_enabled) {
-        return;
+    if pref!(perf_thread_boost_enabled) {
+        #[cfg(target_env = "ohos")]
+        ohos::mark_thread_as_critical()
     }
-    #[cfg(target_env = "ohos")]
-    ohos::mark_thread_as_critical()
 }

--- a/components/shared/base/threadboost.rs
+++ b/components/shared/base/threadboost.rs
@@ -11,7 +11,7 @@
 //! might have for apps to allow the OS to optimize thread performance.
 //!
 //! TODO(#46813): We provide a default implementation here, but the embedder
-//! should be able to customize this (e.g. if they care more about energery efficiency
+//! should be able to customize this (e.g. if they care more about energy efficiency
 //! then raw performance, for example in battery saving mode).
 //! TODO: For android we should look at the performance hint API in the NDK.
 //! TODO: For mobile linux, the ohos implementation could be shared, however other APIs

--- a/components/shared/base/threadboost.rs
+++ b/components/shared/base/threadboost.rs
@@ -52,7 +52,7 @@ mod ohos {
 
     static NON_LITTLE_CPU_CORES: LazyLock<Option<Box<[CoreId]>>> = LazyLock::new(|| {
         non_little_cpus()
-            .inspect_err(|err| log::error!("Failed to determine non-little cpu cores: {}", err))
+            .inspect_err(|error| log::error!("Failed to determine non-little cpu cores: {error}"))
             .ok()?
             .map(|cores| cores.into_boxed_slice())
     });
@@ -60,7 +60,7 @@ mod ohos {
     fn parse_cpu_list() -> Result<Vec<CoreId>, String> {
         let cpu_possible_file = "/sys/devices/system/cpu/possible";
         let list = fs::read_to_string(cpu_possible_file)
-            .map_err(|e| format!("failed to read {cpu_possible_file}: {e:?}"))?;
+            .map_err(|error| format!("failed to read {cpu_possible_file}: {error:?}"))?;
 
         let mut cpus = Vec::new();
         // See <https://docs.kernel.org/admin-guide/cputopology.html> / cpulist_parse
@@ -69,8 +69,8 @@ mod ohos {
                 if let (Ok(a), Ok(b)) = (a.trim().parse::<CoreId>(), b.trim().parse::<CoreId>()) {
                     cpus.extend(a..=b);
                 }
-            } else if let Ok(c) = part.trim().parse::<CoreId>() {
-                cpus.push(c);
+            } else if let Ok(core_id) = part.trim().parse::<CoreId>() {
+                cpus.push(core_id);
             } else {
                 log::warn!("Unexpected CPU line: {part:?} in {cpu_possible_file}.");
             }
@@ -84,10 +84,10 @@ mod ohos {
     fn capacity_of(cpu: CoreId) -> Result<u64, String> {
         let cpu_capacity_file = format!("/sys/devices/system/cpu/cpu{cpu}/cpu_capacity");
         fs::read_to_string(cpu_capacity_file)
-            .map_err(|e| e.to_string())?
+            .map_err(|error| error.to_string())?
             .trim()
             .parse::<u64>()
-            .map_err(|e| e.to_string())
+            .map_err(|error| error.to_string())
     }
 
     /// Determine the CPU ids of cores not in the little class.
@@ -112,7 +112,7 @@ mod ohos {
         let chosen: Vec<CoreId> = cpu_and_caps
             .iter()
             .filter(|&&(_, cap)| cap > little)
-            .map(|&(c, _)| c)
+            .map(|&(cpu, _)| cpu)
             .collect();
         if chosen.len() < 2 {
             return Ok(None);
@@ -130,8 +130,8 @@ mod ohos {
         };
         let ret = unsafe {
             let mut set: libc::cpu_set_t = std::mem::zeroed();
-            for &c in cpus {
-                libc::CPU_SET(c.into(), &mut set);
+            for &cpu in cpus {
+                libc::CPU_SET(cpu.into(), &mut set);
             }
             libc::sched_setaffinity(0, size_of::<libc::cpu_set_t>(), &set)
         };
@@ -151,9 +151,8 @@ mod ohos {
         }
         if let Err(error) = pin_thread_to_medium_or_large_cpus() {
             log::warn!(
-                "Failed to pin {} to medium or large cpus: {:?}",
+                "Failed to pin {} to medium or large cpus: {error:?}",
                 std::thread::current().name().unwrap_or("<unnamed>"),
-                error
             );
         }
     }

--- a/components/shared/base/threadboost.rs
+++ b/components/shared/base/threadboost.rs
@@ -1,0 +1,173 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! Helper to boost critical threads
+//!
+//! On heterogeneous (e.g. big.LITTLE) CPUs the scheduler might not be able to
+//! determine which threads are critical.
+//! This module serves as an entry point to define policies for thread-affinity,
+//! thread priority and core frequency boosting or other mechanisms a platform
+//! might have for apps to allow the OS to optimize thread performance.
+//!
+//! TODO(#46813): We provide a default implementation here, but the embedder
+//! should be able to customize this (e.g. if they care more about energery efficiency
+//! then raw performance, for example in battery saving mode).
+//! TODO: For android we should look at the performance hint API in the NDK.
+//! TODO: For mobile linux, the ohos implementation could be shared, however other APIs
+//!    like uclamp or enhanced thread priorities might work better there?
+
+#[cfg(target_env = "ohos")]
+mod ohos {
+    //! On `ohos` targets we only have the `OH_QoS_SetThreadQoS` API from qos/qos.h,
+    //! which influences scheduling priority, but empirically does not help with ensuring
+    //! important servo threads like script get scheduled on larger cores, presumably because
+    //! we do a lot of IPC, and the workload doesn't pass heuristic thresholds to get promoted
+    //! to a larger core.
+    //! [uclamp_min](https://docs.kernel.org/scheduler/sched-util-clamp.html) is supported but
+    //! ignored (empirically tested) on the hongmeng kernel.
+    //! Thqt leaves thread affinity as a last fallback, which allows us to prevent scheduling a
+    //! thread on little cores. Android developer docs discourages using thread affinity, since it
+    //! will also negatively affect power consumption if the little cores would have been
+    //! sufficient, but for now this is all we have (pending better official OH APIs, perhaps
+    //! modeled after the android performance hint API).
+    use std::fs;
+    use std::sync::LazyLock;
+
+    /// Highest QoS level from OHOS `qos/qos.h` (API 12+).
+    const QOS_USER_INTERACTIVE: i32 = 5;
+
+    #[link(name = "qos")]
+    #[expect(unsafe_code)]
+    unsafe extern "C" {
+        // SAFETY: Calling this function is always safe.
+        safe fn OH_QoS_SetThreadQoS(level: i32) -> i32;
+    }
+
+    // The current maximum supported by CPU_SET is 1024, so u16 is sufficiently large.
+    // <https://man7.org/linux/man-pages/man3/CPU_SET.3.html>
+    type CoreId = u16;
+
+    static NON_LITTLE_CPU_CORES: LazyLock<Option<Box<[CoreId]>>> = LazyLock::new(|| {
+        non_little_cpus()
+            .inspect_err(|err| log::error!("Failed to determine non-little cpu cores: {}", err))
+            .ok()?
+            .map(|cores| cores.into_boxed_slice())
+    });
+
+    fn parse_cpu_list() -> Result<Vec<CoreId>, String> {
+        let cpu_possible_file = "/sys/devices/system/cpu/possible";
+        let list = fs::read_to_string(cpu_possible_file)
+            .map_err(|e| format!("failed to read {cpu_possible_file}: {e:?}"))?;
+
+        let mut cpus = Vec::new();
+        // See <https://docs.kernel.org/admin-guide/cputopology.html> / cpulist_parse
+        for part in list.trim().split(',') {
+            if let Some((a, b)) = part.split_once('-') {
+                if let (Ok(a), Ok(b)) = (a.trim().parse::<CoreId>(), b.trim().parse::<CoreId>()) {
+                    cpus.extend(a..=b);
+                }
+            } else if let Ok(c) = part.trim().parse::<CoreId>() {
+                cpus.push(c);
+            } else {
+                log::warn!("Unexpected CPU line: {part:?} in {cpu_possible_file}.");
+            }
+        }
+        Ok(cpus)
+    }
+
+    /// Per-cpu relative capacity (normalized to 1024 for the strongest core in a system)
+    ///
+    /// <https://www.kernel.org/doc/Documentation/devicetree/bindings/arm/cpu-capacity.txt>
+    fn capacity_of(cpu: CoreId) -> Result<u64, String> {
+        let cpu_capacity_file = format!("/sys/devices/system/cpu/cpu{cpu}/cpu_capacity");
+        fs::read_to_string(cpu_capacity_file)
+            .map_err(|e| e.to_string())?
+            .trim()
+            .parse::<u64>()
+            .map_err(|e| e.to_string())
+    }
+
+    /// Determine the CPU ids of cores not in the little class.
+    ///
+    /// Returns `Err` on internal / parsing errors.
+    /// Returns `Ok(None)` if the cpu is not heterogeneous, or if there would only be a single
+    /// cpu in the non-little group.
+    fn non_little_cpus() -> Result<Option<Vec<CoreId>>, String> {
+        let cpus = parse_cpu_list()?;
+        let cpu_and_caps: Vec<(CoreId, u64)> = cpus
+            .iter()
+            .map(|&cpu| capacity_of(cpu).map(|cap| (cpu, cap)))
+            .collect::<Result<_, _>>()?;
+
+        let mut classes: Vec<u64> = cpu_and_caps.iter().map(|&(_, cap)| cap).collect();
+        classes.sort_unstable();
+        classes.dedup();
+        if classes.len() < 2 {
+            return Ok(None);
+        }
+        let little = classes[0];
+        let chosen: Vec<CoreId> = cpu_and_caps
+            .iter()
+            .filter(|&&(_, cap)| cap > little)
+            .map(|&(c, _)| c)
+            .collect();
+        if chosen.len() < 2 {
+            return Ok(None);
+        }
+        Ok(Some(chosen))
+    }
+
+    #[expect(unsafe_code)]
+    fn pin_thread_to_medium_or_large_cpus() -> Result<(), String> {
+        // Note: If we encountered an error when parsing the cpu structure, then
+        // we logged the error in the LazyLock (once), which avoids flooding the logs
+        // with error messages for every thread we want to pin.
+        let Some(cpus) = NON_LITTLE_CPU_CORES.as_ref() else {
+            return Ok(());
+        };
+        let ret = unsafe {
+            let mut set: libc::cpu_set_t = std::mem::zeroed();
+            for &c in cpus {
+                libc::CPU_SET(c.into(), &mut set);
+            }
+            libc::sched_setaffinity(0, size_of::<libc::cpu_set_t>(), &set)
+        };
+        if ret != 0 {
+            return Err(format!(
+                "Failed to set thread affinity: {:?}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn mark_thread_as_critical() {
+        let qos_rc = OH_QoS_SetThreadQoS(QOS_USER_INTERACTIVE);
+        if qos_rc != 0 {
+            log::warn!("Failed to set QOS_USER_INTERACTIVE");
+        }
+        if let Err(error) = pin_thread_to_medium_or_large_cpus() {
+            log::warn!(
+                "Failed to pin {} to medium or large cpus: {:?}",
+                std::thread::current().name().unwrap_or("<unnamed>"),
+                error
+            );
+        }
+    }
+}
+
+/// Hint to the scheduler that this thread should be prioritised.
+///
+/// TODO: The exact API and inner-workings are subject to change:
+/// - This is a hint to servo / the embedder and can be a no-op.
+/// - We might want to pass a thread identifier (enum variant?) so that we
+///   (or the embedder) can customize the optimization based on the thread
+///   without relying on parsing the thread-name.
+/// - Some optimizations like thread affinity selection also affect children threads,
+///   if spawned after this call, so placement can be important.
+#[allow(unsafe_code)]
+pub fn mark_thread_as_critical() {
+    #[cfg(target_env = "ohos")]
+    ohos::mark_thread_as_critical()
+}

--- a/ports/servoshell/egl/ohos/mod.rs
+++ b/ports/servoshell/egl/ohos/mod.rs
@@ -562,6 +562,9 @@ fn main_thread(init_opts: InitOpts) {
 
     let servo = init_app(init_opts, wakeup).expect("Servo initialization failed");
 
+    // After init_app so the thread affinity mask doesn't affect all children spawned in init_app.
+    servo_base::threadboost::mark_thread_as_critical();
+
     while let Ok(action) = rx.recv() {
         trace!("Wakeup message received!");
         action.do_action(&servo);

--- a/ports/servoshell/egl/ohos/mod.rs
+++ b/ports/servoshell/egl/ohos/mod.rs
@@ -562,9 +562,6 @@ fn main_thread(init_opts: InitOpts) {
 
     let servo = init_app(init_opts, wakeup).expect("Servo initialization failed");
 
-    // After init_app so the thread affinity mask doesn't affect all children spawned in init_app.
-    servo_base::threadboost::mark_thread_as_critical();
-
     while let Ok(action) = rx.recv() {
         trace!("Wakeup message received!");
         action.do_action(&servo);


### PR DESCRIPTION
The abstraction design will need to be iterated on, especially since the implementation might diverge strongly based on the target platfrom. On non heterogeneous platforms, we probably don't need to do anything, since all cores are equal. 

Background: On a harmonyos device the spread-out nature of servo, with threads calling out to other threads, doesn't interact well with the default scheduler, since the threads on the critical path might not be busy enough (consecutively) to be boosted to a medium or large core. Since the little cores on this device are ~1/3-1/4 as capable as the medium/large ones (according to the sysfs capability metric) this can have a large impact on performance.

Improvements on ohos:  
- a moderate 8% reduction in LCP on wikipedia.
- For the reproducer in #45199 it is very noticable and boosts the framerate to 60 fps, where it is capped. With active touch input which raises the display frequency to 120hz, we reach ~74fps.
In speedometer on my test-device the test score improves by ~50%. 

This PR should be seen as a first step towards #46813. The abstraction itself as is, is not great, but partially also can't be avoided since mechanisms will diverge depending on the platform. Part of the reason this PR works as well as it does, despite only explicitly prioritising 3 threads, is that all child threads spawned after the thread affinity mask takes effect inherit the affinity mask (which is an implementation detail of the ohos platform, since other platforms likely would not want to use affinity masks). The thread priority set via `OH_QoS_SetThreadQoS` only affects the current thread and not any children.

Note: I also checked, and notably chromium on ohos doesn't use thread affinity masks. However, it does more work on the main thread, which seems to interact better with the scheduler heuristics since it is boosted to medium cores under load (or perhaps the scheduler is aware of important chromium threads, since it is an important system app).

Testing: We currently don't measure production performance before merging to main. 

