### PR TITLE
script: Fix borrow hazard in RTCPeerConnection offer/answer promises

### DIFF
--- a/components/script/dom/webrtc/rtcpeerconnection.rs
+++ b/components/script/dom/webrtc/rtcpeerconnection.rs
@@ -464,9 +464,10 @@ impl RTCPeerConnection {
                         this.create_offer();
                     } else {
                         let init: RTCSessionDescriptionInit = desc.convert();
-                        for promise in this.offer_promises.borrow_mut().drain(..) {
+                        for promise in this.offer_promises.borrow().iter() {
                             promise.resolve_native(cx, &init);
                         }
+                        this.offer_promises.safe_borrow_mut(cx.no_gc()).clear();
                     }
                 }));
             }));
@@ -493,9 +494,10 @@ impl RTCPeerConnection {
                         this.create_answer();
                     } else {
                         let init: RTCSessionDescriptionInit = desc.convert();
-                        for promise in this.answer_promises.borrow_mut().drain(..) {
+                        for promise in this.answer_promises.borrow().iter() {
                             promise.resolve_native(cx, &init);
                         }
+                        this.answer_promises.safe_borrow_mut(cx.no_gc()).clear();
                     }
                 }));
             }));


### PR DESCRIPTION
Before, `offer_promises` and `answer_promises` were drained while holding a mutable borrow during `resolve_native()`, which can trigger GC and panic on a re-entrant borrow. Rewrote to resolve each promise reading from an immutable borrow, then clear the list afterwards — the same pattern as #46830.

Testing:
- `./mach build -d`: compiles (the `NoGC` token enforces the fix at compile time)
- `./mach test-wpt tests/wpt/tests/webrtc/` with `dom_webrtc_enabled` force-enabled (the pref is off by default, so these code paths are not exercised otherwise): identical results before/after this change — 259 tests / 1750 subtests, zero differences

Fixes #46717.

AI disclosure: this change was developed with AI assistance; I have reviewed the code and verified the testing described above.