### PR TITLE
test: Delay webxr test completion until all checks have completed.

### DIFF
--- a/tests/wpt/tests/webxr/render_state_update.https.html
+++ b/tests/wpt/tests/webxr/render_state_update.https.html
@@ -26,8 +26,8 @@ let testBaseLayer = function(session, fakeDeviceController, t, sessionObjects) {
           assert_not_equals(session, tempSession);
           assert_throws_dom('InvalidStateError', () => session.updateRenderState({ baseLayer : new XRWebGLLayer(tempSession, sessionObjects.gl), }));
         });
+        resolve();
       });
-      resolve();
     });
   });
 };


### PR DESCRIPTION
By resolving the promise test's promise outside of the code that actually performs the checks (after waiting on an async operation to complete), the test could exhibit racy behaviour where the test resources could be cleaned up before the async operation has completed.

Testing: Previously intermittent test result is no longer intermittent.
Fixes: #27535
