### PR TITLE
constellation: Do not request permission for initial about:blank loads.

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1330,57 +1330,8 @@ where
             EmbedderToConstellationMessage::Exit => {
                 self.handle_exit();
             },
-            // Perform a navigation previously requested by script, if approved by the embedder.
-            // If there is already a pending page (self.pending_changes), it will not be overridden;
-            // However, if the id is not encompassed by another change, it will be.
             EmbedderToConstellationMessage::AllowNavigationResponse(pipeline_id, allowed) => {
-                let pending = self.pending_approval_navigations.remove(&pipeline_id);
-
-                let webview_id = match self.pipelines.get(&pipeline_id) {
-                    Some(pipeline) => pipeline.webview_id,
-                    None => return warn!("{}: Attempted to navigate after closure", pipeline_id),
-                };
-
-                match pending {
-                    Some(pending) => {
-                        if allowed {
-                            self.load_url(
-                                webview_id,
-                                pipeline_id,
-                                pending.load_data,
-                                pending.history_behaviour,
-                                pending.target_snapshot_params,
-                            );
-                        } else {
-                            if let Some((sender, id)) = &self.webdriver_load_status_sender &&
-                                pipeline_id == *id
-                            {
-                                let _ = sender.send(WebDriverLoadStatus::NavigationStop);
-                            }
-
-                            let pipeline_is_top_level_pipeline = self
-                                .browsing_contexts
-                                .get(&BrowsingContextId::from(webview_id))
-                                .is_some_and(|ctx| ctx.pipeline_id == pipeline_id);
-                            // If the navigation is refused, and this concerns an iframe,
-                            // we need to take it out of it's "delaying-load-events-mode".
-                            // https://html.spec.whatwg.org/multipage/#delaying-load-events-mode
-                            if !pipeline_is_top_level_pipeline {
-                                self.send_message_to_pipeline(
-                                    pipeline_id,
-                                    ScriptThreadMessage::StopDelayingLoadEventsMode(pipeline_id),
-                                    "Attempted to navigate after closure",
-                                );
-                            }
-                        }
-                    },
-                    None => {
-                        warn!(
-                            "{}: AllowNavigationResponse for unknown request",
-                            pipeline_id
-                        )
-                    },
-                }
+                self.handle_allow_navigation_response(pipeline_id, allowed);
             },
             // Load a new page from a typed url
             // If there is already a pending page (self.pending_changes), it will not be overridden;
@@ -3799,14 +3750,75 @@ where
                 });
             },
         };
-        // Allow the embedder to handle the url itself
-        self.constellation_to_embedder_proxy.send(
-            ConstellationToEmbedderMsg::AllowNavigationRequest(
-                webview_id,
-                source_id,
-                load_data.url,
-            ),
-        );
+
+        if load_data.is_initial_about_blank {
+            assert_eq!(load_data.as_str(), "about:blank");
+            // The initial about:blank is not a navigation; the embedder only
+            // cares about a navigation that follows it.
+            self.handle_allow_navigation_response(source_id, true);
+        } else {
+            // Allow the embedder to handle the url itself
+            self.constellation_to_embedder_proxy.send(
+                ConstellationToEmbedderMsg::AllowNavigationRequest(
+                    webview_id,
+                    source_id,
+                    load_data.url,
+                ),
+            );
+        }
+    }
+
+    /// Perform a navigation previously requested by script, if approved by the embedder.
+    /// If there is already a pending page (self.pending_changes), it will not be overridden;
+    /// However, if the id is not encompassed by another change, it will be.
+    fn handle_allow_navigation_response(&mut self, pipeline_id: PipelineId, allowed: bool) {
+        let pending = self.pending_approval_navigations.remove(&pipeline_id);
+
+        let webview_id = match self.pipelines.get(&pipeline_id) {
+            Some(pipeline) => pipeline.webview_id,
+            None => return warn!("{}: Attempted to navigate after closure", pipeline_id),
+        };
+
+        match pending {
+            Some(pending) => {
+                if allowed {
+                    self.load_url(
+                        webview_id,
+                        pipeline_id,
+                        pending.load_data,
+                        pending.history_behaviour,
+                        pending.target_snapshot_params,
+                    );
+                } else {
+                    if let Some((sender, id)) = &self.webdriver_load_status_sender &&
+                        pipeline_id == *id
+                    {
+                        let _ = sender.send(WebDriverLoadStatus::NavigationStop);
+                    }
+
+                    let pipeline_is_top_level_pipeline = self
+                        .browsing_contexts
+                        .get(&BrowsingContextId::from(webview_id))
+                        .is_some_and(|ctx| ctx.pipeline_id == pipeline_id);
+                    // If the navigation is refused, and this concerns an iframe,
+                    // we need to take it out of it's "delaying-load-events-mode".
+                    // https://html.spec.whatwg.org/multipage/#delaying-load-events-mode
+                    if !pipeline_is_top_level_pipeline {
+                        self.send_message_to_pipeline(
+                            pipeline_id,
+                            ScriptThreadMessage::StopDelayingLoadEventsMode(pipeline_id),
+                            "Attempted to navigate after closure",
+                        );
+                    }
+                }
+            },
+            None => {
+                warn!(
+                    "{}: AllowNavigationResponse for unknown request",
+                    pipeline_id
+                )
+            },
+        }
     }
 
     #[servo_tracing::instrument(skip_all)]

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -3752,7 +3752,7 @@ where
         };
 
         if load_data.is_initial_about_blank {
-            assert_eq!(load_data.as_str(), "about:blank");
+            assert_eq!(load_data.url.as_str(), "about:blank");
             // The initial about:blank is not a navigation; the embedder only
             // cares about a navigation that follows it.
             self.handle_allow_navigation_response(source_id, true);

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -599,6 +599,7 @@ impl HTMLIFrameElement {
             document.has_trustworthy_ancestor_or_current_origin(),
             self.sandboxing_flag_set(),
         );
+        load_data.is_initial_about_blank = true;
         load_data.destination = Destination::IFrame;
         load_data.policy_container = Some(window.as_global_scope().policy_container());
 

--- a/components/script/dom/window/windowproxy.rs
+++ b/components/script/dom/window/windowproxy.rs
@@ -338,7 +338,7 @@ impl WindowProxy {
         };
 
         let blank_url = ServoUrl::parse("about:blank").ok().unwrap();
-        let load_data = LoadData::new(
+        let mut load_data = LoadData::new(
             LoadOrigin::Script(document.origin().snapshot()),
             blank_url,
             Some(document.base_url()),
@@ -352,6 +352,7 @@ impl WindowProxy {
             false,
             sandboxing_flag_set,
         );
+        load_data.is_initial_about_blank = true;
         let load_info = AuxiliaryWebViewCreationRequest {
             load_data: load_data.clone(),
             opener_webview_id: window.webview_id(),

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -135,6 +135,9 @@ pub struct LoadData {
     /// If this is a load operation for an `<iframe>` whose origin is same-origin with its
     /// container documents origin then this is the encoding of the container document.
     pub container_document_encoding: Option<&'static Encoding>,
+
+    /// If this request is for the initial about:blank document.
+    pub is_initial_about_blank: bool,
 }
 
 impl LoadData {
@@ -172,6 +175,7 @@ impl LoadData {
             destination: Destination::Document,
             creation_sandboxing_flag_set,
             container_document_encoding: None,
+            is_initial_about_blank: false,
         }
     }
 


### PR DESCRIPTION
The initial about:blank document is intended to be synchronously available. Our current implementation is too tied to our asynchronous navigation infrastructure, and this gets in the way of the work happening in #46975. This change removes one source of intermittent failures due to timing when a test attempts to navigate the initial about:blank shortly after it is created—when the constellation observes that there is a pending navigation approval for the about:blank, it will silently discard any navigation attempt for the pipeline. I expect to revisit this later after we have decoupled about:blank from our asynchronous navigation infrastructure.

Testing: Not observable behaviour within WPT except via timing changes in tests that involve navigating about:blank iframes/windows.
Fixes: part of #43149
