### PR TITLE
script: Invoke decodeAudioData error callback for detached buffers

### DIFF
--- a/components/script/dom/audio/baseaudiocontext.rs
+++ b/components/script/dom/audio/baseaudiocontext.rs
@@ -10,6 +10,7 @@ use std::sync::{Arc, Mutex};
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
+use js::jsapi::IsDetachedArrayBufferObject;
 use js::realm::CurrentRealm;
 use js::rust::CustomAutoRooterGuard;
 use js::typedarray::ArrayBuffer;
@@ -59,6 +60,7 @@ use crate::dom::bindings::codegen::Bindings::IIRFilterNodeBinding::IIRFilterOpti
 use crate::dom::bindings::codegen::Bindings::OscillatorNodeBinding::OscillatorOptions;
 use crate::dom::bindings::codegen::Bindings::PannerNodeBinding::PannerOptions;
 use crate::dom::bindings::codegen::Bindings::StereoPannerNodeBinding::StereoPannerOptions;
+use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::num::Finite;
@@ -165,6 +167,12 @@ impl BaseAudioContext {
     // https://webaudio.github.io/web-audio-api/#allowed-to-start
     pub(crate) fn is_allowed_to_start(&self) -> bool {
         self.state.get() == AudioContextState::Suspended
+    }
+
+    // Reads the JSObject pointer to check if the array buffer is detached.
+    #[expect(unsafe_code)]
+    fn is_detached_array_buffer(array_buffer: &ArrayBuffer) -> bool {
+        unsafe { IsDetachedArrayBufferObject(*array_buffer.underlying_object()) }
     }
 
     fn push_pending_resume_promise(&self, promise: &Rc<Promise>) {
@@ -461,121 +469,200 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
         &self,
         cx: &mut CurrentRealm,
         audio_data: CustomAutoRooterGuard<ArrayBuffer>,
-        decode_success_callback: Option<Rc<DecodeSuccessCallback>>,
-        decode_error_callback: Option<Rc<DecodeErrorCallback>>,
+        decode_success_callback: Option<Option<Rc<DecodeSuccessCallback>>>,
+        decode_error_callback: Option<Option<Rc<DecodeErrorCallback>>>,
     ) -> Rc<Promise> {
-        // Step 1.
-        let promise = Promise::new_in_realm(cx);
-
-        if let Some(audio_data) = audio_data.to_vec() {
-            // Step 2.
-            // XXX detach array buffer.
-            let uuid = Uuid::new_v4().simple().to_string();
-            let uuid_ = uuid.clone();
-            self.decode_resolvers.safe_borrow_mut(cx.no_gc()).insert(
-                uuid.clone(),
-                DecodeResolver {
-                    promise: promise.clone(),
-                    success_callback: decode_success_callback,
-                    error_callback: decode_error_callback,
-                },
+        // Step 1. If this's relevant global object's associated Document is NOT fully active,
+        // return a promise rejected with "InvalidStateError".
+        if !self.global().as_window().Document().is_fully_active() {
+            let promise = Promise::new_in_realm(cx);
+            promise.reject_error(
+                cx,
+                Error::InvalidState(Some(
+                    "Cannot call decodeAudioData() when the document is not fully active.".into(),
+                )),
             );
-            let decoded_audio = Arc::new(Mutex::new(Vec::new()));
-            let decoded_audio_ = decoded_audio.clone();
-            let decoded_audio__ = decoded_audio.clone();
-            // servo-media returns an audio channel position along
-            // with the AudioDecoderCallback progress callback, which
-            // may not be the same as the index of the decoded_audio
-            // Vec.
-            let channels = Arc::new(Mutex::new(HashMap::new()));
-            let this = Trusted::new(self);
-            let this_ = this.clone();
-            let task_source = self
-                .global()
-                .task_manager()
-                .dom_manipulation_task_source()
-                .to_sendable();
-            let task_source_clone = task_source.clone();
-            let callbacks = AudioDecoderCallbacksBuilder::default()
-                .ready(move |channel_count| {
-                    decoded_audio
-                        .lock()
-                        .unwrap()
-                        .resize(channel_count as usize, Vec::new());
-                })
-                .progress(move |buffer, channel_pos_mask| {
-                    let mut decoded_audio = decoded_audio_.lock().unwrap();
-                    let mut channels = channels.lock().unwrap();
-                    let channel = match channels.entry(channel_pos_mask) {
-                        Entry::Occupied(entry) => *entry.get(),
-                        Entry::Vacant(entry) => {
-                            let x = (channel_pos_mask as f32).log2() as usize;
-                            *entry.insert(x)
-                        },
-                    };
-                    decoded_audio[channel].extend_from_slice((*buffer).as_ref());
-                })
-                .eos(move || {
-                    task_source.queue(task!(audio_decode_eos: move |cx| {
-                        let this = this.root();
-                        let decoded_audio = decoded_audio__.lock().unwrap();
-                        let length = if !decoded_audio.is_empty() {
-                            decoded_audio[0].len()
-                        } else {
-                            0
-                        };
-                        let buffer = AudioBuffer::new(
-                            cx,
-                            this.global().as_window(),
-                            decoded_audio.len() as u32 /* number of channels */,
-                            length as u32,
-                            this.sample_rate,
-                            Some(decoded_audio.as_slice()),
-                        );
-                        // Potential borrow hazard
-                        let resolver = {
-                            let mut resolvers = this.decode_resolvers.safe_borrow_mut(cx.no_gc());
-                            assert!(resolvers.contains_key(&uuid_));
-                            resolvers.remove(&uuid_).unwrap()
-                        };
-                        if let Some(callback) = resolver.success_callback {
-                            let _ = callback.Call__(cx, &buffer, ExceptionHandling::Report);
-                        }
-                        resolver.promise.resolve_native(cx, &buffer);
-                    }));
-                })
-                .error(move |error| {
-                    task_source_clone.queue(task!(audio_decode_eos: move |cx| {
-                        let this = this_.root();
-                        // potential borrow hazard
-                        let resolver = {
-                            let mut resolvers = this.decode_resolvers.safe_borrow_mut(cx.no_gc());
-                            assert!(resolvers.contains_key(&uuid));
-                            resolvers.remove(&uuid).unwrap()
-                        };
-                        if let Some(callback) = resolver.error_callback {
-                            let exception = DOMException::new(cx,
-                                &this.global(),
-                                DOMErrorName::DataCloneError,
-                            );
-                            let _ = callback.Call__(cx, &exception, ExceptionHandling::Report);
-                        }
-                        let error = cformat!("Audio decode error {:?}", error);
-                        resolver.promise.reject_error(cx, Error::Type(error));
-                    }));
-                })
-                .build();
-            self.audio_context_impl
-                .lock()
-                .unwrap()
-                .decode_audio_data(audio_data, callbacks);
-        } else {
-            // Step 3.
-            promise.reject_error(cx, Error::DataClone(None));
             return promise;
         }
 
-        // Step 4.
+        // Step 2. Let promise be a new promise.
+        let promise = Promise::new_in_realm(cx);
+
+        // optional Nullable callbacks: omitted/undefined → None, null → Some(None), fn → Some(Some(cb))
+        let decode_success_callback = decode_success_callback.flatten();
+        let decode_error_callback = decode_error_callback.flatten();
+
+        // Step 3. If audio_data is NOT detached, execute the following steps:
+        // - Append promise to [[pending promises]].
+        // - Detach the audio_data ArrayBuffer. If this operation throws, jump to step 4.1.
+        // - Queue a decoding operation to be performed on another thread.
+        if !Self::is_detached_array_buffer(&audio_data) {
+            if let Some(audio_data) = audio_data.to_vec() {
+                // XXX detach array buffer.
+                let uuid = Uuid::new_v4().simple().to_string();
+                let uuid_ = uuid.clone();
+                self.decode_resolvers.safe_borrow_mut(cx.no_gc()).insert(
+                    uuid.clone(),
+                    DecodeResolver {
+                        promise: promise.clone(),
+                        success_callback: decode_success_callback,
+                        error_callback: decode_error_callback,
+                    },
+                );
+                let decoded_audio = Arc::new(Mutex::new(Vec::new()));
+                let decoded_audio_ = decoded_audio.clone();
+                let decoded_audio__ = decoded_audio.clone();
+                // servo-media returns an audio channel position along
+                // with the AudioDecoderCallback progress callback, which
+                // may not be the same as the index of the decoded_audio
+                // Vec.
+                let channels = Arc::new(Mutex::new(HashMap::new()));
+                let this = Trusted::new(self);
+                let this_ = this.clone();
+                let task_source = self
+                    .global()
+                    .task_manager()
+                    .dom_manipulation_task_source()
+                    .to_sendable();
+                let task_source_clone = task_source.clone();
+                let callbacks = AudioDecoderCallbacksBuilder::default()
+                    .ready(move |channel_count| {
+                        decoded_audio
+                            .lock()
+                            .unwrap()
+                            .resize(channel_count as usize, Vec::new());
+                    })
+                    .progress(move |buffer, channel_pos_mask| {
+                        let mut decoded_audio = decoded_audio_.lock().unwrap();
+                        let mut channels = channels.lock().unwrap();
+                        let channel = match channels.entry(channel_pos_mask) {
+                            Entry::Occupied(entry) => *entry.get(),
+                            Entry::Vacant(entry) => {
+                                let x = (channel_pos_mask as f32).log2() as usize;
+                                *entry.insert(x)
+                            },
+                        };
+                        decoded_audio[channel].extend_from_slice((*buffer).as_ref());
+                    })
+                    .eos(move || {
+                        task_source.queue(task!(audio_decode_eos: move |cx| {
+                            let this = this.root();
+                            let decoded_audio = decoded_audio__.lock().unwrap();
+                            let length = if !decoded_audio.is_empty() {
+                                decoded_audio[0].len()
+                            } else {
+                                0
+                            };
+                            let buffer = AudioBuffer::new(
+                                cx,
+                                this.global().as_window(),
+                                decoded_audio.len() as u32 /* number of channels */,
+                                length as u32,
+                                this.sample_rate,
+                                Some(decoded_audio.as_slice()),
+                            );
+                            // Potential borrow hazard
+                            let resolver = {
+                                let mut resolvers =
+                                    this.decode_resolvers.safe_borrow_mut(cx.no_gc());
+                                assert!(resolvers.contains_key(&uuid_));
+                                resolvers.remove(&uuid_).unwrap()
+                            };
+                            if let Some(callback) = resolver.success_callback {
+                                let _ = callback.Call__(cx, &buffer, ExceptionHandling::Report);
+                            }
+                            resolver.promise.resolve_native(cx, &buffer);
+                        }));
+                    })
+                    .error(move |error| {
+                        task_source_clone.queue(task!(audio_decode_eos: move |cx| {
+                            let this = this_.root();
+                            // potential borrow hazard
+                            let resolver = {
+                                let mut resolvers =
+                                    this.decode_resolvers.safe_borrow_mut(cx.no_gc());
+                                assert!(resolvers.contains_key(&uuid));
+                                resolvers.remove(&uuid).unwrap()
+                            };
+                            if let Some(callback) = resolver.error_callback {
+                                let exception = DOMException::new(
+                                    cx,
+                                    &this.global(),
+                                    DOMErrorName::DataCloneError,
+                                );
+                                let _ =
+                                    callback.Call__(cx, &exception, ExceptionHandling::Report);
+                            }
+                            let error = cformat!("Audio decode error {:?}", error);
+                            resolver.promise.reject_error(cx, Error::Type(error));
+                        }));
+                    })
+                    .build();
+                self.audio_context_impl
+                    .lock()
+                    .unwrap()
+                    .decode_audio_data(audio_data, callbacks);
+            } else {
+                debug_assert!(false, "ArrayBuffer::to_vec failed on non-detached buffer");
+                promise.reject_error(
+                    cx,
+                    Error::DataClone(Some(
+                        "Failed to detach the ArrayBuffer while decoding audio data.".into(),
+                    )),
+                );
+                return promise;
+            }
+        } else {
+            // Step 4. 
+            // Else, execute the following error steps:
+            // - Let error be a DataCloneError.
+            // - Reject promise with error, and remove it from [[pending promises]].
+            // - Queue a media element task to invoke errorCallback with error.
+            promise.reject_error(
+                cx,
+                Error::DataClone(Some(
+                    "Cannot decode audio data from a detached ArrayBuffer.".into(),
+                )),
+            );
+
+            if let Some(callback) = decode_error_callback {
+                // Build the Task object using a unique uuid as a key to remove the callback resolver entry.
+                // Stash the callback with clone of uuid in the decode_resolvers map.
+                // Enqueue the task after the callback is stashed.
+                let uuid = Uuid::new_v4().simple().to_string();
+                let uuid_ = uuid.clone();
+                let this = Trusted::new(self);
+                let task = task!(decode_audio_data_detached_buffer: move |cx| {
+                    let this = this.root();
+                    let resolver = {
+                        let mut resolvers = this.decode_resolvers.safe_borrow_mut(cx.no_gc());
+                        resolvers.remove(&uuid).unwrap()
+                    };
+                    if let Some(callback) = resolver.error_callback {
+                        let exception = DOMException::new(
+                            cx,
+                            &this.global(),
+                            DOMErrorName::DataCloneError,
+                        );
+                        let _ = callback.Call__(cx, &exception, ExceptionHandling::Report);
+                    }
+                });
+                self.decode_resolvers.safe_borrow_mut(cx.no_gc()).insert(
+                    uuid_,
+                    DecodeResolver {
+                        promise: promise.clone(),
+                        success_callback: None,
+                        error_callback: Some(callback),
+                    },
+                );
+                self.global()
+                    .task_manager()
+                    .media_element_task_source()
+                    .queue(task);
+            }
+        }
+
+        // Step 5. Return promise.
         promise
     }
 

--- a/components/script/dom/audio/baseaudiocontext.rs
+++ b/components/script/dom/audio/baseaudiocontext.rs
@@ -488,7 +488,7 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
         // Step 2. Let promise be a new promise.
         let promise = Promise::new_in_realm(cx);
 
-        // flatten the optionally nullable callbacks 
+        // flatten the optionally nullable callbacks
         let decode_success_callback = decode_success_callback.flatten();
         let decode_error_callback = decode_error_callback.flatten();
 
@@ -613,7 +613,7 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
                 return promise;
             }
         } else {
-            // Step 4. 
+            // Step 4.
             // Else, execute the following error steps:
             // - Let error be a DataCloneError.
             // - Reject promise with error, and remove it from [[pending promises]].

--- a/components/script/dom/audio/baseaudiocontext.rs
+++ b/components/script/dom/audio/baseaudiocontext.rs
@@ -488,7 +488,7 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
         // Step 2. Let promise be a new promise.
         let promise = Promise::new_in_realm(cx);
 
-        // optional Nullable callbacks: omitted/undefined → None, null → Some(None), fn → Some(Some(cb))
+        // flatten the optionally nullable callbacks 
         let decode_success_callback = decode_success_callback.flatten();
         let decode_error_callback = decode_error_callback.flatten();
 

--- a/components/script/dom/audio/baseaudiocontext.rs
+++ b/components/script/dom/audio/baseaudiocontext.rs
@@ -618,12 +618,7 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
             // - Let error be a DataCloneError.
             // - Reject promise with error, and remove it from [[pending promises]].
             // - Queue a media element task to invoke errorCallback with error.
-            promise.reject_error(
-                cx,
-                Error::DataClone(Some(
-                    "Cannot decode audio data from a detached ArrayBuffer.".into(),
-                )),
-            );
+            promise.reject_error(cx, Error::DataClone(None));
 
             if let Some(callback) = decode_error_callback {
                 // Build the Task object using a unique uuid as a key to remove the callback resolver entry.

--- a/components/script/dom/audio/baseaudiocontext.rs
+++ b/components/script/dom/audio/baseaudiocontext.rs
@@ -618,7 +618,8 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
             // - Let error be a DataCloneError.
             // - Reject promise with error, and remove it from [[pending promises]].
             // - Queue a media element task to invoke errorCallback with error.
-            promise.reject_error(cx, Error::DataClone(None));
+            let exception = DOMException::new(cx, &self.global(), DOMErrorName::DataCloneError);
+            promise.reject_native(cx, &exception);
 
             if let Some(callback) = decode_error_callback {
                 // Build the Task object using a unique uuid as a key to remove the callback resolver entry.
@@ -627,19 +628,20 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
                 let uuid = Uuid::new_v4().simple().to_string();
                 let uuid_ = uuid.clone();
                 let this = Trusted::new(self);
+                let exception = Trusted::new(&*exception);
                 let task = task!(decode_audio_data_detached_buffer: move |cx| {
                     let this = this.root();
+                    let exception = exception.root();
                     let resolver = {
                         let mut resolvers = this.decode_resolvers.safe_borrow_mut(cx.no_gc());
                         resolvers.remove(&uuid).unwrap()
                     };
                     if let Some(callback) = resolver.error_callback {
-                        let exception = DOMException::new(
+                        let _ = callback.Call__(
                             cx,
-                            &this.global(),
-                            DOMErrorName::DataCloneError,
+                            &exception,
+                            ExceptionHandling::Report
                         );
-                        let _ = callback.Call__(cx, &exception, ExceptionHandling::Report);
                     }
                 });
                 self.decode_resolvers.safe_borrow_mut(cx.no_gc()).insert(

--- a/components/script/dom/audio/baseaudiocontext.rs
+++ b/components/script/dom/audio/baseaudiocontext.rs
@@ -478,9 +478,7 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
             let promise = Promise::new_in_realm(cx);
             promise.reject_error(
                 cx,
-                Error::InvalidState(Some(
-                    "Audio context's document is not fully active.".into(),
-                )),
+                Error::InvalidState(Some("Audio context's document is not fully active.".into())),
             );
             return promise;
         }

--- a/components/script/dom/audio/baseaudiocontext.rs
+++ b/components/script/dom/audio/baseaudiocontext.rs
@@ -479,7 +479,7 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
             promise.reject_error(
                 cx,
                 Error::InvalidState(Some(
-                    "Cannot call decodeAudioData() when the document is not fully active.".into(),
+                    "Audio context's document is not fully active.".into(),
                 )),
             );
             return promise;

--- a/components/script_bindings/webidls/BaseAudioContext.webidl
+++ b/components/script_bindings/webidls/BaseAudioContext.webidl
@@ -28,8 +28,8 @@ interface BaseAudioContext : EventTarget {
                                     unsigned long length,
                                     float sampleRate);
   Promise<AudioBuffer> decodeAudioData(ArrayBuffer audioData,
-                                       optional DecodeSuccessCallback successCallback,
-                                       optional DecodeErrorCallback errorCallback);
+                                       optional DecodeSuccessCallback? successCallback,
+                                       optional DecodeErrorCallback? errorCallback);
   [Throws] AudioBufferSourceNode createBufferSource();
   [Throws] ConstantSourceNode createConstantSource();
   // ScriptProcessorNode createScriptProcessor(optional unsigned long bufferSize = 0,

--- a/python/tidy/error_message_exceptions.txt
+++ b/python/tidy/error_message_exceptions.txt
@@ -9,7 +9,7 @@
 ./components/script/dom/audio/audionode.rs 18
 ./components/script/dom/audio/audioparam.rs 2
 ./components/script/dom/audio/audioscheduledsourcenode.rs 2
-./components/script/dom/audio/baseaudiocontext.rs 4
+./components/script/dom/audio/baseaudiocontext.rs 3
 ./components/script/dom/audio/channelmergernode.rs 2
 ./components/script/dom/audio/channelsplitternode.rs 2
 ./components/script/dom/audio/iirfilternode.rs 3

--- a/tests/wpt/meta/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-detached-execution-context.html.ini
+++ b/tests/wpt/meta/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-detached-execution-context.html.ini
@@ -1,8 +1,0 @@
-[audiocontext-detached-execution-context.html]
-  expected: TIMEOUT
-  [Executing "decoding-on-detached-iframe"]
-    expected: TIMEOUT
-
-  [Audit report]
-    expected: NOTRUN
-

--- a/tests/wpt/meta/webaudio/the-audio-api/the-offlineaudiocontext-interface/offlineaudiocontext-detached-execution-context.html.ini
+++ b/tests/wpt/meta/webaudio/the-audio-api/the-offlineaudiocontext-interface/offlineaudiocontext-detached-execution-context.html.ini
@@ -1,8 +1,0 @@
-[offlineaudiocontext-detached-execution-context.html]
-  expected: TIMEOUT
-  [Executing "decoding-on-detached-iframe"]
-    expected: TIMEOUT
-
-  [Audit report]
-    expected: NOTRUN
-

--- a/tests/wpt/tests/webaudio/the-audio-api/the-audiocontext-interface/callback-detached-buffer.html
+++ b/tests/wpt/tests/webaudio/the-audio-api/the-audiocontext-interface/callback-detached-buffer.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test to verify decodeAudioData() invokes the error callback for a detached ArrayBuffer</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body></body>
+<script>
+promise_test(async t => {
+  const context = new AudioContext();
+  t.add_cleanup(() => context.close());
+
+  // create a detached ArrayBuffer
+  const audioData = new ArrayBuffer(4);
+  structuredClone({}, { transfer: [audioData] });
+
+  // save a reference to the promise res
+  let resolve;
+  const errorInvoked = new Promise(res => { resolve = res; });
+
+  // create decodeAudioData() promise with success and error callbacks
+  const success = t.unreached_func('success callback should not run');
+  const error = t.step_func(err => { resolve(err); });
+  const promise = context.decodeAudioData(audioData, success, error);
+
+  // assert promise rejects with DataCloneError and await pending errorInvoked promise
+  const [, err] = await Promise.all([
+    promise_rejects_dom(t, 'DataCloneError', promise),
+    errorInvoked,
+  ]);
+
+  // err must be a DataCloneError DOMException
+  assert_true(err instanceof DOMException, 'error callback argument is a DOMException');
+  assert_equals(err.name, 'DataCloneError');
+
+}, 'error callback is invoked with DataCloneError');
+</script>


### PR DESCRIPTION
Previously, the detached ArrayBuffer branch only rejected the promise and the `decodeErrorCallback` was never invoked.

Now, we detect if the ArrayBuffer is detached with `IsDetachedArrayBufferObject`, and synchronously reject the promise with `DataCloneError` before enqueuing a media element task to invoke the callback. We use a uuid clone to insert the callback in `decode_resolvers` and use the uuid in the task to find the callback. Because `decode_error_callback` is Rc and not Send, which Task expects, it cannot be moved into the queued closure (so we store the callback in the map and enqueue the Task).

Added Step 1 from the spec to reject with `InvalidStateError` when the document is not fully active.

Updated the `decodeAudioData` success callback and error callback to be optional nullable to match the Web Audio IDL, so we can pass null for an unused callback.

Testing:

- WebIDL and code changes compiles in release build: `.\mach build -r`

- Call `decodeAudioData` after detaching `AudioContext` iframe: `.\mach test-wpt -r tests/wpt/tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-detached-execution-context.html`
- Call `decodeAudioData` after detaching `OfflineAudioContext` iframe: `.\mach test-wpt -r tests/wpt/tests/webaudio/the-audio-api/the-offlineaudiocontext-interface/offlineaudiocontext-detached-execution-context.html`

- Call `decodeAudioData`on a closed context: `.\mach test-wpt -r tests/wpt/tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-suspend-resume-close.html`

- Manually detach buffer with null success callback:

Using console in FireFox Dev Tools:
`.\mach run -r --devtools=6080`

```js
  var ctx = new AudioContext();
  var ab = new ArrayBuffer(4);
  structuredClone({}, { transfer: [ab] });
  var called = false;
  ctx.decodeAudioData(ab, null, function () { called = true; })
    .catch(function (e) { console.log("reject", e.name, e.message); });
  setTimeout(function () { console.log("callback called?", called); }, 500);
```

Fixes #46602.