### PR TITLE
paint: Lock touch panning to its initial dominant axis

### DIFF
--- a/components/paint/touch.rs
+++ b/components/paint/touch.rs
@@ -78,6 +78,16 @@ pub(crate) enum TouchIdMoveTracking {
     Remove,
 }
 
+/// The axis of a pan gesture. Once panning begins, the gesture is locked to the
+/// dominant axis for the rest of the sequence, so that e.g. a vertical pan that
+/// passes over a horizontally scrollable element keeps scrolling the page instead
+/// of switching to horizontal scrolling.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PanAxis {
+    Horizontal,
+    Vertical,
+}
+
 /// A cached [`PaintHitTestResult`] to use during a touch sequence. This
 /// is kept so that the renderer doesn't have to constantly keep making hit tests
 /// while during panning and flinging actions.
@@ -179,6 +189,8 @@ pub(crate) enum TouchSequenceState {
     Touching,
     /// A single touch point is active and has started panning.
     Panning {
+        /// The dominant axis of the pan, locked for the rest of the sequence.
+        axis: PanAxis,
         velocity: Vector2D<f32, DevicePixel>,
     },
     /// A two-finger pinch zoom gesture is active.
@@ -465,16 +477,26 @@ impl TouchHandler {
 
         let action = match touch_sequence.touch_count() {
             1 => {
-                if let Panning { ref mut velocity } = touch_sequence.state {
+                if let Panning {
+                    axis,
+                    ref mut velocity,
+                } = touch_sequence.state
+                {
+                    // Only scroll along the axis that was dominant when panning started,
+                    // so the gesture cannot switch between horizontal and vertical.
+                    let pan_delta = match axis {
+                        PanAxis::Horizontal => Vector2D::new(delta.x, 0.0),
+                        PanAxis::Vertical => Vector2D::new(0.0, delta.y),
+                    };
                     // TODO: Probably we should track 1-3 more points and use a smarter algorithm
-                    *velocity += delta;
+                    *velocity += pan_delta;
                     *velocity /= 2.0;
                     // update the touch point every time when panning.
                     touch_sequence.active_touch_points[idx].point = point;
 
                     // Scroll offsets are opposite to the direction of finger motion.
                     Some(ScrollZoomEvent::Scroll(ScrollEvent {
-                        scroll: Scroll::Delta((-delta).into()),
+                        scroll: Scroll::Delta((-pan_delta).into()),
                         point,
                     }))
                 } else if delta.x.abs() > TOUCH_PAN_MIN_SCREEN_PX * scale ||
@@ -485,8 +507,21 @@ impl TouchHandler {
                         delta = ?delta,
                     )
                     .entered();
+                    // The pan is locked to its dominant axis for the rest of the sequence,
+                    // so that e.g. a vertical pan over a horizontally scrollable element
+                    // keeps scrolling the page instead of switching to horizontal.
+                    let axis = if delta.y.abs() > delta.x.abs() {
+                        PanAxis::Vertical
+                    } else {
+                        PanAxis::Horizontal
+                    };
+                    let pan_delta = match axis {
+                        PanAxis::Horizontal => Vector2D::new(delta.x, 0.0),
+                        PanAxis::Vertical => Vector2D::new(0.0, delta.y),
+                    };
                     touch_sequence.state = Panning {
-                        velocity: Vector2D::new(delta.x, delta.y),
+                        axis,
+                        velocity: pan_delta,
                     };
                     // No clicks should be issued after we transitioned to move.
                     touch_sequence.prevent_click = true;
@@ -495,7 +530,7 @@ impl TouchHandler {
 
                     // Scroll offsets are opposite to the direction of finger motion.
                     Some(ScrollZoomEvent::Scroll(ScrollEvent {
-                        scroll: Scroll::Delta((-delta).into()),
+                        scroll: Scroll::Delta((-pan_delta).into()),
                         point,
                     }))
                 } else {
@@ -564,7 +599,7 @@ impl TouchHandler {
                     touch_sequence.state = PendingClick(point);
                 }
             },
-            Panning { velocity } => {
+            Panning { velocity, .. } => {
                 if velocity.length().abs() >= FLING_MIN_SCREEN_PX {
                     let _span = profile_traits::info_span!(
                         "TouchHandler::FlingStart",

--- a/tests/wpt/meta/pointerevents/touch-action-with-swipe-dir-change.html.ini
+++ b/tests/wpt/meta/pointerevents/touch-action-with-swipe-dir-change.html.ini
@@ -1,18 +1,18 @@
 [touch-action-with-swipe-dir-change.html?touch]
-  [touch-action:pan-x with right,down swipe]
-    expected: FAIL
-
   [touch-action:pan-x with down,right swipe]
     expected: FAIL
 
   [touch-action:pan-y with right,down swipe]
     expected: FAIL
 
-  [touch-action:pan-y with down,right swipe]
-    expected: FAIL
-
   [touch-action:none with right,down swipe]
     expected: FAIL
 
   [touch-action:none with down,right swipe]
+    expected: FAIL
+
+  [touch-action:auto with right,down swipe]
+    expected: FAIL
+
+  [touch-action:auto with down,right swipe]
     expected: FAIL

--- a/tests/wpt/tests/pointerevents/touch-scroll-axis-lock-with-scroll-chain.html
+++ b/tests/wpt/tests/pointerevents/touch-scroll-axis-lock-with-scroll-chain.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<title>Touch scroll chain: axis lock with direction change on a horizontal scroller</title>
+<meta name="variant" content="?touch">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="help" href="https://w3c.github.io/pointerevents/#determining-supported-direct-manipulation-behavior" />
+<link rel="author" title="Euclid Ye" href="mailto:yezhizhenjiakang@gmail.com">
+<link rel=help href="https://github.com/servo/servo/issues/46954">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="pointerevent_support.js"></script>
+<style>
+  /* A horizontal-only scroller nested in a vertically-scrollable page. */
+  #tall-top { height: 20vh; }
+  #tall-bottom { height: 80vh; }
+  #strip { display: flex; overflow-x: auto; min-height: 200px; }
+  .cell { flex: 0 0 140px; }
+</style>
+<div id="tall-top"></div>
+<div id="strip">
+  <span class="cell">1</span><span class="cell">2</span><span class="cell">3</span>
+  <span class="cell">4</span><span class="cell">5</span><span class="cell">6</span>
+  <span class="cell">7</span><span class="cell">8</span><span class="cell">9</span>
+  <span class="cell">10</span><span class="cell">11</span><span class="cell">12</span>
+</div>
+<div id="tall-bottom"></div>
+
+<script>
+  "use strict";
+  const pointer_type = "touch";
+  const strip = document.getElementById("strip");
+
+  assert_true(location.search.length > 0 &&
+      location.search.substring(1) === pointer_type,
+      "Test URL has 'touch' pointer-type");
+
+  // Build a multi-direction touch swipe. Each entry in `directions` is a
+  // semantic scroll direction matching the convention used by
+  // `touchScrollInTarget` in pointerevent_support.js:
+  //   "down"/"up" => scroll the page down/up (finger moves up/down),
+  //   "right"/"left" => scroll the target right/left (finger moves left/right).
+  const offset = 30;
+  const steps_per_direction = 3;
+  const deltas = {
+    "down":  [0, -offset],
+    "up":    [0, offset],
+    "right": [-offset, 0],
+    "left":  [offset, 0],
+  };
+
+  function swipeChain(target, directions) {
+    const rect = target.getBoundingClientRect();
+    const [startX, startY] = getInViewCenterPoint(rect);
+    let x = startX, y = startY;
+    let actions = new test_driver.Actions()
+      .addPointer("touchPointer1", "touch")
+      .pointerMove(startX, startY, {origin: "viewport"})
+      .pointerDown();
+    for (const direction of directions) {
+      const [dx, dy] = deltas[direction];
+      for (let i = 0; i < steps_per_direction; i++) {
+        x += dx;
+        y += dy;
+        actions = actions.pointerMove(x, y, {origin: "viewport"});
+      }
+    }
+    return actions.pause(100).pointerUp().send();
+  }
+
+  // Subtest 1: start by scrolling the page down (vertical), then try to scroll
+  // the strip right (horizontal). The gesture is locked to its initial
+  // (vertical) dominant axis, so the page scrolls and the strip must not move.
+  promise_test(async () => {
+    window.scrollTo(0, 0);
+    strip.scrollLeft = 0;
+
+    await swipeChain(strip, ["down", "right"]);
+
+    assert_greater_than(window.scrollY, 0,
+        "a vertical-then-horizontal swipe on a horizontal scroller should scroll the page");
+    assert_equals(strip.scrollLeft, 0,
+        "the strip must not scroll horizontally once the gesture is locked to the vertical axis");
+  }, "Vertical-then-horizontal swipe locks to vertical: page scrolls, strip does not");
+
+  // Subtest 2: start by scrolling the strip right (horizontal), then try to
+  // scroll the page down (vertical). The gesture is locked to its initial
+  // (horizontal) dominant axis, so the strip scrolls and the page must not move.
+  promise_test(async () => {
+    window.scrollTo(0, 0);
+    strip.scrollLeft = 0;
+
+    await swipeChain(strip, ["right", "down"]);
+
+    assert_greater_than(strip.scrollLeft, 0,
+        "a horizontal-then-vertical swipe on a horizontal scroller should scroll the strip");
+    assert_equals(window.scrollY, 0,
+        "the page must not scroll vertically once the gesture is locked to the horizontal axis");
+  }, "Horizontal-then-vertical swipe locks to horizontal: strip scrolls, page does not");
+</script>


### PR DESCRIPTION
Lock a touch pan gesture to the axis dominant at pan-start, for the whole sequence, to match FF/Chrome.
The video in https://github.com/servo/servo/issues/46954 explains visual difference better.

Testing: For existing test `/pointerevents/touch-action-with-swipe-dir-change.html`,
- New Passing in: 
touch-action:pan-x with right,down swipe
touch-action:pan-y with down,right swipe
- New failure in:
touch-action:auto with right,down swipe
touch-action:auto with down,right swipe

The passing/failure are accidental, as we don't support `touch-action` yet, which controls gesture within element's region.

For right, down, we would now only move horizontally. This matches `pan-x` expectation, but fails `auto` which expects both axis to move.

Also added a new test similar to `touch-action-with-swipe-dir-change.html` to match our issue. This reuses logic introduced in https://github.com/web-platform-tests/wpt/pull/57804 to avoid accelerated scrolling & out of bound error, as we scroll the viewport.

Fixes: https://github.com/servo/servo/issues/46954 which has strange jitter when we pan.
