### PR TITLE
script: Remove Element::set_attribute_from_parser's unused prefix argument

### DIFF
--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -2145,7 +2145,6 @@ impl Element {
         cx: &mut JSContext,
         qname: QualName,
         value: DOMString,
-        prefix: Option<Prefix>,
     ) {
         // Don't set if the attribute already exists, so we can handle add_attrs_if_missing
         if self
@@ -2157,13 +2156,7 @@ impl Element {
             return;
         }
 
-        let name = match prefix {
-            None => qname.local.clone(),
-            Some(ref prefix) => {
-                let name = format!("{}:{}", &**prefix, &*qname.local);
-                LocalName::from(name)
-            },
-        };
+        let name = qname.local.clone();
         let value = self.parse_attribute(&qname.ns, &qname.local, value);
         self.push_new_attribute(
             cx,
@@ -2171,7 +2164,7 @@ impl Element {
             value,
             name,
             qname.ns,
-            prefix,
+            None, // TODO: pass prefix from `qname`.
             AttributeMutationReason::ByParser,
         );
     }

--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -546,12 +546,7 @@ impl Tokenizer {
                     .downcast::<Element>()
                     .expect("tried to set attrs on non-Element in HTML parsing");
                 for attr in attrs {
-                    elem.set_attribute_from_parser(
-                        cx,
-                        attr.name,
-                        DOMString::from(attr.value),
-                        None,
-                    );
+                    elem.set_attribute_from_parser(cx, attr.name, DOMString::from(attr.value));
                 }
             },
             ParseOperation::RemoveFromParent { target } => {

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1940,7 +1940,6 @@ impl TreeSink for Sink {
                 cx,
                 attr.name,
                 DOMString::from(String::from(attr.value)),
-                None,
             );
         }
     }
@@ -2116,7 +2115,7 @@ fn create_element_for_token(
 
     // Step 11. Append each attribute in the given token to element.
     for attr in attrs {
-        element.set_attribute_from_parser(cx, attr.name, attr.value, None);
+        element.set_attribute_from_parser(cx, attr.name, attr.value);
     }
 
     // Record if the tokenizer saw duplicate attributes on this element,

--- a/tests/wpt/meta/dom/nodes/Attr-prefix-xhtml.xhtml.ini
+++ b/tests/wpt/meta/dom/nodes/Attr-prefix-xhtml.xhtml.ini
@@ -1,0 +1,3 @@
+[Attr-prefix-xhtml.xhtml]
+  [Attr.prefix present]
+    expected: FAIL

--- a/tests/wpt/meta/dom/nodes/Attr-prefix.html.ini
+++ b/tests/wpt/meta/dom/nodes/Attr-prefix.html.ini
@@ -1,0 +1,6 @@
+[Attr-prefix.html]
+  [Attr.prefix present (SVG)]
+    expected: FAIL
+
+  [Attr.prefix present (MathML)]
+    expected: FAIL

--- a/tests/wpt/tests/dom/nodes/Attr-prefix-xhtml.xhtml
+++ b/tests/wpt/tests/dom/nodes/Attr-prefix-xhtml.xhtml
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:a="testnamespace">
+<head>
+<title>Attr.prefix</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="attributes.js"></script>
+</head>
+<body>
+<div id="log"/>
+<div id="test" a:testwithprefix="value with prefix" testwithoutprefix="value without prefix"/>
+<script>
+test(function() {
+  var element = document.getElementById("test");
+  attr_is(
+    element.getAttributeNodeNS("testnamespace", "testwithprefix"),
+    "value with prefix",
+    "testwithprefix",
+    "testnamespace",
+    "a",
+    "a:testwithprefix",
+    "Parser-inserted attribute with prefix"
+  );
+}, "Attr.prefix present");
+
+test(function() {
+  var element = document.getElementById("test");
+  attr_is(
+    element.getAttributeNodeNS(null, "testwithoutprefix"),
+    "value without prefix",
+    "testwithoutprefix",
+    null,
+    null,
+    "testwithoutprefix",
+    "Parser-inserted attribute without prefix"
+  );
+}, "Attr.prefix absent");
+</script>
+</body>
+</html>

--- a/tests/wpt/tests/dom/nodes/Attr-prefix.html
+++ b/tests/wpt/tests/dom/nodes/Attr-prefix.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<meta cherset="utf8">
+<title>Attr.prefix</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="attributes.js"></script>
+<div id="log"></div>
+<div id="test" xml:lang="value with prefix" class="value without prefix"></div>
+<svg><g xlink:href="value with prefix" class="value without prefix"/></svg>
+<math xml:lang="value with prefix" class="value without prefix"></math>
+<script>
+test(function() {
+  var element = document.getElementById("test");
+  attr_is(
+    element.getAttributeNodeNS(null, "xml:lang"),
+    "value with prefix",
+    "xml:lang",
+    null,
+    null,
+    "xml:lang",
+    "Parser-inserted attribute with prefix"
+  );
+}, "Attr.prefix present (HTML)");
+
+test(function() {
+  var element = document.getElementById("test");
+  attr_is(
+    element.getAttributeNodeNS(null, "class"),
+    "value without prefix",
+    "class",
+    null,
+    null,
+    "class",
+    "Parser-inserted attribute without prefix"
+  );
+}, "Attr.prefix absent (HTML)");
+
+test(function() {
+  var element = document.getElementsByTagName("g")[0];
+  attr_is(
+    element.getAttributeNodeNS("http://www.w3.org/1999/xlink", "href"),
+    "value with prefix",
+    "href",
+    "http://www.w3.org/1999/xlink",
+    "xlink",
+    "xlink:href",
+    "Parser-inserted attribute with prefix"
+  );
+}, "Attr.prefix present (SVG)");
+
+test(function() {
+  var element = document.getElementsByTagName("g")[0];
+  attr_is(
+    element.getAttributeNodeNS(null, "class"),
+    "value without prefix",
+    "class",
+    null,
+    null,
+    "class",
+    "Parser-inserted attribute without prefix"
+  );
+}, "Attr.prefix absent (SVG)");
+
+test(function() {
+  var element = document.getElementsByTagName("math")[0];
+  attr_is(
+    element.getAttributeNodeNS("http://www.w3.org/XML/1998/namespace", "lang"),
+    "value with prefix",
+    "lang",
+    "http://www.w3.org/XML/1998/namespace",
+    "xml",
+    "xml:lang",
+    "Parser-inserted attribute with prefix"
+  );
+}, "Attr.prefix present (MathML)");
+
+test(function() {
+  var element = document.getElementsByTagName("g")[0];
+  attr_is(
+    element.getAttributeNodeNS(null, "class"),
+    "value without prefix",
+    "class",
+    null,
+    null,
+    "class",
+    "Parser-inserted attribute without prefix"
+  );
+}, "Attr.prefix absent (MathML)");
+</script>
+</body>
+</html>

--- a/tests/wpt/tests/dom/nodes/Attr-prefix.html
+++ b/tests/wpt/tests/dom/nodes/Attr-prefix.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta cherset="utf8">
+<meta charset="utf8">
 <title>Attr.prefix</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/tests/dom/nodes/attributes.js
+++ b/tests/wpt/tests/dom/nodes/attributes.js
@@ -1,18 +1,20 @@
-function attr_is(attr, v, ln, ns, p, n) {
-  assert_equals(attr.value, v)
-  assert_equals(attr.nodeValue, v)
-  assert_equals(attr.textContent, v)
-  assert_equals(attr.localName, ln)
-  assert_equals(attr.namespaceURI, ns)
-  assert_equals(attr.prefix, p)
-  assert_equals(attr.name, n)
-  assert_equals(attr.nodeName, n);
-  assert_equals(attr.specified, true)
+function attr_is(attr, v, ln, ns, p, n, description) {
+  description = description ? description + ": " : "";
+  assert_equals(attr.value, v, description + "value")
+  assert_equals(attr.nodeValue, v, description + "nodeValue")
+  assert_equals(attr.textContent, v, description + "textContent")
+  assert_equals(attr.localName, ln, description + "localName")
+  assert_equals(attr.namespaceURI, ns, description + "namespaceURI")
+  assert_equals(attr.prefix, p, description + "prefix")
+  assert_equals(attr.name, n, description + "name")
+  assert_equals(attr.nodeName, n, description + "nodeName")
+  assert_equals(attr.specified, true, description + "specified")
 }
 
 function attributes_are(el, l) {
   for (var i = 0, il = l.length; i < il; i++) {
-    attr_is(el.attributes[i], l[i][1], l[i][0], (l[i].length < 3) ? null : l[i][2], null, l[i][0])
+    attr_is(el.attributes[i], l[i][1], l[i][0], (l[i].length < 3) ? null : l[i][2], null, l[i][0],
+      "attributes[" + i + "]")
     assert_equals(el.attributes[i].ownerElement, el)
   }
 }


### PR DESCRIPTION
All callers pass `None` for this argument.

In fact, we should be using the `prefix` field of the `qname` argument, but I limited this change to removing the confusing code and adding tests.

This was broken in the move from the hubbub HTML parser to html5ever in 2014 (9da7679367eba53d0f86bff30bc8b005940f044e). At that time, the QualName struct used by html5ever did not include a prefix field, so the information was unavailable.

xml5ever introduced its own QName struct, which included the prefix, in 2016 (c7b51e7aa15d8b3178343daa58a297a514cd9a70). The prefix could have been passed along at that point, but it wasn't.

html5ever's QualName and xml5ever's QName were merged into a shared QualName struct, including the prefix, in 2017 (6c518c89b969d1e9a96c3c5b9fe0da6cfc3637d1). The prefix, now available for HTML as well, was not passed along either.

Testing: added new WPTs, which fail as expected.