### PR TITLE
deps: Update bundled harfbuzz to 14.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3662,9 +3662,9 @@ dependencies = [
 
 [[package]]
 name = "harfbuzz-sys"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "975b6181d2b2d16236036ae09f51cc2b1cdc1506cadd1958d9c6d88a06f8a1a4"
+checksum = "b13f1cead31867a0d5b5e8905c262bc02b77701b8cd45ef402988f33745f9b7c"
 dependencies = [
  "cc",
  "freetype-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ gstreamer-sys = "0.25"
 gstreamer-video = "0.25"
 gstreamer-webrtc = { version = "0.25", features = ["v1_18"] }
 half = "2"
-harfbuzz-sys = { version = "0.7", default-features = false }
+harfbuzz-sys = { version = "0.8", default-features = false }
 headers = "0.4"
 hilog = "0.2.2"
 hitrace = { version = "0.2.0", features = ["api-19", "tracing-rs"] }


### PR DESCRIPTION
pending crates.io release

Testing: Dependency update, covered by existing tests.
