### PR TITLE
canvas: Upgrade `vello_cpu` to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3173,9 +3173,9 @@ dependencies = [
 
 [[package]]
 name = "glifo"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d99fc21d493812643aae86d53b7bbd02f376434a90317e8a790bc209fdd6605e"
+checksum = "ed4a1bb24121291d27230c1b1b44e07d6a9b28cefdb32fe1581dfb84e14f940a"
 dependencies = [
  "bytemuck",
  "foldhash 0.2.0",
@@ -3183,9 +3183,9 @@ dependencies = [
  "log",
  "peniko",
  "png",
- "skrifa 0.42.1",
+ "skrifa 0.44.0",
  "smallvec",
- "vello_common 0.0.9",
+ "vello_common 0.1.0",
 ]
 
 [[package]]
@@ -7914,7 +7914,7 @@ dependencies = [
  "stylo",
  "tracing",
  "vello",
- "vello_cpu 0.0.9",
+ "vello_cpu 0.1.0",
  "webrender_api",
 ]
 
@@ -10981,14 +10981,13 @@ dependencies = [
 
 [[package]]
 name = "vello_common"
-version = "0.0.9"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d672facaa2d697285a786cd9d44d614cd2ce54cdc022504bf339f8fff3b750"
+checksum = "b2e9aed918117e8152c9eddfd8362d73c465c23f26c44786aa331707b8a64fa2"
 dependencies = [
  "bytemuck",
  "fearless_simd 0.4.1",
  "guillotiere",
- "hashbrown 0.17.1",
  "log",
  "peniko",
  "png",
@@ -11009,9 +11008,9 @@ dependencies = [
 
 [[package]]
 name = "vello_cpu"
-version = "0.0.9"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588691169aed86b5c8fb487266afee01323234e6fd0a3f2aaec0eaa8e4007f23"
+checksum = "ac7349e1f55f6b801c7c277958df4ea53e7f20f21e8014910ad888b2ecda93ea"
 dependencies = [
  "bytemuck",
  "crossbeam-channel",
@@ -11021,7 +11020,7 @@ dependencies = [
  "png",
  "rayon",
  "thread_local",
- "vello_common 0.0.9",
+ "vello_common 0.1.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3173,8 +3173,9 @@ dependencies = [
 
 [[package]]
 name = "glifo"
-version = "0.2.0"
-source = "git+https://github.com/linebender/vello?rev=2a3e7dd6e7f9307a013681026e75d508ebd0d368#2a3e7dd6e7f9307a013681026e75d508ebd0d368"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282a26c1e23de04bdab3e34a21b6f877a479b96737792516b9b8b8f69b6661be"
 dependencies = [
  "bytemuck",
  "foldhash 0.2.0",
@@ -3184,7 +3185,7 @@ dependencies = [
  "png",
  "skrifa 0.44.0",
  "smallvec",
- "vello_common 0.1.0",
+ "vello_common 0.2.0",
 ]
 
 [[package]]
@@ -7913,7 +7914,7 @@ dependencies = [
  "stylo",
  "tracing",
  "vello",
- "vello_cpu 0.1.0",
+ "vello_cpu 0.2.0",
  "webrender_api",
 ]
 
@@ -10980,8 +10981,9 @@ dependencies = [
 
 [[package]]
 name = "vello_common"
-version = "0.1.0"
-source = "git+https://github.com/linebender/vello?rev=2a3e7dd6e7f9307a013681026e75d508ebd0d368#2a3e7dd6e7f9307a013681026e75d508ebd0d368"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb2141a2bca6e6d598e471fd4d1d7eed8e020aad6a28187edda07f091a325dd"
 dependencies = [
  "bytemuck",
  "fearless_simd 0.4.1",
@@ -11006,8 +11008,9 @@ dependencies = [
 
 [[package]]
 name = "vello_cpu"
-version = "0.1.0"
-source = "git+https://github.com/linebender/vello?rev=2a3e7dd6e7f9307a013681026e75d508ebd0d368#2a3e7dd6e7f9307a013681026e75d508ebd0d368"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace506ca414548966fcf3c283be94eb1cad8254de488791ee698bf438b0890a9"
 dependencies = [
  "bytemuck",
  "crossbeam-channel",
@@ -11017,7 +11020,7 @@ dependencies = [
  "png",
  "rayon",
  "thread_local",
- "vello_common 0.1.0",
+ "vello_common 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3174,8 +3174,7 @@ dependencies = [
 [[package]]
 name = "glifo"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed4a1bb24121291d27230c1b1b44e07d6a9b28cefdb32fe1581dfb84e14f940a"
+source = "git+https://github.com/linebender/vello?rev=2a3e7dd6e7f9307a013681026e75d508ebd0d368#2a3e7dd6e7f9307a013681026e75d508ebd0d368"
 dependencies = [
  "bytemuck",
  "foldhash 0.2.0",
@@ -10982,8 +10981,7 @@ dependencies = [
 [[package]]
 name = "vello_common"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e9aed918117e8152c9eddfd8362d73c465c23f26c44786aa331707b8a64fa2"
+source = "git+https://github.com/linebender/vello?rev=2a3e7dd6e7f9307a013681026e75d508ebd0d368#2a3e7dd6e7f9307a013681026e75d508ebd0d368"
 dependencies = [
  "bytemuck",
  "fearless_simd 0.4.1",
@@ -11009,8 +11007,7 @@ dependencies = [
 [[package]]
 name = "vello_cpu"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac7349e1f55f6b801c7c277958df4ea53e7f20f21e8014910ad888b2ecda93ea"
+source = "git+https://github.com/linebender/vello?rev=2a3e7dd6e7f9307a013681026e75d508ebd0d368#2a3e7dd6e7f9307a013681026e75d508ebd0d368"
 dependencies = [
  "bytemuck",
  "crossbeam-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8418,7 +8418,7 @@ dependencies = [
  "url",
  "urlpattern",
  "uuid",
- "vello_cpu 0.0.9",
+ "vello_cpu 0.2.0",
  "webrender",
  "webrender_api",
  "wr_malloc_size_of",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,7 +271,7 @@ url = "2.5"
 urlpattern = "0.3"
 uuid = { version = "1.23.3", features = ["v4", "v5"] }
 vello = "0.9"
-vello_cpu = { git = "https://github.com/linebender/vello", rev = "2a3e7dd6e7f9307a013681026e75d508ebd0d368", features = ["multithreading"] }
+vello_cpu = { version = "0.2.0", features = ["multithreading"] }
 warp = "0.4.2"
 web_atoms = "0.2.4"
 webdriver = { version = "0.53.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,7 +271,7 @@ url = "2.5"
 urlpattern = "0.3"
 uuid = { version = "1.23.3", features = ["v4", "v5"] }
 vello = "0.9"
-vello_cpu = { version = "0.1.0", features = ["multithreading"] }
+vello_cpu = { git = "https://github.com/linebender/vello", rev = "2a3e7dd6e7f9307a013681026e75d508ebd0d368", features = ["multithreading"] }
 warp = "0.4.2"
 web_atoms = "0.2.4"
 webdriver = { version = "0.53.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,7 +271,7 @@ url = "2.5"
 urlpattern = "0.3"
 uuid = { version = "1.23.3", features = ["v4", "v5"] }
 vello = "0.9"
-vello_cpu = { version = "0.0.9", features = ["multithreading"] }
+vello_cpu = { version = "0.1.0", features = ["multithreading"] }
 warp = "0.4.2"
 web_atoms = "0.2.4"
 webdriver = { version = "0.53.0", default-features = false }

--- a/components/canvas/vello_cpu_backend.rs
+++ b/components/canvas/vello_cpu_backend.rs
@@ -115,9 +115,7 @@ impl VelloCPUDrawTarget {
         if self.state == State::Drawing {
             self.ignore_clips(|self_| {
                 self_.ctx.flush();
-                self_
-                    .ctx
-                    .render_to_pixmap(&mut self_.resources, &mut self_.pixmap);
+                self_.ctx.render(&mut self_.pixmap, &mut self_.resources);
                 self_.ctx.reset();
                 self_.state = State::Rendered;
             });
@@ -196,11 +194,6 @@ impl GenericDrawTarget for VelloCPUDrawTarget {
         // vello_cpu RenderingContext only ever grows,
         // so we need to use every opportunity to shrink it
         if self.is_viewport_cleared(rect, transform) {
-            // This is to workaround panic until https://github.com/linebender/vello/pull/1732
-            // can be merged and release a new version.
-            if self.state == State::Drawing {
-                self.ctx.flush();
-            }
             self.ctx.reset();
             self.clips.clear(); // no clips are affecting rendering
             self.state = State::Drawing;

--- a/components/script/dom/filesystem/filesystemdirectoryentry.rs
+++ b/components/script/dom/filesystem/filesystemdirectoryentry.rs
@@ -57,6 +57,14 @@ impl FileSystemDirectoryEntry {
     pub(crate) fn push_child(&self, child: &FileSystemEntry) {
         self.children.borrow_mut().push(Dom::from_ref(child));
     }
+
+    pub(crate) fn children(&self) -> Vec<DomRoot<FileSystemEntry>> {
+        self.children
+            .borrow()
+            .iter()
+            .map(|child| DomRoot::from_ref(&**child))
+            .collect()
+    }
 }
 
 impl FileSystemDirectoryEntryMethods<crate::DomTypeHolder> for FileSystemDirectoryEntry {

--- a/components/script/dom/filesystem/filesystemdirectoryreader.rs
+++ b/components/script/dom/filesystem/filesystemdirectoryreader.rs
@@ -7,12 +7,16 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
+use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
+use crate::dom::bindings::callback::ExceptionHandling;
 use crate::dom::bindings::codegen::Bindings::FileSystemDirectoryReaderBinding::{
     FileSystemDirectoryReaderMethods, FileSystemEntriesCallback,
 };
 use crate::dom::bindings::codegen::Bindings::FileSystemEntryBinding::ErrorCallback;
+use crate::dom::bindings::refcounted::Trusted;
+use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::filesystemdirectoryentry::FileSystemDirectoryEntry;
 use crate::dom::globalscope::GlobalScope;
@@ -24,6 +28,15 @@ pub(crate) struct FileSystemDirectoryReader {
     idx: Cell<usize>,
     reading_flag: Cell<bool>,
     done_flag: Cell<bool>,
+    pending_callbacks: DomRefCell<Vec<PendingEntriesCallback>>,
+    next_callback: Cell<usize>,
+}
+
+#[derive(JSTraceable, MallocSizeOf)]
+struct PendingEntriesCallback {
+    id: usize,
+    #[conditional_malloc_size_of]
+    callback: Rc<FileSystemEntriesCallback>,
 }
 
 impl FileSystemDirectoryReader {
@@ -34,6 +47,8 @@ impl FileSystemDirectoryReader {
             idx: Cell::new(0),
             reading_flag: Cell::new(false),
             done_flag: Cell::new(false),
+            pending_callbacks: Default::default(),
+            next_callback: Cell::new(0),
         }
     }
 
@@ -54,9 +69,46 @@ impl FileSystemDirectoryReaderMethods<crate::DomTypeHolder> for FileSystemDirect
     /// <https://wicg.github.io/entries-api/#dom-filesystemdirectoryreader-readentries>
     fn ReadEntries(
         &self,
-        _success_callback: Rc<FileSystemEntriesCallback>,
+        success_callback: Rc<FileSystemEntriesCallback>,
         _error_callback: Option<Rc<ErrorCallback>>,
     ) {
-        // TODO: Implement per spec 7.3. Need to hook embedder.
+        // Per spec §7.3: queue a task to invoke successCallback with the
+        // directory's children that have not yet been produced. The first
+        // call returns all children; subsequent calls return an empty list
+        // (done flag set).
+        let id = self.next_callback.get();
+        let pending_callback = PendingEntriesCallback {
+            id,
+            callback: success_callback,
+        };
+        self.pending_callbacks.borrow_mut().push(pending_callback);
+        self.next_callback.set(id + 1);
+
+        let this = Trusted::new(self);
+        self.global()
+            .task_manager()
+            .dom_manipulation_task_source()
+            .queue(task!(invoke_read_entries: move |cx| {
+                let this = this.root();
+                let maybe_index = this
+                    .pending_callbacks
+                    .borrow()
+                    .iter()
+                    .position(|val| val.id == id);
+                if let Some(index) = maybe_index {
+                    let callback = this
+                        .pending_callbacks
+                        .borrow_mut()
+                        .swap_remove(index)
+                        .callback;
+                    let entries = if this.done_flag.get() {
+                        Vec::new()
+                    } else {
+                        this.done_flag.set(true);
+                        this.dir.children()
+                    };
+                    let _ = callback.Call__(cx, entries, ExceptionHandling::Report);
+                }
+            }));
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -221,4 +221,6 @@ skip = [
 [sources.allow-org]
 github = [
     "servo",
+    # TODO: Remove this after 0.1.1 release
+    "linebender",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -221,6 +221,4 @@ skip = [
 [sources.allow-org]
 github = [
     "servo",
-    # TODO: Remove this after 0.1.1 release
-    "linebender",
 ]

--- a/tests/wpt/meta/html/canvas/element/drawing-rectangles-to-the-canvas/2d.clearRect.shadow.html.ini
+++ b/tests/wpt/meta/html/canvas/element/drawing-rectangles-to-the-canvas/2d.clearRect.shadow.html.ini
@@ -1,5 +1,0 @@
-[2d.clearRect.shadow.html]
-  [clearRect does not draw shadows]
-    expected:
-      if subsuite == "vello_canvas": PASS
-      FAIL

--- a/tests/wpt/meta/html/canvas/element/drawing-rectangles-to-the-canvas/2d.clearRect.zero.html.ini
+++ b/tests/wpt/meta/html/canvas/element/drawing-rectangles-to-the-canvas/2d.clearRect.zero.html.ini
@@ -1,5 +1,0 @@
-[2d.clearRect.zero.html]
-  [clearRect of zero pixels has no effect]
-    expected:
-      if subsuite == "vello_canvas": PASS
-      FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-rectangles-to-the-canvas/2d.clearRect.shadow.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-rectangles-to-the-canvas/2d.clearRect.shadow.html.ini
@@ -1,3 +1,0 @@
-[2d.clearRect.shadow.html]
-  [clearRect does not draw shadows]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-rectangles-to-the-canvas/2d.clearRect.shadow.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-rectangles-to-the-canvas/2d.clearRect.shadow.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.clearRect.shadow.worker.html]
-  [clearRect does not draw shadows]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-rectangles-to-the-canvas/2d.clearRect.zero.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-rectangles-to-the-canvas/2d.clearRect.zero.html.ini
@@ -1,3 +1,0 @@
-[2d.clearRect.zero.html]
-  [clearRect of zero pixels has no effect]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-rectangles-to-the-canvas/2d.clearRect.zero.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-rectangles-to-the-canvas/2d.clearRect.zero.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.clearRect.zero.worker.html]
-  [clearRect of zero pixels has no effect]
-    expected: FAIL


### PR DESCRIPTION
vello_cpu 0.1.0 fixes a few panics and there is a full rewrite of frontend, which as claimed by the author improves performance by 10%.

But we end up upgrading to 0.2.0.

Testing: New passing in WPT. 
Fixes: #46580
Fixes: #46907