### PR TITLE
script: Use `is_in_a_document_tree()` to check if a node is in a tree

### DIFF
--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -1415,7 +1415,7 @@ impl HTMLFormElement {
             // In that case we can't use insert_pre_order, because the position of a element not in
             // the tree can't be compared to anything in the DOM tree.
             let control_element = control.to_element();
-            if control_element.upcast::<Node>().has_parent() {
+            if control_element.upcast::<Node>().is_in_a_document_tree() {
                 controls.insert_pre_order(control_element, root);
             } else {
                 controls.push(Dom::from_ref(control_element));

--- a/tests/wpt/tests/html/semantics/forms/resetting-a-form/form-attribute-detach-crash.html
+++ b/tests/wpt/tests/html/semantics/forms/resetting-a-form/form-attribute-detach-crash.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Crash found by DOM fuzzing</title>
+<link rel="help" href="https://github.com/servo/servo/issues/46790">
+<body>
+    <input form="form2">
+    <div id="div">
+        <form id="form2">
+            <button form="div"> </button>
+        </form>
+    </div>
+
+    <script>
+        document.createElement("ct").appendChild(div);
+    </script>
+</body>


### PR DESCRIPTION
… instead of `.has_parent()`. Being in a tree is a pre-condition of `insert_pre_order()` for its call to `compare_dom_tree_position()`. Failing to uphold that pre-condition caused a panic in some case found by a DOM fuzzer.

Fixes: https://github.com/servo/servo/issues/46790
Testing: adding a new crashtest to WPT, manually checked to crash before the code change