### PR TITLE
clippy: Delete not needed .clippy.toml file

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,2 +1,0 @@
-# Lint for https://github.com/advisories/GHSA-r6v5-fh4h-64xc until we upgrade to time >=0.3.47
-disallowed-types = ["time::format_description::well_known::Rfc2822"]


### PR DESCRIPTION
We do not need this anymore as we are past the required time-rs version.

Testing: If the CI is happy, this should work.
