### PR TITLE
layout: Fix interaction of margin and stretch size on block-level box inside inline box

### DIFF
--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -234,8 +234,7 @@ impl BlockLevelBox {
             self,
             layout.sequential_layout_state.as_deref_mut(),
             &mut layout.placement_state,
-            // Under discussion in <https://github.com/w3c/csswg-drafts/issues/13260>.
-            LogicalSides1D::new(false, false),
+            layout.ignore_block_margins_for_stretch,
             true, /* has_inline_parent */
         );
 
@@ -918,6 +917,10 @@ struct InlineFormattingContextLayout<'layout_data> {
     /// by the boundary between two characters, the text-wrap-mode property of their nearest
     /// common ancestor is used.
     text_wrap_mode: TextWrapMode,
+
+    /// Whether block-level boxes inside this inline formatting context should ignore their
+    /// margins for the purpose of stretching in the block axis.
+    ignore_block_margins_for_stretch: LogicalSides1D<bool>,
 }
 
 impl InlineFormattingContextLayout<'_> {
@@ -2077,6 +2080,7 @@ impl InlineFormattingContext {
         containing_block: &ContainingBlock,
         sequential_layout_state: Option<&mut SequentialLayoutState>,
         collapsible_with_parent_start_margin: CollapsibleWithParentStartMargin,
+        ignore_block_margins_for_stretch: LogicalSides1D<bool>,
     ) -> IndependentFormattingContextLayoutResult {
         // Clear any cached inline fragments from previous layouts.
         for inline_box in self.inline_boxes.iter() {
@@ -2124,6 +2128,7 @@ impl InlineFormattingContext {
             depends_on_block_constraints: false,
             white_space_collapse: style_text.white_space_collapse,
             text_wrap_mode: style_text.text_wrap_mode,
+            ignore_block_margins_for_stretch,
         };
 
         for item in self.inline_items.iter() {

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -718,6 +718,7 @@ impl BlockContainer {
                 containing_block,
                 sequential_layout_state,
                 collapsible_with_parent_start_margin,
+                ignore_block_margins_for_stretch,
             ),
         }
     }

--- a/components/layout/flow/same_formatting_context_block.rs
+++ b/components/layout/flow/same_formatting_context_block.rs
@@ -277,15 +277,28 @@ impl SameFormattingContextBlock {
             },
         };
 
+        let is_anonymous = matches!(
+            self.base.style.pseudo(),
+            Some(PseudoElement::ServoAnonymousBox)
+        );
+
         // https://drafts.csswg.org/css-sizing-4/#stretch-fit-sizing
         // > If this is a block axis size, and the element is in a Block Layout formatting context,
         // > and the parent element does not have a block-start border or padding and is not an
         // > independent formatting context, treat the element’s block-start margin as zero
         // > for the purpose of calculating this size. Do the same for the block-end margin.
-        let ignore_block_margins_for_stretch = LogicalSides1D::new(
-            pbm.border.block_start.is_zero() && pbm.padding.block_start.is_zero(),
-            pbm.border.block_end.is_zero() && pbm.padding.block_end.is_zero(),
-        );
+        //
+        // However, as resolved in https://github.com/w3c/csswg-drafts/issues/13260, we should
+        // check the containing block instead of the parent. Note that anonymous blocks don't
+        // establish a containing block.
+        let ignore_block_margins_for_stretch = if is_anonymous {
+            ignore_block_margins_for_stretch
+        } else {
+            LogicalSides1D::new(
+                pbm.border.block_start.is_zero() && pbm.padding.block_start.is_zero(),
+                pbm.border.block_end.is_zero() && pbm.padding.block_end.is_zero(),
+            )
+        };
 
         let flow_layout = self.contents.layout(
             layout_context,
@@ -314,10 +327,6 @@ impl SameFormattingContextBlock {
             }
         }
 
-        let is_anonymous = matches!(
-            self.base.style.pseudo(),
-            Some(PseudoElement::ServoAnonymousBox)
-        );
         let tentative_block_size = if is_anonymous {
             // Anonymous blocks do not establish a containing block for their children,
             // so we can't use that. However, they always have their sizing properties

--- a/tests/wpt/tests/css/css-sizing/stretch/block-height-011.html
+++ b/tests/wpt/tests/css/css-sizing/stretch/block-height-011.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<title>Stretching block-level on the block axis</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#stretch-fit-sizing">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/13260">
+<meta name="assert" content="The stretch size of a block-level in the block axis
+  treats margins as zero when the containing block has neither border nor padding,
+  and doesn't establish a BFC.">
+
+<style>
+.group { display: inline-block; vertical-align: top; }
+.group > .cb { width: 100px; height: 100px; margin: 25px; }
+.group.border > .cb { border: solid; }
+.group.outline > .cb { outline: solid; }
+.test { margin: 25px; height: stretch; background: cyan; }
+</style>
+
+<div id="log"></div>
+
+<div class="group">
+  <!-- Simple case, the containing block is just the parent. -->
+  <div class="cb">
+    <div class="test"></div>
+  </div>
+
+  <!-- The block-level has an inline parent, the containing block is
+       the nearest block container. -->
+  <div class="cb">
+    <span>
+      <div class="test"></div>
+    </span>
+  </div>
+
+  <!-- Now the inline is wrapped inside an anonymous block, which doesn't
+       establish a containing block. -->
+  <div class="cb">
+    <div></div>
+    <span>
+      <div class="test"></div>
+    </span>
+  </div>
+
+  <!-- The inline now has a border, this shouldn't affect the outcome. -->
+  <div class="cb">
+    <span style="border: solid orange">
+      <div class="test"></div>
+    </span>
+  </div>
+</section>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<script>
+let borderGroup = document.querySelector(".group");
+let outlineGroup = borderGroup.cloneNode(true);
+borderGroup.classList.add("border");
+outlineGroup.classList.add("outline");
+for (let el of borderGroup.querySelectorAll(".test")) {
+  el.dataset.expectedHeight = "50";
+}
+for (let el of outlineGroup.querySelectorAll(".test")) {
+  el.dataset.expectedHeight = "100";
+}
+borderGroup.after(outlineGroup);
+
+checkLayout(".test");
+</script>


### PR DESCRIPTION
For the purpose of resolving a stretch size of a block-level in the block axis, sometimes we need to treat margins as zero. The spec said to check a condition on the parent.

However, it wasn't clear what to do inside of an inline formatting context, since the parent is an inline box. Then we were never treating margins as zero.

But in https://github.com/w3c/csswg-drafts/issues/13260 the CSSWG has resolved to check the condition on the containing block.

So this amends #35904 to implement the new resolution.

Testing: Adding a test
