### PR TITLE
layout: Only update the accessibility tree when updating the rendering.

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -912,7 +912,9 @@ impl LayoutThread {
         reflow_request: &mut ReflowRequest,
         reflow_statistics: &mut ReflowStatistics,
     ) -> bool {
-        if !self.needs_accessibility_update() {
+        if reflow_request.reflow_goal != ReflowGoal::UpdateTheRendering ||
+            !self.needs_accessibility_update()
+        {
             return false;
         }
         let mut accessibility_tree = self.accessibility_tree.borrow_mut();

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -45,8 +45,8 @@ use js::rust::{
     MutableHandleValue,
 };
 use layout_api::{
-    AccessibilityDamage, AxesOverflow, BoxAreaType, CSSPixelRectVec, FragmentType, HitTestFlags,
-    Layout, LayoutImageDestination, PendingImage, PendingImageState, PendingRasterizationImage,
+    AxesOverflow, BoxAreaType, CSSPixelRectVec, FragmentType, HitTestFlags, Layout,
+    LayoutImageDestination, PendingImage, PendingImageState, PendingRasterizationImage,
     PhysicalSides, QueryMsg, ReflowGoal, ReflowPhasesRun, ReflowRequest, ReflowRequestRestyle,
     ReflowStatistics, RestyleReason, ScrollContainerQueryFlags, ScrollContainerResponse,
     TrustedNodeAddress, combine_id_with_fragment_type,
@@ -2722,10 +2722,11 @@ impl Window {
 
         let document_context = self.web_font_context(cx.no_gc());
 
-        let rooted_nodes_for_accessibility_integrity_check =
-            document.rooted_nodes_for_accessibility_integrity_check();
-        let mut accessibility_damage: Option<Vec<(TrustedNodeAddress, AccessibilityDamage)>> = None;
-        if self.layout().accessibility_active() {
+        let mut rooted_nodes_for_accessibility_integrity_check = None;
+        let mut accessibility_damage = None;
+        if reflow_goal == ReflowGoal::UpdateTheRendering && self.layout().accessibility_active() {
+            rooted_nodes_for_accessibility_integrity_check =
+                document.rooted_nodes_for_accessibility_integrity_check();
             let mut accessibility_data = document.accessibility_data_mut();
             accessibility_damage = Some(accessibility_data.drain_pending_accessibility_damage());
         }


### PR DESCRIPTION
In other situations, don't drain accessibility damage or rooted nodes.

I floated this idea on #46996 and thought it might be easiest to make it a standalone patch.

Testing: Existing tests pass.
Fixes: Part of #47182
