### PR TITLE
script: Error proposal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9097,6 +9097,7 @@ dependencies = [
  "stylo",
  "stylo_atoms",
  "tendril",
+ "thiserror 2.0.18",
  "tracing",
  "xml5ever",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -247,6 +247,7 @@ syn = { version = "2", default-features = false, features = ["clone-impls", "der
 synstructure = "0.13"
 sys-locale = "0.3"
 taffy = { version = "0.12.1", default-features = false, features = ["calc", "detailed_layout_info", "grid", "std"] }
+thiserror = "2.0"
 tempfile = "3"
 tendril = { version = "0.5", features = ["encoding_rs"] }
 tikv-jemalloc-sys = "0.6.1"

--- a/components/script/dom/animations/keyframeeffect.rs
+++ b/components/script/dom/animations/keyframeeffect.rs
@@ -28,7 +28,7 @@ use script_bindings::codegen::GenericBindings::KeyframeEffectBinding::{
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::codegen::GenericUnionTypes::UnrestrictedDoubleOrKeyframeEffectOptions;
 use script_bindings::conversions::StringificationBehavior;
-use script_bindings::error::{Error, Fallible};
+use script_bindings::error::{Error, Fallible, OperationError};
 use script_bindings::inheritance::Castable;
 use script_bindings::num::Finite;
 use script_bindings::reflector::reflect_dom_object_with_proto;
@@ -473,12 +473,10 @@ fn get_property_declarations(
         ) {
             Ok(ConversionResult::Success(property_value)) => property_value,
             Ok(ConversionResult::Failure(error_message)) => {
-                return Err(Error::Operation(
-                    error_message
-                        .to_str()
-                        .ok()
-                        .map(|message| message.to_owned()),
-                ));
+                let msg = error_message.to_str().ok();
+                return Err(Error::OperationNew(msg.map(|string| {
+                    OperationError::ConversionResultError(string.to_owned())
+                })));
             },
             Err(_) => return Err(Error::JSFailed),
         };

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -221,6 +221,10 @@ pub(crate) fn create_dom_exception(
             return new_custom_exception(DOMErrorName::OperationError, custom_message);
         },
         Error::Operation(None) => DOMErrorName::OperationError,
+        Error::OperationNew(Some(custom_error)) => {
+            return new_custom_exception(DOMErrorName::OperationError, format!("{custom_error}"));
+        },
+        Error::OperationNew(None) => DOMErrorName::OperationError,
         Error::NotAllowed(Some(custom_message)) => {
             return new_custom_exception(DOMErrorName::NotAllowedError, custom_message);
         },

--- a/components/script/dom/webcrypto/crypto.rs
+++ b/components/script/dom/webcrypto/crypto.rs
@@ -9,6 +9,7 @@ use js::rust::CustomAutoRooterGuard;
 use js::typedarray::{ArrayBufferView, ArrayBufferViewU8, HeapArrayBufferView, TypedArray};
 use rand::TryRng;
 use rand::rngs::SysRng;
+use script_bindings::error::WebCryptoError;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use script_bindings::trace::RootedTraceableBox;
 use uuid::Uuid;
@@ -69,9 +70,7 @@ impl CryptoMethods<crate::DomTypeHolder> for Crypto {
             }
 
             if SysRng.try_fill_bytes(data).is_err() {
-                return Err(Error::Operation(Some(
-                    "Failed to generate random values".into(),
-                )));
+                return Err(WebCryptoError::FailedToGenerateRandomValues.into());
             }
 
             let underlying_object = unsafe { input.underlying_object() };

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -48,6 +48,7 @@ smallvec = { workspace = true }
 stylo = { workspace = true }
 stylo_atoms = { workspace = true }
 tendril = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true, optional = true }
 webxr-api = { workspace = true, optional = true }
 xml5ever = { workspace = true }

--- a/components/script_bindings/error.rs
+++ b/components/script_bindings/error.rs
@@ -7,9 +7,32 @@ use std::ffi::CString;
 use js::context::JSContext;
 use js::error::throw_type_error;
 use js::rust::wrappers2::JS_IsExceptionPending;
+use thiserror::Error;
 
 use crate::codegen::PrototypeList::proto_id_to_name;
 use crate::num::Finite;
+
+#[derive(Clone, Error, Debug, MallocSizeOf)]
+pub enum WebCryptoError {
+    #[error("Failed to generate random values")]
+    FailedToGenerateRandomValues,
+}
+
+#[derive(Clone, Error, Debug, MallocSizeOf)]
+pub enum OperationError {
+    #[error("Generic Error: {0}")]
+    Generic(String),
+    #[error("ConversionResultFailure {0}")]
+    ConversionResultError(String),
+    #[error("WebCrypto Error: {0}")]
+    WebCrypto(#[from] WebCryptoError),
+}
+
+impl From<WebCryptoError> for Error {
+    fn from(value: WebCryptoError) -> Self {
+        Error::OperationNew(Some(value.into()))
+    }
+}
 
 /// DOM exceptions that can be thrown by a native DOM method.
 /// <https://webidl.spec.whatwg.org/#dfn-error-names-table>
@@ -72,6 +95,8 @@ pub enum Error {
     Data(Option<String>),
     /// OperationError DOMException
     Operation(Option<String>),
+    /// OperationError DOMException with types instead of string.
+    OperationNew(Option<OperationError>),
     /// NotAllowedError DOMException
     NotAllowed(Option<String>),
     /// EncodingError DOMException


### PR DESCRIPTION
This PR should be seen as a proposal for error message handling in script crate and not a complete PR.

In this we introduce a new types Error::OperationNew, OperationError and WebCryptoError.
This replaces currently only "Failed to generate random values" error.
We use thiserror crate for easier handling.

Advantage is that we have specific error messages defined in one place instead of multiple. In the future we can change the error macro to just return an error code if we want to save space the strings use.
