### PR TITLE
layout: Compute and report accessibility node bounds

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -11,9 +11,7 @@ use accesskit::{NodeId, Role};
 use app_units::Au;
 use bitflags::bitflags;
 use euclid::Rect;
-use layout_api::{
-    AccessibilityDamage, BoxAreaType, LayoutElement, LayoutNode, LayoutNodeType, NodeRenderingType,
-};
+use layout_api::{AccessibilityDamage, BoxAreaType, LayoutElement, LayoutNode, LayoutNodeType};
 use log::trace;
 use rustc_hash::{FxHashMap, FxHashSet};
 use script::layout_dom::ServoLayoutNode;
@@ -28,7 +26,6 @@ use web_atoms::{LocalName, local_name};
 use crate::ArcRefCell;
 use crate::cell::WeakRefCell;
 use crate::display_list::StackingContextTree;
-use crate::dom::NodeExt;
 use crate::layout_impl::LayoutThread;
 use crate::query::process_box_area_request;
 
@@ -297,13 +294,9 @@ impl AccessibilityTree {
         let Some(root_node) = self.root_node.clone() else {
             return;
         };
-        root_node.borrow_mut().refresh_bounds_for_subtree(
-            root_dom_node,
-            &context,
-            self,
-            update,
-            None,
-        );
+        root_node
+            .borrow_mut()
+            .refresh_bounds_for_subtree(root_dom_node, &context, self, update);
     }
 
     /// Given an iterator of `NodeId`s corresponding to nodes which have received some damage from
@@ -853,19 +846,16 @@ impl AccessibilityNode {
         local_damage
     }
 
-    /// Update this node's bounds from layout, given the context necessary to compute them and the
-    /// bounds inherited from an ancestor (used as a fallback for nodes without their own box).
-    /// Returns the damage caused by the update, and the bounds descendants without their own box
-    /// should inherit.
+    /// Update this node's bounds from the current layout geometry. Returns the damage caused by
+    /// the update.
     fn update_bounds_from_dom_node(
         &mut self,
         dom_node: &ServoLayoutNode<'_>,
         context: &AccessibilityContext<'_>,
-        inherited_bounds: Option<accesskit::Rect>,
-    ) -> (LocalAccessibilityDamage, Option<accesskit::Rect>) {
+    ) -> LocalAccessibilityDamage {
         // Border box with transforms, matching getBoundingClientRect(). Bounds are in CSS pixels,
         // relative to the viewport origin (see the [`accesskit`] composition model).
-        let own_bounds = process_box_area_request(
+        let bounds = process_box_area_request(
             context.layout_thread,
             context.stacking_context_tree,
             *dom_node,
@@ -874,33 +864,22 @@ impl AccessibilityNode {
         )
         .map(au_rect_to_accesskit_rect);
 
-        // TODO(accessibility): Other engines (Blink, WebKit, Gecko) compute bounds for `display: contents`
-        // elements (and other box-less elements) by taking the union of the bounding boxes of their rendered
-        // descendants, rather than inheriting ancestor bounds or leaving them empty.
-        let inheritable_bounds = match dom_node.rendering_type() {
-            NodeRenderingType::Rendered => own_bounds,
-            NodeRenderingType::DelegatesRendering => own_bounds.or(inherited_bounds), // display: contents
-            NodeRenderingType::NotRendered => None,
-        };
-
-        // A text node never has bounds of its own: `LayoutBox::Text` has no `LayoutBoxBase`, and
-        // `Fragment::Text` has no box area, so the query always returns `None` for one. Screen
-        // readers still need geometry for a text run, in order to highlight or magnify it, so fall
-        // back to the bounds of the nearest ancestor which has them.
+        // For now only nodes with a box of their own get bounds; anything else, including
+        // `display: none` content, gets its bounds cleared. That leaves two kinds of nodes
+        // without geometry which assistive technology would like to have some:
         //
-        // TODO(accessibility): These bounds are those of the whole containing box, which is too
-        // large whenever it holds more than this one text run. They should instead be the union of
-        // the rectangles of this node's own `Fragment::Text` fragments.
-        let bounds = match dom_node.type_id() {
-            Some(LayoutNodeType::Text) => own_bounds.or(inherited_bounds),
-            _ => own_bounds,
-        };
-
-        let damage = match bounds {
+        // TODO(accessibility): A text node never has bounds of its own: `LayoutBox::Text` has no
+        // `LayoutBoxBase`, and `Fragment::Text` has no box area, so the query above always returns
+        // `None` for one. Text nodes should get the union of the rectangles of their own
+        // `Fragment::Text` fragments, once `cumulative_box_area_rect()` can handle those.
+        //
+        // TODO(accessibility): A `display: contents` element generates no box either. Other
+        // engines (Blink, WebKit, Gecko) compute its bounds as the union of the bounding boxes of
+        // its rendered descendants.
+        match bounds {
             Some(bounds) => self.set_bounds(bounds),
-            None => self.clear_bounds(), // display: none case
-        };
-        (damage, inheritable_bounds)
+            None => self.clear_bounds(),
+        }
     }
 
     /// Recompute this node's bounds and its descendants', from current layout geometry.
@@ -910,9 +889,8 @@ impl AccessibilityNode {
         context: &AccessibilityContext<'_>,
         tree: &AccessibilityTree,
         update: &mut AccessibilityUpdate,
-        inherited_bounds: Option<accesskit::Rect>,
     ) {
-        let (_, bounds) = self.update_bounds_from_dom_node(dom_node, context, inherited_bounds);
+        self.update_bounds_from_dom_node(dom_node, context);
 
         if self.dirty_state.updated() {
             update.add(self);
@@ -924,7 +902,7 @@ impl AccessibilityNode {
             };
             tree.assert_node_for_id(&child_id)
                 .borrow_mut()
-                .refresh_bounds_for_subtree(&dom_child, context, tree, update, bounds);
+                .refresh_bounds_for_subtree(&dom_child, context, tree, update);
         }
     }
 

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -12,7 +12,7 @@ use app_units::Au;
 use bitflags::bitflags;
 use euclid::Rect;
 use layout_api::{
-    AccessibilityDamage, LayoutElement, LayoutNode, LayoutNodeType, NodeRenderingType,
+    AccessibilityDamage, BoxAreaType, LayoutElement, LayoutNode, LayoutNodeType, NodeRenderingType,
 };
 use log::trace;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -27,7 +27,10 @@ use web_atoms::{LocalName, local_name};
 
 use crate::ArcRefCell;
 use crate::cell::WeakRefCell;
+use crate::display_list::StackingContextTree;
 use crate::dom::NodeExt;
+use crate::layout_impl::LayoutThread;
+use crate::query::process_box_area_request;
 
 bitflags! {
     /// Damage which was caused by changes to the accessibility tree. These changes can cause other
@@ -46,13 +49,16 @@ bitflags! {
     }
 }
 
-/// Computes the bounds for a DOM node's accessibility node, or `None` if it has no geometry.
-/// Bounds must be in CSS pixels, relative to viewport origin (see [`accesskit`] composition model).
-pub(super) type AccessibilityBoundsQuery<'a> =
-    &'a dyn Fn(&ServoLayoutNode<'_>) -> Option<accesskit::Rect>;
+/// Everything the accessibility tree needs from layout in order to compute node bounds during an
+/// update. Bounds can only be computed when the stacking context tree is up-to-date with the
+/// current fragment tree, so this may be unavailable for some updates.
+pub(super) struct AccessibilityContext<'a> {
+    pub(super) layout_thread: &'a LayoutThread,
+    pub(super) stacking_context_tree: &'a StackingContextTree,
+}
 
 /// Convert a rectangle as layout reports it into the one [`accesskit`] wants.
-pub(super) fn au_rect_to_accesskit_rect(rect: Rect<Au, CSSPixel>) -> accesskit::Rect {
+fn au_rect_to_accesskit_rect(rect: Rect<Au, CSSPixel>) -> accesskit::Rect {
     accesskit::Rect::new(
         rect.min_x().to_f64_px(),
         rect.min_y().to_f64_px(),
@@ -204,7 +210,7 @@ impl AccessibilityTree {
         &mut self,
         root_dom_node: &ServoLayoutNode<'dom>,
         mut damage_from_dom: VecDeque<(ServoLayoutNode<'dom>, AccessibilityDamage)>,
-        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
+        context: Option<AccessibilityContext<'_>>,
         rooted_nodes: Option<FxHashSet<OpaqueNode>>,
     ) -> (Option<accesskit::TreeUpdate>, UpdateCounters) {
         let mut update = AccessibilityUpdate::new(rooted_nodes);
@@ -213,7 +219,7 @@ impl AccessibilityTree {
 
         self.apply_changes_from_dom_tree(damage_from_dom, &mut update);
 
-        self.refresh_bounds(root_dom_node, bounds_query, &mut update);
+        self.refresh_bounds(root_dom_node, context, &mut update);
 
         update.finalize(self)
     }
@@ -278,14 +284,14 @@ impl AccessibilityTree {
     fn refresh_bounds<'dom>(
         &self,
         root_dom_node: &ServoLayoutNode<'dom>,
-        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
+        context: Option<AccessibilityContext<'_>>,
         update: &mut AccessibilityUpdate,
     ) {
         // Bounds aren't tracked as `AccessibilityDamage` from the DOM: they can go stale from
         // things that don't involve any DOM change at all, SUCH AS: scrolling, resizing, or
         // zooming. So they are refreshed for the whole tree here, independent of the damage from
-        // the DOM, whenever layout is able to give us a query to compute them with.
-        let Some(bounds_query) = bounds_query else {
+        // the DOM, whenever layout is able to give us the context to compute them with.
+        let Some(context) = context else {
             return;
         };
         let Some(root_node) = self.root_node.clone() else {
@@ -293,7 +299,7 @@ impl AccessibilityTree {
         };
         root_node.borrow_mut().refresh_bounds_for_subtree(
             root_dom_node,
-            bounds_query,
+            &context,
             self,
             update,
             None,
@@ -762,8 +768,8 @@ impl AccessibilityNode {
 
         // Iterate over existing children and DOM children while they match. No action is necessary
         // for these nodes.
-        while let Some(&old_id) = old_child_ids.peek()
-            && let Some(dom_child) = remaining_dom_children.peek()
+        while let Some(&old_id) = old_child_ids.peek() &&
+            let Some(dom_child) = remaining_dom_children.peek()
         {
             if tree.existing_id_for_opaque(dom_child.opaque()) == Some(*old_id) {
                 unchanged_count += 1;
@@ -847,16 +853,26 @@ impl AccessibilityNode {
         local_damage
     }
 
-    /// Update this node's bounds from layout, given a query function and the bounds inherited from
-    /// an ancestor (used as a fallback for nodes without their own box). Returns the damage caused by
-    /// the update, and the bounds descendants without their own box should inherit.
+    /// Update this node's bounds from layout, given the context necessary to compute them and the
+    /// bounds inherited from an ancestor (used as a fallback for nodes without their own box).
+    /// Returns the damage caused by the update, and the bounds descendants without their own box
+    /// should inherit.
     fn update_bounds_from_dom_node(
         &mut self,
         dom_node: &ServoLayoutNode<'_>,
-        bounds_query: AccessibilityBoundsQuery<'_>,
+        context: &AccessibilityContext<'_>,
         inherited_bounds: Option<accesskit::Rect>,
     ) -> (LocalAccessibilityDamage, Option<accesskit::Rect>) {
-        let own_bounds = bounds_query(dom_node);
+        // Border box with transforms, matching getBoundingClientRect(). Bounds are in CSS pixels,
+        // relative to the viewport origin (see the [`accesskit`] composition model).
+        let own_bounds = process_box_area_request(
+            context.layout_thread,
+            context.stacking_context_tree,
+            *dom_node,
+            BoxAreaType::Border,
+            false, /* exclude_transform_and_inline */
+        )
+        .map(au_rect_to_accesskit_rect);
 
         // TODO(accessibility): Other engines (Blink, WebKit, Gecko) compute bounds for `display: contents`
         // elements (and other box-less elements) by taking the union of the bounding boxes of their rendered
@@ -891,13 +907,12 @@ impl AccessibilityNode {
     fn refresh_bounds_for_subtree<'dom>(
         &mut self,
         dom_node: &ServoLayoutNode<'dom>,
-        bounds_query: AccessibilityBoundsQuery<'_>,
+        context: &AccessibilityContext<'_>,
         tree: &AccessibilityTree,
         update: &mut AccessibilityUpdate,
         inherited_bounds: Option<accesskit::Rect>,
     ) {
-        let (_, bounds) =
-            self.update_bounds_from_dom_node(dom_node, bounds_query, inherited_bounds);
+        let (_, bounds) = self.update_bounds_from_dom_node(dom_node, context, inherited_bounds);
 
         if self.dirty_state.updated() {
             update.add(self);
@@ -909,7 +924,7 @@ impl AccessibilityNode {
             };
             tree.assert_node_for_id(&child_id)
                 .borrow_mut()
-                .refresh_bounds_for_subtree(&dom_child, bounds_query, tree, update, bounds);
+                .refresh_bounds_for_subtree(&dom_child, context, tree, update, bounds);
         }
     }
 
@@ -925,8 +940,8 @@ impl AccessibilityNode {
         update.counters.nodes_updated_from_tree += 1;
 
         let mut new_damage = LocalAccessibilityDamage::empty();
-        if local_damage.contains(LocalAccessibilityDamage::SubtreeChanged)
-            || local_damage.contains(LocalAccessibilityDamage::RoleChanged)
+        if local_damage.contains(LocalAccessibilityDamage::SubtreeChanged) ||
+            local_damage.contains(LocalAccessibilityDamage::RoleChanged)
         {
             if let Some(text) = self.label_from_descendants() {
                 new_damage.insert(self.set_label(text.as_str()));

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -213,13 +213,7 @@ impl AccessibilityTree {
 
         self.apply_changes_from_dom_tree(damage_from_dom, &mut update);
 
-        // Bounds aren't tracked as `AccessibilityDamage` from the DOM: they can go stale from
-        // things that don't involve any DOM change at all, such as scrolling, resizing, or
-        // zooming. So refresh them for the whole tree here, independent of `damage_from_dom`,
-        // whenever a `bounds_query` is available.
-        if let Some(bounds_query) = bounds_query {
-            self.refresh_bounds(root_dom_node, bounds_query, &mut update);
-        }
+        self.refresh_bounds(root_dom_node, bounds_query, &mut update);
 
         update.finalize(self)
     }
@@ -284,15 +278,26 @@ impl AccessibilityTree {
     fn refresh_bounds<'dom>(
         &self,
         root_dom_node: &ServoLayoutNode<'dom>,
-        bounds_query: AccessibilityBoundsQuery<'_>,
+        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
         update: &mut AccessibilityUpdate,
     ) {
-        let Some(root_node) = self.root_node else {
+        // Bounds aren't tracked as `AccessibilityDamage` from the DOM: they can go stale from
+        // things that don't involve any DOM change at all, SUCH AS: scrolling, resizing, or
+        // zooming. So they are refreshed for the whole tree here, independent of the damage from
+        // the DOM, whenever layout is able to give us a query to compute them with.
+        let Some(bounds_query) = bounds_query else {
             return;
         };
-        root_node
-            .borrow_mut()
-            .refresh_bounds_for_subtree(root_dom_node, bounds_query, self, update, None);
+        let Some(root_node) = self.root_node.clone() else {
+            return;
+        };
+        root_node.borrow_mut().refresh_bounds_for_subtree(
+            root_dom_node,
+            bounds_query,
+            self,
+            update,
+            None,
+        );
     }
 
     /// Given an iterator of `NodeId`s corresponding to nodes which have received some damage from
@@ -757,8 +762,8 @@ impl AccessibilityNode {
 
         // Iterate over existing children and DOM children while they match. No action is necessary
         // for these nodes.
-        while let Some(&old_id) = old_child_ids.peek() &&
-            let Some(dom_child) = remaining_dom_children.peek()
+        while let Some(&old_id) = old_child_ids.peek()
+            && let Some(dom_child) = remaining_dom_children.peek()
         {
             if tree.existing_id_for_opaque(dom_child.opaque()) == Some(*old_id) {
                 unchanged_count += 1;
@@ -862,8 +867,16 @@ impl AccessibilityNode {
             NodeRenderingType::NotRendered => None,
         };
 
+        // A text node never has bounds of its own: `LayoutBox::Text` has no `LayoutBoxBase`, and
+        // `Fragment::Text` has no box area, so the query always returns `None` for one. Screen
+        // readers still need geometry for a text run, in order to highlight or magnify it, so fall
+        // back to the bounds of the nearest ancestor which has them.
+        //
+        // TODO(accessibility): These bounds are those of the whole containing box, which is too
+        // large whenever it holds more than this one text run. They should instead be the union of
+        // the rectangles of this node's own `Fragment::Text` fragments.
         let bounds = match dom_node.type_id() {
-            Some(LayoutNodeType::Text) => own_bounds.or(inherited_bounds), // Fallback for text fragments
+            Some(LayoutNodeType::Text) => own_bounds.or(inherited_bounds),
             _ => own_bounds,
         };
 
@@ -912,8 +925,8 @@ impl AccessibilityNode {
         update.counters.nodes_updated_from_tree += 1;
 
         let mut new_damage = LocalAccessibilityDamage::empty();
-        if local_damage.contains(LocalAccessibilityDamage::SubtreeChanged) ||
-            local_damage.contains(LocalAccessibilityDamage::RoleChanged)
+        if local_damage.contains(LocalAccessibilityDamage::SubtreeChanged)
+            || local_damage.contains(LocalAccessibilityDamage::RoleChanged)
         {
             if let Some(text) = self.label_from_descendants() {
                 new_damage.insert(self.set_label(text.as_str()));

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -280,10 +280,10 @@ impl AccessibilityTree {
         bounds_query: AccessibilityBoundsQuery<'_>,
         update: &mut AccessibilityUpdate,
     ) {
-        let Some(root_id) = self.existing_id_for_opaque(root_dom_node.opaque()) else {
+        let Some(root_node) = self.root_node else {
             return;
         };
-        self.assert_node_for_id(&root_id)
+        root_node
             .borrow_mut()
             .refresh_bounds_for_subtree(root_dom_node, bounds_query, self, update, None);
     }

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -8,8 +8,12 @@ use std::sync::atomic::AtomicU64;
 use std::sync::{LazyLock, atomic};
 
 use accesskit::{NodeId, Role};
+use app_units::Au;
 use bitflags::bitflags;
-use layout_api::{AccessibilityDamage, LayoutElement, LayoutNode, LayoutNodeType};
+use euclid::Rect;
+use layout_api::{
+    AccessibilityDamage, LayoutElement, LayoutNode, LayoutNodeType, NodeRenderingType,
+};
 use log::trace;
 use rustc_hash::{FxHashMap, FxHashSet};
 use script::layout_dom::ServoLayoutNode;
@@ -18,10 +22,12 @@ use servo_base::print_tree::PrintTree;
 use servo_config::opts::{self, DiagnosticsLogging, DiagnosticsLoggingOption};
 use servo_config::pref;
 use style::dom::OpaqueNode;
+use style_traits::CSSPixel;
 use web_atoms::{LocalName, local_name};
 
 use crate::ArcRefCell;
 use crate::cell::WeakRefCell;
+use crate::dom::NodeExt;
 
 bitflags! {
     /// Damage which was caused by changes to the accessibility tree. These changes can cause other
@@ -35,7 +41,31 @@ bitflags! {
         const RoleChanged = 0b0010;
         /// This node's computed label or text value (for a text node) changed.
         const TextChanged = 0b0100;
+        /// This node's computed bounds changed.
+        const BoundsChanged = 0b1000;
     }
+}
+
+impl LocalAccessibilityDamage {
+    /// Damage that requires ancestor recomputation. Bounds excluded: computed independently per node.
+    const AFFECTS_ANCESTORS: Self = Self::SubtreeChanged
+        .union(Self::RoleChanged)
+        .union(Self::TextChanged);
+}
+
+/// Computes the bounds for a DOM node's accessibility node, or `None` if it has no geometry.
+/// Bounds must be in CSS pixels, relative to viewport origin (see [`accesskit`] composition model).
+pub(super) type AccessibilityBoundsQuery<'a> =
+    &'a dyn Fn(&ServoLayoutNode<'_>) -> Option<accesskit::Rect>;
+
+/// Convert a rectangle as layout reports it into the one [`accesskit`] wants.
+pub(super) fn au_rect_to_accesskit_rect(rect: Rect<Au, CSSPixel>) -> accesskit::Rect {
+    accesskit::Rect::new(
+        rect.min_x().to_f64_px(),
+        rect.min_y().to_f64_px(),
+        rect.max_x().to_f64_px(),
+        rect.max_y().to_f64_px(),
+    )
 }
 
 /// Changes which have occurred during the current update.
@@ -181,13 +211,14 @@ impl AccessibilityTree {
         &mut self,
         root_dom_node: &ServoLayoutNode<'dom>,
         mut damage_from_dom: VecDeque<(ServoLayoutNode<'dom>, AccessibilityDamage)>,
+        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
         rooted_nodes: Option<FxHashSet<OpaqueNode>>,
     ) -> (Option<accesskit::TreeUpdate>, UpdateCounters) {
         let mut update = AccessibilityUpdate::new(rooted_nodes);
 
         self.ensure_root_node(root_dom_node, &mut damage_from_dom, &mut update);
 
-        self.apply_changes_from_dom_tree(damage_from_dom, &mut update);
+        self.apply_changes_from_dom_tree(damage_from_dom, bounds_query, &mut update);
 
         update.finalize(self)
     }
@@ -214,6 +245,7 @@ impl AccessibilityTree {
     fn apply_changes_from_dom_tree<'dom>(
         &mut self,
         damage_from_dom: VecDeque<(ServoLayoutNode<'dom>, AccessibilityDamage)>,
+        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
         update: &mut AccessibilityUpdate,
     ) {
         let mut dom_damage_map = FxHashMap::from(
@@ -229,11 +261,19 @@ impl AccessibilityTree {
         let Some(damage_root) = damage_root else {
             return;
         };
+        // The walk below may not start at the true tree root, so seed the inherited bounds from
+        // the nearest ancestor with already-known bounds (from a previous update).
+        let inherited_bounds = damage_root
+            .borrow()
+            .ancestors()
+            .find_map(|ancestor| ancestor.borrow().bounds());
         let local_damage = damage_root.borrow_mut().update_subtree(
             damage_root.clone(),
             &mut dom_damage_map,
             self,
             update,
+            bounds_query,
+            inherited_bounds,
         );
 
         damage_root.borrow().update_ancestors(local_damage, update);
@@ -594,17 +634,26 @@ impl AccessibilityNode {
         dom_damage_map: &mut FxHashMap<NodeId, (ServoLayoutNode<'dom>, AccessibilityDamage)>,
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate,
+        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
+        inherited_bounds: Option<accesskit::Rect>,
     ) -> LocalAccessibilityDamage {
         let mut local_damage = LocalAccessibilityDamage::empty();
+        // Bounds to propagate to any dirty children below, if this node doesn't have its own.
+        let mut bounds = inherited_bounds;
 
         if let Some((dom_node, dom_damage)) = dom_damage_map.get(&self.id) {
-            local_damage.insert(self.update_node_and_populate_new_descendants_from_dom_node(
-                ref_self,
-                dom_node,
-                *dom_damage,
-                tree,
-                update,
-            ));
+            let (node_damage, new_bounds) = self
+                .update_node_and_populate_new_descendants_from_dom_node(
+                    ref_self,
+                    dom_node,
+                    *dom_damage,
+                    tree,
+                    update,
+                    bounds_query,
+                    inherited_bounds,
+                );
+            local_damage.insert(node_damage);
+            bounds = new_bounds;
 
             self.dirty_state -= DirtyState::HasDamage;
         }
@@ -616,9 +665,15 @@ impl AccessibilityNode {
                 if !child_node.dirty_state.self_or_descendant_has_damage() {
                     continue;
                 }
-                let child_damage =
-                    child_node.update_subtree(strong_child_node, dom_damage_map, tree, update);
-                if !child_damage.is_empty() {
+                let child_damage = child_node.update_subtree(
+                    strong_child_node,
+                    dom_damage_map,
+                    tree,
+                    update,
+                    bounds_query,
+                    bounds,
+                );
+                if child_damage.intersects(LocalAccessibilityDamage::AFFECTS_ANCESTORS) {
                     local_damage.insert(LocalAccessibilityDamage::SubtreeChanged);
                 }
             }
@@ -666,19 +721,38 @@ impl AccessibilityNode {
         dom_damage: AccessibilityDamage,
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate,
-    ) -> LocalAccessibilityDamage {
+        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
+        inherited_bounds: Option<accesskit::Rect>,
+    ) -> (LocalAccessibilityDamage, Option<accesskit::Rect>) {
         update.counters.nodes_updated_from_dom += 1;
 
         let mut local_damage = LocalAccessibilityDamage::empty();
 
         local_damage.insert(self.update_properties_from_dom_node(dom_node, dom_damage));
+
+        // Bounds are refreshed unconditionally whenever a query is available, independent of
+        // `dom_damage`, since geometry can change without other accessibility-relevant damage.
+        let mut bounds = inherited_bounds;
+        if let Some(bounds_query) = bounds_query {
+            let (bounds_damage, new_bounds) =
+                self.update_bounds_from_dom_node(dom_node, bounds_query, inherited_bounds);
+            local_damage.insert(bounds_damage);
+            bounds = new_bounds;
+        }
+
         local_damage.insert(
             self.update_children_and_populate_new_descendants_from_dom_node(
-                ref_self, dom_node, dom_damage, tree, update,
+                ref_self,
+                dom_node,
+                dom_damage,
+                tree,
+                update,
+                bounds_query,
+                bounds,
             ),
         );
 
-        local_damage
+        (local_damage, bounds)
     }
 
     /// Update this node's [`Self::children`] from its corresponding DOM node. If any children are
@@ -690,6 +764,8 @@ impl AccessibilityNode {
         dom_damage: AccessibilityDamage,
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate,
+        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
+        bounds: Option<accesskit::Rect>,
     ) -> LocalAccessibilityDamage {
         if !dom_damage.contains(AccessibilityDamage::Children) {
             return LocalAccessibilityDamage::empty();
@@ -740,13 +816,16 @@ impl AccessibilityNode {
             child.parent_node = Some(weak_self.clone());
 
             if update.is_new(&child_id) {
-                let child_damage = child.update_node_and_populate_new_descendants_from_dom_node(
-                    child_ref.clone(),
-                    &dom_child,
-                    AccessibilityDamage::Rebuild,
-                    tree,
-                    update,
-                );
+                let (child_damage, _) = child
+                    .update_node_and_populate_new_descendants_from_dom_node(
+                        child_ref.clone(),
+                        &dom_child,
+                        AccessibilityDamage::Rebuild,
+                        tree,
+                        update,
+                        bounds_query,
+                        bounds,
+                    );
                 child.update_node_local(child_damage, update);
                 update.add(&mut child);
             } else {
@@ -784,6 +863,35 @@ impl AccessibilityNode {
         }
 
         local_damage
+    }
+
+    /// Update this node's bounds from layout, given a query function and the bounds inherited from
+    /// an ancestor (used as a fallback for nodes without their own box). Returns the damage caused by
+    /// the update, and the bounds descendants without their own box should inherit.
+    fn update_bounds_from_dom_node(
+        &mut self,
+        dom_node: &ServoLayoutNode<'_>,
+        bounds_query: AccessibilityBoundsQuery<'_>,
+        inherited_bounds: Option<accesskit::Rect>,
+    ) -> (LocalAccessibilityDamage, Option<accesskit::Rect>) {
+        let own_bounds = bounds_query(dom_node);
+
+        let inheritable_bounds = match dom_node.rendering_type() {
+            NodeRenderingType::Rendered => own_bounds,
+            NodeRenderingType::DelegatesRendering => own_bounds.or(inherited_bounds), // display: contents
+            NodeRenderingType::NotRendered => None,
+        };
+
+        let bounds = match dom_node.type_id() {
+            Some(LayoutNodeType::Text) => own_bounds.or(inherited_bounds), // Fallback for text fragments
+            _ => own_bounds,
+        };
+
+        let damage = match bounds {
+            Some(bounds) => self.set_bounds(bounds),
+            None => self.clear_bounds(), // display: none case
+        };
+        (damage, inheritable_bounds)
     }
 
     /// Update this node's properties based on changes already made to the accessibility tree.
@@ -927,6 +1035,28 @@ impl AccessibilityNode {
         LocalAccessibilityDamage::TextChanged
     }
 
+    fn bounds(&self) -> Option<accesskit::Rect> {
+        self.accesskit_node.bounds()
+    }
+
+    fn set_bounds(&mut self, bounds: accesskit::Rect) -> LocalAccessibilityDamage {
+        if Some(bounds) == self.accesskit_node.bounds() {
+            return LocalAccessibilityDamage::empty();
+        }
+        self.accesskit_node.set_bounds(bounds);
+        self.dirty_state |= DirtyState::Updated;
+        LocalAccessibilityDamage::BoundsChanged
+    }
+
+    fn clear_bounds(&mut self) -> LocalAccessibilityDamage {
+        if self.accesskit_node.bounds().is_none() {
+            return LocalAccessibilityDamage::empty();
+        }
+        self.accesskit_node.clear_bounds();
+        self.dirty_state |= DirtyState::Updated;
+        LocalAccessibilityDamage::BoundsChanged
+    }
+
     fn assert_integrity(&self, expected_parent: Option<WeakRefCell<AccessibilityNode>>) {
         debug_assert!(pref!(expensive_accessibility_test_assertions_enabled));
 
@@ -965,6 +1095,9 @@ impl Debug for AccessibilityNode {
         }
         if let Some(label) = self.label() {
             write!(f, "\nlabel: {label:?}")?;
+        }
+        if let Some(bounds) = self.bounds() {
+            write!(f, "\nbounds: {bounds:?}")?;
         }
         if !self.child_ids().is_empty() {
             write!(f, "\nchildren: {:?}", self.child_ids())?;

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -46,13 +46,6 @@ bitflags! {
     }
 }
 
-impl LocalAccessibilityDamage {
-    /// Damage that requires ancestor recomputation. Bounds excluded: computed independently per node.
-    const AFFECTS_ANCESTORS: Self = Self::SubtreeChanged
-        .union(Self::RoleChanged)
-        .union(Self::TextChanged);
-}
-
 /// Computes the bounds for a DOM node's accessibility node, or `None` if it has no geometry.
 /// Bounds must be in CSS pixels, relative to viewport origin (see [`accesskit`] composition model).
 pub(super) type AccessibilityBoundsQuery<'a> =
@@ -218,7 +211,15 @@ impl AccessibilityTree {
 
         self.ensure_root_node(root_dom_node, &mut damage_from_dom, &mut update);
 
-        self.apply_changes_from_dom_tree(damage_from_dom, bounds_query, &mut update);
+        self.apply_changes_from_dom_tree(damage_from_dom, &mut update);
+
+        // Bounds aren't tracked as `AccessibilityDamage` from the DOM: they can go stale from
+        // things that don't involve any DOM change at all, such as scrolling, resizing, or
+        // zooming. So refresh them for the whole tree here, independent of `damage_from_dom`,
+        // whenever a `bounds_query` is available.
+        if let Some(bounds_query) = bounds_query {
+            self.refresh_bounds(root_dom_node, bounds_query, &mut update);
+        }
 
         update.finalize(self)
     }
@@ -245,7 +246,6 @@ impl AccessibilityTree {
     fn apply_changes_from_dom_tree<'dom>(
         &mut self,
         damage_from_dom: VecDeque<(ServoLayoutNode<'dom>, AccessibilityDamage)>,
-        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
         update: &mut AccessibilityUpdate,
     ) {
         let mut dom_damage_map = FxHashMap::from(
@@ -261,22 +261,31 @@ impl AccessibilityTree {
         let Some(damage_root) = damage_root else {
             return;
         };
-        // The walk below may not start at the true tree root, so seed the inherited bounds from
-        // the nearest ancestor with already-known bounds (from a previous update).
-        let inherited_bounds = damage_root
-            .borrow()
-            .ancestors()
-            .find_map(|ancestor| ancestor.borrow().bounds());
         let local_damage = damage_root.borrow_mut().update_subtree(
             damage_root.clone(),
             &mut dom_damage_map,
             self,
             update,
-            bounds_query,
-            inherited_bounds,
         );
 
         damage_root.borrow().update_ancestors(local_damage, update);
+    }
+
+    /// Recompute bounds for every node in the tree from current layout geometry, independent of
+    /// [`AccessibilityDamage`] from the DOM. Nodes whose bounds actually changed are added to
+    /// `update`. See [`AccessibilityNode::refresh_bounds_for_subtree()`].
+    fn refresh_bounds<'dom>(
+        &self,
+        root_dom_node: &ServoLayoutNode<'dom>,
+        bounds_query: AccessibilityBoundsQuery<'_>,
+        update: &mut AccessibilityUpdate,
+    ) {
+        let Some(root_id) = self.existing_id_for_opaque(root_dom_node.opaque()) else {
+            return;
+        };
+        self.assert_node_for_id(&root_id)
+            .borrow_mut()
+            .refresh_bounds_for_subtree(root_dom_node, bounds_query, self, update, None);
     }
 
     /// Given an iterator of `NodeId`s corresponding to nodes which have received some damage from
@@ -634,26 +643,17 @@ impl AccessibilityNode {
         dom_damage_map: &mut FxHashMap<NodeId, (ServoLayoutNode<'dom>, AccessibilityDamage)>,
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate,
-        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
-        inherited_bounds: Option<accesskit::Rect>,
     ) -> LocalAccessibilityDamage {
         let mut local_damage = LocalAccessibilityDamage::empty();
-        // Bounds to propagate to any dirty children below, if this node doesn't have its own.
-        let mut bounds = inherited_bounds;
 
         if let Some((dom_node, dom_damage)) = dom_damage_map.get(&self.id) {
-            let (node_damage, new_bounds) = self
-                .update_node_and_populate_new_descendants_from_dom_node(
-                    ref_self,
-                    dom_node,
-                    *dom_damage,
-                    tree,
-                    update,
-                    bounds_query,
-                    inherited_bounds,
-                );
-            local_damage.insert(node_damage);
-            bounds = new_bounds;
+            local_damage.insert(self.update_node_and_populate_new_descendants_from_dom_node(
+                ref_self,
+                dom_node,
+                *dom_damage,
+                tree,
+                update,
+            ));
 
             self.dirty_state -= DirtyState::HasDamage;
         }
@@ -665,15 +665,9 @@ impl AccessibilityNode {
                 if !child_node.dirty_state.self_or_descendant_has_damage() {
                     continue;
                 }
-                let child_damage = child_node.update_subtree(
-                    strong_child_node,
-                    dom_damage_map,
-                    tree,
-                    update,
-                    bounds_query,
-                    bounds,
-                );
-                if child_damage.intersects(LocalAccessibilityDamage::AFFECTS_ANCESTORS) {
+                let child_damage =
+                    child_node.update_subtree(strong_child_node, dom_damage_map, tree, update);
+                if !child_damage.is_empty() {
                     local_damage.insert(LocalAccessibilityDamage::SubtreeChanged);
                 }
             }
@@ -721,38 +715,19 @@ impl AccessibilityNode {
         dom_damage: AccessibilityDamage,
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate,
-        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
-        inherited_bounds: Option<accesskit::Rect>,
-    ) -> (LocalAccessibilityDamage, Option<accesskit::Rect>) {
+    ) -> LocalAccessibilityDamage {
         update.counters.nodes_updated_from_dom += 1;
 
         let mut local_damage = LocalAccessibilityDamage::empty();
 
         local_damage.insert(self.update_properties_from_dom_node(dom_node, dom_damage));
-
-        // Bounds are refreshed unconditionally whenever a query is available, independent of
-        // `dom_damage`, since geometry can change without other accessibility-relevant damage.
-        let mut bounds = inherited_bounds;
-        if let Some(bounds_query) = bounds_query {
-            let (bounds_damage, new_bounds) =
-                self.update_bounds_from_dom_node(dom_node, bounds_query, inherited_bounds);
-            local_damage.insert(bounds_damage);
-            bounds = new_bounds;
-        }
-
         local_damage.insert(
             self.update_children_and_populate_new_descendants_from_dom_node(
-                ref_self,
-                dom_node,
-                dom_damage,
-                tree,
-                update,
-                bounds_query,
-                bounds,
+                ref_self, dom_node, dom_damage, tree, update,
             ),
         );
 
-        (local_damage, bounds)
+        local_damage
     }
 
     /// Update this node's [`Self::children`] from its corresponding DOM node. If any children are
@@ -764,8 +739,6 @@ impl AccessibilityNode {
         dom_damage: AccessibilityDamage,
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate,
-        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
-        bounds: Option<accesskit::Rect>,
     ) -> LocalAccessibilityDamage {
         if !dom_damage.contains(AccessibilityDamage::Children) {
             return LocalAccessibilityDamage::empty();
@@ -816,16 +789,13 @@ impl AccessibilityNode {
             child.parent_node = Some(weak_self.clone());
 
             if update.is_new(&child_id) {
-                let (child_damage, _) = child
-                    .update_node_and_populate_new_descendants_from_dom_node(
-                        child_ref.clone(),
-                        &dom_child,
-                        AccessibilityDamage::Rebuild,
-                        tree,
-                        update,
-                        bounds_query,
-                        bounds,
-                    );
+                let child_damage = child.update_node_and_populate_new_descendants_from_dom_node(
+                    child_ref.clone(),
+                    &dom_child,
+                    AccessibilityDamage::Rebuild,
+                    tree,
+                    update,
+                );
                 child.update_node_local(child_damage, update);
                 update.add(&mut child);
             } else {
@@ -892,6 +862,32 @@ impl AccessibilityNode {
             None => self.clear_bounds(), // display: none case
         };
         (damage, inheritable_bounds)
+    }
+
+    /// Recompute this node's bounds and its descendants', from current layout geometry.
+    fn refresh_bounds_for_subtree<'dom>(
+        &mut self,
+        dom_node: &ServoLayoutNode<'dom>,
+        bounds_query: AccessibilityBoundsQuery<'_>,
+        tree: &AccessibilityTree,
+        update: &mut AccessibilityUpdate,
+        inherited_bounds: Option<accesskit::Rect>,
+    ) {
+        let (_, bounds) =
+            self.update_bounds_from_dom_node(dom_node, bounds_query, inherited_bounds);
+
+        if self.dirty_state.updated() {
+            update.add(self);
+        }
+
+        for dom_child in dom_node.flat_tree_children() {
+            let Some(child_id) = tree.existing_id_for_opaque(dom_child.opaque()) else {
+                continue;
+            };
+            tree.assert_node_for_id(&child_id)
+                .borrow_mut()
+                .refresh_bounds_for_subtree(&dom_child, bounds_query, tree, update, bounds);
+        }
     }
 
     /// Update this node's properties based on changes already made to the accessibility tree.

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -82,6 +82,7 @@ struct AccessibilityUpdate {
 pub struct UpdateCounters {
     pub nodes_updated_from_dom: u32,
     pub nodes_updated_from_tree: u32,
+    pub nodes_updated_bounds: u32,
     pub nodes_in_tree_update: u32,
 }
 
@@ -890,6 +891,7 @@ impl AccessibilityNode {
         tree: &AccessibilityTree,
         update: &mut AccessibilityUpdate,
     ) {
+        update.counters.nodes_updated_bounds += 1;
         self.update_bounds_from_dom_node(dom_node, context);
 
         if self.dirty_state.updated() {

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -274,6 +274,13 @@ impl AccessibilityTree {
     /// Recompute bounds for every node in the tree from current layout geometry, independent of
     /// [`AccessibilityDamage`] from the DOM. Nodes whose bounds actually changed are added to
     /// `update`. See [`AccessibilityNode::refresh_bounds_for_subtree()`].
+    ///
+    /// TODO(accessibility): We might not always need to start from the document root. For instance,
+    /// if layout performed an incremental reflow of a specific subtree, we could potentially
+    /// limit the bounds refresh to that subtree and any elements positioned after it in flow order
+    /// (which may have shifted). However, since viewport-relative coordinates are used, any ancestor
+    /// movement/scroll/zoom shifts all descendants, and layout does not currently provide
+    /// fine-grained bounds damage notifications.
     fn refresh_bounds<'dom>(
         &self,
         root_dom_node: &ServoLayoutNode<'dom>,
@@ -846,6 +853,9 @@ impl AccessibilityNode {
     ) -> (LocalAccessibilityDamage, Option<accesskit::Rect>) {
         let own_bounds = bounds_query(dom_node);
 
+        // TODO(accessibility): Other engines (Blink, WebKit, Gecko) compute bounds for `display: contents`
+        // elements (and other box-less elements) by taking the union of the bounding boxes of their rendered
+        // descendants, rather than inheriting ancestor bounds or leaving them empty.
         let inheritable_bounds = match dom_node.rendering_type() {
             NodeRenderingType::Rendered => own_bounds,
             NodeRenderingType::DelegatesRendering => own_bounds.or(inherited_bounds), // display: contents

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -1301,6 +1301,7 @@ static HTML_ELEMENT_ROLE_MAPPINGS: LazyLock<FxHashMap<LocalName, Role>> = LazyLo
         (local_name!("article"), Role::Article),
         (local_name!("aside"), Role::Complementary),
         (local_name!("body"), Role::RootWebArea),
+        (local_name!("button"), Role::Button),
         (local_name!("footer"), Role::ContentInfo),
         (local_name!("h1"), Role::Heading),
         (local_name!("h2"), Role::Heading),

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -12,7 +12,7 @@ use app_units::Au;
 use bitflags::bitflags;
 use euclid::Rect;
 use layout_api::{
-    AccessibilityDamage, LayoutElement, LayoutNode, LayoutNodeType, NodeRenderingType,
+    AccessibilityDamage, BoxAreaType, LayoutElement, LayoutNode, LayoutNodeType, NodeRenderingType,
 };
 use log::trace;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -28,7 +28,10 @@ use web_atoms::{LocalName, local_name, ns};
 
 use crate::ArcRefCell;
 use crate::cell::WeakRefCell;
+use crate::display_list::StackingContextTree;
 use crate::dom::NodeExt;
+use crate::layout_impl::LayoutThread;
+use crate::query::process_box_area_request;
 
 bitflags! {
     /// Damage which was caused by changes to the accessibility tree. These changes can cause other
@@ -47,13 +50,16 @@ bitflags! {
     }
 }
 
-/// Computes the bounds for a DOM node's accessibility node, or `None` if it has no geometry.
-/// Bounds must be in CSS pixels, relative to viewport origin (see [`accesskit`] composition model).
-pub(super) type AccessibilityBoundsQuery<'a> =
-    &'a dyn Fn(&ServoLayoutNode<'_>) -> Option<accesskit::Rect>;
+/// Everything the accessibility tree needs from layout in order to compute node bounds during an
+/// update. Bounds can only be computed when the stacking context tree is up-to-date with the
+/// current fragment tree, so this may be unavailable for some updates.
+pub(super) struct AccessibilityContext<'a> {
+    pub(super) layout_thread: &'a LayoutThread,
+    pub(super) stacking_context_tree: &'a StackingContextTree,
+}
 
 /// Convert a rectangle as layout reports it into the one [`accesskit`] wants.
-pub(super) fn au_rect_to_accesskit_rect(rect: Rect<Au, CSSPixel>) -> accesskit::Rect {
+fn au_rect_to_accesskit_rect(rect: Rect<Au, CSSPixel>) -> accesskit::Rect {
     accesskit::Rect::new(
         rect.min_x().to_f64_px(),
         rect.min_y().to_f64_px(),
@@ -205,7 +211,7 @@ impl AccessibilityTree {
         &mut self,
         root_dom_node: &ServoLayoutNode<'dom>,
         mut damage_from_dom: VecDeque<(ServoLayoutNode<'dom>, AccessibilityDamage)>,
-        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
+        context: Option<AccessibilityContext<'_>>,
         rooted_nodes: Option<FxHashSet<OpaqueNode>>,
     ) -> (Option<accesskit::TreeUpdate>, UpdateCounters) {
         let mut update = AccessibilityUpdate::new(rooted_nodes);
@@ -214,7 +220,7 @@ impl AccessibilityTree {
 
         self.apply_changes_from_dom_tree(damage_from_dom, &mut update);
 
-        self.refresh_bounds(root_dom_node, bounds_query, &mut update);
+        self.refresh_bounds(root_dom_node, context, &mut update);
 
         update.finalize(self)
     }
@@ -279,14 +285,14 @@ impl AccessibilityTree {
     fn refresh_bounds<'dom>(
         &self,
         root_dom_node: &ServoLayoutNode<'dom>,
-        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
+        context: Option<AccessibilityContext<'_>>,
         update: &mut AccessibilityUpdate,
     ) {
         // Bounds aren't tracked as `AccessibilityDamage` from the DOM: they can go stale from
         // things that don't involve any DOM change at all, SUCH AS: scrolling, resizing, or
         // zooming. So they are refreshed for the whole tree here, independent of the damage from
-        // the DOM, whenever layout is able to give us a query to compute them with.
-        let Some(bounds_query) = bounds_query else {
+        // the DOM, whenever layout is able to give us the context to compute them with.
+        let Some(context) = context else {
             return;
         };
         let Some(root_node) = self.root_node.clone() else {
@@ -294,7 +300,7 @@ impl AccessibilityTree {
         };
         root_node.borrow_mut().refresh_bounds_for_subtree(
             root_dom_node,
-            bounds_query,
+            &context,
             self,
             update,
             None,
@@ -776,8 +782,8 @@ impl AccessibilityNode {
 
         // Iterate over existing children and DOM children while they match. No action is necessary
         // for these nodes.
-        while let Some(&old_id) = old_child_ids.peek()
-            && let Some(dom_child) = remaining_dom_children.peek()
+        while let Some(&old_id) = old_child_ids.peek() &&
+            let Some(dom_child) = remaining_dom_children.peek()
         {
             if tree.existing_id_for_opaque(dom_child.opaque()) == Some(*old_id) {
                 unchanged_count += 1;
@@ -861,16 +867,26 @@ impl AccessibilityNode {
         local_damage
     }
 
-    /// Update this node's bounds from layout, given a query function and the bounds inherited from
-    /// an ancestor (used as a fallback for nodes without their own box). Returns the damage caused by
-    /// the update, and the bounds descendants without their own box should inherit.
+    /// Update this node's bounds from layout, given the context necessary to compute them and the
+    /// bounds inherited from an ancestor (used as a fallback for nodes without their own box).
+    /// Returns the damage caused by the update, and the bounds descendants without their own box
+    /// should inherit.
     fn update_bounds_from_dom_node(
         &mut self,
         dom_node: &ServoLayoutNode<'_>,
-        bounds_query: AccessibilityBoundsQuery<'_>,
+        context: &AccessibilityContext<'_>,
         inherited_bounds: Option<accesskit::Rect>,
     ) -> (LocalAccessibilityDamage, Option<accesskit::Rect>) {
-        let own_bounds = bounds_query(dom_node);
+        // Border box with transforms, matching getBoundingClientRect(). Bounds are in CSS pixels,
+        // relative to the viewport origin (see the [`accesskit`] composition model).
+        let own_bounds = process_box_area_request(
+            context.layout_thread,
+            context.stacking_context_tree,
+            *dom_node,
+            BoxAreaType::Border,
+            false, /* exclude_transform_and_inline */
+        )
+        .map(au_rect_to_accesskit_rect);
 
         // TODO(accessibility): Other engines (Blink, WebKit, Gecko) compute bounds for `display: contents`
         // elements (and other box-less elements) by taking the union of the bounding boxes of their rendered
@@ -905,13 +921,12 @@ impl AccessibilityNode {
     fn refresh_bounds_for_subtree<'dom>(
         &mut self,
         dom_node: &ServoLayoutNode<'dom>,
-        bounds_query: AccessibilityBoundsQuery<'_>,
+        context: &AccessibilityContext<'_>,
         tree: &AccessibilityTree,
         update: &mut AccessibilityUpdate,
         inherited_bounds: Option<accesskit::Rect>,
     ) {
-        let (_, bounds) =
-            self.update_bounds_from_dom_node(dom_node, bounds_query, inherited_bounds);
+        let (_, bounds) = self.update_bounds_from_dom_node(dom_node, context, inherited_bounds);
 
         if self.dirty_state.updated() {
             update.add(self);
@@ -923,7 +938,7 @@ impl AccessibilityNode {
             };
             tree.assert_node_for_id(&child_id)
                 .borrow_mut()
-                .refresh_bounds_for_subtree(&dom_child, bounds_query, tree, update, bounds);
+                .refresh_bounds_for_subtree(&dom_child, context, tree, update, bounds);
         }
     }
 
@@ -939,8 +954,8 @@ impl AccessibilityNode {
         update.counters.nodes_updated_from_tree += 1;
 
         let mut new_damage = LocalAccessibilityDamage::empty();
-        if local_damage.contains(LocalAccessibilityDamage::SubtreeChanged)
-            || local_damage.contains(LocalAccessibilityDamage::RoleChanged)
+        if local_damage.contains(LocalAccessibilityDamage::SubtreeChanged) ||
+            local_damage.contains(LocalAccessibilityDamage::RoleChanged)
         {
             if let Some(text) = self.label_from_descendants() {
                 new_damage.insert(self.set_label(text.as_str()));

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -274,7 +274,8 @@ impl AccessibilityTree {
     ///
     /// TODO(accessibility): We might not always need to start from the document root. However,
     /// since viewport-relative coordinates are used, any ancestor movement/scroll/zoom shifts all
-    /// descendants, and layout does not currently provide fine-grained bounds damage notifications.
+    /// descendants, and layout does not currently provide fine-grained bounds damage
+    /// notifications. See #47162.
     fn refresh_bounds<'dom>(
         &self,
         root_dom_node: &ServoLayoutNode<'dom>,
@@ -882,11 +883,12 @@ impl AccessibilityNode {
         // TODO(accessibility): A text node never has bounds of its own: `LayoutBox::Text` has no
         // `LayoutBoxBase`, and `Fragment::Text` has no box area, so the query above always returns
         // `None` for one. Text nodes should get the union of the rectangles of their own
-        // `Fragment::Text` fragments, once `cumulative_box_area_rect()` can handle those.
+        // `Fragment::Text` fragments, once `cumulative_box_area_rect()` can handle those. See
+        // #47164.
         //
         // TODO(accessibility): A `display: contents` element generates no box either. Other
         // engines (Blink, WebKit, Gecko) compute its bounds as the union of the bounding boxes of
-        // its rendered descendants.
+        // its rendered descendants. See #47163.
         match bounds {
             Some(bounds) => self.set_bounds(bounds),
             None => self.clear_bounds(),

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -866,7 +866,9 @@ impl AccessibilityNode {
         context: &AccessibilityContext<'_>,
     ) {
         // Border box with transforms, matching getBoundingClientRect(). Bounds are in CSS pixels,
-        // relative to the viewport origin (see the [`accesskit`] composition model).
+        // relative to the viewport origin; the embedder's graft node carries the transform that
+        // composes them into AccessKit's coordinate space (see the "Coordinates" section of
+        // <https://docs.rs/accesskit/latest/accesskit/struct.Node.html>).
         let bounds = process_box_area_request(
             context.layout_thread,
             context.stacking_context_tree,

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -8,8 +8,12 @@ use std::sync::atomic::AtomicU64;
 use std::sync::{LazyLock, atomic};
 
 use accesskit::{NodeId, Role};
+use app_units::Au;
 use bitflags::bitflags;
-use layout_api::{AccessibilityDamage, LayoutElement, LayoutNode, LayoutNodeType};
+use euclid::Rect;
+use layout_api::{
+    AccessibilityDamage, LayoutElement, LayoutNode, LayoutNodeType, NodeRenderingType,
+};
 use log::trace;
 use rustc_hash::{FxHashMap, FxHashSet};
 use script::layout_dom::{ServoLayoutElement, ServoLayoutNode};
@@ -19,10 +23,12 @@ use servo_config::opts::{self, DiagnosticsLogging, DiagnosticsLoggingOption};
 use servo_config::pref;
 use style::Atom;
 use style::dom::OpaqueNode;
+use style_traits::CSSPixel;
 use web_atoms::{LocalName, local_name, ns};
 
 use crate::ArcRefCell;
 use crate::cell::WeakRefCell;
+use crate::dom::NodeExt;
 
 bitflags! {
     /// Damage which was caused by changes to the accessibility tree. These changes can cause other
@@ -36,7 +42,31 @@ bitflags! {
         const RoleChanged = 0b0010;
         /// This node's computed label or text value (for a text node) changed.
         const TextChanged = 0b0100;
+        /// This node's computed bounds changed.
+        const BoundsChanged = 0b1000;
     }
+}
+
+impl LocalAccessibilityDamage {
+    /// Damage that requires ancestor recomputation. Bounds excluded: computed independently per node.
+    const AFFECTS_ANCESTORS: Self = Self::SubtreeChanged
+        .union(Self::RoleChanged)
+        .union(Self::TextChanged);
+}
+
+/// Computes the bounds for a DOM node's accessibility node, or `None` if it has no geometry.
+/// Bounds must be in CSS pixels, relative to viewport origin (see [`accesskit`] composition model).
+pub(super) type AccessibilityBoundsQuery<'a> =
+    &'a dyn Fn(&ServoLayoutNode<'_>) -> Option<accesskit::Rect>;
+
+/// Convert a rectangle as layout reports it into the one [`accesskit`] wants.
+pub(super) fn au_rect_to_accesskit_rect(rect: Rect<Au, CSSPixel>) -> accesskit::Rect {
+    accesskit::Rect::new(
+        rect.min_x().to_f64_px(),
+        rect.min_y().to_f64_px(),
+        rect.max_x().to_f64_px(),
+        rect.max_y().to_f64_px(),
+    )
 }
 
 /// Changes which have occurred during the current update.
@@ -182,13 +212,14 @@ impl AccessibilityTree {
         &mut self,
         root_dom_node: &ServoLayoutNode<'dom>,
         mut damage_from_dom: VecDeque<(ServoLayoutNode<'dom>, AccessibilityDamage)>,
+        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
         rooted_nodes: Option<FxHashSet<OpaqueNode>>,
     ) -> (Option<accesskit::TreeUpdate>, UpdateCounters) {
         let mut update = AccessibilityUpdate::new(rooted_nodes);
 
         self.ensure_root_node(root_dom_node, &mut damage_from_dom, &mut update);
 
-        self.apply_changes_from_dom_tree(damage_from_dom, &mut update);
+        self.apply_changes_from_dom_tree(damage_from_dom, bounds_query, &mut update);
 
         update.finalize(self)
     }
@@ -215,6 +246,7 @@ impl AccessibilityTree {
     fn apply_changes_from_dom_tree<'dom>(
         &mut self,
         damage_from_dom: VecDeque<(ServoLayoutNode<'dom>, AccessibilityDamage)>,
+        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
         update: &mut AccessibilityUpdate,
     ) {
         let mut dom_damage_map = FxHashMap::from(
@@ -230,11 +262,19 @@ impl AccessibilityTree {
         let Some(damage_root) = damage_root else {
             return;
         };
+        // The walk below may not start at the true tree root, so seed the inherited bounds from
+        // the nearest ancestor with already-known bounds (from a previous update).
+        let inherited_bounds = damage_root
+            .borrow()
+            .ancestors()
+            .find_map(|ancestor| ancestor.borrow().bounds());
         let local_damage = damage_root.borrow_mut().update_subtree(
             damage_root.clone(),
             &mut dom_damage_map,
             self,
             update,
+            bounds_query,
+            inherited_bounds,
         );
 
         damage_root.borrow().update_ancestors(local_damage, update);
@@ -608,17 +648,26 @@ impl AccessibilityNode {
         dom_damage_map: &mut FxHashMap<NodeId, (ServoLayoutNode<'dom>, AccessibilityDamage)>,
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate,
+        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
+        inherited_bounds: Option<accesskit::Rect>,
     ) -> LocalAccessibilityDamage {
         let mut local_damage = LocalAccessibilityDamage::empty();
+        // Bounds to propagate to any dirty children below, if this node doesn't have its own.
+        let mut bounds = inherited_bounds;
 
         if let Some((dom_node, dom_damage)) = dom_damage_map.get(&self.id) {
-            local_damage.insert(self.update_node_and_populate_new_descendants_from_dom_node(
-                ref_self,
-                dom_node,
-                *dom_damage,
-                tree,
-                update,
-            ));
+            let (node_damage, new_bounds) = self
+                .update_node_and_populate_new_descendants_from_dom_node(
+                    ref_self,
+                    dom_node,
+                    *dom_damage,
+                    tree,
+                    update,
+                    bounds_query,
+                    inherited_bounds,
+                );
+            local_damage.insert(node_damage);
+            bounds = new_bounds;
 
             self.dirty_state -= DirtyState::HasDamage;
         }
@@ -630,9 +679,15 @@ impl AccessibilityNode {
                 if !child_node.dirty_state.self_or_descendant_has_damage() {
                     continue;
                 }
-                let child_damage =
-                    child_node.update_subtree(strong_child_node, dom_damage_map, tree, update);
-                if !child_damage.is_empty() {
+                let child_damage = child_node.update_subtree(
+                    strong_child_node,
+                    dom_damage_map,
+                    tree,
+                    update,
+                    bounds_query,
+                    bounds,
+                );
+                if child_damage.intersects(LocalAccessibilityDamage::AFFECTS_ANCESTORS) {
                     local_damage.insert(LocalAccessibilityDamage::SubtreeChanged);
                 }
             }
@@ -680,19 +735,38 @@ impl AccessibilityNode {
         dom_damage: AccessibilityDamage,
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate,
-    ) -> LocalAccessibilityDamage {
+        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
+        inherited_bounds: Option<accesskit::Rect>,
+    ) -> (LocalAccessibilityDamage, Option<accesskit::Rect>) {
         update.counters.nodes_updated_from_dom += 1;
 
         let mut local_damage = LocalAccessibilityDamage::empty();
 
         local_damage.insert(self.update_properties_from_dom_node(dom_node, dom_damage));
+
+        // Bounds are refreshed unconditionally whenever a query is available, independent of
+        // `dom_damage`, since geometry can change without other accessibility-relevant damage.
+        let mut bounds = inherited_bounds;
+        if let Some(bounds_query) = bounds_query {
+            let (bounds_damage, new_bounds) =
+                self.update_bounds_from_dom_node(dom_node, bounds_query, inherited_bounds);
+            local_damage.insert(bounds_damage);
+            bounds = new_bounds;
+        }
+
         local_damage.insert(
             self.update_children_and_populate_new_descendants_from_dom_node(
-                ref_self, dom_node, dom_damage, tree, update,
+                ref_self,
+                dom_node,
+                dom_damage,
+                tree,
+                update,
+                bounds_query,
+                bounds,
             ),
         );
 
-        local_damage
+        (local_damage, bounds)
     }
 
     /// Update this node's [`Self::children`] from its corresponding DOM node. If any children are
@@ -704,6 +778,8 @@ impl AccessibilityNode {
         dom_damage: AccessibilityDamage,
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate,
+        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
+        bounds: Option<accesskit::Rect>,
     ) -> LocalAccessibilityDamage {
         if !dom_damage.contains(AccessibilityDamage::Children) {
             return LocalAccessibilityDamage::empty();
@@ -754,13 +830,16 @@ impl AccessibilityNode {
             child.parent_node = Some(weak_self.clone());
 
             if update.is_new(&child_id) {
-                let child_damage = child.update_node_and_populate_new_descendants_from_dom_node(
-                    child_ref.clone(),
-                    &dom_child,
-                    AccessibilityDamage::Rebuild,
-                    tree,
-                    update,
-                );
+                let (child_damage, _) = child
+                    .update_node_and_populate_new_descendants_from_dom_node(
+                        child_ref.clone(),
+                        &dom_child,
+                        AccessibilityDamage::Rebuild,
+                        tree,
+                        update,
+                        bounds_query,
+                        bounds,
+                    );
                 child.update_node_local(child_damage, update);
                 update.add(&mut child);
             } else {
@@ -798,6 +877,35 @@ impl AccessibilityNode {
         }
 
         local_damage
+    }
+
+    /// Update this node's bounds from layout, given a query function and the bounds inherited from
+    /// an ancestor (used as a fallback for nodes without their own box). Returns the damage caused by
+    /// the update, and the bounds descendants without their own box should inherit.
+    fn update_bounds_from_dom_node(
+        &mut self,
+        dom_node: &ServoLayoutNode<'_>,
+        bounds_query: AccessibilityBoundsQuery<'_>,
+        inherited_bounds: Option<accesskit::Rect>,
+    ) -> (LocalAccessibilityDamage, Option<accesskit::Rect>) {
+        let own_bounds = bounds_query(dom_node);
+
+        let inheritable_bounds = match dom_node.rendering_type() {
+            NodeRenderingType::Rendered => own_bounds,
+            NodeRenderingType::DelegatesRendering => own_bounds.or(inherited_bounds), // display: contents
+            NodeRenderingType::NotRendered => None,
+        };
+
+        let bounds = match dom_node.type_id() {
+            Some(LayoutNodeType::Text) => own_bounds.or(inherited_bounds), // Fallback for text fragments
+            _ => own_bounds,
+        };
+
+        let damage = match bounds {
+            Some(bounds) => self.set_bounds(bounds),
+            None => self.clear_bounds(), // display: none case
+        };
+        (damage, inheritable_bounds)
     }
 
     /// Update this node's properties based on changes already made to the accessibility tree.
@@ -941,6 +1049,28 @@ impl AccessibilityNode {
         LocalAccessibilityDamage::TextChanged
     }
 
+    fn bounds(&self) -> Option<accesskit::Rect> {
+        self.accesskit_node.bounds()
+    }
+
+    fn set_bounds(&mut self, bounds: accesskit::Rect) -> LocalAccessibilityDamage {
+        if Some(bounds) == self.accesskit_node.bounds() {
+            return LocalAccessibilityDamage::empty();
+        }
+        self.accesskit_node.set_bounds(bounds);
+        self.dirty_state |= DirtyState::Updated;
+        LocalAccessibilityDamage::BoundsChanged
+    }
+
+    fn clear_bounds(&mut self) -> LocalAccessibilityDamage {
+        if self.accesskit_node.bounds().is_none() {
+            return LocalAccessibilityDamage::empty();
+        }
+        self.accesskit_node.clear_bounds();
+        self.dirty_state |= DirtyState::Updated;
+        LocalAccessibilityDamage::BoundsChanged
+    }
+
     fn assert_integrity(&self, expected_parent: Option<WeakRefCell<AccessibilityNode>>) {
         debug_assert!(pref!(expensive_accessibility_test_assertions_enabled));
 
@@ -979,6 +1109,9 @@ impl Debug for AccessibilityNode {
         }
         if let Some(label) = self.label() {
             write!(f, "\nlabel: {label:?}")?;
+        }
+        if let Some(bounds) = self.bounds() {
+            write!(f, "\nbounds: {bounds:?}")?;
         }
         if !self.child_ids().is_empty() {
             write!(f, "\nchildren: {:?}", self.child_ids())?;

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -47,13 +47,6 @@ bitflags! {
     }
 }
 
-impl LocalAccessibilityDamage {
-    /// Damage that requires ancestor recomputation. Bounds excluded: computed independently per node.
-    const AFFECTS_ANCESTORS: Self = Self::SubtreeChanged
-        .union(Self::RoleChanged)
-        .union(Self::TextChanged);
-}
-
 /// Computes the bounds for a DOM node's accessibility node, or `None` if it has no geometry.
 /// Bounds must be in CSS pixels, relative to viewport origin (see [`accesskit`] composition model).
 pub(super) type AccessibilityBoundsQuery<'a> =
@@ -219,7 +212,15 @@ impl AccessibilityTree {
 
         self.ensure_root_node(root_dom_node, &mut damage_from_dom, &mut update);
 
-        self.apply_changes_from_dom_tree(damage_from_dom, bounds_query, &mut update);
+        self.apply_changes_from_dom_tree(damage_from_dom, &mut update);
+
+        // Bounds aren't tracked as `AccessibilityDamage` from the DOM: they can go stale from
+        // things that don't involve any DOM change at all, such as scrolling, resizing, or
+        // zooming. So refresh them for the whole tree here, independent of `damage_from_dom`,
+        // whenever a `bounds_query` is available.
+        if let Some(bounds_query) = bounds_query {
+            self.refresh_bounds(root_dom_node, bounds_query, &mut update);
+        }
 
         update.finalize(self)
     }
@@ -246,7 +247,6 @@ impl AccessibilityTree {
     fn apply_changes_from_dom_tree<'dom>(
         &mut self,
         damage_from_dom: VecDeque<(ServoLayoutNode<'dom>, AccessibilityDamage)>,
-        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
         update: &mut AccessibilityUpdate,
     ) {
         let mut dom_damage_map = FxHashMap::from(
@@ -262,22 +262,31 @@ impl AccessibilityTree {
         let Some(damage_root) = damage_root else {
             return;
         };
-        // The walk below may not start at the true tree root, so seed the inherited bounds from
-        // the nearest ancestor with already-known bounds (from a previous update).
-        let inherited_bounds = damage_root
-            .borrow()
-            .ancestors()
-            .find_map(|ancestor| ancestor.borrow().bounds());
         let local_damage = damage_root.borrow_mut().update_subtree(
             damage_root.clone(),
             &mut dom_damage_map,
             self,
             update,
-            bounds_query,
-            inherited_bounds,
         );
 
         damage_root.borrow().update_ancestors(local_damage, update);
+    }
+
+    /// Recompute bounds for every node in the tree from current layout geometry, independent of
+    /// [`AccessibilityDamage`] from the DOM. Nodes whose bounds actually changed are added to
+    /// `update`. See [`AccessibilityNode::refresh_bounds_for_subtree()`].
+    fn refresh_bounds<'dom>(
+        &self,
+        root_dom_node: &ServoLayoutNode<'dom>,
+        bounds_query: AccessibilityBoundsQuery<'_>,
+        update: &mut AccessibilityUpdate,
+    ) {
+        let Some(root_id) = self.existing_id_for_opaque(root_dom_node.opaque()) else {
+            return;
+        };
+        self.assert_node_for_id(&root_id)
+            .borrow_mut()
+            .refresh_bounds_for_subtree(root_dom_node, bounds_query, self, update, None);
     }
 
     /// Given an iterator of `NodeId`s corresponding to nodes which have received some damage from
@@ -648,26 +657,17 @@ impl AccessibilityNode {
         dom_damage_map: &mut FxHashMap<NodeId, (ServoLayoutNode<'dom>, AccessibilityDamage)>,
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate,
-        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
-        inherited_bounds: Option<accesskit::Rect>,
     ) -> LocalAccessibilityDamage {
         let mut local_damage = LocalAccessibilityDamage::empty();
-        // Bounds to propagate to any dirty children below, if this node doesn't have its own.
-        let mut bounds = inherited_bounds;
 
         if let Some((dom_node, dom_damage)) = dom_damage_map.get(&self.id) {
-            let (node_damage, new_bounds) = self
-                .update_node_and_populate_new_descendants_from_dom_node(
-                    ref_self,
-                    dom_node,
-                    *dom_damage,
-                    tree,
-                    update,
-                    bounds_query,
-                    inherited_bounds,
-                );
-            local_damage.insert(node_damage);
-            bounds = new_bounds;
+            local_damage.insert(self.update_node_and_populate_new_descendants_from_dom_node(
+                ref_self,
+                dom_node,
+                *dom_damage,
+                tree,
+                update,
+            ));
 
             self.dirty_state -= DirtyState::HasDamage;
         }
@@ -679,15 +679,9 @@ impl AccessibilityNode {
                 if !child_node.dirty_state.self_or_descendant_has_damage() {
                     continue;
                 }
-                let child_damage = child_node.update_subtree(
-                    strong_child_node,
-                    dom_damage_map,
-                    tree,
-                    update,
-                    bounds_query,
-                    bounds,
-                );
-                if child_damage.intersects(LocalAccessibilityDamage::AFFECTS_ANCESTORS) {
+                let child_damage =
+                    child_node.update_subtree(strong_child_node, dom_damage_map, tree, update);
+                if !child_damage.is_empty() {
                     local_damage.insert(LocalAccessibilityDamage::SubtreeChanged);
                 }
             }
@@ -735,38 +729,19 @@ impl AccessibilityNode {
         dom_damage: AccessibilityDamage,
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate,
-        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
-        inherited_bounds: Option<accesskit::Rect>,
-    ) -> (LocalAccessibilityDamage, Option<accesskit::Rect>) {
+    ) -> LocalAccessibilityDamage {
         update.counters.nodes_updated_from_dom += 1;
 
         let mut local_damage = LocalAccessibilityDamage::empty();
 
         local_damage.insert(self.update_properties_from_dom_node(dom_node, dom_damage));
-
-        // Bounds are refreshed unconditionally whenever a query is available, independent of
-        // `dom_damage`, since geometry can change without other accessibility-relevant damage.
-        let mut bounds = inherited_bounds;
-        if let Some(bounds_query) = bounds_query {
-            let (bounds_damage, new_bounds) =
-                self.update_bounds_from_dom_node(dom_node, bounds_query, inherited_bounds);
-            local_damage.insert(bounds_damage);
-            bounds = new_bounds;
-        }
-
         local_damage.insert(
             self.update_children_and_populate_new_descendants_from_dom_node(
-                ref_self,
-                dom_node,
-                dom_damage,
-                tree,
-                update,
-                bounds_query,
-                bounds,
+                ref_self, dom_node, dom_damage, tree, update,
             ),
         );
 
-        (local_damage, bounds)
+        local_damage
     }
 
     /// Update this node's [`Self::children`] from its corresponding DOM node. If any children are
@@ -778,8 +753,6 @@ impl AccessibilityNode {
         dom_damage: AccessibilityDamage,
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate,
-        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
-        bounds: Option<accesskit::Rect>,
     ) -> LocalAccessibilityDamage {
         if !dom_damage.contains(AccessibilityDamage::Children) {
             return LocalAccessibilityDamage::empty();
@@ -830,16 +803,13 @@ impl AccessibilityNode {
             child.parent_node = Some(weak_self.clone());
 
             if update.is_new(&child_id) {
-                let (child_damage, _) = child
-                    .update_node_and_populate_new_descendants_from_dom_node(
-                        child_ref.clone(),
-                        &dom_child,
-                        AccessibilityDamage::Rebuild,
-                        tree,
-                        update,
-                        bounds_query,
-                        bounds,
-                    );
+                let child_damage = child.update_node_and_populate_new_descendants_from_dom_node(
+                    child_ref.clone(),
+                    &dom_child,
+                    AccessibilityDamage::Rebuild,
+                    tree,
+                    update,
+                );
                 child.update_node_local(child_damage, update);
                 update.add(&mut child);
             } else {
@@ -906,6 +876,32 @@ impl AccessibilityNode {
             None => self.clear_bounds(), // display: none case
         };
         (damage, inheritable_bounds)
+    }
+
+    /// Recompute this node's bounds and its descendants', from current layout geometry.
+    fn refresh_bounds_for_subtree<'dom>(
+        &mut self,
+        dom_node: &ServoLayoutNode<'dom>,
+        bounds_query: AccessibilityBoundsQuery<'_>,
+        tree: &AccessibilityTree,
+        update: &mut AccessibilityUpdate,
+        inherited_bounds: Option<accesskit::Rect>,
+    ) {
+        let (_, bounds) =
+            self.update_bounds_from_dom_node(dom_node, bounds_query, inherited_bounds);
+
+        if self.dirty_state.updated() {
+            update.add(self);
+        }
+
+        for dom_child in dom_node.flat_tree_children() {
+            let Some(child_id) = tree.existing_id_for_opaque(dom_child.opaque()) else {
+                continue;
+            };
+            tree.assert_node_for_id(&child_id)
+                .borrow_mut()
+                .refresh_bounds_for_subtree(&dom_child, bounds_query, tree, update, bounds);
+        }
     }
 
     /// Update this node's properties based on changes already made to the accessibility tree.

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -214,13 +214,7 @@ impl AccessibilityTree {
 
         self.apply_changes_from_dom_tree(damage_from_dom, &mut update);
 
-        // Bounds aren't tracked as `AccessibilityDamage` from the DOM: they can go stale from
-        // things that don't involve any DOM change at all, such as scrolling, resizing, or
-        // zooming. So refresh them for the whole tree here, independent of `damage_from_dom`,
-        // whenever a `bounds_query` is available.
-        if let Some(bounds_query) = bounds_query {
-            self.refresh_bounds(root_dom_node, bounds_query, &mut update);
-        }
+        self.refresh_bounds(root_dom_node, bounds_query, &mut update);
 
         update.finalize(self)
     }
@@ -285,15 +279,26 @@ impl AccessibilityTree {
     fn refresh_bounds<'dom>(
         &self,
         root_dom_node: &ServoLayoutNode<'dom>,
-        bounds_query: AccessibilityBoundsQuery<'_>,
+        bounds_query: Option<AccessibilityBoundsQuery<'_>>,
         update: &mut AccessibilityUpdate,
     ) {
-        let Some(root_node) = self.root_node else {
+        // Bounds aren't tracked as `AccessibilityDamage` from the DOM: they can go stale from
+        // things that don't involve any DOM change at all, SUCH AS: scrolling, resizing, or
+        // zooming. So they are refreshed for the whole tree here, independent of the damage from
+        // the DOM, whenever layout is able to give us a query to compute them with.
+        let Some(bounds_query) = bounds_query else {
             return;
         };
-        root_node
-            .borrow_mut()
-            .refresh_bounds_for_subtree(root_dom_node, bounds_query, self, update, None);
+        let Some(root_node) = self.root_node.clone() else {
+            return;
+        };
+        root_node.borrow_mut().refresh_bounds_for_subtree(
+            root_dom_node,
+            bounds_query,
+            self,
+            update,
+            None,
+        );
     }
 
     /// Given an iterator of `NodeId`s corresponding to nodes which have received some damage from
@@ -771,8 +776,8 @@ impl AccessibilityNode {
 
         // Iterate over existing children and DOM children while they match. No action is necessary
         // for these nodes.
-        while let Some(&old_id) = old_child_ids.peek() &&
-            let Some(dom_child) = remaining_dom_children.peek()
+        while let Some(&old_id) = old_child_ids.peek()
+            && let Some(dom_child) = remaining_dom_children.peek()
         {
             if tree.existing_id_for_opaque(dom_child.opaque()) == Some(*old_id) {
                 unchanged_count += 1;
@@ -876,8 +881,16 @@ impl AccessibilityNode {
             NodeRenderingType::NotRendered => None,
         };
 
+        // A text node never has bounds of its own: `LayoutBox::Text` has no `LayoutBoxBase`, and
+        // `Fragment::Text` has no box area, so the query always returns `None` for one. Screen
+        // readers still need geometry for a text run, in order to highlight or magnify it, so fall
+        // back to the bounds of the nearest ancestor which has them.
+        //
+        // TODO(accessibility): These bounds are those of the whole containing box, which is too
+        // large whenever it holds more than this one text run. They should instead be the union of
+        // the rectangles of this node's own `Fragment::Text` fragments.
         let bounds = match dom_node.type_id() {
-            Some(LayoutNodeType::Text) => own_bounds.or(inherited_bounds), // Fallback for text fragments
+            Some(LayoutNodeType::Text) => own_bounds.or(inherited_bounds),
             _ => own_bounds,
         };
 
@@ -926,8 +939,8 @@ impl AccessibilityNode {
         update.counters.nodes_updated_from_tree += 1;
 
         let mut new_damage = LocalAccessibilityDamage::empty();
-        if local_damage.contains(LocalAccessibilityDamage::SubtreeChanged) ||
-            local_damage.contains(LocalAccessibilityDamage::RoleChanged)
+        if local_damage.contains(LocalAccessibilityDamage::SubtreeChanged)
+            || local_damage.contains(LocalAccessibilityDamage::RoleChanged)
         {
             if let Some(text) = self.label_from_descendants() {
                 new_damage.insert(self.set_label(text.as_str()));

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -83,6 +83,7 @@ struct AccessibilityUpdate {
 pub struct UpdateCounters {
     pub nodes_updated_from_dom: u32,
     pub nodes_updated_from_tree: u32,
+    pub nodes_updated_bounds: u32,
     pub nodes_in_tree_update: u32,
 }
 
@@ -904,6 +905,7 @@ impl AccessibilityNode {
         tree: &AccessibilityTree,
         update: &mut AccessibilityUpdate,
     ) {
+        update.counters.nodes_updated_bounds += 1;
         self.update_bounds_from_dom_node(dom_node, context);
 
         if self.dirty_state.updated() {

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -281,10 +281,10 @@ impl AccessibilityTree {
         bounds_query: AccessibilityBoundsQuery<'_>,
         update: &mut AccessibilityUpdate,
     ) {
-        let Some(root_id) = self.existing_id_for_opaque(root_dom_node.opaque()) else {
+        let Some(root_node) = self.root_node else {
             return;
         };
-        self.assert_node_for_id(&root_id)
+        root_node
             .borrow_mut()
             .refresh_bounds_for_subtree(root_dom_node, bounds_query, self, update, None);
     }

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -272,12 +272,9 @@ impl AccessibilityTree {
     /// [`AccessibilityDamage`] from the DOM. Nodes whose bounds actually changed are added to
     /// `update`. See [`AccessibilityNode::refresh_bounds_for_subtree()`].
     ///
-    /// TODO(accessibility): We might not always need to start from the document root. For instance,
-    /// if layout performed an incremental reflow of a specific subtree, we could potentially
-    /// limit the bounds refresh to that subtree and any elements positioned after it in flow order
-    /// (which may have shifted). However, since viewport-relative coordinates are used, any ancestor
-    /// movement/scroll/zoom shifts all descendants, and layout does not currently provide
-    /// fine-grained bounds damage notifications.
+    /// TODO(accessibility): We might not always need to start from the document root. However,
+    /// since viewport-relative coordinates are used, any ancestor movement/scroll/zoom shifts all
+    /// descendants, and layout does not currently provide fine-grained bounds damage notifications.
     fn refresh_bounds<'dom>(
         &self,
         root_dom_node: &ServoLayoutNode<'dom>,

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -46,8 +46,7 @@ bitflags! {
 }
 
 /// Everything the accessibility tree needs from layout in order to compute node bounds during an
-/// update. Bounds can only be computed when the stacking context tree is up-to-date with the
-/// current fragment tree, so this may be unavailable for some updates.
+/// update.
 pub(super) struct AccessibilityContext<'a> {
     pub(super) layout_thread: &'a LayoutThread,
     pub(super) stacking_context_tree: &'a StackingContextTree,
@@ -207,7 +206,7 @@ impl AccessibilityTree {
         &mut self,
         root_dom_node: &ServoLayoutNode<'dom>,
         mut damage_from_dom: VecDeque<(ServoLayoutNode<'dom>, AccessibilityDamage)>,
-        context: Option<AccessibilityContext<'_>>,
+        context: AccessibilityContext<'_>,
         rooted_nodes: Option<FxHashSet<OpaqueNode>>,
     ) -> (Option<accesskit::TreeUpdate>, UpdateCounters) {
         let mut update = AccessibilityUpdate::new(rooted_nodes);
@@ -279,16 +278,12 @@ impl AccessibilityTree {
     fn refresh_bounds<'dom>(
         &self,
         root_dom_node: &ServoLayoutNode<'dom>,
-        context: Option<AccessibilityContext<'_>>,
+        context: AccessibilityContext<'_>,
         update: &mut AccessibilityUpdate,
     ) {
         // Bounds aren't tracked as `AccessibilityDamage` from the DOM: they can go stale from
-        // things that don't involve any DOM change at all, SUCH AS: scrolling, resizing, or
-        // zooming. So they are refreshed for the whole tree here, independent of the damage from
-        // the DOM, whenever layout is able to give us the context to compute them with.
-        let Some(context) = context else {
-            return;
-        };
+        // scrolling, resizing, or zooming without any DOM change. Refresh them for the whole tree
+        // independently of damage from the DOM.
         let Some(root_node) = self.root_node.clone() else {
             return;
         };

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -42,8 +42,6 @@ bitflags! {
         const RoleChanged = 0b0010;
         /// This node's computed label or text value (for a text node) changed.
         const TextChanged = 0b0100;
-        /// This node's computed bounds changed.
-        const BoundsChanged = 0b1000;
     }
 }
 
@@ -861,13 +859,12 @@ impl AccessibilityNode {
         local_damage
     }
 
-    /// Update this node's bounds from the current layout geometry. Returns the damage caused by
-    /// the update.
+    /// Update this node's bounds from the current layout geometry.
     fn update_bounds_from_dom_node(
         &mut self,
         dom_node: &ServoLayoutNode<'_>,
         context: &AccessibilityContext<'_>,
-    ) -> LocalAccessibilityDamage {
+    ) {
         // Border box with transforms, matching getBoundingClientRect(). Bounds are in CSS pixels,
         // relative to the viewport origin (see the [`accesskit`] composition model).
         let bounds = process_box_area_request(
@@ -1067,22 +1064,20 @@ impl AccessibilityNode {
         self.accesskit_node.bounds()
     }
 
-    fn set_bounds(&mut self, bounds: accesskit::Rect) -> LocalAccessibilityDamage {
+    fn set_bounds(&mut self, bounds: accesskit::Rect) {
         if Some(bounds) == self.accesskit_node.bounds() {
-            return LocalAccessibilityDamage::empty();
+            return;
         }
         self.accesskit_node.set_bounds(bounds);
         self.dirty_state |= DirtyState::Updated;
-        LocalAccessibilityDamage::BoundsChanged
     }
 
-    fn clear_bounds(&mut self) -> LocalAccessibilityDamage {
+    fn clear_bounds(&mut self) {
         if self.accesskit_node.bounds().is_none() {
-            return LocalAccessibilityDamage::empty();
+            return;
         }
         self.accesskit_node.clear_bounds();
         self.dirty_state |= DirtyState::Updated;
-        LocalAccessibilityDamage::BoundsChanged
     }
 
     fn assert_integrity(&self, expected_parent: Option<WeakRefCell<AccessibilityNode>>) {

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -1315,6 +1315,7 @@ static HTML_ELEMENT_ROLE_MAPPINGS: LazyLock<FxHashMap<LocalName, Role>> = LazyLo
         (local_name!("article"), Role::Article),
         (local_name!("aside"), Role::Complementary),
         (local_name!("body"), Role::RootWebArea),
+        (local_name!("button"), Role::Button),
         (local_name!("footer"), Role::ContentInfo),
         (local_name!("h1"), Role::Heading),
         (local_name!("h2"), Role::Heading),

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -275,6 +275,13 @@ impl AccessibilityTree {
     /// Recompute bounds for every node in the tree from current layout geometry, independent of
     /// [`AccessibilityDamage`] from the DOM. Nodes whose bounds actually changed are added to
     /// `update`. See [`AccessibilityNode::refresh_bounds_for_subtree()`].
+    ///
+    /// TODO(accessibility): We might not always need to start from the document root. For instance,
+    /// if layout performed an incremental reflow of a specific subtree, we could potentially
+    /// limit the bounds refresh to that subtree and any elements positioned after it in flow order
+    /// (which may have shifted). However, since viewport-relative coordinates are used, any ancestor
+    /// movement/scroll/zoom shifts all descendants, and layout does not currently provide
+    /// fine-grained bounds damage notifications.
     fn refresh_bounds<'dom>(
         &self,
         root_dom_node: &ServoLayoutNode<'dom>,
@@ -860,6 +867,9 @@ impl AccessibilityNode {
     ) -> (LocalAccessibilityDamage, Option<accesskit::Rect>) {
         let own_bounds = bounds_query(dom_node);
 
+        // TODO(accessibility): Other engines (Blink, WebKit, Gecko) compute bounds for `display: contents`
+        // elements (and other box-less elements) by taking the union of the bounding boxes of their rendered
+        // descendants, rather than inheriting ancestor bounds or leaving them empty.
         let inheritable_bounds = match dom_node.rendering_type() {
             NodeRenderingType::Rendered => own_bounds,
             NodeRenderingType::DelegatesRendering => own_bounds.or(inherited_bounds), // display: contents

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -1315,7 +1315,6 @@ static HTML_ELEMENT_ROLE_MAPPINGS: LazyLock<FxHashMap<LocalName, Role>> = LazyLo
         (local_name!("article"), Role::Article),
         (local_name!("aside"), Role::Complementary),
         (local_name!("body"), Role::RootWebArea),
-        (local_name!("button"), Role::Button),
         (local_name!("footer"), Role::ContentInfo),
         (local_name!("h1"), Role::Heading),
         (local_name!("h2"), Role::Heading),

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -11,9 +11,7 @@ use accesskit::{NodeId, Role};
 use app_units::Au;
 use bitflags::bitflags;
 use euclid::Rect;
-use layout_api::{
-    AccessibilityDamage, BoxAreaType, LayoutElement, LayoutNode, LayoutNodeType, NodeRenderingType,
-};
+use layout_api::{AccessibilityDamage, BoxAreaType, LayoutElement, LayoutNode, LayoutNodeType};
 use log::trace;
 use rustc_hash::{FxHashMap, FxHashSet};
 use script::layout_dom::{ServoLayoutElement, ServoLayoutNode};
@@ -29,7 +27,6 @@ use web_atoms::{LocalName, local_name, ns};
 use crate::ArcRefCell;
 use crate::cell::WeakRefCell;
 use crate::display_list::StackingContextTree;
-use crate::dom::NodeExt;
 use crate::layout_impl::LayoutThread;
 use crate::query::process_box_area_request;
 
@@ -298,13 +295,9 @@ impl AccessibilityTree {
         let Some(root_node) = self.root_node.clone() else {
             return;
         };
-        root_node.borrow_mut().refresh_bounds_for_subtree(
-            root_dom_node,
-            &context,
-            self,
-            update,
-            None,
-        );
+        root_node
+            .borrow_mut()
+            .refresh_bounds_for_subtree(root_dom_node, &context, self, update);
     }
 
     /// Given an iterator of `NodeId`s corresponding to nodes which have received some damage from
@@ -867,19 +860,16 @@ impl AccessibilityNode {
         local_damage
     }
 
-    /// Update this node's bounds from layout, given the context necessary to compute them and the
-    /// bounds inherited from an ancestor (used as a fallback for nodes without their own box).
-    /// Returns the damage caused by the update, and the bounds descendants without their own box
-    /// should inherit.
+    /// Update this node's bounds from the current layout geometry. Returns the damage caused by
+    /// the update.
     fn update_bounds_from_dom_node(
         &mut self,
         dom_node: &ServoLayoutNode<'_>,
         context: &AccessibilityContext<'_>,
-        inherited_bounds: Option<accesskit::Rect>,
-    ) -> (LocalAccessibilityDamage, Option<accesskit::Rect>) {
+    ) -> LocalAccessibilityDamage {
         // Border box with transforms, matching getBoundingClientRect(). Bounds are in CSS pixels,
         // relative to the viewport origin (see the [`accesskit`] composition model).
-        let own_bounds = process_box_area_request(
+        let bounds = process_box_area_request(
             context.layout_thread,
             context.stacking_context_tree,
             *dom_node,
@@ -888,33 +878,22 @@ impl AccessibilityNode {
         )
         .map(au_rect_to_accesskit_rect);
 
-        // TODO(accessibility): Other engines (Blink, WebKit, Gecko) compute bounds for `display: contents`
-        // elements (and other box-less elements) by taking the union of the bounding boxes of their rendered
-        // descendants, rather than inheriting ancestor bounds or leaving them empty.
-        let inheritable_bounds = match dom_node.rendering_type() {
-            NodeRenderingType::Rendered => own_bounds,
-            NodeRenderingType::DelegatesRendering => own_bounds.or(inherited_bounds), // display: contents
-            NodeRenderingType::NotRendered => None,
-        };
-
-        // A text node never has bounds of its own: `LayoutBox::Text` has no `LayoutBoxBase`, and
-        // `Fragment::Text` has no box area, so the query always returns `None` for one. Screen
-        // readers still need geometry for a text run, in order to highlight or magnify it, so fall
-        // back to the bounds of the nearest ancestor which has them.
+        // For now only nodes with a box of their own get bounds; anything else, including
+        // `display: none` content, gets its bounds cleared. That leaves two kinds of nodes
+        // without geometry which assistive technology would like to have some:
         //
-        // TODO(accessibility): These bounds are those of the whole containing box, which is too
-        // large whenever it holds more than this one text run. They should instead be the union of
-        // the rectangles of this node's own `Fragment::Text` fragments.
-        let bounds = match dom_node.type_id() {
-            Some(LayoutNodeType::Text) => own_bounds.or(inherited_bounds),
-            _ => own_bounds,
-        };
-
-        let damage = match bounds {
+        // TODO(accessibility): A text node never has bounds of its own: `LayoutBox::Text` has no
+        // `LayoutBoxBase`, and `Fragment::Text` has no box area, so the query above always returns
+        // `None` for one. Text nodes should get the union of the rectangles of their own
+        // `Fragment::Text` fragments, once `cumulative_box_area_rect()` can handle those.
+        //
+        // TODO(accessibility): A `display: contents` element generates no box either. Other
+        // engines (Blink, WebKit, Gecko) compute its bounds as the union of the bounding boxes of
+        // its rendered descendants.
+        match bounds {
             Some(bounds) => self.set_bounds(bounds),
-            None => self.clear_bounds(), // display: none case
-        };
-        (damage, inheritable_bounds)
+            None => self.clear_bounds(),
+        }
     }
 
     /// Recompute this node's bounds and its descendants', from current layout geometry.
@@ -924,9 +903,8 @@ impl AccessibilityNode {
         context: &AccessibilityContext<'_>,
         tree: &AccessibilityTree,
         update: &mut AccessibilityUpdate,
-        inherited_bounds: Option<accesskit::Rect>,
     ) {
-        let (_, bounds) = self.update_bounds_from_dom_node(dom_node, context, inherited_bounds);
+        self.update_bounds_from_dom_node(dom_node, context);
 
         if self.dirty_state.updated() {
             update.add(self);
@@ -938,7 +916,7 @@ impl AccessibilityNode {
             };
             tree.assert_node_for_id(&child_id)
                 .borrow_mut()
-                .refresh_bounds_for_subtree(&dom_child, context, tree, update, bounds);
+                .refresh_bounds_for_subtree(&dom_child, context, tree, update);
         }
     }
 

--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -75,11 +75,15 @@ impl InnerDOMLayoutData {
     }
 
     fn fragments(&self) -> Vec<Fragment> {
-        self.self_box
-            .borrow()
-            .as_ref()
-            .and_then(|layout_box| layout_box.with_base(|base| base.fragments().clone()))
+        self.with_fragments(<[Fragment]>::to_vec)
             .unwrap_or_default()
+    }
+
+    /// Run callback on fragments without cloning. None if node has no box.
+    fn with_fragments<T>(&self, callback: impl FnOnce(&[Fragment]) -> T) -> Option<T> {
+        let self_box = self.self_box.borrow();
+        let layout_box = self_box.as_ref()?;
+        layout_box.with_base(|base| callback(&base.fragments()))
     }
 
     fn repair_style(&self, node: &ServoLayoutNode, context: &SharedStyleContext) {
@@ -360,6 +364,9 @@ pub(crate) trait NodeExt<'dom> {
     fn rendering_type(&self) -> NodeRenderingType;
 
     fn fragments_for_pseudo(&self, pseudo_element: Option<PseudoElement>) -> Vec<Fragment>;
+
+    /// Run callback on fragments without cloning. None if no box. Prefer over fragments_for_pseudo on hot paths.
+    fn with_fragments<T>(&self, callback: impl FnOnce(&[Fragment]) -> T) -> Option<T>;
     fn with_layout_box_base(&self, callback: impl FnMut(&LayoutBoxBase));
     fn with_layout_box_base_including_pseudos(&self, callback: impl FnMut(&LayoutBoxBase));
 
@@ -597,6 +604,10 @@ impl<'dom> NodeExt<'dom> for ServoLayoutNode<'dom> {
                 .unwrap_or_default(),
             None => layout_data.fragments(),
         }
+    }
+
+    fn with_fragments<T>(&self, callback: impl FnOnce(&[Fragment]) -> T) -> Option<T> {
+        self.inner_layout_data()?.with_fragments(callback)
     }
 
     fn repair_style(&self, context: &SharedStyleContext) {

--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -79,7 +79,7 @@ impl InnerDOMLayoutData {
             .unwrap_or_default()
     }
 
-    /// Run callback on fragments without cloning. None if node has no box.
+    /// Run `callback` on the fragments without cloning them. Returns `None` if the node has no box.
     fn with_fragments<T>(&self, callback: impl FnOnce(&[Fragment]) -> T) -> Option<T> {
         let self_box = self.self_box.borrow();
         let layout_box = self_box.as_ref()?;
@@ -365,7 +365,7 @@ pub(crate) trait NodeExt<'dom> {
 
     fn fragments_for_pseudo(&self, pseudo_element: Option<PseudoElement>) -> Vec<Fragment>;
 
-    /// Run callback on fragments without cloning. None if no box. Prefer over fragments_for_pseudo on hot paths.
+    /// Run `callback` on the fragments without cloning them. Returns `None` if the node has no box.
     fn with_fragments<T>(&self, callback: impl FnOnce(&[Fragment]) -> T) -> Option<T>;
     fn with_layout_box_base(&self, callback: impl FnMut(&LayoutBoxBase));
     fn with_layout_box_base_including_pseudos(&self, callback: impl FnMut(&LayoutBoxBase));

--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -75,11 +75,15 @@ impl InnerDOMLayoutData {
     }
 
     fn fragments(&self) -> Vec<Fragment> {
-        self.self_box
-            .borrow()
-            .as_ref()
-            .and_then(|layout_box| layout_box.with_base(|base| base.fragments().clone()))
+        self.with_fragments(<[Fragment]>::to_vec)
             .unwrap_or_default()
+    }
+
+    /// Run callback on fragments without cloning. None if node has no box.
+    fn with_fragments<T>(&self, callback: impl FnOnce(&[Fragment]) -> T) -> Option<T> {
+        let self_box = self.self_box.borrow();
+        let layout_box = self_box.as_ref()?;
+        layout_box.with_base(|base| callback(&base.fragments()))
     }
 
     fn repair_style(&self, node: &ServoLayoutNode, context: &SharedStyleContext) {
@@ -360,6 +364,9 @@ pub(crate) trait NodeExt<'dom> {
     fn rendering_type(&self) -> NodeRenderingType;
 
     fn fragments_for_pseudo(&self, pseudo_element: Option<PseudoElement>) -> Vec<Fragment>;
+
+    /// Run callback on fragments without cloning. None if no box. Prefer over fragments_for_pseudo on hot paths.
+    fn with_fragments<T>(&self, callback: impl FnOnce(&[Fragment]) -> T) -> Option<T>;
     fn with_layout_box_base(&self, callback: impl FnMut(&LayoutBoxBase));
     fn with_layout_box_base_including_pseudos(&self, callback: impl FnMut(&LayoutBoxBase));
 
@@ -598,6 +605,10 @@ impl<'dom> NodeExt<'dom> for ServoLayoutNode<'dom> {
                 .unwrap_or_default(),
             None => layout_data.fragments(),
         }
+    }
+
+    fn with_fragments<T>(&self, callback: impl FnOnce(&[Fragment]) -> T) -> Option<T> {
+        self.inner_layout_data()?.with_fragments(callback)
     }
 
     fn repair_style(&self, context: &SharedStyleContext) {

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -927,15 +927,18 @@ impl LayoutThread {
         reflow_statistics: &mut ReflowStatistics,
         reflow_phases_run: ReflowPhasesRun,
     ) -> bool {
+        if !self.accessibility_active() {
+            return false;
+        }
+
         // Bounds go stale when geometry changes (stacking context tree rebuild or scroll offset),
         // even without any `AccessibilityDamage` from the DOM, so those cases must still reach
         // `update_tree()` below, which refreshes bounds for the whole tree independently of
         // `damage`.
-        let geometry_may_have_changed = self.accessibility_active() &&
-            reflow_phases_run.intersects(
-                ReflowPhasesRun::BuiltStackingContextTree |
-                    ReflowPhasesRun::UpdatedScrollNodeOffset,
-            );
+        let geometry_may_have_changed = reflow_phases_run.intersects(
+            ReflowPhasesRun::BuiltStackingContextTree |
+                ReflowPhasesRun::UpdatedScrollNodeOffset,
+        );
         if !self.needs_accessibility_update() && !geometry_may_have_changed {
             return false;
         }

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -927,8 +927,10 @@ impl LayoutThread {
         reflow_statistics: &mut ReflowStatistics,
         reflow_phases_run: ReflowPhasesRun,
     ) -> bool {
-        // Bounds go stale when geometry changes (stacking context tree rebuild or scroll offset)
-        // FIXME(accessibility): layout queries leave bounds stale; need geometry damage tracking
+        // Bounds go stale when geometry changes (stacking context tree rebuild or scroll offset),
+        // even without any `AccessibilityDamage` from the DOM, so those cases must still reach
+        // `update_tree()` below, which refreshes bounds for the whole tree independently of
+        // `damage`.
         let geometry_may_have_changed = self.accessibility_active() &&
             reflow_phases_run.intersects(
                 ReflowPhasesRun::BuiltStackingContextTree |
@@ -941,16 +943,15 @@ impl LayoutThread {
         let Some(accessibility_tree) = accessibility_tree.as_mut() else {
             return false;
         };
-        let Some(damage) = &reflow_request.accessibility_damage else {
-            return false;
-        };
 
         let accessibility_tree = &mut *accessibility_tree;
         let rooted_nodes =
             std::mem::take(&mut reflow_request.rooted_nodes_for_accessibility_integrity_check);
 
-        let damage: VecDeque<_> = damage
+        let damage: VecDeque<_> = reflow_request
+            .accessibility_damage
             .iter()
+            .flatten()
             .map(|(address, damage)| unsafe { (ServoLayoutNode::new(address), *damage) })
             .collect();
 

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1010,6 +1010,7 @@ impl LayoutThread {
 
         reflow_statistics.nodes_updated_from_dom = counters.nodes_updated_from_dom;
         reflow_statistics.nodes_updated_from_tree = counters.nodes_updated_from_tree;
+        reflow_statistics.nodes_updated_bounds = counters.nodes_updated_bounds;
         reflow_statistics.nodes_in_tree_update = counters.nodes_in_tree_update;
 
         self.needs_accessibility_update.set(false);

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -81,7 +81,7 @@ use url::Url;
 use webrender_api::ExternalScrollId;
 use webrender_api::units::{DevicePixel, LayoutVector2D};
 
-use crate::accessibility_tree::{AccessibilityTree, au_rect_to_accesskit_rect};
+use crate::accessibility_tree::{AccessibilityContext, AccessibilityTree};
 use crate::context::{CachedImageOrError, ImageResolver, LayoutContext};
 use crate::display_list::{DisplayListBuilder, HitTest, PaintTimingHandler, StackingContextTree};
 use crate::dom::NodeExt;
@@ -271,9 +271,9 @@ impl Layout for LayoutThread {
         let device = self.stylist.device_mut();
         let device_pixel_ratio = Scale::new(viewport_details.hidpi_scale_factor.get());
         let device_size = viewport_details.device_size.cast_unit();
-        if device.viewport_size() == viewport_details.size
-            && device.device_pixel_ratio() == device_pixel_ratio
-            && device.device_size() == device_size
+        if device.viewport_size() == viewport_details.size &&
+            device.device_pixel_ratio() == device_pixel_ratio &&
+            device.device_size() == device_size
         {
             return false;
         }
@@ -674,8 +674,8 @@ impl Layout for LayoutThread {
 
     fn ensure_stacking_context_tree(&self, viewport_details: ViewportDetails) {
         with_layout_state(|| {
-            if self.stacking_context_tree.borrow().is_some()
-                && !self.need_new_stacking_context_tree.get()
+            if self.stacking_context_tree.borrow().is_some() &&
+                !self.need_new_stacking_context_tree.get()
             {
                 return;
             }
@@ -887,8 +887,8 @@ impl LayoutThread {
         // If only the stacking context tree is required, and it's up-to-date,
         // layout is unnecessary, otherwise a layout is necessary.
         if necessary_phases == ReflowPhases::StackingContextTreeConstruction {
-            return self.stacking_context_tree.borrow().is_some()
-                && !self.need_new_stacking_context_tree.get();
+            return self.stacking_context_tree.borrow().is_some() &&
+                !self.need_new_stacking_context_tree.get();
         }
 
         // Otherwise, the only interesting thing is whether the current display
@@ -970,35 +970,29 @@ impl LayoutThread {
 
         // Only compute bounds from a stacking context tree matching the current fragment tree.
         //
-        // Reflows for goals which do not need a stacking context tree, such as most
-        // `LayoutQuery`s, still reach this point when the accessibility tree needs an update.
-        // Those reflows may have laid out a new fragment tree without rebuilding the stacking
-        // context tree for it, in which case bounds computed now would come from stale spatial
-        // nodes. Skip them and let the next reflow which rebuilds the tree refresh them.
+        // Reflows for visual updates (`UpdateTheRendering`, and scroll updates, which need an
+        // up-to-date stacking context tree to run at all) guarantee that. Query reflows still
+        // reach this point when the accessibility tree needs an update, but may have laid out a
+        // new fragment tree without rebuilding the stacking context tree for it, in which case
+        // bounds computed now would come from stale spatial nodes. Skip bounds for those and let
+        // the next reflow for a visual update refresh them.
         let stacking_context_tree = self.stacking_context_tree.borrow();
-        let bounds_query = stacking_context_tree
-            .as_ref()
-            .filter(|_| !self.need_new_stacking_context_tree.get())
-            .map(|stacking_context_tree| {
-                move |node: &ServoLayoutNode<'_>| {
-                    // Border box with transforms, matching getBoundingClientRect()
-                    process_box_area_request(
-                        self,
+        let accessibility_context = match reflow_request.reflow_goal {
+            ReflowGoal::UpdateTheRendering | ReflowGoal::UpdateScrollNode(..) => {
+                stacking_context_tree
+                    .as_ref()
+                    .map(|stacking_context_tree| AccessibilityContext {
+                        layout_thread: self,
                         stacking_context_tree,
-                        *node,
-                        BoxAreaType::Border,
-                        false, /* exclude_transform_and_inline */
-                    )
-                    .map(au_rect_to_accesskit_rect)
-                }
-            });
+                    })
+            },
+            ReflowGoal::LayoutQuery(..) => None,
+        };
 
         let (tree_update, counters) = accessibility_tree.update_tree(
             root_element,
             damage,
-            bounds_query
-                .as_ref()
-                .map(|query| query as &dyn Fn(&ServoLayoutNode<'_>) -> Option<accesskit::Rect>),
+            accessibility_context,
             rooted_nodes,
         );
         if let Some(tree_update) = tree_update {
@@ -1046,8 +1040,8 @@ impl LayoutThread {
                 .as_document()
                 .unwrap()
                 .root_element();
-            if let Some(root_element) = root_element
-                && self.handle_accessibility_tree_update(
+            if let Some(root_element) = root_element &&
+                self.handle_accessibility_tree_update(
                     &root_element.as_node(),
                     &mut reflow_request,
                     &mut reflow_statistics,
@@ -1108,9 +1102,9 @@ impl LayoutThread {
             reflow_phases_run.insert(ReflowPhasesRun::UpdatedAccessibilityTree);
         }
 
-        if self.debug.is_enabled(DiagnosticsLoggingOption::FlowTree)
-            && reflow_phases_run.contains(ReflowPhasesRun::RanLayout)
-            && let Some(fragment_tree) = &*self.fragment_tree.borrow()
+        if self.debug.is_enabled(DiagnosticsLoggingOption::FlowTree) &&
+            reflow_phases_run.contains(ReflowPhasesRun::RanLayout) &&
+            let Some(fragment_tree) = &*self.fragment_tree.borrow()
         {
             fragment_tree.print();
         }
@@ -1571,8 +1565,8 @@ impl LayoutThread {
             built_display_list,
         );
 
-        if paint_timing_handler.did_lcp_candidate_update()
-            && let Some(lcp_candidate) = paint_timing_handler.largest_contentful_paint_candidate()
+        if paint_timing_handler.did_lcp_candidate_update() &&
+            let Some(lcp_candidate) = paint_timing_handler.largest_contentful_paint_candidate()
         {
             self.paint_api.send_lcp_candidate(
                 lcp_candidate,
@@ -1959,14 +1953,14 @@ impl ReflowPhases {
         let is_inset_longhand = |longhand: LonghandId| {
             matches!(
                 longhand,
-                LonghandId::Top
-                    | LonghandId::Right
-                    | LonghandId::Bottom
-                    | LonghandId::Left
-                    | LonghandId::InsetInlineStart
-                    | LonghandId::InsetInlineEnd
-                    | LonghandId::InsetBlockStart
-                    | LonghandId::InsetBlockEnd
+                LonghandId::Top |
+                    LonghandId::Right |
+                    LonghandId::Bottom |
+                    LonghandId::Left |
+                    LonghandId::InsetInlineStart |
+                    LonghandId::InsetInlineEnd |
+                    LonghandId::InsetBlockStart |
+                    LonghandId::InsetBlockEnd
             )
         };
 
@@ -1991,22 +1985,22 @@ impl ReflowPhases {
                 QueryMsg::NodesFromPointQuery => {
                     Self::StackingContextTreeConstruction | Self::DisplayListConstruction
                 },
-                QueryMsg::BoxArea
-                | QueryMsg::BoxAreas
-                | QueryMsg::ElementsFromPoint
-                | QueryMsg::FlushForUpdateTheRenderingQuery
-                | QueryMsg::OffsetParentQuery
-                | QueryMsg::ScrollingAreaOrOffsetQuery
-                | QueryMsg::TextIndexQuery => Self::StackingContextTreeConstruction,
-                QueryMsg::ClientRectQuery
-                | QueryMsg::CurrentCSSZoomQuery
-                | QueryMsg::EffectiveOverflow
-                | QueryMsg::ElementInnerOuterTextQuery
-                | QueryMsg::InnerWindowDimensionsQuery
-                | QueryMsg::PaddingQuery
-                | QueryMsg::ResolvedFontStyleQuery
-                | QueryMsg::ScrollParentQuery
-                | QueryMsg::StyleQuery => Self::empty(),
+                QueryMsg::BoxArea |
+                QueryMsg::BoxAreas |
+                QueryMsg::ElementsFromPoint |
+                QueryMsg::FlushForUpdateTheRenderingQuery |
+                QueryMsg::OffsetParentQuery |
+                QueryMsg::ScrollingAreaOrOffsetQuery |
+                QueryMsg::TextIndexQuery => Self::StackingContextTreeConstruction,
+                QueryMsg::ClientRectQuery |
+                QueryMsg::CurrentCSSZoomQuery |
+                QueryMsg::EffectiveOverflow |
+                QueryMsg::ElementInnerOuterTextQuery |
+                QueryMsg::InnerWindowDimensionsQuery |
+                QueryMsg::PaddingQuery |
+                QueryMsg::ResolvedFontStyleQuery |
+                QueryMsg::ScrollParentQuery |
+                QueryMsg::StyleQuery => Self::empty(),
             },
             ReflowGoal::UpdateScrollNode(..) | ReflowGoal::UpdateTheRendering => {
                 Self::StackingContextTreeConstruction | Self::DisplayListConstruction

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -271,9 +271,9 @@ impl Layout for LayoutThread {
         let device = self.stylist.device_mut();
         let device_pixel_ratio = Scale::new(viewport_details.hidpi_scale_factor.get());
         let device_size = viewport_details.device_size.cast_unit();
-        if device.viewport_size() == viewport_details.size &&
-            device.device_pixel_ratio() == device_pixel_ratio &&
-            device.device_size() == device_size
+        if device.viewport_size() == viewport_details.size
+            && device.device_pixel_ratio() == device_pixel_ratio
+            && device.device_size() == device_size
         {
             return false;
         }
@@ -674,8 +674,8 @@ impl Layout for LayoutThread {
 
     fn ensure_stacking_context_tree(&self, viewport_details: ViewportDetails) {
         with_layout_state(|| {
-            if self.stacking_context_tree.borrow().is_some() &&
-                !self.need_new_stacking_context_tree.get()
+            if self.stacking_context_tree.borrow().is_some()
+                && !self.need_new_stacking_context_tree.get()
             {
                 return;
             }
@@ -695,16 +695,27 @@ impl Layout for LayoutThread {
         &mut self,
         scroll_states: &FxHashMap<ExternalScrollId, LayoutVector2D>,
     ) {
-        let mut stacking_context_tree = self.stacking_context_tree.borrow_mut();
-        let Some(stacking_context_tree) = stacking_context_tree.as_mut() else {
-            warn!("Received scroll offsets before finishing layout.");
-            return;
-        };
+        {
+            let mut stacking_context_tree = self.stacking_context_tree.borrow_mut();
+            let Some(stacking_context_tree) = stacking_context_tree.as_mut() else {
+                warn!("Received scroll offsets before finishing layout.");
+                return;
+            };
 
-        stacking_context_tree
-            .paint_info
-            .scroll_tree
-            .set_all_scroll_offsets(scroll_states);
+            stacking_context_tree
+                .paint_info
+                .scroll_tree
+                .set_all_scroll_offsets(scroll_states);
+        }
+
+        // Accessibility node bounds are relative to the viewport origin, so a scroll performed by
+        // the renderer makes every one of them stale without any reflow occuring. Asking
+        // for an accessibility update BOTH schedules a rendering update and STOPS that update's
+        // reflow from being skipped entirely, so that the bounds are recomputed against these new
+        // scroll offsets.
+        if self.accessibility_active() {
+            self.set_needs_accessibility_update();
+        }
     }
 
     fn scroll_offset(&self, id: ExternalScrollId) -> Option<LayoutVector2D> {
@@ -876,8 +887,8 @@ impl LayoutThread {
         // If only the stacking context tree is required, and it's up-to-date,
         // layout is unnecessary, otherwise a layout is necessary.
         if necessary_phases == ReflowPhases::StackingContextTreeConstruction {
-            return self.stacking_context_tree.borrow().is_some() &&
-                !self.need_new_stacking_context_tree.get();
+            return self.stacking_context_tree.borrow().is_some()
+                && !self.need_new_stacking_context_tree.get();
         }
 
         // Otherwise, the only interesting thing is whether the current display
@@ -936,8 +947,7 @@ impl LayoutThread {
         // `update_tree()` below, which refreshes bounds for the whole tree independently of
         // `damage`.
         let geometry_may_have_changed = reflow_phases_run.intersects(
-            ReflowPhasesRun::BuiltStackingContextTree |
-                ReflowPhasesRun::UpdatedScrollNodeOffset,
+            ReflowPhasesRun::BuiltStackingContextTree | ReflowPhasesRun::UpdatedScrollNodeOffset,
         );
         if !self.needs_accessibility_update() && !geometry_may_have_changed {
             return false;
@@ -958,7 +968,13 @@ impl LayoutThread {
             .map(|(address, damage)| unsafe { (ServoLayoutNode::new(address), *damage) })
             .collect();
 
-        // Only compute bounds from a stacking context tree matching current fragment tree
+        // Only compute bounds from a stacking context tree matching the current fragment tree.
+        //
+        // Reflows for goals which do not need a stacking context tree, such as most
+        // `LayoutQuery`s, still reach this point when the accessibility tree needs an update.
+        // Those reflows may have laid out a new fragment tree without rebuilding the stacking
+        // context tree for it, in which case bounds computed now would come from stale spatial
+        // nodes. Skip them and let the next reflow which rebuilds the tree refresh them.
         let stacking_context_tree = self.stacking_context_tree.borrow();
         let bounds_query = stacking_context_tree
             .as_ref()
@@ -1016,12 +1032,36 @@ impl LayoutThread {
 
         if self.can_skip_reflow_request_entirely(&reflow_request) {
             // We can skip layout, but we might need to update a scroll node.
-            return self
-                .handle_update_scroll_node_request(&reflow_request)
-                .then(|| ReflowResult {
-                    reflow_phases_run: ReflowPhasesRun::UpdatedScrollNodeOffset,
-                    ..Default::default()
-                });
+            if !self.handle_update_scroll_node_request(&reflow_request) {
+                return None;
+            }
+
+            let mut reflow_phases_run = ReflowPhasesRun::UpdatedScrollNodeOffset;
+            let mut reflow_statistics = Default::default();
+
+            // Accessibility node bounds are relative to the viewport origin, so scrolling makes
+            // every one of them stale, even though no layout ran and nothing in the DOM changed.
+            let document = unsafe { ServoLayoutNode::new(&reflow_request.document) };
+            let root_element = unsafe { document.dangerous_style_node() }
+                .as_document()
+                .unwrap()
+                .root_element();
+            if let Some(root_element) = root_element
+                && self.handle_accessibility_tree_update(
+                    &root_element.as_node(),
+                    &mut reflow_request,
+                    &mut reflow_statistics,
+                    reflow_phases_run,
+                )
+            {
+                reflow_phases_run.insert(ReflowPhasesRun::UpdatedAccessibilityTree);
+            }
+
+            return Some(ReflowResult {
+                reflow_phases_run,
+                reflow_statistics,
+                ..Default::default()
+            });
         }
 
         let document = unsafe { ServoLayoutNode::new(&reflow_request.document) };
@@ -1068,9 +1108,9 @@ impl LayoutThread {
             reflow_phases_run.insert(ReflowPhasesRun::UpdatedAccessibilityTree);
         }
 
-        if self.debug.is_enabled(DiagnosticsLoggingOption::FlowTree) &&
-            reflow_phases_run.contains(ReflowPhasesRun::RanLayout) &&
-            let Some(fragment_tree) = &*self.fragment_tree.borrow()
+        if self.debug.is_enabled(DiagnosticsLoggingOption::FlowTree)
+            && reflow_phases_run.contains(ReflowPhasesRun::RanLayout)
+            && let Some(fragment_tree) = &*self.fragment_tree.borrow()
         {
             fragment_tree.print();
         }
@@ -1531,8 +1571,8 @@ impl LayoutThread {
             built_display_list,
         );
 
-        if paint_timing_handler.did_lcp_candidate_update() &&
-            let Some(lcp_candidate) = paint_timing_handler.largest_contentful_paint_candidate()
+        if paint_timing_handler.did_lcp_candidate_update()
+            && let Some(lcp_candidate) = paint_timing_handler.largest_contentful_paint_candidate()
         {
             self.paint_api.send_lcp_candidate(
                 lcp_candidate,
@@ -1919,14 +1959,14 @@ impl ReflowPhases {
         let is_inset_longhand = |longhand: LonghandId| {
             matches!(
                 longhand,
-                LonghandId::Top |
-                    LonghandId::Right |
-                    LonghandId::Bottom |
-                    LonghandId::Left |
-                    LonghandId::InsetInlineStart |
-                    LonghandId::InsetInlineEnd |
-                    LonghandId::InsetBlockStart |
-                    LonghandId::InsetBlockEnd
+                LonghandId::Top
+                    | LonghandId::Right
+                    | LonghandId::Bottom
+                    | LonghandId::Left
+                    | LonghandId::InsetInlineStart
+                    | LonghandId::InsetInlineEnd
+                    | LonghandId::InsetBlockStart
+                    | LonghandId::InsetBlockEnd
             )
         };
 
@@ -1951,22 +1991,22 @@ impl ReflowPhases {
                 QueryMsg::NodesFromPointQuery => {
                     Self::StackingContextTreeConstruction | Self::DisplayListConstruction
                 },
-                QueryMsg::BoxArea |
-                QueryMsg::BoxAreas |
-                QueryMsg::ElementsFromPoint |
-                QueryMsg::FlushForUpdateTheRenderingQuery |
-                QueryMsg::OffsetParentQuery |
-                QueryMsg::ScrollingAreaOrOffsetQuery |
-                QueryMsg::TextIndexQuery => Self::StackingContextTreeConstruction,
-                QueryMsg::ClientRectQuery |
-                QueryMsg::CurrentCSSZoomQuery |
-                QueryMsg::EffectiveOverflow |
-                QueryMsg::ElementInnerOuterTextQuery |
-                QueryMsg::InnerWindowDimensionsQuery |
-                QueryMsg::PaddingQuery |
-                QueryMsg::ResolvedFontStyleQuery |
-                QueryMsg::ScrollParentQuery |
-                QueryMsg::StyleQuery => Self::empty(),
+                QueryMsg::BoxArea
+                | QueryMsg::BoxAreas
+                | QueryMsg::ElementsFromPoint
+                | QueryMsg::FlushForUpdateTheRenderingQuery
+                | QueryMsg::OffsetParentQuery
+                | QueryMsg::ScrollingAreaOrOffsetQuery
+                | QueryMsg::TextIndexQuery => Self::StackingContextTreeConstruction,
+                QueryMsg::ClientRectQuery
+                | QueryMsg::CurrentCSSZoomQuery
+                | QueryMsg::EffectiveOverflow
+                | QueryMsg::ElementInnerOuterTextQuery
+                | QueryMsg::InnerWindowDimensionsQuery
+                | QueryMsg::PaddingQuery
+                | QueryMsg::ResolvedFontStyleQuery
+                | QueryMsg::ScrollParentQuery
+                | QueryMsg::StyleQuery => Self::empty(),
             },
             ReflowGoal::UpdateScrollNode(..) | ReflowGoal::UpdateTheRendering => {
                 Self::StackingContextTreeConstruction | Self::DisplayListConstruction

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -81,7 +81,7 @@ use url::Url;
 use webrender_api::ExternalScrollId;
 use webrender_api::units::{DevicePixel, LayoutVector2D};
 
-use crate::accessibility_tree::AccessibilityTree;
+use crate::accessibility_tree::{AccessibilityTree, au_rect_to_accesskit_rect};
 use crate::context::{CachedImageOrError, ImageResolver, LayoutContext};
 use crate::display_list::{DisplayListBuilder, HitTest, PaintTimingHandler, StackingContextTree};
 use crate::dom::NodeExt;
@@ -946,8 +946,33 @@ impl LayoutThread {
             .map(|(address, damage)| unsafe { (ServoLayoutNode::new(address), *damage) })
             .collect();
 
-        let (tree_update, counters) =
-            accessibility_tree.update_tree(root_element, damage, rooted_nodes);
+        // Only compute bounds from a stacking context tree matching current fragment tree
+        let stacking_context_tree = self.stacking_context_tree.borrow();
+        let bounds_query = stacking_context_tree
+            .as_ref()
+            .filter(|_| !self.need_new_stacking_context_tree.get())
+            .map(|stacking_context_tree| {
+                move |node: &ServoLayoutNode<'_>| {
+                    // Border box with transforms, matching getBoundingClientRect()
+                    process_box_area_request(
+                        self,
+                        stacking_context_tree,
+                        *node,
+                        BoxAreaType::Border,
+                        false, /* exclude_transform_and_inline */
+                    )
+                    .map(au_rect_to_accesskit_rect)
+                }
+            });
+
+        let (tree_update, counters) = accessibility_tree.update_tree(
+            root_element,
+            damage,
+            bounds_query
+                .as_ref()
+                .map(|query| query as &dyn Fn(&ServoLayoutNode<'_>) -> Option<accesskit::Rect>),
+            rooted_nodes,
+        );
         if let Some(tree_update) = tree_update {
             // FIXME: Handle send error. Could have a method on accessibility tree to
             // finalise after sending, removing accessibility damage? On fail, retain damage

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -925,8 +925,16 @@ impl LayoutThread {
         root_element: &ServoLayoutNode,
         reflow_request: &mut ReflowRequest,
         reflow_statistics: &mut ReflowStatistics,
+        reflow_phases_run: ReflowPhasesRun,
     ) -> bool {
-        if !self.needs_accessibility_update() {
+        // Bounds go stale when geometry changes (stacking context tree rebuild or scroll offset)
+        // FIXME(accessibility): layout queries leave bounds stale; need geometry damage tracking
+        let geometry_may_have_changed = self.accessibility_active() &&
+            reflow_phases_run.intersects(
+                ReflowPhasesRun::BuiltStackingContextTree |
+                    ReflowPhasesRun::UpdatedScrollNodeOffset,
+            );
+        if !self.needs_accessibility_update() && !geometry_may_have_changed {
             return false;
         }
         let mut accessibility_tree = self.accessibility_tree.borrow_mut();
@@ -1051,6 +1059,7 @@ impl LayoutThread {
             &root_element.as_node(),
             &mut reflow_request,
             &mut reflow_statistics,
+            reflow_phases_run,
         ) {
             reflow_phases_run.insert(ReflowPhasesRun::UpdatedAccessibilityTree);
         }

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -933,7 +933,9 @@ impl LayoutThread {
         reflow_statistics: &mut ReflowStatistics,
         reflow_phases_run: ReflowPhasesRun,
     ) -> bool {
-        if reflow_request.reflow_goal != ReflowGoal::UpdateTheRendering {
+        if reflow_request.reflow_goal != ReflowGoal::UpdateTheRendering ||
+            !self.accessibility_active()
+        {
             return false;
         }
 
@@ -941,10 +943,9 @@ impl LayoutThread {
         // even without any `AccessibilityDamage` from the DOM, so those cases must still reach
         // `update_tree()` below, which refreshes bounds for the whole tree independently of
         // `damage`.
-        let geometry_may_have_changed = self.accessibility_active() &&
-            reflow_phases_run.intersects(
-                ReflowPhasesRun::BuiltStackingContextTree |
-                    ReflowPhasesRun::UpdatedScrollNodeOffset,
+        let geometry_may_have_changed = reflow_phases_run.intersects(
+            ReflowPhasesRun::BuiltStackingContextTree |
+                ReflowPhasesRun::UpdatedScrollNodeOffset,
         );
         if !self.needs_accessibility_update() && !geometry_may_have_changed {
             return false;

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -955,6 +955,16 @@ impl LayoutThread {
         };
 
         let accessibility_tree = &mut *accessibility_tree;
+
+        // Check for the stacking context tree before draining any state out of `reflow_request`, so
+        // that we don't discard accessibility damage if it is missing. In practice it is always
+        // present here, since we only reach this method for an `UpdateTheRendering` reflow.
+        let stacking_context_tree = self.stacking_context_tree.borrow();
+        let Some(stacking_context_tree) = stacking_context_tree.as_ref() else {
+            return false;
+        };
+        debug_assert!(!self.need_new_stacking_context_tree.get());
+
         let rooted_nodes =
             std::mem::take(&mut reflow_request.rooted_nodes_for_accessibility_integrity_check);
 
@@ -965,11 +975,6 @@ impl LayoutThread {
             .map(|(address, damage)| unsafe { (ServoLayoutNode::new(address), *damage) })
             .collect();
 
-        let stacking_context_tree = self.stacking_context_tree.borrow();
-        let Some(stacking_context_tree) = stacking_context_tree.as_ref() else {
-            return false;
-        };
-        debug_assert!(!self.need_new_stacking_context_tree.get());
         let accessibility_context = AccessibilityContext {
             layout_thread: self,
             stacking_context_tree,

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -931,10 +931,20 @@ impl LayoutThread {
         root_element: &ServoLayoutNode,
         reflow_request: &mut ReflowRequest,
         reflow_statistics: &mut ReflowStatistics,
+        reflow_phases_run: ReflowPhasesRun,
     ) -> bool {
-        if reflow_request.reflow_goal != ReflowGoal::UpdateTheRendering ||
-            !self.needs_accessibility_update()
-        {
+        if reflow_request.reflow_goal != ReflowGoal::UpdateTheRendering {
+            return false;
+        }
+
+        // Bounds go stale when geometry changes (stacking context tree rebuild or scroll offset)
+        // FIXME(accessibility): layout queries leave bounds stale; need geometry damage tracking
+        let geometry_may_have_changed = self.accessibility_active() &&
+            reflow_phases_run.intersects(
+                ReflowPhasesRun::BuiltStackingContextTree |
+                    ReflowPhasesRun::UpdatedScrollNodeOffset,
+        );
+        if !self.needs_accessibility_update() && !geometry_may_have_changed {
             return false;
         }
         let mut accessibility_tree = self.accessibility_tree.borrow_mut();
@@ -1059,6 +1069,7 @@ impl LayoutThread {
             &root_element.as_node(),
             &mut reflow_request,
             &mut reflow_statistics,
+            reflow_phases_run,
         ) {
             reflow_phases_run.insert(ReflowPhasesRun::UpdatedAccessibilityTree);
         }

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -947,17 +947,8 @@ impl LayoutThread {
             return false;
         }
 
-        // Bounds go stale when geometry changes, even without any `AccessibilityDamage` from the
-        // DOM, so those cases must still reach `update_tree()` below, which refreshes bounds for
-        // the whole tree independently of `damage`. Scrolls request an accessibility update, so
-        // they are covered by `needs_accessibility_update()`; every other geometry change is
-        // committed by an "update the rendering" reflow, which roughly corresponds to a visual
-        // update.
-        let is_rendering_update =
-            matches!(reflow_request.reflow_goal, ReflowGoal::UpdateTheRendering);
-        if !self.needs_accessibility_update() && !is_rendering_update {
-            return false;
-        }
+        // Bounds can become stale without any `AccessibilityDamage` from the DOM. Every geometry
+        // change is committed by an "update the rendering" reflow, so refresh bounds on each one.
         let mut accessibility_tree = self.accessibility_tree.borrow_mut();
         let Some(accessibility_tree) = accessibility_tree.as_mut() else {
             return false;
@@ -974,18 +965,15 @@ impl LayoutThread {
             .map(|(address, damage)| unsafe { (ServoLayoutNode::new(address), *damage) })
             .collect();
 
-        // Skip bounds while `need_new_stacking_context_tree` is set: the tree predates the
-        // current fragment tree, so bounds resolved against it would be stale. Keyed off that
-        // flag rather than `reflow_goal` because damage drains on every reflow regardless of
-        // goal, and query reflows reaching this point have already rebuilt the tree.
         let stacking_context_tree = self.stacking_context_tree.borrow();
-        let accessibility_context = stacking_context_tree
-            .as_ref()
-            .filter(|_| !self.need_new_stacking_context_tree.get())
-            .map(|stacking_context_tree| AccessibilityContext {
-                layout_thread: self,
-                stacking_context_tree,
-            });
+        let Some(stacking_context_tree) = stacking_context_tree.as_ref() else {
+            return false;
+        };
+        debug_assert!(!self.need_new_stacking_context_tree.get());
+        let accessibility_context = AccessibilityContext {
+            layout_thread: self,
+            stacking_context_tree,
+        };
 
         let (tree_update, counters) = accessibility_tree.update_tree(
             root_element,

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -697,18 +697,16 @@ impl Layout for LayoutThread {
         &mut self,
         scroll_states: &FxHashMap<ExternalScrollId, LayoutVector2D>,
     ) {
-        {
-            let mut stacking_context_tree = self.stacking_context_tree.borrow_mut();
-            let Some(stacking_context_tree) = stacking_context_tree.as_mut() else {
-                warn!("Received scroll offsets before finishing layout.");
-                return;
-            };
+        let mut stacking_context_tree = self.stacking_context_tree.borrow_mut();
+        let Some(stacking_context_tree) = stacking_context_tree.as_mut() else {
+            warn!("Received scroll offsets before finishing layout.");
+            return;
+        };
 
-            stacking_context_tree
-                .paint_info
-                .scroll_tree
-                .set_all_scroll_offsets(scroll_states);
-        }
+        stacking_context_tree
+            .paint_info
+            .scroll_tree
+            .set_all_scroll_offsets(scroll_states);
 
         // Accessibility node bounds are relative to the viewport origin, so a scroll performed by
         // the renderer makes every one of them stale without any reflow occuring. Asking

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -708,11 +708,11 @@ impl Layout for LayoutThread {
             .scroll_tree
             .set_all_scroll_offsets(scroll_states);
 
-        // Accessibility node bounds are relative to the viewport origin, so a scroll performed by
-        // the renderer makes every one of them stale without any reflow occuring. Asking
-        // for an accessibility update BOTH schedules a rendering update and STOPS that update's
-        // reflow from being skipped entirely, so that the bounds are recomputed against these new
-        // scroll offsets. See #47161 for a transform-based alternative to recomputing every node.
+        // Accessibility node bounds are relative to the viewport origin, so a renderer scroll
+        // makes every one of them stale without any reflow occurring. Requesting an accessibility
+        // update schedules a rendering update and prevents that update's reflow from being skipped,
+        // allowing the bounds to be recomputed against the new scroll offsets. See #47161 for a
+        // transform-based alternative to recomputing every node.
         if self.accessibility_active() {
             self.set_needs_accessibility_update();
         }

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -976,26 +976,18 @@ impl LayoutThread {
             .map(|(address, damage)| unsafe { (ServoLayoutNode::new(address), *damage) })
             .collect();
 
-        // Only compute bounds from a stacking context tree matching the current fragment tree.
-        //
-        // Reflows for visual updates (`UpdateTheRendering`, and scroll updates, which need an
-        // up-to-date stacking context tree to run at all) guarantee that. Query reflows still
-        // reach this point when the accessibility tree needs an update, but may have laid out a
-        // new fragment tree without rebuilding the stacking context tree for it, in which case
-        // bounds computed now would come from stale spatial nodes. Skip bounds for those and let
-        // the next reflow for a visual update refresh them.
+        // Skip bounds while `need_new_stacking_context_tree` is set: the tree predates the
+        // current fragment tree, so bounds resolved against it would be stale. Keyed off that
+        // flag rather than `reflow_goal` because damage drains on every reflow regardless of
+        // goal, and query reflows reaching this point have already rebuilt the tree.
         let stacking_context_tree = self.stacking_context_tree.borrow();
-        let accessibility_context = match reflow_request.reflow_goal {
-            ReflowGoal::UpdateTheRendering | ReflowGoal::UpdateScrollNode(..) => {
-                stacking_context_tree
-                    .as_ref()
-                    .map(|stacking_context_tree| AccessibilityContext {
-                        layout_thread: self,
-                        stacking_context_tree,
-                    })
-            },
-            ReflowGoal::LayoutQuery(..) => None,
-        };
+        let accessibility_context = stacking_context_tree
+            .as_ref()
+            .filter(|_| !self.need_new_stacking_context_tree.get())
+            .map(|stacking_context_tree| AccessibilityContext {
+                layout_thread: self,
+                stacking_context_tree,
+            });
 
         let (tree_update, counters) = accessibility_tree.update_tree(
             root_element,

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1018,6 +1018,7 @@ impl LayoutThread {
 
         reflow_statistics.nodes_updated_from_dom = counters.nodes_updated_from_dom;
         reflow_statistics.nodes_updated_from_tree = counters.nodes_updated_from_tree;
+        reflow_statistics.nodes_updated_bounds = counters.nodes_updated_bounds;
         reflow_statistics.nodes_in_tree_update = counters.nodes_in_tree_update;
 
         self.needs_accessibility_update.set(false);

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -82,7 +82,7 @@ use url::Url;
 use webrender_api::ExternalScrollId;
 use webrender_api::units::{DevicePixel, LayoutVector2D};
 
-use crate::accessibility_tree::AccessibilityTree;
+use crate::accessibility_tree::{AccessibilityTree, au_rect_to_accesskit_rect};
 use crate::context::{CachedImageOrError, ImageResolver, LayoutContext};
 use crate::display_list::{DisplayListBuilder, HitTest, PaintTimingHandler, StackingContextTree};
 use crate::dom::NodeExt;
@@ -954,8 +954,33 @@ impl LayoutThread {
             .map(|(address, damage)| unsafe { (ServoLayoutNode::new(address), *damage) })
             .collect();
 
-        let (tree_update, counters) =
-            accessibility_tree.update_tree(root_element, damage, rooted_nodes);
+        // Only compute bounds from a stacking context tree matching current fragment tree
+        let stacking_context_tree = self.stacking_context_tree.borrow();
+        let bounds_query = stacking_context_tree
+            .as_ref()
+            .filter(|_| !self.need_new_stacking_context_tree.get())
+            .map(|stacking_context_tree| {
+                move |node: &ServoLayoutNode<'_>| {
+                    // Border box with transforms, matching getBoundingClientRect()
+                    process_box_area_request(
+                        self,
+                        stacking_context_tree,
+                        *node,
+                        BoxAreaType::Border,
+                        false, /* exclude_transform_and_inline */
+                    )
+                    .map(au_rect_to_accesskit_rect)
+                }
+            });
+
+        let (tree_update, counters) = accessibility_tree.update_tree(
+            root_element,
+            damage,
+            bounds_query
+                .as_ref()
+                .map(|query| query as &dyn Fn(&ServoLayoutNode<'_>) -> Option<accesskit::Rect>),
+            rooted_nodes,
+        );
         if let Some(tree_update) = tree_update {
             // FIXME: Handle send error. Could have a method on accessibility tree to
             // finalise after sending, removing accessibility damage? On fail, retain damage

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -272,9 +272,9 @@ impl Layout for LayoutThread {
         let device = self.stylist.device_mut();
         let device_pixel_ratio = Scale::new(viewport_details.hidpi_scale_factor.get());
         let device_size = viewport_details.device_size.cast_unit();
-        if device.viewport_size() == viewport_details.size &&
-            device.device_pixel_ratio() == device_pixel_ratio &&
-            device.device_size() == device_size
+        if device.viewport_size() == viewport_details.size
+            && device.device_pixel_ratio() == device_pixel_ratio
+            && device.device_size() == device_size
         {
             return false;
         }
@@ -676,8 +676,8 @@ impl Layout for LayoutThread {
 
     fn ensure_stacking_context_tree(&self, viewport_details: ViewportDetails) {
         with_layout_state(|| {
-            if self.stacking_context_tree.borrow().is_some() &&
-                !self.need_new_stacking_context_tree.get()
+            if self.stacking_context_tree.borrow().is_some()
+                && !self.need_new_stacking_context_tree.get()
             {
                 return;
             }
@@ -697,16 +697,27 @@ impl Layout for LayoutThread {
         &mut self,
         scroll_states: &FxHashMap<ExternalScrollId, LayoutVector2D>,
     ) {
-        let mut stacking_context_tree = self.stacking_context_tree.borrow_mut();
-        let Some(stacking_context_tree) = stacking_context_tree.as_mut() else {
-            warn!("Received scroll offsets before finishing layout.");
-            return;
-        };
+        {
+            let mut stacking_context_tree = self.stacking_context_tree.borrow_mut();
+            let Some(stacking_context_tree) = stacking_context_tree.as_mut() else {
+                warn!("Received scroll offsets before finishing layout.");
+                return;
+            };
 
-        stacking_context_tree
-            .paint_info
-            .scroll_tree
-            .set_all_scroll_offsets(scroll_states);
+            stacking_context_tree
+                .paint_info
+                .scroll_tree
+                .set_all_scroll_offsets(scroll_states);
+        }
+
+        // Accessibility node bounds are relative to the viewport origin, so a scroll performed by
+        // the renderer makes every one of them stale without any reflow occuring. Asking
+        // for an accessibility update BOTH schedules a rendering update and STOPS that update's
+        // reflow from being skipped entirely, so that the bounds are recomputed against these new
+        // scroll offsets.
+        if self.accessibility_active() {
+            self.set_needs_accessibility_update();
+        }
     }
 
     fn scroll_offset(&self, id: ExternalScrollId) -> Option<LayoutVector2D> {
@@ -882,8 +893,8 @@ impl LayoutThread {
         // If only the stacking context tree is required, and it's up-to-date,
         // layout is unnecessary, otherwise a layout is necessary.
         if necessary_phases == ReflowPhases::StackingContextTreeConstruction {
-            return self.stacking_context_tree.borrow().is_some() &&
-                !self.need_new_stacking_context_tree.get();
+            return self.stacking_context_tree.borrow().is_some()
+                && !self.need_new_stacking_context_tree.get();
         }
 
         // Otherwise, the only interesting thing is whether the current display
@@ -944,8 +955,7 @@ impl LayoutThread {
         // `update_tree()` below, which refreshes bounds for the whole tree independently of
         // `damage`.
         let geometry_may_have_changed = reflow_phases_run.intersects(
-            ReflowPhasesRun::BuiltStackingContextTree |
-                ReflowPhasesRun::UpdatedScrollNodeOffset,
+            ReflowPhasesRun::BuiltStackingContextTree | ReflowPhasesRun::UpdatedScrollNodeOffset,
         );
         if !self.needs_accessibility_update() && !geometry_may_have_changed {
             return false;
@@ -966,7 +976,13 @@ impl LayoutThread {
             .map(|(address, damage)| unsafe { (ServoLayoutNode::new(address), *damage) })
             .collect();
 
-        // Only compute bounds from a stacking context tree matching current fragment tree
+        // Only compute bounds from a stacking context tree matching the current fragment tree.
+        //
+        // Reflows for goals which do not need a stacking context tree, such as most
+        // `LayoutQuery`s, still reach this point when the accessibility tree needs an update.
+        // Those reflows may have laid out a new fragment tree without rebuilding the stacking
+        // context tree for it, in which case bounds computed now would come from stale spatial
+        // nodes. Skip them and let the next reflow which rebuilds the tree refresh them.
         let stacking_context_tree = self.stacking_context_tree.borrow();
         let bounds_query = stacking_context_tree
             .as_ref()
@@ -1024,12 +1040,36 @@ impl LayoutThread {
 
         if self.can_skip_reflow_request_entirely(&reflow_request) {
             // We can skip layout, but we might need to update a scroll node.
-            return self
-                .handle_update_scroll_node_request(&reflow_request)
-                .then(|| ReflowResult {
-                    reflow_phases_run: ReflowPhasesRun::UpdatedScrollNodeOffset,
-                    ..Default::default()
-                });
+            if !self.handle_update_scroll_node_request(&reflow_request) {
+                return None;
+            }
+
+            let mut reflow_phases_run = ReflowPhasesRun::UpdatedScrollNodeOffset;
+            let mut reflow_statistics = Default::default();
+
+            // Accessibility node bounds are relative to the viewport origin, so scrolling makes
+            // every one of them stale, even though no layout ran and nothing in the DOM changed.
+            let document = unsafe { ServoLayoutNode::new(&reflow_request.document) };
+            let root_element = unsafe { document.dangerous_style_node() }
+                .as_document()
+                .unwrap()
+                .root_element();
+            if let Some(root_element) = root_element
+                && self.handle_accessibility_tree_update(
+                    &root_element.as_node(),
+                    &mut reflow_request,
+                    &mut reflow_statistics,
+                    reflow_phases_run,
+                )
+            {
+                reflow_phases_run.insert(ReflowPhasesRun::UpdatedAccessibilityTree);
+            }
+
+            return Some(ReflowResult {
+                reflow_phases_run,
+                reflow_statistics,
+                ..Default::default()
+            });
         }
 
         let document = unsafe { ServoLayoutNode::new(&reflow_request.document) };
@@ -1076,9 +1116,9 @@ impl LayoutThread {
             reflow_phases_run.insert(ReflowPhasesRun::UpdatedAccessibilityTree);
         }
 
-        if self.debug.is_enabled(DiagnosticsLoggingOption::FlowTree) &&
-            reflow_phases_run.contains(ReflowPhasesRun::RanLayout) &&
-            let Some(fragment_tree) = &*self.fragment_tree.borrow()
+        if self.debug.is_enabled(DiagnosticsLoggingOption::FlowTree)
+            && reflow_phases_run.contains(ReflowPhasesRun::RanLayout)
+            && let Some(fragment_tree) = &*self.fragment_tree.borrow()
         {
             fragment_tree.print();
         }
@@ -1539,8 +1579,8 @@ impl LayoutThread {
             built_display_list,
         );
 
-        if paint_timing_handler.did_lcp_candidate_update() &&
-            let Some(lcp_candidate) = paint_timing_handler.largest_contentful_paint_candidate()
+        if paint_timing_handler.did_lcp_candidate_update()
+            && let Some(lcp_candidate) = paint_timing_handler.largest_contentful_paint_candidate()
         {
             self.paint_api.send_lcp_candidate(
                 lcp_candidate,
@@ -1927,14 +1967,14 @@ impl ReflowPhases {
         let is_inset_longhand = |longhand: LonghandId| {
             matches!(
                 longhand,
-                LonghandId::Top |
-                    LonghandId::Right |
-                    LonghandId::Bottom |
-                    LonghandId::Left |
-                    LonghandId::InsetInlineStart |
-                    LonghandId::InsetInlineEnd |
-                    LonghandId::InsetBlockStart |
-                    LonghandId::InsetBlockEnd
+                LonghandId::Top
+                    | LonghandId::Right
+                    | LonghandId::Bottom
+                    | LonghandId::Left
+                    | LonghandId::InsetInlineStart
+                    | LonghandId::InsetInlineEnd
+                    | LonghandId::InsetBlockStart
+                    | LonghandId::InsetBlockEnd
             )
         };
 
@@ -1959,22 +1999,22 @@ impl ReflowPhases {
                 QueryMsg::NodesFromPointQuery => {
                     Self::StackingContextTreeConstruction | Self::DisplayListConstruction
                 },
-                QueryMsg::BoxArea |
-                QueryMsg::BoxAreas |
-                QueryMsg::ElementsFromPoint |
-                QueryMsg::FlushForUpdateTheRenderingQuery |
-                QueryMsg::OffsetParentQuery |
-                QueryMsg::ScrollingAreaOrOffsetQuery |
-                QueryMsg::TextIndexQuery => Self::StackingContextTreeConstruction,
-                QueryMsg::ClientRectQuery |
-                QueryMsg::CurrentCSSZoomQuery |
-                QueryMsg::EffectiveOverflow |
-                QueryMsg::ElementInnerOuterTextQuery |
-                QueryMsg::InnerWindowDimensionsQuery |
-                QueryMsg::PaddingQuery |
-                QueryMsg::ResolvedFontStyleQuery |
-                QueryMsg::ScrollParentQuery |
-                QueryMsg::StyleQuery => Self::empty(),
+                QueryMsg::BoxArea
+                | QueryMsg::BoxAreas
+                | QueryMsg::ElementsFromPoint
+                | QueryMsg::FlushForUpdateTheRenderingQuery
+                | QueryMsg::OffsetParentQuery
+                | QueryMsg::ScrollingAreaOrOffsetQuery
+                | QueryMsg::TextIndexQuery => Self::StackingContextTreeConstruction,
+                QueryMsg::ClientRectQuery
+                | QueryMsg::CurrentCSSZoomQuery
+                | QueryMsg::EffectiveOverflow
+                | QueryMsg::ElementInnerOuterTextQuery
+                | QueryMsg::InnerWindowDimensionsQuery
+                | QueryMsg::PaddingQuery
+                | QueryMsg::ResolvedFontStyleQuery
+                | QueryMsg::ScrollParentQuery
+                | QueryMsg::StyleQuery => Self::empty(),
             },
             ReflowGoal::UpdateScrollNode(..) | ReflowGoal::UpdateTheRendering => {
                 Self::StackingContextTreeConstruction | Self::DisplayListConstruction

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -937,8 +937,10 @@ impl LayoutThread {
             return false;
         }
 
-        // Bounds go stale when geometry changes (stacking context tree rebuild or scroll offset)
-        // FIXME(accessibility): layout queries leave bounds stale; need geometry damage tracking
+        // Bounds go stale when geometry changes (stacking context tree rebuild or scroll offset),
+        // even without any `AccessibilityDamage` from the DOM, so those cases must still reach
+        // `update_tree()` below, which refreshes bounds for the whole tree independently of
+        // `damage`.
         let geometry_may_have_changed = self.accessibility_active() &&
             reflow_phases_run.intersects(
                 ReflowPhasesRun::BuiltStackingContextTree |
@@ -951,16 +953,15 @@ impl LayoutThread {
         let Some(accessibility_tree) = accessibility_tree.as_mut() else {
             return false;
         };
-        let Some(damage) = &reflow_request.accessibility_damage else {
-            return false;
-        };
 
         let accessibility_tree = &mut *accessibility_tree;
         let rooted_nodes =
             std::mem::take(&mut reflow_request.rooted_nodes_for_accessibility_integrity_check);
 
-        let damage: VecDeque<_> = damage
+        let damage: VecDeque<_> = reflow_request
+            .accessibility_damage
             .iter()
+            .flatten()
             .map(|(address, damage)| unsafe { (ServoLayoutNode::new(address), *damage) })
             .collect();
 

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -82,7 +82,7 @@ use url::Url;
 use webrender_api::ExternalScrollId;
 use webrender_api::units::{DevicePixel, LayoutVector2D};
 
-use crate::accessibility_tree::{AccessibilityTree, au_rect_to_accesskit_rect};
+use crate::accessibility_tree::{AccessibilityContext, AccessibilityTree};
 use crate::context::{CachedImageOrError, ImageResolver, LayoutContext};
 use crate::display_list::{DisplayListBuilder, HitTest, PaintTimingHandler, StackingContextTree};
 use crate::dom::NodeExt;
@@ -272,9 +272,9 @@ impl Layout for LayoutThread {
         let device = self.stylist.device_mut();
         let device_pixel_ratio = Scale::new(viewport_details.hidpi_scale_factor.get());
         let device_size = viewport_details.device_size.cast_unit();
-        if device.viewport_size() == viewport_details.size
-            && device.device_pixel_ratio() == device_pixel_ratio
-            && device.device_size() == device_size
+        if device.viewport_size() == viewport_details.size &&
+            device.device_pixel_ratio() == device_pixel_ratio &&
+            device.device_size() == device_size
         {
             return false;
         }
@@ -676,8 +676,8 @@ impl Layout for LayoutThread {
 
     fn ensure_stacking_context_tree(&self, viewport_details: ViewportDetails) {
         with_layout_state(|| {
-            if self.stacking_context_tree.borrow().is_some()
-                && !self.need_new_stacking_context_tree.get()
+            if self.stacking_context_tree.borrow().is_some() &&
+                !self.need_new_stacking_context_tree.get()
             {
                 return;
             }
@@ -893,8 +893,8 @@ impl LayoutThread {
         // If only the stacking context tree is required, and it's up-to-date,
         // layout is unnecessary, otherwise a layout is necessary.
         if necessary_phases == ReflowPhases::StackingContextTreeConstruction {
-            return self.stacking_context_tree.borrow().is_some()
-                && !self.need_new_stacking_context_tree.get();
+            return self.stacking_context_tree.borrow().is_some() &&
+                !self.need_new_stacking_context_tree.get();
         }
 
         // Otherwise, the only interesting thing is whether the current display
@@ -978,35 +978,29 @@ impl LayoutThread {
 
         // Only compute bounds from a stacking context tree matching the current fragment tree.
         //
-        // Reflows for goals which do not need a stacking context tree, such as most
-        // `LayoutQuery`s, still reach this point when the accessibility tree needs an update.
-        // Those reflows may have laid out a new fragment tree without rebuilding the stacking
-        // context tree for it, in which case bounds computed now would come from stale spatial
-        // nodes. Skip them and let the next reflow which rebuilds the tree refresh them.
+        // Reflows for visual updates (`UpdateTheRendering`, and scroll updates, which need an
+        // up-to-date stacking context tree to run at all) guarantee that. Query reflows still
+        // reach this point when the accessibility tree needs an update, but may have laid out a
+        // new fragment tree without rebuilding the stacking context tree for it, in which case
+        // bounds computed now would come from stale spatial nodes. Skip bounds for those and let
+        // the next reflow for a visual update refresh them.
         let stacking_context_tree = self.stacking_context_tree.borrow();
-        let bounds_query = stacking_context_tree
-            .as_ref()
-            .filter(|_| !self.need_new_stacking_context_tree.get())
-            .map(|stacking_context_tree| {
-                move |node: &ServoLayoutNode<'_>| {
-                    // Border box with transforms, matching getBoundingClientRect()
-                    process_box_area_request(
-                        self,
+        let accessibility_context = match reflow_request.reflow_goal {
+            ReflowGoal::UpdateTheRendering | ReflowGoal::UpdateScrollNode(..) => {
+                stacking_context_tree
+                    .as_ref()
+                    .map(|stacking_context_tree| AccessibilityContext {
+                        layout_thread: self,
                         stacking_context_tree,
-                        *node,
-                        BoxAreaType::Border,
-                        false, /* exclude_transform_and_inline */
-                    )
-                    .map(au_rect_to_accesskit_rect)
-                }
-            });
+                    })
+            },
+            ReflowGoal::LayoutQuery(..) => None,
+        };
 
         let (tree_update, counters) = accessibility_tree.update_tree(
             root_element,
             damage,
-            bounds_query
-                .as_ref()
-                .map(|query| query as &dyn Fn(&ServoLayoutNode<'_>) -> Option<accesskit::Rect>),
+            accessibility_context,
             rooted_nodes,
         );
         if let Some(tree_update) = tree_update {
@@ -1054,8 +1048,8 @@ impl LayoutThread {
                 .as_document()
                 .unwrap()
                 .root_element();
-            if let Some(root_element) = root_element
-                && self.handle_accessibility_tree_update(
+            if let Some(root_element) = root_element &&
+                self.handle_accessibility_tree_update(
                     &root_element.as_node(),
                     &mut reflow_request,
                     &mut reflow_statistics,
@@ -1116,9 +1110,9 @@ impl LayoutThread {
             reflow_phases_run.insert(ReflowPhasesRun::UpdatedAccessibilityTree);
         }
 
-        if self.debug.is_enabled(DiagnosticsLoggingOption::FlowTree)
-            && reflow_phases_run.contains(ReflowPhasesRun::RanLayout)
-            && let Some(fragment_tree) = &*self.fragment_tree.borrow()
+        if self.debug.is_enabled(DiagnosticsLoggingOption::FlowTree) &&
+            reflow_phases_run.contains(ReflowPhasesRun::RanLayout) &&
+            let Some(fragment_tree) = &*self.fragment_tree.borrow()
         {
             fragment_tree.print();
         }
@@ -1579,8 +1573,8 @@ impl LayoutThread {
             built_display_list,
         );
 
-        if paint_timing_handler.did_lcp_candidate_update()
-            && let Some(lcp_candidate) = paint_timing_handler.largest_contentful_paint_candidate()
+        if paint_timing_handler.did_lcp_candidate_update() &&
+            let Some(lcp_candidate) = paint_timing_handler.largest_contentful_paint_candidate()
         {
             self.paint_api.send_lcp_candidate(
                 lcp_candidate,
@@ -1967,14 +1961,14 @@ impl ReflowPhases {
         let is_inset_longhand = |longhand: LonghandId| {
             matches!(
                 longhand,
-                LonghandId::Top
-                    | LonghandId::Right
-                    | LonghandId::Bottom
-                    | LonghandId::Left
-                    | LonghandId::InsetInlineStart
-                    | LonghandId::InsetInlineEnd
-                    | LonghandId::InsetBlockStart
-                    | LonghandId::InsetBlockEnd
+                LonghandId::Top |
+                    LonghandId::Right |
+                    LonghandId::Bottom |
+                    LonghandId::Left |
+                    LonghandId::InsetInlineStart |
+                    LonghandId::InsetInlineEnd |
+                    LonghandId::InsetBlockStart |
+                    LonghandId::InsetBlockEnd
             )
         };
 
@@ -1999,22 +1993,22 @@ impl ReflowPhases {
                 QueryMsg::NodesFromPointQuery => {
                     Self::StackingContextTreeConstruction | Self::DisplayListConstruction
                 },
-                QueryMsg::BoxArea
-                | QueryMsg::BoxAreas
-                | QueryMsg::ElementsFromPoint
-                | QueryMsg::FlushForUpdateTheRenderingQuery
-                | QueryMsg::OffsetParentQuery
-                | QueryMsg::ScrollingAreaOrOffsetQuery
-                | QueryMsg::TextIndexQuery => Self::StackingContextTreeConstruction,
-                QueryMsg::ClientRectQuery
-                | QueryMsg::CurrentCSSZoomQuery
-                | QueryMsg::EffectiveOverflow
-                | QueryMsg::ElementInnerOuterTextQuery
-                | QueryMsg::InnerWindowDimensionsQuery
-                | QueryMsg::PaddingQuery
-                | QueryMsg::ResolvedFontStyleQuery
-                | QueryMsg::ScrollParentQuery
-                | QueryMsg::StyleQuery => Self::empty(),
+                QueryMsg::BoxArea |
+                QueryMsg::BoxAreas |
+                QueryMsg::ElementsFromPoint |
+                QueryMsg::FlushForUpdateTheRenderingQuery |
+                QueryMsg::OffsetParentQuery |
+                QueryMsg::ScrollingAreaOrOffsetQuery |
+                QueryMsg::TextIndexQuery => Self::StackingContextTreeConstruction,
+                QueryMsg::ClientRectQuery |
+                QueryMsg::CurrentCSSZoomQuery |
+                QueryMsg::EffectiveOverflow |
+                QueryMsg::ElementInnerOuterTextQuery |
+                QueryMsg::InnerWindowDimensionsQuery |
+                QueryMsg::PaddingQuery |
+                QueryMsg::ResolvedFontStyleQuery |
+                QueryMsg::ScrollParentQuery |
+                QueryMsg::StyleQuery => Self::empty(),
             },
             ReflowGoal::UpdateScrollNode(..) | ReflowGoal::UpdateTheRendering => {
                 Self::StackingContextTreeConstruction | Self::DisplayListConstruction

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -940,7 +940,6 @@ impl LayoutThread {
         root_element: &ServoLayoutNode,
         reflow_request: &mut ReflowRequest,
         reflow_statistics: &mut ReflowStatistics,
-        reflow_phases_run: ReflowPhasesRun,
     ) -> bool {
         if reflow_request.reflow_goal != ReflowGoal::UpdateTheRendering ||
             !self.accessibility_active()
@@ -948,14 +947,15 @@ impl LayoutThread {
             return false;
         }
 
-        // Bounds go stale when geometry changes (stacking context tree rebuild or scroll offset),
-        // even without any `AccessibilityDamage` from the DOM, so those cases must still reach
-        // `update_tree()` below, which refreshes bounds for the whole tree independently of
-        // `damage`.
-        let geometry_may_have_changed = reflow_phases_run.intersects(
-            ReflowPhasesRun::BuiltStackingContextTree | ReflowPhasesRun::UpdatedScrollNodeOffset,
-        );
-        if !self.needs_accessibility_update() && !geometry_may_have_changed {
+        // Bounds go stale when geometry changes, even without any `AccessibilityDamage` from the
+        // DOM, so those cases must still reach `update_tree()` below, which refreshes bounds for
+        // the whole tree independently of `damage`. Scrolls request an accessibility update, so
+        // they are covered by `needs_accessibility_update()`; every other geometry change is
+        // committed by an "update the rendering" reflow, which roughly corresponds to a visual
+        // update.
+        let is_rendering_update =
+            matches!(reflow_request.reflow_goal, ReflowGoal::UpdateTheRendering);
+        if !self.needs_accessibility_update() && !is_rendering_update {
             return false;
         }
         let mut accessibility_tree = self.accessibility_tree.borrow_mut();
@@ -1072,7 +1072,6 @@ impl LayoutThread {
             &root_element.as_node(),
             &mut reflow_request,
             &mut reflow_statistics,
-            reflow_phases_run,
         ) {
             reflow_phases_run.insert(ReflowPhasesRun::UpdatedAccessibilityTree);
         }

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1025,36 +1025,12 @@ impl LayoutThread {
 
         if self.can_skip_reflow_request_entirely(&reflow_request) {
             // We can skip layout, but we might need to update a scroll node.
-            if !self.handle_update_scroll_node_request(&reflow_request) {
-                return None;
-            }
-
-            let mut reflow_phases_run = ReflowPhasesRun::UpdatedScrollNodeOffset;
-            let mut reflow_statistics = Default::default();
-
-            // Accessibility node bounds are relative to the viewport origin, so scrolling makes
-            // every one of them stale, even though no layout ran and nothing in the DOM changed.
-            let document = unsafe { ServoLayoutNode::new(&reflow_request.document) };
-            let root_element = unsafe { document.dangerous_style_node() }
-                .as_document()
-                .unwrap()
-                .root_element();
-            if let Some(root_element) = root_element &&
-                self.handle_accessibility_tree_update(
-                    &root_element.as_node(),
-                    &mut reflow_request,
-                    &mut reflow_statistics,
-                    reflow_phases_run,
-                )
-            {
-                reflow_phases_run.insert(ReflowPhasesRun::UpdatedAccessibilityTree);
-            }
-
-            return Some(ReflowResult {
-                reflow_phases_run,
-                reflow_statistics,
-                ..Default::default()
-            });
+            return self
+                .handle_update_scroll_node_request(&reflow_request)
+                .then(|| ReflowResult {
+                    reflow_phases_run: ReflowPhasesRun::UpdatedScrollNodeOffset,
+                    ..Default::default()
+                });
         }
 
         let document = unsafe { ServoLayoutNode::new(&reflow_request.document) };
@@ -1614,6 +1590,14 @@ impl LayoutThread {
                 offset,
                 external_scroll_id,
             );
+
+            // Accessibility node bounds are relative to the viewport origin, so a script scroll
+            // makes every one of them stale even though no layout ran. Requesting an accessibility
+            // update lets the next "update the rendering" reflow recompute them, mirroring how
+            // `set_scroll_offsets_from_renderer()` handles renderer scrolls.
+            if self.accessibility_active() {
+                self.set_needs_accessibility_update();
+            }
             true
         } else {
             false

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -712,7 +712,7 @@ impl Layout for LayoutThread {
         // the renderer makes every one of them stale without any reflow occuring. Asking
         // for an accessibility update BOTH schedules a rendering update and STOPS that update's
         // reflow from being skipped entirely, so that the bounds are recomputed against these new
-        // scroll offsets.
+        // scroll offsets. See #47161 for a transform-based alternative to recomputing every node.
         if self.accessibility_active() {
             self.set_needs_accessibility_update();
         }

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -57,13 +57,11 @@ use crate::layout_impl::LayoutThread;
 use crate::style_ext::ComputedValuesExt;
 use crate::taffy::SpecificTaffyGridInfo;
 
-/// Get a scroll node that would represents this [`ServoLayoutNode`]'s transform and
-/// calculate its cumulative transform from its root scroll node to the scroll node.
-fn root_transform_for_layout_node(
+/// Calculate cumulative transform from root scroll node. Takes fragments (avoids recollecting).
+fn root_transform_for_fragments(
     scroll_tree: &ScrollTree,
-    node: ServoLayoutNode<'_>,
+    fragments: &[Fragment],
 ) -> Option<FastLayoutTransform> {
-    let fragments = node.fragments_for_pseudo(None);
     let box_fragment = fragments
         .first()
         .and_then(Fragment::retrieve_box_fragment)?;
@@ -117,7 +115,7 @@ pub(crate) fn process_box_area_request(
     }
 
     let Some(transform) =
-        root_transform_for_layout_node(&stacking_context_tree.paint_info.scroll_tree, node)
+        root_transform_for_fragments(&stacking_context_tree.paint_info.scroll_tree, &fragments)
     else {
         return Some(Rect::new(rect_union.origin, Size2D::zero()));
     };
@@ -131,20 +129,21 @@ pub(crate) fn process_box_areas_request(
     node: ServoLayoutNode<'_>,
     area: BoxAreaType,
 ) -> CSSPixelRectVec {
-    let fragments = node
-        .fragments_for_pseudo(None)
+    let fragments = node.fragments_for_pseudo(None);
+    let transform =
+        root_transform_for_fragments(&stacking_context_tree.paint_info.scroll_tree, &fragments);
+
+    let rects = fragments
         .into_iter()
         .filter_map(move |fragment| fragment.cumulative_box_area_rect(area, layout_thread.into()));
 
-    let Some(transform) =
-        root_transform_for_layout_node(&stacking_context_tree.paint_info.scroll_tree, node)
-    else {
-        return fragments
+    let Some(transform) = transform else {
+        return rects
             .map(|rect| Rect::new(rect.origin, Size2D::zero()))
             .collect();
     };
 
-    fragments
+    rects
         .filter_map(move |rect| transform_au_rectangle(rect, transform))
         .collect()
 }

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -95,32 +95,35 @@ pub(crate) fn process_box_area_request(
     area: BoxAreaType,
     exclude_transform_and_inline: bool,
 ) -> Option<Rect<Au, CSSPixel>> {
-    let fragments = node.fragments_for_pseudo(None);
-    let mut rects = fragments
-        .iter()
-        .filter(|fragment| {
-            !exclude_transform_and_inline ||
-                fragment
-                    .retrieve_box_fragment()
-                    .is_none_or(|fragment| !fragment.with_style().is_inline_box())
-        })
-        .filter_map(|node| node.cumulative_box_area_rect(area, layout_thread.into()))
-        .peekable();
+    // Borrow fragments to avoid cloning (hot path for accessibility & getBoundingClientRect)
+    node.with_fragments(|fragments| {
+        let mut rects = fragments
+            .iter()
+            .filter(|fragment| {
+                !exclude_transform_and_inline ||
+                    fragment
+                        .retrieve_box_fragment()
+                        .is_none_or(|fragment| !fragment.with_style().is_inline_box())
+            })
+            .filter_map(|node| node.cumulative_box_area_rect(area, layout_thread.into()))
+            .peekable();
 
-    rects.peek()?;
-    let rect_union = rects.fold(Rect::zero(), |unioned_rect, rect| rect.union(&unioned_rect));
+        rects.peek()?;
+        let rect_union = rects.fold(Rect::zero(), |unioned_rect, rect| rect.union(&unioned_rect));
 
-    if exclude_transform_and_inline {
-        return Some(rect_union);
-    }
+        if exclude_transform_and_inline {
+            return Some(rect_union);
+        }
 
-    let Some(transform) =
-        root_transform_for_fragments(&stacking_context_tree.paint_info.scroll_tree, &fragments)
-    else {
-        return Some(Rect::new(rect_union.origin, Size2D::zero()));
-    };
+        let Some(transform) =
+            root_transform_for_fragments(&stacking_context_tree.paint_info.scroll_tree, fragments)
+        else {
+            return Some(Rect::new(rect_union.origin, Size2D::zero()));
+        };
 
-    transform_au_rectangle(rect_union, transform)
+        transform_au_rectangle(rect_union, transform)
+    })
+    .flatten()
 }
 
 pub(crate) fn process_box_areas_request(

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -122,8 +122,7 @@ pub(crate) fn process_box_area_request(
         };
 
         transform_au_rectangle(rect_union, transform)
-    })
-    .flatten()
+    })?
 }
 
 pub(crate) fn process_box_areas_request(

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -60,13 +60,11 @@ use crate::layout_impl::LayoutThread;
 use crate::style_ext::ComputedValuesExt;
 use crate::taffy::SpecificTaffyGridInfo;
 
-/// Get a scroll node that would represents this [`ServoLayoutNode`]'s transform and
-/// calculate its cumulative transform from its root scroll node to the scroll node.
-fn root_transform_for_layout_node(
+/// Calculate cumulative transform from root scroll node. Takes fragments (avoids recollecting).
+fn root_transform_for_fragments(
     scroll_tree: &ScrollTree,
-    node: ServoLayoutNode<'_>,
+    fragments: &[Fragment],
 ) -> Option<FastLayoutTransform> {
-    let fragments = node.fragments_for_pseudo(None);
     let box_fragment = fragments
         .first()
         .and_then(Fragment::retrieve_box_fragment)?;
@@ -120,7 +118,7 @@ pub(crate) fn process_box_area_request(
     }
 
     let Some(transform) =
-        root_transform_for_layout_node(&stacking_context_tree.paint_info.scroll_tree, node)
+        root_transform_for_fragments(&stacking_context_tree.paint_info.scroll_tree, &fragments)
     else {
         return Some(Rect::new(rect_union.origin, Size2D::zero()));
     };
@@ -134,20 +132,21 @@ pub(crate) fn process_box_areas_request(
     node: ServoLayoutNode<'_>,
     area: BoxAreaType,
 ) -> CSSPixelRectVec {
-    let fragments = node
-        .fragments_for_pseudo(None)
+    let fragments = node.fragments_for_pseudo(None);
+    let transform =
+        root_transform_for_fragments(&stacking_context_tree.paint_info.scroll_tree, &fragments);
+
+    let rects = fragments
         .into_iter()
         .filter_map(move |fragment| fragment.cumulative_box_area_rect(area, layout_thread.into()));
 
-    let Some(transform) =
-        root_transform_for_layout_node(&stacking_context_tree.paint_info.scroll_tree, node)
-    else {
-        return fragments
+    let Some(transform) = transform else {
+        return rects
             .map(|rect| Rect::new(rect.origin, Size2D::zero()))
             .collect();
     };
 
-    fragments
+    rects
         .filter_map(move |rect| transform_au_rectangle(rect, transform))
         .collect()
 }

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -98,32 +98,35 @@ pub(crate) fn process_box_area_request(
     area: BoxAreaType,
     exclude_transform_and_inline: bool,
 ) -> Option<Rect<Au, CSSPixel>> {
-    let fragments = node.fragments_for_pseudo(None);
-    let mut rects = fragments
-        .iter()
-        .filter(|fragment| {
-            !exclude_transform_and_inline ||
-                fragment
-                    .retrieve_box_fragment()
-                    .is_none_or(|fragment| !fragment.with_style().is_inline_box())
-        })
-        .filter_map(|node| node.cumulative_box_area_rect(area, layout_thread.into()))
-        .peekable();
+    // Borrow fragments to avoid cloning (hot path for accessibility & getBoundingClientRect)
+    node.with_fragments(|fragments| {
+        let mut rects = fragments
+            .iter()
+            .filter(|fragment| {
+                !exclude_transform_and_inline ||
+                    fragment
+                        .retrieve_box_fragment()
+                        .is_none_or(|fragment| !fragment.with_style().is_inline_box())
+            })
+            .filter_map(|node| node.cumulative_box_area_rect(area, layout_thread.into()))
+            .peekable();
 
-    rects.peek()?;
-    let rect_union = rects.fold(Rect::zero(), |unioned_rect, rect| rect.union(&unioned_rect));
+        rects.peek()?;
+        let rect_union = rects.fold(Rect::zero(), |unioned_rect, rect| rect.union(&unioned_rect));
 
-    if exclude_transform_and_inline {
-        return Some(rect_union);
-    }
+        if exclude_transform_and_inline {
+            return Some(rect_union);
+        }
 
-    let Some(transform) =
-        root_transform_for_fragments(&stacking_context_tree.paint_info.scroll_tree, &fragments)
-    else {
-        return Some(Rect::new(rect_union.origin, Size2D::zero()));
-    };
+        let Some(transform) =
+            root_transform_for_fragments(&stacking_context_tree.paint_info.scroll_tree, fragments)
+        else {
+            return Some(Rect::new(rect_union.origin, Size2D::zero()));
+        };
 
-    transform_au_rectangle(rect_union, transform)
+        transform_au_rectangle(rect_union, transform)
+    })
+    .flatten()
 }
 
 pub(crate) fn process_box_areas_request(

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -60,7 +60,7 @@ use crate::layout_impl::LayoutThread;
 use crate::style_ext::ComputedValuesExt;
 use crate::taffy::SpecificTaffyGridInfo;
 
-/// Calculate cumulative transform from root scroll node. Takes fragments (avoids recollecting).
+/// Calculate the cumulative transform from the root scroll node for `fragments`.
 fn root_transform_for_fragments(
     scroll_tree: &ScrollTree,
     fragments: &[Fragment],
@@ -98,7 +98,8 @@ pub(crate) fn process_box_area_request(
     area: BoxAreaType,
     exclude_transform_and_inline: bool,
 ) -> Option<Rect<Au, CSSPixel>> {
-    // Borrow fragments to avoid cloning (hot path for accessibility & getBoundingClientRect)
+    // Borrow fragments to avoid cloning on this hot path for accessibility and
+    // `getBoundingClientRect()`.
     node.with_fragments(|fragments| {
         let mut rects = fragments
             .iter()

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -125,8 +125,7 @@ pub(crate) fn process_box_area_request(
         };
 
         transform_au_rectangle(rect_union, transform)
-    })
-    .flatten()
+    })?
 }
 
 pub(crate) fn process_box_areas_request(

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -1271,6 +1271,7 @@ impl Painter {
         if !webview_renderer.set_hidpi_scale_factor(new_scale_factor) {
             return;
         }
+        webview_renderer.webview.notify_viewport_updated();
 
         self.send_root_pipeline_display_list();
         self.set_needs_repaint(RepaintReason::Resize);
@@ -1301,6 +1302,7 @@ impl Painter {
         let new_viewport_rect = Rect::from(new_size).to_box2d();
         for webview_renderer in self.webview_renderers.values_mut() {
             webview_renderer.set_rect(new_viewport_rect);
+            webview_renderer.webview.notify_viewport_updated();
         }
 
         let mut transaction = Transaction::new();
@@ -1312,8 +1314,10 @@ impl Painter {
     }
 
     pub(crate) fn set_page_zoom(&mut self, webview_id: WebViewId, new_zoom: f32) {
-        if let Some(webview_renderer) = self.webview_renderers.get_mut(&webview_id) {
-            webview_renderer.set_page_zoom(Scale::new(new_zoom));
+        if let Some(webview_renderer) = self.webview_renderers.get_mut(&webview_id) &&
+            webview_renderer.set_page_zoom(Scale::new(new_zoom))
+        {
+            webview_renderer.webview.notify_viewport_updated();
         }
     }
 

--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -843,6 +843,10 @@ impl WebViewRenderer {
         let pinch_zoom_result = self.set_pinch_zoom(new_pinch_zoom);
         if pinch_zoom_result == PinchZoomResult::DidPinchZoom {
             self.send_pinch_zoom_infos_to_script();
+            // Pinch zoom changes the viewport transform without touching the pipeline, so no reflow
+            // will occur. Notify the embedding layer so it can refresh the accessibility root node,
+            // whose transform scales by the pinch zoom.
+            self.webview.notify_viewport_updated();
         }
 
         (pinch_zoom_result, scroll_result)
@@ -1000,15 +1004,18 @@ impl WebViewRenderer {
         PinchZoomResult::DidPinchZoom
     }
 
+    /// Set the page zoom for this renderer, returning `true` if the value actually changed.
     pub(crate) fn set_page_zoom(
         &mut self,
         new_page_zoom: Scale<f32, CSSPixel, DeviceIndependentPixel>,
-    ) {
+    ) -> bool {
         let new_page_zoom = new_page_zoom.clamp(MIN_PAGE_ZOOM, MAX_PAGE_ZOOM);
         let old_zoom = std::mem::replace(&mut self.page_zoom, new_page_zoom);
-        if old_zoom != self.page_zoom {
-            self.send_window_size_message();
+        if old_zoom == self.page_zoom {
+            return false;
         }
+        self.send_window_size_message();
+        true
     }
 
     /// The scale to use when displaying this [`WebViewRenderer`] in WebRender

--- a/components/script/dom/testing/accessibilityupdateresult.rs
+++ b/components/script/dom/testing/accessibilityupdateresult.rs
@@ -14,6 +14,7 @@ pub(crate) struct AccessibilityUpdateResult {
     reflector_: Reflector,
     nodes_updated_from_dom: u32,
     nodes_updated_from_tree: u32,
+    nodes_updated_bounds: u32,
     nodes_in_tree_update: u32,
 }
 
@@ -21,12 +22,14 @@ impl AccessibilityUpdateResult {
     pub(crate) fn new_inherited(
         nodes_updated_from_dom: u32,
         nodes_updated_from_tree: u32,
+        nodes_updated_bounds: u32,
         nodes_in_tree_update: u32,
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
             nodes_updated_from_dom,
             nodes_updated_from_tree,
+            nodes_updated_bounds,
             nodes_in_tree_update,
         }
     }
@@ -36,12 +39,14 @@ impl AccessibilityUpdateResult {
         global: &GlobalScope,
         nodes_updated_from_dom: u32,
         nodes_updated_from_tree: u32,
+        nodes_updated_bounds: u32,
         nodes_in_tree_update: u32,
     ) -> DomRoot<Self> {
         reflect_dom_object_with_cx(
             Box::new(Self::new_inherited(
                 nodes_updated_from_dom,
                 nodes_updated_from_tree,
+                nodes_updated_bounds,
                 nodes_in_tree_update,
             )),
             global,
@@ -57,6 +62,10 @@ impl AccessibilityUpdateResultMethods<crate::DomTypeHolder> for AccessibilityUpd
 
     fn NodesUpdatedFromTree(&self) -> u32 {
         self.nodes_updated_from_tree
+    }
+
+    fn NodesUpdatedBounds(&self) -> u32 {
+        self.nodes_updated_bounds
     }
 
     fn NodesInTreeUpdate(&self) -> u32 {

--- a/components/script/dom/testing/servotestutils.rs
+++ b/components/script/dom/testing/servotestutils.rs
@@ -97,6 +97,7 @@ impl ServoTestUtilsMethods<crate::DomTypeHolder> for ServoTestUtils {
             global,
             statistics.nodes_updated_from_dom,
             statistics.nodes_updated_from_tree,
+            statistics.nodes_updated_bounds,
             statistics.nodes_in_tree_update,
         )
     }

--- a/components/script_bindings/webidls/ServoTestUtils.webidl
+++ b/components/script_bindings/webidls/ServoTestUtils.webidl
@@ -40,5 +40,6 @@ interface LayoutResult {
 interface AccessibilityUpdateResult {
     readonly attribute unsigned long nodesUpdatedFromDom;
     readonly attribute unsigned long nodesUpdatedFromTree;
+    readonly attribute unsigned long nodesUpdatedBounds;
     readonly attribute unsigned long nodesInTreeUpdate;
 };

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -327,6 +327,7 @@ impl ServoInner {
         }
 
         self.paint.borrow_mut().perform_updates();
+        self.resend_accessibility_root_nodes_for_viewport_changes();
         self.send_new_frame_ready_messages();
         self.handle_delegate_errors();
         self.clean_up_destroyed_webview_handles();
@@ -336,6 +337,27 @@ impl ServoInner {
         }
 
         true
+    }
+
+    /// send, again, the root accessibility node for any [`WebView`] whose viewport geometry changed
+    /// post-last-spin (see [`WebView::note_accessibility_viewport_changed()`]). This runs
+    /// after `perform_updates` so the paint `RefCell` is no longer borrowed, and our
+    /// embedder-facing methods calling into the [`WebViewDelegate`] avoid re-entrant
+    /// borrows within the embedder!
+    fn resend_accessibility_root_nodes_for_viewport_changes(&self) {
+        // Collect handles first so the `webviews` borrow is released before we call into the
+        // WebViewDelegate, which the embedder may re-enter.
+        let webviews: Vec<WebView> = self
+            .webviews
+            .borrow()
+            .values()
+            .filter_map(WebView::from_weak_handle)
+            .collect();
+        for webview in webviews {
+            if webview.take_accessibility_viewport_changed() {
+                webview.send_accessibility_root_node();
+            }
+        }
     }
 
     fn send_new_frame_ready_messages(&self) {

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -339,7 +339,7 @@ impl ServoInner {
         true
     }
 
-    /// send, again, the root accessibility node for any [`WebView`] whose viewport geometry changed
+    /// Resend the root accessibility node for any [`WebView`] whose viewport geometry changed
     /// post-last-spin (see [`WebView::note_accessibility_viewport_changed()`]). This runs
     /// after `perform_updates` so the paint `RefCell` is no longer borrowed, and our
     /// embedder-facing methods calling into the [`WebViewDelegate`] avoid re-entrant

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -8,7 +8,7 @@ mod common;
 use std::collections::VecDeque;
 use std::rc::Rc;
 
-use accesskit::{NodeId, Role, TreeId, TreeUpdate};
+use accesskit::{NodeId, Rect, Role, TreeId, TreeUpdate};
 use accesskit_consumer::TreeChangeHandler;
 use servo::{DiagnosticsLoggingOption, LoadStatus, Opts, Preferences, WebViewBuilder};
 use url::Url;
@@ -290,9 +290,11 @@ fn test_accessibility_basic_mutation() {
     let mut updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
     assert_eq!(updates.len(), 1);
     let update = updates.pop().expect("Guaranteed by assert above");
-    assert_eq!(update.nodes.len(), 1);
-    assert_eq!(update.nodes[0].1.role(), Role::RootWebArea);
-    assert_eq!(update.nodes[0].1.children().len(), 1);
+    // The `<html>` element is also re-sent, because removing the `<h2>` made the document shorter
+    // and therefore changed its bounds.
+    assert_eq!(update.nodes.len(), 2);
+    let root_web_area = find_node_with_role(&update, Role::RootWebArea);
+    assert_eq!(root_web_area.children().len(), 1);
     tree.update_and_process_changes(update, &mut NoOpChangeHandler);
 
     let root = assert_tree_structure_and_get_root_web_area(&tree);
@@ -379,10 +381,11 @@ fn test_accessibility_text_change() {
     let mut updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
     assert_eq!(updates.len(), 1);
     let update = updates.pop().expect("Guaranteed by assert above");
-    assert_eq!(update.nodes.len(), 2);
-    assert_eq!(update.nodes[0].1.role(), Role::TextRun);
-    assert_eq!(update.nodes[1].1.role(), Role::Heading);
-    assert_eq!(update.nodes[1].1.children().len(), 1);
+    // Text reflow changes bounds on heading and ancestors
+    assert_eq!(update.nodes.len(), 4);
+    let _ = find_node_with_role(&update, Role::TextRun);
+    let heading = find_node_with_role(&update, Role::Heading);
+    assert_eq!(heading.children().len(), 1);
     tree.update_and_process_changes(update, &mut NoOpChangeHandler);
     let root = assert_tree_structure_and_get_root_web_area(&tree);
     let children: Vec<accesskit_consumer::Node> = root.children().collect();
@@ -536,10 +539,228 @@ fn test_accessibility_descendants_of_heading_change() {
     );
 }
 
+#[test]
+fn test_accessibility_bounds() {
+    let url = "data:text/html,<!DOCTYPE html>\
+               <div id='box' style='position:absolute;left:10px;top:20px;\
+               width:100px;height:50px'></div>";
+    let (_servo_test, _delegate, _webview, tree) = build_webview_and_tree(url);
+
+    let scroll_view = find_first_matching_node(tree.state().root(), |node| {
+        node.role() == Role::ScrollView
+    })
+    .expect(
+        "Tree should include a scroll view corresponding to the WebView. (covers whole viewport)",
+    );
+    assert_rect_eq(
+        scroll_view
+            .raw_bounds()
+            .expect("WebView node should have bounds"),
+        Rect::new(0.0, 0.0, TEST_VIEWPORT_SIZE, TEST_VIEWPORT_SIZE),
+    );
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let div = root
+        .children()
+        .next()
+        .expect("Root web area should have at least one child.");
+    assert_eq!(div.data().html_tag(), Some("div"));
+
+    // No transforms between div and container; bounds are viewport-relative CSS pixels
+    let expected = Rect::new(10.0, 20.0, 110.0, 70.0);
+    assert_rect_eq(div.raw_bounds().expect("div should have bounds"), expected);
+    assert_rect_eq(
+        div.bounding_box().expect("div should have a bounding box"),
+        expected,
+    );
+}
+
+#[test]
+fn test_accessibility_text_run_bounds() {
+    let url = "data:text/html,<!DOCTYPE html>\
+               <h1 style='position:absolute;left:0;top:0;margin:0;\
+               width:300px;height:40px'>Servo</h1>";
+    let (_servo_test, _delegate, _webview, tree) = build_webview_and_tree(url);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let heading = root
+        .children()
+        .next()
+        .expect("Root web area should have at least one child.");
+    assert_eq!(heading.role(), Role::Heading);
+    let expected = Rect::new(0.0, 0.0, 300.0, 40.0);
+    assert_rect_eq(
+        heading.raw_bounds().expect("heading should have bounds"),
+        expected,
+    );
+
+    // Text nodes inherit container bounds (screen readers need geometry)
+    let text_run = find_first_matching_node(heading, |node| node.role() == Role::TextRun)
+        .expect("Heading should contain a TextRun");
+    assert_rect_eq(
+        text_run.raw_bounds().expect("TextRun should have bounds"),
+        expected,
+    );
+}
+
+#[test]
+fn test_accessibility_bounds_through_display_contents() {
+    // display: contents has no box; text inherits parent bounds
+    let url = "data:text/html,<!DOCTYPE html>\
+               <div style='position:absolute;left:0;top:0;width:200px;height:30px'>\
+               <span style='display:contents'>hello</span></div>";
+    let (_servo_test, _delegate, _webview, tree) = build_webview_and_tree(url);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let text_run = find_first_matching_node(root, |node| node.role() == Role::TextRun)
+        .expect("Document should contain a TextRun");
+    assert_rect_eq(
+        text_run
+            .raw_bounds()
+            .expect("Text inside a `display: contents` element should still have bounds"),
+        Rect::new(0.0, 0.0, 200.0, 30.0),
+    );
+}
+
+#[test]
+fn test_accessibility_bounds_omitted_for_display_none() {
+    // display: none: no geometry, text must not inherit ancestor bounds
+    let url = "data:text/html,<!DOCTYPE html>\
+               <div style='position:absolute;left:0;top:0;width:200px;height:30px'>\
+               <span id='hidden' style='display:none'>hidden</span></div>";
+    let (_servo_test, _delegate, _webview, tree) = build_webview_and_tree(url);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    for node in find_all_matching_nodes(root, |node| {
+        node.data().html_tag() == Some("span") || node.role() == Role::TextRun
+    }) {
+        assert!(
+            node.raw_bounds().is_none(),
+            "`display: none` content should have no bounds, but {:?} had {:?}",
+            node.role(),
+            node.raw_bounds()
+        );
+    }
+}
+
+#[test]
+fn test_accessibility_bounds_updated_after_relayout() {
+    let url = "data:text/html,<!DOCTYPE html>\
+               <div id='box' style='position:absolute;left:10px;top:20px;\
+               width:100px;height:50px'></div>";
+    let (servo_test, delegate, webview, mut tree) = build_webview_and_tree(url);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let div = root.children().next().expect("Should have a div child");
+    let div_id = div.locate().0; // Maps to layout's NodeId
+    assert_rect_eq(
+        div.raw_bounds().expect("div should have bounds"),
+        Rect::new(10.0, 20.0, 110.0, 70.0),
+    );
+
+    // Relayout with geometry changes auto-refreshes accessibility tree
+    let _ = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "const box = document.getElementById('box');\
+         box.style.left = '30px'; box.style.width = '200px';",
+    );
+
+    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
+    let expected = Rect::new(30.0, 20.0, 230.0, 70.0);
+    let updated_bounds = updates
+        .iter()
+        .flat_map(|update| update.nodes.iter())
+        .filter(|(id, _)| *id == div_id)
+        .filter_map(|(_, node)| node.bounds())
+        .next_back()
+        .expect("The div should have been re-sent with new bounds");
+    assert_rect_eq(updated_bounds, expected);
+
+    for update in updates {
+        tree.update_and_process_changes(update, &mut NoOpChangeHandler);
+    }
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let div = root.children().next().expect("Should have a div child");
+    assert_rect_eq(div.raw_bounds().expect("div should have bounds"), expected);
+}
+
+#[test]
+fn test_accessibility_unchanged_bounds_are_not_resent() {
+    // Absolutely positioned divs; resizing one doesn't affect the other
+    let url = "data:text/html,<!DOCTYPE html>\
+               <div id='a' style='position:absolute;left:0;top:0;width:10px;height:10px'></div>\
+               <div id='b' style='position:absolute;left:100px;top:100px;\
+               width:10px;height:10px'></div>";
+    let (servo_test, delegate, webview, tree) = build_webview_and_tree(url);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let children: Vec<accesskit_consumer::Node> = root.children().collect();
+    assert_eq!(children.len(), 2);
+    let (node_a, node_b) = (children[0], children[1]);
+    assert_rect_eq(
+        node_a.raw_bounds().expect("a should have bounds"),
+        Rect::new(0.0, 0.0, 10.0, 10.0),
+    );
+    assert_rect_eq(
+        node_b.raw_bounds().expect("b should have bounds"),
+        Rect::new(100.0, 100.0, 110.0, 110.0),
+    );
+    let node_b_id = node_b.locate().0;
+
+    let _ = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "document.getElementById('a').style.width = '50px';",
+    );
+
+    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
+    let resent_ids: Vec<NodeId> = updates
+        .iter()
+        .flat_map(|update| update.nodes.iter())
+        .map(|(id, _)| *id)
+        .collect();
+    assert!(
+        !resent_ids.contains(&node_b_id),
+        "A node whose bounds did not change should not be re-serialized, but got {resent_ids:?}"
+    );
+}
+
 // ************************************************************************************************
 // If you're adding a new test here, consider adding a matching test in
 // tests/wpt/mozilla/tests/accessibility-tree/
 // ************************************************************************************************
+
+/// Rendering context size in device pixels (HiDPI scale = 1.0 in tests, so also CSS pixels).
+const TEST_VIEWPORT_SIZE: f64 = 500.0;
+
+/// Find the single node with the given role in a [`TreeUpdate`]. The order of the nodes in an
+/// update is unspecified, so tests must not depend on it.
+#[track_caller]
+fn find_node_with_role(update: &TreeUpdate, role: Role) -> &accesskit::Node {
+    let mut matches = update.nodes.iter().filter(|(_, node)| node.role() == role);
+    let node = matches
+        .next()
+        .unwrap_or_else(|| panic!("Update should contain a node with role {role:?}"));
+    assert!(
+        matches.next().is_none(),
+        "Update should contain exactly one node with role {role:?}"
+    );
+    &node.1
+}
+
+#[track_caller]
+fn assert_rect_eq(actual: Rect, expected: Rect) {
+    // Bounds are converted from `Au`, which has a resolution of 1/60th of a CSS pixel.
+    const EPSILON: f64 = 0.05;
+    assert!(
+        (actual.x0 - expected.x0).abs() < EPSILON &&
+            (actual.y0 - expected.y0).abs() < EPSILON &&
+            (actual.x1 - expected.x1).abs() < EPSILON &&
+            (actual.y1 - expected.y1).abs() < EPSILON,
+        "expected bounds {expected:?} but got {actual:?}"
+    );
+}
 
 fn build_test() -> ServoTest {
     let servo_test = ServoTest::new_with_builder(|builder| {
@@ -605,6 +826,13 @@ fn build_tree(tree_updates: Vec<TreeUpdate>) -> accesskit_consumer::Tree {
 
     // We need to make a graft node so that we have a non-graft node to set as the initial focused
     // node for the tree.
+    //
+    // This stands in for the node an embedder builds to graft in a WebView's tree (see
+    // `ports/servoshell/desktop/gui.rs`). It deliberately has no transform: the WebView is at the
+    // origin of the window and the HiDPI scale factor is 1.0 in tests, so composed bounds are
+    // equal to the viewport-relative CSS pixel bounds that layout produces. It also sets no
+    // bounds, matching the embedder, as AccessKit consumers exclude graft nodes from the
+    // presented tree and never read them.
     let graft_node_id = NodeId(0x1);
     let mut graft_node = accesskit::Node::new(Role::GenericContainer);
     graft_node.set_tree_id(tree_id);

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -10,10 +10,17 @@ use std::rc::Rc;
 
 use accesskit::{NodeId, Rect, Role, TreeId, TreeUpdate};
 use accesskit_consumer::TreeChangeHandler;
-use servo::{DiagnosticsLoggingOption, LoadStatus, Opts, Preferences, WebViewBuilder};
+use servo::{
+    DiagnosticsLoggingOption, LoadStatus, Opts, Preferences, Scroll, WebViewBuilder, WebViewPoint,
+    WebViewVector,
+};
 use url::Url;
+use webrender_api::units::{DevicePoint, DeviceVector2D};
 
-use crate::common::{ServoTest, WebViewDelegateImpl, evaluate_javascript};
+use crate::common::{
+    ServoTest, WebViewDelegateImpl, evaluate_javascript,
+    show_webview_and_wait_for_rendering_to_be_ready,
+};
 
 struct NoOpChangeHandler;
 
@@ -686,6 +693,57 @@ fn test_accessibility_bounds_updated_after_relayout() {
 }
 
 #[test]
+fn test_accessibility_bounds_updated_after_renderer_scroll() {
+    let url = "data:text/html,<!DOCTYPE html>\
+               <button style='position:absolute;left:10px;top:100px;\
+               width:100px;height:50px'>Target</button>\
+               <div style='width:2000px;height:2000px'></div>";
+    let (servo_test, delegate, webview, mut tree) = build_webview_and_tree(url);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let button = find_first_matching_node(root, |node| node.role() == Role::Button)
+        .expect("Document should contain a button");
+    let button_id = button.locate().0; // Maps to layout's NodeId
+    assert_rect_eq(
+        button.raw_bounds().expect("button should have bounds"),
+        Rect::new(10.0, 100.0, 110.0, 150.0),
+    );
+
+    // The renderer can only scroll a scene it has already received.
+    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
+    delegate.last_accesskit_tree_updates.borrow_mut().clear();
+
+    // A positive delta reveals more content at the bottom and right, so this is equivalent to the
+    // `window.scrollTo(20, 40)` of the test above.
+    webview.notify_scroll_event(
+        Scroll::Delta(WebViewVector::Device(DeviceVector2D::new(20.0, 40.0))),
+        WebViewPoint::Device(DevicePoint::new(250.0, 250.0)),
+    );
+
+    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
+    let expected = Rect::new(-10.0, 60.0, 90.0, 110.0);
+    let updated_bounds = updates
+        .iter()
+        .flat_map(|update| update.nodes.iter())
+        .filter(|(id, _)| *id == button_id)
+        .filter_map(|(_, node)| node.bounds())
+        .next_back()
+        .expect("The button should have been re-sent with new bounds");
+    assert_rect_eq(updated_bounds, expected);
+
+    for update in updates {
+        tree.update_and_process_changes(update, &mut NoOpChangeHandler);
+    }
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let button = find_first_matching_node(root, |node| node.role() == Role::Button)
+        .expect("Document should contain a button");
+    assert_rect_eq(
+        button.raw_bounds().expect("button should have bounds"),
+        expected,
+    );
+}
+
+#[test]
 fn test_accessibility_unchanged_bounds_are_not_resent() {
     // Absolutely positioned divs; resizing one doesn't affect the other
     let url = "data:text/html,<!DOCTYPE html>\
@@ -754,10 +812,10 @@ fn assert_rect_eq(actual: Rect, expected: Rect) {
     // Bounds are converted from `Au`, which has a resolution of 1/60th of a CSS pixel.
     const EPSILON: f64 = 0.05;
     assert!(
-        (actual.x0 - expected.x0).abs() < EPSILON &&
-            (actual.y0 - expected.y0).abs() < EPSILON &&
-            (actual.x1 - expected.x1).abs() < EPSILON &&
-            (actual.y1 - expected.y1).abs() < EPSILON,
+        (actual.x0 - expected.x0).abs() < EPSILON
+            && (actual.y0 - expected.y0).abs() < EPSILON
+            && (actual.x1 - expected.x1).abs() < EPSILON
+            && (actual.y1 - expected.y1).abs() < EPSILON,
         "expected bounds {expected:?} but got {actual:?}"
     );
 }

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -595,37 +595,58 @@ fn test_accessibility_text_run_bounds() {
         .next()
         .expect("Root web area should have at least one child.");
     assert_eq!(heading.role(), Role::Heading);
-    let expected = Rect::new(0.0, 0.0, 300.0, 40.0);
     assert_rect_eq(
         heading.raw_bounds().expect("heading should have bounds"),
-        expected,
+        Rect::new(0.0, 0.0, 300.0, 40.0),
     );
 
-    // Text nodes inherit container bounds (screen readers need geometry)
+    // TODO(accessibility): Text nodes have no layout box of their own, so no bounds are computed
+    // for them yet. They should eventually get the union of the rectangles of their own
+    // `Fragment::Text` fragments. This assertion demonstrates the current behaviour; flip it once
+    // text run bounds are implemented.
     let text_run = find_first_matching_node(heading, |node| node.role() == Role::TextRun)
         .expect("Heading should contain a TextRun");
-    assert_rect_eq(
-        text_run.raw_bounds().expect("TextRun should have bounds"),
-        expected,
+    assert!(
+        text_run.raw_bounds().is_none(),
+        "TextRun bounds are not implemented yet, but got {:?}",
+        text_run.raw_bounds()
     );
 }
 
 #[test]
-fn test_accessibility_bounds_through_display_contents() {
-    // display: contents has no box; text inherits parent bounds
+fn test_accessibility_bounds_omitted_for_display_contents() {
     let url = "data:text/html,<!DOCTYPE html>\
                <div style='position:absolute;left:0;top:0;width:200px;height:30px'>\
                <span style='display:contents'>hello</span></div>";
     let (_servo_test, _delegate, _webview, tree) = build_webview_and_tree(url);
 
     let root = assert_tree_structure_and_get_root_web_area(&tree);
-    let text_run = find_first_matching_node(root, |node| node.role() == Role::TextRun)
-        .expect("Document should contain a TextRun");
+    let div = root
+        .children()
+        .next()
+        .expect("Root web area should have at least one child.");
     assert_rect_eq(
-        text_run
-            .raw_bounds()
-            .expect("Text inside a `display: contents` element should still have bounds"),
+        div.raw_bounds().expect("div should have bounds"),
         Rect::new(0.0, 0.0, 200.0, 30.0),
+    );
+
+    // TODO(accessibility): A `display: contents` element generates no box, so no bounds are
+    // computed for it yet. Other engines (Blink, WebKit, Gecko) compute its bounds as the union of
+    // the bounding boxes of its rendered descendants. This test demonstrates the current
+    // behaviour; flip these assertions once that is implemented.
+    let span = find_first_matching_node(root, |node| node.data().html_tag() == Some("span"))
+        .expect("Document should contain the `display: contents` span");
+    assert!(
+        span.raw_bounds().is_none(),
+        "`display: contents` bounds are not implemented yet, but got {:?}",
+        span.raw_bounds()
+    );
+    let text_run = find_first_matching_node(span, |node| node.role() == Role::TextRun)
+        .expect("The `display: contents` span should contain a TextRun");
+    assert!(
+        text_run.raw_bounds().is_none(),
+        "TextRun bounds are not implemented yet, but got {:?}",
+        text_run.raw_bounds()
     );
 }
 
@@ -812,10 +833,10 @@ fn assert_rect_eq(actual: Rect, expected: Rect) {
     // Bounds are converted from `Au`, which has a resolution of 1/60th of a CSS pixel.
     const EPSILON: f64 = 0.05;
     assert!(
-        (actual.x0 - expected.x0).abs() < EPSILON
-            && (actual.y0 - expected.y0).abs() < EPSILON
-            && (actual.x1 - expected.x1).abs() < EPSILON
-            && (actual.y1 - expected.y1).abs() < EPSILON,
+        (actual.x0 - expected.x0).abs() < EPSILON &&
+            (actual.y0 - expected.y0).abs() < EPSILON &&
+            (actual.x1 - expected.x1).abs() < EPSILON &&
+            (actual.y1 - expected.y1).abs() < EPSILON,
         "expected bounds {expected:?} but got {actual:?}"
     );
 }

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -11,6 +11,7 @@ use std::rc::Rc;
 
 use accesskit::{NodeId, Rect, Role, TreeId, TreeUpdate};
 use accesskit_consumer::TreeChangeHandler;
+use euclid::Scale;
 use servo::{
     DiagnosticsLoggingOption, LoadStatus, Opts, Preferences, Scroll, WebViewBuilder, WebViewPoint,
     WebViewVector,
@@ -657,6 +658,28 @@ fn test_accessibility_bounds() {
     assert_rect_eq(
         div.bounding_box().expect("div should have a bounding box"),
         expected,
+    );
+}
+
+#[test]
+fn test_accessibility_webview_bounds_updated_after_hidpi_change() {
+    let (servo_test, delegate, webview, mut tree) =
+        build_webview_and_tree("data:text/html,<!DOCTYPE html>");
+
+    webview.set_hidpi_scale_factor(Scale::new(2.0));
+
+    for update in wait_for_min_updates(&servo_test, delegate, 1) {
+        tree.update_and_process_changes(update, &mut NoOpChangeHandler);
+    }
+
+    let scroll_view =
+        find_first_matching_node(tree.state().root(), |node| node.role() == Role::ScrollView)
+            .expect("Tree should include a scroll view corresponding to the WebView");
+    assert_rect_eq(
+        scroll_view
+            .raw_bounds()
+            .expect("WebView node should have bounds"),
+        Rect::new(0.0, 0.0, TEST_VIEWPORT_SIZE / 2.0, TEST_VIEWPORT_SIZE / 2.0),
     );
 }
 

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -10,10 +10,17 @@ use std::rc::Rc;
 
 use accesskit::{NodeId, Rect, Role, TreeId, TreeUpdate};
 use accesskit_consumer::TreeChangeHandler;
-use servo::{DiagnosticsLoggingOption, LoadStatus, Opts, Preferences, WebViewBuilder};
+use servo::{
+    DiagnosticsLoggingOption, LoadStatus, Opts, Preferences, Scroll, WebViewBuilder, WebViewPoint,
+    WebViewVector,
+};
 use url::Url;
+use webrender_api::units::{DevicePoint, DeviceVector2D};
 
-use crate::common::{ServoTest, WebViewDelegateImpl, evaluate_javascript};
+use crate::common::{
+    ServoTest, WebViewDelegateImpl, evaluate_javascript,
+    show_webview_and_wait_for_rendering_to_be_ready,
+};
 
 struct NoOpChangeHandler;
 
@@ -766,6 +773,57 @@ fn test_accessibility_bounds_updated_after_relayout() {
 }
 
 #[test]
+fn test_accessibility_bounds_updated_after_renderer_scroll() {
+    let url = "data:text/html,<!DOCTYPE html>\
+               <button style='position:absolute;left:10px;top:100px;\
+               width:100px;height:50px'>Target</button>\
+               <div style='width:2000px;height:2000px'></div>";
+    let (servo_test, delegate, webview, mut tree) = build_webview_and_tree(url);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let button = find_first_matching_node(root, |node| node.role() == Role::Button)
+        .expect("Document should contain a button");
+    let button_id = button.locate().0; // Maps to layout's NodeId
+    assert_rect_eq(
+        button.raw_bounds().expect("button should have bounds"),
+        Rect::new(10.0, 100.0, 110.0, 150.0),
+    );
+
+    // The renderer can only scroll a scene it has already received.
+    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
+    delegate.last_accesskit_tree_updates.borrow_mut().clear();
+
+    // A positive delta reveals more content at the bottom and right, so this is equivalent to the
+    // `window.scrollTo(20, 40)` of the test above.
+    webview.notify_scroll_event(
+        Scroll::Delta(WebViewVector::Device(DeviceVector2D::new(20.0, 40.0))),
+        WebViewPoint::Device(DevicePoint::new(250.0, 250.0)),
+    );
+
+    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
+    let expected = Rect::new(-10.0, 60.0, 90.0, 110.0);
+    let updated_bounds = updates
+        .iter()
+        .flat_map(|update| update.nodes.iter())
+        .filter(|(id, _)| *id == button_id)
+        .filter_map(|(_, node)| node.bounds())
+        .next_back()
+        .expect("The button should have been re-sent with new bounds");
+    assert_rect_eq(updated_bounds, expected);
+
+    for update in updates {
+        tree.update_and_process_changes(update, &mut NoOpChangeHandler);
+    }
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let button = find_first_matching_node(root, |node| node.role() == Role::Button)
+        .expect("Document should contain a button");
+    assert_rect_eq(
+        button.raw_bounds().expect("button should have bounds"),
+        expected,
+    );
+}
+
+#[test]
 fn test_accessibility_unchanged_bounds_are_not_resent() {
     // Absolutely positioned divs; resizing one doesn't affect the other
     let url = "data:text/html,<!DOCTYPE html>\
@@ -834,10 +892,10 @@ fn assert_rect_eq(actual: Rect, expected: Rect) {
     // Bounds are converted from `Au`, which has a resolution of 1/60th of a CSS pixel.
     const EPSILON: f64 = 0.05;
     assert!(
-        (actual.x0 - expected.x0).abs() < EPSILON &&
-            (actual.y0 - expected.y0).abs() < EPSILON &&
-            (actual.x1 - expected.x1).abs() < EPSILON &&
-            (actual.y1 - expected.y1).abs() < EPSILON,
+        (actual.x0 - expected.x0).abs() < EPSILON
+            && (actual.y0 - expected.y0).abs() < EPSILON
+            && (actual.x1 - expected.x1).abs() < EPSILON
+            && (actual.y1 - expected.y1).abs() < EPSILON,
         "expected bounds {expected:?} but got {actual:?}"
     );
 }

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -681,7 +681,7 @@ fn test_accessibility_text_run_bounds() {
     // TODO(accessibility): Text nodes have no layout box of their own, so no bounds are computed
     // for them yet. They should eventually get the union of the rectangles of their own
     // `Fragment::Text` fragments. This assertion demonstrates the current behaviour; flip it once
-    // text run bounds are implemented.
+    // text run bounds are implemented. See #47164.
     let text_run = find_first_matching_node(heading, |node| node.role() == Role::TextRun)
         .expect("Heading should contain a TextRun");
     assert!(
@@ -711,7 +711,7 @@ fn test_accessibility_bounds_omitted_for_display_contents() {
     // TODO(accessibility): A `display: contents` element generates no box, so no bounds are
     // computed for it yet. Other engines (Blink, WebKit, Gecko) compute its bounds as the union of
     // the bounding boxes of its rendered descendants. This test demonstrates the current
-    // behaviour; flip these assertions once that is implemented.
+    // behaviour; flip these assertions once that is implemented. See #47163.
     let span = find_first_matching_node(root, |node| node.data().html_tag() == Some("span"))
         .expect("Document should contain the `display: contents` span");
     assert!(

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -8,7 +8,7 @@ mod common;
 use std::collections::VecDeque;
 use std::rc::Rc;
 
-use accesskit::{NodeId, Role, TreeId, TreeUpdate};
+use accesskit::{NodeId, Rect, Role, TreeId, TreeUpdate};
 use accesskit_consumer::TreeChangeHandler;
 use servo::{DiagnosticsLoggingOption, LoadStatus, Opts, Preferences, WebViewBuilder};
 use url::Url;
@@ -302,9 +302,11 @@ fn test_accessibility_basic_mutation() {
     let mut updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
     assert_eq!(updates.len(), 1);
     let update = updates.pop().expect("Guaranteed by assert above");
-    assert_eq!(update.nodes.len(), 1);
-    assert_eq!(update.nodes[0].1.role(), Role::RootWebArea);
-    assert_eq!(update.nodes[0].1.children().len(), 1);
+    // The `<html>` element is also re-sent, because removing the `<h2>` made the document shorter
+    // and therefore changed its bounds.
+    assert_eq!(update.nodes.len(), 2);
+    let root_web_area = find_node_with_role(&update, Role::RootWebArea);
+    assert_eq!(root_web_area.children().len(), 1);
     tree.update_and_process_changes(update, &mut NoOpChangeHandler);
 
     let root = assert_tree_structure_and_get_root_web_area(&tree);
@@ -391,10 +393,11 @@ fn test_accessibility_text_change() {
     let mut updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
     assert_eq!(updates.len(), 1);
     let update = updates.pop().expect("Guaranteed by assert above");
-    assert_eq!(update.nodes.len(), 2);
-    assert_eq!(update.nodes[0].1.role(), Role::TextRun);
-    assert_eq!(update.nodes[1].1.role(), Role::Heading);
-    assert_eq!(update.nodes[1].1.children().len(), 1);
+    // Text reflow changes bounds on heading and ancestors
+    assert_eq!(update.nodes.len(), 4);
+    let _ = find_node_with_role(&update, Role::TextRun);
+    let heading = find_node_with_role(&update, Role::Heading);
+    assert_eq!(heading.children().len(), 1);
     tree.update_and_process_changes(update, &mut NoOpChangeHandler);
     let root = assert_tree_structure_and_get_root_web_area(&tree);
     let children: Vec<accesskit_consumer::Node> = root.children().collect();
@@ -616,10 +619,228 @@ fn test_accessibility_descendants_of_heading_change() {
     );
 }
 
+#[test]
+fn test_accessibility_bounds() {
+    let url = "data:text/html,<!DOCTYPE html>\
+               <div id='box' style='position:absolute;left:10px;top:20px;\
+               width:100px;height:50px'></div>";
+    let (_servo_test, _delegate, _webview, tree) = build_webview_and_tree(url);
+
+    let scroll_view = find_first_matching_node(tree.state().root(), |node| {
+        node.role() == Role::ScrollView
+    })
+    .expect(
+        "Tree should include a scroll view corresponding to the WebView. (covers whole viewport)",
+    );
+    assert_rect_eq(
+        scroll_view
+            .raw_bounds()
+            .expect("WebView node should have bounds"),
+        Rect::new(0.0, 0.0, TEST_VIEWPORT_SIZE, TEST_VIEWPORT_SIZE),
+    );
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let div = root
+        .children()
+        .next()
+        .expect("Root web area should have at least one child.");
+    assert_eq!(div.data().html_tag(), Some("div"));
+
+    // No transforms between div and container; bounds are viewport-relative CSS pixels
+    let expected = Rect::new(10.0, 20.0, 110.0, 70.0);
+    assert_rect_eq(div.raw_bounds().expect("div should have bounds"), expected);
+    assert_rect_eq(
+        div.bounding_box().expect("div should have a bounding box"),
+        expected,
+    );
+}
+
+#[test]
+fn test_accessibility_text_run_bounds() {
+    let url = "data:text/html,<!DOCTYPE html>\
+               <h1 style='position:absolute;left:0;top:0;margin:0;\
+               width:300px;height:40px'>Servo</h1>";
+    let (_servo_test, _delegate, _webview, tree) = build_webview_and_tree(url);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let heading = root
+        .children()
+        .next()
+        .expect("Root web area should have at least one child.");
+    assert_eq!(heading.role(), Role::Heading);
+    let expected = Rect::new(0.0, 0.0, 300.0, 40.0);
+    assert_rect_eq(
+        heading.raw_bounds().expect("heading should have bounds"),
+        expected,
+    );
+
+    // Text nodes inherit container bounds (screen readers need geometry)
+    let text_run = find_first_matching_node(heading, |node| node.role() == Role::TextRun)
+        .expect("Heading should contain a TextRun");
+    assert_rect_eq(
+        text_run.raw_bounds().expect("TextRun should have bounds"),
+        expected,
+    );
+}
+
+#[test]
+fn test_accessibility_bounds_through_display_contents() {
+    // display: contents has no box; text inherits parent bounds
+    let url = "data:text/html,<!DOCTYPE html>\
+               <div style='position:absolute;left:0;top:0;width:200px;height:30px'>\
+               <span style='display:contents'>hello</span></div>";
+    let (_servo_test, _delegate, _webview, tree) = build_webview_and_tree(url);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let text_run = find_first_matching_node(root, |node| node.role() == Role::TextRun)
+        .expect("Document should contain a TextRun");
+    assert_rect_eq(
+        text_run
+            .raw_bounds()
+            .expect("Text inside a `display: contents` element should still have bounds"),
+        Rect::new(0.0, 0.0, 200.0, 30.0),
+    );
+}
+
+#[test]
+fn test_accessibility_bounds_omitted_for_display_none() {
+    // display: none: no geometry, text must not inherit ancestor bounds
+    let url = "data:text/html,<!DOCTYPE html>\
+               <div style='position:absolute;left:0;top:0;width:200px;height:30px'>\
+               <span id='hidden' style='display:none'>hidden</span></div>";
+    let (_servo_test, _delegate, _webview, tree) = build_webview_and_tree(url);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    for node in find_all_matching_nodes(root, |node| {
+        node.data().html_tag() == Some("span") || node.role() == Role::TextRun
+    }) {
+        assert!(
+            node.raw_bounds().is_none(),
+            "`display: none` content should have no bounds, but {:?} had {:?}",
+            node.role(),
+            node.raw_bounds()
+        );
+    }
+}
+
+#[test]
+fn test_accessibility_bounds_updated_after_relayout() {
+    let url = "data:text/html,<!DOCTYPE html>\
+               <div id='box' style='position:absolute;left:10px;top:20px;\
+               width:100px;height:50px'></div>";
+    let (servo_test, delegate, webview, mut tree) = build_webview_and_tree(url);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let div = root.children().next().expect("Should have a div child");
+    let div_id = div.locate().0; // Maps to layout's NodeId
+    assert_rect_eq(
+        div.raw_bounds().expect("div should have bounds"),
+        Rect::new(10.0, 20.0, 110.0, 70.0),
+    );
+
+    // Relayout with geometry changes auto-refreshes accessibility tree
+    let _ = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "const box = document.getElementById('box');\
+         box.style.left = '30px'; box.style.width = '200px';",
+    );
+
+    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
+    let expected = Rect::new(30.0, 20.0, 230.0, 70.0);
+    let updated_bounds = updates
+        .iter()
+        .flat_map(|update| update.nodes.iter())
+        .filter(|(id, _)| *id == div_id)
+        .filter_map(|(_, node)| node.bounds())
+        .next_back()
+        .expect("The div should have been re-sent with new bounds");
+    assert_rect_eq(updated_bounds, expected);
+
+    for update in updates {
+        tree.update_and_process_changes(update, &mut NoOpChangeHandler);
+    }
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let div = root.children().next().expect("Should have a div child");
+    assert_rect_eq(div.raw_bounds().expect("div should have bounds"), expected);
+}
+
+#[test]
+fn test_accessibility_unchanged_bounds_are_not_resent() {
+    // Absolutely positioned divs; resizing one doesn't affect the other
+    let url = "data:text/html,<!DOCTYPE html>\
+               <div id='a' style='position:absolute;left:0;top:0;width:10px;height:10px'></div>\
+               <div id='b' style='position:absolute;left:100px;top:100px;\
+               width:10px;height:10px'></div>";
+    let (servo_test, delegate, webview, tree) = build_webview_and_tree(url);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let children: Vec<accesskit_consumer::Node> = root.children().collect();
+    assert_eq!(children.len(), 2);
+    let (node_a, node_b) = (children[0], children[1]);
+    assert_rect_eq(
+        node_a.raw_bounds().expect("a should have bounds"),
+        Rect::new(0.0, 0.0, 10.0, 10.0),
+    );
+    assert_rect_eq(
+        node_b.raw_bounds().expect("b should have bounds"),
+        Rect::new(100.0, 100.0, 110.0, 110.0),
+    );
+    let node_b_id = node_b.locate().0;
+
+    let _ = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "document.getElementById('a').style.width = '50px';",
+    );
+
+    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
+    let resent_ids: Vec<NodeId> = updates
+        .iter()
+        .flat_map(|update| update.nodes.iter())
+        .map(|(id, _)| *id)
+        .collect();
+    assert!(
+        !resent_ids.contains(&node_b_id),
+        "A node whose bounds did not change should not be re-serialized, but got {resent_ids:?}"
+    );
+}
+
 // ************************************************************************************************
 // If you're adding a new test here, consider adding a matching test in
 // tests/wpt/mozilla/tests/accessibility-tree/
 // ************************************************************************************************
+
+/// Rendering context size in device pixels (HiDPI scale = 1.0 in tests, so also CSS pixels).
+const TEST_VIEWPORT_SIZE: f64 = 500.0;
+
+/// Find the single node with the given role in a [`TreeUpdate`]. The order of the nodes in an
+/// update is unspecified, so tests must not depend on it.
+#[track_caller]
+fn find_node_with_role(update: &TreeUpdate, role: Role) -> &accesskit::Node {
+    let mut matches = update.nodes.iter().filter(|(_, node)| node.role() == role);
+    let node = matches
+        .next()
+        .unwrap_or_else(|| panic!("Update should contain a node with role {role:?}"));
+    assert!(
+        matches.next().is_none(),
+        "Update should contain exactly one node with role {role:?}"
+    );
+    &node.1
+}
+
+#[track_caller]
+fn assert_rect_eq(actual: Rect, expected: Rect) {
+    // Bounds are converted from `Au`, which has a resolution of 1/60th of a CSS pixel.
+    const EPSILON: f64 = 0.05;
+    assert!(
+        (actual.x0 - expected.x0).abs() < EPSILON &&
+            (actual.y0 - expected.y0).abs() < EPSILON &&
+            (actual.x1 - expected.x1).abs() < EPSILON &&
+            (actual.y1 - expected.y1).abs() < EPSILON,
+        "expected bounds {expected:?} but got {actual:?}"
+    );
+}
 
 fn build_test() -> ServoTest {
     let servo_test = ServoTest::new_with_builder(|builder| {
@@ -685,6 +906,13 @@ fn build_tree(tree_updates: Vec<TreeUpdate>) -> accesskit_consumer::Tree {
 
     // We need to make a graft node so that we have a non-graft node to set as the initial focused
     // node for the tree.
+    //
+    // This stands in for the node an embedder builds to graft in a WebView's tree (see
+    // `ports/servoshell/desktop/gui.rs`). It deliberately has no transform: the WebView is at the
+    // origin of the window and the HiDPI scale factor is 1.0 in tests, so composed bounds are
+    // equal to the viewport-relative CSS pixel bounds that layout produces. It also sets no
+    // bounds, matching the embedder, as AccessKit consumers exclude graft nodes from the
+    // presented tree and never read them.
     let graft_node_id = NodeId(0x1);
     let mut graft_node = accesskit::Node::new(Role::GenericContainer);
     graft_node.set_tree_id(tree_id);

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -18,10 +18,7 @@ use servo::{
 use url::Url;
 use webrender_api::units::{DevicePoint, DeviceVector2D};
 
-use crate::common::{
-    ServoTest, WebViewDelegateImpl, evaluate_javascript,
-    show_webview_and_wait_for_rendering_to_be_ready,
-};
+use crate::common::{ServoTest, WebViewDelegateImpl, evaluate_javascript};
 
 struct NoOpChangeHandler;
 
@@ -810,10 +807,6 @@ fn test_accessibility_bounds_updated_after_renderer_scroll() {
         main.raw_bounds().expect("main should have bounds"),
         Rect::new(10.0, 100.0, 110.0, 150.0),
     );
-
-    // The renderer can only scroll a scene it has already received.
-    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
-    delegate.last_accesskit_tree_updates.borrow_mut().clear();
 
     // A positive delta reveals more content at the bottom and right, so this is equivalent to
     // `window.scrollTo(20, 40)`.

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -839,6 +839,50 @@ fn test_accessibility_bounds_updated_after_renderer_scroll() {
 }
 
 #[test]
+fn test_accessibility_bounds_updated_after_script_scroll() {
+    let url = "data:text/html,<!DOCTYPE html>\
+               <main style='position:absolute;left:10px;top:100px;\
+               width:100px;height:50px'>Target</main>\
+               <div style='width:2000px;height:2000px'></div>";
+    let (servo_test, delegate, webview, mut tree) = build_webview_and_tree(url);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let main = find_first_matching_node(root, |node| node.role() == Role::Main)
+        .expect("Document should contain a main element");
+    let main_id = main.locate().0; // Maps to layout's NodeId
+    assert_rect_eq(
+        main.raw_bounds().expect("main should have bounds"),
+        Rect::new(10.0, 100.0, 110.0, 150.0),
+    );
+
+    // Scrolling the viewport down and to the right shifts every viewport-relative bound up and to
+    // the left by the same amount, mirroring `..._after_renderer_scroll` but driven from script.
+    let _ = evaluate_javascript(&servo_test, webview.clone(), "window.scrollTo(20, 40);");
+
+    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
+    let expected = Rect::new(-10.0, 60.0, 90.0, 110.0);
+    let updated_bounds = updates
+        .iter()
+        .flat_map(|update| update.nodes.iter())
+        .filter(|(id, _)| *id == main_id)
+        .filter_map(|(_, node)| node.bounds())
+        .next_back()
+        .expect("The main element should have been re-sent with new bounds");
+    assert_rect_eq(updated_bounds, expected);
+
+    for update in updates {
+        tree.update_and_process_changes(update, &mut NoOpChangeHandler);
+    }
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let main = find_first_matching_node(root, |node| node.role() == Role::Main)
+        .expect("Document should contain a main element");
+    assert_rect_eq(
+        main.raw_bounds().expect("main should have bounds"),
+        expected,
+    );
+}
+
+#[test]
 fn test_accessibility_unchanged_bounds_are_not_resent() {
     // Absolutely positioned divs; resizing one doesn't affect the other
     let url = "data:text/html,<!DOCTYPE html>\

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -5,6 +5,7 @@
 //! WebView API unit tests.
 mod common;
 
+use std::cell::Cell;
 use std::collections::VecDeque;
 use std::rc::Rc;
 
@@ -814,8 +815,8 @@ fn test_accessibility_bounds_updated_after_renderer_scroll() {
     show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
     delegate.last_accesskit_tree_updates.borrow_mut().clear();
 
-    // A positive delta reveals more content at the bottom and right, so this is equivalent to the
-    // `window.scrollTo(20, 40)` of the test above.
+    // A positive delta reveals more content at the bottom and right, so this is equivalent to
+    // `window.scrollTo(20, 40)`.
     webview.notify_scroll_event(
         Scroll::Delta(WebViewVector::Device(DeviceVector2D::new(20.0, 40.0))),
         WebViewPoint::Device(DevicePoint::new(250.0, 250.0)),

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -675,37 +675,58 @@ fn test_accessibility_text_run_bounds() {
         .next()
         .expect("Root web area should have at least one child.");
     assert_eq!(heading.role(), Role::Heading);
-    let expected = Rect::new(0.0, 0.0, 300.0, 40.0);
     assert_rect_eq(
         heading.raw_bounds().expect("heading should have bounds"),
-        expected,
+        Rect::new(0.0, 0.0, 300.0, 40.0),
     );
 
-    // Text nodes inherit container bounds (screen readers need geometry)
+    // TODO(accessibility): Text nodes have no layout box of their own, so no bounds are computed
+    // for them yet. They should eventually get the union of the rectangles of their own
+    // `Fragment::Text` fragments. This assertion demonstrates the current behaviour; flip it once
+    // text run bounds are implemented.
     let text_run = find_first_matching_node(heading, |node| node.role() == Role::TextRun)
         .expect("Heading should contain a TextRun");
-    assert_rect_eq(
-        text_run.raw_bounds().expect("TextRun should have bounds"),
-        expected,
+    assert!(
+        text_run.raw_bounds().is_none(),
+        "TextRun bounds are not implemented yet, but got {:?}",
+        text_run.raw_bounds()
     );
 }
 
 #[test]
-fn test_accessibility_bounds_through_display_contents() {
-    // display: contents has no box; text inherits parent bounds
+fn test_accessibility_bounds_omitted_for_display_contents() {
     let url = "data:text/html,<!DOCTYPE html>\
                <div style='position:absolute;left:0;top:0;width:200px;height:30px'>\
                <span style='display:contents'>hello</span></div>";
     let (_servo_test, _delegate, _webview, tree) = build_webview_and_tree(url);
 
     let root = assert_tree_structure_and_get_root_web_area(&tree);
-    let text_run = find_first_matching_node(root, |node| node.role() == Role::TextRun)
-        .expect("Document should contain a TextRun");
+    let div = root
+        .children()
+        .next()
+        .expect("Root web area should have at least one child.");
     assert_rect_eq(
-        text_run
-            .raw_bounds()
-            .expect("Text inside a `display: contents` element should still have bounds"),
+        div.raw_bounds().expect("div should have bounds"),
         Rect::new(0.0, 0.0, 200.0, 30.0),
+    );
+
+    // TODO(accessibility): A `display: contents` element generates no box, so no bounds are
+    // computed for it yet. Other engines (Blink, WebKit, Gecko) compute its bounds as the union of
+    // the bounding boxes of its rendered descendants. This test demonstrates the current
+    // behaviour; flip these assertions once that is implemented.
+    let span = find_first_matching_node(root, |node| node.data().html_tag() == Some("span"))
+        .expect("Document should contain the `display: contents` span");
+    assert!(
+        span.raw_bounds().is_none(),
+        "`display: contents` bounds are not implemented yet, but got {:?}",
+        span.raw_bounds()
+    );
+    let text_run = find_first_matching_node(span, |node| node.role() == Role::TextRun)
+        .expect("The `display: contents` span should contain a TextRun");
+    assert!(
+        text_run.raw_bounds().is_none(),
+        "TextRun bounds are not implemented yet, but got {:?}",
+        text_run.raw_bounds()
     );
 }
 
@@ -892,10 +913,10 @@ fn assert_rect_eq(actual: Rect, expected: Rect) {
     // Bounds are converted from `Au`, which has a resolution of 1/60th of a CSS pixel.
     const EPSILON: f64 = 0.05;
     assert!(
-        (actual.x0 - expected.x0).abs() < EPSILON
-            && (actual.y0 - expected.y0).abs() < EPSILON
-            && (actual.x1 - expected.x1).abs() < EPSILON
-            && (actual.y1 - expected.y1).abs() < EPSILON,
+        (actual.x0 - expected.x0).abs() < EPSILON &&
+            (actual.y0 - expected.y0).abs() < EPSILON &&
+            (actual.x1 - expected.x1).abs() < EPSILON &&
+            (actual.y1 - expected.y1).abs() < EPSILON,
         "expected bounds {expected:?} but got {actual:?}"
     );
 }

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -398,8 +398,7 @@ fn test_accessibility_text_change() {
     let mut updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
     assert_eq!(updates.len(), 1);
     let update = updates.pop().expect("Guaranteed by assert above");
-    // Text reflow changes bounds on heading and ancestors
-    assert_eq!(update.nodes.len(), 4);
+    // Appending text always re-sends the two nodes whose contents changed
     let _ = find_node_with_role(&update, Role::TextRun);
     let heading = find_node_with_role(&update, Role::Heading);
     assert_eq!(heading.children().len(), 1);

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -5,7 +5,6 @@
 //! WebView API unit tests.
 mod common;
 
-use std::cell::Cell;
 use std::collections::VecDeque;
 use std::rc::Rc;
 

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -797,17 +797,17 @@ fn test_accessibility_bounds_updated_after_relayout() {
 #[test]
 fn test_accessibility_bounds_updated_after_renderer_scroll() {
     let url = "data:text/html,<!DOCTYPE html>\
-               <button style='position:absolute;left:10px;top:100px;\
-               width:100px;height:50px'>Target</button>\
+               <main style='position:absolute;left:10px;top:100px;\
+               width:100px;height:50px'>Target</main>\
                <div style='width:2000px;height:2000px'></div>";
     let (servo_test, delegate, webview, mut tree) = build_webview_and_tree(url);
 
     let root = assert_tree_structure_and_get_root_web_area(&tree);
-    let button = find_first_matching_node(root, |node| node.role() == Role::Button)
-        .expect("Document should contain a button");
-    let button_id = button.locate().0; // Maps to layout's NodeId
+    let main = find_first_matching_node(root, |node| node.role() == Role::Main)
+        .expect("Document should contain a main element");
+    let main_id = main.locate().0; // Maps to layout's NodeId
     assert_rect_eq(
-        button.raw_bounds().expect("button should have bounds"),
+        main.raw_bounds().expect("main should have bounds"),
         Rect::new(10.0, 100.0, 110.0, 150.0),
     );
 
@@ -827,20 +827,20 @@ fn test_accessibility_bounds_updated_after_renderer_scroll() {
     let updated_bounds = updates
         .iter()
         .flat_map(|update| update.nodes.iter())
-        .filter(|(id, _)| *id == button_id)
+        .filter(|(id, _)| *id == main_id)
         .filter_map(|(_, node)| node.bounds())
         .next_back()
-        .expect("The button should have been re-sent with new bounds");
+        .expect("The main element should have been re-sent with new bounds");
     assert_rect_eq(updated_bounds, expected);
 
     for update in updates {
         tree.update_and_process_changes(update, &mut NoOpChangeHandler);
     }
     let root = assert_tree_structure_and_get_root_web_area(&tree);
-    let button = find_first_matching_node(root, |node| node.role() == Role::Button)
-        .expect("Document should contain a button");
+    let main = find_first_matching_node(root, |node| node.role() == Role::Main)
+        .expect("Document should contain a main element");
     assert_rect_eq(
-        button.raw_bounds().expect("button should have bounds"),
+        main.raw_bounds().expect("main should have bounds"),
         expected,
     );
 }

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -8,7 +8,8 @@ use std::rc::{Rc, Weak};
 use std::time::Duration;
 
 use accesskit::{
-    Node as AccesskitNode, NodeId, Role, Tree, TreeId, TreeUpdate, Uuid as AccesskitUuid,
+    Affine as AccesskitAffine, Node as AccesskitNode, NodeId, Rect as AccesskitRect, Role, Tree,
+    TreeId, TreeUpdate, Uuid as AccesskitUuid,
 };
 use dpi::PhysicalSize;
 use embedder_traits::{
@@ -942,9 +943,6 @@ impl WebView {
     }
 
     pub(crate) fn notify_document_accessibility_tree_id(&self, grafted_tree_id: TreeId) {
-        let Some(webview_accesskit_tree_id) = self.inner().accesskit_tree_id else {
-            return;
-        };
         let old_grafted_tree_id = self
             .inner_mut()
             .grafted_accesskit_tree_id
@@ -954,8 +952,51 @@ impl WebView {
         if old_grafted_tree_id == Some(grafted_tree_id) {
             return;
         }
+        self.send_accessibility_root_node();
+    }
+
+    /// Send the `WebView`-level accessibility root node, which grafts in the current document's
+    /// tree and carries the viewport bounds and scale that the document's own node bounds are
+    /// resolved against.
+    ///
+    /// This must be re-sent whenever that geometry changes, not only when the grafted document
+    /// changes, because the document nodes underneath are expressed relative to it.
+    pub(crate) fn send_accessibility_root_node(&self) {
+        let Some(webview_accesskit_tree_id) = self.inner().accesskit_tree_id else {
+            return;
+        };
+        let Some(grafted_tree_id) = self.inner().grafted_accesskit_tree_id else {
+            return;
+        };
         let root_node_id = NodeId(0);
         let mut root_node = AccesskitNode::new(Role::ScrollView);
+        // The root node covers the whole viewport, in the same coordinate space as the bounds of
+        // the document nodes grafted underneath it: CSS pixels relative to the viewport origin.
+        //
+        // Its transform converts those CSS pixels into the device independent pixels that the
+        // embedder positions this subtree in. That scale is everything which maps a CSS pixel to
+        // a device pixel — page zoom and pinch zoom — except the HiDPI scale factor, which is
+        // deliberately left out: it is the embedder which scales device independent pixels to the
+        // physical pixels AccessKit ultimately expects, and which translates this subtree to the
+        // WebView's position within its window. See `bounds_for_dom_node()` in
+        // `components/layout/accessibility_tree.rs` for the full contract.
+        let device_pixels_per_css_pixel = self.device_pixels_per_css_pixel().get();
+        let css_pixels_per_device_independent_pixel =
+            device_pixels_per_css_pixel / self.hidpi_scale_factor().get();
+        let size =
+            self.size() / Scale::<f32, CSSPixel, DevicePixel>::new(device_pixels_per_css_pixel);
+        root_node.set_bounds(AccesskitRect::new(
+            0.0,
+            0.0,
+            size.width as f64,
+            size.height as f64,
+        ));
+        // AccessKit asks that a node with an identity transform leave it unset.
+        if css_pixels_per_device_independent_pixel != 1.0 {
+            root_node.set_transform(AccesskitAffine::scale(
+                css_pixels_per_device_independent_pixel as f64,
+            ));
+        }
         let graft_node_id = NodeId(1);
         let mut graft_node = AccesskitNode::new(Role::GenericContainer);
         graft_node.set_tree_id(grafted_tree_id);

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -459,6 +459,9 @@ impl WebView {
             .servo
             .paint()
             .resize_rendering_context(self.id(), new_size);
+
+        // The accessibility root node's bounds cover the viewport, so they have to follow it.
+        self.send_accessibility_root_node();
     }
 
     /// Get the HiDPI scale factor for this [`WebView`].
@@ -664,6 +667,9 @@ impl WebView {
             .servo
             .paint()
             .set_page_zoom(self.id(), new_zoom);
+
+        // The accessibility root node scales CSS pixels by the zoom, so it has to follow it.
+        self.send_accessibility_root_node();
     }
 
     /// Get the page zoom of the [`WebView`].

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -488,6 +488,10 @@ impl WebView {
             .servo
             .paint()
             .set_hidpi_scale_factor(self.id(), new_scale_factor);
+
+        // The accessibility root node's bounds depend on the CSS viewport size, which changes
+        // with the HiDPI scale factor even though its transform deliberately excludes that scale.
+        self.send_accessibility_root_node();
     }
 
     /// Make this [`WebView`] visible within its [`RenderingContext`].

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -992,20 +992,17 @@ impl WebView {
         // The root node covers the whole viewport, in the same coordinate space as the bounds of
         // the document nodes grafted underneath it: CSS pixels relative to the viewport origin.
         //
-        // Its transform converts those CSS pixels into the device independent pixels that the
-        // embedder positions this subtree in. That scale is everything which maps a CSS pixel to
-        // a device pixel — page zoom and pinch zoom — except the HiDPI scale factor, which is
-        // deliberately left out: it is the embedder which scales device independent pixels to the
-        // physical pixels AccessKit ultimately expects, and which translates this subtree to the
-        // WebView's position within its window. See `update_bounds_from_dom_node()` in
-        // `components/layout/accessibility_tree.rs` for the full contract.
+        // Its transform converts those CSS pixels into device pixels. That scale is everything
+        // which maps a CSS pixel to a device pixel — page zoom, pinch zoom and HiDPI scale factor.
+        //
+        // See `update_bounds_from_dom_node()` in
+        // `components/layout/accessibility_tree.rs` for how bounds are computed for web contents.
+
         // Compute the ratio from the WebView's current settings. `device_pixels_per_css_pixel()`
         // reports the ratio the latest rendered display list was produced with, which lags behind
         // the zoom/HiDPI change that triggered this call, since reflow is asynchronous.
         let device_pixels_per_css_pixel =
             self.page_zoom() * self.hidpi_scale_factor().get() * self.pinch_zoom();
-        let device_independent_pixels_per_css_pixel =
-            device_pixels_per_css_pixel / self.hidpi_scale_factor().get();
         let size =
             self.size() / Scale::<f32, CSSPixel, DevicePixel>::new(device_pixels_per_css_pixel);
         root_node.set_bounds(AccesskitRect::new(
@@ -1015,9 +1012,9 @@ impl WebView {
             size.height as f64,
         ));
         // AccessKit asks that a node with an identity transform leave it unset.
-        if device_independent_pixels_per_css_pixel != 1.0 {
+        if device_pixels_per_css_pixel != 1.0 {
             root_node.set_transform(AccesskitAffine::scale(
-                device_independent_pixels_per_css_pixel as f64,
+                device_pixels_per_css_pixel as f64,
             ));
         }
         let graft_node_id = NodeId(1);

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::{Ref, RefCell, RefMut};
+use std::cell::{Cell, Ref, RefCell, RefMut};
 use std::hash::Hash;
 use std::rc::{Rc, Weak};
 
@@ -114,6 +114,14 @@ pub(crate) struct WebViewInner {
     /// A counter for changes to the grafted accesskit tree for this webview.
     /// See [`Self::grafted_accesskit_tree_id`].
     grafted_accesskit_tree_epoch: Option<Epoch>,
+    /// Set when the paint layer applies a change to this [`WebView`]'s accessibility viewport
+    /// geometry — its size, page or pinch zoom, or HiDPI scale — via
+    /// [`WebViewTrait::notify_viewport_updated()`]. The root accessibility node is re-sent from
+    /// [`Servo`]'s event loop rather than from there, so that nothing calls into the
+    /// [`WebViewDelegate`] while the paint `RefCell` (or an embedder-facing method) is on the stack,
+    /// which could cause re-entrant `RefCell` borrows. See
+    /// [`WebView::note_accessibility_viewport_changed()`].
+    accessibility_viewport_changed: Cell<bool>,
 
     rendering_context: Rc<dyn RenderingContext>,
     user_content_manager: Option<Rc<UserContentManager>>,
@@ -165,6 +173,7 @@ impl WebView {
             accesskit_tree_id: None,
             grafted_accesskit_tree_id: None,
             grafted_accesskit_tree_epoch: None,
+            accessibility_viewport_changed: Cell::new(false),
             hidpi_scale_factor: builder.hidpi_scale_factor,
             load_status: LoadStatus::Started,
             status_text: None,
@@ -958,6 +967,23 @@ impl WebView {
         self.send_accessibility_root_node();
     }
 
+    /// Record that this [`WebView`]'s accessibility viewport geometry changed (its size, page or
+    /// pinch zoom, or HiDPI scale). The root accessibility node covers the viewport and carries the
+    /// scale the grafted document nodes are resolved against, so it must be re-sent whenever that
+    /// geometry changes. This is called from the paint layer via
+    /// [`WebViewTrait::notify_viewport_updated()`]; the re-send itself is deferred to [`Servo`]'s
+    /// event loop (see `Servo::resend_accessibility_root_nodes_for_viewport_changes()`) so that it
+    /// never calls into the [`WebViewDelegate`] while the paint `RefCell` (or the embedder-facing
+    /// method that triggered the change) is on the stack.
+    pub(crate) fn note_accessibility_viewport_changed(&self) {
+        self.inner().accessibility_viewport_changed.set(true);
+    }
+
+    /// Take (and reset) the flag set by [`Self::note_accessibility_viewport_changed()`].
+    pub(crate) fn take_accessibility_viewport_changed(&self) -> bool {
+        self.inner().accessibility_viewport_changed.take()
+    }
+
     /// Send the `WebView`-level accessibility root node, which grafts in the current document's
     /// tree and carries the viewport bounds and scale that the document's own node bounds are
     /// resolved against.
@@ -1068,6 +1094,12 @@ impl WebViewTrait for ServoRendererWebView {
     fn set_animating(&self, new_value: bool) {
         if let Some(webview) = WebView::from_weak_handle(&self.weak_handle) {
             webview.set_animating(new_value);
+        }
+    }
+
+    fn notify_viewport_updated(&self) {
+        if let Some(webview) = WebView::from_weak_handle(&self.weak_handle) {
+            webview.note_accessibility_viewport_changed();
         }
     }
 }

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -981,10 +981,14 @@ impl WebView {
         // a device pixel — page zoom and pinch zoom — except the HiDPI scale factor, which is
         // deliberately left out: it is the embedder which scales device independent pixels to the
         // physical pixels AccessKit ultimately expects, and which translates this subtree to the
-        // WebView's position within its window. See `bounds_for_dom_node()` in
+        // WebView's position within its window. See `update_bounds_from_dom_node()` in
         // `components/layout/accessibility_tree.rs` for the full contract.
-        let device_pixels_per_css_pixel = self.device_pixels_per_css_pixel().get();
-        let css_pixels_per_device_independent_pixel =
+        // Compute the ratio from the WebView's current settings. `device_pixels_per_css_pixel()`
+        // reports the ratio the latest rendered display list was produced with, which lags behind
+        // the zoom/HiDPI change that triggered this call, since reflow is asynchronous.
+        let device_pixels_per_css_pixel =
+            self.page_zoom() * self.hidpi_scale_factor().get() * self.pinch_zoom();
+        let device_independent_pixels_per_css_pixel =
             device_pixels_per_css_pixel / self.hidpi_scale_factor().get();
         let size =
             self.size() / Scale::<f32, CSSPixel, DevicePixel>::new(device_pixels_per_css_pixel);
@@ -995,9 +999,9 @@ impl WebView {
             size.height as f64,
         ));
         // AccessKit asks that a node with an identity transform leave it unset.
-        if css_pixels_per_device_independent_pixel != 1.0 {
+        if device_independent_pixels_per_css_pixel != 1.0 {
             root_node.set_transform(AccesskitAffine::scale(
-                css_pixels_per_device_independent_pixel as f64,
+                device_independent_pixels_per_css_pixel as f64,
             ));
         }
         let graft_node_id = NodeId(1);

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -7,7 +7,8 @@ use std::hash::Hash;
 use std::rc::{Rc, Weak};
 
 use accesskit::{
-    Node as AccesskitNode, NodeId, Role, Tree, TreeId, TreeUpdate, Uuid as AccesskitUuid,
+    Affine as AccesskitAffine, Node as AccesskitNode, NodeId, Rect as AccesskitRect, Role, Tree,
+    TreeId, TreeUpdate, Uuid as AccesskitUuid,
 };
 use dpi::PhysicalSize;
 use embedder_traits::{
@@ -935,9 +936,6 @@ impl WebView {
     }
 
     pub(crate) fn notify_document_accessibility_tree_id(&self, grafted_tree_id: TreeId) {
-        let Some(webview_accesskit_tree_id) = self.inner().accesskit_tree_id else {
-            return;
-        };
         let old_grafted_tree_id = self
             .inner_mut()
             .grafted_accesskit_tree_id
@@ -947,8 +945,51 @@ impl WebView {
         if old_grafted_tree_id == Some(grafted_tree_id) {
             return;
         }
+        self.send_accessibility_root_node();
+    }
+
+    /// Send the `WebView`-level accessibility root node, which grafts in the current document's
+    /// tree and carries the viewport bounds and scale that the document's own node bounds are
+    /// resolved against.
+    ///
+    /// This must be re-sent whenever that geometry changes, not only when the grafted document
+    /// changes, because the document nodes underneath are expressed relative to it.
+    pub(crate) fn send_accessibility_root_node(&self) {
+        let Some(webview_accesskit_tree_id) = self.inner().accesskit_tree_id else {
+            return;
+        };
+        let Some(grafted_tree_id) = self.inner().grafted_accesskit_tree_id else {
+            return;
+        };
         let root_node_id = NodeId(0);
         let mut root_node = AccesskitNode::new(Role::ScrollView);
+        // The root node covers the whole viewport, in the same coordinate space as the bounds of
+        // the document nodes grafted underneath it: CSS pixels relative to the viewport origin.
+        //
+        // Its transform converts those CSS pixels into the device independent pixels that the
+        // embedder positions this subtree in. That scale is everything which maps a CSS pixel to
+        // a device pixel — page zoom and pinch zoom — except the HiDPI scale factor, which is
+        // deliberately left out: it is the embedder which scales device independent pixels to the
+        // physical pixels AccessKit ultimately expects, and which translates this subtree to the
+        // WebView's position within its window. See `bounds_for_dom_node()` in
+        // `components/layout/accessibility_tree.rs` for the full contract.
+        let device_pixels_per_css_pixel = self.device_pixels_per_css_pixel().get();
+        let css_pixels_per_device_independent_pixel =
+            device_pixels_per_css_pixel / self.hidpi_scale_factor().get();
+        let size =
+            self.size() / Scale::<f32, CSSPixel, DevicePixel>::new(device_pixels_per_css_pixel);
+        root_node.set_bounds(AccesskitRect::new(
+            0.0,
+            0.0,
+            size.width as f64,
+            size.height as f64,
+        ));
+        // AccessKit asks that a node with an identity transform leave it unset.
+        if css_pixels_per_device_independent_pixel != 1.0 {
+            root_node.set_transform(AccesskitAffine::scale(
+                css_pixels_per_device_independent_pixel as f64,
+            ));
+        }
         let graft_node_id = NodeId(1);
         let mut graft_node = AccesskitNode::new(Role::GenericContainer);
         graft_node.set_tree_id(grafted_tree_id);

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -1013,9 +1013,7 @@ impl WebView {
         ));
         // AccessKit asks that a node with an identity transform leave it unset.
         if device_pixels_per_css_pixel != 1.0 {
-            root_node.set_transform(AccesskitAffine::scale(
-                device_pixels_per_css_pixel as f64,
-            ));
+            root_node.set_transform(AccesskitAffine::scale(device_pixels_per_css_pixel as f64));
         }
         let graft_node_id = NodeId(1);
         let mut graft_node = AccesskitNode::new(Role::GenericContainer);

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -470,9 +470,6 @@ impl WebView {
             .servo
             .paint()
             .resize_rendering_context(self.id(), new_size);
-
-        // The accessibility root node's bounds cover the viewport, so they have to follow it.
-        self.send_accessibility_root_node();
     }
 
     /// Get the HiDPI scale factor for this [`WebView`].
@@ -497,10 +494,6 @@ impl WebView {
             .servo
             .paint()
             .set_hidpi_scale_factor(self.id(), new_scale_factor);
-
-        // The accessibility root node's bounds depend on the CSS viewport size, which changes
-        // with the HiDPI scale factor even though its transform deliberately excludes that scale.
-        self.send_accessibility_root_node();
     }
 
     /// Make this [`WebView`] visible within its [`RenderingContext`].
@@ -686,9 +679,6 @@ impl WebView {
             .servo
             .paint()
             .set_page_zoom(self.id(), new_zoom);
-
-        // The accessibility root node scales CSS pixels by the zoom, so it has to follow it.
-        self.send_accessibility_root_node();
     }
 
     /// Get the page zoom of the [`WebView`].

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -461,6 +461,9 @@ impl WebView {
             .servo
             .paint()
             .resize_rendering_context(self.id(), new_size);
+
+        // The accessibility root node's bounds cover the viewport, so they have to follow it.
+        self.send_accessibility_root_node();
     }
 
     /// Get the HiDPI scale factor for this [`WebView`].
@@ -670,6 +673,9 @@ impl WebView {
             .servo
             .paint()
             .set_page_zoom(self.id(), new_zoom);
+
+        // The accessibility root node scales CSS pixels by the zoom, so it has to follow it.
+        self.send_accessibility_root_node();
     }
 
     /// Get the page zoom of the [`WebView`].

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -675,6 +675,9 @@ pub struct ReflowStatistics {
     /// A count of the number of accessibility nodes which were checked for changes based on data
     /// already in the accessibility tree (whether the check resulted in changes or not).
     pub nodes_updated_from_tree: u32,
+    /// A count of the number of accessibility nodes which had their bounds recomputed from layout
+    /// geometry (whether the recomputation resulted in changes or not).
+    pub nodes_updated_bounds: u32,
     /// A count of the number of accessibility nodes actually serialized to the TreeUpdate.
     pub nodes_in_tree_update: u32,
 }

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -688,6 +688,9 @@ pub struct ReflowStatistics {
     /// A count of the number of accessibility nodes which were checked for changes based on data
     /// already in the accessibility tree (whether the check resulted in changes or not).
     pub nodes_updated_from_tree: u32,
+    /// A count of the number of accessibility nodes which had their bounds recomputed from layout
+    /// geometry (whether the recomputation resulted in changes or not).
+    pub nodes_updated_bounds: u32,
     /// A count of the number of accessibility nodes actually serialized to the TreeUpdate.
     pub nodes_in_tree_update: u32,
 }

--- a/components/shared/paint/lib.rs
+++ b/components/shared/paint/lib.rs
@@ -801,6 +801,10 @@ pub trait WebViewTrait {
     fn id(&self) -> WebViewId;
     fn screen_geometry(&self) -> Option<ScreenGeometry>;
     fn set_animating(&self, new_value: bool);
+    /// Notify the embedding layer that this `WebView`'s viewport geometry changed — its size, page
+    /// or pinch zoom, or HiDPI scale — so it can refresh geometry, such as the accessibility root
+    /// node, that the embedder derives from the viewport rather than from a pipeline update.
+    fn notify_viewport_updated(&self);
 }
 
 /// What entity is reporting that a `Pipeline` has exited. Only when all have

--- a/ports/servoshell/desktop/gui.rs
+++ b/ports/servoshell/desktop/gui.rs
@@ -593,6 +593,20 @@ impl Gui {
                     let id = egui::Id::new(webview_id);
                     ctx.accesskit_node_builder(id, |node| {
                         node.set_tree_id(tree_id);
+                        // The grafted WebView tree reports bounds in device independent pixels
+                        // relative to the WebView's own origin, so this node supplies the offset
+                        // of the WebView within the window. `available_rect` is in egui points,
+                        // and one device independent pixel is one egui point, because egui's own
+                        // root node already applies the points-to-physical-pixels scale to this
+                        // entire subtree. Multiplying by `pixels_per_point` here would apply that
+                        // scale twice.
+                        //
+                        // Only the transform is set: AccessKit consumers exclude graft nodes from
+                        // the presented tree, so bounds on this node would never be read.
+                        node.set_transform(accesskit::Affine::translate((
+                            available_rect.min.x as f64,
+                            available_rect.min.y as f64,
+                        )));
                     });
                 }
             }

--- a/ports/servoshell/desktop/gui.rs
+++ b/ports/servoshell/desktop/gui.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use accesskit::Affine;
 use dpi::PhysicalSize;
 use egui::text::{CCursor, CCursorRange};
 use egui::text_edit::TextEditState;
@@ -589,25 +590,24 @@ impl Gui {
             let available_rect = ctx.available_rect_before_wrap();
 
             // Build a graft node for each WebView.
+            let affine = {
+                // The grafted WebView tree reports bounds in device pixels relative to the
+                // WebView's own origin, so this node supplies the offset of the WebView within
+                // the window, and scales it to the same scale as the rest of the nodes in egui's
+                // AccessKit tree.
+                let scale = (1.0 / window.platform_window().hidpi_scale_factor().get()) as f64;
+                let x = available_rect.min.x as f64;
+                let y =  available_rect.min.y as f64;
+                Affine::new([scale, 0.0, 0.0, scale, x, y])
+            };
             for (webview_id, webview) in window.webviews() {
                 if let Some(tree_id) = webview.accesskit_tree_id() {
                     let id = egui::Id::new(webview_id);
                     ctx.accesskit_node_builder(id, |node| {
                         node.set_tree_id(tree_id);
-                        // The grafted WebView tree reports bounds in device independent pixels
-                        // relative to the WebView's own origin, so this node supplies the offset
-                        // of the WebView within the window. `available_rect` is in egui points,
-                        // and one device independent pixel is one egui point, because egui's own
-                        // root node already applies the points-to-physical-pixels scale to this
-                        // entire subtree. Multiplying by `pixels_per_point` here would apply that
-                        // scale twice.
-                        //
                         // Only the transform is set: AccessKit consumers exclude graft nodes from
                         // the presented tree, so bounds on this node would never be read.
-                        node.set_transform(accesskit::Affine::translate((
-                            available_rect.min.x as f64,
-                            available_rect.min.y as f64,
-                        )));
+                        node.set_transform(affine);
                     });
                 }
             }

--- a/ports/servoshell/desktop/gui.rs
+++ b/ports/servoshell/desktop/gui.rs
@@ -597,7 +597,7 @@ impl Gui {
                 // AccessKit tree.
                 let scale = (1.0 / window.platform_window().hidpi_scale_factor().get()) as f64;
                 let x = available_rect.min.x as f64;
-                let y =  available_rect.min.y as f64;
+                let y = available_rect.min.y as f64;
                 Affine::new([scale, 0.0, 0.0, scale, x, y])
             };
             for (webview_id, webview) in window.webviews() {

--- a/ports/servoshell/desktop/gui.rs
+++ b/ports/servoshell/desktop/gui.rs
@@ -594,6 +594,20 @@ impl Gui {
                     let id = egui::Id::new(webview_id);
                     ctx.accesskit_node_builder(id, |node| {
                         node.set_tree_id(tree_id);
+                        // The grafted WebView tree reports bounds in device independent pixels
+                        // relative to the WebView's own origin, so this node supplies the offset
+                        // of the WebView within the window. `available_rect` is in egui points,
+                        // and one device independent pixel is one egui point, because egui's own
+                        // root node already applies the points-to-physical-pixels scale to this
+                        // entire subtree. Multiplying by `pixels_per_point` here would apply that
+                        // scale twice.
+                        //
+                        // Only the transform is set: AccessKit consumers exclude graft nodes from
+                        // the presented tree, so bounds on this node would never be read.
+                        node.set_transform(accesskit::Affine::translate((
+                            available_rect.min.x as f64,
+                            available_rect.min.y as f64,
+                        )));
                     });
                 }
             }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -11388,42 +11388,42 @@
   "testharness": {
    "accessibility-tree": {
     "accessibility-update-basic-mutation.html": [
-     "c5a01a3e528caa3d3925140ea8f575865c549c26",
+     "67ef9b7e69a56c5b50920b4a1bc987cab81d6114",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-children-of-heading-change.html": [
-     "ab99aa03cc40917d5d57159d73ac137db37900b8",
+     "f3fcc102de641f065058123fee7305bce52ab7c5",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-descendants-of-heading-change.html": [
-     "93eb71919ef1055271731d9b2aa476cb43dc3b42",
+     "7cd9409f391adfff42f97623beafb6604c9fa3da",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-mutation-move-nodes.html": [
-     "37da877ec1f10341d26cd9f6701c304af8ae5952",
+     "b6fc6ef97291bdd67957e202c3a9b14e0e74f013",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-partial-subtree-move-and-delete.html": [
-     "b6655b8c1c29d2d1faa4db042ef791b61ae5f79c",
+     "81a6dcf0f7e5d7eb6fa5938d04696b783e02526f",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-text-change.html": [
-     "86b2ff626306b6d4aab36baef7fdeed7296fa97d",
+     "12db168a263d741f5ef4404012eea670a20c0681",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-basic-mutation.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-basic-mutation.html
@@ -16,6 +16,8 @@
 
       assert_equals(initial.nodesUpdatedFromDom, 19, "nodesUpdatedFromDom");
       assert_equals(initial.nodesUpdatedFromTree, 19, "nodesUpdatedFromTree");
+      // Bounds are refreshed for every node in the tree
+      assert_equals(initial.nodesUpdatedBounds, 19, "nodesUpdatedBounds");
       assert_equals(initial.nodesInTreeUpdate, 19, "nodesInTreeUpdate");
 
       document.getElementById("h2").remove();
@@ -28,8 +30,12 @@
       // changed
       assert_equals(update.nodesUpdatedFromTree, 3, "nodesUpdatedFromTree");
 
-      // The only node in the tree update should be the parent <section> of the removed <h2>
-      assert_equals(update.nodesInTreeUpdate, 1, "nodesInTreeUpdate");
+      // Bounds are refreshed for every node still in the tree (the <h2> and its text are gone)
+      assert_equals(update.nodesUpdatedBounds, 17, "nodesUpdatedBounds");
+
+      // The tree update holds the parent <section> of the removed <h2>, plus the <body> and the
+      // document, whose heights shrank when the <h2> was removed
+      assert_equals(update.nodesInTreeUpdate, 3, "nodesInTreeUpdate");
     }, "Remove h2 should update one node");
 
     done();

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-children-of-heading-change.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-children-of-heading-change.html
@@ -13,6 +13,8 @@
 
       assert_equals(initial.nodesUpdatedFromDom, 15, "nodesUpdatedFromDom");
       assert_equals(initial.nodesUpdatedFromTree, 15, "nodesUpdatedFromTree");
+      // Bounds are refreshed for every node in the tree
+      assert_equals(initial.nodesUpdatedBounds, 15, "nodesUpdatedBounds");
       assert_equals(initial.nodesInTreeUpdate, 15, "nodesInTreeUpdate");
 
       document.querySelector("code").remove();
@@ -26,8 +28,11 @@
       // <html>, <body>, <h2>
       assert_equals(update.nodesUpdatedFromTree, 3, "nodesUpdatedFromTree");
 
+      // Bounds are refreshed for every node still in the tree (the <code> and its text are gone)
+      assert_equals(update.nodesUpdatedBounds, 13, "nodesUpdatedBounds");
+
       // Changed nodes:
-      // - <h2>, children and label changed
+      // - <h2>, children and label changed (its geometry did not: the text still fits one line)
       assert_equals(update.nodesInTreeUpdate, 1, "nodesInTreeUpdate");
     }, "");
 

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-descendants-of-heading-change.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-descendants-of-heading-change.html
@@ -15,6 +15,8 @@
 
       assert_equals(initial.nodesUpdatedFromDom, 18, "nodesUpdatedFromDom");
       assert_equals(initial.nodesUpdatedFromTree, 18, "nodesUpdatedFromTree");
+      // Bounds are refreshed for every node in the tree
+      assert_equals(initial.nodesUpdatedBounds, 18, "nodesUpdatedBounds");
       assert_equals(initial.nodesInTreeUpdate, 18, "nodesInTreeUpdate");
 
       document.querySelector("strong").remove();
@@ -28,9 +30,12 @@
       // <html>, <body>, <h2>, <em>
       assert_equals(update.nodesUpdatedFromTree, 4, "nodesUpdatedFromTree");
 
+      // Bounds are refreshed for every node still in the tree (the <strong> and its text are gone)
+      assert_equals(update.nodesUpdatedBounds, 16, "nodesUpdatedBounds");
+
       // Changed nodes:
       // - <h2>, label changed
-      // - <em>, children changed
+      // - <em>, children changed (and its inline box narrowed, changing its bounds)
       assert_equals(update.nodesInTreeUpdate, 2, "nodesInTreeUpdate");
     }, "");
 

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-mutation-move-nodes.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-mutation-move-nodes.html
@@ -18,6 +18,8 @@
 
       assert_equals(initial.nodesUpdatedFromDom, 23, "nodesUpdatedFromDom");
       assert_equals(initial.nodesUpdatedFromTree, 23, "nodesUpdatedFromTree");
+      // Bounds are refreshed for every node in the tree
+      assert_equals(initial.nodesUpdatedBounds, 23, "nodesUpdatedBounds");
       assert_equals(initial.nodesInTreeUpdate, 23, "nodesInTreeUpdate");
 
       div1.moveBefore(h1, null);
@@ -38,10 +40,13 @@
       // - div2
       assert_equals(update.nodesUpdatedFromTree, 5, "nodesUpdatedFromTree");
 
+      // Bounds are refreshed for every node in the tree; moving nodes removes none
+      assert_equals(update.nodesUpdatedBounds, 23, "nodesUpdatedBounds");
+
       //  updated nodes:
       // - <section>, which had 2 children removed
-      // - div1, which had 1 node (<h1>) added
-      // - div2, which had 1 node (<h2>) added
+      // - div1, which had 1 node (<h1>) added (and now wraps it, changing its bounds)
+      // - div2, which had 1 node (<h2>) added (and now wraps it, changing its bounds)
       assert_equals(update.nodesInTreeUpdate, 3, "nodesInTreeUpdate");
     }, "Moving two nodes should update 3 nodes");
 

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-partial-subtree-move-and-delete.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-partial-subtree-move-and-delete.html
@@ -21,6 +21,8 @@
 
       assert_equals(initial.nodesUpdatedFromDom, 29, "nodesUpdatedFromDom");
       assert_equals(initial.nodesUpdatedFromTree, 29, "nodesUpdatedFromTree");
+      // Bounds are refreshed for every node in the tree
+      assert_equals(initial.nodesUpdatedBounds, 29, "nodesUpdatedBounds");
       assert_equals(initial.nodesInTreeUpdate, 29, "nodesInTreeUpdate");
 
       div3.moveBefore(div2, h2);
@@ -39,11 +41,19 @@
       // <html>, <body>, <section>, div3, div2
       assert_equals(update.nodesUpdatedFromTree, 5, "nodesUpdatedFromTree");
 
+      // Bounds are refreshed for every node still in the tree. Gone are div1, the <p> and its
+      // text, plus the two whitespace-only text nodes that were direct children of div1: one
+      // between div1's start tag and div2 (div2 itself moved out, but not its whitespace
+      // siblings), and one between div2 and div1's end tag.
+      assert_equals(update.nodesUpdatedBounds, 24, "nodesUpdatedBounds");
+
       // Changed nodes:
-      // - <section>, children changed
-      // - div2, children changed
-      // - div3, children changed
-      assert_equals(update.nodesInTreeUpdate, 3, "nodesInTreeUpdate");
+      // - <section>, children changed (and it shrank, changing its bounds)
+      // - div2, children changed (and it is now empty, changing its bounds)
+      // - div3, children changed (and it now wraps more content, changing its bounds)
+      // - <h2>, which moved up when the <p> was removed, changing its bounds
+      // - <body> and the document, whose heights shrank, changing their bounds
+      assert_equals(update.nodesInTreeUpdate, 6, "nodesInTreeUpdate");
     }, "");
 
     done();

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-text-change.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-text-change.html
@@ -15,6 +15,8 @@
 
       assert_equals(initial.nodesUpdatedFromDom, 16, "nodesUpdatedFromDom");
       assert_equals(initial.nodesUpdatedFromTree, 16, "nodesUpdatedFromTree");
+      // Bounds are refreshed for every node in the tree
+      assert_equals(initial.nodesUpdatedBounds, 16, "nodesUpdatedBounds");
       assert_equals(initial.nodesInTreeUpdate, 16, "nodesInTreeUpdate");
 
       h1.firstChild.appendData(", now with more text");
@@ -26,9 +28,13 @@
       // The document, <body>, <section>, <h1> and the text node.
       assert_equals(update.nodesUpdatedFromTree, 5, "nodesUpdatedFromTree");
 
+      // Bounds are refreshed for every node in the tree; no nodes were added or removed
+      assert_equals(update.nodesUpdatedBounds, 16, "nodesUpdatedBounds");
+
       //  updated nodes:
       // - <h1>, computed label changed
       // - text child of <h1>, value changed
+      // (the longer text still fits on one line, so no bounds changed)
       assert_equals(update.nodesInTreeUpdate, 2, "nodesInTreeUpdate");
     }, "Append data to text node should update 2 nodes");
 


### PR DESCRIPTION
Added bounds (pos + size) to the nodes in Servo's accessibilty tree. Assistive tech relies on these to do things like:

- determine what precisely is under the cursor
- magnify the area around the focused element

Before this no node had bounds, so the above (and more, i'm sure) wasn't possible. This PR adds those bounds, and syncs them with existing damage tracking, plus adds tests to ensure this behavior is maintained.

Testing: This change adds new testing information in `ServoTestUtils` and starts using it in Servos-specific accessibility tests.
Fixes #46245 