### PR TITLE
OHOS: Also push `HarmonyOS Sans SC` & `HarmonyOS Sans TC` as candidate fallback fonts when special characters are encountered. 

### DIFF
--- a/components/fonts/platform/freetype/ohos/font_list.rs
+++ b/components/fonts/platform/freetype/ohos/font_list.rs
@@ -495,6 +495,10 @@ pub fn fallback_font_families(options: FallbackFontSelectionOptions) -> Vec<&'st
                 families.push("Noto Sans CJK SC");
                 families.push("Noto Sans Mono CJK SC");
             },
+            UnicodeBlock::CJKSymbolsandPunctuation => {
+                families.push("HarmonyOS Sans SC");
+                families.push("HarmonyOS Sans TC");
+            },
             _ => {},
         }
     }


### PR DESCRIPTION
Currently, `fallback_font_families()` only push `HarmonyOS Sans SC` & `HarmonyOS Sans TC` when a character is a Chinese character (e.g. `你`, `我`, etc.). However, there are also Chinese special characters such as Chinese brackets ( `【】`). These special characters are not considered as Han scripts by `unicode_script`. As a result, these special characters won't be rendered on OHOS devices.

Therefore, we need to also consider `HarmonyOS Sans SC` & `HarmonyOS Sans TC` if we encounter special characters.

Testing: Manual testing.
