### PR TITLE
script: Tidy up comments in `subtlecrypto.rs`

### DIFF
--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -195,6 +195,7 @@ impl CryptoAlgorithm {
     }
 }
 
+/// <https://w3c.github.io/webcrypto/#subtlecrypto-interface>
 #[dom_struct]
 pub(crate) struct SubtleCrypto {
     reflector_: Reflector,

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -4774,6 +4774,7 @@ fn normalize_algorithm<Op: Operation>(
 // Ed25519:           <https://w3c.github.io/webcrypto/#ed25519-registration>
 // X25519:            <https://w3c.github.io/webcrypto/#x25519-registration>
 // Ed448:             <https://wicg.github.io/webcrypto-secure-curves/#ed448-registration>
+// X448:              <https://wicg.github.io/webcrypto-secure-curves/#x448-registration>
 // AES-CTR:           <https://w3c.github.io/webcrypto/#aes-ctr-registration>
 // AES-CBC:           <https://w3c.github.io/webcrypto/#aes-cbc-registration>
 // AES-GCM:           <https://w3c.github.io/webcrypto/#aes-gcm-registration>
@@ -4788,6 +4789,9 @@ fn normalize_algorithm<Op: Operation>(
 // ChaCha20-Poly1305: <https://wicg.github.io/webcrypto-modern-algos/#chacha20-poly1305-registration>
 // SHA-3:             <https://wicg.github.io/webcrypto-modern-algos/#sha3-registration>
 // cSHAKE:            <https://wicg.github.io/webcrypto-modern-algos/#cshake-registration>
+// TurboSHAKE:        <https://wicg.github.io/webcrypto-modern-algos/#turboshake-registration>
+// KangarooTwelve:    <https://wicg.github.io/webcrypto-modern-algos/#kangarootwelve-registration>
+// KMAC:              <https://wicg.github.io/webcrypto-modern-algos/#kmac-registration>
 // Argon2:            <https://wicg.github.io/webcrypto-modern-algos/#argon2-registration>
 
 trait Operation {

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -6307,7 +6307,7 @@ impl EncapsulateAlgorithm {
     }
 }
 
-// The value of the key "decapsulate" in the internal object supportedAlgorithms
+/// The value of the key "decapsulate" in the internal object supportedAlgorithms
 struct DecapsulateOperation {}
 
 impl Operation for DecapsulateOperation {
@@ -6356,7 +6356,7 @@ impl DecapsulateAlgorithm {
     }
 }
 
-// The value of the key "getPublicKey" in the internal object supportedAlgorithms
+/// The value of the key "getPublicKey" in the internal object supportedAlgorithms
 struct GetPublicKeyOperation {}
 
 impl Operation for GetPublicKeyOperation {


### PR DESCRIPTION
- Add spec link to `struct SubtleCrypto` block.
- Add missing spec links on algorithm registrations.
- Change the regular comments for `DecapsulateOperation` and `GetPublicKeyOperation` to outer documentation comments.

Testing: No test since there is no actual code change.