### PR TITLE
android: Replace `ServoCoordinates` with built-in `Size`

### DIFF
--- a/ports/servoshell/egl/android/mod.rs
+++ b/ports/servoshell/egl/android/mod.rs
@@ -250,10 +250,10 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_setExperimentalMode<'local>(
 pub extern "C" fn Java_org_servo_servoview_JNIServo_resize<'local>(
     mut env: EnvUnowned<'local>,
     _: JClass<'local>,
-    coordinates: JObject<'local>,
+    size: JObject<'local>,
 ) {
     env.with_env(|env| -> jni::errors::Result<_> {
-        let viewport_rect = jni_coordinate_to_rust_viewport_rect(env, &coordinates)?;
+        let viewport_rect = jni_coordinate_to_rust_viewport_rect(env, &size)?;
         debug!("resize {viewport_rect:#?}");
         call(env, |s| s.resize(viewport_rect));
         Ok(())
@@ -600,11 +600,11 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_resumePainting<'local>(
     mut env: EnvUnowned<'local>,
     _: JClass<'local>,
     surface: JObject<'local>,
-    coordinates: JObject<'local>,
+    size: JObject<'local>,
 ) {
     env.with_env(|env| -> jni::errors::Result<_> {
         debug!("resumePainting");
-        let viewport_rect = jni_coordinate_to_rust_viewport_rect(env, &coordinates)?;
+        let viewport_rect = jni_coordinate_to_rust_viewport_rect(env, &size)?;
         let (_, window_handle) = display_and_window_handle(env, &surface);
 
         call(env, |s| {
@@ -902,10 +902,14 @@ fn new_string_as_jvalue<'local>(
 
 fn jni_coordinate_to_rust_viewport_rect<'local>(
     env: &mut Env<'local>,
-    obj: &JObject<'local>,
+    size: &JObject<'local>,
 ) -> Result<Rect<i32, DevicePixel>, Error> {
-    let width = env.get_field(obj, jni_str!("width"), jni_sig!("I"))?.i()?;
-    let height = env.get_field(obj, jni_str!("height"), jni_sig!("I"))?.i()?;
+    let width = env
+        .call_method(size, jni_str!("getWidth"), jni_sig!("()I"), &[])?
+        .i()?;
+    let height = env
+        .call_method(size, jni_str!("getHeight"), jni_sig!("()I"), &[])?
+        .i()?;
 
     Ok(Rect::new(Point2D::origin(), Size2D::new(width, height)))
 }
@@ -975,15 +979,11 @@ fn get_options<'local>(
         .get_field(opts, jni_str!("enableLogs"), jni_sig!("Z"))?
         .z()?;
 
-    let coordinates = env
-        .get_field(
-            opts,
-            jni_str!("coordinates"),
-            jni_sig!("Lorg/servo/servoview/JNIServo$ServoCoordinates;"),
-        )?
+    let size = env
+        .get_field(opts, jni_str!("size"), jni_sig!("Landroid/util/Size;"))?
         .l()?;
 
-    let viewport_rect = jni_coordinate_to_rust_viewport_rect(env, &coordinates)?;
+    let viewport_rect = jni_coordinate_to_rust_viewport_rect(env, &size)?;
 
     let mut args: Vec<String> = args
         .and_then(|args| {

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.kt
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.kt
@@ -6,6 +6,7 @@
 package org.servo.servoview
 
 import android.content.Context
+import android.util.Size
 import android.view.Surface
 
 /**
@@ -28,7 +29,7 @@ internal class JNIServo {
 
     external fun performUpdates()
 
-    external fun resize(coords: ServoCoordinates)
+    external fun resize(size: Size)
 
     external fun reload()
 
@@ -64,7 +65,7 @@ internal class JNIServo {
 
     external fun pausePainting()
 
-    external fun resumePainting(surface: Surface, coords: ServoCoordinates)
+    external fun resumePainting(surface: Surface, size: Size)
 
     external fun mediaSessionAction(action: Int)
 
@@ -80,7 +81,7 @@ internal class JNIServo {
         var url: String? = null
 
         @JvmField
-        var coordinates: ServoCoordinates? = null
+        var size: Size? = null
 
         @JvmField
         var density: Float = 1f
@@ -93,14 +94,6 @@ internal class JNIServo {
 
         @JvmField
         var experimentalMode: Boolean = false
-    }
-
-    class ServoCoordinates {
-        @JvmField
-        var width: Int = 0
-
-        @JvmField
-        var height: Int = 0
     }
 
     interface Callbacks {

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.java
@@ -6,10 +6,10 @@
 package org.servo.servoview;
 
 import android.content.Context;
+import android.util.Size;
 import android.view.KeyEvent;
 import android.view.Surface;
 
-import org.servo.servoview.JNIServo.ServoCoordinates;
 import org.servo.servoview.JNIServo.ServoOptions;
 
 public class Servo {
@@ -41,8 +41,8 @@ public class Servo {
         runCallback.inGLThread(() -> jni.performUpdates());
     }
 
-    public void resize(ServoCoordinates coords) {
-        runCallback.inGLThread(() -> jni.resize(coords));
+    public void resize(Size size) {
+        runCallback.inGLThread(() -> jni.resize(size));
     }
 
     public void reload() {
@@ -113,8 +113,8 @@ public class Servo {
         runCallback.inGLThread(() -> jni.pausePainting());
     }
 
-    public void resumePainting(Surface surface, ServoCoordinates coords) {
-        runCallback.inGLThread(() -> jni.resumePainting(surface, coords));
+    public void resumePainting(Surface surface, Size size) {
+        runCallback.inGLThread(() -> jni.resumePainting(surface, size));
     }
 
     public void suspend(boolean suspended) {

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
@@ -11,6 +11,7 @@ import android.os.Looper;
 import android.util.AttributeSet;
 import android.util.DisplayMetrics;
 import android.util.Log;
+import android.util.Size;
 import android.view.Choreographer;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -19,7 +20,6 @@ import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.View;
 
-import org.servo.servoview.JNIServo.ServoCoordinates;
 import org.servo.servoview.JNIServo.ServoOptions;
 import org.servo.servoview.Servo.Client;
 import org.servo.servoview.Servo.RunCallback;
@@ -203,15 +203,13 @@ public class ServoView extends SurfaceView
         public void surfaceCreated(SurfaceHolder holder) {
             Log.d(LOGTAG, "GLThread::surfaceCreated");
 
-            ServoCoordinates coords = new ServoCoordinates();
-            coords.width = servoView.getWidth();
-            coords.height = servoView.getHeight();
+            Size size = new Size(servoView.getWidth(), servoView.getHeight());
 
             Surface surface = holder.getSurface();
             ServoOptions options = new ServoOptions();
             options.args = servoView.servoArgs;
             options.url = servoView.initialUri;
-            options.coordinates = coords;
+            options.size = size;
             options.logStr = servoLog;
             options.enableLogs = true;
             options.experimentalMode = servoView.experimentalMode;
@@ -223,7 +221,7 @@ public class ServoView extends SurfaceView
                         options, servoView, client, servoView.getContext(), surface);
             } else {
                 paused = false;
-                servoView.servo.resumePainting(surface, coords);
+                servoView.servo.resumePainting(surface, size);
             }
 
             Choreographer.getInstance().postFrameCallback(servoView);
@@ -232,10 +230,7 @@ public class ServoView extends SurfaceView
 
         public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
             Log.d(LOGTAG, "GLThread::surfaceChanged");
-            ServoCoordinates coords = new ServoCoordinates();
-            coords.width = width;
-            coords.height = height;
-            servoView.servo.resize(coords);
+            servoView.servo.resize(new Size(width, height));
         }
 
         public void surfaceDestroyed(SurfaceHolder holder) {


### PR DESCRIPTION
For simplicities sake, Android's `Size` class is used instead of the bespoke `ServoCoordinates` which does a similar thing.

`Size` has a slightly better API, where its constructor requires that `width` and `height` are provided and the object is then subsequently immutable. Since `ServoCoordinates` just has an empty constructor with public fields, it's easy to forget either `width` or `height`, and it's created object is mutable.

Testing: There are no automated tests for Android.