### PR TITLE
More gracefully handle header parsing errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8707,6 +8707,7 @@ dependencies = [
  "nom 8.0.0",
  "parking_lot",
  "quick_cache",
+ "rand 0.10.2",
  "regex",
  "resvg",
  "rustc-hash 2.1.3",

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -60,6 +60,7 @@ parking_lot = { workspace = true }
 pixels = { workspace = true }
 profile_traits = { workspace = true }
 quick_cache = { workspace = true, features = ["ahash"] }
+rand = { workspace = true }
 regex = { workspace = true }
 resvg = { workspace = true }
 rustc-hash = { workspace = true }

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -340,11 +340,10 @@ fn set_request_cookies(
 ) {
     let mut cookie_jar = cookie_jar.write();
     cookie_jar.remove_expired_cookies_for_url(url);
-    if let Some(cookie_list) = cookie_jar.cookies_for_url(url, CookieSource::HTTP) {
-        headers.insert(
-            header::COOKIE,
-            HeaderValue::from_bytes(cookie_list.as_bytes()).unwrap(),
-        );
+    if let Some(cookie_list) = cookie_jar.cookies_for_url(url, CookieSource::HTTP) &&
+        let Ok(cookie_list_header_value) = HeaderValue::from_bytes(cookie_list.as_bytes())
+    {
+        headers.insert(header::COOKIE, cookie_list_header_value);
     }
 }
 

--- a/components/net/protocols/data.rs
+++ b/components/net/protocols/data.rs
@@ -6,7 +6,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 use data_url::DataUrl;
-use headers::HeaderValue;
+use http::HeaderValue;
 use net_traits::http_status::HttpStatus;
 use net_traits::request::Request;
 use net_traits::response::{Response, ResponseBody};
@@ -35,11 +35,15 @@ impl ProtocolHandler for DataProtocolHander {
                     let mut response =
                         Response::new(url, ResourceFetchTiming::new(request.timing_type()));
                     *response.body.lock() = ResponseBody::Done(bytes);
-                    let mime = data_url.mime_type();
-                    response.headers.insert(
-                        http::header::CONTENT_TYPE,
-                        HeaderValue::from_str(&mime.to_string()).unwrap(),
-                    );
+
+                    if let Ok(content_type_header_value) =
+                        HeaderValue::from_str(&data_url.mime_type().to_string())
+                    {
+                        response
+                            .headers
+                            .insert(http::header::CONTENT_TYPE, content_type_header_value);
+                    }
+
                     response.status = HttpStatus::default();
                     Some(response)
                 },

--- a/components/net/websocket_loader.rs
+++ b/components/net/websocket_loader.rs
@@ -16,8 +16,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use async_tungstenite::WebSocketStream;
 use async_tungstenite::tokio::{ConnectStream, client_async_tls_with_connector_and_config};
-use base64::Engine;
 use futures::stream::StreamExt;
+use headers::{
+    Authorization, Connection, HeaderMapExt, SecWebsocketKey, SecWebsocketVersion, Upgrade,
+};
 use http::HeaderMap;
 use http::header::{self, HeaderName, HeaderValue};
 use ipc_channel::ipc::IpcSender;
@@ -65,22 +67,25 @@ pub fn create_handshake_request(
             .ok_or_else(|| Error::Url(UrlError::NoHostName))?
     );
     headers.insert("Host", HeaderValue::from_str(&host)?);
+
     // https://websockets.spec.whatwg.org/#concept-websocket-establish
     // 3. Append (`Upgrade`, `websocket`) to request’s header list.
-    headers.insert("Upgrade", HeaderValue::from_static("websocket"));
+    headers.typed_insert(Upgrade::websocket());
 
     // 4. Append (`Connection`, `Upgrade`) to request’s header list.
-    headers.insert("Connection", HeaderValue::from_static("upgrade"));
+    headers.typed_insert(Connection::upgrade());
 
     // 5. Let keyValue be a nonce consisting of a randomly selected 16-byte value that has been
     // forgiving-base64-encoded and isomorphic encoded.
-    let key = HeaderValue::from_str(&tungstenite::handshake::client::generate_key()).unwrap();
+    let mut nonce: [u8; 16] = [0; 16];
+    rand::fill(&mut nonce);
+    let sec_websocket_key_header: SecWebsocketKey = nonce.into();
 
     // 6. Append (`Sec-WebSocket-Key`, keyValue) to request’s header list.
-    headers.insert("Sec-WebSocket-Key", key);
+    headers.typed_insert(sec_websocket_key_header);
 
     // 7. Append (`Sec-WebSocket-Version`, `13`) to request’s header list.
-    headers.insert("Sec-Websocket-Version", HeaderValue::from_static("13"));
+    headers.typed_insert(SecWebsocketVersion::V13);
 
     // 8. For each protocol in protocols, combine (`Sec-WebSocket-Protocol`, protocol) in request’s
     // header list.
@@ -103,15 +108,10 @@ pub fn create_handshake_request(
     }
 
     if request.url.password().is_some() || request.url.username() != "" {
-        let basic = base64::engine::general_purpose::STANDARD.encode(format!(
-            "{}:{}",
+        headers.typed_insert(Authorization::basic(
             request.url.username(),
-            request.url.password().unwrap_or("")
+            request.url.password().unwrap_or(""),
         ));
-        headers.insert(
-            "Authorization",
-            HeaderValue::from_str(&format!("Basic {}", basic))?,
-        );
     }
     Ok(request.headers(headers).build())
 }

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -718,13 +718,14 @@ impl EventSourceTimeoutCallback {
         // Step 5.3: If the EventSource object's last event ID string is not the empty string, then:
         //  - Let lastEventIDValue be the EventSource object's last event ID string, encoded as UTF-8.
         //  - Set (`Last-Event-ID`, lastEventIDValue) in request's header list.
-        if !event_source.last_event_id.borrow().is_empty() {
-            // TODO(eijebong): Change this once typed header support custom values
-            request.headers.insert(
-                HeaderName::from_static("last-event-id"),
+        if !event_source.last_event_id.borrow().is_empty() &&
+            let Ok(header_value) =
                 HeaderValue::from_str(&String::from(event_source.last_event_id.borrow().clone()))
-                    .unwrap(),
-            );
+        {
+            // TODO(eijebong): Change this once typed header support custom values
+            request
+                .headers
+                .insert(HeaderName::from_static("last-event-id"), header_value);
         }
 
         // Step 5.4: Fetch request and process the response obtained in this fashion, if

--- a/components/script/dom/fetch/headers.rs
+++ b/components/script/dom/fetch/headers.rs
@@ -114,18 +114,15 @@ impl HeadersMethods<crate::DomTypeHolder> for Headers {
         }
 
         // 4. Append (name, value) to headers’s header list.
-        match HeaderValue::from_bytes(&valid_value) {
-            Ok(value) => {
-                self.header_list
-                    .borrow_mut()
-                    .append(HeaderName::from_str(&valid_name).unwrap(), value);
+        match (
+            HeaderName::from_str(&valid_name),
+            HeaderValue::from_bytes(&valid_value),
+        ) {
+            (Ok(name), Ok(value)) => {
+                self.header_list.borrow_mut().append(name, value);
             },
-            Err(_) => {
-                // can't add the header, but we don't need to panic the browser over it
-                warn!(
-                    "Servo thinks \"{:?}\" is a valid HTTP header value but HeaderValue doesn't.",
-                    valid_value
-                );
+            _ => {
+                warn!("Could not set header \"{valid_name:?}: {valid_value:?}\"");
             },
         };
 
@@ -223,18 +220,15 @@ impl HeadersMethods<crate::DomTypeHolder> for Headers {
 
         // 4. Set (name, value) in this’s header list.
         // https://fetch.spec.whatwg.org/#concept-header-list-set
-        match HeaderValue::from_bytes(&valid_value) {
-            Ok(value) => {
-                self.header_list
-                    .borrow_mut()
-                    .insert(HeaderName::from_str(&valid_name).unwrap(), value);
+        match (
+            HeaderName::from_str(&valid_name),
+            HeaderValue::from_bytes(&valid_value),
+        ) {
+            (Ok(name), Ok(value)) => {
+                self.header_list.borrow_mut().insert(name, value);
             },
-            Err(_) => {
-                // can't add the header, but we don't need to panic the browser over it
-                warn!(
-                    "Servo thinks \"{:?}\" is a valid HTTP header value but HeaderValue doesn't.",
-                    valid_value
-                );
+            _ => {
+                warn!("Could not set header:  \"{valid_name:?}: {valid_value:?}\"");
             },
         };
 

--- a/components/script/dom/fetch/request.rs
+++ b/components/script/dom/fetch/request.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 use cssparser::match_ignore_ascii_case;
 use dom_struct::dom_struct;
 use http::Method as HttpMethod;
-use http::header::{HeaderName, HeaderValue};
+use http::header::{CONTENT_TYPE, HeaderValue};
 use http::method::InvalidMethod;
 use js::context::JSContext;
 use js::rust::HandleObject;
@@ -350,13 +350,14 @@ impl Request {
         // TODO
 
         // Step 28. Set this’s request to request.
-        let r = Request::from_net_request(cx, global, proto, request);
+        let request = Request::from_net_request(cx, global, proto, request);
 
         // Step 29. Let signals be « signal » if signal is non-null; otherwise « ».
         let signals = signal.map_or(vec![], |s| vec![s]);
         // Step 30. Set this’s signal to the result of creating a dependent
         // abort signal from signals, using AbortSignal and this’s relevant realm.
-        r.signal
+        request
+            .signal
             .set(Some(&AbortSignal::create_dependent_abort_signal(
                 cx, signals, global,
             )));
@@ -366,7 +367,9 @@ impl Request {
         //
         // "or_init" looks unclear here, but it always enters the block since r
         // hasn't had any other way to initialize its headers
-        r.headers.or_init(|| Headers::for_request(cx, &r.global()));
+        request
+            .headers
+            .or_init(|| Headers::for_request(cx, &request.global()));
 
         // Step 33. If init is not empty, then:
         //
@@ -393,8 +396,8 @@ impl Request {
         // deep copied headers in Step 25.
 
         // Step 32. If this’s request’s mode is "no-cors", then:
-        if r.request.borrow().mode == NetTraitsRequestMode::NoCors {
-            let borrowed_request = r.request.borrow();
+        if request.request.borrow().mode == NetTraitsRequestMode::NoCors {
+            let borrowed_request = request.request.borrow();
             // Step 32.1. If this’s request’s method is not a CORS-safelisted method, then throw a TypeError.
             if !is_cors_safelisted_method(&borrowed_request.method) {
                 return Err(Error::Type(
@@ -403,7 +406,7 @@ impl Request {
                 ));
             }
             // Step 32.2. Set this’s headers’s guard to "request-no-cors".
-            r.Headers(cx).set_guard(Guard::RequestNoCors);
+            request.Headers(cx).set_guard(Guard::RequestNoCors);
         }
 
         match headers_copy {
@@ -415,22 +418,23 @@ impl Request {
                 // but an input with headers is given, set request's
                 // headers as the input's Headers.
                 if let RequestInfo::Request(ref input_request) = input {
-                    r.Headers(cx)
+                    request
+                        .Headers(cx)
                         .copy_from_headers(&input_request.Headers(cx))?;
                 }
             },
             // Step 33.5. Otherwise, fill this’s headers with headers.
-            Some(headers_copy) => r.Headers(cx).fill(Some(headers_copy))?,
+            Some(headers_copy) => request.Headers(cx).fill(Some(headers_copy))?,
         }
 
         // Step 33.5 depending on how we got here
         // Copy the headers list onto the headers of net_traits::Request
-        r.request.borrow_mut().headers = r.Headers(cx).get_headers_list();
+        request.request.borrow_mut().headers = request.Headers(cx).get_headers_list();
 
         // Step 34. Let inputBody be input’s request’s body if input is a Request object; otherwise null.
         let input_body = if let RequestInfo::Request(ref mut input_request) = input {
             let mut input_request_request = input_request.request.borrow_mut();
-            r.body_stream.set(input_request.body().as_deref());
+            request.body_stream.set(input_request.body().as_deref());
             input_request_request.body.take()
         } else {
             None
@@ -439,7 +443,7 @@ impl Request {
         // Step 35. If either init["body"] exists and is non-null or inputBody is non-null,
         // and request’s method is `GET` or `HEAD`, then throw a TypeError.
         if init.body.as_ref().is_some_and(|body| body.is_some()) || input_body.is_some() {
-            let req = r.request.borrow();
+            let req = request.request.borrow();
             let req_method = &req.method;
             match *req_method {
                 HttpMethod::GET => {
@@ -462,39 +466,40 @@ impl Request {
         if let Some(Some(ref input_init_body)) = init.body {
             // Step 37.1. Let bodyWithType be the result of extracting init["body"], with keepalive set to request’s keepalive.
             let mut body_with_type =
-                input_init_body.extract(cx, global, r.request.borrow().keep_alive)?;
+                input_init_body.extract(cx, global, request.request.borrow().keep_alive)?;
 
             // Step 37.3. Let type be bodyWithType’s type.
             if let Some(contents) = body_with_type.content_type.take() {
-                let ct_header_name = b"Content-Type";
                 // Step 37.4. If type is non-null and this’s headers’s header list
                 // does not contain `Content-Type`, then append (`Content-Type`, type) to this’s headers.
-                if !r
+                let content_type_header_name = b"Content-Type";
+                if !request
                     .Headers(cx)
-                    .Has(ByteString::new(ct_header_name.to_vec()))
+                    .Has(ByteString::new(content_type_header_name.to_vec()))
                     .unwrap()
                 {
-                    let ct_header_val = contents.as_bytes();
-                    r.Headers(cx).Append(
-                        ByteString::new(ct_header_name.to_vec()),
-                        ByteString::new(ct_header_val.to_vec()),
+                    let content_type_header_value = contents.as_bytes();
+                    request.Headers(cx).Append(
+                        ByteString::new(content_type_header_name.to_vec()),
+                        ByteString::new(content_type_header_value.to_vec()),
                     )?;
 
-                    // In Servo r.Headers's header list isn't a pointer to
-                    // the same actual list as r.request's, and so we need to
-                    // append to both lists to keep them in sync.
-                    if let Ok(v) = HeaderValue::from_bytes(&ct_header_val) {
-                        r.request
+                    // In Servo request.Headers's header list isn't a pointer to the same
+                    // actual list as request.request's, and so we need to append to both lists
+                    // to keep them in sync.
+                    if let Ok(header_value) = HeaderValue::from_bytes(&content_type_header_value) {
+                        request
+                            .request
                             .borrow_mut()
                             .headers
-                            .insert(HeaderName::from_bytes(ct_header_name).unwrap(), v);
+                            .insert(CONTENT_TYPE, header_value);
                     }
                 }
             }
 
             // Step 37.2. Set initBody to bodyWithType’s body.
             let (net_body, stream) = body_with_type.into_net_request_body(cx);
-            r.body_stream.set(Some(&*stream));
+            request.body_stream.set(Some(&*stream));
             init_body = Some(net_body);
         }
 
@@ -520,7 +525,7 @@ impl Request {
                 ));
             }
             // Step 39.2. If this’s request’s mode is neither "same-origin" nor "cors", then throw a TypeError.
-            let request_mode = &r.request.borrow().mode;
+            let request_mode = &request.request.borrow().mode;
             if *request_mode != NetTraitsRequestMode::CorsMode &&
                 *request_mode != NetTraitsRequestMode::SameOrigin
             {
@@ -543,9 +548,9 @@ impl Request {
         }
 
         // Step 42. Set this’s request’s body to finalBody.
-        r.request.borrow_mut().body = final_body;
+        request.request.borrow_mut().body = final_body;
 
-        Ok(r)
+        Ok(request)
     }
 
     /// <https://fetch.spec.whatwg.org/#concept-request-clone>

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -13,10 +13,10 @@ use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use dom_struct::dom_struct;
 use embedder_traits::{MediaPositionState, MediaSessionEvent, MediaSessionPlaybackState};
 use euclid::default::Size2D;
-use headers::{ContentLength, ContentRange, HeaderMapExt};
+use headers::{ContentLength, ContentRange, HeaderMapExt, Range as RangeHeader};
 use html5ever::{LocalName, Prefix, QualName, local_name, ns};
 use http::StatusCode;
-use http::header::{self, HeaderMap, HeaderValue};
+use http::header::HeaderMap;
 use js::context::JSContext;
 use js::realm::CurrentRealm;
 use layout_api::MediaFrame;
@@ -1445,11 +1445,9 @@ impl HTMLMediaElement {
             HTMLMediaElementTypeId::HTMLVideoElement => Destination::Video,
         };
         let mut headers = HeaderMap::new();
-        // FIXME(eijebong): Use typed headers once we have a constructor for the range header
-        headers.insert(
-            header::RANGE,
-            HeaderValue::from_str(&format!("bytes={}-", offset.unwrap_or(0))).unwrap(),
-        );
+        if let Ok(range_header_value) = RangeHeader::bytes(offset.unwrap_or(0)..) {
+            headers.typed_insert(range_header_value);
+        }
         let url = match self.resource_url.borrow().as_ref() {
             Some(url) => url.clone(),
             None => self.blob_url.borrow().as_ref().unwrap().clone(),

--- a/components/script/dom/navigator/navigator.rs
+++ b/components/script/dom/navigator/navigator.rs
@@ -577,10 +577,9 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
                 //
                 // We cannot use typed header insertion with `mime::Mime` parsing here,
                 // since it lowercases `charset=UTF-8`: https://github.com/hyperium/mime/issues/116
-                headers.insert(
-                    header::CONTENT_TYPE,
-                    HeaderValue::from_str(&content_type.str()).unwrap(),
-                );
+                if let Ok(content_type_header_value) = HeaderValue::from_str(&content_type.str()) {
+                    headers.insert(header::CONTENT_TYPE, content_type_header_value);
+                }
             }
             request_body = Some(extracted_body.into_net_request_body(cx).0);
         }

--- a/components/script/dom/xmlhttprequest/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest/xmlhttprequest.rs
@@ -486,10 +486,15 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
             None => value.into(),
         };
 
-        headers.insert(
-            HeaderName::from_str(name_str).unwrap(),
-            HeaderValue::from_bytes(&value).unwrap(),
-        );
+        if let (Ok(header_name), Ok(header_value)) = (
+            HeaderName::from_str(name_str),
+            HeaderValue::from_bytes(&value),
+        ) {
+            headers.insert(header_name, header_value);
+        } else {
+            warn!("Not setting header in XMLHttpRequest {name_str:?}: {value:?}");
+        }
+
         Ok(())
     }
 
@@ -561,8 +566,13 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
         // Step 1. If this’s state is not opened, then throw an "InvalidStateError" DOMException.
         // Step 2. If this’s send() flag is set, then throw an "InvalidStateError" DOMException.
         if self.ready_state.get() != XMLHttpRequestState::Opened || self.send_flag.get() {
-            return Err(Error::InvalidState(None));
+            return Err(Error::InvalidState(Some(
+                "XMLHttpRequest not open or already sent".into(),
+            )));
         }
+        let Some(url) = self.request_url.borrow().clone() else {
+            return Err(Error::InvalidState(Some("XMLHttpRequest not open".into())));
+        };
 
         // Step 3. If this’s request method is `GET` or `HEAD`, then set body to null.
         let data = match *self.request_method.borrow() {
@@ -697,11 +707,7 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
         } else {
             CredentialsMode::CredentialsSameOrigin
         };
-        let use_url_credentials = if let Some(ref url) = *self.request_url.borrow() {
-            !url.username().is_empty() || url.password().is_some()
-        } else {
-            unreachable!()
-        };
+        let use_url_credentials = !url.username().is_empty() || url.password().is_some();
 
         let content_type = match extracted_or_serialized.as_mut() {
             Some(body) => body.content_type.take(),
@@ -709,23 +715,19 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
         };
 
         let global = self.global();
-        let mut request = RequestBuilder::new(
-            global.webview_id(),
-            self.request_url.borrow().clone().unwrap(),
-            self.referrer.clone(),
-        )
-        .method(self.request_method.borrow().clone())
-        .headers((*self.request_headers.borrow()).clone())
-        .unsafe_request(true)
-        // XXXManishearth figure out how to avoid this clone
-        .body(extracted_or_serialized.map(|e| e.into_net_request_body(cx).0))
-        .synchronous(self.sync.get())
-        .mode(RequestMode::CorsMode)
-        .use_cors_preflight(self.upload_listener.get())
-        .credentials_mode(credentials_mode)
-        .use_url_credentials(use_url_credentials)
-        .with_global_scope(&global)
-        .referrer_policy(self.referrer_policy);
+        let mut request = RequestBuilder::new(global.webview_id(), url, self.referrer.clone())
+            .method(self.request_method.borrow().clone())
+            .headers((*self.request_headers.borrow()).clone())
+            .unsafe_request(true)
+            // XXXManishearth figure out how to avoid this clone
+            .body(extracted_or_serialized.map(|e| e.into_net_request_body(cx).0))
+            .synchronous(self.sync.get())
+            .mode(RequestMode::CorsMode)
+            .use_cors_preflight(self.upload_listener.get())
+            .credentials_mode(credentials_mode)
+            .use_url_credentials(use_url_credentials)
+            .with_global_scope(&global)
+            .referrer_policy(self.referrer_policy);
 
         // step 4 (second half)
         if let Some(content_type) = content_type {
@@ -741,46 +743,46 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
                 _ => None,
             };
 
+            // We cannot use typed header insertion with `mime::Mime` parsing here,
+            // since it lowercases `charset=UTF-8`: https://github.com/hyperium/mime/issues/116
             let mut content_type_set = false;
-            if !request.headers.contains_key(header::CONTENT_TYPE) {
-                request.headers.insert(
-                    header::CONTENT_TYPE,
-                    HeaderValue::from_str(&content_type.str()).unwrap(),
-                );
+            if !request.headers.contains_key(header::CONTENT_TYPE) &&
+                let Ok(content_type_value) = HeaderValue::from_str(&content_type.str())
+            {
+                request
+                    .headers
+                    .insert(header::CONTENT_TYPE, content_type_value);
                 content_type_set = true;
             }
 
             if !content_type_set {
-                let ct = request.headers.typed_get::<ContentType>();
-                if let Some(ct) = ct &&
-                    let Some(encoding) = encoding
+                let content_type = request.headers.typed_get::<ContentType>();
+                if let Some(content_type) = content_type &&
+                    let Some(encoding) = encoding &&
+                    let Ok(mime) = content_type.to_string().parse::<Mime>()
                 {
-                    let mime: Mime = ct.to_string().parse().unwrap();
                     for param in mime.parameters.iter() {
-                        if param.0 == CHARSET && !param.1.eq_ignore_ascii_case(encoding) {
-                            let params_iter = mime.parameters.iter();
-                            let new_params: Vec<(String, String)> = params_iter
-                                .filter(|p| p.0 != CHARSET)
-                                .map(|p| (p.0.clone(), p.1.clone()))
-                                .collect();
+                        if param.0 == CHARSET && !param.1.as_str().eq_ignore_ascii_case(encoding) {
+                            let new_params: Vec<_> =
+                                mime.parameters.iter().filter(|p| p.0 != CHARSET).collect();
 
                             let new_mime = format!(
-                                "{}/{};charset={}{}{}",
+                                "{}/{};charset={encoding}{}{}",
                                 mime.type_,
                                 mime.subtype,
-                                encoding,
                                 if new_params.is_empty() { "" } else { "; " },
                                 new_params
                                     .iter()
-                                    .map(|p| format!("{}={}", p.0, p.1))
+                                    .map(|param| format!("{}={}", param.0, param.1))
                                     .collect::<Vec<String>>()
                                     .join("; ")
                             );
 
-                            request.headers.insert(
-                                header::CONTENT_TYPE,
-                                HeaderValue::from_str(&new_mime).unwrap(),
-                            );
+                            if let Ok(content_type_header) = HeaderValue::from_str(&new_mime) {
+                                request
+                                    .headers
+                                    .insert(header::CONTENT_TYPE, content_type_header);
+                            }
                         }
                     }
                 }
@@ -1709,14 +1711,23 @@ impl XHRTimeoutCallback {
 
 fn serialize_document(doc: &Document) -> Fallible<DOMString> {
     let mut writer = vec![];
-    match serialize(
+    if serialize(
         &mut writer,
         &HtmlSerialize::new(doc.upcast::<Node>()),
         SerializeOpts::default(),
-    ) {
-        Ok(_) => Ok(DOMString::from(String::from_utf8(writer).unwrap())),
-        Err(_) => Err(Error::InvalidState(None)),
-    }
+    )
+    .is_err()
+    {
+        return Err(Error::InvalidState(Some(
+            "Could not serialize document".into(),
+        )));
+    };
+    let Ok(string) = String::from_utf8(writer) else {
+        return Err(Error::InvalidState(Some(
+            "Could not serialize document".into(),
+        )));
+    };
+    Ok(DOMString::from(string))
 }
 
 /// Returns whether `bs` is a `field-value`, as defined by

--- a/python/tidy/error_message_exceptions.txt
+++ b/python/tidy/error_message_exceptions.txt
@@ -130,7 +130,7 @@
 ./components/script/dom/workers/workerglobalscope.rs 4
 ./components/script/dom/worklet/paintworkletglobalscope.rs 2
 ./components/script/dom/worklet/worklet.rs 2
-./components/script/dom/xmlhttprequest/xmlhttprequest.rs 32
+./components/script/dom/xmlhttprequest/xmlhttprequest.rs 30
 ./components/script/dom/xpath/xpathexpression.rs 2
 ./components/script/dom/xpath/xpathresult.rs 1
 ./components/script/drag_data_store.rs 1


### PR DESCRIPTION
This change is mainly a code health improvement which more gracefully handles
the case that a header name or value cannot be parsed. Instead a
panicking, a warning is issued in more cases. In addition, a few other
`unwrap`s are replaced with graceful error handling in
`xmlhttprequest.rs`. Finally, some header addition is done via typed
headers. This cannot be used for the "Content-Type" header as `hyper`
seems to destroy the original case of the header, leading to WPT
failures.

Testing: This change shold not modify behavior so should be covered by existing tests.
