### PR TITLE
net: Respect temporary_storage option for disk_cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8731,6 +8731,7 @@ dependencies = [
  "servo_arc",
  "sha2 0.11.0",
  "smallvec",
+ "tempfile",
  "time",
  "tokio",
  "tokio-rustls",

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -80,6 +80,7 @@ sea-query = { workspace = true }
 sea-query-rusqlite = { workspace = true }
 sha2 = { workspace = true }
 smallvec = { workspace = true }
+tempfile = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread", "sync"] }
 tokio-rustls = { workspace = true }

--- a/components/net/disk_cache.rs
+++ b/components/net/disk_cache.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::collections::VecDeque;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -51,7 +52,7 @@ struct DiskCacheInner {
 #[derive(MallocSizeOf)]
 /// A struct representing the disk cache.
 pub(crate) struct DiskCache {
-    path: String,
+    path: PathBuf,
     max_size: usize,
     // the non constant data.
     inner: TokioMutex<DiskCacheInner>,
@@ -79,6 +80,30 @@ impl Iden for DiskCacheTable {
     }
 }
 
+/// Get the storage path out of `network_http_disk_cache` preference and `temporary_storage` option.
+fn storage_dir() -> Option<PathBuf> {
+    let disk_storage_path = pref!(network_http_disk_cache);
+    match (
+        servo_config::opts::get().temporary_storage,
+        disk_storage_path.is_empty(),
+    ) {
+        (false, false) => None,
+        (true, true) => {
+            let tmp_dir = tempfile::tempdir().unwrap();
+            let mut path = tmp_dir.path().to_path_buf();
+            path.set_file_name("cache.sqlite3");
+            Some(path)
+        },
+        (true, false) => {
+            error!(
+                "Temporary storage cannot be set with explicit disk storage path. Disabling http_disk_cache"
+            );
+            None
+        },
+        (false, true) => Some(disk_storage_path.into()),
+    }
+}
+
 impl DiskCache {
     /// Creates a new [`DiskCache`] if the preference if set.
     /// Creates the sqlite table if it does not exist and starts the db connection.
@@ -86,11 +111,12 @@ impl DiskCache {
     pub(crate) fn new(
         cache_assignment: HttpCacheAssignment,
     ) -> (Option<Arc<DiskCache>>, MemoryCacheLifecycle) {
-        let disk_cache_path = pref!(network_http_disk_cache);
         // For private browsing we currently do not want to store any disk cache.
-        if disk_cache_path.is_empty() || cache_assignment == HttpCacheAssignment::Private {
-            (None, MemoryCacheLifecycle::empty())
-        } else {
+        let disk_cache_path = storage_dir();
+
+        if let Some(disk_cache_path) = disk_cache_path &&
+            cache_assignment != HttpCacheAssignment::Private
+        {
             let Ok(max_disk_cache_size) = pref!(network_http_disk_cache_size).try_into() else {
                 return (None, MemoryCacheLifecycle::empty());
             };
@@ -160,6 +186,8 @@ impl DiskCache {
                     disk_cache: Some(disk_cache_data),
                 },
             )
+        } else {
+            (None, MemoryCacheLifecycle::empty())
         }
     }
 

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -396,10 +396,6 @@ struct CmdArgs {
     #[bpaf(argument("~/.config/servo"))]
     config_dir: Option<PathBuf>,
 
-    /// Use temporary storage (data on disk will not persist across restarts).
-    #[bpaf(long)]
-    temporary_storage: bool,
-
     ///
     ///  Run as a content process and connect to the given pipe.
     #[bpaf(argument("servo-ipc-channel.abcdefg"))]
@@ -535,6 +531,9 @@ struct CmdArgs {
     #[bpaf(long("simulate-touch-events"))]
     simulate_touch_events: bool,
 
+    /// Use temporary storage (data on disk will not persist across restarts).
+    #[bpaf(long)]
+    temporary_storage: bool,
     /// Define a custom filter for traces. Overrides `SERVO_TRACING` if set.
     #[bpaf(long("tracing-filter"), argument("FILTER"))]
     tracing_filter: Option<String>,


### PR DESCRIPTION
This PR has two changes:
- Make the disk_cache respect temporary_storage option to create disk_cache in a temporary location.
- Reorder servoshell CmdArgs to be in alphabetical order.

Testing: WPT run (which enables disk cache with the temporary flag) was done here: https://github.com/Narfinger/servo/actions/runs/31575386386/job/94053742771
