### PR TITLE
pixels: Implement OHOS library for image decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6065,6 +6065,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ohos-image-kit-sys"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd17403cafc1c28e512dc94597c5cf4522d978dc0747692994615c4df8e2d8c6"
+dependencies = [
+ "ohos-rawfile-sys",
+ "ohos-sys-opaque-types",
+]
+
+[[package]]
 name = "ohos-ime"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6088,6 +6098,15 @@ name = "ohos-media-sys"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ffb75eb3dc3eefa0e4c9d641369b609091d77e395f1f56c9eaddead6e9330b6"
+dependencies = [
+ "ohos-sys-opaque-types",
+]
+
+[[package]]
+name = "ohos-rawfile-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5096029eddb1dbf0f216ce61049d2456525eb0373c465a75d366fc05f5a521b5"
 dependencies = [
  "ohos-sys-opaque-types",
 ]
@@ -8872,6 +8891,7 @@ dependencies = [
  "image",
  "log",
  "malloc_size_of_derive",
+ "ohos-image-kit-sys",
  "serde",
  "servo-base",
  "servo-malloc-size-of",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6059,6 +6059,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ohos-image-kit-sys"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd17403cafc1c28e512dc94597c5cf4522d978dc0747692994615c4df8e2d8c6"
+dependencies = [
+ "ohos-rawfile-sys",
+ "ohos-sys-opaque-types",
+]
+
+[[package]]
 name = "ohos-ime"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6101,6 +6111,15 @@ name = "ohos-pasteboard-sys"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a26fed7fe51d995248785dddb53afeb3f862a4094d406e09de7ab36169411c"
+dependencies = [
+ "ohos-sys-opaque-types",
+]
+
+[[package]]
+name = "ohos-rawfile-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5096029eddb1dbf0f216ce61049d2456525eb0373c465a75d366fc05f5a521b5"
 dependencies = [
  "ohos-sys-opaque-types",
 ]
@@ -8885,11 +8904,13 @@ dependencies = [
 name = "servo-pixels"
 version = "0.5.0"
 dependencies = [
+ "cfg-if",
  "criterion",
  "euclid",
  "image",
  "log",
  "malloc_size_of_derive",
+ "ohos-image-kit-sys",
  "serde",
  "servo-base",
  "servo-malloc-size-of",

--- a/components/pixels/Cargo.toml
+++ b/components/pixels/Cargo.toml
@@ -22,7 +22,7 @@ malloc_size_of_derive = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 servo-base = { workspace = true }
 webrender_api = { workspace = true }
-
+ohos-image-kit-sys = {version = "0.3.6", features = ["api-20", "picture"]}
 [dev-dependencies]
 criterion = { workspace = true, features = ["html_reports"] }
 

--- a/components/pixels/Cargo.toml
+++ b/components/pixels/Cargo.toml
@@ -22,7 +22,7 @@ malloc_size_of_derive = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 servo-base = { workspace = true }
 webrender_api = { workspace = true }
-ohos-image-kit-sys = {version = "0.3.6", features = ["api-20", "picture"]}
+ohos-image-kit-sys = { version = "0.3.6", features = ["api-20", "picture"] }
 [dev-dependencies]
 criterion = { workspace = true, features = ["html_reports"] }
 

--- a/components/pixels/Cargo.toml
+++ b/components/pixels/Cargo.toml
@@ -14,6 +14,7 @@ name = "pixels"
 path = "lib.rs"
 
 [dependencies]
+cfg-if = { workspace = true }
 euclid = { workspace = true }
 image = { workspace = true }
 log = { workspace = true }
@@ -22,7 +23,10 @@ malloc_size_of_derive = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 servo-base = { workspace = true }
 webrender_api = { workspace = true }
+
+[target.'cfg(target_env = "ohos")'.dependencies]
 ohos-image-kit-sys = { version = "0.3.6", features = ["api-20", "picture"] }
+
 [dev-dependencies]
 criterion = { workspace = true, features = ["html_reports"] }
 

--- a/components/pixels/decoding.rs
+++ b/components/pixels/decoding.rs
@@ -20,6 +20,7 @@ use crate::{
     rgba8_premultiply_inplace,
 };
 
+#[cfg_attr(target_env = "ohos", expect(dead_code))]
 enum GenericImageDecoder<'a> {
     Apng(Box<png::ApngDecoder<Cursor<&'a [u8]>>>),
     Png(Box<png::PngDecoder<Cursor<&'a [u8]>>>),
@@ -183,6 +184,7 @@ impl<'a> AnimationDecoder<'a> for GenericImageDecoder<'a> {
     }
 }
 
+#[cfg_attr(target_env = "ohos", expect(dead_code))]
 #[derive(Debug)]
 /// Servo Default Image decoder using image-rs for decoding.
 pub(crate) struct DefaultImageDecoder<'a> {

--- a/components/pixels/decoding.rs
+++ b/components/pixels/decoding.rs
@@ -1,0 +1,377 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::io::Cursor;
+use std::sync::Arc;
+use std::time::Duration;
+use std::{cmp, fmt, vec};
+
+use image::codecs::{bmp, gif, ico, jpeg, png, webp};
+use image::error::ImageFormatHint;
+use image::metadata::LoopCount;
+use image::{
+    AnimationDecoder, DynamicImage, ImageDecoder, ImageError, ImageFormat, ImageResult, Limits,
+};
+use log::{debug, error};
+
+use crate::{
+    CorsStatus, ImageFrame, ImageMetadata, PixelFormat, RasterImage, Repeat,
+    rgba8_premultiply_inplace,
+};
+
+enum GenericImageDecoder<'a> {
+    Apng(Box<png::ApngDecoder<Cursor<&'a [u8]>>>),
+    Png(Box<png::PngDecoder<Cursor<&'a [u8]>>>),
+    Gif(Box<gif::GifDecoder<Cursor<&'a [u8]>>>),
+    Webp(Box<webp::WebPDecoder<Cursor<&'a [u8]>>>),
+    Jpeg(Box<jpeg::JpegDecoder<Cursor<&'a [u8]>>>),
+    Bmp(Box<bmp::BmpDecoder<Cursor<&'a [u8]>>>),
+    Ico(Box<ico::IcoDecoder<Cursor<&'a [u8]>>>),
+}
+
+impl<'a> std::fmt::Debug for GenericImageDecoder<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Apng(_) => f.debug_tuple("Apng").finish(),
+            Self::Png(_) => f.debug_tuple("Png").finish(),
+            Self::Gif(_) => f.debug_tuple("Gif").finish(),
+            Self::Webp(_) => f.debug_tuple("Webp").finish(),
+            Self::Jpeg(_) => f.debug_tuple("Jpeg").finish(),
+            Self::Bmp(_) => f.debug_tuple("Bmp").finish(),
+            Self::Ico(_) => f.debug_tuple("Ico").finish(),
+        }
+    }
+}
+
+/// Notice that we implement methods that are implemented by default. However, these methods are necessary as
+impl<'a> image::ImageDecoder for GenericImageDecoder<'a> {
+    fn dimensions(&self) -> (u32, u32) {
+        match self {
+            GenericImageDecoder::Apng(_) => {
+                unreachable!("Animated image should never go into non-animated values")
+            },
+            GenericImageDecoder::Png(d) => d.dimensions(),
+            GenericImageDecoder::Gif(d) => d.dimensions(),
+            GenericImageDecoder::Webp(d) => d.dimensions(),
+            GenericImageDecoder::Jpeg(d) => d.dimensions(),
+            GenericImageDecoder::Bmp(d) => d.dimensions(),
+            GenericImageDecoder::Ico(d) => d.dimensions(),
+        }
+    }
+
+    fn color_type(&self) -> image::ColorType {
+        match self {
+            GenericImageDecoder::Apng(_) => {
+                unreachable!("Animated image should never go into non-animated values")
+            },
+            GenericImageDecoder::Png(d) => d.color_type(),
+            GenericImageDecoder::Gif(d) => d.color_type(),
+            GenericImageDecoder::Webp(d) => d.color_type(),
+            GenericImageDecoder::Jpeg(d) => d.color_type(),
+            GenericImageDecoder::Bmp(d) => d.color_type(),
+            GenericImageDecoder::Ico(d) => d.color_type(),
+        }
+    }
+
+    fn read_image(self, buf: &mut [u8]) -> ImageResult<()>
+    where
+        Self: Sized,
+    {
+        match self {
+            GenericImageDecoder::Apng(_) => {
+                unreachable!("Animated image should never go into non-animated values")
+            },
+            GenericImageDecoder::Png(d) => d.read_image(buf),
+            GenericImageDecoder::Gif(d) => d.read_image(buf),
+            GenericImageDecoder::Webp(d) => d.read_image(buf),
+            GenericImageDecoder::Jpeg(d) => d.read_image(buf),
+            GenericImageDecoder::Bmp(d) => d.read_image(buf),
+            GenericImageDecoder::Ico(d) => d.read_image(buf),
+        }
+    }
+
+    fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
+        match *self {
+            GenericImageDecoder::Apng(_) => {
+                unreachable!("Animated image should never go into non-animated values")
+            },
+            GenericImageDecoder::Png(d) => d.read_image_boxed(buf),
+            GenericImageDecoder::Gif(d) => d.read_image_boxed(buf),
+            GenericImageDecoder::Webp(d) => d.read_image_boxed(buf),
+            GenericImageDecoder::Jpeg(d) => d.read_image_boxed(buf),
+            GenericImageDecoder::Bmp(d) => d.read_image_boxed(buf),
+            GenericImageDecoder::Ico(d) => d.read_image_boxed(buf),
+        }
+    }
+
+    fn icc_profile(&mut self) -> ImageResult<Option<Vec<u8>>> {
+        match self {
+            GenericImageDecoder::Apng(_) => {
+                unreachable!("Animated image should never go into non-animated values")
+            },
+            GenericImageDecoder::Png(d) => d.icc_profile(),
+            GenericImageDecoder::Gif(d) => d.icc_profile(),
+            GenericImageDecoder::Webp(d) => d.icc_profile(),
+            GenericImageDecoder::Jpeg(d) => d.icc_profile(),
+            GenericImageDecoder::Bmp(d) => d.icc_profile(),
+            GenericImageDecoder::Ico(d) => d.icc_profile(),
+        }
+    }
+
+    fn exif_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
+        match self {
+            GenericImageDecoder::Apng(_) => {
+                unreachable!("Animated image should never go into non-animated values")
+            },
+            GenericImageDecoder::Png(d) => d.exif_metadata(),
+            GenericImageDecoder::Gif(d) => d.exif_metadata(),
+            GenericImageDecoder::Webp(d) => d.exif_metadata(),
+            GenericImageDecoder::Jpeg(d) => d.exif_metadata(),
+            GenericImageDecoder::Bmp(d) => d.exif_metadata(),
+            GenericImageDecoder::Ico(d) => d.exif_metadata(),
+        }
+    }
+
+    fn xmp_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
+        match self {
+            GenericImageDecoder::Apng(_) => {
+                unreachable!("Animated image should never go into non-animated values")
+            },
+            GenericImageDecoder::Png(d) => d.xmp_metadata(),
+            GenericImageDecoder::Gif(d) => d.xmp_metadata(),
+            GenericImageDecoder::Webp(d) => d.xmp_metadata(),
+            GenericImageDecoder::Jpeg(d) => d.xmp_metadata(),
+            GenericImageDecoder::Bmp(d) => d.xmp_metadata(),
+            GenericImageDecoder::Ico(d) => d.xmp_metadata(),
+        }
+    }
+
+    fn iptc_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
+        match self {
+            GenericImageDecoder::Apng(_) => {
+                unreachable!("Animated image should never go into non-animated values")
+            },
+            GenericImageDecoder::Png(d) => d.iptc_metadata(),
+            GenericImageDecoder::Gif(d) => d.iptc_metadata(),
+            GenericImageDecoder::Webp(d) => d.iptc_metadata(),
+            GenericImageDecoder::Jpeg(d) => d.iptc_metadata(),
+            GenericImageDecoder::Bmp(d) => d.iptc_metadata(),
+            GenericImageDecoder::Ico(d) => d.iptc_metadata(),
+        }
+    }
+}
+
+/// See documentation on imp `image::ImageDecoder`
+impl<'a> AnimationDecoder<'a> for GenericImageDecoder<'a> {
+    fn into_frames(self) -> image::Frames<'a> {
+        match self {
+            GenericImageDecoder::Apng(decoder) => decoder.into_frames(),
+            GenericImageDecoder::Gif(decoder) => decoder.into_frames(),
+            GenericImageDecoder::Webp(decoder) => decoder.into_frames(),
+            _ => unreachable!("Should never decode these images with animated decoder"),
+        }
+    }
+
+    fn loop_count(&self) -> LoopCount {
+        match self {
+            GenericImageDecoder::Apng(decoder) => decoder.loop_count(),
+            GenericImageDecoder::Gif(decoder) => decoder.loop_count(),
+            GenericImageDecoder::Webp(decoder) => decoder.loop_count(),
+            _ => unreachable!("Should never decode these images with animated decoder"),
+        }
+    }
+}
+
+#[derive(Debug)]
+/// Servo Default Image decoder using image-rs for decoding.
+pub(crate) struct DefaultImageDecoder<'a> {
+    decoder: GenericImageDecoder<'a>,
+}
+
+/// Main Image decoder trait.
+pub(crate) trait ServoImageDecoder<'a>: Sized + std::fmt::Debug {
+    /// Create a decoder for a `format` from a `buffer`.
+    fn make_decoder(format: ImageFormat, buffer: &'a [u8]) -> ImageResult<Self>;
+    fn is_animated(&self) -> bool;
+    /// Return the created decoder in `impl ImageDecoder`
+    fn decoder(self) -> impl ImageDecoder;
+    /// Return the created decoder in `impl AnimationDecoder` if animated.
+    fn animated_decoder(self) -> impl AnimationDecoder<'a>;
+}
+
+impl<'a> ServoImageDecoder<'a> for DefaultImageDecoder<'a> {
+    fn make_decoder(format: ImageFormat, buffer: &'a [u8]) -> ImageResult<Self> {
+        let reader = Cursor::new(buffer);
+        let decoder = match format {
+            ImageFormat::Png => {
+                let limits = Limits::default();
+                let png_decoder = png::PngDecoder::with_limits(reader, limits)?;
+                if png_decoder.is_apng().unwrap_or_default() {
+                    let decoder = png_decoder.apng()?;
+                    GenericImageDecoder::Apng(Box::new(decoder))
+                } else {
+                    GenericImageDecoder::Png(Box::new(png_decoder))
+                }
+            },
+            ImageFormat::Gif => GenericImageDecoder::Gif(Box::new(gif::GifDecoder::new(reader)?)),
+            ImageFormat::WebP => {
+                GenericImageDecoder::Webp(Box::new(webp::WebPDecoder::new(reader)?))
+            },
+            ImageFormat::Jpeg => {
+                GenericImageDecoder::Jpeg(Box::new(jpeg::JpegDecoder::new(reader)?))
+            },
+            ImageFormat::Bmp => GenericImageDecoder::Bmp(Box::new(bmp::BmpDecoder::new(reader)?)),
+            ImageFormat::Ico => GenericImageDecoder::Ico(Box::new(ico::IcoDecoder::new(reader)?)),
+            _ => {
+                return Err(ImageError::Unsupported(
+                    ImageFormatHint::Exact(format).into(),
+                ));
+            },
+        };
+        Ok(DefaultImageDecoder { decoder })
+    }
+
+    fn is_animated(&self) -> bool {
+        match &self.decoder {
+            GenericImageDecoder::Apng(_) | GenericImageDecoder::Gif(_) => true,
+            GenericImageDecoder::Webp(decoder) => decoder.has_animation(),
+            GenericImageDecoder::Png(_) |
+            GenericImageDecoder::Jpeg(_) |
+            GenericImageDecoder::Bmp(_) |
+            GenericImageDecoder::Ico(_) => false,
+        }
+    }
+
+    fn decoder(self) -> impl ImageDecoder {
+        self.decoder
+    }
+
+    fn animated_decoder(self) -> impl AnimationDecoder<'a> {
+        self.decoder
+    }
+}
+
+pub(crate) fn decode_static_image(
+    cors_status: CorsStatus,
+    mut image_decoder: impl ImageDecoder,
+) -> Option<RasterImage> {
+    let orientation = image_decoder.orientation();
+
+    let Ok(mut dynamic_image) = DynamicImage::from_decoder(image_decoder) else {
+        error!("Image decoding error");
+        return None;
+    };
+
+    if let Ok(orientation) = orientation {
+        dynamic_image.apply_orientation(orientation);
+    }
+
+    let mut rgba = dynamic_image.into_rgba8();
+
+    // Store pre-multiplied data as that prevents having to do conversions of the data at later
+    // times. This does cause an issue with some canvas APIs. See:
+    // https://github.com/servo/servo/issues/40257
+    let is_opaque = rgba8_premultiply_inplace(&mut rgba);
+
+    let frame = ImageFrame {
+        delay: None,
+        byte_range: 0..rgba.len(),
+        width: rgba.width(),
+        height: rgba.height(),
+    };
+    Some(RasterImage {
+        metadata: ImageMetadata {
+            width: rgba.width(),
+            height: rgba.height(),
+        },
+        format: PixelFormat::RGBA8,
+        frames: vec![frame],
+        bytes: Arc::new(rgba.into_vec()),
+        id: None,
+        cors_status,
+        is_opaque,
+        loop_count: None,
+    })
+}
+
+pub(crate) fn decode_animated_image<'a, T>(
+    cors_status: CorsStatus,
+    animated_image_decoder: T,
+) -> Option<RasterImage>
+where
+    T: AnimationDecoder<'a>,
+{
+    let mut width = 0;
+    let mut height = 0;
+
+    // This uses `map_while`, because the first non-decodable frame seems to
+    // send the frame iterator into an infinite loop. See
+    // <https://github.com/image-rs/image/issues/2442>.
+    let mut frame_data = vec![];
+    let mut total_number_of_bytes = 0;
+    let mut is_opaque = true;
+    let loop_count = match animated_image_decoder.loop_count() {
+        LoopCount::Finite(repeat_time) => Repeat::Finite(repeat_time),
+        LoopCount::Infinite => Repeat::Infinite,
+    };
+    let frames: Vec<ImageFrame> = animated_image_decoder
+        .into_frames()
+        .map_while(|decoded_frame| {
+            let mut animated_frame = match decoded_frame {
+                Ok(decoded_frame) => decoded_frame,
+                Err(error) => {
+                    debug!("decode Animated frame error: {error}");
+                    return None;
+                },
+            };
+
+            // Store pre-multiplied data as that prevents having to do conversions of the data at later
+            // times. This does cause an issue with some canvas APIs. See:
+            // https://github.com/servo/servo/issues/40257
+            is_opaque = rgba8_premultiply_inplace(animated_frame.buffer_mut()) && is_opaque;
+
+            let frame_start = total_number_of_bytes;
+            total_number_of_bytes += animated_frame.buffer().len();
+
+            // The image size should be at least as large as the largest frame.
+            let frame_width = animated_frame.buffer().width();
+            let frame_height = animated_frame.buffer().height();
+            width = cmp::max(width, frame_width);
+            height = cmp::max(height, frame_height);
+
+            let frame = ImageFrame {
+                byte_range: frame_start..total_number_of_bytes,
+                delay: Some(Duration::from(animated_frame.delay())),
+                width: frame_width,
+                height: frame_height,
+            };
+
+            frame_data.push(animated_frame);
+
+            Some(frame)
+        })
+        .collect();
+
+    if frames.is_empty() {
+        debug!("Animated Image decoding error");
+        return None;
+    }
+
+    // Coalesce the frame data into one single shared memory region.
+    let mut bytes = Vec::with_capacity(total_number_of_bytes);
+    for frame in frame_data {
+        bytes.extend_from_slice(frame.buffer());
+    }
+
+    Some(RasterImage {
+        metadata: ImageMetadata { width, height },
+        cors_status,
+        frames,
+        id: None,
+        format: PixelFormat::RGBA8,
+        bytes: Arc::new(bytes),
+        is_opaque,
+        loop_count: Some(loop_count),
+    })
+}

--- a/components/pixels/decoding.rs
+++ b/components/pixels/decoding.rs
@@ -194,8 +194,8 @@ pub(crate) struct DefaultImageDecoder<'a> {
 
 /// Main Image decoder trait.
 pub(crate) trait ServoImageDecoder<'a>: Sized + std::fmt::Debug {
-    /// Create a decoder for a `format` from a `buffer`.
-    fn make_decoder(format: ImageFormat, buffer: &'a [u8]) -> ImageResult<Self>;
+    /// Create a decoder for a `buffer`. Return an error if the format is not supported.
+    fn make_decoder(buffer: &'a [u8]) -> ImageResult<Self>;
     fn is_animated(&self) -> bool;
     /// Return the created decoder in `impl ImageDecoder`
     fn decoder(self) -> impl ImageDecoder;
@@ -204,7 +204,8 @@ pub(crate) trait ServoImageDecoder<'a>: Sized + std::fmt::Debug {
 }
 
 impl<'a> ServoImageDecoder<'a> for DefaultImageDecoder<'a> {
-    fn make_decoder(format: ImageFormat, buffer: &'a [u8]) -> ImageResult<Self> {
+    fn make_decoder(buffer: &'a [u8]) -> ImageResult<Self> {
+        let format = image::guess_format(buffer)?;
         let reader = Cursor::new(buffer);
         let decoder = match format {
             ImageFormat::Png => {

--- a/components/pixels/decoding.rs
+++ b/components/pixels/decoding.rs
@@ -20,6 +20,7 @@ use crate::{
     rgba8_premultiply_inplace,
 };
 
+#[cfg_attr(target_env = "ohos", expect(dead_code))]
 enum GenericImageDecoder<'a> {
     Apng(Box<png::ApngDecoder<Cursor<&'a [u8]>>>),
     Png(Box<png::PngDecoder<Cursor<&'a [u8]>>>),
@@ -184,6 +185,7 @@ impl<'a> AnimationDecoder<'a> for GenericImageDecoder<'a> {
     }
 }
 
+#[cfg_attr(target_env = "ohos", expect(dead_code))]
 #[derive(Debug)]
 /// Servo Default Image decoder using image-rs for decoding.
 pub(crate) struct DefaultImageDecoder<'a> {

--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -3,6 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 mod decoding;
+#[cfg(target_env = "ohos")]
+mod ohos_decoder;
 mod snapshot;
 
 use std::borrow::Cow;
@@ -540,8 +542,13 @@ pub fn load_from_memory(buffer: &[u8], cors_status: CorsStatus) -> Option<Raster
             None
         },
         Ok(format) => {
-            let Ok(image_decoder) = decoding::DefaultImageDecoder::make_decoder(format, buffer)
-            else {
+            //let image_decoder_result = ohos_decoder::OhosImageDecoder::make_decoder(format, buffer);
+            let image_decoder_result = cfg_select! {
+               target_env = "ohos" => {ohos_decoder::OhosImageDecoder::make_decoder(format, buffer) }
+               _ => { decoding::DefaultImageDecoder::make_decoder(format, buffer) }
+            };
+
+            let Ok(image_decoder) = image_decoder_result else {
                 return None;
             };
 

--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -2,25 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+mod decoding;
 mod snapshot;
 
 use std::borrow::Cow;
-use std::io::Cursor;
+use std::fmt;
 use std::num::NonZeroU32;
 use std::ops::Range;
 use std::sync::Arc;
 use std::time::Duration;
-use std::{cmp, fmt, vec};
 
 use euclid::default::{Point2D, Rect, Size2D};
-use image::codecs::{bmp, gif, ico, jpeg, png, webp};
-use image::error::ImageFormatHint;
 use image::imageops::{self, FilterType};
-use image::metadata::LoopCount;
-use image::{
-    AnimationDecoder, DynamicImage, ImageBuffer, ImageDecoder, ImageError, ImageFormat,
-    ImageResult, Limits, Rgba,
-};
+use image::{ImageBuffer, ImageFormat, Rgba};
 use log::{debug, error};
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
@@ -30,6 +24,8 @@ use webrender_api::units::DeviceIntSize;
 use webrender_api::{
     ImageDescriptor, ImageDescriptorFlags, ImageFormat as WebRenderImageFormat, ImageKey,
 };
+
+use crate::decoding::ServoImageDecoder;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, MallocSizeOf, PartialEq, Serialize)]
 pub enum FilterQuality {
@@ -544,39 +540,15 @@ pub fn load_from_memory(buffer: &[u8], cors_status: CorsStatus) -> Option<Raster
             None
         },
         Ok(format) => {
-            let Ok(image_decoder) = make_decoder(format, buffer) else {
+            let Ok(image_decoder) = decoding::DefaultImageDecoder::make_decoder(format, buffer)
+            else {
                 return None;
             };
-            match image_decoder {
-                GenericImageDecoder::Png(png_decoder) => {
-                    if png_decoder.is_apng().unwrap_or_default() {
-                        let Ok(apng_decoder) = png_decoder.apng() else {
-                            return None;
-                        };
-                        decode_animated_image(cors_status, apng_decoder)
-                    } else {
-                        decode_static_image(cors_status, *png_decoder)
-                    }
-                },
-                GenericImageDecoder::Gif(animation_decoder) => {
-                    decode_animated_image(cors_status, *animation_decoder)
-                },
-                GenericImageDecoder::Webp(webp_decoder) => {
-                    if webp_decoder.has_animation() {
-                        decode_animated_image(cors_status, *webp_decoder)
-                    } else {
-                        decode_static_image(cors_status, *webp_decoder)
-                    }
-                },
-                GenericImageDecoder::Bmp(image_decoder) => {
-                    decode_static_image(cors_status, *image_decoder)
-                },
-                GenericImageDecoder::Jpeg(image_decoder) => {
-                    decode_static_image(cors_status, *image_decoder)
-                },
-                GenericImageDecoder::Ico(image_decoder) => {
-                    decode_static_image(cors_status, *image_decoder)
-                },
+
+            if image_decoder.is_animated() {
+                decoding::decode_animated_image(cors_status, image_decoder.animated_decoder())
+            } else {
+                decoding::decode_static_image(cors_status, image_decoder.decoder())
             }
         },
     }
@@ -731,162 +703,6 @@ fn is_webp(buffer: &[u8]) -> bool {
     // > of the whole file is at most 4 GiB minus 2 bytes.
     let len: usize = u32::from_le_bytes(size) as usize;
     buffer[8..].len() >= len && &buffer[8..12] == b"WEBP"
-}
-
-enum GenericImageDecoder<R: std::io::BufRead + std::io::Seek> {
-    Png(Box<png::PngDecoder<R>>),
-    Gif(Box<gif::GifDecoder<R>>),
-    Webp(Box<webp::WebPDecoder<R>>),
-    Jpeg(Box<jpeg::JpegDecoder<R>>),
-    Bmp(Box<bmp::BmpDecoder<R>>),
-    Ico(Box<ico::IcoDecoder<R>>),
-}
-
-fn make_decoder(
-    format: ImageFormat,
-    buffer: &[u8],
-) -> ImageResult<GenericImageDecoder<Cursor<&[u8]>>> {
-    let limits = Limits::default();
-    let reader = Cursor::new(buffer);
-    Ok(match format {
-        ImageFormat::Png => {
-            GenericImageDecoder::Png(Box::new(png::PngDecoder::with_limits(reader, limits)?))
-        },
-        ImageFormat::Gif => GenericImageDecoder::Gif(Box::new(gif::GifDecoder::new(reader)?)),
-        ImageFormat::WebP => GenericImageDecoder::Webp(Box::new(webp::WebPDecoder::new(reader)?)),
-        ImageFormat::Jpeg => GenericImageDecoder::Jpeg(Box::new(jpeg::JpegDecoder::new(reader)?)),
-        ImageFormat::Bmp => GenericImageDecoder::Bmp(Box::new(bmp::BmpDecoder::new(reader)?)),
-        ImageFormat::Ico => GenericImageDecoder::Ico(Box::new(ico::IcoDecoder::new(reader)?)),
-        _ => {
-            return Err(ImageError::Unsupported(
-                ImageFormatHint::Exact(format).into(),
-            ));
-        },
-    })
-}
-
-fn decode_static_image(
-    cors_status: CorsStatus,
-    mut image_decoder: impl ImageDecoder,
-) -> Option<RasterImage> {
-    let orientation = image_decoder.orientation();
-
-    let Ok(mut dynamic_image) = DynamicImage::from_decoder(image_decoder) else {
-        debug!("Image decoding error");
-        return None;
-    };
-
-    if let Ok(orientation) = orientation {
-        dynamic_image.apply_orientation(orientation);
-    }
-
-    let mut rgba = dynamic_image.into_rgba8();
-
-    // Store pre-multiplied data as that prevents having to do conversions of the data at later
-    // times. This does cause an issue with some canvas APIs. See:
-    // https://github.com/servo/servo/issues/40257
-    let is_opaque = rgba8_premultiply_inplace(&mut rgba);
-
-    let frame = ImageFrame {
-        delay: None,
-        byte_range: 0..rgba.len(),
-        width: rgba.width(),
-        height: rgba.height(),
-    };
-    Some(RasterImage {
-        metadata: ImageMetadata {
-            width: rgba.width(),
-            height: rgba.height(),
-        },
-        format: PixelFormat::RGBA8,
-        frames: vec![frame],
-        bytes: Arc::new(rgba.into_vec()),
-        id: None,
-        cors_status,
-        is_opaque,
-        loop_count: None,
-    })
-}
-
-fn decode_animated_image<'a, T>(
-    cors_status: CorsStatus,
-    animated_image_decoder: T,
-) -> Option<RasterImage>
-where
-    T: AnimationDecoder<'a>,
-{
-    let mut width = 0;
-    let mut height = 0;
-
-    // This uses `map_while`, because the first non-decodable frame seems to
-    // send the frame iterator into an infinite loop. See
-    // <https://github.com/image-rs/image/issues/2442>.
-    let mut frame_data = vec![];
-    let mut total_number_of_bytes = 0;
-    let mut is_opaque = true;
-    let loop_count = match animated_image_decoder.loop_count() {
-        LoopCount::Finite(repeat_time) => Repeat::Finite(repeat_time),
-        LoopCount::Infinite => Repeat::Infinite,
-    };
-    let frames: Vec<ImageFrame> = animated_image_decoder
-        .into_frames()
-        .map_while(|decoded_frame| {
-            let mut animated_frame = match decoded_frame {
-                Ok(decoded_frame) => decoded_frame,
-                Err(error) => {
-                    debug!("decode Animated frame error: {error}");
-                    return None;
-                },
-            };
-
-            // Store pre-multiplied data as that prevents having to do conversions of the data at later
-            // times. This does cause an issue with some canvas APIs. See:
-            // https://github.com/servo/servo/issues/40257
-            is_opaque = rgba8_premultiply_inplace(animated_frame.buffer_mut()) && is_opaque;
-
-            let frame_start = total_number_of_bytes;
-            total_number_of_bytes += animated_frame.buffer().len();
-
-            // The image size should be at least as large as the largest frame.
-            let frame_width = animated_frame.buffer().width();
-            let frame_height = animated_frame.buffer().height();
-            width = cmp::max(width, frame_width);
-            height = cmp::max(height, frame_height);
-
-            let frame = ImageFrame {
-                byte_range: frame_start..total_number_of_bytes,
-                delay: Some(Duration::from(animated_frame.delay())),
-                width: frame_width,
-                height: frame_height,
-            };
-
-            frame_data.push(animated_frame);
-
-            Some(frame)
-        })
-        .collect();
-
-    if frames.is_empty() {
-        debug!("Animated Image decoding error");
-        return None;
-    }
-
-    // Coalesce the frame data into one single shared memory region.
-    let mut bytes = Vec::with_capacity(total_number_of_bytes);
-    for frame in frame_data {
-        bytes.extend_from_slice(frame.buffer());
-    }
-
-    Some(RasterImage {
-        metadata: ImageMetadata { width, height },
-        cors_status,
-        frames,
-        id: None,
-        format: PixelFormat::RGBA8,
-        bytes: Arc::new(bytes),
-        is_opaque,
-        loop_count: Some(loop_count),
-    })
 }
 
 #[cfg(test)]

--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -535,9 +535,12 @@ pub fn load_from_memory(buffer: &[u8], cors_status: CorsStatus) -> Option<Raster
         return None;
     }
 
-    let image_decoder_result = cfg_select! {
-       target_env = "ohos" => {ohos_decoder::OhosImageDecoder::make_decoder(buffer) }
-       _ => { decoding::DefaultImageDecoder::make_decoder(buffer) }
+    cfg_if::cfg_if! {
+       if #[cfg(target_env = "ohos")] {
+           let image_decoder_result = ohos_decoder::OhosImageDecoder::make_decoder(buffer);
+       } else {
+           let image_decoder_result = decoding::DefaultImageDecoder::make_decoder(buffer);
+       }
     };
 
     let Ok(image_decoder) = image_decoder_result else {

--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -16,8 +16,8 @@ use std::time::Duration;
 
 use euclid::default::{Point2D, Rect, Size2D};
 use image::imageops::{self, FilterType};
-use image::{ImageBuffer, ImageFormat, Rgba};
-use log::{debug, error};
+use image::{ImageBuffer, Rgba};
+use log::error;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 use servo_base::generic_channel::GenericSharedMemory;
@@ -535,48 +535,19 @@ pub fn load_from_memory(buffer: &[u8], cors_status: CorsStatus) -> Option<Raster
         return None;
     }
 
-    let image_fmt_result = detect_image_format(buffer);
-    match image_fmt_result {
-        Err(msg) => {
-            debug!("{}", msg);
-            None
-        },
-        Ok(format) => {
-            //let image_decoder_result = ohos_decoder::OhosImageDecoder::make_decoder(format, buffer);
-            let image_decoder_result = cfg_select! {
-               target_env = "ohos" => {ohos_decoder::OhosImageDecoder::make_decoder(format, buffer) }
-               _ => { decoding::DefaultImageDecoder::make_decoder(format, buffer) }
-            };
+    let image_decoder_result = cfg_select! {
+       target_env = "ohos" => {ohos_decoder::OhosImageDecoder::make_decoder(buffer) }
+       _ => { decoding::DefaultImageDecoder::make_decoder(buffer) }
+    };
 
-            let Ok(image_decoder) = image_decoder_result else {
-                return None;
-            };
+    let Ok(image_decoder) = image_decoder_result else {
+        return None;
+    };
 
-            if image_decoder.is_animated() {
-                decoding::decode_animated_image(cors_status, image_decoder.animated_decoder())
-            } else {
-                decoding::decode_static_image(cors_status, image_decoder.decoder())
-            }
-        },
-    }
-}
-
-// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img
-pub fn detect_image_format(buffer: &[u8]) -> Result<ImageFormat, &str> {
-    if is_gif(buffer) {
-        Ok(ImageFormat::Gif)
-    } else if is_jpeg(buffer) {
-        Ok(ImageFormat::Jpeg)
-    } else if is_png(buffer) {
-        Ok(ImageFormat::Png)
-    } else if is_webp(buffer) {
-        Ok(ImageFormat::WebP)
-    } else if is_bmp(buffer) {
-        Ok(ImageFormat::Bmp)
-    } else if is_ico(buffer) {
-        Ok(ImageFormat::Ico)
+    if image_decoder.is_animated() {
+        decoding::decode_animated_image(cors_status, image_decoder.animated_decoder())
     } else {
-        Err("Image Format Not Supported")
+        decoding::decode_static_image(cors_status, image_decoder.decoder())
     }
 }
 
@@ -674,68 +645,5 @@ pub fn generic_transform_inplace<
         if CLEAR_ALPHA {
             rgba[3] = u8::MAX;
         }
-    }
-}
-
-fn is_gif(buffer: &[u8]) -> bool {
-    buffer.starts_with(b"GIF87a") || buffer.starts_with(b"GIF89a")
-}
-
-fn is_jpeg(buffer: &[u8]) -> bool {
-    buffer.starts_with(&[0xff, 0xd8, 0xff])
-}
-
-fn is_png(buffer: &[u8]) -> bool {
-    buffer.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
-}
-
-fn is_bmp(buffer: &[u8]) -> bool {
-    buffer.starts_with(&[0x42, 0x4D])
-}
-
-fn is_ico(buffer: &[u8]) -> bool {
-    buffer.starts_with(&[0x00, 0x00, 0x01, 0x00])
-}
-
-fn is_webp(buffer: &[u8]) -> bool {
-    // https://developers.google.com/speed/webp/docs/riff_container
-    // First four bytes: `RIFF`, header size 12 bytes
-    if !buffer.starts_with(b"RIFF") || buffer.len() < 12 {
-        return false;
-    }
-    let size: [u8; 4] = [buffer[4], buffer[5], buffer[6], buffer[7]];
-    // Bytes 4..8 are a little endian u32 indicating
-    // > The size of the file in bytes, starting at offset 8.
-    // > The maximum value of this field is 2^32 minus 10 bytes and thus the size
-    // > of the whole file is at most 4 GiB minus 2 bytes.
-    let len: usize = u32::from_le_bytes(size) as usize;
-    buffer[8..].len() >= len && &buffer[8..12] == b"WEBP"
-}
-
-#[cfg(test)]
-mod test {
-    use super::detect_image_format;
-
-    #[test]
-    fn test_supported_images() {
-        let gif1 = [b'G', b'I', b'F', b'8', b'7', b'a'];
-        let gif2 = [b'G', b'I', b'F', b'8', b'9', b'a'];
-        let jpeg = [0xff, 0xd8, 0xff];
-        let png = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
-        let webp = [
-            b'R', b'I', b'F', b'F', 0x04, 0x00, 0x00, 0x00, b'W', b'E', b'B', b'P',
-        ];
-        let bmp = [0x42, 0x4D];
-        let ico = [0x00, 0x00, 0x01, 0x00];
-        let junk_format = [0x01, 0x02, 0x03, 0x04, 0x05];
-
-        assert!(detect_image_format(&gif1).is_ok());
-        assert!(detect_image_format(&gif2).is_ok());
-        assert!(detect_image_format(&jpeg).is_ok());
-        assert!(detect_image_format(&png).is_ok());
-        assert!(detect_image_format(&webp).is_ok());
-        assert!(detect_image_format(&bmp).is_ok());
-        assert!(detect_image_format(&ico).is_ok());
-        assert!(detect_image_format(&junk_format).is_err());
     }
 }

--- a/components/pixels/ohos_decoder.rs
+++ b/components/pixels/ohos_decoder.rs
@@ -1,0 +1,291 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::vec::IntoIter;
+use std::{fmt, mem, ptr};
+
+use image::error::{ImageFormatHint, UnsupportedError};
+use image::{
+    AnimationDecoder, Frame, Frames, ImageBuffer, ImageDecoder, ImageError, ImageFormat,
+    ImageResult, Pixel, RgbaImage,
+};
+use ohos_image_kit_sys::native_image::common::ImageResult as OhosImageResult;
+use ohos_image_kit_sys::native_image::image_source::{
+    OH_DecodingOptions, OH_DecodingOptions_Create, OH_DecodingOptions_Release,
+    OH_DecodingOptions_SetPixelFormat, OH_ImageSource_Info, OH_ImageSourceInfo_Create,
+    OH_ImageSourceInfo_GetHeight, OH_ImageSourceInfo_GetWidth, OH_ImageSourceInfo_Release,
+    OH_ImageSourceNative, OH_ImageSourceNative_CreateFromDataWithUserBuffer,
+    OH_ImageSourceNative_CreatePixelmap, OH_ImageSourceNative_CreatePixelmapList,
+    OH_ImageSourceNative_GetFrameCount, OH_ImageSourceNative_GetImageInfo,
+    OH_ImageSourceNative_Release,
+};
+use ohos_image_kit_sys::native_image::pixelmap::{
+    OH_PixelmapNative, OH_PixelmapNative_GetByteCount, OH_PixelmapNative_ReadPixels,
+    OH_PixelmapNative_Release, PIXEL_FORMAT,
+};
+
+use crate::decoding::ServoImageDecoder;
+
+pub(crate) struct OhosImageDecoder<'a> {
+    format: ImageFormat,
+    /// The data needs to be alive according to documentation on `OH_ImageSourceNative_CreateFromDataWithUserBuffer`.
+    _data: &'a [u8],
+    image_source: *mut OH_ImageSourceNative,
+    decoding_option: *mut OH_DecodingOptions,
+    image_info: *mut OH_ImageSource_Info,
+}
+
+impl<'a> std::fmt::Debug for OhosImageDecoder<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OhosImageDecoder").finish()
+    }
+}
+
+impl<'a> OhosImageDecoder<'a> {
+    fn new(format: ImageFormat, data: &'a [u8]) -> Result<Self, ()> {
+        unsafe {
+            /// Use OH_ImageSourceNative_GetSupportedFormats to ask for which mimetypes are ok.
+            let mut image_source_native = ptr::null_mut();
+            let res = OH_ImageSourceNative_CreateFromDataWithUserBuffer(
+                data.as_ptr().cast_mut(),
+                data.len(),
+                &raw mut image_source_native,
+            );
+            if res != OhosImageResult::SUCCESS || image_source_native.is_null() {
+                log::error!("Something wrong with CreateFromData");
+                return Err(());
+            }
+            let mut decoding_options = ptr::null_mut();
+            let res = OH_DecodingOptions_Create(&raw mut decoding_options);
+            OH_DecodingOptions_SetPixelFormat(
+                decoding_options,
+                PIXEL_FORMAT::PIXEL_FORMAT_RGBA_8888.0 as i32,
+            );
+            if res != OhosImageResult::SUCCESS || decoding_options.is_null() {
+                log::error!("Something wrong with doing decoding options");
+                todo!("Cleanup imagesourcneative");
+                return Err(());
+            }
+
+            let mut image_info = ptr::null_mut();
+            let res = OH_ImageSourceInfo_Create(&raw mut image_info);
+            if res != OhosImageResult::SUCCESS || image_info.is_null() {
+                log::error!("Could not get image info");
+                todo!("Cleanup imagesourcenative and decodingoptions");
+                return Err(());
+            }
+
+            if OH_ImageSourceNative_GetImageInfo(image_source_native, 0, image_info) !=
+                OhosImageResult::SUCCESS
+            {
+                log::error!("Could not populate image info");
+                todo!("cleanup imagesourcenative, decodingoption and imagesourceinfo");
+                return Err(());
+            }
+
+            Ok(OhosImageDecoder {
+                format,
+                _data: data,
+                image_source: image_source_native,
+                decoding_option: decoding_options,
+                image_info,
+            })
+        }
+    }
+}
+
+impl<'a> Drop for OhosImageDecoder<'a> {
+    fn drop(&mut self) {
+        unsafe {
+            if OH_DecodingOptions_Release(self.decoding_option) != OhosImageResult::SUCCESS {
+                log::error!("Cleaning up of decoding options failed");
+            }
+            if OH_ImageSourceNative_Release(self.image_source) != OhosImageResult::SUCCESS {
+                log::error!("Cleaning up of ImageSourceNative failed");
+            }
+            if OH_ImageSourceInfo_Release(self.image_info) != OhosImageResult::SUCCESS {
+                log::error!("Cleaning up of ImageSourceInfo failed");
+            }
+        }
+    }
+}
+
+impl<'a> ImageDecoder for OhosImageDecoder<'a> {
+    fn dimensions(&self) -> (u32, u32) {
+        unsafe {
+            let mut width = 20;
+            if OH_ImageSourceInfo_GetWidth(self.image_info, &raw mut width) !=
+                OhosImageResult::SUCCESS
+            {
+                log::error!("Could not get width");
+            }
+            let mut height = 20;
+            if OH_ImageSourceInfo_GetHeight(self.image_info, &raw mut height) !=
+                OhosImageResult::SUCCESS
+            {
+                log::error!("Could not get height");
+            }
+            (width, height)
+        }
+    }
+
+    fn color_type(&self) -> image::ColorType {
+        // Fixed by setup
+        image::ColorType::Rgba8
+    }
+
+    fn read_image(self, buf: &mut [u8]) -> ImageResult<()>
+    where
+        Self: Sized,
+    {
+        unsafe {
+            let mut pixmap = ptr::null_mut();
+            let res = OH_ImageSourceNative_CreatePixelmap(
+                self.image_source,
+                self.decoding_option,
+                &raw mut pixmap,
+            );
+            if res != OhosImageResult::SUCCESS || pixmap.is_null() {
+                log::error!("Could not create pixmap");
+                return Err(ImageError::Unsupported(
+                    ImageFormatHint::Exact(self.format).into(),
+                ));
+            }
+
+            if write_pixmap_to_buffer(pixmap, buf).is_err() {
+                log::error!("Could not decode pixmap");
+                return Err(ImageError::Unsupported(
+                    ImageFormatHint::Exact(self.format).into(),
+                ));
+            }
+
+            if OH_PixelmapNative_Release(pixmap) != OhosImageResult::SUCCESS {
+                log::error!("Could not release pixmap");
+            }
+        }
+        Ok(())
+    }
+
+    fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
+        self.read_image(buf)
+    }
+}
+
+/// We will only write as much data as the pixmap is given.
+/// SAFETY:
+/// The caller is responsible for having the buffer be large enough.
+unsafe fn write_pixmap_to_buffer(
+    pixmap: *mut OH_PixelmapNative,
+    buffer: &mut [u8],
+) -> Result<(), ()> {
+    unsafe {
+        let mut buffer_size = 0;
+        if OH_PixelmapNative_GetByteCount(pixmap, &raw mut buffer_size) != OhosImageResult::SUCCESS
+        {
+            log::error!("Could not get byte count");
+            return Err(());
+        }
+
+        if OH_PixelmapNative_ReadPixels(
+            pixmap,
+            buffer.as_mut_ptr(),
+            &raw mut buffer_size as *mut usize,
+        ) != OhosImageResult::SUCCESS
+        {
+            log::error!("Could not read pixels from pixmap");
+            return Err(());
+        }
+    }
+    Ok(())
+}
+
+impl<'a> ServoImageDecoder<'a> for OhosImageDecoder<'a> {
+    fn make_decoder(format: ImageFormat, buffer: &'a [u8]) -> ImageResult<Self> {
+        OhosImageDecoder::new(format, buffer)
+            .map_err(|_| ImageError::Unsupported(ImageFormatHint::Exact(format).into()))
+    }
+
+    fn is_animated(&self) -> bool {
+        let mut frame_count = 0;
+        unsafe {
+            if OH_ImageSourceNative_GetFrameCount(self.image_source, &mut frame_count) !=
+                OhosImageResult::SUCCESS
+            {
+                log::error!("Frame call failed. Just going to abort");
+                return false;
+            }
+        }
+        frame_count > 1
+    }
+
+    fn decoder(self) -> impl ImageDecoder {
+        self
+    }
+
+    fn animated_decoder(self) -> impl AnimationDecoder<'a> {
+        self
+    }
+}
+
+struct OhosAnimationIterator {
+    inner_iterator: IntoIter<*mut OH_PixelmapNative>,
+    width: u32,
+    height: u32,
+}
+
+impl Iterator for OhosAnimationIterator {
+    type Item = ImageResult<Frame>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let Some(next_frame) = self.inner_iterator.next() else {
+            return None;
+        };
+
+        let mut buffer = vec![0_u8; 4 * (self.width * self.height) as usize];
+        unsafe {
+            if write_pixmap_to_buffer(next_frame, &mut buffer).is_err() {
+                log::error!("ERROR IN DOING BUFFER :(");
+            }
+        };
+
+        let Some(rgba_image) = RgbaImage::from_raw(self.width, self.height, buffer) else {
+            log::error!("failed, aborting");
+            return None;
+        };
+        Some(Ok(Frame::new(rgba_image)))
+    }
+}
+
+impl<'a> AnimationDecoder<'a> for OhosImageDecoder<'a> {
+    fn into_frames(self) -> image::Frames<'a> {
+        unsafe {
+            let (width, height) = self.dimensions();
+            let mut frame_count = 0;
+            if OH_ImageSourceNative_GetFrameCount(self.image_source, &mut frame_count) !=
+                OhosImageResult::SUCCESS
+            {
+                log::error!("Could not get frame count");
+            }
+            let mut result_pixmap_vector = vec![ptr::null_mut(); frame_count as usize];
+            let result_pixmap_ptr = result_pixmap_vector.as_mut_ptr();
+            if OH_ImageSourceNative_CreatePixelmapList(
+                self.image_source,
+                self.decoding_option,
+                result_pixmap_ptr,
+                frame_count as usize,
+            ) != OhosImageResult::SUCCESS
+            {
+                log::error!("Something wrong with pixmap vector thingy");
+            }
+
+            let frame_iterator = Box::new(OhosAnimationIterator {
+                inner_iterator: result_pixmap_vector.into_iter(),
+                width,
+                height,
+            });
+
+            Frames::new(frame_iterator)
+        }
+    }
+}

--- a/components/pixels/ohos_decoder.rs
+++ b/components/pixels/ohos_decoder.rs
@@ -3,13 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::vec::IntoIter;
-use std::{fmt, mem, ptr};
+use std::{fmt, ptr};
 
-use image::error::{ImageFormatHint, UnsupportedError};
-use image::{
-    AnimationDecoder, Frame, Frames, ImageBuffer, ImageDecoder, ImageError, ImageFormat,
-    ImageResult, Pixel, RgbaImage,
-};
+use image::error::ImageFormatHint;
+use image::{AnimationDecoder, Frame, Frames, ImageDecoder, ImageError, ImageResult, RgbaImage};
 use ohos_image_kit_sys::native_image::common::ImageResult as OhosImageResult;
 use ohos_image_kit_sys::native_image::image_source::{
     OH_DecodingOptions, OH_DecodingOptions_Create, OH_DecodingOptions_Release,
@@ -28,7 +25,6 @@ use ohos_image_kit_sys::native_image::pixelmap::{
 use crate::decoding::ServoImageDecoder;
 
 pub(crate) struct OhosImageDecoder<'a> {
-    format: ImageFormat,
     /// The data needs to be alive according to documentation on `OH_ImageSourceNative_CreateFromDataWithUserBuffer`.
     _data: &'a [u8],
     image_source: *mut OH_ImageSourceNative,
@@ -45,7 +41,6 @@ impl<'a> std::fmt::Debug for OhosImageDecoder<'a> {
 impl<'a> OhosImageDecoder<'a> {
     fn new(data: &'a [u8]) -> Result<Self, ()> {
         unsafe {
-            /// Use OH_ImageSourceNative_GetSupportedFormats to ask for which mimetypes are ok.
             let mut image_source_native = ptr::null_mut();
             let res = OH_ImageSourceNative_CreateFromDataWithUserBuffer(
                 data.as_ptr().cast_mut(),
@@ -64,7 +59,7 @@ impl<'a> OhosImageDecoder<'a> {
             );
             if res != OhosImageResult::SUCCESS || decoding_options.is_null() {
                 log::error!("Something wrong with doing decoding options");
-                todo!("Cleanup imagesourcneative");
+                OH_ImageSourceNative_Release(image_source_native);
                 return Err(());
             }
 
@@ -72,7 +67,8 @@ impl<'a> OhosImageDecoder<'a> {
             let res = OH_ImageSourceInfo_Create(&raw mut image_info);
             if res != OhosImageResult::SUCCESS || image_info.is_null() {
                 log::error!("Could not get image info");
-                todo!("Cleanup imagesourcenative and decodingoptions");
+                OH_DecodingOptions_Release(decoding_options);
+                OH_ImageSourceNative_Release(image_source_native);
                 return Err(());
             }
 
@@ -80,12 +76,13 @@ impl<'a> OhosImageDecoder<'a> {
                 OhosImageResult::SUCCESS
             {
                 log::error!("Could not populate image info");
-                todo!("cleanup imagesourcenative, decodingoption and imagesourceinfo");
+                OH_ImageSourceInfo_Release(image_info);
+                OH_DecodingOptions_Release(decoding_options);
+                OH_ImageSourceNative_Release(image_source_native);
                 return Err(());
             }
 
             Ok(OhosImageDecoder {
-                format,
                 _data: data,
                 image_source: image_source_native,
                 decoding_option: decoding_options,
@@ -148,16 +145,12 @@ impl<'a> ImageDecoder for OhosImageDecoder<'a> {
             );
             if res != OhosImageResult::SUCCESS || pixmap.is_null() {
                 log::error!("Could not create pixmap");
-                return Err(ImageError::Unsupported(
-                    ImageFormatHint::Exact(self.format).into(),
-                ));
+                return Err(ImageError::Unsupported(ImageFormatHint::Unknown.into()));
             }
 
             if write_pixmap_to_buffer(pixmap, buf).is_err() {
                 log::error!("Could not decode pixmap");
-                return Err(ImageError::Unsupported(
-                    ImageFormatHint::Exact(self.format).into(),
-                ));
+                return Err(ImageError::Unsupported(ImageFormatHint::Unknown.into()));
             }
 
             if OH_PixelmapNative_Release(pixmap) != OhosImageResult::SUCCESS {
@@ -201,9 +194,9 @@ unsafe fn write_pixmap_to_buffer(
 }
 
 impl<'a> ServoImageDecoder<'a> for OhosImageDecoder<'a> {
-    fn make_decoder(format: ImageFormat, buffer: &'a [u8]) -> ImageResult<Self> {
-        OhosImageDecoder::new(format, buffer)
-            .map_err(|_| ImageError::Unsupported(ImageFormatHint::Exact(format).into()))
+    fn make_decoder(buffer: &'a [u8]) -> ImageResult<Self> {
+        OhosImageDecoder::new(buffer)
+            .map_err(|_| ImageError::Unsupported(ImageFormatHint::Unknown.into()))
     }
 
     fn is_animated(&self) -> bool {
@@ -228,6 +221,18 @@ impl<'a> ServoImageDecoder<'a> for OhosImageDecoder<'a> {
     }
 }
 
+/// Wrapper struct for the ptr.
+/// We need to be careful to release all *mut OH_PixelmapNative that are not zero.
+struct OHPixelmapNative(*mut OH_PixelmapNative);
+
+impl Drop for OHPixelmapNative {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe { OH_PixelmapNative_Release(self.0) };
+        }
+    }
+}
+
 struct OhosAnimationIterator {
     inner_iterator: IntoIter<*mut OH_PixelmapNative>,
     width: u32,
@@ -238,14 +243,12 @@ impl Iterator for OhosAnimationIterator {
     type Item = ImageResult<Frame>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let Some(next_frame) = self.inner_iterator.next() else {
-            return None;
-        };
+        let next_frame = self.inner_iterator.next().map(OHPixelmapNative)?;
 
         let mut buffer = vec![0_u8; 4 * (self.width * self.height) as usize];
         unsafe {
-            if write_pixmap_to_buffer(next_frame, &mut buffer).is_err() {
-                log::error!("ERROR IN DOING BUFFER :(");
+            if write_pixmap_to_buffer(next_frame.0, &mut buffer).is_err() {
+                log::error!("Could not write pixmap buffer")
             }
         };
 
@@ -276,7 +279,7 @@ impl<'a> AnimationDecoder<'a> for OhosImageDecoder<'a> {
                 frame_count as usize,
             ) != OhosImageResult::SUCCESS
             {
-                log::error!("Something wrong with pixmap vector thingy");
+                log::error!("Something wrong with creating pixmap list");
             }
 
             let frame_iterator = Box::new(OhosAnimationIterator {

--- a/components/pixels/ohos_decoder.rs
+++ b/components/pixels/ohos_decoder.rs
@@ -2,12 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::num::NonZeroU32;
 use std::vec::IntoIter;
-use std::{fmt, ptr};
+use std::{fmt, ptr, slice};
 
 use image::error::ImageFormatHint;
+use image::metadata::LoopCount;
 use image::{AnimationDecoder, Frame, Frames, ImageDecoder, ImageError, ImageResult, RgbaImage};
-use ohos_image_kit_sys::native_image::common::ImageResult as OhosImageResult;
+use ohos_image_kit_sys::native_image::common::{Image_String, ImageResult as OhosImageResult};
 use ohos_image_kit_sys::native_image::image_source::{
     OH_DecodingOptions, OH_DecodingOptions_Create, OH_DecodingOptions_Release,
     OH_DecodingOptions_SetPixelFormat, OH_ImageSource_Info, OH_ImageSourceInfo_Create,
@@ -15,7 +17,7 @@ use ohos_image_kit_sys::native_image::image_source::{
     OH_ImageSourceNative, OH_ImageSourceNative_CreateFromDataWithUserBuffer,
     OH_ImageSourceNative_CreatePixelmap, OH_ImageSourceNative_CreatePixelmapList,
     OH_ImageSourceNative_GetFrameCount, OH_ImageSourceNative_GetImageInfo,
-    OH_ImageSourceNative_Release,
+    OH_ImageSourceNative_GetImageProperty, OH_ImageSourceNative_Release,
 };
 use ohos_image_kit_sys::native_image::pixelmap::{
     OH_PixelmapNative, OH_PixelmapNative_GetByteCount, OH_PixelmapNative_ReadPixels,
@@ -289,6 +291,45 @@ impl<'a> AnimationDecoder<'a> for OhosImageDecoder<'a> {
             });
 
             Frames::new(frame_iterator)
+        }
+    }
+
+    fn loop_count(&self) -> image::metadata::LoopCount {
+        let mut loop_count_str = "LoopCount".to_owned();
+        let mut image_string = Image_String {
+            data: loop_count_str.as_mut_ptr(),
+            size: loop_count_str.len(),
+        };
+
+        let mut image_string_target = Image_String {
+            data: ptr::null_mut(),
+            size: 0,
+        };
+
+        let slice = unsafe {
+            if OH_ImageSourceNative_GetImageProperty(
+                self.image_source,
+                &raw mut image_string,
+                &raw mut image_string_target,
+            ) != OhosImageResult::SUCCESS ||
+                image_string_target.data.is_null()
+            {
+                log::info!("Could not decode loop count");
+                return LoopCount::Finite(NonZeroU32::new(1).unwrap());
+            }
+
+            slice::from_raw_parts(image_string_target.data, image_string_target.size)
+        };
+        let string = String::from_utf8_lossy(slice);
+        log::error!("STRING FOUND {:?}", string);
+        if let Ok(loop_count) = string.parse::<u32>() {
+            if loop_count == 0 {
+                LoopCount::Infinite
+            } else {
+                LoopCount::Finite(NonZeroU32::new(loop_count).unwrap())
+            }
+        } else {
+            LoopCount::Finite(NonZeroU32::new(1).unwrap())
         }
     }
 }

--- a/components/pixels/ohos_decoder.rs
+++ b/components/pixels/ohos_decoder.rs
@@ -43,7 +43,7 @@ impl<'a> std::fmt::Debug for OhosImageDecoder<'a> {
 }
 
 impl<'a> OhosImageDecoder<'a> {
-    fn new(format: ImageFormat, data: &'a [u8]) -> Result<Self, ()> {
+    fn new(data: &'a [u8]) -> Result<Self, ()> {
         unsafe {
             /// Use OH_ImageSourceNative_GetSupportedFormats to ask for which mimetypes are ok.
             let mut image_source_native = ptr::null_mut();

--- a/ports/servoshell/egl/ohos/mod.rs
+++ b/ports/servoshell/egl/ohos/mod.rs
@@ -786,7 +786,6 @@ static LOGGER: LazyLock<hilog::Logger> = LazyLock::new(|| {
     let mut builder = hilog::Builder::new();
     builder.set_domain(hilog::LogDomain::new(0xE0C3));
     let filters = [
-        "fonts",
         "servo",
         "servoshell",
         "servoshell::egl:gl_glue",

--- a/ports/servoshell/egl/ohos/mod.rs
+++ b/ports/servoshell/egl/ohos/mod.rs
@@ -791,7 +791,6 @@ static LOGGER: LazyLock<hilog::Logger> = LazyLock::new(|| {
     let mut builder = hilog::Builder::new();
     builder.set_domain(hilog::LogDomain::new(0xE0C3));
     let filters = [
-        "fonts",
         "servo",
         "servoshell",
         "servoshell::egl:gl_glue",


### PR DESCRIPTION
This implements the decoding part of images using OHOS system libraries. We slightly modify the trait to not include the image format. Ohos Decoder does not need to know the format before decoding. Additionally, image-rs has a way internally to detect the format, removing a bunch off code.

This does not mean that we do not need the system crate (or the decoders). In the future we are going to implement a similar Encoding trait (needed in Snapshots).

Testing: Tested locally on device and non-ohos platforms can be tested with WPT.
