### PR TITLE
media: avoid crash in pulsesink

### DIFF
--- a/components/media/backends/gstreamer/lib.rs
+++ b/components/media/backends/gstreamer/lib.rs
@@ -103,6 +103,22 @@ impl GStreamerBackend {
             }
         }
 
+        // This is a workaround for a race condition in GStreamer. Real fix is
+        // in
+        // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/12194
+        // . This will hold a connection to the server but it won't create
+        // streams. This happens during READY -> PAUSED.
+        #[cfg(target_os = "linux")]
+        {
+            static PULSESINK_KEEPALIVE: std::sync::OnceLock<Option<gstreamer::Element>> =
+                std::sync::OnceLock::new();
+            PULSESINK_KEEPALIVE.get_or_init(|| {
+                let sink = gstreamer::ElementFactory::make("pulsesink").build().ok()?;
+                sink.set_state(gstreamer::State::Ready).ok()?;
+                Some(sink)
+            });
+        }
+
         let mut errors = vec![];
         for plugin in plugins {
             let mut path = plugin_dir.clone();


### PR DESCRIPTION
Hold a reference to pulsesink to avoid the crash. Real fix will be in https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/12194 .

Fixes: https://github.com/servo/servo/issues/46251
