### PR TITLE
layout: Take `OffsetMap` into account when getting glyph character index

### DIFF
--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -351,6 +351,17 @@ impl SharedTextRunData {
         offset_map.map(range.start + self.original_offset) - offset_in_ifc_text..
             offset_map.map(range.end + self.original_offset) - offset_in_ifc_text
     }
+
+    /// Map an offset in the originating `TextRun`s DOM node's transformed text (by white
+    /// space collapse and `text-transform`) to untransformed text for use by the DOM.
+    pub(crate) fn map_transformed_offset_to_dom_offset(
+        &self,
+        offset: Utf32CodeUnits,
+    ) -> Utf32CodeUnits {
+        let offset_map = self.offset_map.borrow();
+        let offset_in_ifc_text = Utf32CodeUnits(self.character_range_in_ifc_text.start);
+        offset_map.reverse_map(offset + offset_in_ifc_text) - self.original_offset
+    }
 }
 
 /// A single [`TextRun`] for the box tree. These are all descendants of

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -500,7 +500,10 @@ impl TextFragment {
         // If the click was far enough above the top of the fragment, then pick the first index.
         let max_vertical_offset = self.base.rect().height().scale_by(0.25);
         if point_in_fragment.y < -max_vertical_offset {
-            return Some(self.character_range_in_dom_node.start);
+            return Some(
+                self.run_data
+                    .map_transformed_offset_to_dom_offset(self.character_range_in_dom_node.start),
+            );
         }
 
         // If the click was below the fragment, return `None`, which will cause the
@@ -528,7 +531,10 @@ impl TextFragment {
             }
         }
 
-        Some(current_character)
+        Some(
+            self.run_data
+                .map_transformed_offset_to_dom_offset(current_character),
+        )
     }
 }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13455,6 +13455,15 @@
       }
      ]
     ],
+    "mousedown-edit-point-textarea-003.html": [
+     "274c6dd2b6537f87758af08d46a9bf9d5eddf5c8",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
     "sequential-focus-navigation-across-documents-001.html": [
      "40c2ff0e0fd0e85110825c7836eb767880d6dd61",
      [

--- a/tests/wpt/mozilla/tests/input-events/mousedown-edit-point-textarea-003.html
+++ b/tests/wpt/mozilla/tests/input-events/mousedown-edit-point-textarea-003.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+
+<title>Clicking in the padding of a &lt;textara&gt; should move the edit point properly</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="input-events.js"></script>
+
+<!-- The uppercase ß character is transformed into 'SS'. Clicking beyond that
+transformed character should move the cursor to the end of the line (and not
+to the end of the subsequent line). This shows that `text-transform` is taken
+into account when determining edit points via mouse clicks. -->
+<textarea id="target" style="height: 300px; width: 300px; text-transform: uppercase;">
+&#x00DF;
+</textarea>
+
+<script>
+promise_test(async test => {
+    let targetRect = getTextEntryContentRect(target);
+    await (new test_driver.Actions()
+        .pointerMove(targetRect.right - 10, targetRect.top + 10)
+        .pointerDown().pointerUp()
+        .send());
+    assert_equals(target.selectionStart, 1);
+    assert_equals(target.selectionEnd, 1);
+});
+</script>


### PR DESCRIPTION
When text is transformed by `InlineFormattingContext` construction, we
keep an `OffsetMap` to map between indices pre-and-post-transform.
This change ensures the map is used when mapping back to
pre-transformed DOM indices, meaning that moving the edit point with
the mouse in `<textarea>` that has a CSS `text-transform` or is
subject to white space collapse works properly.

Testing: A Servo-specific WPT test is added for this change as it depends on mouse interaction behavior.
