### PR TITLE
script: Remove unnecessary clone on HTMLScriptElement::prepare_the_script_text

### DIFF
--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -552,7 +552,7 @@ impl HTMLScriptElement {
         // Step 1. If script’s script text value is not equal to its child text content,
         // set script’s script text to the result of executing
         // Get Trusted Type compliant string, with the following arguments:
-        if self.script_text.borrow().clone() != self.text() {
+        if *self.script_text.borrow() != self.text() {
             *self.script_text.borrow_mut() = TrustedScript::get_trusted_type_compliant_string(
                 cx,
                 &self.owner_global(),


### PR DESCRIPTION
This should not need a clone to compare two domstrings.

Testing: WPT test should find if this was necessary for some reason.
