### PR TITLE
Enable the `wayland-data-control` for `arboard`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "windows-sys 0.52.0",
+ "wl-clipboard-rs",
  "x11rb",
 ]
 
@@ -2689,6 +2690,12 @@ dependencies = [
  "smallvec",
  "writeable",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fixedbitset"
@@ -6213,6 +6220,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6381,11 +6398,21 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
  "indexmap",
  "serde",
@@ -8457,7 +8484,7 @@ dependencies = [
  "malloc_size_of_derive",
  "num-complex",
  "num-traits",
- "petgraph",
+ "petgraph 0.8.3",
  "rustc-hash 2.1.3",
  "serde",
  "servo-base",
@@ -10658,6 +10685,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce607aae8ab0ab3abf3a2723a9ab6f09bb8639ed83fdd888d857b8e556c868d8"
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aac5e8971f245c3389a5a76e648bfc80803ae066a1243a75db0064d7c1129d63"
+dependencies = [
+ "fnv",
+ "memchr",
+ "nom 7.1.3",
+ "once_cell",
+ "petgraph 0.6.5",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12299,6 +12339,25 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "wl-clipboard-rs"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5ff8d0e60065f549fafd9d6cb626203ea64a798186c80d8e7df4f8af56baeb"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix 0.38.44",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ aes-gcm = { version = "0.11", features = ["hazmat", "zeroize"] }
 aes-kw = { version = "0.3", features = ["zeroize"] }
 android_logger = "0.15"
 app_units = "0.7"
-arboard = "3"
+arboard = { version = "3", features = ["wayland-data-control"] }
 argon2 = { version = "=0.6.0-rc.8", features = ["alloc"] }
 arrayvec = "0.7"
 async-compression = { version = "0.4.12", default-features = false }

--- a/deny.toml
+++ b/deny.toml
@@ -217,6 +217,10 @@ skip = [
     "wgpu-hal",
     "wgpu-naga-bridge",
     "wgpu-types",
+
+    # Duplicated by arboard
+    "petgraph",
+    "fixedbitset",
 ]
 
 # github.com organizations to allow git sources for


### PR DESCRIPTION
Addresses #45470 by enabling the `wayland-data-control` feature as suggested by Gae24. I am not entirely sure what the interaction of this is with the [ext-data-control-v1](https://wayland.app/protocols/ext-data-control-v1) and [wlr-data-control-unstable-v1](https://wayland.app/protocols/wlr-data-control-unstable-v1) features is, I checked the compatibility list and noticed that one of the two isn't supported on kwin, but clipboard does work with kwin on my system.

I also tested this on Niri where clipboard did not work before, and works with this change. I don't have any other wayland WMs to test with ready, but if you want further testing i'm happy to install some.