### PR TITLE
script: Claim blob URLs before fetching script sources.

### DIFF
--- a/components/script/dom/html/documentmetadata/htmllinkelement.rs
+++ b/components/script/dom/html/documentmetadata/htmllinkelement.rs
@@ -63,6 +63,7 @@ use crate::links::LinkRelations;
 use crate::network_listener::{FetchResponseListener, ResourceTimingListener, submit_timing};
 use crate::script_module::{ScriptFetchOptions, fetch_a_modulepreload_module};
 use crate::stylesheet_loader::{ElementStylesheetLoader, StylesheetContextSource, StylesheetOwner};
+use crate::url::ensure_blob_referenced_by_url_is_kept_alive;
 
 #[derive(Clone, Copy, JSTraceable, MallocSizeOf, PartialEq)]
 pub(crate) struct RequestGenerationId(u32);
@@ -983,6 +984,7 @@ impl HTMLLinkElement {
         let Ok(url) = document.encoding_parse_a_url(&href_attribute_value.str()) else {
             return;
         };
+        let url = ensure_blob_referenced_by_url_is_kept_alive(&global, url);
 
         // Step 6. Let settings object be el's node document's relevant settings object.
 
@@ -1000,7 +1002,7 @@ impl HTMLLinkElement {
             .unwrap_or_else(|| {
                 global
                     .import_map()
-                    .resolve_a_module_integrity_metadata(&url)
+                    .resolve_a_module_integrity_metadata(&url.url())
             });
 
         // Step 11. Let referrer policy be the current state of el's referrerpolicy attribute.

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -14,6 +14,7 @@ use encoding_rs::Encoding;
 use html5ever::{LocalName, Prefix, local_name};
 use js::context::JSContext;
 use js::rust::HandleObject;
+use net_traits::blob_url_store::UrlWithBlobClaim;
 use net_traits::http_status::HttpStatus;
 use net_traits::request::{
     CorsSettings, Destination, ParserMetadata, Referrer, RequestBuilder, RequestId,
@@ -59,13 +60,14 @@ use crate::dom::performance::performanceresourcetiming::InitiatorType;
 use crate::dom::trustedtypes::trustedscript::TrustedScript;
 use crate::dom::trustedtypes::trustedscripturl::TrustedScriptURL;
 use crate::dom::window::Window;
-use crate::fetch::{RequestWithGlobalScope, create_a_potential_cors_request};
+use crate::fetch::{RequestWithGlobalScope, create_a_potential_cors_request_with_claim};
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::script_module::{
     ImportMap, ModuleTree, ScriptFetchOptions, fetch_an_external_module_script,
     fetch_inline_module_script, parse_an_import_map_string, register_import_map,
 };
 use crate::script_runtime::IntroductionType;
+use crate::url::ensure_blob_referenced_by_url_is_kept_alive;
 
 #[dom_struct]
 pub(crate) struct HTMLScriptElement {
@@ -282,7 +284,7 @@ struct ClassicContext {
     /// The response metadata received to date.
     metadata: Option<Metadata>,
     /// The initial URL requested.
-    url: ServoUrl,
+    url: UrlWithBlobClaim,
     /// Indicates whether the request failed, and why
     status: Result<(), NetworkError>,
     /// The fetch options of the script
@@ -358,7 +360,10 @@ impl FetchResponseListener for ClassicContext {
 
         match (response.as_ref(), self.status.as_ref()) {
             (Err(error), _) | (_, Err(error)) => {
-                error!("Fetching classic script failed {:?} ({})", error, self.url);
+                error!(
+                    "Fetching classic script failed {:?} ({:?})",
+                    error, self.url
+                );
                 // Step 6, response is an error.
                 *elem.result.borrow_mut() = Some(Err(()));
                 finish_fetching_a_script(&elem, self.kind, cx);
@@ -464,7 +469,7 @@ impl ResourceTimingListener for ClassicContext {
                 .local_name()
                 .to_string(),
         );
-        (initiator_type, self.url.clone())
+        (initiator_type, self.url.url())
     }
 
     fn resource_timing_global(&self) -> DomRoot<GlobalScope> {
@@ -477,14 +482,14 @@ impl ResourceTimingListener for ClassicContext {
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn script_fetch_request(
     webview_id: WebViewId,
-    url: ServoUrl,
+    url: UrlWithBlobClaim,
     cors_setting: Option<CorsSettings>,
     options: ScriptFetchOptions,
     referrer: Referrer,
 ) -> RequestBuilder {
     // We intentionally ignore options' credentials_mode member for classic scripts.
     // The mode is initialized by create_a_potential_cors_request.
-    create_a_potential_cors_request(
+    create_a_potential_cors_request_with_claim(
         Some(webview_id),
         url,
         Destination::Script,
@@ -502,7 +507,7 @@ pub(crate) fn script_fetch_request(
 fn fetch_a_classic_script(
     script: &HTMLScriptElement,
     kind: ExternalScriptKind,
-    url: ServoUrl,
+    url: UrlWithBlobClaim,
     cors_setting: Option<CorsSettings>,
     options: ScriptFetchOptions,
     character_encoding: &'static Encoding,
@@ -800,6 +805,7 @@ impl HTMLScriptElement {
                     return;
                 },
             };
+            let url = ensure_blob_referenced_by_url_is_kept_alive(global, url);
 
             // Step 31.7. If el is potentially render-blocking, then block rendering on el.
             if self.potentially_render_blocking() && doc.allows_adding_render_blocking_elements() {
@@ -808,7 +814,7 @@ impl HTMLScriptElement {
             }
 
             // Step 31.8. Set el's delaying the load event to true.
-            self.delay_load_event(&delayed_document, url.clone());
+            self.delay_load_event(&delayed_document, url.url());
 
             // Step 31.9. If el is currently render-blocking, then set options's render-blocking to true.
             if self.marked_as_render_blocking.get() {
@@ -827,7 +833,7 @@ impl HTMLScriptElement {
                     if integrity_val_is_none {
                         options.integrity_metadata = global
                             .import_map()
-                            .resolve_a_module_integrity_metadata(&url);
+                            .resolve_a_module_integrity_metadata(&url.url());
                     }
 
                     let script = DomRoot::from_ref(self);

--- a/components/script/dom/servoparser/prefetch.rs
+++ b/components/script/dom/servoparser/prefetch.rs
@@ -13,6 +13,7 @@ use html5ever::tokenizer::{
 use html5ever::{Attribute, LocalName, local_name};
 use js::jsapi::JSTracer;
 use markup5ever::TokenizerResult;
+use net_traits::blob_url_store::UrlWithBlobClaim;
 use net_traits::request::{
     CorsSettings, CredentialsMode, Destination, ParserMetadata, Referrer, RequestClient,
 };
@@ -133,7 +134,7 @@ impl TokenSink for PrefetchSink {
                         .unwrap_or_default();
                     let request = script_fetch_request(
                         self.webview_id,
-                        url,
+                        UrlWithBlobClaim::from_url_without_having_claimed_blob(url),
                         cors_setting,
                         ScriptFetchOptions {
                             referrer_policy: self.referrer_policy,

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -529,7 +529,7 @@ impl DedicatedWorkerGlobalScope {
                             fetch_a_module_worker_script_graph(
                                 cx,
                                 global_scope,
-                                worker_url.url(),
+                                worker_url,
                                 request_client,
                                 Destination::Worker,
                                 referrer,

--- a/components/script/dom/workers/sharedworkerglobalscope.rs
+++ b/components/script/dom/workers/sharedworkerglobalscope.rs
@@ -539,7 +539,7 @@ impl SharedWorkerGlobalScope {
                         fetch_a_module_worker_script_graph(
                             cx,
                             global_scope,
-                            worker_url.url(),
+                            worker_url,
                             request_client,
                             Destination::SharedWorker,
                             referrer,

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -770,6 +770,8 @@ impl RequestWithGlobalScope for RequestBuilder {
 }
 
 /// <https://html.spec.whatwg.org/multipage/#create-a-potential-cors-request>
+/// This function is temporary, since it does not ensure that blob URLs are claimed
+/// appropriately. All callers must migrate to create_a_potential_cors_request_with_claim.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn create_a_potential_cors_request(
     webview_id: Option<WebViewId>,
@@ -779,26 +781,42 @@ pub(crate) fn create_a_potential_cors_request(
     same_origin_fallback: Option<bool>,
     referrer: Referrer,
 ) -> RequestBuilder {
-    RequestBuilder::new(
+    create_a_potential_cors_request_with_claim(
         webview_id,
         UrlWithBlobClaim::from_url_without_having_claimed_blob(url),
+        destination,
+        cors_setting,
+        same_origin_fallback,
         referrer,
     )
-    // Step 1. Let mode be "no-cors" if corsAttributeState is No CORS, and "cors" otherwise.
-    .mode(match cors_setting {
-        Some(_) => RequestMode::CorsMode,
-        // Step 2. If same-origin fallback flag is set and mode is "no-cors", set mode to "same-origin".
-        None if same_origin_fallback == Some(true) => RequestMode::SameOrigin,
-        None => RequestMode::NoCors,
-    })
-    .credentials_mode(match cors_setting {
-        // Step 4. If corsAttributeState is Anonymous, set credentialsMode to "same-origin".
-        Some(CorsSettings::Anonymous) => CredentialsMode::CredentialsSameOrigin,
-        // Step 3. Let credentialsMode be "include".
-        _ => CredentialsMode::Include,
-    })
-    // Step 5. Return a new request whose URL is url, destination is destination,
-    // mode is mode, credentials mode is credentialsMode, and whose use-URL-credentials flag is set.
-    .destination(destination)
-    .use_url_credentials(true)
+}
+
+/// <https://html.spec.whatwg.org/multipage/#create-a-potential-cors-request>
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn create_a_potential_cors_request_with_claim(
+    webview_id: Option<WebViewId>,
+    url: UrlWithBlobClaim,
+    destination: Destination,
+    cors_setting: Option<CorsSettings>,
+    same_origin_fallback: Option<bool>,
+    referrer: Referrer,
+) -> RequestBuilder {
+    RequestBuilder::new(webview_id, url, referrer)
+        // Step 1. Let mode be "no-cors" if corsAttributeState is No CORS, and "cors" otherwise.
+        .mode(match cors_setting {
+            Some(_) => RequestMode::CorsMode,
+            // Step 2. If same-origin fallback flag is set and mode is "no-cors", set mode to "same-origin".
+            None if same_origin_fallback == Some(true) => RequestMode::SameOrigin,
+            None => RequestMode::NoCors,
+        })
+        .credentials_mode(match cors_setting {
+            // Step 4. If corsAttributeState is Anonymous, set credentialsMode to "same-origin".
+            Some(CorsSettings::Anonymous) => CredentialsMode::CredentialsSameOrigin,
+            // Step 3. Let credentialsMode be "include".
+            _ => CredentialsMode::Include,
+        })
+        // Step 5. Return a new request whose URL is url, destination is destination,
+        // mode is mode, credentials mode is credentialsMode, and whose use-URL-credentials flag is set.
+        .destination(destination)
+        .use_url_credentials(true)
 }

--- a/components/script/module_loading.rs
+++ b/components/script/module_loading.rs
@@ -22,6 +22,7 @@ use js::rust::wrappers2::{
     GetRequestedModulesCount, JS_GetModulePrivate, ModuleEvaluate, ModuleLink,
 };
 use js::rust::{HandleValue, IntoHandle};
+use net_traits::blob_url_store::UrlWithBlobClaim;
 use net_traits::request::{Destination, Referrer, RequestClient};
 use script_bindings::reflector::DomObject;
 use script_bindings::settings_stack::run_a_callback;
@@ -39,6 +40,7 @@ use crate::script_module::{
     fetch_a_single_module_script, gen_type_error, module_script_from_reference_private,
 };
 use crate::script_runtime::IntroductionType;
+use crate::url::ensure_blob_referenced_by_url_is_kept_alive;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct OnRejectedHandler {
@@ -478,11 +480,11 @@ pub(crate) fn host_load_imported_module(
         return;
     };
 
-    let url = url.unwrap();
+    let url = ensure_blob_referenced_by_url_is_kept_alive(global, url.unwrap());
 
     // Step 10. Let fetchOptions be the result of getting the descendant script fetch options given
     // originalFetchOptions, url, and settingsObject.
-    let fetch_options = original_fetch_options.descendant_fetch_options(&url, &global_scope);
+    let fetch_options = original_fetch_options.descendant_fetch_options(&url.url(), &global_scope);
 
     // Step 13. If loadState is not undefined, then:
     // Note: loadState is undefined only in dynamic imports
@@ -558,7 +560,7 @@ pub(crate) fn host_load_imported_module(
 #[expect(clippy::too_many_arguments)]
 fn fetch_a_single_imported_module_script(
     cx: &mut JSContext,
-    url: ServoUrl,
+    url: UrlWithBlobClaim,
     fetch_client: RequestClient,
     global: &GlobalScope,
     destination: Destination,

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -38,6 +38,7 @@ use js::rust::wrappers2::{
 };
 use js::rust::{Handle, HandleValue, ToString, transform_str_to_source_text};
 use mime::Mime;
+use net_traits::blob_url_store::UrlWithBlobClaim;
 use net_traits::http_status::HttpStatus;
 use net_traits::mime_classifier::MimeClassifier;
 use net_traits::policy_container::PolicyContainer;
@@ -83,7 +84,6 @@ use crate::network_listener::{self, FetchResponseListener, ResourceTimingListene
 use crate::realms::enter_auto_realm;
 use crate::script_runtime::IntroductionType;
 use crate::task::NonSendTaskBox;
-use crate::url::ensure_blob_referenced_by_url_is_kept_alive;
 
 pub(crate) fn gen_type_error(
     cx: &mut JSContext,
@@ -1166,7 +1166,7 @@ unsafe extern "C" fn import_meta_resolve(cx: *mut RawJSContext, argc: u32, vp: *
 pub(crate) fn fetch_a_module_worker_script_graph(
     cx: &mut JSContext,
     global: &GlobalScope,
-    url: ServoUrl,
+    url: UrlWithBlobClaim,
     fetch_client: RequestClient,
     destination: Destination,
     referrer: Referrer,
@@ -1224,7 +1224,7 @@ pub(crate) fn fetch_a_module_worker_script_graph(
 /// <https://html.spec.whatwg.org/multipage/#fetch-a-module-script-tree>
 pub(crate) fn fetch_an_external_module_script(
     cx: &mut JSContext,
-    url: ServoUrl,
+    url: UrlWithBlobClaim,
     global: &GlobalScope,
     options: ScriptFetchOptions,
     on_complete: impl FnOnce(&mut JSContext, Option<Rc<ModuleTree>>) + Clone + 'static,
@@ -1268,7 +1268,7 @@ pub(crate) fn fetch_an_external_module_script(
 /// <https://html.spec.whatwg.org/multipage/#fetch-a-modulepreload-module-script-graph>
 pub(crate) fn fetch_a_modulepreload_module(
     cx: &mut JSContext,
-    url: ServoUrl,
+    url: UrlWithBlobClaim,
     destination: Destination,
     global: &GlobalScope,
     options: ScriptFetchOptions,
@@ -1460,7 +1460,7 @@ fn fetch_the_descendants_and_link_module_script(
 #[expect(clippy::too_many_arguments)]
 pub(crate) fn fetch_a_single_module_script(
     cx: &mut JSContext,
-    url: ServoUrl,
+    url: UrlWithBlobClaim,
     fetch_client: RequestClient,
     global: &GlobalScope,
     destination: Destination,
@@ -1481,7 +1481,7 @@ pub(crate) fn fetch_a_single_module_script(
     // when inspecting moduleRequest.[[Attributes]] in HostLoadImportedModule or fetch a single imported module script.
 
     // Step 4. Let moduleMap be settingsObject's module map.
-    let module_request = (url.clone(), module_type);
+    let module_request = (url.url(), module_type);
     let entry = global.get_module_map_entry(&module_request);
 
     let pending = match entry {
@@ -1572,20 +1572,16 @@ pub(crate) fn fetch_a_single_module_script(
         // TODO Step 11. Set request's initiator type to "script".
 
         // Step 12. Set up the module script request given request and options.
-        let request = RequestBuilder::new(
-            global.webview_id(),
-            ensure_blob_referenced_by_url_is_kept_alive(global, url.clone()),
-            referrer,
-        )
-        .destination(destination)
-        .parser_metadata(options.parser_metadata)
-        .integrity_metadata(options.integrity_metadata.clone())
-        .credentials_mode(options.credentials_mode)
-        .referrer_policy(options.referrer_policy)
-        .mode(mode)
-        .cryptographic_nonce_metadata(options.cryptographic_nonce.clone())
-        .client(fetch_client)
-        .pipeline_id(Some(global.pipeline_id()));
+        let request = RequestBuilder::new(global.webview_id(), url, referrer)
+            .destination(destination)
+            .parser_metadata(options.parser_metadata)
+            .integrity_metadata(options.integrity_metadata.clone())
+            .credentials_mode(options.credentials_mode)
+            .referrer_policy(options.referrer_policy)
+            .mode(mode)
+            .cryptographic_nonce_metadata(options.cryptographic_nonce.clone())
+            .client(fetch_client)
+            .pipeline_id(Some(global.pipeline_id()));
 
         let context = ModuleContext {
             owner: Trusted::new(global),

--- a/tests/wpt/meta/FileAPI/url/sandboxed-iframe.html.ini
+++ b/tests/wpt/meta/FileAPI/url/sandboxed-iframe.html.ini
@@ -1,8 +1,5 @@
 [sandboxed-iframe.html]
   expected: TIMEOUT
-  [Blob URLs can be used in <script> tags]
-    expected: TIMEOUT
-
   [Blob URLs can be used in iframes, and are treated same origin]
     expected: FAIL
 

--- a/tests/wpt/meta/fetch/corb/script-html-via-cross-origin-blob-url.sub.html.ini
+++ b/tests/wpt/meta/fetch/corb/script-html-via-cross-origin-blob-url.sub.html.ini
@@ -1,2 +1,0 @@
-[script-html-via-cross-origin-blob-url.sub.html]
-  expected: ERROR

--- a/tests/wpt/meta/fetch/corb/script-html-via-cross-origin-blob-url.sub.html.ini
+++ b/tests/wpt/meta/fetch/corb/script-html-via-cross-origin-blob-url.sub.html.ini
@@ -1,4 +1,2 @@
 [script-html-via-cross-origin-blob-url.sub.html]
   expected: ERROR
-  [script-html-via-cross-origin-blob-url]
-    expected: FAIL

--- a/tests/wpt/meta/fetch/metadata/generated/css-font-face.sub.tentative.html.ini
+++ b/tests/wpt/meta/fetch/metadata/generated/css-font-face.sub.tentative.html.ini
@@ -1,4 +1,4 @@
-[scss-font-face.sub.tentative.html]
+[css-font-face.sub.tentative.html]
   [sec-fetch-site - Not sent to non-trustworthy same-origin destination]
     expected: [FAIL, PASS]
 
@@ -26,7 +26,6 @@
   [sec-fetch-dest - Not sent to non-trustworthy cross-site destination]
     expected: [FAIL, PASS]
 
-[css-font-face.sub.tentative.html]
   [sec-fetch-site - HTTPS downgrade (header not sent)]
     expected: FAIL
 

--- a/tests/wpt/meta/fetch/metadata/generated/css-font-face.sub.tentative.html.ini
+++ b/tests/wpt/meta/fetch/metadata/generated/css-font-face.sub.tentative.html.ini
@@ -1,4 +1,4 @@
-[css-font-face.sub.tentative.html]
+[scss-font-face.sub.tentative.html]
   [sec-fetch-site - Not sent to non-trustworthy same-origin destination]
     expected: [FAIL, PASS]
 
@@ -26,6 +26,7 @@
   [sec-fetch-dest - Not sent to non-trustworthy cross-site destination]
     expected: [FAIL, PASS]
 
+[css-font-face.sub.tentative.html]
   [sec-fetch-site - HTTPS downgrade (header not sent)]
     expected: FAIL
 

--- a/tests/wpt/tests/FileAPI/url/url-in-tags-revoke.window.js
+++ b/tests/wpt/tests/FileAPI/url/url-in-tags-revoke.window.js
@@ -94,10 +94,29 @@ async_test(t => {
   e.onload = t.step_func_done(() => {
     assert_equals(window.script_test_result, run_result);
   });
+  e.onerror = t.unreached_func();
 
   document.body.appendChild(e);
   URL.revokeObjectURL(url);
 }, 'Fetching a blob URL immediately before revoking it works in <script> tags.');
+
+async_test(t => {
+  const run_result = 'test_script_OK';
+  const blob_contents = 'window.script_test_result = "' + run_result + '";';
+  const blob = new Blob([blob_contents], {type: "application/javascript"});
+  const url = URL.createObjectURL(blob);
+
+  const e = document.createElement('script');
+  e.setAttribute('src', url);
+  e.setAttribute('type', 'module');
+  e.onload = t.step_func_done(() => {
+    assert_equals(window.script_test_result, run_result);
+  });
+  e.onerror = t.unreached_func();
+
+  document.body.appendChild(e);
+  URL.revokeObjectURL(url);
+}, 'Fetching a blob URL immediately before revoking it works in module <script> tags.');
 
 async_test(t => {
   const channel_name = 'a-click-test';

--- a/tests/wpt/tests/FileAPI/url/url-in-tags.window.js
+++ b/tests/wpt/tests/FileAPI/url/url-in-tags.window.js
@@ -16,9 +16,27 @@ async_test(t => {
   e.onload = t.step_func_done(() => {
     assert_equals(window.test_result, run_result);
   });
+  e.onerror = t.unreached_func();
 
   document.body.appendChild(e);
 }, 'Blob URLs can be used in <script> tags');
+
+async_test(t => {
+  const run_result = 'test_script_OK';
+  const blob_contents = 'window.test_result = "' + run_result + '";';
+  const blob = new Blob([blob_contents], {type: 'application/javascript'});
+  const url = URL.createObjectURL(blob);
+
+  const e = document.createElement('script');
+  e.setAttribute('src', url);
+  e.setAttribute('type', 'module');
+  e.onload = t.step_func_done(() => {
+    assert_equals(window.test_result, run_result);
+  });
+  e.onerror = t.unreached_func();
+
+  document.body.appendChild(e);
+}, 'Blob URLs can be used in module <script> tags');
 
 async_test(t => {
   const run_result = 'test_frame_OK';


### PR DESCRIPTION
These changes push forward the blob URL claim migration a bit further, now making it possible for other callers of create_potential_cors_request to be migrated incrementally. The UrlWithBlobClaim type ensures that any blob URL referenced remains valid while the value is alive, even if the blob is revoked.

Testing: Previously intermittent test now passes consistently. Added new module-specific tests as well.
Part of #25226
Fixes: #19978
