### PR TITLE
script: More carefully handle dirty root and descendant damage marking

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -775,119 +775,153 @@ impl Document {
         closed_any_websocket
     }
 
+    /// This is a port of Gecko's restyle root architecture. The idea is that we track a
+    /// node which is the root of restyle damage. Below that root, certain nodes can be
+    /// marked with a HAS_DIRTY_DESCENDANTS flag which means they should be traversed
+    /// during styling and damage propagation. Above the dirty root nothing should be
+    /// marked with the HAS_DIRTY_DESCENDANTS flag.
+    ///
+    /// The overall algorithm is as follows:
+    /// * When the first dirty element is noted, we just set it as the restyle root.
+    /// * When additional dirty elements are noted, we propagate the given bit up
+    ///   the tree, until we either reach the dirty root or the document root.
+    /// * If we reach the document root, we then propagate the HAS_DIRTY_DESCENDANTS
+    ///   flags up the tree until we cross the path of the new root. Once
+    ///   we find this common ancestor, we record it as the restyle root, and then
+    ///   clear the bits between the new restyle root and the document root.
+    ///
+    /// TODO: This function should take an `Element` and not a `Node`.
     pub(crate) fn note_node_with_dirty_descendants(&self, node: &Node) {
         debug_assert!(*node.owner_doc() == *self);
         if !node.is_connected() {
             return;
         }
 
-        let parent = match node.parent_in_flat_tree() {
-            FlatTreeParent::Parent(parent) => parent,
-            FlatTreeParent::NotInFlatTree => return,
-            FlatTreeParent::RootNode => {
-                // There is no parent so this is the Document node, so we
-                // behave as if we were called with the document element.
-                let Some(document_element) = self.GetDocumentElement() else {
-                    // Trigger update if the document element was removed.
-                    if !self.root_removal_noted.get() {
-                        self.add_restyle_reason(RestyleReason::DOMChanged);
-                        self.root_removal_noted.set(true);
-                    }
-                    return;
-                };
+        let parent_element = match node.parent_in_flat_tree() {
+            FlatTreeParent::Parent(parent) => DomRoot::downcast::<Element>(parent),
+            FlatTreeParent::RootNode => self.GetDocumentElement().inspect(|_| {
                 // This ensures that if the document element is removed in the future, it
                 // will trigger a new empty display list.
+                // TODO: This bookkeeping should move to another method.
                 self.root_removal_noted.set(false);
-
-                if let Some(dirty_root) = self.dirty_root.get() &&
-                    dirty_root.is_connected()
-                {
-                    // There was an existing dirty root so we mark its
-                    // ancestors as dirty until the document element.
-                    for ancestor in dirty_root
-                        .upcast::<Node>()
-                        .inclusive_ancestors_in_flat_tree()
-                    {
-                        if ancestor.is::<Element>() {
-                            ancestor.set_flag(NodeFlags::HAS_DIRTY_DESCENDANTS, true);
-                        }
-                    }
-                }
-                self.dirty_root.set(Some(&document_element));
-                return;
-            },
+            }),
+            FlatTreeParent::NotInFlatTree => return,
         };
 
-        if let Some(parent_element) = parent.downcast::<Element>() {
-            if !parent_element.is_styled() {
-                return;
+        // If the parent isn't an element, try to use the document element.
+        let Some(parent_element) = parent_element.or_else(|| self.GetDocumentElement()) else {
+            // If there is no document element, attempt to trigger a new root removal update,
+            // but do not do any updating of the dirty root or HAS_DIRTY_DESCENDANTS flags.
+            // TODO: This bookkeeping should move to another method.
+            if !self.root_removal_noted.get() {
+                self.add_restyle_reason(RestyleReason::DOMChanged);
+                self.root_removal_noted.set(true);
             }
-            if parent_element.is_display_none() {
-                return;
-            }
+            return;
+        };
+
+        // If the parent isn't styled, then it either isn't part of the flat tree or will
+        // be styled later, ensuring the layout of the dirtied node as well.
+        if !parent_element.is_styled() {
+            return;
+        }
+        // If the parent has `display: none`, the change that caused the node to be dirty
+        // will not affect style or layout.
+        if parent_element.is_display_none() {
+            return;
         }
 
-        let element_parent: DomRoot<Element>;
-        let element = match node.downcast::<Element>() {
-            Some(element) => element,
-            None => {
-                // Current node is not an element, it's probably a text node,
-                // we try to get its element parent.
-                match DomRoot::downcast::<Element>(parent) {
-                    Some(parent) => {
-                        element_parent = parent;
-                        &element_parent
-                    },
-                    None => {
-                        // Parent is not an element so it must be a document,
-                        // and this is not an element either, so there is
-                        // nothing to do.
-                        return;
-                    },
-                }
-            },
+        let Some(old_dirty_root) = self.dirty_root.get() else {
+            // If there is no dirty root, then this node (or its parent if it is not an
+            // element) is the new dirty root and we have minimal work to do.
+            let new_dirty_root = match node.downcast::<Element>() {
+                Some(element) => element,
+                None => &*parent_element,
+            };
+
+            new_dirty_root
+                .upcast::<Node>()
+                .set_flag(NodeFlags::HAS_DIRTY_DESCENDANTS, true);
+            self.set_dirty_root(Some(new_dirty_root));
+            return;
         };
 
-        let dirty_root = match self.dirty_root.get() {
-            Some(root) if root.is_connected() => root,
-            _ => {
-                element
-                    .upcast::<Node>()
-                    .set_flag(NodeFlags::HAS_DIRTY_DESCENDANTS, true);
-                self.dirty_root.set(Some(element));
-                return;
-            },
-        };
+        let old_dirty_root_node = old_dirty_root.upcast::<Node>();
+        let start_element = node.downcast::<Element>().unwrap_or(&*parent_element);
+        for ancestor in start_element
+            .upcast::<Node>()
+            .inclusive_ancestors_in_flat_tree()
+        {
+            // Never mark the Document node as having dirty descendants. It's never the dirty root.
+            if !ancestor.is::<Element>() {
+                break;
+            }
 
-        for ancestor in element.upcast::<Node>().inclusive_ancestors_in_flat_tree() {
             if ancestor.get_flag(NodeFlags::HAS_DIRTY_DESCENDANTS) {
                 return;
             }
 
-            if ancestor.is::<Element>() {
-                ancestor.set_flag(NodeFlags::HAS_DIRTY_DESCENDANTS, true);
+            ancestor.set_flag(NodeFlags::HAS_DIRTY_DESCENDANTS, true);
+
+            // If this node is already under the existing dirty root, there is nothing else to
+            // do apart from marking this node as having dirty descendants. We need to ensure
+            // we mark the root as having dirty descendants now because that has become true.
+            if old_dirty_root_node == &*ancestor {
+                return;
             }
         }
 
-        // Find the new dirty root. If `Node::common_ancestors_in_flat_tree` returns `None`, this
-        // means that the old dirty root is no longer part of the flat tree and `element` is the new
-        // dirty root.
-        let new_dirty_root = element
-            .upcast::<Node>()
-            .common_ancestor_in_flat_tree(dirty_root.upcast())
-            .unwrap_or_else(|| DomRoot::from_ref(element.upcast()));
+        let common_element_ancestor = old_dirty_root_node
+            .inclusive_ancestors_in_flat_tree()
+            .skip(1) // Skip the old root itself.
+            .find_map(|ancestor| {
+                // Never mark the Document node as having dirty descendants. It's never the dirty root.
+                let element = ancestor.downcast::<Element>().map(DomRoot::from_ref)?;
+                if ancestor.get_flag(NodeFlags::HAS_DIRTY_DESCENDANTS) {
+                    return Some(element);
+                }
+                ancestor.set_flag(NodeFlags::HAS_DIRTY_DESCENDANTS, true);
+                None
+            });
 
-        let mut has_dirty_descendants = true;
-        for ancestor in dirty_root
+        // In the case that there was no common ancestor dirty root, one or both of the nodes
+        // is not in the flat tree any longer. When this happens just move the dirty root to
+        // the document element.
+        let Some(new_dirty_root) = common_element_ancestor else {
+            let new_dirty_root = self.GetDocumentElement();
+            if let Some(new_dirty_root) = new_dirty_root.as_ref() {
+                new_dirty_root
+                    .upcast::<Node>()
+                    .set_flag(NodeFlags::HAS_DIRTY_DESCENDANTS, true);
+            }
+            self.set_dirty_root(new_dirty_root.as_deref());
+            return;
+        };
+
+        // Now mark all nodes *above* the new dirty root as not having dirty descendants
+        // to ensure our invariant that nothing above the dirty root is marked with this
+        // flag.
+        for ancestor in new_dirty_root
             .upcast::<Node>()
             .inclusive_ancestors_in_flat_tree()
+            .skip(1)
         {
-            ancestor.set_flag(NodeFlags::HAS_DIRTY_DESCENDANTS, has_dirty_descendants);
-            has_dirty_descendants &= *ancestor != *new_dirty_root;
+            ancestor.set_flag(NodeFlags::HAS_DIRTY_DESCENDANTS, false)
         }
 
-        self.dirty_root
-            .set(Some(new_dirty_root.downcast::<Element>().unwrap()));
+        self.set_dirty_root(Some(&*new_dirty_root));
+    }
+
+    fn set_dirty_root(&self, new_dirty_root: Option<&Element>) {
+        // Assertion: No nodes above the dirty root should be marked with the HAS_DIRTY_DESCENDANTS flag.
+        debug_assert!(new_dirty_root.as_ref().is_none_or(|new_dirty_root| {
+            new_dirty_root
+                .upcast::<Node>()
+                .inclusive_ancestors_in_flat_tree()
+                .skip(1)
+                .all(|node| !node.get_flag(NodeFlags::HAS_DIRTY_DESCENDANTS))
+        }));
+        self.dirty_root.set(new_dirty_root);
     }
 
     pub(crate) fn take_dirty_root(&self) -> Option<DomRoot<Element>> {
@@ -4650,6 +4684,37 @@ impl Document {
         self.image_animation_manager
             .borrow_mut()
             .cancel_animations_for_node(node);
+    }
+
+    /// Clear style and layout data on this [`Node`] and all descendants. This is used to clean
+    /// up the data when a [`Node`] becomes detached from the flat tree. Note that this
+    /// operates on shadow-including descendants.
+    pub(crate) fn remove_style_and_layout_data_from_subtree(
+        &self,
+        no_gc: &NoGC,
+        subtree_root: &Node,
+    ) {
+        for node in subtree_root.traverse_preorder_non_rooting(no_gc, ShadowIncluding::Yes) {
+            self.clean_up_style_and_layout_data_for_node(&node);
+        }
+    }
+
+    pub(crate) fn clean_up_style_and_layout_data_for_node(&self, node: &Node) {
+        node.clear_layout_data();
+        if let Some(element) = node.downcast::<Element>() {
+            element.clean_up_style_data();
+
+            // If this element no longer has any layout or style data, nothing underneath it
+            // can either, and it no longer needs to serve as a layout root. This method is
+            // generally called when a node is leaving the flat tree and no longer takes part
+            // in layout.
+            if self.dirty_root == Some(element) {
+                self.dirty_root.clear();
+            }
+        }
+
+        node.set_flag(NodeFlags::OVERLAPS_DOCUMENT_SELECTION, false);
+        node.set_flag(NodeFlags::HAS_DIRTY_DESCENDANTS, false);
     }
 
     /// An implementation of <https://drafts.csswg.org/web-animations-1/#update-animations-and-send-events>.

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -710,10 +710,11 @@ impl Element {
         // Step 8. Set shadow’s slot assignment to slotAssignment
         //
         // Step 10. Set shadow’s clonable to clonable
+        let document = self.node.owner_doc();
         let shadow_root = ShadowRoot::new(
             cx,
             self,
-            &self.node.owner_doc(),
+            &document,
             mode,
             slot_assignment_mode,
             clonable,
@@ -725,7 +726,7 @@ impl Element {
         // longer in the flat tree.
         let node = self.upcast::<Node>();
         if node.is_connected() {
-            node.remove_style_and_layout_data_from_subtree(cx.no_gc());
+            document.remove_style_and_layout_data_from_subtree(cx.no_gc(), node);
         }
         if let Some(selection) = self.owner_document().selection() &&
             node.get_flag(NodeFlags::OVERLAPS_DOCUMENT_SELECTION)

--- a/components/script/dom/html/htmlslotelement.rs
+++ b/components/script/dom/html/htmlslotelement.rs
@@ -326,10 +326,10 @@ impl HTMLSlotElement {
 
         // Clear the style and layout data for all previously assigned slottables as well as
         // marking them as dirty, as they need a full restyle and layout.
+        let document = self.owner_document();
+        let had_assigned_nodes = !self.assigned_nodes().is_empty();
         for slottable in self.assigned_nodes().iter() {
-            slottable
-                .node()
-                .remove_style_and_layout_data_from_subtree(cx);
+            document.remove_style_and_layout_data_from_subtree(cx.no_gc(), slottable.node());
             slottable.node().dirty(NodeDamage::Other);
         }
 
@@ -358,12 +358,20 @@ impl HTMLSlotElement {
             slottable.set_assigned_slot(Some(self));
         }
 
+        // If the `<slot>` element did not have assigned nodes before, be sure to clear
+        // the style and layout data on the fallback content of the element.
+        if !had_assigned_nodes && !slottables.is_empty() {
+            let node = self.upcast::<Node>();
+            for child in node.children() {
+                document.remove_style_and_layout_data_from_subtree(cx.no_gc(), &child);
+            }
+            node.dirty(NodeDamage::Other);
+        }
+
         // Also clear the style and layout data for all currently assigned slottables
         // as well as marking them as dirty, as they need a full restyle and layout.
         for slottable in slottables.iter() {
-            slottable
-                .node()
-                .remove_style_and_layout_data_from_subtree(cx);
+            document.remove_style_and_layout_data_from_subtree(cx.no_gc(), slottable.node());
             slottable.node().dirty(NodeDamage::Other);
         }
 

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -371,23 +371,6 @@ impl Node {
         }
     }
 
-    /// Clear style and layout data on this [`Node`] and all descendants. This is used to clean
-    /// up the data when a [`Node`] becomes detached from the flat tree. Note that this
-    /// operates on both DOM and flat tree descendants.
-    pub(crate) fn remove_style_and_layout_data_from_subtree(&self, no_gc: &NoGC) {
-        for node in self.traverse_preorder_non_rooting(no_gc, ShadowIncluding::Yes) {
-            node.clean_up_style_and_layout_data();
-        }
-    }
-
-    fn clean_up_style_and_layout_data(&self) {
-        self.layout_data.borrow_mut().take();
-        if let Some(element) = self.downcast::<Element>() {
-            element.clean_up_style_data();
-        }
-        self.set_flag(NodeFlags::OVERLAPS_DOCUMENT_SELECTION, false);
-    }
-
     /// Clean up flags and runs steps 11-14 of remove a node.
     /// <https://dom.spec.whatwg.org/#concept-node-remove>
     pub(crate) fn complete_remove_subtree(
@@ -424,9 +407,10 @@ impl Node {
 
         // Since both the initial traversal in light dom and the inner traversal
         // in shadow DOM share the same code, we define a closure to prevent omissions.
+        let document = root.owner_doc();
         let cleanup_node = |cx: &mut JSContext, node: &Node| {
-            node.owner_doc().cancel_animations_for_node(node);
-            node.clean_up_style_and_layout_data();
+            document.cancel_animations_for_node(node);
+            document.clean_up_style_and_layout_data_for_node(node);
 
             // Step 11 & 14.1. Run the removing steps.
             // This needs to be in its own loop, because unbind_from_tree may
@@ -486,9 +470,10 @@ impl Node {
             .union(NodeFlags::HANDLED_SNAPSHOT)
             .union(NodeFlags::OVERLAPS_DOCUMENT_SELECTION);
 
+        let document = root.owner_document();
         for node in root.traverse_preorder(ShadowIncluding::No) {
             node.set_flag(RESET_FLAGS | NodeFlags::IS_IN_SHADOW_TREE, false);
-            node.clean_up_style_and_layout_data();
+            document.clean_up_style_and_layout_data_for_node(&node);
 
             // Unregister the `id` and `name` attributes for this node. Note that they
             // will be re-registered when added to the tree again.
@@ -513,7 +498,7 @@ impl Node {
                     .traverse_preorder(ShadowIncluding::Yes)
                 {
                     node.set_flag(RESET_FLAGS, false);
-                    node.clean_up_style_and_layout_data();
+                    document.clean_up_style_and_layout_data_for_node(&node);
                 }
             }
         }
@@ -914,6 +899,10 @@ impl Node {
             node = p
         }
         doc.inclusive_descendants_version.set(version);
+    }
+
+    pub(crate) fn clear_layout_data(&self) {
+        self.layout_data.take();
     }
 
     pub(crate) fn dirty(&self, damage: NodeDamage) {

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -2664,6 +2664,10 @@ impl Window {
             None
         };
 
+        if let Some(selection) = document.selection() {
+            selection.set_flags_for_visible_selection(cx.no_gc());
+        }
+
         let restyle_reason = document.restyle_reason(cx.no_gc());
         document.clear_restyle_reasons();
         let restyle = if restyle_reason.needs_restyle() {
@@ -2699,10 +2703,6 @@ impl Window {
         } else {
             None
         };
-
-        if let Some(selection) = document.selection() {
-            selection.set_flags_for_visible_selection(cx.no_gc());
-        }
 
         // If there are any duplicate ids, their targets may need to be updated in the id map before
         // layout runs, so that the map can gather their elements in DOM order.

--- a/tests/wpt/tests/shadow-dom/crashtests/modify-sibling-of-shadowroot-after-attach.html
+++ b/tests/wpt/tests/shadow-dom/crashtests/modify-sibling-of-shadowroot-after-attach.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/46024">
+
+<div id="shadowroot">
+    <span id="insideshadowroot"></span>
+</div>
+<script>
+  onload = _ => {
+    document.body.offsetTop;
+    insideshadowroot.innerText = "Changed";
+    shadowroot.attachShadow({mode: "open"});
+    document.body.appendChild(document.createElement("div"));
+  }
+</script>


### PR DESCRIPTION
Script passes a dirty root to layout along with setting the
HAS_DIRTY_DESCENDANTS flag on elements at or below that root indicating
that children need to be traversed. There was an undocumented invariant
that no nodes above that dirty root were marked with
HAS_DIRTY_DESCENDANTS, as the flag itself was used to determine
when the dirty root is raised to some common ancestor of the old dirty
root and a damaged node.

There were some problems with the old implementation and this change
fixes them by hewing closer to Gecko (from which we took this design).
Notably:

- In the complex situation where we cannot trivially calculate the dirty
  root, we now calculate it by walking up from the old dirty root and
  finding the first element which already has the flag set.
- When removing nodes from the flat tree, if they were the previous
  dirty root, the dirty root is cleared.
- Ensure that all marking traversals for the HAS_DIRTY_DESCENDANTS flag
  marking happen in the flat tree.
- When slotting nodes into `<slot>` elements, the style and layout data
  of fallback content is cleared, and the dirty root is potentially reset.
- Comments are added everywhere in this tricky algorithm explaining what
  the heck is going on.
- The new debug assertion for the invariant found a case where we were
  triggering restyles too late before a relayout -- when setting selection flags.
  This is moved earlier in the method.

Testing: This change adds a new WPT crash test.
Fixes: #46024.
Fixes: #46883.
