### PR TITLE
crown: allow `std::collections::hash_map::Values` in `unrooted_must_root` lint.

### DIFF
--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -136,6 +136,11 @@ impl<K, V, S> HashMapTracedValues<K, V, S> {
     pub(crate) fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
+
+    #[inline]
+    pub(crate) fn values(&self) -> std::collections::hash_map::Values<'_, K, V> {
+        self.0.values()
+    }
 }
 
 impl<K, V, S> HashMapTracedValues<K, V, S>

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -520,8 +520,8 @@ impl IDBFactory {
             error!("Failed to send SyncOperation::AbortPendingUpgrade");
         }
 
-        for (_, requests) in connections.iter() {
-            for (_, request) in requests.iter() {
+        for requests in connections.values() {
+            for request in requests.values() {
                 if let Some(database) = request.pending_connection() {
                     database.close_a_database_connection(true /* forced */);
                 }

--- a/components/script/dom/webrtc/rtcpeerconnection.rs
+++ b/components/script/dom/webrtc/rtcpeerconnection.rs
@@ -761,7 +761,7 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
         self.controller.borrow_mut().as_ref().unwrap().quit();
 
         // Step 6
-        for (_, val) in self.data_channels.borrow().iter() {
+        for val in self.data_channels.borrow().values() {
             val.on_state_change(cx, DataChannelState::Closed);
         }
 

--- a/components/script/script_window_proxies.rs
+++ b/components/script/script_window_proxies.rs
@@ -37,7 +37,7 @@ impl ScriptWindowProxies {
         &self,
         name: &DOMString,
     ) -> Option<DomRoot<WindowProxy>> {
-        for (_, proxy) in self.map.borrow().iter() {
+        for proxy in self.map.borrow().values() {
             if proxy.get_name() == *name {
                 return Some(DomRoot::from_ref(&**proxy));
             }

--- a/support/crown/src/unrooted_must_root.rs
+++ b/support/crown/src/unrooted_must_root.rs
@@ -139,8 +139,6 @@ fn is_unrooted_ty<'tcx>(
                         did.did(),
                         &[sym::core, sym::slice, sym::iter, sym.IterMut],
                     ) ||
-                    match_def_path(cx, did.did(), &[sym.accountable_refcell, sym.Ref]) ||
-                    match_def_path(cx, did.did(), &[sym.accountable_refcell, sym.RefMut]) ||
                     match_def_path(
                         cx,
                         did.did(),
@@ -520,7 +518,6 @@ symbols! {
     rc
     Rc
     cell
-    accountable_refcell
     Ref
     RefMut
     Iter

--- a/support/crown/src/unrooted_must_root.rs
+++ b/support/crown/src/unrooted_must_root.rs
@@ -176,6 +176,11 @@ fn is_unrooted_ty<'tcx>(
                     match_def_path(
                         cx,
                         did.did(),
+                        &[sym::std, sym.collections, sym.hash, sym.map, sym.Values],
+                    ) ||
+                    match_def_path(
+                        cx,
+                        did.did(),
                         &[sym::std, sym.collections, sym.hash, sym.set, sym.Iter],
                     )
                 {
@@ -520,6 +525,7 @@ symbols! {
     RefMut
     Iter
     IterMut
+    Values
     collections
     hash
     map

--- a/support/crown/tests/run-pass/unrooted_must_root_allowed_std_types.rs
+++ b/support/crown/tests/run-pass/unrooted_must_root_allowed_std_types.rs
@@ -19,13 +19,7 @@ pub struct StdTypes {
     vector: Vec<MustRoot>,
 }
 
-fn new_std_types(_: &()) -> &mut StdTypes {
-    unimplemented!()
-}
-
-fn test_std_types() {
-    let std_types = new_std_types(&());
-
+fn test_std_types(std_types: &mut StdTypes) {
     // Ref
     let foo = std_types.refcell.borrow();
     // RefMut

--- a/support/crown/tests/run-pass/unrooted_must_root_allowed_std_types.rs
+++ b/support/crown/tests/run-pass/unrooted_must_root_allowed_std_types.rs
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// compile-flags: --error-format=human
+//@rustc-env:RUSTC_BOOTSTRAP=1
+
+use std::collections::{HashMap, HashSet};
+use std::collections::hash_map::Entry;
+use std::cell::{RefCell};
+
+#[crown::unrooted_must_root_lint::must_root]
+struct MustRoot;
+
+#[crown::unrooted_must_root_lint::must_root]
+pub struct StdTypes {
+    refcell: RefCell<MustRoot>,
+    hashmap: HashMap<(), MustRoot>,
+    hashset: HashSet<MustRoot>,
+    vector: Vec<MustRoot>,
+}
+
+fn new_std_types(_: &()) -> &StdTypes {
+    unimplemented!()
+}
+fn new_std_types_mut(_: &()) -> &mut StdTypes {
+    unimplemented!()
+}
+
+fn test_std_types() {
+    let std_types = new_std_types(&());
+    let std_types_mut = new_std_types_mut(&());
+
+    // Ref
+    let _ = std_types.refcell.borrow();
+    // RefMut
+    let _ = std_types.refcell.borrow_mut();
+
+    // slice Iter
+    for val in std_types.vector.iter() {
+       let _ = val;
+    }
+    // iter
+    let _ = std_types.vector[..].iter();
+    // iter_mut
+    let _ = std_types_mut.vector[..].iter_mut();
+
+    // hashmap Entry
+    match std_types_mut.hashmap.entry(()) {
+        // OccupiedEntry
+        Entry::Occupied(_) => (),
+        // VacantEntry
+        Entry::Vacant(_) => (),
+    }
+
+    // hashmap iter
+    for (_, val) in std_types.hashmap.iter() {
+       let _ = val;
+    }
+
+    // hasmap values
+    for val in std_types.hashmap.values() {
+       let _ = val;
+    }
+
+    // hashset iter
+    for val in std_types.hashset.iter() {
+       let _ = val;
+    }
+}
+
+fn main() {}

--- a/support/crown/tests/run-pass/unrooted_must_root_allowed_std_types.rs
+++ b/support/crown/tests/run-pass/unrooted_must_root_allowed_std_types.rs
@@ -19,33 +19,30 @@ pub struct StdTypes {
     vector: Vec<MustRoot>,
 }
 
-fn new_std_types(_: &()) -> &StdTypes {
-    unimplemented!()
-}
-fn new_std_types_mut(_: &()) -> &mut StdTypes {
+fn new_std_types(_: &()) -> &mut StdTypes {
     unimplemented!()
 }
 
 fn test_std_types() {
     let std_types = new_std_types(&());
-    let std_types_mut = new_std_types_mut(&());
 
     // Ref
-    let _ = std_types.refcell.borrow();
+    let foo = std_types.refcell.borrow();
     // RefMut
-    let _ = std_types.refcell.borrow_mut();
+    let foo = std_types.refcell.borrow_mut();
 
     // slice Iter
-    let _ = std_types.vector[..].iter();
+    let foo = std_types.vector[..].iter();
     // slice IterMut
-    let _ = std_types_mut.vector[..].iter_mut();
+    let foo = std_types.vector[..].iter_mut();
 
     // hashmap Entry
-    match std_types_mut.hashmap.entry(()) {
+    let entry = std_types.hashmap.entry(());
+    match entry {
         // OccupiedEntry
-        Entry::Occupied(_) => (),
+        Entry::Occupied(occupied_entry) => (),
         // VacantEntry
-        Entry::Vacant(_) => (),
+        Entry::Vacant(vacant_entry) => (),
     }
 
     // hashmap Iter

--- a/support/crown/tests/run-pass/unrooted_must_root_allowed_std_types.rs
+++ b/support/crown/tests/run-pass/unrooted_must_root_allowed_std_types.rs
@@ -36,12 +36,8 @@ fn test_std_types() {
     let _ = std_types.refcell.borrow_mut();
 
     // slice Iter
-    for val in std_types.vector.iter() {
-       let _ = val;
-    }
-    // iter
     let _ = std_types.vector[..].iter();
-    // iter_mut
+    // slice IterMut
     let _ = std_types_mut.vector[..].iter_mut();
 
     // hashmap Entry
@@ -52,17 +48,17 @@ fn test_std_types() {
         Entry::Vacant(_) => (),
     }
 
-    // hashmap iter
+    // hashmap Iter
     for (_, val) in std_types.hashmap.iter() {
        let _ = val;
     }
 
-    // hasmap values
+    // hashmap Values
     for val in std_types.hashmap.values() {
        let _ = val;
     }
 
-    // hashset iter
+    // hashset Iter
     for val in std_types.hashset.iter() {
        let _ = val;
     }


### PR DESCRIPTION
Adds a new case for `is_unrooted_ty` for the `std::collections::hash_map::Values` type.
Removes the cases relating to `accountable_refcell` as the crate was removed: https://github.com/servo/servo/issues/44709 
Refactors existing hashmap `iter()`s that don't use the key to use `values()` instead. 

Testing: Added a new run-pass test to validate all pointer-like types in the std library that we currently allow.
Fixes: #46920