### PR TITLE
ohos: Add target ohos to the hitrace feature guards to address clippy warnings

### DIFF
--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -70,7 +70,7 @@ pub fn init_tracing(filter_directives: Option<&str>) {
             subscriber.with(perfetto_layer)
         };
 
-        #[cfg(feature = "tracing-hitrace")]
+        #[cfg(all(feature = "tracing-hitrace", target_env = "ohos"))]
         let subscriber = {
             // Set up a HitraceLayer for performance tracing.
             subscriber.with(HitraceLayer::default())
@@ -159,12 +159,12 @@ pub const VERSION: &str = concat!("Servo ", env!("CARGO_PKG_VERSION"), "-", env!
 /// [come from]: https://docs.rs/tracing-subscriber/0.3.18/src/tracing_subscriber/registry/sharded.rs.html#237-269
 /// [packed representation]: https://docs.rs/sharded-slab/0.1.7/sharded_slab/trait.Config.html
 /// [`ThreadId`]: std::thread::ThreadId
-#[cfg(feature = "tracing-hitrace")]
+#[cfg(all(feature = "tracing-hitrace", target_env = "ohos"))]
 #[derive(Default)]
 struct HitraceLayer {}
 
 cfg_if! {
-    if #[cfg(feature = "tracing-hitrace")] {
+    if #[cfg(all(feature = "tracing-hitrace", target_env = "ohos"))] {
         use std::cell::RefCell;
         use std::fmt;
         use std::fmt::Write;


### PR DESCRIPTION
when doing `cargo clippy --all-targets --all-features` we currently have several different warning, and one of them is ohos related,
because the `hitrace` crate has some functions like `start_trace_ex` be guarded with `target_env = "ohos"`, but on the servo side, we only checked for the `feature = "tracing-hitrace"`, so it resulted in 

```
error[E0425]: cannot find function `start_trace_ex` in crate `hitrace`
   --> ports/servoshell/lib.rs:284:26
    |
284 |                 hitrace::start_trace_ex(
```

this PR adds the `target_env = "ohos"` in the servo side, and thus gets rid of the clippy warning

Testing: there are no tests

