### PR TITLE
layout: Map between pre-transformed and post-transformed selection offsets during display list construction

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -16,6 +16,7 @@ use net_traits::image_cache::Image as CachedImage;
 use paint_api::display_list::{PaintDisplayListInfo, SpatialTreeNodeInfo};
 use servo_arc::Arc as ServoArc;
 use servo_base::id::{PipelineId, ScrollTreeNodeId};
+use servo_base::text::Utf32CodeUnits;
 use servo_config::opts::{DiagnosticsLogging, DiagnosticsLoggingOption};
 use servo_config::{pref, prefs};
 use servo_url::ServoUrl;
@@ -1284,7 +1285,8 @@ impl Fragment {
         fragment_x_offset: Au,
         justification_adjustment: Au,
     ) {
-        let Some(shared_selection) = &fragment.run_data.selection else {
+        let run_data = &fragment.run_data;
+        let Some(shared_selection) = &run_data.selection else {
             return;
         };
 
@@ -1293,8 +1295,16 @@ impl Fragment {
             return;
         }
 
-        if fragment.character_range_in_dom_node.start > shared_selection.character_range.end ||
-            fragment.character_range_in_dom_node.end < shared_selection.character_range.start
+        // The selection character range is in pre-transformed character offsets, so use the
+        // OffsetMap contained within `run_data` to convert it to post-transformed character
+        // offsets. This allows updating this selection directly from the DOM (skipping layout).
+        let dom_selection_range = &shared_selection.character_range;
+        let selection_character_range = run_data.map_dom_range_to_transformed_range(
+            Utf32CodeUnits(dom_selection_range.start)..Utf32CodeUnits(dom_selection_range.end),
+        );
+
+        if fragment.character_range_in_dom_node.start > selection_character_range.end ||
+            fragment.character_range_in_dom_node.end < selection_character_range.start
         {
             return;
         }
@@ -1306,7 +1316,7 @@ impl Fragment {
         if fragment.is_empty_for_text_cursor &&
             !fragment
                 .character_range_in_dom_node
-                .contains(&shared_selection.character_range.start)
+                .contains(&selection_character_range.start)
         {
             return;
         }
@@ -1316,9 +1326,9 @@ impl Fragment {
         let mut start_advance = None;
         let mut end_advance = None;
         for glyph_store in fragment.glyphs.iter() {
-            let glyph_store_character_count = glyph_store.character_count();
+            let glyph_store_character_count = Utf32CodeUnits(glyph_store.character_count());
             if current_character_index + glyph_store_character_count <
-                shared_selection.character_range.start
+                selection_character_range.start
             {
                 current_advance += glyph_store.total_advance() +
                     (justification_adjustment * glyph_store.total_word_separators() as i32);
@@ -1326,22 +1336,22 @@ impl Fragment {
                 continue;
             }
 
-            if current_character_index >= shared_selection.character_range.end {
+            if current_character_index >= selection_character_range.end {
                 break;
             }
 
             for glyph in glyph_store.glyphs() {
-                if current_character_index >= shared_selection.character_range.start {
+                if current_character_index >= selection_character_range.start {
                     start_advance = start_advance.or(Some(current_advance));
                 }
 
-                current_character_index += glyph.character_count();
+                current_character_index += Utf32CodeUnits(glyph.character_count());
                 current_advance += glyph.advance();
                 if glyph.char_is_word_separator() {
                     current_advance += justification_adjustment;
                 }
 
-                if current_character_index <= shared_selection.character_range.end {
+                if current_character_index <= selection_character_range.end {
                     end_advance = Some(current_advance);
                 }
             }
@@ -1351,7 +1361,7 @@ impl Fragment {
         let end_x = end_advance.unwrap_or(current_advance);
 
         let parent_style = fragment.style();
-        if !shared_selection.character_range.is_empty() {
+        if !selection_character_range.is_empty() {
             let selection_rect = Rect::new(
                 containing_block_rect.origin +
                     Vector2D::new(fragment_x_offset + start_x, Au::zero()),

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -30,6 +30,7 @@ use crate::dom::{LayoutBox, NodeExt};
 use crate::dom_traversal::{BoxTreeString, NodeAndStyleInfo};
 use crate::flow::BlockLevelBox;
 use crate::flow::float::FloatBox;
+use crate::flow::inline::text_run::SharedTextRunData;
 use crate::flow::inline::text_transform::{OffsetMap, TextTransformationIterator};
 use crate::formatting_contexts::IndependentFormattingContext;
 use crate::positioned::AbsolutelyPositionedBox;
@@ -106,7 +107,7 @@ pub(crate) struct InlineFormattingContextBuilder {
 
     /// An [`OffsetMap`] used to map selections from their offset before inline formatting
     /// context text transformation to their offsets after transformation.
-    pub offset_map: OffsetMap,
+    pub offset_map: ArcRefCell<OffsetMap>,
 }
 
 impl InlineFormattingContextBuilder {
@@ -150,7 +151,9 @@ impl InlineFormattingContextBuilder {
 
         let new_characters = Utf32CodeUnits::length_of(string_to_push);
         self.current_character_offset += new_characters.0;
-        self.offset_map.push_range(new_characters, new_characters);
+        self.offset_map
+            .borrow_mut()
+            .push_range(new_characters, new_characters);
     }
 
     fn shared_inline_styles(&self) -> SharedInlineStyles {
@@ -403,8 +406,8 @@ impl InlineFormattingContextBuilder {
         info: &NodeAndStyleInfo<'dom>,
         document_selection: Option<RangeAny<Utf32CodeUnits>>,
     ) {
-        let original_size_before = self.offset_map.total_original_size();
-        let final_size_before = self.offset_map.total_final_size();
+        let mut offset_map = self.offset_map.borrow_mut();
+        let original_size_before = offset_map.total_original_size();
 
         let bidi_class_map = icu_properties::maps::bidi_class();
         let white_space_collapse = info.style.clone_white_space_collapse();
@@ -416,7 +419,7 @@ impl InlineFormattingContextBuilder {
             self.last_inline_box_ended_with_collapsible_white_space,
             self.on_word_boundary,
         ) {
-            self.offset_map.push_iteration(&iteration);
+            offset_map.push_iteration(&iteration);
             for &character in iteration.characters() {
                 character_count += 1;
 
@@ -451,14 +454,11 @@ impl InlineFormattingContextBuilder {
         }
 
         let selection = info.node.form_control_selection_in_text_node().or_else(|| {
-            let mapped_range = document_selection?.map(|offset| {
-                self.offset_map.map(original_size_before + offset) - final_size_before
-            });
-
+            let document_selection = document_selection?;
             // Range unbounded at the start: the concrete start is offset zero.
-            let start = mapped_range.start.unwrap_or(Utf32CodeUnits(0));
+            let start = document_selection.start.unwrap_or(Utf32CodeUnits(0));
             // Range unbounded at the end: the concrete end is the full length.
-            let end = mapped_range.end.unwrap_or(Utf32CodeUnits(character_count));
+            let end = document_selection.end.unwrap_or(Utf32CodeUnits(text.len()));
 
             if start == end {
                 return None;
@@ -491,10 +491,15 @@ impl InlineFormattingContextBuilder {
         let box_slot = info.node.is_text_node().then(|| info.node.box_slot());
         let text_run = ArcRefCell::new(TextRun::new(
             info.into(),
-            current_inline_styles,
+            SharedTextRunData {
+                inline_styles: current_inline_styles,
+                character_range_in_ifc_text: new_character_range,
+                original_offset: original_size_before,
+                selection,
+                offset_map: self.offset_map.clone(),
+            }
+            .into(),
             new_utf8_range,
-            new_character_range,
-            selection,
             box_slot
                 .as_ref()
                 .and_then(|box_slot| box_slot.take_layout_box_as_text_run()),
@@ -528,8 +533,8 @@ impl InlineFormattingContextBuilder {
         }
 
         assert!(self.inline_box_stack.is_empty());
-        assert_eq!(
-            self.offset_map.total_final_size().0,
+        debug_assert_eq!(
+            self.offset_map.borrow().total_final_size().0,
             self.current_character_offset
         );
 

--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -9,6 +9,7 @@ use app_units::Au;
 use bitflags::bitflags;
 use fonts::ShapedTextSlice;
 use itertools::Either;
+use servo_base::text::Utf32CodeUnits;
 use style::Zero;
 use style::computed_values::position::T as Position;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
@@ -965,7 +966,7 @@ pub(super) struct TextRunLineItem {
     pub text: Vec<Arc<ShapedTextSlice>>,
     /// The range of characters this [`TextRunLineItem`] represents within the text of its
     /// original DOM node (modified by text transformation).
-    pub character_range_in_dom_node: Range<usize>,
+    pub character_range_in_dom_node: Range<Utf32CodeUnits>,
     /// Whether or not this [`TextFragment`] is an empty fragment added for the
     /// benefit of placing a text cursor on an otherwise empty editable line.
     pub is_empty_for_text_cursor: bool,

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -100,6 +100,7 @@ use line::{
 use malloc_size_of_derive::MallocSizeOf;
 use script::layout_dom::ServoLayoutNode;
 use servo_arc::Arc as ServoArc;
+use servo_base::text::Utf32CodeUnits;
 use style::Zero;
 use style::computed_values::line_break::T as LineBreak;
 use style::computed_values::text_wrap_mode::T as TextWrapMode;
@@ -1632,7 +1633,7 @@ impl InlineFormattingContextLayout<'_> {
         glyph_store: Arc<ShapedTextSlice>,
         text_run: &TextRun,
         info: &FontAndScriptInfo,
-        character_range: Range<usize>,
+        character_range: Range<Utf32CodeUnits>,
     ) {
         let inline_advance = glyph_store.total_advance();
         let flags = if glyph_store.is_whitespace() {
@@ -1723,8 +1724,8 @@ impl InlineFormattingContextLayout<'_> {
                 text_fragment_run_data: caret_placeholder.run_data,
                 base_fragment_info: BaseFragmentInfo::anonymous(),
                 info: FontAndScriptInfo::simple_for_font(font),
-                character_range_in_dom_node: caret_placeholder.character_index..
-                    caret_placeholder.character_index + 1,
+                character_range_in_dom_node: Utf32CodeUnits(caret_placeholder.character_index)..
+                    Utf32CodeUnits(caret_placeholder.character_index + 1),
                 is_empty_for_text_cursor: true,
             },
         ));

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -15,7 +15,7 @@ use layout_api::SharedSelection;
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use servo_arc::Arc as ServoArc;
-use servo_base::text::is_bidi_control;
+use servo_base::text::{Utf32CodeUnits, is_bidi_control};
 use smallvec::SmallVec;
 use style::Zero;
 use style::computed_values::font_kerning::T as FontKerning;
@@ -35,6 +35,7 @@ use crate::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::dom::WeakLayoutBox;
 use crate::flow::inline::shaping_queue::ShapingQueueEntry;
+use crate::flow::inline::text_transform::OffsetMap;
 use crate::flow::inline::{BidiLevels, LineBlockSizes, LineItem, SegmentContentFlags};
 use crate::fragment_tree::BaseFragmentInfo;
 
@@ -278,7 +279,8 @@ impl TextRunSegment {
                 run.clone(),
                 text_run,
                 &self.info,
-                character_range_start - run_start..new_character_range_end - run_start,
+                Utf32CodeUnits(character_range_start - run_start)..
+                    Utf32CodeUnits(new_character_range_end - run_start),
             );
 
             character_range_start = new_character_range_end;
@@ -312,22 +314,43 @@ pub(crate) enum TextRunItem {
     TextSegment(Box<TextRunSegment>),
 }
 
-/// A data structure that holds per-[`TextRun`] data used on `TextFragment`s.
+/// A data structure that holds per-`TextRun` data used on `TextFragment`s.
 /// This ensures that the data is not duplicated between fragments.
 #[derive(Debug, MallocSizeOf)]
 pub(crate) struct SharedTextRunData {
-    /// The [`crate::SharedStyle`] from this [`TextRun`]'s parent element. This is
+    /// The [`crate::SharedStyle`] from this `TextRun`'s parent element. This is
     /// shared so that incremental layout can simply update the parent element and
     /// this [`TextRun`] will be updated automatically.
     pub inline_styles: SharedInlineStyles,
     /// The range of characters in this text in `InlineFormattingContext::text_content`
-    /// of the `InlineFormattingContext` that owns this [`TextRun`]. These are counting
+    /// of the `InlineFormattingContext` that owns this `TextRun`. These are counting
     /// `char`s, *not* UTF-8 offsets.
     pub character_range_in_ifc_text: Range<usize>,
-    /// The selected text in this [`TextRun`]. This may either be document selection or
-    /// form control selection.
+    /// The original offset of this `TextRun` in the `InlineFormattingContext`'s input
+    /// text (untransformed by white space collapse and `text-transform`).
+    pub original_offset: Utf32CodeUnits,
+    /// The selected text in this `TextRun`. This may either be document selection or form control
+    /// selection.
     #[conditional_malloc_size_of]
     pub selection: Option<SharedSelection>,
+    /// The [`OffsetMap`] used when creating this `TextRun`'s `InlineFormattingContext`. This
+    /// is used for mapping between DOM text offsets and layout text offsets (and vice-versa).
+    pub offset_map: ArcRefCell<OffsetMap>,
+}
+
+impl SharedTextRunData {
+    /// Map a range in the originating `TextRun`'s DOM node text into the range in the
+    /// `TextRun`'s layout transformed (by white space collapse and `text-transform`)
+    /// text.
+    pub(crate) fn map_dom_range_to_transformed_range(
+        &self,
+        range: Range<Utf32CodeUnits>,
+    ) -> Range<Utf32CodeUnits> {
+        let offset_map = self.offset_map.borrow();
+        let offset_in_ifc_text = Utf32CodeUnits(self.character_range_in_ifc_text.start);
+        offset_map.map(range.start + self.original_offset) - offset_in_ifc_text..
+            offset_map.map(range.end + self.original_offset) - offset_in_ifc_text
+    }
 }
 
 /// A single [`TextRun`] for the box tree. These are all descendants of
@@ -364,10 +387,8 @@ pub(crate) struct TextRun {
 impl TextRun {
     pub(crate) fn new(
         base_fragment_info: BaseFragmentInfo,
-        inline_styles: SharedInlineStyles,
+        run_data: Arc<SharedTextRunData>,
         text_range: Range<usize>,
-        character_range: Range<usize>,
-        selection: Option<SharedSelection>,
         old_text_run: Option<ArcRefCell<TextRun>>,
     ) -> Self {
         // If there was a previous box tree layout of this text run, try to preserve the old shaped text.
@@ -376,12 +397,7 @@ impl TextRun {
             .unwrap_or_default();
         Self {
             base_fragment_info,
-            run_data: SharedTextRunData {
-                inline_styles,
-                character_range_in_ifc_text: character_range,
-                selection,
-            }
-            .into(),
+            run_data,
             parent_box: None,
             text_range,
             items,

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -14,6 +14,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use servo_arc::Arc as ServoArc;
 use servo_base::id::PipelineId;
 use servo_base::print_tree::PrintTree;
+use servo_base::text::Utf32CodeUnits;
 use servo_url::ServoUrl;
 use style::Zero;
 use style::properties::ComputedValues;
@@ -104,7 +105,7 @@ pub(crate) struct TextFragment {
     pub justification_adjustment: Au,
     /// The range of characters this [`TextFragment`] represents within the text of its
     /// original DOM node (modified by text transformation).
-    pub character_range_in_dom_node: Range<usize>,
+    pub character_range_in_dom_node: Range<Utf32CodeUnits>,
     /// Whether or not this [`TextFragment`] is an empty fragment added for the
     /// benefit of placing a text cursor on an otherwise empty editable line.
     pub is_empty_for_text_cursor: bool,
@@ -495,7 +496,7 @@ impl TextFragment {
     pub(crate) fn character_offset(
         &self,
         point_in_fragment: Point2D<Au, CSSPixel>,
-    ) -> Option<usize> {
+    ) -> Option<Utf32CodeUnits> {
         // If the click was far enough above the top of the fragment, then pick the first index.
         let max_vertical_offset = self.base.rect().height().scale_by(0.25);
         if point_in_fragment.y < -max_vertical_offset {
@@ -523,7 +524,7 @@ impl TextFragment {
                     return Some(current_character);
                 }
                 current_offset += advance;
-                current_character += glyph.character_count();
+                current_character += Utf32CodeUnits(glyph.character_count());
             }
         }
 

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -1449,11 +1449,13 @@ pub fn find_character_offset_in_fragment_descendants(
         }
     }
 
-    closest_relative_fragment.and_then(|closest_fragment| {
-        closest_fragment
-            .fragment
-            .character_offset(closest_fragment.point_in_fragment)
-    })
+    closest_relative_fragment
+        .and_then(|closest_fragment| {
+            closest_fragment
+                .fragment
+                .character_offset(closest_fragment.point_in_fragment)
+        })
+        .map(|offset| offset.0)
 }
 
 pub fn process_containing_block_query(node: ServoLayoutNode) -> Option<UntrustedNodeAddress> {

--- a/tests/wpt/tests/css/css-text/text-transform/reference/text-transform-upperlower-108-ref.html
+++ b/tests/wpt/tests/css/css-text/text-transform/reference/text-transform-upperlower-108-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<title>CSS3 Text, text transform in textarea element: German sharp S, uppercase and selection</title>
+<meta name="assert" content="text-transform: uppercase will uppercase the German sharp S as described in Unicode's SpecialCasing.txt .">
+<link rel='author' title='Martin Robinson' href='mailto:mrobinson@igalia.com'>
+<link rel='help' href='https://drafts.csswg.org/css-text-3/#text-transform'>
+</head>
+
+<body>
+    <p class="instructions">Test passes if both characters below are selected.</p>
+    <textarea id="textarea" style="text-transform: uppercase">SS</textarea>
+    <script>
+        textarea.focus();
+        textarea.setSelectionRange(0, 2);
+    </script>
+</body>
+</html>

--- a/tests/wpt/tests/css/css-text/text-transform/text-transform-upperlower-108.html
+++ b/tests/wpt/tests/css/css-text/text-transform/text-transform-upperlower-108.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<title>CSS3 Text, text transform in textarea element: German sharp S, uppercase and selection</title>
+<meta name="assert" content="text-transform: uppercase will uppercase the German sharp S as described in Unicode's SpecialCasing.txt .">
+<link rel='author' title='Martin Robinson' href='mailto:mrobinson@igalia.com'>
+<link rel='help' href='https://drafts.csswg.org/css-text-3/#text-transform'>
+<link rel="match" href="reference/text-transform-upperlower-108-ref.html">
+</head>
+
+<body>
+    <p class="instructions">Test passes if both characters below are selected.</p>
+    <textarea id="textarea" style="text-transform: uppercase">&#x00DF;</textarea>
+    <script>
+        textarea.focus();
+        textarea.setSelectionRange(0, 1);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
There are two types of DOM-node-relative text offsets to consider in
layout. One is pre-transformed, that is before any white space collapse
or `text-transform` is applied to the node's text content. This is how
selections are stored, so that they can be updated without triggering a
full layout. The other is post-transformed, that is after white space
collapse and `text-transform`. This is how glyph character advances are
measured. This changes moves the mapping from the first to the second to
display list construction, so that it is done also for form control
selections. This fixes the behavior of visual selections and
`text-transform` in form control elements and is also foundational for
ensuring that the reverse transform can happen during hit testing.

Testing: This change adds a new WPT test.
