### PR TITLE
Skip selection offsets when an entire node is selected

### DIFF
--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -8,7 +8,7 @@ use std::ops::{ControlFlow, Range};
 
 use icu_properties::BidiClass;
 use layout_api::{LayoutNode, SharedSelection};
-use servo_base::text::Utf32CodeUnits;
+use servo_base::text::{RangeAny, Utf32CodeUnits};
 use style::computed_values::direction::T as Direction;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::dom::NodeInfo;
@@ -336,10 +336,28 @@ impl InlineFormattingContextBuilder {
             return false;
         }
 
-        let intersect_ranges = |a: Range<Utf32CodeUnits>, b: Range<Utf32CodeUnits>| {
-            let start = a.start.max(b.start);
-            let end = b.end.min(b.end);
-            if start < end { Some(start..end) } else { None }
+        let intersect_ranges = |a: RangeAny<Utf32CodeUnits>, b: RangeAny<Utf32CodeUnits>| {
+            // TODO: https://github.com/rust-lang/rust/issues/144273
+            // let start = a.start.reduce(b.start, std::cmp::max);
+            // let end = a.end.reduce(b.end, std::cmp::min);
+            let start = match (a.start, b.start) {
+                (None, None) => None,
+                (None, Some(b)) => Some(b),
+                (Some(a), None) => Some(a),
+                (Some(a), Some(b)) => Some(a.max(b)),
+            };
+            let end = match (a.end, b.end) {
+                (None, None) => None,
+                (None, Some(b)) => Some(b),
+                (Some(a), None) => Some(a),
+                (Some(a), Some(b)) => Some(a.min(b)),
+            };
+            if start.is_none_or(|s| end.is_none_or(|e| s < e)) {
+                Some(RangeAny { start, end })
+            } else {
+                // `max()..min()` producing a "backwards" range means the intersection is empty
+                None
+            }
         };
 
         // Push any leading white space first.
@@ -350,9 +368,11 @@ impl InlineFormattingContextBuilder {
         if first_letter_range.start != 0 {
             let leading_whitespace_range = 0..first_letter_range.start;
             let leading_whitespace_selection_range =
-                document_selection.clone().and_then(|document_selection| {
-                    let leading_whitespace_range_u32 =
-                        Utf32CodeUnits::zero()..first_letter_range_u32.start;
+                document_selection.and_then(|document_selection| {
+                    let leading_whitespace_range_u32 = RangeAny {
+                        start: None,
+                        end: Some(first_letter_range_u32.start),
+                    };
                     intersect_ranges(document_selection, leading_whitespace_range_u32)
                 });
 
@@ -372,15 +392,10 @@ impl InlineFormattingContextBuilder {
         box_slot.set(LayoutBox::InlineLevel(inline_item));
 
         let first_letter_text = Cow::Borrowed(&text[first_letter_range.clone()]);
-        let first_letter_selection_range =
-            document_selection.clone().and_then(|document_selection| {
-                intersect_ranges(document_selection, (*first_letter_range_u32).clone()).map(
-                    |range| {
-                        range.start - first_letter_range_u32.start..
-                            range.end - first_letter_range_u32.start
-                    },
-                )
-            });
+        let first_letter_selection_range = document_selection.and_then(|document_selection| {
+            intersect_ranges(document_selection, (*first_letter_range_u32).clone().into())
+                .map(|range| range.map(|x| x - first_letter_range_u32.start))
+        });
         self.push_text(
             first_letter_text.into(),
             &first_letter_info,
@@ -391,10 +406,12 @@ impl InlineFormattingContextBuilder {
 
         // Now push the non-first-letter text.
         let remaining_selection_range = document_selection.and_then(|document_selection| {
-            let remaining_text_range_u32 = first_letter_range_u32.end..document_selection.end;
-            intersect_ranges(document_selection, remaining_text_range_u32).map(|range| {
-                range.start - first_letter_range_u32.end..range.end - first_letter_range_u32.end
-            })
+            let remaining_text_range_u32 = RangeAny {
+                start: Some(first_letter_range_u32.end),
+                end: document_selection.end,
+            };
+            intersect_ranges(document_selection, remaining_text_range_u32)
+                .map(|range| range.map(|x| x - first_letter_range_u32.end))
         });
         self.push_text(
             Cow::Borrowed(&text[first_letter_range.end..]).into(),
@@ -409,7 +426,7 @@ impl InlineFormattingContextBuilder {
         &mut self,
         text: BoxTreeString<'dom>,
         info: &NodeAndStyleInfo<'dom>,
-        document_selection: Option<Range<Utf32CodeUnits>>,
+        document_selection: Option<RangeAny<Utf32CodeUnits>>,
     ) {
         let bidi_class_map = icu_properties::maps::bidi_class();
         let white_space_collapse = info.style.clone_white_space_collapse();
@@ -457,10 +474,19 @@ impl InlineFormattingContextBuilder {
         }
 
         let document_selection = document_selection.map(|document_selection| {
-            self.offset_map
-                .map(original_size_before + document_selection.start)..
-                self.offset_map
-                    .map(original_size_before + document_selection.end)
+            let start = if let Some(start) = document_selection.start {
+                self.offset_map.map(start)
+            } else {
+                // Range unbounded at the start: the concrete start is offset zero
+                Utf32CodeUnits(0)
+            };
+            let end = if let Some(end) = document_selection.end {
+                self.offset_map.map(end)
+            } else {
+                // Range unbounded at the end: the concrete end is the full length
+                Utf32CodeUnits(character_count)
+            };
+            original_size_before + start..original_size_before + end
         });
 
         if let Some(last_character) = new_text.chars().next_back() {

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -336,30 +336,6 @@ impl InlineFormattingContextBuilder {
             return false;
         }
 
-        let intersect_ranges = |a: RangeAny<Utf32CodeUnits>, b: RangeAny<Utf32CodeUnits>| {
-            // TODO: https://github.com/rust-lang/rust/issues/144273
-            // let start = a.start.reduce(b.start, std::cmp::max);
-            // let end = a.end.reduce(b.end, std::cmp::min);
-            let start = match (a.start, b.start) {
-                (None, None) => None,
-                (None, Some(b)) => Some(b),
-                (Some(a), None) => Some(a),
-                (Some(a), Some(b)) => Some(a.max(b)),
-            };
-            let end = match (a.end, b.end) {
-                (None, None) => None,
-                (None, Some(b)) => Some(b),
-                (Some(a), None) => Some(a),
-                (Some(a), Some(b)) => Some(a.min(b)),
-            };
-            if start.is_none_or(|s| end.is_none_or(|e| s < e)) {
-                Some(RangeAny { start, end })
-            } else {
-                // `max()..min()` producing a "backwards" range means the intersection is empty
-                None
-            }
-        };
-
         // Push any leading white space first.
         let first_letter_range_u32 = LazyCell::new(|| {
             Utf32CodeUnits::length_of(&text[..first_letter_range.start])..
@@ -373,7 +349,7 @@ impl InlineFormattingContextBuilder {
                         start: None,
                         end: Some(first_letter_range_u32.start),
                     };
-                    intersect_ranges(document_selection, leading_whitespace_range_u32)
+                    document_selection.intersect(leading_whitespace_range_u32)
                 });
 
             self.push_text(
@@ -393,8 +369,9 @@ impl InlineFormattingContextBuilder {
 
         let first_letter_text = Cow::Borrowed(&text[first_letter_range.clone()]);
         let first_letter_selection_range = document_selection.and_then(|document_selection| {
-            intersect_ranges(document_selection, (*first_letter_range_u32).clone().into())
-                .map(|range| range.map(|x| x - first_letter_range_u32.start))
+            document_selection
+                .intersect((*first_letter_range_u32).clone().into())
+                .map(|range| range.map(|offset| offset - first_letter_range_u32.start))
         });
         self.push_text(
             first_letter_text.into(),
@@ -410,8 +387,9 @@ impl InlineFormattingContextBuilder {
                 start: Some(first_letter_range_u32.end),
                 end: document_selection.end,
             };
-            intersect_ranges(document_selection, remaining_text_range_u32)
-                .map(|range| range.map(|x| x - first_letter_range_u32.end))
+            document_selection
+                .intersect(remaining_text_range_u32)
+                .map(|range| range.map(|offset| offset - first_letter_range_u32.end))
         });
         self.push_text(
             Cow::Borrowed(&text[first_letter_range.end..]).into(),
@@ -474,18 +452,16 @@ impl InlineFormattingContextBuilder {
         }
 
         let document_selection = document_selection.map(|document_selection| {
-            let start = if let Some(start) = document_selection.start {
-                self.offset_map.map(start)
-            } else {
+            let start = document_selection
+                .start
+                .map(|offset| self.offset_map.map(offset))
                 // Range unbounded at the start: the concrete start is offset zero
-                Utf32CodeUnits(0)
-            };
-            let end = if let Some(end) = document_selection.end {
-                self.offset_map.map(end)
-            } else {
+                .unwrap_or(Utf32CodeUnits(0));
+            let end = document_selection
+                .end
+                .map(|offset| self.offset_map.map(offset))
                 // Range unbounded at the end: the concrete end is the full length
-                Utf32CodeUnits(character_count)
-            };
+                .unwrap_or(Utf32CodeUnits(character_count));
             original_size_before + start..original_size_before + end
         });
 

--- a/components/script/dom/node/layout_dom.rs
+++ b/components/script/dom/node/layout_dom.rs
@@ -4,8 +4,6 @@
 
 //! Methods for layout of node
 
-use std::ops::Range;
-
 use atomic_refcell::AtomicRef;
 use layout_api::{
     GenericLayoutData, HTMLCanvasData, HTMLMediaData, LayoutElementType, LayoutNodeType,
@@ -17,7 +15,7 @@ use script_bindings::codegen::InheritTypes::{
     ElementTypeId, HTMLElementTypeId, SVGElementTypeId, SVGGraphicsElementTypeId,
 };
 use servo_base::id::{BrowsingContextId, PipelineId};
-use servo_base::text::Utf32CodeUnits;
+use servo_base::text::{RangeAny, Utf32CodeUnits};
 use servo_url::ServoUrl;
 use style::dom::OpaqueNode;
 use style::selector_parser::PseudoElement;
@@ -249,7 +247,7 @@ impl<'dom> LayoutDom<'dom, Node> {
     }
 
     #[expect(unsafe_code)]
-    pub(crate) fn document_selection_in_text_node(&self) -> Option<Range<Utf32CodeUnits>> {
+    pub(crate) fn document_selection_in_text_node(&self) -> Option<RangeAny<Utf32CodeUnits>> {
         let unsafe_self = self.unsafe_get();
         if !unsafe_self.get_flag(NodeFlags::OVERLAPS_DOCUMENT_SELECTION) {
             return None;
@@ -271,19 +269,9 @@ impl<'dom> LayoutDom<'dom, Node> {
         let is_start_node = unsafe { range_start.node().to_layout() } == *self;
         let is_end_node = unsafe { range_end.node().to_layout() } == *self;
 
-        let start_offset = if is_start_node {
-            range_start.offset().to_utf32_code_units_in(&text)
-        } else {
-            Utf32CodeUnits(0)
-        };
-
-        let end_offset = if is_end_node {
-            range_end.offset().to_utf32_code_units_in(&text)
-        } else {
-            Utf32CodeUnits::length_of(&text)
-        };
-
-        Some(start_offset..end_offset)
+        let start = is_start_node.then(|| range_start.offset().to_utf32_code_units_in(&text));
+        let end = is_end_node.then(|| range_end.offset().to_utf32_code_units_in(&text));
+        Some(RangeAny { start, end })
     }
 
     /// Get the selection for the given node. This only works for text nodes that are in

--- a/components/script/layout_dom/servo_layout_node.rs
+++ b/components/script/layout_dom/servo_layout_node.rs
@@ -6,7 +6,6 @@
 #![deny(missing_docs)]
 
 use std::fmt;
-use std::ops::Range;
 
 use atomic_refcell::AtomicRef;
 use layout_api::{
@@ -17,7 +16,7 @@ use net_traits::image_cache::Image;
 use pixels::ImageMetadata;
 use servo_arc::Arc;
 use servo_base::id::{BrowsingContextId, PipelineId};
-use servo_base::text::Utf32CodeUnits;
+use servo_base::text::{RangeAny, Utf32CodeUnits};
 use servo_url::ServoUrl;
 use style;
 use style::context::SharedStyleContext;
@@ -248,7 +247,7 @@ impl<'dom> LayoutNode<'dom> for ServoLayoutNode<'dom> {
         self.node.text_content()
     }
 
-    fn document_selection_in_text_node(&self) -> Option<Range<Utf32CodeUnits>> {
+    fn document_selection_in_text_node(&self) -> Option<RangeAny<Utf32CodeUnits>> {
         // Pseudo-elements do not ever have document selection.
         if !self.pseudo_element_chain.is_empty() {
             return None;

--- a/components/shared/base/text.rs
+++ b/components/shared/base/text.rs
@@ -59,11 +59,43 @@ pub struct RangeAny<T> {
 }
 
 impl<T> RangeAny<T> {
+    /// Apply `Option::map` to each bound of this range
     pub fn map<U>(self, f: impl Fn(T) -> U + Copy) -> RangeAny<U> {
         let Self { start, end } = self;
         RangeAny {
             start: start.map(f),
             end: end.map(f),
+        }
+    }
+
+    /// Returns the intersection of two ranges, if it is non-empty
+    pub fn intersect(self, other: Self) -> Option<Self>
+    where
+        T: Ord,
+    {
+        // TODO: https://github.com/rust-lang/rust/issues/144273
+        // let start = a.start.reduce(b.start, std::cmp::max);
+        // let end = a.end.reduce(b.end, std::cmp::min);
+        let start = match (self.start, other.start) {
+            (None, None) => None,
+            (None, Some(b)) => Some(b),
+            (Some(a), None) => Some(a),
+            (Some(a), Some(b)) => Some(a.max(b)),
+        };
+        let end = match (self.end, other.end) {
+            (None, None) => None,
+            (None, Some(b)) => Some(b),
+            (Some(a), None) => Some(a),
+            (Some(a), Some(b)) => Some(a.min(b)),
+        };
+        if start
+            .as_ref()
+            .is_none_or(|start| end.as_ref().is_none_or(|end| start < end))
+        {
+            Some(RangeAny { start, end })
+        } else {
+            // `max()..min()` producing a "backwards" range means the intersection is empty
+            None
         }
     }
 }

--- a/components/shared/base/text.rs
+++ b/components/shared/base/text.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::iter::Sum;
-use std::ops::{Add, AddAssign, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Range, Sub, SubAssign};
 
 use malloc_size_of_derive::MallocSizeOf;
 
@@ -47,6 +47,34 @@ pub fn is_cjk(codepoint: char) -> bool {
     // https://en.wikipedia.org/wiki/Plane_(Unicode)#Supplementary_Ideographic_Plane
     // https://en.wikipedia.org/wiki/Plane_(Unicode)#Tertiary_Ideographic_Plane
     unicode_plane(codepoint) == 2 || unicode_plane(codepoint) == 3
+}
+
+/// Equivalent to either `Range`, `RangeTo`, `RangeFrom`, or `RangeFull`
+#[derive(Clone, Copy)]
+pub struct RangeAny<T> {
+    /// `None` means zero
+    pub start: Option<T>,
+    /// `None` means the full available length
+    pub end: Option<T>,
+}
+
+impl<T> RangeAny<T> {
+    pub fn map<U>(self, f: impl Fn(T) -> U + Copy) -> RangeAny<U> {
+        let Self { start, end } = self;
+        RangeAny {
+            start: start.map(f),
+            end: end.map(f),
+        }
+    }
+}
+
+impl<T> From<Range<T>> for RangeAny<T> {
+    fn from(value: Range<T>) -> Self {
+        Self {
+            start: Some(value.start),
+            end: Some(value.end),
+        }
+    }
 }
 
 macro_rules! unicode_length_type {

--- a/components/shared/layout/layout_node.rs
+++ b/components/shared/layout/layout_node.rs
@@ -6,14 +6,13 @@
 #![deny(missing_docs)]
 
 use std::fmt::Debug;
-use std::ops::Range;
 
 use atomic_refcell::AtomicRef;
 use net_traits::image_cache::Image;
 use pixels::ImageMetadata;
 use servo_arc::Arc;
 use servo_base::id::{BrowsingContextId, PipelineId};
-use servo_base::text::Utf32CodeUnits;
+use servo_base::text::{RangeAny, Utf32CodeUnits};
 use servo_url::ServoUrl;
 use style::context::SharedStyleContext;
 use style::dom::{NodeInfo, OpaqueNode, TNode};
@@ -174,7 +173,7 @@ pub trait LayoutNode<'dom>: Copy + Debug + NodeInfo + Send + Sync {
     /// For a text node, returns which range of this text is part of the document selection
     ///
     /// Returned offsets are counted in `char`s in the `self.text_content()` string.
-    fn document_selection_in_text_node(&self) -> Option<Range<Utf32CodeUnits>>;
+    fn document_selection_in_text_node(&self) -> Option<RangeAny<Utf32CodeUnits>>;
 
     /// If this node manages a selection, this returns the shared selection for the node.
     fn selection(&self) -> Option<SharedSelection>;


### PR DESCRIPTION
When many DOM nodes are part of the selection many of them are known to be entirely selected and computing any offset is not needed. Instead of always carrying a range (start/end pair) of offsets, this PR introduces a new `RangeAny` type where both bounds are optional, with a missing bound meaning unbounded on that side. For nodes that are entirely selected, the selection range is unbounded on both sides and no offset computation is needed. The computation skipped includes converting between UTF-8/UTF-16/UTF-32 offsets, and lookups in `OffsetMap` to compensate for whitespace collapsing and `text-transform`.

Testing: expecting no behavior change and no change in WPT test results
