### PR TITLE
release: Validate tag before release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,15 @@ jobs:
       name: publish
       deployment: false
     steps:
+      - name: Validate release tag
+        if: ${{ inputs.release_tag != '' && inputs.regular_release }}
+        run: |
+          # Check if the tag starts with a v and is cargo-semver compatible, i.e `vX.Y.Z` with
+          # an optional `-suffix`.
+          if [[ ! "${{ inputs.release_tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.+)?$ ]]; then
+            echo "Error: release_tag '${{ inputs.release_tag }}' is not of the form vX.Y.Z or vX.Y.Z-<suffix>."
+            exit 1
+          fi
       - id: create-release
         run: |
           if [[ "${{ inputs.release_tag }}" != "" ]]; then


### PR DESCRIPTION
We should consistently use the `v` prefix for real releases. This doesn't completely prevent issues, since the job just creates a release draft, which can be edited manually before publish, but getting the tag right here, makes it less likely to forget to add the `v` prefix.
Motivated by https://github.com/servo/servo/issues/46908.

Testing: Not covered by automated tests. Manually verified `0.0.5` fails and `v0.0.5` passes in my fork.
