### PR TITLE
layout: Consistently map back to DOM offsets from layout offsets

### DIFF
--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -501,13 +501,24 @@ impl TextFragment {
         &self,
         point_in_fragment: Point2D<Au, CSSPixel>,
     ) -> Option<Utf32CodeUnits> {
+        self.unmapped_character_offset(point_in_fragment)
+            .map(|character_offset| {
+                self.run_data
+                    .map_transformed_offset_to_dom_offset(character_offset)
+            })
+    }
+
+    /// Like [`Self::character_offset`], but returning the character offset in layout text (after
+    /// applying white space collapse and the `text-transform` property), instead of the original DOM
+    /// text.
+    fn unmapped_character_offset(
+        &self,
+        point_in_fragment: Point2D<Au, CSSPixel>,
+    ) -> Option<Utf32CodeUnits> {
         // If the click was far enough above the top of the fragment, then pick the first index.
         let max_vertical_offset = self.base.rect().height().scale_by(0.25);
         if point_in_fragment.y < -max_vertical_offset {
-            return Some(
-                self.run_data
-                    .map_transformed_offset_to_dom_offset(self.character_range_in_dom_node.start),
-            );
+            return Some(self.character_range_in_dom_node.start);
         }
 
         // If the click was below the fragment, return `None`, which will cause the
@@ -535,10 +546,7 @@ impl TextFragment {
             }
         }
 
-        Some(
-            self.run_data
-                .map_transformed_offset_to_dom_offset(current_character),
-        )
+        Some(current_character)
     }
 }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13456,7 +13456,7 @@
      ]
     ],
     "mousedown-edit-point-textarea-003.html": [
-     "274c6dd2b6537f87758af08d46a9bf9d5eddf5c8",
+     "c500beee5c343e05923a42cc42f5b48455e13bea",
      [
       null,
       {

--- a/tests/wpt/mozilla/tests/input-events/mousedown-edit-point-textarea-003.html
+++ b/tests/wpt/mozilla/tests/input-events/mousedown-edit-point-textarea-003.html
@@ -7,13 +7,21 @@
 <script src="/resources/testdriver-vendor.js"></script>
 <script src="/resources/testdriver-actions.js"></script>
 <script src="input-events.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 
 <!-- The uppercase ß character is transformed into 'SS'. Clicking beyond that
 transformed character should move the cursor to the end of the line (and not
 to the end of the subsequent line). This shows that `text-transform` is taken
 into account when determining edit points via mouse clicks. -->
-<textarea id="target" style="height: 300px; width: 300px; text-transform: uppercase;">
+<textarea id="target" style="height: 100px; width: 500px; text-transform: uppercase;">
 &#x00DF;
+</textarea>
+
+<br/>
+
+<!-- This is the same test as above, but offset by some introductory characters. -->
+<textarea id="target2" style="height: 100px; width: 500px; text-transform: uppercase; font: 50px/1 Ahem;">
+  &#x00DF;abc
 </textarea>
 
 <script>
@@ -25,5 +33,20 @@ promise_test(async test => {
         .send());
     assert_equals(target.selectionStart, 1);
     assert_equals(target.selectionEnd, 1);
-});
+}, "Edit point selection properly takes into account text-transform");
+
+promise_test(async test => {
+    let targetRect = getTextEntryContentRect(target2);
+    let middleOfFirstLine = (50 / 2) + targetRect.top;
+    await (new test_driver.Actions()
+        .pointerMove(targetRect.left  + (50 * 5) + 5, middleOfFirstLine)
+        .pointerDown().pointerUp()
+        .send());
+
+    // The resulting index of the selection is one less than the number of
+    // glyph widths, because one of those glyphs was a single character
+    // expanded into 'SS'.
+    assert_equals(target2.selectionStart, 4);
+    assert_equals(target2.selectionEnd, 4);
+}, "Edit point selection properly takes into account text-transform in the middle of a line");
 </script>


### PR DESCRIPTION
When mapping a character offset in layout text (transformed by white
space collapse and `text-transform`) back to the original DOM offset,
during hit testing, there was a single return path that wasn't
properly doing that mapping. This change makes it so that the
`character_offset` method wraps an `unmapped_character_offset` method
and consistently uses the offset map. This fixes an issue with
interactive edit point and selection updates.

Testing: This changes adds a Servo-specific test (edit point selection behavior is unspecified).
