### PR TITLE
script: Use NoGC for note_dirty_element

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -825,7 +825,7 @@ impl Document {
     ///   flags up the tree until we cross the path of the new root. Once
     ///   we find this common ancestor, we record it as the restyle root, and then
     ///   clear the bits between the new restyle root and the document root.
-    pub(crate) fn note_dirty_element(&self, element: &Element) {
+    pub(crate) fn note_dirty_element(&self, no_gc: &NoGC, element: &Element) {
         let node = element.upcast::<Node>();
 
         debug_assert!(*node.owner_doc() == *self);
@@ -833,8 +833,8 @@ impl Document {
             return;
         }
 
-        let parent_element = match node.parent_in_flat_tree() {
-            FlatTreeParent::Parent(parent) => DomRoot::downcast::<Element>(parent),
+        let parent_element = match node.parent_in_flat_tree(no_gc) {
+            FlatTreeParent::Parent(parent) => UnrootedDom::downcast::<Element>(parent),
             FlatTreeParent::NotInFlatTree | FlatTreeParent::RootNode => return,
         };
 
@@ -856,12 +856,15 @@ impl Document {
 
         let Some(old_dirty_root) = self.dirty_root.get() else {
             node.set_flag(NodeFlags::HAS_DIRTY_DESCENDANTS, true);
-            self.set_dirty_root(Some(element));
+            self.set_dirty_root(no_gc, Some(element));
             return;
         };
 
         let old_dirty_root_node = old_dirty_root.upcast::<Node>();
-        for ancestor in element.upcast::<Node>().inclusive_ancestors_in_flat_tree() {
+        for ancestor in element
+            .upcast::<Node>()
+            .inclusive_ancestors_in_flat_tree_unrooted(no_gc)
+        {
             // Never mark the Document node as having dirty descendants. It's never the dirty root.
             if !ancestor.is::<Element>() {
                 break;
@@ -876,13 +879,13 @@ impl Document {
             // If this node is already under the existing dirty root, there is nothing else to
             // do apart from marking this node as having dirty descendants. We need to ensure
             // we mark the root as having dirty descendants now because that has become true.
-            if old_dirty_root_node == &*ancestor {
+            if old_dirty_root_node == &**ancestor {
                 return;
             }
         }
 
         let common_element_ancestor = old_dirty_root_node
-            .inclusive_ancestors_in_flat_tree()
+            .inclusive_ancestors_in_flat_tree_unrooted(no_gc)
             .skip(1) // Skip the old root itself.
             .find_map(|ancestor| {
                 // Never mark the Document node as having dirty descendants. It's never the dirty root.
@@ -904,7 +907,7 @@ impl Document {
                     .upcast::<Node>()
                     .set_flag(NodeFlags::HAS_DIRTY_DESCENDANTS, true);
             }
-            self.set_dirty_root(new_dirty_root.as_deref());
+            self.set_dirty_root(no_gc, new_dirty_root.as_deref());
             return;
         };
 
@@ -913,21 +916,21 @@ impl Document {
         // flag.
         for ancestor in new_dirty_root
             .upcast::<Node>()
-            .inclusive_ancestors_in_flat_tree()
+            .inclusive_ancestors_in_flat_tree_unrooted(no_gc)
             .skip(1)
         {
             ancestor.set_flag(NodeFlags::HAS_DIRTY_DESCENDANTS, false)
         }
 
-        self.set_dirty_root(Some(&*new_dirty_root));
+        self.set_dirty_root(no_gc, Some(&*new_dirty_root));
     }
 
-    fn set_dirty_root(&self, new_dirty_root: Option<&Element>) {
+    fn set_dirty_root(&self, no_gc: &NoGC, new_dirty_root: Option<&Element>) {
         // Assertion: No nodes above the dirty root should be marked with the HAS_DIRTY_DESCENDANTS flag.
         debug_assert!(new_dirty_root.as_ref().is_none_or(|new_dirty_root| {
             new_dirty_root
                 .upcast::<Node>()
-                .inclusive_ancestors_in_flat_tree()
+                .inclusive_ancestors_in_flat_tree_unrooted(no_gc)
                 .skip(1)
                 .all(|node| !node.get_flag(NodeFlags::HAS_DIRTY_DESCENDANTS))
         }));
@@ -3249,11 +3252,13 @@ impl Document {
     /// <https://drafts.csswg.org/resize-observer/#has-active-resize-observations>
     pub(crate) fn gather_active_resize_observations_at_depth(
         &self,
+        no_gc: &NoGC,
         depth: &ResizeObservationDepth,
     ) -> bool {
         let mut has_active_resize_observations = false;
         for observer in self.resize_observers.borrow_mut().iter_mut() {
             observer.gather_active_resize_observations_at_depth(
+                no_gc,
                 depth,
                 &mut has_active_resize_observations,
             );

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -522,7 +522,7 @@ impl DocumentEventHandler {
 
         let common_ancestor = match related_target.as_ref() {
             Some(related_target) => event_target
-                .common_ancestor_in_flat_tree(related_target)
+                .common_ancestor_in_flat_tree(cx.no_gc(), related_target)
                 .unwrap_or_else(|| DomRoot::from_ref(event_target)),
             None => DomRoot::from_ref(event_target),
         };
@@ -530,8 +530,9 @@ impl DocumentEventHandler {
         // We need to create a target chain in case the event target shares
         // its boundaries with its ancestors.
         let mut targets: Vec<_> = event_target
-            .inclusive_ancestors_in_flat_tree()
-            .take_while(|node| *node != common_ancestor)
+            .inclusive_ancestors_in_flat_tree_unrooted(cx.no_gc())
+            .take_while(|node| *node != *common_ancestor)
+            .map(|node| node.as_rooted())
             .collect();
 
         // The order for dispatching mouseenter/pointerenter events starts from the topmost
@@ -2389,7 +2390,8 @@ impl DocumentEventHandler {
     ) {
         let mut targets: Vec<_> = target_element
             .upcast::<Node>()
-            .inclusive_ancestors_in_flat_tree()
+            .inclusive_ancestors_in_flat_tree_unrooted(cx.no_gc())
+            .map(|node| node.as_rooted())
             .collect();
 
         // Reverse to dispatch from topmost ancestor to target

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -380,7 +380,7 @@ impl Element {
         self.style_data.borrow_mut().take();
     }
 
-    pub(crate) fn restyle(&self, damage: NodeDamage) {
+    pub(crate) fn restyle(&self, no_gc: &NoGC, damage: NodeDamage) {
         let doc = self.node.owner_doc();
         let mut restyle = doc.ensure_pending_restyle(self);
 
@@ -391,13 +391,13 @@ impl Element {
         match damage {
             NodeDamage::Style => {},
             NodeDamage::ContentOrHeritage => {
-                doc.note_dirty_element(self);
+                doc.note_dirty_element(no_gc, self);
                 restyle
                     .damage
                     .insert(RestyleDamage::from(LayoutDamage::DescendantHasBoxDamage));
             },
             NodeDamage::Other => {
-                doc.note_dirty_element(self);
+                doc.note_dirty_element(no_gc, self);
                 restyle.damage.insert(RestyleDamage::reconstruct());
             },
         }
@@ -411,7 +411,7 @@ impl Element {
     pub(crate) fn note_dirty_descendants(&self, no_gc: &NoGC) {
         self.upcast::<Node>()
             .owner_doc_unrooted(no_gc)
-            .note_dirty_element(self);
+            .note_dirty_element(no_gc, self);
     }
 
     pub(crate) fn set_is(&self, is: LocalName) {

--- a/components/script/dom/html/form_controls/htmlbuttonelement.rs
+++ b/components/script/dom/html/form_controls/htmlbuttonelement.rs
@@ -521,12 +521,14 @@ impl Activatable for HTMLButtonElement {
         // Adhoc, this step is needed so that file inputs button activates the input.
         if let Some(pseudo_element) = self.upcast::<Node>().implemented_pseudo_element() {
             if pseudo_element == PseudoElement::FileSelectorButton {
-                let FlatTreeParent::Parent(parent) = self.upcast::<Node>().parent_in_flat_tree()
+                let FlatTreeParent::Parent(parent) =
+                    self.upcast::<Node>().parent_in_flat_tree(cx.no_gc())
                 else {
                     return;
                 };
 
                 parent
+                    .as_rooted()
                     .downcast::<HTMLInputElement>()
                     .expect("File select button should always be a child of an input element")
                     .activation_behavior(cx, event, target);

--- a/components/script/dom/html/htmlslotelement.rs
+++ b/components/script/dom/html/htmlslotelement.rs
@@ -376,7 +376,8 @@ impl HTMLSlotElement {
         }
 
         if let Some(selection) = self.owner_document().selection() &&
-            let FlatTreeParent::Parent(parent) = self.upcast::<Node>().parent_in_flat_tree() &&
+            let FlatTreeParent::Parent(parent) =
+                self.upcast::<Node>().parent_in_flat_tree(cx.no_gc()) &&
             parent.get_flag(NodeFlags::OVERLAPS_DOCUMENT_SELECTION)
         {
             selection.set_visible_selection_dirty();

--- a/components/script/dom/node/iterators.rs
+++ b/components/script/dom/node/iterators.rs
@@ -558,11 +558,8 @@ impl<'no_gc> UnrootedFollowingFlatTreeNodesTraversal<'no_gc> {
         if let Some(next_sibling) = previous.next_flat_tree_sibling_unrooted(no_gc) {
             return Some(PrePostIteration::Enter(next_sibling));
         }
-        match previous.parent_in_flat_tree() {
-            FlatTreeParent::Parent(parent_node) => {
-                let parent_node = UnrootedDom::from_dom(parent_node.as_traced(), no_gc);
-                Some(PrePostIteration::Leave(parent_node))
-            },
+        match previous.parent_in_flat_tree(no_gc) {
+            FlatTreeParent::Parent(parent_node) => Some(PrePostIteration::Leave(parent_node)),
             FlatTreeParent::NotInFlatTree => None,
             FlatTreeParent::RootNode => None,
         }

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -2051,7 +2051,7 @@ impl Node {
     ) -> Option<UnrootedDom<'a, HTMLSlotElement>> {
         let rare_data = self.rare_data.borrow();
         let assigned_slot = rare_data.as_ref()?.slottable_data.assigned_slot.as_ref()?;
-        Some(UnrootedDom::from_dom(Dom::from_ref(&*assigned_slot), no_gc))
+        Some(UnrootedDom::from_dom(Dom::from_ref(assigned_slot), no_gc))
     }
 
     pub(crate) fn set_assigned_slot(&self, assigned_slot: Option<&HTMLSlotElement>) {

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -919,13 +919,13 @@ impl Node {
                     self.add_pending_accessibility_damage(AccessibilityDamage::Text);
                 }
             },
-            NodeTypeId::Element(_) => self.downcast::<Element>().unwrap().restyle(damage),
+            NodeTypeId::Element(_) => self.downcast::<Element>().unwrap().restyle(no_gc, damage),
             NodeTypeId::DocumentFragment(DocumentFragmentTypeId::ShadowRoot) => self
                 .downcast::<ShadowRoot>()
                 .unwrap()
                 .Host()
                 .upcast::<Element>()
-                .restyle(damage),
+                .restyle(no_gc, damage),
             _ => {},
         };
     }
@@ -990,12 +990,18 @@ impl Node {
         })
     }
 
-    pub(crate) fn common_ancestor_in_flat_tree(&self, other: &Node) -> Option<DomRoot<Node>> {
-        self.inclusive_ancestors_in_flat_tree().find(|ancestor| {
-            other
-                .inclusive_ancestors_in_flat_tree()
-                .any(|node| node == *ancestor)
-        })
+    pub(crate) fn common_ancestor_in_flat_tree(
+        &self,
+        no_gc: &NoGC,
+        other: &Node,
+    ) -> Option<DomRoot<Node>> {
+        self.inclusive_ancestors_in_flat_tree_unrooted(no_gc)
+            .find(|ancestor| {
+                other
+                    .inclusive_ancestors_in_flat_tree_unrooted(no_gc)
+                    .any(|node| node == *ancestor)
+            })
+            .map(|node| node.as_rooted())
     }
 
     pub(crate) fn following_flat_tree_nodes_unrooted<'no_gc>(
@@ -2039,6 +2045,15 @@ impl Node {
         Some(assigned_slot)
     }
 
+    pub(crate) fn assigned_slot_unrooted<'a>(
+        &self,
+        no_gc: &'a NoGC,
+    ) -> Option<UnrootedDom<'a, HTMLSlotElement>> {
+        let rare_data = self.rare_data.borrow();
+        let assigned_slot = rare_data.as_ref()?.slottable_data.assigned_slot.as_ref()?;
+        Some(UnrootedDom::from_dom(Dom::from_ref(&*assigned_slot), no_gc))
+    }
+
     pub(crate) fn set_assigned_slot(&self, assigned_slot: Option<&HTMLSlotElement>) {
         self.ensure_rare_data().slottable_data.assigned_slot = assigned_slot.map(Dom::from_ref);
     }
@@ -2074,17 +2089,20 @@ impl Node {
     /// The parent might not have a flat tree relationship with the node if
     ///  - It's a light tree child of a shadow host.
     ///  - It's fallback content for an assigned slot.
-    pub(crate) fn parent_in_flat_tree(&self) -> FlatTreeParent {
-        if let Some(assigned_slot) = self.assigned_slot() {
-            return FlatTreeParent::Parent(DomRoot::upcast(assigned_slot));
+    pub(crate) fn parent_in_flat_tree<'b>(&self, no_gc: &'b NoGC) -> FlatTreeParent<'b> {
+        if let Some(assigned_slot) = self.assigned_slot_unrooted(no_gc) {
+            return FlatTreeParent::Parent(UnrootedDom::upcast::<Node>(assigned_slot));
         }
 
-        let Some(parent) = self.GetParentNode() else {
+        let Some(parent) = self.get_parent_node_unrooted(no_gc) else {
             return FlatTreeParent::RootNode;
         };
 
         if let Some(shadow_root) = parent.downcast::<ShadowRoot>() {
-            return FlatTreeParent::Parent(DomRoot::from_ref(shadow_root.Host().upcast::<Node>()));
+            return FlatTreeParent::Parent(UnrootedDom::from_dom(
+                Dom::from_ref(shadow_root.Host().upcast::<Node>()),
+                no_gc,
+            ));
         }
 
         if parent
@@ -2104,15 +2122,21 @@ impl Node {
         FlatTreeParent::Parent(parent)
     }
 
-    pub(crate) fn inclusive_ancestors_in_flat_tree(
+    pub(crate) fn inclusive_ancestors_in_flat_tree_unrooted<'a>(
         &self,
-    ) -> impl Iterator<Item = DomRoot<Node>> + use<> {
-        SimpleNodeIterator::new(Some(DomRoot::from_ref(self)), move |node| {
-            match node.parent_in_flat_tree() {
-                FlatTreeParent::Parent(parent) => Some(parent),
+        no_gc: &'a NoGC,
+    ) -> impl Iterator<Item = UnrootedDom<'a, Node>> + use<'a> {
+        UnrootedSimpleNodeIterator::new(
+            Some(UnrootedDom::from_dom(Dom::from_ref(self), no_gc)),
+            move |node, no_gc| match node.parent_in_flat_tree(no_gc) {
+                FlatTreeParent::Parent(parent) => {
+                    // Supoptimal
+                    Some(UnrootedDom::from_dom(Dom::from_ref(&*parent), no_gc))
+                },
                 FlatTreeParent::NotInFlatTree | FlatTreeParent::RootNode => None,
-            }
-        })
+            },
+            no_gc,
+        )
     }
 
     /// We are marking this as an implemented pseudo element.
@@ -2708,7 +2732,7 @@ impl Node {
             }
         }
 
-        Self::maybe_dirty_visible_selection_for_newly_inserted_nodes(parent, new_nodes);
+        Self::maybe_dirty_visible_selection_for_newly_inserted_nodes(cx.no_gc(), parent, new_nodes);
 
         if let SuppressObserver::Unsuppressed = suppress_observers {
             // Step 9. Run the children changed steps for parent.
@@ -2758,6 +2782,7 @@ impl Node {
     /// If insertion of any of the given nodes happened within an existing visible
     /// selection, mark the [`Document`]'s visible selection as dirty.
     pub(crate) fn maybe_dirty_visible_selection_for_newly_inserted_nodes(
+        no_gc: &NoGC,
         parent: &Node,
         inserted_nodes: &[&Node],
     ) {
@@ -2766,7 +2791,7 @@ impl Node {
         };
 
         for node in inserted_nodes {
-            match node.parent_in_flat_tree() {
+            match node.parent_in_flat_tree(no_gc) {
                 FlatTreeParent::RootNode | FlatTreeParent::NotInFlatTree => {},
                 FlatTreeParent::Parent(parent) => {
                     if parent.get_flag(NodeFlags::OVERLAPS_DOCUMENT_SELECTION) {
@@ -4393,7 +4418,11 @@ impl VirtualMethods for Node {
             .content_and_heritage_changed(cx.no_gc(), self);
 
         if let Some(parent) = self.GetParentNode() {
-            Self::maybe_dirty_visible_selection_for_newly_inserted_nodes(&parent, &[self]);
+            Self::maybe_dirty_visible_selection_for_newly_inserted_nodes(
+                cx.no_gc(),
+                &parent,
+                &[self],
+            );
         }
     }
 
@@ -4493,9 +4522,9 @@ where
 }
 
 /// The return value of [`Node::parent_in_flat_tree`].
-pub(crate) enum FlatTreeParent {
+pub(crate) enum FlatTreeParent<'a> {
     /// The parent in the flat tree.
-    Parent(DomRoot<Node>),
+    Parent(UnrootedDom<'a, Node>),
     /// This node has a parent (it's not the root), but it does not share a flat tree
     /// relationship with its parent.
     NotInFlatTree,

--- a/components/script/dom/resizeobserver/resizeobserver.rs
+++ b/components/script/dom/resizeobserver/resizeobserver.rs
@@ -10,7 +10,7 @@ use dom_struct::dom_struct;
 use euclid::num::Zero;
 use euclid::{Rect, Size2D};
 use html5ever::ns;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::rust::HandleObject;
 use layout_api::BoxAreaType;
 use script_bindings::cell::DomRefCell;
@@ -85,6 +85,7 @@ impl ResizeObserver {
     /// <https://drafts.csswg.org/resize-observer/#has-active-resize-observations>
     pub(crate) fn gather_active_resize_observations_at_depth(
         &self,
+        no_gc: &NoGC,
         depth: &ResizeObservationDepth,
         has_active: &mut bool,
     ) {
@@ -98,7 +99,7 @@ impl ResizeObserver {
             // Step 2.2.1 If observation.isActive() is true
             if observation.is_active(target) {
                 // Step 2.2.1.1 Let targetDepth be result of calculate depth for node for observation.target.
-                let target_depth = calculate_depth_for_node(target);
+                let target_depth = calculate_depth_for_node(no_gc, target);
 
                 // Step 2.2.1.2 If targetDepth is greater than depth then add observation to [[activeTargets]].
                 if target_depth > *depth {
@@ -140,7 +141,7 @@ impl ResizeObserver {
             entries.push(entry);
             observation.state.set(ObservationState::Done);
 
-            let target_depth = calculate_depth_for_node(target);
+            let target_depth = calculate_depth_for_node(cx.no_gc(), target);
             if target_depth < *shallowest_target_depth {
                 *shallowest_target_depth = target_depth;
             }
@@ -363,9 +364,11 @@ impl ResizeObservation {
 }
 
 /// <https://drafts.csswg.org/resize-observer/#calculate-depth-for-node>
-fn calculate_depth_for_node(target: &Element) -> ResizeObservationDepth {
+fn calculate_depth_for_node(no_gc: &NoGC, target: &Element) -> ResizeObservationDepth {
     let node = target.upcast::<Node>();
-    let depth = node.inclusive_ancestors_in_flat_tree().count();
+    let depth = node
+        .inclusive_ancestors_in_flat_tree_unrooted(no_gc)
+        .count();
     ResizeObservationDepth(depth)
 }
 

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -130,11 +130,15 @@ impl Selection {
         };
 
         let start_position = position_in_flat_tree_for_selection(
+            no_gc,
             range.start_container(),
             range.start_offset() as usize,
         );
-        let end_position =
-            position_in_flat_tree_for_selection(range.end_container(), range.end_offset() as usize);
+        let end_position = position_in_flat_tree_for_selection(
+            no_gc,
+            range.end_container(),
+            range.end_offset() as usize,
+        );
         let start_node = start_position.node();
         let end_node = end_position.node();
 
@@ -166,10 +170,10 @@ impl Selection {
         //   as the in-order tree walk will be guaranteed to walk them.
         // - We do not need to mark these nodes as dirty as they are guaranteed to not be
         //   leaves (the only nodes that show visible selection).
-        let mut maybe_parent = start_node.parent_in_flat_tree();
+        let mut maybe_parent = start_node.parent_in_flat_tree(no_gc);
         while let FlatTreeParent::Parent(parent) = maybe_parent {
             add_selection_flag(&parent);
-            maybe_parent = parent.parent_in_flat_tree();
+            maybe_parent = parent.parent_in_flat_tree(no_gc);
         }
 
         let mut traversal = start_node.following_flat_tree_nodes_unrooted(no_gc);
@@ -870,6 +874,7 @@ impl FlatTreeNodePosition {
 /// boundaries. This projects the given position onto the flat tree, accounting for origin
 /// nodes that may not actually be in the flat tree at all.
 fn position_in_flat_tree_for_selection(
+    no_gc: &NoGC,
     container: DomRoot<Node>,
     offset: usize,
 ) -> FlatTreeNodePosition {
@@ -885,11 +890,11 @@ fn position_in_flat_tree_for_selection(
     };
 
     if let Some(child) = container.children().nth(offset) {
-        if let FlatTreeParent::Parent(_) = child.parent_in_flat_tree() {
+        if let FlatTreeParent::Parent(_) = child.parent_in_flat_tree(no_gc) {
             return FlatTreeNodePosition::Before(child);
         }
     } else if let Some(last_child) = container.GetLastChild() &&
-        let FlatTreeParent::Parent(_) = last_child.parent_in_flat_tree()
+        let FlatTreeParent::Parent(_) = last_child.parent_in_flat_tree(no_gc)
     {
         return FlatTreeNodePosition::After(shadow_host_or_node(&container));
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1220,7 +1220,7 @@ impl ScriptThread {
 
             // Run the resize observer steps.
             let mut depth = Default::default();
-            while document.gather_active_resize_observations_at_depth(&depth) {
+            while document.gather_active_resize_observations_at_depth(cx.no_gc(), &depth) {
                 // Note: this will reflow the doc.
                 depth = document.broadcast_active_resize_observations(cx);
             }


### PR DESCRIPTION
This uses the NoGC framework for note_dirty_element.
This replaces the `inclusive_ancestors_in_flat_tree` with an unrooted variant.
Additionally, parent_in_flat_tree now always returns an unrooted value as it was easier then implementing the logic separately and a new FlatTreeParent struct.
In the cases where we still need the rooted version we use the 'as_rooted()' function.

The rest of the changes is just "bubbling up" the NoGC parameter.
This saves us in total a 0.2% cpu in a busy script thread slice on walrusaudio.com

Testing: This changes just the rooting behavior, hence, no extra tests are necessary.
