### PR TITLE
script: Implement async FileSystemEntry.getParent() success callback

### DIFF
--- a/components/script/dom/filesystem/filesystementry.rs
+++ b/components/script/dom/filesystem/filesystementry.rs
@@ -2,14 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::cell::Cell;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::Reflector;
 
+use crate::dom::bindings::callback::ExceptionHandling;
+use crate::dom::bindings::codegen::Bindings::FileSystemBinding::FileSystemMethods;
 use crate::dom::bindings::codegen::Bindings::FileSystemEntryBinding::{
     ErrorCallback, FileSystemEntryCallback, FileSystemEntryMethods,
 };
+use crate::dom::bindings::refcounted::Trusted;
+use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::USVString;
 use crate::dom::filesystem::FileSystem;
@@ -21,6 +27,15 @@ pub(crate) struct FileSystemEntry {
     full_path: USVString,
     is_file: bool,
     filesystem: MutNullableDom<FileSystem>,
+    pending_callbacks: DomRefCell<Vec<PendingEntryCallback>>,
+    next_callback: Cell<usize>,
+}
+
+#[derive(JSTraceable, MallocSizeOf)]
+struct PendingEntryCallback {
+    id: usize,
+    #[conditional_malloc_size_of]
+    callback: Rc<FileSystemEntryCallback>,
 }
 
 impl FileSystemEntry {
@@ -35,6 +50,8 @@ impl FileSystemEntry {
             full_path,
             is_file,
             filesystem: MutNullableDom::new(None),
+            pending_callbacks: Default::default(),
+            next_callback: Cell::new(0),
         }
     }
 
@@ -74,9 +91,48 @@ impl FileSystemEntryMethods<crate::DomTypeHolder> for FileSystemEntry {
     /// <https://wicg.github.io/entries-api/#dom-filesystementry-getparent>
     fn GetParent(
         &self,
-        _success_callback: Option<Rc<FileSystemEntryCallback>>,
+        success_callback: Option<Rc<FileSystemEntryCallback>>,
         _error_callback: Option<Rc<ErrorCallback>>,
     ) {
-        // TODO: Implement per spec 7.1. Need to hook embedder.
+        let Some(callback) = success_callback else {
+            return;
+        };
+        // Per spec 7.1: in parallel,
+        // 1. (TODO) Let `path` be the result of resolve ".." relative to this's full path.
+        // 2. (TODO) Let `item` be the result of evaluating a path with this’s root and path.
+        // 3. (TODO) Queue errorCallback if `item` is failure.
+        // 4 - 5.  Queue a task to invoke
+        // successCallback with the parent directory entry.
+        //
+        // NOTE: For now, the parent is always the root directory, which is correct
+        // as the `FileSystemEntry` can only be created by webkitGetAsEntry(), which is
+        // single level DnD.
+
+        let id = self.next_callback.get();
+        let pending_callback = PendingEntryCallback { id, callback };
+        self.pending_callbacks.borrow_mut().push(pending_callback);
+        self.next_callback.set(id + 1);
+
+        let this = Trusted::new(self);
+        self.global()
+            .task_manager()
+            .dom_manipulation_task_source()
+            .queue(task!(invoke_get_parent: move |cx| {
+                let this = this.root();
+                let maybe_index = this
+                    .pending_callbacks
+                    .borrow()
+                    .iter()
+                    .position(|val| val.id == id);
+                if let Some(index) = maybe_index {
+                    let callback = this
+                        .pending_callbacks
+                        .safe_borrow_mut(cx.no_gc())
+                        .swap_remove(index)
+                        .callback;
+                    let entry = DomRoot::upcast::<FileSystemEntry>(this.Filesystem().Root());
+                    let _ = callback.Call__(cx, &entry, ExceptionHandling::Report);
+                }
+            }));
     }
 }

--- a/tests/wpt/tests/entries-api/filesystementry-getParent.html
+++ b/tests/wpt/tests/entries-api/filesystementry-getParent.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Entries API: FileSystemEntry.getParent() with script-created DataTransfer</title>
+<link rel=help href="https://wicg.github.io/entries-api/#dom-filesystementry-getparent">
+<link rel=author title="Euclid Ye" href="mailto:yezhizhenjiakang@gmail.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+async_test(t => {
+  const file = new File(['hello world'], 'test.txt', { type: 'text/plain' });
+  const dt = new DataTransfer();
+  dt.items.add(file);
+
+  const entry = dt.items[0].webkitGetAsEntry();
+
+  entry.getParent(
+    t.step_func_done(parent => {
+      assert_true(parent.isDirectory);
+      assert_false(parent.isFile);
+      assert_equals(parent.name, '');
+      assert_equals(parent.fullPath, '/');
+    }),
+    t.unreached_func('getParent() should not invoke the error callback')
+  );
+}, 'getParent() on a root-level file entry returns the root directory');
+
+async_test(t => {
+  const file = new File(['hello world'], 'test.txt', { type: 'text/plain' });
+  const dt = new DataTransfer();
+  dt.items.add(file);
+
+  const entry = dt.items[0].webkitGetAsEntry();
+  const root = entry.filesystem.root;
+
+  root.getParent(
+    t.step_func_done(parent => {
+      assert_true(parent.isDirectory, 'parent should be a directory');
+      assert_equals(parent.name, '', 'root name is empty string');
+      assert_equals(parent.fullPath, '/', 'parent of root is root itself');
+    }),
+    t.unreached_func('getParent() should not invoke the error callback')
+  );
+}, 'getParent() on the root directory returns the root itself');
+</script>


### PR DESCRIPTION
Testing: Added an automated test unlike those existing manual ones. The major difference is, it does not require OS drag-and-drop support, but still tests the full DnD script path programatically.

Part of https://github.com/servo/servo/issues/45653
