### PR TITLE
canvas: Add pref to control thread_pool_canvas_workers

### DIFF
--- a/components/canvas/vello_cpu_backend.rs
+++ b/components/canvas/vello_cpu_backend.rs
@@ -155,6 +155,7 @@ fn worker_thread_count(size: &Size2D<u16>) -> u16 {
     if u32::from(size.width) * u32::from(size.height) < SMALL_CANVAS_SIZE {
         0
     } else {
+        // The fallback `3` is the default value from `prefs.rs`
         pref!(thread_pool_canvas_workers).try_into().unwrap_or(3)
     }
 }

--- a/components/canvas/vello_cpu_backend.rs
+++ b/components/canvas/vello_cpu_backend.rs
@@ -16,6 +16,7 @@ use servo_canvas_traits::canvas::{
     CompositionOptions, CompositionOrBlending, CompositionStyle, FillOrStrokeStyle, FillRule,
     LineOptions, Path, ShadowOptions, TextRun,
 };
+use servo_config::pref;
 use vello_cpu::{RenderSettings, kurbo, peniko};
 use webrender_api::{ImageDescriptor, ImageDescriptorFlags};
 
@@ -154,9 +155,7 @@ fn worker_thread_count(size: &Size2D<u16>) -> u16 {
     if u32::from(size.width) * u32::from(size.height) < SMALL_CANVAS_SIZE {
         0
     } else {
-        // <https://github.com/linebender/vello/blob/c95b228e1cf73bf96338e8c8ae0d145553f8f99c/sparse_strips/vello_cpu/examples/basic.rs#L51>
-        // According to this example 2-4 give the best results.
-        3
+        pref!(thread_pool_canvas_workers).try_into().unwrap_or(3)
     }
 }
 

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -592,6 +592,8 @@ impl Preferences {
             thread_pool_workers_max: 4,
             thread_pool_async_runtime_workers_max: 6,
             thread_pool_fallback_workers: 3,
+            // <https://github.com/linebender/vello/blob/c95b228e1cf73bf96338e8c8ae0d145553f8f99c/sparse_strips/vello_cpu/examples/basic.rs#L51>
+            // According to this example 2-4 give the best results.
             thread_pool_canvas_workers: 3,
             thread_pool_webrender_workers_max: 4,
             webgl_testing_context_creation_error: false,

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -395,6 +395,12 @@ pub struct Preferences {
     pub thread_pool_fallback_workers: u64,
     /// Maximum number of workers for the asynchronous networking runtime thread pool
     pub thread_pool_async_runtime_workers_max: u64,
+    /// Number of worker threads used to rasterize a canvas.
+    /// This preference currently only affects the vello_cpu backend.
+    /// Setting this pref to `0` uses the single-threaded backend and
+    /// avoids creating a threadpool.
+    /// For small canvas sizes this pref is ignored and no threadpool is created.
+    pub thread_pool_canvas_workers: u64,
     /// Maximum number of workers for WebRender
     pub thread_pool_webrender_workers_max: u64,
     /// The user-agent to use for Servo. This can also be set via [`UserAgentPlatform`] in
@@ -586,6 +592,7 @@ impl Preferences {
             thread_pool_workers_max: 4,
             thread_pool_async_runtime_workers_max: 6,
             thread_pool_fallback_workers: 3,
+            thread_pool_canvas_workers: 3,
             thread_pool_webrender_workers_max: 4,
             webgl_testing_context_creation_error: false,
             user_agent: String::new(),


### PR DESCRIPTION
Local experimentation showed that after pinning canvas threads to non-little cores, I can't observe a performance benefit on my device using multithreading.
The potential benefits of multithreading likely highly vary depending on the scenario and device, so having a pref to be able to turn off multithreading or fine-tune the workers, seems useful.

Testing: No behavior change.

