### PR TITLE
script: Make Range client rects empty when not in the document

### DIFF
--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -353,11 +353,16 @@ impl Range {
         self.abstract_range().Collapsed()
     }
 
+    /// <https://drafts.csswg.org/cssom-view/#dom-range-getclientrects>
     fn client_rects<'a>(&self, no_gc: &'a NoGC) -> impl Iterator<Item = Rect<Au, CSSPixel>> + 'a {
+        // > The getClientRects() method, when invoked, must return an empty DOMRectList
+        // > object if the range is not in the document.
+
         // FIXME: For text nodes that are only partially selected, this should return the client
         // rect of the selected part, not the whole text node.
         let start = self.start_container();
         let end = self.end_container();
+        let in_document_tree = self.start_and_end_are_in_document_tree();
         let document = start.owner_doc();
         let end_clone = UnrootedDom::from_dom(Dom::from_ref(&*end), no_gc);
         start
@@ -365,6 +370,7 @@ impl Range {
             .take_while(move |node| *node != *end)
             .chain(iter::once(end_clone))
             .flat_map(move |node| node.border_boxes())
+            .take_while(move |_| in_document_tree)
     }
 
     /// <https://dom.spec.whatwg.org/#concept-range-bp-set>

--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -4,6 +4,7 @@
 
 use std::cell::RefCell;
 use std::cmp::{Ordering, PartialOrd};
+use std::iter;
 use std::rc::Rc;
 
 use app_units::Au;
@@ -353,22 +354,35 @@ impl Range {
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-range-getclientrects>
-    fn client_rects<'a>(&self, no_gc: &'a NoGC) -> impl Iterator<Item = Rect<Au, CSSPixel>> + 'a {
-        // > The getClientRects() method, when invoked, must return an empty DOMRectList
-        // > object if the range is not in the document.
-
+    fn client_rects(&self, no_gc: &NoGC) -> Vec<Rect<Au, CSSPixel>> {
         // FIXME: For text nodes that are only partially selected, this should return the client
         // rect of the selected part, not the whole text node.
         let start = self.start_container();
         let end = self.end_container();
-        let in_document_tree = self.start_and_end_are_in_document_tree();
+        // > The getClientRects() method, when invoked, must return an empty DOMRectList
+        // > object if the range is not in the document.
+        if !start.is_connected() || !end.is_connected() {
+            return vec![];
+        }
+
+        // Per the spec, only Text nodes contribute rects when the range is collapsed
+        // (including when the boundary points are identical).
+        if self.collapsed() {
+            if start.is::<CharacterData>() {
+                return start.border_boxes();
+            } else {
+                return vec![];
+            }
+        }
+
         let document = start.owner_doc();
         let end_clone = UnrootedDom::from_dom(Dom::from_ref(&*end), no_gc);
         start
             .following_nodes_unrooted(no_gc, document.upcast::<Node>(), ShadowIncluding::No)
-            .take_while(move |node| in_document_tree && *node != *end)
-            .chain(in_document_tree.then_some(end_clone))
+            .take_while(move |node| *node != *end)
+            .chain(iter::once(end_clone))
             .flat_map(move |node| node.border_boxes())
+            .collect()
     }
 
     /// <https://dom.spec.whatwg.org/#concept-range-bp-set>
@@ -1251,7 +1265,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         let start = self.start_container();
         let window = start.owner_window();
 
-        let client_rects: Vec<_> = self.client_rects(cx.no_gc()).collect();
+        let client_rects = self.client_rects(cx.no_gc());
         let client_rects = client_rects
             .iter()
             .map(|rect| {
@@ -1280,7 +1294,9 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         // Step 3. If all rectangles in list have zero width or height, return the first rectangle in list.
         // Step 4. Otherwise, return a DOMRect object describing the smallest rectangle that includes all
         // of the rectangles in list of which the height or width is not zero.
-        let bounding_rect = list.fold(euclid::Rect::zero(), |acc, rect| acc.union(&rect));
+        let bounding_rect = list
+            .into_iter()
+            .fold(euclid::Rect::zero(), |acc, rect| acc.union(&rect));
 
         DOMRect::new(
             cx,

--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -4,7 +4,6 @@
 
 use std::cell::RefCell;
 use std::cmp::{Ordering, PartialOrd};
-use std::iter;
 use std::rc::Rc;
 
 use app_units::Au;
@@ -367,10 +366,9 @@ impl Range {
         let end_clone = UnrootedDom::from_dom(Dom::from_ref(&*end), no_gc);
         start
             .following_nodes_unrooted(no_gc, document.upcast::<Node>(), ShadowIncluding::No)
-            .take_while(move |node| *node != *end)
-            .chain(iter::once(end_clone))
+            .take_while(move |node| in_document_tree && *node != *end)
+            .chain(in_document_tree.then_some(end_clone))
             .flat_map(move |node| node.border_boxes())
-            .take_while(move |_| in_document_tree)
     }
 
     /// <https://dom.spec.whatwg.org/#concept-range-bp-set>

--- a/tests/wpt/meta/css/cssom-view/range-bounding-client-rect-with-shadow-dom.html.ini
+++ b/tests/wpt/meta/css/cssom-view/range-bounding-client-rect-with-shadow-dom.html.ini
@@ -1,0 +1,3 @@
+[range-bounding-client-rect-with-shadow-dom.html]
+  [a collapsed range at a text node returns client rects]
+    expected: FAIL

--- a/tests/wpt/tests/css/cssom-view/range-bounding-client-rect-with-shadow-dom.html
+++ b/tests/wpt/tests/css/cssom-view/range-bounding-client-rect-with-shadow-dom.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Range.getClientRects and getBoundingClientRect for ranges not in the document</title>
+<link rel=help href="https://github.com/servo/servo/issues/47115">
+<link rel="author" title="Euclid Ye" href="mailto:yezhizhenjiakang@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/cssom-view-1/#dom-range-getclientrects">
+<link rel="help" href="https://drafts.csswg.org/cssom-view-1/#dom-range-getboundingclientrect">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<span id="light">Light</span>
+<span id="host"></span>
+<script>
+  const host = document.getElementById("host");
+  const shadowRoot = host.attachShadow({ mode: "open" });
+  shadowRoot.innerHTML = "<mark id=\"shadow\">Shadow</mark>";
+  const shadowMark = shadowRoot.getElementById("shadow");
+
+  test(() => {
+    const range = document.createRange();
+    range.setStartBefore(document.getElementById("light"));
+    range.setEndAfter(shadowMark);
+
+    assert_equals(range.getClientRects().length, 0,
+      "getClientRects() returns an empty list for a range that is not in the document");
+
+    const rect = range.getBoundingClientRect();
+    assert_equals(rect.x, 0, "x");
+    assert_equals(rect.y, 0, "y");
+    assert_equals(rect.width, 0, "width");
+    assert_equals(rect.height, 0, "height");
+  }, "getBoundingClientRect returns a zero rect for a range crossing a shadow boundary");
+
+  test(() => {
+    const range = document.createRange();
+    range.selectNode(shadowMark);
+
+    assert_not_equals(range.getClientRects().length, 0,
+      "getClientRects() returns client rects for a range inside a shadow tree");
+    assert_true(range.getBoundingClientRect().width > 0);
+  }, "ranges entirely inside a shadow tree return client rects");
+
+  test(() => {
+    const detached = document.createElement("div");
+    detached.textContent = "detached";
+    const range = document.createRange();
+    range.selectNodeContents(detached);
+
+    assert_equals(range.getClientRects().length, 0,
+      "getClientRects() returns an empty list for a range in a detached tree");
+    assert_equals(range.getBoundingClientRect().width, 0);
+  }, "ranges in a detached tree return empty rects");
+
+  test(() => {
+    const text = document.getElementById("light").firstChild;
+    const range = document.createRange();
+    range.setStart(text, 1);
+    range.setEnd(text, 1);
+
+    assert_not_equals(range.getClientRects().length, 0,
+      "a collapsed range at a text node still returns client rects");
+    assert_true(range.getBoundingClientRect().height > 0);
+  }, "a collapsed range at a text node returns client rects");
+</script>


### PR DESCRIPTION
https://drafts.csswg.org/cssom-view/#dom-range-getclientrects
> The getClientRects() method, when invoked, must return an empty DOMRectList object if the range is not in the document.

Testing: Added a test `tests/wpt/tests/css/cssom-view/range-bounding-client-rect-with-shadow-dom.html` since no existing test cover this.
Fixes: #47115
