### PR TITLE
allocator: Enable jemalloc stats feature

### DIFF
--- a/components/allocator/Cargo.toml
+++ b/components/allocator/Cargo.toml
@@ -23,7 +23,7 @@ rustc-hash = { workspace = true, optional = true }
 
 [target.'cfg(not(any(windows, target_env = "ohos")))'.dependencies]
 libc = { workspace = true }
-tikv-jemalloc-sys = { workspace = true, optional = true }
+tikv-jemalloc-sys = { workspace = true, optional = true, features = ["stats"] }
 tikv-jemallocator = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
We need to enable this feature to get the jemalloc related statistics in `about:memory`, otherwise they will not appear.

Testing: Not covered by automated tests
