### PR TITLE
threadboost: Fine-tune boosting and explicitly boost webrender threads

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -150,6 +150,7 @@ use servo_base::id::{
     PainterId, PipelineId, PipelineNamespace, PipelineNamespaceId, PipelineNamespaceRequest,
     ScriptEventLoopId, WebViewId,
 };
+use servo_base::threadboost::{BoostAffinity, ThreadPriority};
 use servo_base::{Epoch, generic_channel};
 #[cfg(feature = "bluetooth")]
 use servo_bluetooth_traits::BluetoothRequest;
@@ -628,7 +629,7 @@ where
         thread::Builder::new()
             .name("Constellation".to_owned())
             .spawn(move || {
-                servo_base::threadboost::mark_thread_as_critical();
+                servo_base::threadboost::boost_thread(ThreadPriority::Elevated, BoostAffinity::Boost);
                 let (script_ipc_sender, script_ipc_receiver) =
                     generic_channel::channel().expect("ipc channel failure");
                 let script_receiver = script_ipc_receiver.route_preserving_errors();

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -39,7 +39,8 @@ use servo_geometry::DeviceIndependentPixel;
 use smallvec::SmallVec;
 use style_traits::CSSPixel;
 use webrender::{
-    MemoryReport, ONE_TIME_USAGE_HINT, RenderApi, ShaderPrecacheFlags, Transaction, UploadMethod,
+    MemoryReport, ONE_TIME_USAGE_HINT, RenderApi, RenderBackendHooks, SceneBuilderHooks,
+    ShaderPrecacheFlags, Transaction, UploadMethod,
 };
 use webrender_api::units::{
     DevicePixel, DevicePoint, LayoutPoint, LayoutRect, LayoutSize, LayoutTransform, LayoutVector2D,
@@ -214,6 +215,7 @@ impl Painter {
             rayon::ThreadPoolBuilder::new()
                 .num_threads(worker_threads)
                 .thread_name(|idx| format!("WRWorker#{}", idx))
+                .start_handler(|_| servo_base::threadboost::mark_thread_as_critical())
                 .build()
                 .expect("Unable to initialize WebRender worker pool."),
         ));
@@ -246,6 +248,8 @@ impl Painter {
                 // This ensures that we can use the `PainterId` as the `IdNamespace`, which allows mapping
                 // from `FontKey`, `FontInstanceKey`, and `ImageKey` back to `PainterId`.
                 namespace_alloc_by_client: true,
+                render_backend_hooks: Some(Box::new(BoostWebRenderThread)),
+                scene_builder_hooks: Some(Box::new(BoostWebRenderThread)),
                 shared_font_namespace: Some(painter_id.into()),
                 ..Default::default()
             },
@@ -1597,4 +1601,39 @@ pub(crate) enum PaintMetricState {
     Seen(WebRenderEpoch, bool /* first_reflow */),
     /// The metric has been sent to the constellation and no more work needs to be done.
     Sent,
+}
+
+/// Hook implementation to boost webrender thread priority.
+struct BoostWebRenderThread;
+
+impl RenderBackendHooks for BoostWebRenderThread {
+    fn init_thread(&self) {
+        servo_base::threadboost::mark_thread_as_critical();
+    }
+}
+
+impl SceneBuilderHooks for BoostWebRenderThread {
+    fn register(&self) {
+        servo_base::threadboost::mark_thread_as_critical();
+    }
+
+    fn pre_scene_build(&self) {}
+
+    fn pre_scene_swap(&self) {}
+
+    fn post_scene_swap(
+        &self,
+        _document_id: &Vec<DocumentId>,
+        _info: webrender::PipelineInfo,
+        _schedule_frame: bool,
+    ) {
+    }
+
+    fn post_resource_update(&self, _document_ids: &Vec<DocumentId>) {}
+
+    fn post_empty_scene_build(&self) {}
+
+    fn poke(&self) {}
+
+    fn deregister(&self) {}
 }

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -33,6 +33,7 @@ use servo_base::Epoch;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_base::generic_channel::{GenericReceiver, GenericSharedMemory};
 use servo_base::id::{PainterId, PipelineId, WebViewId};
+use servo_base::threadboost::{BoostAffinity, ThreadPriority};
 use servo_config::{opts, pref};
 use servo_constellation_traits::{EmbedderToConstellationMessage, PaintMetricEvent};
 use servo_geometry::DeviceIndependentPixel;
@@ -215,7 +216,12 @@ impl Painter {
             rayon::ThreadPoolBuilder::new()
                 .num_threads(worker_threads)
                 .thread_name(|idx| format!("WRWorker#{}", idx))
-                .start_handler(|_| servo_base::threadboost::mark_thread_as_critical())
+                .start_handler(|_| {
+                    servo_base::threadboost::boost_thread(
+                        ThreadPriority::Elevated,
+                        BoostAffinity::Boost,
+                    )
+                })
                 .build()
                 .expect("Unable to initialize WebRender worker pool."),
         ));
@@ -1608,13 +1614,13 @@ struct BoostWebRenderThread;
 
 impl RenderBackendHooks for BoostWebRenderThread {
     fn init_thread(&self) {
-        servo_base::threadboost::mark_thread_as_critical();
+        servo_base::threadboost::boost_thread(ThreadPriority::Elevated, BoostAffinity::Boost);
     }
 }
 
 impl SceneBuilderHooks for BoostWebRenderThread {
     fn register(&self) {
-        servo_base::threadboost::mark_thread_as_critical();
+        servo_base::threadboost::boost_thread(ThreadPriority::Elevated, BoostAffinity::Boost);
     }
 
     fn pre_scene_build(&self) {}

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -85,6 +85,7 @@ use servo_base::generic_channel::GenericSender;
 use servo_base::id::{
     BrowsingContextId, HistoryStateId, PipelineId, PipelineNamespace, ScriptEventLoopId, WebViewId,
 };
+use servo_base::threadboost::{BoostAffinity, ThreadPriority};
 use servo_base::{Epoch, generic_channel};
 use servo_canvas_traits::webgl::WebGLPipeline;
 use servo_config::opts::{self, DiagnosticsLoggingOption};
@@ -503,7 +504,10 @@ impl ScriptThreadFactory for ScriptThread {
                 SCRIPT_THREAD_ROOT.with(|root| {
                     root.set(Some(Rc::as_ptr(&script_thread)));
                 });
-                servo_base::threadboost::mark_thread_as_critical();
+                servo_base::threadboost::boost_thread(
+                    ThreadPriority::Critical,
+                    BoostAffinity::Boost,
+                );
                 let mut failsafe = ScriptMemoryFailsafe::new(&script_thread);
 
                 memory_profiler_sender.run_with_memory_reporting(

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -1001,10 +1001,6 @@ impl Servo {
             prefs::add_observer(Box::new(constellation_proxy.clone()));
         }
 
-        // Note: This marks the embedder thread as critical, we'll want to
-        // evaluate that in the future.
-        servo_base::threadboost::mark_thread_as_critical();
-
         Servo(Rc::new(ServoInner {
             delegate: RefCell::new(Rc::new(DefaultServoDelegate)),
             paint,

--- a/components/shared/base/threadboost.rs
+++ b/components/shared/base/threadboost.rs
@@ -20,7 +20,7 @@
 use servo_config::pref;
 
 #[cfg(target_env = "ohos")]
-mod ohos {
+mod platform {
     //! On `ohos` targets we only have the `OH_QoS_SetThreadQoS` API from qos/qos.h,
     //! which influences scheduling priority, but empirically does not help with ensuring
     //! important servo threads like script get scheduled on larger cores, presumably because
@@ -36,7 +36,9 @@ mod ohos {
     use std::fs;
     use std::sync::LazyLock;
 
-    /// Highest QoS level from OHOS `qos/qos.h` (API 12+).
+    // Constants copied from `qos/qos.h`. Avoids depending on ohos-libqos-sys just for this one function.
+    // See also <https://docs.rs/ohos-libqos-sys/0.1.0/src/ohos_libqos_sys/qos_ffi.rs.html#21>
+    const QOS_USER_INITIATED: i32 = 3;
     const QOS_USER_INTERACTIVE: i32 = 5;
 
     #[link(name = "qos")]
@@ -144,12 +146,18 @@ mod ohos {
         Ok(())
     }
 
-    pub fn mark_thread_as_critical() {
-        let qos_rc = OH_QoS_SetThreadQoS(QOS_USER_INTERACTIVE);
+    pub fn boost_thread(priority: ThreadPriority, boost_affinity: BoostAffinity) {
+        let qos_rc = match priority {
+            ThreadPriority::Elevated => OH_QoS_SetThreadQoS(QOS_USER_INITIATED),
+            ThreadPriority::Critical => OH_QoS_SetThreadQoS(QOS_USER_INTERACTIVE),
+            ThreadPriority::Default => 0,
+        };
         if qos_rc != 0 {
-            log::warn!("Failed to set QOS_USER_INTERACTIVE");
+            log::warn!("Failed to boost thread priority. `OH_QoS_SetThreadQoS` returned {qos_rc}");
         }
-        if let Err(error) = pin_thread_to_medium_or_large_cpus() {
+        if matches!(boost_affinity, BoostAffinity::Boost) &&
+            let Err(error) = pin_thread_to_medium_or_large_cpus()
+        {
             log::warn!(
                 "Failed to pin {} to medium or large cpus: {error:?}",
                 std::thread::current().name().unwrap_or("<unnamed>"),
@@ -158,7 +166,32 @@ mod ohos {
     }
 }
 
+#[cfg(not(target_env = "ohos"))]
+mod platform {
+    pub fn boost_thread(_: super::ThreadPriority, _: super::BoostAffinity) {}
+}
+
+pub enum ThreadPriority {
+    /// Priority will remain unchanged.
+    Default,
+    /// Increase the thread priority.
+    Elevated,
+    /// Higher priority than `Elevated`, should be used sparingly.
+    Critical,
+}
+
+/// On heterougenous systems (e.g. big.LITTLE architecture), select
+/// whether we should attempt to boost this thread to a larger core.
+/// The exact effect is platform specific, a hint and may be ignored.
+pub enum BoostAffinity {
+    No,
+    /// Prioritize Medium or Large cores and avoid small cores.
+    Boost,
+}
+
 /// Hint to the scheduler that this thread should be prioritised.
+///
+/// No effect if `pref!(perf_thread_boost_enabled)` is `false`.
 ///
 /// TODO: The exact API and inner-workings are subject to change:
 /// - This is a hint to servo / the embedder and can be a no-op.
@@ -168,9 +201,8 @@ mod ohos {
 /// - Some optimizations like thread affinity selection also affect children threads,
 ///   if spawned after this call, so placement can be important.
 #[allow(unsafe_code)]
-pub fn mark_thread_as_critical() {
+pub fn boost_thread(priority: ThreadPriority, boost_affinity: BoostAffinity) {
     if pref!(perf_thread_boost_enabled) {
-        #[cfg(target_env = "ohos")]
-        ohos::mark_thread_as_critical()
+        platform::boost_thread(priority, boost_affinity)
     }
 }

--- a/components/shared/base/threadboost.rs
+++ b/components/shared/base/threadboost.rs
@@ -36,6 +36,8 @@ mod platform {
     use std::fs;
     use std::sync::LazyLock;
 
+    use super::{BoostAffinity, ThreadPriority};
+
     // Constants copied from `qos/qos.h`. Avoids depending on ohos-libqos-sys just for this one function.
     // See also <https://docs.rs/ohos-libqos-sys/0.1.0/src/ohos_libqos_sys/qos_ffi.rs.html#21>
     const QOS_USER_INITIATED: i32 = 3;


### PR DESCRIPTION
Follow-up to #46843.

Instead of boosting the embedder thread, which happened to also boost the webrender (children) threads (threads spawned after we changed the thread affinity for the embedder thread), boost the webrender threads explicitly and remove the embedder thread boost. This seems to have the same net performance, hence it's better to avoid changing the properties of the embedder thread.
Additionally modified the boosting API, so that we can specify a priority level, and opt-in to the thread affinity boosting. This gives us more flexibility, since some threads might just want one or the other. 
In the future this might also be useful if we want to de-prioritize certain threads.

Testing: We don't have any automated tests measuring performance or thread placement.

