### PR TITLE
fonts: Optimize hasher by using `FxHashMap` in CachedShapeData

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -234,8 +234,8 @@ impl FontMetrics {
 
 #[derive(Debug, Default)]
 struct CachedShapeData {
-    glyph_advances: HashMap<GlyphId, FractionalPixel>,
-    glyph_indices: HashMap<char, Option<GlyphId>>,
+    glyph_advances: FxHashMap<GlyphId, FractionalPixel>,
+    glyph_indices: FxHashMap<char, Option<GlyphId>>,
     shaped_text: HashMap<ShapeCacheEntry, Arc<ShapedText>>,
 }
 


### PR DESCRIPTION
For they glyph caches using the faster FxHasher should be fine from a DoS perspective and FxHashMap should probably be the default choice for integer / integer-like keys. For shaped_text we keep the standard hashmap since it contains a web controlled string. I don't expect this change to be measurable (and i didn't attempt to), it's a drive-by change while looking at surrounding code.

Testing: No observable behavior change, so existing tests should suffice.
