### PR TITLE
layout: Unify the way that selection is represented in the box tree

### DIFF
--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -150,8 +150,7 @@ impl InlineFormattingContextBuilder {
 
         let new_characters = Utf32CodeUnits::length_of(string_to_push);
         self.current_character_offset += new_characters.0;
-        self.offset_map
-            .push_range(Utf32CodeUnits(0), new_characters);
+        self.offset_map.push_range(new_characters, new_characters);
     }
 
     fn shared_inline_styles(&self) -> SharedInlineStyles {
@@ -452,31 +451,25 @@ impl InlineFormattingContextBuilder {
         }
 
         let selection = info.node.form_control_selection_in_text_node().or_else(|| {
-            document_selection.and_then(|document_selection| {
-                let start = document_selection
-                    .start
-                    .map(|offset| {
-                        self.offset_map.map(original_size_before + offset) - final_size_before
-                    })
-                    // Range unbounded at the start: the concrete start is offset zero
-                    .unwrap_or(Utf32CodeUnits(0));
-                let end = document_selection
-                    .end
-                    .map(|offset| {
-                        self.offset_map.map(original_size_before + offset) - final_size_before
-                    })
-                    // Range unbounded at the end: the concrete end is the full length
-                    .unwrap_or(Utf32CodeUnits(character_count));
+            let mapped_range = document_selection?.map(|offset| {
+                self.offset_map.map(original_size_before + offset) - final_size_before
+            });
 
-                if start == end {
-                    return None;
-                }
-                Some(Arc::new(AtomicRefCell::new(ScriptSelection {
-                    range: TextByteRange::default(),
-                    character_range: start.0..end.0,
-                    enabled: true,
-                })))
-            })
+            // Range unbounded at the start: the concrete start is offset zero.
+            let start = mapped_range.start.unwrap_or(Utf32CodeUnits(0));
+            // Range unbounded at the end: the concrete end is the full length.
+            let end = mapped_range.end.unwrap_or(Utf32CodeUnits(character_count));
+
+            if start == end {
+                return None;
+            }
+            debug_assert!(end > start);
+
+            Some(Arc::new(AtomicRefCell::new(ScriptSelection {
+                range: TextByteRange::default(),
+                character_range: start.0..end.0,
+                enabled: true,
+            })))
         });
 
         if let Some(last_character) = new_text.chars().next_back() {

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -5,9 +5,12 @@
 use std::borrow::Cow;
 use std::cell::LazyCell;
 use std::ops::Range;
+use std::sync::Arc;
 
+use atomic_refcell::AtomicRefCell;
+use fonts::TextByteRange;
 use icu_properties::BidiClass;
-use layout_api::{LayoutNode, SharedSelection};
+use layout_api::{LayoutNode, ScriptSelection};
 use servo_base::text::{RangeAny, Utf32CodeUnits};
 use style::computed_values::direction::T as Direction;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
@@ -52,10 +55,6 @@ pub(crate) struct InlineFormattingContextBuilder {
     /// used to properly set the text range of new [`InlineItem::TextRun`]s. Note that this is
     /// different from the UTF-8 code point offset.
     current_character_offset: usize,
-
-    /// If the [`InlineFormattingContext`] that we are building has a selection shared with its
-    /// originating node in the DOM, this will not be `None`.
-    pub shared_selection: Option<SharedSelection>,
 
     /// Whether the last processed node ended with whitespace. This is used to
     /// implement rule 4 of <https://www.w3.org/TR/css-text-3/#collapse>:
@@ -136,7 +135,6 @@ impl InlineFormattingContextBuilder {
             shared_inline_styles_stack: vec![SharedInlineStyles::from_info_and_context(
                 info, context,
             )],
-            shared_selection: info.node.selection(),
             has_right_to_left_content,
             ..Default::default()
         }
@@ -408,7 +406,6 @@ impl InlineFormattingContextBuilder {
     ) {
         let bidi_class_map = icu_properties::maps::bidi_class();
         let white_space_collapse = info.style.clone_white_space_collapse();
-        let original_size_before = self.offset_map.total_original_size();
         let mut character_count = 0;
         let mut new_text = String::with_capacity(text.len());
         for iteration in TextTransformationIterator::new(
@@ -451,19 +448,29 @@ impl InlineFormattingContextBuilder {
             return;
         }
 
-        let document_selection = document_selection.map(|document_selection| {
-            let start = document_selection
-                .start
-                .map(|offset| self.offset_map.map(offset))
-                // Range unbounded at the start: the concrete start is offset zero
-                .unwrap_or(Utf32CodeUnits(0));
-            let end = document_selection
-                .end
-                .map(|offset| self.offset_map.map(offset))
-                // Range unbounded at the end: the concrete end is the full length
-                .unwrap_or(Utf32CodeUnits(character_count));
-            original_size_before + start..original_size_before + end
-        });
+        let selection = info
+            .node
+            .form_control_selection_in_text_node()
+            .filter(|selection| selection.borrow().enabled)
+            .or_else(|| {
+                document_selection.map(|document_selection| {
+                    let start = document_selection
+                        .start
+                        .map(|offset| self.offset_map.map(offset))
+                        // Range unbounded at the start: the concrete start is offset zero
+                        .unwrap_or(Utf32CodeUnits(0));
+                    let end = document_selection
+                        .end
+                        .map(|offset| self.offset_map.map(offset))
+                        // Range unbounded at the end: the concrete end is the full length
+                        .unwrap_or(Utf32CodeUnits(character_count));
+                    Arc::new(AtomicRefCell::new(ScriptSelection {
+                        range: TextByteRange::default(),
+                        character_range: start.0..end.0,
+                        enabled: true,
+                    }))
+                })
+            });
 
         if let Some(last_character) = new_text.chars().next_back() {
             self.on_word_boundary = last_character.is_whitespace();
@@ -487,7 +494,7 @@ impl InlineFormattingContextBuilder {
             current_inline_styles,
             new_utf8_range,
             new_character_range,
-            document_selection.unwrap_or_default(),
+            selection,
             box_slot
                 .as_ref()
                 .and_then(|box_slot| box_slot.take_layout_box_as_text_run()),

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -404,6 +404,9 @@ impl InlineFormattingContextBuilder {
         info: &NodeAndStyleInfo<'dom>,
         document_selection: Option<RangeAny<Utf32CodeUnits>>,
     ) {
+        let original_size_before = self.offset_map.total_original_size();
+        let final_size_before = self.offset_map.total_final_size();
+
         let bidi_class_map = icu_properties::maps::bidi_class();
         let white_space_collapse = info.style.clone_white_space_collapse();
         let mut character_count = 0;
@@ -448,29 +451,33 @@ impl InlineFormattingContextBuilder {
             return;
         }
 
-        let selection = info
-            .node
-            .form_control_selection_in_text_node()
-            .filter(|selection| selection.borrow().enabled)
-            .or_else(|| {
-                document_selection.map(|document_selection| {
-                    let start = document_selection
-                        .start
-                        .map(|offset| self.offset_map.map(offset))
-                        // Range unbounded at the start: the concrete start is offset zero
-                        .unwrap_or(Utf32CodeUnits(0));
-                    let end = document_selection
-                        .end
-                        .map(|offset| self.offset_map.map(offset))
-                        // Range unbounded at the end: the concrete end is the full length
-                        .unwrap_or(Utf32CodeUnits(character_count));
-                    Arc::new(AtomicRefCell::new(ScriptSelection {
-                        range: TextByteRange::default(),
-                        character_range: start.0..end.0,
-                        enabled: true,
-                    }))
-                })
-            });
+        let selection = info.node.form_control_selection_in_text_node().or_else(|| {
+            document_selection.and_then(|document_selection| {
+                let start = document_selection
+                    .start
+                    .map(|offset| {
+                        self.offset_map.map(original_size_before + offset) - final_size_before
+                    })
+                    // Range unbounded at the start: the concrete start is offset zero
+                    .unwrap_or(Utf32CodeUnits(0));
+                let end = document_selection
+                    .end
+                    .map(|offset| {
+                        self.offset_map.map(original_size_before + offset) - final_size_before
+                    })
+                    // Range unbounded at the end: the concrete end is the full length
+                    .unwrap_or(Utf32CodeUnits(character_count));
+
+                if start == end {
+                    return None;
+                }
+                Some(Arc::new(AtomicRefCell::new(ScriptSelection {
+                    range: TextByteRange::default(),
+                    character_range: start.0..end.0,
+                    enabled: true,
+                })))
+            })
+        });
 
         if let Some(last_character) = new_text.chars().next_back() {
             self.on_word_boundary = last_character.is_whitespace();

--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -969,8 +969,8 @@ pub(crate) struct TextRunOffsets {
     /// The selection range of the containing inline formatting context.
     #[ignore_malloc_size_of = "This is stored primarily in the DOM"]
     pub shared_selection: SharedSelection,
-    /// The range of characters this [`TextRun`] represents within the entire text of its
-    /// inline formatting context.
+    /// The range of characters this [`TextRun`] represents within the text of its
+    /// original DOM node (modified by text transformation).
     pub character_range: Range<usize>,
 }
 

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -879,9 +879,7 @@ struct InlineFormattingContextLayout<'layout_data> {
     /// placed on the second line, because we add those borders in
     /// [`InlineFormattingContextLayout::finish_inline_box()`].
     ///
-    /// If this field is `Some`, a hard line break should be processed before any new content. The
-    /// `usize` stores the character offset of the originating hard line break, which is used to
-    /// generate placeholders for carets on otherwise empty lines.
+    /// If this field is `true`, a hard line break should be processed before any new content.
     force_line_break_before_new_content: bool,
 
     /// When deferring a forced line break, this field stores a potential caret placeholder
@@ -1613,6 +1611,7 @@ impl InlineFormattingContextLayout<'_> {
         if !self.force_line_break_before_new_content {
             return;
         }
+        self.force_line_break_before_new_content = false;
 
         self.commit_current_segment_to_line();
         self.process_line_break(

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -91,7 +91,7 @@ use icu_locid::subtags::{Language, language};
 use icu_properties::{self, LineBreak as ICULineBreak};
 use icu_segmenter::{LineBreakOptions, LineBreakStrictness, LineBreakWordOption};
 use inline_box::{InlineBox, InlineBoxContainerState, InlineBoxIdentifier, InlineBoxes};
-use layout_api::{LayoutNode, SharedSelection};
+use layout_api::LayoutNode;
 use line::{
     AbsolutelyPositionedLineItem, AtomicLineItem, FloatLineItem, LineItem, LineItemLayout,
     TextRunLineItem,
@@ -125,7 +125,9 @@ use crate::dom_traversal::NodeAndStyleInfo;
 use crate::flow::float::{FloatBox, SequentialLayoutState};
 use crate::flow::inline::line::TextRunOffsets;
 use crate::flow::inline::shaping_queue::ShapingQueue;
-use crate::flow::inline::text_run::{FontAndScriptInfo, TextRunItem, TextRunSegment};
+use crate::flow::inline::text_run::{
+    CaretPlaceholder, FontAndScriptInfo, TextRunItem, TextRunSegment,
+};
 use crate::flow::{
     BlockLevelBox, CollapsibleWithParentStartMargin, FloatSide, PlacementState,
     compute_inline_content_sizes_for_block_level_boxes, layout_block_level_child,
@@ -476,15 +478,9 @@ struct LineUnderConstruction {
     /// Whether the current line is for a block-level box.
     for_block_level: bool,
 
-    /// The starting character offset of this line.
-    ///
-    /// This is used to generate empty `TextRunLineItem` to hold text carets on otherwise
-    /// empty lines.
-    ///
-    /// TODO: This is only guaranteed to be accurate for the first line or when the previous line
-    /// ended with a hard line break. Eventually this should be updated during content processing so
-    /// that text carets work outside of text inputs.
-    starting_character_offset: usize,
+    /// If this line is empty and contains a selection, this field will be used to create
+    /// an empty [`TextFragment`] for holding a text caret.
+    caret_placeholder: Option<CaretPlaceholder>,
 }
 
 impl LineUnderConstruction {
@@ -499,7 +495,7 @@ impl LineUnderConstruction {
             placement_among_floats: OnceCell::new(),
             line_items: Vec::new(),
             for_block_level: false,
-            starting_character_offset: 0,
+            caret_placeholder: None,
         }
     }
 
@@ -886,7 +882,11 @@ struct InlineFormattingContextLayout<'layout_data> {
     /// If this field is `Some`, a hard line break should be processed before any new content. The
     /// `usize` stores the character offset of the originating hard line break, which is used to
     /// generate placeholders for carets on otherwise empty lines.
-    force_line_break_before_new_content: Option<usize>,
+    force_line_break_before_new_content: bool,
+
+    /// When deferring a forced line break, this field stores a potential caret placeholder
+    /// used to create a [`TextFragment`] to hold a caret on an otherwise empty line.
+    caret_placeholder: Option<CaretPlaceholder>,
 
     /// When a `<br>` element has `clear`, this needs to be applied after the linebreak,
     /// which will be processed *after* the `<br>` element is processed. This member
@@ -913,8 +913,6 @@ struct InlineFormattingContextLayout<'layout_data> {
     /// by the boundary between two characters, the text-wrap-mode property of their nearest
     /// common ancestor is used.
     text_wrap_mode: TextWrapMode,
-
-    shared_selection_for_empty_text_run: Option<SharedSelection>,
 }
 
 impl InlineFormattingContextLayout<'_> {
@@ -1030,7 +1028,6 @@ impl InlineFormattingContextLayout<'_> {
         );
         self.inline_box_states.push(inline_box_state.clone());
         self.inline_box_state_stack.push(inline_box_state);
-        self.shared_selection_for_empty_text_run = None;
     }
 
     /// Finish laying out a particular [`InlineBox`] into line items. This will
@@ -1073,7 +1070,6 @@ impl InlineFormattingContextLayout<'_> {
             .push(LineItem::InlineEndBoxPaddingBorderMargin(
                 inline_box_state.identifier,
             ));
-        self.shared_selection_for_empty_text_run = None;
     }
 
     fn finish_last_line(&mut self) {
@@ -1574,7 +1570,10 @@ impl InlineFormattingContextLayout<'_> {
             available_line_space.inline
     }
 
-    fn defer_forced_line_break_at_character_offset(&mut self, line_break_offset: usize) {
+    fn defer_forced_line_break_at_character_offset(
+        &mut self,
+        caret_placeholder: &Option<CaretPlaceholder>,
+    ) {
         // If the current portion of the unbreakable segment does not fit on the current line
         // we need to put it on a new line *before* actually triggering the hard line break.
         if !self.unbreakable_segment_fits_on_line() {
@@ -1585,7 +1584,8 @@ impl InlineFormattingContextLayout<'_> {
         }
 
         // Defer the actual line break until we've cleared all ending inline boxes.
-        self.force_line_break_before_new_content = Some(line_break_offset);
+        self.force_line_break_before_new_content = true;
+        self.caret_placeholder = caret_placeholder.clone();
 
         // In quirks mode, the line-height isn't automatically added to the line. If we consider a
         // forced line break a kind of preserved white space, quirks mode requires that we add the
@@ -1610,10 +1610,9 @@ impl InlineFormattingContextLayout<'_> {
     }
 
     fn possibly_flush_deferred_forced_line_break(&mut self) {
-        let Some(line_break_character_offset) = self.force_line_break_before_new_content.take()
-        else {
+        if !self.force_line_break_before_new_content {
             return;
-        };
+        }
 
         self.commit_current_segment_to_line();
         self.process_line_break(
@@ -1621,7 +1620,7 @@ impl InlineFormattingContextLayout<'_> {
             false, /* for_block_level */
         );
 
-        self.current_line.starting_character_offset = line_break_character_offset + 1;
+        self.current_line.caret_placeholder = self.caret_placeholder.take();
     }
 
     fn push_line_item_to_unbreakable_segment(&mut self, line_item: LineItem) {
@@ -1697,6 +1696,10 @@ impl InlineFormattingContextLayout<'_> {
     /// If the current line is empty and this [`InlineFormattingContext`] has a selection, push an
     /// empty [`LineItem::TextRun`] so that text carets can be placed on otherwise empty lines.
     fn possibly_push_empty_text_run_to_line_for_text_caret(&mut self) {
+        let Some(caret_placeholder) = self.current_line.caret_placeholder.take() else {
+            return;
+        };
+
         // If the last content line item is a text item, then the placeholder for the text caret is not necessary.
         if self
             .current_line
@@ -1709,13 +1712,10 @@ impl InlineFormattingContextLayout<'_> {
             return;
         }
 
-        let line_start_offset = self.current_line.starting_character_offset;
-        let Some(shared_selection) = self.shared_selection_for_empty_text_run.clone() else {
-            return;
-        };
         let offsets = TextRunOffsets {
-            shared_selection,
-            character_range: line_start_offset..line_start_offset + 1,
+            shared_selection: caret_placeholder.shared_selection,
+            character_range: caret_placeholder.character_index..
+                caret_placeholder.character_index + 1,
         };
 
         let inline_container_state = self.current_inline_container_state();
@@ -2108,13 +2108,13 @@ impl InlineFormattingContext {
             cloneable_inline_box_end_pbm_size: Au::zero(),
             inline_box_states: Vec::with_capacity(self.inline_boxes.len()),
             current_line_segment: UnbreakableSegmentUnderConstruction::new(),
-            force_line_break_before_new_content: None,
+            force_line_break_before_new_content: false,
+            caret_placeholder: None,
             deferred_br_clear: Clear::None,
             have_deferred_soft_wrap_opportunity: false,
             depends_on_block_constraints: false,
             white_space_collapse: style_text.white_space_collapse,
             text_wrap_mode: style_text.text_wrap_mode,
-            shared_selection_for_empty_text_run: None,
         };
 
         for item in self.inline_items.iter() {
@@ -2641,8 +2641,6 @@ impl IndependentFormattingContext {
         {
             layout.have_deferred_soft_wrap_opportunity = true;
         }
-
-        layout.shared_selection_for_empty_text_run = None;
     }
 
     /// Picks either the first or the last baseline, depending on `baseline-source`.

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -184,11 +184,6 @@ pub(crate) struct InlineFormattingContext {
     /// will require reordering during layout.
     has_right_to_left_content: bool,
 
-    /// If this [`InlineFormattingContext`] has a selection shared with its originating
-    /// node in the DOM, this will not be `None`.
-    #[ignore_malloc_size_of = "This is stored primarily in the DOM"]
-    shared_selection: Option<SharedSelection>,
-
     /// The cached multiplier for `tab-size: <number>`:
     /// <https://drafts.csswg.org/css-text/#tab-size-property>
     /// > the advance width of the space character (U+0020) of the nearest block container ancestor
@@ -918,6 +913,8 @@ struct InlineFormattingContextLayout<'layout_data> {
     /// by the boundary between two characters, the text-wrap-mode property of their nearest
     /// common ancestor is used.
     text_wrap_mode: TextWrapMode,
+
+    shared_selection_for_empty_text_run: Option<SharedSelection>,
 }
 
 impl InlineFormattingContextLayout<'_> {
@@ -1033,6 +1030,7 @@ impl InlineFormattingContextLayout<'_> {
         );
         self.inline_box_states.push(inline_box_state.clone());
         self.inline_box_state_stack.push(inline_box_state);
+        self.shared_selection_for_empty_text_run = None;
     }
 
     /// Finish laying out a particular [`InlineBox`] into line items. This will
@@ -1074,7 +1072,8 @@ impl InlineFormattingContextLayout<'_> {
             .line_items
             .push(LineItem::InlineEndBoxPaddingBorderMargin(
                 inline_box_state.identifier,
-            ))
+            ));
+        self.shared_selection_for_empty_text_run = None;
     }
 
     fn finish_last_line(&mut self) {
@@ -1698,15 +1697,6 @@ impl InlineFormattingContextLayout<'_> {
     /// If the current line is empty and this [`InlineFormattingContext`] has a selection, push an
     /// empty [`LineItem::TextRun`] so that text carets can be placed on otherwise empty lines.
     fn possibly_push_empty_text_run_to_line_for_text_caret(&mut self) {
-        let line_start_offset = self.current_line.starting_character_offset;
-        let Some(shared_selection) = self.ifc.shared_selection.clone() else {
-            return;
-        };
-        let offsets = TextRunOffsets {
-            shared_selection,
-            character_range: line_start_offset..line_start_offset + 1,
-        };
-
         // If the last content line item is a text item, then the placeholder for the text caret is not necessary.
         if self
             .current_line
@@ -1718,6 +1708,15 @@ impl InlineFormattingContextLayout<'_> {
         {
             return;
         }
+
+        let line_start_offset = self.current_line.starting_character_offset;
+        let Some(shared_selection) = self.shared_selection_for_empty_text_run.clone() else {
+            return;
+        };
+        let offsets = TextRunOffsets {
+            shared_selection,
+            character_range: line_start_offset..line_start_offset + 1,
+        };
 
         let inline_container_state = self.current_inline_container_state();
         let Some(font) = inline_container_state.default_font.clone() else {
@@ -2035,7 +2034,6 @@ impl InlineFormattingContext {
             contains_floats: builder.contains_floats,
             is_single_line_text_input,
             has_right_to_left_content,
-            shared_selection: builder.shared_selection,
             tab_size_multiplier: Default::default(),
         }
     }
@@ -2116,6 +2114,7 @@ impl InlineFormattingContext {
             depends_on_block_constraints: false,
             white_space_collapse: style_text.white_space_collapse,
             text_wrap_mode: style_text.text_wrap_mode,
+            shared_selection_for_empty_text_run: None,
         };
 
         for item in self.inline_items.iter() {
@@ -2642,6 +2641,8 @@ impl IndependentFormattingContext {
         {
             layout.have_deferred_soft_wrap_opportunity = true;
         }
+
+        layout.shared_selection_for_empty_text_run = None;
     }
 
     /// Picks either the first or the last baseline, depending on `baseline-source`.

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -267,14 +267,14 @@ impl TextRunSegment {
         let mut character_range_start = self.character_range.start;
         for (run_index, run) in self.runs.iter().enumerate() {
             let new_character_range_end = character_range_start + run.character_count();
-            let offsets = text_run.selection.clone().map(|shared_selection| {
-                ifc.shared_selection_for_empty_text_run = Some(shared_selection.clone());
-                TextRunOffsets {
+            let offsets = text_run
+                .selection
+                .clone()
+                .map(|shared_selection| TextRunOffsets {
                     shared_selection,
                     character_range: character_range_start - text_run.character_range.start..
                         new_character_range_end - text_run.character_range.start,
-                }
-            });
+                });
 
             // Break before each unbreakable run in this TextRun, except the first unless the
             // linebreaker was set to break before the first run.
@@ -292,11 +292,21 @@ impl TextRunSegment {
     }
 }
 
+#[derive(Clone, Debug, MallocSizeOf)]
+pub(crate) struct CaretPlaceholder {
+    /// Character index of the preserved newline in the IFC's transformed text, relative
+    /// to the start of the DOM node.
+    pub character_index: usize,
+    /// The [`SharedSelection`] of this caret placeholder.
+    #[conditional_malloc_size_of]
+    pub shared_selection: SharedSelection,
+}
+
 /// A single item in a [`TextRun`].
 #[derive(Debug, MallocSizeOf)]
 pub(crate) enum TextRunItem {
     /// A hard line break i.e. a "\n" as other types line breaks are normalized to "\n".
-    LineBreak { character_index: usize },
+    LineBreak(Option<CaretPlaceholder>),
     /// A preserved tab character that should advance the line to a tab stop.
     Tab { bidi_level: Level },
     /// Any other text for which a font can be matched. We store a `Box` here as [`TextRunSegment`]
@@ -474,9 +484,14 @@ impl TextRun {
 
             if character == '\n' {
                 finish_current_segment(&mut current, &mut results);
-                results.push(TextRunItem::LineBreak {
-                    character_index: current_character_index,
-                });
+                results.push(TextRunItem::LineBreak(self.selection.clone().map(
+                    |shared_selection| CaretPlaceholder {
+                        // The placeholder that is placed after a newline is for the index after that newline.
+                        // The newline itself is at the end of the previous line.
+                        character_index: relative_character_index + 1,
+                        shared_selection,
+                    },
+                )));
                 continue;
             }
 
@@ -556,8 +571,6 @@ impl TextRun {
     }
 
     pub(super) fn layout_into_line_items(&self, ifc: &mut InlineFormattingContextLayout) {
-        ifc.shared_selection_for_empty_text_run = None;
-
         if self.text_range.is_empty() {
             return;
         }
@@ -579,8 +592,8 @@ impl TextRun {
                 // If this whitespace forces a line break, queue up a hard line break the next time we
                 // see any content. We don't line break immediately, because we'd like to finish processing
                 // any ongoing inline boxes before ending the line.
-                TextRunItem::LineBreak { character_index } => {
-                    ifc.defer_forced_line_break_at_character_offset(*character_index);
+                TextRunItem::LineBreak(caret_placeholder) => {
+                    ifc.defer_forced_line_break_at_character_offset(caret_placeholder);
                 },
                 TextRunItem::Tab { bidi_level } => self.process_preserved_tab(ifc, *bidi_level),
                 TextRunItem::TextSegment(segment) => {

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -7,19 +7,15 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use app_units::Au;
-use atomic_refcell::AtomicRefCell;
 use fonts::font_feature_values::ResolvedFontVariantAlternates;
-use fonts::{
-    ByteIndex, FontContext, FontRef, ShapedText, ShapedTextSlice, ShapingFlags, ShapingOptions,
-    TextByteRange,
-};
+use fonts::{FontContext, FontRef, ShapedText, ShapedTextSlice, ShapingFlags, ShapingOptions};
 use icu_locid::subtags::Language;
 use icu_properties::{self, LineBreak};
-use layout_api::ScriptSelection;
+use layout_api::SharedSelection;
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use servo_arc::Arc as ServoArc;
-use servo_base::text::{Utf32CodeUnits, is_bidi_control};
+use servo_base::text::is_bidi_control;
 use smallvec::SmallVec;
 use style::Zero;
 use style::computed_values::font_kerning::T as FontKerning;
@@ -271,26 +267,14 @@ impl TextRunSegment {
         let mut character_range_start = self.character_range.start;
         for (run_index, run) in self.runs.iter().enumerate() {
             let new_character_range_end = character_range_start + run.character_count();
-            let offsets = ifc
-                .ifc
-                .shared_selection
-                .clone()
-                .or_else(|| {
-                    if text_run.document_selection.is_empty() {
-                        None
-                    } else {
-                        Some(Arc::new(AtomicRefCell::new(ScriptSelection {
-                            range: TextByteRange::new(ByteIndex::zero(), ByteIndex::zero()),
-                            character_range: text_run.document_selection.start.0..
-                                text_run.document_selection.end.0,
-                            enabled: true,
-                        })))
-                    }
-                })
-                .map(|shared_selection| TextRunOffsets {
+            let offsets = text_run.selection.clone().map(|shared_selection| {
+                ifc.shared_selection_for_empty_text_run = Some(shared_selection.clone());
+                TextRunOffsets {
                     shared_selection,
-                    character_range: character_range_start..new_character_range_end,
-                });
+                    character_range: character_range_start - text_run.character_range.start..
+                        new_character_range_end - text_run.character_range.start,
+                }
+            });
 
             // Break before each unbreakable run in this TextRun, except the first unless the
             // linebreaker was set to break before the first run.
@@ -350,8 +334,10 @@ pub(crate) struct TextRun {
     /// These are counting `char`s, *not* UTF-8 offsets.
     pub character_range: Range<usize>,
 
-    /// The range of `char` characters in this `TextRun` that overlap the Document’s selection
-    pub document_selection: Range<Utf32CodeUnits>,
+    /// The selected text in this `TextRun`. This may either be document selection or form control
+    /// selection.
+    #[conditional_malloc_size_of]
+    pub selection: Option<SharedSelection>,
 
     /// The [`TextRunItem`]s of this text run. This is produced by segmenting the incoming text
     /// by things such as font and script as well as separating out hard line breaks.
@@ -365,7 +351,7 @@ impl TextRun {
         inline_styles: SharedInlineStyles,
         text_range: Range<usize>,
         character_range: Range<usize>,
-        document_selection: Range<Utf32CodeUnits>,
+        selection: Option<SharedSelection>,
         old_text_run: Option<ArcRefCell<TextRun>>,
     ) -> Self {
         // If there was a previous box tree layout of this text run, try to preserve the old shaped text.
@@ -378,7 +364,7 @@ impl TextRun {
             inline_styles,
             text_range,
             character_range,
-            document_selection,
+            selection,
             items,
         }
     }
@@ -570,6 +556,8 @@ impl TextRun {
     }
 
     pub(super) fn layout_into_line_items(&self, ifc: &mut InlineFormattingContextLayout) {
+        ifc.shared_selection_for_empty_text_run = None;
+
         if self.text_range.is_empty() {
             return;
         }

--- a/components/script/dom/node/layout_dom.rs
+++ b/components/script/dom/node/layout_dom.rs
@@ -280,14 +280,7 @@ impl<'dom> LayoutDom<'dom, Node> {
     ///
     /// As we want to expose the selection on the inner text node of the widget's shadow
     /// DOM, we must find the shadow root and then access the containing element itself.
-    pub(crate) fn selection(self) -> Option<SharedSelection> {
-        if let Some(input) = self.downcast::<HTMLInputElement>() {
-            return input.selection_for_layout();
-        }
-        if let Some(textarea) = self.downcast::<HTMLTextAreaElement>() {
-            return Some(textarea.selection_for_layout());
-        }
-
+    pub(crate) fn form_control_selection_in_text_node(self) -> Option<SharedSelection> {
         let shadow_root = self
             .containing_shadow_root_for_layout()?
             .get_host_for_layout();

--- a/components/script/layout_dom/servo_layout_node.rs
+++ b/components/script/layout_dom/servo_layout_node.rs
@@ -256,8 +256,8 @@ impl<'dom> LayoutNode<'dom> for ServoLayoutNode<'dom> {
         self.node.document_selection_in_text_node()
     }
 
-    fn selection(&self) -> Option<SharedSelection> {
-        self.node.selection()
+    fn form_control_selection_in_text_node(&self) -> Option<SharedSelection> {
+        self.node.form_control_selection_in_text_node()
     }
 
     fn image_url(&self) -> Option<ServoUrl> {

--- a/components/shared/layout/layout_node.rs
+++ b/components/shared/layout/layout_node.rs
@@ -176,8 +176,6 @@ pub trait LayoutNode<'dom>: Copy + Debug + NodeInfo + Send + Sync {
     fn document_selection_in_text_node(&self) -> Option<RangeAny<Utf32CodeUnits>>;
 
     /// For a text node, returns which range of this text is part of a form control selection.
-    ///
-    /// Returned offsets are counted in `char`s in the `self.text_content()` string.
     fn form_control_selection_in_text_node(&self) -> Option<SharedSelection>;
 
     /// If this is an image element, returns its URL. If this is not an image element, fails.

--- a/components/shared/layout/layout_node.rs
+++ b/components/shared/layout/layout_node.rs
@@ -175,8 +175,10 @@ pub trait LayoutNode<'dom>: Copy + Debug + NodeInfo + Send + Sync {
     /// Returned offsets are counted in `char`s in the `self.text_content()` string.
     fn document_selection_in_text_node(&self) -> Option<RangeAny<Utf32CodeUnits>>;
 
-    /// If this node manages a selection, this returns the shared selection for the node.
-    fn selection(&self) -> Option<SharedSelection>;
+    /// For a text node, returns which range of this text is part of a form control selection.
+    ///
+    /// Returned offsets are counted in `char`s in the `self.text_content()` string.
+    fn form_control_selection_in_text_node(&self) -> Option<SharedSelection>;
 
     /// If this is an image element, returns its URL. If this is not an image element, fails.
     fn image_url(&self) -> Option<ServoUrl>;


### PR DESCRIPTION
Previously, document selection and form control selection were handled
through different paths in layout. This change makes it so that they
share more of the same code. Selection is now always handled
per-`TextRun` rather than at the IFC level. This will simplify the way
that text offsets are calculated during hit testing.

Testing: This should not change observable behavior so should be
covered by existing tests.
