### PR TITLE
build: Configure jemalloc with 64KB page size on linux-arm64

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -422,6 +422,18 @@ class CommandBase(object):
                 print("Hint: Ninja-build is available on github at: https://github.com/ninja-build/ninja/releases")
                 exit(1)
 
+        # jemalloc requires to be compiled with a page size that is at least equal to the one
+        # used by the kernel of machine on which it will run.
+        # Some linux distros for arm64 configure the page size to 16KB (e.g. Raspberry Pi OS 13)
+        # and few others use a 64KB page size. The upstream 'jemalloc` has switched to 64KB pages
+        # as the default, but this is not available in `tikv-jemalloc` yet, so we configure it here.
+        # FIXME: Remove after `tikv-jemalloc` ships the change to default to 64KB page size.
+        # See https://github.com/servo/servo/issues/47114
+        if "aarch64-unknown-linux-gnu" == self.target.triple():
+            # The value of the environment variable represents the number of bits in the address
+            # space, so 2^16 means we use 64KB as the page size.
+            env["AARCH64_UNKNOWN_LINUX_GNU_JEMALLOC_SYS_WITH_LG_PAGE"] = "16"
+
         # Increase stylo thread stack size to 8 MiB for all builds
         # to match the recursion depth of Chromium.
         # This only reserves virtual memory space and has almost no overhead.


### PR DESCRIPTION
Raspberry Pi OS 13 (used by Pi 5) ships with a kernel that uses 16KB pages on rPI 5 based systems and `jemalloc` requires that it be compiled with a page size that is at least equal to the base size that will be used by the runtime kernel.

The upstream `jemalloc` maintained by Meta now ships with 64KB as the default, but `tikv-jemalloc` doesn't have this change yet.

This patch forces jemalloc to use the 64KB page size using the `AARCH64_UNKNOWN_LINUX_GNU_JEMALLOC_SYS_WITH_LG_PAGE` environment variable supported by jemalloc.

Testing: A production build of servo with the patch has been tested on both rPi 500 (16KB kernel page size) and rPi 400 (4KB kernel page size) and it works on both. Raspberry PI OS 13 was used for testing both configurations.

In addition, the Speedometer 3 and Jetstream 2 benchmarks were run using WebKit's run-benchmark script against both 4KB and 64KB builds of servo on rPi 400 and there was negligible difference in metrics. It wasn't possible to get a good idea of memory consumption due to #42769, but the benchmarks completed multiple iterations successfully.

Fixes: #46855