### PR TITLE
mach: Fix windows servoshell version bump regex

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -571,7 +571,7 @@ class PackageCommands(CommandBase):
 
         replacements = {
             "ports/servoshell/platform/windows/servoshell.exe.manifest": r'assemblyIdentity[^\/>]+version="(?P<version>.*?).0\"[^\/>]*\/>',
-            "support/windows/ServoShell.wxs.mako": r'<Package(.|\n)*Version="(?P<version>.*?)".*>',
+            "support/windows/servoshell.wxs.mako": r'<Package(.|\n)*Version="(?P<version>.*?)".*>',
             "ports/servoshell/platform/macos/Info.plist": r"<key>CFBundleShortVersionString</key>\n\s*<string>(?P<version>.*?)</string>",
             "support/android/apk/servoapp/build.gradle.kts": r'versionName\s*=\s*"(?P<version>.*?)"',
             "support/openharmony/oh-package.json5": r'"version"\s*:\s*"(?P<version>.*?)"',

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -571,7 +571,7 @@ class PackageCommands(CommandBase):
 
         replacements = {
             "ports/servoshell/platform/windows/servoshell.exe.manifest": r'assemblyIdentity[^\/>]+version="(?P<version>.*?).0\"[^\/>]*\/>',
-            "support/windows/servoshell.wxs.mako": r'<Package(.|\n)*Version="(?P<version>.*?)".*>',
+            "support/windows/servoshell.wxs.mako": r'<Package(?:.|\n)*?\sVersion="(?P<version>[^"]*)"',
             "ports/servoshell/platform/macos/Info.plist": r"<key>CFBundleShortVersionString</key>\n\s*<string>(?P<version>.*?)</string>",
             "support/android/apk/servoapp/build.gradle.kts": r'versionName\s*=\s*"(?P<version>.*?)"',
             "support/openharmony/oh-package.json5": r'"version"\s*:\s*"(?P<version>.*?)"',


### PR DESCRIPTION
Recent refactoring broke `./mach release`:

- The path to the `wxs.mako` file is now lowercase.
- The added `InstallerVersion` field meant `./mach release` now changed the wrong field (InstallerVersion instead of version). This is fixed by performing lazy matching, requiring whitespace before `Version`, and not requiring the closing `>` tag after Version anymore.

Testing: `./mach release` is not covered by automated tests
