### PR TITLE
script: Move `WorkletThreadPool` intialization out of `ScriptThread`

### DIFF
--- a/components/script/dom/testing/testworklet.rs
+++ b/components/script/dom/testing/testworklet.rs
@@ -15,14 +15,12 @@ use crate::dom::bindings::codegen::Bindings::TestWorkletBinding::TestWorkletMeth
 use crate::dom::bindings::codegen::Bindings::WorkletBinding::Worklet_Binding::WorkletMethods;
 use crate::dom::bindings::codegen::Bindings::WorkletBinding::WorkletOptions;
 use crate::dom::bindings::error::Fallible;
-use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::promise::Promise;
 use crate::dom::window::Window;
 use crate::dom::worklet::Worklet;
 use crate::dom::workletglobalscope::WorkletGlobalScopeType;
-use crate::script_thread::ScriptThread;
 
 #[dom_struct]
 pub(crate) struct TestWorklet {
@@ -73,8 +71,10 @@ impl TestWorkletMethods<crate::DomTypeHolder> for TestWorklet {
 
     fn Lookup(&self, key: DOMString) -> Option<DOMString> {
         let id = self.worklet.worklet_id();
-        let pool = ScriptThread::worklet_thread_pool(self.global().image_cache());
-        pool.test_worklet_lookup(id, String::from(key))
+
+        self.worklet
+            .get_worklet_thread_pool()
+            .test_worklet_lookup(id, String::from(key))
             .map(DOMString::from)
     }
 }

--- a/components/script/dom/worklet/worklet.rs
+++ b/components/script/dom/worklet/worklet.rs
@@ -59,7 +59,6 @@ use crate::microtask::MicrotaskQueue;
 use crate::realms::enter_auto_realm;
 use crate::script_module::fetch_a_module_script_graph;
 use crate::script_runtime::{IntroductionType, Runtime, ScriptThreadEventCategory};
-use crate::script_thread::ScriptThread;
 use crate::task_source::TaskSourceName;
 use crate::url::ensure_blob_referenced_by_url_is_kept_alive;
 
@@ -129,6 +128,28 @@ impl Worklet {
     pub(crate) fn worklet_global_scope_type(&self) -> WorkletGlobalScopeType {
         self.global_type
     }
+
+    pub(crate) fn get_worklet_thread_pool(&self) -> &Rc<WorkletThreadPool> {
+        let global = self.window.global();
+
+        let init = WorkletGlobalScopeInit {
+            to_script_thread_sender: self.window.main_thread_script_chan().clone(),
+            resource_threads: global.resource_threads().clone(),
+            storage_threads: global.storage_threads().clone(),
+            mem_profiler_chan: global.mem_profiler_chan().clone(),
+            time_profiler_chan: global.time_profiler_chan().clone(),
+            devtools_chan: global.devtools_chan().cloned(),
+            script_to_constellation_sender: global.script_to_constellation_chan().sender,
+            to_embedder_sender: global.script_to_embedder_chan().clone(),
+            image_cache: global.image_cache(),
+            #[cfg(feature = "webgpu")]
+            gpu_id_hub: global.wgpu_id_hub(),
+        };
+
+        self.droppable_field
+            .thread_pool
+            .get_or_init(|| Rc::new(WorkletThreadPool::spawn(init)))
+    }
 }
 
 impl WorkletMethods<crate::DomTypeHolder> for Worklet {
@@ -172,9 +193,7 @@ impl WorkletMethods<crate::DomTypeHolder> for Worklet {
         // NOTE: We skip step 6.3 because we do not implement the `added modules list` yet
         // <https://html.spec.whatwg.org/multipage/#concept-worklet-added-modules-list>
 
-        self.droppable_field
-            .thread_pool
-            .get_or_init(|| ScriptThread::worklet_thread_pool(self.global().image_cache()))
+        self.get_worklet_thread_pool()
             .fetch_and_invoke_a_worklet_script(
                 self.window.pipeline_id(),
                 self.droppable_field.worklet_id,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -60,7 +60,7 @@ use js::rust::wrappers2::{JS_AddInterruptCallback, JS_GC, SetWindowProxyClass};
 use layout_api::{LayoutConfig, LayoutFactory, RestyleReason, ScriptThreadFactory};
 use media::WindowGLContext;
 use metrics::MAX_TASK_NS;
-use net_traits::image_cache::{ImageCache, ImageCacheFactory, ImageCacheResponseMessage};
+use net_traits::image_cache::{ImageCacheFactory, ImageCacheResponseMessage};
 use net_traits::request::{Referrer, RequestId};
 use net_traits::response::ResponseInit;
 use net_traits::{
@@ -143,8 +143,6 @@ use crate::dom::types::DebuggerGlobalScope;
 use crate::dom::webgpu::identityhub::IdentityHub;
 use crate::dom::window::Window;
 use crate::dom::windowproxy::{CreatorBrowsingContextInfo, WindowProxy};
-use crate::dom::worklet::WorkletThreadPool;
-use crate::dom::workletglobalscope::WorkletGlobalScopeInit;
 use crate::fetch::FetchCanceller;
 use crate::messaging::{
     CommonScriptMsg, MainThreadScriptMsg, MixedMessage, ScriptEventLoopSender,
@@ -341,9 +339,6 @@ pub struct ScriptThread {
     #[no_trace]
     #[cfg(feature = "webxr")]
     webxr_registry: Option<webxr_api::Registry>,
-
-    /// The worklet thread pool
-    worklet_thread_pool: DomRefCell<Option<Rc<WorkletThreadPool>>>,
 
     /// A list of pipelines containing documents that finished loading all their blocking
     /// resources during a turn of the event loop.
@@ -775,39 +770,6 @@ impl ScriptThread {
         })
     }
 
-    /// The worklet will use the given `ImageCache`.
-    pub(crate) fn worklet_thread_pool(image_cache: Arc<dyn ImageCache>) -> Rc<WorkletThreadPool> {
-        with_optional_script_thread(|script_thread| {
-            let script_thread = script_thread.unwrap();
-            script_thread
-                .worklet_thread_pool
-                .borrow_mut()
-                .get_or_insert_with(|| {
-                    let init = WorkletGlobalScopeInit {
-                        to_script_thread_sender: script_thread.senders.self_sender.clone(),
-                        resource_threads: script_thread.resource_threads.clone(),
-                        storage_threads: script_thread.storage_threads.clone(),
-                        mem_profiler_chan: script_thread.senders.memory_profiler_sender.clone(),
-                        time_profiler_chan: script_thread.senders.time_profiler_sender.clone(),
-                        devtools_chan: script_thread.senders.devtools_server_sender.clone(),
-                        script_to_constellation_sender: script_thread
-                            .senders
-                            .pipeline_to_constellation_sender
-                            .clone(),
-                        to_embedder_sender: script_thread
-                            .senders
-                            .pipeline_to_embedder_sender
-                            .clone(),
-                        image_cache,
-                        #[cfg(feature = "webgpu")]
-                        gpu_id_hub: script_thread.gpu_id_hub.clone(),
-                    };
-                    Rc::new(WorkletThreadPool::spawn(init))
-                })
-                .clone()
-        })
-    }
-
     fn handle_register_paint_worklet(
         &self,
         pipeline_id: PipelineId,
@@ -1020,7 +982,6 @@ impl ScriptThread {
                     webgl_chan: state.webgl_chan,
                     #[cfg(feature = "webxr")]
                     webxr_registry: state.webxr_registry,
-                    worklet_thread_pool: Default::default(),
                     docs_with_no_blocking_loads: Default::default(),
                     custom_element_reaction_stack: Rc::new(CustomElementReactionStack::new()),
                     paint_api: state.cross_process_paint_api,


### PR DESCRIPTION
 This PR is a part of refactoring Worklet for implementing AudioWorklet

Remove Worklet Thread Pool from `ScriptThread`.
The Worklet Thread Pool is currently unused by the `ScriptThread`.

For `AudioWorklet`s, each `AudioContext` will need its own `Worklet`, so `Worklet`s can be defined on the `AudioContext`.

For the Paint Worklet, the initialization will be done by `Window` in a follow up PR. 

Testing: existing worklet WPT covers the changes. 