### PR TITLE
android: Inline `InitOptions`

### DIFF
--- a/ports/servoshell/egl/android/mod.rs
+++ b/ports/servoshell/egl/android/mod.rs
@@ -44,17 +44,6 @@ fn callback_ref() -> &'static JObject<'static> {
     CALLBACK_OBJECT.get().expect("Servo init failed").as_ref()
 }
 
-struct InitOptions {
-    args: Vec<String>,
-    url: Option<String>,
-    viewport_rect: Rect<i32, DevicePixel>,
-    density: f32,
-    #[cfg(feature = "webxr")]
-    xr_discovery: Option<servo::webxr::Discovery>,
-    window_handle: RawWindowHandle,
-    display_handle: RawDisplayHandle,
-}
-
 struct HostCallbacks {
     jvm: JavaVM,
 }
@@ -110,16 +99,29 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_init<'local>(
     surface: JObject<'local>,
 ) {
     env.with_env(|env| -> jni::errors::Result<_> {
-        let (init_opts, log_str) = get_options(
-            env,
-            args,
-            url,
-            size,
-            density,
-            logStr,
-            experimental_mode,
-            &surface,
-        )?;
+        let args = JString::cast_local(env, args)?.try_to_string(env).ok();
+        let url = JString::cast_local(env, url)?.try_to_string(env).ok();
+        let log_str = JString::cast_local(env, logStr)?.try_to_string(env).ok();
+
+        let viewport_rect = jni_coordinate_to_rust_viewport_rect(env, &size)?;
+
+        let mut args: Vec<String> = args
+            .and_then(|args| {
+                serde_json::from_str(&args)
+                    .inspect_err(|_| {
+                        error!(
+                            "Invalid arguments. Servo arguments must be formatted as a JSON array"
+                        )
+                    })
+                    .ok()
+            })
+            .unwrap_or_default();
+
+        if experimental_mode {
+            args.push("--enable-experimental-web-platform-features".to_owned());
+        }
+
+        let (display_handle, window_handle) = display_and_window_handle(env, &surface);
 
         if log {
             // Note: Android debug logs are stripped from a release build.
@@ -192,7 +194,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_init<'local>(
         }
 
         let (opts, mut preferences, servoshell_preferences) =
-            match parse_command_line_arguments(init_opts.args.as_slice()) {
+            match parse_command_line_arguments(args.as_slice()) {
                 ArgumentParsingResult::ContentProcess(..) => {
                     unreachable!("Android does not have support for multiprocess yet.")
                 },
@@ -211,28 +213,28 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_init<'local>(
 
         let (display_handle, window_handle) = unsafe {
             (
-                DisplayHandle::borrow_raw(init_opts.display_handle),
-                WindowHandle::borrow_raw(init_opts.window_handle),
+                DisplayHandle::borrow_raw(display_handle),
+                WindowHandle::borrow_raw(window_handle),
             )
         };
 
-        let hidpi_scale_factor = Scale::new(init_opts.density);
+        let hidpi_scale_factor = Scale::new(density);
 
         APP.with(|app| {
             let new_app = App::new(AppInitOptions {
                 host,
                 event_loop_waker,
-                initial_url: init_opts.url,
+                initial_url: url,
                 opts,
                 preferences,
                 servoshell_preferences,
                 #[cfg(feature = "webxr")]
-                xr_discovery: init_opts.xr_discovery,
+                xr_discovery: None,
             });
             new_app.add_platform_window(
                 display_handle,
                 window_handle,
-                init_opts.viewport_rect,
+                viewport_rect,
                 hidpi_scale_factor,
                 None,
             );
@@ -960,50 +962,6 @@ fn set_default_config_dir<'local>(
         .set(config_dir)
         .inspect_err(|path| warn!("Default config dir was already set to {path:?}"));
     Ok(())
-}
-
-fn get_options<'local>(
-    env: &mut Env<'local>,
-    args: JString<'local>,
-    url: JString<'local>,
-    size: JObject<'local>,
-    density: jfloat,
-    logStr: JString<'local>,
-    experimental_mode: jboolean,
-    surface: &JObject<'local>,
-) -> Result<(InitOptions, Option<String>), Error> {
-    let args = JString::cast_local(env, args)?.try_to_string(env).ok();
-    let url = JString::cast_local(env, url)?.try_to_string(env).ok();
-    let log_str = JString::cast_local(env, logStr)?.try_to_string(env).ok();
-
-    let viewport_rect = jni_coordinate_to_rust_viewport_rect(env, &size)?;
-
-    let mut args: Vec<String> = args
-        .and_then(|args| {
-            serde_json::from_str(&args)
-                .inspect_err(|_| {
-                    error!("Invalid arguments. Servo arguments must be formatted as a JSON array")
-                })
-                .ok()
-        })
-        .unwrap_or_default();
-
-    if experimental_mode {
-        args.push("--enable-experimental-web-platform-features".to_owned());
-    }
-
-    let (display_handle, window_handle) = display_and_window_handle(env, surface);
-    let opts = InitOptions {
-        args,
-        url,
-        viewport_rect,
-        density,
-        xr_discovery: None,
-        window_handle,
-        display_handle,
-    };
-
-    Ok((opts, log_str))
 }
 
 fn display_and_window_handle(


### PR DESCRIPTION
This can be seen as the Rust equivalent to #46916. Wrapping some of these `init()` options in a `struct` and then immediately unwrapping them makes the code harder to following by being a bit obtuse.

Testing: There are no automated tests for Android.