### PR TITLE
net: Add memory reporting for the SVG id map, broken image icon, and the `SvgFontResolver`

### DIFF
--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -1076,8 +1076,14 @@ impl<'a> MallocSizeOf for usvg::Options<'a> {
         self.font_family.size_of(ops) +
             self.languages.size_of(ops) +
             self.style_sheet.size_of(ops) +
-            self.fontdb.conditional_shallow_size_of(ops) +
+            self.fontdb.conditional_size_of(ops) +
             self.resources_dir.size_of(ops)
+    }
+}
+
+impl MallocSizeOf for usvg::Font {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        self.families().size_of(ops) + self.variations().size_of(ops)
     }
 }
 

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -1089,8 +1089,14 @@ impl<'a> MallocSizeOf for usvg::Options<'a> {
         self.font_family.size_of(ops) +
             self.languages.size_of(ops) +
             self.style_sheet.size_of(ops) +
-            self.fontdb.conditional_shallow_size_of(ops) +
+            self.fontdb.conditional_size_of(ops) +
             self.resources_dir.size_of(ops)
+    }
+}
+
+impl MallocSizeOf for usvg::Font {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        self.families().size_of(ops) + self.variations().size_of(ops)
     }
 }
 

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -815,10 +815,11 @@ impl ImageCacheFactory for ImageCacheFactoryImpl {
             None
         });
         let font_resolver2 = font_resolver.clone();
-        let font_resolver = usvg::FontResolver {
-            select_font: Box::new(move |font, database| font_resolver.resolve(font, database)),
+        let font_resolver3 = font_resolver.clone();
+        let usvg_font_resolver = usvg::FontResolver {
+            select_font: Box::new(move |font, database| font_resolver2.resolve(font, database)),
             select_fallback: Box::new(move |char, ids, database| {
-                font_resolver2.resolve_fallback(char, ids, database)
+                font_resolver3.resolve_fallback(char, ids, database)
             }),
         };
 
@@ -827,7 +828,7 @@ impl ImageCacheFactory for ImageCacheFactoryImpl {
                 resolve_data: usvg::ImageHrefResolver::default_data_resolver(),
                 resolve_string: image_string_href_resolver,
             },
-            font_resolver,
+            font_resolver: usvg_font_resolver,
             fontdb: Arc::new(fontdb::Database::new()),
             ..usvg::Options::default()
         };
@@ -849,6 +850,7 @@ impl ImageCacheFactory for ImageCacheFactoryImpl {
             broken_image_icon_data: self.broken_image_icon_data.clone(),
             thread_pool: self.thread_pool.clone(),
             usvg_options: Arc::new(opt),
+            svg_font_resolver: font_resolver.clone(),
         })
     }
 }
@@ -865,17 +867,37 @@ pub struct ImageCacheImpl {
     thread_pool: Arc<ThreadPool>,
     /// The options for usvg. Contains a fontdb::Database and fontresolver.
     usvg_options: Arc<usvg::Options<'static>>,
+    /// This is only used inside `usvg::Options` but is here so we can measure it.
+    svg_font_resolver: Arc<dyn FontResolver>,
 }
 
 impl ImageCache for ImageCacheImpl {
     fn memory_reports(&self, prefix: &str, ops: &mut MallocSizeOfOps) -> Vec<Report> {
         let store_size = self.store.lock().size_of(ops);
         let fontdb_size = self.usvg_options.conditional_size_of(ops);
+        let broken_image_size = self.broken_image_icon_data.conditional_size_of(ops);
+        let svg_id_map = self.svg_id_image_id_map.conditional_size_of(ops);
+        let svg_font_resolver = self.svg_font_resolver.size_of(ops);
         vec![
             Report {
                 path: path![prefix, "image-cache"],
                 kind: ReportKind::ExplicitSystemHeapSize,
                 size: store_size,
+            },
+            Report {
+                path: path![prefix, "image-cache", "svg_id_map"],
+                kind: ReportKind::ExplicitSystemHeapSize,
+                size: svg_id_map,
+            },
+            Report {
+                path: path![prefix, "image-cache", "broken_image"],
+                kind: ReportKind::ExplicitSystemHeapSize,
+                size: broken_image_size,
+            },
+            Report {
+                path: path![prefix, "image-cache", "svg_font_resolver"],
+                kind: ReportKind::ExplicitSystemHeapSize,
+                size: svg_font_resolver,
             },
             Report {
                 path: path![prefix, "image-cache", "usvg_options"],

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -850,7 +850,7 @@ impl ImageCacheFactory for ImageCacheFactoryImpl {
             broken_image_icon_data: self.broken_image_icon_data.clone(),
             thread_pool: self.thread_pool.clone(),
             usvg_options: Arc::new(opt),
-            svg_font_resolver: font_resolver.clone(),
+            usvg_font_resolver: font_resolver.clone(),
         })
     }
 }
@@ -868,7 +868,7 @@ pub struct ImageCacheImpl {
     /// The options for usvg. Contains a fontdb::Database and fontresolver.
     usvg_options: Arc<usvg::Options<'static>>,
     /// This is only used inside `usvg::Options` but is here so we can measure it.
-    svg_font_resolver: Arc<dyn FontResolver>,
+    usvg_font_resolver: Arc<dyn FontResolver>,
 }
 
 impl ImageCache for ImageCacheImpl {
@@ -877,7 +877,7 @@ impl ImageCache for ImageCacheImpl {
         let fontdb_size = self.usvg_options.conditional_size_of(ops);
         let broken_image_size = self.broken_image_icon_data.conditional_size_of(ops);
         let svg_id_map = self.svg_id_image_id_map.conditional_size_of(ops);
-        let svg_font_resolver = self.svg_font_resolver.size_of(ops);
+        let svg_font_resolver = self.usvg_font_resolver.size_of(ops);
         vec![
             Report {
                 path: path![prefix, "image-cache", "cache"],

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -815,10 +815,11 @@ impl ImageCacheFactory for ImageCacheFactoryImpl {
             None
         });
         let font_resolver2 = font_resolver.clone();
-        let font_resolver = usvg::FontResolver {
-            select_font: Box::new(move |font, database| font_resolver.resolve(font, database)),
+        let font_resolver3 = font_resolver.clone();
+        let usvg_font_resolver = usvg::FontResolver {
+            select_font: Box::new(move |font, database| font_resolver2.resolve(font, database)),
             select_fallback: Box::new(move |char, ids, database| {
-                font_resolver2.resolve_fallback(char, ids, database)
+                font_resolver3.resolve_fallback(char, ids, database)
             }),
         };
 
@@ -827,7 +828,7 @@ impl ImageCacheFactory for ImageCacheFactoryImpl {
                 resolve_data: usvg::ImageHrefResolver::default_data_resolver(),
                 resolve_string: image_string_href_resolver,
             },
-            font_resolver,
+            font_resolver: usvg_font_resolver,
             fontdb: Arc::new(fontdb::Database::new()),
             ..usvg::Options::default()
         };
@@ -849,6 +850,7 @@ impl ImageCacheFactory for ImageCacheFactoryImpl {
             broken_image_icon_data: self.broken_image_icon_data.clone(),
             thread_pool: self.thread_pool.clone(),
             usvg_options: Arc::new(opt),
+            svg_font_resolver: font_resolver.clone(),
         })
     }
 }
@@ -865,17 +867,37 @@ pub struct ImageCacheImpl {
     thread_pool: Arc<ThreadPool>,
     /// The options for usvg. Contains a fontdb::Database and fontresolver.
     usvg_options: Arc<usvg::Options<'static>>,
+    /// This is only used inside `usvg::Options` but is here so we can measure it.
+    svg_font_resolver: Arc<dyn FontResolver>,
 }
 
 impl ImageCache for ImageCacheImpl {
     fn memory_reports(&self, prefix: &str, ops: &mut MallocSizeOfOps) -> Vec<Report> {
         let store_size = self.store.lock().size_of(ops);
         let fontdb_size = self.usvg_options.conditional_size_of(ops);
+        let broken_image_size = self.broken_image_icon_data.conditional_size_of(ops);
+        let svg_id_map = self.svg_id_image_id_map.conditional_size_of(ops);
+        let svg_font_resolver = self.svg_font_resolver.size_of(ops);
         vec![
             Report {
                 path: path![prefix, "image-cache", "cache"],
                 kind: ReportKind::ExplicitSystemHeapSize,
                 size: store_size,
+            },
+            Report {
+                path: path![prefix, "image-cache", "svg_id_map"],
+                kind: ReportKind::ExplicitSystemHeapSize,
+                size: svg_id_map,
+            },
+            Report {
+                path: path![prefix, "image-cache", "broken_image"],
+                kind: ReportKind::ExplicitSystemHeapSize,
+                size: broken_image_size,
+            },
+            Report {
+                path: path![prefix, "image-cache", "svg_font_resolver"],
+                kind: ReportKind::ExplicitSystemHeapSize,
+                size: svg_font_resolver,
             },
             Report {
                 path: path![prefix, "image-cache", "usvg_options"],

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -890,7 +890,7 @@ impl ImageCache for ImageCacheImpl {
                 size: svg_id_map,
             },
             Report {
-                path: path![prefix, "image-cache", "broken_image"],
+                path: path![prefix, "image-cache", "broken_image_icon"],
                 kind: ReportKind::ExplicitSystemHeapSize,
                 size: broken_image_size,
             },

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -867,6 +867,8 @@ pub struct ImageCacheImpl {
     thread_pool: Arc<ThreadPool>,
     /// The options for usvg. Contains a fontdb::Database and fontresolver.
     usvg_options: Arc<usvg::Options<'static>>,
+    /// A font resolve used for resolving fonts when rasterizing SVGs.
+    ///
     /// This is only used inside `usvg::Options` but is here so we can measure it.
     usvg_font_resolver: Arc<dyn FontResolver>,
 }

--- a/components/net/tests/image_cache.rs
+++ b/components/net/tests/image_cache.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crossbeam_channel::{Receiver, Sender, unbounded};
+use malloc_size_of::MallocSizeOf;
 use net::image_cache::ImageCacheFactoryImpl;
 use net_traits::image_cache::{
     FontResolver, ImageCache, ImageCacheFactory, ImageCacheResponseMessage, ImageCacheResult,
@@ -28,6 +29,13 @@ use webrender_api::ImageKey;
 use crate::mock_origin;
 
 struct DummyFontResolver;
+
+impl MallocSizeOf for DummyFontResolver {
+    fn size_of(&self, _ops: &mut malloc_size_of::MallocSizeOfOps) -> usize {
+        0
+    }
+}
+
 impl FontResolver for DummyFontResolver {
     fn resolve(&self, _: &Font, _: &mut Arc<fontdb::Database>) -> Option<fontdb::ID> {
         None

--- a/components/net/tests/image_cache.rs
+++ b/components/net/tests/image_cache.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crossbeam_channel::{Receiver, Sender, unbounded};
-use malloc_size_of::MallocSizeOf;
+use malloc_size_of_derive::MallocSizeOf;
 use net::image_cache::ImageCacheFactoryImpl;
 use net_traits::image_cache::{
     FontResolver, ImageCache, ImageCacheFactory, ImageCacheResponseMessage, ImageCacheResult,
@@ -28,13 +28,8 @@ use webrender_api::ImageKey;
 
 use crate::mock_origin;
 
+#[derive(MallocSizeOf)]
 struct DummyFontResolver;
-
-impl MallocSizeOf for DummyFontResolver {
-    fn size_of(&self, _ops: &mut malloc_size_of::MallocSizeOfOps) -> usize {
-        0
-    }
-}
 
 impl FontResolver for DummyFontResolver {
     fn resolve(&self, _: &Font, _: &mut Arc<fontdb::Database>) -> Option<fontdb::ID> {

--- a/components/script/event_loop/svg_font.rs
+++ b/components/script/event_loop/svg_font.rs
@@ -23,10 +23,12 @@ use style::values::computed::{
 use webrender_api::FontVariation;
 
 /// Used to dynamically query fonts used in SVGs and insert them into the fontDB used when rasterizing.
+#[derive(MallocSizeOf)]
 pub struct SvgFontResolver {
     /// Cache for Font to ID
     font_id_cache: Mutex<FxHashMap<Font, fontdb::ID>>,
     fallback_id_cache: Mutex<FxHashMap<char, Vec<fontdb::ID>>>,
+    #[conditional_malloc_size_of]
     context: Arc<FontContext>,
 }
 

--- a/components/script/svg_font.rs
+++ b/components/script/svg_font.rs
@@ -23,10 +23,12 @@ use style::values::computed::{
 use webrender_api::FontVariation;
 
 /// Used to dynamically query fonts used in SVGs and insert them into the fontDB used when rasterizing.
+#[derive(MallocSizeOf)]
 pub struct SvgFontResolver {
     /// Cache for Font to ID
     font_id_cache: Mutex<FxHashMap<Font, fontdb::ID>>,
     fallback_id_cache: Mutex<FxHashMap<char, Vec<fontdb::ID>>>,
+    #[conditional_malloc_size_of]
     context: Arc<FontContext>,
 }
 

--- a/components/shared/net/image_cache.rs
+++ b/components/shared/net/image_cache.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 
 use log::debug;
-use malloc_size_of::MallocSizeOfOps;
+use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use malloc_size_of_derive::MallocSizeOf;
 use paint_api::CrossProcessPaintApi;
 use pixels::{CorsStatus, ImageMetadata, RasterImage};
@@ -26,7 +26,7 @@ use crate::request::CorsSettings;
 // ======================================================================
 
 /// An interface for resolving font families and styles for SVG images.
-pub trait FontResolver: Sync + Send {
+pub trait FontResolver: Sync + Send + MallocSizeOf {
     /// Attempt to resolve a font reference using the provided database of fonts.
     /// Adding new fonts to the database is allowed. Return an index into the database
     /// if the font resolves to an entry, otherwise return None.


### PR DESCRIPTION
This adds Memory Reporting for the SVG id map, the broken image icon, and the SVG font resolver. We add an `Arc` reference to the SVG font resolver to` ImageCacheImpl` in order to measure it more easily.

Testing: Memory reporting is not tested.
