### PR TITLE
script: Move GPUAdapter, GPUSupportedFeatures, GPUSupportedLimits and WGSLLanguageFeatures to script_webgpu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9140,9 +9140,12 @@ dependencies = [
 name = "servo-script-webgpu"
 version = "0.4.0"
 dependencies = [
+ "indexmap",
  "log",
  "malloc_size_of_derive",
  "mozjs",
+ "num-traits",
+ "servo-base",
  "servo-deny-public-fields",
  "servo-dom-struct",
  "servo-jstraceable-derive",
@@ -9150,6 +9153,7 @@ dependencies = [
  "servo-script-bindings",
  "servo-webgpu-traits",
  "wgpu-core 30.0.0",
+ "wgpu-types 30.0.0",
 ]
 
 [[package]]

--- a/components/script/dom/bindings/reflector.rs
+++ b/components/script/dom/bindings/reflector.rs
@@ -2,13 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use js::context::JSContext;
 use script_bindings::reflector::DomGlobalGeneric;
 use script_bindings::root::DomRoot;
 
 use crate::DomTypeHolder;
 use crate::dom::types::GlobalScope;
-use crate::realms::enter_auto_realm;
 
 pub(crate) trait DomGlobal {
     /// Returns the [relevant global] in the same realm as the callee object.
@@ -20,21 +18,7 @@ pub(crate) trait DomGlobal {
 }
 
 impl<T: DomGlobalGeneric<DomTypeHolder>> DomGlobal for T {
-    #[expect(unsafe_code)]
     fn global(&self) -> DomRoot<GlobalScope> {
-        // SAFETY: We only use this `cx` to enter a realm. That does not
-        // incur a GC and hence is safe to perform. We do not want to
-        // pass a `cx` as parameter to this function, as this used in
-        // loads of places. At the same time, it also isn't necessary in
-        // nearly all cases to enter realm, since we are already in the
-        // correct realm.
-        //
-        // However, there are cases where it is difficult to ensure that
-        // we are in the correct realm. Hence we always enter a realm here
-        // even if that is unnecessary at times.
-        let cx = unsafe { JSContext::get_from_thread() };
-        let cx = &mut cx.expect("JS runtime has shut down");
-        let _realm = enter_auto_realm(cx, self);
         <Self as DomGlobalGeneric<DomTypeHolder>>::global_from_reflector(self)
     }
 }

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -3623,6 +3623,10 @@ impl GlobalScopeHelpers<crate::DomTypeHolder> for GlobalScope {
     fn is_secure_context(&self) -> bool {
         self.is_secure_context()
     }
+
+    fn pipeline_id(&self) -> PipelineId {
+        self.pipeline_id()
+    }
 }
 
 impl OwnerWindow<DomTypeHolder> for GlobalScope {}

--- a/components/script/dom/promise/promise.rs
+++ b/components/script/dom/promise/promise.rs
@@ -618,3 +618,15 @@ pub(crate) fn wait_for_all_promise(
     // Return promise.
     promise
 }
+
+impl script_bindings::interfaces::PromiseHelpers<crate::DomTypeHolder> for Promise {
+    fn new_in_realm(
+        cx: &mut CurrentRealm,
+    ) -> Rc<<crate::DomTypeHolder as script_bindings::DomTypes>::Promise> {
+        Promise::new_in_realm(cx)
+    }
+
+    fn reject_error(&self, cx: &mut js::context::JSContext, error: script_bindings::error::Error) {
+        Promise::reject_error(self, cx, error);
+    }
+}

--- a/components/script/dom/webgpu/gpuadapter_promise_listener.rs
+++ b/components/script/dom/webgpu/gpuadapter_promise_listener.rs
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::rc::Rc;
+
+use js::jsapi::HandleObject;
+use script_bindings::cformat;
+use script_bindings::codegen::GenericBindings::WebGPUBinding::GPUDeviceLostReason;
+use webgpu_traits::{RequestDeviceError, WebGPUDeviceResponse};
+
+use crate::dom::bindings::error::Error;
+use crate::dom::bindings::reflector::DomGlobal;
+use crate::dom::gpuadapter::GPUAdapter;
+use crate::dom::promise::Promise;
+use crate::dom::types::GPUDevice;
+use crate::routed_promise::RoutedPromiseListener;
+
+impl RoutedPromiseListener<WebGPUDeviceResponse> for GPUAdapter {
+    /// <https://www.w3.org/TR/webgpu/#dom-gpuadapter-requestdevice>
+    fn handle_response(
+        &self,
+        cx: &mut js::context::JSContext,
+        response: WebGPUDeviceResponse,
+        promise: &Rc<Promise>,
+    ) {
+        match response {
+            // 3.1 Let device be a new device with the capabilities described by descriptor.
+            (device_id, queue_id, Ok(descriptor)) => {
+                let device = GPUDevice::new(
+                    cx,
+                    &self.global(),
+                    self.channel(),
+                    self,
+                    HandleObject::null(),
+                    descriptor.required_features,
+                    descriptor.required_limits,
+                    device_id,
+                    queue_id,
+                    descriptor.label.unwrap_or_default(),
+                );
+                self.global().add_gpu_device(&device);
+                promise.resolve_native(cx, &device);
+            },
+            // 1. If features are not supported reject promise with a TypeError.
+            (_, _, Err(RequestDeviceError::UnsupportedFeature(f))) => promise.reject_error(
+                cx,
+                Error::Type(cformat!(
+                    "{}",
+                    wgpu_core::instance::RequestDeviceError::UnsupportedFeature(f)
+                )),
+            ),
+            // 2. If limits are not supported reject promise with an OperationError.
+            (_, _, Err(RequestDeviceError::LimitsExceeded(l))) => {
+                warn!(
+                    "{}",
+                    wgpu_core::instance::RequestDeviceError::LimitsExceeded(l)
+                );
+                promise.reject_error(cx, Error::Operation(None))
+            },
+            // 3. user agent otherwise cannot fulfill the request
+            (device_id, queue_id, Err(RequestDeviceError::Other(e))) => {
+                // TODO(sagudev): firefox always says operation error,
+                // meanwhile we create "invalid" device that is not invalid in wgpu
+                // causing crashes when one tries to use it
+                // 1. Let device be a new device.
+                let device = GPUDevice::new(
+                    cx,
+                    &self.global(),
+                    self.channel(),
+                    self,
+                    HandleObject::null(),
+                    wgpu_types::Features::default(),
+                    wgpu_types::Limits::default(),
+                    device_id,
+                    queue_id,
+                    String::new(),
+                );
+                // 2. Lose the device(device, "unknown").
+                device.lose(GPUDeviceLostReason::Unknown, e);
+                promise.resolve_native(cx, &device);
+            },
+        }
+    }
+}

--- a/components/script/dom/webgpu/gpuadapter_promise_listener.rs
+++ b/components/script/dom/webgpu/gpuadapter_promise_listener.rs
@@ -56,7 +56,10 @@ impl RoutedPromiseListener<WebGPUDeviceResponse> for GPUAdapter {
                     "{}",
                     wgpu_core::instance::RequestDeviceError::LimitsExceeded(l)
                 );
-                promise.reject_error(cx, Error::Operation(None))
+                promise.reject_error(
+                    cx,
+                    Error::Operation(Some("WebGPU Device Limit exceeded".to_string())),
+                )
             },
             // 3. user agent otherwise cannot fulfill the request
             (device_id, queue_id, Err(RequestDeviceError::Other(e))) => {

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -12,6 +12,7 @@ use js::jsapi::{HandleObject, Heap, JSObject};
 use js::realm::CurrentRealm;
 use script_bindings::cell::DomRefCell;
 use script_bindings::cformat;
+use script_bindings::codegen::GenericBindings::WebGPUBinding::GPUAdapterMethods;
 use script_bindings::reflector::reflect_weak_referenceable_dom_object;
 use webgpu_traits::{
     PopError, WebGPU, WebGPUComputePipeline, WebGPUComputePipelineResponse, WebGPUDevice,
@@ -30,7 +31,7 @@ use super::gpusupportedlimits::GPUSupportedLimits;
 use crate::conversions::Convert;
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventInit;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
-    GPUAdapterMethods, GPUBindGroupDescriptor, GPUBindGroupLayoutDescriptor, GPUBufferDescriptor,
+    GPUBindGroupDescriptor, GPUBindGroupLayoutDescriptor, GPUBufferDescriptor,
     GPUCommandEncoderDescriptor, GPUComputePipelineDescriptor, GPUDeviceLostReason,
     GPUDeviceMethods, GPUErrorFilter, GPUExternalTextureDescriptor, GPUPipelineErrorReason,
     GPUPipelineLayoutDescriptor, GPUQuerySetDescriptor, GPURenderBundleEncoderDescriptor,

--- a/components/script/dom/webgpu/mod.rs
+++ b/components/script/dom/webgpu/mod.rs
@@ -2,8 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::rc::Rc;
+use std::sync::Arc;
+
+use js::realm::CurrentRealm;
+use script_webgpu::promise::{WebGPUGlobalTrait, WebGPUPromiseTrait};
+
+use crate::dom::bindings::reflector::DomGlobal;
+use crate::dom::types::GPUAdapter;
+use crate::dom::{GlobalScope, Promise};
+use crate::routed_promise::callback_promise;
+
 pub(crate) mod gpu;
-pub(crate) mod gpuadapter;
+pub(crate) mod gpuadapter_promise_listener;
+pub(crate) mod gpuadapter {
+    pub(crate) type GPUAdapter = script_webgpu::gpuadapter::GPUAdapter<crate::DomTypeHolder>;
+}
 pub(crate) mod gpuadapterinfo {
     pub(crate) type GPUAdapterInfo =
         script_webgpu::gpuadapterinfo::GPUAdapterInfo<crate::DomTypeHolder>;
@@ -63,8 +77,14 @@ pub(crate) mod gpushaderstage {
     pub(crate) type GPUShaderStage =
         script_webgpu::gpushaderstage::GPUShaderStage<crate::DomTypeHolder>;
 }
-pub(crate) mod gpusupportedfeatures;
-pub(crate) mod gpusupportedlimits;
+pub(crate) mod gpusupportedfeatures {
+    pub(crate) type GPUSupportedFeatures =
+        script_webgpu::gpusupportedfeatures::GPUSupportedFeatures<crate::DomTypeHolder>;
+}
+pub(crate) mod gpusupportedlimits {
+    pub(crate) type GPUSupportedLimits =
+        script_webgpu::gpusupportedlimits::GPUSupportedLimits<crate::DomTypeHolder>;
+}
 pub(crate) mod gputexture;
 pub(crate) mod gputextureusage {
     pub(crate) type GPUTextureUsage =
@@ -76,4 +96,37 @@ pub(crate) mod gpuvalidationerror;
 pub(crate) mod identityhub {
     pub(crate) type IdentityHub = script_webgpu::identityhub::IdentityHub;
 }
-pub(crate) mod wgsllanguagefeatures;
+pub(crate) mod wgsllanguagefeatures {
+    pub(crate) type WGSLLanguageFeatures =
+        script_webgpu::wgsllanguagefeatures::WGSLLanguageFeatures<crate::DomTypeHolder>;
+}
+
+impl WebGPUPromiseTrait<crate::DomTypeHolder> for Promise {
+    fn new_in_realm(
+        cx: &mut CurrentRealm,
+    ) -> Rc<<crate::DomTypeHolder as script_bindings::DomTypes>::Promise> {
+        Promise::new_in_realm(cx)
+    }
+
+    fn callback_promise(
+        self: &Rc<Self>,
+        d: &GPUAdapter,
+    ) -> servo_base::generic_channel::GenericCallback<webgpu_traits::WebGPUDeviceResponse> {
+        let task_manager = <GPUAdapter as DomGlobal>::global(d).task_manager();
+        callback_promise(self, d, task_manager.dom_manipulation_task_source())
+    }
+
+    fn reject_error(&self, cx: &mut js::context::JSContext, error: script_bindings::error::Error) {
+        Promise::reject_error(self, cx, error);
+    }
+}
+
+impl WebGPUGlobalTrait for GlobalScope {
+    fn global_wgpu_id_hub(&self) -> Arc<script_webgpu::identityhub::IdentityHub> {
+        self.wgpu_id_hub()
+    }
+
+    fn global_pipeline_id(&self) -> servo_base::id::PipelineId {
+        self.pipeline_id()
+    }
+}

--- a/components/script/dom/webgpu/mod.rs
+++ b/components/script/dom/webgpu/mod.rs
@@ -5,7 +5,6 @@
 use std::rc::Rc;
 use std::sync::Arc;
 
-use js::realm::CurrentRealm;
 use script_webgpu::promise::{WebGPUGlobalTrait, WebGPUPromiseTrait};
 
 use crate::dom::bindings::reflector::DomGlobal;
@@ -102,12 +101,6 @@ pub(crate) mod wgsllanguagefeatures {
 }
 
 impl WebGPUPromiseTrait<crate::DomTypeHolder> for Promise {
-    fn new_in_realm(
-        cx: &mut CurrentRealm,
-    ) -> Rc<<crate::DomTypeHolder as script_bindings::DomTypes>::Promise> {
-        Promise::new_in_realm(cx)
-    }
-
     fn callback_promise(
         self: &Rc<Self>,
         d: &GPUAdapter,
@@ -115,18 +108,10 @@ impl WebGPUPromiseTrait<crate::DomTypeHolder> for Promise {
         let task_manager = <GPUAdapter as DomGlobal>::global(d).task_manager();
         callback_promise(self, d, task_manager.dom_manipulation_task_source())
     }
-
-    fn reject_error(&self, cx: &mut js::context::JSContext, error: script_bindings::error::Error) {
-        Promise::reject_error(self, cx, error);
-    }
 }
 
 impl WebGPUGlobalTrait for GlobalScope {
     fn global_wgpu_id_hub(&self) -> Arc<script_webgpu::identityhub::IdentityHub> {
         self.wgpu_id_hub()
-    }
-
-    fn global_pipeline_id(&self) -> servo_base::id::PipelineId {
-        self.pipeline_id()
     }
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1718,7 +1718,7 @@ Unions = {
 }
 
 SubCrates = {
-    'script_webgpu': ['GPUAdapterInfo', 'GPUBufferUsage', 'GPUCommandBuffer',
+    'script_webgpu': ['GPUAdapter', 'GPUAdapterInfo', 'GPUBufferUsage', 'GPUCommandBuffer',
     'GPUCompilationInfo', 'GPUCompilationMessage', 'GPUDeviceLostInfo', 'GPUMapMode', 'GPURenderBundle', 'GPUShaderStage',
-    'GPUTextureUsage',],
+    'GPUSupportedLimits', 'GPUSupportedFeatures', 'GPUTextureUsage', 'WGSLLanguageFeatures'],
 }

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -3539,26 +3539,19 @@ class CGIteratorDerives(CGThing):
         iterableInterface = self.descriptor.interface.iterableInterface
         assert iterableInterface is not None
         name = iterableInterface.identifier.name
+        (generics, suffix) = ("<D: DomTypes>", "<D>") if self.generic else ("", "")
         if self.generic:
             bindingModule = f"crate::codegen::Bindings::{toBindingNamespace(self.descriptor.interface.identifier.name)}"
-            return f"""
-    impl<D: DomTypes> crate::dom::bindings::iterable::IteratorDerives for {name}<D> {{
+        else:
+            bindingModule = f"crate::dom::bindings::codegen::Bindings::{toBindingPath(self.descriptor)}"
+        return f"""
+    impl{generics} crate::dom::bindings::iterable::IteratorDerives for {name}{suffix} {{
         #[inline]
         fn derives(class: &'static DOMClass) -> bool {{
             unsafe {{ ptr::eq(class, &{bindingModule}::Class.get().dom_class) }}
         }}
     }}
     """
-        else:
-            bindingModule = f"crate::dom::bindings::codegen::Bindings::{toBindingPath(self.descriptor)}"
-            return f"""
-impl crate::dom::bindings::iterable::IteratorDerives for {name} {{
-    #[inline]
-    fn derives(class: &'static DOMClass) -> bool {{
-        unsafe {{ ptr::eq(class, &{bindingModule}::Class.get().dom_class) }}
-    }}
-}}
-"""
 
 
 class CGDomObjectWrap(CGThing):
@@ -8117,7 +8110,7 @@ class CGConcreteBindingRoot(CGThing):
 
 
         for d in descriptors:
-            ifaceName:str = d.interface.identifier.name
+            ifaceName: str = d.interface.identifier.name
             should_skip = ifaceName.removesuffix('Setlike') not in only_interfaces
 
 

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -3530,16 +3530,28 @@ class CGIteratorDerives(CGThing):
     """
     Class for codegen of an implementation of the IteratorDerives trait.
     """
-    def __init__(self, descriptor: Descriptor) -> None:
+    def __init__(self, descriptor: Descriptor, generic: bool = False) -> None:
         CGThing.__init__(self)
         self.descriptor = descriptor
+        self.generic = generic
 
     def define(self) -> str:
         iterableInterface = self.descriptor.interface.iterableInterface
         assert iterableInterface is not None
         name = iterableInterface.identifier.name
-        bindingModule = f"crate::dom::bindings::codegen::Bindings::{toBindingPath(self.descriptor)}"
-        return f"""
+        if self.generic:
+            bindingModule = f"crate::codegen::Bindings::{toBindingNamespace(self.descriptor.interface.identifier.name)}"
+            return f"""
+    impl<D: DomTypes> crate::dom::bindings::iterable::IteratorDerives for {name}<D> {{
+        #[inline]
+        fn derives(class: &'static DOMClass) -> bool {{
+            unsafe {{ ptr::eq(class, &{bindingModule}::Class.get().dom_class) }}
+        }}
+    }}
+    """
+        else:
+            bindingModule = f"crate::dom::bindings::codegen::Bindings::{toBindingPath(self.descriptor)}"
+            return f"""
 impl crate::dom::bindings::iterable::IteratorDerives for {name} {{
     #[inline]
     fn derives(class: &'static DOMClass) -> bool {{
@@ -8105,8 +8117,8 @@ class CGConcreteBindingRoot(CGThing):
 
 
         for d in descriptors:
-            ifaceName = d.interface.identifier.name
-            should_skip = ifaceName not in only_interfaces
+            ifaceName:str = d.interface.identifier.name
+            should_skip = ifaceName.removesuffix('Setlike') not in only_interfaces
 
 
             cgthings += [
@@ -8116,6 +8128,7 @@ class CGConcreteBindingRoot(CGThing):
             ]
 
             if should_skip:
+                # Things we should generate even if the type is skipped, i.e., things that are needed in the `script` crate
                 if not generic:
                     if d.interface.isIteratorInterface():
                         cgthings.append(CGDomObjectIteratorWrap(d))
@@ -8126,23 +8139,22 @@ class CGConcreteBindingRoot(CGThing):
                             cgthings.append(CGDomObjectWrap(d, generic=generic))
                 continue
 
+            # These are all things that will be generated in the subcrates
             for marker in ["Serializable", "Transferable"]:
                 if d.interface.getExtendedAttribute(marker):
                     cgthings += [CGStructuredCloneMarker(d, marker)]
 
             if d.concrete:
                 if not d.interface.isIteratorInterface():
-                    cgthings.append(CGAssertInheritance(d, generic =generic))
+                    cgthings.append(CGAssertInheritance(d, generic = generic))
                 else:
-                    cgthings.append(CGIteratorDerives(d))
-
-
+                    cgthings.append(CGIteratorDerives(d, generic = generic))
 
             if (
                 (d.concrete or d.hasDescendants())
                 and not d.interface.isIteratorInterface()
             ):
-                cgthings.append(CGIDLInterface(d, generic=generic))
+                cgthings.append(CGIDLInterface(d, generic = generic))
 
             if not generic:
                 if d.interface.isIteratorInterface():

--- a/components/script_bindings/interfaces.rs
+++ b/components/script_bindings/interfaces.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::RefCell;
+use std::rc::Rc;
 use std::thread::LocalKey;
 
 use js::context::JSContext;
@@ -10,6 +11,7 @@ use js::glue::JSPrincipalsCallbacks;
 use js::jsapi::{CallArgs, JSObject};
 use js::realm::CurrentRealm;
 use js::rust::{HandleObject, MutableHandleObject};
+use servo_base::id::PipelineId;
 use servo_url::{MutableOrigin, ServoUrl};
 
 use crate::DomTypes;
@@ -80,6 +82,13 @@ pub trait GlobalScopeHelpers<D: DomTypes> {
     fn get_url(&self) -> ServoUrl;
 
     fn is_secure_context(&self) -> bool;
+
+    fn pipeline_id(&self) -> PipelineId;
+}
+
+pub trait PromiseHelpers<D: DomTypes> {
+    fn new_in_realm(cx: &mut CurrentRealm) -> Rc<D::Promise>;
+    fn reject_error(&self, cx: &mut JSContext, error: Error);
 }
 
 pub trait DocumentHelpers {

--- a/components/script_bindings/reflector.rs
+++ b/components/script_bindings/reflector.rs
@@ -13,6 +13,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use crate::conversions::DerivedFrom;
 use crate::interfaces::GlobalScopeHelpers;
 use crate::iterable::{Iterable, IterableIterator};
+use crate::realms::enter_auto_realm;
 use crate::root::{Dom, DomRoot, Root};
 use crate::{DomTypes, JSTraceable};
 
@@ -222,6 +223,19 @@ pub trait DomGlobalGeneric<D: DomTypes>: DomObject {
     where
         Self: Sized,
     {
+        // SAFETY: We only use this `cx` to enter a realm. That does not
+        // incur a GC and hence is safe to perform. We do not want to
+        // pass a `cx` as parameter to this function, as this used in
+        // loads of places. At the same time, it also isn't necessary in
+        // nearly all cases to enter realm, since we are already in the
+        // correct realm.
+        //
+        // However, there are cases where it is difficult to ensure that
+        // we are in the correct realm. Hence we always enter a realm here
+        // even if that is unnecessary at times.
+        let cx = unsafe { JSContext::get_from_thread() };
+        let cx = &mut cx.expect("JS runtime has shut down");
+        let _realm = enter_auto_realm::<D>(cx, self);
         D::GlobalScope::from_reflector(self)
     }
 }

--- a/components/script_webgpu/Cargo.toml
+++ b/components/script_webgpu/Cargo.toml
@@ -20,11 +20,15 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(crown)'] }
 [dependencies]
 deny_public_fields = { workspace = true }
 dom_struct = { workspace = true }
+indexmap = { workspace = true }
 js = { workspace = true }
-log = { workspace = true }
 jstraceable_derive = { workspace = true }
+log = { workspace = true }
 script_bindings = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
+num-traits = { workspace = true }
+servo-base = { workspace = true }
 webgpu_traits = { workspace = true }
 wgpu-core = { workspace = true }
+wgpu-types = { workspace = true }

--- a/components/script_webgpu/gpuadapter.rs
+++ b/components/script_webgpu/gpuadapter.rs
@@ -14,6 +14,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use script_bindings::codegen::GenericBindings::WebGPUBinding::{
     GPUAdapterMethods, GPUAdapterWrap, GPUDeviceDescriptor,
 };
+use script_bindings::interfaces::{GlobalScopeHelpers, PromiseHelpers};
 use script_bindings::like::Setlike;
 use script_bindings::reflector::{DomGlobalGeneric, Reflector, reflect_dom_object_with_wrap};
 use script_bindings::{DomTypes, cformat};
@@ -207,8 +208,8 @@ where
             GPUSupportedFeatures = GPUSupportedFeatures<D>,
             GPUSupportedLimits = GPUSupportedLimits<D>,
         >,
-    D::Promise: WebGPUPromiseTrait<D>,
-    D::GlobalScope: WebGPUGlobalTrait,
+    D::Promise: WebGPUPromiseTrait<D> + PromiseHelpers<D>,
+    D::GlobalScope: WebGPUGlobalTrait + GlobalScopeHelpers<D>,
 {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapter-requestdevice>
     fn RequestDevice(
@@ -257,7 +258,7 @@ where
         };
         let device_id = self.global().global_wgpu_id_hub().create_device_id();
         let queue_id = self.global().global_wgpu_id_hub().create_queue_id();
-        let pipeline_id = self.global().global_pipeline_id();
+        let pipeline_id = self.global().pipeline_id();
         if self
             .droppable
             .channel

--- a/components/script_webgpu/gpuadapter.rs
+++ b/components/script_webgpu/gpuadapter.rs
@@ -238,7 +238,10 @@ where
             for (limit, value) in (*limits).iter() {
                 if !set_limit(&mut required_limits, &limit.str(), *value) {
                     warn!("Unknown GPUDevice limit: {limit}");
-                    promise.reject_error(cx, Error::Operation(None));
+                    promise.reject_error(
+                        cx,
+                        Error::Operation(Some(format!("Unknown GPUDevice limit: {limit}"))),
+                    );
                     return promise;
                 }
             }
@@ -269,7 +272,10 @@ where
             })
             .is_err()
         {
-            promise.reject_error(cx, Error::Operation(None));
+            promise.reject_error(
+                cx,
+                Error::Operation(Some("Could not Request GPU Device".to_string())),
+            );
         }
         // Step 5
         promise

--- a/components/script_webgpu/gpuadapter.rs
+++ b/components/script_webgpu/gpuadapter.rs
@@ -5,7 +5,6 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
 use js::jsapi::{HandleObject, Heap, JSObject};
 use js::realm::CurrentRealm;
 use jstraceable_derive::JSTraceable;
@@ -193,9 +192,6 @@ where
     }
 
     fn global(&self) -> DomRoot<D::GlobalScope> {
-        let cx = unsafe { JSContext::get_from_thread() };
-        let cx = &mut cx.expect("JS runtime has shut down");
-        let _realm = script_bindings::realms::enter_auto_realm::<D>(cx, self);
         <Self as DomGlobalGeneric<D>>::global_from_reflector(self)
     }
 }

--- a/components/script_webgpu/gpuadapter.rs
+++ b/components/script_webgpu/gpuadapter.rs
@@ -5,31 +5,28 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsapi::{HandleObject, Heap, JSObject};
 use js::realm::CurrentRealm;
-use script_bindings::cformat;
+use jstraceable_derive::JSTraceable;
+use log::warn;
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{
+    GPUAdapterMethods, GPUAdapterWrap, GPUDeviceDescriptor,
+};
 use script_bindings::like::Setlike;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
-use webgpu_traits::{
-    RequestDeviceError, WebGPU, WebGPUAdapter, WebGPUDeviceResponse, WebGPURequest,
-};
-use wgpu_types::{self, AdapterInfo, ExperimentalFeatures, MemoryHints};
+use script_bindings::reflector::{DomGlobalGeneric, Reflector, reflect_dom_object_with_wrap};
+use script_bindings::{DomTypes, cformat};
+use webgpu_traits::{WebGPU, WebGPUAdapter, WebGPURequest};
+use wgpu_types::{AdapterInfo, ExperimentalFeatures, MemoryHints};
 
-use super::gpusupportedfeatures::GPUSupportedFeatures;
-use super::gpusupportedlimits::set_limit;
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
-    GPUAdapterMethods, GPUDeviceDescriptor, GPUDeviceLostReason,
-};
 use crate::dom::bindings::error::Error;
-use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
-use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
-use crate::dom::types::{GPUAdapterInfo, GPUSupportedLimits};
-use crate::dom::webgpu::gpudevice::GPUDevice;
-use crate::dom::webgpu::gpusupportedfeatures::gpu_to_wgt_feature;
-use crate::routed_promise::{RoutedPromiseListener, callback_promise};
+use crate::gpuadapterinfo::GPUAdapterInfo;
+use crate::gpusupportedfeatures::{GPUSupportedFeatures, gpu_to_wgt_feature};
+use crate::gpusupportedlimits::{GPUSupportedLimits, set_limit};
+use crate::promise::{WebGPUGlobalTrait, WebGPUPromiseTrait};
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUAdapter {
@@ -55,24 +52,32 @@ impl Drop for DroppableGPUAdapter {
 }
 
 #[dom_struct]
-pub(crate) struct GPUAdapter {
+pub struct GPUAdapter<D: DomTypes> {
     reflector_: Reflector,
     name: DOMString,
     #[ignore_malloc_size_of = "mozjs"]
     extensions: Heap<*mut JSObject>,
-    features: Dom<GPUSupportedFeatures>,
-    limits: Dom<GPUSupportedLimits>,
-    info: Dom<GPUAdapterInfo>,
+    features: Dom<GPUSupportedFeatures<D>>,
+    limits: Dom<GPUSupportedLimits<D>>,
+    info: Dom<GPUAdapterInfo<D>>,
     droppable: DroppableGPUAdapter,
 }
 
-impl GPUAdapter {
+impl<D> GPUAdapter<D>
+where
+    D: DomTypes<
+            GPUAdapter = GPUAdapter<D>,
+            GPUAdapterInfo = GPUAdapterInfo<D>,
+            GPUSupportedFeatures = GPUSupportedFeatures<D>,
+            GPUSupportedLimits = GPUSupportedLimits<D>,
+        >,
+{
     fn new_inherited(
         channel: WebGPU,
         name: DOMString,
-        features: &GPUSupportedFeatures,
-        limits: &GPUSupportedLimits,
-        info: &GPUAdapterInfo,
+        features: &GPUSupportedFeatures<D>,
+        limits: &GPUSupportedLimits<D>,
+        info: &GPUAdapterInfo<D>,
         adapter: WebGPUAdapter,
     ) -> Self {
         Self {
@@ -87,9 +92,9 @@ impl GPUAdapter {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn new(
+    pub fn new(
         cx: &mut js::context::JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         channel: WebGPU,
         name: DOMString,
         extensions: HandleObject,
@@ -101,12 +106,13 @@ impl GPUAdapter {
         let features = GPUSupportedFeatures::Constructor(cx, global, None, features).unwrap();
         let limits = GPUSupportedLimits::new(cx, global, limits);
         let info = GPUAdapter::create_adapter_info(cx, global, info, &features);
-        let dom_root = reflect_dom_object_with_cx(
+        let dom_root = reflect_dom_object_with_wrap::<D, _, _>(
             Box::new(GPUAdapter::new_inherited(
                 channel, name, &features, &limits, &info, adapter,
             )),
             global,
             cx,
+            GPUAdapterWrap::<D>,
         );
         dom_root.extensions.set(*extensions);
         dom_root
@@ -115,10 +121,10 @@ impl GPUAdapter {
     /// <https://gpuweb.github.io/gpuweb/#abstract-opdef-new-adapter-info>
     fn create_adapter_info(
         cx: &mut js::context::JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         info: AdapterInfo,
-        features: &GPUSupportedFeatures,
-    ) -> DomRoot<GPUAdapterInfo> {
+        features: &GPUSupportedFeatures<D>,
+    ) -> DomRoot<GPUAdapterInfo<D>> {
         // Step 2. If the vendor is known, set adapterInfo.vendor to the name of adapter’s vendor as
         // a normalized identifier string. To preserve privacy, the user agent may instead set
         // adapterInfo.vendor to the empty string or a reasonable approximation of the vendor as a
@@ -180,22 +186,40 @@ impl GPUAdapter {
             is_fallback_adapter,
         )
     }
+
+    pub fn channel(&self) -> WebGPU {
+        self.droppable.channel.clone()
+    }
+
+    fn global(&self) -> DomRoot<D::GlobalScope> {
+        let cx = unsafe { JSContext::get_from_thread() };
+        let cx = &mut cx.expect("JS runtime has shut down");
+        let _realm = script_bindings::realms::enter_auto_realm::<D>(cx, self);
+        <Self as DomGlobalGeneric<D>>::global_from_reflector(self)
+    }
 }
 
-impl GPUAdapterMethods<crate::DomTypeHolder> for GPUAdapter {
+impl<D> GPUAdapterMethods<D> for GPUAdapter<D>
+where
+    D: DomTypes<
+            GPUAdapter = GPUAdapter<D>,
+            GPUAdapterInfo = GPUAdapterInfo<D>,
+            GPUSupportedFeatures = GPUSupportedFeatures<D>,
+            GPUSupportedLimits = GPUSupportedLimits<D>,
+        >,
+    D::Promise: WebGPUPromiseTrait<D>,
+    D::GlobalScope: WebGPUGlobalTrait,
+{
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapter-requestdevice>
     fn RequestDevice(
         &self,
         cx: &mut CurrentRealm<'_>,
         descriptor: &GPUDeviceDescriptor,
-    ) -> Rc<Promise> {
+    ) -> Rc<D::Promise> {
         // Step 2
-        let promise = Promise::new_in_realm(cx);
-        let callback = callback_promise(
-            &promise,
-            self,
-            self.global().task_manager().dom_manipulation_task_source(),
-        );
+        let promise = D::Promise::new_in_realm(cx);
+
+        let callback = WebGPUPromiseTrait::<D>::callback_promise(&promise, self);
         let mut required_features = wgpu_types::Features::empty();
         for &ext in descriptor.requiredFeatures.iter() {
             if let Some(feature) = gpu_to_wgt_feature(ext) {
@@ -228,9 +252,9 @@ impl GPUAdapterMethods<crate::DomTypeHolder> for GPUAdapter {
             trace: wgpu_types::Trace::Off,
             experimental_features: ExperimentalFeatures::disabled(),
         };
-        let device_id = self.global().wgpu_id_hub().create_device_id();
-        let queue_id = self.global().wgpu_id_hub().create_queue_id();
-        let pipeline_id = self.global().pipeline_id();
+        let device_id = self.global().global_wgpu_id_hub().create_device_id();
+        let queue_id = self.global().global_wgpu_id_hub().create_queue_id();
+        let pipeline_id = self.global().global_pipeline_id();
         if self
             .droppable
             .channel
@@ -252,85 +276,17 @@ impl GPUAdapterMethods<crate::DomTypeHolder> for GPUAdapter {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapter-features>
-    fn Features(&self) -> DomRoot<GPUSupportedFeatures> {
+    fn Features(&self) -> DomRoot<GPUSupportedFeatures<D>> {
         DomRoot::from_ref(&self.features)
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapter-limits>
-    fn Limits(&self) -> DomRoot<GPUSupportedLimits> {
+    fn Limits(&self) -> DomRoot<GPUSupportedLimits<D>> {
         DomRoot::from_ref(&self.limits)
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapter-info>
-    fn Info(&self) -> DomRoot<GPUAdapterInfo> {
+    fn Info(&self) -> DomRoot<GPUAdapterInfo<D>> {
         DomRoot::from_ref(&self.info)
-    }
-}
-
-impl RoutedPromiseListener<WebGPUDeviceResponse> for GPUAdapter {
-    /// <https://www.w3.org/TR/webgpu/#dom-gpuadapter-requestdevice>
-    fn handle_response(
-        &self,
-        cx: &mut js::context::JSContext,
-        response: WebGPUDeviceResponse,
-        promise: &Rc<Promise>,
-    ) {
-        match response {
-            // 3.1 Let device be a new device with the capabilities described by descriptor.
-            (device_id, queue_id, Ok(descriptor)) => {
-                let device = GPUDevice::new(
-                    cx,
-                    &self.global(),
-                    self.droppable.channel.clone(),
-                    self,
-                    HandleObject::null(),
-                    descriptor.required_features,
-                    descriptor.required_limits,
-                    device_id,
-                    queue_id,
-                    descriptor.label.unwrap_or_default(),
-                );
-                self.global().add_gpu_device(&device);
-                promise.resolve_native(cx, &device);
-            },
-            // 1. If features are not supported reject promise with a TypeError.
-            (_, _, Err(RequestDeviceError::UnsupportedFeature(f))) => promise.reject_error(
-                cx,
-                Error::Type(cformat!(
-                    "{}",
-                    wgpu_core::instance::RequestDeviceError::UnsupportedFeature(f)
-                )),
-            ),
-            // 2. If limits are not supported reject promise with an OperationError.
-            (_, _, Err(RequestDeviceError::LimitsExceeded(l))) => {
-                warn!(
-                    "{}",
-                    wgpu_core::instance::RequestDeviceError::LimitsExceeded(l)
-                );
-                promise.reject_error(cx, Error::Operation(None))
-            },
-            // 3. user agent otherwise cannot fulfill the request
-            (device_id, queue_id, Err(RequestDeviceError::Other(e))) => {
-                // TODO(sagudev): firefox always says operation error,
-                // meanwhile we create "invalid" device that is not invalid in wgpu
-                // causing crashes when one tries to use it
-                // 1. Let device be a new device.
-                let device = GPUDevice::new(
-                    cx,
-                    &self.global(),
-                    self.droppable.channel.clone(),
-                    self,
-                    HandleObject::null(),
-                    wgpu_types::Features::default(),
-                    wgpu_types::Limits::default(),
-                    device_id,
-                    queue_id,
-                    String::new(),
-                );
-                // 2. Lose the device(device, "unknown").
-                device.lose(GPUDeviceLostReason::Unknown, e);
-                promise.resolve_native(cx, &device);
-            },
-        }
     }
 }

--- a/components/script_webgpu/gpusupportedfeatures.rs
+++ b/components/script_webgpu/gpusupportedfeatures.rs
@@ -4,25 +4,29 @@
 
 // check-tidy: no specs after this line
 
+use std::marker::PhantomData;
+
 use dom_struct::dom_struct;
 use indexmap::IndexSet;
 use js::context::JSContext;
 use js::rust::HandleObject;
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
 use script_bindings::cell::DomRefCell;
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{
+    GPUFeatureName, GPUSupportedFeaturesMethods, GPUSupportedFeaturesWrap,
+};
 use script_bindings::like::Setlike;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_wrap};
 use wgpu_types::Features;
 
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
-    GPUFeatureName, GPUSupportedFeaturesMethods,
-};
+use crate::JSTraceable;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
-use crate::dom::globalscope::GlobalScope;
 
 #[dom_struct]
-pub(crate) struct GPUSupportedFeatures {
+pub struct GPUSupportedFeatures<D: DomTypes> {
     reflector: Reflector,
     // internal storage for features
     #[custom_trace]
@@ -30,15 +34,20 @@ pub(crate) struct GPUSupportedFeatures {
     #[ignore_malloc_size_of = "defined in wgpu-types"]
     #[no_trace]
     features: Features,
+    #[no_trace = "PhantomData does not exist"]
+    phantom: PhantomData<D>,
 }
 
-impl GPUSupportedFeatures {
+impl<D> GPUSupportedFeatures<D>
+where
+    D: DomTypes<GPUSupportedFeatures = GPUSupportedFeatures<D>>,
+{
     fn new(
         cx: &mut JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         proto: Option<HandleObject>,
         features: Features,
-    ) -> DomRoot<GPUSupportedFeatures> {
+    ) -> DomRoot<GPUSupportedFeatures<D>> {
         let mut set = IndexSet::new();
         // everything that wgpu currently does is considered as part of "core"
         set.insert(GPUFeatureName::Core_features_and_limits);
@@ -92,36 +101,38 @@ impl GPUSupportedFeatures {
         }
         */
 
-        reflect_dom_object_with_proto(
-            cx,
+        reflect_dom_object_with_proto_and_wrap::<D, _, _>(
             Box::new(GPUSupportedFeatures {
                 reflector: Reflector::new(),
                 internal: DomRefCell::new(set),
                 features,
+                phantom: PhantomData,
             }),
             global,
             proto,
+            cx,
+            GPUSupportedFeaturesWrap::<D>,
         )
     }
 
     #[expect(non_snake_case)]
-    pub(crate) fn Constructor(
+    pub fn Constructor(
         cx: &mut JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         proto: Option<HandleObject>,
         features: Features,
-    ) -> Fallible<DomRoot<GPUSupportedFeatures>> {
+    ) -> Fallible<DomRoot<GPUSupportedFeatures<D>>> {
         Ok(GPUSupportedFeatures::new(cx, global, proto, features))
     }
 }
 
-impl GPUSupportedFeatures {
-    pub(crate) fn wgpu_features(&self) -> &Features {
+impl<D: DomTypes> GPUSupportedFeatures<D> {
+    pub fn wgpu_features(&self) -> &Features {
         &self.features
     }
 }
 
-impl GPUSupportedFeaturesMethods<crate::DomTypeHolder> for GPUSupportedFeatures {
+impl<D: DomTypes> GPUSupportedFeaturesMethods<D> for GPUSupportedFeatures<D> {
     fn Size(&self) -> u32 {
         self.internal.borrow().len() as u32
     }
@@ -153,7 +164,7 @@ pub(crate) fn gpu_to_wgt_feature(feature: GPUFeatureName) -> Option<Features> {
     }
 }
 
-impl Setlike for GPUSupportedFeatures {
+impl<D: DomTypes> Setlike for GPUSupportedFeatures<D> {
     type Key = DOMString;
 
     #[inline(always)]

--- a/components/script_webgpu/gpusupportedlimits.rs
+++ b/components/script_webgpu/gpusupportedlimits.rs
@@ -2,41 +2,57 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use GPUSupportedLimits_Binding::GPUSupportedLimitsMethods;
+use std::marker::PhantomData;
+
 use dom_struct::dom_struct;
 use js::context::JSContext;
+use malloc_size_of_derive::MallocSizeOf;
 use num_traits::bounds::UpperBounded;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::DomTypes;
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{
+    GPUSupportedLimitsMethods, GPUSupportedLimitsWrap,
+};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_wrap};
 use wgpu_types::Limits;
 
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUSupportedLimits_Binding;
+use crate::JSTraceable;
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::globalscope::GlobalScope;
 
 /// <https://gpuweb.github.io/gpuweb/#gpusupportedlimits>
 #[dom_struct]
-pub(crate) struct GPUSupportedLimits {
+pub struct GPUSupportedLimits<D: DomTypes> {
     reflector_: Reflector,
     #[ignore_malloc_size_of = "defined in wgpu-types"]
     #[no_trace]
     limits: Limits,
+    #[no_trace = "PhantomData does not exist"]
+    phantom: PhantomData<D>,
 }
 
-impl GPUSupportedLimits {
+impl<D> GPUSupportedLimits<D>
+where
+    D: DomTypes<GPUSupportedLimits = GPUSupportedLimits<D>>,
+{
     fn new_inherited(limits: Limits) -> Self {
         Self {
             reflector_: Reflector::new(),
             limits,
+            phantom: PhantomData,
         }
     }
 
-    pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope, limits: Limits) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(Box::new(Self::new_inherited(limits)), global, cx)
+    pub fn new(cx: &mut JSContext, global: &D::GlobalScope, limits: Limits) -> DomRoot<Self> {
+        reflect_dom_object_with_wrap::<D, _, _>(
+            Box::new(Self::new_inherited(limits)),
+            global,
+            cx,
+            GPUSupportedLimitsWrap::<D>,
+        )
     }
 }
 
 // Limits are ordered by their declaration in the spec.
-impl GPUSupportedLimitsMethods<crate::DomTypeHolder> for GPUSupportedLimits {
+impl<D: DomTypes> GPUSupportedLimitsMethods<D> for GPUSupportedLimits<D> {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxtexturedimension1d>
     fn MaxTextureDimension1D(&self) -> u32 {
         self.limits.max_texture_dimension_1d

--- a/components/script_webgpu/lib.rs
+++ b/components/script_webgpu/lib.rs
@@ -6,6 +6,7 @@
 // Register the linter `crown`, which is the Servo-specific linter for the script crate.
 #![cfg_attr(crown, register_tool(crown))]
 
+pub mod gpuadapter;
 pub mod gpuadapterinfo;
 pub mod gpubufferusage;
 pub mod gpucommandbuffer;
@@ -15,12 +16,17 @@ pub mod gpudevicelostinfo;
 pub mod gpumapmode;
 pub mod gpurenderbundle;
 pub mod gpushaderstage;
+pub mod gpusupportedfeatures;
+pub mod gpusupportedlimits;
 pub mod gputextureusage;
 pub mod identityhub;
+pub mod promise;
+pub mod wgsllanguagefeatures;
 
 pub(crate) use js::gc::Traceable as JSTraceable;
 pub(crate) use jstraceable_derive::JSTraceable;
 pub(crate) use script_bindings::reflector::{DomObject, MutDomObject, Reflector};
+pub(crate) use script_bindings::trace::CustomTraceable;
 
 pub(crate) use crate::dom::bindings::inheritance::HasParent;
 
@@ -48,6 +54,7 @@ pub(crate) mod codegen {
         use script_bindings::root::{Dom, DomRoot, Root};
         use script_bindings::utils::DOMClass;
 
+        use crate::gpuadapter::GPUAdapter;
         use crate::gpuadapterinfo::GPUAdapterInfo;
         use crate::gpubufferusage::GPUBufferUsage;
         use crate::gpucommandbuffer::GPUCommandBuffer;
@@ -57,7 +64,10 @@ pub(crate) mod codegen {
         use crate::gpumapmode::GPUMapMode;
         use crate::gpurenderbundle::GPURenderBundle;
         use crate::gpushaderstage::GPUShaderStage;
+        use crate::gpusupportedfeatures::GPUSupportedFeatures;
+        use crate::gpusupportedlimits::GPUSupportedLimits;
         use crate::gputextureusage::GPUTextureUsage;
+        use crate::wgsllanguagefeatures::WGSLLanguageFeatures;
         include!(concat!(
             env!("OUT_DIR"),
             "/ConcreteBindings/WebGPUBinding.rs"

--- a/components/script_webgpu/promise.rs
+++ b/components/script_webgpu/promise.rs
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::rc::Rc;
+use std::sync::Arc;
+
+use js::context::JSContext;
+use js::realm::CurrentRealm;
+use script_bindings::DomTypes;
+use script_bindings::error::Error;
+use servo_base::generic_channel::GenericCallback;
+use servo_base::id::PipelineId;
+use webgpu_traits::WebGPUDeviceResponse;
+
+use crate::gpuadapter::GPUAdapter;
+use crate::identityhub::IdentityHub;
+
+/// The main trait for creating and using promises in script_webgpu.
+pub trait WebGPUPromiseTrait<D: DomTypes> {
+    fn new_in_realm(cx: &mut CurrentRealm) -> Rc<D::Promise>;
+    fn callback_promise(
+        self: &Rc<Self>,
+        d: &GPUAdapter<D>,
+    ) -> GenericCallback<WebGPUDeviceResponse>;
+    fn reject_error(&self, cx: &mut JSContext, error: Error);
+}
+
+pub trait WebGPUGlobalTrait {
+    fn global_wgpu_id_hub(&self) -> Arc<IdentityHub>;
+    fn global_pipeline_id(&self) -> PipelineId;
+}

--- a/components/script_webgpu/promise.rs
+++ b/components/script_webgpu/promise.rs
@@ -5,12 +5,8 @@
 use std::rc::Rc;
 use std::sync::Arc;
 
-use js::context::JSContext;
-use js::realm::CurrentRealm;
 use script_bindings::DomTypes;
-use script_bindings::error::Error;
 use servo_base::generic_channel::GenericCallback;
-use servo_base::id::PipelineId;
 use webgpu_traits::WebGPUDeviceResponse;
 
 use crate::gpuadapter::GPUAdapter;
@@ -18,15 +14,12 @@ use crate::identityhub::IdentityHub;
 
 /// The main trait for creating and using promises in script_webgpu.
 pub trait WebGPUPromiseTrait<D: DomTypes> {
-    fn new_in_realm(cx: &mut CurrentRealm) -> Rc<D::Promise>;
     fn callback_promise(
         self: &Rc<Self>,
         d: &GPUAdapter<D>,
     ) -> GenericCallback<WebGPUDeviceResponse>;
-    fn reject_error(&self, cx: &mut JSContext, error: Error);
 }
 
 pub trait WebGPUGlobalTrait {
     fn global_wgpu_id_hub(&self) -> Arc<IdentityHub>;
-    fn global_pipeline_id(&self) -> PipelineId;
 }

--- a/components/script_webgpu/wgsllanguagefeatures.rs
+++ b/components/script_webgpu/wgsllanguagefeatures.rs
@@ -4,57 +4,70 @@
 
 // check-tidy: no specs after this line
 
+use std::marker::PhantomData;
+
 use dom_struct::dom_struct;
 use indexmap::IndexSet;
 use js::context::JSContext;
-use js::rust::HandleObject;
+use js::gc::HandleObject;
+use jstraceable_derive::JSTraceable;
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
 use script_bindings::cell::DomRefCell;
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{
+    WGSLLanguageFeaturesMethods, WGSLLanguageFeaturesWrap,
+};
 use script_bindings::like::Setlike;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_wrap};
 use wgpu_core::naga::front::wgsl::ImplementedLanguageExtension;
 
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::WGSLLanguageFeaturesMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
-use crate::dom::globalscope::GlobalScope;
 
 #[dom_struct]
-pub struct WGSLLanguageFeatures {
+pub struct WGSLLanguageFeatures<D: DomTypes> {
     reflector: Reflector,
     // internal storage for features
     #[custom_trace]
     internal: DomRefCell<IndexSet<DOMString>>,
+    #[no_trace = "PhantomData does not exist"]
+    phantom: PhantomData<D>,
 }
 
-impl WGSLLanguageFeatures {
-    pub(crate) fn new(
+impl<D> WGSLLanguageFeatures<D>
+where
+    D: DomTypes<WGSLLanguageFeatures = WGSLLanguageFeatures<D>>,
+{
+    pub fn new(
         cx: &mut JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<Self> {
         let set = ImplementedLanguageExtension::all()
             .iter()
             .map(|le| le.to_ident().into())
             .collect();
-        reflect_dom_object_with_proto(
-            cx,
+        reflect_dom_object_with_proto_and_wrap::<D, _, _>(
             Box::new(Self {
                 reflector: Reflector::new(),
                 internal: DomRefCell::new(set),
+                phantom: PhantomData,
             }),
             global,
             proto,
+            cx,
+            WGSLLanguageFeaturesWrap::<D>,
         )
     }
 }
 
-impl WGSLLanguageFeaturesMethods<crate::DomTypeHolder> for WGSLLanguageFeatures {
+impl<D: DomTypes> WGSLLanguageFeaturesMethods<D> for WGSLLanguageFeatures<D> {
     fn Size(&self) -> u32 {
         self.internal.borrow().len() as u32
     }
 }
 
-impl Setlike for WGSLLanguageFeatures {
+impl<D: DomTypes> Setlike for WGSLLanguageFeatures<D> {
     type Key = DOMString;
 
     #[inline(always)]

--- a/python/tidy/error_message_exceptions.txt
+++ b/python/tidy/error_message_exceptions.txt
@@ -101,7 +101,6 @@
 ./components/script/dom/webcrypto/subtlecrypto/x448_operation.rs 2
 ./components/script/dom/webgl/webglrenderingcontext.rs 4
 ./components/script/dom/webgpu/gpu.rs 1
-./components/script/dom/webgpu/gpuadapter.rs 3
 ./components/script/dom/webgpu/gpubuffer.rs 7
 ./components/script/dom/webgpu/gpucanvascontext.rs 1
 ./components/script/dom/webgpu/gpudevice.rs 1


### PR DESCRIPTION
This moves GPUAdapter, GPUSupportedFeatures, GPUSupportedLimits and WGSLLanguageFeatures to script_webgpu crate.
Of note:
- Creation of PromiseHelper Trait which handles creation and usage of Promise. 
- Creation of WebGPUGlobalTrait which handles access to GlobalScope variables.
- Adding of global() method to GPUAdapter which returns `DomRoot<D::GlobalScope>`.  This also moved functionality from DomGlobal impl to  DomGlobalGeneric.
- We added Error messages to gpuadapter and the new gpuadapter_promise_listener.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: WebGPU WPT tests should find if there is anything wrong. WPT run here: https://github.com/Narfinger/servo/actions/runs/30824929512
Part of https://github.com/servo/servo/issues/46658
