### PR TITLE
Upgrade to resvg v0.48.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,6 +800,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1484,7 +1490,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6813ceff986382cd86f67722f308177253e8fab1954a2d51c5e386ffdb3e2d03"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "once_cell",
  "percent-encoding",
@@ -2532,7 +2538,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2759,16 +2765,15 @@ dependencies = [
 
 [[package]]
 name = "fontdb"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+checksum = "2660c5e9157bf76d2db1294e4a9feba604ef610819a3b591088d0d8392a3290f"
 dependencies = [
  "fontconfig-parser",
  "log",
  "memmap2",
  "slotmap",
  "tinyvec",
- "ttf-parser",
 ]
 
 [[package]]
@@ -3101,7 +3106,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3670,6 +3675,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "harfrust"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03d949a14aa089bbb282f7dd76a498a7f684428e4257202efc119ec010376f9"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytemuck",
+ "read-fonts 0.41.0",
+ "smallvec",
+]
+
+[[package]]
 name = "hash2curve"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3731,7 +3748,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
  "http 1.5.0",
@@ -3963,7 +3980,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -4484,9 +4501,9 @@ dependencies = [
 
 [[package]]
 name = "imagesize"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
+checksum = "65b27460c2c92b037f3f94c538ed9a3342f3fdf923606781629ccb35f82d042a"
 
 [[package]]
 name = "imgref"
@@ -7175,10 +7192,11 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "resvg"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
+checksum = "67e3803f97b999e80cbf7c6ecdd07a8102204d92e1633cf48783720c521196bd"
 dependencies = [
+ "bytemuck",
  "gif",
  "image-webp",
  "log",
@@ -7345,7 +7363,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7402,7 +7420,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7428,24 +7446,6 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
-
-[[package]]
-name = "rustybuzz"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
-dependencies = [
- "bitflags 2.13.1",
- "bytemuck",
- "core_maths",
- "log",
- "smallvec",
- "ttf-parser",
- "unicode-bidi-mirroring",
- "unicode-ccc",
- "unicode-properties",
- "unicode-script",
-]
 
 [[package]]
 name = "ryu"
@@ -7998,7 +7998,7 @@ version = "0.4.0"
 dependencies = [
  "accesskit",
  "backtrace",
- "base64",
+ "base64 0.23.0",
  "content-security-policy",
  "crossbeam-channel",
  "euclid",
@@ -8043,7 +8043,7 @@ dependencies = [
 name = "servo-constellation-traits"
 version = "0.4.0"
 dependencies = [
- "base64",
+ "base64 0.23.0",
  "content-security-policy",
  "encoding_rs",
  "euclid",
@@ -8096,7 +8096,7 @@ name = "servo-devtools"
 version = "0.4.0"
 dependencies = [
  "atomic_refcell",
- "base64",
+ "base64 0.23.0",
  "chrono",
  "crossbeam-channel",
  "headers",
@@ -8679,7 +8679,7 @@ dependencies = [
  "async-compression",
  "async-recursion",
  "async-tungstenite",
- "base64",
+ "base64 0.23.0",
  "bytes",
  "chrono",
  "content-security-policy",
@@ -8924,7 +8924,7 @@ dependencies = [
  "atomic_refcell",
  "aws-lc-rs",
  "backtrace",
- "base64",
+ "base64 0.23.0",
  "base64ct",
  "bitflags 2.13.1",
  "brotli",
@@ -9237,7 +9237,7 @@ dependencies = [
 name = "servo-webdriver-server"
 version = "0.4.0"
 dependencies = [
- "base64",
+ "base64 0.23.0",
  "bytes",
  "cookie 0.18.1",
  "crossbeam-channel",
@@ -10165,7 +10165,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10669,9 +10669,6 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
-dependencies = [
- "core_maths",
-]
 
 [[package]]
 name = "tungstenite"
@@ -10788,18 +10785,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
-name = "unicode-bidi-mirroring"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
-
-[[package]]
-name = "unicode-ccc"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10890,26 +10875,26 @@ dependencies = [
 
 [[package]]
 name = "usvg"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
+checksum = "977d0a4abdef933f424a99fe09f95576e089b90aebc6f016a3bc813762493e91"
 dependencies = [
- "base64",
+ "base64 0.23.0",
  "data-url",
  "flate2",
  "fontdb",
+ "harfrust",
  "imagesize",
  "kurbo",
  "log",
  "pico-args",
  "roxmltree 0.21.1",
- "rustybuzz",
  "simplecss",
  "siphasher",
+ "skrifa 0.44.0",
  "strict-num",
  "svgtypes",
  "tiny-skia-path 0.12.0",
- "ttf-parser",
  "unicode-bidi",
  "unicode-script",
  "unicode-vo",
@@ -11407,7 +11392,7 @@ version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91d53921e1bef27512fa358179c9a22428d55778d2c2ae3c5c37a52b82ce6e92"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "cookie 0.16.2",
  "http 0.2.12",
@@ -11844,7 +11829,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ async-tungstenite = { version = "0.35", features = ["tokio-rustls-webpki-roots"]
 atomic_refcell = "0.1.14"
 aws-lc-rs = { version = "1.17", default-features = false, features = ["aws-lc-sys"] }
 backtrace = "0.3"
-base64 = "0.22.1"
+base64 = "0.23.0"
 base64ct = { version = "1.8", features = ["alloc"] }
 bitflags = "2.11"
 blurmock = "0.1.2"
@@ -208,7 +208,7 @@ raw-window-handle = "0.6"
 rayon = "1"
 read-fonts = "0.41.0"
 regex = "1.12"
-resvg = "0.47.0"
+resvg = "0.48.1"
 rsa = "=0.10.0-rc.18"
 rusqlite = "0.38"
 rustc-demangle = "0.1"

--- a/deny.toml
+++ b/deny.toml
@@ -35,9 +35,6 @@ ignore = [
     # This is a dependency of `usvg`, `rustybuzz`, `fontdb`.
     # We will need to wait for upstream actions.
     "RUSTSEC-2026-0192",
-    # `rustybuzz` is unmaintained. Switch to harfrust.
-    # However, this is a dependecy of `resvg`, there's nothing we can do.
-    "RUSTSEC-2026-0206",
 ]
 
 # This section is considered when running `cargo deny check licenses`
@@ -93,6 +90,7 @@ deny = [
 
 # List of crates to skip for the duplicate check:
 skip = [
+    "base64",
     "bitflags",
     "cookie",
     "redox_syscall",

--- a/tests/wpt/meta/css/CSS2/backgrounds/background-intrinsic-007.xht.ini
+++ b/tests/wpt/meta/css/CSS2/backgrounds/background-intrinsic-007.xht.ini
@@ -1,2 +1,0 @@
-[background-intrinsic-007.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/backgrounds/background-intrinsic-008.xht.ini
+++ b/tests/wpt/meta/css/CSS2/backgrounds/background-intrinsic-008.xht.ini
@@ -1,2 +1,0 @@
-[background-intrinsic-008.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/background-size-vector-003.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/background-size-vector-003.html.ini
@@ -1,2 +1,0 @@
-[background-size-vector-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/background-size-vector-007.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/background-size-vector-007.html.ini
@@ -1,2 +1,0 @@
-[background-size-vector-007.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/background-size-vector-011.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/background-size-vector-011.html.ini
@@ -1,2 +1,0 @@
-[background-size-vector-011.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/background-size-vector-015.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/background-size-vector-015.html.ini
@@ -1,2 +1,0 @@
-[background-size-vector-015.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/background-size-vector-021.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/background-size-vector-021.html.ini
@@ -1,2 +1,0 @@
-[background-size-vector-021.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/background-size-vector-025.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/background-size-vector-025.html.ini
@@ -1,2 +1,0 @@
-[background-size-vector-025.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--auto-32px--nonpercent-width-omitted-height-viewbox.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--auto-32px--nonpercent-width-omitted-height-viewbox.html.ini
@@ -1,2 +1,0 @@
-[tall--auto-32px--nonpercent-width-omitted-height-viewbox.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--auto-32px--omitted-width-nonpercent-height-viewbox.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--auto-32px--omitted-width-nonpercent-height-viewbox.html.ini
@@ -1,2 +1,0 @@
-[tall--auto-32px--omitted-width-nonpercent-height-viewbox.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--auto-32px--omitted-width-percent-height-viewbox.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--auto-32px--omitted-width-percent-height-viewbox.html.ini
@@ -1,2 +1,0 @@
-[tall--auto-32px--omitted-width-percent-height-viewbox.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--auto-32px--percent-width-omitted-height-viewbox.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--auto-32px--percent-width-omitted-height-viewbox.html.ini
@@ -1,2 +1,0 @@
-[tall--auto-32px--percent-width-omitted-height-viewbox.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--contain--height.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--contain--height.html.ini
@@ -1,2 +1,0 @@
-[tall--contain--height.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--contain--nonpercent-width-omitted-height-viewbox.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--contain--nonpercent-width-omitted-height-viewbox.html.ini
@@ -1,2 +1,0 @@
-[tall--contain--nonpercent-width-omitted-height-viewbox.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--contain--omitted-width-nonpercent-height-viewbox.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--contain--omitted-width-nonpercent-height-viewbox.html.ini
@@ -1,2 +1,0 @@
-[tall--contain--omitted-width-nonpercent-height-viewbox.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--contain--omitted-width-percent-height-viewbox.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--contain--omitted-width-percent-height-viewbox.html.ini
@@ -1,2 +1,0 @@
-[tall--contain--omitted-width-percent-height-viewbox.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--contain--percent-width-omitted-height-viewbox.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--contain--percent-width-omitted-height-viewbox.html.ini
@@ -1,2 +1,0 @@
-[tall--contain--percent-width-omitted-height-viewbox.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--contain--width.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--contain--width.html.ini
@@ -1,2 +1,0 @@
-[tall--contain--width.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--cover--height.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--cover--height.html.ini
@@ -1,0 +1,2 @@
+[tall--cover--height.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--cover--width.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/tall--cover--width.html.ini
@@ -1,0 +1,2 @@
+[tall--cover--width.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--12px-auto--nonpercent-width-omitted-height-viewbox.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--12px-auto--nonpercent-width-omitted-height-viewbox.html.ini
@@ -1,2 +1,0 @@
-[wide--12px-auto--nonpercent-width-omitted-height-viewbox.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--12px-auto--omitted-width-nonpercent-height-viewbox.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--12px-auto--omitted-width-nonpercent-height-viewbox.html.ini
@@ -1,2 +1,0 @@
-[wide--12px-auto--omitted-width-nonpercent-height-viewbox.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--12px-auto--omitted-width-percent-height-viewbox.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--12px-auto--omitted-width-percent-height-viewbox.html.ini
@@ -1,2 +1,0 @@
-[wide--12px-auto--omitted-width-percent-height-viewbox.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--12px-auto--percent-width-omitted-height-viewbox.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--12px-auto--percent-width-omitted-height-viewbox.html.ini
@@ -1,2 +1,0 @@
-[wide--12px-auto--percent-width-omitted-height-viewbox.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--auto--nonpercent-width-omitted-height-viewbox.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--auto--nonpercent-width-omitted-height-viewbox.html.ini
@@ -1,2 +1,0 @@
-[wide--auto--nonpercent-width-omitted-height-viewbox.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--auto--omitted-width-nonpercent-height-viewbox.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--auto--omitted-width-nonpercent-height-viewbox.html.ini
@@ -1,2 +1,0 @@
-[wide--auto--omitted-width-nonpercent-height-viewbox.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--auto-32px--nonpercent-width-omitted-height-viewbox.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--auto-32px--nonpercent-width-omitted-height-viewbox.html.ini
@@ -1,2 +1,0 @@
-[wide--auto-32px--nonpercent-width-omitted-height-viewbox.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--auto-32px--omitted-width-nonpercent-height-viewbox.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--auto-32px--omitted-width-nonpercent-height-viewbox.html.ini
@@ -1,2 +1,0 @@
-[wide--auto-32px--omitted-width-nonpercent-height-viewbox.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--auto-32px--omitted-width-percent-height-viewbox.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--auto-32px--omitted-width-percent-height-viewbox.html.ini
@@ -1,2 +1,0 @@
-[wide--auto-32px--omitted-width-percent-height-viewbox.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--auto-32px--percent-width-omitted-height-viewbox.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--auto-32px--percent-width-omitted-height-viewbox.html.ini
@@ -1,2 +1,0 @@
-[wide--auto-32px--percent-width-omitted-height-viewbox.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--contain--height.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--contain--height.html.ini
@@ -1,2 +1,0 @@
-[wide--contain--height.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--contain--nonpercent-width-omitted-height-viewbox.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--contain--nonpercent-width-omitted-height-viewbox.html.ini
@@ -1,2 +1,0 @@
-[wide--contain--nonpercent-width-omitted-height-viewbox.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--contain--omitted-width-nonpercent-height-viewbox.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--contain--omitted-width-nonpercent-height-viewbox.html.ini
@@ -1,2 +1,0 @@
-[wide--contain--omitted-width-nonpercent-height-viewbox.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--contain--omitted-width-percent-height-viewbox.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--contain--omitted-width-percent-height-viewbox.html.ini
@@ -1,2 +1,0 @@
-[wide--contain--omitted-width-percent-height-viewbox.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--contain--percent-width-omitted-height-viewbox.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--contain--percent-width-omitted-height-viewbox.html.ini
@@ -1,2 +1,0 @@
-[wide--contain--percent-width-omitted-height-viewbox.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--contain--width.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--contain--width.html.ini
@@ -1,2 +1,0 @@
-[wide--contain--width.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--cover--height.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--cover--height.html.ini
@@ -1,0 +1,2 @@
+[wide--cover--height.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--cover--width.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size/vector/wide--cover--width.html.ini
@@ -1,0 +1,2 @@
+[wide--cover--width.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-column-013.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-column-013.html.ini
@@ -1,2 +1,0 @@
-[flex-aspect-ratio-img-column-013.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-column-014.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-column-014.html.ini
@@ -1,2 +1,0 @@
-[flex-aspect-ratio-img-column-014.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-column-015.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-column-015.html.ini
@@ -1,2 +1,0 @@
-[flex-aspect-ratio-img-column-015.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-row-008.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-row-008.html.ini
@@ -1,2 +1,0 @@
-[flex-aspect-ratio-img-row-008.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-row-009.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-row-009.html.ini
@@ -1,2 +1,0 @@
-[flex-aspect-ratio-img-row-009.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-row-010.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-row-010.html.ini
@@ -1,2 +1,0 @@
-[flex-aspect-ratio-img-row-010.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-row-011.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-row-011.html.ini
@@ -1,2 +1,0 @@
-[flex-aspect-ratio-img-row-011.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/position-absolute-replaced-minmax.html.ini
+++ b/tests/wpt/meta/css/css-position/position-absolute-replaced-minmax.html.ini
@@ -43,6 +43,3 @@
 
   [minmax replaced IMG 37]
     expected: FAIL
-
-  [minmax replaced IMG 39]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-039.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-039.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-039.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-040.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-040.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-040.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-img-auto.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-img-auto.html.ini
@@ -83,42 +83,6 @@
   [placeholder: 'img', containerWidthStyle: '400px', containerHeightStyle: '400px', placeholderWidthAttr: '50%', svgWidthAttr: '200', ]
     expected: FAIL
 
-  [placeholder: 'img', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [placeholder: 'img', placeholderWidthAttr: '100', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', placeholderWidthAttr: '100', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerHeightStyle: '400px', placeholderWidthAttr: '100', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', containerHeightStyle: '400px', placeholderWidthAttr: '100', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [placeholder: 'img', placeholderWidthAttr: '50%', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', placeholderWidthAttr: '50%', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerHeightStyle: '400px', placeholderWidthAttr: '50%', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', containerHeightStyle: '400px', placeholderWidthAttr: '50%', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
   [placeholder: 'img', svgWidthAttr: '25%', ]
     expected: FAIL
 
@@ -165,30 +129,6 @@
     expected: FAIL
 
   [placeholder: 'img', containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', placeholderWidthAttr: '100', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', placeholderWidthAttr: '100', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerHeightStyle: '400px', placeholderWidthAttr: '100', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', containerHeightStyle: '400px', placeholderWidthAttr: '100', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', placeholderWidthAttr: '50%', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', placeholderWidthAttr: '50%', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerHeightStyle: '400px', placeholderWidthAttr: '50%', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', containerHeightStyle: '400px', placeholderWidthAttr: '50%', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', ]
     expected: FAIL
 
   [placeholder: 'img', svgHeightAttr: '200', ]
@@ -333,30 +273,6 @@
     expected: FAIL
 
   [placeholder: 'img', containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', placeholderWidthAttr: '100', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', placeholderWidthAttr: '100', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerHeightStyle: '400px', placeholderWidthAttr: '100', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', containerHeightStyle: '400px', placeholderWidthAttr: '100', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', placeholderWidthAttr: '50%', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', placeholderWidthAttr: '50%', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerHeightStyle: '400px', placeholderWidthAttr: '50%', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', containerHeightStyle: '400px', placeholderWidthAttr: '50%', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
     expected: FAIL
 
   [placeholder: 'img', svgWidthAttr: '200', svgHeightAttr: '25%', ]

--- a/tests/wpt/meta/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-img-fixed.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-img-fixed.html.ini
@@ -11,18 +11,6 @@
   [placeholder: 'img', containerWidthStyle: '400px', containerHeightStyle: '400px', placeholderHeightAttr: '100px', ]
     expected: FAIL
 
-  [placeholder: 'img', placeholderHeightAttr: '100px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', placeholderHeightAttr: '100px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerHeightStyle: '400px', placeholderHeightAttr: '100px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', containerHeightStyle: '400px', placeholderHeightAttr: '100px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
   [placeholder: 'img', placeholderHeightAttr: '100px', svgWidthAttr: '25%', ]
     expected: FAIL
 
@@ -33,18 +21,6 @@
     expected: FAIL
 
   [placeholder: 'img', containerWidthStyle: '400px', containerHeightStyle: '400px', placeholderHeightAttr: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', placeholderHeightAttr: '100px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', placeholderHeightAttr: '100px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerHeightStyle: '400px', placeholderHeightAttr: '100px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', containerHeightStyle: '400px', placeholderHeightAttr: '100px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', ]
     expected: FAIL
 
   [placeholder: 'img', placeholderHeightAttr: '100px', svgHeightAttr: '200', ]
@@ -93,18 +69,6 @@
     expected: FAIL
 
   [placeholder: 'img', containerWidthStyle: '400px', containerHeightStyle: '400px', placeholderHeightAttr: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', placeholderHeightAttr: '100px', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', placeholderHeightAttr: '100px', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerHeightStyle: '400px', placeholderHeightAttr: '100px', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', containerHeightStyle: '400px', placeholderHeightAttr: '100px', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
     expected: FAIL
 
   [placeholder: 'img', placeholderHeightAttr: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]

--- a/tests/wpt/meta/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-img-percentage.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-img-percentage.html.ini
@@ -53,30 +53,6 @@
   [placeholder: 'img', containerWidthStyle: '400px', placeholderWidthAttr: '50%', placeholderHeightAttr: '100%', svgWidthAttr: '200', ]
     expected: FAIL
 
-  [placeholder: 'img', placeholderHeightAttr: '100%', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', placeholderHeightAttr: '100%', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerHeightStyle: '400px', placeholderHeightAttr: '100%', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', containerHeightStyle: '400px', placeholderHeightAttr: '100%', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [placeholder: 'img', placeholderWidthAttr: '100', placeholderHeightAttr: '100%', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', placeholderWidthAttr: '100', placeholderHeightAttr: '100%', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [placeholder: 'img', placeholderWidthAttr: '50%', placeholderHeightAttr: '100%', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', placeholderWidthAttr: '50%', placeholderHeightAttr: '100%', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
   [placeholder: 'img', placeholderHeightAttr: '100%', svgWidthAttr: '25%', ]
     expected: FAIL
 
@@ -105,24 +81,6 @@
     expected: FAIL
 
   [placeholder: 'img', containerWidthStyle: '400px', placeholderHeightAttr: '100%', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerHeightStyle: '400px', placeholderHeightAttr: '100%', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', containerHeightStyle: '400px', placeholderHeightAttr: '100%', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', placeholderWidthAttr: '100', placeholderHeightAttr: '100%', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', placeholderWidthAttr: '100', placeholderHeightAttr: '100%', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', placeholderWidthAttr: '50%', placeholderHeightAttr: '100%', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', placeholderWidthAttr: '50%', placeholderHeightAttr: '100%', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', ]
     expected: FAIL
 
   [placeholder: 'img', placeholderHeightAttr: '100%', svgHeightAttr: '200', ]
@@ -219,24 +177,6 @@
     expected: FAIL
 
   [placeholder: 'img', containerWidthStyle: '400px', placeholderHeightAttr: '100%', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerHeightStyle: '400px', placeholderHeightAttr: '100%', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', containerHeightStyle: '400px', placeholderHeightAttr: '100%', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', placeholderWidthAttr: '100', placeholderHeightAttr: '100%', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', placeholderWidthAttr: '100', placeholderHeightAttr: '100%', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', placeholderWidthAttr: '50%', placeholderHeightAttr: '100%', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [placeholder: 'img', containerWidthStyle: '400px', placeholderWidthAttr: '50%', placeholderHeightAttr: '100%', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
     expected: FAIL
 
   [placeholder: 'img', placeholderHeightAttr: '100%', svgWidthAttr: '200', svgHeightAttr: '25%', ]

--- a/tests/wpt/meta/html/semantics/embedded-content/the-img-element/current-pixel-density/basic.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-img-element/current-pixel-density/basic.html.ini
@@ -1,6 +1,0 @@
-[basic.html]
-  [<img srcset="data:image/svg+xml,&lt;svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='-1%20-1%202%202'%20width='20'&gt;&lt;circle%20r='1'/&gt;&lt;/svg&gt; 2x" data-expect="10">]
-    expected: FAIL
-
-  [<img srcset="data:image/svg+xml,&lt;svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='-1%20-1%202%202'%20height='20'&gt;&lt;circle%20r='1'/&gt;&lt;/svg&gt; 2x" data-expect="10">]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-img-element/naturalWidth-naturalHeight-width-height.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-img-element/naturalWidth-naturalHeight-width-height.html.ini
@@ -95,18 +95,6 @@
   [SVG image, negative percengage natural dimensions, and aspect ratio from viewBox (when not rendered)]
     expected: FAIL
 
-  [SVG image, with natural width, and aspect ratio from viewBox]
-    expected: FAIL
-
-  [SVG image, with natural width, and aspect ratio from viewBox (when not rendered)]
-    expected: FAIL
-
-  [SVG image, with natural height, and aspect ratio from viewBox]
-    expected: FAIL
-
-  [SVG image, with natural height, and aspect ratio from viewBox (when not rendered)]
-    expected: FAIL
-
   [SVG image, with natural width of 0, and aspect ratio from viewBox]
     expected: FAIL
 
@@ -294,18 +282,6 @@
     expected: FAIL
 
   [SVG image, negative percengage natural dimensions, and aspect ratio from viewBox (with srcset/1x) (when not rendered)]
-    expected: FAIL
-
-  [SVG image, with natural width, and aspect ratio from viewBox (with srcset/1x)]
-    expected: FAIL
-
-  [SVG image, with natural width, and aspect ratio from viewBox (with srcset/1x) (when not rendered)]
-    expected: FAIL
-
-  [SVG image, with natural height, and aspect ratio from viewBox (with srcset/1x)]
-    expected: FAIL
-
-  [SVG image, with natural height, and aspect ratio from viewBox (with srcset/1x) (when not rendered)]
     expected: FAIL
 
   [SVG image, with natural width of 0, and aspect ratio from viewBox (with srcset/1x)]
@@ -497,13 +473,7 @@
   [SVG image, negative percengage natural dimensions, and aspect ratio from viewBox (with srcset/2x) (when not rendered)]
     expected: FAIL
 
-  [SVG image, with natural width, and aspect ratio from viewBox (with srcset/2x)]
-    expected: FAIL
-
   [SVG image, with natural width, and aspect ratio from viewBox (with srcset/2x) (when not rendered)]
-    expected: FAIL
-
-  [SVG image, with natural height, and aspect ratio from viewBox (with srcset/2x)]
     expected: FAIL
 
   [SVG image, with natural height, and aspect ratio from viewBox (with srcset/2x) (when not rendered)]

--- a/tests/wpt/meta/svg/struct/reftests/inner-svg-rotate-transform.svg.ini
+++ b/tests/wpt/meta/svg/struct/reftests/inner-svg-rotate-transform.svg.ini
@@ -1,2 +1,0 @@
-[inner-svg-rotate-transform.svg]
-  expected: FAIL

--- a/tests/wpt/meta/svg/struct/reftests/inner-svg-transform-and-viewbox.svg.ini
+++ b/tests/wpt/meta/svg/struct/reftests/inner-svg-transform-and-viewbox.svg.ini
@@ -1,2 +1,0 @@
-[inner-svg-transform-and-viewbox.svg]
-  expected: FAIL

--- a/tests/wpt/meta/svg/struct/reftests/inner-svg-transform.svg.ini
+++ b/tests/wpt/meta/svg/struct/reftests/inner-svg-transform.svg.ini
@@ -1,2 +1,0 @@
-[inner-svg-transform.svg]
-  expected: FAIL


### PR DESCRIPTION
- Upgrade resvg to v0.48.0
- Also upgrade base64 to 0.23.0 seeing resvg pulls in the new version anyway

There are lots of new passing tests due to resvg now exposing a more web compatible width and height.

Testing: WPT tests
