### PR TITLE
script: init `WorkletThreadPool` in `Window`

### DIFF
--- a/components/script/dom/testing/testworklet.rs
+++ b/components/script/dom/testing/testworklet.rs
@@ -42,13 +42,13 @@ impl TestWorklet {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<TestWorklet> {
-        let worklet_thread_pool = Rc::new(WorkletThreadPool::spawn(window.into()));
+        let worklet_thread_pool = window.into();
 
         let worklet = Worklet::new(
             cx,
             window,
             WorkletGlobalScopeType::Test,
-            Box::new(|| worklet_thread_pool),
+            Box::new(|| Rc::new(WorkletThreadPool::spawn(worklet_thread_pool))),
         );
         reflect_dom_object_with_proto(
             cx,

--- a/components/script/dom/testing/testworklet.rs
+++ b/components/script/dom/testing/testworklet.rs
@@ -41,7 +41,12 @@ impl TestWorklet {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<TestWorklet> {
-        let worklet = Worklet::new(cx, window, WorkletGlobalScopeType::Test);
+        let worklet = Worklet::new(
+            cx,
+            window,
+            WorkletGlobalScopeType::Test,
+            window.init_worklet_thread_pool(),
+        );
         reflect_dom_object_with_proto(
             cx,
             Box::new(TestWorklet::new_inherited(&worklet)),
@@ -73,7 +78,8 @@ impl TestWorkletMethods<crate::DomTypeHolder> for TestWorklet {
         let id = self.worklet.worklet_id();
 
         self.worklet
-            .get_worklet_thread_pool()
+            .get_window()
+            .init_worklet_thread_pool()
             .test_worklet_lookup(id, String::from(key))
             .map(DOMString::from)
     }

--- a/components/script/dom/testing/testworklet.rs
+++ b/components/script/dom/testing/testworklet.rs
@@ -42,13 +42,12 @@ impl TestWorklet {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<TestWorklet> {
-        let worklet_thread_pool = window.into();
-
+        let worklet_global_scope_init = window.into();
         let worklet = Worklet::new(
             cx,
             window,
             WorkletGlobalScopeType::Test,
-            Box::new(|| Rc::new(WorkletThreadPool::spawn(worklet_thread_pool))),
+            Box::new(|| Rc::new(WorkletThreadPool::spawn(worklet_global_scope_init))),
         );
         reflect_dom_object_with_proto(
             cx,

--- a/components/script/dom/testing/testworklet.rs
+++ b/components/script/dom/testing/testworklet.rs
@@ -41,11 +41,13 @@ impl TestWorklet {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<TestWorklet> {
+        let worklet_thread_pool = window.init_worklet_thread_pool();
+
         let worklet = Worklet::new(
             cx,
             window,
             WorkletGlobalScopeType::Test,
-            window.init_worklet_thread_pool(),
+            Box::new(|| worklet_thread_pool),
         );
         reflect_dom_object_with_proto(
             cx,
@@ -78,8 +80,7 @@ impl TestWorkletMethods<crate::DomTypeHolder> for TestWorklet {
         let id = self.worklet.worklet_id();
 
         self.worklet
-            .get_window()
-            .init_worklet_thread_pool()
+            .get_worklet_thread_pool()
             .test_worklet_lookup(id, String::from(key))
             .map(DOMString::from)
     }

--- a/components/script/dom/testing/testworklet.rs
+++ b/components/script/dom/testing/testworklet.rs
@@ -11,6 +11,7 @@ use js::realm::CurrentRealm;
 use js::rust::HandleObject;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
+use crate::dom::WorkletThreadPool;
 use crate::dom::bindings::codegen::Bindings::TestWorkletBinding::TestWorkletMethods;
 use crate::dom::bindings::codegen::Bindings::WorkletBinding::Worklet_Binding::WorkletMethods;
 use crate::dom::bindings::codegen::Bindings::WorkletBinding::WorkletOptions;
@@ -41,7 +42,7 @@ impl TestWorklet {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<TestWorklet> {
-        let worklet_thread_pool = window.init_worklet_thread_pool();
+        let worklet_thread_pool = Rc::new(WorkletThreadPool::spawn(window.into()));
 
         let worklet = Worklet::new(
             cx,
@@ -80,7 +81,7 @@ impl TestWorkletMethods<crate::DomTypeHolder> for TestWorklet {
         let id = self.worklet.worklet_id();
 
         self.worklet
-            .get_worklet_thread_pool()
+            .worklet_thread_pool()
             .test_worklet_lookup(id, String::from(key))
             .map(DOMString::from)
     }

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -105,6 +105,7 @@ use time::Duration as TimeDuration;
 use webrender_api::ExternalScrollId;
 use webrender_api::units::{DeviceIntSize, DevicePixel, LayoutPixel, LayoutPoint};
 
+use crate::dom::WorkletThreadPool;
 use crate::dom::bindings::codegen::Bindings::AnimationFrameProviderBinding::FrameRequestCallback;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::{
     DocumentMethods, DocumentReadyState, NamedPropertyValue,
@@ -190,9 +191,8 @@ use crate::dom::window::screen::Screen;
 use crate::dom::window::scrolling_box::{ScrollingBox, ScrollingBoxSource};
 use crate::dom::window::useractivation::UserActivationTimestamp;
 use crate::dom::windowproxy::{WindowProxy, WindowProxyHandler};
-use crate::dom::WorkletThreadPool;
 use crate::dom::worklet::Worklet;
-use crate::dom::workletglobalscope::{WorkletGlobalScopeType};
+use crate::dom::workletglobalscope::WorkletGlobalScopeType;
 use crate::layout_image::fetch_image_for_layout;
 use crate::messaging::{MainThreadScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::microtask::UserMicrotask;

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -705,7 +705,6 @@ impl Window {
         debug!("Creating new paint worklet.");
 
         let worklet_global_scope_init = self.into();
-
         Worklet::new(
             cx,
             self,

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -192,7 +192,7 @@ use crate::dom::webgpu::identityhub::IdentityHub;
 use crate::dom::windowproxy::{WindowProxy, WindowProxyHandler};
 use crate::dom::WorkletThreadPool;
 use crate::dom::worklet::Worklet;
-use crate::dom::workletglobalscope::{WorkletGlobalScopeInit, WorkletGlobalScopeType};
+use crate::dom::workletglobalscope::{WorkletGlobalScopeType};
 use crate::layout_image::fetch_image_for_layout;
 use crate::messaging::{MainThreadScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::microtask::UserMicrotask;
@@ -707,48 +707,15 @@ impl Window {
 
     fn new_paint_worklet(&self, cx: &mut JSContext) -> DomRoot<Worklet> {
         debug!("Creating new paint worklet.");
-        let global = self.global();
 
-        let init = WorkletGlobalScopeInit {
-            to_script_thread_sender: self.main_thread_script_chan().clone(),
-            resource_threads: global.resource_threads().clone(),
-            storage_threads: global.storage_threads().clone(),
-            mem_profiler_chan: global.mem_profiler_chan().clone(),
-            time_profiler_chan: global.time_profiler_chan().clone(),
-            devtools_chan: global.devtools_chan().cloned(),
-            script_to_constellation_sender: global.script_to_constellation_chan().sender,
-            to_embedder_sender: global.script_to_embedder_chan().clone(),
-            image_cache: global.image_cache(),
-            #[cfg(feature = "webgpu")]
-            gpu_id_hub: global.wgpu_id_hub(),
-        };
+        let worklet_global_scope_init = self.into();
 
         Worklet::new(
             cx,
             self,
             WorkletGlobalScopeType::Paint,
-            Box::new(|| Rc::new(WorkletThreadPool::spawn(init))),
+            Box::new(|| Rc::new(WorkletThreadPool::spawn(worklet_global_scope_init))),
         )
-    }
-
-    pub(crate) fn init_worklet_thread_pool(&self) -> Rc<WorkletThreadPool> {
-        let global = self.global();
-
-        let init = WorkletGlobalScopeInit {
-            to_script_thread_sender: self.main_thread_script_chan().clone(),
-            resource_threads: global.resource_threads().clone(),
-            storage_threads: global.storage_threads().clone(),
-            mem_profiler_chan: global.mem_profiler_chan().clone(),
-            time_profiler_chan: global.time_profiler_chan().clone(),
-            devtools_chan: global.devtools_chan().cloned(),
-            script_to_constellation_sender: global.script_to_constellation_chan().sender,
-            to_embedder_sender: global.script_to_embedder_chan().clone(),
-            image_cache: global.image_cache(),
-            #[cfg(feature = "webgpu")]
-            gpu_id_hub: global.wgpu_id_hub(),
-        };
-
-        Rc::new(WorkletThreadPool::spawn(init))
     }
 
     pub(crate) fn register_image_cache_listener(

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -707,13 +707,27 @@ impl Window {
 
     fn new_paint_worklet(&self, cx: &mut JSContext) -> DomRoot<Worklet> {
         debug!("Creating new paint worklet.");
-        let worklet_thread_pool = self.init_worklet_thread_pool();
+        let global = self.global();
+
+        let init = WorkletGlobalScopeInit {
+            to_script_thread_sender: self.main_thread_script_chan().clone(),
+            resource_threads: global.resource_threads().clone(),
+            storage_threads: global.storage_threads().clone(),
+            mem_profiler_chan: global.mem_profiler_chan().clone(),
+            time_profiler_chan: global.time_profiler_chan().clone(),
+            devtools_chan: global.devtools_chan().cloned(),
+            script_to_constellation_sender: global.script_to_constellation_chan().sender,
+            to_embedder_sender: global.script_to_embedder_chan().clone(),
+            image_cache: global.image_cache(),
+            #[cfg(feature = "webgpu")]
+            gpu_id_hub: global.wgpu_id_hub(),
+        };
 
         Worklet::new(
             cx,
             self,
             WorkletGlobalScopeType::Paint,
-            Box::new(|| worklet_thread_pool),
+            Box::new(|| Rc::new(WorkletThreadPool::spawn(init))),
         )
     }
 

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -703,13 +703,27 @@ impl Window {
 
     fn new_paint_worklet(&self, cx: &mut JSContext) -> DomRoot<Worklet> {
         debug!("Creating new paint worklet.");
-        let worklet_thread_pool = self.init_worklet_thread_pool();
+        let global = self.global();
+
+        let init = WorkletGlobalScopeInit {
+            to_script_thread_sender: self.main_thread_script_chan().clone(),
+            resource_threads: global.resource_threads().clone(),
+            storage_threads: global.storage_threads().clone(),
+            mem_profiler_chan: global.mem_profiler_chan().clone(),
+            time_profiler_chan: global.time_profiler_chan().clone(),
+            devtools_chan: global.devtools_chan().cloned(),
+            script_to_constellation_sender: global.script_to_constellation_chan().sender,
+            to_embedder_sender: global.script_to_embedder_chan().clone(),
+            image_cache: global.image_cache(),
+            #[cfg(feature = "webgpu")]
+            gpu_id_hub: global.wgpu_id_hub(),
+        };
 
         Worklet::new(
             cx,
             self,
             WorkletGlobalScopeType::Paint,
-            Box::new(|| worklet_thread_pool),
+            Box::new(|| Rc::new(WorkletThreadPool::spawn(init))),
         )
     }
 

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -190,8 +190,9 @@ use crate::dom::visualviewport::{VisualViewport, VisualViewportChanges};
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::identityhub::IdentityHub;
 use crate::dom::windowproxy::{WindowProxy, WindowProxyHandler};
+use crate::dom::WorkletThreadPool;
 use crate::dom::worklet::Worklet;
-use crate::dom::workletglobalscope::WorkletGlobalScopeType;
+use crate::dom::workletglobalscope::{WorkletGlobalScopeInit, WorkletGlobalScopeType};
 use crate::layout_image::fetch_image_for_layout;
 use crate::messaging::{MainThreadScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::microtask::UserMicrotask;
@@ -706,7 +707,29 @@ impl Window {
 
     fn new_paint_worklet(&self, cx: &mut JSContext) -> DomRoot<Worklet> {
         debug!("Creating new paint worklet.");
-        Worklet::new(cx, self, WorkletGlobalScopeType::Paint)
+        let worklet_thread_pool = self.init_worklet_thread_pool();
+
+        Worklet::new(cx, self, WorkletGlobalScopeType::Paint, worklet_thread_pool)
+    }
+
+    pub(crate) fn init_worklet_thread_pool(&self) -> Rc<WorkletThreadPool> {
+        let global = self.global();
+
+        let init = WorkletGlobalScopeInit {
+            to_script_thread_sender: self.main_thread_script_chan().clone(),
+            resource_threads: global.resource_threads().clone(),
+            storage_threads: global.storage_threads().clone(),
+            mem_profiler_chan: global.mem_profiler_chan().clone(),
+            time_profiler_chan: global.time_profiler_chan().clone(),
+            devtools_chan: global.devtools_chan().cloned(),
+            script_to_constellation_sender: global.script_to_constellation_chan().sender,
+            to_embedder_sender: global.script_to_embedder_chan().clone(),
+            image_cache: global.image_cache(),
+            #[cfg(feature = "webgpu")]
+            gpu_id_hub: global.wgpu_id_hub(),
+        };
+
+        Rc::new(WorkletThreadPool::spawn(init))
     }
 
     pub(crate) fn register_image_cache_listener(

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -190,8 +190,9 @@ use crate::dom::window::screen::Screen;
 use crate::dom::window::scrolling_box::{ScrollingBox, ScrollingBoxSource};
 use crate::dom::window::useractivation::UserActivationTimestamp;
 use crate::dom::windowproxy::{WindowProxy, WindowProxyHandler};
+use crate::dom::WorkletThreadPool;
 use crate::dom::worklet::Worklet;
-use crate::dom::workletglobalscope::WorkletGlobalScopeType;
+use crate::dom::workletglobalscope::{WorkletGlobalScopeInit, WorkletGlobalScopeType};
 use crate::layout_image::fetch_image_for_layout;
 use crate::messaging::{MainThreadScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::microtask::UserMicrotask;
@@ -702,7 +703,29 @@ impl Window {
 
     fn new_paint_worklet(&self, cx: &mut JSContext) -> DomRoot<Worklet> {
         debug!("Creating new paint worklet.");
-        Worklet::new(cx, self, WorkletGlobalScopeType::Paint)
+        let worklet_thread_pool = self.init_worklet_thread_pool();
+
+        Worklet::new(cx, self, WorkletGlobalScopeType::Paint, worklet_thread_pool)
+    }
+
+    pub(crate) fn init_worklet_thread_pool(&self) -> Rc<WorkletThreadPool> {
+        let global = self.global();
+
+        let init = WorkletGlobalScopeInit {
+            to_script_thread_sender: self.main_thread_script_chan().clone(),
+            resource_threads: global.resource_threads().clone(),
+            storage_threads: global.storage_threads().clone(),
+            mem_profiler_chan: global.mem_profiler_chan().clone(),
+            time_profiler_chan: global.time_profiler_chan().clone(),
+            devtools_chan: global.devtools_chan().cloned(),
+            script_to_constellation_sender: global.script_to_constellation_chan().sender,
+            to_embedder_sender: global.script_to_embedder_chan().clone(),
+            image_cache: global.image_cache(),
+            #[cfg(feature = "webgpu")]
+            gpu_id_hub: global.wgpu_id_hub(),
+        };
+
+        Rc::new(WorkletThreadPool::spawn(init))
     }
 
     pub(crate) fn register_image_cache_listener(

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -705,7 +705,12 @@ impl Window {
         debug!("Creating new paint worklet.");
         let worklet_thread_pool = self.init_worklet_thread_pool();
 
-        Worklet::new(cx, self, WorkletGlobalScopeType::Paint, worklet_thread_pool)
+        Worklet::new(
+            cx,
+            self,
+            WorkletGlobalScopeType::Paint,
+            Box::new(|| worklet_thread_pool),
+        )
     }
 
     pub(crate) fn init_worklet_thread_pool(&self) -> Rc<WorkletThreadPool> {

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -709,7 +709,6 @@ impl Window {
         debug!("Creating new paint worklet.");
 
         let worklet_global_scope_init = self.into();
-
         Worklet::new(
             cx,
             self,

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -105,6 +105,7 @@ use time::Duration as TimeDuration;
 use webrender_api::ExternalScrollId;
 use webrender_api::units::{DeviceIntSize, DevicePixel, LayoutPixel, LayoutPoint};
 
+use crate::dom::WorkletThreadPool;
 use crate::dom::bindings::codegen::Bindings::AnimationFrameProviderBinding::FrameRequestCallback;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::{
     DocumentMethods, DocumentReadyState, NamedPropertyValue,
@@ -190,9 +191,8 @@ use crate::dom::visualviewport::{VisualViewport, VisualViewportChanges};
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::identityhub::IdentityHub;
 use crate::dom::windowproxy::{WindowProxy, WindowProxyHandler};
-use crate::dom::WorkletThreadPool;
 use crate::dom::worklet::Worklet;
-use crate::dom::workletglobalscope::{WorkletGlobalScopeType};
+use crate::dom::workletglobalscope::WorkletGlobalScopeType;
 use crate::layout_image::fetch_image_for_layout;
 use crate::messaging::{MainThreadScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::microtask::UserMicrotask;

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -192,7 +192,7 @@ use crate::dom::window::useractivation::UserActivationTimestamp;
 use crate::dom::windowproxy::{WindowProxy, WindowProxyHandler};
 use crate::dom::WorkletThreadPool;
 use crate::dom::worklet::Worklet;
-use crate::dom::workletglobalscope::{WorkletGlobalScopeInit, WorkletGlobalScopeType};
+use crate::dom::workletglobalscope::{WorkletGlobalScopeType};
 use crate::layout_image::fetch_image_for_layout;
 use crate::messaging::{MainThreadScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::microtask::UserMicrotask;
@@ -703,48 +703,15 @@ impl Window {
 
     fn new_paint_worklet(&self, cx: &mut JSContext) -> DomRoot<Worklet> {
         debug!("Creating new paint worklet.");
-        let global = self.global();
 
-        let init = WorkletGlobalScopeInit {
-            to_script_thread_sender: self.main_thread_script_chan().clone(),
-            resource_threads: global.resource_threads().clone(),
-            storage_threads: global.storage_threads().clone(),
-            mem_profiler_chan: global.mem_profiler_chan().clone(),
-            time_profiler_chan: global.time_profiler_chan().clone(),
-            devtools_chan: global.devtools_chan().cloned(),
-            script_to_constellation_sender: global.script_to_constellation_chan().sender,
-            to_embedder_sender: global.script_to_embedder_chan().clone(),
-            image_cache: global.image_cache(),
-            #[cfg(feature = "webgpu")]
-            gpu_id_hub: global.wgpu_id_hub(),
-        };
+        let worklet_global_scope_init = self.into();
 
         Worklet::new(
             cx,
             self,
             WorkletGlobalScopeType::Paint,
-            Box::new(|| Rc::new(WorkletThreadPool::spawn(init))),
+            Box::new(|| Rc::new(WorkletThreadPool::spawn(worklet_global_scope_init))),
         )
-    }
-
-    pub(crate) fn init_worklet_thread_pool(&self) -> Rc<WorkletThreadPool> {
-        let global = self.global();
-
-        let init = WorkletGlobalScopeInit {
-            to_script_thread_sender: self.main_thread_script_chan().clone(),
-            resource_threads: global.resource_threads().clone(),
-            storage_threads: global.storage_threads().clone(),
-            mem_profiler_chan: global.mem_profiler_chan().clone(),
-            time_profiler_chan: global.time_profiler_chan().clone(),
-            devtools_chan: global.devtools_chan().cloned(),
-            script_to_constellation_sender: global.script_to_constellation_chan().sender,
-            to_embedder_sender: global.script_to_embedder_chan().clone(),
-            image_cache: global.image_cache(),
-            #[cfg(feature = "webgpu")]
-            gpu_id_hub: global.wgpu_id_hub(),
-        };
-
-        Rc::new(WorkletThreadPool::spawn(init))
     }
 
     pub(crate) fn register_image_cache_listener(

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -709,7 +709,12 @@ impl Window {
         debug!("Creating new paint worklet.");
         let worklet_thread_pool = self.init_worklet_thread_pool();
 
-        Worklet::new(cx, self, WorkletGlobalScopeType::Paint, worklet_thread_pool)
+        Worklet::new(
+            cx,
+            self,
+            WorkletGlobalScopeType::Paint,
+            Box::new(|| worklet_thread_pool),
+        )
     }
 
     pub(crate) fn init_worklet_thread_pool(&self) -> Rc<WorkletThreadPool> {

--- a/components/script/dom/worklet/worklet.rs
+++ b/components/script/dom/worklet/worklet.rs
@@ -42,7 +42,6 @@ use crate::dom::bindings::codegen::Bindings::WorkletBinding::{WorkletMethods, Wo
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::TrustedPromise;
-use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
 use crate::dom::bindings::trace::{CustomTraceable, JSTraceable, RootedTraceableBox};
@@ -94,14 +93,21 @@ pub(crate) struct Worklet {
 }
 
 impl Worklet {
-    fn new_inherited(window: &Window, global_type: WorkletGlobalScopeType) -> Worklet {
+    fn new_inherited(
+        window: &Window,
+        global_type: WorkletGlobalScopeType,
+        thread_pool: Rc<WorkletThreadPool>,
+    ) -> Worklet {
+        let thread_pool_cell = OnceCell::new();
+        thread_pool_cell.get_or_init(|| thread_pool);
+
         Worklet {
             reflector: Reflector::new(),
             window: Dom::from_ref(window),
             global_type,
             droppable_field: DroppableField {
                 worklet_id: WorkletId::new(),
-                thread_pool: OnceCell::new(),
+                thread_pool: thread_pool_cell,
             },
         }
     }
@@ -110,13 +116,18 @@ impl Worklet {
         cx: &mut JSContext,
         window: &Window,
         global_type: WorkletGlobalScopeType,
+        thread_pool: Rc<WorkletThreadPool>,
     ) -> DomRoot<Worklet> {
         debug!("Creating worklet {:?}.", global_type);
         reflect_dom_object_with_cx(
-            Box::new(Worklet::new_inherited(window, global_type)),
+            Box::new(Worklet::new_inherited(window, global_type, thread_pool)),
             window,
             cx,
         )
+    }
+
+    pub(crate) fn get_window(&self) -> &Dom<Window> {
+        &self.window
     }
 
     #[cfg(feature = "testbinding")]
@@ -127,28 +138,6 @@ impl Worklet {
     #[expect(dead_code)]
     pub(crate) fn worklet_global_scope_type(&self) -> WorkletGlobalScopeType {
         self.global_type
-    }
-
-    pub(crate) fn get_worklet_thread_pool(&self) -> &Rc<WorkletThreadPool> {
-        let global = self.window.global();
-
-        let init = WorkletGlobalScopeInit {
-            to_script_thread_sender: self.window.main_thread_script_chan().clone(),
-            resource_threads: global.resource_threads().clone(),
-            storage_threads: global.storage_threads().clone(),
-            mem_profiler_chan: global.mem_profiler_chan().clone(),
-            time_profiler_chan: global.time_profiler_chan().clone(),
-            devtools_chan: global.devtools_chan().cloned(),
-            script_to_constellation_sender: global.script_to_constellation_chan().sender,
-            to_embedder_sender: global.script_to_embedder_chan().clone(),
-            image_cache: global.image_cache(),
-            #[cfg(feature = "webgpu")]
-            gpu_id_hub: global.wgpu_id_hub(),
-        };
-
-        self.droppable_field
-            .thread_pool
-            .get_or_init(|| Rc::new(WorkletThreadPool::spawn(init)))
     }
 }
 
@@ -193,20 +182,26 @@ impl WorkletMethods<crate::DomTypeHolder> for Worklet {
         // NOTE: We skip step 6.3 because we do not implement the `added modules list` yet
         // <https://html.spec.whatwg.org/multipage/#concept-worklet-added-modules-list>
 
-        self.get_worklet_thread_pool()
-            .fetch_and_invoke_a_worklet_script(
-                self.window.pipeline_id(),
-                self.droppable_field.worklet_id,
-                self.global_type,
-                self.window.origin().immutable().clone(),
-                global_scope.api_base_url(),
-                module_url_record,
-                global_scope.policy_container(),
-                options.credentials,
-                pending_tasks_struct,
-                &promise,
-                global_scope.inherited_secure_context(),
-            );
+        match self.droppable_field.thread_pool.get() {
+            Some(thread_pool) => {
+                thread_pool.fetch_and_invoke_a_worklet_script(
+                    self.window.pipeline_id(),
+                    self.droppable_field.worklet_id,
+                    self.global_type,
+                    self.window.origin().immutable().clone(),
+                    global_scope.api_base_url(),
+                    module_url_record,
+                    global_scope.policy_container(),
+                    options.credentials,
+                    pending_tasks_struct,
+                    &promise,
+                    global_scope.inherited_secure_context(),
+                );
+            },
+            None => {
+                // TODO: throw an exception?
+            },
+        }
 
         // Step 7. Return promise
         debug!("Returning promise.");

--- a/components/script/dom/worklet/worklet.rs
+++ b/components/script/dom/worklet/worklet.rs
@@ -79,7 +79,9 @@ struct DroppableField {
 impl Drop for DroppableField {
     fn drop(&mut self) {
         let worklet_id = self.worklet_id;
-        self.thread_pool.exit_worklet(worklet_id);
+        if let Some(thread_pool) = LazyCell::get(&self.thread_pool) {
+            thread_pool.exit_worklet(worklet_id);
+        }
     }
 }
 
@@ -96,9 +98,9 @@ impl Worklet {
     fn new_inherited(
         window: &Window,
         global_type: WorkletGlobalScopeType,
-        thread_pool: Box<dyn FnOnce() -> Rc<WorkletThreadPool>>,
+        thread_pool_constructor: Box<dyn FnOnce() -> Rc<WorkletThreadPool>>,
     ) -> Worklet {
-        let thread_pool = LazyCell::new(thread_pool);
+        let thread_pool = LazyCell::new(thread_pool_constructor);
 
         Worklet {
             reflector: Reflector::new(),
@@ -125,7 +127,7 @@ impl Worklet {
         )
     }
 
-    pub(crate) fn get_worklet_thread_pool(&self) -> &WorkletThreadPool {
+    pub(crate) fn worklet_thread_pool(&self) -> &WorkletThreadPool {
         &self.droppable_field.thread_pool
     }
 

--- a/components/script/dom/worklet/worklet.rs
+++ b/components/script/dom/worklet/worklet.rs
@@ -10,7 +10,7 @@
 //! thread pool implementation, which only performs GC or code loading on
 //! a backup thread, not on the primary worklet thread.
 
-use std::cell::{OnceCell, RefCell, RefMut};
+use std::cell::{self, RefCell, RefMut};
 use std::cmp::max;
 use std::collections::hash_map;
 use std::rc::Rc;
@@ -44,7 +44,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::TrustedPromise;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
-use crate::dom::bindings::trace::{CustomTraceable, JSTraceable, RootedTraceableBox};
+use crate::dom::bindings::trace::{JSTraceable, RootedTraceableBox};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 #[cfg(feature = "testbinding")]
@@ -65,21 +65,21 @@ use crate::url::ensure_blob_referenced_by_url_is_kept_alive;
 const WORKLET_THREAD_POOL_SIZE: u32 = 3;
 const MIN_GC_THRESHOLD: u32 = 1_000_000;
 
+type LazyCell<T> = cell::LazyCell<T, Box<dyn FnOnce() -> T>>;
+
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableField {
     worklet_id: WorkletId,
     /// The cached version of the script thread's WorkletThreadPool. We keep this cached
     /// because we may need to access it after the script thread has terminated.
     #[ignore_malloc_size_of = "Difficult to measure memory usage of Rc<...> types"]
-    thread_pool: OnceCell<Rc<WorkletThreadPool>>,
+    thread_pool: Rc<LazyCell<Rc<WorkletThreadPool>>>,
 }
 
 impl Drop for DroppableField {
     fn drop(&mut self) {
         let worklet_id = self.worklet_id;
-        if let Some(thread_pool) = self.thread_pool.get_mut() {
-            thread_pool.exit_worklet(worklet_id);
-        }
+        self.thread_pool.exit_worklet(worklet_id);
     }
 }
 
@@ -96,10 +96,9 @@ impl Worklet {
     fn new_inherited(
         window: &Window,
         global_type: WorkletGlobalScopeType,
-        thread_pool: Rc<WorkletThreadPool>,
+        thread_pool: Box<dyn FnOnce() -> Rc<WorkletThreadPool>>,
     ) -> Worklet {
-        let thread_pool_cell = OnceCell::new();
-        thread_pool_cell.get_or_init(|| thread_pool);
+        let thread_pool = Rc::new(LazyCell::new(thread_pool));
 
         Worklet {
             reflector: Reflector::new(),
@@ -107,7 +106,7 @@ impl Worklet {
             global_type,
             droppable_field: DroppableField {
                 worklet_id: WorkletId::new(),
-                thread_pool: thread_pool_cell,
+                thread_pool,
             },
         }
     }
@@ -116,7 +115,7 @@ impl Worklet {
         cx: &mut JSContext,
         window: &Window,
         global_type: WorkletGlobalScopeType,
-        thread_pool: Rc<WorkletThreadPool>,
+        thread_pool: Box<dyn FnOnce() -> Rc<WorkletThreadPool>>,
     ) -> DomRoot<Worklet> {
         debug!("Creating worklet {:?}.", global_type);
         reflect_dom_object_with_cx(
@@ -126,8 +125,8 @@ impl Worklet {
         )
     }
 
-    pub(crate) fn get_window(&self) -> &Dom<Window> {
-        &self.window
+    pub(crate) fn get_worklet_thread_pool(&self) -> Rc<LazyCell<Rc<WorkletThreadPool>>> {
+        self.droppable_field.thread_pool.clone()
     }
 
     #[cfg(feature = "testbinding")]
@@ -182,26 +181,21 @@ impl WorkletMethods<crate::DomTypeHolder> for Worklet {
         // NOTE: We skip step 6.3 because we do not implement the `added modules list` yet
         // <https://html.spec.whatwg.org/multipage/#concept-worklet-added-modules-list>
 
-        match self.droppable_field.thread_pool.get() {
-            Some(thread_pool) => {
-                thread_pool.fetch_and_invoke_a_worklet_script(
-                    self.window.pipeline_id(),
-                    self.droppable_field.worklet_id,
-                    self.global_type,
-                    self.window.origin().immutable().clone(),
-                    global_scope.api_base_url(),
-                    module_url_record,
-                    global_scope.policy_container(),
-                    options.credentials,
-                    pending_tasks_struct,
-                    &promise,
-                    global_scope.inherited_secure_context(),
-                );
-            },
-            None => {
-                // TODO: throw an exception?
-            },
-        }
+        self.droppable_field
+            .thread_pool
+            .fetch_and_invoke_a_worklet_script(
+                self.window.pipeline_id(),
+                self.droppable_field.worklet_id,
+                self.global_type,
+                self.window.origin().immutable().clone(),
+                global_scope.api_base_url(),
+                module_url_record,
+                global_scope.policy_container(),
+                options.credentials,
+                pending_tasks_struct,
+                &promise,
+                global_scope.inherited_secure_context(),
+            );
 
         // Step 7. Return promise
         debug!("Returning promise.");

--- a/components/script/dom/worklet/worklet.rs
+++ b/components/script/dom/worklet/worklet.rs
@@ -65,7 +65,7 @@ use crate::url::ensure_blob_referenced_by_url_is_kept_alive;
 const WORKLET_THREAD_POOL_SIZE: u32 = 3;
 const MIN_GC_THRESHOLD: u32 = 1_000_000;
 
-type LazyCell<T> = cell::LazyCell<T, Box<dyn FnOnce() -> T>>;
+type LazyCellWithBoxedInitializer<T> = cell::LazyCell<T, Box<dyn FnOnce() -> T>>;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableField {
@@ -75,7 +75,7 @@ struct DroppableField {
     /// NOTE: Do not access the `thread_pool` field directly, instead use the
     /// `Worklet::worklet_thread_pool` method to access the Thread Pool.
     #[ignore_malloc_size_of = "Difficult to measure memory usage of Rc<...> types"]
-    thread_pool: LazyCell<Rc<WorkletThreadPool>>,
+    thread_pool: LazyCellWithBoxedInitializer<Rc<WorkletThreadPool>>,
 
     /// NOTE: The `is_thread_pool_initialized` field is a temporary workaround because
     /// using the `LazyCell::get()` method requires Rust version >1.94.0 and is not
@@ -113,7 +113,7 @@ impl Worklet {
             global_type,
             droppable_field: DroppableField {
                 worklet_id: WorkletId::new(),
-                thread_pool: LazyCell::new(thread_pool_constructor),
+                thread_pool: LazyCellWithBoxedInitializer::new(thread_pool_constructor),
                 is_thread_pool_initialized: Cell::new(false),
             },
         }

--- a/components/script/dom/worklet/worklet.rs
+++ b/components/script/dom/worklet/worklet.rs
@@ -73,7 +73,7 @@ struct DroppableField {
     /// The cached version of the script thread's WorkletThreadPool. We keep this cached
     /// because we may need to access it after the script thread has terminated.
     #[ignore_malloc_size_of = "Difficult to measure memory usage of Rc<...> types"]
-    thread_pool: Rc<LazyCell<Rc<WorkletThreadPool>>>,
+    thread_pool: LazyCell<Rc<WorkletThreadPool>>,
 }
 
 impl Drop for DroppableField {
@@ -98,7 +98,7 @@ impl Worklet {
         global_type: WorkletGlobalScopeType,
         thread_pool: Box<dyn FnOnce() -> Rc<WorkletThreadPool>>,
     ) -> Worklet {
-        let thread_pool = Rc::new(LazyCell::new(thread_pool));
+        let thread_pool = LazyCell::new(thread_pool);
 
         Worklet {
             reflector: Reflector::new(),
@@ -125,8 +125,8 @@ impl Worklet {
         )
     }
 
-    pub(crate) fn get_worklet_thread_pool(&self) -> Rc<LazyCell<Rc<WorkletThreadPool>>> {
-        self.droppable_field.thread_pool.clone()
+    pub(crate) fn get_worklet_thread_pool(&self) -> &WorkletThreadPool {
+        &self.droppable_field.thread_pool
     }
 
     #[cfg(feature = "testbinding")]

--- a/components/script/dom/worklet/worklet.rs
+++ b/components/script/dom/worklet/worklet.rs
@@ -72,21 +72,20 @@ struct DroppableField {
     worklet_id: WorkletId,
     /// The cached version of the script thread's WorkletThreadPool. We keep this cached
     /// because we may need to access it after the script thread has terminated.
-    /// NOTE: Do not access thread_pool directly from the struct as it will cause the `is_thread_pool_initialized` field on Worklet to go out sync.
-    /// Use the `worklet_thread_pool` method instead.
+    /// NOTE: Do not access the `thread_pool` field directly, instead use the
+    /// `Worklet::worklet_thread_pool` method to access the Thread Pool.
     #[ignore_malloc_size_of = "Difficult to measure memory usage of Rc<...> types"]
     thread_pool: LazyCell<Rc<WorkletThreadPool>>,
 
-    /// NOTE: is_thread_pool_initialized is a workaround because we use a `LazyCell` to
-    /// initialize the Thread Pool. The `LazyCell::get()` method is not supported by the
-    /// current MSRV (Minimum Supported Rust Version)
+    /// NOTE: The `is_thread_pool_initialized` field is a temporary workaround because
+    /// using the `LazyCell::get()` method requires Rust version >1.94.0 and is not
+    /// supported by the current MSRV (Minimum Supported Rust Version).
     is_thread_pool_initialized: Cell<bool>,
 }
 
 impl Drop for DroppableField {
     fn drop(&mut self) {
         let worklet_id = self.worklet_id;
-
         if self.is_thread_pool_initialized.get() {
             self.thread_pool.exit_worklet(worklet_id);
         }
@@ -108,15 +107,13 @@ impl Worklet {
         global_type: WorkletGlobalScopeType,
         thread_pool_constructor: Box<dyn FnOnce() -> Rc<WorkletThreadPool>>,
     ) -> Worklet {
-        let thread_pool = LazyCell::new(thread_pool_constructor);
-
         Worklet {
             reflector: Reflector::new(),
             window: Dom::from_ref(window),
             global_type,
             droppable_field: DroppableField {
                 worklet_id: WorkletId::new(),
-                thread_pool,
+                thread_pool: LazyCell::new(thread_pool_constructor),
                 is_thread_pool_initialized: Cell::new(false),
             },
         }
@@ -126,11 +123,15 @@ impl Worklet {
         cx: &mut JSContext,
         window: &Window,
         global_type: WorkletGlobalScopeType,
-        thread_pool: Box<dyn FnOnce() -> Rc<WorkletThreadPool>>,
+        thread_pool_consturctor: Box<dyn FnOnce() -> Rc<WorkletThreadPool>>,
     ) -> DomRoot<Worklet> {
         debug!("Creating worklet {:?}.", global_type);
         reflect_dom_object_with_cx(
-            Box::new(Worklet::new_inherited(window, global_type, thread_pool)),
+            Box::new(Worklet::new_inherited(
+                window,
+                global_type,
+                thread_pool_consturctor,
+            )),
             window,
             cx,
         )

--- a/components/script/dom/worklet/worklet.rs
+++ b/components/script/dom/worklet/worklet.rs
@@ -65,7 +65,7 @@ use crate::url::ensure_blob_referenced_by_url_is_kept_alive;
 const WORKLET_THREAD_POOL_SIZE: u32 = 3;
 const MIN_GC_THRESHOLD: u32 = 1_000_000;
 
-type LazyCell<T> = cell::LazyCell<T, Box<dyn FnOnce() -> T>>;
+type LazyCellWithBoxedInitializer<T> = cell::LazyCell<T, Box<dyn FnOnce() -> T>>;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableField {
@@ -75,7 +75,7 @@ struct DroppableField {
     /// NOTE: Do not access the `thread_pool` field directly, instead use the
     /// `Worklet::worklet_thread_pool` method to access the Thread Pool.
     #[ignore_malloc_size_of = "Difficult to measure memory usage of Rc<...> types"]
-    thread_pool: LazyCell<Rc<WorkletThreadPool>>,
+    thread_pool: LazyCellWithBoxedInitializer<Rc<WorkletThreadPool>>,
 
     /// NOTE: The `is_thread_pool_initialized` field is a temporary workaround because
     /// using the `LazyCell::get()` method requires Rust version >1.94.0 and is not
@@ -113,7 +113,7 @@ impl Worklet {
             global_type,
             droppable_field: DroppableField {
                 worklet_id: WorkletId::new(),
-                thread_pool: LazyCell::new(thread_pool_constructor),
+                thread_pool: LazyCellWithBoxedInitializer::new(thread_pool_constructor),
                 is_thread_pool_initialized: Cell::new(false),
             },
         }
@@ -123,14 +123,14 @@ impl Worklet {
         cx: &mut JSContext,
         window: &Window,
         global_type: WorkletGlobalScopeType,
-        thread_pool_consturctor: Box<dyn FnOnce() -> Rc<WorkletThreadPool>>,
+        thread_pool_constructor: Box<dyn FnOnce() -> Rc<WorkletThreadPool>>,
     ) -> DomRoot<Worklet> {
         debug!("Creating worklet {:?}.", global_type);
         reflect_dom_object_with_cx(
             Box::new(Worklet::new_inherited(
                 window,
                 global_type,
-                thread_pool_consturctor,
+                thread_pool_constructor,
             )),
             window,
             cx,

--- a/components/script/dom/worklet/worklet.rs
+++ b/components/script/dom/worklet/worklet.rs
@@ -10,7 +10,7 @@
 //! thread pool implementation, which only performs GC or code loading on
 //! a backup thread, not on the primary worklet thread.
 
-use std::cell::{self, RefCell, RefMut};
+use std::cell::{self, Cell, RefCell, RefMut};
 use std::cmp::max;
 use std::collections::hash_map;
 use std::rc::Rc;
@@ -72,15 +72,23 @@ struct DroppableField {
     worklet_id: WorkletId,
     /// The cached version of the script thread's WorkletThreadPool. We keep this cached
     /// because we may need to access it after the script thread has terminated.
+    /// NOTE: Do not access thread_pool directly from the struct as it will cause the `is_thread_pool_initialized` field on Worklet to go out sync.
+    /// Use the `worklet_thread_pool` method instead.
     #[ignore_malloc_size_of = "Difficult to measure memory usage of Rc<...> types"]
     thread_pool: LazyCell<Rc<WorkletThreadPool>>,
+
+    /// NOTE: is_thread_pool_initialized is a workaround because we use a `LazyCell` to
+    /// initialize the Thread Pool. The `LazyCell::get()` method is not supported by the
+    /// current MSRV (Minimum Supported Rust Version)
+    is_thread_pool_initialized: Cell<bool>,
 }
 
 impl Drop for DroppableField {
     fn drop(&mut self) {
         let worklet_id = self.worklet_id;
-        if let Some(thread_pool) = LazyCell::get(&self.thread_pool) {
-            thread_pool.exit_worklet(worklet_id);
+
+        if self.is_thread_pool_initialized.get() {
+            self.thread_pool.exit_worklet(worklet_id);
         }
     }
 }
@@ -109,6 +117,7 @@ impl Worklet {
             droppable_field: DroppableField {
                 worklet_id: WorkletId::new(),
                 thread_pool,
+                is_thread_pool_initialized: Cell::new(false),
             },
         }
     }
@@ -128,6 +137,7 @@ impl Worklet {
     }
 
     pub(crate) fn worklet_thread_pool(&self) -> &WorkletThreadPool {
+        self.droppable_field.is_thread_pool_initialized.set(true);
         &self.droppable_field.thread_pool
     }
 
@@ -183,8 +193,7 @@ impl WorkletMethods<crate::DomTypeHolder> for Worklet {
         // NOTE: We skip step 6.3 because we do not implement the `added modules list` yet
         // <https://html.spec.whatwg.org/multipage/#concept-worklet-added-modules-list>
 
-        self.droppable_field
-            .thread_pool
+        self.worklet_thread_pool()
             .fetch_and_invoke_a_worklet_script(
                 self.window.pipeline_id(),
                 self.droppable_field.worklet_id,

--- a/components/script/dom/worklet/workletglobalscope.rs
+++ b/components/script/dom/worklet/workletglobalscope.rs
@@ -22,6 +22,7 @@ use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use storage_traits::StorageThreads;
 use stylo_atoms::Atom;
 
+use crate::dom::Window;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::trace::CustomTraceable;
@@ -221,6 +222,26 @@ impl WorkletGlobalScope {
         if !self.closing.load(Ordering::SeqCst) {
             self.microtask_queue
                 .checkpoint(cx, vec![DomRoot::from_ref(&self.globalscope)]);
+        }
+    }
+}
+
+impl From<&Window> for WorkletGlobalScopeInit {
+    fn from(dom: &Window) -> Self {
+        let global = dom.as_global_scope();
+
+        WorkletGlobalScopeInit {
+            to_script_thread_sender: dom.main_thread_script_chan().clone(),
+            resource_threads: global.resource_threads().clone(),
+            storage_threads: global.storage_threads().clone(),
+            mem_profiler_chan: global.mem_profiler_chan().clone(),
+            time_profiler_chan: global.time_profiler_chan().clone(),
+            devtools_chan: global.devtools_chan().cloned(),
+            script_to_constellation_sender: global.script_to_constellation_chan().sender,
+            to_embedder_sender: global.script_to_embedder_chan().clone(),
+            image_cache: global.image_cache(),
+            #[cfg(feature = "webgpu")]
+            gpu_id_hub: global.wgpu_id_hub(),
         }
     }
 }

--- a/components/script/dom/worklet/workletglobalscope.rs
+++ b/components/script/dom/worklet/workletglobalscope.rs
@@ -227,21 +227,21 @@ impl WorkletGlobalScope {
 }
 
 impl From<&Window> for WorkletGlobalScopeInit {
-    fn from(dom: &Window) -> Self {
-        let global = dom.as_global_scope();
+    fn from(window: &Window) -> Self {
+        let global_scope = window.as_global_scope();
 
         WorkletGlobalScopeInit {
-            to_script_thread_sender: dom.main_thread_script_chan().clone(),
-            resource_threads: global.resource_threads().clone(),
-            storage_threads: global.storage_threads().clone(),
-            mem_profiler_chan: global.mem_profiler_chan().clone(),
-            time_profiler_chan: global.time_profiler_chan().clone(),
-            devtools_chan: global.devtools_chan().cloned(),
-            script_to_constellation_sender: global.script_to_constellation_chan().sender,
-            to_embedder_sender: global.script_to_embedder_chan().clone(),
-            image_cache: global.image_cache(),
+            to_script_thread_sender: window.main_thread_script_chan().clone(),
+            resource_threads: global_scope.resource_threads().clone(),
+            storage_threads: global_scope.storage_threads().clone(),
+            mem_profiler_chan: global_scope.mem_profiler_chan().clone(),
+            time_profiler_chan: global_scope.time_profiler_chan().clone(),
+            devtools_chan: global_scope.devtools_chan().cloned(),
+            script_to_constellation_sender: global_scope.script_to_constellation_chan().sender,
+            to_embedder_sender: global_scope.script_to_embedder_chan().clone(),
+            image_cache: global_scope.image_cache(),
             #[cfg(feature = "webgpu")]
-            gpu_id_hub: global.wgpu_id_hub(),
+            gpu_id_hub: global_scope.wgpu_id_hub(),
         }
     }
 }


### PR DESCRIPTION
This PR is a part of refactoring Worklet for implementing AudioWorklet

- Move the initialization of the `WorkletThreadPool` to `window/window.rs`
- Use `LazyCell` to spawn a new `WorkletThreadPool`

The `WorkletThreadPool` exists on the `ScriptThread` for the Paint Worklet.
For the AudioWorklet, the `WorkletThreadPool` will live on the `AudioContext` as each `AudioContext` needs it's own Worklet Thread.

Moving to `LazyCell` allows `AddModule` to be agnostic about constructing the `WorkletThreadPool` instead of initializing it from the `ScriptThread`.
 
Testing: existing worklet WPT covers the changes.
