### PR TITLE
android: Make `glThread` immutable

### DIFF
--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
@@ -29,7 +29,7 @@ public class ServoView extends SurfaceView
         RunCallback,
         Choreographer.FrameCallback {
     private static final String LOGTAG = "ServoView";
-    private GLThread glThread;
+    private final GLThread glThread;
     protected Servo servo = null;
     private String servoArgs;
     private String initialUri;
@@ -37,16 +37,11 @@ public class ServoView extends SurfaceView
     private boolean experimentalMode;
 
     public ServoView(Context context) {
-        super(context);
-        init();
+        this(context, null);
     }
 
     public ServoView(Context context, AttributeSet attrs) {
         super(context, attrs);
-        init();
-    }
-
-    private void init() {
         setFocusable(true);
         setFocusableInTouchMode(true);
         setClickable(true);


### PR DESCRIPTION
By doing the initialisation steps directly in the constructor's initialisation section, we can make `glThread` final as the Java compiler knows that we only initialise `glThread` on instantiation. Previously, we could've theoretically called `init()` from elsewhere, hence we couldn't make the immutable guarantee to Java.

Testing: There are no automated tests for Android.