### PR TITLE
script: Ignore http status code error in image fetching

### DIFF
--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -16,7 +16,6 @@ use html5ever::{LocalName, Prefix, QualName, local_name, ns};
 use js::context::JSContext;
 use js::rust::HandleObject;
 use mime::{self, Mime};
-use net_traits::http_status::HttpStatus;
 use net_traits::image_cache::{
     Image, ImageCache, ImageCacheResult, ImageLoadListener, ImageOrMetadataAvailable,
     ImageResponse, PendingImageId,
@@ -274,24 +273,13 @@ impl FetchResponseListener for ImageContext {
             }
         }
 
-        let status = metadata
-            .as_ref()
-            .map(|m| m.status.clone())
-            .unwrap_or_else(HttpStatus::new_error);
-
-        self.status = {
-            if status.is_error() {
-                Err(NetworkError::ResourceLoadError(
-                    "No http status code received".to_owned(),
-                ))
-            } else if status.is_success() {
-                Ok(())
-            } else {
-                Err(NetworkError::ResourceLoadError(format!(
-                    "HTTP error code {}",
-                    status.code()
-                )))
-            }
+        // The HTTP status code is ignored here. Ok NetworkError is treated
+        // as real error
+        self.status = match metadata.as_ref().map(|m| m.status.clone()) {
+            None => Err(NetworkError::ResourceLoadError(
+                "No http status code received".to_owned(),
+            )),
+            Some(_) => Ok(()),
         };
     }
 

--- a/tests/wpt/meta/html/semantics/embedded-content/the-img-element/404-response-with-actual-image-data.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-img-element/404-response-with-actual-image-data.html.ini
@@ -1,3 +1,0 @@
-[404-response-with-actual-image-data.html]
-  [404 response with actual image data should be rendered and load event is fired]
-    expected: FAIL

--- a/tests/wpt/meta/preload/preload-error.sub.html.ini
+++ b/tests/wpt/meta/preload/preload-error.sub.html.ini
@@ -13,6 +13,3 @@
 
   [MIME-blocked-nosniff (style): preload events]
     expected: FAIL
-
-  [404 (image): main]
-    expected: FAIL


### PR DESCRIPTION
According to the issue, this PR simplified the status in HTMLImageElement.
In image fetching, the returned HTTP status code is no longer checked.
As long as the image data can be successfully decoded
an error HTML like 404 will be ignored, and set the status to Ok(())

Testing: After this change, there are two test cases in wpt that respond 404 while fetching image will become PASS.

Fixes: https://github.com/servo/servo/issues/46696