### PR TITLE
paint: Switch forgotten IpcChannel to GenericChannel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6763,6 +6763,7 @@ name = "profile_tests"
 version = "0.5.0"
 dependencies = [
  "ipc-channel",
+ "servo-base",
  "servo-config",
  "servo-profile",
  "servo-profile-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8798,7 +8798,6 @@ dependencies = [
  "euclid",
  "gleam",
  "image",
- "ipc-channel",
  "log",
  "rayon",
  "rustc-hash 2.1.3",

--- a/components/paint/Cargo.toml
+++ b/components/paint/Cargo.toml
@@ -31,7 +31,6 @@ embedder_traits = { workspace = true }
 euclid = { workspace = true }
 gleam = { workspace = true }
 image = { workspace = true }
-ipc-channel = { workspace = true }
 log = { workspace = true }
 malloc_size_of = { workspace = true }
 media = { workspace = true }

--- a/components/paint/paint.rs
+++ b/components/paint/paint.rs
@@ -19,7 +19,6 @@ use embedder_traits::{
 };
 use euclid::{Scale, Size2D};
 use image::RgbaImage;
-use ipc_channel::ipc::{self};
 use log::{debug, warn};
 use paint_api::rendering_context::RenderingContext;
 use paint_api::{
@@ -31,7 +30,7 @@ use profile_traits::mem::{
 };
 use profile_traits::path;
 use profile_traits::time::{self as profile_time};
-use servo_base::generic_channel::{GenericSender, RoutedReceiver};
+use servo_base::generic_channel::{self, GenericSender, RoutedReceiver};
 use servo_base::id::{PainterId, PipelineId, WebViewId};
 use servo_canvas_traits::webgl::{WebGLContextId, WebGLThreads};
 use servo_config::pref;
@@ -356,7 +355,7 @@ impl Paint {
         }
 
         // Tell the profiler, memory profiler, and scrolling timer to shut down.
-        if let Ok((sender, receiver)) = ipc::channel() {
+        if let Some((sender, receiver)) = generic_channel::channel() {
             self.time_profiler_chan
                 .send(profile_time::ProfilerMsg::Exit(sender));
             let _ = receiver.recv();

--- a/components/shared/profile/time.rs
+++ b/components/shared/profile/time.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use ipc_channel::ipc::IpcSender;
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
@@ -46,7 +45,7 @@ pub enum ProfilerMsg {
     /// Message used to get time spend entries for a particular ProfilerBuckets (in nanoseconds)
     Get(
         (ProfilerCategory, Option<TimerMetadata>),
-        IpcSender<ProfilerData>,
+        GenericSender<ProfilerData>,
     ),
     /// Message used to force print the profiling metrics
     Print,
@@ -55,7 +54,7 @@ pub enum ProfilerMsg {
     BlockedLayoutQuery(String),
 
     /// Tells the profiler to shut down.
-    Exit(IpcSender<()>),
+    Exit(GenericSender<()>),
 }
 
 /// Usage sites of variants marked “Rust tracing only” are not visible to rust-analyzer.

--- a/components/storage/tests/cache_storage.rs
+++ b/components/storage/tests/cache_storage.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use servo_base::generic_channel::{self, GenericSend};
+use servo_base::generic_channel;
 use storage::CacheStorageThreadFactory;
 use storage_traits::cache_storage::{CacheStorageThreadHandle, CacheStorageThreadMessage};
 

--- a/tests/unit/profile/Cargo.toml
+++ b/tests/unit/profile/Cargo.toml
@@ -13,6 +13,7 @@ path = "lib.rs"
 doctest = false
 
 [dependencies]
+servo-base = { workspace = true }
 ipc-channel = { workspace = true }
 profile = { workspace = true }
 profile_traits = { workspace = true }

--- a/tests/unit/profile/time.rs
+++ b/tests/unit/profile/time.rs
@@ -5,10 +5,10 @@
 use std::thread;
 
 use ::time::Duration;
-use ipc_channel::ipc;
 use profile::time;
 use profile_traits::ipc as ProfiledIpc;
 use profile_traits::time::{ProfilerCategory, ProfilerData, ProfilerMsg};
+use servo_base::generic_channel;
 use servo_config::opts::OutputOptions;
 
 #[test]
@@ -16,7 +16,7 @@ fn time_profiler_smoke_test() {
     let chan = time::Profiler::create(&None, None);
     assert!(true, "Can create the profiler thread");
 
-    let (ipcchan, _ipcport) = ipc::channel().unwrap();
+    let (ipcchan, _ipcport) = generic_channel::channel().unwrap();
     chan.send(ProfilerMsg::Exit(ipcchan));
     assert!(true, "Can tell the profiler thread to exit");
 }
@@ -73,7 +73,7 @@ fn channel_profiler_test() {
     let val_profile_receiver = profiled_receiver.recv().unwrap();
     assert_eq!(val_profile_receiver, 43);
 
-    let (sender, receiver) = ipc::channel().unwrap();
+    let (sender, receiver) = generic_channel::channel().unwrap();
     chan.send(ProfilerMsg::Get(
         (ProfilerCategory::IpcReceiver, None),
         sender.clone(),
@@ -98,7 +98,7 @@ fn bytes_channel_profiler_test() {
     let val_profile_receiver = profiled_receiver.recv().unwrap();
     assert_eq!(val_profile_receiver, [1, 2, 3]);
 
-    let (sender, receiver) = ipc::channel().unwrap();
+    let (sender, receiver) = generic_channel::channel().unwrap();
     chan.send(ProfilerMsg::Get(
         (ProfilerCategory::IpcBytesReceiver, None),
         sender.clone(),


### PR DESCRIPTION
This just switches the channel for profiling exit msg to GenericChannel to be more consistent.

Testing: Does not change functionality.
