### PR TITLE
layout: Add `TextFragmentRunData`

### DIFF
--- a/components/layout/display_list/hit_test.rs
+++ b/components/layout/display_list/hit_test.rs
@@ -272,7 +272,7 @@ impl Fragment {
                 Cursor::Default,
             ),
             Fragment::Text(text) => hit_test_fragment_inner(
-                &text.base.style(),
+                &text.style(),
                 text.base.rect(),
                 BorderRadius::zero(),
                 FragmentFlags::empty(),

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -769,7 +769,7 @@ impl PaintTraversalHandler for DisplayListBuilder<'_> {
     fn visit_iframe(&mut self, state: &TraversalState, fragment: &Arc<IFrameFragment>) {
         fragment.base.visit_fragment(self);
 
-        let style = fragment.base.style();
+        let style = fragment.style.borrow();
         if style.get_inherited_box().visibility != Visibility::Visible {
             return;
         }
@@ -801,7 +801,7 @@ impl PaintTraversalHandler for DisplayListBuilder<'_> {
     ) {
         fragment.base.visit_fragment(self);
 
-        let style = fragment.base.style();
+        let style = fragment.style.borrow();
         if style.get_inherited_box().visibility != Visibility::Visible {
             return;
         }
@@ -863,7 +863,7 @@ impl PaintTraversalHandler for DisplayListBuilder<'_> {
     ) {
         fragment.base.visit_fragment(self);
 
-        let style = fragment.base.style();
+        let style = fragment.style();
         if style.get_inherited_box().visibility != Visibility::Visible {
             return;
         }
@@ -1033,7 +1033,7 @@ impl Fragment {
         let mut baseline_origin = rect.origin;
         baseline_origin.y += fragment.font_metrics.ascent;
 
-        let include_whitespace = fragment.offsets.is_some() ||
+        let include_whitespace = fragment.run_data.selection.is_some() ||
             state
                 .text_decorations
                 .iter()
@@ -1050,7 +1050,7 @@ impl Fragment {
             return;
         }
 
-        let parent_style = fragment.base.style();
+        let parent_style = fragment.style();
         let color = parent_style.clone_color();
         let font_size = parent_style.clone_font_size();
         let font_metrics = &fragment.font_metrics;
@@ -1284,17 +1284,17 @@ impl Fragment {
         fragment_x_offset: Au,
         justification_adjustment: Au,
     ) {
-        let Some(offsets) = fragment.offsets.as_ref() else {
+        let Some(shared_selection) = &fragment.run_data.selection else {
             return;
         };
 
-        let shared_selection = offsets.shared_selection.borrow();
+        let shared_selection = shared_selection.borrow();
         if !shared_selection.enabled {
             return;
         }
 
-        if offsets.character_range.start > shared_selection.character_range.end ||
-            offsets.character_range.end < shared_selection.character_range.start
+        if fragment.character_range.start > shared_selection.character_range.end ||
+            fragment.character_range.end < shared_selection.character_range.start
         {
             return;
         }
@@ -1304,14 +1304,14 @@ impl Fragment {
         // This code ensure that it is only painted if the cursor is on the starting index of the empty
         // fragment.
         if fragment.is_empty_for_text_cursor &&
-            !offsets
+            !fragment
                 .character_range
                 .contains(&shared_selection.character_range.start)
         {
             return;
         }
 
-        let mut current_character_index = offsets.character_range.start;
+        let mut current_character_index = fragment.character_range.start;
         let mut current_advance = Au::zero();
         let mut start_advance = None;
         let mut end_advance = None;
@@ -1350,7 +1350,7 @@ impl Fragment {
         let start_x = start_advance.unwrap_or(current_advance);
         let end_x = end_advance.unwrap_or(current_advance);
 
-        let parent_style = fragment.base.style();
+        let parent_style = fragment.style();
         if !shared_selection.character_range.is_empty() {
             let selection_rect = Rect::new(
                 containing_block_rect.origin +
@@ -1360,8 +1360,7 @@ impl Fragment {
             .to_webrender();
 
             if let Some(selection_color) = fragment
-                .selected_style
-                .borrow()
+                .selected_style()
                 .clone_background_color()
                 .as_absolute()
             {

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1293,8 +1293,8 @@ impl Fragment {
             return;
         }
 
-        if fragment.character_range.start > shared_selection.character_range.end ||
-            fragment.character_range.end < shared_selection.character_range.start
+        if fragment.character_range_in_dom_node.start > shared_selection.character_range.end ||
+            fragment.character_range_in_dom_node.end < shared_selection.character_range.start
         {
             return;
         }
@@ -1305,13 +1305,13 @@ impl Fragment {
         // fragment.
         if fragment.is_empty_for_text_cursor &&
             !fragment
-                .character_range
+                .character_range_in_dom_node
                 .contains(&shared_selection.character_range.start)
         {
             return;
         }
 
-        let mut current_character_index = fragment.character_range.start;
+        let mut current_character_index = fragment.character_range_in_dom_node.start;
         let mut current_advance = Au::zero();
         let mut start_advance = None;
         let mut end_advance = None;

--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -21,10 +21,8 @@ use unicode_bidi::{BidiInfo, Level};
 use super::inline_box::{InlineBoxContainerState, InlineBoxIdentifier, InlineBoxTreePathToken};
 use super::{InlineFormattingContextLayout, LineBlockSizes, line_height};
 use crate::cell::ArcRefCell;
-use crate::flow::inline::text_run::FontAndScriptInfo;
-use crate::fragment_tree::{
-    BaseFragment, BaseFragmentInfo, BoxFragment, Fragment, TextFragment, TextFragmentRunData,
-};
+use crate::flow::inline::text_run::{FontAndScriptInfo, SharedTextRunData};
+use crate::fragment_tree::{BaseFragment, BaseFragmentInfo, BoxFragment, Fragment, TextFragment};
 use crate::geom::{
     LogicalRect, LogicalSides, LogicalVec2, PhysicalRect, PhysicalSize, ToLogical,
     ToLogicalWithContainingBlock,
@@ -708,7 +706,7 @@ impl LineItemLayout<'_, '_> {
                     font_key,
                     glyphs: text_item.text,
                     justification_adjustment: self.justification_adjustment,
-                    character_range: text_item.character_range,
+                    character_range_in_dom_node: text_item.character_range_in_dom_node,
                     is_empty_for_text_cursor: text_item.is_empty_for_text_cursor,
                 })),
                 content_rect,
@@ -961,13 +959,13 @@ impl LineItem {
 }
 
 pub(super) struct TextRunLineItem {
-    pub text_fragment_run_data: Arc<TextFragmentRunData>,
+    pub text_fragment_run_data: Arc<SharedTextRunData>,
     pub info: FontAndScriptInfo,
     pub base_fragment_info: BaseFragmentInfo,
     pub text: Vec<Arc<ShapedTextSlice>>,
     /// The range of characters this [`TextRunLineItem`] represents within the text of its
     /// original DOM node (modified by text transformation).
-    pub character_range: Range<usize>,
+    pub character_range_in_dom_node: Range<usize>,
     /// Whether or not this [`TextFragment`] is an empty fragment added for the
     /// benefit of placing a text cursor on an otherwise empty editable line.
     pub is_empty_for_text_cursor: bool,

--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -9,8 +9,6 @@ use app_units::Au;
 use bitflags::bitflags;
 use fonts::ShapedTextSlice;
 use itertools::Either;
-use layout_api::SharedSelection;
-use malloc_size_of_derive::MallocSizeOf;
 use style::Zero;
 use style::computed_values::position::T as Position;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
@@ -21,10 +19,12 @@ use style::values::specified::box_::DisplayOutside;
 use unicode_bidi::{BidiInfo, Level};
 
 use super::inline_box::{InlineBoxContainerState, InlineBoxIdentifier, InlineBoxTreePathToken};
-use super::{InlineFormattingContextLayout, LineBlockSizes, SharedInlineStyles, line_height};
+use super::{InlineFormattingContextLayout, LineBlockSizes, line_height};
 use crate::cell::ArcRefCell;
 use crate::flow::inline::text_run::FontAndScriptInfo;
-use crate::fragment_tree::{BaseFragment, BaseFragmentInfo, BoxFragment, Fragment, TextFragment};
+use crate::fragment_tree::{
+    BaseFragment, BaseFragmentInfo, BoxFragment, Fragment, TextFragment, TextFragmentRunData,
+};
 use crate::geom::{
     LogicalRect, LogicalSides, LogicalVec2, PhysicalRect, PhysicalSize, ToLogical,
     ToLogicalWithContainingBlock,
@@ -702,17 +702,13 @@ impl LineItemLayout<'_, '_> {
             .fragments_and_data
             .push(FragmentAndData::new(
                 Fragment::Text(Arc::new(TextFragment {
-                    base: BaseFragment::new(
-                        text_item.base_fragment_info,
-                        text_item.inline_styles.style.clone(),
-                        PhysicalRect::zero(),
-                    ),
-                    selected_style: text_item.inline_styles.selected.clone(),
+                    base: BaseFragment::new(text_item.base_fragment_info, PhysicalRect::zero()),
+                    run_data: text_item.text_fragment_run_data,
                     font_metrics: font_metrics.clone(),
                     font_key,
                     glyphs: text_item.text,
                     justification_adjustment: self.justification_adjustment,
-                    offsets: text_item.offsets,
+                    character_range: text_item.character_range,
                     is_empty_for_text_cursor: text_item.is_empty_for_text_cursor,
                 })),
                 content_rect,
@@ -964,24 +960,14 @@ impl LineItem {
     }
 }
 
-#[derive(Debug, MallocSizeOf)]
-pub(crate) struct TextRunOffsets {
-    /// The selection range of the containing inline formatting context.
-    #[ignore_malloc_size_of = "This is stored primarily in the DOM"]
-    pub shared_selection: SharedSelection,
-    /// The range of characters this [`TextRun`] represents within the text of its
-    /// original DOM node (modified by text transformation).
-    pub character_range: Range<usize>,
-}
-
 pub(super) struct TextRunLineItem {
+    pub text_fragment_run_data: Arc<TextFragmentRunData>,
     pub info: FontAndScriptInfo,
     pub base_fragment_info: BaseFragmentInfo,
-    pub inline_styles: SharedInlineStyles,
     pub text: Vec<Arc<ShapedTextSlice>>,
-    /// When necessary, this field store the [`TextRunOffsets`] for a particular
-    /// [`TextRunLineItem`]. This is currently only used inside of text inputs.
-    pub offsets: Option<Box<TextRunOffsets>>,
+    /// The range of characters this [`TextRunLineItem`] represents within the text of its
+    /// original DOM node (modified by text transformation).
+    pub character_range: Range<usize>,
     /// Whether or not this [`TextFragment`] is an empty fragment added for the
     /// benefit of placing a text cursor on an otherwise empty editable line.
     pub is_empty_for_text_cursor: bool,
@@ -990,7 +976,8 @@ pub(super) struct TextRunLineItem {
 impl TextRunLineItem {
     fn trim_whitespace_at_end(&mut self, whitespace_trimmed: &mut Au) -> bool {
         if matches!(
-            self.inline_styles
+            self.text_fragment_run_data
+                .inline_styles
                 .style
                 .borrow()
                 .get_inherited_text()
@@ -1020,7 +1007,8 @@ impl TextRunLineItem {
 
     fn trim_whitespace_at_start(&mut self, whitespace_trimmed: &mut Au) -> bool {
         if matches!(
-            self.inline_styles
+            self.text_fragment_run_data
+                .inline_styles
                 .style
                 .borrow()
                 .get_inherited_text()

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -1686,7 +1686,7 @@ impl InlineFormattingContextLayout<'_> {
                 text_fragment_run_data: text_run.run_data.clone(),
                 base_fragment_info: text_run.base_fragment_info,
                 info: info.clone(),
-                character_range,
+                character_range_in_dom_node: character_range,
                 is_empty_for_text_cursor: false,
             },
         ));
@@ -1723,7 +1723,7 @@ impl InlineFormattingContextLayout<'_> {
                 text_fragment_run_data: caret_placeholder.run_data,
                 base_fragment_info: BaseFragmentInfo::anonymous(),
                 info: FontAndScriptInfo::simple_for_font(font),
-                character_range: caret_placeholder.character_index..
+                character_range_in_dom_node: caret_placeholder.character_index..
                     caret_placeholder.character_index + 1,
                 is_empty_for_text_cursor: true,
             },

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -78,6 +78,7 @@ pub mod text_transform;
 
 use std::cell::{Cell, OnceCell};
 use std::mem;
+use std::ops::Range;
 use std::rc::Rc;
 use std::sync::{Arc, OnceLock};
 
@@ -123,7 +124,6 @@ use crate::context::LayoutContext;
 use crate::dom::WeakLayoutBox;
 use crate::dom_traversal::NodeAndStyleInfo;
 use crate::flow::float::{FloatBox, SequentialLayoutState};
-use crate::flow::inline::line::TextRunOffsets;
 use crate::flow::inline::shaping_queue::ShapingQueue;
 use crate::flow::inline::text_run::{
     CaretPlaceholder, FontAndScriptInfo, TextRunItem, TextRunSegment,
@@ -1632,11 +1632,11 @@ impl InlineFormattingContextLayout<'_> {
         glyph_store: Arc<ShapedTextSlice>,
         text_run: &TextRun,
         info: &FontAndScriptInfo,
-        offsets: Option<TextRunOffsets>,
+        character_range: Range<usize>,
     ) {
         let inline_advance = glyph_store.total_advance();
         let flags = if glyph_store.is_whitespace() {
-            SegmentContentFlags::from(text_run.inline_styles.style.borrow().get_inherited_text())
+            SegmentContentFlags::from(text_run.inline_styles().style.borrow().get_inherited_text())
         } else {
             SegmentContentFlags::empty()
         };
@@ -1683,10 +1683,10 @@ impl InlineFormattingContextLayout<'_> {
             current_inline_box_identifier,
             TextRunLineItem {
                 text: vec![glyph_store],
+                text_fragment_run_data: text_run.run_data.clone(),
                 base_fragment_info: text_run.base_fragment_info,
-                inline_styles: text_run.inline_styles.clone(),
                 info: info.clone(),
-                offsets: offsets.map(Box::new),
+                character_range,
                 is_empty_for_text_cursor: false,
             },
         ));
@@ -1711,12 +1711,6 @@ impl InlineFormattingContextLayout<'_> {
             return;
         }
 
-        let offsets = TextRunOffsets {
-            shared_selection: caret_placeholder.shared_selection,
-            character_range: caret_placeholder.character_index..
-                caret_placeholder.character_index + 1,
-        };
-
         let inline_container_state = self.current_inline_container_state();
         let Some(font) = inline_container_state.default_font.clone() else {
             return;
@@ -1726,10 +1720,11 @@ impl InlineFormattingContextLayout<'_> {
             self.current_inline_box_identifier(),
             TextRunLineItem {
                 text: Default::default(),
+                text_fragment_run_data: caret_placeholder.run_data,
                 base_fragment_info: BaseFragmentInfo::anonymous(),
-                inline_styles: self.ifc.shared_inline_styles.clone(),
                 info: FontAndScriptInfo::simple_for_font(font),
-                offsets: Some(Box::new(offsets)),
+                character_range: caret_placeholder.character_index..
+                    caret_placeholder.character_index + 1,
                 is_empty_for_text_cursor: true,
             },
         ));
@@ -2239,7 +2234,7 @@ impl InlineFormattingContext {
             },
             InlineItem::TextRun(text_run) => {
                 let text_run = &*text_run.borrow();
-                let parent_style = text_run.inline_styles.style.borrow();
+                let parent_style = text_run.inline_styles().style.borrow();
                 text_run.items.iter().all(|item| match item {
                     TextRunItem::LineBreak { .. } => false,
                     TextRunItem::Tab { .. } => false,
@@ -2908,7 +2903,7 @@ impl<'layout_data> ContentSizesComputation<'layout_data> {
             },
             InlineItem::TextRun(text_run) => {
                 let text_run = &*text_run.borrow();
-                let parent_style = text_run.inline_styles.style.borrow();
+                let parent_style = text_run.inline_styles().style.borrow();
                 for item in text_run.items.iter() {
                     match item {
                         TextRunItem::LineBreak { .. } => {

--- a/components/layout/flow/inline/shaping_queue.rs
+++ b/components/layout/flow/inline/shaping_queue.rs
@@ -294,7 +294,7 @@ impl<'a> ShapingQueue<'a> {
 
         for entry in self.queue.drain(..) {
             let mut text_run = entry.text_run.borrow_mut();
-            let style = text_run.inline_styles.style.borrow().clone();
+            let style = text_run.inline_styles().style.borrow().clone();
             let (runs, break_at_start) =
                 slicer.slice_shaped_text_at_line_break_opportunities(&entry, &style);
 

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -36,7 +36,7 @@ use crate::context::LayoutContext;
 use crate::dom::WeakLayoutBox;
 use crate::flow::inline::shaping_queue::ShapingQueueEntry;
 use crate::flow::inline::{BidiLevels, LineBlockSizes, LineItem, SegmentContentFlags};
-use crate::fragment_tree::{BaseFragmentInfo, TextFragmentRunData};
+use crate::fragment_tree::BaseFragmentInfo;
 
 // There are two reasons why we might want to break at the start:
 //
@@ -273,7 +273,7 @@ impl TextRunSegment {
                 ifc.process_soft_wrap_opportunity();
             }
 
-            let run_start = text_run.run_data.character_range.start;
+            let run_start = text_run.run_data.character_range_in_ifc_text.start;
             ifc.push_glyph_store_to_unbreakable_segment(
                 run.clone(),
                 text_run,
@@ -294,7 +294,7 @@ impl TextRunSegment {
 pub(crate) struct CaretPlaceholder {
     /// The [`TextFragmentRunData`] of the [`TextRun`] that contains this caret placeholder.
     #[conditional_malloc_size_of]
-    pub run_data: Arc<TextFragmentRunData>,
+    pub run_data: Arc<SharedTextRunData>,
     /// Character index of the preserved newline in the IFC's transformed text, relative
     /// to the start of the DOM node.
     pub character_index: usize,
@@ -312,6 +312,24 @@ pub(crate) enum TextRunItem {
     TextSegment(Box<TextRunSegment>),
 }
 
+/// A data structure that holds per-[`TextRun`] data used on `TextFragment`s.
+/// This ensures that the data is not duplicated between fragments.
+#[derive(Debug, MallocSizeOf)]
+pub(crate) struct SharedTextRunData {
+    /// The [`crate::SharedStyle`] from this [`TextRun`]'s parent element. This is
+    /// shared so that incremental layout can simply update the parent element and
+    /// this [`TextRun`] will be updated automatically.
+    pub inline_styles: SharedInlineStyles,
+    /// The range of characters in this text in `InlineFormattingContext::text_content`
+    /// of the `InlineFormattingContext` that owns this [`TextRun`]. These are counting
+    /// `char`s, *not* UTF-8 offsets.
+    pub character_range_in_ifc_text: Range<usize>,
+    /// The selected text in this [`TextRun`]. This may either be document selection or
+    /// form control selection.
+    #[conditional_malloc_size_of]
+    pub selection: Option<SharedSelection>,
+}
+
 /// A single [`TextRun`] for the box tree. These are all descendants of
 /// [`super::InlineBox`] or the root of the [`super::InlineFormattingContext`].  During
 /// box tree construction, text is split into [`TextRun`]s based on their font, script,
@@ -327,7 +345,7 @@ pub(crate) struct TextRun {
     /// Data to be used by all [`TextFragment`]s spawned by this [`TextRun`] to avoid
     /// having to clone the data into each fragment.
     #[conditional_malloc_size_of]
-    pub run_data: Arc<TextFragmentRunData>,
+    pub run_data: Arc<SharedTextRunData>,
 
     /// A weak reference to the parent of this layout box. This becomes valid as soon
     /// as the *parent* of this box is added to the tree.
@@ -358,9 +376,9 @@ impl TextRun {
             .unwrap_or_default();
         Self {
             base_fragment_info,
-            run_data: TextFragmentRunData {
+            run_data: SharedTextRunData {
                 inline_styles,
-                character_range,
+                character_range_in_ifc_text: character_range,
                 selection,
             }
             .into(),
@@ -473,7 +491,7 @@ impl TextRun {
         for (relative_character_index, (character, next_character)) in char_iterator.enumerate() {
             // The current character index within the entire inline formatting context's text.
             let current_character_index =
-                self.run_data.character_range.start + relative_character_index;
+                self.run_data.character_range_in_ifc_text.start + relative_character_index;
 
             let current_byte_index = next_byte_index;
             next_byte_index += character.len_utf8();

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -34,10 +34,9 @@ use super::{InlineFormattingContextLayout, SharedInlineStyles};
 use crate::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::dom::WeakLayoutBox;
-use crate::flow::inline::line::TextRunOffsets;
 use crate::flow::inline::shaping_queue::ShapingQueueEntry;
 use crate::flow::inline::{BidiLevels, LineBlockSizes, LineItem, SegmentContentFlags};
-use crate::fragment_tree::BaseFragmentInfo;
+use crate::fragment_tree::{BaseFragmentInfo, TextFragmentRunData};
 
 // There are two reasons why we might want to break at the start:
 //
@@ -267,14 +266,6 @@ impl TextRunSegment {
         let mut character_range_start = self.character_range.start;
         for (run_index, run) in self.runs.iter().enumerate() {
             let new_character_range_end = character_range_start + run.character_count();
-            let offsets = text_run
-                .selection
-                .clone()
-                .map(|shared_selection| TextRunOffsets {
-                    shared_selection,
-                    character_range: character_range_start - text_run.character_range.start..
-                        new_character_range_end - text_run.character_range.start,
-                });
 
             // Break before each unbreakable run in this TextRun, except the first unless the
             // linebreaker was set to break before the first run.
@@ -282,7 +273,14 @@ impl TextRunSegment {
                 ifc.process_soft_wrap_opportunity();
             }
 
-            ifc.push_glyph_store_to_unbreakable_segment(run.clone(), text_run, &self.info, offsets);
+            let run_start = text_run.run_data.character_range.start;
+            ifc.push_glyph_store_to_unbreakable_segment(
+                run.clone(),
+                text_run,
+                &self.info,
+                character_range_start - run_start..new_character_range_end - run_start,
+            );
+
             character_range_start = new_character_range_end;
         }
     }
@@ -294,12 +292,12 @@ impl TextRunSegment {
 
 #[derive(Clone, Debug, MallocSizeOf)]
 pub(crate) struct CaretPlaceholder {
+    /// The [`TextFragmentRunData`] of the [`TextRun`] that contains this caret placeholder.
+    #[conditional_malloc_size_of]
+    pub run_data: Arc<TextFragmentRunData>,
     /// Character index of the preserved newline in the IFC's transformed text, relative
     /// to the start of the DOM node.
     pub character_index: usize,
-    /// The [`SharedSelection`] of this caret placeholder.
-    #[conditional_malloc_size_of]
-    pub shared_selection: SharedSelection,
 }
 
 /// A single item in a [`TextRun`].
@@ -326,28 +324,18 @@ pub(crate) struct TextRun {
     /// original text node in the DOM for the text.
     pub base_fragment_info: BaseFragmentInfo,
 
+    /// Data to be used by all [`TextFragment`]s spawned by this [`TextRun`] to avoid
+    /// having to clone the data into each fragment.
+    #[conditional_malloc_size_of]
+    pub run_data: Arc<TextFragmentRunData>,
+
     /// A weak reference to the parent of this layout box. This becomes valid as soon
     /// as the *parent* of this box is added to the tree.
     pub parent_box: Option<WeakLayoutBox>,
 
-    /// The [`crate::SharedStyle`] from this [`TextRun`]s parent element. This is
-    /// shared so that incremental layout can simply update the parent element and
-    /// this [`TextRun`] will be updated automatically.
-    pub inline_styles: SharedInlineStyles,
-
     /// The range of text in [`super::InlineFormattingContext::text_content`] of the
     /// [`super::InlineFormattingContext`] that owns this [`TextRun`]. These are UTF-8 offsets.
     pub text_range: Range<usize>,
-
-    /// The range of characters in this text in [`super::InlineFormattingContext::text_content`]
-    /// of the [`super::InlineFormattingContext`] that owns this [`TextRun`].
-    /// These are counting `char`s, *not* UTF-8 offsets.
-    pub character_range: Range<usize>,
-
-    /// The selected text in this `TextRun`. This may either be document selection or form control
-    /// selection.
-    #[conditional_malloc_size_of]
-    pub selection: Option<SharedSelection>,
 
     /// The [`TextRunItem`]s of this text run. This is produced by segmenting the incoming text
     /// by things such as font and script as well as separating out hard line breaks.
@@ -370,13 +358,20 @@ impl TextRun {
             .unwrap_or_default();
         Self {
             base_fragment_info,
+            run_data: TextFragmentRunData {
+                inline_styles,
+                character_range,
+                selection,
+            }
+            .into(),
             parent_box: None,
-            inline_styles,
             text_range,
-            character_range,
-            selection,
             items,
         }
+    }
+
+    pub(super) fn inline_styles(&self) -> &SharedInlineStyles {
+        &self.run_data.inline_styles
     }
 
     pub(super) fn segment(
@@ -386,7 +381,7 @@ impl TextRun {
         layout_context: &LayoutContext,
         bidi_levels: &BidiLevels,
     ) -> SmallVec<[ShapingQueueEntry; 1]> {
-        let parent_style = self.inline_styles.style.borrow().clone();
+        let parent_style = self.inline_styles().style.borrow().clone();
         let items = self.segment_text_by_font(
             layout_context,
             formatting_context_text,
@@ -477,21 +472,22 @@ impl TextRun {
         let mut next_byte_index = self.text_range.start;
         for (relative_character_index, (character, next_character)) in char_iterator.enumerate() {
             // The current character index within the entire inline formatting context's text.
-            let current_character_index = self.character_range.start + relative_character_index;
+            let current_character_index =
+                self.run_data.character_range.start + relative_character_index;
 
             let current_byte_index = next_byte_index;
             next_byte_index += character.len_utf8();
 
             if character == '\n' {
                 finish_current_segment(&mut current, &mut results);
-                results.push(TextRunItem::LineBreak(self.selection.clone().map(
-                    |shared_selection| CaretPlaceholder {
+                results.push(TextRunItem::LineBreak(
+                    self.run_data.selection.is_some().then(|| CaretPlaceholder {
+                        run_data: self.run_data.clone(),
                         // The placeholder that is placed after a newline is for the index after that newline.
                         // The newline itself is at the end of the previous line.
                         character_index: relative_character_index + 1,
-                        shared_selection,
-                    },
-                )));
+                    }),
+                ));
                 continue;
             }
 
@@ -610,7 +606,7 @@ impl TextRun {
         bidi_level: Level,
     ) {
         let advance = ifc_layout.ifc.next_tab_stop_after_inline_advance(
-            &self.inline_styles.style.borrow(),
+            &self.inline_styles().style.borrow(),
             ifc_layout.potential_line_size().inline,
         );
         if advance.is_zero() {

--- a/components/layout/fragment_tree/base_fragment.rs
+++ b/components/layout/fragment_tree/base_fragment.rs
@@ -5,7 +5,6 @@
 use std::sync::atomic::{AtomicU8, Ordering};
 
 use app_units::Au;
-use atomic_refcell::AtomicRef;
 use bitflags::bitflags;
 use layout_api::{LayoutElement, LayoutNode, PseudoElementChain, combine_id_with_fragment_type};
 use malloc_size_of::malloc_size_of_is_0;
@@ -13,14 +12,11 @@ use malloc_size_of_derive::MallocSizeOf;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use script::layout_dom::ServoLayoutNode;
-use servo_arc::Arc as ServoArc;
 use style::dom::OpaqueNode;
-use style::properties::ComputedValues;
 use style::selector_parser::PseudoElement;
 use stylo_atoms::atom;
 use web_atoms::{local_name, ns};
 
-use crate::SharedStyle;
 use crate::dom_traversal::NodeAndStyleInfo;
 use crate::geom::{PhysicalPoint, PhysicalRect, PhysicalSize, SyncPhysicalRectAu};
 
@@ -53,10 +49,6 @@ pub(crate) struct BaseFragment {
     /// layout.
     pub flags: FragmentFlags,
 
-    /// The style for this [`BaseFragment`]. Depending on the fragment type this is either
-    /// a shared or non-shared style.
-    pub style: SharedStyle,
-
     /// The content rect of this fragment in the parent fragment's content rectangle. This
     /// does not include padding, border, or margin -- it only includes content. This is
     /// relative to the parent containing block.
@@ -81,15 +73,10 @@ impl std::fmt::Debug for BaseFragment {
 }
 
 impl BaseFragment {
-    pub(crate) fn new(
-        base_fragment_info: BaseFragmentInfo,
-        style: SharedStyle,
-        rect: PhysicalRect<Au>,
-    ) -> Self {
+    pub(crate) fn new(base_fragment_info: BaseFragmentInfo, rect: PhysicalRect<Au>) -> Self {
         Self {
             tag: base_fragment_info.tag,
             flags: base_fragment_info.flags,
-            style,
             rect: SyncPhysicalRectAu::new(rect),
             status: AtomicU8::new(FragmentStatus::New as u8),
         }
@@ -126,15 +113,6 @@ impl BaseFragment {
 
     pub(crate) fn set_status(&self, new_status: FragmentStatus) {
         self.status.store(new_status as u8, Ordering::Relaxed)
-    }
-
-    pub(crate) fn repair_style(&self, style: &ServoArc<ComputedValues>) {
-        *self.style.borrow_mut() = style.clone();
-        self.set_status(FragmentStatus::StyleChanged);
-    }
-
-    pub(crate) fn style<'a>(&'a self) -> AtomicRef<'a, ServoArc<ComputedValues>> {
-        self.style.borrow()
     }
 }
 

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -116,6 +116,9 @@ impl BoxFragmentRareData {
 pub(crate) struct BoxFragment {
     pub base: BaseFragment,
 
+    /// The style for this [`BoxFragment`].
+    pub style: SharedStyle,
+
     pub children: Vec<Fragment>,
 
     /// This [`BoxFragment`]'s containing block rectangle in coordinates relative to
@@ -167,7 +170,8 @@ impl BoxFragment {
     ) -> Self {
         let rare_data = BoxFragmentRareData::new(specific_layout_info);
         Self {
-            base: BaseFragment::new(base_fragment_info, style.into(), content_rect),
+            base: BaseFragment::new(base_fragment_info, content_rect),
+            style: style.into(),
             children,
             cumulative_containing_block_rect: Default::default(),
             padding,
@@ -189,7 +193,7 @@ impl BoxFragment {
     }
 
     pub(crate) fn style<'a>(&'a self) -> AtomicRef<'a, ServoArc<ComputedValues>> {
-        self.base.style()
+        self.style.borrow()
     }
 
     pub(crate) fn with_style(self: &Arc<Self>) -> BoxFragmentWithStyle<'_> {

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -9,7 +9,7 @@ use app_units::Au;
 use atomic_refcell::AtomicRef;
 use euclid::{Point2D, Rect, Size2D};
 use fonts::{FontMetrics, ShapedTextSlice};
-use layout_api::{BoxAreaType, SharedSelection};
+use layout_api::BoxAreaType;
 use malloc_size_of_derive::MallocSizeOf;
 use servo_arc::Arc as ServoArc;
 use servo_base::id::PipelineId;
@@ -26,7 +26,7 @@ use super::{
 };
 use crate::SharedStyle;
 use crate::cell::{ArcRefCell, RefOrAtomicRef};
-use crate::flow::inline::SharedInlineStyles;
+use crate::flow::inline::text_run::SharedTextRunData;
 use crate::fragment_tree::FragmentStatus;
 use crate::geom::{LogicalSides, PhysicalPoint, PhysicalRect};
 use crate::layout_impl::LayoutThread;
@@ -90,29 +90,11 @@ impl LayoutRootFragment {
     }
 }
 
-/// A data structure that holds per-`TextRun` data used on `TextFragment`s.
-/// This ensures that the data is not duplicated between fragments.
-#[derive(Debug, MallocSizeOf)]
-pub(crate) struct TextFragmentRunData {
-    /// The [`crate::SharedStyle`] from this `TextRun`'s parent element. This is
-    /// shared so that incremental layout can simply update the parent element and
-    /// this [`TextRun`] will be updated automatically.
-    pub inline_styles: SharedInlineStyles,
-    /// The range of characters in this text in `InlineFormattingContext::text_content`
-    /// of the `InlineFormattingContext` that owns this `TextRun`. These are counting
-    /// `char`s, *not* UTF-8 offsets.
-    pub character_range: Range<usize>,
-    /// The selected text in this `TextRun`. This may either be document selection or form control
-    /// selection.
-    #[conditional_malloc_size_of]
-    pub selection: Option<SharedSelection>,
-}
-
 #[derive(MallocSizeOf)]
 pub(crate) struct TextFragment {
     pub base: BaseFragment,
     #[conditional_malloc_size_of]
-    pub run_data: Arc<TextFragmentRunData>,
+    pub run_data: Arc<SharedTextRunData>,
     #[conditional_malloc_size_of]
     pub font_metrics: Arc<FontMetrics>,
     pub font_key: FontInstanceKey,
@@ -122,7 +104,7 @@ pub(crate) struct TextFragment {
     pub justification_adjustment: Au,
     /// The range of characters this [`TextFragment`] represents within the text of its
     /// original DOM node (modified by text transformation).
-    pub character_range: Range<usize>,
+    pub character_range_in_dom_node: Range<usize>,
     /// Whether or not this [`TextFragment`] is an empty fragment added for the
     /// benefit of placing a text cursor on an otherwise empty editable line.
     pub is_empty_for_text_cursor: bool,
@@ -421,20 +403,22 @@ impl Fragment {
         if let Some(base) = self.base() {
             base.set_status(FragmentStatus::StyleChanged);
         }
-        self.with_shared_style(|style| *style.borrow_mut() = new_style.clone());
-    }
 
-    fn with_shared_style(&self, callback: impl FnOnce(&SharedStyle)) {
-        match self {
-            Fragment::LayoutRoot(fragment) => callback(&fragment.inner_box_fragment().style),
-            Fragment::Box(fragment) => callback(&fragment.style),
-            Fragment::Text(fragment) => callback(&fragment.run_data.inline_styles.style),
-            Fragment::AbsoluteOrFixedPositionedPlaceholder(_) => {},
-            Fragment::Positioning(fragment) => callback(&fragment.style),
-            Fragment::Image(fragment) => callback(&fragment.style),
-            Fragment::IFrame(fragment) => callback(&fragment.style),
-            Fragment::Float(fragment) => callback(&fragment.style),
-        }
+        let inner_box_fragment;
+        let shared_style = match self {
+            Fragment::LayoutRoot(fragment) => {
+                inner_box_fragment = fragment.inner_box_fragment();
+                &inner_box_fragment.style
+            },
+            Fragment::Box(fragment) => &fragment.style,
+            Fragment::Text(fragment) => &fragment.run_data.inline_styles.style,
+            Fragment::AbsoluteOrFixedPositionedPlaceholder(_) => return,
+            Fragment::Positioning(fragment) => &fragment.style,
+            Fragment::Image(fragment) => &fragment.style,
+            Fragment::IFrame(fragment) => &fragment.style,
+            Fragment::Float(fragment) => &fragment.style,
+        };
+        *shared_style.borrow_mut() = new_style.clone();
     }
 
     pub(crate) fn retrieve_box_fragment(&self) -> Option<RefOrAtomicRef<'_, Arc<BoxFragment>>> {
@@ -515,7 +499,7 @@ impl TextFragment {
         // If the click was far enough above the top of the fragment, then pick the first index.
         let max_vertical_offset = self.base.rect().height().scale_by(0.25);
         if point_in_fragment.y < -max_vertical_offset {
-            return Some(self.character_range.start);
+            return Some(self.character_range_in_dom_node.start);
         }
 
         // If the click was below the fragment, return `None`, which will cause the
@@ -527,7 +511,7 @@ impl TextFragment {
             return None;
         }
 
-        let mut current_character = self.character_range.start;
+        let mut current_character = self.character_range_in_dom_node.start;
         let mut current_offset = Au::zero();
         for glyph_store in &self.glyphs {
             for glyph in glyph_store.glyphs() {

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -2,18 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::ops::Range;
 use std::sync::Arc;
 
 use app_units::Au;
 use atomic_refcell::AtomicRef;
 use euclid::{Point2D, Rect, Size2D};
 use fonts::{FontMetrics, ShapedTextSlice};
-use layout_api::BoxAreaType;
+use layout_api::{BoxAreaType, SharedSelection};
 use malloc_size_of_derive::MallocSizeOf;
+use servo_arc::Arc as ServoArc;
 use servo_base::id::PipelineId;
 use servo_base::print_tree::PrintTree;
 use servo_url::ServoUrl;
 use style::Zero;
+use style::properties::ComputedValues;
 use style_traits::CSSPixel;
 use webrender_api::{FontInstanceKey, ImageKey};
 
@@ -23,7 +26,8 @@ use super::{
 };
 use crate::SharedStyle;
 use crate::cell::{ArcRefCell, RefOrAtomicRef};
-use crate::flow::inline::line::TextRunOffsets;
+use crate::flow::inline::SharedInlineStyles;
+use crate::fragment_tree::FragmentStatus;
 use crate::geom::{LogicalSides, PhysicalPoint, PhysicalRect};
 use crate::layout_impl::LayoutThread;
 use crate::style_ext::ComputedValuesExt;
@@ -86,10 +90,29 @@ impl LayoutRootFragment {
     }
 }
 
+/// A data structure that holds per-`TextRun` data used on `TextFragment`s.
+/// This ensures that the data is not duplicated between fragments.
+#[derive(Debug, MallocSizeOf)]
+pub(crate) struct TextFragmentRunData {
+    /// The [`crate::SharedStyle`] from this `TextRun`'s parent element. This is
+    /// shared so that incremental layout can simply update the parent element and
+    /// this [`TextRun`] will be updated automatically.
+    pub inline_styles: SharedInlineStyles,
+    /// The range of characters in this text in `InlineFormattingContext::text_content`
+    /// of the `InlineFormattingContext` that owns this `TextRun`. These are counting
+    /// `char`s, *not* UTF-8 offsets.
+    pub character_range: Range<usize>,
+    /// The selected text in this `TextRun`. This may either be document selection or form control
+    /// selection.
+    #[conditional_malloc_size_of]
+    pub selection: Option<SharedSelection>,
+}
+
 #[derive(MallocSizeOf)]
 pub(crate) struct TextFragment {
     pub base: BaseFragment,
-    pub selected_style: SharedStyle,
+    #[conditional_malloc_size_of]
+    pub run_data: Arc<TextFragmentRunData>,
     #[conditional_malloc_size_of]
     pub font_metrics: Arc<FontMetrics>,
     pub font_key: FontInstanceKey,
@@ -97,9 +120,9 @@ pub(crate) struct TextFragment {
     pub glyphs: Vec<Arc<ShapedTextSlice>>,
     /// Extra space to add for each justification opportunity.
     pub justification_adjustment: Au,
-    /// When necessary, this field store the [`TextRunOffsets`] for a particular
-    /// [`TextRunLineItem`]. This is currently only used inside of text inputs.
-    pub offsets: Option<Box<TextRunOffsets>>,
+    /// The range of characters this [`TextFragment`] represents within the text of its
+    /// original DOM node (modified by text transformation).
+    pub character_range: Range<usize>,
     /// Whether or not this [`TextFragment`] is an empty fragment added for the
     /// benefit of placing a text cursor on an otherwise empty editable line.
     pub is_empty_for_text_cursor: bool,
@@ -108,6 +131,7 @@ pub(crate) struct TextFragment {
 #[derive(MallocSizeOf)]
 pub(crate) struct ImageFragment {
     pub base: BaseFragment,
+    pub style: SharedStyle,
     pub clip: PhysicalRect<Au>,
     pub image_key: Option<ImageKey>,
     pub showing_broken_image_icon: bool,
@@ -117,6 +141,7 @@ pub(crate) struct ImageFragment {
 #[derive(MallocSizeOf)]
 pub(crate) struct IFrameFragment {
     pub base: BaseFragment,
+    pub style: SharedStyle,
     pub pipeline_id: PipelineId,
 }
 
@@ -392,6 +417,26 @@ impl Fragment {
         }
     }
 
+    pub(crate) fn repair_style(&self, new_style: &ServoArc<ComputedValues>) {
+        if let Some(base) = self.base() {
+            base.set_status(FragmentStatus::StyleChanged);
+        }
+        self.with_shared_style(|style| *style.borrow_mut() = new_style.clone());
+    }
+
+    fn with_shared_style(&self, callback: impl FnOnce(&SharedStyle)) {
+        match self {
+            Fragment::LayoutRoot(fragment) => callback(&fragment.inner_box_fragment().style),
+            Fragment::Box(fragment) => callback(&fragment.style),
+            Fragment::Text(fragment) => callback(&fragment.run_data.inline_styles.style),
+            Fragment::AbsoluteOrFixedPositionedPlaceholder(_) => {},
+            Fragment::Positioning(fragment) => callback(&fragment.style),
+            Fragment::Image(fragment) => callback(&fragment.style),
+            Fragment::IFrame(fragment) => callback(&fragment.style),
+            Fragment::Float(fragment) => callback(&fragment.style),
+        }
+    }
+
     pub(crate) fn retrieve_box_fragment(&self) -> Option<RefOrAtomicRef<'_, Arc<BoxFragment>>> {
         match self {
             Fragment::LayoutRoot(layout_root_fragment) => Some(RefOrAtomicRef::AtomicRef(
@@ -406,6 +451,14 @@ impl Fragment {
 }
 
 impl TextFragment {
+    pub(crate) fn style<'a>(&'a self) -> AtomicRef<'a, ServoArc<ComputedValues>> {
+        self.run_data.inline_styles.style.borrow()
+    }
+
+    pub(crate) fn selected_style<'a>(&'a self) -> AtomicRef<'a, ServoArc<ComputedValues>> {
+        self.run_data.inline_styles.selected.borrow()
+    }
+
     pub fn print(&self, tree: &mut PrintTree) {
         tree.add_item(format!(
             "Text num_glyphs={} box={:?}",
@@ -460,10 +513,9 @@ impl TextFragment {
         point_in_fragment: Point2D<Au, CSSPixel>,
     ) -> Option<usize> {
         // If the click was far enough above the top of the fragment, then pick the first index.
-        let offsets = self.offsets.as_ref()?;
         let max_vertical_offset = self.base.rect().height().scale_by(0.25);
         if point_in_fragment.y < -max_vertical_offset {
-            return Some(offsets.character_range.start);
+            return Some(self.character_range.start);
         }
 
         // If the click was below the fragment, return `None`, which will cause the
@@ -475,7 +527,7 @@ impl TextFragment {
             return None;
         }
 
-        let mut current_character = offsets.character_range.start;
+        let mut current_character = self.character_range.start;
         let mut current_offset = Au::zero();
         for glyph_store in &self.glyphs {
             for glyph in glyph_store.glyphs() {

--- a/components/layout/fragment_tree/positioning_fragment.rs
+++ b/components/layout/fragment_tree/positioning_fragment.rs
@@ -12,6 +12,7 @@ use servo_base::print_tree::PrintTree;
 use style::properties::ComputedValues;
 
 use super::{BaseFragment, BaseFragmentInfo, Fragment};
+use crate::SharedStyle;
 use crate::fragment_tree::ContainingBlockCalculation;
 use crate::geom::{PhysicalRect, SyncPhysicalRectAu};
 
@@ -21,6 +22,10 @@ use crate::geom::{PhysicalRect, SyncPhysicalRectAu};
 #[derive(MallocSizeOf)]
 pub(crate) struct PositioningFragment {
     pub base: BaseFragment,
+
+    /// The style for this [`PositioningFragment`].
+    pub style: SharedStyle,
+
     pub children: Vec<Fragment>,
 
     /// The scrollable overflow of this anonymous fragment's children.
@@ -67,7 +72,8 @@ impl PositioningFragment {
         is_line_box: bool,
     ) -> Arc<Self> {
         Arc::new(Self {
-            base: BaseFragment::new(base_fragment_info, style.into(), rect),
+            base: BaseFragment::new(base_fragment_info, rect),
+            style: style.into(),
             children,
             scrollable_overflow: Default::default(),
             scrollable_overflow_is_up_to_date: AtomicBool::new(false),

--- a/components/layout/layout_box_base.rs
+++ b/components/layout/layout_box_base.rs
@@ -143,10 +143,8 @@ impl LayoutBoxBase {
 
     pub(crate) fn repair_style(&mut self, new_style: &ServoArc<ComputedValues>) {
         self.style = new_style.clone();
-        for fragment in self.fragments.borrow_mut().iter_mut() {
-            if let Some(base) = fragment.base() {
-                base.repair_style(new_style);
-            }
+        for fragment in self.fragments.borrow().iter() {
+            fragment.repair_style(new_style);
         }
     }
 

--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -506,7 +506,7 @@ impl ReplacedContents {
         let (object_fit_size, rect) = self.calculate_fragment_rect(style, size);
         let clip = PhysicalRect::new(PhysicalPoint::origin(), size);
 
-        let base = BaseFragment::new(self.base_fragment_info, style.clone().into(), rect);
+        let base = BaseFragment::new(self.base_fragment_info, rect);
         match &self.kind {
             ReplacedContentKind::Image(image_info) => image_info
                 .image
@@ -533,6 +533,7 @@ impl ReplacedContents {
                 .map(|image_key| {
                     Fragment::Image(Arc::new(ImageFragment {
                         base,
+                        style: style.clone().into(),
                         clip,
                         image_key: Some(image_key),
                         showing_broken_image_icon: image_info.showing_broken_image_icon,
@@ -544,6 +545,7 @@ impl ReplacedContents {
             ReplacedContentKind::Video(video_info) => {
                 vec![Fragment::Image(Arc::new(ImageFragment {
                     base,
+                    style: style.clone().into(),
                     clip,
                     image_key: video_info.image_key,
                     showing_broken_image_icon: false,
@@ -568,6 +570,7 @@ impl ReplacedContents {
                 );
                 vec![Fragment::IFrame(Arc::new(IFrameFragment {
                     base,
+                    style: style.clone().into(),
                     pipeline_id: iframe.pipeline_id,
                 }))]
             },
@@ -584,6 +587,7 @@ impl ReplacedContents {
 
                 vec![Fragment::Image(Arc::new(ImageFragment {
                     base,
+                    style: style.clone().into(),
                     clip,
                     image_key: Some(image_key),
                     showing_broken_image_icon: false,
@@ -636,6 +640,7 @@ impl ReplacedContents {
                     .map(|image_key| {
                         Fragment::Image(Arc::new(ImageFragment {
                             base,
+                            style: style.clone().into(),
                             clip,
                             image_key: Some(image_key),
                             showing_broken_image_icon: false,


### PR DESCRIPTION
Add a shared data structure to be used with all `TextFragment`s that
are generated by a `TextRun`. The idea here is that no matter how many
`TextFragment`s a `TextRuns` generates, the shared data is only in
memory once. This opens up the way for exposing more data (such as the
`InlineFormattingContext`'s `OffsetMap`) on each `TextFragment`. This
will be used converting glyph offsets into DOM offsets and for
incremental layout of `Document` selections. Longer-term the in-memory
size of `TextFragment`s will be minimized using an approach like this.

Testing: This should not change observable behavior so is covered by existing tests.
