### PR TITLE
script: Properly clear selection flags on siblings

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -3094,6 +3094,12 @@ impl Document {
         if self.window().has_pending_media_query_evaluation() {
             return true;
         }
+        if self
+            .selection()
+            .is_some_and(|selection| selection.visible_selection_dirty())
+        {
+            return true;
+        }
 
         false
     }

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -68,6 +68,10 @@ impl Selection {
         )
     }
 
+    pub(crate) fn visible_selection_dirty(&self) -> bool {
+        self.visible_selection_dirty.get()
+    }
+
     fn set_range(&self, new_range: Option<&Range>) {
         // If we are setting to literally the same Range object and not just the same
         // positions, then there's nothing changing and no task to queue.
@@ -110,7 +114,7 @@ impl Selection {
                         next = traversal.next_skipping_subtree();
                     }
                 },
-                PrePostIteration::Leave(_) => {},
+                PrePostIteration::Leave(_) => next = traversal.next(),
             }
         }
     }

--- a/tests/wpt/tests/selection/selection-incremental-change-repaint-ref.html
+++ b/tests/wpt/tests/selection/selection-incremental-change-repaint-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>Active selection after incremental selection update</title>
+<link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+<div>
+    <span id="span1">1234<span id="span2">1234</span></span>
+</div>
+
+<script>
+  let span1Text = span1.firstChild;
+  getSelection().setBaseAndExtent(span1Text, 0, span1Text, 4);
+</script>

--- a/tests/wpt/tests/selection/selection-incremental-change-repaint.html
+++ b/tests/wpt/tests/selection/selection-incremental-change-repaint.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>Active selection after incremental selection update</title>
+<link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+<link rel="match" href="selection-incremental-change-repaint-ref.html">
+<meta name="assert" content="The rendering of a selection should update properly after it changes incrementally.">
+
+<div>
+    <span id="span1">1234<span id="span2">1234</span></span>
+</div>
+
+<script>
+  let span1Text = span1.firstChild;
+  let span2Text = span2.firstChild;
+  getSelection().setBaseAndExtent(span1Text, 0, span2Text, 3);
+  document.body.offsetWidth;
+  getSelection().setBaseAndExtent(span1Text, 0, span1Text, 4);
+</script>


### PR DESCRIPTION
There were two issues interfering with proper rendering of incremental
selection updates:

- During the selection flag clearing traversal, when leaving a node the
  traversal was not advanced. This meant that flags were cleared on
  descendants but not siblings of nodes.
- When selection was updated via DOM APIs, there was nothing triggering
  a new rendering update.

Unfortunately these changes have to happen together, as there is no way
to test the second issue in isolation -- things that trigger a
screenshot also trigger rendering updates. The second issue will be
better covered once tests for interactive document selection updates are
implemented though. In addition, the reference for the test must also
use selection APIs as Servo does not yet support `::selection` fully.

Testing: This change adds a WPT test.
