### PR TITLE
script: Pass the prefix from the parser when creating attributes

### DIFF
--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -2203,7 +2203,13 @@ impl Element {
             return;
         }
 
-        let name = qname.local.clone();
+        let name = match qname.prefix {
+            None => qname.local.clone(),
+            Some(ref prefix) => {
+                let name = format!("{}:{}", &**prefix, &*qname.local);
+                LocalName::from(name)
+            },
+        };
         let value = self.parse_attribute(&qname.ns, &qname.local, value);
         self.push_new_attribute(
             cx,
@@ -2211,7 +2217,7 @@ impl Element {
             value,
             name,
             qname.ns,
-            None, // TODO: pass prefix from `qname`.
+            qname.prefix,
             AttributeMutationReason::ByParser,
         );
     }

--- a/tests/wpt/meta/dom/nodes/Attr-prefix-xhtml.xhtml.ini
+++ b/tests/wpt/meta/dom/nodes/Attr-prefix-xhtml.xhtml.ini
@@ -1,3 +1,0 @@
-[Attr-prefix-xhtml.xhtml]
-  [Attr.prefix present]
-    expected: FAIL

--- a/tests/wpt/meta/dom/nodes/Attr-prefix.html.ini
+++ b/tests/wpt/meta/dom/nodes/Attr-prefix.html.ini
@@ -1,6 +1,0 @@
-[Attr-prefix.html]
-  [Attr.prefix present (SVG)]
-    expected: FAIL
-
-  [Attr.prefix present (MathML)]
-    expected: FAIL

--- a/tests/wpt/meta/dom/nodes/Node-cloneNode-svg.html.ini
+++ b/tests/wpt/meta/dom/nodes/Node-cloneNode-svg.html.ini
@@ -1,7 +1,0 @@
-[Node-cloneNode-svg.html]
-  [cloned <use>'s xlink:href attribute should have the right properties]
-    expected: FAIL
-
-  [cloned <svg>'s xmlns:xlink attribute should have the right properties]
-    expected: FAIL
-

--- a/tests/wpt/meta/trusted-types/Element-setAttribute-respects-Elements-node-documents-globals-CSP-after-adoption-from-TT-realm.html.ini
+++ b/tests/wpt/meta/trusted-types/Element-setAttribute-respects-Elements-node-documents-globals-CSP-after-adoption-from-TT-realm.html.ini
@@ -1,3 +1,0 @@
-[Element-setAttribute-respects-Elements-node-documents-globals-CSP-after-adoption-from-TT-realm.html]
-  [Trusted types are not enforced for setAttributeNode and\n              setAttributeNS after moving the target node from a TT-realm to a\n              non-TT realm for script.xlink:href]
-    expected: FAIL

--- a/tests/wpt/meta/trusted-types/Element-setAttribute-respects-Elements-node-documents-globals-CSP-after-adoption-from-non-TT-realm.html.ini
+++ b/tests/wpt/meta/trusted-types/Element-setAttribute-respects-Elements-node-documents-globals-CSP-after-adoption-from-non-TT-realm.html.ini
@@ -1,2 +1,0 @@
-[Element-setAttribute-respects-Elements-node-documents-globals-CSP-after-adoption-from-non-TT-realm.html]
-  expected: ERROR


### PR DESCRIPTION
Follow-up to #46868: now passing the correct prefix and qualified name when creating elements from the parser.

Testing: WPTs now pass.