### PR TITLE
fonts: Synthesize variations from `font-style` for macos & freetype systems

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -20,10 +20,12 @@ use icu_locid::subtags::Language;
 use log::debug;
 use malloc_size_of_derive::MallocSizeOf;
 use parking_lot::RwLock;
-use read_fonts::FontRead;
+use read_fonts::collections::int_set::Domain;
+use read_fonts::tables::fvar::Fvar;
 use read_fonts::tables::name::Name as NameTable;
 use read_fonts::tables::os2::{Os2, SelectionFlags};
 use read_fonts::types::Tag;
+use read_fonts::{FontRead, ReadError};
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use servo_base::id::PainterId;
@@ -31,8 +33,10 @@ use servo_base::text::{UnicodeBlock, UnicodeBlockMethod};
 use skrifa::string::LocalizedString;
 use smallvec::SmallVec;
 use style::Atom;
+use style::computed_values::font_optical_sizing::T as FontOpticalSizing;
 use style::computed_values::font_variant_caps;
 use style::computed_values::font_variant_position::T as FontVariantPosition;
+use style::font_face::FontStyleRange;
 use style::properties::style_structs::Font as FontStyleStruct;
 use style::values::computed::font::{
     FamilyName, FontFamilyNameSyntax, GenericFontFamily, SingleFontFamily,
@@ -63,11 +67,13 @@ pub(crate) const COLR: Tag = Tag::new(b"COLR");
 pub(crate) const CWSH: Tag = Tag::new(b"cwsh");
 pub(crate) const FRAC: Tag = Tag::new(b"frac");
 pub(crate) const DLIG: Tag = Tag::new(b"dlig");
+pub(crate) const FVAR: Tag = Tag::new(b"fvar");
 pub(crate) const FWID: Tag = Tag::new(b"fwid");
 pub(crate) const GPOS: Tag = Tag::new(b"GPOS");
 pub(crate) const GSUB: Tag = Tag::new(b"GSUB");
 pub(crate) const HIST: Tag = Tag::new(b"hist");
 pub(crate) const HLIG: Tag = Tag::new(b"hlig");
+pub(crate) const ITAL: Tag = Tag::new(b"ital");
 pub(crate) const JP04: Tag = Tag::new(b"jp04");
 pub(crate) const JP78: Tag = Tag::new(b"jp78");
 pub(crate) const JP83: Tag = Tag::new(b"jp83");
@@ -85,6 +91,7 @@ pub(crate) const PWID: Tag = Tag::new(b"pwid");
 pub(crate) const RUBY: Tag = Tag::new(b"ruby");
 pub(crate) const SALT: Tag = Tag::new(b"salt");
 pub(crate) const SBIX: Tag = Tag::new(b"sbix");
+pub(crate) const SLNT: Tag = Tag::new(b"slnt");
 pub(crate) const SMPL: Tag = Tag::new(b"smpl");
 pub(crate) const SUBS: Tag = Tag::new(b"subs");
 pub(crate) const SUPS: Tag = Tag::new(b"sups");
@@ -92,6 +99,10 @@ pub(crate) const SWSH: Tag = Tag::new(b"swsh");
 pub(crate) const TNUM: Tag = Tag::new(b"tnum");
 pub(crate) const TRAD: Tag = Tag::new(b"trad");
 pub(crate) const ZERO: Tag = Tag::new(b"zero");
+
+/// The number of degrees to slant the font face by if the `font-style` is `italic`
+/// but the font does not support native italic.
+const SLNT_VALUE_FOR_ITALIC_STYLE: f32 = 14.0;
 
 pub const LAST_RESORT_GLYPH_ADVANCE: FractionalPixel = 10.0;
 
@@ -163,6 +174,10 @@ pub trait PlatformFontMethods: Sized {
     /// Return all the variation values that the font was instantiated with.
     fn variations(&self) -> &[FontVariation];
 
+    fn set_variations(&mut self, _variations: &[FontVariation]) -> Result<(), &'static str> {
+        Ok(())
+    }
+
     fn descriptor_from_os2_table(os2: &Os2) -> FontTemplateDescriptor {
         let mut style = FontStyle::NORMAL;
         if os2.fs_selection().contains(SelectionFlags::ITALIC) {
@@ -192,6 +207,12 @@ pub(crate) type FractionalPixel = f64;
 
 pub(crate) trait FontTableMethods {
     fn buffer(&self) -> &[u8];
+    fn parse_as_specific_table<'a, Table>(&'a self) -> Result<Table, ReadError>
+    where
+        Table: FontRead<'a>,
+    {
+        Table::read(read_fonts::FontData::new(self.buffer()))
+    }
 }
 
 #[derive(Clone, Debug, Default, Deserialize, MallocSizeOf, PartialEq, Serialize)]
@@ -336,13 +357,22 @@ impl Font {
             is_bold && allows_synthetic_bold
         };
 
-        let handle = PlatformFont::new_from_template(
+        // TODO: Don't pass the variation settings to this method, we'll set the variations later.
+        // This might cause issues with the core text font cache on macos.
+        let mut handle = PlatformFont::new_from_template(
             template.clone(),
             Some(descriptor.pt_size),
             &descriptor.variation_settings,
             &data,
             synthetic_bold,
         )?;
+
+        // Compute the variations
+        if servo_config::pref!(layout_variable_fonts_enabled) {
+            let used_variations = compute_variations(&descriptor, &template, &handle);
+            handle.set_variations(&used_variations)?;
+        }
+
         let metrics = Arc::new(handle.metrics());
 
         Ok(Font {
@@ -1103,4 +1133,141 @@ pub(crate) fn map_platform_values_to_style_values(mapping: &[(f64, f64)], value:
     }
 
     mapping[mapping.len() - 1].1
+}
+
+/// <https://drafts.csswg.org/css-fonts-4/#apply-font-matching-variations>
+fn compute_variations(
+    descriptor: &FontDescriptor,
+    template: &FontTemplateRef,
+    platform_font: &PlatformFont,
+) -> Vec<FontVariation> {
+    let font_face_rule = template.font_face_rule();
+
+    // The steps in this algorithm are inverted order because they are listed in ascending order of precedence.
+    let mut variations: Vec<FontVariation> = vec![];
+
+    let mut add_variation = |variation: FontVariation| {
+        if !variations
+            .iter()
+            .any(|existing_variation| existing_variation.tag == variation.tag)
+        {
+            variations.push(variation);
+        }
+    };
+
+    // Step 12. Font variations implied by the value of the font-variation-settings property are applied.
+    // These values should be clamped to the values that are supported by the font.
+    // NOTE: Clamping happens inside the PlatformFont.
+    descriptor
+        .variation_settings
+        .iter()
+        .copied()
+        .for_each(&mut add_variation);
+
+    // Step 9. Font variations implied by the value of the font-optical-sizing property are applied.
+    // NOTE The precise behaviour of font-optical-sizing:auto is not defined.
+    // We choose to set "opsz" to the font size if it's not already set elsewhere. This is the easiest
+    // at the end of this function, so we move this step down.
+
+    if let Some(font_face_rule) = &font_face_rule {
+        // Step 6. If the font is defined via an @font-face rule, the font variations implied by the font-variation-settings
+        // descriptor in the @font-face rule are applied.
+        if let Some(variation_settings) = font_face_rule.font_variation_settings.as_ref() {
+            variation_settings
+                .0
+                .iter()
+                .map(|variation| FontVariation {
+                    tag: variation.tag.0,
+                    value: variation.value.get().expect(
+                        "The value is enforced to be resolvable at parse time \
+                        (see FontVariationSettings::parse_for_font_face_rule).",
+                    ),
+                })
+                .for_each(&mut add_variation);
+        }
+    }
+
+    // Step 2. Font variations as enabled by the font-weight, font-width, and font-style properties are applied.
+    //
+    // The application of the value enabled by font-style is affected by font selection, because this property might
+    // select an italic or an oblique font. The value applied is the closest matching value as determined by the font
+    // matching algorithm. User agents must apply at most one value due to the font-style property; both "ital" and
+    // "slnt" values must not be set together.
+    //
+    // If the selected font is defined in an @font-face rule, then the values applied at this step should be clamped
+    // to the value of the font-weight, font-width, and font-style descriptors in that @font-face rule.
+    // TODO: Clamp weight/stretch to the descriptors from the @font-face rule, if any
+    // NOTE: font-stretch is a legacy alias to font-width
+    add_variation(FontVariation {
+        tag: Tag::new(b"wght").to_u32(),
+        value: descriptor.weight.value(),
+    });
+
+    add_variation(FontVariation {
+        tag: Tag::new(b"wdth").to_u32(),
+        value: descriptor.stretch.0.to_float(),
+    });
+
+    let fvar_table = platform_font.table_for_tag(FVAR);
+    let has_ital_axis = fvar_table
+        .as_ref()
+        .and_then(|table| table.parse_as_specific_table::<Fvar<'_>>().ok())
+        .and_then(|fvar: Fvar<'_>| fvar.axis_instance_arrays().ok())
+        .is_some_and(|axis_instance_arrays| {
+            axis_instance_arrays
+                .axes()
+                .iter()
+                .any(|axis| axis.axis_tag() == ITAL)
+        });
+
+    let clamped_font_style = font_face_rule
+        .as_ref()
+        .and_then(|descriptor| descriptor.font_style.as_ref())
+        .map(|font_style_range| match font_style_range {
+            FontStyleRange::Italic => FontStyle::ITALIC,
+            FontStyleRange::Oblique(min_angle, max_angle) => {
+                let specified_angle = if descriptor.style == FontStyle::ITALIC {
+                    SLNT_VALUE_FOR_ITALIC_STYLE
+                } else {
+                    descriptor.style.oblique_degrees()
+                };
+                let clamped_angle = specified_angle
+                    .min(max_angle.degrees().unwrap_or(f32::INFINITY))
+                    .max(min_angle.degrees().unwrap_or(f32::NEG_INFINITY));
+                FontStyle::oblique(clamped_angle)
+            },
+        })
+        .unwrap_or(descriptor.style);
+    // TODO: We should recognize when a font has neither a ital nor a slnt axis and then
+    // synthesize an appropriate font face if allowed by font-synthesis.
+    if has_ital_axis {
+        add_variation(FontVariation {
+            tag: ITAL.to_u32(),
+            value: (clamped_font_style != FontStyle::NORMAL) as u32 as f32,
+        });
+    } else {
+        // Note: CSS and OpenType measure slnt in opposite directions, so we need to negate the
+        // angles.
+        if clamped_font_style == FontStyle::ITALIC {
+            add_variation(FontVariation {
+                tag: SLNT.to_u32(),
+                value: -SLNT_VALUE_FOR_ITALIC_STYLE,
+            });
+        } else {
+            add_variation(FontVariation {
+                tag: SLNT.to_u32(),
+                value: -clamped_font_style.oblique_degrees(),
+            });
+        }
+    }
+
+    // This is the implementation for Step 9. Refer to the note on Step 9 for an explanation of why it's here.
+    if descriptor.optical_sizing == FontOpticalSizing::Auto {
+        add_variation(FontVariation {
+            tag: Tag::new(b"opsz").to_u32(),
+            value: descriptor.pt_size.to_f32_px(),
+        });
+    }
+
+    variations
 }

--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -154,7 +154,11 @@ pub trait PlatformFontMethods: Sized {
     /// `self` is consumed to work around platform differences. On some platforms, changing the
     /// variations requires creating an entirely new font face, whereas on others the returned
     /// font is `self`.
-    fn copy_with_variations(self, _variations: &[FontVariation]) -> Result<Self, &'static str> {
+    fn copy_with_variations(
+        self,
+        _font_identifer: &FontIdentifier,
+        _variations: &[FontVariation],
+    ) -> Result<Self, &'static str> {
         Err("not implemented")
     }
 
@@ -365,7 +369,7 @@ impl Font {
         // Compute and apply the OpenType variations
         let handle = if servo_config::pref!(layout_variable_fonts_enabled) {
             let used_variations = compute_variations(&descriptor, &template, &handle);
-            handle.copy_with_variations(&used_variations)?
+            handle.copy_with_variations(&template.identifier(), &used_variations)?
         } else {
             handle
         };

--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -152,7 +152,7 @@ pub trait PlatformFontMethods: Sized {
     /// Create a platform font with the given variations from a existing font.
     ///
     /// `self` is consumed to work around platform differences. On some platforms, changing the
-    /// variations requires creating an entirely new font face, whereas on others `self` the returned
+    /// variations requires creating an entirely new font face, whereas on others the returned
     /// font is `self`.
     fn copy_with_variations(self, _variations: &[FontVariation]) -> Result<Self, &'static str> {
         Err("not implemented")

--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -20,10 +20,12 @@ use icu_locid::subtags::Language;
 use log::debug;
 use malloc_size_of_derive::MallocSizeOf;
 use parking_lot::RwLock;
-use read_fonts::FontRead;
+use read_fonts::collections::int_set::Domain;
+use read_fonts::tables::fvar::Fvar;
 use read_fonts::tables::name::Name as NameTable;
 use read_fonts::tables::os2::{Os2, SelectionFlags};
 use read_fonts::types::Tag;
+use read_fonts::{FontRead, ReadError};
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use servo_base::id::PainterId;
@@ -31,8 +33,10 @@ use servo_base::text::{UnicodeBlock, UnicodeBlockMethod};
 use skrifa::string::LocalizedString;
 use smallvec::SmallVec;
 use style::Atom;
+use style::computed_values::font_optical_sizing::T as FontOpticalSizing;
 use style::computed_values::font_variant_caps;
 use style::computed_values::font_variant_position::T as FontVariantPosition;
+use style::font_face::FontStyleRange;
 use style::properties::style_structs::Font as FontStyleStruct;
 use style::values::computed::font::{
     FamilyName, FontFamilyNameSyntax, GenericFontFamily, SingleFontFamily,
@@ -63,11 +67,13 @@ pub(crate) const COLR: Tag = Tag::new(b"COLR");
 pub(crate) const CWSH: Tag = Tag::new(b"cwsh");
 pub(crate) const FRAC: Tag = Tag::new(b"frac");
 pub(crate) const DLIG: Tag = Tag::new(b"dlig");
+pub(crate) const FVAR: Tag = Tag::new(b"fvar");
 pub(crate) const FWID: Tag = Tag::new(b"fwid");
 pub(crate) const GPOS: Tag = Tag::new(b"GPOS");
 pub(crate) const GSUB: Tag = Tag::new(b"GSUB");
 pub(crate) const HIST: Tag = Tag::new(b"hist");
 pub(crate) const HLIG: Tag = Tag::new(b"hlig");
+pub(crate) const ITAL: Tag = Tag::new(b"ital");
 pub(crate) const JP04: Tag = Tag::new(b"jp04");
 pub(crate) const JP78: Tag = Tag::new(b"jp78");
 pub(crate) const JP83: Tag = Tag::new(b"jp83");
@@ -85,6 +91,7 @@ pub(crate) const PWID: Tag = Tag::new(b"pwid");
 pub(crate) const RUBY: Tag = Tag::new(b"ruby");
 pub(crate) const SALT: Tag = Tag::new(b"salt");
 pub(crate) const SBIX: Tag = Tag::new(b"sbix");
+pub(crate) const SLNT: Tag = Tag::new(b"slnt");
 pub(crate) const SMPL: Tag = Tag::new(b"smpl");
 pub(crate) const SUBS: Tag = Tag::new(b"subs");
 pub(crate) const SUPS: Tag = Tag::new(b"sups");
@@ -92,6 +99,10 @@ pub(crate) const SWSH: Tag = Tag::new(b"swsh");
 pub(crate) const TNUM: Tag = Tag::new(b"tnum");
 pub(crate) const TRAD: Tag = Tag::new(b"trad");
 pub(crate) const ZERO: Tag = Tag::new(b"zero");
+
+/// The number of degrees to slant the font face by if the `font-style` is `italic`
+/// but the font does not support native italic.
+const SLNT_VALUE_FOR_ITALIC_STYLE: f32 = 14.0;
 
 pub const LAST_RESORT_GLYPH_ADVANCE: FractionalPixel = 10.0;
 
@@ -105,7 +116,6 @@ pub trait PlatformFontMethods: Sized {
     fn new_from_template(
         template: FontTemplateRef,
         pt_size: Option<Au>,
-        variations: &[FontVariation],
         data: &Option<FontData>,
         synthetic_bold: bool,
     ) -> Result<PlatformFont, &'static str> {
@@ -113,18 +123,14 @@ pub trait PlatformFontMethods: Sized {
         let font_identifier = template.identifier.clone();
 
         match font_identifier {
-            FontIdentifier::Local(font_identifier) => Self::new_from_local_font_identifier(
-                font_identifier,
-                pt_size,
-                variations,
-                synthetic_bold,
-            ),
+            FontIdentifier::Local(font_identifier) => {
+                Self::new_from_local_font_identifier(font_identifier, pt_size, synthetic_bold)
+            },
             FontIdentifier::Web(_) | FontIdentifier::ArrayBuffer(_) => Self::new_from_data(
                 font_identifier,
                 data.as_ref()
                     .expect("Should never create a web font without data."),
                 pt_size,
-                variations,
                 synthetic_bold,
             ),
         }
@@ -133,7 +139,6 @@ pub trait PlatformFontMethods: Sized {
     fn new_from_local_font_identifier(
         font_identifier: LocalFontIdentifier,
         pt_size: Option<Au>,
-        variations: &[FontVariation],
         synthetic_bold: bool,
     ) -> Result<PlatformFont, &'static str>;
 
@@ -141,9 +146,17 @@ pub trait PlatformFontMethods: Sized {
         font_identifier: FontIdentifier,
         data: &FontData,
         pt_size: Option<Au>,
-        variations: &[FontVariation],
         synthetic_bold: bool,
     ) -> Result<PlatformFont, &'static str>;
+
+    /// Create a platform font with the given variations from a existing font.
+    ///
+    /// `self` is consumed to work around platform differences. On some platforms, changing the
+    /// variations requires creating an entirely new font face, whereas on others `self` the returned
+    /// font is `self`.
+    fn copy_with_variations(self, _variations: &[FontVariation]) -> Result<Self, &'static str> {
+        Err("not implemented")
+    }
 
     /// Get a [`FontTemplateDescriptor`] from a [`PlatformFont`]. This is used to get
     /// descriptors for web fonts.
@@ -192,6 +205,12 @@ pub(crate) type FractionalPixel = f64;
 
 pub(crate) trait FontTableMethods {
     fn buffer(&self) -> &[u8];
+    fn parse_as_specific_table<'a, Table>(&'a self) -> Result<Table, ReadError>
+    where
+        Table: FontRead<'a>,
+    {
+        Table::read(read_fonts::FontData::new(self.buffer()))
+    }
 }
 
 #[derive(Clone, Debug, Default, Deserialize, MallocSizeOf, PartialEq, Serialize)]
@@ -339,10 +358,18 @@ impl Font {
         let handle = PlatformFont::new_from_template(
             template.clone(),
             Some(descriptor.pt_size),
-            &descriptor.variation_settings,
             &data,
             synthetic_bold,
         )?;
+
+        // Compute and apply the OpenType variations
+        let handle = if servo_config::pref!(layout_variable_fonts_enabled) {
+            let used_variations = compute_variations(&descriptor, &template, &handle);
+            handle.copy_with_variations(&used_variations)?
+        } else {
+            handle
+        };
+
         let metrics = Arc::new(handle.metrics());
 
         Ok(Font {
@@ -1103,4 +1130,141 @@ pub(crate) fn map_platform_values_to_style_values(mapping: &[(f64, f64)], value:
     }
 
     mapping[mapping.len() - 1].1
+}
+
+/// <https://drafts.csswg.org/css-fonts-4/#apply-font-matching-variations>
+fn compute_variations(
+    descriptor: &FontDescriptor,
+    template: &FontTemplateRef,
+    platform_font: &PlatformFont,
+) -> Vec<FontVariation> {
+    let font_face_rule = template.font_face_rule();
+
+    // The steps in this algorithm are inverted order because they are listed in ascending order of precedence.
+    let mut variations: Vec<FontVariation> = vec![];
+
+    let mut add_variation = |variation: FontVariation| {
+        if !variations
+            .iter()
+            .any(|existing_variation| existing_variation.tag == variation.tag)
+        {
+            variations.push(variation);
+        }
+    };
+
+    // Step 12. Font variations implied by the value of the font-variation-settings property are applied.
+    // These values should be clamped to the values that are supported by the font.
+    // NOTE: Clamping happens inside the PlatformFont.
+    descriptor
+        .variation_settings
+        .iter()
+        .copied()
+        .for_each(&mut add_variation);
+
+    // Step 9. Font variations implied by the value of the font-optical-sizing property are applied.
+    // NOTE The precise behaviour of font-optical-sizing:auto is not defined.
+    // We choose to set "opsz" to the font size if it's not already set elsewhere. This is the easiest
+    // at the end of this function, so we move this step down.
+
+    if let Some(font_face_rule) = &font_face_rule {
+        // Step 6. If the font is defined via an @font-face rule, the font variations implied by the font-variation-settings
+        // descriptor in the @font-face rule are applied.
+        if let Some(variation_settings) = font_face_rule.font_variation_settings.as_ref() {
+            variation_settings
+                .0
+                .iter()
+                .map(|variation| FontVariation {
+                    tag: variation.tag.0,
+                    value: variation.value.get().expect(
+                        "The value is enforced to be resolvable at parse time \
+                        (see FontVariationSettings::parse_for_font_face_rule).",
+                    ),
+                })
+                .for_each(&mut add_variation);
+        }
+    }
+
+    // Step 2. Font variations as enabled by the font-weight, font-width, and font-style properties are applied.
+    //
+    // The application of the value enabled by font-style is affected by font selection, because this property might
+    // select an italic or an oblique font. The value applied is the closest matching value as determined by the font
+    // matching algorithm. User agents must apply at most one value due to the font-style property; both "ital" and
+    // "slnt" values must not be set together.
+    //
+    // If the selected font is defined in an @font-face rule, then the values applied at this step should be clamped
+    // to the value of the font-weight, font-width, and font-style descriptors in that @font-face rule.
+    // TODO: Clamp weight/stretch to the descriptors from the @font-face rule, if any
+    // NOTE: font-stretch is a legacy alias to font-width
+    add_variation(FontVariation {
+        tag: Tag::new(b"wght").to_u32(),
+        value: descriptor.weight.value(),
+    });
+
+    add_variation(FontVariation {
+        tag: Tag::new(b"wdth").to_u32(),
+        value: descriptor.stretch.0.to_float(),
+    });
+
+    let fvar_table = platform_font.table_for_tag(FVAR);
+    let has_ital_axis = fvar_table
+        .as_ref()
+        .and_then(|table| table.parse_as_specific_table::<Fvar<'_>>().ok())
+        .and_then(|fvar: Fvar<'_>| fvar.axis_instance_arrays().ok())
+        .is_some_and(|axis_instance_arrays| {
+            axis_instance_arrays
+                .axes()
+                .iter()
+                .any(|axis| axis.axis_tag() == ITAL)
+        });
+
+    let clamped_font_style = font_face_rule
+        .as_ref()
+        .and_then(|descriptor| descriptor.font_style.as_ref())
+        .map(|font_style_range| match font_style_range {
+            FontStyleRange::Italic => FontStyle::ITALIC,
+            FontStyleRange::Oblique(min_angle, max_angle) => {
+                let specified_angle = if descriptor.style == FontStyle::ITALIC {
+                    SLNT_VALUE_FOR_ITALIC_STYLE
+                } else {
+                    descriptor.style.oblique_degrees()
+                };
+                let clamped_angle = specified_angle
+                    .min(max_angle.degrees().unwrap_or(f32::INFINITY))
+                    .max(min_angle.degrees().unwrap_or(f32::NEG_INFINITY));
+                FontStyle::oblique(clamped_angle)
+            },
+        })
+        .unwrap_or(descriptor.style);
+    // TODO: We should recognize when a font has neither a ital nor a slnt axis and then
+    // synthesize an appropriate font face if allowed by font-synthesis.
+    if has_ital_axis {
+        add_variation(FontVariation {
+            tag: ITAL.to_u32(),
+            value: (clamped_font_style != FontStyle::NORMAL) as u32 as f32,
+        });
+    } else {
+        // Note: CSS and OpenType measure slnt in opposite directions, so we need to negate the
+        // angles.
+        if clamped_font_style == FontStyle::ITALIC {
+            add_variation(FontVariation {
+                tag: SLNT.to_u32(),
+                value: -SLNT_VALUE_FOR_ITALIC_STYLE,
+            });
+        } else {
+            add_variation(FontVariation {
+                tag: SLNT.to_u32(),
+                value: -clamped_font_style.oblique_degrees(),
+            });
+        }
+    }
+
+    // This is the implementation for Step 9. Refer to the note on Step 9 for an explanation of why it's here.
+    if descriptor.optical_sizing == FontOpticalSizing::Auto {
+        add_variation(FontVariation {
+            tag: Tag::new(b"opsz").to_u32(),
+            value: descriptor.pt_size.to_f32_px(),
+        });
+    }
+
+    variations
 }

--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -36,7 +36,6 @@ use style::Atom;
 use style::computed_values::font_optical_sizing::T as FontOpticalSizing;
 use style::computed_values::font_variant_caps;
 use style::computed_values::font_variant_position::T as FontVariantPosition;
-use style::font_face::FontStyleRange;
 use style::properties::style_structs::Font as FontStyleStruct;
 use style::values::computed::font::{
     FamilyName, FontFamilyNameSyntax, GenericFontFamily, SingleFontFamily,
@@ -100,10 +99,6 @@ pub(crate) const TNUM: Tag = Tag::new(b"tnum");
 pub(crate) const TRAD: Tag = Tag::new(b"trad");
 pub(crate) const ZERO: Tag = Tag::new(b"zero");
 
-/// The number of degrees to slant the font face by if the `font-style` is `italic`
-/// but the font does not support native italic.
-const SLNT_VALUE_FOR_ITALIC_STYLE: f32 = 14.0;
-
 pub const LAST_RESORT_GLYPH_ADVANCE: FractionalPixel = 10.0;
 
 // PlatformFont encapsulates access to the platform's font API,
@@ -159,7 +154,8 @@ pub trait PlatformFontMethods: Sized {
         _font_identifer: &FontIdentifier,
         _variations: &[FontVariation],
     ) -> Result<Self, &'static str> {
-        Err("not implemented")
+        // TODO: Get rid of this default implementation once windows support is added.
+        Ok(self)
     }
 
     /// Get a [`FontTemplateDescriptor`] from a [`PlatformFont`]. This is used to get
@@ -365,10 +361,13 @@ impl Font {
             &data,
             synthetic_bold,
         )?;
+        let variation_axes = VariationAxes::from_platform_font(&handle);
 
         // Compute and apply the OpenType variations
-        let handle = if servo_config::pref!(layout_variable_fonts_enabled) {
-            let used_variations = compute_variations(&descriptor, &template, &handle);
+        let handle = if servo_config::pref!(layout_variable_fonts_enabled) &&
+            variation_axes.contains(VariationAxes::IS_VARIABLE)
+        {
+            let used_variations = compute_variations(&descriptor, &template, variation_axes);
             handle.copy_with_variations(&template.identifier(), &used_variations)?
         } else {
             handle
@@ -1140,7 +1139,7 @@ pub(crate) fn map_platform_values_to_style_values(mapping: &[(f64, f64)], value:
 fn compute_variations(
     descriptor: &FontDescriptor,
     template: &FontTemplateRef,
-    platform_font: &PlatformFont,
+    variation_axes: VariationAxes,
 ) -> Vec<FontVariation> {
     let font_face_rule = template.font_face_rule();
 
@@ -1209,56 +1208,60 @@ fn compute_variations(
         value: descriptor.stretch.0.to_float(),
     });
 
-    let fvar_table = platform_font.table_for_tag(FVAR);
-    let has_ital_axis = fvar_table
-        .as_ref()
-        .and_then(|table| table.parse_as_specific_table::<Fvar<'_>>().ok())
-        .and_then(|fvar: Fvar<'_>| fvar.axis_instance_arrays().ok())
-        .is_some_and(|axis_instance_arrays| {
-            axis_instance_arrays
-                .axes()
-                .iter()
-                .any(|axis| axis.axis_tag() == ITAL)
-        });
+    if variation_axes.intersects(VariationAxes::ITAL | VariationAxes::SLNT) {
+        let clamped_font_style = font_face_rule
+            .as_ref()
+            .and_then(|descriptor| descriptor.font_style.as_ref())
+            .map(|font_style_range| {
+                let computed_font_style_range =
+                    font_style_range.compute().expect("never returns None");
 
-    let clamped_font_style = font_face_rule
-        .as_ref()
-        .and_then(|descriptor| descriptor.font_style.as_ref())
-        .map(|font_style_range| match font_style_range {
-            FontStyleRange::Italic => FontStyle::ITALIC,
-            FontStyleRange::Oblique(min_angle, max_angle) => {
+                if computed_font_style_range.0 == FontStyle::ITALIC {
+                    debug_assert_eq!(computed_font_style_range.1, FontStyle::ITALIC);
+                    return FontStyle::ITALIC;
+                }
+                debug_assert_ne!(computed_font_style_range.1, FontStyle::ITALIC);
+
                 let specified_angle = if descriptor.style == FontStyle::ITALIC {
-                    SLNT_VALUE_FOR_ITALIC_STYLE
+                    FontStyle::DEFAULT_OBLIQUE_DEGREES as f32
                 } else {
                     descriptor.style.oblique_degrees()
                 };
+
                 let clamped_angle = specified_angle
-                    .min(max_angle.degrees().unwrap_or(f32::INFINITY))
-                    .max(min_angle.degrees().unwrap_or(f32::NEG_INFINITY));
+                    .min(computed_font_style_range.1.oblique_degrees())
+                    .max(computed_font_style_range.0.oblique_degrees());
                 FontStyle::oblique(clamped_angle)
-            },
-        })
-        .unwrap_or(descriptor.style);
-    // TODO: We should recognize when a font has neither a ital nor a slnt axis and then
-    // synthesize an appropriate font face if allowed by font-synthesis.
-    if has_ital_axis {
-        add_variation(FontVariation {
-            tag: ITAL.to_u32(),
-            value: (clamped_font_style != FontStyle::NORMAL) as u32 as f32,
-        });
-    } else {
-        // Note: CSS and OpenType measure slnt in opposite directions, so we need to negate the
-        // angles.
-        if clamped_font_style == FontStyle::ITALIC {
+            })
+            .unwrap_or(descriptor.style);
+
+        // TODO: We should recognize when a font has neither a ital nor a slnt axis and then
+        // synthesize an appropriate font face if allowed by font-synthesis.
+
+        // When both a `ital` and a `slnt` axis are available then we prefer `ital` for
+        // `font-style: italic` and `slnt` for `font-style: oblique`.
+        let use_ital_axis = (variation_axes.contains(VariationAxes::ITAL) &&
+            clamped_font_style == FontStyle::ITALIC) ||
+            !variation_axes.contains(VariationAxes::SLNT);
+        if use_ital_axis {
             add_variation(FontVariation {
-                tag: SLNT.to_u32(),
-                value: -SLNT_VALUE_FOR_ITALIC_STYLE,
+                tag: ITAL.to_u32(),
+                value: (clamped_font_style != FontStyle::NORMAL) as u32 as f32,
             });
         } else {
-            add_variation(FontVariation {
-                tag: SLNT.to_u32(),
-                value: -clamped_font_style.oblique_degrees(),
-            });
+            // Note: CSS and OpenType measure slnt in opposite directions, so we need to negate the
+            // angles.
+            if clamped_font_style == FontStyle::ITALIC {
+                add_variation(FontVariation {
+                    tag: SLNT.to_u32(),
+                    value: (-FontStyle::DEFAULT_OBLIQUE_DEGREES) as f32,
+                });
+            } else {
+                add_variation(FontVariation {
+                    tag: SLNT.to_u32(),
+                    value: -clamped_font_style.oblique_degrees(),
+                });
+            }
         }
     }
 
@@ -1271,4 +1274,56 @@ fn compute_variations(
     }
 
     variations
+}
+
+bitflags! {
+    #[derive(Clone, Copy, Debug)]
+    struct VariationAxes: u8 {
+        /// Whether the font has any variation axes at all.
+        const IS_VARIABLE = 1;
+
+        /// Whether the font as a `ital` axis.
+        ///
+        /// Never set without `IS_VARIABLE`.
+        const ITAL = 1 << 1;
+
+        /// Whether the font as a `slnt` axis.
+        ///
+        /// Never set without `IS_VARIABLE`.
+        const SLNT = 1 << 2;
+    }
+}
+
+impl VariationAxes {
+    fn from_platform_font(platform_font: &PlatformFont) -> Self {
+        let Some(fvar_table) = platform_font.table_for_tag(FVAR) else {
+            // This is not a variable font.
+            return VariationAxes::empty();
+        };
+
+        let Some(variation_axes) = fvar_table
+            .parse_as_specific_table::<Fvar<'_>>()
+            .ok()
+            .and_then(|fvar: Fvar<'_>| fvar.axis_instance_arrays().ok())
+            .map(|instance_arrays| instance_arrays.axes())
+        else {
+            // The fvar table is malformed.
+            return VariationAxes::empty();
+        };
+
+        if variation_axes.is_empty() {
+            return VariationAxes::empty();
+        }
+
+        let mut result = VariationAxes::IS_VARIABLE;
+        for axis in variation_axes {
+            match axis.axis_tag() {
+                ITAL => result |= VariationAxes::ITAL,
+                SLNT => result |= VariationAxes::SLNT,
+                _ => {},
+            }
+        }
+
+        result
+    }
 }

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -242,13 +242,6 @@ impl FontContext {
         font_template: FontTemplateRef,
         font_descriptor: &FontDescriptor,
     ) -> Option<FontRef> {
-        let font_descriptor = if servo_config::pref!(layout_variable_fonts_enabled) {
-            let variation_settings = font_template.borrow().compute_variations(font_descriptor);
-            &font_descriptor.with_variation_settings(variation_settings)
-        } else {
-            font_descriptor
-        };
-
         self.get_font_maybe_synthesizing_small_caps(
             font_template,
             font_descriptor,

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -242,13 +242,6 @@ impl FontContext {
         font_template: FontTemplateRef,
         font_descriptor: &FontDescriptor,
     ) -> Option<FontRef> {
-        let font_descriptor = if servo_config::pref!(layout_variable_fonts_enabled) {
-            let variation_settings = font_template.borrow().compute_variations(font_descriptor);
-            &font_descriptor.with_variation_settings(variation_settings)
-        } else {
-            font_descriptor
-        };
-
         self.get_font_maybe_synthesizing_small_caps(
             font_template,
             font_descriptor,
@@ -556,8 +549,7 @@ impl FontContext {
         );
 
         let identifier = FontIdentifier::Web(url);
-        let Ok(handle) =
-            PlatformFont::new_from_data(identifier.clone(), &font_data, None, &[], false)
+        let Ok(handle) = PlatformFont::new_from_data(identifier.clone(), &font_data, None, false)
         else {
             return false;
         };
@@ -974,7 +966,7 @@ impl FontContext {
 
         let identifier = FontIdentifier::ArrayBuffer(Uuid::new_v4());
         let handle =
-            PlatformFont::new_from_data(identifier.clone(), &font_data, None, &[], false).ok()?;
+            PlatformFont::new_from_data(identifier.clone(), &font_data, None, false).ok()?;
 
         let new_template = FontTemplate::new(identifier.clone(), handle.descriptor(), None);
 

--- a/components/fonts/platform/freetype/font.rs
+++ b/components/fonts/platform/freetype/font.rs
@@ -395,6 +395,15 @@ impl PlatformFontMethods for PlatformFont {
     fn variations(&self) -> &[FontVariation] {
         &self.variations
     }
+
+    fn set_variations(&mut self, variations: &[FontVariation]) -> Result<(), &'static str> {
+        let library = FreeTypeLibraryHandle::get().lock();
+        self.variations = self
+            .face
+            .lock()
+            .set_variations_for_font(variations, &library)?;
+        Ok(())
+    }
 }
 
 impl PlatformFont {

--- a/components/fonts/platform/freetype/font.rs
+++ b/components/fonts/platform/freetype/font.rs
@@ -68,14 +68,11 @@ impl PlatformFontMethods for PlatformFont {
         _font_identifier: FontIdentifier,
         font_data: &FontData,
         requested_size: Option<Au>,
-        variations: &[FontVariation],
         synthetic_bold: bool,
     ) -> Result<PlatformFont, &'static str> {
         let library = FreeTypeLibraryHandle::get().lock();
         let data = FontBackingStore::Web(font_data.clone());
         let face = FreeTypeFace::new_from_memory(&library, data, 0)?;
-
-        let normalized_variations = face.set_variations_for_font(variations, &library)?;
 
         let (requested_face_size, actual_face_size) = match requested_size {
             Some(requested_size) => (requested_size, face.set_size(requested_size)?),
@@ -91,7 +88,7 @@ impl PlatformFontMethods for PlatformFont {
             requested_face_size,
             actual_face_size,
             table_provider_data,
-            variations: normalized_variations,
+            variations: vec![],
             synthetic_bold,
         })
     }
@@ -99,7 +96,6 @@ impl PlatformFontMethods for PlatformFont {
     fn new_from_local_font_identifier(
         font_identifier: LocalFontIdentifier,
         requested_size: Option<Au>,
-        variations: &[FontVariation],
         synthetic_bold: bool,
     ) -> Result<PlatformFont, &'static str> {
         let library = FreeTypeLibraryHandle::get().lock();
@@ -118,8 +114,6 @@ impl PlatformFontMethods for PlatformFont {
             face_index,
         )?;
 
-        let normalized_variations = face.set_variations_for_font(variations, &library)?;
-
         let (requested_face_size, actual_face_size) = match requested_size {
             Some(requested_size) => (requested_size, face.set_size(requested_size)?),
             None => (Au::zero(), Au::zero()),
@@ -135,9 +129,18 @@ impl PlatformFontMethods for PlatformFont {
             requested_face_size,
             actual_face_size,
             table_provider_data,
-            variations: normalized_variations,
+            variations: vec![],
             synthetic_bold,
         })
+    }
+
+    fn copy_with_variations(mut self, variations: &[FontVariation]) -> Result<Self, &'static str> {
+        let library = FreeTypeLibraryHandle::get().lock();
+        self.variations = self
+            .face
+            .lock()
+            .set_variations_for_font(variations, &library)?;
+        Ok(self)
     }
 
     fn descriptor(&self) -> FontTemplateDescriptor {

--- a/components/fonts/platform/freetype/font.rs
+++ b/components/fonts/platform/freetype/font.rs
@@ -134,7 +134,11 @@ impl PlatformFontMethods for PlatformFont {
         })
     }
 
-    fn copy_with_variations(mut self, variations: &[FontVariation]) -> Result<Self, &'static str> {
+    fn copy_with_variations(
+        mut self,
+        _: &FontIdentifier,
+        variations: &[FontVariation],
+    ) -> Result<Self, &'static str> {
         let library = FreeTypeLibraryHandle::get().lock();
         self.variations = self
             .face

--- a/components/fonts/platform/macos/core_text_font_cache.rs
+++ b/components/fonts/platform/macos/core_text_font_cache.rs
@@ -47,18 +47,17 @@ impl CoreTextFontCache {
         font_identifier: FontIdentifier,
         data: Option<&FontData>,
         pt_size: f64,
-        variations: &[FontVariation],
         synthetic_bold: bool,
     ) -> Option<PlatformFont> {
-        //// If you pass a zero font size to one of the Core Text APIs, it'll replace it with
-        //// 12.0. We don't want that! (Issue #10492.)
+        // If you pass a zero font size to one of the Core Text APIs, it'll replace it with
+        // 12.0. We don't want that! (Issue #10492.)
         let clamped_pt_size = pt_size.max(0.01);
         let au_size = Au::from_f64_px(clamped_pt_size);
 
         let key = CoreTextFontCacheKey {
             size: au_size,
             synthetic_bold,
-            variations: variations.to_owned(),
+            variations: Vec::new(),
         };
 
         let cache = CACHE.0.get_or_init(Default::default);
@@ -70,34 +69,6 @@ impl CoreTextFontCache {
             {
                 return Some(platform_font.clone());
             }
-        }
-
-        if !key.variations.is_empty() {
-            let core_text_font_no_variations = Self::core_text_font(
-                font_identifier.clone(),
-                data,
-                clamped_pt_size,
-                &[],
-                synthetic_bold,
-            )?;
-            let mut cache = cache.write();
-            let entry = cache.entry(font_identifier).or_default();
-
-            // It could be that between the time of the cache miss above and now, after the write lock
-            // on the cache has been acquired, the cache was populated with the data that we need. Thus
-            // check again and return the CTFont if it is is already cached.
-            if let Some(core_text_font) = entry.get(&key) {
-                return Some(core_text_font.clone());
-            }
-
-            let platform_font = Self::add_variations_to_font(
-                core_text_font_no_variations,
-                &key.variations,
-                clamped_pt_size,
-                synthetic_bold,
-            );
-            entry.insert(key, platform_font.clone());
-            return Some(platform_font);
         }
 
         let mut cache = cache.write();
@@ -161,15 +132,44 @@ impl CoreTextFontCache {
         Some(PlatformFont::new_with_ctfont(ctfont, synthetic_bold))
     }
 
-    fn add_variations_to_font(
+    pub(crate) fn add_variations_to_font(
         platform_font: PlatformFont,
+        font_identifier: &FontIdentifier,
         specified_variations: &[FontVariation],
-        pt_size: f64,
-        synthetic_bold: bool,
     ) -> PlatformFont {
         if specified_variations.is_empty() {
             return platform_font;
         }
+
+        let pt_size = unsafe { platform_font.ctfont.size() };
+        let synthetic_bold = platform_font.synthetic_bold;
+        let key = CoreTextFontCacheKey {
+            size: Au::from_f64_px(pt_size),
+            synthetic_bold,
+            variations: specified_variations.to_owned(),
+        };
+
+        let cache = CACHE.0.get_or_init(Default::default);
+        {
+            let cache = cache.read();
+            if let Some(platform_font) = cache
+                .get(font_identifier)
+                .and_then(|identifier_cache| identifier_cache.get(&key))
+            {
+                return platform_font.clone();
+            }
+        }
+
+        let mut cache = cache.write();
+        let entry = cache.entry(font_identifier.clone()).or_default();
+
+        // It could be that between the time of the cache miss above and now, after the write lock
+        // on the cache has been acquired, the cache was populated with the data that we need. Thus
+        // check again and return the CTFont if it is is already cached.
+        if let Some(core_text_font) = entry.get(&key) {
+            return core_text_font.clone();
+        }
+
         let Some(variations) = Self::get_variation_axis_information(&platform_font) else {
             return platform_font;
         };
@@ -236,7 +236,11 @@ impl CoreTextFontCache {
         let ctfont = unsafe {
             CTFont::with_font_descriptor(&descriptor_with_variations, pt_size, std::ptr::null())
         };
-        PlatformFont::new_with_ctfont_and_variations(ctfont, variations, synthetic_bold)
+        let platform_font =
+            PlatformFont::new_with_ctfont_and_variations(ctfont, variations, synthetic_bold);
+
+        entry.insert(key, platform_font.clone());
+        platform_font
     }
 
     fn get_variation_axis_information(

--- a/components/fonts/platform/macos/font.rs
+++ b/components/fonts/platform/macos/font.rs
@@ -252,14 +252,13 @@ impl PlatformFontMethods for PlatformFont {
         font_identifier: FontIdentifier,
         data: &FontData,
         requested_size: Option<Au>,
-        variations: &[FontVariation],
         synthetic_bold: bool,
     ) -> Result<PlatformFont, &'static str> {
         Self::new(
             font_identifier,
             Some(data),
             requested_size,
-            variations,
+            &[],
             synthetic_bold,
         )
     }
@@ -267,14 +266,13 @@ impl PlatformFontMethods for PlatformFont {
     fn new_from_local_font_identifier(
         font_identifier: LocalFontIdentifier,
         requested_size: Option<Au>,
-        variations: &[FontVariation],
         synthetic_bold: bool,
     ) -> Result<PlatformFont, &'static str> {
         Self::new(
             FontIdentifier::Local(font_identifier),
             None,
             requested_size,
-            variations,
+            &[],
             synthetic_bold,
         )
     }

--- a/components/fonts/platform/macos/font.rs
+++ b/components/fonts/platform/macos/font.rs
@@ -63,7 +63,7 @@ pub struct PlatformFont {
     pub(crate) ctfont: CFRetained<CTFont>,
     variations: Vec<FontVariation>,
     h_kern_subtable: Option<CachedKernTable>,
-    synthetic_bold: bool,
+    pub(crate) synthetic_bold: bool,
 }
 
 // From https://developer.apple.com/documentation/coretext:
@@ -110,20 +110,15 @@ impl PlatformFont {
         font_identifier: FontIdentifier,
         data: Option<&FontData>,
         requested_size: Option<Au>,
-        variations: &[FontVariation],
         synthetic_bold: bool,
     ) -> Result<PlatformFont, &'static str> {
         let size = match requested_size {
             Some(s) => s.to_f64_px(),
             None => 0.0,
         };
-        let Some(mut platform_font) = CoreTextFontCache::core_text_font(
-            font_identifier,
-            data,
-            size,
-            variations,
-            synthetic_bold,
-        ) else {
+        let Some(mut platform_font) =
+            CoreTextFontCache::core_text_font(font_identifier, data, size, synthetic_bold)
+        else {
             return Err("Could not generate CTFont for FontTemplateData");
         };
 
@@ -254,13 +249,7 @@ impl PlatformFontMethods for PlatformFont {
         requested_size: Option<Au>,
         synthetic_bold: bool,
     ) -> Result<PlatformFont, &'static str> {
-        Self::new(
-            font_identifier,
-            Some(data),
-            requested_size,
-            &[],
-            synthetic_bold,
-        )
+        Self::new(font_identifier, Some(data), requested_size, synthetic_bold)
     }
 
     fn new_from_local_font_identifier(
@@ -272,9 +261,24 @@ impl PlatformFontMethods for PlatformFont {
             FontIdentifier::Local(font_identifier),
             None,
             requested_size,
-            &[],
             synthetic_bold,
         )
+    }
+
+    /// Create a platform font with the given variations from a existing font.
+    ///
+    /// `self` is consumed to work around platform differences. On some platforms, changing the
+    /// variations requires creating an entirely new font face, whereas on others the returned
+    /// font is `self`.
+    fn copy_with_variations(
+        self,
+        font_identifier: &FontIdentifier,
+        variations: &[FontVariation],
+    ) -> Result<Self, &'static str> {
+        let mut platform_font =
+            CoreTextFontCache::add_variations_to_font(self, font_identifier, variations);
+        platform_font.load_h_kern_subtable();
+        Ok(platform_font)
     }
 
     fn descriptor(&self) -> FontTemplateDescriptor {

--- a/components/fonts/platform/windows/font.rs
+++ b/components/fonts/platform/windows/font.rs
@@ -182,20 +182,18 @@ impl PlatformFontMethods for PlatformFont {
         _font_identifier: FontIdentifier,
         data: &FontData,
         pt_size: Option<Au>,
-        variations: &[FontVariation],
         synthetic_bold: bool,
     ) -> Result<Self, &'static str> {
         let font_face = FontFile::new_from_buffer(Arc::new(data.clone()))
             .ok_or("Could not create FontFile")?
             .create_face(0 /* face_index */, DWRITE_FONT_SIMULATIONS_NONE)
             .map_err(|_| "Could not create FontFace")?;
-        Self::new_with_variations(font_face, pt_size, variations, synthetic_bold)
+        Self::new_with_variations(font_face, pt_size, &[], synthetic_bold)
     }
 
     fn new_from_local_font_identifier(
         font_identifier: LocalFontIdentifier,
         pt_size: Option<Au>,
-        variations: &[FontVariation],
         synthetic_bold: bool,
     ) -> Result<PlatformFont, &'static str> {
         let font_face = FontCollection::system()
@@ -204,7 +202,7 @@ impl PlatformFontMethods for PlatformFont {
             .flatten()
             .ok_or("Could not create Font from descriptor")?
             .create_font_face();
-        Self::new_with_variations(font_face, pt_size, variations, synthetic_bold)
+        Self::new_with_variations(font_face, pt_size, &[], synthetic_bold)
     }
 
     fn descriptor(&self) -> FontTemplateDescriptor {

--- a/components/fonts/tests/font.rs
+++ b/components/fonts/tests/font.rs
@@ -33,7 +33,7 @@ fn make_font(path: PathBuf) -> Font {
 
     let identifier = FontIdentifier::Web(ServoUrl::from_file_path(path).unwrap());
     let platform_font =
-        PlatformFont::new_from_data(identifier.clone(), &data, None, &[], false).unwrap();
+        PlatformFont::new_from_data(identifier.clone(), &data, None, false).unwrap();
 
     let template = FontTemplate::new(identifier, platform_font.descriptor(), None);
     let descriptor = FontDescriptor {

--- a/components/fonts/tests/font_context.rs
+++ b/components/fonts/tests/font_context.rs
@@ -186,7 +186,6 @@ mod font_context {
             let handle = PlatformFont::new_from_local_font_identifier(
                 local_font_identifier.clone(),
                 None,
-                &[],
                 false,
             )
             .expect("Could not load test font");

--- a/components/fonts/tests/font_template.rs
+++ b/components/fonts/tests/font_template.rs
@@ -36,7 +36,7 @@ fn test_font_template_descriptor() {
             .unwrap();
         let data = FontData::from_bytes(&bytes);
 
-        let handle = PlatformFont::new_from_data(identifier, &data, None, &[], false).unwrap();
+        let handle = PlatformFont::new_from_data(identifier, &data, None, false).unwrap();
         handle.descriptor()
     }
 

--- a/components/shared/fonts/font_descriptor.rs
+++ b/components/shared/fonts/font_descriptor.rs
@@ -28,6 +28,9 @@ pub struct FontDescriptor {
     pub style: FontStyle,
     pub variant: font_variant_caps::T,
     pub pt_size: Au,
+    /// The value of the `@font-variation-settings` property.
+    ///
+    /// This does not include synthesized variations from `font-style`, `font-stretch` etc.
     pub variation_settings: Vec<FontVariation>,
     pub synthesis_weight: FontSynthesis,
     pub optical_sizing: FontOpticalSizing,

--- a/components/shared/fonts/font_descriptor.rs
+++ b/components/shared/fonts/font_descriptor.rs
@@ -62,15 +62,6 @@ impl<'a> From<&'a FontStyleStruct> for FontDescriptor {
     }
 }
 
-impl FontDescriptor {
-    pub fn with_variation_settings(&self, variation_settings: Vec<FontVariation>) -> Self {
-        FontDescriptor {
-            variation_settings,
-            ..*self
-        }
-    }
-}
-
 /// This data structure represents the various optional descriptors that can be
 /// applied to a `@font-face` rule in CSS. These are used to create a [`FontTemplate`]
 /// from the given font data used as the source of the `@font-face` rule. If values

--- a/components/shared/fonts/font_template.rs
+++ b/components/shared/fonts/font_template.rs
@@ -8,16 +8,12 @@ use std::sync::Arc;
 
 use atomic_refcell::{AtomicRef, AtomicRefCell};
 use malloc_size_of_derive::MallocSizeOf;
-use read_fonts::collections::int_set::Domain;
-use read_fonts::types::Tag;
 use serde::{Deserialize, Serialize};
-use style::computed_values::font_optical_sizing::T as FontOpticalSizing;
 use style::computed_values::font_stretch::T as FontStretch;
 use style::computed_values::font_style::T as FontStyle;
 use style::font_face::{ComputedFontStretchRange, ComputedFontStyleRange, ComputedFontWeightRange};
 use style::properties::generated::font_face::Descriptors as FontFaceRuleDescriptors;
 use style::values::computed::font::FontWeight;
-use webrender_api::FontVariation;
 
 use crate::{CSSFontFaceDescriptors, FontDescriptor, FontIdentifier};
 
@@ -192,76 +188,6 @@ impl FontTemplate {
 
     pub fn identifier(&self) -> &FontIdentifier {
         &self.identifier
-    }
-
-    /// <https://drafts.csswg.org/css-fonts-4/#apply-font-matching-variations>
-    pub fn compute_variations(&self, descriptor: &FontDescriptor) -> Vec<FontVariation> {
-        // The steps in this algorithm are inverted order because they are listed in ascending order of precedence.
-        let mut variations: Vec<FontVariation> = vec![];
-
-        let mut add_variation = |variation: FontVariation| {
-            if !variations
-                .iter()
-                .any(|existing_variation| existing_variation.tag == variation.tag)
-            {
-                variations.push(variation);
-            }
-        };
-
-        // Step 12. Font variations implied by the value of the font-variation-settings property are applied.
-        // These values should be clamped to the values that are supported by the font.
-        // NOTE: Clamping happens inside the PlatformFont.
-        descriptor
-            .variation_settings
-            .iter()
-            .copied()
-            .for_each(&mut add_variation);
-
-        // Step 9. Font variations implied by the value of the font-optical-sizing property are applied.
-        // NOTE The precise behaviour of font-optical-sizing:auto is not defined.
-        // We choose to set "opsz" to the font size if it's not already set elsewhere. This is the easiest
-        // at the end of this function, so we move this step down.
-
-        if let Some(font_face_rule) = &self.font_face_rule {
-            // Step 6. If the font is defined via an @font-face rule, the font variations implied by the font-variation-settings
-            // descriptor in the @font-face rule are applied.
-            if let Some(variation_settings) = font_face_rule.font_variation_settings.as_ref() {
-                variation_settings
-                    .0
-                    .iter()
-                    .map(|variation| FontVariation {
-                        tag: variation.tag.0,
-                        value: variation.value.get().expect(
-                            "The value is enforced to be resolvable at parse time \
-                            (see FontVariationSettings::parse_for_font_face_rule).",
-                        ),
-                    })
-                    .for_each(&mut add_variation);
-            }
-        }
-
-        // Step 2. Font variations as enabled by the font-weight, font-width, and font-style properties are applied.
-        // FIXME: Apply variations for font-style
-        // NOTE: font-stretch is a legacy alias to font-width
-        add_variation(FontVariation {
-            tag: Tag::new(b"wght").to_u32(),
-            value: descriptor.weight.value(),
-        });
-
-        add_variation(FontVariation {
-            tag: Tag::new(b"wdth").to_u32(),
-            value: descriptor.stretch.0.to_float(),
-        });
-
-        // This is the implementation for Step 9. Refer to the note on Step 9 for an explanation of why it's here.
-        if descriptor.optical_sizing == FontOpticalSizing::Auto {
-            add_variation(FontVariation {
-                tag: Tag::new(b"opsz").to_u32(),
-                value: descriptor.pt_size.to_f32_px(),
-            });
-        }
-
-        variations
     }
 
     pub fn is_defined_by_font_face_rule(&self, rule: &FontFaceRuleDescriptors) -> bool {

--- a/tests/wpt/meta/css/css-fonts/font-face-style-auto-variable.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-face-style-auto-variable.html.ini
@@ -1,2 +1,0 @@
-[font-face-style-auto-variable.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-face-style-default-variable.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-face-style-default-variable.html.ini
@@ -1,2 +1,0 @@
-[font-face-style-default-variable.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/matching/range-descriptor-reversed.html.ini
+++ b/tests/wpt/meta/css/css-fonts/matching/range-descriptor-reversed.html.ini
@@ -1,2 +1,0 @@
-[range-descriptor-reversed.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/variations/font-slant-1.html.ini
+++ b/tests/wpt/meta/css/css-fonts/variations/font-slant-1.html.ini
@@ -1,2 +1,0 @@
-[font-slant-1.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/variations/slnt-backslant-variable.html.ini
+++ b/tests/wpt/meta/css/css-fonts/variations/slnt-backslant-variable.html.ini
@@ -1,2 +1,0 @@
-[slnt-backslant-variable.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/variations/slnt-variable.html.ini
+++ b/tests/wpt/meta/css/css-fonts/variations/slnt-variable.html.ini
@@ -1,2 +1,0 @@
-[slnt-variable.html]
-  expected: FAIL


### PR DESCRIPTION
Synthesizing variations from `font-style` requires a bit more work than for other properties because depending on which variation axes the font has we need to set either `ital` (to 0 or 1) or `slnt` (to a number of degrees). Currently we synthesize variations too early, when the font data is not yet avaiable. That's why this change moves the implementation of https://drafts.csswg.org/css-fonts-4/#apply-font-matching-variations to `Font::new`.

On macos and windows `PlatformFont::copy_with_variations` is not yet implemented, so variations are synthesized but they do nothing. I hope to fix this in future changes but its hard to approach since I don't have access to macos/windows machines.

Testing: New tests start to pass
Part of https://github.com/servo/servo/issues/38800