### PR TITLE
pixels: Create Image Decoder trait

### DIFF
--- a/components/pixels/decoding.rs
+++ b/components/pixels/decoding.rs
@@ -1,0 +1,377 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::io::Cursor;
+use std::sync::Arc;
+use std::time::Duration;
+use std::{cmp, fmt, vec};
+
+use image::codecs::{bmp, gif, ico, jpeg, png, webp};
+use image::error::ImageFormatHint;
+use image::metadata::LoopCount;
+use image::{
+    AnimationDecoder, DynamicImage, ImageDecoder, ImageError, ImageFormat, ImageResult, Limits,
+};
+use log::{debug, error};
+
+use crate::{
+    CorsStatus, ImageFrame, ImageMetadata, PixelFormat, RasterImage, Repeat,
+    rgba8_premultiply_inplace,
+};
+
+enum GenericImageDecoder<'a> {
+    Apng(Box<png::ApngDecoder<Cursor<&'a [u8]>>>),
+    Png(Box<png::PngDecoder<Cursor<&'a [u8]>>>),
+    Gif(Box<gif::GifDecoder<Cursor<&'a [u8]>>>),
+    Webp(Box<webp::WebPDecoder<Cursor<&'a [u8]>>>),
+    Jpeg(Box<jpeg::JpegDecoder<Cursor<&'a [u8]>>>),
+    Bmp(Box<bmp::BmpDecoder<Cursor<&'a [u8]>>>),
+    Ico(Box<ico::IcoDecoder<Cursor<&'a [u8]>>>),
+}
+
+impl<'a> std::fmt::Debug for GenericImageDecoder<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Apng(_) => f.debug_tuple("Apng").finish(),
+            Self::Png(_) => f.debug_tuple("Png").finish(),
+            Self::Gif(_) => f.debug_tuple("Gif").finish(),
+            Self::Webp(_) => f.debug_tuple("Webp").finish(),
+            Self::Jpeg(_) => f.debug_tuple("Jpeg").finish(),
+            Self::Bmp(_) => f.debug_tuple("Bmp").finish(),
+            Self::Ico(_) => f.debug_tuple("Ico").finish(),
+        }
+    }
+}
+
+/// Notice that we implement methods that are implemented by default. However, these methods are necessary as
+impl<'a> image::ImageDecoder for GenericImageDecoder<'a> {
+    fn dimensions(&self) -> (u32, u32) {
+        match self {
+            GenericImageDecoder::Apng(_) => {
+                unreachable!("Animated image should never go into non-animated values")
+            },
+            GenericImageDecoder::Png(d) => d.dimensions(),
+            GenericImageDecoder::Gif(d) => d.dimensions(),
+            GenericImageDecoder::Webp(d) => d.dimensions(),
+            GenericImageDecoder::Jpeg(d) => d.dimensions(),
+            GenericImageDecoder::Bmp(d) => d.dimensions(),
+            GenericImageDecoder::Ico(d) => d.dimensions(),
+        }
+    }
+
+    fn color_type(&self) -> image::ColorType {
+        match self {
+            GenericImageDecoder::Apng(_) => {
+                unreachable!("Animated image should never go into non-animated values")
+            },
+            GenericImageDecoder::Png(d) => d.color_type(),
+            GenericImageDecoder::Gif(d) => d.color_type(),
+            GenericImageDecoder::Webp(d) => d.color_type(),
+            GenericImageDecoder::Jpeg(d) => d.color_type(),
+            GenericImageDecoder::Bmp(d) => d.color_type(),
+            GenericImageDecoder::Ico(d) => d.color_type(),
+        }
+    }
+
+    fn read_image(self, buf: &mut [u8]) -> ImageResult<()>
+    where
+        Self: Sized,
+    {
+        match self {
+            GenericImageDecoder::Apng(_) => {
+                unreachable!("Animated image should never go into non-animated values")
+            },
+            GenericImageDecoder::Png(d) => d.read_image(buf),
+            GenericImageDecoder::Gif(d) => d.read_image(buf),
+            GenericImageDecoder::Webp(d) => d.read_image(buf),
+            GenericImageDecoder::Jpeg(d) => d.read_image(buf),
+            GenericImageDecoder::Bmp(d) => d.read_image(buf),
+            GenericImageDecoder::Ico(d) => d.read_image(buf),
+        }
+    }
+
+    fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
+        match *self {
+            GenericImageDecoder::Apng(_) => {
+                unreachable!("Animated image should never go into non-animated values")
+            },
+            GenericImageDecoder::Png(d) => d.read_image_boxed(buf),
+            GenericImageDecoder::Gif(d) => d.read_image_boxed(buf),
+            GenericImageDecoder::Webp(d) => d.read_image_boxed(buf),
+            GenericImageDecoder::Jpeg(d) => d.read_image_boxed(buf),
+            GenericImageDecoder::Bmp(d) => d.read_image_boxed(buf),
+            GenericImageDecoder::Ico(d) => d.read_image_boxed(buf),
+        }
+    }
+
+    fn icc_profile(&mut self) -> ImageResult<Option<Vec<u8>>> {
+        match self {
+            GenericImageDecoder::Apng(_) => {
+                unreachable!("Animated image should never go into non-animated values")
+            },
+            GenericImageDecoder::Png(d) => d.icc_profile(),
+            GenericImageDecoder::Gif(d) => d.icc_profile(),
+            GenericImageDecoder::Webp(d) => d.icc_profile(),
+            GenericImageDecoder::Jpeg(d) => d.icc_profile(),
+            GenericImageDecoder::Bmp(d) => d.icc_profile(),
+            GenericImageDecoder::Ico(d) => d.icc_profile(),
+        }
+    }
+
+    fn exif_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
+        match self {
+            GenericImageDecoder::Apng(_) => {
+                unreachable!("Animated image should never go into non-animated values")
+            },
+            GenericImageDecoder::Png(d) => d.exif_metadata(),
+            GenericImageDecoder::Gif(d) => d.exif_metadata(),
+            GenericImageDecoder::Webp(d) => d.exif_metadata(),
+            GenericImageDecoder::Jpeg(d) => d.exif_metadata(),
+            GenericImageDecoder::Bmp(d) => d.exif_metadata(),
+            GenericImageDecoder::Ico(d) => d.exif_metadata(),
+        }
+    }
+
+    fn xmp_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
+        match self {
+            GenericImageDecoder::Apng(_) => {
+                unreachable!("Animated image should never go into non-animated values")
+            },
+            GenericImageDecoder::Png(d) => d.xmp_metadata(),
+            GenericImageDecoder::Gif(d) => d.xmp_metadata(),
+            GenericImageDecoder::Webp(d) => d.xmp_metadata(),
+            GenericImageDecoder::Jpeg(d) => d.xmp_metadata(),
+            GenericImageDecoder::Bmp(d) => d.xmp_metadata(),
+            GenericImageDecoder::Ico(d) => d.xmp_metadata(),
+        }
+    }
+
+    fn iptc_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
+        match self {
+            GenericImageDecoder::Apng(_) => {
+                unreachable!("Animated image should never go into non-animated values")
+            },
+            GenericImageDecoder::Png(d) => d.iptc_metadata(),
+            GenericImageDecoder::Gif(d) => d.iptc_metadata(),
+            GenericImageDecoder::Webp(d) => d.iptc_metadata(),
+            GenericImageDecoder::Jpeg(d) => d.iptc_metadata(),
+            GenericImageDecoder::Bmp(d) => d.iptc_metadata(),
+            GenericImageDecoder::Ico(d) => d.iptc_metadata(),
+        }
+    }
+}
+
+/// See documentation on imp `image::ImageDecoder`
+impl<'a> AnimationDecoder<'a> for GenericImageDecoder<'a> {
+    fn into_frames(self) -> image::Frames<'a> {
+        match self {
+            GenericImageDecoder::Apng(decoder) => decoder.into_frames(),
+            GenericImageDecoder::Gif(decoder) => decoder.into_frames(),
+            GenericImageDecoder::Webp(decoder) => decoder.into_frames(),
+            _ => unreachable!("Should never decode these images with animated decoder"),
+        }
+    }
+
+    fn loop_count(&self) -> LoopCount {
+        match self {
+            GenericImageDecoder::Apng(decoder) => decoder.loop_count(),
+            GenericImageDecoder::Gif(decoder) => decoder.loop_count(),
+            GenericImageDecoder::Webp(decoder) => decoder.loop_count(),
+            _ => unreachable!("Should never decode these images with animated decoder"),
+        }
+    }
+}
+
+#[derive(Debug)]
+/// Servo Default Image decoder using image-rs for decoding.
+pub(crate) struct DefaultImageDecoder<'a> {
+    decoder: GenericImageDecoder<'a>,
+}
+
+/// Main Image decoder trait.
+pub(crate) trait ServoImageDecoder<'a>: Sized + std::fmt::Debug {
+    /// Create a decoder for a `format` from a `buffer`.
+    fn make_decoder(format: ImageFormat, buffer: &'a [u8]) -> ImageResult<Self>;
+    fn is_animated(&self) -> bool;
+    /// Return the created decoder in `impl ImageDecoder`
+    fn decoder(self) -> impl ImageDecoder;
+    /// Return the created decoder in `impl AnimationDecoder` if animated.
+    fn animated_decoder(self) -> impl AnimationDecoder<'a>;
+}
+
+impl<'a> ServoImageDecoder<'a> for DefaultImageDecoder<'a> {
+    fn make_decoder(format: ImageFormat, buffer: &'a [u8]) -> ImageResult<Self> {
+        let reader = Cursor::new(buffer);
+        let decoder = match format {
+            ImageFormat::Png => {
+                let limits = Limits::default();
+                let png_decoder = png::PngDecoder::with_limits(reader, limits)?;
+                if png_decoder.is_apng().unwrap_or_default() {
+                    let decoder = png_decoder.apng()?;
+                    GenericImageDecoder::Apng(Box::new(decoder))
+                } else {
+                    GenericImageDecoder::Png(Box::new(png_decoder))
+                }
+            },
+            ImageFormat::Gif => GenericImageDecoder::Gif(Box::new(gif::GifDecoder::new(reader)?)),
+            ImageFormat::WebP => {
+                GenericImageDecoder::Webp(Box::new(webp::WebPDecoder::new(reader)?))
+            },
+            ImageFormat::Jpeg => {
+                GenericImageDecoder::Jpeg(Box::new(jpeg::JpegDecoder::new(reader)?))
+            },
+            ImageFormat::Bmp => GenericImageDecoder::Bmp(Box::new(bmp::BmpDecoder::new(reader)?)),
+            ImageFormat::Ico => GenericImageDecoder::Ico(Box::new(ico::IcoDecoder::new(reader)?)),
+            _ => {
+                return Err(ImageError::Unsupported(
+                    ImageFormatHint::Exact(format).into(),
+                ));
+            },
+        };
+        Ok(DefaultImageDecoder { decoder })
+    }
+
+    fn is_animated(&self) -> bool {
+        match &self.decoder {
+            GenericImageDecoder::Apng(_) | GenericImageDecoder::Gif(_) => true,
+            GenericImageDecoder::Webp(decoder) => decoder.has_animation(),
+            GenericImageDecoder::Png(_) |
+            GenericImageDecoder::Jpeg(_) |
+            GenericImageDecoder::Bmp(_) |
+            GenericImageDecoder::Ico(_) => false,
+        }
+    }
+
+    fn decoder(self) -> impl ImageDecoder {
+        self.decoder
+    }
+
+    fn animated_decoder(self) -> impl AnimationDecoder<'a> {
+        self.decoder
+    }
+}
+
+pub(crate) fn decode_static_image(
+    cors_status: CorsStatus,
+    mut image_decoder: impl ImageDecoder,
+) -> Option<RasterImage> {
+    let orientation = image_decoder.orientation();
+
+    let Ok(mut dynamic_image) = DynamicImage::from_decoder(image_decoder) else {
+        error!("Image decoding error");
+        return None;
+    };
+
+    if let Ok(orientation) = orientation {
+        dynamic_image.apply_orientation(orientation);
+    }
+
+    let mut rgba = dynamic_image.into_rgba8();
+
+    // Store pre-multiplied data as that prevents having to do conversions of the data at later
+    // times. This does cause an issue with some canvas APIs. See:
+    // https://github.com/servo/servo/issues/40257
+    let is_opaque = rgba8_premultiply_inplace(&mut rgba);
+
+    let frame = ImageFrame {
+        delay: None,
+        byte_range: 0..rgba.len(),
+        width: rgba.width(),
+        height: rgba.height(),
+    };
+    Some(RasterImage {
+        metadata: ImageMetadata {
+            width: rgba.width(),
+            height: rgba.height(),
+        },
+        format: PixelFormat::RGBA8,
+        frames: vec![frame],
+        bytes: Arc::new(rgba.into_vec()),
+        id: None,
+        cors_status,
+        is_opaque,
+        loop_count: None,
+    })
+}
+
+pub(crate) fn decode_animated_image<'a, T>(
+    cors_status: CorsStatus,
+    animated_image_decoder: T,
+) -> Option<RasterImage>
+where
+    T: AnimationDecoder<'a>,
+{
+    let mut width = 0;
+    let mut height = 0;
+
+    // This uses `map_while`, because the first non-decodable frame seems to
+    // send the frame iterator into an infinite loop. See
+    // <https://github.com/image-rs/image/issues/2442>.
+    let mut frame_data = vec![];
+    let mut total_number_of_bytes = 0;
+    let mut is_opaque = true;
+    let loop_count = match animated_image_decoder.loop_count() {
+        LoopCount::Finite(repeat_time) => Repeat::Finite(repeat_time),
+        LoopCount::Infinite => Repeat::Infinite,
+    };
+    let frames: Vec<ImageFrame> = animated_image_decoder
+        .into_frames()
+        .map_while(|decoded_frame| {
+            let mut animated_frame = match decoded_frame {
+                Ok(decoded_frame) => decoded_frame,
+                Err(error) => {
+                    debug!("decode Animated frame error: {error}");
+                    return None;
+                },
+            };
+
+            // Store pre-multiplied data as that prevents having to do conversions of the data at later
+            // times. This does cause an issue with some canvas APIs. See:
+            // https://github.com/servo/servo/issues/40257
+            is_opaque = rgba8_premultiply_inplace(animated_frame.buffer_mut()) && is_opaque;
+
+            let frame_start = total_number_of_bytes;
+            total_number_of_bytes += animated_frame.buffer().len();
+
+            // The image size should be at least as large as the largest frame.
+            let frame_width = animated_frame.buffer().width();
+            let frame_height = animated_frame.buffer().height();
+            width = cmp::max(width, frame_width);
+            height = cmp::max(height, frame_height);
+
+            let frame = ImageFrame {
+                byte_range: frame_start..total_number_of_bytes,
+                delay: Some(Duration::from(animated_frame.delay())),
+                width: frame_width,
+                height: frame_height,
+            };
+
+            frame_data.push(animated_frame);
+
+            Some(frame)
+        })
+        .collect();
+
+    if frames.is_empty() {
+        debug!("Animated Image decoding error");
+        return None;
+    }
+
+    // Coalesce the frame data into one single shared memory region.
+    let mut bytes = Vec::with_capacity(total_number_of_bytes);
+    for frame in frame_data {
+        bytes.extend_from_slice(frame.buffer());
+    }
+
+    Some(RasterImage {
+        metadata: ImageMetadata { width, height },
+        cors_status,
+        frames,
+        id: None,
+        format: PixelFormat::RGBA8,
+        bytes: Arc::new(bytes),
+        is_opaque,
+        loop_count: Some(loop_count),
+    })
+}

--- a/components/pixels/decoding.rs
+++ b/components/pixels/decoding.rs
@@ -163,7 +163,7 @@ impl<'a> image::ImageDecoder for GenericImageDecoder<'a> {
     }
 }
 
-/// See documentation on imp `image::ImageDecoder`
+/// See documentation on impl `image::ImageDecoder`
 impl<'a> AnimationDecoder<'a> for GenericImageDecoder<'a> {
     fn into_frames(self) -> image::Frames<'a> {
         match self {
@@ -260,7 +260,7 @@ pub(crate) fn decode_static_image(
     let orientation = image_decoder.orientation();
 
     let Ok(mut dynamic_image) = DynamicImage::from_decoder(image_decoder) else {
-        error!("Image decoding error");
+        debug!("Image decoding error");
         return None;
     };
 

--- a/components/pixels/decoding.rs
+++ b/components/pixels/decoding.rs
@@ -13,7 +13,7 @@ use image::metadata::LoopCount;
 use image::{
     AnimationDecoder, DynamicImage, ImageDecoder, ImageError, ImageFormat, ImageResult, Limits,
 };
-use log::{debug, error};
+use log::debug;
 
 use crate::{
     CorsStatus, ImageFrame, ImageMetadata, PixelFormat, RasterImage, Repeat,

--- a/components/pixels/decoding.rs
+++ b/components/pixels/decoding.rs
@@ -44,7 +44,8 @@ impl<'a> std::fmt::Debug for GenericImageDecoder<'a> {
     }
 }
 
-/// Notice that we implement methods that are implemented by default. However, these methods are necessary as
+/// Notice that we implement methods that are implemented by default. However, these methods are necessary as the default implementation
+/// will return not correct defaults.
 impl<'a> image::ImageDecoder for GenericImageDecoder<'a> {
     fn dimensions(&self) -> (u32, u32) {
         match self {

--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -2,25 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+mod decoding;
 mod snapshot;
 
 use std::borrow::Cow;
-use std::io::Cursor;
+use std::fmt;
 use std::num::NonZeroU32;
 use std::ops::Range;
 use std::sync::Arc;
 use std::time::Duration;
-use std::{cmp, fmt, vec};
 
 use euclid::default::{Point2D, Rect, Size2D};
-use image::codecs::{bmp, gif, ico, jpeg, png, webp};
-use image::error::ImageFormatHint;
 use image::imageops::{self, FilterType};
-use image::metadata::LoopCount;
-use image::{
-    AnimationDecoder, DynamicImage, ImageBuffer, ImageDecoder, ImageError, ImageFormat,
-    ImageResult, Limits, Rgba,
-};
+use image::{ImageBuffer, ImageFormat, Rgba};
 use log::{debug, error};
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
@@ -30,6 +24,8 @@ use webrender_api::units::DeviceIntSize;
 use webrender_api::{
     ImageDescriptor, ImageDescriptorFlags, ImageFormat as WebRenderImageFormat, ImageKey,
 };
+
+use crate::decoding::ServoImageDecoder;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, MallocSizeOf, PartialEq, Serialize)]
 pub enum FilterQuality {
@@ -544,39 +540,15 @@ pub fn load_from_memory(buffer: &[u8], cors_status: CorsStatus) -> Option<Raster
             None
         },
         Ok(format) => {
-            let Ok(image_decoder) = make_decoder(format, buffer) else {
+            let Ok(image_decoder) = decoding::DefaultImageDecoder::make_decoder(format, buffer)
+            else {
                 return None;
             };
-            match image_decoder {
-                GenericImageDecoder::Png(png_decoder) => {
-                    if png_decoder.is_apng().unwrap_or_default() {
-                        let Ok(apng_decoder) = png_decoder.apng() else {
-                            return None;
-                        };
-                        decode_animated_image(cors_status, apng_decoder)
-                    } else {
-                        decode_static_image(cors_status, *png_decoder)
-                    }
-                },
-                GenericImageDecoder::Gif(animation_decoder) => {
-                    decode_animated_image(cors_status, *animation_decoder)
-                },
-                GenericImageDecoder::Webp(webp_decoder) => {
-                    if webp_decoder.has_animation() {
-                        decode_animated_image(cors_status, *webp_decoder)
-                    } else {
-                        decode_static_image(cors_status, *webp_decoder)
-                    }
-                },
-                GenericImageDecoder::Bmp(image_decoder) => {
-                    decode_static_image(cors_status, *image_decoder)
-                },
-                GenericImageDecoder::Jpeg(image_decoder) => {
-                    decode_static_image(cors_status, *image_decoder)
-                },
-                GenericImageDecoder::Ico(image_decoder) => {
-                    decode_static_image(cors_status, *image_decoder)
-                },
+
+            if image_decoder.is_animated() {
+                decoding::decode_animated_image(cors_status, image_decoder.animated_decoder())
+            } else {
+                decoding::decode_static_image(cors_status, image_decoder.decoder())
             }
         },
     }
@@ -731,162 +703,6 @@ fn is_webp(buffer: &[u8]) -> bool {
     // > of the whole file is at most 4 GiB minus 2 bytes.
     let len: usize = u32::from_le_bytes(size) as usize;
     buffer[8..].len() >= len && &buffer[8..12] == b"WEBP"
-}
-
-enum GenericImageDecoder<R: std::io::BufRead + std::io::Seek> {
-    Png(Box<png::PngDecoder<R>>),
-    Gif(Box<gif::GifDecoder<R>>),
-    Webp(Box<webp::WebPDecoder<R>>),
-    Jpeg(Box<jpeg::JpegDecoder<R>>),
-    Bmp(Box<bmp::BmpDecoder<R>>),
-    Ico(Box<ico::IcoDecoder<R>>),
-}
-
-fn make_decoder(
-    format: ImageFormat,
-    buffer: &[u8],
-) -> ImageResult<GenericImageDecoder<Cursor<&[u8]>>> {
-    let limits = Limits::default();
-    let reader = Cursor::new(buffer);
-    Ok(match format {
-        ImageFormat::Png => {
-            GenericImageDecoder::Png(Box::new(png::PngDecoder::with_limits(reader, limits)?))
-        },
-        ImageFormat::Gif => GenericImageDecoder::Gif(Box::new(gif::GifDecoder::new(reader)?)),
-        ImageFormat::WebP => GenericImageDecoder::Webp(Box::new(webp::WebPDecoder::new(reader)?)),
-        ImageFormat::Jpeg => GenericImageDecoder::Jpeg(Box::new(jpeg::JpegDecoder::new(reader)?)),
-        ImageFormat::Bmp => GenericImageDecoder::Bmp(Box::new(bmp::BmpDecoder::new(reader)?)),
-        ImageFormat::Ico => GenericImageDecoder::Ico(Box::new(ico::IcoDecoder::new(reader)?)),
-        _ => {
-            return Err(ImageError::Unsupported(
-                ImageFormatHint::Exact(format).into(),
-            ));
-        },
-    })
-}
-
-fn decode_static_image(
-    cors_status: CorsStatus,
-    mut image_decoder: impl ImageDecoder,
-) -> Option<RasterImage> {
-    let orientation = image_decoder.orientation();
-
-    let Ok(mut dynamic_image) = DynamicImage::from_decoder(image_decoder) else {
-        debug!("Image decoding error");
-        return None;
-    };
-
-    if let Ok(orientation) = orientation {
-        dynamic_image.apply_orientation(orientation);
-    }
-
-    let mut rgba = dynamic_image.into_rgba8();
-
-    // Store pre-multiplied data as that prevents having to do conversions of the data at later
-    // times. This does cause an issue with some canvas APIs. See:
-    // https://github.com/servo/servo/issues/40257
-    let is_opaque = rgba8_premultiply_inplace(&mut rgba);
-
-    let frame = ImageFrame {
-        delay: None,
-        byte_range: 0..rgba.len(),
-        width: rgba.width(),
-        height: rgba.height(),
-    };
-    Some(RasterImage {
-        metadata: ImageMetadata {
-            width: rgba.width(),
-            height: rgba.height(),
-        },
-        format: PixelFormat::RGBA8,
-        frames: vec![frame],
-        bytes: Arc::new(rgba.into_vec()),
-        id: None,
-        cors_status,
-        is_opaque,
-        loop_count: None,
-    })
-}
-
-fn decode_animated_image<'a, T>(
-    cors_status: CorsStatus,
-    animated_image_decoder: T,
-) -> Option<RasterImage>
-where
-    T: AnimationDecoder<'a>,
-{
-    let mut width = 0;
-    let mut height = 0;
-
-    // This uses `map_while`, because the first non-decodable frame seems to
-    // send the frame iterator into an infinite loop. See
-    // <https://github.com/image-rs/image/issues/2442>.
-    let mut frame_data = vec![];
-    let mut total_number_of_bytes = 0;
-    let mut is_opaque = true;
-    let loop_count = match animated_image_decoder.loop_count() {
-        LoopCount::Finite(repeat_time) => Repeat::Finite(repeat_time),
-        LoopCount::Infinite => Repeat::Infinite,
-    };
-    let frames: Vec<ImageFrame> = animated_image_decoder
-        .into_frames()
-        .map_while(|decoded_frame| {
-            let mut animated_frame = match decoded_frame {
-                Ok(decoded_frame) => decoded_frame,
-                Err(error) => {
-                    debug!("decode Animated frame error: {error}");
-                    return None;
-                },
-            };
-
-            // Store pre-multiplied data as that prevents having to do conversions of the data at later
-            // times. This does cause an issue with some canvas APIs. See:
-            // https://github.com/servo/servo/issues/40257
-            is_opaque = rgba8_premultiply_inplace(animated_frame.buffer_mut()) && is_opaque;
-
-            let frame_start = total_number_of_bytes;
-            total_number_of_bytes += animated_frame.buffer().len();
-
-            // The image size should be at least as large as the largest frame.
-            let frame_width = animated_frame.buffer().width();
-            let frame_height = animated_frame.buffer().height();
-            width = cmp::max(width, frame_width);
-            height = cmp::max(height, frame_height);
-
-            let frame = ImageFrame {
-                byte_range: frame_start..total_number_of_bytes,
-                delay: Some(Duration::from(animated_frame.delay())),
-                width: frame_width,
-                height: frame_height,
-            };
-
-            frame_data.push(animated_frame);
-
-            Some(frame)
-        })
-        .collect();
-
-    if frames.is_empty() {
-        debug!("Animated Image decoding error");
-        return None;
-    }
-
-    // Coalesce the frame data into one single shared memory region.
-    let mut bytes = Vec::with_capacity(total_number_of_bytes);
-    for frame in frame_data {
-        bytes.extend_from_slice(frame.buffer());
-    }
-
-    Some(RasterImage {
-        metadata: ImageMetadata { width, height },
-        cors_status,
-        frames,
-        id: None,
-        format: PixelFormat::RGBA8,
-        bytes: Arc::new(bytes),
-        is_opaque,
-        loop_count: Some(loop_count),
-    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
In the future we want to have platform being able to supply their own way to decode images (either because of resource constraints or because not all formats might make sense).
This creates a trait to abstract over this.
We create a `ServoImageDecoder` trait with a couple of methods to create a decoder and get an `impl image::Decoder`/`impl image::AnimationDecoder` out of it.
We also cleanup the way that animation and apngs are handled.

In the future we will use this trait to implement image decoding on OHOS platforms without using image-rs.

Testing: WPT tests should find anything that is wrong. (https://github.com/Narfinger/servo/actions/runs/31089302869)
