### PR TITLE
servoshell: Only hide toolbar when full-screen is from Web API

### DIFF
--- a/ports/servoshell/desktop/gui.rs
+++ b/ports/servoshell/desktop/gui.rs
@@ -391,7 +391,8 @@ impl Gui {
 
             // TODO: While in fullscreen add some way to mitigate the increased phishing risk
             // when not displaying the URL bar: https://github.com/servo/servo/issues/32443
-            if winit_window.fullscreen().is_none() {
+            // Show toolbar unless fullscreen is from document (web API)
+            if !headed_window.is_fullscreen_from_document() {
                 let frame = egui::Frame::default()
                     .fill(ctx.style().visuals.window_fill)
                     .inner_margin(4.0);

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -69,6 +69,7 @@ pub struct HeadedWindow {
     /// It equals viewport size + (0, toolbar height).
     inner_size: Cell<PhysicalSize<u32>>,
     fullscreen: Cell<bool>,
+    fullscreen_from_document: Cell<bool>,
     device_pixel_ratio_override: Option<f32>,
     xr_window_poses: RefCell<Vec<Rc<XRWindowPose>>>,
     modifiers_state: Cell<ModifiersState>,
@@ -197,6 +198,7 @@ impl HeadedWindow {
             winit_window,
             webview_relative_mouse_point: Cell::new(Point2D::zero()),
             fullscreen: Cell::new(false),
+            fullscreen_from_document: Cell::new(false),
             inner_size: Cell::new(inner_size),
             screen_size,
             device_pixel_ratio_override: servoshell_preferences.device_pixel_ratio_override,
@@ -789,6 +791,10 @@ impl HeadedWindow {
             }
         }
     }
+
+    pub(crate) fn is_fullscreen_from_document(&self) -> bool {
+        self.fullscreen_from_document.get()
+    }
 }
 
 impl PlatformWindow for HeadedWindow {
@@ -928,6 +934,7 @@ impl PlatformWindow for HeadedWindow {
             });
         }
         self.fullscreen.set(state);
+        self.fullscreen_from_document.set(state);
     }
 
     fn get_fullscreen(&self) -> bool {


### PR DESCRIPTION
This hides toolbar when full-screen is from Web API

> Please view changes with `Hide whitespaces` option

Testing: Attached Screenshot
- MacOS: Fixed (Tabbar and Tool-bar are visible)
<img width="1280" height="828" alt="Screenshot 2026-08-08 at 10 06 59 PM" src="https://github.com/user-attachments/assets/4b76f33f-0027-4f96-857b-e7faa8cc359a" />

- Linux : No Effect
<img width="2560" height="1440" alt="Screenshot from 2026-08-10 11-43-05" src="https://github.com/user-attachments/assets/ba6b6a93-40d9-4ecf-b51d-6f0cfa69bb34" />
- Windows: No Effect
<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/fcdcb9ef-9189-45fd-813f-7e9a1c999dea" />


Fixes: #47144
