### PR TITLE
android: Inline `ServoOptions`

### DIFF
--- a/ports/servoshell/egl/android/mod.rs
+++ b/ports/servoshell/egl/android/mod.rs
@@ -99,12 +99,27 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_init<'local>(
     mut env: EnvUnowned<'local>,
     _: JClass<'local>,
     context: JObject<'local>,
-    opts: JObject<'local>,
+    args: JString<'local>,
+    url: JString<'local>,
+    size: JObject<'local>,
+    density: jfloat,
+    logStr: JString<'local>,
+    log: jboolean,
+    experimental_mode: jboolean,
     callbacks_obj: JObject<'local>,
     surface: JObject<'local>,
 ) {
     env.with_env(|env| -> jni::errors::Result<_> {
-        let (init_opts, log, log_str) = get_options(env, &opts, &surface)?;
+        let (init_opts, log_str) = get_options(
+            env,
+            args,
+            url,
+            size,
+            density,
+            logStr,
+            experimental_mode,
+            &surface,
+        )?;
 
         if log {
             // Note: Android debug logs are stripped from a release build.
@@ -914,17 +929,6 @@ fn jni_coordinate_to_rust_viewport_rect<'local>(
     Ok(Rect::new(Point2D::origin(), Size2D::new(width, height)))
 }
 
-fn get_field_as_string<'local>(
-    env: &mut Env<'local>,
-    obj: &JObject<'local>,
-    field: &JNIStr,
-) -> Result<String, Error> {
-    let string_value = env
-        .get_field(obj, field, jni_sig!("Ljava/lang/String;"))?
-        .l()?;
-    JString::cast_local(env, string_value)?.try_to_string(env)
-}
-
 fn set_default_config_dir<'local>(
     env: &mut Env<'local>,
     context: &JObject<'local>,
@@ -960,28 +964,17 @@ fn set_default_config_dir<'local>(
 
 fn get_options<'local>(
     env: &mut Env<'local>,
-    opts: &JObject<'local>,
+    args: JString<'local>,
+    url: JString<'local>,
+    size: JObject<'local>,
+    density: jfloat,
+    logStr: JString<'local>,
+    experimental_mode: jboolean,
     surface: &JObject<'local>,
-) -> Result<(InitOptions, bool, Option<String>), Error> {
-    let args = get_field_as_string(env, opts, jni_str!("args")).ok();
-    let url = get_field_as_string(env, opts, jni_str!("url")).ok();
-    let log_str = get_field_as_string(env, opts, jni_str!("logStr")).ok();
-
-    let experimental_mode = env
-        .get_field(opts, jni_str!("experimentalMode"), jni_sig!("Z"))?
-        .z()?;
-
-    let density = env
-        .get_field(opts, jni_str!("density"), jni_sig!("F"))?
-        .f()?;
-
-    let log = env
-        .get_field(opts, jni_str!("enableLogs"), jni_sig!("Z"))?
-        .z()?;
-
-    let size = env
-        .get_field(opts, jni_str!("size"), jni_sig!("Landroid/util/Size;"))?
-        .l()?;
+) -> Result<(InitOptions, Option<String>), Error> {
+    let args = JString::cast_local(env, args)?.try_to_string(env).ok();
+    let url = JString::cast_local(env, url)?.try_to_string(env).ok();
+    let log_str = JString::cast_local(env, logStr)?.try_to_string(env).ok();
 
     let viewport_rect = jni_coordinate_to_rust_viewport_rect(env, &size)?;
 
@@ -1010,7 +1003,7 @@ fn get_options<'local>(
         display_handle,
     };
 
-    Ok((opts, log, log_str))
+    Ok((opts, log_str))
 }
 
 fn display_and_window_handle(

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.kt
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.kt
@@ -22,7 +22,13 @@ internal class JNIServo {
 
     external fun init(
         context: Context,
-        options: ServoOptions,
+        args: String,
+        url: String,
+        size: Size,
+        density: Float,
+        logStr: String,
+        enableLogs: Boolean,
+        experimentalMode: Boolean,
         callbacks: Callbacks,
         surface: Surface,
     )
@@ -72,29 +78,6 @@ internal class JNIServo {
     external fun setExperimentalMode(enable: Boolean)
 
     external fun doFrame()
-
-    class ServoOptions {
-        @JvmField
-        var args: String? = null
-
-        @JvmField
-        var url: String? = null
-
-        @JvmField
-        var size: Size? = null
-
-        @JvmField
-        var density: Float = 1f
-
-        @JvmField
-        var logStr: String? = null
-
-        @JvmField
-        var enableLogs: Boolean = false
-
-        @JvmField
-        var experimentalMode: Boolean = false
-    }
 
     interface Callbacks {
         fun wakeup()

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.java
@@ -10,8 +10,6 @@ import android.util.Size;
 import android.view.KeyEvent;
 import android.view.Surface;
 
-import org.servo.servoview.JNIServo.ServoOptions;
-
 public class Servo {
     private static final String LOGTAG = "Servo";
     private JNIServo jni = new JNIServo();
@@ -19,7 +17,13 @@ public class Servo {
     private Callbacks servoCallbacks;
 
     public Servo(
-            ServoOptions options,
+            String args,
+            String url,
+            Size size,
+            float density,
+            String logStr,
+            boolean enableLogs,
+            boolean experimentalMode,
             RunCallback runCallback,
             Client client,
             Context context,
@@ -29,7 +33,20 @@ public class Servo {
 
         servoCallbacks = new Callbacks(client, jni, runCallback);
 
-        this.runCallback.inGLThread(() -> jni.init(context, options, servoCallbacks, surface));
+        this.runCallback.inGLThread(
+                () -> jni.init(
+                    context,
+                    args,
+                    url,
+                    size,
+                    density,
+                    logStr,
+                    enableLogs,
+                    experimentalMode,
+                    servoCallbacks,
+                    surface
+                )
+        );
     }
 
     public String version() {

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
@@ -9,7 +9,6 @@ import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.AttributeSet;
-import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.Size;
 import android.view.Choreographer;
@@ -20,7 +19,6 @@ import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.View;
 
-import org.servo.servoview.JNIServo.ServoOptions;
 import org.servo.servoview.Servo.Client;
 import org.servo.servoview.Servo.RunCallback;
 
@@ -206,19 +204,21 @@ public class ServoView extends SurfaceView
             Size size = new Size(servoView.getWidth(), servoView.getHeight());
 
             Surface surface = holder.getSurface();
-            ServoOptions options = new ServoOptions();
-            options.args = servoView.servoArgs;
-            options.url = servoView.initialUri;
-            options.size = size;
-            options.logStr = servoLog;
-            options.enableLogs = true;
-            options.experimentalMode = servoView.experimentalMode;
 
-            DisplayMetrics metrics = servoView.getResources().getDisplayMetrics();
-            options.density = metrics.density;
             if (servoView.servo == null && !paused) {
                 servoView.servo = new Servo(
-                        options, servoView, client, servoView.getContext(), surface);
+                        servoView.servoArgs,
+                        servoView.initialUri,
+                        size,
+                        servoView.getResources().getDisplayMetrics().density,
+                        servoLog,
+                        true,
+                        servoView.experimentalMode,
+                        servoView,
+                        client,
+                        servoView.getContext(),
+                        surface
+                );
             } else {
                 paused = false;
                 servoView.servo.resumePainting(surface, size);


### PR DESCRIPTION
`ServoOptions` essentially just wraps a bunch of arguments that are passed that to `JNIServo#init(...)`. 
By inlining `ServoOptions`:

1. We no longer have nullable `ServoOptions` fields that the Rust-side assumes to be non-null.
2. Although at first glance of the parameter list, the usage of `ServoOptions` looks cleaner, the invocation of the `init` function is more verbose due to the required instantiation of `ServoOptions`.
3. The Rust-side is cleaner since we don't have to do a bunch of `get_field`s any more.
4. We're no longer exposing `ServoOptions` via the public-API of `Servo`. All JNI related things should have a private API, per https://github.com/servo/servo/pull/46771.

Testing: There are no automated tests for Android.