### PR TITLE
script: Cache UrlExtraData for about:blank

### DIFF
--- a/components/script/css.rs
+++ b/components/script/css.rs
@@ -4,13 +4,19 @@
 
 //! Helpers for CSS value parsing.
 
+use std::sync::LazyLock;
+
 use style::context::QuirksMode;
 use style::error_reporting::ParseErrorReporter;
 use style::parser::ParserContext;
 use style::stylesheets::{CssRuleType, Origin, UrlExtraData};
 use style_traits::ParsingMode;
+use url::Url;
 
 use crate::dom::document::Document;
+
+pub(crate) static ANONYMOUS_CONTENT_URL_DATA: LazyLock<UrlExtraData> =
+    LazyLock::new(|| Url::parse("about:blank").unwrap().into());
 
 /// Creates a `ParserContext` from the given document.
 ///

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -46,12 +46,11 @@ use style::values::specified::color::Color;
 use style_traits::values::ToCss;
 use style_traits::{CssWriter, ParsingMode};
 use unicode_script::Script;
-use url::Url;
 use webrender_api::ImageKey;
 
 use crate::canvas_context::{CanvasContext, OffscreenRenderingContext, RenderingContext};
 use crate::conversions::Convert;
-use crate::css::parser_context_for_anonymous_content;
+use crate::css::{ANONYMOUS_CONTENT_URL_DATA, parser_context_for_anonymous_content};
 use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::{
     CanvasDirection, CanvasFillRule, CanvasImageSource, CanvasLineCap, CanvasLineJoin,
     CanvasTextAlign, CanvasTextBaseline, ImageDataMethods,
@@ -2646,9 +2645,11 @@ pub(super) fn parse_color(
     let string = string.str();
     let mut input = ParserInput::new(&string);
     let mut parser = Parser::new(&mut input);
-    let url = Url::parse("about:blank").unwrap().into();
-    let context =
-        parser_context_for_anonymous_content(CssRuleType::Style, ParsingMode::DEFAULT, &url);
+    let context = parser_context_for_anonymous_content(
+        CssRuleType::Style,
+        ParsingMode::DEFAULT,
+        &ANONYMOUS_CONTENT_URL_DATA,
+    );
 
     // Step 1. Parse input as a <color>. If the result is failure, return failure;
     // otherwise, let color be the result.

--- a/components/script/dom/geometry/dommatrixreadonly.rs
+++ b/components/script/dom/geometry/dommatrixreadonly.rs
@@ -24,9 +24,8 @@ use servo_base::id::{DomMatrixId, DomMatrixIndex};
 use servo_constellation_traits::DomMatrix;
 use style::stylesheets::CssRuleType;
 use style_traits::ParsingMode;
-use url::Url;
 
-use crate::css::parser_context_for_anonymous_content;
+use crate::css::{ANONYMOUS_CONTENT_URL_DATA, parser_context_for_anonymous_content};
 use crate::dom::bindings::buffer_source::create_buffer_source;
 use crate::dom::bindings::codegen::Bindings::DOMMatrixBinding::{
     DOMMatrix2DInit, DOMMatrixInit, DOMMatrixMethods,
@@ -1242,9 +1241,11 @@ pub(crate) fn transform_to_matrix(value: &str) -> Fallible<(bool, Transform3D<f6
 
     let mut input = ParserInput::new(value);
     let mut parser = Parser::new(&mut input);
-    let url_data = Url::parse("about:blank").unwrap().into();
-    let context =
-        parser_context_for_anonymous_content(CssRuleType::Style, ParsingMode::DEFAULT, &url_data);
+    let context = parser_context_for_anonymous_content(
+        CssRuleType::Style,
+        ParsingMode::DEFAULT,
+        &ANONYMOUS_CONTENT_URL_DATA,
+    );
 
     let transform = match parser.parse_entirely(|t| transform::parse(&context, t)) {
         Ok(result) => result,

--- a/components/script/dom/html/form_controls/input_type/color_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/color_input_type.rs
@@ -16,9 +16,8 @@ use style::selector_parser::PseudoElement;
 use style::stylesheets::CssRuleType;
 use style::values::specified::Color;
 use style_traits::{ParsingMode, ToCss};
-use url::Url;
 
-use crate::css::parser_context_for_anonymous_content;
+use crate::css::{ANONYMOUS_CONTENT_URL_DATA, parser_context_for_anonymous_content};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::str::{DOMString, FromInputValueString};
 use crate::dom::document_embedder_controls::ControlElement;
@@ -268,14 +267,14 @@ impl SpecificInputActivationType for ColorInputActivation {
     }
 }
 
-fn parse_color_value(value: &str, url: Url) -> AbsoluteColor {
-    // TODO: Use a dummy url here, like gecko
-    // https://searchfox.org/firefox-main/rev/3eaf7e2acf8186eb7aa579561eaa1312cb89132b/servo/ports/geckolib/glue.rs#8931
-    let urlextradata = url.into();
+fn parse_color_value(value: &str, _url: Url) -> AbsoluteColor {
+    // Color-parsing does not use a URL, but ParserContext requires it as a parameter.
+    // We pass ANONYMOUS_CONTENT_URL_DATA since that's cheap and it will be ignored anyway.
+    let urlextradata = &ANONYMOUS_CONTENT_URL_DATA;
     let context = parser_context_for_anonymous_content(
         CssRuleType::Style,
         ParsingMode::DEFAULT,
-        &urlextradata,
+        urlextradata,
     );
     let mut input = ParserInput::new(value);
     let mut input = Parser::new(&mut input);

--- a/components/script/dom/html/form_controls/input_type/color_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/color_input_type.rs
@@ -96,10 +96,7 @@ impl ColorInputType {
 
         // Step 3. Let color be the result of parsing value.
         // Step 4. If color is failure, then set color to opaque black.
-        let color = parse_color_value(
-            &value.str(),
-            input.owner_document().url().as_url().to_owned(),
-        );
+        let color = parse_color_value(&value.str());
 
         // Step 5. Set element's value to the result of serializing a color well control color
         // given element and color.
@@ -198,11 +195,8 @@ impl SpecificInputType for ColorInputType {
     fn show_the_picker_if_applicable(&self, input: &HTMLInputElement) {
         let document = input.owner_document();
         let current_value = input.Value();
-        let current_color = parse_color_value(
-            &current_value.str(),
-            input.owner_document().url().as_url().to_owned(),
-        )
-        .to_color_space(ColorSpace::Srgb);
+        let current_color =
+            parse_color_value(&current_value.str()).to_color_space(ColorSpace::Srgb);
         let current_color = RgbColor {
             red: (current_color.components.0 * 255.0).round() as u8,
             green: (current_color.components.1 * 255.0).round() as u8,
@@ -267,7 +261,7 @@ impl SpecificInputActivationType for ColorInputActivation {
     }
 }
 
-fn parse_color_value(value: &str, _url: Url) -> AbsoluteColor {
+fn parse_color_value(value: &str) -> AbsoluteColor {
     // Color-parsing does not use a URL, but ParserContext requires it as a parameter.
     // We pass ANONYMOUS_CONTENT_URL_DATA since that's cheap and it will be ignored anyway.
     let urlextradata = &ANONYMOUS_CONTENT_URL_DATA;

--- a/components/script/dom/intersectionobserver/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver/intersectionobserver.rs
@@ -21,9 +21,8 @@ use style::stylesheets::CssRuleType;
 use style::values::computed::Overflow;
 use style::values::specified::intersection_observer::IntersectionObserverMargin;
 use style_traits::{CSSPixel, ParsingMode, ToCss};
-use url::Url;
 
-use crate::css::parser_context_for_anonymous_content;
+use crate::css::{ANONYMOUS_CONTENT_URL_DATA, parser_context_for_anonymous_content};
 use crate::dom::bindings::callback::ExceptionHandling;
 use crate::dom::bindings::codegen::Bindings::IntersectionObserverBinding::{
     IntersectionObserverCallback, IntersectionObserverInit, IntersectionObserverMethods,
@@ -893,9 +892,11 @@ fn parse_a_margin(value: Option<&DOMString>) -> Result<IntersectionObserverMargi
     let mut input = ParserInput::new(value);
     let mut parser = Parser::new(&mut input);
 
-    let url = Url::parse("about:blank").unwrap().into();
-    let context =
-        parser_context_for_anonymous_content(CssRuleType::Style, ParsingMode::DEFAULT, &url);
+    let context = parser_context_for_anonymous_content(
+        CssRuleType::Style,
+        ParsingMode::DEFAULT,
+        &ANONYMOUS_CONTENT_URL_DATA,
+    );
 
     parser
         .parse_entirely(|p| IntersectionObserverMargin::parse(&context, p))

--- a/components/script/dom/srcset.rs
+++ b/components/script/dom/srcset.rs
@@ -16,10 +16,9 @@ use style::attr::parse_unsigned_integer;
 use style::stylesheets::CssRuleType;
 use style::values::specified::source_size_list::SourceSizeList;
 use style_traits::ParsingMode;
-use url::Url;
 use xml5ever::local_name;
 
-use crate::css::parser_context_for_anonymous_content;
+use crate::css::{ANONYMOUS_CONTENT_URL_DATA, parser_context_for_anonymous_content};
 use crate::dom::htmlimageelement::HTMLImageElement;
 use crate::dom::htmllinkelement::HTMLLinkElement;
 use crate::dom::htmlpictureelement::HTMLPictureElement;
@@ -348,11 +347,13 @@ impl SourceSet {
 pub fn parse_a_sizes_attribute(value: &str) -> SourceSizeList {
     let mut input = ParserInput::new(value);
     let mut parser = Parser::new(&mut input);
-    let url_data = Url::parse("about:blank").unwrap().into();
     // FIXME(emilio): why ::empty() instead of ::DEFAULT? Also, what do
     // browsers do regarding quirks-mode in a media list?
-    let context =
-        parser_context_for_anonymous_content(CssRuleType::Style, ParsingMode::empty(), &url_data);
+    let context = parser_context_for_anonymous_content(
+        CssRuleType::Style,
+        ParsingMode::empty(),
+        &ANONYMOUS_CONTENT_URL_DATA,
+    );
     SourceSizeList::parse(&context, &mut parser)
 }
 


### PR DESCRIPTION
Instead of parsing `about:blank` every time `parser_context_for_anonymous_content` is called,
we cache the value in a LazyLock.
Two caller locations actually pass in a real URL, so I kept `url_data` in the signature, and only changed
the caller locations which constructed `UrlExtraData` from `about:blank`.
The parsing showed up in a perf profile while investigating canvas performance.

Testing: This does not change observable behavior and is thus covered by existing tests.

