### PR TITLE
script: Fire `focusin`/`focusout`

### DIFF
--- a/components/script/dom/document/focus.rs
+++ b/components/script/dom/document/focus.rs
@@ -543,6 +543,7 @@ impl DocumentFocusHandler {
         );
         let event = event.upcast::<Event>();
         event.set_trusted(true);
+        event.set_composed(true);
         event.fire(cx, event_target);
     }
 

--- a/components/script/dom/document/focus.rs
+++ b/components/script/dom/document/focus.rs
@@ -398,9 +398,22 @@ impl DocumentFocusHandler {
             // Step 2.4: If blur event target is not null, fire a focus event named blur at
             // blur event target, with related blur target as the related target.
             if let Some(blur_event_target) = blur_event_target {
+                // According to https://w3c.github.io/uievents/#focusout,
+                // "Blur" must be fired before "FocusOut".
+                // "A user agent MUST dispatch this event when an event target loses focus.
+                // The event target MUST be the element which lost focus. The blur event MUST fire before the dispatch of this event type.
+                // This event type is similar to blur, but does bubble."
+                // "This event" refers to "focusout" in this context.
                 self.fire_focus_event(
                     cx,
                     FocusEventType::Blur,
+                    blur_event_target,
+                    related_blur_target,
+                );
+
+                self.fire_focus_event(
+                    cx,
+                    FocusEventType::FocusOut,
                     blur_event_target,
                     related_blur_target,
                 );
@@ -475,9 +488,22 @@ impl DocumentFocusHandler {
             // Step 4.4: If focus event target is not null, fire a focus event named focus at
             // focus event target, with related focus target as the related target.
             if let Some(focus_event_target) = focus_event_target {
+                // According to https://w3c.github.io/uievents/#focusin,
+                // "Focus" must be fired before "FocusIn".
+                // "A user agent MUST dispatch this event when an event target receives focus.
+                // The event target MUST be the element which received focus. The focus event MUST fire before the dispatch of this event type.
+                // This event type is similar to focus, but does bubble."
+                // "This event" refers to "focusin" in this context.
                 self.fire_focus_event(
                     cx,
                     FocusEventType::Focus,
+                    focus_event_target,
+                    related_focus_target,
+                );
+
+                self.fire_focus_event(
+                    cx,
+                    FocusEventType::FocusIn,
                     focus_event_target,
                     related_focus_target,
                 );
@@ -496,13 +522,20 @@ impl DocumentFocusHandler {
         let event_name = match focus_event_type {
             FocusEventType::Focus => "focus".into(),
             FocusEventType::Blur => "blur".into(),
+            FocusEventType::FocusIn => "focusin".into(),
+            FocusEventType::FocusOut => "focusout".into(),
+        };
+
+        let event_bubbles = match focus_event_type {
+            FocusEventType::Focus | FocusEventType::Blur => EventBubbles::DoesNotBubble,
+            FocusEventType::FocusIn | FocusEventType::FocusOut => EventBubbles::Bubbles,
         };
 
         let event = FocusEvent::new(
             cx,
             &self.window,
             event_name,
-            EventBubbles::DoesNotBubble,
+            event_bubbles,
             EventCancelable::NotCancelable,
             Some(&self.window),
             0i32,

--- a/components/script/dom/document/focus.rs
+++ b/components/script/dom/document/focus.rs
@@ -398,12 +398,8 @@ impl DocumentFocusHandler {
             // Step 2.4: If blur event target is not null, fire a focus event named blur at
             // blur event target, with related blur target as the related target.
             if let Some(blur_event_target) = blur_event_target {
-                // According to https://w3c.github.io/uievents/#focusout,
-                // "Blur" must be fired before "FocusOut".
-                // "A user agent MUST dispatch this event when an event target loses focus.
-                // The event target MUST be the element which lost focus. The blur event MUST fire before the dispatch of this event type.
-                // This event type is similar to blur, but does bubble."
-                // "This event" refers to "focusout" in this context.
+                // <https://w3c.github.io/uievents/#focusout>
+                // "blur" must be fired before "focusout".
                 self.fire_focus_event(
                     cx,
                     FocusEventType::Blur,
@@ -488,12 +484,8 @@ impl DocumentFocusHandler {
             // Step 4.4: If focus event target is not null, fire a focus event named focus at
             // focus event target, with related focus target as the related target.
             if let Some(focus_event_target) = focus_event_target {
-                // According to https://w3c.github.io/uievents/#focusin,
-                // "Focus" must be fired before "FocusIn".
-                // "A user agent MUST dispatch this event when an event target receives focus.
-                // The event target MUST be the element which received focus. The focus event MUST fire before the dispatch of this event type.
-                // This event type is similar to focus, but does bubble."
-                // "This event" refers to "focusin" in this context.
+                // <https://w3c.github.io/uievents/#focusin>
+                // "focus" must be fired before "focusIn".
                 self.fire_focus_event(
                     cx,
                     FocusEventType::Focus,

--- a/components/script/dom/event/focusevent.rs
+++ b/components/script/dom/event/focusevent.rs
@@ -26,6 +26,10 @@ pub(crate) enum FocusEventType {
     Focus,
     /// Element lost focus. Doesn't bubble.
     Blur,
+    /// Element gained focus. Bubbles.
+    FocusIn,
+    /// Element lost focus. Bubbles.
+    FocusOut,
 }
 
 #[dom_struct]

--- a/tests/wpt/meta/css/selectors/focus-in-focusin-event-001.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-in-focusin-event-001.html.ini
@@ -1,2 +1,6 @@
 [focus-in-focusin-event-001.html]
-  expected: TIMEOUT
+  [Checks that ':focus-visible' pseudo-class matches inside 'focusin' event handler]
+    expected: FAIL
+
+  [Checks that ':focus-within' pseudo-class matches inside 'focusin' event handler]
+    expected: FAIL

--- a/tests/wpt/meta/custom-elements/form-associated/disabled-delegatesFocus.html.ini
+++ b/tests/wpt/meta/custom-elements/form-associated/disabled-delegatesFocus.html.ini
@@ -1,3 +1,0 @@
-[disabled-delegatesFocus.html]
-  [Focus events fire on disabled form-associated custom elements with delegatesFocus]
-    expected: FAIL

--- a/tests/wpt/meta/dom/events/no-focus-events-at-clicking-editable-content-in-link.html.ini
+++ b/tests/wpt/meta/dom/events/no-focus-events-at-clicking-editable-content-in-link.html.ini
@@ -1,6 +1,3 @@
 [no-focus-events-at-clicking-editable-content-in-link.html]
-  [Click editable element in link]
-    expected: FAIL
-
   [Click editable link]
     expected: FAIL

--- a/tests/wpt/meta/dom/nodes/moveBefore/fire-focusin-focusout.html.ini
+++ b/tests/wpt/meta/dom/nodes/moveBefore/fire-focusin-focusout.html.ini
@@ -1,13 +1,4 @@
 [fire-focusin-focusout.html]
-  [Don't fire focusin/out when reparenting focused element directly]
-    expected: FAIL
-
-  [Don't fire focusin/out when reparenting an element that has focus within]
-    expected: FAIL
-
-  [Don't fire focusin/out when moving to the same parent]
-    expected: FAIL
-
   [Don't fire focusin and then correct when moving to an inert subtree]
     expected: FAIL
 

--- a/tests/wpt/meta/focus/activeelement-after-nested-loses-focus.html.ini
+++ b/tests/wpt/meta/focus/activeelement-after-nested-loses-focus.html.ini
@@ -1,0 +1,3 @@
+[activeelement-after-nested-loses-focus.html]
+  [Use focusout and click events to test ancestors' activeElements are cleared and updated correctly when nested child loses focus]
+    expected: FAIL

--- a/tests/wpt/meta/html/interaction/focus/composed.window.js.ini
+++ b/tests/wpt/meta/html/interaction/focus/composed.window.js.ini
@@ -1,3 +1,0 @@
-[composed.window.html]
-  [Focus events are composed]
-    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/untriaged/events/event-dispatch/test-003.html.ini
+++ b/tests/wpt/meta/shadow-dom/untriaged/events/event-dispatch/test-003.html.ini
@@ -1,4 +1,0 @@
-[test-003.html]
-  expected: TIMEOUT
-  [A_05_05_03_T01]
-    expected: TIMEOUT

--- a/tests/wpt/meta/uievents/order-of-events/focus-events/focus-automated-blink-webkit.html.ini
+++ b/tests/wpt/meta/uievents/order-of-events/focus-events/focus-automated-blink-webkit.html.ini
@@ -1,7 +1,3 @@
 [focus-automated-blink-webkit.html]
-  expected: TIMEOUT
-  [Focus-related events should fire in the correct order (same DocumentOwner)]
-    expected: NOTRUN
-
   [Focus-related events should fire in the correct order (different DocumentOwner)]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/uievents/order-of-events/focus-events/focus-contained.html.ini
+++ b/tests/wpt/meta/uievents/order-of-events/focus-events/focus-contained.html.ini
@@ -1,3 +1,0 @@
-[focus-contained.html]
-  [Focus-related events should fire in the correct order]
-    expected: FAIL

--- a/tests/wpt/meta/uievents/order-of-events/focus-events/focus.html.ini
+++ b/tests/wpt/meta/uievents/order-of-events/focus-events/focus.html.ini
@@ -1,3 +1,0 @@
-[focus.html]
-  [Focus-related events should fire in the correct order]
-    expected: FAIL


### PR DESCRIPTION
Add basic support for `focusin`/`focusout` `FocusEvent` type.
The code fires focusin/focusout **unconditionally** alongside focus/blur. Same-document scenarios work correctly, but cross-document cases (e.g. across iframes) have known gaps because FocusEvent's impl is not complete yet:
https://github.com/servo/servo/blob/49fa5106cac95620e985ede1c0ddf744709e6c62/components/script/dom/document/focus.rs#L273. Cross-document support will be addressed in a follow-up (subtask 2 of #46979).

Also fix a minor issue, to set composed flag for https://html.spec.whatwg.org/multipage/interaction.html#fire-a-focus-event

Testing: Existing WPT tests. There are some new passing & failling tests. For detail, see https://github.com/servo/servo/pull/46980#issuecomment-5177445471
Fixes: part of #46979 
