### PR TITLE
deps: Update mozjs to 0.21.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5244,9 +5244,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63ef76cde759845cfc57234cf7af545da7b1a4e523dbd9e25796cbb395d559e7"
+checksum = "e6fff40896bf504f30c85dbadd34ddbb148a80d5dde0f878984806b1568fb0d6"
 dependencies = [
  "bindgen",
  "cc",
@@ -5259,9 +5259,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "140.13.0-1"
+version = "140.13.0-2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9853ef9f182c6fbc5dae54da58b0170c6ba5cbf9e19d18a0dfad25ed1e90a2"
+checksum = "08abcc45d1d261688f60ca6f2ed051e60e3b8e4de5a96e2581dfa7fa637b63f2"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ inventory = "0.3.24"
 ipc-channel = "0.22"
 itertools = "0.15"
 jni = "0.22"
-js = { package = "mozjs", version = "=0.21.1", default-features = false, features = ["intl", "libz-sys"] }
+js = { package = "mozjs", version = "=0.21.2", default-features = false, features = ["intl", "libz-sys"] }
 k12 = "0.5"
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.13.1", features = ["euclid"] }


### PR DESCRIPTION
Includes https://github.com/servo/mozjs/pull/732 (simple cleanup PR)

Testing: Covered by existing tests

