### PR TITLE
script: Use inclusive_ancestors_unrooted in interior of UnrootedFollowingNodeIterator

### DIFF
--- a/components/script/dom/node/iterators.rs
+++ b/components/script/dom/node/iterators.rs
@@ -126,8 +126,8 @@ impl<'b> UnrootedFollowingNodeIterator<'b> {
             return current.get_next_sibling_unrooted(self.no_gc);
         }
 
-        for ancestor in current.inclusive_ancestors(self.shadow_including) {
-            if **self.root == *ancestor {
+        for ancestor in current.inclusive_ancestors_unrooted(self.no_gc, self.shadow_including) {
+            if self.root == ancestor {
                 break;
             }
             if let Some(next_sibling) = ancestor.get_next_sibling_unrooted(self.no_gc) {

--- a/components/script_bindings/dom.rs
+++ b/components/script_bindings/dom.rs
@@ -173,7 +173,7 @@ impl<'a, T: DomObject> PartialEq<T> for UnrootedDom<'a, T> {
     }
 }
 
-impl<'a, T: DomObject> PartialEq<UnrootedDom<'a, T>> for UnrootedDom<'a, T> {
+impl<'a, 'b, T: DomObject> PartialEq<UnrootedDom<'a, T>> for UnrootedDom<'b, T> {
     fn eq(&self, other: &UnrootedDom<'a, T>) -> bool {
         self.inner == other.inner
     }


### PR DESCRIPTION
This uses inclusive_ancestors_unrooted instead of the rooted variant in the interior of UnrootedFollowingNodeIterator (in next_skipping_children_impl).
Additionally, this PR relaxes the PartialEq for UnrootedDom to allow comparing UnrootedDom<'a,T> with UnrootedDom<'b, T>.

This saves 0.4% of cpu in a slice on walrusaudio.com

Testing: This does not have a specific testcase but inclusive_ancestors_unrooted is tested enough now to be equivalent to the rooted version. So this change should be equivalent.
