### PR TITLE
canvas: Box the enum with large size difference in variants

### DIFF
--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -303,6 +303,13 @@ impl CanvasPaintThread {
     }
 }
 
+#[cfg_attr(
+    feature = "vello",
+    expect(
+        clippy::large_enum_variant,
+        reason = "Current consensus is on keeping enum instead of boxing it. https://github.com/servo/servo/pull/46863"
+    )
+)]
 enum Canvas {
     #[cfg(feature = "vello")]
     Vello(CanvasData<crate::vello_backend::VelloDrawTarget>),


### PR DESCRIPTION
Address the clippy warning that there is "large size difference between variants" and that "enum is at least 1200 bytes" and resides in the stack.

```bash
cargo clippy --all-targets --all-features
warning: large size difference between variants
   --> components/canvas/canvas_paint_thread.rs:306:1
    |
306 | / enum Canvas {
307 | |     #[cfg(feature = "vello")]
308 | |     Vello(CanvasData<crate::vello_backend::VelloDrawTarget>),
    | |     -------------------------------------------------------- the second-largest variant contains at least 632 bytes
309 | |     VelloCPU(CanvasData<crate::vello_cpu_backend::VelloCPUDrawTarget>),
    | |     ------------------------------------------------------------------ the largest variant contains at least 1200 bytes
310 | | }
    | |_^ the entire enum is at least 1200 bytes
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#large_enum_variant
    = note: `#[warn(clippy::large_enum_variant)]` on by default
help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
    |
309 -     VelloCPU(CanvasData<crate::vello_cpu_backend::VelloCPUDrawTarget>),
309 +     VelloCPU(Box<CanvasData<crate::vello_cpu_backend::VelloCPUDrawTarget>>),
    |
```

There were a warning suppression before, which got removed in https://github.com/servo/servo/pull/41040/
~~And I assume that the decision to go with the large enum instead of Box'ing was not a deliberate one, as I did not find relevant discussion or comments on the matter.~~

~~So I assume that using box would benefit us by making the Canvas struct instances a bit smaller (per each Canvas) in size when Vello feature is active~~

Testing: I have no tests

UPD: comments pointed out that the change might be unnecessary, so I documented the warning in the code