### PR TITLE
deps: Bump mozjs to 0.21.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5244,9 +5244,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6fff40896bf504f30c85dbadd34ddbb148a80d5dde0f878984806b1568fb0d6"
+checksum = "29596ccede272dfd26a6377d65be42dc8da3d6f41916d29a9ce8a7945b0a235b"
 dependencies = [
  "bindgen",
  "cc",
@@ -5259,9 +5259,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "140.13.0-2"
+version = "140.13.0-3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08abcc45d1d261688f60ca6f2ed051e60e3b8e4de5a96e2581dfa7fa637b63f2"
+checksum = "7a7f303ebd1ccc07f1748a8ed9048df7dd88e23ac706b63fb89af82c80145fa8"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ inventory = "0.3.24"
 ipc-channel = "0.22"
 itertools = "0.15"
 jni = "0.22"
-js = { package = "mozjs", version = "=0.21.2", default-features = false, features = ["intl", "libz-sys"] }
+js = { package = "mozjs", version = "=0.21.3", default-features = false, features = ["intl", "libz-sys"] }
 k12 = "0.5"
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.13.1", features = ["euclid"] }


### PR DESCRIPTION
Companion PR to  https://github.com/servo/mozjs/pull/789, with a minor build-system refactor and no other changes.

try run: https://github.com/jschwe/servo/actions/runs/31407322992

Testing: Dependency update, covered by existing tests. No functional changes in mozjs.
