### PR TITLE
release: Bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "malloc_size_of_tests"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "servo-malloc-size-of",
  "servo_arc",
@@ -6760,7 +6760,7 @@ dependencies = [
 
 [[package]]
 name = "profile_tests"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ipc-channel",
  "servo-config",
@@ -7485,7 +7485,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script_tests"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "encoding_rs",
  "euclid",
@@ -7736,7 +7736,7 @@ dependencies = [
 
 [[package]]
 name = "servo"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -7815,7 +7815,7 @@ dependencies = [
 
 [[package]]
 name = "servo-allocator"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "backtrace",
  "libc",
@@ -7828,7 +7828,7 @@ dependencies = [
 
 [[package]]
 name = "servo-background-hang-monitor"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "backtrace",
  "crossbeam-channel",
@@ -7845,7 +7845,7 @@ dependencies = [
 
 [[package]]
 name = "servo-background-hang-monitor-api"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "servo-base",
@@ -7853,7 +7853,7 @@ dependencies = [
 
 [[package]]
 name = "servo-base"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "accesskit",
  "crossbeam-channel",
@@ -7877,7 +7877,7 @@ dependencies = [
 
 [[package]]
 name = "servo-bluetooth"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bitflags 2.13.1",
  "blurmock",
@@ -7895,7 +7895,7 @@ dependencies = [
 
 [[package]]
 name = "servo-bluetooth-traits"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "regex",
  "serde",
@@ -7905,7 +7905,7 @@ dependencies = [
 
 [[package]]
 name = "servo-canvas"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bytemuck",
  "crossbeam-channel",
@@ -7933,7 +7933,7 @@ dependencies = [
 
 [[package]]
 name = "servo-canvas-traits"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -7954,7 +7954,7 @@ dependencies = [
 
 [[package]]
 name = "servo-capi"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "dpi",
  "libc",
@@ -7965,14 +7965,14 @@ dependencies = [
 
 [[package]]
 name = "servo-capi-tests"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "servo-config"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "num_enum",
  "serde",
@@ -7984,7 +7984,7 @@ dependencies = [
 
 [[package]]
 name = "servo-config-macro"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7994,7 +7994,7 @@ dependencies = [
 
 [[package]]
 name = "servo-constellation"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "accesskit",
  "backtrace",
@@ -8041,7 +8041,7 @@ dependencies = [
 
 [[package]]
 name = "servo-constellation-traits"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64 0.23.0",
  "content-security-policy",
@@ -8077,14 +8077,14 @@ dependencies = [
 
 [[package]]
 name = "servo-default-resources"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "servo-embedder-traits",
 ]
 
 [[package]]
 name = "servo-deny-public-fields"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -8093,7 +8093,7 @@ dependencies = [
 
 [[package]]
 name = "servo-devtools"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "atomic_refcell",
  "base64 0.23.0",
@@ -8122,7 +8122,7 @@ dependencies = [
 
 [[package]]
 name = "servo-devtools-traits"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "http 1.5.0",
  "malloc_size_of_derive",
@@ -8138,7 +8138,7 @@ dependencies = [
 
 [[package]]
 name = "servo-dom-struct"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -8148,7 +8148,7 @@ dependencies = [
 
 [[package]]
 name = "servo-embedder-traits"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "accesskit",
  "bitflags 2.13.1",
@@ -8181,7 +8181,7 @@ dependencies = [
 
 [[package]]
 name = "servo-fonts"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -8240,7 +8240,7 @@ dependencies = [
 
 [[package]]
 name = "servo-fonts-traits"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "atomic_refcell",
  "dwrote",
@@ -8264,7 +8264,7 @@ dependencies = [
 
 [[package]]
 name = "servo-geometry"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "app_units",
  "euclid",
@@ -8276,7 +8276,7 @@ dependencies = [
 
 [[package]]
 name = "servo-hyper-serde"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cookie 0.18.1",
  "headers",
@@ -8293,7 +8293,7 @@ dependencies = [
 
 [[package]]
 name = "servo-jstraceable-derive"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -8302,7 +8302,7 @@ dependencies = [
 
 [[package]]
 name = "servo-layout"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "accesskit",
  "app_units",
@@ -8362,7 +8362,7 @@ dependencies = [
 
 [[package]]
 name = "servo-layout-api"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -8395,7 +8395,7 @@ dependencies = [
 
 [[package]]
 name = "servo-malloc-size-of"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -8437,7 +8437,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "servo-base",
  "servo-media-audio",
@@ -8449,7 +8449,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-audio"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "byte-slice-cast",
  "euclid",
@@ -8472,7 +8472,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-auto"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "servo-media-dummy",
  "servo-media-gstreamer",
@@ -8480,7 +8480,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-derive"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8489,7 +8489,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-dummy"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "servo-base",
  "servo-media",
@@ -8502,7 +8502,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-examples"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "euclid",
  "rand 0.10.2",
@@ -8515,7 +8515,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "byte-slice-cast",
  "glib",
@@ -8546,7 +8546,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "gstreamer",
  "servo-media-player",
@@ -8554,7 +8554,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render-android"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8567,7 +8567,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render-unix"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8582,7 +8582,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-ohos"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "crossbeam-channel",
  "libc",
@@ -8604,7 +8604,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-player"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "malloc_size_of_derive",
  "serde",
@@ -8616,7 +8616,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-streams"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "malloc_size_of_derive",
  "servo-malloc-size-of",
@@ -8625,7 +8625,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-thread"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "euclid",
  "ipc-channel",
@@ -8643,7 +8643,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-traits"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "malloc_size_of_derive",
  "servo-malloc-size-of",
@@ -8651,7 +8651,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-webrtc"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "log",
  "servo-media-streams",
@@ -8660,7 +8660,7 @@ dependencies = [
 
 [[package]]
 name = "servo-metrics"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "malloc_size_of_derive",
  "servo-base",
@@ -8674,7 +8674,7 @@ dependencies = [
 
 [[package]]
 name = "servo-net"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-compression",
  "async-recursion",
@@ -8749,7 +8749,7 @@ dependencies = [
 
 [[package]]
 name = "servo-net-traits"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "content-security-policy",
  "cookie 0.18.1",
@@ -8790,7 +8790,7 @@ dependencies = [
 
 [[package]]
 name = "servo-paint"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bitflags 2.13.1",
  "crossbeam-channel",
@@ -8830,7 +8830,7 @@ dependencies = [
 
 [[package]]
 name = "servo-paint-api"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bitflags 2.13.1",
  "crossbeam-channel",
@@ -8865,7 +8865,7 @@ dependencies = [
 
 [[package]]
 name = "servo-pixels"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "euclid",
@@ -8880,7 +8880,7 @@ dependencies = [
 
 [[package]]
 name = "servo-profile"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "libc",
  "log",
@@ -8897,7 +8897,7 @@ dependencies = [
 
 [[package]]
 name = "servo-profile-traits"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "crossbeam-channel",
  "ipc-channel",
@@ -8913,7 +8913,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -9062,7 +9062,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script-bindings"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "atomic_refcell",
  "bitflags 2.13.1",
@@ -9104,7 +9104,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script-traits"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "accesskit",
  "crossbeam-channel",
@@ -9139,7 +9139,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script-webgpu"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "log",
  "malloc_size_of_derive",
@@ -9155,7 +9155,7 @@ dependencies = [
 
 [[package]]
 name = "servo-storage"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "libc",
  "log",
@@ -9182,7 +9182,7 @@ dependencies = [
 
 [[package]]
 name = "servo-storage-traits"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "malloc_size_of_derive",
  "serde",
@@ -9195,7 +9195,7 @@ dependencies = [
 
 [[package]]
 name = "servo-timers"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "crossbeam-channel",
  "malloc_size_of_derive",
@@ -9204,7 +9204,7 @@ dependencies = [
 
 [[package]]
 name = "servo-tracing"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -9214,7 +9214,7 @@ dependencies = [
 
 [[package]]
 name = "servo-url"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "encoding_rs",
  "malloc_size_of_derive",
@@ -9227,7 +9227,7 @@ dependencies = [
 
 [[package]]
 name = "servo-wakelock"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "servo-embedder-traits",
@@ -9235,7 +9235,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webdriver-server"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64 0.23.0",
  "bytes",
@@ -9266,7 +9266,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgl"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bitflags 2.13.1",
  "byteorder",
@@ -9291,7 +9291,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgpu"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arrayvec",
  "euclid",
@@ -9309,7 +9309,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgpu-traits"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arrayvec",
  "malloc_size_of_derive",
@@ -9324,7 +9324,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webvtt"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "html5ever",
  "markup5ever",
@@ -9334,7 +9334,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webxr"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -9352,7 +9352,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webxr-api"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "euclid",
  "ipc-channel",
@@ -9367,7 +9367,7 @@ dependencies = [
 
 [[package]]
 name = "servo-xpath"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "log",
  "malloc_size_of_derive",
@@ -9386,7 +9386,7 @@ dependencies = [
 
 [[package]]
 name = "servoshell"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "accesskit",
  "android_logger",
@@ -9858,7 +9858,7 @@ dependencies = [
 
 [[package]]
 name = "style_tests"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "app_units",
  "cssparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default-members = ["ports/servoshell"]
 exclude = [".cargo", "support/crown"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 authors = ["The Servo Project Developers"]
 repository = "https://github.com/servo/servo"
 # A generic description for packages that don't have a meaningful description yet.
@@ -301,74 +301,74 @@ zeroize = "1.8"
 # be listed here, between the `Begin` and `End` comments, so that we can easily find and
 # update the version requirements when bumping the workspace version.
 # Begin workspace-version dependencies - Don't change this comment, we grep for it in scripts!
-deny_public_fields = { package = "servo-deny-public-fields", version = "=0.4.0", path = "components/deny_public_fields" }
-devtools = { package = "servo-devtools", version = "=0.4.0", path = "components/devtools" }
-devtools_traits = { package = "servo-devtools-traits", version = "=0.4.0", path = "components/shared/devtools" }
-dom_struct = { package = "servo-dom-struct", version = "=0.4.0", path = "components/dom_struct" }
-embedder_traits = { package = "servo-embedder-traits", version = "=0.4.0", path = "components/shared/embedder" }
-fonts = { package = "servo-fonts", version = "=0.4.0", path = "components/fonts" }
-fonts_traits = { package = "servo-fonts-traits", version = "=0.4.0", path = "components/shared/fonts" }
-hyper_serde = { package = "servo-hyper-serde", version = "=0.4.0", path = "components/hyper_serde" }
-jstraceable_derive = { package = "servo-jstraceable-derive", version = "=0.4.0", path = "components/jstraceable_derive" }
-layout = { package = "servo-layout", version = "=0.4.0", path = "components/layout" }
-layout_api = { package = "servo-layout-api", version = "=0.4.0", path = "components/shared/layout" }
-malloc_size_of = { package = "servo-malloc-size-of", version = "=0.4.0", path = "components/malloc_size_of" }
-media = { package = "servo-media-thread", version = "=0.4.0", path = "components/media/media-thread" }
-metrics = { package = "servo-metrics", version = "=0.4.0", path = "components/metrics" }
-net = { package = "servo-net", version = "=0.4.0", path = "components/net" }
-net_traits = { package = "servo-net-traits", version = "=0.4.0", path = "components/shared/net" }
-paint = { package = "servo-paint", version = "=0.4.0", path = "components/paint" }
-paint_api = { package = "servo-paint-api", version = "=0.4.0", path = "components/shared/paint" }
-pixels = { package = "servo-pixels", version = "=0.4.0", path = "components/pixels" }
-profile = { package = "servo-profile", version = "=0.4.0", path = "components/profile" }
-profile_traits = { package = "servo-profile-traits", version = "=0.4.0", path = "components/shared/profile" }
-script = { package = "servo-script", version = "=0.4.0", path = "components/script" }
-script_bindings = { package = "servo-script-bindings", version = "=0.4.0", path = "components/script_bindings" }
-script_webgpu = { package = "servo-script-webgpu", version = "=0.4.0", path = "components/script_webgpu" }
-script_traits = { package = "servo-script-traits", version = "=0.4.0", path = "components/shared/script" }
-servo = { version = "=0.4.0", path = "components/servo", default-features = false }
-servo-allocator = { version = "=0.4.0", path = "components/allocator" }
-servo-background-hang-monitor = { version = "=0.4.0", path = "components/background_hang_monitor" }
-servo-background-hang-monitor-api = { version = "=0.4.0", path = "components/shared/background_hang_monitor" }
-servo-base = { version = "=0.4.0", path = "components/shared/base" }
-servo-bluetooth = { version = "=0.4.0", path = "components/bluetooth" }
-servo-bluetooth-traits = { version = "=0.4.0", path = "components/shared/bluetooth" }
-servo-canvas = { version = "=0.4.0", path = "components/canvas" }
-servo-canvas-traits = { version = "=0.4.0", path = "components/shared/canvas" }
-servo-config = { version = "=0.4.0", path = "components/config" }
-servo-config-macro = { version = "=0.4.0", path = "components/config/macro" }
-servo-constellation = { version = "=0.4.0", path = "components/constellation" }
-servo-constellation-traits = { version = "=0.4.0", path = "components/shared/constellation" }
-servo-default-resources = { version = "=0.4.0", path = "components/default-resources" }
-servo-geometry = { version = "=0.4.0", path = "components/geometry" }
-servo-media = { version = "=0.4.0", path = "components/media/servo-media" }
-servo-media-audio = { version = "=0.4.0", path = "components/media/audio" }
-servo-media-auto = { version = "=0.4.0", path = "components/media/backends/auto" }
-servo-media-derive = { version = "=0.4.0", path = "components/media/servo-media-derive" }
-servo-media-dummy = { version = "=0.4.0", path = "components/media/backends/dummy" }
-servo-media-gstreamer = { version = "=0.4.0", path = "components/media/backends/gstreamer" }
-servo-media-gstreamer-render = { version = "=0.4.0", path = "components/media/backends/gstreamer/render" }
-servo-media-gstreamer-render-android = { version = "=0.4.0", path = "components/media/backends/gstreamer/render-android" }
-servo-media-gstreamer-render-unix = { version = "=0.4.0", path = "components/media/backends/gstreamer/render-unix" }
-servo-media-ohos = { version = "=0.4.0", path = "components/media/backends/ohos" }
-servo-media-player = { version = "=0.4.0", path = "components/media/player" }
-servo-media-streams = { version = "=0.4.0", path = "components/media/streams" }
-servo-media-traits = { version = "=0.4.0", path = "components/media/traits" }
-servo-media-webrtc = { version = "=0.4.0", path = "components/media/webrtc" }
-servo-tracing = { version = "=0.4.0", path = "components/servo_tracing" }
-servo-url = { version = "=0.4.0", path = "components/url" }
-servo-wakelock = { version = "=0.4.0", path = "components/wakelock" }
-servo-webvtt = { version = "=0.4.0", path = "components/webvtt" }
-storage = { package = "servo-storage", version = "=0.4.0", path = "components/storage" }
-storage_traits = { package = "servo-storage-traits", version = "=0.4.0", path = "components/shared/storage" }
-timers = { package = "servo-timers", version = "=0.4.0", path = "components/timers" }
-webdriver_server = { package = "servo-webdriver-server", version = "=0.4.0", path = "components/webdriver_server" }
-webgl = { package = "servo-webgl", version = "=0.4.0", path = "components/webgl", default-features = false }
-webgpu = { package = "servo-webgpu", version = "=0.4.0", path = "components/webgpu" }
-webgpu_traits = { package = "servo-webgpu-traits", version = "=0.4.0", path = "components/shared/webgpu" }
-webxr = { package = "servo-webxr", version = "=0.4.0", path = "components/webxr" }
-webxr-api = { package = "servo-webxr-api", version = "=0.4.0", path = "components/shared/webxr" }
-xpath = { package = "servo-xpath", version = "=0.4.0", path = "components/xpath" }
+deny_public_fields = { package = "servo-deny-public-fields", version = "=0.5.0", path = "components/deny_public_fields" }
+devtools = { package = "servo-devtools", version = "=0.5.0", path = "components/devtools" }
+devtools_traits = { package = "servo-devtools-traits", version = "=0.5.0", path = "components/shared/devtools" }
+dom_struct = { package = "servo-dom-struct", version = "=0.5.0", path = "components/dom_struct" }
+embedder_traits = { package = "servo-embedder-traits", version = "=0.5.0", path = "components/shared/embedder" }
+fonts = { package = "servo-fonts", version = "=0.5.0", path = "components/fonts" }
+fonts_traits = { package = "servo-fonts-traits", version = "=0.5.0", path = "components/shared/fonts" }
+hyper_serde = { package = "servo-hyper-serde", version = "=0.5.0", path = "components/hyper_serde" }
+jstraceable_derive = { package = "servo-jstraceable-derive", version = "=0.5.0", path = "components/jstraceable_derive" }
+layout = { package = "servo-layout", version = "=0.5.0", path = "components/layout" }
+layout_api = { package = "servo-layout-api", version = "=0.5.0", path = "components/shared/layout" }
+malloc_size_of = { package = "servo-malloc-size-of", version = "=0.5.0", path = "components/malloc_size_of" }
+media = { package = "servo-media-thread", version = "=0.5.0", path = "components/media/media-thread" }
+metrics = { package = "servo-metrics", version = "=0.5.0", path = "components/metrics" }
+net = { package = "servo-net", version = "=0.5.0", path = "components/net" }
+net_traits = { package = "servo-net-traits", version = "=0.5.0", path = "components/shared/net" }
+paint = { package = "servo-paint", version = "=0.5.0", path = "components/paint" }
+paint_api = { package = "servo-paint-api", version = "=0.5.0", path = "components/shared/paint" }
+pixels = { package = "servo-pixels", version = "=0.5.0", path = "components/pixels" }
+profile = { package = "servo-profile", version = "=0.5.0", path = "components/profile" }
+profile_traits = { package = "servo-profile-traits", version = "=0.5.0", path = "components/shared/profile" }
+script = { package = "servo-script", version = "=0.5.0", path = "components/script" }
+script_bindings = { package = "servo-script-bindings", version = "=0.5.0", path = "components/script_bindings" }
+script_webgpu = { package = "servo-script-webgpu", version = "=0.5.0", path = "components/script_webgpu" }
+script_traits = { package = "servo-script-traits", version = "=0.5.0", path = "components/shared/script" }
+servo = { version = "=0.5.0", path = "components/servo", default-features = false }
+servo-allocator = { version = "=0.5.0", path = "components/allocator" }
+servo-background-hang-monitor = { version = "=0.5.0", path = "components/background_hang_monitor" }
+servo-background-hang-monitor-api = { version = "=0.5.0", path = "components/shared/background_hang_monitor" }
+servo-base = { version = "=0.5.0", path = "components/shared/base" }
+servo-bluetooth = { version = "=0.5.0", path = "components/bluetooth" }
+servo-bluetooth-traits = { version = "=0.5.0", path = "components/shared/bluetooth" }
+servo-canvas = { version = "=0.5.0", path = "components/canvas" }
+servo-canvas-traits = { version = "=0.5.0", path = "components/shared/canvas" }
+servo-config = { version = "=0.5.0", path = "components/config" }
+servo-config-macro = { version = "=0.5.0", path = "components/config/macro" }
+servo-constellation = { version = "=0.5.0", path = "components/constellation" }
+servo-constellation-traits = { version = "=0.5.0", path = "components/shared/constellation" }
+servo-default-resources = { version = "=0.5.0", path = "components/default-resources" }
+servo-geometry = { version = "=0.5.0", path = "components/geometry" }
+servo-media = { version = "=0.5.0", path = "components/media/servo-media" }
+servo-media-audio = { version = "=0.5.0", path = "components/media/audio" }
+servo-media-auto = { version = "=0.5.0", path = "components/media/backends/auto" }
+servo-media-derive = { version = "=0.5.0", path = "components/media/servo-media-derive" }
+servo-media-dummy = { version = "=0.5.0", path = "components/media/backends/dummy" }
+servo-media-gstreamer = { version = "=0.5.0", path = "components/media/backends/gstreamer" }
+servo-media-gstreamer-render = { version = "=0.5.0", path = "components/media/backends/gstreamer/render" }
+servo-media-gstreamer-render-android = { version = "=0.5.0", path = "components/media/backends/gstreamer/render-android" }
+servo-media-gstreamer-render-unix = { version = "=0.5.0", path = "components/media/backends/gstreamer/render-unix" }
+servo-media-ohos = { version = "=0.5.0", path = "components/media/backends/ohos" }
+servo-media-player = { version = "=0.5.0", path = "components/media/player" }
+servo-media-streams = { version = "=0.5.0", path = "components/media/streams" }
+servo-media-traits = { version = "=0.5.0", path = "components/media/traits" }
+servo-media-webrtc = { version = "=0.5.0", path = "components/media/webrtc" }
+servo-tracing = { version = "=0.5.0", path = "components/servo_tracing" }
+servo-url = { version = "=0.5.0", path = "components/url" }
+servo-wakelock = { version = "=0.5.0", path = "components/wakelock" }
+servo-webvtt = { version = "=0.5.0", path = "components/webvtt" }
+storage = { package = "servo-storage", version = "=0.5.0", path = "components/storage" }
+storage_traits = { package = "servo-storage-traits", version = "=0.5.0", path = "components/shared/storage" }
+timers = { package = "servo-timers", version = "=0.5.0", path = "components/timers" }
+webdriver_server = { package = "servo-webdriver-server", version = "=0.5.0", path = "components/webdriver_server" }
+webgl = { package = "servo-webgl", version = "=0.5.0", path = "components/webgl", default-features = false }
+webgpu = { package = "servo-webgpu", version = "=0.5.0", path = "components/webgpu" }
+webgpu_traits = { package = "servo-webgpu-traits", version = "=0.5.0", path = "components/shared/webgpu" }
+webxr = { package = "servo-webxr", version = "=0.5.0", path = "components/webxr" }
+webxr-api = { package = "servo-webxr-api", version = "=0.5.0", path = "components/shared/webxr" }
+xpath = { package = "servo-xpath", version = "=0.5.0", path = "components/xpath" }
 # End workspace-version dependencies - Don't change this comment, we grep for it in scripts!
 
 # RSA key generation could be very slow without compilation

--- a/ports/servoshell/platform/macos/Info.plist
+++ b/ports/servoshell/platform/macos/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.0</string>
+	<string>0.5.0</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSPrincipalClass</key>

--- a/ports/servoshell/platform/windows/servoshell.exe.manifest
+++ b/ports/servoshell/platform/windows/servoshell.exe.manifest
@@ -4,7 +4,7 @@
           xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <assemblyIdentity type="win32"
                     name="servo.ServoShell"
-                    version="0.4.0.0"/>
+                    version="0.5.0.0"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>

--- a/resources/resource_protocol/license.html
+++ b/resources/resource_protocol/license.html
@@ -54,12 +54,10 @@
             <li><a href="#Unicode-3.0">Unicode License v3</a></li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a></li>
             <li><a href="#ISC">ISC License</a></li>
-            <li><a href="#BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</a></li>
             <li><a href="#Zlib">zlib License</a></li>
+            <li><a href="#BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</a></li>
             <li><a href="#BSL-1.0">Boost Software License 1.0</a></li>
             <li><a href="#CDLA-Permissive-2.0">Community Data License Agreement Permissive 2.0</a></li>
-            <li><a href="#CC0-1.0">Creative Commons Zero v1.0 Universal</a></li>
-            <li><a href="#NCSA">University of Illinois/NCSA Open Source License</a></li>
             <li><a href="#OFL-1.1">SIL Open Font License 1.1</a></li>
             <li><a href="#Ubuntu-font-1.0">Ubuntu Font Licence v1.0</a></li>
         </ul>
@@ -1122,6 +1120,7 @@
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/psychon/as-raw-xcb-connection ">as-raw-xcb-connection 1.0.1</a></li>
                         <li><a href=" https://github.com/hsivonen/chardetng ">chardetng 0.1.17</a></li>
+                        <li><a href=" https://github.com/KyleMayes/clang-sys ">clang-sys 1.9.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">cmov 0.5.4</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">ctutils 0.4.2</a></li>
                         <li><a href=" https://github.com/hsivonen/encoding_c ">encoding_c 0.9.8</a></li>
@@ -1133,7 +1132,7 @@
                         <li><a href=" https://github.com/linebender/kurbo ">polycool 0.4.0</a></li>
                         <li><a href=" https://github.com/rust-windowing/raw-window-metal ">raw-window-metal 1.1.0</a></li>
                         <li><a href=" https://github.com/nvzqz/static-assertions-rs ">static_assertions 1.1.0</a></li>
-                        <li><a href=" https://github.com/Lokathor/tinyvec ">tinyvec 1.11.0</a></li>
+                        <li><a href=" https://github.com/Lokathor/tinyvec ">tinyvec 1.12.0</a></li>
                         <li><a href=" https://github.com/hsivonen/utf16_iter ">utf16_iter 1.0.5</a></li>
                         <li><a href=" https://github.com/hsivonen/utf8_iter ">utf8_iter 1.0.4</a></li>
                         <li><a href=" https://github.com/hsivonen/write16 ">write16 1.0.0</a></li>
@@ -1783,216 +1782,6 @@ Software.
    See the License for the specific language governing permissions and
    limitations under the License.
    </pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/KyleMayes/clang-sys ">clang-sys 1.8.1</a>
-                    </p>
-                <pre class="license-text">
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      &quot;control&quot; means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      &quot;Source&quot; form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      &quot;Object&quot; form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      &quot;Work&quot; shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      &quot;Contribution&quot; shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-      replaced with your own identifying information. (Don&#x27;t include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same &quot;printed page&quot; as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-</pre>
             </li>
             <li class="license">
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
@@ -2657,8 +2446,8 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.52</a></li>
-                        <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.52</a></li>
+                        <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.55</a></li>
+                        <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.55</a></li>
                     </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3286,7 +3075,7 @@ Software.
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/awxkee/moxcms.git ">moxcms 0.8.1</a></li>
-                        <li><a href=" https://github.com/awxkee/pxfm ">pxfm 0.1.29</a></li>
+                        <li><a href=" https://github.com/awxkee/pxfm ">pxfm 0.1.30</a></li>
                         <li><a href=" https://github.com/awxkee/yuvutils-rs ">yuv 0.8.16</a></li>
                     </ul>
                 <pre class="license-text">                                 Apache License
@@ -3502,9 +3291,8 @@ Software.
                         <li><a href=" https://github.com/enarx/ciborium ">ciborium 0.2.2</a></li>
                         <li><a href=" https://github.com/brendanzab/codespan ">codespan-reporting 0.13.1</a></li>
                         <li><a href=" https://github.com/entropyxyz/crypto-primes ">crypto-primes 0.7.2</a></li>
-                        <li><a href=" https://github.com/kornelski/imgref ">imgref 1.12.2</a></li>
                         <li><a href=" https://github.com/rustls/rustls-platform-verifier ">rustls-platform-verifier 0.7.0</a></li>
-                        <li><a href=" https://github.com/Voultapher/self_cell ">self_cell 1.2.2</a></li>
+                        <li><a href=" https://github.com/Voultapher/self_cell ">self_cell 1.3.0</a></li>
                         <li><a href=" https://github.com/1Password/sys-locale ">sys-locale 0.3.2</a></li>
                         <li><a href=" https://github.com/etemesi254/zune-image ">zune-core 0.5.1</a></li>
                         <li><a href=" https://github.com/etemesi254/zune-image/tree/dev/crates/zune-jpeg ">zune-jpeg 0.5.15</a></li>
@@ -4141,12 +3929,12 @@ Software.
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-query 1.1.5</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-wincon 3.0.11</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.14</a></li>
-                        <li><a href=" https://github.com/clap-rs/clap ">clap 4.6.1</a></li>
-                        <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.6.0</a></li>
+                        <li><a href=" https://github.com/clap-rs/clap ">clap 4.6.4</a></li>
+                        <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.6.2</a></li>
                         <li><a href=" https://github.com/clap-rs/clap ">clap_lex 1.1.0</a></li>
                         <li><a href=" https://github.com/jamesmunns/cobs.rs ">cobs 0.3.0</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">colorchoice 1.0.5</a></li>
-                        <li><a href=" https://github.com/rust-ammonia/rust-content-security-policy ">content-security-policy 0.8.0</a></li>
+                        <li><a href=" https://github.com/rust-ammonia/rust-content-security-policy ">content-security-policy 0.8.1</a></li>
                         <li><a href=" https://github.com/srijs/rust-crc32fast ">crc32fast 1.5.0</a></li>
                         <li><a href=" https://github.com/rust-cli/env_logger ">env_filter 0.1.4</a></li>
                         <li><a href=" https://github.com/rust-cli/env_logger ">env_logger 0.11.8</a></li>
@@ -4161,15 +3949,14 @@ Software.
                         <li><a href=" https://github.com/jni-rs/jni-sys ">jni-sys 0.3.1</a></li>
                         <li><a href=" https://github.com/jni-rs/jni-sys ">jni-sys 0.4.1</a></li>
                         <li><a href=" https://github.com/cobalt-org/kstring ">kstring 2.0.2</a></li>
-                        <li><a href=" https://github.com/wcampbell0x2a/no-std-io2 ">no_std_io2 0.9.4</a></li>
                         <li><a href=" https://github.com/polyfill-rs/once_cell_polyfill ">once_cell_polyfill 1.70.2</a></li>
                         <li><a href=" http://github.com/tailhook/quick-error ">quick-error 2.0.1</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">serde_spanned 1.1.1</a></li>
-                        <li><a href=" https://github.com/toml-rs/toml ">toml 1.1.2+spec-1.1.0</a></li>
+                        <li><a href=" https://github.com/toml-rs/toml ">toml 1.1.3+spec-1.1.0</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">toml_datetime 1.1.1+spec-1.1.0</a></li>
-                        <li><a href=" https://github.com/toml-rs/toml ">toml_edit 0.25.12+spec-1.1.0</a></li>
+                        <li><a href=" https://github.com/toml-rs/toml ">toml_edit 0.25.13+spec-1.1.0</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">toml_parser 1.1.2+spec-1.1.0</a></li>
-                        <li><a href=" https://github.com/toml-rs/toml ">toml_writer 1.1.1+spec-1.1.0</a></li>
+                        <li><a href=" https://github.com/toml-rs/toml ">toml_writer 1.1.2+spec-1.1.0</a></li>
                         <li><a href=" https://github.com/gifnksm/topological-sort-rs ">topological-sort 0.1.0</a></li>
                         <li><a href=" https://github.com/swgillespie/unicode-categories ">unicode_categories 0.1.1</a></li>
                     </ul>
@@ -4579,15 +4366,15 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-channel 0.3.32</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-core 0.3.32</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-executor 0.3.32</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-io 0.3.32</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-macro 0.3.32</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-sink 0.3.32</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-task 0.3.32</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-util 0.3.32</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures 0.3.32</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-channel 0.3.33</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-core 0.3.33</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-executor 0.3.33</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-io 0.3.33</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-macro 0.3.33</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-sink 0.3.33</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-task 0.3.33</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-util 0.3.33</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures 0.3.33</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -5217,7 +5004,7 @@ limitations under the License.
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/hyperium/http ">http 0.2.12</a></li>
-                        <li><a href=" https://github.com/hyperium/http ">http 1.4.2</a></li>
+                        <li><a href=" https://github.com/hyperium/http ">http 1.5.0</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -5635,9 +5422,10 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/RustCrypto/signatures ">ecdsa 0.17.0-rc.22</a></li>
+                        <li><a href=" https://github.com/RustCrypto/signatures ">ecdsa 0.17.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/signatures ">ed25519 3.0.0</a></li>
-                        <li><a href=" https://github.com/RustCrypto/signatures ">rfc6979 0.6.0-pre.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/signatures ">ed448 0.5.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/signatures ">rfc6979 0.6.0</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -6685,7 +6473,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.14.1</a>
+                            <a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.15.1</a>
                     </p>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -7316,7 +7104,7 @@ limitations under the License.
                         <li><a href=" https://github.com/rust-windowing/keyboard-types ">keyboard-types 0.8.3</a></li>
                         <li><a href=" https://github.com/Elzair/page_size_rs ">page_size 0.6.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/RSA ">rsa 0.10.0-rc.18</a></li>
-                        <li><a href=" https://github.com/SeaQL/sea-query ">sea-query 1.0.0-rc.31</a></li>
+                        <li><a href=" https://github.com/SeaQL/sea-query ">sea-query 1.0.1</a></li>
                         <li><a href=" https://github.com/image-rs/weezl ">weezl 0.1.12</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
@@ -7526,15 +7314,12 @@ limitations under the License.</pre>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/servo/stylo ">servo_arc 0.4.3</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_malloc_size_of 0.18.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-malloc-size-of 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_malloc_size_of 0.19.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-malloc-size-of 0.5.0</a></li>
                         <li><a href=" https://github.com/gimli-rs/addr2line ">addr2line 0.25.1</a></li>
                         <li><a href=" https://github.com/tkaitchuck/ahash ">ahash 0.8.12</a></li>
-                        <li><a href=" https://github.com/rust-embedded-community/aligned ">aligned 0.4.3</a></li>
-                        <li><a href=" https://github.com/rust-fuzz/arbitrary/ ">arbitrary 1.4.2</a></li>
-                        <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.9.1</a></li>
-                        <li><a href=" https://github.com/bluss/arrayvec ">arrayvec 0.7.7</a></li>
-                        <li><a href=" https://github.com/japaric/as-slice ">as-slice 0.2.1</a></li>
+                        <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.9.2</a></li>
+                        <li><a href=" https://github.com/bluss/arrayvec ">arrayvec 0.7.8</a></li>
                         <li><a href=" https://github.com/smol-rs/async-channel ">async-channel 2.5.0</a></li>
                         <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.42</a></li>
                         <li><a href=" https://github.com/smol-rs/async-executor ">async-executor 1.14.0</a></li>
@@ -7547,16 +7332,16 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/cuviper/autocfg ">autocfg 1.5.1</a></li>
                         <li><a href=" https://github.com/rust-lang/backtrace-rs ">backtrace 0.3.76</a></li>
                         <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.22.1</a></li>
+                        <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.23.0</a></li>
                         <li><a href=" https://github.com/bitflags/bitflags ">bitflags 1.3.2</a></li>
-                        <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.13.0</a></li>
-                        <li><a href=" https://github.com/tuffy/bitstream-io ">bitstream-io 4.10.0</a></li>
+                        <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.13.1</a></li>
                         <li><a href=" https://github.com/smol-rs/blocking ">blocking 1.6.2</a></li>
-                        <li><a href=" https://github.com/pacak/bpaf ">bpaf 0.9.26</a></li>
+                        <li><a href=" https://github.com/pacak/bpaf ">bpaf 0.9.27</a></li>
                         <li><a href=" https://github.com/pacak/bpaf ">bpaf_derive 0.5.26</a></li>
                         <li><a href=" https://github.com/mikedilger/buf-read-ext ">buf-read-ext 0.4.0</a></li>
                         <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.20.3</a></li>
                         <li><a href=" https://github.com/japaric/cast.rs ">cast 0.3.0</a></li>
-                        <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.62</a></li>
+                        <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.67</a></li>
                         <li><a href=" https://github.com/jethrogb/rust-cexpr ">cexpr 0.6.0</a></li>
                         <li><a href=" https://github.com/rust-lang/cfg-if ">cfg-if 1.0.4</a></li>
                         <li><a href=" https://github.com/servo/cgl-rs ">cgl 0.3.2</a></li>
@@ -7572,44 +7357,44 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/servo/core-foundation-rs ">core-text 20.1.0</a></li>
                         <li><a href=" https://github.com/criterion-rs/criterion.rs ">criterion-plot 0.8.2</a></li>
                         <li><a href=" https://github.com/criterion-rs/criterion.rs ">criterion 0.8.2</a></li>
-                        <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-channel 0.5.15</a></li>
-                        <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-deque 0.8.6</a></li>
-                        <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-epoch 0.9.18</a></li>
-                        <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-utils 0.8.21</a></li>
+                        <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-channel 0.5.16</a></li>
+                        <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-deque 0.8.7</a></li>
+                        <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-epoch 0.9.20</a></li>
+                        <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-utils 0.8.22</a></li>
                         <li><a href=" https://github.com/dalek-cryptography/curve25519-dalek ">curve25519-dalek-derive 0.1.1</a></li>
                         <li><a href=" https://github.com/servo/rust-url ">data-url 0.3.2</a></li>
                         <li><a href=" https://github.com/yaahc/displaydoc ">displaydoc 0.2.6</a></li>
-                        <li><a href=" https://github.com/rayon-rs/either ">either 1.16.0</a></li>
+                        <li><a href=" https://github.com/rayon-rs/either ">either 1.17.0</a></li>
                         <li><a href=" https://github.com/indexmap-rs/equivalent ">equivalent 1.0.2</a></li>
                         <li><a href=" https://github.com/lambda-fairy/rust-errno ">errno 0.3.14</a></li>
                         <li><a href=" https://github.com/servo/euclid ">euclid 0.22.14</a></li>
                         <li><a href=" https://github.com/smol-rs/event-listener-strategy ">event-listener-strategy 0.5.4</a></li>
-                        <li><a href=" https://github.com/smol-rs/event-listener ">event-listener 5.4.1</a></li>
-                        <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.4.1</a></li>
+                        <li><a href=" https://github.com/smol-rs/event-listener ">event-listener 5.4.2</a></li>
+                        <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.5.0</a></li>
                         <li><a href=" https://github.com/alexcrichton/filetime ">filetime 0.2.29</a></li>
                         <li><a href=" https://github.com/rust-lang/cc-rs ">find-msvc-tools 0.1.9</a></li>
                         <li><a href=" https://github.com/petgraph/fixedbitset ">fixedbitset 0.5.7</a></li>
                         <li><a href=" https://github.com/rust-lang/flate2-rs ">flate2 1.1.9</a></li>
                         <li><a href=" https://github.com/servo/rust-fnv ">fnv 1.0.7</a></li>
                         <li><a href=" https://github.com/servo/rust-url ">form_urlencoded 1.2.2</a></li>
-                        <li><a href=" https://github.com/servo/rust-freetype ">freetype 0.7.2</a></li>
+                        <li><a href=" https://github.com/servo/rust-freetype ">freetype 0.8.0</a></li>
                         <li><a href=" https://github.com/smol-rs/futures-lite ">futures-lite 2.6.1</a></li>
                         <li><a href=" https://github.com/servo/gaol ">gaol 0.2.1</a></li>
                         <li><a href=" https://codeberg.org/swsnr/gethostname.rs.git ">gethostname 1.1.0</a></li>
                         <li><a href=" https://github.com/gimli-rs/gimli ">gimli 0.32.3</a></li>
                         <li><a href=" https://github.com/servo/gleam ">gleam 0.15.1</a></li>
-                        <li><a href=" https://github.com/rust-lang/glob ">glob 0.3.3</a></li>
+                        <li><a href=" https://github.com/rust-lang/glob ">glob 0.3.4</a></li>
                         <li><a href=" https://github.com/zkcrypto/group ">group 0.14.0</a></li>
-                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-app 0.25.0</a></li>
-                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-audio 0.25.0</a></li>
-                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-base 0.25.0</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-app 0.25.2</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-audio 0.25.3</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-base 0.25.3</a></li>
                         <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-gl-egl 0.25.0</a></li>
-                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-gl 0.25.0</a></li>
-                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-sdp 0.25.0</a></li>
-                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-video 0.25.0</a></li>
-                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-webrtc 0.25.0</a></li>
-                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer 0.25.1</a></li>
-                        <li><a href=" https://github.com/servo/rust-harfbuzz ">harfbuzz-sys 0.6.1</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-gl 0.25.2</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-sdp 0.25.3</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-video 0.25.3</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-webrtc 0.25.2</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer 0.25.3</a></li>
+                        <li><a href=" https://github.com/servo/rust-harfbuzz ">harfbuzz-sys 0.7.0</a></li>
                         <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.15.5</a></li>
                         <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.16.1</a></li>
                         <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.17.1</a></li>
@@ -7626,11 +7411,10 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.13.0</a></li>
                         <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.14.0</a></li>
                         <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.15.0</a></li>
-                        <li><a href=" https://github.com/rust-lang/jobserver-rs ">jobserver 0.1.34</a></li>
+                        <li><a href=" https://github.com/rust-lang/jobserver-rs ">jobserver 0.1.35</a></li>
                         <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys ">js-sys 0.3.94</a></li>
                         <li><a href=" https://github.com/timothee-haudebourg/khronos-egl ">khronos-egl 6.0.0</a></li>
                         <li><a href=" https://github.com/rust-lang-nursery/lazy-static.rs ">lazy_static 1.5.0</a></li>
-                        <li><a href=" https://github.com/rust-fuzz/libfuzzer ">libfuzzer-sys 0.4.13</a></li>
                         <li><a href=" https://github.com/rust-lang/libz-sys ">libz-sys 1.1.29</a></li>
                         <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.12.1</a></li>
                         <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.4.15</a></li>
@@ -7639,7 +7423,6 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/bholley/malloc_size_of_derive ">malloc_size_of_derive 0.1.3</a></li>
                         <li><a href=" https://github.com/servo/html5ever ">markup5ever 0.39.0</a></li>
                         <li><a href=" https://github.com/hyperium/mime ">mime 0.3.17</a></li>
-                        <li><a href=" https://github.com/rust-num/num-bigint ">num-bigint 0.4.6</a></li>
                         <li><a href=" https://github.com/rust-num/num-complex ">num-complex 0.4.6</a></li>
                         <li><a href=" https://github.com/rust-num/num-derive ">num-derive 0.4.2</a></li>
                         <li><a href=" https://github.com/rust-num/num-integer ">num-integer 0.1.46</a></li>
@@ -7666,30 +7449,30 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/jamesmunns/postcard ">postcard 1.1.3</a></li>
                         <li><a href=" https://github.com/rayon-rs/rayon ">rayon-core 1.13.0</a></li>
                         <li><a href=" https://github.com/rayon-rs/rayon ">rayon 1.12.0</a></li>
-                        <li><a href=" https://github.com/rust-lang/regex ">regex-automata 0.4.13</a></li>
+                        <li><a href=" https://github.com/rust-lang/regex ">regex-automata 0.4.16</a></li>
                         <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.8.11</a></li>
-                        <li><a href=" https://github.com/rust-lang/regex ">regex 1.12.4</a></li>
+                        <li><a href=" https://github.com/rust-lang/regex ">regex 1.13.1</a></li>
                         <li><a href=" https://github.com/ron-rs/ron ">ron 0.12.2</a></li>
                         <li><a href=" https://github.com/RazrFalcon/roxmltree ">roxmltree 0.20.0</a></li>
                         <li><a href=" https://github.com/RazrFalcon/roxmltree ">roxmltree 0.21.1</a></li>
-                        <li><a href=" https://github.com/rust-lang/rustc-demangle ">rustc-demangle 0.1.27</a></li>
+                        <li><a href=" https://github.com/rust-lang/rustc-demangle ">rustc-demangle 0.1.28</a></li>
                         <li><a href=" https://github.com/rust-lang-nursery/rustc-hash ">rustc-hash 1.1.0</a></li>
                         <li><a href=" https://github.com/djc/rustc-version-rs ">rustc_version 0.4.1</a></li>
                         <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 0.38.44</a></li>
                         <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 1.1.4</a></li>
                         <li><a href=" https://github.com/rustls/rustls-native-certs ">rustls-native-certs 0.8.4</a></li>
-                        <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.41</a></li>
+                        <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.42</a></li>
                         <li><a href=" https://github.com/alexcrichton/scoped-tls ">scoped-tls 1.0.1</a></li>
                         <li><a href=" https://github.com/bluss/scopeguard ">scopeguard 1.2.0</a></li>
                         <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys 2.17.0</a></li>
                         <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework 3.7.0</a></li>
                         <li><a href=" https://github.com/vorner/signal-hook ">signal-hook-registry 1.4.8</a></li>
-                        <li><a href=" https://github.com/seancroach/simd_cesu8 ">simd_cesu8 1.1.1</a></li>
+                        <li><a href=" https://github.com/seancroach/simd_cesu8 ">simd_cesu8 1.2.0</a></li>
                         <li><a href=" https://github.com/linebender/simplecss ">simplecss 0.2.2</a></li>
                         <li><a href=" https://github.com/servo/smallbitvec ">smallbitvec 2.6.1</a></li>
                         <li><a href=" https://github.com/servo/rust-smallvec ">smallvec 1.15.2</a></li>
                         <li><a href=" https://github.com/rust-analyzer/smol_str ">smol_str 0.2.2</a></li>
-                        <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.6.4</a></li>
+                        <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.6.5</a></li>
                         <li><a href=" https://github.com/storyyeller/stable_deref_trait ">stable_deref_trait 1.2.1</a></li>
                         <li><a href=" https://github.com/servo/string-cache ">string_cache 0.9.0</a></li>
                         <li><a href=" https://github.com/servo/string-cache ">string_cache_codegen 0.6.1</a></li>
@@ -7698,22 +7481,21 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/gdesmott/system-deps ">system-deps 7.0.8</a></li>
                         <li><a href=" https://github.com/composefs/tar-rs ">tar 0.4.46</a></li>
                         <li><a href=" https://github.com/Stebalien/tempfile ">tempfile 3.23.0</a></li>
-                        <li><a href=" https://github.com/servo/html5ever ">tendril 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/html5ever ">tendril 0.5.1</a></li>
+                        <li><a href=" https://github.com/Amanieu/thread_local-rs ">thread_local 1.1.10</a></li>
                         <li><a href=" https://github.com/tikv/jemallocator ">tikv-jemalloc-sys 0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7</a></li>
                         <li><a href=" https://github.com/tikv/jemallocator ">tikv-jemallocator 0.6.1</a></li>
                         <li><a href=" https://github.com/bheisler/TinyTemplate ">tinytemplate 1.2.1</a></li>
                         <li><a href=" https://github.com/harfbuzz/ttf-parser ">ttf-parser 0.25.1</a></li>
-                        <li><a href=" https://github.com/snapview/tungstenite-rs ">tungstenite 0.29.0</a></li>
+                        <li><a href=" https://github.com/snapview/tungstenite-rs ">tungstenite 0.30.0</a></li>
                         <li><a href=" https://github.com/seanmonstar/unicase ">unicase 2.9.0</a></li>
-                        <li><a href=" https://github.com/RazrFalcon/unicode-bidi-mirroring ">unicode-bidi-mirroring 0.4.0</a></li>
                         <li><a href=" https://github.com/servo/unicode-bidi ">unicode-bidi 0.3.18</a></li>
-                        <li><a href=" https://github.com/RazrFalcon/unicode-ccc ">unicode-ccc 0.4.0</a></li>
                         <li><a href=" https://github.com/unicode-rs/unicode-properties ">unicode-properties 0.1.4</a></li>
                         <li><a href=" https://github.com/unicode-rs/unicode-segmentation ">unicode-segmentation 1.13.3</a></li>
                         <li><a href=" https://github.com/RazrFalcon/unicode-vo ">unicode-vo 0.1.0</a></li>
                         <li><a href=" https://github.com/unicode-rs/unicode-width ">unicode-width 0.2.2</a></li>
                         <li><a href=" https://github.com/servo/rust-url ">url 2.5.8</a></li>
-                        <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.23.4</a></li>
+                        <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.24.0</a></li>
                         <li><a href=" https://github.com/SergioBenitez/version_check ">version_check 0.9.5</a></li>
                         <li><a href=" https://github.com/bytecodealliance/wasi ">wasi 0.11.1+wasi-snapshot-preview1</a></li>
                         <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures ">wasm-bindgen-futures 0.4.67</a></li>
@@ -8145,7 +7927,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/kyren/hashlink ">hashlink 0.10.0</a>
+                            <a href=" https://github.com/djc/hashlink ">hashlink 0.11.1</a>
                     </p>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -8353,7 +8135,7 @@ limitations under the License.</pre>
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/contain-rs/bit-set ">bit-set 0.9.1</a></li>
+                        <li><a href=" https://github.com/contain-rs/bit-set ">bit-set 0.10.0</a></li>
                         <li><a href=" https://github.com/contain-rs/bit-vec ">bit-vec 0.9.1</a></li>
                         <li><a href=" https://github.com/EmbarkStudios/cfg-expr ">cfg-expr 0.20.8</a></li>
                         <li><a href=" https://github.com/marcianx/downcast-rs ">downcast-rs 1.2.1</a></li>
@@ -8778,13 +8560,13 @@ limitations under the License.</pre>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/RustCrypto/AEADs ">aes-gcm 0.11.0</a></li>
-                        <li><a href=" https://github.com/RustCrypto/block-ciphers ">aes 0.9.1</a></li>
+                        <li><a href=" https://github.com/RustCrypto/block-ciphers ">aes 0.9.2</a></li>
                         <li><a href=" https://github.com/RustCrypto/password-hashes ">argon2 0.6.0-rc.8</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats ">base16ct 1.0.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats ">base64ct 1.8.3</a></li>
                         <li><a href=" https://github.com/RustCrypto/hashes ">blake2 0.11.0-rc.6</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.10.4</a></li>
-                        <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.12.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.12.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">block-padding 0.4.2</a></li>
                         <li><a href=" https://github.com/RustCrypto/block-modes ">cbc 0.2.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/stream-ciphers ">chacha20 0.10.1</a></li>
@@ -8800,31 +8582,33 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/RustCrypto/XOFs ">cshake 0.2.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/block-modes ">ctr 0.10.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">dbl 0.5.0</a></li>
-                        <li><a href=" https://github.com/RustCrypto/formats ">der 0.8.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/formats ">der 0.8.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/traits ">digest 0.10.7</a></li>
                         <li><a href=" https://github.com/RustCrypto/traits ">digest 0.11.3</a></li>
-                        <li><a href=" https://github.com/RustCrypto/traits ">elliptic-curve 0.14.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/elliptic-curves/tree/master/ed448-goldilocks ">ed448-goldilocks 0.14.0-pre.15</a></li>
+                        <li><a href=" https://github.com/RustCrypto/traits ">elliptic-curve 0.14.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/universal-hashes ">ghash 0.6.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/elliptic-curves ">hash2curve 0.14.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/MACs ">hmac 0.13.0</a></li>
-                        <li><a href=" https://github.com/RustCrypto/hybrid-array ">hybrid-array 0.4.12</a></li>
+                        <li><a href=" https://github.com/RustCrypto/hybrid-array ">hybrid-array 0.4.13</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">inout 0.2.2</a></li>
                         <li><a href=" https://github.com/RustCrypto/XOFs ">k12 0.5.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/sponges ">keccak 0.2.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/KEMs ">ml-kem 0.3.2</a></li>
                         <li><a href=" https://github.com/RustCrypto/KEMs ">module-lattice 0.2.3</a></li>
                         <li><a href=" https://github.com/RustCrypto/AEADs ">ocb3 0.2.0-rc.3</a></li>
-                        <li><a href=" https://github.com/RustCrypto/elliptic-curves ">p256 0.14.0-rc.14</a></li>
-                        <li><a href=" https://github.com/RustCrypto/elliptic-curves ">p384 0.14.0-rc.14</a></li>
-                        <li><a href=" https://github.com/RustCrypto/elliptic-curves ">p521 0.14.0-rc.14</a></li>
+                        <li><a href=" https://github.com/RustCrypto/elliptic-curves ">p256 0.14.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/elliptic-curves ">p384 0.14.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/elliptic-curves ">p521 0.14.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/traits ">password-hash 0.6.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats ">pem-rfc7468 1.0.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats ">phc 0.6.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats ">pkcs1 0.8.0-rc.4</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats ">pkcs8 0.11.0</a></li>
-                        <li><a href=" https://github.com/RustCrypto/universal-hashes ">poly1305 0.9.0</a></li>
-                        <li><a href=" https://github.com/RustCrypto/universal-hashes ">polyval 0.7.1</a></li>
+                        <li><a href=" https://github.com/RustCrypto/universal-hashes ">poly1305 0.9.1</a></li>
+                        <li><a href=" https://github.com/RustCrypto/universal-hashes ">polyval 0.7.3</a></li>
                         <li><a href=" https://github.com/RustCrypto/elliptic-curves ">primefield 0.14.0</a></li>
-                        <li><a href=" https://github.com/RustCrypto/elliptic-curves ">primeorder 0.14.0-rc.14</a></li>
+                        <li><a href=" https://github.com/RustCrypto/elliptic-curves ">primeorder 0.14.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats ">sec1 0.8.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/hashes ">sha1 0.10.6</a></li>
                         <li><a href=" https://github.com/RustCrypto/hashes ">sha1 0.11.0</a></li>
@@ -8838,6 +8622,8 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/RustCrypto/utils ">sponge-cursor 0.1.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/XOFs ">turboshake 0.7.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/traits ">universal-hash 0.6.1</a></li>
+                        <li><a href=" https://github.com/RustCrypto/elliptic-curves ">wnaf 0.14.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/elliptic-curves/tree/master/x448 ">x448 0.14.0-pre.12</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -10498,6 +10284,83 @@ limitations under the License.
             </li>
             <li class="license">
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
+                    <h4>Used by:</h4>
+                    <ul class="license-used-by">
+                        <li><a href=" https://github.com/googlefonts/fontations ">font-types 0.12.1</a></li>
+                        <li><a href=" https://github.com/googlefonts/fontations ">read-fonts 0.41.0</a></li>
+                        <li><a href=" https://github.com/googlefonts/fontations ">skrifa 0.44.0</a></li>
+                    </ul>
+                <pre class="license-text">Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+&quot;License&quot; shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+&quot;Licensor&quot; shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+&quot;Legal Entity&quot; shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, &quot;control&quot; means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+&quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+&quot;Source&quot; form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+&quot;Object&quot; form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+&quot;Work&quot; shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+&quot;Derivative Works&quot; shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+&quot;Contribution&quot; shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, &quot;submitted&quot; means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+&quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a &quot;NOTICE&quot; text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+Copyright 2019 Fontations Developers
+
+Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
                             <a href=" https://github.com/meithecatte/enumflags2 ">enumflags2 0.7.12</a>
@@ -11435,7 +11298,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/mmastrac/linktime ">ctor 1.0.7</a>
+                            <a href=" https://github.com/mmastrac/linktime ">ctor 1.0.12</a>
                     </p>
                 <pre class="license-text">Apache License
                            Version 2.0, January 2004
@@ -11644,8 +11507,8 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/Lokathor/bytemuck ">bytemuck 1.25.0</a></li>
-                        <li><a href=" https://github.com/Lokathor/bytemuck ">bytemuck_derive 1.10.2</a></li>
+                        <li><a href=" https://github.com/Lokathor/bytemuck ">bytemuck 1.25.1</a></li>
+                        <li><a href=" https://github.com/Lokathor/bytemuck ">bytemuck_derive 1.11.0</a></li>
                     </ul>
                 <pre class="license-text">Apache License
 Version 2.0, January 2004
@@ -12341,7 +12204,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/servo/servo ">servo-hyper-serde 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-hyper-serde 0.5.0</a></li>
                         <li><a href=" https://github.com/alexheretic/ab-glyph ">ab_glyph 0.2.32</a></li>
                         <li><a href=" https://github.com/alexheretic/ab-glyph ">ab_glyph_rasterizer 0.1.10</a></li>
                         <li><a href=" https://github.com/AccessKit/accesskit ">accesskit 0.24.0</a></li>
@@ -12355,10 +12218,9 @@ limitations under the License.
                         <li><a href=" https://github.com/rust-mobile/android-activity ">android-activity 0.6.1</a></li>
                         <li><a href=" https://github.com/nical/android_system_properties ">android_system_properties 0.1.5</a></li>
                         <li><a href=" https://github.com/zrzka/anes-rs ">anes 0.1.6</a></li>
-                        <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.102</a></li>
                         <li><a href=" https://github.com/1Password/arboard ">arboard 3.6.1</a></li>
                         <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.89</a></li>
-                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.41.0</a></li>
+                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.43.0</a></li>
                         <li><a href=" https://github.com/jrmuizel/build-parallel ">build-parallel 0.1.2</a></li>
                         <li><a href=" https://github.com/linebender/color ">color 0.3.3</a></li>
                         <li><a href=" https://github.com/soc/directories-rs ">directories 6.0.0</a></li>
@@ -12385,8 +12247,6 @@ limitations under the License.
                         <li><a href=" https://gitlab.com/gilrs-project/gilrs ">gilrs 0.11.1</a></li>
                         <li><a href=" https://github.com/brendanzab/gl-rs/ ">gl_generator 0.14.0</a></li>
                         <li><a href=" https://github.com/linebender/vello ">glifo 0.1.1</a></li>
-                        <li><a href=" https://github.com/zakarumych/gpu-descriptor ">gpu-descriptor-types 0.2.0</a></li>
-                        <li><a href=" https://github.com/zakarumych/gpu-descriptor ">gpu-descriptor 0.3.2</a></li>
                         <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-play 0.25.0</a></li>
                         <li><a href=" https://github.com/nical/guillotiere ">guillotiere 0.7.0</a></li>
                         <li><a href=" https://github.com/VoidStarKat/half-rs ">half 2.7.1</a></li>
@@ -12394,7 +12254,6 @@ limitations under the License.
                         <li><a href=" https://github.com/TedDriggs/ident_case ">ident_case 1.0.1</a></li>
                         <li><a href=" https://github.com/image-rs/image-webp ">image-webp 0.2.4</a></li>
                         <li><a href=" https://github.com/image-rs/image ">image 0.25.10</a></li>
-                        <li><a href=" https://github.com/dtolnay/inherent ">inherent 1.0.13</a></li>
                         <li><a href=" https://github.com/dtolnay/inventory ">inventory 0.3.24</a></li>
                         <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.18</a></li>
                         <li><a href=" https://github.com/jni-rs/jni-rs ">jni-macros 0.22.4</a></li>
@@ -12402,12 +12261,13 @@ limitations under the License.
                         <li><a href=" https://github.com/jni-rs/jni-rs ">jni 0.22.4</a></li>
                         <li><a href=" https://github.com/RustCrypto/traits ">kem 0.3.0</a></li>
                         <li><a href=" https://github.com/brendanzab/gl-rs/ ">khronos_api 3.1.0</a></li>
-                        <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.186</a></li>
+                        <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.189</a></li>
                         <li><a href=" https://github.com/linebender/raw_resource_handle ">linebender_resource_handle 0.1.1</a></li>
                         <li><a href=" https://github.com/LukasKalbertodt/litrs ">litrs 1.0.0</a></li>
                         <li><a href=" https://github.com/JohnTitor/mach2 ">mach2 0.6.0</a></li>
                         <li><a href=" https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide ">miniz_oxide 0.8.9</a></li>
-                        <li><a href=" https://github.com/gfx-rs/wgpu ">naga 29.0.3</a></li>
+                        <li><a href=" https://github.com/gfx-rs/wgpu ">naga-types 30.0.0</a></li>
+                        <li><a href=" https://github.com/gfx-rs/wgpu ">naga 30.0.0</a></li>
                         <li><a href=" https://github.com/rust-windowing/android-ndk-rs ">ndk-context 0.1.1</a></li>
                         <li><a href=" https://github.com/rust-mobile/ndk ">ndk-sys 0.6.0+11769913</a></li>
                         <li><a href=" https://github.com/rust-mobile/ndk ">ndk 0.9.0</a></li>
@@ -12437,58 +12297,58 @@ limitations under the License.
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-window-manager-sys 0.1.4</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-window-sys 0.1.7</a></li>
                         <li><a href=" https://github.com/Ralith/openxrs ">openxr 0.21.1</a></li>
+                        <li><a href=" https://gitlab.com/kornelski/ordered-channel ">ordered-channel 1.2.0</a></li>
                         <li><a href=" https://github.com/alexheretic/owned-ttf-parser ">owned_ttf_parser 0.25.1</a></li>
                         <li><a href=" https://github.com/dtolnay/paste ">paste 1.0.15</a></li>
-                        <li><a href=" https://github.com/as1100k/pastey ">pastey 0.1.1</a></li>
-                        <li><a href=" https://github.com/as1100k/pastey ">pastey 0.2.2</a></li>
+                        <li><a href=" https://github.com/as1100k/pastey ">pastey 0.2.3</a></li>
                         <li><a href=" https://github.com/taiki-e/pin-project ">pin-project-internal 1.1.13</a></li>
                         <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.17</a></li>
                         <li><a href=" https://github.com/taiki-e/pin-project ">pin-project 1.1.13</a></li>
                         <li><a href=" https://github.com/taiki-e/portable-atomic-util ">portable-atomic-util 0.2.7</a></li>
-                        <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic 1.13.1</a></li>
+                        <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic 1.14.0</a></li>
                         <li><a href=" https://github.com/dtolnay/prettyplease ">prettyplease 0.2.37</a></li>
-                        <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.106</a></li>
-                        <li><a href=" https://github.com/aclysma/profiling ">profiling-procmacros 1.0.18</a></li>
+                        <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.107</a></li>
                         <li><a href=" https://github.com/aclysma/profiling ">profiling 1.0.18</a></li>
-                        <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.46</a></li>
+                        <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.47</a></li>
                         <li><a href=" https://github.com/r-efi/r-efi ">r-efi 5.3.0</a></li>
-                        <li><a href=" https://github.com/rust-random/rand ">rand 0.10.1</a></li>
-                        <li><a href=" https://github.com/rust-random/rand ">rand 0.9.4</a></li>
+                        <li><a href=" https://github.com/rust-random/rand ">rand 0.10.2</a></li>
+                        <li><a href=" https://github.com/rust-random/rand ">rand 0.9.5</a></li>
                         <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.9.0</a></li>
                         <li><a href=" https://github.com/gfx-rs/range-alloc ">range-alloc 0.1.5</a></li>
                         <li><a href=" https://github.com/rust-windowing/raw-window-handle ">raw-window-handle 0.6.2</a></li>
-                        <li><a href=" https://github.com/linebender/resvg ">resvg 0.47.0</a></li>
-                        <li><a href=" https://github.com/rust-lang/rustc-hash ">rustc-hash 2.1.2</a></li>
+                        <li><a href=" https://github.com/linebender/resvg ">resvg 0.48.1</a></li>
+                        <li><a href=" https://github.com/rust-lang/rustc-hash ">rustc-hash 2.1.3</a></li>
                         <li><a href=" https://github.com/rustls/rustls-platform-verifier ">rustls-platform-verifier-android 0.1.1</a></li>
-                        <li><a href=" https://github.com/dtolnay/rustversion ">rustversion 1.0.22</a></li>
+                        <li><a href=" https://github.com/dtolnay/rustversion ">rustversion 1.0.23</a></li>
                         <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.23</a></li>
                         <li><a href=" https://github.com/SeaQL/sea-query ">sea-query-derive 1.0.0</a></li>
-                        <li><a href=" https://github.com/SeaQL/sea-query ">sea-query-rusqlite 0.8.0-rc.15</a></li>
+                        <li><a href=" https://github.com/SeaQL/sea-query ">sea-query-rusqlite 0.8.0</a></li>
                         <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.28</a></li>
                         <li><a href=" https://github.com/dtolnay/seq-macro ">seq-macro 0.3.6</a></li>
                         <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.228</a></li>
                         <li><a href=" https://github.com/serde-rs/bytes ">serde_bytes 0.11.19</a></li>
                         <li><a href=" https://github.com/serde-rs/serde ">serde_core 1.0.228</a></li>
                         <li><a href=" https://github.com/serde-rs/serde ">serde_derive 1.0.228</a></li>
-                        <li><a href=" https://github.com/serde-rs/json ">serde_json 1.0.150</a></li>
+                        <li><a href=" https://github.com/serde-rs/json ">serde_json 1.0.151</a></li>
                         <li><a href=" https://github.com/dtolnay/serde-repr ">serde_repr 0.1.20</a></li>
                         <li><a href=" https://github.com/serde-rs/test ">serde_test 1.0.177</a></li>
                         <li><a href=" https://github.com/nox/serde_urlencoded ">serde_urlencoded 0.7.1</a></li>
                         <li><a href=" https://github.com/comex/rust-shlex ">shlex 1.3.0</a></li>
+                        <li><a href=" https://github.com/comex/rust-shlex ">shlex 2.0.1</a></li>
                         <li><a href=" https://github.com/rusticstuff/simdutf8 ">simdutf8 0.1.5</a></li>
                         <li><a href=" https://github.com/jedisct1/rust-siphash ">siphasher 1.0.3</a></li>
                         <li><a href=" https://github.com/gfx-rs/rspirv ">spirv 0.4.0+sdk-1.4.341.0</a></li>
                         <li><a href=" https://github.com/nical/rust_debug ">svg_fmt 0.4.5</a></li>
-                        <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.118</a></li>
+                        <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.119</a></li>
                         <li><a href=" https://github.com/Actyx/sync_wrapper ">sync_wrapper 1.0.2</a></li>
-                        <li><a href=" https://github.com/mozilla/thin-vec ">thin-vec 0.2.18</a></li>
+                        <li><a href=" https://github.com/mozilla/thin-vec ">thin-vec 0.2.19</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 1.0.69</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 2.0.18</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 1.0.69</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 2.0.18</a></li>
                         <li><a href=" https://github.com/time-rs/time ">time-core 0.1.9</a></li>
-                        <li><a href=" https://github.com/time-rs/time ">time-macros 0.2.30</a></li>
-                        <li><a href=" https://github.com/time-rs/time ">time 0.3.51</a></li>
+                        <li><a href=" https://github.com/time-rs/time ">time-macros 0.2.32</a></li>
+                        <li><a href=" https://github.com/time-rs/time ">time 0.3.55</a></li>
                         <li><a href=" https://github.com/dtolnay/typeid ">typeid 1.0.3</a></li>
                         <li><a href=" https://github.com/open-i18n/rust-unic/ ">unic-char-property 0.9.0</a></li>
                         <li><a href=" https://github.com/open-i18n/rust-unic/ ">unic-char-range 0.9.0</a></li>
@@ -12496,8 +12356,7 @@ limitations under the License.
                         <li><a href=" https://github.com/open-i18n/rust-unic/ ">unic-ucd-ident 0.9.0</a></li>
                         <li><a href=" https://github.com/open-i18n/rust-unic/ ">unic-ucd-version 0.9.0</a></li>
                         <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.24</a></li>
-                        <li><a href=" https://github.com/linebender/resvg ">usvg 0.47.0</a></li>
-                        <li><a href=" https://github.com/SimonSapin/rust-utf8 ">utf-8 0.7.6</a></li>
+                        <li><a href=" https://github.com/linebender/resvg ">usvg 0.48.1</a></li>
                         <li><a href=" https://github.com/alacritty/vte ">utf8parse 0.2.2</a></li>
                         <li><a href=" https://github.com/linebender/vello ">vello_common 0.0.6</a></li>
                         <li><a href=" https://github.com/linebender/vello ">vello_common 0.0.9</a></li>
@@ -12505,13 +12364,13 @@ limitations under the License.
                         <li><a href=" https://github.com/linebender/vello ">vello_cpu 0.0.9</a></li>
                         <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip2 1.0.2+wasi-0.2.9</a></li>
                         <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip3 0.4.0+wasi-0.3.0-rc-2026-01-06</a></li>
-                        <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core-deps-apple 29.0.3</a></li>
-                        <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core-deps-emscripten 29.0.3</a></li>
-                        <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core-deps-windows-linux-android 29.0.3</a></li>
-                        <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core 29.0.3</a></li>
-                        <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-hal 29.0.3</a></li>
-                        <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-naga-bridge 29.0.3</a></li>
-                        <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-types 29.0.3</a></li>
+                        <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core-deps-apple 30.0.0</a></li>
+                        <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core-deps-emscripten 30.0.0</a></li>
+                        <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core-deps-windows-linux-android 30.0.0</a></li>
+                        <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core 30.0.0</a></li>
+                        <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-hal 30.0.0</a></li>
+                        <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-naga-bridge 30.0.0</a></li>
+                        <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-types 30.0.0</a></li>
                         <li><a href=" https://github.com/retep998/winapi-rs ">winapi-i686-pc-windows-gnu 0.4.0</a></li>
                         <li><a href=" https://github.com/retep998/winapi-rs ">winapi-x86_64-pc-windows-gnu 0.4.0</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">xcomponent-sys 0.3.6</a></li>
@@ -12845,105 +12704,6 @@ limitations under the License.
                 <h3 id="BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/rust-av/v_frame ">v_frame 0.3.9</a>
-                    </p>
-                <pre class="license-text">BSD 2-Clause License
-
-Copyright (c) 2017-2022, the rav1e contributors
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-- Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-
-- Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot;
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/xiph/rav1e/ ">rav1e 0.8.1</a>
-                    </p>
-                <pre class="license-text">BSD 2-Clause License
-
-Copyright (c) 2017-2023, the rav1e contributors
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot;
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/rust-av/av1-grain ">av1-grain 0.2.5</a>
-                    </p>
-                <pre class="license-text">BSD 2-Clause License
-
-Copyright (c) 2022-2022, the rav1e contributors
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-- Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-
-- Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot;
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</h3>
-                    <p>
-                        Used by
                             <a href=" https://github.com/droundy/arrayref ">arrayref 0.3.9</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2015 David Roundy &lt;roundyd@physics.oregonstate.edu&gt;
@@ -13012,7 +12772,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/servo/mozangle ">mozangle 0.5.5</a>
+                            <a href=" https://github.com/servo/mozangle ">mozangle 0.6.0</a>
                     </p>
                 <pre class="license-text">// Copyright (C) 2002-2013 The ANGLE Project Authors. 
 // All rights reserved.
@@ -13087,80 +12847,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             </li>
             <li class="license">
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/kornelski/avif-serialize ">avif-serialize 0.8.9</a>
-                    </p>
-                <pre class="license-text">BSD 3-Clause License
-
-Copyright (c) 2020, Cloudflare, Inc.
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot;
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/kornelski/cavif-rs ">ravif 0.13.0</a>
-                    </p>
-                <pre class="license-text">BSD 3-Clause License
-
-Copyright (c) 2020, Kornel
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot;
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/RazrFalcon/tiny-skia/tree/master/path ">tiny-skia-path 0.11.4</a></li>
@@ -13204,7 +12890,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/servo/fontsan ">fontsan 0.6.1</a>
+                            <a href=" https://github.com/servo/fontsan ">fontsan 0.7.0</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2015 The Servo Project Developers. All rights reserved.
 
@@ -13298,7 +12984,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek ">curve25519-dalek 5.0.0-rc.1</a>
+                            <a href=" https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek ">curve25519-dalek 5.0.0</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2016-2021 isis agora lovecruft. All rights reserved.
 Copyright (c) 2016-2021 Henry de Valence. All rights reserved.
@@ -13335,7 +13021,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek ">ed25519-dalek 3.0.0-rc.1</a>
+                            <a href=" https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek ">ed25519-dalek 3.0.0</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2017-2019 isis agora lovecruft. All rights reserved.
 
@@ -13371,7 +13057,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/dalek-cryptography/curve25519-dalek/tree/main/x25519-dalek ">x25519-dalek 3.0.0-rc.1</a>
+                            <a href=" https://github.com/dalek-cryptography/curve25519-dalek/tree/main/x25519-dalek ">x25519-dalek 3.0.0</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2017-2021 isis agora lovecruft. All rights reserved.
 Copyright (c) 2019-2021 DebugSteven. All rights reserved.
@@ -13408,9 +13094,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/servo/servo ">servo-script-bindings 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script-bindings 0.5.0</a></li>
                         <li><a href=" https://github.com/dropbox/rust-alloc-no-stdlib ">alloc-stdlib 0.2.4</a></li>
-                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.41.0</a></li>
+                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.43.0</a></li>
                         <li><a href=" https://github.com/mitsuhiko/sha1-smol ">sha1_smol 1.0.1</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) &lt;year&gt; &lt;owner&gt;. 
@@ -13550,140 +13236,11 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 </pre>
             </li>
             <li class="license">
-                <h3 id="CC0-1.0">Creative Commons Zero v1.0 Universal</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/lifthrasiir/hexf ">hexf-parse 0.2.1</a>
-                    </p>
-                <pre class="license-text">Creative Commons Legal Code
-
-CC0 1.0 Universal
-
-    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
-    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
-    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
-    INFORMATION ON AN &quot;AS-IS&quot; BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
-    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
-    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
-    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
-    HEREUNDER.
-
-Statement of Purpose
-
-The laws of most jurisdictions throughout the world automatically confer
-exclusive Copyright and Related Rights (defined below) upon the creator
-and subsequent owner(s) (each and all, an &quot;owner&quot;) of an original work of
-authorship and/or a database (each, a &quot;Work&quot;).
-
-Certain owners wish to permanently relinquish those rights to a Work for
-the purpose of contributing to a commons of creative, cultural and
-scientific works (&quot;Commons&quot;) that the public can reliably and without fear
-of later claims of infringement build upon, modify, incorporate in other
-works, reuse and redistribute as freely as possible in any form whatsoever
-and for any purposes, including without limitation commercial purposes.
-These owners may contribute to the Commons to promote the ideal of a free
-culture and the further production of creative, cultural and scientific
-works, or to gain reputation or greater distribution for their Work in
-part through the use and efforts of others.
-
-For these and/or other purposes and motivations, and without any
-expectation of additional consideration or compensation, the person
-associating CC0 with a Work (the &quot;Affirmer&quot;), to the extent that he or she
-is an owner of Copyright and Related Rights in the Work, voluntarily
-elects to apply CC0 to the Work and publicly distribute the Work under its
-terms, with knowledge of his or her Copyright and Related Rights in the
-Work and the meaning and intended legal effect of CC0 on those rights.
-
-1. Copyright and Related Rights. A Work made available under CC0 may be
-protected by copyright and related or neighboring rights (&quot;Copyright and
-Related Rights&quot;). Copyright and Related Rights include, but are not
-limited to, the following:
-
-  i. the right to reproduce, adapt, distribute, perform, display,
-     communicate, and translate a Work;
- ii. moral rights retained by the original author(s) and/or performer(s);
-iii. publicity and privacy rights pertaining to a person&#x27;s image or
-     likeness depicted in a Work;
- iv. rights protecting against unfair competition in regards to a Work,
-     subject to the limitations in paragraph 4(a), below;
-  v. rights protecting the extraction, dissemination, use and reuse of data
-     in a Work;
- vi. database rights (such as those arising under Directive 96/9/EC of the
-     European Parliament and of the Council of 11 March 1996 on the legal
-     protection of databases, and under any national implementation
-     thereof, including any amended or successor version of such
-     directive); and
-vii. other similar, equivalent or corresponding rights throughout the
-     world based on applicable law or treaty, and any national
-     implementations thereof.
-
-2. Waiver. To the greatest extent permitted by, but not in contravention
-of, applicable law, Affirmer hereby overtly, fully, permanently,
-irrevocably and unconditionally waives, abandons, and surrenders all of
-Affirmer&#x27;s Copyright and Related Rights and associated claims and causes
-of action, whether now known or unknown (including existing as well as
-future claims and causes of action), in the Work (i) in all territories
-worldwide, (ii) for the maximum duration provided by applicable law or
-treaty (including future time extensions), (iii) in any current or future
-medium and for any number of copies, and (iv) for any purpose whatsoever,
-including without limitation commercial, advertising or promotional
-purposes (the &quot;Waiver&quot;). Affirmer makes the Waiver for the benefit of each
-member of the public at large and to the detriment of Affirmer&#x27;s heirs and
-successors, fully intending that such Waiver shall not be subject to
-revocation, rescission, cancellation, termination, or any other legal or
-equitable action to disrupt the quiet enjoyment of the Work by the public
-as contemplated by Affirmer&#x27;s express Statement of Purpose.
-
-3. Public License Fallback. Should any part of the Waiver for any reason
-be judged legally invalid or ineffective under applicable law, then the
-Waiver shall be preserved to the maximum extent permitted taking into
-account Affirmer&#x27;s express Statement of Purpose. In addition, to the
-extent the Waiver is so judged Affirmer hereby grants to each affected
-person a royalty-free, non transferable, non sublicensable, non exclusive,
-irrevocable and unconditional license to exercise Affirmer&#x27;s Copyright and
-Related Rights in the Work (i) in all territories worldwide, (ii) for the
-maximum duration provided by applicable law or treaty (including future
-time extensions), (iii) in any current or future medium and for any number
-of copies, and (iv) for any purpose whatsoever, including without
-limitation commercial, advertising or promotional purposes (the
-&quot;License&quot;). The License shall be deemed effective as of the date CC0 was
-applied by Affirmer to the Work. Should any part of the License for any
-reason be judged legally invalid or ineffective under applicable law, such
-partial invalidity or ineffectiveness shall not invalidate the remainder
-of the License, and in such case Affirmer hereby affirms that he or she
-will not (i) exercise any of his or her remaining Copyright and Related
-Rights in the Work or (ii) assert any associated claims and causes of
-action with respect to the Work, in either case contrary to Affirmer&#x27;s
-express Statement of Purpose.
-
-4. Limitations and Disclaimers.
-
- a. No trademark or patent rights held by Affirmer are waived, abandoned,
-    surrendered, licensed or otherwise affected by this document.
- b. Affirmer offers the Work as-is and makes no representations or
-    warranties of any kind concerning the Work, express, implied,
-    statutory or otherwise, including without limitation warranties of
-    title, merchantability, fitness for a particular purpose, non
-    infringement, or the absence of latent or other defects, accuracy, or
-    the present or absence of errors, whether or not discoverable, all to
-    the greatest extent permissible under applicable law.
- c. Affirmer disclaims responsibility for clearing rights of other persons
-    that may apply to the Work or any use thereof, including without
-    limitation any person&#x27;s Copyright and Related Rights in the Work.
-    Further, Affirmer disclaims responsibility for obtaining any necessary
-    consents, permissions or other rights required for any use of the
-    Work.
- d. Affirmer understands and acknowledges that Creative Commons is not a
-    party to this document and has no duty or obligation with respect to
-    this CC0 or use of the Work.
-</pre>
-            </li>
-            <li class="license">
                 <h3 id="CDLA-Permissive-2.0">Community Data License Agreement Permissive 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-root-certs 1.0.8</a></li>
-                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-roots 1.0.8</a></li>
+                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-root-certs 1.0.9</a></li>
+                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-roots 1.0.9</a></li>
                     </ul>
                 <pre class="license-text"># Community Data License Agreement - Permissive - Version 2.0
 
@@ -13773,7 +13330,7 @@ insights.
                 <h3 id="ISC">ISC License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/hannobraun/inotify-sys ">inotify-sys 0.1.5</a>
+                            <a href=" https://github.com/hannobraun/inotify-sys ">inotify-sys 0.1.8</a>
                     </p>
                 <pre class="license-text">Copyright (c) Hanno Braun and contributors
 
@@ -13793,7 +13350,7 @@ THIS SOFTWARE.</pre>
                 <h3 id="ISC">ISC License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/hannobraun/inotify-rs ">inotify 0.11.2</a>
+                            <a href=" https://github.com/hannobraun/inotify-rs ">inotify 0.11.4</a>
                     </p>
                 <pre class="license-text">Copyright (c) Hanno Braun and contributors
 
@@ -13862,8 +13419,8 @@ third-party/chromium/LICENSE.
                 <h3 id="ISC">ISC License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.17.0</a></li>
-                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.41.0</a></li>
+                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.17.3</a></li>
+                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.43.0</a></li>
                     </ul>
                 <pre class="license-text">ISC License:
 
@@ -13873,35 +13430,6 @@ Copyright (c) 1995-2003 by Internet Software Consortium
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 
 THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND ISC DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/harfbuzz/rustybuzz ">rustybuzz 0.20.1</a>
-                    </p>
-                <pre class="license-text">    MIT License
-
-    Copyright (c) Microsoft Corporation.
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the &quot;Software&quot;), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in all
-    copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-    SOFTWARE
 </pre>
             </li>
             <li class="license">
@@ -13964,34 +13492,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/servo/fontsan ">fontsan-woff2 0.1.1</a>
-                    </p>
-                <pre class="license-text">Copyright (c) 2013-2017 by the WOFF2 Authors.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/tokio-rs/mio ">mio 1.2.1</a>
+                            <a href=" https://github.com/tokio-rs/mio ">mio 1.2.2</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2014 Carl Lerche and other MIO contributors
 
@@ -14018,8 +13519,8 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/rusqlite/rusqlite ">libsqlite3-sys 0.35.0</a></li>
-                        <li><a href=" https://github.com/rusqlite/rusqlite ">rusqlite 0.37.0</a></li>
+                        <li><a href=" https://github.com/rusqlite/rusqlite ">libsqlite3-sys 0.36.0</a></li>
+                        <li><a href=" https://github.com/rusqlite/rusqlite ">rusqlite 0.38.0</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) 2014 The rusqlite developers
 
@@ -14158,7 +13659,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/hyperium/hyper ">hyper 1.10.1</a>
+                            <a href=" https://github.com/hyperium/hyper ">hyper 1.11.0</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2014-2026 Sean McArthur
 
@@ -14213,13 +13714,13 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-backend 0.3.15</a></li>
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-client 0.31.14</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-backend 0.3.16</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-client 0.31.15</a></li>
                         <li><a href=" https://github.com/smithay/wayland-rs ">wayland-cursor 0.31.14</a></li>
                         <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols-plasma 0.3.12</a></li>
                         <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols-wlr 0.3.12</a></li>
                         <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols 0.32.13</a></li>
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-scanner 0.31.10</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-scanner 0.31.11</a></li>
                         <li><a href=" https://github.com/smithay/wayland-rs ">wayland-sys 0.31.11</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) 2015 Elinor Berger
@@ -14322,7 +13823,7 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/sdroege/async-tungstenite ">async-tungstenite 0.34.1</a>
+                            <a href=" https://github.com/sdroege/async-tungstenite ">async-tungstenite 0.35.0</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2017 Daniel Abramov
 Copyright (c) 2017 Alexey Galakhov
@@ -14379,6 +13880,7 @@ SOFTWARE.</pre>
                     <ul class="license-used-by">
                         <li><a href=" https://gitlab.redox-os.org/redox-os/syscall ">redox_syscall 0.4.1</a></li>
                         <li><a href=" https://gitlab.redox-os.org/redox-os/syscall ">redox_syscall 0.5.18</a></li>
+                        <li><a href=" https://gitlab.redox-os.org/redox-os/syscall ">redox_syscall 0.9.1</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) 2017 Redox OS Developers
 
@@ -14469,7 +13971,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/tokio-rs/bytes ">bytes 1.12.0</a>
+                            <a href=" https://github.com/tokio-rs/bytes ">bytes 1.12.1</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2018 Carl Lerche
 
@@ -14796,44 +14298,12 @@ THE SOFTWARE.
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/hyperium/http-body ">http-body 1.0.1</a>
-                    </p>
-                <pre class="license-text">Copyright (c) 2019-2024 Sean McArthur &amp; Hyper Contributors
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the &quot;Software&quot;), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/hyperium/http-body ">http-body-util 0.1.3</a>
-                    </p>
-                <pre class="license-text">Copyright (c) 2019-2025 Sean McArthur &amp; Hyper Contributors
+                    <h4>Used by:</h4>
+                    <ul class="license-used-by">
+                        <li><a href=" https://github.com/hyperium/http-body ">http-body-util 0.1.4</a></li>
+                        <li><a href=" https://github.com/hyperium/http-body ">http-body 1.1.0</a></li>
+                    </ul>
+                <pre class="license-text">Copyright (c) 2019-2026 Sean McArthur &amp; Hyper Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -14971,12 +14441,12 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus 5.16.0</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_macros 5.16.0</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_names 4.3.2</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_xml 5.1.1</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant 5.12.0</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant_derive 5.12.0</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus 5.18.0</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_macros 5.18.0</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_names 4.3.4</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_xml 5.2.1</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant 5.13.1</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant_derive 5.13.1</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) 2024 Zeeshan Ali Khan &amp; zbus contributors
 
@@ -15189,6 +14659,35 @@ SOFTWARE.
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
+                    <p>
+                        Used by
+                            <a href=" https://github.com/Roughsketch/imagesize ">imagesize 0.15.0</a>
+                    </p>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2017 Maiddog
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/TedDriggs/darling ">darling 0.20.11</a></li>
@@ -15198,65 +14697,6 @@ SOFTWARE.
                 <pre class="license-text">MIT License
 
 Copyright (c) 2017 Ted Driggs
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/lukaslueg/built ">built 0.8.1</a>
-                    </p>
-                <pre class="license-text">MIT License
-
-Copyright (c) 2017-2023 Lukas Lueg
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                    <h4>Used by:</h4>
-                    <ul class="license-used-by">
-                        <li><a href=" https://github.com/lu-zero/arg_enum_proc_macro ">arg_enum_proc_macro 0.3.4</a></li>
-                        <li><a href=" https://github.com/lu-zero/interpolate_name ">interpolate_name 0.2.4</a></li>
-                    </ul>
-                <pre class="license-text">MIT License
-
-Copyright (c) 2018 Luca Barbato
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -15315,64 +14755,6 @@ SOFTWARE.
                 <pre class="license-text">MIT License
 
 Copyright (c) 2019 Kornel
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/lu-zero/noop_proc_macro ">noop_proc_macro 0.3.0</a>
-                    </p>
-                <pre class="license-text">MIT License
-
-Copyright (c) 2019 Luca Barbato
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/rust-av/av-scenechange ">av-scenechange 0.14.1</a>
-                    </p>
-                <pre class="license-text">MIT License
-
-Copyright (c) 2019 Multimedia and Rust
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -15457,7 +14839,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/tokio-rs/tokio ">tokio-macros 2.7.0</a>
+                            <a href=" https://github.com/tokio-rs/tokio ">tokio-macros 2.7.1</a>
                     </p>
                 <pre class="license-text">MIT License
 
@@ -15487,7 +14869,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/katharostech/cfg_aliases ">cfg_aliases 0.2.1</a>
+                            <a href=" https://github.com/katharostech/cfg_aliases ">cfg_aliases 0.2.2</a>
                     </p>
                 <pre class="license-text">MIT License
 
@@ -15567,35 +14949,6 @@ SOFTWARE.
                 <pre class="license-text">MIT License
 
 Copyright (c) 2021 Adel Prokurov
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/shssoichiro/maybe-rayon ">maybe-rayon 0.1.1</a>
-                    </p>
-                <pre class="license-text">MIT License
-
-Copyright (c) 2021 Joshua Holmer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -15707,70 +15060,11 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/sarah-ek/aligned-vec/ ">aligned-vec 0.6.4</a>
-                    </p>
-                <pre class="license-text">MIT License
-
-Copyright (c) 2022 sarah
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://gitlab.redox-os.org/redox-os/libredox.git ">libredox 0.1.17</a>
+                            <a href=" https://gitlab.redox-os.org/redox-os/libredox.git ">libredox 0.1.18</a>
                     </p>
                 <pre class="license-text">MIT License
 
 Copyright (c) 2023 4lDO2
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                    <h4>Used by:</h4>
-                    <ul class="license-used-by">
-                        <li><a href=" https://github.com/sarah-ek/equator/ ">equator-macro 0.4.2</a></li>
-                        <li><a href=" https://github.com/sarah-ek/equator/ ">equator 0.4.2</a></li>
-                    </ul>
-                <pre class="license-text">MIT License
-
-Copyright (c) 2023 sarah
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -15818,6 +15112,35 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                    <p>
+                        Used by
+                            <a href=" https://github.com/Spxg/sqlite-wasm-rs ">sqlite-wasm-rs 0.5.5</a>
+                    </p>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2024 Spxg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
@@ -15875,9 +15198,11 @@ SOFTWARE.</pre>
                         <li><a href=" https://github.com/plotters-rs/plotters ">plotters-backend 0.3.7</a></li>
                         <li><a href=" https://github.com/plotters-rs/plotters.git ">plotters-svg 0.3.7</a></li>
                         <li><a href=" https://github.com/plotters-rs/plotters ">plotters 0.3.7</a></li>
-                        <li><a href=" https://github.com/lu-zero/simd_helpers ">simd_helpers 0.1.0</a></li>
-                        <li><a href=" https://github.com/DioxusLabs/taffy ">taffy 0.11.0</a></li>
+                        <li><a href=" https://crates.io/crates/rsqlite-vfs ">rsqlite-vfs 0.1.1</a></li>
+                        <li><a href=" https://github.com/DioxusLabs/taffy ">taffy 0.12.2</a></li>
                         <li><a href=" https://github.com/reem/rust-void.git ">void 1.0.2</a></li>
+                        <li><a href=" https://github.com/nicoburns/wuff ">wuff-capi 0.2.0</a></li>
+                        <li><a href=" https://github.com/nicoburns/wuff ">wuff 0.2.7</a></li>
                     </ul>
                 <pre class="license-text">MIT License
 
@@ -15932,9 +15257,9 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/tokio-rs/tokio ">tokio-stream 0.1.18</a></li>
-                        <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util 0.7.18</a></li>
-                        <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.52.3</a></li>
+                        <li><a href=" https://github.com/tokio-rs/tokio ">tokio-stream 0.1.19</a></li>
+                        <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util 0.7.19</a></li>
+                        <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.53.1</a></li>
                     </ul>
                 <pre class="license-text">MIT License
 
@@ -15963,7 +15288,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/mcountryman/simd-adler32 ">simd-adler32 0.3.9</a>
+                            <a href=" https://github.com/mcountryman/simd-adler32 ">simd-adler32 0.3.10</a>
                     </p>
                 <pre class="license-text">MIT License
 
@@ -15992,11 +15317,9 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/Roughsketch/imagesize ">imagesize 0.14.0</a>
+                            <a href=" https://github.com/PistonDevelopers/freetype-sys.git ">freetype-sys 0.23.0</a>
                     </p>
                 <pre class="license-text">MIT License
-
-Copyright (c) 2017 Maiddog
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -16081,19 +15404,19 @@ SOFTWARE.
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/zeenix/endi ">endi 1.1.1</a></li>
                         <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-app-sys 0.25.0</a></li>
-                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-audio-sys 0.25.0</a></li>
-                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-base-sys 0.25.0</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-audio-sys 0.25.3</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-base-sys 0.25.3</a></li>
                         <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-gl-egl-sys 0.25.0</a></li>
                         <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-gl-sys 0.25.0</a></li>
                         <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-sdp-sys 0.25.0</a></li>
-                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-sys 0.25.0</a></li>
-                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-video-sys 0.25.0</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-sys 0.25.2</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-video-sys 0.25.3</a></li>
                         <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-webrtc-sys 0.25.0</a></li>
                         <li><a href=" https://github.com/AltF02/x11-rs.git ">x11-dl 2.21.0</a></li>
                         <li><a href=" https://github.com/luukvanderduim/zbus-lockstep ">zbus-lockstep-macros 0.5.2</a></li>
                         <li><a href=" https://github.com/luukvanderduim/zbus-lockstep ">zbus-lockstep 0.5.2</a></li>
-                        <li><a href=" https://github.com/dtolnay/zmij ">zmij 1.0.21</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant_utils 3.4.0</a></li>
+                        <li><a href=" https://github.com/dtolnay/zmij ">zmij 1.0.23</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant_utils 3.5.0</a></li>
                     </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -16124,7 +15447,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/winnow-rs/winnow ">winnow 1.0.3</a>
+                            <a href=" https://github.com/winnow-rs/winnow ">winnow 1.0.4</a>
                     </p>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -16150,43 +15473,13 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">gio-sys 0.22.0</a></li>
-                        <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">glib-macros 0.22.2</a></li>
-                        <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">glib-sys 0.22.3</a></li>
-                        <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">glib 0.22.4</a></li>
-                        <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">gobject-sys 0.22.0</a></li>
+                        <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">gio-sys 0.22.8</a></li>
+                        <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">glib-macros 0.22.6</a></li>
+                        <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">glib-sys 0.22.8</a></li>
+                        <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">glib 0.22.8</a></li>
+                        <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">gobject-sys 0.22.6</a></li>
                     </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/PistonDevelopers/freetype-sys.git ">freetype-sys 0.20.1</a>
-                    </p>
-                <pre class="license-text">The MIT License (MIT)
-
-Copyright (c) 2014 PistonDevelopers
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
@@ -16276,8 +15569,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                         <li><a href=" https://github.com/image-rs/byteorder-lite ">byteorder-lite 0.1.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/byteorder ">byteorder 1.5.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/fst ">fst 0.4.7</a></li>
-                        <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.29</a></li>
-                        <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.8.2</a></li>
+                        <li><a href=" https://github.com/BurntSushi/jiff ">jiff-core 0.1.0</a></li>
+                        <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.35</a></li>
+                        <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.8.3</a></li>
                         <li><a href=" https://github.com/BurntSushi/quickcheck ">quickcheck 1.1.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/walkdir ">walkdir 2.5.0</a></li>
                     </ul>
@@ -16426,36 +15720,6 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/image-rs/y4m.git ">y4m 0.8.0</a>
-                    </p>
-                <pre class="license-text">The MIT License (MIT)
-
-Copyright (c) 2015-2019 PistonDevelopers
-Copyright (c) 2019 image-rs contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
                             <a href=" https://github.com/ia0/data-encoding ">data-encoding 2.11.0</a>
                     </p>
                 <pre class="license-text">The MIT License (MIT)
@@ -16486,7 +15750,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.41.0</a>
+                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.43.0</a>
                     </p>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -16724,7 +15988,7 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/RazrFalcon/fontdb ">fontdb 0.23.0</a>
+                            <a href=" https://github.com/RazrFalcon/fontdb ">fontdb 0.24.0</a>
                     </p>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -16758,6 +16022,36 @@ SOFTWARE.
                 <pre class="license-text">The MIT License (MIT)
 
 Copyright (c) 2023 Kirill Chibisov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                    <p>
+                        Used by
+                            <a href=" https://github.com/harfbuzz/harfrust ">harfrust 0.12.0</a>
+                    </p>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) HarfBuzz developers
+Copyright (c) 2020 Yevhenii Reizner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -16947,7 +16241,7 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/tafia/quick-xml ">quick-xml 0.39.4</a>
+                            <a href=" https://github.com/tafia/quick-xml ">quick-xml 0.41.0</a>
                     </p>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -16972,21 +16266,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://gitlab.com/kornelski/loop9.git ">loop9 0.1.5</a>
-                    </p>
-                <pre class="license-text">© Kornel Lesiński
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 </pre>
             </li>
             <li class="license">
@@ -18141,7 +17420,7 @@ defined by the Mozilla Public License, v. 2.0.
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/upsuper/dtoa-short ">dtoa-short 0.3.5</a></li>
                         <li><a href=" https://github.com/asajeffrey/swapper ">swapper 0.1.0</a></li>
-                        <li><a href=" https://github.com/badboy/zeitstempel ">zeitstempel 0.2.1</a></li>
+                        <li><a href=" https://github.com/badboy/zeitstempel ">zeitstempel 0.2.2</a></li>
                     </ul>
                 <pre class="license-text">Mozilla Public License Version 2.0
 &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
@@ -18524,6 +17803,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/servo/rust-cssparser ">cssparser-macros 0.7.0</a></li>
                         <li><a href=" https://github.com/servo/rust-cssparser ">cssparser 0.37.0</a></li>
+                        <li><a href=" https://github.com/servo/mozjs/ ">mozjs_sys 140.13.0-0</a></li>
                     </ul>
                 <pre class="license-text">Mozilla Public License Version 2.0
 &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
@@ -18904,96 +18184,97 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/servo/stylo ">stylo 0.18.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">selectors 0.38.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_atoms 0.18.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_derive 0.18.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_dom 0.18.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_static_prefs 0.18.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_traits 0.18.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">to_shmem 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo 0.19.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">selectors 0.39.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_atoms 0.19.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_derive 0.19.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_dom 0.19.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_static_prefs 0.19.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_traits 0.19.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">to_shmem 0.5.0</a></li>
                         <li><a href=" https://github.com/servo/stylo ">to_shmem_derive 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-allocator 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-background-hang-monitor 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-bluetooth 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-canvas 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-config 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-config-macro 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-constellation 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-default-resources 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-deny-public-fields 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-devtools 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-dom-struct 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-fonts 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-geometry 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-jstraceable-derive 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-layout 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-audio 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-auto 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-dummy 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render-android 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render-unix 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-ohos 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-examples 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-thread 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-player 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-derive 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-streams 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-traits 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-webrtc 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-metrics 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-net 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-paint 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-pixels 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-profile 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-script 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-script-bindings 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-tracing 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-background-hang-monitor-api 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-base 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-bluetooth-traits 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-canvas-traits 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-constellation-traits 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-devtools-traits 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-embedder-traits 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-fonts-traits 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-layout-api 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-net-traits 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-paint-api 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-profile-traits 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-script-traits 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-storage-traits 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webgpu-traits 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webxr-api 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-storage 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-timers 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-url 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-wakelock 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webdriver-server 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webgl 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webgpu 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webxr 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-xpath 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-capi 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servoshell 0.4.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-capi-tests 0.4.0</a></li>
-                        <li><a href=" https://crates.io/crates/malloc_size_of_tests ">malloc_size_of_tests 0.4.0</a></li>
-                        <li><a href=" https://crates.io/crates/profile_tests ">profile_tests 0.4.0</a></li>
-                        <li><a href=" https://crates.io/crates/script_tests ">script_tests 0.4.0</a></li>
-                        <li><a href=" https://crates.io/crates/style_tests ">style_tests 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-allocator 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-background-hang-monitor 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-bluetooth 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-canvas 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-config 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-config-macro 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-constellation 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-default-resources 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-deny-public-fields 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-devtools 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-dom-struct 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-fonts 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-geometry 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-jstraceable-derive 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-layout 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-audio 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-auto 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-dummy 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render-android 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render-unix 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-ohos 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-examples 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-thread 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-player 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-derive 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-streams 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-traits 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-webrtc 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-metrics 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-net 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-paint 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-pixels 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-profile 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script-bindings 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script-webgpu 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-tracing 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-background-hang-monitor-api 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-base 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-bluetooth-traits 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-canvas-traits 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-constellation-traits 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-devtools-traits 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-embedder-traits 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-fonts-traits 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-layout-api 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-net-traits 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-paint-api 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-profile-traits 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script-traits 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-storage-traits 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webgpu-traits 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webxr-api 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-storage 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-timers 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-url 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-wakelock 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webdriver-server 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webgl 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webgpu 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webvtt 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webxr 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-xpath 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-capi 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servoshell 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-capi-tests 0.5.0</a></li>
+                        <li><a href=" https://crates.io/crates/malloc_size_of_tests ">malloc_size_of_tests 0.5.0</a></li>
+                        <li><a href=" https://crates.io/crates/profile_tests ">profile_tests 0.5.0</a></li>
+                        <li><a href=" https://crates.io/crates/script_tests ">script_tests 0.5.0</a></li>
+                        <li><a href=" https://crates.io/crates/style_tests ">style_tests 0.5.0</a></li>
                         <li><a href=" https://github.com/servo/app_units ">app_units 0.7.8</a></li>
                         <li><a href=" https://github.com/servo/dwrote-rs ">dwrote 0.11.5</a></li>
-                        <li><a href=" https://github.com/servo/mozjs/ ">mozjs_sys 140.12.0-0</a></li>
                         <li><a href=" https://github.com/soc/option-ext.git ">option-ext 0.2.0</a></li>
                         <li><a href=" https://hg.mozilla.org/mozilla-central/file/tip/testing/webdriver ">webdriver 0.53.0</a></li>
-                        <li><a href=" https://github.com/servo/webrender ">webrender 0.69.0</a></li>
-                        <li><a href=" https://github.com/servo/webrender ">webrender_api 0.69.0</a></li>
-                        <li><a href=" https://github.com/servo/webrender ">webrender_build 0.69.0</a></li>
-                        <li><a href=" https://crates.io/crates/wr_glyph_rasterizer ">wr_glyph_rasterizer 0.69.0</a></li>
+                        <li><a href=" https://github.com/servo/webrender ">webrender 0.70.0</a></li>
+                        <li><a href=" https://github.com/servo/webrender ">webrender_api 0.70.0</a></li>
+                        <li><a href=" https://github.com/servo/webrender ">webrender_build 0.70.0</a></li>
+                        <li><a href=" https://crates.io/crates/wr_glyph_rasterizer ">wr_glyph_rasterizer 0.70.0</a></li>
                     </ul>
                 <pre class="license-text">Mozilla Public License Version 2.0
 &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
@@ -19374,7 +18655,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/servo/mozjs/ ">mozjs 0.16.4</a>
+                            <a href=" https://github.com/servo/mozjs/ ">mozjs 0.21.0</a>
                     </p>
                 <pre class="license-text">Mozilla Public License Version 2.0
 &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
@@ -19750,29 +19031,6 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
 This Source Code Form is &quot;Incompatible With Secondary Licenses&quot;, as
 defined by the Mozilla Public License, v. 2.0.
 
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="NCSA">University of Illinois/NCSA Open Source License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/rust-fuzz/libfuzzer ">libfuzzer-sys 0.4.13</a>
-                    </p>
-                <pre class="license-text">University of Illinois/NCSA Open Source License
-
-Copyright (c) &lt;Year&gt; &lt;Owner Organization Name&gt;. All rights reserved.
-
-Developed by: &lt;Name of Development Group&gt; &lt;Name of Institution&gt; &lt;URL for Development Group/Institution&gt;
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal with the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-     * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimers.
-
-     * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimers in the documentation and/or other materials provided with the distribution.
-
-     * Neither the names of &lt;Name of Development Group, Name of Institution&gt;, nor the names of its contributors may be used to endorse or promote products derived from this Software without specific prior written permission.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
 </pre>
             </li>
             <li class="license">

--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -16,7 +16,7 @@ android {
         minSdk = libs.versions.android.sdk.min.get().toInt()
         targetSdk = 34
         versionCode = generatedVersionCode
-        versionName = "0.4.0"
+        versionName = "0.5.0"
     }
 
     compileOptions {

--- a/support/openharmony/entry/oh-package.json5
+++ b/support/openharmony/entry/oh-package.json5
@@ -5,7 +5,7 @@
   "name": "servoshell",
   "description": "Please describe the basic information.",
   "main": "",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "dependencies": {
     "libservoshell.so": "file:./src/main/cpp/types/libentry"
   }

--- a/support/openharmony/oh-package.json5
+++ b/support/openharmony/oh-package.json5
@@ -8,6 +8,6 @@
   "name": "servoshell",
   "description": "Servo browser shell",
   "main": "",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "dependencies": {}
 }

--- a/support/windows/servoshell.wxs.mako
+++ b/support/windows/servoshell.wxs.mako
@@ -4,7 +4,7 @@
            UpgradeCode="060cd15d-eab1-4614-b438-3988e3efdcf1"
            Language="1033"
            Codepage="1252"
-           Version="0.4.0"
+           Version="0.5.0"
            InstallerVersion="200">
     <SummaryInformation Keywords="Installer"
                         Description="Servo Tech Demo Installer"


### PR DESCRIPTION
Monthly version bump, slightly delayed this time.
Created by running `./mach release 0.5.0`

Testing: Not required
