### PR TITLE
build: Support Homebrew GStreamer on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ For more detailed build instructions, see the Servo Book under [Getting the Code
 - Install `uv`: `curl -LsSf https://astral.sh/uv/install.sh | sh` 
 - Install `rustup`: `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
 - Restart your shell to make sure `cargo` is available
+- Install GStreamer (one of the following):
+  - **Option A — Official installer (recommended):**
+    Download and install both packages from https://gstreamer.freedesktop.org/download/:
+    - Runtime: `gstreamer-1.0-<version>-universal.pkg`
+    - Development: `gstreamer-1.0-devel-<version>-universal.pkg`
+  - **Option B — Homebrew:**
+    ```shell
+    brew install gstreamer libnice-gstreamer
+    ```
 - Install the other dependencies: `./mach bootstrap`
 - Build servoshell: `./mach build`
 

--- a/python/servo/platform/macos.py
+++ b/python/servo/platform/macos.py
@@ -32,13 +32,44 @@ class MacOS(Base):
 
     def gstreamer_root(self, target: BuildTarget) -> Optional[str]:
         # We do not support building with gstreamer while cross-compiling on MacOS.
-        if target.is_cross_build() or not os.path.exists(GSTREAMER_ROOT):
+        if target.is_cross_build():
             return None
-        return GSTREAMER_ROOT
+        if os.path.exists(GSTREAMER_ROOT):
+            return GSTREAMER_ROOT
+        try:
+            import subprocess
+            result = subprocess.run(
+                ["pkg-config", "--variable=prefix", "gstreamer-1.0"],
+                capture_output=True, text=True, timeout=5
+            )
+            if result.returncode == 0:
+                prefix = result.stdout.strip()
+                if os.path.exists(prefix):
+                    return prefix
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            pass
+        return None
 
     def is_gstreamer_installed(self, target: BuildTarget) -> bool:
+        if target.is_cross_build():
+            return False
         # Servo only supports the official GStreamer distribution on MacOS.
-        return not target.is_cross_build() and os.path.exists(GSTREAMER_ROOT)
+        if os.path.exists(GSTREAMER_ROOT):
+            return True
+        try:
+            import subprocess
+            result = subprocess.run(
+                ["pkg-config", "--modversion", "gstreamer-1.0"],
+                capture_output=True, text=True, timeout=5
+            )
+            if result.returncode == 0:
+                version = result.stdout.strip()
+                major, minor, *_ = version.split(".")
+                if int(major) >= 1 and int(minor) >= 18:
+                    return True
+        except (FileNotFoundError, subprocess.TimeoutExpired, ValueError):
+            pass
+        return False
 
     def _platform_bootstrap(self, force: bool, yes: bool) -> bool:
         installed_something = False


### PR DESCRIPTION
Hi there, I found this project after finding [Igalia](https://www.igalia.com/), and found it interesting. First I've tried it on my android phone and decided to give a try on first steps checking if I would be able to contribute to it. First thing I faced was being able to link GStreamer on macos. So I got together with the llm agent and was able to get it compiled and running on my machine. So I've changed the README adding instructions for installing GStreamer from both pkg and homebrew (macos package manager) and changed the python scripts so it can use the homebrew GStreamer. 

I've also took care to mention the llm coding agent as linux kernel requires it to be reported by the `Assisted-by` on the commit. Btw according to pi built in cost tracker the hole investigation and changes costed me $0.035 usd. 

Following commit description generated by the llm coding agent
 
> Accept Homebrew GStreamer installations via pkg-config when the official GStreamer.framework is not found. This allows building Servo on macOS with either the official GStreamer installer or Homebrew.
> 
> Update README to document both installation options.
> 
> Assisted-by: MiMo-v2.5-pro:1T pi-0.83.0

I was able to run servo and navigate around using `./mach run https://duckduckgo.com ` command 
