### PR TITLE
script: Add error message for invalid selectors.

### DIFF
--- a/components/script/layout_dom/servo_dangerous_style_node.rs
+++ b/components/script/layout_dom/servo_dangerous_style_node.rs
@@ -52,7 +52,9 @@ impl<'dom> ServoDangerousStyleNode<'dom> {
 
         // Step 2. If selector is failure, then throw a "SyntaxError" DOMException.
         let Ok(selector_list) = selector_or_error else {
-            return Err(Error::Syntax(None));
+            return Err(Error::Syntax(Some(format!(
+                "'{selector}' is an invalid selector"
+            ))));
         };
 
         // Step 3. Return the result of match a selector against a tree with selector

--- a/python/tidy/error_message_exceptions.txt
+++ b/python/tidy/error_message_exceptions.txt
@@ -133,6 +133,5 @@
 ./components/script/dom/xpath/xpathresult.rs 1
 ./components/script/drag_data_store.rs 1
 ./components/script/indexeddb.rs 2
-./components/script/layout_dom/servo_dangerous_style_node.rs 1
 ./components/script/xpath.rs 1
 ./components/script_bindings/proxyhandler.rs 1


### PR DESCRIPTION
This provides more useful error messages when websites are doing invalid things with selectors.

Testing: No tests for the contents of error messages.
Part of #40756
