### PR TITLE
layout: Paint outlines below positioned descendants

### DIFF
--- a/components/layout/display_list/paint_traversal.rs
+++ b/components/layout/display_list/paint_traversal.rs
@@ -84,6 +84,22 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
             self.traverse_stacking_context_inner(&state, root_fragment);
         }
 
+        // > Step 11: If the UA uses out-of-band outlines, draw all of root’s outlines
+        // > (those that it skipped drawing due to not using in-band outlines during the
+        // > current invocation of this algorithm) into canvas.
+        //
+        // Unlike in the specification, this is done before painting positioned descendants
+        // (steps 9 and 10). The specification allows painting outlines either in-band
+        // (under all in-flow content) or out-of-band (over everything), but other browsers
+        // paint outlines above in-flow content and negative `z-index` descendants, yet
+        // below positioned descendants with `z-index: auto` or higher.
+        // See <https://github.com/servo/servo/issues/46686>.
+        if old_outlines_length < self.outlines.len() {
+            for (state, outline_fragment) in &self.outlines.split_off(old_outlines_length) {
+                self.handler.visit_box_for_outline(state, outline_fragment);
+            }
+        }
+
         // > Step 9: For each of root’s positioned descendants with z-index: auto or
         // > z-index: 0, in tree order:
         // >   ↪ descendant has z-index: auto
@@ -97,15 +113,6 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
         for child in children {
             assert!(child.z_index >= 0);
             self.traverse_stacking_context(&state, child);
-        }
-
-        // > Step 11: If the UA uses out-of-band outlines, draw all of root’s outlines
-        // > (those that it skipped drawing due to not using in-band outlines during the
-        // > current invocation of this algorithm) into canvas.
-        if old_outlines_length < self.outlines.len() {
-            for (state, outline_fragment) in &self.outlines.split_off(old_outlines_length) {
-                self.handler.visit_box_for_outline(state, outline_fragment);
-            }
         }
 
         self.handler

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -8048,6 +8048,19 @@
       ]
      ]
     },
+    "outline-below-positioned-descendants.html": [
+     "06cf1afb74054b1b782e300fcb1483562be97dfe",
+     [
+      null,
+      [
+       [
+        "/_mozilla/mozilla/outline-below-positioned-descendants-ref.html",
+        "=="
+       ]
+      ],
+      {}
+     ]
+    ],
     "partial-shadow-dom-layout-style.html": [
      "8fb21b893e40ae756ec4c9f812f8df37d6fd0aac",
      [
@@ -11023,6 +11036,10 @@
     ],
     "old-page.py": [
      "3f096b6f5a6611f97f625d8a0420aaa96f2e2b01",
+     []
+    ],
+    "outline-below-positioned-descendants-ref.html": [
+     "8d495b24e4a75798b128d355124da99e2e9e716f",
      []
     ],
     "partial-shadow-dom-layout-style-ref.html": [

--- a/tests/wpt/mozilla/tests/mozilla/outline-below-positioned-descendants-ref.html
+++ b/tests/wpt/mozilla/tests/mozilla/outline-below-positioned-descendants-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: borders and outlines are painted below positioned descendants with non-negative z-index</title>
+<style>
+body {
+  margin: 0;
+}
+.child {
+  width: 200px;
+  height: 200px;
+  background: blue;
+}
+</style>
+<div class="child"></div>

--- a/tests/wpt/mozilla/tests/mozilla/outline-below-positioned-descendants.html
+++ b/tests/wpt/mozilla/tests/mozilla/outline-below-positioned-descendants.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Borders and outlines are painted below positioned descendants with non-negative z-index</title>
+<link rel="help" href="https://github.com/servo/servo/issues/46686">
+<link rel="match" href="outline-below-positioned-descendants-ref.html">
+<style>
+body {
+  margin: 0;
+}
+.box {
+  width: 100px;
+  height: 100px;
+  border: 10px solid red;
+  outline: 20px solid red;
+  outline-offset: -30px;
+}
+.child {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 200px;
+  height: 200px;
+  background: blue;
+}
+</style>
+<div class="box"><div class="child"></div></div>


### PR DESCRIPTION
Outlines were emitted at step 11 of the stacking context traversal, after positioned descendants, so a box's outline was drawn on top of its absolutely positioned children. Firefox paints outlines above in-flow content and negative z-index descendants, but below positioned descendants with `z-index: auto` or higher.

Emit the collected outlines before steps 9 and 10 instead. The specification leaves the placement of out-of-band outlines up to the UA, so this stays within the allowed behaviour while matching other engines.

Testing: New reftest, `outline-below-positioned-descendants.html`, which fails without this change.
Fixes: #46686

Tested this in both Firefox, Chome and Edge. With the fix, Servo's rendering matches all three.