### PR TITLE
script: Fix GC borrow hazard in HTMLImageElement::abort_request

### DIFF
--- a/components/script/dom/html/embedded_content/htmlimageelement.rs
+++ b/components/script/dom/html/embedded_content/htmlimageelement.rs
@@ -569,11 +569,12 @@ impl HTMLImageElement {
         request: ImageRequestPhase,
         cx: &mut js::context::JSContext,
     ) {
-        let mut request = match request {
-            ImageRequestPhase::Current => self.current_request.borrow_mut(),
-            ImageRequestPhase::Pending => self.pending_request.borrow_mut(),
+        let request = match request {
+            ImageRequestPhase::Current => &self.current_request,
+            ImageRequestPhase::Pending => &self.pending_request,
         };
-        LoadBlocker::terminate(&request.blocker, cx);
+        LoadBlocker::terminate(&request.borrow().blocker, cx);
+        let mut request = request.safe_borrow_mut(cx);
         request.state = state;
         request.image = None;
         request.metadata = None;


### PR DESCRIPTION
Rewrote GC handling in the `abort_request` function to prevent potential crashes due to conflicts with the GC during mutable borrows, and to perform immutable borrows when possible.

Testing: Ran `./mach test-wpt tests/wpt/tests/html/semantics/embedded-content/the-img-element/ `, 135/135 passed
Fixes: #34107 