### PR TITLE
net: Don't treat usvg_options as a child of the image-cache.

### DIFF
--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -873,7 +873,7 @@ impl ImageCache for ImageCacheImpl {
         let fontdb_size = self.usvg_options.conditional_size_of(ops);
         vec![
             Report {
-                path: path![prefix, "image-cache"],
+                path: path![prefix, "image-cache", "cache"],
                 kind: ReportKind::ExplicitSystemHeapSize,
                 size: store_size,
             },


### PR DESCRIPTION
about:memory assumes that any path like `a b c` is a component of the path `a b` and contributes to `a b`'s total size. Since that is not the case for the usvg_options part of the image cache, we need to differentiate them.

Testing: No tests for about:memory.