### PR TITLE
WebDriver: add fullscreen_window and minimize_window support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7450,8 +7450,9 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.38.0"
-source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad7c25c97cc59c4858df8724a3789caa6ee509b628dfe6df34e8a8084c8a84e"
 dependencies = [
  "bitflags 2.13.0",
  "cssparser",
@@ -9202,7 +9203,8 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9672,8 +9674,9 @@ dependencies = [
 
 [[package]]
 name = "stylo"
-version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "049fb023adcc72e8814fed99d225a45faa95b0e54b7f433eabb6e88c66c90ded"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9728,8 +9731,9 @@ dependencies = [
 
 [[package]]
 name = "stylo_atoms"
-version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55651489a0c27f66d08e7c9cf8ee449328c0de291e37227fc1bbcffb2d7e681e"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9737,8 +9741,9 @@ dependencies = [
 
 [[package]]
 name = "stylo_derive"
-version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e39f4962458b9e9efc91684666509a1811bc690f90188508108583187d19e83c"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9749,8 +9754,9 @@ dependencies = [
 
 [[package]]
 name = "stylo_dom"
-version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697851c070e9a9630825e99f7a34ac0ffd31cd969aac38281b8d002ebe675be5"
 dependencies = [
  "bitflags 2.13.0",
  "stylo_malloc_size_of",
@@ -9758,8 +9764,9 @@ dependencies = [
 
 [[package]]
 name = "stylo_malloc_size_of"
-version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5634944bf69cf6b6900d3f0116c3b2530cf55706b1044ddf5d0da45d5d09a527"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9775,16 +9782,18 @@ dependencies = [
 
 [[package]]
 name = "stylo_static_prefs"
-version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f62c30d50b9d26dd6dc040d0ae0b1c6139c3547c6689cf6ed201ca21f4c77a3"
 dependencies = [
  "toml",
 ]
 
 [[package]]
 name = "stylo_traits"
-version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd00a0e8c8becc53b3a87e31f28836e7467147d6e463a7e69c37fdd97f4e09c0"
 dependencies = [
  "app_units",
  "bitflags 2.13.0",
@@ -10203,8 +10212,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "to_shmem"
-version = "0.4.0"
-source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c81cee0d28327337a94f3f32a1a77c03bbfd926510f3b42956f9d914e7810c"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -10217,7 +10227,8 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba1f5563024b63bb6acb4558452d9ba737518c1d11fcc1861febe98d1e31cf4"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,9 +1673,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,14 +215,14 @@ rustls-pki-types = "1.14"
 rustls-platform-verifier = "0.7.0"
 sea-query = { version = "=1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = "=0.8.0-rc.15"
-selectors = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
+selectors = { version = "0.39" }
 seq-macro = "0.3.6"
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
 serde_test = "1.0"
-servo_arc = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
+servo_arc = { version = "0.4.3" }
 sha1 = "0.11"
 sha2 = "0.11"
 sha3 = "0.12"
@@ -232,12 +232,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 speexdsp-resampler = "0.1.0"
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
+stylo = { version = "0.19" }
+stylo_atoms = { version = "0.19" }
+stylo_dom = { version = "0.19" }
+stylo_malloc_size_of = { version = "0.19" }
+stylo_static_prefs = { version = "0.19" }
+stylo_traits = { version = "0.19" }
 surfman = { version = "0.13.0", features = ["chains"] }
 swapper = "0.1"
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -4808,6 +4808,8 @@ where
             WebDriverCommandMsg::GetViewportSize(..) |
             WebDriverCommandMsg::SetWindowRect(..) |
             WebDriverCommandMsg::MaximizeWebView(..) |
+            WebDriverCommandMsg::FullscreenWebView(..) |
+            WebDriverCommandMsg::MinimizeWebView(..) |
             WebDriverCommandMsg::LoadUrl(..) |
             WebDriverCommandMsg::Refresh(..) |
             WebDriverCommandMsg::InputEvent(..) |

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -118,6 +118,10 @@ pub enum WebDriverCommandMsg {
     ),
     /// Maximize the window. Send back result window rectangle.
     MaximizeWebView(WebViewId, GenericOneshotSender<DeviceIndependentIntRect>),
+    /// Fullscreen the window. Send back result window rectangle.
+    FullscreenWebView(WebViewId, GenericOneshotSender<DeviceIndependentIntRect>),
+    /// Minimize the window. Send back result window rectangle.
+    MinimizeWebView(WebViewId, GenericOneshotSender<DeviceIndependentIntRect>),
     /// Take a screenshot of the viewport.
     TakeScreenshot(
         WebViewId,

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -998,6 +998,62 @@ impl Handler {
         Ok(WebDriverResponse::WindowRect(window_size_response))
     }
 
+    /// <https://w3c.github.io/webdriver/#fullscreen-window>
+    fn handle_fullscreen_window(&mut self) -> WebDriverResult<WebDriverResponse> {
+        // Step 1. If the remote end does not support the Fullscreen Window command for session's
+        // current top-level browsing context for any reason,
+        // return error with error code unsupported operation.
+        let webview_id = self.webview_id()?;
+        // Step 2. If session's current top-level browsing context is no longer open,
+        // return error with error code no such window.
+        self.verify_top_level_browsing_context_is_open(webview_id)?;
+
+        // Step 3. Try to handle any user prompts with session.
+        self.handle_any_user_prompts(self.webview_id()?)?;
+
+        // Step 4. Fullscreen the window of session's current top-level browsing context.
+        let (sender, receiver) = generic_channel::oneshot().unwrap();
+        self.send_message_to_embedder(WebDriverCommandMsg::FullscreenWebView(webview_id, sender))?;
+
+        let window_rect = wait_for_oneshot_response(receiver)?;
+        debug!("Result window_rect: {window_rect:?}");
+        let window_size_response = WindowRectResponse {
+            x: window_rect.min.x,
+            y: window_rect.min.y,
+            width: window_rect.width(),
+            height: window_rect.height(),
+        };
+        Ok(WebDriverResponse::WindowRect(window_size_response))
+    }
+
+    /// <https://w3c.github.io/webdriver/#minimize-window>
+    fn handle_minimize_window(&mut self) -> WebDriverResult<WebDriverResponse> {
+        // Step 1. If the remote end does not support the Minimize Window command for session's
+        // current top-level browsing context for any reason,
+        // return error with error code unsupported operation.
+        let webview_id = self.webview_id()?;
+        // Step 2. If session's current top-level browsing context is no longer open,
+        // return error with error code no such window.
+        self.verify_top_level_browsing_context_is_open(webview_id)?;
+
+        // Step 3. Try to handle any user prompts with session.
+        self.handle_any_user_prompts(self.webview_id()?)?;
+
+        // Step 4. Iconify the window of session's current top-level browsing context.
+        let (sender, receiver) = generic_channel::oneshot().unwrap();
+        self.send_message_to_embedder(WebDriverCommandMsg::MinimizeWebView(webview_id, sender))?;
+
+        let window_rect = wait_for_oneshot_response(receiver)?;
+        debug!("Result window_rect: {window_rect:?}");
+        let window_size_response = WindowRectResponse {
+            x: window_rect.min.x,
+            y: window_rect.min.y,
+            width: window_rect.width(),
+            height: window_rect.height(),
+        };
+        Ok(WebDriverResponse::WindowRect(window_size_response))
+    }
+
     fn handle_is_enabled(&self, element: &WebElement) -> WebDriverResult<WebDriverResponse> {
         // Step 1. If session's current browsing context is no longer open,
         // return error with error code no such window.
@@ -2740,6 +2796,8 @@ impl WebDriverHandler<ServoExtensionRoute> for Handler {
             WebDriverCommand::NewWindow(ref parameters) => self.handle_new_window(parameters),
             WebDriverCommand::CloseWindow => self.handle_close_window(),
             WebDriverCommand::MaximizeWindow => self.handle_maximize_window(),
+            WebDriverCommand::FullscreenWindow => self.handle_fullscreen_window(),
+            WebDriverCommand::MinimizeWindow => self.handle_minimize_window(),
             WebDriverCommand::SwitchToFrame(ref parameters) => {
                 self.handle_switch_to_frame(parameters)
             },

--- a/deny.toml
+++ b/deny.toml
@@ -205,9 +205,3 @@ skip = [
     # of ml-kem.
     "sha3",
 ]
-
-# github.com organizations to allow git sources for
-[sources.allow-org]
-github = [
-    "servo",
-]

--- a/deny.toml
+++ b/deny.toml
@@ -45,6 +45,9 @@ ignore = [
     #
     # We must use this version of quick-xml until `winit` upgrades `sctk`.
     "RUSTSEC-2026-0195",
+    # `rustybuzz` is unmaintained. Switch to harfrust.
+    # However, this is a dependecy of `resvg`, there's nothing we can do.
+    "RUSTSEC-2026-0206",
 ]
 
 # This section is considered when running `cargo deny check licenses`

--- a/deny.toml
+++ b/deny.toml
@@ -35,6 +35,16 @@ ignore = [
     # This is a dependency of `usvg`, `rustybuzz`, `fontdb`.
     # We will need to wait for upstream actions.
     "RUSTSEC-2026-0192",
+    # Vulnerability in `quick-xml`: Quadratic run time when checking a start
+    # tag for duplicate attribute names.
+    #
+    # We must use this version of quick-xml until `winit` upgrades `sctk`.
+    "RUSTSEC-2026-0194",
+    # Vulnerability in `quick-xml`: Unbounded namespace-declaration allocation
+    # in `NsReader` enables memory-exhaustion denial of service.
+    #
+    # We must use this version of quick-xml until `winit` upgrades `sctk`.
+    "RUSTSEC-2026-0195",
 ]
 
 # This section is considered when running `cargo deny check licenses`

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -1031,6 +1031,10 @@ impl PlatformWindow for HeadedWindow {
         self.winit_window.set_maximized(true);
     }
 
+    fn minimize(&self, _webview: &WebView) {
+        self.winit_window.set_minimized(true);
+    }
+
     /// Handle servoshell key bindings that may have been prevented by the page in the active webview.
     fn notify_input_event_handled(
         &self,

--- a/ports/servoshell/webdriver.rs
+++ b/ports/servoshell/webdriver.rs
@@ -229,6 +229,28 @@ impl RunningAppState {
                         warn!("Failed to send response of GetWindowSize: {error}");
                     }
                 },
+                WebDriverCommandMsg::FullscreenWebView(webview_id, response_sender) => {
+                    let Some(webview) = self.webview_by_id(webview_id) else {
+                        continue;
+                    };
+                    let platform_window = self.platform_window_for_webview(&webview);
+                    platform_window.set_fullscreen(true);
+
+                    if let Err(error) = response_sender.send(platform_window.window_rect()) {
+                        warn!("Failed to send response of GetWindowSize: {error}");
+                    }
+                },
+                WebDriverCommandMsg::MinimizeWebView(webview_id, response_sender) => {
+                    let Some(webview) = self.webview_by_id(webview_id) else {
+                        continue;
+                    };
+                    let platform_window = self.platform_window_for_webview(&webview);
+                    platform_window.minimize(&webview);
+
+                    if let Err(error) = response_sender.send(platform_window.window_rect()) {
+                        warn!("Failed to send response of GetWindowSize: {error}");
+                    }
+                },
                 WebDriverCommandMsg::SetWindowRect(webview_id, requested_rect, size_sender) => {
                     let Some(webview) = self.webview_by_id(webview_id) else {
                         continue;

--- a/ports/servoshell/window.rs
+++ b/ports/servoshell/window.rs
@@ -417,6 +417,7 @@ pub(crate) trait PlatformWindow {
     }
     fn window_rect(&self) -> DeviceIndependentIntRect;
     fn maximize(&self, _: &WebView) {}
+    fn minimize(&self, _: &WebView) {}
     fn focus(&self) {}
     fn has_platform_focus(&self) -> bool {
         true

--- a/python/wpt/exporter/step.py
+++ b/python/wpt/exporter/step.py
@@ -111,10 +111,10 @@ class CreateOrUpdateBranchForPRStep(Step):
             # TODO: If we could cleverly parse and manipulate the full commit diff
             # we could avoid cloning the servo repository altogether and only
             # have to fetch the commit diffs from GitHub.
-            # NB: The output of git show might include binary files or non-UTF8 text,
+            # NB: The output of git might include binary files or non-UTF8 text,
             # so store the content of the diff as a `bytes`.
             diff = local_servo_repo.run_without_encoding(
-                "show", "--binary", "--format=%b", sha, "--", UPSTREAMABLE_PATH
+                "diff-tree", "--binary", "--no-commit-id", "-p", sha, "--", UPSTREAMABLE_PATH
             )
 
             # Retrieve the diff of any changes to files that are relevant

--- a/python/wpt/test.py
+++ b/python/wpt/test.py
@@ -624,6 +624,10 @@ def setUpModule() -> None:
     def setup_mock_repo(repo_name: str, local_repo: LocalGitRepo, default_branch: str) -> None:
         subprocess.check_output(["cp", "-R", "-p", os.path.join(TESTS_DIR, repo_name), local_repo.path])
         local_repo.run("init", "-b", default_branch)
+        # Prevent git from doing auto maintenance in the background, which can interfere
+        # with file operations.
+        local_repo.run("config", "gc.auto", "0")
+        local_repo.run("config", "maintenance.auto", "false")
         local_repo.run("add", ".")
         local_repo.run("commit", "-a", "-m", "Initial commit")
 
@@ -636,7 +640,7 @@ def setUpModule() -> None:
 
 def tearDownModule() -> None:
     # pylint: disable=invalid-name
-    shutil.rmtree(TMP_DIR)
+    shutil.rmtree(TMP_DIR, ignore_errors=True)
 
 
 def run_tests() -> bool:


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fixes #47072

Adds the missing `WebDriverCommandMsg::FullscreenWebView` and `WebDriverCommandMsg::MinimizeWebView` variants and the servoshell handling that forwards them to the platform window, plus the `fullscreen_window` / `minimize_window` server-side routes in `webdriver_server` mirroring the existing `maximize_window` path.

Today `fullscreen_window` and `minimize_window` are 0% in the wdspec run (2026-08-06 nightly): the `WebDriverCommand::FullscreenWindow` / `WebDriverCommand::MinimizeWindow` commands (which exist in the `webdriver` 0.53.0 crate) fall through to the catch-all "Command not implemented" arm, returning `unsupported operation`. The two new variants are the only missing pieces; the winit APIs (`Window::set_fullscreen` and `Window::set_minimized`) are already exercised by servoshell for other paths.

Changed:

- `components/shared/embedder/webdriver.rs`: two new `WebDriverCommandMsg` variants, mirroring `MaximizeWebView` (reply with `DeviceIndependentIntRect`).
- `ports/servoshell/webdriver.rs`: handlers that call `platform_window.set_fullscreen(true)` / `platform_window.minimize(&webview)` and reply with the resulting window rect.
- `ports/servoshell/window.rs` + `desktop/headed_window.rs`: new `PlatformWindow::minimize` (default no-op; winit `set_minimized(true)` in the headed implementation). `set_fullscreen(bool)` already existed on the trait.
- `components/webdriver_server/lib.rs`: `handle_fullscreen_window` / `handle_minimize_window` + route arms.
- `components/constellation/constellation.rs`: new variants added to the embedder-only unreachable group.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [X] These changes fix #47072 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because the coverage is the existing wpt wdspec modules (`fullscreen_window` and `minimize_window`), which will be exercised by the wdspec CI run.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you with the review as well as with the follow-up work. -->

Note: this patch has not yet been CI-built; it was validated against the v0.4.0 tag source (winit 0.30.13 APIs verified against the vendored crate, message/reply shapes bound to the existing `MaximizeWebView` path).
