### PR TITLE
script: Gracefully handle when password and username cannot be set in `XMLHttpRequest`

### DIFF
--- a/components/script/dom/xmlhttprequest/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest/xmlhttprequest.rs
@@ -386,13 +386,17 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
                 // Step 8. If parsedURL’s host is non-null, then:
                 if parsed_url.host().is_some() {
                     // Step 8.1 If the username argument is not null, set the username given parsedURL and username.
-                    if let Some(user_str) = username {
-                        parsed_url.set_username(&user_str.0).unwrap();
+                    if let Some(user_str) = username &&
+                        let Err(error) = parsed_url.set_username(&user_str.0)
+                    {
+                        warn!("Could not set username on XMLHttpRequest: {error:?}");
                     }
 
                     // Step 8.2 If the password argument is not null, set the password given parsedURL and password.
-                    if let Some(pass_str) = password {
-                        parsed_url.set_password(Some(&pass_str.0)).unwrap();
+                    if let Some(pass_str) = password &&
+                        let Err(error) = parsed_url.set_password(Some(&pass_str.0))
+                    {
+                        warn!("Could not set password on XMLHttpRequest: {error:?}");
                     }
                 }
 


### PR DESCRIPTION
When using file URLs it's possible that `rust-url` will give an error
when trying to set a password or username on the URL. Instead of
panicking when this happens, just issue a warning and move on.

Testing: It's surprisingly difficult to write an automated test for this
change. It only happens when using a relative file URL, which AFAIK is not
possible to test with WPT.
Fixes: #46887.
