### PR TITLE
Resolve DOM/glyph positions during hit testing

### DIFF
--- a/components/layout/display_list/hit_test.rs
+++ b/components/layout/display_list/hit_test.rs
@@ -6,17 +6,20 @@ use std::sync::Arc;
 
 use app_units::Au;
 use embedder_traits::Cursor;
-use euclid::{Box2D, Vector2D};
+use euclid::{Box2D, Point2D, Vector2D};
 use kurbo::{Ellipse, Shape};
-use layout_api::ElementsFromPointResult;
+use layout_api::{HitTestFlags, HitTestResult, HitTestResultItem};
 use rustc_hash::FxHashMap;
 use servo_base::id::ScrollTreeNodeId;
+use servo_base::text::Utf32CodeUnits;
 use servo_geometry::FastLayoutTransform;
 use style::computed_values::backface_visibility::T as BackfaceVisibility;
 use style::computed_values::pointer_events::T as PointerEvents;
 use style::computed_values::visibility::T as Visibility;
+use style::dom::OpaqueNode;
 use style::properties::ComputedValues;
 use style::values::computed::ui::CursorKind;
+use style_traits::CSSPixel;
 use webrender_api::BorderRadius;
 use webrender_api::units::{LayoutPoint, LayoutRect, LayoutSize, RectExt};
 
@@ -26,7 +29,15 @@ use crate::display_list::{StackingContext, StackingContextTree, ToWebRender, Tra
 use crate::fragment_tree::{BoxFragmentWithStyle, Fragment, FragmentFlags, TextFragment};
 use crate::geom::PhysicalRect;
 
+struct DomPositionCandidate {
+    fragment: Fragment,
+    node: OpaqueNode,
+    point_in_target: Point2D<f32, CSSPixel>,
+}
+
 pub(crate) struct HitTest<'a> {
+    /// The flags which describe how to perform this [`HitTest`]
+    flags: HitTestFlags,
     /// The point to test for this hit test, relative to the page.
     point_to_test: LayoutPoint,
     /// A cached version of [`Self::point_to_test`] projected to a spatial node, to avoid
@@ -35,7 +46,9 @@ pub(crate) struct HitTest<'a> {
     /// The stacking context tree against which to perform the hit test.
     stacking_context_tree: &'a StackingContextTree,
     /// The resulting [`HitTestResultItems`] for this hit test.
-    results: Vec<ElementsFromPointResult>,
+    items: Vec<HitTestResultItem>,
+    /// Candidate for `HitTestResult::dom_position_for_selection`
+    dom_position_candidate: Option<DomPositionCandidate>,
     /// A cache of hit test results for shared clip nodes.
     clip_hit_test_results: FxHashMap<ClipId, bool>,
     /// Collected reference frame clips. For painting, reference frame clips are handled
@@ -46,14 +59,17 @@ pub(crate) struct HitTest<'a> {
 
 impl<'a> HitTest<'a> {
     pub(crate) fn run(
+        flags: HitTestFlags,
         stacking_context_tree: &'a StackingContextTree,
         point_to_test: LayoutPoint,
-    ) -> Vec<ElementsFromPointResult> {
+    ) -> HitTestResult {
         let mut hit_test = Self {
+            flags,
             point_to_test,
             projected_point_to_test: None,
             stacking_context_tree,
-            results: Vec::new(),
+            items: Vec::new(),
+            dom_position_candidate: None,
             clip_hit_test_results: FxHashMap::default(),
             collected_reference_frame_clips: Default::default(),
         };
@@ -66,9 +82,105 @@ impl<'a> HitTest<'a> {
         //
         // TODO: Eventually PaintTraversal should support walking backward through
         // fragments.
-        hit_test.results.reverse();
+        hit_test.items.reverse();
 
-        hit_test.results
+        HitTestResult {
+            dom_position_for_selection: hit_test.dom_position(),
+            items: hit_test.items,
+        }
+    }
+
+    fn dom_position(&self) -> Option<(OpaqueNode, Utf32CodeUnits)> {
+        let hit = self.dom_position_candidate.as_ref()?;
+        if let Fragment::Text(text_fragment) = &hit.fragment {
+            let character_offset =
+                text_fragment.character_offset(hit.point_in_target.map(Au::from_f32_px))?;
+            return Some((hit.node, character_offset));
+        }
+
+        struct ClosestFragment {
+            fragment: Arc<TextFragment>,
+            node: OpaqueNode,
+            point_in_fragment: Point2D<Au, CSSPixel>,
+            distance: Au,
+            point_in_vertical_bounds: bool,
+        }
+
+        impl ClosestFragment {
+            fn should_replace(&self, new_distance: Au, point_in_vertical_bounds: bool) -> bool {
+                if point_in_vertical_bounds && !self.point_in_vertical_bounds {
+                    return true;
+                }
+                if self.point_in_vertical_bounds && !point_in_vertical_bounds {
+                    return false;
+                }
+                new_distance <= self.distance
+            }
+        }
+
+        fn maybe_update_closest(
+            fragment: &Fragment,
+            point_in_fragment: Point2D<Au, CSSPixel>,
+            closest_fragment: &mut Option<ClosestFragment>,
+        ) {
+            let Fragment::Text(text_fragment) = fragment else {
+                return;
+            };
+
+            let (distance, point_in_vertical_bounds) = {
+                (
+                    text_fragment.distance_to_point_for_glyph_offset(point_in_fragment),
+                    text_fragment.point_is_within_vertical_boundaries(point_in_fragment),
+                )
+            };
+
+            if let Some(tag) = text_fragment.base.tag.as_ref() &&
+                closest_fragment.as_ref().is_none_or(|closest_fragment| {
+                    closest_fragment.should_replace(distance, point_in_vertical_bounds)
+                })
+            {
+                *closest_fragment = Some(ClosestFragment {
+                    fragment: text_fragment.clone(),
+                    node: tag.node,
+                    point_in_fragment,
+                    distance,
+                    point_in_vertical_bounds,
+                });
+            }
+        }
+
+        fn collect_relevant_children(
+            fragment: &Fragment,
+            point_in_viewport: Point2D<Au, CSSPixel>,
+            closest_fragment: &mut Option<ClosestFragment>,
+        ) {
+            maybe_update_closest(fragment, point_in_viewport, closest_fragment);
+
+            if let Some(children) = fragment.children() {
+                for child in children.iter() {
+                    let offset = child
+                        .base()
+                        .map(|base| base.rect().origin)
+                        .unwrap_or_default();
+                    let point = point_in_viewport - offset.to_vector();
+                    collect_relevant_children(child, point, closest_fragment);
+                }
+            }
+        }
+
+        let mut closest_fragment = None;
+        if let Some(point_in_fragment) = self.stacking_context_tree.offset_in_fragment(
+            &hit.fragment,
+            self.point_to_test.map(Au::from_f32_px).cast_unit(),
+        ) {
+            collect_relevant_children(&hit.fragment, point_in_fragment, &mut closest_fragment);
+        }
+
+        let closest_fragment = closest_fragment?;
+        let character_offset = closest_fragment
+            .fragment
+            .character_offset(closest_fragment.point_in_fragment)?;
+        Some((closest_fragment.node, character_offset))
     }
 
     /// Perform a hit test against the clip node for the given [`ClipId`], returning
@@ -246,11 +358,19 @@ impl Fragment {
                         fragment_rect.origin.y.to_f32_px(),
                     );
 
-                hit_test.results.push(ElementsFromPointResult {
+                hit_test.items.push(HitTestResultItem {
                     node: tag.node,
                     point_in_target,
                     cursor: cursor(style.get_inherited_ui().cursor.keyword, auto_cursor),
                 });
+
+                if hit_test.flags.intersects(HitTestFlags::IncludeDomPosition) {
+                    hit_test.dom_position_candidate = Some(DomPositionCandidate {
+                        fragment: self.clone(),
+                        node: tag.node,
+                        point_in_target,
+                    });
+                }
 
                 // Since there is no reverse PaintTraversal, hit testing always searches
                 // the entire fragment tree (in stacking context order), which is why this

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -134,9 +134,7 @@ use crate::flow::{
     compute_inline_content_sizes_for_block_level_boxes, layout_block_level_child,
 };
 use crate::formatting_contexts::{Baselines, IndependentFormattingContext};
-use crate::fragment_tree::{
-    BaseFragmentInfo, CollapsedMargin, Fragment, FragmentFlags, PositioningFragment,
-};
+use crate::fragment_tree::{CollapsedMargin, Fragment, FragmentFlags, PositioningFragment};
 use crate::geom::{LogicalRect, LogicalSides1D, LogicalVec2, ToLogical};
 use crate::layout_box_base::LayoutBoxBase;
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext};
@@ -1725,7 +1723,7 @@ impl InlineFormattingContextLayout<'_> {
             TextRunLineItem {
                 text: Default::default(),
                 text_fragment_run_data: caret_placeholder.run_data,
-                base_fragment_info: BaseFragmentInfo::anonymous(),
+                base_fragment_info: caret_placeholder.base_fragment_info,
                 info: FontAndScriptInfo::simple_for_font(font),
                 character_range_in_dom_node: Utf32CodeUnits(caret_placeholder.character_index)..
                     Utf32CodeUnits(caret_placeholder.character_index + 1),

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -297,7 +297,7 @@ pub(crate) struct CaretPlaceholder {
     /// The [`TextFragmentRunData`] of the [`TextRun`] that contains this caret placeholder.
     #[conditional_malloc_size_of]
     pub run_data: Arc<SharedTextRunData>,
-    /// The `BaseFragmentInfo` of the originating text node node that this caret placeholder is in.
+    /// The `BaseFragmentInfo` of the originating text node that this caret placeholder is in.
     pub base_fragment_info: BaseFragmentInfo,
     /// Character index of the preserved newline in the IFC's transformed text, relative
     /// to the start of the DOM node.

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -297,6 +297,8 @@ pub(crate) struct CaretPlaceholder {
     /// The [`TextFragmentRunData`] of the [`TextRun`] that contains this caret placeholder.
     #[conditional_malloc_size_of]
     pub run_data: Arc<SharedTextRunData>,
+    /// The `BaseFragmentInfo` of the originating text node node that this caret placeholder is in.
+    pub base_fragment_info: BaseFragmentInfo,
     /// Character index of the preserved newline in the IFC's transformed text, relative
     /// to the start of the DOM node.
     pub character_index: usize,
@@ -528,6 +530,7 @@ impl TextRun {
                 results.push(TextRunItem::LineBreak(
                     self.run_data.selection.is_some().then(|| CaretPlaceholder {
                         run_data: self.run_data.clone(),
+                        base_fragment_info: self.base_fragment_info,
                         // The placeholder that is placed after a newline is for the index after that newline.
                         // The newline itself is at the end of the previous line.
                         character_index: relative_character_index + 1,

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -16,15 +16,15 @@ use bitflags::bitflags;
 use embedder_traits::{
     EmbedderMsg, ScriptToEmbedderChan, Theme, UntrustedNodeAddress, ViewportDetails,
 };
-use euclid::{Point2D, Rect, Scale, Size2D};
+use euclid::{Rect, Scale, Size2D};
 use fonts::{FontContext, FontContextWebFontMethods};
 use fonts_traits::{StylesheetWebFontLoadFinishedCallback, WebFontSetDifference};
 use icu_locid::subtags::Language;
 use layout_api::{
-    AxesOverflow, BoxAreaType, CSSPixelRectVec, DangerousStyleNode, IFrameSizes, Layout,
-    LayoutConfig, LayoutDamage, LayoutElement, LayoutFactory, LayoutNode, NodeRenderingType,
-    OffsetParentResponse, PhysicalSides, QueryMsg, ReflowGoal, ReflowPhasesRun, ReflowRequest,
-    ReflowRequestRestyle, ReflowResult, ReflowStatistics, ScrollContainerQueryFlags,
+    AxesOverflow, BoxAreaType, CSSPixelRectVec, DangerousStyleNode, HitTestFlags, HitTestResult,
+    IFrameSizes, Layout, LayoutConfig, LayoutDamage, LayoutElement, LayoutFactory, LayoutNode,
+    NodeRenderingType, OffsetParentResponse, PhysicalSides, QueryMsg, ReflowGoal, ReflowPhasesRun,
+    ReflowRequest, ReflowRequestRestyle, ReflowResult, ReflowStatistics, ScrollContainerQueryFlags,
     ScrollContainerResponse, TrustedNodeAddress, with_layout_state,
 };
 use log::{debug, warn};
@@ -86,13 +86,12 @@ use crate::context::{CachedImageOrError, ImageResolver, LayoutContext};
 use crate::display_list::{DisplayListBuilder, HitTest, PaintTimingHandler, StackingContextTree};
 use crate::dom::NodeExt;
 use crate::query::{
-    find_character_offset_in_fragment_descendants, get_the_text_steps, process_box_area_request,
-    process_box_areas_request, process_client_rect_request,
-    process_containing_block_descendant_query, process_containing_block_query,
-    process_current_css_zoom_query, process_effective_overflow_query,
-    process_node_scroll_area_request, process_offset_parent_query, process_padding_request,
-    process_resolved_font_style_query, process_resolved_style_request,
-    process_scroll_container_query,
+    get_the_text_steps, process_box_area_request, process_box_areas_request,
+    process_client_rect_request, process_containing_block_descendant_query,
+    process_containing_block_query, process_current_css_zoom_query,
+    process_effective_overflow_query, process_node_scroll_area_request,
+    process_offset_parent_query, process_padding_request, process_resolved_font_style_query,
+    process_resolved_style_request, process_scroll_container_query,
 };
 use crate::traversal::{RecalcStyle, compute_damage_and_rebuild_box_tree};
 use crate::{BoxTree, FragmentTree};
@@ -567,33 +566,16 @@ impl Layout for LayoutThread {
     }
 
     #[servo_tracing::instrument(skip_all)]
-    fn query_text_index(
+    fn hit_test(
         &self,
-        node: TrustedNodeAddress,
-        point_in_node: Point2D<Au, CSSPixel>,
-    ) -> Option<usize> {
-        with_layout_state(|| {
-            let node = unsafe { ServoLayoutNode::new(&node) };
-            let stacking_context_tree = self.stacking_context_tree.borrow_mut();
-            let stacking_context_tree = stacking_context_tree.as_ref()?;
-            find_character_offset_in_fragment_descendants(
-                &node,
-                stacking_context_tree,
-                point_in_node,
-            )
-        })
-    }
-
-    #[servo_tracing::instrument(skip_all)]
-    fn query_elements_from_point(
-        &self,
+        flags: HitTestFlags,
         point: webrender_api::units::LayoutPoint,
-    ) -> Vec<layout_api::ElementsFromPointResult> {
+    ) -> HitTestResult {
         with_layout_state(|| {
             self.stacking_context_tree
                 .borrow_mut()
                 .as_mut()
-                .map(|tree| HitTest::run(tree, point))
+                .map(|tree| HitTest::run(flags, tree, point))
                 .unwrap_or_default()
         })
     }

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use app_units::Au;
 use embedder_traits::UntrustedNodeAddress;
-use euclid::{Point2D, Rect, Size2D};
+use euclid::{Rect, Size2D};
 use itertools::Itertools;
 use layout_api::{
     AxesOverflow, BoxAreaType, CSSPixelRectVec, DangerousStyleElementOf, LayoutElement,
@@ -52,7 +52,7 @@ use crate::display_list::{StackingContextTree, au_rect_to_length_rect};
 use crate::dom::NodeExt;
 use crate::flow::inline::text_transform::TextTransformationIterator;
 use crate::fragment_tree::{
-    BoxFragment, Fragment, FragmentFlags, FragmentTree, SpecificLayoutInfo, TextFragment,
+    BoxFragment, Fragment, FragmentFlags, FragmentTree, SpecificLayoutInfo,
 };
 use crate::layout_impl::LayoutThread;
 use crate::style_ext::ComputedValuesExt;
@@ -1365,98 +1365,6 @@ fn rendered_text_collection_steps(
         },
     };
     items
-}
-
-struct ClosestFragment {
-    fragment: Arc<TextFragment>,
-    point_in_fragment: Point2D<Au, CSSPixel>,
-    distance: Au,
-    point_in_vertical_bounds: bool,
-}
-
-impl ClosestFragment {
-    fn should_replace(&self, new_distance: Au, point_in_vertical_bounds: bool) -> bool {
-        if point_in_vertical_bounds && !self.point_in_vertical_bounds {
-            return true;
-        }
-        if self.point_in_vertical_bounds && !point_in_vertical_bounds {
-            return false;
-        }
-        new_distance <= self.distance
-    }
-}
-
-pub fn find_character_offset_in_fragment_descendants(
-    node: &ServoLayoutNode,
-    stacking_context_tree: &StackingContextTree,
-    point_in_viewport: Point2D<Au, CSSPixel>,
-) -> Option<usize> {
-    fn maybe_update_closest(
-        fragment: &Fragment,
-        point_in_fragment: Point2D<Au, CSSPixel>,
-        closest_relative_fragment: &mut Option<ClosestFragment>,
-    ) {
-        let Fragment::Text(text_fragment) = fragment else {
-            return;
-        };
-
-        let (distance, point_in_vertical_bounds) = {
-            (
-                text_fragment.distance_to_point_for_glyph_offset(point_in_fragment),
-                text_fragment.point_is_within_vertical_boundaries(point_in_fragment),
-            )
-        };
-
-        if closest_relative_fragment
-            .as_ref()
-            .is_none_or(|closest_fragment| {
-                closest_fragment.should_replace(distance, point_in_vertical_bounds)
-            })
-        {
-            *closest_relative_fragment = Some(ClosestFragment {
-                fragment: text_fragment.clone(),
-                point_in_fragment,
-                distance,
-                point_in_vertical_bounds,
-            });
-        }
-    }
-
-    fn collect_relevant_children(
-        fragment: &Fragment,
-        point_in_viewport: Point2D<Au, CSSPixel>,
-        closest_relative_fragment: &mut Option<ClosestFragment>,
-    ) {
-        maybe_update_closest(fragment, point_in_viewport, closest_relative_fragment);
-
-        if let Some(children) = fragment.children() {
-            for child in children.iter() {
-                let offset = child
-                    .base()
-                    .map(|base| base.rect().origin)
-                    .unwrap_or_default();
-                let point = point_in_viewport - offset.to_vector();
-                collect_relevant_children(child, point, closest_relative_fragment);
-            }
-        }
-    }
-
-    let mut closest_relative_fragment = None;
-    for fragment in &node.fragments_for_pseudo(None) {
-        if let Some(point_in_fragment) =
-            stacking_context_tree.offset_in_fragment(fragment, point_in_viewport)
-        {
-            collect_relevant_children(fragment, point_in_fragment, &mut closest_relative_fragment);
-        }
-    }
-
-    closest_relative_fragment
-        .and_then(|closest_fragment| {
-            closest_fragment
-                .fragment
-                .character_offset(closest_fragment.point_in_fragment)
-        })
-        .map(|offset| offset.0)
 }
 
 pub fn process_containing_block_query(node: ServoLayoutNode) -> Option<UntrustedNodeAddress> {

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -23,7 +23,7 @@ use embedder_traits::{
 use euclid::{Point2D, Vector2D};
 use js::context::JSContext;
 use keyboard_types::{Code, Key, KeyState, Modifiers, NamedKey};
-use layout_api::{ScrollContainerQueryFlags, node_id_from_scroll_id};
+use layout_api::{HitTestFlags, ScrollContainerQueryFlags, node_id_from_scroll_id};
 use rustc_hash::FxHashMap;
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
@@ -452,10 +452,11 @@ impl DocumentEventHandler {
                 element.set_hover_state(false);
             }
 
+            let flags = HitTestFlags::empty();
             if let Some(hit_test_result) = self
                 .most_recent_mousemove_point
                 .get()
-                .and_then(|point| self.window.hit_test_from_point_in_viewport(point))
+                .and_then(|point| self.window.hit_test_from_point_in_viewport(flags, point))
             {
                 let mouse_out_event = MouseEvent::new_for_platform_motion_event(
                     cx,
@@ -580,11 +581,18 @@ impl DocumentEventHandler {
         let released_disconnected =
             self.release_disconnected_pointer_capture(cx, pointer_id, "mouse", true);
 
+        let flags = if input_event.primary_button_is_pressed() {
+            HitTestFlags::IncludeDomPosition
+        } else {
+            HitTestFlags::empty()
+        };
+
         // Always do full hit test so we can keep `current_hover_target` in sync
         // with the actual element under the pointer. Boundary events for hover
         // transitions are suppressed while pointer capture is active: per spec,
         // pointer events are retargeted to the capture element.
-        let Some(hit_test_result) = self.window.hit_test_from_input_event(input_event) else {
+        let Some(hit_test_result) = self.window.hit_test_from_input_event(flags, input_event)
+        else {
             return;
         };
 
@@ -797,9 +805,10 @@ impl DocumentEventHandler {
             return;
         };
 
+        let flags = HitTestFlags::empty();
         let Some(hit_test_result) = self
             .window
-            .hit_test_from_point_in_viewport(most_recent_mousemove_point)
+            .hit_test_from_point_in_viewport(flags, most_recent_mousemove_point)
         else {
             return;
         };
@@ -860,8 +869,14 @@ impl DocumentEventHandler {
         event: MouseButtonEvent,
         input_event: &ConstellationInputEvent,
     ) {
+        let flags = if input_event.primary_button_is_pressed() {
+            HitTestFlags::IncludeDomPosition
+        } else {
+            HitTestFlags::empty()
+        };
         // Ignore all incoming events without a hit test.
-        let Some(hit_test_result) = self.window.hit_test_from_input_event(input_event) else {
+        let Some(hit_test_result) = self.window.hit_test_from_input_event(flags, input_event)
+        else {
             return;
         };
 
@@ -1215,8 +1230,10 @@ impl DocumentEventHandler {
         event: EmbedderTouchEvent,
         input_event: &ConstellationInputEvent,
     ) -> InputEventResult {
+        let flags = HitTestFlags::empty();
         // Ignore all incoming events without a hit test.
-        let Some(hit_test_result) = self.window.hit_test_from_input_event(input_event) else {
+        let Some(hit_test_result) = self.window.hit_test_from_input_event(flags, input_event)
+        else {
             self.update_active_touch_points_when_early_return(event);
             return Default::default();
         };
@@ -1612,7 +1629,9 @@ impl DocumentEventHandler {
         input_event: &ConstellationInputEvent,
     ) -> InputEventResult {
         // Ignore all incoming events without a hit test.
-        let Some(hit_test_result) = self.window.hit_test_from_input_event(input_event) else {
+        let flags = HitTestFlags::empty();
+        let Some(hit_test_result) = self.window.hit_test_from_input_event(flags, input_event)
+        else {
             return Default::default();
         };
 

--- a/components/script/dom/document/documentorshadowroot.rs
+++ b/components/script/dom/document/documentorshadowroot.rs
@@ -10,6 +10,7 @@ use embedder_traits::UntrustedNodeAddress;
 use js::context::JSContext;
 use js::conversions::FromJSValConvertible;
 use js::rust::HandleValue;
+use layout_api::HitTestFlags;
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
 use script_bindings::codegen::GenericBindings::ShadowRootBinding::ShadowRootMethods;
@@ -188,10 +189,11 @@ impl DocumentOrShadowRoot {
             return None;
         }
 
-        let results = self
+        let flags = HitTestFlags::empty();
+        let result = self
             .window
-            .elements_from_point_query(LayoutPoint::new(x, y));
-        let Some(result) = results.first() else {
+            .elements_from_point_query(flags, LayoutPoint::new(x, y));
+        let Some(result) = result.items.first() else {
             return document_element;
         };
 
@@ -231,11 +233,13 @@ impl DocumentOrShadowRoot {
         // box, that would be a target for hit testing at coordinates x,y even if nothing
         // would be overlapping it, when applying the transforms that apply to the
         // descendants of the viewport, append the associated element to sequence.
-        let nodes = self
+        let flags = HitTestFlags::empty();
+        let result = self
             .window
-            .elements_from_point_query(LayoutPoint::new(x, y));
+            .elements_from_point_query(flags, LayoutPoint::new(x, y));
 
-        let mut elements: Vec<_> = nodes
+        let mut elements: Vec<_> = result
+            .items
             .iter()
             .flat_map(|result| {
                 // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that

--- a/components/script/dom/event/inputevent.rs
+++ b/components/script/dom/event/inputevent.rs
@@ -8,6 +8,7 @@ use euclid::Point2D;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::reflector::reflect_dom_object_with_proto;
+use servo_base::text::Utf32CodeUnits;
 use style::Atom;
 use style_traits::CSSPixel;
 
@@ -125,6 +126,7 @@ impl InputEventMethods<crate::DomTypeHolder> for InputEvent {
 /// `PaintHitTestResult` against our current layout.
 pub(crate) struct HitTestResult {
     pub node: DomRoot<Node>,
+    pub dom_position_for_selection: Option<(DomRoot<Node>, Utf32CodeUnits)>,
     pub cursor: Cursor,
     pub point_in_node: Point2D<f32, CSSPixel>,
     pub point_in_frame: Point2D<f32, CSSPixel>,

--- a/components/script/dom/event/mouseevent.rs
+++ b/components/script/dom/event/mouseevent.rs
@@ -12,9 +12,11 @@ use js::context::JSContext;
 use js::rust::HandleObject;
 use keyboard_types::Modifiers;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
+use script_bindings::dom::MutNullableDom;
 use script_bindings::match_domstring_ascii;
 use script_bindings::reflector::reflect_dom_object_with_proto;
 use script_traits::ConstellationInputEvent;
+use servo_base::text::Utf32CodeUnits;
 use style::Atom;
 use style_traits::CSSPixel;
 
@@ -80,6 +82,15 @@ pub(crate) struct MouseEvent {
 
     #[no_trace]
     point_in_target: Cell<Option<Point2D<f32, CSSPixel>>>,
+
+    /// Together with `dom_position_offset`, if both are present, a position in the DOM tree
+    /// near the cursor at time of this event.
+    dom_position_container: MutNullableDom<Node>,
+
+    /// Together with `dom_position_container`, if both are present, a position in the DOM tree
+    /// near the cursor at time of this event.
+    #[no_trace]
+    dom_position_offset: Cell<Option<Utf32CodeUnits>>,
 }
 
 impl MouseEvent {
@@ -93,6 +104,8 @@ impl MouseEvent {
             button: Cell::new(0),
             buttons: Cell::new(0),
             point_in_target: Cell::new(None),
+            dom_position_container: MutNullableDom::default(),
+            dom_position_offset: Cell::new(None),
         }
     }
 
@@ -125,6 +138,7 @@ impl MouseEvent {
         buttons: u16,
         related_target: Option<&EventTarget>,
         point_in_target: Option<Point2D<f32, CSSPixel>>,
+        dom_position_for_selection: Option<&(DomRoot<Node>, Utf32CodeUnits)>,
     ) -> DomRoot<MouseEvent> {
         Self::new_with_proto(
             cx,
@@ -143,6 +157,7 @@ impl MouseEvent {
             buttons,
             related_target,
             point_in_target,
+            dom_position_for_selection,
         )
     }
 
@@ -164,6 +179,7 @@ impl MouseEvent {
         buttons: u16,
         related_target: Option<&EventTarget>,
         point_in_target: Option<Point2D<f32, CSSPixel>>,
+        dom_position_for_selection: Option<&(DomRoot<Node>, Utf32CodeUnits)>,
     ) -> DomRoot<MouseEvent> {
         let ev = MouseEvent::new_uninitialized_with_proto(cx, window, proto);
         ev.initialize_mouse_event(
@@ -180,6 +196,7 @@ impl MouseEvent {
             buttons,
             related_target,
             point_in_target,
+            dom_position_for_selection,
         );
         ev
     }
@@ -201,6 +218,7 @@ impl MouseEvent {
         buttons: u16,
         related_target: Option<&EventTarget>,
         point_in_target: Option<Point2D<f32, CSSPixel>>,
+        dom_position_for_selection: Option<&(DomRoot<Node>, Utf32CodeUnits)>,
     ) {
         self.uievent.initialize_ui_event(
             event_type,
@@ -221,6 +239,10 @@ impl MouseEvent {
         // Legacy mapping per spec: left/middle/right => 1/2/3 (button + 1), else 0.
         let w = if button >= 0 { (button as u32) + 1 } else { 0 };
         self.uievent.set_which(w);
+        if let Some((node, offset)) = dom_position_for_selection {
+            self.dom_position_container.set(Some(node));
+            self.dom_position_offset.set(Some(*offset));
+        }
     }
 
     pub(crate) fn new_for_platform_motion_event(
@@ -261,6 +283,7 @@ impl MouseEvent {
             input_event.pressed_mouse_buttons,
             None,
             None,
+            hit_test_result.dom_position_for_selection.as_ref(),
         );
 
         let event = mouse_event.upcast::<Event>();
@@ -268,6 +291,10 @@ impl MouseEvent {
         event.set_trusted(true);
 
         mouse_event
+    }
+
+    pub(crate) fn dom_offset_for_selection(&self) -> Option<Utf32CodeUnits> {
+        self.dom_position_offset.get()
     }
 
     /// Create a [MouseEvent] triggered by the embedder.
@@ -305,16 +332,13 @@ impl MouseEvent {
             pressed_mouse_buttons,
             None,
             Some(hit_test_result.point_in_node),
+            hit_test_result.dom_position_for_selection.as_ref(),
         );
 
         mouse_event.upcast::<Event>().set_trusted(true);
         mouse_event.upcast::<Event>().set_composed(true);
 
         mouse_event
-    }
-
-    pub(crate) fn point_in_viewport(&self) -> Option<Point2D<f32, CSSPixel>> {
-        Some(self.client_point.get().to_f32())
     }
 
     /// Create a PointerEvent from this MouseEvent.
@@ -489,6 +513,7 @@ impl MouseEventMethods<crate::DomTypeHolder> for MouseEvent {
             init.button,
             init.buttons,
             init.relatedTarget.as_deref(),
+            None,
             None,
         );
         event

--- a/components/script/dom/event/pointerevent.rs
+++ b/components/script/dom/event/pointerevent.rs
@@ -195,6 +195,7 @@ impl PointerEvent {
             buttons,
             related_target,
             point_in_target,
+            None,
         );
         ev.pointer_id.set(pointer_id);
         ev.width.set(width);

--- a/components/script/dom/event/wheelevent.rs
+++ b/components/script/dom/event/wheelevent.rs
@@ -186,6 +186,7 @@ impl WheelEvent {
             buttons,
             related_target,
             point_in_target,
+            None,
         );
         self.delta_x.set(delta_x);
         self.delta_y.set(delta_y);

--- a/components/script/dom/html/form_controls/htmlinputelement.rs
+++ b/components/script/dom/html/form_controls/htmlinputelement.rs
@@ -1988,12 +1988,7 @@ impl HTMLInputElement {
         if !self.input_type().is_textual_or_password() || self.textinput.borrow().is_empty() {
             return;
         }
-        let node = self.upcast();
-        if self
-            .textinput
-            .borrow_mut()
-            .handle_mouse_event(node, mouse_event)
-        {
+        if self.textinput.borrow_mut().handle_mouse_event(mouse_event) {
             self.maybe_update_shared_selection();
         }
     }

--- a/components/script/dom/html/form_controls/htmltextareaelement.rs
+++ b/components/script/dom/html/form_controls/htmltextareaelement.rs
@@ -223,12 +223,7 @@ impl HTMLTextAreaElement {
         if self.textinput.borrow().is_empty() {
             return;
         }
-        let node = self.upcast();
-        if self
-            .textinput
-            .borrow_mut()
-            .handle_mouse_event(node, mouse_event)
-        {
+        if self.textinput.borrow_mut().handle_mouse_event(mouse_event) {
             self.maybe_update_shared_selection();
         }
     }

--- a/components/script/dom/html/form_controls/text_input.rs
+++ b/components/script/dom/html/form_controls/text_input.rs
@@ -30,7 +30,6 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::inputevent::InputEvent;
 use crate::dom::keyboardevent::KeyboardEvent;
 use crate::dom::mouseevent::MouseEvent;
-use crate::dom::node::{Node, NodeTraits};
 use crate::dom::types::{ClipboardEvent, UIEvent};
 use crate::drag_data_store::Kind;
 
@@ -891,14 +890,14 @@ impl<T: ClipboardProvider> TextInput<T> {
         )
     }
 
-    fn edit_point_for_mouse_event(&self, node: &Node, event: &MouseEvent) -> RopeIndex {
-        node.owner_window()
-            .text_index_query_on_node_for_event(node, event)
-            .map(|grapheme_index| {
+    fn edit_point_for_mouse_event(&self, event: &MouseEvent) -> RopeIndex {
+        event
+            .dom_offset_for_selection()
+            .map(|character_offset| {
                 self.rope.move_by(
                     Default::default(),
                     RopeMovement::Character,
-                    grapheme_index as isize,
+                    character_offset.0 as isize,
                 )
             })
             .unwrap_or_else(|| self.rope.last_index())
@@ -906,7 +905,7 @@ impl<T: ClipboardProvider> TextInput<T> {
 
     /// Handle a mouse even that has happened in this [`TextInput`]. Returns `true` if the selection
     /// in the input may have changed and `false` otherwise.
-    pub(crate) fn handle_mouse_event(&mut self, node: &Node, mouse_event: &MouseEvent) -> bool {
+    pub(crate) fn handle_mouse_event(&mut self, mouse_event: &MouseEvent) -> bool {
         // Cancel any ongoing drags if we see a mouseup of any kind or notice
         // that a button other than the primary button is pressed.
         let event_type = mouse_event.upcast::<Event>().type_();
@@ -915,11 +914,11 @@ impl<T: ClipboardProvider> TextInput<T> {
         }
 
         if event_type == atom!("mousedown") {
-            return self.handle_mousedown(node, mouse_event);
+            return self.handle_mousedown(mouse_event);
         }
 
         if event_type == atom!("mousemove") && self.currently_dragging {
-            self.edit_point = self.edit_point_for_mouse_event(node, mouse_event);
+            self.edit_point = self.edit_point_for_mouse_event(mouse_event);
             self.update_selection_direction();
             return true;
         }
@@ -931,7 +930,7 @@ impl<T: ClipboardProvider> TextInput<T> {
     /// given [`Node`].
     ///
     /// Returns `true` if the [`TextInput`] changed at all or `false` otherwise.
-    fn handle_mousedown(&mut self, node: &Node, mouse_event: &MouseEvent) -> bool {
+    fn handle_mousedown(&mut self, mouse_event: &MouseEvent) -> bool {
         assert_eq!(mouse_event.upcast::<Event>().type_(), atom!("mousedown"));
 
         // Only update the cursor in text fields when the primary buton is pressed.
@@ -962,7 +961,7 @@ impl<T: ClipboardProvider> TextInput<T> {
             },
             1 => {
                 self.clear_selection();
-                self.edit_point = self.edit_point_for_mouse_event(node, mouse_event);
+                self.edit_point = self.edit_point_for_mouse_event(mouse_event);
                 self.selection_origin = Some(self.edit_point);
                 self.update_selection_direction();
                 true

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -45,11 +45,11 @@ use js::rust::{
     MutableHandleValue,
 };
 use layout_api::{
-    AccessibilityDamage, AxesOverflow, BoxAreaType, CSSPixelRectVec, ElementsFromPointResult,
-    FragmentType, Layout, LayoutImageDestination, PendingImage, PendingImageState,
-    PendingRasterizationImage, PhysicalSides, QueryMsg, ReflowGoal, ReflowPhasesRun, ReflowRequest,
-    ReflowRequestRestyle, ReflowStatistics, RestyleReason, ScrollContainerQueryFlags,
-    ScrollContainerResponse, TrustedNodeAddress, combine_id_with_fragment_type,
+    AccessibilityDamage, AxesOverflow, BoxAreaType, CSSPixelRectVec, FragmentType, HitTestFlags,
+    Layout, LayoutImageDestination, PendingImage, PendingImageState, PendingRasterizationImage,
+    PhysicalSides, QueryMsg, ReflowGoal, ReflowPhasesRun, ReflowRequest, ReflowRequestRestyle,
+    ReflowStatistics, RestyleReason, ScrollContainerQueryFlags, ScrollContainerResponse,
+    TrustedNodeAddress, combine_id_with_fragment_type,
 };
 use malloc_size_of::MallocSizeOf;
 use media::WindowGLContext;
@@ -91,6 +91,7 @@ use servo_geometry::DeviceIndependentIntRect;
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use storage_traits::StorageThreads;
 use storage_traits::webstorage_thread::WebStorageType;
+use style::dom::OpaqueNode;
 use style::error_reporting::{ContextualParseError, ParseErrorReporter};
 use style::properties::PropertyId;
 use style::properties::style_structs::Font;
@@ -183,7 +184,7 @@ use crate::dom::storage::Storage;
 #[cfg(feature = "bluetooth")]
 use crate::dom::testrunner::TestRunner;
 use crate::dom::trustedtypes::trustedtypepolicyfactory::TrustedTypePolicyFactory;
-use crate::dom::types::{FontFace, ImageBitmap, MouseEvent, SVGSVGElement, UIEvent};
+use crate::dom::types::{FontFace, ImageBitmap, SVGSVGElement, UIEvent};
 use crate::dom::useractivation::UserActivationTimestamp;
 use crate::dom::visualviewport::{VisualViewport, VisualViewportChanges};
 #[cfg(feature = "webgpu")]
@@ -3209,28 +3210,13 @@ impl Window {
             .map(|(source, overflow)| ScrollingBox::new(source, overflow))
     }
 
-    pub(crate) fn text_index_query_on_node_for_event(
-        &self,
-        node: &Node,
-        mouse_event: &MouseEvent,
-    ) -> Option<usize> {
-        // dispatch_key_event (document.rs) triggers a click event when releasing
-        // the space key. There's no nice way to catch this so let's use this for
-        // now.
-        let point_in_viewport = mouse_event.point_in_viewport()?.map(Au::from_f32_px);
-
-        self.layout_reflow(QueryMsg::TextIndexQuery);
-        self.layout
-            .borrow()
-            .query_text_index(node.to_trusted_node_address(), point_in_viewport)
-    }
-
     pub(crate) fn elements_from_point_query(
         &self,
+        flags: HitTestFlags,
         point: LayoutPoint,
-    ) -> Vec<ElementsFromPointResult> {
+    ) -> layout_api::HitTestResult {
         self.layout_reflow(QueryMsg::ElementsFromPoint);
-        self.layout().query_elements_from_point(point)
+        self.layout().hit_test(flags, point)
     }
 
     pub(crate) fn query_effective_overflow(&self, node: &Node) -> Option<AxesOverflow> {
@@ -3249,9 +3235,11 @@ impl Window {
 
     pub(crate) fn hit_test_from_input_event(
         &self,
+        flags: HitTestFlags,
         input_event: &ConstellationInputEvent,
     ) -> Option<HitTestResult> {
         self.hit_test_from_point_in_viewport(
+            flags,
             input_event.hit_test_result.as_ref()?.point_in_viewport,
         )
     }
@@ -3259,23 +3247,28 @@ impl Window {
     #[expect(unsafe_code)]
     pub(crate) fn hit_test_from_point_in_viewport(
         &self,
+        flags: HitTestFlags,
         point_in_frame: Point2D<f32, CSSPixel>,
     ) -> Option<HitTestResult> {
-        let result = self
-            .elements_from_point_query(point_in_frame.cast_unit())
-            .into_iter()
-            .nth(0)?;
+        let result = self.elements_from_point_query(flags, point_in_frame.cast_unit());
+        let item = result.items.into_iter().next()?;
 
         let point_relative_to_initial_containing_block =
             point_in_frame + self.scroll_offset().cast_unit();
 
         // SAFETY: This is safe because `Window::query_elements_from_point` has ensured that
         // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
-        let address = UntrustedNodeAddress(result.node.0 as *const c_void);
+        let from_opaque_node = |node: OpaqueNode| {
+            let address = UntrustedNodeAddress(node.0 as *const c_void);
+            unsafe { from_untrusted_node_address(address) }
+        };
         Some(HitTestResult {
-            node: unsafe { from_untrusted_node_address(address) },
-            cursor: result.cursor,
-            point_in_node: result.point_in_target,
+            node: from_opaque_node(item.node),
+            dom_position_for_selection: result
+                .dom_position_for_selection
+                .map(|(node, offset)| (from_opaque_node(node), offset)),
+            cursor: item.cursor,
+            point_in_node: item.point_in_target,
             point_in_frame,
             point_relative_to_initial_containing_block,
         })

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -55,6 +55,7 @@ use servo_arc::Arc as ServoArc;
 use servo_base::Epoch;
 use servo_base::generic_channel::GenericSender;
 use servo_base::id::{BrowsingContextId, PipelineId, WebViewId};
+use servo_base::text::Utf32CodeUnits;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use style::Atom;
 use style::animation::DocumentAnimationSet;
@@ -267,6 +268,13 @@ pub struct LayoutConfig {
     pub embedder_chan: ScriptToEmbedderChan,
 }
 
+bitflags! {
+    pub struct HitTestFlags: u8 {
+        /// Whether to populate [`ElementsFromPointResult::dom_position_for_selection`]
+        const IncludeDomPosition = 0b0000_0001;
+    }
+}
+
 pub trait LayoutFactory: Send + Sync {
     fn create(&self, config: LayoutConfig) -> Box<dyn Layout>;
 }
@@ -392,13 +400,7 @@ pub trait Layout {
         animation_timeline_value: f64,
     ) -> Option<ServoArc<Font>>;
     fn query_scrolling_area(&self, node: Option<TrustedNodeAddress>) -> Rect<i32, CSSPixel>;
-    /// Find the character offset of the point in the given node, if it has text content.
-    fn query_text_index(
-        &self,
-        node: TrustedNodeAddress,
-        point: Point2D<Au, CSSPixel>,
-    ) -> Option<usize>;
-    fn query_elements_from_point(&self, point: LayoutPoint) -> Vec<ElementsFromPointResult>;
+    fn hit_test(&self, flags: HitTestFlags, point: LayoutPoint) -> HitTestResult;
     fn query_effective_overflow(&self, node: TrustedNodeAddress) -> Option<AxesOverflow>;
     fn stylist_mut(&mut self) -> &mut Stylist;
 
@@ -906,9 +908,16 @@ impl ImageAnimationState {
     }
 }
 
+/// The result of a hit test query.
+#[derive(Debug, Default)]
+pub struct HitTestResult {
+    pub items: Vec<HitTestResultItem>,
+    pub dom_position_for_selection: Option<(OpaqueNode, Utf32CodeUnits)>,
+}
+
 /// Describe an item that matched a hit-test query.
 #[derive(Debug)]
-pub struct ElementsFromPointResult {
+pub struct HitTestResultItem {
     /// An [`OpaqueNode`] that contains a pointer to the node hit by
     /// this hit test result.
     pub node: OpaqueNode,

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -367,6 +367,15 @@ pub struct ConstellationInputEvent {
     pub event: InputEventAndId,
 }
 
+impl ConstellationInputEvent {
+    /// Returns whether `pressed_mouse_buttons` includes the primarry button
+    pub fn primary_button_is_pressed(&self) -> bool {
+        /// <https://w3c.github.io/pointerevents/#dom-mouseevent-buttons>
+        const PRIMARY_BUTTON_MASK: u16 = 1;
+        (self.pressed_mouse_buttons & PRIMARY_BUTTON_MASK) != 0
+    }
+}
+
 /// All of the information necessary to create a new [`ScriptThread`] for a new [`EventLoop`].
 ///
 /// NB: *DO NOT* add any Senders or Receivers here! pcwalton will have to rewrite your code if you


### PR DESCRIPTION
Previously, finding a glyph closest to a viewport point was handled after hit testing, deeper in the `<input>`/`<textarea>` code. Since this will soon need to be shared with interactive update of `Document` selection, this change moves it to hit testing itself. When the hit test hits a `TextFragment` directly, this avoids a `FragmentTree` walk. In general, we should know that some input events will need this information and some will not. For instance, when a mouse button is pressed we likely need it, because selection is ongoing. This allows us to opt in to this extra work when asking for the hit test. This can eventually give us a more faithful update of the "sequential focus navigation starting point" which currently cannot be placed inside of text nodes.

In addition, this change moves away from the "element from point" terminology to "hit test" for the query name. Not everything returned is an `Element`, most obviously text nodes in this case.

Testing: This should not change observable behavior so is covered by existing tests. 