### PR TITLE
script: More consistent compareDocumentPosition for disconnected nodes

### DIFF
--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -4197,16 +4197,18 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
                     .collect::<SmallVec<[_; 20]>>();
 
                 if self_and_ancestors.last() != other_and_ancestors.last() {
-                    let random = as_uintptr(self_and_ancestors.last().unwrap()) <
-                        as_uintptr(other_and_ancestors.last().unwrap());
-                    let random = if random {
+                    // Auto-deref and compare the addresses of GC-owned `&Node`s,
+                    // more stable than addresses of SmallVec-owned `&Root<Dom<Node>>`
+                    let arbitrary = as_uintptr::<Node>(self_and_ancestors.last().unwrap()) <
+                        as_uintptr::<Node>(other_and_ancestors.last().unwrap());
+                    let arbitrary = if arbitrary {
                         NodeConstants::DOCUMENT_POSITION_FOLLOWING
                     } else {
                         NodeConstants::DOCUMENT_POSITION_PRECEDING
                     };
 
                     // Disconnected.
-                    return random +
+                    return arbitrary +
                         NodeConstants::DOCUMENT_POSITION_DISCONNECTED +
                         NodeConstants::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC;
                 }

--- a/tests/wpt/tests/dom/nodes/Node-compareDocumentPosition.html
+++ b/tests/wpt/tests/dom/nodes/Node-compareDocumentPosition.html
@@ -29,13 +29,22 @@ testNodes.forEach(function(referenceName) {
       // constraint that this is to be consistent, together and terminate these
       // steps."
       if (furthestAncestor(reference) !== furthestAncestor(other)) {
-        // TODO: Test that it's consistent.
-        assert_in_array(result, [Node.DOCUMENT_POSITION_DISCONNECTED +
-                                 Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC +
-                                 Node.DOCUMENT_POSITION_PRECEDING,
-                                 Node.DOCUMENT_POSITION_DISCONNECTED +
-                                 Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC +
-                                 Node.DOCUMENT_POSITION_FOLLOWING]);
+        var expected1 = Node.DOCUMENT_POSITION_DISCONNECTED +
+                        Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC +
+                        Node.DOCUMENT_POSITION_PRECEDING;
+        var expected2 = Node.DOCUMENT_POSITION_DISCONNECTED +
+                        Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC +
+                        Node.DOCUMENT_POSITION_FOLLOWING;
+        assert_in_array(result, [expected1, expected2]);
+
+        // TODO: What does "consistent" mean exactly? Is it transitive? A total order?
+        // Here we test that the relation is anticommutative: a < b => b > a; a > b => b < a
+        var anticommutativeResult = other.compareDocumentPosition(reference);
+        if (result === expected1) {
+          assert_equals(anticommutativeResult, expected2);
+        } else {
+          assert_equals(anticommutativeResult, expected1);
+        }
         return;
       }
 


### PR DESCRIPTION
When comparing disconnected nodes by pointer addresses, use stable GC-owned pointers rather than temporary pointers to pointers.

Testing: extending WPT to test the relation is anti-commutative (`a < b => b < a`) and manually checking that it fails before the code change
