### PR TITLE
android / ohos: Respect `device_pixel_ratio_override` in servoshell

### DIFF
--- a/ports/servoshell/egl/android/mod.rs
+++ b/ports/servoshell/egl/android/mod.rs
@@ -217,8 +217,11 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_init<'local>(
                 WindowHandle::borrow_raw(window_handle),
             )
         };
-
-        let hidpi_scale_factor = Scale::new(density);
+        let hidpi_scale_factor = Scale::new(
+            servoshell_preferences
+                .device_pixel_ratio_override
+                .unwrap_or(density),
+        );
 
         APP.with(|app| {
             let new_app = App::new(AppInitOptions {

--- a/ports/servoshell/egl/ohos/mod.rs
+++ b/ports/servoshell/egl/ohos/mod.rs
@@ -527,7 +527,12 @@ impl ServoAction {
                 let display_handle = unsafe { DisplayHandle::borrow_raw(display_handle) };
                 let window_handle = unsafe { WindowHandle::borrow_raw(window_handle) };
 
-                let hidpi_factor = Scale::new(get_display_density());
+                let hidpi_factor = Scale::new(
+                    servo
+                        .servoshell_preferences()
+                        .device_pixel_ratio_override
+                        .unwrap_or_else(get_display_density),
+                );
                 servo.add_platform_window(
                     display_handle,
                     window_handle,


### PR DESCRIPTION
If the servoshell preference is set, it should be respected instead of ignored.
Desktop already respected this preference.

Testing: Not tested. 

