### PR TITLE
script: Remove `reflect_dom_object_with_proto_and_cx`

### DIFF
--- a/components/script/dom/animations/animation.rs
+++ b/components/script/dom/animations/animation.rs
@@ -8,7 +8,7 @@ use js::rust::HandleObject;
 use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::inheritance::Castable;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use script_bindings::root::DomRoot;
 
 use crate::dom::animationeffect::AnimationEffect;
@@ -45,7 +45,7 @@ impl Animation {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto_and_cx(Box::new(Self::new_inherited()), global, proto, cx)
+        reflect_dom_object_with_proto(cx, Box::new(Self::new_inherited()), global, proto)
     }
 
     pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<Self> {

--- a/components/script/dom/audio/analysernode.rs
+++ b/components/script/dom/audio/analysernode.rs
@@ -9,7 +9,7 @@ use js::context::{JSContext, NoGC};
 use js::rust::{CustomAutoRooterGuard, HandleObject};
 use js::typedarray::{Float32Array, Uint8Array};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_base::generic_channel::GenericCallback;
 use servo_media::audio::analyser_node::AnalysisEngine;
 use servo_media::audio::audio_node::AudioNodeInit;
@@ -107,7 +107,7 @@ impl AnalyserNode {
         let callback_oncelock = Arc::new(OnceLock::new());
         let node =
             AnalyserNode::new_inherited(cx, window, context, options, callback_oncelock.clone())?;
-        let object = reflect_dom_object_with_proto_and_cx(Box::new(node), window, proto, cx);
+        let object = reflect_dom_object_with_proto(cx, Box::new(node), window, proto);
         let task_source = window
             .as_global_scope()
             .task_manager()

--- a/components/script/dom/audio/audiobuffer.rs
+++ b/components/script/dom/audio/audiobuffer.rs
@@ -9,7 +9,7 @@ use js::context::JSContext;
 use js::rust::{CustomAutoRooterGuard, HandleObject};
 use js::typedarray::{Float32, Float32Array, HeapFloat32Array};
 use script_bindings::cell::{DomRefCell, Ref};
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use script_bindings::trace::RootedTraceableBox;
 use servo_media::audio::buffer_source_node::AudioBuffer as ServoMediaAudioBuffer;
 
@@ -109,7 +109,7 @@ impl AudioBuffer {
         initial_data: Option<&[Vec<f32>]>,
     ) -> DomRoot<AudioBuffer> {
         let buffer = AudioBuffer::new_inherited(number_of_channels, length, sample_rate);
-        let buffer = reflect_dom_object_with_proto_and_cx(Box::new(buffer), global, proto, cx);
+        let buffer = reflect_dom_object_with_proto(cx, Box::new(buffer), global, proto);
         buffer.set_initial_data(initial_data);
         buffer
     }

--- a/components/script/dom/audio/audiocontext.rs
+++ b/components/script/dom/audio/audiocontext.rs
@@ -8,7 +8,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::realm::CurrentRealm;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_base::id::PipelineId;
 use servo_media::audio::context::{LatencyCategory, ProcessingState, RealTimeAudioContextOptions};
 
@@ -92,7 +92,7 @@ impl AudioContext {
     ) -> Fallible<DomRoot<AudioContext>> {
         let pipeline_id = window.pipeline_id();
         let context = AudioContext::new_inherited(options, pipeline_id)?;
-        let context = reflect_dom_object_with_proto_and_cx(Box::new(context), window, proto, cx);
+        let context = reflect_dom_object_with_proto(cx, Box::new(context), window, proto);
         context.resume();
         Ok(context)
     }

--- a/components/script/dom/audio/offlineaudiocompletionevent.rs
+++ b/components/script/dom/audio/offlineaudiocompletionevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::audio::audiobuffer::AudioBuffer;
@@ -63,7 +63,7 @@ impl OfflineAudioCompletionEvent {
         rendered_buffer: &AudioBuffer,
     ) -> DomRoot<OfflineAudioCompletionEvent> {
         let event = Box::new(OfflineAudioCompletionEvent::new_inherited(rendered_buffer));
-        let ev = reflect_dom_object_with_proto_and_cx(event, window, proto, cx);
+        let ev = reflect_dom_object_with_proto(cx, event, window, proto);
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bool::from(bubbles), bool::from(cancelable));

--- a/components/script/dom/event/closeevent.rs
+++ b/components/script/dom/event/closeevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::CloseEventBinding;
@@ -66,7 +66,7 @@ impl CloseEvent {
         reason: DOMString,
     ) -> DomRoot<CloseEvent> {
         let event = Box::new(CloseEvent::new_inherited(wasClean, code, reason));
-        let ev = reflect_dom_object_with_proto_and_cx(event, global, proto, cx);
+        let ev = reflect_dom_object_with_proto(cx, event, global, proto);
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bool::from(bubbles), bool::from(cancelable));

--- a/components/script/dom/event/commandevent.rs
+++ b/components/script/dom/event/commandevent.rs
@@ -7,7 +7,7 @@ use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::codegen::GenericBindings::NodeBinding::NodeMethods;
 use script_bindings::inheritance::Castable;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::CommandEventBinding;
@@ -52,7 +52,7 @@ impl CommandEvent {
         command: DOMString,
     ) -> DomRoot<CommandEvent> {
         let event = Box::new(CommandEvent::new_inherited(source, command));
-        let event = reflect_dom_object_with_proto_and_cx(event, window, proto, cx);
+        let event = reflect_dom_object_with_proto(cx, event, window, proto);
         {
             let event = event.upcast::<Event>();
             event.init_event(type_, bool::from(bubbles), bool::from(cancelable));

--- a/components/script/dom/event/event.rs
+++ b/components/script/dom/event/event.rs
@@ -15,7 +15,7 @@ use keyboard_types::{Key, NamedKey};
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::PointerEventBinding::PointerEventMethods;
 use script_bindings::match_domstring_ascii;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use servo_base::cross_process_instant::CrossProcessInstant;
 use stylo_atoms::Atom;
 
@@ -139,7 +139,7 @@ impl Event {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<Event> {
-        reflect_dom_object_with_proto_and_cx(Box::new(Event::new_inherited()), global, proto, cx)
+        reflect_dom_object_with_proto(cx, Box::new(Event::new_inherited()), global, proto)
     }
 
     pub(crate) fn new(

--- a/components/script/dom/event/messageevent.rs
+++ b/components/script/dom/event/messageevent.rs
@@ -8,7 +8,7 @@ use js::jsapi::Heap;
 use js::jsval::JSVal;
 use js::rust::{HandleObject, HandleValue, MutableHandleValue};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -131,7 +131,7 @@ impl MessageEvent {
             lastEventId,
             ports,
         ));
-        let ev = reflect_dom_object_with_proto_and_cx(ev, global, proto, cx);
+        let ev = reflect_dom_object_with_proto(cx, ev, global, proto);
         ev.data.set(data.get());
 
         ev

--- a/components/script/dom/event/toggleevent.rs
+++ b/components/script/dom/event/toggleevent.rs
@@ -7,7 +7,7 @@ use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::codegen::GenericBindings::NodeBinding::NodeMethods;
 use script_bindings::inheritance::Castable;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -76,7 +76,7 @@ impl ToggleEvent {
         source: Option<&Element>,
     ) -> DomRoot<ToggleEvent> {
         let event = Box::new(ToggleEvent::new_inherited(old_state, new_state, source));
-        let event = reflect_dom_object_with_proto_and_cx(event, window, proto, cx);
+        let event = reflect_dom_object_with_proto(cx, event, window, proto);
         {
             let event = event.upcast::<Event>();
             event.init_event(type_, bool::from(bubbles), bool::from(cancelable));

--- a/components/script/dom/event/uievent.rs
+++ b/components/script/dom/event/uievent.rs
@@ -8,7 +8,7 @@ use std::default::Default;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_config::pref;
 use stylo_atoms::Atom;
 
@@ -58,7 +58,7 @@ impl UIEvent {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<UIEvent> {
-        reflect_dom_object_with_proto_and_cx(Box::new(UIEvent::new_inherited()), window, proto, cx)
+        reflect_dom_object_with_proto(cx, Box::new(UIEvent::new_inherited()), window, proto)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/components/script/dom/fetch/headers.rs
+++ b/components/script/dom/fetch/headers.rs
@@ -17,7 +17,7 @@ use net_traits::request::is_cors_safelisted_request_header;
 use net_traits::trim_http_whitespace;
 use script_bindings::cell::DomRefCell;
 use script_bindings::cformat;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::HeadersBinding::{HeadersInit, HeadersMethods};
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
@@ -62,7 +62,7 @@ impl Headers {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<Headers> {
-        reflect_dom_object_with_proto_and_cx(Box::new(Headers::new_inherited()), global, proto, cx)
+        reflect_dom_object_with_proto(cx, Box::new(Headers::new_inherited()), global, proto)
     }
 }
 

--- a/components/script/dom/geometry/dommatrix.rs
+++ b/components/script/dom/geometry/dommatrix.rs
@@ -8,7 +8,7 @@ use js::context::{JSContext, NoGC};
 use js::rust::{CustomAutoRooterGuard, HandleObject};
 use js::typedarray::{Float32Array, Float64Array};
 use rustc_hash::FxHashMap;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use script_bindings::str::DOMString;
 use servo_base::id::{DomMatrixId, DomMatrixIndex};
 use servo_constellation_traits::DomMatrix;
@@ -53,7 +53,7 @@ impl DOMMatrix {
         matrix: Transform3D<f64>,
     ) -> DomRoot<Self> {
         let dommatrix = Self::new_inherited(is2D, matrix);
-        reflect_dom_object_with_proto_and_cx(Box::new(dommatrix), global, proto, cx)
+        reflect_dom_object_with_proto(cx, Box::new(dommatrix), global, proto)
     }
 
     pub(crate) fn new_inherited(is2D: bool, matrix: Transform3D<f64>) -> Self {

--- a/components/script/dom/geometry/dommatrixreadonly.rs
+++ b/components/script/dom/geometry/dommatrixreadonly.rs
@@ -18,7 +18,7 @@ use js::typedarray::{Float32Array, Float64Array, HeapFloat32Array, HeapFloat64Ar
 use rustc_hash::FxHashMap;
 use script_bindings::cell::{DomRefCell, Ref};
 use script_bindings::cformat;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use script_bindings::trace::RootedTraceableBox;
 use servo_base::id::{DomMatrixId, DomMatrixIndex};
 use servo_constellation_traits::DomMatrix;
@@ -76,7 +76,7 @@ impl DOMMatrixReadOnly {
         matrix: Transform3D<f64>,
     ) -> DomRoot<Self> {
         let dommatrix = Self::new_inherited(is2D, matrix);
-        reflect_dom_object_with_proto_and_cx(Box::new(dommatrix), global, proto, cx)
+        reflect_dom_object_with_proto(cx, Box::new(dommatrix), global, proto)
     }
 
     pub(crate) fn new_inherited(is2D: bool, matrix: Transform3D<f64>) -> Self {

--- a/components/script/dom/intersectionobserver/intersectionobserverentry.rs
+++ b/components/script/dom/intersectionobserver/intersectionobserverentry.rs
@@ -7,7 +7,7 @@ use std::cell::Cell;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::DOMRectReadOnlyBinding::DOMRectInit;
 use crate::dom::bindings::codegen::Bindings::IntersectionObserverEntryBinding::{
@@ -91,7 +91,7 @@ impl IntersectionObserverEntry {
             intersection_ratio,
             target,
         ));
-        reflect_dom_object_with_proto_and_cx(observer, window, proto, cx)
+        reflect_dom_object_with_proto(cx, observer, window, proto)
     }
 
     fn new_from_dictionary(
@@ -113,7 +113,7 @@ impl IntersectionObserverEntry {
             init.intersectionRatio,
             &init.target,
         ));
-        reflect_dom_object_with_proto_and_cx(observer, window, proto, cx)
+        reflect_dom_object_with_proto(cx, observer, window, proto)
     }
 }
 

--- a/components/script/dom/media/mediaquerylistevent.rs
+++ b/components/script/dom/media/mediaquerylistevent.rs
@@ -7,7 +7,7 @@ use std::cell::Cell;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -43,7 +43,7 @@ impl MediaQueryListEvent {
             media,
             matches: Cell::new(matches),
         });
-        reflect_dom_object_with_proto_and_cx(ev, global, proto, cx)
+        reflect_dom_object_with_proto(cx, ev, global, proto)
     }
 
     pub(crate) fn new(

--- a/components/script/dom/mutationobserver/mutationobserver.rs
+++ b/components/script/dom/mutationobserver/mutationobserver.rs
@@ -12,7 +12,7 @@ use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::callback::OwnerWindow;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::MutationObserverBinding::MutationObserver_Binding::MutationObserverMethods;
 use crate::dom::bindings::codegen::Bindings::MutationObserverBinding::{
@@ -80,7 +80,7 @@ impl MutationObserver {
         callback: Rc<MutationCallback>,
     ) -> DomRoot<MutationObserver> {
         let boxed_observer = Box::new(MutationObserver::new_inherited(callback));
-        reflect_dom_object_with_proto_and_cx(boxed_observer, global, proto, cx)
+        reflect_dom_object_with_proto(cx, boxed_observer, global, proto)
     }
 
     fn new_inherited(callback: Rc<MutationCallback>) -> MutationObserver {

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -38,7 +38,7 @@ use script_bindings::codegen::GenericBindings::EventBinding::EventMethods;
 use script_bindings::codegen::GenericBindings::ProcessingInstructionBinding::ProcessingInstructionMethods;
 use script_bindings::codegen::InheritTypes::{DocumentFragmentTypeId, TextTypeId};
 use script_bindings::reflector::{
-    DomObject, DomObjectWrap, WeakReferenceableDomObjectWrap, reflect_dom_object_with_proto_and_cx,
+    DomObject, DomObjectWrap, WeakReferenceableDomObjectWrap, reflect_dom_object_with_proto,
     reflect_weak_referenceable_dom_object_with_proto,
 };
 use script_traits::DocumentActivity;
@@ -2246,7 +2246,7 @@ impl Node {
         N: DerivedFrom<Node> + DomObject + DomObjectWrap<crate::DomTypeHolder>,
     {
         let window = document.window();
-        reflect_dom_object_with_proto_and_cx(node, window, proto, cx)
+        reflect_dom_object_with_proto(cx, node, window, proto)
     }
 
     pub(crate) fn reflect_weak_referenceable_node_with_proto<N>(

--- a/components/script/dom/resizeobserver/resizeobserver.rs
+++ b/components/script/dom/resizeobserver/resizeobserver.rs
@@ -14,7 +14,7 @@ use js::context::JSContext;
 use js::rust::HandleObject;
 use layout_api::BoxAreaType;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use style_traits::CSSPixel;
 
 use crate::dom::bindings::callback::ExceptionHandling;
@@ -77,7 +77,7 @@ impl ResizeObserver {
         callback: Rc<ResizeObserverCallback>,
     ) -> DomRoot<ResizeObserver> {
         let observer = Box::new(ResizeObserver::new_inherited(callback));
-        reflect_dom_object_with_proto_and_cx(observer, window, proto, cx)
+        reflect_dom_object_with_proto(cx, observer, window, proto)
     }
 
     /// Step 2 of <https://drafts.csswg.org/resize-observer/#gather-active-observations-h>

--- a/components/script/dom/resizeobserver/resizeobserverentry.rs
+++ b/components/script/dom/resizeobserver/resizeobserverentry.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::MutableHandleValue;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::ResizeObserverEntryBinding::ResizeObserverEntryMethods;
 use crate::dom::bindings::root::{Dom, DomRoot};
@@ -74,7 +74,7 @@ impl ResizeObserverEntry {
             content_box_size,
             device_pixel_content_box_size,
         ));
-        reflect_dom_object_with_proto_and_cx(entry, window, None, cx)
+        reflect_dom_object_with_proto(cx, entry, window, None)
     }
 }
 

--- a/components/script/dom/resizeobserver/resizeobserversize.rs
+++ b/components/script/dom/resizeobserver/resizeobserversize.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::ResizeObserverSizeBinding::ResizeObserverSizeMethods;
 use crate::dom::bindings::root::DomRoot;
@@ -55,7 +55,7 @@ impl ResizeObserverSize {
         size_impl: ResizeObserverSizeImpl,
     ) -> DomRoot<ResizeObserverSize> {
         let observer_size = Box::new(ResizeObserverSize::new_inherited(size_impl));
-        reflect_dom_object_with_proto_and_cx(observer_size, window, None, cx)
+        reflect_dom_object_with_proto(cx, observer_size, window, None)
     }
 }
 

--- a/components/script/dom/serviceworker/extendablemessageevent.rs
+++ b/components/script/dom/serviceworker/extendablemessageevent.rs
@@ -7,7 +7,7 @@ use js::context::JSContext;
 use js::jsapi::Heap;
 use js::jsval::JSVal;
 use js::rust::{HandleObject, HandleValue, MutableHandleValue};
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::ExtendableEventBinding::ExtendableEvent_Binding::ExtendableEventMethods;
@@ -160,7 +160,7 @@ impl ExtendableMessageEvent {
             source,
             ports,
         ));
-        let ev = reflect_dom_object_with_proto_and_cx(ev, global, proto, cx);
+        let ev = reflect_dom_object_with_proto(cx, ev, global, proto);
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bubbles, cancelable);

--- a/components/script/dom/stream/bytelengthqueuingstrategy.rs
+++ b/components/script/dom/stream/bytelengthqueuingstrategy.rs
@@ -11,7 +11,7 @@ use js::gc::{HandleValue, MutableHandleValue};
 use js::jsapi::CallArgs;
 use js::jsval::{JSVal, UndefinedValue};
 use js::rust::HandleObject;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::FunctionBinding::Function;
 use crate::dom::bindings::codegen::Bindings::QueuingStrategyBinding::{
@@ -44,7 +44,7 @@ impl ByteLengthQueuingStrategy {
         proto: Option<HandleObject>,
         init: f64,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto_and_cx(Box::new(Self::new_inherited(init)), global, proto, cx)
+        reflect_dom_object_with_proto(cx, Box::new(Self::new_inherited(init)), global, proto)
     }
 }
 

--- a/components/script/dom/stream/countqueuingstrategy.rs
+++ b/components/script/dom/stream/countqueuingstrategy.rs
@@ -9,7 +9,7 @@ use js::context::JSContext;
 use js::jsapi::CallArgs;
 use js::jsval::{Int32Value, JSVal};
 use js::rust::HandleObject;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::FunctionBinding::Function;
 use crate::dom::bindings::codegen::Bindings::QueuingStrategyBinding::{
@@ -41,7 +41,7 @@ impl CountQueuingStrategy {
         proto: Option<HandleObject>,
         init: f64,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto_and_cx(Box::new(Self::new_inherited(init)), global, proto, cx)
+        reflect_dom_object_with_proto(cx, Box::new(Self::new_inherited(init)), global, proto)
     }
 }
 

--- a/components/script/dom/webvtt/vttcue.rs
+++ b/components/script/dom/webvtt/vttcue.rs
@@ -8,7 +8,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_webvtt::{
     WebVttCue, WebVttCueSize, WebVttLineAlignment, WebVttLineAndPositionSetting,
     WebVttPositionAlignment, WebVttSnapToLines, WebVttTextAlignment, WebVttWritingDirection,
@@ -97,7 +97,8 @@ impl VTTCue {
         align: AlignSetting,
         track: Option<&TextTrack>,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto_and_cx(
+        reflect_dom_object_with_proto(
+            cx,
             Box::new(Self::new_inherited(
                 start_time,
                 end_time,
@@ -115,7 +116,6 @@ impl VTTCue {
             )),
             window,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/webvtt/vttregion.rs
+++ b/components/script/dom/webvtt/vttregion.rs
@@ -8,7 +8,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
 use crate::dom::bindings::codegen::Bindings::VTTRegionBinding::{ScrollSetting, VTTRegionMethods};
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
@@ -46,7 +46,7 @@ impl VTTRegion {
     }
 
     fn new(cx: &mut JSContext, window: &Window, proto: Option<HandleObject>) -> DomRoot<Self> {
-        reflect_dom_object_with_proto_and_cx(Box::new(Self::new_inherited()), window, proto, cx)
+        reflect_dom_object_with_proto(cx, Box::new(Self::new_inherited()), window, proto)
     }
 }
 

--- a/components/script/dom/webxr/xrray.rs
+++ b/components/script/dom/webxr/xrray.rs
@@ -7,7 +7,7 @@ use euclid::{Angle, RigidTransform3D, Rotation3D, Vector3D};
 use js::context::JSContext;
 use js::rust::HandleObject;
 use js::typedarray::{Float32, HeapFloat32Array};
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use script_bindings::trace::RootedTraceableBox;
 use webxr_api::{ApiSpace, Ray};
 
@@ -45,7 +45,7 @@ impl XRRay {
         proto: Option<HandleObject>,
         ray: Ray<ApiSpace>,
     ) -> DomRoot<XRRay> {
-        reflect_dom_object_with_proto_and_cx(Box::new(XRRay::new_inherited(ray)), window, proto, cx)
+        reflect_dom_object_with_proto(cx, Box::new(XRRay::new_inherited(ray)), window, proto)
     }
 
     pub(crate) fn ray(&self) -> Ray<ApiSpace> {

--- a/components/script_bindings/reflector.rs
+++ b/components/script_bindings/reflector.rs
@@ -313,24 +313,6 @@ where
 
 /// Create the reflector for a new DOM object and yield ownership to the
 /// reflector.
-/// Deprecated, use `reflect_dom_object_with_proto` instead.
-pub fn reflect_dom_object_with_proto_and_cx<D, T, U>(
-    obj: Box<T>,
-    global: &U,
-    proto: Option<HandleObject>,
-    cx: &mut JSContext,
-) -> DomRoot<T>
-where
-    D: DomTypes,
-    T: DomObject + DomObjectWrap<D>,
-    U: DerivedFrom<D::GlobalScope>,
-{
-    let global_scope = global.upcast();
-    unsafe { T::WRAP(cx, global_scope, proto, obj) }
-}
-
-/// Create the reflector for a new DOM object and yield ownership to the
-/// reflector.
 pub fn reflect_weak_referenceable_dom_object<D, T, U>(
     cx: &mut JSContext,
     obj: Rc<T>,


### PR DESCRIPTION
This migrates all remaining usages of `reflect_dom_object_with_proto_and_cx`. This PR is the result of applying the following regex replacement to the codebase:

Before:

```
reflect_dom_object_with_proto_and_cx\(([^<]+),\s+?cx\)
```

After:

```
reflect_dom_object_with_proto(cx, $1);
```

Part of #40600

Testing: it compiles