### PR TITLE
script: Prevent borrow hazards in Element::ensure_rare_data.

### DIFF
--- a/components/script/dom/bindings/constructor.rs
+++ b/components/script/dom/bindings/constructor.rs
@@ -173,10 +173,10 @@ fn html_constructor(
             // Step 7.2-7.5 are performed in the generated caller code.
 
             // Step 7.6 Set element's custom element state to "custom".
-            element.set_custom_element_state(CustomElementState::Custom);
+            element.set_custom_element_state(CustomElementState::Custom, cx.no_gc());
 
             // Step 7.7 Set element's custom element definition to definition.
-            element.set_custom_element_definition(definition);
+            element.set_custom_element_definition(definition, cx.no_gc());
 
             // Step 7.8 Set element's is value to isValue.
             if let Some(is_value) = is_value {

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -759,7 +759,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
             // Step 4.2. If inclusiveDescendant's custom element registry is null:
             if element.custom_element_registry().is_none() {
                 // Step 4.2.1. Set inclusiveDescendant's custom element registry to this.
-                element.set_custom_element_registry(Some(self));
+                element.set_custom_element_registry(Some(self), cx.no_gc());
 
                 // Step 4.2.2. If this's is scoped is true, then append
                 // inclusiveDescendant's node document to this's scoped document set.
@@ -959,7 +959,7 @@ impl CustomElementDefinition {
         // Element's `is` is None by default
 
         // Step 5.1.3.11. Set result’s custom element registry to registry.
-        element.set_custom_element_registry(registry);
+        element.set_custom_element_registry(registry, cx.no_gc());
 
         Ok(element)
     }
@@ -982,10 +982,10 @@ pub(crate) fn upgrade_element(
     }
 
     // Step 2. Set element's custom element definition to definition.
-    element.set_custom_element_definition(Rc::clone(&definition));
+    element.set_custom_element_definition(Rc::clone(&definition), cx.no_gc());
 
     // Step 3. Set element's custom element state to "failed".
-    element.set_custom_element_state(CustomElementState::Failed);
+    element.set_custom_element_state(CustomElementState::Failed, cx.no_gc());
 
     // Step 4. For each attribute in element's attribute list, in order, enqueue a custom element callback reaction
     // with element, callback name "attributeChangedCallback", and « attribute's local name, null, attribute's value,
@@ -1028,7 +1028,7 @@ pub(crate) fn upgrade_element(
     // Step 8 exception handling
     if let Err(error) = result {
         // Step 8.exception.1
-        element.clear_custom_element_definition();
+        element.clear_custom_element_definition(cx.no_gc());
 
         // Step 8.exception.2
         element.clear_reaction_queue();
@@ -1085,7 +1085,7 @@ pub(crate) fn upgrade_element(
     }
 
     // Step 10
-    element.set_custom_element_state(CustomElementState::Custom);
+    element.set_custom_element_state(CustomElementState::Custom, cx.no_gc());
 }
 
 /// <https://html.spec.whatwg.org/multipage/#concept-upgrade-an-element>
@@ -1115,7 +1115,7 @@ fn run_upgrade_constructor(
 
         let args = HandleValueArray::empty();
         // Step 8.2. Set element's custom element state to "precustomized".
-        element.set_custom_element_state(CustomElementState::Precustomized);
+        element.set_custom_element_state(CustomElementState::Precustomized, cx.no_gc());
 
         // Step 9.3. Let constructResult be the result of constructing C, with no arguments.
         // https://webidl.spec.whatwg.org/#construct-a-callback-function
@@ -1442,12 +1442,20 @@ impl CustomElementReactionStack {
                     // Step 3.4.1. If disconnectedCallback is not null, then call
                     // disconnectedCallback with no arguments.
                     if let Some(disconnected_callback) = disconnected_callback {
-                        element.push_callback_reaction(disconnected_callback, Box::new([]));
+                        element.push_callback_reaction(
+                            disconnected_callback,
+                            Box::new([]),
+                            cx.no_gc(),
+                        );
                     }
                     // Step 3.4.2. If connectedCallback is not null, then call
                     // connectedCallback with no arguments.
                     if let Some(connected_callback) = connected_callback {
-                        element.push_callback_reaction(connected_callback, Box::new([]));
+                        element.push_callback_reaction(
+                            connected_callback,
+                            Box::new([]),
+                            cx.no_gc(),
+                        );
                     }
 
                     self.enqueue_element(cx, element);
@@ -1466,7 +1474,7 @@ impl CustomElementReactionStack {
 
         // Step 6. Add a new callback reaction to element's custom element reaction queue, with
         // callback function callback and arguments args.
-        element.push_callback_reaction(callback, args.into_boxed_slice());
+        element.push_callback_reaction(callback, args.into_boxed_slice(), cx.no_gc());
 
         // Step 7. Enqueue an element on the appropriate element queue given element.
         self.enqueue_element(cx, element);
@@ -1481,7 +1489,7 @@ impl CustomElementReactionStack {
     ) {
         // Step 1. Add a new upgrade reaction to element's custom element reaction queue,
         // with custom element definition definition.
-        element.push_upgrade_reaction(definition);
+        element.push_upgrade_reaction(definition, cx.no_gc());
 
         // Step 2. Enqueue an element on the appropriate element queue given element.
         self.enqueue_element(cx, element);

--- a/components/script/dom/element/create.rs
+++ b/components/script/dom/element/create.rs
@@ -181,8 +181,8 @@ fn create_html_element(
             // interface, localName, the HTML namespace, prefix, "undefined", is, and registry.
             let element = create_native_html_element(cx, name, prefix, document, creator, proto);
             element.set_is(definition.name.clone());
-            element.set_custom_element_state(CustomElementState::Undefined);
-            element.set_custom_element_registry(registry.as_deref());
+            element.set_custom_element_state(CustomElementState::Undefined, cx.no_gc());
+            element.set_custom_element_registry(registry.as_deref(), cx.no_gc());
 
             match mode {
                 // Step 4.3. If synchronousCustomElements is true, then run this step while catching any exceptions:
@@ -213,7 +213,7 @@ fn create_html_element(
                         registry.as_deref(),
                     ) {
                         Ok(element) => {
-                            element.set_custom_element_definition(definition.clone());
+                            element.set_custom_element_definition(definition.clone(), cx.no_gc());
                             element
                         },
                         Err(error) => {
@@ -234,8 +234,9 @@ fn create_html_element(
                             let element = DomRoot::upcast::<Element>(HTMLUnknownElement::new(
                                 cx, local_name, prefix, document, proto,
                             ));
-                            element.set_custom_element_state(CustomElementState::Failed);
-                            element.set_custom_element_registry(registry.as_deref());
+                            element
+                                .set_custom_element_state(CustomElementState::Failed, cx.no_gc());
+                            element.set_custom_element_registry(registry.as_deref(), cx.no_gc());
                             element
                         },
                     };
@@ -250,8 +251,8 @@ fn create_html_element(
                     let result = DomRoot::upcast::<Element>(HTMLElement::new(
                         cx, name.local, prefix, document, proto,
                     ));
-                    result.set_custom_element_state(CustomElementState::Undefined);
-                    result.set_custom_element_registry(registry.as_deref());
+                    result.set_custom_element_state(CustomElementState::Undefined, cx.no_gc());
+                    result.set_custom_element_registry(registry.as_deref(), cx.no_gc());
                     // Step 4.2.2. Enqueue a custom element upgrade reaction given result and definition.
                     ScriptThread::enqueue_upgrade_reaction(cx, &result, definition);
                     return result;
@@ -272,13 +273,13 @@ fn create_html_element(
     match is {
         Some(is) => {
             result.set_is(is);
-            result.set_custom_element_state(CustomElementState::Undefined);
-            result.set_custom_element_registry(registry.as_deref());
+            result.set_custom_element_state(CustomElementState::Undefined, cx.no_gc());
+            result.set_custom_element_registry(registry.as_deref(), cx.no_gc());
         },
         None => {
             if is_valid_custom_element_name(&name.local) {
-                result.set_custom_element_state(CustomElementState::Undefined);
-                result.set_custom_element_registry(registry.as_deref());
+                result.set_custom_element_state(CustomElementState::Undefined, cx.no_gc());
+                result.set_custom_element_registry(registry.as_deref(), cx.no_gc());
             } else {
                 // Note: This is a performance optimization. See the doc comment of the method for
                 // more information.

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -1024,9 +1024,18 @@ impl Element {
         cx: &mut JSContext,
         document: &Document,
     ) -> DomRoot<Range> {
-        self.ensure_rare_data(cx.no_gc())
-            .contenteditable_selection_range
-            .or_init(|| Range::new_with_doc(cx, document, None))
+        let Some(selection_range) = self
+            .rare_data()
+            .as_ref()
+            .and_then(|data| data.contenteditable_selection_range.get())
+        else {
+            let range = Range::new_with_doc(cx, document, None);
+            self.ensure_rare_data(cx.no_gc())
+                .contenteditable_selection_range
+                .set(Some(&*range));
+            return range;
+        };
+        selection_range
     }
 
     /// <https://drafts.csswg.org/cssom-view/#scrolling-events>
@@ -2752,13 +2761,15 @@ impl Element {
     }
 
     pub(crate) fn ensure_element_internals(&self, cx: &mut JSContext) -> DomRoot<ElementInternals> {
-        let mut rare_data = self.ensure_rare_data(cx.no_gc());
-        DomRoot::from_ref(rare_data.element_internals.get_or_insert_with(|| {
+        let Some(element_internals) = self.get_element_internals() else {
             let elem = self
                 .downcast::<HTMLElement>()
                 .expect("ensure_element_internals should only be called for an HTMLElement");
-            Dom::from_ref(&*ElementInternals::new(cx, elem))
-        }))
+            let internals = ElementInternals::new(cx, elem);
+            self.ensure_rare_data(cx.no_gc()).element_internals = Some(Dom::from_ref(&*internals));
+            return internals;
+        };
+        element_internals
     }
 
     pub(crate) fn outer_html(&self, cx: &mut JSContext) -> Fallible<DOMString> {
@@ -4543,9 +4554,12 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
 
     /// <https://drafts.csswg.org/css-shadow-parts/#dom-element-part>
     fn Part(&self, cx: &mut JSContext) -> DomRoot<DOMTokenList> {
-        self.ensure_rare_data(cx.no_gc())
-            .part
-            .or_init(|| DOMTokenList::new(cx, self, &local_name!("part"), None))
+        let Some(part) = self.rare_data().as_ref().and_then(|data| data.part.get()) else {
+            let part = DOMTokenList::new(cx, self, &local_name!("part"), None);
+            self.ensure_rare_data(cx.no_gc()).part.set(Some(&*part));
+            return part;
+        };
+        part
     }
 
     /// <https://drafts.csswg.org/web-animations-1/#dom-animatable-animate>

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -335,8 +335,8 @@ impl Element {
         }
     }
 
-    pub(crate) fn set_had_duplicate_attributes(&self) {
-        self.ensure_rare_data().had_duplicate_attributes = true;
+    pub(crate) fn set_had_duplicate_attributes(&self, no_gc: &NoGC) {
+        self.ensure_rare_data(no_gc).had_duplicate_attributes = true;
     }
 
     pub(crate) fn new(
@@ -365,8 +365,11 @@ impl Element {
         self.rare_data.borrow_mut()
     }
 
-    pub(crate) fn ensure_rare_data(&self) -> RefMut<'_, Box<ElementRareData>> {
-        let mut rare_data = self.rare_data.borrow_mut();
+    pub(crate) fn ensure_rare_data<'a: 'b, 'b>(
+        &'a self,
+        no_gc: &'b NoGC,
+    ) -> RefMut<'b, Box<ElementRareData>> {
+        let mut rare_data = self.rare_data.safe_borrow_mut(no_gc);
         if rare_data.is_none() {
             *rare_data = Some(Default::default());
         }
@@ -424,10 +427,10 @@ impl Element {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-element-custom-element-state>
-    pub(crate) fn set_custom_element_state(&self, state: CustomElementState) {
+    pub(crate) fn set_custom_element_state(&self, state: CustomElementState, no_gc: &NoGC) {
         // no need to inflate rare data for uncustomized
         if state != CustomElementState::Uncustomized {
-            self.ensure_rare_data().custom_element_state = state;
+            self.ensure_rare_data(no_gc).custom_element_state = state;
         }
 
         let in_defined_state = matches!(
@@ -449,27 +452,40 @@ impl Element {
         self.get_custom_element_state() == CustomElementState::Custom
     }
 
-    pub(crate) fn set_custom_element_definition(&self, definition: Rc<CustomElementDefinition>) {
-        self.ensure_rare_data().custom_element_definition = Some(definition);
+    pub(crate) fn set_custom_element_definition(
+        &self,
+        definition: Rc<CustomElementDefinition>,
+        no_gc: &NoGC,
+    ) {
+        self.ensure_rare_data(no_gc).custom_element_definition = Some(definition);
     }
 
     pub(crate) fn get_custom_element_definition(&self) -> Option<Rc<CustomElementDefinition>> {
         self.rare_data().as_ref()?.custom_element_definition.clone()
     }
 
-    pub(crate) fn clear_custom_element_definition(&self) {
-        self.ensure_rare_data().custom_element_definition = None;
+    pub(crate) fn clear_custom_element_definition(&self, no_gc: &NoGC) {
+        self.ensure_rare_data(no_gc).custom_element_definition = None;
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-    pub(crate) fn push_callback_reaction(&self, function: Rc<Function>, args: Box<[Heap<JSVal>]>) {
-        self.ensure_rare_data()
+    pub(crate) fn push_callback_reaction(
+        &self,
+        function: Rc<Function>,
+        args: Box<[Heap<JSVal>]>,
+        no_gc: &NoGC,
+    ) {
+        self.ensure_rare_data(no_gc)
             .custom_element_reaction_queue
             .push(CustomElementReaction::Callback(function, args));
     }
 
-    pub(crate) fn push_upgrade_reaction(&self, definition: Rc<CustomElementDefinition>) {
-        self.ensure_rare_data()
+    pub(crate) fn push_upgrade_reaction(
+        &self,
+        definition: Rc<CustomElementDefinition>,
+        no_gc: &NoGC,
+    ) {
+        self.ensure_rare_data(no_gc)
             .custom_element_reaction_queue
             .push(CustomElementReaction::Upgrade(definition));
     }
@@ -752,7 +768,7 @@ impl Element {
         shadow_root.set_serializable(serializable);
 
         // Step 12. Set element’s shadow root to shadow
-        self.ensure_rare_data().shadow_root = Some(Dom::from_ref(&*shadow_root));
+        self.ensure_rare_data(cx.no_gc()).shadow_root = Some(Dom::from_ref(&*shadow_root));
         shadow_root
             .upcast::<Node>()
             .set_containing_shadow_root(Some(&shadow_root));
@@ -840,10 +856,11 @@ impl Element {
 
     /// Return all IntersectionObserverRegistration for this element.
     /// Lazily initialize the raredata if it does not exist.
-    pub(crate) fn registered_intersection_observers_mut(
-        &self,
-    ) -> RefMut<'_, Vec<IntersectionObserverRegistration>> {
-        RefMut::map(self.ensure_rare_data(), |rare_data| {
+    pub(crate) fn registered_intersection_observers_mut<'a: 'b, 'b>(
+        &'a self,
+        no_gc: &'b NoGC,
+    ) -> RefMut<'b, Vec<IntersectionObserverRegistration>> {
+        RefMut::map(self.ensure_rare_data(no_gc), |rare_data| {
             &mut rare_data.registered_intersection_observers
         })
     }
@@ -882,15 +899,20 @@ impl Element {
     pub(crate) fn add_initial_intersection_observer_registration(
         &self,
         observer: &IntersectionObserver,
+        no_gc: &NoGC,
     ) {
-        self.ensure_rare_data()
+        self.ensure_rare_data(no_gc)
             .registered_intersection_observers
             .push(IntersectionObserverRegistration::new_initial(observer));
     }
 
     /// Removes a certain IntersectionObserver.
-    pub(crate) fn remove_intersection_observer(&self, observer: &IntersectionObserver) {
-        self.ensure_rare_data()
+    pub(crate) fn remove_intersection_observer(
+        &self,
+        observer: &IntersectionObserver,
+        no_gc: &NoGC,
+    ) {
+        self.ensure_rare_data(no_gc)
             .registered_intersection_observers
             .retain(|reg_obs| *reg_obs.observer != *observer)
     }
@@ -1002,7 +1024,7 @@ impl Element {
         cx: &mut JSContext,
         document: &Document,
     ) -> DomRoot<Range> {
-        self.ensure_rare_data()
+        self.ensure_rare_data(cx.no_gc())
             .contenteditable_selection_range
             .or_init(|| Range::new_with_doc(cx, document, None))
     }
@@ -1720,8 +1742,12 @@ impl Element {
         *self.prefix.borrow_mut() = prefix;
     }
 
-    pub(crate) fn set_custom_element_registry(&self, registry: Option<&CustomElementRegistry>) {
-        self.ensure_rare_data().custom_element_registry = registry.map(Dom::from_ref);
+    pub(crate) fn set_custom_element_registry(
+        &self,
+        registry: Option<&CustomElementRegistry>,
+        no_gc: &NoGC,
+    ) {
+        self.ensure_rare_data(no_gc).custom_element_registry = registry.map(Dom::from_ref);
     }
 
     pub(crate) fn custom_element_registry(&self) -> Option<DomRoot<CustomElementRegistry>> {
@@ -2482,8 +2508,8 @@ impl Element {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#nonce-attributes>
-    pub(crate) fn update_nonce_internal_slot(&self, nonce: String) {
-        self.ensure_rare_data().cryptographic_nonce = nonce;
+    pub(crate) fn update_nonce_internal_slot(&self, nonce: String, no_gc: &NoGC) {
+        self.ensure_rare_data(no_gc).cryptographic_nonce = nonce;
     }
 
     /// <https://html.spec.whatwg.org/multipage/#nonce-attributes>
@@ -2519,7 +2545,7 @@ impl Element {
         // Step 2.2: Set an attribute value for element using "nonce" and the empty string.
         self.set_string_attribute(cx, &local_name!("nonce"), "".into());
         // Step 2.3: Set element's [[CryptographicNonce]] to nonce.
-        self.update_nonce_internal_slot(nonce);
+        self.update_nonce_internal_slot(nonce, cx.no_gc());
     }
 
     /// <https://www.w3.org/TR/CSP/#is-element-nonceable>
@@ -2726,7 +2752,7 @@ impl Element {
     }
 
     pub(crate) fn ensure_element_internals(&self, cx: &mut JSContext) -> DomRoot<ElementInternals> {
-        let mut rare_data = self.ensure_rare_data();
+        let mut rare_data = self.ensure_rare_data(cx.no_gc());
         DomRoot::from_ref(rare_data.element_internals.get_or_insert_with(|| {
             let elem = self
                 .downcast::<HTMLElement>()
@@ -4517,7 +4543,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
 
     /// <https://drafts.csswg.org/css-shadow-parts/#dom-element-part>
     fn Part(&self, cx: &mut JSContext) -> DomRoot<DOMTokenList> {
-        self.ensure_rare_data()
+        self.ensure_rare_data(cx.no_gc())
             .part
             .or_init(|| DOMTokenList::new(cx, self, &local_name!("part"), None))
     }
@@ -4674,7 +4700,7 @@ impl VirtualMethods for Element {
             },
             local_name!("name") => {
                 // Keep the name in rare data for fast access
-                self.ensure_rare_data().name_attribute =
+                self.ensure_rare_data(cx.no_gc()).name_attribute =
                     mutation.new_value(attr).and_then(|value| {
                         let value = value.as_atom();
                         if value != &atom!("") {
@@ -4874,7 +4900,7 @@ impl VirtualMethods for Element {
         }
         let elem = copy.downcast::<Element>().unwrap();
         if let Some(rare_data) = self.rare_data().as_ref() {
-            elem.update_nonce_internal_slot(rare_data.cryptographic_nonce.clone());
+            elem.update_nonce_internal_slot(rare_data.cryptographic_nonce.clone(), cx.no_gc());
         }
     }
 }
@@ -4901,7 +4927,8 @@ impl Element {
             rect.size = doc.window().viewport_details().size.round().to_i32();
         }
 
-        self.ensure_rare_data().client_rect = Some(self.owner_window().cache_layout_value(rect));
+        self.ensure_rare_data(no_gc).client_rect =
+            Some(self.owner_window().cache_layout_value(rect));
         rect
     }
 

--- a/components/script/dom/html/htmldialogelement.rs
+++ b/components/script/dom/html/htmldialogelement.rs
@@ -149,6 +149,7 @@ impl HTMLDialogElement {
                 .focus_handler()
                 .focused_area()
                 .element(),
+            cx.no_gc(),
         );
 
         // TODO: Step 17. Let document be subject's node document.
@@ -223,11 +224,14 @@ impl HTMLDialogElement {
         // TODO: Step 11. Set subject's request close source element to null.
 
         // Step 12. If subject's previously focused element is not null, then:
-        if let Some(element) = self.upcast::<HTMLElement>().previously_focused_element() {
+        if let Some(element) = self
+            .upcast::<HTMLElement>()
+            .previously_focused_element(cx.no_gc())
+        {
             // Step 12.1. Let element be subject's previously focused element.
             // Step 12.2. Set subject's previously focused element to null.
             self.upcast::<HTMLElement>()
-                .set_previously_focused_element(None);
+                .set_previously_focused_element(None, cx.no_gc());
 
             // Step 12.3. If subject's node document's focused area of the document's DOM anchor is
             // a shadow-including inclusive descendant of subject, or wasModal is true, then run the
@@ -404,6 +408,7 @@ impl HTMLDialogElementMethods<crate::DomTypeHolder> for HTMLDialogElement {
                 .focus_handler()
                 .focused_area()
                 .element(),
+            cx.no_gc(),
         );
 
         // TODO: Step 8. Let document be this's node document.

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -181,16 +181,16 @@ impl HTMLElement {
         // TODO
     }
 
-    pub(crate) fn previously_focused_element(&self) -> Option<DomRoot<Element>> {
+    pub(crate) fn previously_focused_element(&self, no_gc: &NoGC) -> Option<DomRoot<Element>> {
         self.upcast::<Element>()
-            .ensure_rare_data()
+            .ensure_rare_data(no_gc)
             .previously_focused_element
             .get()
     }
 
-    pub(crate) fn set_previously_focused_element(&self, element: Option<&Element>) {
+    pub(crate) fn set_previously_focused_element(&self, element: Option<&Element>, no_gc: &NoGC) {
         self.upcast::<Element>()
-            .ensure_rare_data()
+            .ensure_rare_data(no_gc)
             .previously_focused_element
             .set(element);
     }
@@ -783,9 +783,9 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-noncedelement-nonce>
-    fn SetNonce(&self, _cx: &mut JSContext, value: DOMString) {
+    fn SetNonce(&self, cx: &mut JSContext, value: DOMString) {
         self.as_element()
-            .update_nonce_internal_slot(String::from(value))
+            .update_nonce_internal_slot(String::from(value), cx.no_gc())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-fe-autofocus>
@@ -1294,10 +1294,10 @@ impl VirtualMethods for HTMLElement {
             (&local_name!("nonce"), mutation) => match mutation {
                 AttributeMutation::Set(..) => {
                     let nonce = &**attr.value();
-                    element.update_nonce_internal_slot(nonce.to_owned());
+                    element.update_nonce_internal_slot(nonce.to_owned(), cx.no_gc());
                 },
                 AttributeMutation::Removed => {
-                    element.update_nonce_internal_slot("".to_owned());
+                    element.update_nonce_internal_slot("".to_owned(), cx.no_gc());
                 },
             },
             _ => {},

--- a/components/script/dom/intersectionobserver/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver/intersectionobserver.rs
@@ -10,7 +10,7 @@ use app_units::Au;
 use cssparser::{Parser, ParserInput};
 use dom_struct::dom_struct;
 use euclid::{Rect, SideOffsets2D, Size2D, Vector2D};
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::rust::{HandleObject, MutableHandleValue};
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
@@ -279,7 +279,7 @@ impl IntersectionObserver {
     }
 
     /// <https://w3c.github.io/IntersectionObserver/#observe-target-element>
-    fn observe_target_element(&self, target: &Element) {
+    fn observe_target_element(&self, target: &Element, no_gc: &NoGC) {
         // Step 1
         // > If target is in observer’s internal [[ObservationTargets]] slot, return.
         let is_present = self
@@ -297,7 +297,7 @@ impl IntersectionObserver {
         // > a previousIsIntersecting property set to false, and a previousIsVisible property set to false.
         // Step 3
         // > Append intersectionObserverRegistration to target’s internal [[RegisteredIntersectionObservers]] slot.
-        target.add_initial_intersection_observer_registration(self);
+        target.add_initial_intersection_observer_registration(self, no_gc);
 
         if self.observation_targets.borrow().is_empty() {
             self.connect_to_owner();
@@ -318,12 +318,12 @@ impl IntersectionObserver {
     }
 
     /// <https://w3c.github.io/IntersectionObserver/#unobserve-target-element>
-    fn unobserve_target_element(&self, target: &Element) {
+    fn unobserve_target_element(&self, target: &Element, no_gc: &NoGC) {
         // Step 1
         // > Remove the IntersectionObserverRegistration record whose observer property is equal to
         // > this from target’s internal [[RegisteredIntersectionObservers]] slot, if present.
         target
-            .registered_intersection_observers_mut()
+            .registered_intersection_observers_mut(no_gc)
             .retain(|registration| &*registration.observer != self);
 
         // Step 2
@@ -796,24 +796,24 @@ impl IntersectionObserverMethods<crate::DomTypeHolder> for IntersectionObserver 
     /// > Run the observe a target Element algorithm, providing this and target.
     ///
     /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-observe>
-    fn Observe(&self, target: &Element) {
-        self.observe_target_element(target);
+    fn Observe(&self, no_gc: &NoGC, target: &Element) {
+        self.observe_target_element(target, no_gc);
     }
 
     /// > Run the unobserve a target Element algorithm, providing this and target.
     ///
     /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-unobserve>
-    fn Unobserve(&self, target: &Element) {
-        self.unobserve_target_element(target);
+    fn Unobserve(&self, no_gc: &NoGC, target: &Element) {
+        self.unobserve_target_element(target, no_gc);
     }
 
     /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-disconnect>
-    fn Disconnect(&self) {
+    fn Disconnect(&self, no_gc: &NoGC) {
         // > For each target in this’s internal [[ObservationTargets]] slot:
         self.observation_targets.borrow().iter().for_each(|target| {
             // > 1. Remove the IntersectionObserverRegistration record whose observer property is equal to
             // >    this from target’s internal [[RegisteredIntersectionObservers]] slot.
-            target.remove_intersection_observer(self);
+            target.remove_intersection_observer(self, no_gc);
         });
         // > 2. Remove target from this’s internal [[ObservationTargets]] slot.
         self.observation_targets.borrow_mut().clear();

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -3116,7 +3116,7 @@ impl Node {
                     None,
                 );
                 // TODO: Move this into `Element::create`
-                element.set_custom_element_registry(registry.as_deref());
+                element.set_custom_element_registry(registry.as_deref(), cx.no_gc());
                 DomRoot::upcast::<Node>(element)
             },
         };

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -2121,7 +2121,7 @@ fn create_element_for_token(
     // Record if the tokenizer saw duplicate attributes on this element,
     // used for CSP nonce validation (step 3 of "is element nonceable").
     if had_duplicate_attributes {
-        element.set_had_duplicate_attributes();
+        element.set_had_duplicate_attributes(cx.no_gc());
     }
 
     // Step 12. If willExecuteScript is true:

--- a/components/script/dom/svg/svgelement.rs
+++ b/components/script/dom/svg/svgelement.rs
@@ -105,10 +105,10 @@ impl VirtualMethods for SVGElement {
             match mutation {
                 AttributeMutation::Set(..) => {
                     let nonce = &**attr.value();
-                    element.update_nonce_internal_slot(nonce.to_owned());
+                    element.update_nonce_internal_slot(nonce.to_owned(), cx.no_gc());
                 },
                 AttributeMutation::Removed => {
-                    element.update_nonce_internal_slot(String::new());
+                    element.update_nonce_internal_slot(String::new(), cx.no_gc());
                 },
             }
         }
@@ -172,9 +172,9 @@ impl SVGElementMethods<crate::DomTypeHolder> for SVGElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-noncedelement-nonce>
-    fn SetNonce(&self, _cx: &mut JSContext, value: DOMString) {
+    fn SetNonce(&self, cx: &mut JSContext, value: DOMString) {
         self.as_element()
-            .update_nonce_internal_slot(String::from(value))
+            .update_nonce_internal_slot(String::from(value), cx.no_gc())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-fe-autofocus>

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -833,7 +833,8 @@ DOMInterfaces = {
 },
 
 'IntersectionObserver': {
-    'cx': ['Thresholds']
+    'cx': ['Thresholds'],
+    'no_gc': ['Disconnect', 'Observe', 'Unobserve'],
 },
 
 'KeyframeEffect': {


### PR DESCRIPTION
Element::ensure_rare_data returns a dynamic mutable borrow, so by using safe_borrow_mut we can statically prevent multiple lurking borrow hazards. First noticed in an unexpected test failure in #46990.

Testing: Existing test coverage suffices.
Fixes: #47004
