### PR TITLE
layout: Map document selection offsets across inline formatting context text transformations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8306,6 +8306,7 @@ version = "0.4.0"
 dependencies = [
  "accesskit",
  "app_units",
+ "arrayvec",
  "atomic_refcell",
  "bitflags 2.13.0",
  "data-url",

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -21,6 +21,7 @@ tracing = ["dep:tracing"]
 [dependencies]
 accesskit = { workspace = true }
 app_units = { workspace = true }
+arrayvec = { workspace = true }
 atomic_refcell = { workspace = true }
 bitflags = { workspace = true }
 data-url = { workspace = true }

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -155,8 +155,8 @@ impl InlineFormattingContextBuilder {
         self.text_segments.push(string_to_push.to_owned());
         self.current_text_offset += string_to_push.len();
 
-        let new_characters = string_to_push.chars().count();
-        self.current_character_offset += new_characters;
+        let new_characters = Utf32CodeUnits::length_of(string_to_push);
+        self.current_character_offset += new_characters.0;
         self.offset_map
             .push_synthetic_control_characters(new_characters);
     }
@@ -464,14 +464,9 @@ impl InlineFormattingContextBuilder {
         }
 
         let document_selection = document_selection.map(|document_selection| {
-            Utf32CodeUnits(
-                self.offset_map
-                    .map(self.current_original_character_offset + document_selection.start.0),
-            )..
-                Utf32CodeUnits(
-                    self.offset_map
-                        .map(self.current_original_character_offset + document_selection.end.0),
-                )
+            let current = Utf32CodeUnits(self.current_original_character_offset);
+            self.offset_map.map(current + document_selection.start)..
+                self.offset_map.map(current + document_selection.end)
         });
         self.current_original_character_offset += consumed_characters;
 
@@ -598,7 +593,7 @@ impl InlineFormattingContextBuilder {
 
         assert!(self.inline_box_stack.is_empty());
         assert_eq!(
-            self.offset_map.total_final_size(),
+            self.offset_map.total_final_size().0,
             self.current_character_offset
         );
 

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -4,19 +4,15 @@
 
 use std::borrow::Cow;
 use std::cell::LazyCell;
-use std::char::{ToLowercase, ToUppercase};
 use std::ops::{ControlFlow, Range};
 
 use icu_properties::BidiClass;
-use icu_segmenter::WordSegmenter;
 use layout_api::{LayoutNode, SharedSelection};
 use servo_base::text::Utf32CodeUnits;
-use style::computed_values::_webkit_text_security::T as WebKitTextSecurity;
 use style::computed_values::direction::T as Direction;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::dom::NodeInfo;
 use style::selector_parser::PseudoElement;
-use style::values::specified::text::TextTransformCase;
 use unicode_bidi::Level;
 use unicode_categories::UnicodeCategories;
 
@@ -31,6 +27,7 @@ use crate::dom::{LayoutBox, NodeExt};
 use crate::dom_traversal::{BoxTreeString, NodeAndStyleInfo};
 use crate::flow::BlockLevelBox;
 use crate::flow::float::FloatBox;
+use crate::flow::inline::text_transform::{OffsetMap, TextTransformationIterator};
 use crate::formatting_contexts::IndependentFormattingContext;
 use crate::positioned::AbsolutelyPositionedBox;
 use crate::style_ext::ComputedValuesExt;
@@ -55,6 +52,11 @@ pub(crate) struct InlineFormattingContextBuilder {
     /// used to properly set the text range of new [`InlineItem::TextRun`]s. Note that this is
     /// different from the UTF-8 code point offset.
     current_character_offset: usize,
+
+    /// The current character (UTF32 code unit) offsets in the input text string for this
+    /// [`InlineFormattingContextBuilder`]. This can be used to map to final offsets using
+    /// [`Self::offset_map`].
+    current_original_character_offset: usize,
 
     /// If the [`InlineFormattingContext`] that we are building has a selection shared with its
     /// originating node in the DOM, this will not be `None`.
@@ -106,7 +108,11 @@ pub(crate) struct InlineFormattingContextBuilder {
     /// Whether or not the inline formatting context under construction has any kind of
     /// right-to-left content such as a character with an RTL character class or a `dir`
     /// attribute specifying right-to-left content.
-    pub(crate) has_right_to_left_content: bool,
+    pub has_right_to_left_content: bool,
+
+    /// An [`OffsetMap`] used to map selections from their offset before inline formatting
+    /// context text transformation to their offsets after transformation.
+    pub offset_map: OffsetMap,
 }
 
 impl InlineFormattingContextBuilder {
@@ -148,7 +154,10 @@ impl InlineFormattingContextBuilder {
     fn push_control_character_string(&mut self, string_to_push: &str) {
         self.text_segments.push(string_to_push.to_owned());
         self.current_text_offset += string_to_push.len();
-        self.current_character_offset += string_to_push.chars().count();
+
+        let new_characters = string_to_push.chars().count();
+        self.current_character_offset += new_characters;
+        self.offset_map.expand(new_characters);
     }
 
     fn shared_inline_styles(&self) -> SharedInlineStyles {
@@ -404,52 +413,28 @@ impl InlineFormattingContextBuilder {
         info: &NodeAndStyleInfo<'dom>,
         document_selection: Option<Range<Utf32CodeUnits>>,
     ) {
-        let white_space_collapse = info.style.clone_white_space_collapse();
-        let collapsed = WhitespaceCollapse::new(
-            text.chars(),
-            white_space_collapse,
+        let iterator = TextTransformationIterator::new(
+            &text,
+            &info.style,
             self.last_inline_box_ended_with_collapsible_white_space,
+            self.on_word_boundary,
         );
-
-        // TODO: Not all text transforms are about case, this logic should stop ignoring
-        // TextTransform::FULL_WIDTH and TextTransform::FULL_SIZE_KANA.
-        let text_transform = info.style.clone_text_transform().case();
-        let capitalized_text: String;
-        let char_iterator: Box<dyn Iterator<Item = char>> = match text_transform {
-            TextTransformCase::None => Box::new(collapsed),
-            TextTransformCase::Capitalize => {
-                // `TextTransformation` doesn't support capitalization, so we must capitalize the whole
-                // string at once and make a copy. Here `on_word_boundary` indicates whether or not the
-                // inline formatting context as a whole is on a word boundary. This is different from
-                // `last_inline_box_ended_with_collapsible_white_space` because the word boundaries are
-                // between atomic inlines and at the start of the IFC, and because preserved spaces
-                // are a word boundary.
-                let collapsed_string: String = collapsed.collect();
-                capitalized_text = capitalize_string(&collapsed_string, self.on_word_boundary);
-                Box::new(capitalized_text.chars())
-            },
-            _ => {
-                // If `text-transform` is active, wrap the `WhitespaceCollapse` iterator in
-                // a `TextTransformation` iterator.
-                Box::new(TextTransformation::new(collapsed, text_transform))
-            },
-        };
-
-        let char_iterator = if info.style.clone__webkit_text_security() != WebKitTextSecurity::None
-        {
-            Box::new(TextSecurityTransform::new(
-                char_iterator,
-                info.style.clone__webkit_text_security(),
-            ))
-        } else {
-            char_iterator
-        };
 
         let bidi_class_map = icu_properties::maps::bidi_class();
         let white_space_collapse = info.style.clone_white_space_collapse();
         let mut character_count = 0;
-        let new_text: String = char_iterator
-            .inspect(|&character| {
+        let mut consumed_characters = 0;
+        let new_text: String = iterator
+            .filter_map(|text_step| {
+                consumed_characters += text_step.consumed_character_count;
+
+                let Some(character) = text_step.character else {
+                    self.offset_map.collapse(text_step.consumed_character_count);
+                    return None;
+                };
+
+                self.offset_map
+                    .process_character(text_step.consumed_character_count, 1);
                 character_count += 1;
 
                 // If this character has a strong right-to-left class the new inline formatting context will
@@ -473,12 +458,27 @@ impl InlineFormattingContextBuilder {
                         },
                         WhiteSpaceCollapse::Preserve | WhiteSpaceCollapse::BreakSpaces => false,
                     };
+
+                Some(character)
             })
             .collect();
 
         if new_text.is_empty() {
+            self.current_original_character_offset += consumed_characters;
             return;
         }
+
+        let document_selection = document_selection.map(|document_selection| {
+            Utf32CodeUnits(
+                self.offset_map
+                    .map(self.current_original_character_offset + document_selection.start.0),
+            )..
+                Utf32CodeUnits(
+                    self.offset_map
+                        .map(self.current_original_character_offset + document_selection.end.0),
+                )
+        });
+        self.current_original_character_offset += consumed_characters;
 
         if let Some(last_character) = new_text.chars().next_back() {
             self.on_word_boundary = last_character.is_whitespace();
@@ -550,20 +550,17 @@ impl InlineFormattingContextBuilder {
 
         let mut text_run = text_run_arc.borrow_mut();
         if let Some(next_text_selection) = new_text_selection {
-            let existing_characters = text_run.character_range.end - text_run.character_range.start;
             if !text_run.document_selection.is_empty() {
                 // If both the new and old text had selections, they are only compatible
-                // if the old selection extends to the end of the old run run.
-                if text_run.document_selection.end.0 == existing_characters {
-                    text_run.document_selection.end += next_text_selection.end;
+                // if the old selection extends to the start of the new selection
+                if text_run.document_selection.end.0 == next_text_selection.start.0 {
+                    text_run.document_selection.end = next_text_selection.end;
                 } else {
                     return ControlFlow::Continue(());
                 }
             } else {
                 // If only the new part of the text run has a selection, we can use it directly.
-                text_run.document_selection = Utf32CodeUnits(existing_characters) +
-                    next_text_selection.start..
-                    Utf32CodeUnits(existing_characters) + next_text_selection.end;
+                text_run.document_selection = next_text_selection.start..next_text_selection.end;
             }
         }
 
@@ -605,6 +602,11 @@ impl InlineFormattingContextBuilder {
         }
 
         assert!(self.inline_box_stack.is_empty());
+        assert_eq!(
+            self.offset_map.total_final_size(),
+            self.current_character_offset
+        );
+
         Some(InlineFormattingContext::new_with_builder(
             self,
             layout_context,
@@ -613,338 +615,6 @@ impl InlineFormattingContextBuilder {
             default_bidi_level,
         ))
     }
-}
-
-fn preserve_segment_break() -> bool {
-    true
-}
-
-pub struct WhitespaceCollapse<InputIterator> {
-    char_iterator: InputIterator,
-    white_space_collapse: WhiteSpaceCollapse,
-
-    /// Whether or not we should collapse white space completely at the start of the string.
-    /// This is true when the last character handled in our owning [`super::InlineFormattingContext`]
-    /// was collapsible white space.
-    remove_collapsible_white_space_at_start: bool,
-
-    /// Whether or not the last character produced was newline. There is special behavior
-    /// we do after each newline.
-    following_newline: bool,
-
-    /// Whether or not we have seen any non-white space characters, indicating that we are not
-    /// in a collapsible white space section at the beginning of the string.
-    have_seen_non_white_space_characters: bool,
-
-    /// Whether the last character that we processed was a non-newline white space character. When
-    /// collapsing white space we need to wait until the next non-white space character or the end
-    /// of the string to push a single white space.
-    inside_white_space: bool,
-
-    /// When we enter a collapsible white space region, we may need to wait to produce a single
-    /// white space character as soon as we encounter a non-white space character. When that
-    /// happens we queue up the non-white space character for the next iterator call.
-    character_pending_to_return: Option<char>,
-}
-
-impl<InputIterator> WhitespaceCollapse<InputIterator> {
-    pub fn new(
-        char_iterator: InputIterator,
-        white_space_collapse: WhiteSpaceCollapse,
-        trim_beginning_white_space: bool,
-    ) -> Self {
-        Self {
-            char_iterator,
-            white_space_collapse,
-            remove_collapsible_white_space_at_start: trim_beginning_white_space,
-            inside_white_space: false,
-            following_newline: false,
-            have_seen_non_white_space_characters: false,
-            character_pending_to_return: None,
-        }
-    }
-
-    fn is_leading_trimmed_white_space(&self) -> bool {
-        !self.have_seen_non_white_space_characters && self.remove_collapsible_white_space_at_start
-    }
-
-    /// Whether or not we need to produce a space character if the next character is not a newline
-    /// and not white space. This happens when we are exiting a section of white space and we
-    /// waited to produce a single space character for the entire section of white space (but
-    /// not following or preceding a newline).
-    fn need_to_produce_space_character_after_white_space(&self) -> bool {
-        self.inside_white_space && !self.following_newline && !self.is_leading_trimmed_white_space()
-    }
-}
-
-impl<InputIterator> Iterator for WhitespaceCollapse<InputIterator>
-where
-    InputIterator: Iterator<Item = char>,
-{
-    type Item = char;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        // Point 4.1.1 first bullet:
-        // > If white-space is set to normal, nowrap, or pre-line, whitespace
-        // > characters are considered collapsible
-        // If whitespace is not considered collapsible, it is preserved entirely, which
-        // means that we can simply return the input string exactly.
-        if self.white_space_collapse == WhiteSpaceCollapse::Preserve ||
-            self.white_space_collapse == WhiteSpaceCollapse::BreakSpaces
-        {
-            // From <https://drafts.csswg.org/css-text-3/#white-space-processing>:
-            // > Carriage returns (U+000D) are treated identically to spaces (U+0020) in all respects.
-            //
-            // In the non-preserved case these are converted to space below.
-            return match self.char_iterator.next() {
-                Some('\r') => Some(' '),
-                next => next,
-            };
-        }
-
-        if let Some(character) = self.character_pending_to_return.take() {
-            self.inside_white_space = false;
-            self.have_seen_non_white_space_characters = true;
-            self.following_newline = false;
-            return Some(character);
-        }
-
-        while let Some(character) = self.char_iterator.next() {
-            // Don't push non-newline whitespace immediately. Instead wait to push it until we
-            // know that it isn't followed by a newline. See `push_pending_whitespace_if_needed`
-            // above.
-            if InlineFormattingContextBuilder::is_document_white_space(character) &&
-                character != '\n'
-            {
-                self.inside_white_space = true;
-                continue;
-            }
-
-            // Point 4.1.1:
-            // > 2. Collapsible segment breaks are transformed for rendering according to the
-            // >    segment break transformation rules.
-            if character == '\n' {
-                // From <https://drafts.csswg.org/css-text-3/#line-break-transform>
-                // (4.1.3 -- the segment break transformation rules):
-                //
-                // > When white-space is pre, pre-wrap, or pre-line, segment breaks are not
-                // > collapsible and are instead transformed into a preserved line feed"
-                if self.white_space_collapse != WhiteSpaceCollapse::Collapse {
-                    self.inside_white_space = false;
-                    self.following_newline = true;
-                    return Some(character);
-
-                // Point 4.1.3:
-                // > 1. First, any collapsible segment break immediately following another
-                // >    collapsible segment break is removed.
-                // > 2. Then any remaining segment break is either transformed into a space (U+0020)
-                // >    or removed depending on the context before and after the break.
-                } else if !self.following_newline &&
-                    preserve_segment_break() &&
-                    !self.is_leading_trimmed_white_space()
-                {
-                    self.inside_white_space = false;
-                    self.following_newline = true;
-                    return Some(' ');
-                } else {
-                    self.following_newline = true;
-                    continue;
-                }
-            }
-
-            // Point 4.1.1:
-            // > 2. Any sequence of collapsible spaces and tabs immediately preceding or
-            // >    following a segment break is removed.
-            // > 3. Every collapsible tab is converted to a collapsible space (U+0020).
-            // > 4. Any collapsible space immediately following another collapsible space—even
-            // >    one outside the boundary of the inline containing that space, provided both
-            // >    spaces are within the same inline formatting context—is collapsed to have zero
-            // >    advance width.
-            if self.need_to_produce_space_character_after_white_space() {
-                self.inside_white_space = false;
-                self.character_pending_to_return = Some(character);
-                return Some(' ');
-            }
-
-            self.inside_white_space = false;
-            self.have_seen_non_white_space_characters = true;
-            self.following_newline = false;
-            return Some(character);
-        }
-
-        if self.need_to_produce_space_character_after_white_space() {
-            self.inside_white_space = false;
-            return Some(' ');
-        }
-
-        None
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.char_iterator.size_hint()
-    }
-
-    fn count(self) -> usize
-    where
-        Self: Sized,
-    {
-        self.char_iterator.count()
-    }
-}
-
-enum PendingCaseConversionResult {
-    Uppercase(ToUppercase),
-    Lowercase(ToLowercase),
-}
-
-impl PendingCaseConversionResult {
-    fn next(&mut self) -> Option<char> {
-        match self {
-            PendingCaseConversionResult::Uppercase(to_uppercase) => to_uppercase.next(),
-            PendingCaseConversionResult::Lowercase(to_lowercase) => to_lowercase.next(),
-        }
-    }
-}
-
-/// This is an iterator that consumes a char iterator and produces character transformed
-/// by the given CSS `text-transform` value. It currently does not support
-/// `text-transform: capitalize` because Unicode segmentation libraries do not support
-/// streaming input one character at a time.
-pub struct TextTransformation<InputIterator> {
-    /// The input character iterator.
-    char_iterator: InputIterator,
-    /// The `text-transform` value to use.
-    text_transform: TextTransformCase,
-    /// If an uppercasing or lowercasing produces more than one character, this
-    /// caches them so that they can be returned in subsequent iterator calls.
-    pending_case_conversion_result: Option<PendingCaseConversionResult>,
-}
-
-impl<InputIterator> TextTransformation<InputIterator> {
-    pub fn new(char_iterator: InputIterator, text_transform: TextTransformCase) -> Self {
-        Self {
-            char_iterator,
-            text_transform,
-            pending_case_conversion_result: None,
-        }
-    }
-}
-
-impl<InputIterator> Iterator for TextTransformation<InputIterator>
-where
-    InputIterator: Iterator<Item = char>,
-{
-    type Item = char;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some(character) = self
-            .pending_case_conversion_result
-            .as_mut()
-            .and_then(|result| result.next())
-        {
-            return Some(character);
-        }
-        self.pending_case_conversion_result = None;
-
-        for character in self.char_iterator.by_ref() {
-            match self.text_transform {
-                TextTransformCase::None => return Some(character),
-                TextTransformCase::Uppercase => {
-                    let mut pending_result =
-                        PendingCaseConversionResult::Uppercase(character.to_uppercase());
-                    if let Some(character) = pending_result.next() {
-                        self.pending_case_conversion_result = Some(pending_result);
-                        return Some(character);
-                    }
-                },
-                TextTransformCase::Lowercase => {
-                    let mut pending_result =
-                        PendingCaseConversionResult::Lowercase(character.to_lowercase());
-                    if let Some(character) = pending_result.next() {
-                        self.pending_case_conversion_result = Some(pending_result);
-                        return Some(character);
-                    }
-                },
-                // `text-transform: capitalize` currently cannot work on a per-character basis,
-                // so must be handled outside of this iterator.
-                TextTransformCase::Capitalize => return Some(character),
-            }
-        }
-        None
-    }
-}
-
-pub struct TextSecurityTransform<InputIterator> {
-    /// The input character iterator.
-    char_iterator: InputIterator,
-    /// The `-webkit-text-security` value to use.
-    text_security: WebKitTextSecurity,
-}
-
-impl<InputIterator> TextSecurityTransform<InputIterator> {
-    pub fn new(char_iterator: InputIterator, text_security: WebKitTextSecurity) -> Self {
-        Self {
-            char_iterator,
-            text_security,
-        }
-    }
-}
-
-impl<InputIterator> Iterator for TextSecurityTransform<InputIterator>
-where
-    InputIterator: Iterator<Item = char>,
-{
-    type Item = char;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        // The behavior of `-webkit-text-security` isn't specified, so we have some
-        // flexibility in the implementation. We just need to maintain a rough
-        // compatability with other browsers.
-        Some(match self.char_iterator.next()? {
-            // This is not ideal, but zero width space is used for some special reasons in
-            // `<input>` fields, so these remain untransformed, otherwise they would show up
-            // in empty text fields.
-            '\u{200B}' => '\u{200B}',
-            // Newlines are preserved, so that `<br>` keeps working as expected.
-            '\n' => '\n',
-            character => match self.text_security {
-                WebKitTextSecurity::None => character,
-                WebKitTextSecurity::Circle => '○',
-                WebKitTextSecurity::Disc => '●',
-                WebKitTextSecurity::Square => '■',
-            },
-        })
-    }
-}
-
-/// Given a string and whether the start of the string represents a word boundary, create a copy of
-/// the string with letters after word boundaries capitalized.
-pub(crate) fn capitalize_string(string: &str, allow_word_at_start: bool) -> String {
-    let mut output_string = String::new();
-    output_string.reserve(string.len());
-
-    let word_segmenter = WordSegmenter::new_auto();
-    let mut bounds = word_segmenter.segment_str(string).peekable();
-    let mut byte_index = 0;
-    for character in string.chars() {
-        let current_byte_index = byte_index;
-        byte_index += character.len_utf8();
-
-        if let Some(next_index) = bounds.peek() &&
-            *next_index == current_byte_index
-        {
-            bounds.next();
-
-            if current_byte_index != 0 || allow_word_at_start {
-                output_string.extend(character.to_uppercase());
-                continue;
-            }
-        }
-
-        output_string.push(character);
-    }
-
-    output_string
 }
 
 /// Computes the range of the first letter.

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -421,8 +421,7 @@ impl InlineFormattingContextBuilder {
             self.on_word_boundary,
         ) {
             self.offset_map.push_iteration(&iteration);
-
-            iteration.each_char(|character| {
+            for &character in iteration.characters() {
                 character_count += 1;
 
                 // If this character has a strong right-to-left class the new inline formatting context will
@@ -448,7 +447,7 @@ impl InlineFormattingContextBuilder {
                     };
 
                 new_text.push(character)
-            });
+            }
         }
 
         if new_text.is_empty() {

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -153,7 +153,7 @@ impl InlineFormattingContextBuilder {
         let new_characters = Utf32CodeUnits::length_of(string_to_push);
         self.current_character_offset += new_characters.0;
         self.offset_map
-            .push_synthetic_control_characters(new_characters);
+            .push_range(Utf32CodeUnits(0), new_characters);
     }
 
     fn shared_inline_styles(&self) -> SharedInlineStyles {

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -53,11 +53,6 @@ pub(crate) struct InlineFormattingContextBuilder {
     /// different from the UTF-8 code point offset.
     current_character_offset: usize,
 
-    /// The current character (UTF32 code unit) offsets in the input text string for this
-    /// [`InlineFormattingContextBuilder`]. This can be used to map to final offsets using
-    /// [`Self::offset_map`].
-    current_original_character_offset: usize,
-
     /// If the [`InlineFormattingContext`] that we are building has a selection shared with its
     /// originating node in the DOM, this will not be `None`.
     pub shared_selection: Option<SharedSelection>,
@@ -416,8 +411,8 @@ impl InlineFormattingContextBuilder {
     ) {
         let bidi_class_map = icu_properties::maps::bidi_class();
         let white_space_collapse = info.style.clone_white_space_collapse();
+        let original_size_before = self.offset_map.total_original_size();
         let mut character_count = 0;
-        let mut consumed_characters = 0;
         let mut new_text = String::with_capacity(text.len());
         for iteration in TextTransformationIterator::new(
             &text,
@@ -425,8 +420,6 @@ impl InlineFormattingContextBuilder {
             self.last_inline_box_ended_with_collapsible_white_space,
             self.on_word_boundary,
         ) {
-            consumed_characters += iteration.consumed_character_count();
-
             self.offset_map.push_iteration(&iteration);
 
             iteration.each_char(|character| {
@@ -459,16 +452,15 @@ impl InlineFormattingContextBuilder {
         }
 
         if new_text.is_empty() {
-            self.current_original_character_offset += consumed_characters;
             return;
         }
 
         let document_selection = document_selection.map(|document_selection| {
-            let current = Utf32CodeUnits(self.current_original_character_offset);
-            self.offset_map.map(current + document_selection.start)..
-                self.offset_map.map(current + document_selection.end)
+            self.offset_map
+                .map(original_size_before + document_selection.start)..
+                self.offset_map
+                    .map(original_size_before + document_selection.end)
         });
-        self.current_original_character_offset += consumed_characters;
 
         if let Some(last_character) = new_text.chars().next_back() {
             self.on_word_boundary = last_character.is_whitespace();

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -413,55 +413,52 @@ impl InlineFormattingContextBuilder {
         info: &NodeAndStyleInfo<'dom>,
         document_selection: Option<Range<Utf32CodeUnits>>,
     ) {
-        let iterator = TextTransformationIterator::new(
-            &text,
-            &info.style,
-            self.last_inline_box_ended_with_collapsible_white_space,
-            self.on_word_boundary,
-        );
-
         let bidi_class_map = icu_properties::maps::bidi_class();
         let white_space_collapse = info.style.clone_white_space_collapse();
         let mut character_count = 0;
         let mut consumed_characters = 0;
-        let new_text: String = iterator
-            .filter_map(|text_step| {
-                consumed_characters += text_step.consumed_character_count;
+        let mut new_text = String::with_capacity(text.len());
+        for text_step in TextTransformationIterator::new(
+            &text,
+            &info.style,
+            self.last_inline_box_ended_with_collapsible_white_space,
+            self.on_word_boundary,
+        ) {
+            consumed_characters += text_step.consumed_character_count;
 
-                let Some(character) = text_step.character else {
-                    self.offset_map.collapse(text_step.consumed_character_count);
-                    return None;
+            let Some(character) = text_step.character else {
+                self.offset_map.collapse(text_step.consumed_character_count);
+                continue;
+            };
+
+            self.offset_map
+                .process_character(text_step.consumed_character_count, 1);
+            character_count += 1;
+
+            // If this character has a strong right-to-left class the new inline formatting context will
+            // need to be BiDi-aware. This match is derived from the list of strong right-to-left classes
+            // at https://www.unicode.org/reports/tr44/#Bidi_Class_Values.
+            self.has_right_to_left_content = self.has_right_to_left_content ||
+                matches!(
+                    bidi_class_map.get(character),
+                    BidiClass::RightToLeft |
+                        BidiClass::ArabicLetter |
+                        BidiClass::RightToLeftEmbedding |
+                        BidiClass::RightToLeftIsolate |
+                        BidiClass::RightToLeftOverride
+                );
+
+            self.is_empty = self.is_empty &&
+                match white_space_collapse {
+                    WhiteSpaceCollapse::Collapse => Self::is_document_white_space(character),
+                    WhiteSpaceCollapse::PreserveBreaks => {
+                        Self::is_document_white_space(character) && character != '\n'
+                    },
+                    WhiteSpaceCollapse::Preserve | WhiteSpaceCollapse::BreakSpaces => false,
                 };
 
-                self.offset_map
-                    .process_character(text_step.consumed_character_count, 1);
-                character_count += 1;
-
-                // If this character has a strong right-to-left class the new inline formatting context will
-                // need to be BiDi-aware. This match is derived from the list of strong right-to-left classes
-                // at https://www.unicode.org/reports/tr44/#Bidi_Class_Values.
-                self.has_right_to_left_content = self.has_right_to_left_content ||
-                    matches!(
-                        bidi_class_map.get(character),
-                        BidiClass::RightToLeft |
-                            BidiClass::ArabicLetter |
-                            BidiClass::RightToLeftEmbedding |
-                            BidiClass::RightToLeftIsolate |
-                            BidiClass::RightToLeftOverride
-                    );
-
-                self.is_empty = self.is_empty &&
-                    match white_space_collapse {
-                        WhiteSpaceCollapse::Collapse => Self::is_document_white_space(character),
-                        WhiteSpaceCollapse::PreserveBreaks => {
-                            Self::is_document_white_space(character) && character != '\n'
-                        },
-                        WhiteSpaceCollapse::Preserve | WhiteSpaceCollapse::BreakSpaces => false,
-                    };
-
-                Some(character)
-            })
-            .collect();
+            new_text.push(character)
+        }
 
         if new_text.is_empty() {
             self.current_original_character_offset += consumed_characters;

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -157,7 +157,8 @@ impl InlineFormattingContextBuilder {
 
         let new_characters = string_to_push.chars().count();
         self.current_character_offset += new_characters;
-        self.offset_map.expand(new_characters);
+        self.offset_map
+            .push_synthetic_control_characters(new_characters);
     }
 
     fn shared_inline_styles(&self) -> SharedInlineStyles {
@@ -418,46 +419,43 @@ impl InlineFormattingContextBuilder {
         let mut character_count = 0;
         let mut consumed_characters = 0;
         let mut new_text = String::with_capacity(text.len());
-        for text_step in TextTransformationIterator::new(
+        for iteration in TextTransformationIterator::new(
             &text,
             &info.style,
             self.last_inline_box_ended_with_collapsible_white_space,
             self.on_word_boundary,
         ) {
-            consumed_characters += text_step.consumed_character_count;
+            consumed_characters += iteration.consumed_character_count();
 
-            let Some(character) = text_step.character else {
-                self.offset_map.collapse(text_step.consumed_character_count);
-                continue;
-            };
+            self.offset_map.push_iteration(&iteration);
 
-            self.offset_map
-                .process_character(text_step.consumed_character_count, 1);
-            character_count += 1;
+            iteration.each_char(|character| {
+                character_count += 1;
 
-            // If this character has a strong right-to-left class the new inline formatting context will
-            // need to be BiDi-aware. This match is derived from the list of strong right-to-left classes
-            // at https://www.unicode.org/reports/tr44/#Bidi_Class_Values.
-            self.has_right_to_left_content = self.has_right_to_left_content ||
-                matches!(
-                    bidi_class_map.get(character),
-                    BidiClass::RightToLeft |
-                        BidiClass::ArabicLetter |
-                        BidiClass::RightToLeftEmbedding |
-                        BidiClass::RightToLeftIsolate |
-                        BidiClass::RightToLeftOverride
-                );
+                // If this character has a strong right-to-left class the new inline formatting context will
+                // need to be BiDi-aware. This match is derived from the list of strong right-to-left classes
+                // at https://www.unicode.org/reports/tr44/#Bidi_Class_Values.
+                self.has_right_to_left_content = self.has_right_to_left_content ||
+                    matches!(
+                        bidi_class_map.get(character),
+                        BidiClass::RightToLeft |
+                            BidiClass::ArabicLetter |
+                            BidiClass::RightToLeftEmbedding |
+                            BidiClass::RightToLeftIsolate |
+                            BidiClass::RightToLeftOverride
+                    );
 
-            self.is_empty = self.is_empty &&
-                match white_space_collapse {
-                    WhiteSpaceCollapse::Collapse => Self::is_document_white_space(character),
-                    WhiteSpaceCollapse::PreserveBreaks => {
-                        Self::is_document_white_space(character) && character != '\n'
-                    },
-                    WhiteSpaceCollapse::Preserve | WhiteSpaceCollapse::BreakSpaces => false,
-                };
+                self.is_empty = self.is_empty &&
+                    match white_space_collapse {
+                        WhiteSpaceCollapse::Collapse => Self::is_document_white_space(character),
+                        WhiteSpaceCollapse::PreserveBreaks => {
+                            Self::is_document_white_space(character) && character != '\n'
+                        },
+                        WhiteSpaceCollapse::Preserve | WhiteSpaceCollapse::BreakSpaces => false,
+                    };
 
-            new_text.push(character)
+                new_text.push(character)
+            });
         }
 
         if new_text.is_empty() {

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -73,6 +73,7 @@ pub mod inline_box;
 pub mod line;
 mod line_breaker;
 pub mod text_run;
+pub mod text_transform;
 
 use std::cell::{Cell, OnceCell};
 use std::mem;

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -261,9 +261,8 @@ impl TextRunSegment {
                     } else {
                         Some(Arc::new(AtomicRefCell::new(ScriptSelection {
                             range: TextByteRange::new(ByteIndex::zero(), ByteIndex::zero()),
-                            character_range: text_run.character_range.start +
-                                text_run.document_selection.start.0..
-                                text_run.character_range.start + text_run.document_selection.end.0,
+                            character_range: text_run.document_selection.start.0..
+                                text_run.document_selection.end.0,
                             enabled: true,
                         })))
                     }

--- a/components/layout/flow/inline/text_transform.rs
+++ b/components/layout/flow/inline/text_transform.rs
@@ -351,6 +351,10 @@ pub(crate) fn capitalization_iterator(
             bounds.next();
         }
 
+        // TODO: currently we titlecase the first `char` of each word,
+        // instead it should be the first typographic letter unit:
+        // https://drafts.csswg.org/css-text-4/#typographic-letter-unit
+        // WPT /css/css-text/text-transform/text-transform-capitalize-026.html
         if at_word_start &&
             let CharacterTransformIteration::OneToOne(_) = iteration &&
             (current_byte_index != 0 || allow_word_at_start)

--- a/components/layout/flow/inline/text_transform.rs
+++ b/components/layout/flow/inline/text_transform.rs
@@ -52,26 +52,27 @@ impl<'a> TextTransformationIterator<'a> {
         on_word_boundary: bool,
     ) -> Self {
         let white_space_collapse = style.clone_white_space_collapse();
-        let mut iterator: Box<dyn Iterator<Item = CharacterTransformIteration>> = Box::new(
-            WhitespaceCollapse::new(text.chars(), white_space_collapse, trim_leading_white_space),
-        );
+        let iterator =
+            WhitespaceCollapse::new(text.chars(), white_space_collapse, trim_leading_white_space);
 
         // TODO: Not all text transforms are about case, this logic should stop ignoring
         // TextTransform::FULL_WIDTH and TextTransform::FULL_SIZE_KANA.
         let text_transform = style.clone_text_transform();
-        match text_transform.case() {
-            TextTransformCase::None => {},
+        let mut iterator = match text_transform.case() {
+            TextTransformCase::None => {
+                Box::new(iterator) as Box<dyn Iterator<Item = CharacterTransformIteration>>
+            },
             TextTransformCase::Lowercase => {
-                iterator = Box::new(simple_case_transform_iterator(iterator, char::to_lowercase))
+                Box::new(simple_case_transform_iterator(iterator, char::to_lowercase))
             },
             TextTransformCase::Uppercase => {
-                iterator = Box::new(simple_case_transform_iterator(iterator, char::to_uppercase))
+                Box::new(simple_case_transform_iterator(iterator, char::to_uppercase))
             },
             TextTransformCase::Capitalize => {
-                iterator = Box::new(capitalization_iterator(iterator, on_word_boundary))
+                Box::new(capitalization_iterator(iterator, on_word_boundary))
             },
             // TODO: implement `math-auto` and enable it in Stylo
-        }
+        };
         if text_transform.intersects(TextTransform::FULL_WIDTH) {
             // TODO: implement `full-width`
             // iterator = Box::new(full_width_iterator(iterator));
@@ -290,8 +291,8 @@ impl Iterator for WhitespaceCollapse<'_> {
     }
 }
 
-fn simple_case_transform_iterator<'a, CharacterIterator>(
-    input_iterator: Box<dyn Iterator<Item = CharacterTransformIteration> + 'a>,
+fn simple_case_transform_iterator<CharacterIterator>(
+    input_iterator: impl Iterator<Item = CharacterTransformIteration>,
     mapping: impl Fn(char) -> CharacterIterator,
 ) -> impl Iterator<Item = CharacterTransformIteration>
 where
@@ -311,8 +312,8 @@ where
 
 /// Given a string and whether the start of the string represents a word boundary, create a copy of
 /// the string with letters after word boundaries capitalized.
-pub(crate) fn capitalization_iterator<'a>(
-    input_iterator: Box<dyn Iterator<Item = CharacterTransformIteration> + 'a>,
+pub(crate) fn capitalization_iterator(
+    input_iterator: impl Iterator<Item = CharacterTransformIteration>,
     allow_word_at_start: bool,
 ) -> impl Iterator<Item = CharacterTransformIteration> {
     let steps: Vec<_> = input_iterator.collect();

--- a/components/layout/flow/inline/text_transform.rs
+++ b/components/layout/flow/inline/text_transform.rs
@@ -10,10 +10,7 @@
 //! handle this as well as code to map from offsets in the original DOM node to the final
 //! IFC text and vice-versa.
 
-use std::cmp::Ordering;
-
 use icu_segmenter::WordSegmenter;
-use itertools::Either;
 use malloc_size_of_derive::MallocSizeOf;
 use style::computed_values::_webkit_text_security::T as WebKitTextSecurity;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
@@ -28,15 +25,16 @@ use crate::flow::inline::construct::InlineFormattingContextBuilder;
 /// and produce an optional character. Consumption of characters greater than
 /// the characters stored in [`CharacterTransformIteration`] indicate that those
 /// characters have been collapsed.
-pub struct CharacterTransformIteration {
-    /// The number of characters consumed when producing the optional character
-    /// in this iteration. This can indicate that a certain number of characters
-    /// have been collapsed in the input stream.
-    pub consumed_character_count: usize,
-    /// If this iteration produced a character, it is stored in this field. If no
-    /// character is stored here, the iteration collapsed the
-    /// [`Self::consumed_character_count`] characters.
-    pub character: Option<char>,
+#[derive(Clone, Copy)]
+pub enum CharacterTransformIteration {
+    /// A character mapped from exactly one character in a DOM text node
+    OneToOne(char),
+    WhitespaceCharsCollapsedToOneSpace(usize),
+    WhitespaceCharsCollapsedToOneNewline(usize),
+    WhitespaceCharsCollapsedToNothing(usize),
+    ToLowercase(char),
+    ToUppercase(char),
+    ToTitlecase(char),
 }
 
 pub(crate) struct TextTransformationIterator<'a>(
@@ -65,15 +63,19 @@ impl<'a> TextTransformationIterator<'a> {
             TextTransformCase::None => {
                 Box::new(iterator) as Box<dyn Iterator<Item = CharacterTransformIteration>>
             },
-            TextTransformCase::Lowercase => {
-                Box::new(simple_case_transform_iterator(iterator, char::to_lowercase))
-            },
-            TextTransformCase::Uppercase => {
-                Box::new(simple_case_transform_iterator(iterator, char::to_uppercase))
-            },
-            TextTransformCase::Capitalize => {
-                Box::new(capitalization_iterator(iterator, on_word_boundary))
-            },
+            TextTransformCase::Lowercase => Box::new(simple_case_transform_iterator(
+                iterator,
+                CharacterTransformIteration::ToLowercase,
+            )),
+            TextTransformCase::Uppercase => Box::new(simple_case_transform_iterator(
+                iterator,
+                CharacterTransformIteration::ToUppercase,
+            )),
+            TextTransformCase::Capitalize => Box::new(capitalization_iterator(
+                text.len(),
+                iterator,
+                on_word_boundary,
+            )),
             // TODO: implement `math-auto` and enable it in Stylo
         };
         if text_transform.intersects(TextTransform::FULL_WIDTH) {
@@ -97,26 +99,41 @@ impl Iterator for TextTransformationIterator<'_> {
 }
 
 impl CharacterTransformIteration {
-    fn identity(character: char) -> Self {
-        Self {
-            consumed_character_count: 1,
-            character: Some(character),
+    pub(crate) fn consumed_character_count(&self) -> usize {
+        match *self {
+            CharacterTransformIteration::OneToOne(_) => 1,
+            CharacterTransformIteration::ToLowercase(_) |
+            CharacterTransformIteration::ToUppercase(_) |
+            CharacterTransformIteration::ToTitlecase(_) => 1,
+            CharacterTransformIteration::WhitespaceCharsCollapsedToOneSpace(count) |
+            CharacterTransformIteration::WhitespaceCharsCollapsedToOneNewline(count) |
+            CharacterTransformIteration::WhitespaceCharsCollapsedToNothing(count) => count,
         }
     }
 
-    /// `character_iter` must be non-empty
-    fn from_char_iter(
-        mut consumed_character_count: usize,
-        character_iter: impl Iterator<Item = char>,
-    ) -> impl Iterator<Item = Self> {
-        character_iter.map(move |transformed_character| {
-            CharacterTransformIteration {
-                // Iterations after the first use zero:
-                consumed_character_count: std::mem::take(&mut consumed_character_count),
-                character: Some(transformed_character),
-            }
-        })
+    pub(crate) fn each_char(&self, mut each: impl FnMut(char)) {
+        match *self {
+            CharacterTransformIteration::OneToOne(c) => each(c),
+            CharacterTransformIteration::WhitespaceCharsCollapsedToOneSpace(_) => each(' '),
+            CharacterTransformIteration::WhitespaceCharsCollapsedToOneNewline(_) => each('\n'),
+            CharacterTransformIteration::WhitespaceCharsCollapsedToNothing(_) => {},
+            CharacterTransformIteration::ToLowercase(c) => c.to_lowercase().for_each(each),
+            CharacterTransformIteration::ToUppercase(c) => c.to_uppercase().for_each(each),
+            CharacterTransformIteration::ToTitlecase(c) => to_titlecase(c).for_each(each),
+        }
     }
+
+    pub fn push_chars_to(&self, string: &mut String) {
+        self.each_char(|character| string.push(character));
+    }
+}
+
+// TODO: replace this function with `character.to_titlecase()` when available:
+// https://github.com/rust-lang/rust/issues/153892
+// because of:
+// https://doc.rust-lang.org/stable/std/primitive.char.html#difference-from-uppercase
+fn to_titlecase(character: char) -> impl ExactSizeIterator<Item = char> {
+    character.to_uppercase()
 }
 
 pub struct WhitespaceCollapse<InputIterator> {
@@ -157,11 +174,14 @@ impl<InputIterator: Iterator<Item = char>> WhitespaceCollapse<InputIterator> {
     /// In some cases, white space is replaced by a single character (when not
     /// following a newline and when leading whitespace is not being trimmed). In all
     /// other cases, the white space is simply removed. This method handles that.
-    fn character_for_collapsed_whitespace(&self) -> Option<char> {
+    fn iteration_for_collapsed_whitespace(
+        &self,
+        collapsed_whitespace: usize,
+    ) -> CharacterTransformIteration {
         if !self.following_newline && !self.trimming_leading_white_space {
-            Some(' ')
+            CharacterTransformIteration::WhitespaceCharsCollapsedToOneSpace(collapsed_whitespace)
         } else {
-            None
+            CharacterTransformIteration::WhitespaceCharsCollapsedToNothing(collapsed_whitespace)
         }
     }
 
@@ -169,10 +189,8 @@ impl<InputIterator: Iterator<Item = char>> WhitespaceCollapse<InputIterator> {
         &self,
         collected_whitespace: usize,
     ) -> Option<CharacterTransformIteration> {
-        (collected_whitespace != 0).then(|| CharacterTransformIteration {
-            consumed_character_count: collected_whitespace,
-            character: self.character_for_collapsed_whitespace(),
-        })
+        (collected_whitespace != 0)
+            .then(|| self.iteration_for_collapsed_whitespace(collected_whitespace))
     }
 }
 
@@ -193,8 +211,8 @@ impl<InputIterator: Iterator<Item = char>> Iterator for WhitespaceCollapse<Input
             //
             // In the non-preserved case these are converted to space below.
             return match self.input_iterator.next() {
-                Some('\r') => Some(CharacterTransformIteration::identity(' ')),
-                next => next.map(CharacterTransformIteration::identity),
+                Some('\r') => Some(CharacterTransformIteration::OneToOne(' ')),
+                next => next.map(CharacterTransformIteration::OneToOne),
             };
         }
 
@@ -202,7 +220,7 @@ impl<InputIterator: Iterator<Item = char>> Iterator for WhitespaceCollapse<Input
             // Once we produce a non-whitespace character, we are no longer trimming leading whitespace.
             self.trimming_leading_white_space = false;
             self.following_newline = false;
-            return Some(CharacterTransformIteration::identity(character));
+            return Some(CharacterTransformIteration::OneToOne(character));
         }
 
         // When we enter a collapsible white space region, we may need to wait to produce
@@ -236,17 +254,16 @@ impl<InputIterator: Iterator<Item = char>> Iterator for WhitespaceCollapse<Input
                 // >    collapsible segment break is removed.
                 // > 2. Then any remaining segment break is either transformed into a space (U+0020)
                 // >    or removed depending on the context before and after the break.
-                let maybe_character = if self.white_space_collapse != WhiteSpaceCollapse::Collapse {
-                    Some('\n')
+                let iteration = if self.white_space_collapse != WhiteSpaceCollapse::Collapse {
+                    CharacterTransformIteration::WhitespaceCharsCollapsedToOneNewline(
+                        collected_whitespace + 1,
+                    )
                 } else {
-                    self.character_for_collapsed_whitespace()
+                    self.iteration_for_collapsed_whitespace(collected_whitespace + 1)
                 };
 
                 self.following_newline = true;
-                return Some(CharacterTransformIteration {
-                    consumed_character_count: collected_whitespace + 1,
-                    character: maybe_character,
-                });
+                return Some(iteration);
             }
 
             // Non-whitespace character
@@ -268,7 +285,7 @@ impl<InputIterator: Iterator<Item = char>> Iterator for WhitespaceCollapse<Input
             // Once we produce a non-whitespace character, we are no longer trimming leading whitespace.
             self.trimming_leading_white_space = false;
             self.following_newline = false;
-            return Some(CharacterTransformIteration::identity(character));
+            return Some(CharacterTransformIteration::OneToOne(character));
         }
 
         self.iteration_for_collected_white_space(collected_whitespace)
@@ -283,21 +300,15 @@ impl<InputIterator: Iterator<Item = char>> Iterator for WhitespaceCollapse<Input
     }
 }
 
-fn simple_case_transform_iterator<CharacterIterator>(
+fn simple_case_transform_iterator(
     input_iterator: impl Iterator<Item = CharacterTransformIteration>,
-    mapping: impl Fn(char) -> CharacterIterator,
-) -> impl Iterator<Item = CharacterTransformIteration>
-where
-    CharacterIterator: Iterator<Item = char>,
-{
-    input_iterator.flat_map(move |text_step| {
-        if let Some(character) = text_step.character {
-            Either::Right(CharacterTransformIteration::from_char_iter(
-                text_step.consumed_character_count,
-                mapping(character),
-            ))
+    mapping: impl Fn(char) -> CharacterTransformIteration,
+) -> impl Iterator<Item = CharacterTransformIteration> {
+    input_iterator.map(move |iteration| {
+        if let CharacterTransformIteration::OneToOne(character) = iteration {
+            mapping(character)
         } else {
-            Either::Left(std::iter::once(text_step))
+            iteration
         }
     })
 }
@@ -305,21 +316,33 @@ where
 /// Given a string and whether the start of the string represents a word boundary, create a copy of
 /// the string with letters after word boundaries capitalized.
 pub(crate) fn capitalization_iterator(
+    size_hint: usize,
     input_iterator: impl Iterator<Item = CharacterTransformIteration>,
     allow_word_at_start: bool,
 ) -> impl Iterator<Item = CharacterTransformIteration> {
-    let steps: Vec<_> = input_iterator.collect();
-    let string: String = steps.iter().filter_map(|step| step.character).collect();
+    let iterations: Vec<_> = input_iterator.collect();
+    let mut string = String::with_capacity(size_hint);
+    for iteration in &iterations {
+        iteration.push_chars_to(&mut string);
+    }
 
     let word_segmenter = WordSegmenter::new_auto();
     let mut bounds = word_segmenter.segment_str(&string).peekable();
 
-    let mut output = Vec::with_capacity(steps.len());
+    let mut output = Vec::with_capacity(iterations.len());
     let mut current_byte_index = 0;
-    for text_step in steps.into_iter() {
-        let Some(character) = text_step.character else {
-            output.push(text_step);
-            continue;
+    for iteration in iterations.into_iter() {
+        let character = match iteration {
+            CharacterTransformIteration::OneToOne(c) => c,
+            CharacterTransformIteration::WhitespaceCharsCollapsedToOneSpace(_) => ' ',
+            CharacterTransformIteration::WhitespaceCharsCollapsedToOneNewline(_) => '\n',
+            CharacterTransformIteration::WhitespaceCharsCollapsedToNothing(_) => {
+                output.push(iteration);
+                continue;
+            },
+            CharacterTransformIteration::ToLowercase(_) |
+            CharacterTransformIteration::ToUppercase(_) |
+            CharacterTransformIteration::ToTitlecase(_) => unreachable!(),
         };
 
         let at_word_start = bounds.peek() == Some(&current_byte_index);
@@ -327,17 +350,13 @@ pub(crate) fn capitalization_iterator(
             bounds.next();
         }
 
-        if at_word_start && (current_byte_index != 0 || allow_word_at_start) {
-            output.extend(CharacterTransformIteration::from_char_iter(
-                text_step.consumed_character_count,
-                // TODO: use `character.to_titlecase()` when available:
-                // https://github.com/rust-lang/rust/issues/153892
-                // because of:
-                // https://doc.rust-lang.org/stable/std/primitive.char.html#difference-from-uppercase
-                character.to_uppercase(),
-            ));
+        if at_word_start &&
+            let CharacterTransformIteration::OneToOne(_) = iteration &&
+            (current_byte_index != 0 || allow_word_at_start)
+        {
+            output.push(CharacterTransformIteration::ToTitlecase(character));
         } else {
-            output.push(text_step);
+            output.push(iteration);
         }
 
         current_byte_index += character.len_utf8();
@@ -422,33 +441,49 @@ impl OffsetMap {
         }
     }
 
-    pub fn collapse(&mut self, length: usize) {
+    fn collapse(&mut self, length: usize) {
         self.add_or_ammend_entry(OffsetMapEntryType::Collapse, length);
         self.total_original_size += length;
     }
 
-    pub fn expand(&mut self, length: usize) {
+    fn expand(&mut self, length: usize) {
         self.add_or_ammend_entry(OffsetMapEntryType::Expand, length);
         self.total_final_size += length;
     }
 
-    pub fn identity(&mut self, length: usize) {
+    fn identity(&mut self, length: usize) {
         self.add_or_ammend_entry(OffsetMapEntryType::Identity, length);
         self.total_original_size += length;
         self.total_final_size += length;
     }
 
-    pub fn process_character(&mut self, original_length: usize, new_length: usize) {
-        match original_length.cmp(&new_length) {
-            Ordering::Less => {
-                self.identity(original_length);
-                self.expand(new_length - original_length);
+    fn case_map(&mut self, new_length: usize) {
+        self.identity(1);
+        if new_length > 1 {
+            self.expand(new_length - 1);
+        }
+    }
+
+    pub(crate) fn push_synthetic_control_characters(&mut self, count: usize) {
+        self.expand(count);
+    }
+
+    pub(crate) fn push_iteration(&mut self, iteration: &CharacterTransformIteration) {
+        match *iteration {
+            CharacterTransformIteration::OneToOne(_) => self.identity(1),
+            CharacterTransformIteration::WhitespaceCharsCollapsedToOneSpace(count) |
+            CharacterTransformIteration::WhitespaceCharsCollapsedToOneNewline(count) => {
+                self.identity(1);
+                if count > 1 {
+                    self.collapse(count - 1);
+                }
             },
-            Ordering::Equal => self.identity(original_length),
-            Ordering::Greater => {
-                self.identity(new_length);
-                self.collapse(original_length - new_length);
+            CharacterTransformIteration::WhitespaceCharsCollapsedToNothing(count) => {
+                self.collapse(count)
             },
+            CharacterTransformIteration::ToLowercase(c) => self.case_map(c.to_lowercase().len()),
+            CharacterTransformIteration::ToUppercase(c) => self.case_map(c.to_uppercase().len()),
+            CharacterTransformIteration::ToTitlecase(c) => self.case_map(to_titlecase(c).len()),
         }
     }
 
@@ -494,10 +529,14 @@ fn test_offsetmap_basic_expansion() {
     let final_string = "aabbbccccde";
 
     let mut offset_map = OffsetMap::default();
-    offset_map.process_character(1, 2);
-    offset_map.process_character(1, 3);
-    offset_map.process_character(1, 4);
-    offset_map.process_character(2, 2);
+    offset_map.identity(1);
+    offset_map.expand(1);
+    offset_map.identity(1);
+    offset_map.expand(2);
+    offset_map.identity(1);
+    offset_map.expand(3);
+    offset_map.identity(1);
+    offset_map.identity(1);
 
     assert_eq!(offset_map.map(0), 0);
     assert_eq!(offset_map.map(1), 2);
@@ -525,10 +564,13 @@ fn test_offsetmap_basic_collapse() {
     let final_string = "abcde";
 
     let mut offset_map = OffsetMap::default();
-    offset_map.process_character(2, 1);
-    offset_map.process_character(3, 1);
     offset_map.identity(1);
-    offset_map.process_character(4, 1);
+    offset_map.collapse(1);
+    offset_map.identity(1);
+    offset_map.collapse(2);
+    offset_map.identity(1);
+    offset_map.identity(1);
+    offset_map.collapse(3);
     offset_map.identity(1);
 
     assert_eq!(offset_map.map(0), 0);

--- a/components/layout/flow/inline/text_transform.rs
+++ b/components/layout/flow/inline/text_transform.rs
@@ -110,6 +110,20 @@ impl CharacterTransformIteration {
             ..self
         }
     }
+
+    /// `character_iter` must be non-empty
+    fn from_char_iter(
+        mut consumed_character_count: usize,
+        character_iter: impl Iterator<Item = char>,
+    ) -> impl Iterator<Item = Self> {
+        character_iter.map(move |transformed_character| {
+            CharacterTransformIteration {
+                // Iterations after the first use zero:
+                consumed_character_count: std::mem::take(&mut consumed_character_count),
+                character: Some(transformed_character),
+            }
+        })
+    }
 }
 
 pub struct WhitespaceCollapse<'a> {
@@ -282,24 +296,14 @@ where
     CharacterIterator: Iterator<Item = char>,
 {
     input_iterator.flat_map(move |text_step| {
-        let Some(character) = text_step.character else {
-            return Either::Left(std::iter::once(text_step));
-        };
-
-        let mut transformed_iter = mapping(character);
-        let mut first = true;
-        Either::Right(std::iter::from_fn(move || {
-            transformed_iter
-                .next()
-                .map(|transformed_character| CharacterTransformIteration {
-                    consumed_character_count: if std::mem::take(&mut first) {
-                        text_step.consumed_character_count
-                    } else {
-                        0
-                    },
-                    character: Some(transformed_character),
-                })
-        }))
+        if let Some(character) = text_step.character {
+            Either::Right(CharacterTransformIteration::from_char_iter(
+                text_step.consumed_character_count,
+                mapping(character),
+            ))
+        } else {
+            Either::Left(std::iter::once(text_step))
+        }
     })
 }
 
@@ -329,18 +333,10 @@ pub(crate) fn capitalization_iterator<'a>(
         }
 
         if at_word_start && (current_byte_index != 0 || allow_word_at_start) {
-            let transformed_characters = character.to_uppercase();
-            let mut first = true;
-            for transformed_character in transformed_characters {
-                output.push(CharacterTransformIteration {
-                    consumed_character_count: if std::mem::take(&mut first) {
-                        text_step.consumed_character_count
-                    } else {
-                        0
-                    },
-                    character: Some(transformed_character),
-                });
-            }
+            output.extend(CharacterTransformIteration::from_char_iter(
+                text_step.consumed_character_count,
+                character.to_uppercase(),
+            ));
         } else {
             output.push(text_step);
         }

--- a/components/layout/flow/inline/text_transform.rs
+++ b/components/layout/flow/inline/text_transform.rs
@@ -26,16 +26,16 @@ use crate::flow::inline::construct::InlineFormattingContextBuilder;
 /// and produce an optional character. Consumption of characters greater than
 /// the characters stored in [`CharacterTransformIteration`] indicate that those
 /// characters have been collapsed.
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub enum CharacterTransformIteration {
     /// A character mapped from exactly one character in a DOM text node
     OneToOne(char),
     WhitespaceCharsCollapsedToOneSpace(usize),
     WhitespaceCharsCollapsedToOneNewline(usize),
     WhitespaceCharsCollapsedToNothing(usize),
-    ToLowercase(char),
-    ToUppercase(char),
-    ToTitlecase(char),
+    ToLowercase(std::char::ToLowercase),
+    ToUppercase(std::char::ToUppercase),
+    ToTitlecase(ToTitleCase),
 }
 
 pub(crate) struct TextTransformationIterator<'a>(
@@ -64,14 +64,16 @@ impl<'a> TextTransformationIterator<'a> {
             TextTransformCase::None => {
                 Box::new(iterator) as Box<dyn Iterator<Item = CharacterTransformIteration>>
             },
-            TextTransformCase::Lowercase => Box::new(simple_case_transform_iterator(
-                iterator,
-                CharacterTransformIteration::ToLowercase,
-            )),
-            TextTransformCase::Uppercase => Box::new(simple_case_transform_iterator(
-                iterator,
-                CharacterTransformIteration::ToUppercase,
-            )),
+            TextTransformCase::Lowercase => {
+                Box::new(simple_case_transform_iterator(iterator, |c| {
+                    CharacterTransformIteration::ToLowercase(c.to_lowercase())
+                }))
+            },
+            TextTransformCase::Uppercase => {
+                Box::new(simple_case_transform_iterator(iterator, |c| {
+                    CharacterTransformIteration::ToUppercase(c.to_uppercase())
+                }))
+            },
             TextTransformCase::Capitalize => Box::new(capitalization_iterator(
                 text.len(),
                 iterator,
@@ -112,19 +114,19 @@ impl CharacterTransformIteration {
         }
     }
 
-    pub(crate) fn each_char(&self, mut each: impl FnMut(char)) {
-        match *self {
+    pub(crate) fn each_char(self, mut each: impl FnMut(char)) {
+        match self {
             CharacterTransformIteration::OneToOne(c) => each(c),
             CharacterTransformIteration::WhitespaceCharsCollapsedToOneSpace(_) => each(' '),
             CharacterTransformIteration::WhitespaceCharsCollapsedToOneNewline(_) => each('\n'),
             CharacterTransformIteration::WhitespaceCharsCollapsedToNothing(_) => {},
-            CharacterTransformIteration::ToLowercase(c) => c.to_lowercase().for_each(each),
-            CharacterTransformIteration::ToUppercase(c) => c.to_uppercase().for_each(each),
-            CharacterTransformIteration::ToTitlecase(c) => to_titlecase(c).for_each(each),
+            CharacterTransformIteration::ToLowercase(iter) => iter.for_each(each),
+            CharacterTransformIteration::ToUppercase(iter) => iter.for_each(each),
+            CharacterTransformIteration::ToTitlecase(iter) => iter.for_each(each),
         }
     }
 
-    pub fn push_chars_to(&self, string: &mut String) {
+    pub fn push_chars_to(self, string: &mut String) {
         self.each_char(|character| string.push(character));
     }
 }
@@ -133,9 +135,10 @@ impl CharacterTransformIteration {
 // https://github.com/rust-lang/rust/issues/153892
 // because of:
 // https://doc.rust-lang.org/stable/std/primitive.char.html#difference-from-uppercase
-fn to_titlecase(character: char) -> impl ExactSizeIterator<Item = char> {
+fn to_titlecase(character: char) -> ToTitleCase {
     character.to_uppercase()
 }
+type ToTitleCase = std::char::ToUppercase;
 
 pub struct WhitespaceCollapse<InputIterator> {
     input_iterator: InputIterator,
@@ -324,7 +327,7 @@ pub(crate) fn capitalization_iterator(
     let iterations: Vec<_> = input_iterator.collect();
     let mut string = String::with_capacity(size_hint);
     for iteration in &iterations {
-        iteration.push_chars_to(&mut string);
+        iteration.clone().push_chars_to(&mut string);
     }
 
     let word_segmenter = WordSegmenter::new_auto();
@@ -359,7 +362,9 @@ pub(crate) fn capitalization_iterator(
             let CharacterTransformIteration::OneToOne(_) = iteration &&
             (current_byte_index != 0 || allow_word_at_start)
         {
-            output.push(CharacterTransformIteration::ToTitlecase(character));
+            output.push(CharacterTransformIteration::ToTitlecase(to_titlecase(
+                character,
+            )));
         } else {
             output.push(iteration);
         }
@@ -470,26 +475,20 @@ impl OffsetMap {
     }
 
     pub(crate) fn push_iteration(&mut self, iteration: &CharacterTransformIteration) {
-        match *iteration {
+        match iteration {
             CharacterTransformIteration::OneToOne(_) => {
                 self.push_range(Utf32CodeUnits(1), Utf32CodeUnits(1));
             },
             CharacterTransformIteration::WhitespaceCharsCollapsedToOneSpace(original_length) |
             CharacterTransformIteration::WhitespaceCharsCollapsedToOneNewline(original_length) => {
-                self.push_range(Utf32CodeUnits(original_length), Utf32CodeUnits(1));
+                self.push_range(Utf32CodeUnits(*original_length), Utf32CodeUnits(1));
             },
             CharacterTransformIteration::WhitespaceCharsCollapsedToNothing(original_length) => {
-                self.push_range(Utf32CodeUnits(original_length), Utf32CodeUnits(0));
+                self.push_range(Utf32CodeUnits(*original_length), Utf32CodeUnits(0));
             },
-            CharacterTransformIteration::ToLowercase(original_character) => {
-                self.push_mapped_char(original_character.to_lowercase().len())
-            },
-            CharacterTransformIteration::ToUppercase(original_character) => {
-                self.push_mapped_char(original_character.to_uppercase().len())
-            },
-            CharacterTransformIteration::ToTitlecase(original_character) => {
-                self.push_mapped_char(to_titlecase(original_character).len())
-            },
+            CharacterTransformIteration::ToLowercase(iter) => self.push_mapped_char(iter.len()),
+            CharacterTransformIteration::ToUppercase(iter) => self.push_mapped_char(iter.len()),
+            CharacterTransformIteration::ToTitlecase(iter) => self.push_mapped_char(iter.len()),
         }
     }
 
@@ -560,10 +559,18 @@ fn test_offsetmap_basic_expansion() {
     assert_eq!(original_string.to_uppercase(), final_string);
 
     let mut offset_map = OffsetMap::default();
-    offset_map.push_iteration(&CharacterTransformIteration::ToUppercase('a'));
-    offset_map.push_iteration(&CharacterTransformIteration::ToUppercase('ß'));
-    offset_map.push_iteration(&CharacterTransformIteration::ToUppercase('ΰ'));
-    offset_map.push_iteration(&CharacterTransformIteration::ToUppercase('b'));
+    offset_map.push_iteration(&CharacterTransformIteration::ToUppercase(
+        'a'.to_uppercase(),
+    ));
+    offset_map.push_iteration(&CharacterTransformIteration::ToUppercase(
+        'ß'.to_uppercase(),
+    ));
+    offset_map.push_iteration(&CharacterTransformIteration::ToUppercase(
+        'ΰ'.to_uppercase(),
+    ));
+    offset_map.push_iteration(&CharacterTransformIteration::ToUppercase(
+        'b'.to_uppercase(),
+    ));
 
     assert_eq!(offset_map.map(c(0)).0, 0);
     assert_eq!(offset_map.map(c(1)).0, 1);

--- a/components/layout/flow/inline/text_transform.rs
+++ b/components/layout/flow/inline/text_transform.rs
@@ -58,7 +58,7 @@ impl CharacterTransformIteration {
         }
     }
 
-    fn collapse(character: Option<char>, amount_collapsed: usize) -> Self {
+    fn collapse(amount_collapsed: usize, character: Option<char>) -> Self {
         Self {
             consumed: Utf32CodeUnits(amount_collapsed),
             characters: character.into_iter().collect(),
@@ -117,9 +117,9 @@ impl<InputIterator: Iterator<Item = char>> WhitespaceCollapse<InputIterator> {
         collapsed_whitespace: usize,
     ) -> CharacterTransformIteration {
         if !self.following_newline && !self.trimming_leading_white_space {
-            CharacterTransformIteration::collapse(Some(' '), collapsed_whitespace)
+            CharacterTransformIteration::collapse(collapsed_whitespace, Some(' '))
         } else {
-            CharacterTransformIteration::collapse(None, collapsed_whitespace)
+            CharacterTransformIteration::collapse(collapsed_whitespace, None)
         }
     }
 
@@ -193,7 +193,7 @@ impl<InputIterator: Iterator<Item = char>> Iterator for WhitespaceCollapse<Input
                 // > 2. Then any remaining segment break is either transformed into a space (U+0020)
                 // >    or removed depending on the context before and after the break.
                 let iteration = if self.white_space_collapse != WhiteSpaceCollapse::Collapse {
-                    CharacterTransformIteration::collapse(Some('\n'), collected_whitespace + 1)
+                    CharacterTransformIteration::collapse(collected_whitespace + 1, Some('\n'))
                 } else {
                     self.iteration_for_collapsed_whitespace(collected_whitespace + 1)
                 };
@@ -265,8 +265,8 @@ impl<'a> TextTransformationIterator<'a> {
                 }))
             },
             TextTransformCase::Capitalize => Box::new(capitalization_iterator(
-                text.len(),
                 iterator,
+                text.len(),
                 on_word_boundary,
             )),
             // TODO: implement `math-auto` and enable it in Stylo
@@ -302,11 +302,13 @@ fn simple_case_transform_iterator(
     })
 }
 
-/// Given a string and whether the start of the string represents a word boundary, create a copy of
-/// the string with letters after word boundaries capitalized.
+/// Given an input iterator, a size hint for the number items in the iterator,
+/// and a boolean determining whether the start of the input represents a word
+/// boundary, return an iterator that capitalizes one-to-one mapped characters
+/// from the input iterator.
 pub(crate) fn capitalization_iterator(
-    size_hint: usize,
     input_iterator: impl Iterator<Item = CharacterTransformIteration>,
+    size_hint: usize,
     allow_word_at_start: bool,
 ) -> impl Iterator<Item = CharacterTransformIteration> {
     let mut iterations: Vec<_> = input_iterator.collect();
@@ -355,9 +357,11 @@ pub(crate) fn capitalization_iterator(
     iterations.into_iter()
 }
 
-// The behavior of `-webkit-text-security` isn't specified, so we have some
-// flexibility in the implementation. We just need to maintain a rough
-// compatibility with other browsers.
+/// Map a character according to the rules of the `-webkit-text-security` CSS property.
+///
+/// Note: The behavior of `-webkit-text-security` isn't specified, so we have some
+/// flexibility in the implementation. We just need to maintain a rough compatibility with
+/// other browsers.
 fn map_character_for_webkit_text_security(mode: WebKitTextSecurity, character: char) -> char {
     if let WebKitTextSecurity::None = mode {
         return character;
@@ -512,8 +516,6 @@ impl OffsetMap {
 
 #[test]
 fn test_offsetmap_basic_expansion() {
-    use servo_base::text::Utf32CodeUnits as c;
-
     let original_string = "aßΰb";
     let final_string = "ASS\u{3a5}\u{308}\u{301}B";
     assert_eq!(original_string.to_uppercase(), final_string);
@@ -532,23 +534,23 @@ fn test_offsetmap_basic_expansion() {
         'b'.to_uppercase(),
     ));
 
-    assert_eq!(offset_map.map(c(0)).0, 0);
-    assert_eq!(offset_map.map(c(1)).0, 1);
-    assert_eq!(offset_map.map(c(2)).0, 3);
-    assert_eq!(offset_map.map(c(3)).0, 6);
-    assert_eq!(offset_map.map(c(4)).0, 7);
+    assert_eq!(offset_map.map(Utf32CodeUnits(0)).0, 0);
+    assert_eq!(offset_map.map(Utf32CodeUnits(1)).0, 1);
+    assert_eq!(offset_map.map(Utf32CodeUnits(2)).0, 3);
+    assert_eq!(offset_map.map(Utf32CodeUnits(3)).0, 6);
+    assert_eq!(offset_map.map(Utf32CodeUnits(4)).0, 7);
 
     // Beyond the last index should always map to the index after the last character
     // (for handling selections).
-    assert_eq!(offset_map.map(c(5)).0, 7);
-    assert_eq!(offset_map.map(c(100)).0, 7);
+    assert_eq!(offset_map.map(Utf32CodeUnits(5)).0, 7);
+    assert_eq!(offset_map.map(Utf32CodeUnits(100)).0, 7);
 
     let map_substring = |offset: usize, length: usize| {
         let start = offset_map
-            .map(c(offset))
+            .map(Utf32CodeUnits(offset))
             .to_utf8_code_units_in(final_string);
         let end = offset_map
-            .map(c(offset + length))
+            .map(Utf32CodeUnits(offset + length))
             .to_utf8_code_units_in(final_string);
         &final_string[start.0..end.0]
     };
@@ -561,13 +563,11 @@ fn test_offsetmap_basic_expansion() {
 
 #[test]
 fn test_offsetmap_basic_collapse() {
-    use servo_base::text::Utf32CodeUnits as c;
-
     let _original_string = "  aaa  b \nc";
     let final_string = "aaa b\nc";
 
     let mut offset_map = OffsetMap::default();
-    offset_map.push_iteration(&CharacterTransformIteration::collapse(None, 2));
+    offset_map.push_iteration(&CharacterTransformIteration::collapse(2, None));
     offset_map.push_iteration(&CharacterTransformIteration::one_to_one('a'));
     offset_map.push_iteration(&CharacterTransformIteration::one_to_one('a'));
     offset_map.push_iteration(&CharacterTransformIteration::one_to_one('a'));
@@ -577,34 +577,34 @@ fn test_offsetmap_basic_collapse() {
         "Consecutive one-to-one mappings are merged"
     );
 
-    offset_map.push_iteration(&CharacterTransformIteration::collapse(Some(' '), 2));
+    offset_map.push_iteration(&CharacterTransformIteration::collapse(2, Some(' ')));
     offset_map.push_iteration(&CharacterTransformIteration::one_to_one('b'));
-    offset_map.push_iteration(&CharacterTransformIteration::collapse(Some('\n'), 2));
+    offset_map.push_iteration(&CharacterTransformIteration::collapse(2, Some('\n')));
     offset_map.push_iteration(&CharacterTransformIteration::one_to_one('c'));
 
-    assert_eq!(offset_map.map(c(0)).0, 0);
-    assert_eq!(offset_map.map(c(1)).0, 0);
-    assert_eq!(offset_map.map(c(2)).0, 0);
-    assert_eq!(offset_map.map(c(3)).0, 1);
-    assert_eq!(offset_map.map(c(4)).0, 2);
-    assert_eq!(offset_map.map(c(5)).0, 3);
+    assert_eq!(offset_map.map(Utf32CodeUnits(0)).0, 0);
+    assert_eq!(offset_map.map(Utf32CodeUnits(1)).0, 0);
+    assert_eq!(offset_map.map(Utf32CodeUnits(2)).0, 0);
+    assert_eq!(offset_map.map(Utf32CodeUnits(3)).0, 1);
+    assert_eq!(offset_map.map(Utf32CodeUnits(4)).0, 2);
+    assert_eq!(offset_map.map(Utf32CodeUnits(5)).0, 3);
     // Mapping from the middle of the collapsed sequence should map to after the replacement.
-    assert_eq!(offset_map.map(c(6)).0, 4);
-    assert_eq!(offset_map.map(c(7)).0, 4);
-    assert_eq!(offset_map.map(c(8)).0, 5);
+    assert_eq!(offset_map.map(Utf32CodeUnits(6)).0, 4);
+    assert_eq!(offset_map.map(Utf32CodeUnits(7)).0, 4);
+    assert_eq!(offset_map.map(Utf32CodeUnits(8)).0, 5);
     // Mapping from the middle of the collapsed sequence should map to after the replacement.
-    assert_eq!(offset_map.map(c(9)).0, 6);
-    assert_eq!(offset_map.map(c(10)).0, 6);
-    assert_eq!(offset_map.map(c(11)).0, 7);
+    assert_eq!(offset_map.map(Utf32CodeUnits(9)).0, 6);
+    assert_eq!(offset_map.map(Utf32CodeUnits(10)).0, 6);
+    assert_eq!(offset_map.map(Utf32CodeUnits(11)).0, 7);
 
     // Beyond the last index should always map to the index after the last character
     // (for handling selections).
-    assert_eq!(offset_map.map(c(12)).0, 7);
-    assert_eq!(offset_map.map(c(100)).0, 7);
+    assert_eq!(offset_map.map(Utf32CodeUnits(12)).0, 7);
+    assert_eq!(offset_map.map(Utf32CodeUnits(100)).0, 7);
 
     let map_substring = |offset: usize, length: usize| {
-        let start = offset_map.map(c(offset)).0;
-        let end = offset_map.map(c(offset + length)).0;
+        let start = offset_map.map(Utf32CodeUnits(offset)).0;
+        let end = offset_map.map(Utf32CodeUnits(offset + length)).0;
         &final_string[start..end]
     };
     assert_eq!(map_substring(0, 1), "");

--- a/components/layout/flow/inline/text_transform.rs
+++ b/components/layout/flow/inline/text_transform.rs
@@ -21,6 +21,13 @@ use style::values::specified::text::{TextTransform, TextTransformCase};
 
 use crate::flow::inline::construct::InlineFormattingContextBuilder;
 
+/// <https://github.com/rust-lang/rust/blob/1.97.1/library/core/src/char/mod.rs#L523>
+///
+/// This is the maximum amount of characters that can be produced from case mapping,
+/// and by consequence the maximum amount of characters that can be produced during
+/// inline formatting context text transformation.
+const MAX_CASE_MAPPING_LENGTH: usize = 3;
+
 /// A single iteration in a pipeline of character iterators, that handle things like
 /// whitespace collapse and `text-transform` processing for text in an
 /// [`InlineFormattingContext`]. Each iteration can consume multiple characters and
@@ -32,7 +39,7 @@ pub struct CharacterTransformIteration {
     /// The number of characters consumed during this iteration of character transformation.
     consumed: Utf32CodeUnits,
     /// The characters that were produced during this iteration.
-    characters: ArrayVec<char, 3>,
+    characters: ArrayVec<char, MAX_CASE_MAPPING_LENGTH>,
 }
 
 impl CharacterTransformIteration {

--- a/components/layout/flow/inline/text_transform.rs
+++ b/components/layout/flow/inline/text_transform.rs
@@ -11,7 +11,6 @@
 //! IFC text and vice-versa.
 
 use std::cmp::Ordering;
-use std::str::Chars;
 
 use icu_segmenter::WordSegmenter;
 use itertools::Either;
@@ -51,14 +50,18 @@ impl<'a> TextTransformationIterator<'a> {
         trim_leading_white_space: bool,
         on_word_boundary: bool,
     ) -> Self {
+        let text_security = style.clone__webkit_text_security();
+        let chars = text
+            .chars()
+            .map(move |character| text_security_map_character(text_security, character));
         let white_space_collapse = style.clone_white_space_collapse();
         let iterator =
-            WhitespaceCollapse::new(text.chars(), white_space_collapse, trim_leading_white_space);
+            WhitespaceCollapse::new(chars, white_space_collapse, trim_leading_white_space);
 
         // TODO: Not all text transforms are about case, this logic should stop ignoring
         // TextTransform::FULL_WIDTH and TextTransform::FULL_SIZE_KANA.
         let text_transform = style.clone_text_transform();
-        let mut iterator = match text_transform.case() {
+        let iterator = match text_transform.case() {
             TextTransformCase::None => {
                 Box::new(iterator) as Box<dyn Iterator<Item = CharacterTransformIteration>>
             },
@@ -82,10 +85,6 @@ impl<'a> TextTransformationIterator<'a> {
             // iterator = Box::new(full_size_kana_iterator(iterator));
         }
 
-        let text_security = style.clone__webkit_text_security();
-        if text_security != WebKitTextSecurity::None {
-            iterator = Box::new(TextSecurityTransform::new(iterator, text_security));
-        }
         Self(iterator)
     }
 }
@@ -105,13 +104,6 @@ impl CharacterTransformIteration {
         }
     }
 
-    fn with_character(self, character: char) -> Self {
-        Self {
-            character: Some(character),
-            ..self
-        }
-    }
-
     /// `character_iter` must be non-empty
     fn from_char_iter(
         mut consumed_character_count: usize,
@@ -127,8 +119,8 @@ impl CharacterTransformIteration {
     }
 }
 
-pub struct WhitespaceCollapse<'a> {
-    input_iterator: Chars<'a>,
+pub struct WhitespaceCollapse<InputIterator> {
+    input_iterator: InputIterator,
     white_space_collapse: WhiteSpaceCollapse,
 
     /// Whether or not we are in the process of collapse leading white space. This is true
@@ -147,9 +139,9 @@ pub struct WhitespaceCollapse<'a> {
     character_pending_to_return: Option<char>,
 }
 
-impl<'a> WhitespaceCollapse<'a> {
+impl<InputIterator: Iterator<Item = char>> WhitespaceCollapse<InputIterator> {
     pub fn new(
-        input_iterator: Chars<'a>,
+        input_iterator: InputIterator,
         white_space_collapse: WhiteSpaceCollapse,
         should_trim_leading_white_space: bool,
     ) -> Self {
@@ -184,7 +176,7 @@ impl<'a> WhitespaceCollapse<'a> {
     }
 }
 
-impl Iterator for WhitespaceCollapse<'_> {
+impl<InputIterator: Iterator<Item = char>> Iterator for WhitespaceCollapse<InputIterator> {
     type Item = CharacterTransformIteration;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -354,53 +346,29 @@ pub(crate) fn capitalization_iterator(
     output.into_iter()
 }
 
-pub struct TextSecurityTransform<InputIterator> {
-    /// The input character iterator.
-    iterator: InputIterator,
-    /// The `-webkit-text-security` value to use.
-    text_security: WebKitTextSecurity,
-}
-
-impl<InputIterator> TextSecurityTransform<InputIterator> {
-    pub fn new(iterator: InputIterator, text_security: WebKitTextSecurity) -> Self {
-        Self {
-            iterator,
-            text_security,
-        }
-    }
-}
-
-impl<InputIterator> Iterator for TextSecurityTransform<InputIterator>
-where
-    InputIterator: Iterator<Item = CharacterTransformIteration>,
-{
-    type Item = CharacterTransformIteration;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        // The behavior of `-webkit-text-security` isn't specified, so we have some
-        // flexibility in the implementation. We just need to maintain a rough
-        // compatibility with other browsers.
-        let text_step = self.iterator.next()?;
-        let Some(character) = text_step.character else {
-            return Some(text_step);
-        };
-
-        let mapped_character = match character {
+// The behavior of `-webkit-text-security` isn't specified, so we have some
+// flexibility in the implementation. We just need to maintain a rough
+// compatibility with other browsers.
+fn text_security_map_character(mode: WebKitTextSecurity, character: char) -> char {
+    if let WebKitTextSecurity::None = mode {
+        character
+    } else {
+        // TODO: when MSRV is 1.95+
+        // std::hint::cold_path();
+        match character {
             // This is not ideal, but zero width space is used for some special reasons in
             // `<input>` fields, so these remain untransformed, otherwise they would show up
             // in empty text fields.
             '\u{200B}' => '\u{200B}',
             // Newlines are preserved, so that `<br>` keeps working as expected.
             '\n' => '\n',
-            character => match self.text_security {
-                WebKitTextSecurity::None => character,
+            _ => match mode {
+                WebKitTextSecurity::None => character, // unreachable
                 WebKitTextSecurity::Circle => '○',
                 WebKitTextSecurity::Disc => '●',
                 WebKitTextSecurity::Square => '■',
             },
-        };
-
-        Some(text_step.with_character(mapped_character))
+        }
     }
 }
 

--- a/components/layout/flow/inline/text_transform.rs
+++ b/components/layout/flow/inline/text_transform.rs
@@ -12,6 +12,7 @@
 
 use icu_segmenter::WordSegmenter;
 use malloc_size_of_derive::MallocSizeOf;
+use servo_base::text::Utf32CodeUnits;
 use style::computed_values::_webkit_text_security::T as WebKitTextSecurity;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::properties::ComputedValues;
@@ -391,205 +392,252 @@ fn text_security_map_character(mode: WebKitTextSecurity, character: char) -> cha
     }
 }
 
-#[derive(PartialEq, MallocSizeOf)]
-enum OffsetMapEntryType {
-    // Represents text that is the same size in the original string as in the final
-    // string.
-    Identity,
-    // Represents text that is shorter in the final string than in the original
-    // string.
-    Collapse,
-    // Represents text that is longer in the final string than in the original
-    // string.
-    Expand,
+#[derive(MallocSizeOf, Clone, Copy)]
+struct OffsetMapKnownPosition {
+    original_offset: Utf32CodeUnits,
+    final_offset: Utf32CodeUnits,
 }
-
-#[derive(MallocSizeOf)]
-struct OffsetMapEntry(OffsetMapEntryType, usize);
 
 #[derive(Default, MallocSizeOf)]
 pub struct OffsetMap {
-    total_original_size: usize,
-    total_final_size: usize,
-    entries: Vec<OffsetMapEntry>,
+    /// Not including `IMPLICIT_KNOWN_POSITION_AT_START`
+    known_positions: Vec<OffsetMapKnownPosition>,
+    /// `Default` initializes to `false`
+    last_range_maps_one_to_one: bool,
 }
 
 impl std::fmt::Debug for OffsetMap {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OffsetMap")
-            .field("total_original_size", &self.total_original_size)
-            .field("total_final_size", &self.total_final_size)
+            .field("total_original_size", &self.total_original_size())
+            .field("total_final_size", &self.total_final_size())
             .finish()
     }
 }
 
+static IMPLICIT_KNOWN_POSITION_AT_START: OffsetMapKnownPosition = OffsetMapKnownPosition {
+    original_offset: Utf32CodeUnits(0),
+    final_offset: Utf32CodeUnits(0),
+};
+
 impl OffsetMap {
-    pub fn total_final_size(&self) -> usize {
-        self.total_final_size
+    fn last_known_position(&self) -> &OffsetMapKnownPosition {
+        self.known_positions
+            .last()
+            .unwrap_or(&IMPLICIT_KNOWN_POSITION_AT_START)
     }
 
-    fn add_or_ammend_entry(&mut self, entry_type: OffsetMapEntryType, length: usize) {
-        if length == 0 {
-            return;
-        }
-
-        match self.entries.last_mut() {
-            Some(OffsetMapEntry(old_entry_type, old_length)) if *old_entry_type == entry_type => {
-                *old_length += length
-            },
-            _ => self.entries.push(OffsetMapEntry(entry_type, length)),
-        }
+    pub fn total_original_size(&self) -> Utf32CodeUnits {
+        self.last_known_position().original_offset
     }
 
-    fn collapse(&mut self, length: usize) {
-        self.add_or_ammend_entry(OffsetMapEntryType::Collapse, length);
-        self.total_original_size += length;
+    pub fn total_final_size(&self) -> Utf32CodeUnits {
+        self.last_known_position().final_offset
     }
 
-    fn expand(&mut self, length: usize) {
-        self.add_or_ammend_entry(OffsetMapEntryType::Expand, length);
-        self.total_final_size += length;
+    fn push_range(
+        &mut self,
+        additional_original_length: Utf32CodeUnits,
+        additional_final_length: Utf32CodeUnits,
+    ) {
+        let last = self.last_known_position();
+        self.known_positions.push(OffsetMapKnownPosition {
+            original_offset: last.original_offset + additional_original_length,
+            final_offset: last.final_offset + additional_final_length,
+        })
     }
 
-    fn identity(&mut self, length: usize) {
-        self.add_or_ammend_entry(OffsetMapEntryType::Identity, length);
-        self.total_original_size += length;
-        self.total_final_size += length;
+    pub(crate) fn push_synthetic_control_characters(&mut self, count: Utf32CodeUnits) {
+        self.push_range(Utf32CodeUnits(0), count);
     }
 
-    fn case_map(&mut self, new_length: usize) {
-        self.identity(1);
-        if new_length > 1 {
-            self.expand(new_length - 1);
-        }
-    }
-
-    pub(crate) fn push_synthetic_control_characters(&mut self, count: usize) {
-        self.expand(count);
+    fn push_mapped_char(&mut self, new_length: usize) {
+        self.push_range(Utf32CodeUnits(1), Utf32CodeUnits(new_length));
     }
 
     pub(crate) fn push_iteration(&mut self, iteration: &CharacterTransformIteration) {
         match *iteration {
-            CharacterTransformIteration::OneToOne(_) => self.identity(1),
-            CharacterTransformIteration::WhitespaceCharsCollapsedToOneSpace(count) |
-            CharacterTransformIteration::WhitespaceCharsCollapsedToOneNewline(count) => {
-                self.identity(1);
-                if count > 1 {
-                    self.collapse(count - 1);
+            CharacterTransformIteration::OneToOne(_) => {
+                if self.last_range_maps_one_to_one &&
+                    let Some(last) = self.known_positions.last_mut()
+                {
+                    last.original_offset += Utf32CodeUnits(1);
+                    last.final_offset += Utf32CodeUnits(1);
+                } else {
+                    self.push_range(Utf32CodeUnits(1), Utf32CodeUnits(1));
+                    self.last_range_maps_one_to_one = true;
                 }
+                return; // skip `self.last_range_maps_one_to_one = false` below
             },
-            CharacterTransformIteration::WhitespaceCharsCollapsedToNothing(count) => {
-                self.collapse(count)
+            CharacterTransformIteration::WhitespaceCharsCollapsedToOneSpace(original_length) |
+            CharacterTransformIteration::WhitespaceCharsCollapsedToOneNewline(original_length) => {
+                self.push_range(Utf32CodeUnits(original_length), Utf32CodeUnits(1));
             },
-            CharacterTransformIteration::ToLowercase(c) => self.case_map(c.to_lowercase().len()),
-            CharacterTransformIteration::ToUppercase(c) => self.case_map(c.to_uppercase().len()),
-            CharacterTransformIteration::ToTitlecase(c) => self.case_map(to_titlecase(c).len()),
+            CharacterTransformIteration::WhitespaceCharsCollapsedToNothing(original_length) => {
+                self.push_range(Utf32CodeUnits(original_length), Utf32CodeUnits(0));
+            },
+            CharacterTransformIteration::ToLowercase(original_character) => {
+                self.push_mapped_char(original_character.to_lowercase().len())
+            },
+            CharacterTransformIteration::ToUppercase(original_character) => {
+                self.push_mapped_char(original_character.to_uppercase().len())
+            },
+            CharacterTransformIteration::ToTitlecase(original_character) => {
+                self.push_mapped_char(to_titlecase(original_character).len())
+            },
         }
+        // In all cases except `OneToOne`
+        self.last_range_maps_one_to_one = false;
     }
 
-    pub fn map(&self, target_original_offset: usize) -> usize {
-        // Allow mapping one index past the size of the map, as this can be used for
-        // selection which can index one character past the end of the last character
-        // in the string.
-        if target_original_offset > self.total_original_size {
-            return self.total_final_size;
-        }
+    pub fn map(&self, target_original_offset: Utf32CodeUnits) -> Utf32CodeUnits {
+        self.map_common(
+            target_original_offset,
+            |position| position.original_offset,
+            |position| position.final_offset,
+        )
+    }
 
-        let mut offset_in_original_string = 0;
-        let mut offset_in_final_string = 0;
-        for entry in self.entries.iter() {
-            match entry.0 {
-                OffsetMapEntryType::Identity
-                    if offset_in_original_string + entry.1 > target_original_offset =>
-                {
-                    return offset_in_final_string +
-                        (target_original_offset - offset_in_original_string);
-                },
-                OffsetMapEntryType::Identity => {
-                    offset_in_final_string += entry.1;
-                    offset_in_original_string += entry.1;
-                },
-                OffsetMapEntryType::Collapse
-                    if offset_in_original_string + entry.1 > target_original_offset =>
-                {
-                    return offset_in_final_string;
-                },
-                OffsetMapEntryType::Collapse => offset_in_original_string += entry.1,
-                OffsetMapEntryType::Expand => offset_in_final_string += entry.1,
-            }
-        }
+    pub fn reverse_map(&self, target_final_offset: Utf32CodeUnits) -> Utf32CodeUnits {
+        self.map_common(
+            target_final_offset,
+            |position| position.final_offset,
+            |position| position.original_offset,
+        )
+    }
 
-        offset_in_final_string
+    fn map_common(
+        &self,
+        target_offset: Utf32CodeUnits,
+        get_input_offset: impl Copy + Fn(&OffsetMapKnownPosition) -> Utf32CodeUnits,
+        get_output_offset: impl Fn(&OffsetMapKnownPosition) -> Utf32CodeUnits,
+    ) -> Utf32CodeUnits {
+        if target_offset.0 == 0 {
+            // Implict known position
+            return Utf32CodeUnits(0);
+        }
+        match self
+            .known_positions
+            .binary_search_by_key(&target_offset, get_input_offset)
+        {
+            Ok(index) => {
+                // Exact known position
+                get_output_offset(&self.known_positions[index])
+            },
+            Err(index) => {
+                // `index` is where inserting a new position would keep the `Vec` sorted
+                if let Some(position_after) = self.known_positions.get(index) {
+                    let position_before = if index > 0 {
+                        &self.known_positions[index - 1]
+                    } else {
+                        &IMPLICIT_KNOWN_POSITION_AT_START
+                    };
+                    debug_assert!(target_offset > get_input_offset(position_before));
+                    debug_assert!(target_offset < get_input_offset(position_after));
+                    let offset_within_range = target_offset - get_input_offset(position_before);
+                    let candidate = get_output_offset(position_before) + offset_within_range;
+                    // If the output range is shorter, to go beyond it
+                    let upper_bound = get_output_offset(position_after);
+                    upper_bound.min(candidate)
+                } else {
+                    // `target_offset` at or past the end of the text covered by this map
+                    get_output_offset(self.last_known_position())
+                }
+            },
+        }
     }
 }
 
 #[test]
 fn test_offsetmap_basic_expansion() {
-    let _original_string = "abcde";
-    let final_string = "aabbbccccde";
+    use servo_base::text::Utf32CodeUnits as c;
+
+    let original_string = "aßΰb";
+    let final_string = "ASS\u{3a5}\u{308}\u{301}B";
+    assert_eq!(original_string.to_uppercase(), final_string);
 
     let mut offset_map = OffsetMap::default();
-    offset_map.identity(1);
-    offset_map.expand(1);
-    offset_map.identity(1);
-    offset_map.expand(2);
-    offset_map.identity(1);
-    offset_map.expand(3);
-    offset_map.identity(1);
-    offset_map.identity(1);
+    offset_map.push_iteration(&CharacterTransformIteration::ToUppercase('a'));
+    offset_map.push_iteration(&CharacterTransformIteration::ToUppercase('ß'));
+    offset_map.push_iteration(&CharacterTransformIteration::ToUppercase('ΰ'));
+    offset_map.push_iteration(&CharacterTransformIteration::ToUppercase('b'));
 
-    assert_eq!(offset_map.map(0), 0);
-    assert_eq!(offset_map.map(1), 2);
-    assert_eq!(offset_map.map(2), 5);
-    assert_eq!(offset_map.map(3), 9);
-    assert_eq!(offset_map.map(4), 10);
+    assert_eq!(offset_map.map(c(0)).0, 0);
+    assert_eq!(offset_map.map(c(1)).0, 1);
+    assert_eq!(offset_map.map(c(2)).0, 3);
+    assert_eq!(offset_map.map(c(3)).0, 6);
+    assert_eq!(offset_map.map(c(4)).0, 7);
 
     // Beyond the last index should always map to the index after the last character
     // (for handling selections).
-    assert_eq!(offset_map.map(5), 11);
-    assert_eq!(offset_map.map(100), 11);
+    assert_eq!(offset_map.map(c(5)).0, 7);
+    assert_eq!(offset_map.map(c(100)).0, 7);
 
-    let map_substring =
-        |offset, length| &final_string[offset_map.map(offset)..offset_map.map(offset + length)];
-    assert_eq!(map_substring(0, 1), "aa");
-    assert_eq!(map_substring(0, 2), "aabbb");
-    assert_eq!(map_substring(0, 3), "aabbbcccc");
-    assert_eq!(map_substring(0, 4), "aabbbccccd");
-    assert_eq!(map_substring(1, 1), "bbb");
+    let map_substring = |offset: usize, length: usize| {
+        let start = offset_map
+            .map(c(offset))
+            .to_utf8_code_units_in(final_string);
+        let end = offset_map
+            .map(c(offset + length))
+            .to_utf8_code_units_in(final_string);
+        &final_string[start.0..end.0]
+    };
+    assert_eq!(map_substring(0, 1), "A");
+    assert_eq!(map_substring(0, 2), "ASS");
+    assert_eq!(map_substring(0, 3), "ASS\u{3a5}\u{308}\u{301}");
+    assert_eq!(map_substring(0, 4), "ASS\u{3a5}\u{308}\u{301}B");
+    assert_eq!(map_substring(1, 1), "SS");
 }
 
 #[test]
 fn test_offsetmap_basic_collapse() {
-    let _original_string = "AABBBcDDDDe";
-    let final_string = "abcde";
+    use servo_base::text::Utf32CodeUnits as c;
+
+    let _original_string = "  aaa  b \nc";
+    let final_string = "aaa b\nc";
 
     let mut offset_map = OffsetMap::default();
-    offset_map.identity(1);
-    offset_map.collapse(1);
-    offset_map.identity(1);
-    offset_map.collapse(2);
-    offset_map.identity(1);
-    offset_map.identity(1);
-    offset_map.collapse(3);
-    offset_map.identity(1);
+    offset_map.push_iteration(&CharacterTransformIteration::WhitespaceCharsCollapsedToNothing(2));
+    offset_map.push_iteration(&CharacterTransformIteration::OneToOne('a'));
+    offset_map.push_iteration(&CharacterTransformIteration::OneToOne('a'));
+    offset_map.push_iteration(&CharacterTransformIteration::OneToOne('a'));
+    assert_eq!(offset_map.known_positions.len(), 2); // merging consecutive `OneToOne`
+    offset_map.push_iteration(&CharacterTransformIteration::WhitespaceCharsCollapsedToOneSpace(2));
+    offset_map.push_iteration(&CharacterTransformIteration::OneToOne('b'));
+    offset_map
+        .push_iteration(&CharacterTransformIteration::WhitespaceCharsCollapsedToOneNewline(2));
+    offset_map.push_iteration(&CharacterTransformIteration::OneToOne('c'));
 
-    assert_eq!(offset_map.map(0), 0);
-    // Mapping between characters should map to the index after the final one.
-    assert_eq!(offset_map.map(1), 1);
-    assert_eq!(offset_map.map(2), 1);
-    assert_eq!(offset_map.map(5), 2);
-    assert_eq!(offset_map.map(6), 3);
-    assert_eq!(offset_map.map(10), 4);
+    assert_eq!(offset_map.map(c(0)).0, 0);
+    assert_eq!(offset_map.map(c(1)).0, 0);
+    assert_eq!(offset_map.map(c(2)).0, 0);
+    assert_eq!(offset_map.map(c(3)).0, 1);
+    assert_eq!(offset_map.map(c(4)).0, 2);
+    assert_eq!(offset_map.map(c(5)).0, 3);
+    // Mapping from the middle of the collapsed sequence should map to after the replacement.
+    assert_eq!(offset_map.map(c(6)).0, 4);
+    assert_eq!(offset_map.map(c(7)).0, 4);
+    assert_eq!(offset_map.map(c(8)).0, 5);
+    // Mapping from the middle of the collapsed sequence should map to after the replacement.
+    assert_eq!(offset_map.map(c(9)).0, 6);
+    assert_eq!(offset_map.map(c(10)).0, 6);
+    assert_eq!(offset_map.map(c(11)).0, 7);
 
     // Beyond the last index should always map to the index after the last character
     // (for handling selections).
-    assert_eq!(offset_map.map(11), 5);
-    assert_eq!(offset_map.map(100), 5);
+    assert_eq!(offset_map.map(c(12)).0, 7);
+    assert_eq!(offset_map.map(c(100)).0, 7);
 
-    let map_substring =
-        |offset, length| &final_string[offset_map.map(offset)..offset_map.map(offset + length)];
-    assert_eq!(map_substring(0, 2), "a");
-    assert_eq!(map_substring(0, 3), "ab");
-    assert_eq!(map_substring(0, 6), "abc");
-    assert_eq!(map_substring(0, 10), "abcd");
+    let map_substring = |offset: usize, length: usize| {
+        let start = offset_map.map(c(offset)).0;
+        let end = offset_map.map(c(offset + length)).0;
+        &final_string[start..end]
+    };
+    assert_eq!(map_substring(0, 1), "");
+    assert_eq!(map_substring(0, 3), "a");
+    assert_eq!(map_substring(0, 5), "aaa");
+    assert_eq!(map_substring(0, 6), "aaa ");
+    assert_eq!(map_substring(0, 7), "aaa ");
+    assert_eq!(map_substring(0, 8), "aaa b");
+    assert_eq!(map_substring(0, 11), "aaa b\nc");
 }

--- a/components/layout/flow/inline/text_transform.rs
+++ b/components/layout/flow/inline/text_transform.rs
@@ -1,0 +1,590 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! # Logic for text transform in inline formatting contexts
+//!
+//! Inline formatting contexts do a variety of text transformations on their text content
+//! including white space collapsing, application of the `text-transform` CSS property,
+//! and application of the `-webkit-text-security` property. This module contains code to
+//! handle this as well as code to map from offsets in the original DOM node to the final
+//! IFC text and vice-versa.
+
+use std::cmp::Ordering;
+use std::str::Chars;
+
+use icu_segmenter::WordSegmenter;
+use itertools::Either;
+use malloc_size_of_derive::MallocSizeOf;
+use style::computed_values::_webkit_text_security::T as WebKitTextSecurity;
+use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
+use style::properties::ComputedValues;
+use style::values::specified::text::TextTransformCase;
+
+use crate::flow::inline::construct::InlineFormattingContextBuilder;
+
+/// A single iteration in a pipeline of character iterators, that handle things
+/// like whitespace collapse and `text-transform` processing for text in an
+/// [`InlineFormattingContext`]. Each iteration can consume multiple characters
+/// and produce an optional character. Consumption of characters greater than
+/// the characters stored in [`CharacterTransformIteration`] indicate that those
+/// characters have been collapsed.
+pub struct CharacterTransformIteration {
+    /// The number of characters consumed when producing the optional character
+    /// in this iteration. This can indicate that a certain number of characters
+    /// have been collapsed in the input stream.
+    pub consumed_character_count: usize,
+    /// If this iteration produced a character, it is stored in this field. If no
+    /// character is stored here, the iteration collapsed the
+    /// [`Self::consumed_character_count`] characters.
+    pub character: Option<char>,
+}
+
+pub(crate) struct TextTransformationIterator<'a>(
+    Box<dyn Iterator<Item = CharacterTransformIteration> + 'a>,
+);
+
+impl<'a> TextTransformationIterator<'a> {
+    pub(crate) fn new(
+        text: &'a str,
+        style: &ComputedValues,
+        trim_leading_white_space: bool,
+        on_word_boundary: bool,
+    ) -> Self {
+        let white_space_collapse = style.clone_white_space_collapse();
+        let iterator = Box::new(WhitespaceCollapse::new(
+            text.chars(),
+            white_space_collapse,
+            trim_leading_white_space,
+        ));
+
+        // TODO: Not all text transforms are about case, this logic should stop ignoring
+        // TextTransform::FULL_WIDTH and TextTransform::FULL_SIZE_KANA.
+        let text_transform = style.clone_text_transform().case();
+        let iterator = match text_transform {
+            TextTransformCase::None => iterator,
+            _ => text_transform_iterator(iterator, text_transform, on_word_boundary),
+        };
+
+        let text_security = style.clone__webkit_text_security();
+        let char_iterator: Box<dyn Iterator<Item = CharacterTransformIteration>> =
+            match text_security {
+                WebKitTextSecurity::None => iterator,
+                _ => Box::new(TextSecurityTransform::new(iterator, text_security)),
+            };
+        Self(char_iterator)
+    }
+}
+
+impl Iterator for TextTransformationIterator<'_> {
+    type Item = CharacterTransformIteration;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl CharacterTransformIteration {
+    fn identity(character: char) -> Self {
+        Self {
+            consumed_character_count: 1,
+            character: Some(character),
+        }
+    }
+
+    fn with_character(self, character: char) -> Self {
+        Self {
+            character: Some(character),
+            ..self
+        }
+    }
+}
+
+pub struct WhitespaceCollapse<'a> {
+    input_iterator: Chars<'a>,
+    white_space_collapse: WhiteSpaceCollapse,
+
+    /// Whether or not we are in the process of collapse leading white space. This is true
+    /// when the last character handled in our owning [`super::InlineFormattingContext`]
+    /// was collapsible white space and we have not seen any non-whitespace characters
+    /// during processing of this iterator's input.
+    trimming_leading_white_space: bool,
+
+    /// Whether or not the last character produced was newline. There is special behavior
+    /// we do after each newline.
+    following_newline: bool,
+
+    /// When whitespace collapses before a non-whitespace character, the iterator returns
+    /// the collapsed whitespace and in the next iteration the non-whitespace character
+    /// must be returned. This value caches it until the next iteration.
+    character_pending_to_return: Option<char>,
+}
+
+impl<'a> WhitespaceCollapse<'a> {
+    pub fn new(
+        input_iterator: Chars<'a>,
+        white_space_collapse: WhiteSpaceCollapse,
+        should_trim_leading_white_space: bool,
+    ) -> Self {
+        Self {
+            input_iterator,
+            white_space_collapse,
+            following_newline: false,
+            trimming_leading_white_space: should_trim_leading_white_space,
+            character_pending_to_return: None,
+        }
+    }
+
+    /// In some cases, white space is replaced by a single character (when not
+    /// following a newline and when leading whitespace is not being trimmed). In all
+    /// other cases, the white space is simply removed. This method handles that.
+    fn character_for_collapsed_whitespace(&self) -> Option<char> {
+        if !self.following_newline && !self.trimming_leading_white_space {
+            Some(' ')
+        } else {
+            None
+        }
+    }
+
+    fn iteration_for_collected_white_space(
+        &self,
+        collected_whitespace: usize,
+    ) -> Option<CharacterTransformIteration> {
+        (collected_whitespace != 0).then(|| CharacterTransformIteration {
+            consumed_character_count: collected_whitespace,
+            character: self.character_for_collapsed_whitespace(),
+        })
+    }
+}
+
+impl Iterator for WhitespaceCollapse<'_> {
+    type Item = CharacterTransformIteration;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Point 4.1.1 first bullet:
+        // > If white-space is set to normal, nowrap, or pre-line, whitespace
+        // > characters are considered collapsible
+        // If whitespace is not considered collapsible, it is preserved entirely, which
+        // means that we can simply return the input string exactly.
+        if self.white_space_collapse == WhiteSpaceCollapse::Preserve ||
+            self.white_space_collapse == WhiteSpaceCollapse::BreakSpaces
+        {
+            // From <https://drafts.csswg.org/css-text-3/#white-space-processing>:
+            // > Carriage returns (U+000D) are treated identically to spaces (U+0020) in all respects.
+            //
+            // In the non-preserved case these are converted to space below.
+            return match self.input_iterator.next() {
+                Some('\r') => Some(CharacterTransformIteration::identity(' ')),
+                next => next.map(CharacterTransformIteration::identity),
+            };
+        }
+
+        if let Some(character) = self.character_pending_to_return.take() {
+            // Once we produce a non-whitespace character, we are no longer trimming leading whitespace.
+            self.trimming_leading_white_space = false;
+            self.following_newline = false;
+            return Some(CharacterTransformIteration::identity(character));
+        }
+
+        // When we enter a collapsible white space region, we may need to wait to produce
+        // a single white space character as soon as we encounter a non-white space
+        // character. When that happens we queue up the non-white space character for the
+        // next iterator call.
+        let mut collected_whitespace = 0;
+
+        while let Some(character) = self.input_iterator.next() {
+            // Don't push non-newline whitespace immediately. Instead wait to push it until we
+            // know that it isn't followed by a newline. See `push_pending_whitespace_if_needed`
+            // above.
+            if InlineFormattingContextBuilder::is_document_white_space(character) &&
+                character != '\n'
+            {
+                collected_whitespace += 1;
+                continue;
+            }
+
+            // Point 4.1.1:
+            // > 2. Collapsible segment breaks are transformed for rendering according to the
+            // >    segment break transformation rules.
+            if character == '\n' {
+                // From <https://drafts.csswg.org/css-text-3/#line-break-transform>
+                // (4.1.3 -- the segment break transformation rules):
+                //
+                // > When white-space is pre, pre-wrap, or pre-line, segment breaks are not
+                // > collapsible and are instead transformed into a preserved line feed"
+                //
+                // > 1. First, any collapsible segment break immediately following another
+                // >    collapsible segment break is removed.
+                // > 2. Then any remaining segment break is either transformed into a space (U+0020)
+                // >    or removed depending on the context before and after the break.
+                let maybe_character = if self.white_space_collapse != WhiteSpaceCollapse::Collapse {
+                    Some('\n')
+                } else {
+                    self.character_for_collapsed_whitespace()
+                };
+
+                self.following_newline = true;
+                return Some(CharacterTransformIteration {
+                    consumed_character_count: collected_whitespace + 1,
+                    character: maybe_character,
+                });
+            }
+
+            // Point 4.1.1:
+            // > 2. Any sequence of collapsible spaces and tabs immediately preceding or
+            // >    following a segment break is removed.
+            // > 3. Every collapsible tab is converted to a collapsible space (U+0020).
+            // > 4. Any collapsible space immediately following another collapsible space—even
+            // >    one outside the boundary of the inline containing that space, provided both
+            // >    spaces are within the same inline formatting context—is collapsed to have zero
+            // >    advance width.
+            if let Some(iteration) = self.iteration_for_collected_white_space(collected_whitespace)
+            {
+                self.character_pending_to_return = Some(character);
+                return Some(iteration);
+            }
+
+            // Once we produce a non-whitespace character, we are no longer trimming leading whitespace.
+            self.trimming_leading_white_space = false;
+            self.following_newline = false;
+            return Some(CharacterTransformIteration::identity(character));
+        }
+
+        self.iteration_for_collected_white_space(collected_whitespace)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.input_iterator.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.input_iterator.count()
+    }
+}
+
+fn text_transform_iterator<'a>(
+    input_iterator: Box<dyn Iterator<Item = CharacterTransformIteration> + 'a>,
+    text_transform: TextTransformCase,
+    allow_word_at_start: bool,
+) -> Box<dyn Iterator<Item = CharacterTransformIteration> + 'a> {
+    match text_transform {
+        TextTransformCase::Lowercase => Box::new(simple_case_transform_iterator(
+            input_iterator,
+            char::to_lowercase,
+        )),
+        TextTransformCase::Uppercase => Box::new(simple_case_transform_iterator(
+            input_iterator,
+            char::to_uppercase,
+        )),
+        TextTransformCase::None => input_iterator,
+        TextTransformCase::Capitalize => {
+            Box::new(capitalization_iterator(input_iterator, allow_word_at_start))
+        },
+    }
+}
+
+fn simple_case_transform_iterator<'a, CharacterIterator>(
+    input_iterator: Box<dyn Iterator<Item = CharacterTransformIteration> + 'a>,
+    mapping: impl Fn(char) -> CharacterIterator,
+) -> impl Iterator<Item = CharacterTransformIteration>
+where
+    CharacterIterator: Iterator<Item = char>,
+{
+    input_iterator.flat_map(move |text_step| {
+        let Some(character) = text_step.character else {
+            return Either::Left(std::iter::once(text_step));
+        };
+
+        let mut transformed_iter = mapping(character);
+        let mut first = true;
+        Either::Right(std::iter::from_fn(move || {
+            transformed_iter
+                .next()
+                .map(|transformed_character| CharacterTransformIteration {
+                    consumed_character_count: if std::mem::take(&mut first) {
+                        text_step.consumed_character_count
+                    } else {
+                        0
+                    },
+                    character: Some(transformed_character),
+                })
+        }))
+    })
+}
+
+/// Given a string and whether the start of the string represents a word boundary, create a copy of
+/// the string with letters after word boundaries capitalized.
+pub(crate) fn capitalization_iterator<'a>(
+    input_iterator: Box<dyn Iterator<Item = CharacterTransformIteration> + 'a>,
+    allow_word_at_start: bool,
+) -> impl Iterator<Item = CharacterTransformIteration> {
+    let steps: Vec<_> = input_iterator.collect();
+    let string: String = steps.iter().filter_map(|step| step.character).collect();
+
+    let word_segmenter = WordSegmenter::new_auto();
+    let mut bounds = word_segmenter.segment_str(&string).peekable();
+
+    let mut output = Vec::with_capacity(steps.len());
+    let mut current_byte_index = 0;
+    for text_step in steps.into_iter() {
+        let Some(character) = text_step.character else {
+            output.push(text_step);
+            continue;
+        };
+
+        let at_word_start = bounds.peek() == Some(&current_byte_index);
+        if at_word_start {
+            bounds.next();
+        }
+
+        if at_word_start && (current_byte_index != 0 || allow_word_at_start) {
+            let transformed_characters = character.to_uppercase();
+            let mut first = true;
+            for transformed_character in transformed_characters {
+                output.push(CharacterTransformIteration {
+                    consumed_character_count: if std::mem::take(&mut first) {
+                        text_step.consumed_character_count
+                    } else {
+                        0
+                    },
+                    character: Some(transformed_character),
+                });
+            }
+        } else {
+            output.push(text_step);
+        }
+
+        current_byte_index += character.len_utf8();
+    }
+
+    output.into_iter()
+}
+
+pub struct TextSecurityTransform<InputIterator> {
+    /// The input character iterator.
+    iterator: InputIterator,
+    /// The `-webkit-text-security` value to use.
+    text_security: WebKitTextSecurity,
+}
+
+impl<InputIterator> TextSecurityTransform<InputIterator> {
+    pub fn new(iterator: InputIterator, text_security: WebKitTextSecurity) -> Self {
+        Self {
+            iterator,
+            text_security,
+        }
+    }
+}
+
+impl<InputIterator> Iterator for TextSecurityTransform<InputIterator>
+where
+    InputIterator: Iterator<Item = CharacterTransformIteration>,
+{
+    type Item = CharacterTransformIteration;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // The behavior of `-webkit-text-security` isn't specified, so we have some
+        // flexibility in the implementation. We just need to maintain a rough
+        // compatibility with other browsers.
+        let text_step = self.iterator.next()?;
+        let Some(character) = text_step.character else {
+            return Some(text_step);
+        };
+
+        let mapped_character = match character {
+            // This is not ideal, but zero width space is used for some special reasons in
+            // `<input>` fields, so these remain untransformed, otherwise they would show up
+            // in empty text fields.
+            '\u{200B}' => '\u{200B}',
+            // Newlines are preserved, so that `<br>` keeps working as expected.
+            '\n' => '\n',
+            character => match self.text_security {
+                WebKitTextSecurity::None => character,
+                WebKitTextSecurity::Circle => '○',
+                WebKitTextSecurity::Disc => '●',
+                WebKitTextSecurity::Square => '■',
+            },
+        };
+
+        Some(text_step.with_character(mapped_character))
+    }
+}
+
+#[derive(PartialEq, MallocSizeOf)]
+enum OffsetMapEntryType {
+    // Represents text that is the same size in the original string as in the final
+    // string.
+    Identity,
+    // Represents text that is shorter in the final string than in the original
+    // string.
+    Collapse,
+    // Represents text that is longer in the final string than in the original
+    // string.
+    Expand,
+}
+
+#[derive(MallocSizeOf)]
+struct OffsetMapEntry(OffsetMapEntryType, usize);
+
+#[derive(Default, MallocSizeOf)]
+pub struct OffsetMap {
+    total_original_size: usize,
+    total_final_size: usize,
+    entries: Vec<OffsetMapEntry>,
+}
+
+impl std::fmt::Debug for OffsetMap {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OffsetMap")
+            .field("total_original_size", &self.total_original_size)
+            .field("total_final_size", &self.total_final_size)
+            .finish()
+    }
+}
+
+impl OffsetMap {
+    pub fn total_final_size(&self) -> usize {
+        self.total_final_size
+    }
+
+    fn add_or_ammend_entry(&mut self, entry_type: OffsetMapEntryType, length: usize) {
+        if length == 0 {
+            return;
+        }
+
+        match self.entries.last_mut() {
+            Some(OffsetMapEntry(old_entry_type, old_length)) if *old_entry_type == entry_type => {
+                *old_length += length
+            },
+            _ => self.entries.push(OffsetMapEntry(entry_type, length)),
+        }
+    }
+
+    pub fn collapse(&mut self, length: usize) {
+        self.add_or_ammend_entry(OffsetMapEntryType::Collapse, length);
+        self.total_original_size += length;
+    }
+
+    pub fn expand(&mut self, length: usize) {
+        self.add_or_ammend_entry(OffsetMapEntryType::Expand, length);
+        self.total_final_size += length;
+    }
+
+    pub fn identity(&mut self, length: usize) {
+        self.add_or_ammend_entry(OffsetMapEntryType::Identity, length);
+        self.total_original_size += length;
+        self.total_final_size += length;
+    }
+
+    pub fn process_character(&mut self, original_length: usize, new_length: usize) {
+        match original_length.cmp(&new_length) {
+            Ordering::Less => {
+                self.identity(original_length);
+                self.expand(new_length - original_length);
+            },
+            Ordering::Equal => self.identity(original_length),
+            Ordering::Greater => {
+                self.identity(new_length);
+                self.collapse(original_length - new_length);
+            },
+        }
+    }
+
+    pub fn map(&self, target_original_offset: usize) -> usize {
+        // Allow mapping one index past the size of the map, as this can be used for
+        // selection which can index one character past the end of the last character
+        // in the string.
+        if target_original_offset > self.total_original_size {
+            return self.total_final_size;
+        }
+
+        let mut offset_in_original_string = 0;
+        let mut offset_in_final_string = 0;
+        for entry in self.entries.iter() {
+            match entry.0 {
+                OffsetMapEntryType::Identity
+                    if offset_in_original_string + entry.1 > target_original_offset =>
+                {
+                    return offset_in_final_string +
+                        (target_original_offset - offset_in_original_string);
+                },
+                OffsetMapEntryType::Identity => {
+                    offset_in_final_string += entry.1;
+                    offset_in_original_string += entry.1;
+                },
+                OffsetMapEntryType::Collapse
+                    if offset_in_original_string + entry.1 > target_original_offset =>
+                {
+                    return offset_in_final_string;
+                },
+                OffsetMapEntryType::Collapse => offset_in_original_string += entry.1,
+                OffsetMapEntryType::Expand => offset_in_final_string += entry.1,
+            }
+        }
+
+        offset_in_final_string
+    }
+}
+
+#[test]
+fn test_offsetmap_basic_expansion() {
+    let _original_string = "abcde";
+    let final_string = "aabbbccccde";
+
+    let mut offset_map = OffsetMap::default();
+    offset_map.process_character(1, 2);
+    offset_map.process_character(1, 3);
+    offset_map.process_character(1, 4);
+    offset_map.process_character(2, 2);
+
+    assert_eq!(offset_map.map(0), 0);
+    assert_eq!(offset_map.map(1), 2);
+    assert_eq!(offset_map.map(2), 5);
+    assert_eq!(offset_map.map(3), 9);
+    assert_eq!(offset_map.map(4), 10);
+
+    // Beyond the last index should always map to the index after the last character
+    // (for handling selections).
+    assert_eq!(offset_map.map(5), 11);
+    assert_eq!(offset_map.map(100), 11);
+
+    let map_substring =
+        |offset, length| &final_string[offset_map.map(offset)..offset_map.map(offset + length)];
+    assert_eq!(map_substring(0, 1), "aa");
+    assert_eq!(map_substring(0, 2), "aabbb");
+    assert_eq!(map_substring(0, 3), "aabbbcccc");
+    assert_eq!(map_substring(0, 4), "aabbbccccd");
+    assert_eq!(map_substring(1, 1), "bbb");
+}
+
+#[test]
+fn test_offsetmap_basic_collapse() {
+    let _original_string = "AABBBcDDDDe";
+    let final_string = "abcde";
+
+    let mut offset_map = OffsetMap::default();
+    offset_map.process_character(2, 1);
+    offset_map.process_character(3, 1);
+    offset_map.identity(1);
+    offset_map.process_character(4, 1);
+    offset_map.identity(1);
+
+    assert_eq!(offset_map.map(0), 0);
+    // Mapping between characters should map to the index after the final one.
+    assert_eq!(offset_map.map(1), 1);
+    assert_eq!(offset_map.map(2), 1);
+    assert_eq!(offset_map.map(5), 2);
+    assert_eq!(offset_map.map(6), 3);
+    assert_eq!(offset_map.map(10), 4);
+
+    // Beyond the last index should always map to the index after the last character
+    // (for handling selections).
+    assert_eq!(offset_map.map(11), 5);
+    assert_eq!(offset_map.map(100), 5);
+
+    let map_substring =
+        |offset, length| &final_string[offset_map.map(offset)..offset_map.map(offset + length)];
+    assert_eq!(map_substring(0, 2), "a");
+    assert_eq!(map_substring(0, 3), "ab");
+    assert_eq!(map_substring(0, 6), "abc");
+    assert_eq!(map_substring(0, 10), "abcd");
+}

--- a/components/layout/flow/inline/text_transform.rs
+++ b/components/layout/flow/inline/text_transform.rs
@@ -423,7 +423,7 @@ impl OffsetMap {
         self.last_known_position().final_offset
     }
 
-    fn push_range(
+    pub fn push_range(
         &mut self,
         additional_original_length: Utf32CodeUnits,
         additional_final_length: Utf32CodeUnits,
@@ -443,10 +443,6 @@ impl OffsetMap {
             });
         }
         self.last_range_maps_one_to_one = this_range_maps_one_to_one;
-    }
-
-    pub(crate) fn push_synthetic_control_characters(&mut self, count: Utf32CodeUnits) {
-        self.push_range(Utf32CodeUnits(0), count);
     }
 
     pub(crate) fn push_iteration(&mut self, iteration: &CharacterTransformIteration) {

--- a/components/layout/flow/inline/text_transform.rs
+++ b/components/layout/flow/inline/text_transform.rs
@@ -444,11 +444,21 @@ impl OffsetMap {
         additional_original_length: Utf32CodeUnits,
         additional_final_length: Utf32CodeUnits,
     ) {
-        let last = self.last_known_position();
-        self.known_positions.push(OffsetMapKnownPosition {
-            original_offset: last.original_offset + additional_original_length,
-            final_offset: last.final_offset + additional_final_length,
-        })
+        let this_range_maps_one_to_one = additional_original_length == additional_final_length;
+        if this_range_maps_one_to_one &&
+            self.last_range_maps_one_to_one &&
+            let Some(last) = self.known_positions.last_mut()
+        {
+            last.original_offset += additional_original_length;
+            last.final_offset += additional_final_length;
+        } else {
+            let last = self.last_known_position();
+            self.known_positions.push(OffsetMapKnownPosition {
+                original_offset: last.original_offset + additional_original_length,
+                final_offset: last.final_offset + additional_final_length,
+            });
+        }
+        self.last_range_maps_one_to_one = this_range_maps_one_to_one;
     }
 
     pub(crate) fn push_synthetic_control_characters(&mut self, count: Utf32CodeUnits) {
@@ -462,16 +472,7 @@ impl OffsetMap {
     pub(crate) fn push_iteration(&mut self, iteration: &CharacterTransformIteration) {
         match *iteration {
             CharacterTransformIteration::OneToOne(_) => {
-                if self.last_range_maps_one_to_one &&
-                    let Some(last) = self.known_positions.last_mut()
-                {
-                    last.original_offset += Utf32CodeUnits(1);
-                    last.final_offset += Utf32CodeUnits(1);
-                } else {
-                    self.push_range(Utf32CodeUnits(1), Utf32CodeUnits(1));
-                    self.last_range_maps_one_to_one = true;
-                }
-                return; // skip `self.last_range_maps_one_to_one = false` below
+                self.push_range(Utf32CodeUnits(1), Utf32CodeUnits(1));
             },
             CharacterTransformIteration::WhitespaceCharsCollapsedToOneSpace(original_length) |
             CharacterTransformIteration::WhitespaceCharsCollapsedToOneNewline(original_length) => {
@@ -490,8 +491,6 @@ impl OffsetMap {
                 self.push_mapped_char(to_titlecase(original_character).len())
             },
         }
-        // In all cases except `OneToOne`
-        self.last_range_maps_one_to_one = false;
     }
 
     pub fn map(&self, target_original_offset: Utf32CodeUnits) -> Utf32CodeUnits {

--- a/components/layout/flow/inline/text_transform.rs
+++ b/components/layout/flow/inline/text_transform.rs
@@ -256,6 +256,8 @@ impl Iterator for WhitespaceCollapse<'_> {
                 });
             }
 
+            // Non-whitespace character
+
             // Point 4.1.1:
             // > 2. Any sequence of collapsible spaces and tabs immediately preceding or
             // >    following a segment break is removed.
@@ -335,6 +337,10 @@ pub(crate) fn capitalization_iterator<'a>(
         if at_word_start && (current_byte_index != 0 || allow_word_at_start) {
             output.extend(CharacterTransformIteration::from_char_iter(
                 text_step.consumed_character_count,
+                // TODO: use `character.to_titlecase()` when available:
+                // https://github.com/rust-lang/rust/issues/153892
+                // because of:
+                // https://doc.rust-lang.org/stable/std/primitive.char.html#difference-from-uppercase
                 character.to_uppercase(),
             ));
         } else {

--- a/components/layout/flow/inline/text_transform.rs
+++ b/components/layout/flow/inline/text_transform.rs
@@ -19,7 +19,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use style::computed_values::_webkit_text_security::T as WebKitTextSecurity;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::properties::ComputedValues;
-use style::values::specified::text::TextTransformCase;
+use style::values::specified::text::{TextTransform, TextTransformCase};
 
 use crate::flow::inline::construct::InlineFormattingContextBuilder;
 
@@ -52,27 +52,40 @@ impl<'a> TextTransformationIterator<'a> {
         on_word_boundary: bool,
     ) -> Self {
         let white_space_collapse = style.clone_white_space_collapse();
-        let iterator = Box::new(WhitespaceCollapse::new(
-            text.chars(),
-            white_space_collapse,
-            trim_leading_white_space,
-        ));
+        let mut iterator: Box<dyn Iterator<Item = CharacterTransformIteration>> = Box::new(
+            WhitespaceCollapse::new(text.chars(), white_space_collapse, trim_leading_white_space),
+        );
 
         // TODO: Not all text transforms are about case, this logic should stop ignoring
         // TextTransform::FULL_WIDTH and TextTransform::FULL_SIZE_KANA.
-        let text_transform = style.clone_text_transform().case();
-        let iterator = match text_transform {
-            TextTransformCase::None => iterator,
-            _ => text_transform_iterator(iterator, text_transform, on_word_boundary),
-        };
+        let text_transform = style.clone_text_transform();
+        match text_transform.case() {
+            TextTransformCase::None => {},
+            TextTransformCase::Lowercase => {
+                iterator = Box::new(simple_case_transform_iterator(iterator, char::to_lowercase))
+            },
+            TextTransformCase::Uppercase => {
+                iterator = Box::new(simple_case_transform_iterator(iterator, char::to_uppercase))
+            },
+            TextTransformCase::Capitalize => {
+                iterator = Box::new(capitalization_iterator(iterator, on_word_boundary))
+            },
+            // TODO: implement `math-auto` and enable it in Stylo
+        }
+        if text_transform.intersects(TextTransform::FULL_WIDTH) {
+            // TODO: implement `full-width`
+            // iterator = Box::new(full_width_iterator(iterator));
+        }
+        if text_transform.intersects(TextTransform::FULL_SIZE_KANA) {
+            // TODO: implement `full-size-kana`
+            // iterator = Box::new(full_size_kana_iterator(iterator));
+        }
 
         let text_security = style.clone__webkit_text_security();
-        let char_iterator: Box<dyn Iterator<Item = CharacterTransformIteration>> =
-            match text_security {
-                WebKitTextSecurity::None => iterator,
-                _ => Box::new(TextSecurityTransform::new(iterator, text_security)),
-            };
-        Self(char_iterator)
+        if text_security != WebKitTextSecurity::None {
+            iterator = Box::new(TextSecurityTransform::new(iterator, text_security));
+        }
+        Self(iterator)
     }
 }
 
@@ -258,27 +271,6 @@ impl Iterator for WhitespaceCollapse<'_> {
 
     fn count(self) -> usize {
         self.input_iterator.count()
-    }
-}
-
-fn text_transform_iterator<'a>(
-    input_iterator: Box<dyn Iterator<Item = CharacterTransformIteration> + 'a>,
-    text_transform: TextTransformCase,
-    allow_word_at_start: bool,
-) -> Box<dyn Iterator<Item = CharacterTransformIteration> + 'a> {
-    match text_transform {
-        TextTransformCase::Lowercase => Box::new(simple_case_transform_iterator(
-            input_iterator,
-            char::to_lowercase,
-        )),
-        TextTransformCase::Uppercase => Box::new(simple_case_transform_iterator(
-            input_iterator,
-            char::to_uppercase,
-        )),
-        TextTransformCase::None => input_iterator,
-        TextTransformCase::Capitalize => {
-            Box::new(capitalization_iterator(input_iterator, allow_word_at_start))
-        },
     }
 }
 

--- a/components/layout/flow/inline/text_transform.rs
+++ b/components/layout/flow/inline/text_transform.rs
@@ -20,109 +20,63 @@ use style::values::specified::text::{TextTransform, TextTransformCase};
 
 use crate::flow::inline::construct::InlineFormattingContextBuilder;
 
-/// A single iteration in a pipeline of character iterators, that handle things
-/// like whitespace collapse and `text-transform` processing for text in an
-/// [`InlineFormattingContext`]. Each iteration can consume multiple characters
-/// and produce an optional character. Consumption of characters greater than
-/// the characters stored in [`CharacterTransformIteration`] indicate that those
-/// characters have been collapsed.
-#[derive(Clone)]
-pub enum CharacterTransformIteration {
-    /// A character mapped from exactly one character in a DOM text node
-    OneToOne(char),
-    WhitespaceCharsCollapsedToOneSpace(usize),
-    WhitespaceCharsCollapsedToOneNewline(usize),
-    WhitespaceCharsCollapsedToNothing(usize),
-    ToLowercase(std::char::ToLowercase),
-    ToUppercase(std::char::ToUppercase),
-    ToTitlecase(ToTitleCase),
-}
-
-pub(crate) struct TextTransformationIterator<'a>(
-    Box<dyn Iterator<Item = CharacterTransformIteration> + 'a>,
-);
-
-impl<'a> TextTransformationIterator<'a> {
-    pub(crate) fn new(
-        text: &'a str,
-        style: &ComputedValues,
-        trim_leading_white_space: bool,
-        on_word_boundary: bool,
-    ) -> Self {
-        let text_security = style.clone__webkit_text_security();
-        let chars = text
-            .chars()
-            .map(move |character| text_security_map_character(text_security, character));
-        let white_space_collapse = style.clone_white_space_collapse();
-        let iterator =
-            WhitespaceCollapse::new(chars, white_space_collapse, trim_leading_white_space);
-
-        // TODO: Not all text transforms are about case, this logic should stop ignoring
-        // TextTransform::FULL_WIDTH and TextTransform::FULL_SIZE_KANA.
-        let text_transform = style.clone_text_transform();
-        let iterator = match text_transform.case() {
-            TextTransformCase::None => {
-                Box::new(iterator) as Box<dyn Iterator<Item = CharacterTransformIteration>>
-            },
-            TextTransformCase::Lowercase => {
-                Box::new(simple_case_transform_iterator(iterator, |c| {
-                    CharacterTransformIteration::ToLowercase(c.to_lowercase())
-                }))
-            },
-            TextTransformCase::Uppercase => {
-                Box::new(simple_case_transform_iterator(iterator, |c| {
-                    CharacterTransformIteration::ToUppercase(c.to_uppercase())
-                }))
-            },
-            TextTransformCase::Capitalize => Box::new(capitalization_iterator(
-                text.len(),
-                iterator,
-                on_word_boundary,
-            )),
-            // TODO: implement `math-auto` and enable it in Stylo
-        };
-        if text_transform.intersects(TextTransform::FULL_WIDTH) {
-            // TODO: implement `full-width`
-            // iterator = Box::new(full_width_iterator(iterator));
-        }
-        if text_transform.intersects(TextTransform::FULL_SIZE_KANA) {
-            // TODO: implement `full-size-kana`
-            // iterator = Box::new(full_size_kana_iterator(iterator));
-        }
-
-        Self(iterator)
-    }
-}
-
-impl Iterator for TextTransformationIterator<'_> {
-    type Item = CharacterTransformIteration;
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next()
-    }
+/// A single iteration in a pipeline of character iterators, that handle things like
+/// whitespace collapse and `text-transform` processing for text in an
+/// [`InlineFormattingContext`]. Each iteration can consume multiple characters and
+/// produce zero or more characters (up to 3). Consumption of characters greater than the
+/// characters produced by [`CharacterTransformIteration`] indicate that those characters
+/// have been collapsed.
+#[derive(Clone, Copy)]
+pub struct CharacterTransformIteration {
+    /// The number of characters consumed during this iteration of character transformation.
+    consumed: Utf32CodeUnits,
+    /// The number of characters actually produced during this iteration.
+    produced: Utf32CodeUnits,
+    /// The characters that were produced during this iteration.
+    characters: [char; 3],
 }
 
 impl CharacterTransformIteration {
-    pub(crate) fn consumed_character_count(&self) -> usize {
-        match *self {
-            CharacterTransformIteration::OneToOne(_) => 1,
-            CharacterTransformIteration::ToLowercase(_) |
-            CharacterTransformIteration::ToUppercase(_) |
-            CharacterTransformIteration::ToTitlecase(_) => 1,
-            CharacterTransformIteration::WhitespaceCharsCollapsedToOneSpace(count) |
-            CharacterTransformIteration::WhitespaceCharsCollapsedToOneNewline(count) |
-            CharacterTransformIteration::WhitespaceCharsCollapsedToNothing(count) => count,
+    fn case_mapped(iterator: impl ExactSizeIterator<Item = char>) -> Self {
+        debug_assert!(iterator.len() <= 3);
+
+        let mut characters = ['\0'; 3];
+        let mut produced = 0;
+        for (array_entry, character) in characters.iter_mut().zip(iterator) {
+            *array_entry = character;
+            produced += 1;
+        }
+
+        Self {
+            consumed: Utf32CodeUnits(1),
+            produced: Utf32CodeUnits(produced),
+            characters,
         }
     }
 
+    fn one_to_one(character: char) -> Self {
+        Self {
+            consumed: Utf32CodeUnits(1),
+            produced: Utf32CodeUnits(1),
+            characters: [character, '\0', '\0'],
+        }
+    }
+
+    fn collapse(character: Option<char>, amount_collapsed: usize) -> Self {
+        Self {
+            consumed: Utf32CodeUnits(amount_collapsed),
+            produced: Utf32CodeUnits(if character.is_some() { 1 } else { 0 }),
+            characters: [character.unwrap_or_default(), '\0', '\0'],
+        }
+    }
+
+    fn is_one_to_one(&self) -> bool {
+        self.produced.0 == 1 && self.consumed.0 == 1
+    }
+
     pub(crate) fn each_char(self, mut each: impl FnMut(char)) {
-        match self {
-            CharacterTransformIteration::OneToOne(c) => each(c),
-            CharacterTransformIteration::WhitespaceCharsCollapsedToOneSpace(_) => each(' '),
-            CharacterTransformIteration::WhitespaceCharsCollapsedToOneNewline(_) => each('\n'),
-            CharacterTransformIteration::WhitespaceCharsCollapsedToNothing(_) => {},
-            CharacterTransformIteration::ToLowercase(iter) => iter.for_each(each),
-            CharacterTransformIteration::ToUppercase(iter) => iter.for_each(each),
-            CharacterTransformIteration::ToTitlecase(iter) => iter.for_each(each),
+        for character in &self.characters[..self.produced.0] {
+            each(*character)
         }
     }
 
@@ -130,15 +84,6 @@ impl CharacterTransformIteration {
         self.each_char(|character| string.push(character));
     }
 }
-
-// TODO: replace this function with `character.to_titlecase()` when available:
-// https://github.com/rust-lang/rust/issues/153892
-// because of:
-// https://doc.rust-lang.org/stable/std/primitive.char.html#difference-from-uppercase
-fn to_titlecase(character: char) -> ToTitleCase {
-    character.to_uppercase()
-}
-type ToTitleCase = std::char::ToUppercase;
 
 pub struct WhitespaceCollapse<InputIterator> {
     input_iterator: InputIterator,
@@ -183,9 +128,9 @@ impl<InputIterator: Iterator<Item = char>> WhitespaceCollapse<InputIterator> {
         collapsed_whitespace: usize,
     ) -> CharacterTransformIteration {
         if !self.following_newline && !self.trimming_leading_white_space {
-            CharacterTransformIteration::WhitespaceCharsCollapsedToOneSpace(collapsed_whitespace)
+            CharacterTransformIteration::collapse(Some(' '), collapsed_whitespace)
         } else {
-            CharacterTransformIteration::WhitespaceCharsCollapsedToNothing(collapsed_whitespace)
+            CharacterTransformIteration::collapse(None, collapsed_whitespace)
         }
     }
 
@@ -215,8 +160,8 @@ impl<InputIterator: Iterator<Item = char>> Iterator for WhitespaceCollapse<Input
             //
             // In the non-preserved case these are converted to space below.
             return match self.input_iterator.next() {
-                Some('\r') => Some(CharacterTransformIteration::OneToOne(' ')),
-                next => next.map(CharacterTransformIteration::OneToOne),
+                Some('\r') => Some(CharacterTransformIteration::one_to_one(' ')),
+                next => next.map(CharacterTransformIteration::one_to_one),
             };
         }
 
@@ -224,7 +169,7 @@ impl<InputIterator: Iterator<Item = char>> Iterator for WhitespaceCollapse<Input
             // Once we produce a non-whitespace character, we are no longer trimming leading whitespace.
             self.trimming_leading_white_space = false;
             self.following_newline = false;
-            return Some(CharacterTransformIteration::OneToOne(character));
+            return Some(CharacterTransformIteration::one_to_one(character));
         }
 
         // When we enter a collapsible white space region, we may need to wait to produce
@@ -259,9 +204,7 @@ impl<InputIterator: Iterator<Item = char>> Iterator for WhitespaceCollapse<Input
                 // > 2. Then any remaining segment break is either transformed into a space (U+0020)
                 // >    or removed depending on the context before and after the break.
                 let iteration = if self.white_space_collapse != WhiteSpaceCollapse::Collapse {
-                    CharacterTransformIteration::WhitespaceCharsCollapsedToOneNewline(
-                        collected_whitespace + 1,
-                    )
+                    CharacterTransformIteration::collapse(Some('\n'), collected_whitespace + 1)
                 } else {
                     self.iteration_for_collapsed_whitespace(collected_whitespace + 1)
                 };
@@ -289,28 +232,90 @@ impl<InputIterator: Iterator<Item = char>> Iterator for WhitespaceCollapse<Input
             // Once we produce a non-whitespace character, we are no longer trimming leading whitespace.
             self.trimming_leading_white_space = false;
             self.following_newline = false;
-            return Some(CharacterTransformIteration::OneToOne(character));
+            return Some(CharacterTransformIteration::one_to_one(character));
         }
 
         self.iteration_for_collected_white_space(collected_whitespace)
     }
+}
 
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.input_iterator.size_hint()
-    }
+pub(crate) struct TextTransformationIterator<'a>(
+    Box<dyn Iterator<Item = CharacterTransformIteration> + 'a>,
+);
 
-    fn count(self) -> usize {
-        self.input_iterator.count()
+impl<'a> TextTransformationIterator<'a> {
+    pub(crate) fn new(
+        text: &'a str,
+        style: &ComputedValues,
+        trim_leading_white_space: bool,
+        on_word_boundary: bool,
+    ) -> Self {
+        let text_security = style.clone__webkit_text_security();
+        let chars = text
+            .chars()
+            .map(move |character| map_character_for_webkit_text_security(text_security, character));
+        let white_space_collapse = style.clone_white_space_collapse();
+        let iterator =
+            WhitespaceCollapse::new(chars, white_space_collapse, trim_leading_white_space);
+
+        // TODO: Not all text transforms are about case, this logic should stop ignoring
+        // TextTransform::FULL_WIDTH and TextTransform::FULL_SIZE_KANA.
+        let text_transform = style.clone_text_transform();
+        let iterator = match text_transform.case() {
+            TextTransformCase::None => {
+                Box::new(iterator) as Box<dyn Iterator<Item = CharacterTransformIteration>>
+            },
+            TextTransformCase::Lowercase => {
+                Box::new(simple_case_transform_iterator(iterator, |character| {
+                    CharacterTransformIteration::case_mapped(character.to_lowercase())
+                }))
+            },
+            TextTransformCase::Uppercase => {
+                Box::new(simple_case_transform_iterator(iterator, |character| {
+                    CharacterTransformIteration::case_mapped(character.to_uppercase())
+                }))
+            },
+            TextTransformCase::Capitalize => Box::new(capitalization_iterator(
+                text.len(),
+                iterator,
+                on_word_boundary,
+            )),
+            // TODO: implement `math-auto` and enable it in Stylo
+        };
+        if text_transform.intersects(TextTransform::FULL_WIDTH) {
+            // TODO: implement `full-width`
+        }
+        if text_transform.intersects(TextTransform::FULL_SIZE_KANA) {
+            // TODO: implement `full-size-kana`
+        }
+
+        Self(iterator)
     }
 }
+
+impl Iterator for TextTransformationIterator<'_> {
+    type Item = CharacterTransformIteration;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+// TODO: replace this function with `character.to_titlecase()` when available:
+// https://github.com/rust-lang/rust/issues/153892
+// because of:
+// https://doc.rust-lang.org/stable/std/primitive.char.html#difference-from-uppercase
+fn to_titlecase(character: char) -> ToTitleCase {
+    character.to_uppercase()
+}
+type ToTitleCase = std::char::ToUppercase;
 
 fn simple_case_transform_iterator(
     input_iterator: impl Iterator<Item = CharacterTransformIteration>,
     mapping: impl Fn(char) -> CharacterTransformIteration,
 ) -> impl Iterator<Item = CharacterTransformIteration> {
     input_iterator.map(move |iteration| {
-        if let CharacterTransformIteration::OneToOne(character) = iteration {
-            mapping(character)
+        if iteration.is_one_to_one() {
+            mapping(iteration.characters[0])
         } else {
             iteration
         }
@@ -324,30 +329,22 @@ pub(crate) fn capitalization_iterator(
     input_iterator: impl Iterator<Item = CharacterTransformIteration>,
     allow_word_at_start: bool,
 ) -> impl Iterator<Item = CharacterTransformIteration> {
-    let iterations: Vec<_> = input_iterator.collect();
+    let mut iterations: Vec<_> = input_iterator.collect();
     let mut string = String::with_capacity(size_hint);
     for iteration in &iterations {
-        iteration.clone().push_chars_to(&mut string);
+        iteration.push_chars_to(&mut string);
     }
 
     let word_segmenter = WordSegmenter::new_auto();
     let mut bounds = word_segmenter.segment_str(&string).peekable();
 
-    let mut output = Vec::with_capacity(iterations.len());
     let mut current_byte_index = 0;
-    for iteration in iterations.into_iter() {
-        let character = match iteration {
-            CharacterTransformIteration::OneToOne(c) => c,
-            CharacterTransformIteration::WhitespaceCharsCollapsedToOneSpace(_) => ' ',
-            CharacterTransformIteration::WhitespaceCharsCollapsedToOneNewline(_) => '\n',
-            CharacterTransformIteration::WhitespaceCharsCollapsedToNothing(_) => {
-                output.push(iteration);
-                continue;
-            },
-            CharacterTransformIteration::ToLowercase(_) |
-            CharacterTransformIteration::ToUppercase(_) |
-            CharacterTransformIteration::ToTitlecase(_) => unreachable!(),
-        };
+    for iteration in iterations.iter_mut() {
+        let mut bytes_to_advance = 0;
+        iteration.each_char(|character| bytes_to_advance += character.len_utf8());
+        if bytes_to_advance == 0 {
+            continue;
+        }
 
         let at_word_start = bounds.peek() == Some(&current_byte_index);
         if at_word_start {
@@ -358,46 +355,42 @@ pub(crate) fn capitalization_iterator(
         // instead it should be the first typographic letter unit:
         // https://drafts.csswg.org/css-text-4/#typographic-letter-unit
         // WPT /css/css-text/text-transform/text-transform-capitalize-026.html
-        if at_word_start &&
-            let CharacterTransformIteration::OneToOne(_) = iteration &&
+        if iteration.is_one_to_one() &&
+            at_word_start &&
             (current_byte_index != 0 || allow_word_at_start)
         {
-            output.push(CharacterTransformIteration::ToTitlecase(to_titlecase(
-                character,
-            )));
-        } else {
-            output.push(iteration);
+            *iteration =
+                CharacterTransformIteration::case_mapped(to_titlecase(iteration.characters[0]));
         }
 
-        current_byte_index += character.len_utf8();
+        current_byte_index += bytes_to_advance;
     }
 
-    output.into_iter()
+    iterations.into_iter()
 }
 
 // The behavior of `-webkit-text-security` isn't specified, so we have some
 // flexibility in the implementation. We just need to maintain a rough
 // compatibility with other browsers.
-fn text_security_map_character(mode: WebKitTextSecurity, character: char) -> char {
+fn map_character_for_webkit_text_security(mode: WebKitTextSecurity, character: char) -> char {
     if let WebKitTextSecurity::None = mode {
-        character
-    } else {
-        // TODO: when MSRV is 1.95+
-        // std::hint::cold_path();
-        match character {
-            // This is not ideal, but zero width space is used for some special reasons in
-            // `<input>` fields, so these remain untransformed, otherwise they would show up
-            // in empty text fields.
-            '\u{200B}' => '\u{200B}',
-            // Newlines are preserved, so that `<br>` keeps working as expected.
-            '\n' => '\n',
-            _ => match mode {
-                WebKitTextSecurity::None => character, // unreachable
-                WebKitTextSecurity::Circle => '○',
-                WebKitTextSecurity::Disc => '●',
-                WebKitTextSecurity::Square => '■',
-            },
-        }
+        return character;
+    }
+
+    // TODO: When MSRV is 1.95+ use std::hint::cold_path().
+    match character {
+        // This is not ideal, but zero width space is used for some special reasons in
+        // `<input>` fields, so these remain untransformed, otherwise they would show up
+        // in empty text fields.
+        '\u{200B}' => '\u{200B}',
+        // Newlines are preserved, so that `<br>` keeps working as expected.
+        '\n' => '\n',
+        _ => match mode {
+            WebKitTextSecurity::None => character, // unreachable
+            WebKitTextSecurity::Circle => '○',
+            WebKitTextSecurity::Disc => '●',
+            WebKitTextSecurity::Square => '■',
+        },
     }
 }
 
@@ -470,26 +463,8 @@ impl OffsetMap {
         self.push_range(Utf32CodeUnits(0), count);
     }
 
-    fn push_mapped_char(&mut self, new_length: usize) {
-        self.push_range(Utf32CodeUnits(1), Utf32CodeUnits(new_length));
-    }
-
     pub(crate) fn push_iteration(&mut self, iteration: &CharacterTransformIteration) {
-        match iteration {
-            CharacterTransformIteration::OneToOne(_) => {
-                self.push_range(Utf32CodeUnits(1), Utf32CodeUnits(1));
-            },
-            CharacterTransformIteration::WhitespaceCharsCollapsedToOneSpace(original_length) |
-            CharacterTransformIteration::WhitespaceCharsCollapsedToOneNewline(original_length) => {
-                self.push_range(Utf32CodeUnits(*original_length), Utf32CodeUnits(1));
-            },
-            CharacterTransformIteration::WhitespaceCharsCollapsedToNothing(original_length) => {
-                self.push_range(Utf32CodeUnits(*original_length), Utf32CodeUnits(0));
-            },
-            CharacterTransformIteration::ToLowercase(iter) => self.push_mapped_char(iter.len()),
-            CharacterTransformIteration::ToUppercase(iter) => self.push_mapped_char(iter.len()),
-            CharacterTransformIteration::ToTitlecase(iter) => self.push_mapped_char(iter.len()),
-        }
+        self.push_range(iteration.consumed, iteration.produced);
     }
 
     pub fn map(&self, target_original_offset: Utf32CodeUnits) -> Utf32CodeUnits {
@@ -559,16 +534,16 @@ fn test_offsetmap_basic_expansion() {
     assert_eq!(original_string.to_uppercase(), final_string);
 
     let mut offset_map = OffsetMap::default();
-    offset_map.push_iteration(&CharacterTransformIteration::ToUppercase(
+    offset_map.push_iteration(&CharacterTransformIteration::case_mapped(
         'a'.to_uppercase(),
     ));
-    offset_map.push_iteration(&CharacterTransformIteration::ToUppercase(
+    offset_map.push_iteration(&CharacterTransformIteration::case_mapped(
         'ß'.to_uppercase(),
     ));
-    offset_map.push_iteration(&CharacterTransformIteration::ToUppercase(
+    offset_map.push_iteration(&CharacterTransformIteration::case_mapped(
         'ΰ'.to_uppercase(),
     ));
-    offset_map.push_iteration(&CharacterTransformIteration::ToUppercase(
+    offset_map.push_iteration(&CharacterTransformIteration::case_mapped(
         'b'.to_uppercase(),
     ));
 
@@ -607,16 +582,20 @@ fn test_offsetmap_basic_collapse() {
     let final_string = "aaa b\nc";
 
     let mut offset_map = OffsetMap::default();
-    offset_map.push_iteration(&CharacterTransformIteration::WhitespaceCharsCollapsedToNothing(2));
-    offset_map.push_iteration(&CharacterTransformIteration::OneToOne('a'));
-    offset_map.push_iteration(&CharacterTransformIteration::OneToOne('a'));
-    offset_map.push_iteration(&CharacterTransformIteration::OneToOne('a'));
-    assert_eq!(offset_map.known_positions.len(), 2); // merging consecutive `OneToOne`
-    offset_map.push_iteration(&CharacterTransformIteration::WhitespaceCharsCollapsedToOneSpace(2));
-    offset_map.push_iteration(&CharacterTransformIteration::OneToOne('b'));
-    offset_map
-        .push_iteration(&CharacterTransformIteration::WhitespaceCharsCollapsedToOneNewline(2));
-    offset_map.push_iteration(&CharacterTransformIteration::OneToOne('c'));
+    offset_map.push_iteration(&CharacterTransformIteration::collapse(None, 2));
+    offset_map.push_iteration(&CharacterTransformIteration::one_to_one('a'));
+    offset_map.push_iteration(&CharacterTransformIteration::one_to_one('a'));
+    offset_map.push_iteration(&CharacterTransformIteration::one_to_one('a'));
+    assert_eq!(
+        offset_map.known_positions.len(),
+        2,
+        "Consecutive one-to-one mappings are merged"
+    );
+
+    offset_map.push_iteration(&CharacterTransformIteration::collapse(Some(' '), 2));
+    offset_map.push_iteration(&CharacterTransformIteration::one_to_one('b'));
+    offset_map.push_iteration(&CharacterTransformIteration::collapse(Some('\n'), 2));
+    offset_map.push_iteration(&CharacterTransformIteration::one_to_one('c'));
 
     assert_eq!(offset_map.map(c(0)).0, 0);
     assert_eq!(offset_map.map(c(1)).0, 0);

--- a/components/layout/flow/inline/text_transform.rs
+++ b/components/layout/flow/inline/text_transform.rs
@@ -10,6 +10,7 @@
 //! handle this as well as code to map from offsets in the original DOM node to the final
 //! IFC text and vice-versa.
 
+use arrayvec::ArrayVec;
 use icu_segmenter::WordSegmenter;
 use malloc_size_of_derive::MallocSizeOf;
 use servo_base::text::Utf32CodeUnits;
@@ -26,62 +27,43 @@ use crate::flow::inline::construct::InlineFormattingContextBuilder;
 /// produce zero or more characters (up to 3). Consumption of characters greater than the
 /// characters produced by [`CharacterTransformIteration`] indicate that those characters
 /// have been collapsed.
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct CharacterTransformIteration {
     /// The number of characters consumed during this iteration of character transformation.
     consumed: Utf32CodeUnits,
-    /// The number of characters actually produced during this iteration.
-    produced: Utf32CodeUnits,
     /// The characters that were produced during this iteration.
-    characters: [char; 3],
+    characters: ArrayVec<char, 3>,
 }
 
 impl CharacterTransformIteration {
     fn case_mapped(iterator: impl ExactSizeIterator<Item = char>) -> Self {
         debug_assert!(iterator.len() <= 3);
-
-        let mut characters = ['\0'; 3];
-        let mut produced = 0;
-        for (array_entry, character) in characters.iter_mut().zip(iterator) {
-            *array_entry = character;
-            produced += 1;
-        }
-
         Self {
             consumed: Utf32CodeUnits(1),
-            produced: Utf32CodeUnits(produced),
-            characters,
+            characters: iterator.collect(),
         }
     }
 
     fn one_to_one(character: char) -> Self {
         Self {
             consumed: Utf32CodeUnits(1),
-            produced: Utf32CodeUnits(1),
-            characters: [character, '\0', '\0'],
+            characters: std::iter::once(character).collect(),
         }
     }
 
     fn collapse(character: Option<char>, amount_collapsed: usize) -> Self {
         Self {
             consumed: Utf32CodeUnits(amount_collapsed),
-            produced: Utf32CodeUnits(if character.is_some() { 1 } else { 0 }),
-            characters: [character.unwrap_or_default(), '\0', '\0'],
+            characters: character.into_iter().collect(),
         }
     }
 
     fn is_one_to_one(&self) -> bool {
-        self.produced.0 == 1 && self.consumed.0 == 1
+        self.characters.len() == 1 && self.consumed.0 == 1
     }
 
-    pub(crate) fn each_char(self, mut each: impl FnMut(char)) {
-        for character in &self.characters[..self.produced.0] {
-            each(*character)
-        }
-    }
-
-    pub fn push_chars_to(self, string: &mut String) {
-        self.each_char(|character| string.push(character));
+    pub(crate) fn characters(&self) -> &[char] {
+        &self.characters
     }
 }
 
@@ -300,15 +282,6 @@ impl Iterator for TextTransformationIterator<'_> {
     }
 }
 
-// TODO: replace this function with `character.to_titlecase()` when available:
-// https://github.com/rust-lang/rust/issues/153892
-// because of:
-// https://doc.rust-lang.org/stable/std/primitive.char.html#difference-from-uppercase
-fn to_titlecase(character: char) -> ToTitleCase {
-    character.to_uppercase()
-}
-type ToTitleCase = std::char::ToUppercase;
-
 fn simple_case_transform_iterator(
     input_iterator: impl Iterator<Item = CharacterTransformIteration>,
     mapping: impl Fn(char) -> CharacterTransformIteration,
@@ -332,7 +305,7 @@ pub(crate) fn capitalization_iterator(
     let mut iterations: Vec<_> = input_iterator.collect();
     let mut string = String::with_capacity(size_hint);
     for iteration in &iterations {
-        iteration.push_chars_to(&mut string);
+        string.extend(iteration.characters());
     }
 
     let word_segmenter = WordSegmenter::new_auto();
@@ -340,8 +313,11 @@ pub(crate) fn capitalization_iterator(
 
     let mut current_byte_index = 0;
     for iteration in iterations.iter_mut() {
-        let mut bytes_to_advance = 0;
-        iteration.each_char(|character| bytes_to_advance += character.len_utf8());
+        let bytes_to_advance: usize = iteration
+            .characters()
+            .iter()
+            .map(|character| character.len_utf8())
+            .sum();
         if bytes_to_advance == 0 {
             continue;
         }
@@ -359,8 +335,11 @@ pub(crate) fn capitalization_iterator(
             at_word_start &&
             (current_byte_index != 0 || allow_word_at_start)
         {
+            // TODO: Replace this with a call to `character.to_titlecase()` when available:
+            // See: https://github.com/rust-lang/rust/issues/153892
+            // See: https://doc.rust-lang.org/stable/std/primitive.char.html#difference-from-uppercase
             *iteration =
-                CharacterTransformIteration::case_mapped(to_titlecase(iteration.characters[0]));
+                CharacterTransformIteration::case_mapped(iteration.characters[0].to_uppercase());
         }
 
         current_byte_index += bytes_to_advance;
@@ -464,7 +443,10 @@ impl OffsetMap {
     }
 
     pub(crate) fn push_iteration(&mut self, iteration: &CharacterTransformIteration) {
-        self.push_range(iteration.consumed, iteration.produced);
+        self.push_range(
+            iteration.consumed,
+            Utf32CodeUnits(iteration.characters.len()),
+        );
     }
 
     pub fn map(&self, target_original_offset: Utf32CodeUnits) -> Utf32CodeUnits {

--- a/components/layout/flow/inline/text_transform.rs
+++ b/components/layout/flow/inline/text_transform.rs
@@ -44,7 +44,7 @@ pub struct CharacterTransformIteration {
 
 impl CharacterTransformIteration {
     fn case_mapped(iterator: impl ExactSizeIterator<Item = char>) -> Self {
-        debug_assert!(iterator.len() <= 3);
+        debug_assert!(iterator.len() <= MAX_CASE_MAPPING_LENGTH);
         Self {
             consumed: Utf32CodeUnits(1),
             characters: iterator.collect(),
@@ -69,7 +69,7 @@ impl CharacterTransformIteration {
         self.characters.len() == 1 && self.consumed.0 == 1
     }
 
-    pub(crate) fn characters(&self) -> &[char] {
+    pub fn characters(&self) -> &[char] {
         &self.characters
     }
 }

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -1137,7 +1137,7 @@ fn rendered_text_collection_steps(
                     trim_leading_white_space,
                     on_word_boundary,
                 ) {
-                    iteration.push_chars_to(&mut transformed_text);
+                    transformed_text.extend(iteration.characters());
                 }
 
                 let is_preformatted_element =

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -1130,14 +1130,15 @@ fn rendered_text_collection_steps(
                 // rules are slightly modified: collapsible spaces at the end of lines are always
                 // collapsed, but they are only removed if the line is the last line of the block,
                 // or it ends with a br element. Soft hyphens should be preserved.
-                let mut transformed_text: String = TextTransformationIterator::new(
+                let mut transformed_text = String::with_capacity(text_content.len());
+                for iteration in TextTransformationIterator::new(
                     &text_content,
                     style,
                     trim_leading_white_space,
                     on_word_boundary,
-                )
-                .filter_map(|text_step| text_step.character)
-                .collect();
+                ) {
+                    iteration.push_chars_to(&mut transformed_text);
+                }
 
                 let is_preformatted_element =
                     white_space_collapse == WhiteSpaceCollapseValue::Preserve;

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -44,13 +44,12 @@ use style::values::generics::font::LineHeight;
 use style::values::generics::position::AspectRatio;
 use style::values::specified::GenericGridTemplateComponent;
 use style::values::specified::box_::DisplayInside;
-use style::values::specified::text::TextTransformCase;
 use style_traits::{CSSPixel, ParsingMode, ToCss};
 
 use crate::cell::RefOrAtomicRef;
 use crate::display_list::{StackingContextTree, au_rect_to_length_rect};
 use crate::dom::NodeExt;
-use crate::flow::inline::construct::{TextTransformation, WhitespaceCollapse, capitalize_string};
+use crate::flow::inline::text_transform::TextTransformationIterator;
 use crate::fragment_tree::{
     BoxFragment, Fragment, FragmentFlags, FragmentTree, SpecificLayoutInfo, TextFragment,
 };
@@ -1114,16 +1113,15 @@ fn rendered_text_collection_steps(
                     display,
                     Display::InlineBlock | Display::InlineFlex | Display::InlineGrid
                 );
+
                 // Now we need to decide on whether to remove beginning white space or not, this
                 // is mainly decided by the elements we rendered before, but may be overwritten by the white-space
                 // property.
-                let trim_beginning_white_space =
+                let trim_leading_white_space =
                     !preserve_whitespace && (state.may_start_with_whitespace || is_inline);
-                let with_white_space_rules_applied = WhitespaceCollapse::new(
-                    text_content.chars(),
-                    white_space_collapse,
-                    trim_beginning_white_space,
-                );
+                // FIXME: This assumes the element always start at a word boundary. But can fail:
+                // a<span style="text-transform: capitalize">b</span>c
+                let on_word_boundary = true;
 
                 // Step 4: If node is a Text node, then for each CSS text box produced by node, in
                 // content order, compute the text of the box after application of the CSS
@@ -1132,17 +1130,14 @@ fn rendered_text_collection_steps(
                 // rules are slightly modified: collapsible spaces at the end of lines are always
                 // collapsed, but they are only removed if the line is the last line of the block,
                 // or it ends with a br element. Soft hyphens should be preserved.
-                let text_transform = style.clone_text_transform().case();
-                let mut transformed_text: String =
-                    TextTransformation::new(with_white_space_rules_applied, text_transform)
-                        .collect();
-
-                // Since iterator for capitalize not doing anything, we must handle it outside here
-                // FIXME: This assumes the element always start at a word boundary. But can fail:
-                // a<span style="text-transform: capitalize">b</span>c
-                if TextTransformCase::Capitalize == text_transform {
-                    transformed_text = capitalize_string(&transformed_text, true);
-                }
+                let mut transformed_text: String = TextTransformationIterator::new(
+                    &text_content,
+                    style,
+                    trim_leading_white_space,
+                    on_word_boundary,
+                )
+                .filter_map(|text_step| text_step.character)
+                .collect();
 
                 let is_preformatted_element =
                     white_space_collapse == WhiteSpaceCollapseValue::Preserve;

--- a/components/layout/tests/text.rs
+++ b/components/layout/tests/text.rs
@@ -9,13 +9,15 @@ mod text {
     #[test]
     fn test_collapse_whitespace() {
         let collapse = |input: &str, white_space_collapse, trim_beginning_white_space| {
-            WhitespaceCollapse::new(
+            let mut string = String::new();
+            for iteration in WhitespaceCollapse::new(
                 input.chars(),
                 white_space_collapse,
                 trim_beginning_white_space,
-            )
-            .filter_map(|iteration| iteration.character)
-            .collect::<String>()
+            ) {
+                iteration.push_chars_to(&mut string);
+            }
+            string
         };
 
         let output = collapse("H ", WhiteSpaceCollapse::Collapse, false);

--- a/components/layout/tests/text.rs
+++ b/components/layout/tests/text.rs
@@ -15,7 +15,7 @@ mod text {
                 white_space_collapse,
                 trim_beginning_white_space,
             ) {
-                iteration.push_chars_to(&mut string);
+                string.extend(iteration.characters());
             }
             string
         };

--- a/components/layout/tests/text.rs
+++ b/components/layout/tests/text.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 mod text {
-    use layout::flow::inline::construct::WhitespaceCollapse;
+    use layout::flow::inline::text_transform::WhitespaceCollapse;
     use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 
     #[test]
@@ -14,6 +14,7 @@ mod text {
                 white_space_collapse,
                 trim_beginning_white_space,
             )
+            .filter_map(|iteration| iteration.character)
             .collect::<String>()
         };
 

--- a/components/shared/base/text.rs
+++ b/components/shared/base/text.rs
@@ -188,6 +188,21 @@ impl Utf32CodeUnits {
         // https://github.com/rust-lang/rust/blob/main/library/core/src/str/count.rs
         Self(string.chars().count())
     }
+
+    pub fn to_utf8_code_units_in(self, string: &str) -> Utf8CodeUnits {
+        let mut current_utf32_offset = Utf32CodeUnits(0);
+        for (current_utf8_offset, byte) in string.bytes().enumerate() {
+            if (byte & 0b1100_0000) == 0b1000_0000 {
+                // UTF-8 continuation byte
+                continue;
+            }
+            if current_utf32_offset >= self {
+                return Utf8CodeUnits(current_utf8_offset);
+            }
+            current_utf32_offset.0 += 1;
+        }
+        Utf8CodeUnits(string.len())
+    }
 }
 
 #[cfg(test)]

--- a/tests/wpt/meta/css/css-text/text-transform/text-transform-upperlower-105.html.ini
+++ b/tests/wpt/meta/css/css-text/text-transform/text-transform-upperlower-105.html.ini
@@ -1,2 +1,0 @@
-[text-transform-upperlower-105.html]
-  expected: FAIL


### PR DESCRIPTION
This change adds an `OffsetMap` type which is used to map DOM text
offsets to post-text transformation offsets during inline formatting
context construction. This is necessary to properly display selections
across text that is modified due to white space collapsing or CSS
`text-transform` processing.

This change fixes on test case in WPT dealing with `text-transform`
as a side effect.

Testing: This change updates WPT tests results.
