### PR TITLE
script: Guard brotli transport stream with feature flag

### DIFF
--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -16,6 +16,8 @@ path = "lib.rs"
 
 [features]
 bluetooth = ['servo-bluetooth-traits', 'script_bindings/bluetooth']
+# Allow brotli to be used in stream/compressionstream
+brotli-compression-stream = ["dep:brotli"]
 crown = ['js/crown']
 debugmozjs = ['js/debugmozjs']
 gamepad = ["script_bindings/gamepad", "embedder_traits/gamepad"]
@@ -52,7 +54,7 @@ backtrace = { workspace = true }
 base64 = { workspace = true }
 base64ct = { workspace = true }
 bitflags = { workspace = true }
-brotli = { workspace = true }
+brotli = { workspace = true, optional = true }
 buf-read-ext = { workspace = true }
 cbc = { workspace = true }
 chacha20poly1305 = { workspace = true }

--- a/components/script/dom/stream/compressionstream.rs
+++ b/components/script/dom/stream/compressionstream.rs
@@ -69,7 +69,7 @@ impl CompressionStream {
             context: RefCell::new(CompressionContext::new(format)?),
         })
     }
-
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))] // reflect will only be called on the box which is fine
     fn new_with_proto(
         cx: &mut JSContext,
         global: &GlobalScope,

--- a/components/script/dom/stream/compressionstream.rs
+++ b/components/script/dom/stream/compressionstream.rs
@@ -250,7 +250,7 @@ impl CompressionContext {
             ))),
             #[cfg(not(feature = "brotli-compression-stream"))]
             CompressionFormat::Brotli => {
-                return Err(Error::Operation(Some("Brotli not supported".into())));
+                return Err(Error::NotSupported(Some("Brotli not supported".into())));
             },
             CompressionFormat::Deflate => {
                 Encoder::Deflate(ZlibEncoder::new(Vec::new(), Compression::default()))

--- a/components/script/dom/stream/compressionstream.rs
+++ b/components/script/dom/stream/compressionstream.rs
@@ -2,11 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#[cfg(feature = "brotli-compression-stream")]
 use std::borrow::BorrowMut;
 use std::cell::RefCell;
 use std::io::{self, Write};
 use std::ptr;
 
+#[cfg(feature = "brotli-compression-stream")]
 use brotli::CompressorWriter as BrotliEncoder;
 use dom_struct::dom_struct;
 use flate2::Compression;
@@ -32,8 +34,11 @@ use crate::dom::types::{
     GlobalScope, ReadableStream, TransformStream, TransformStreamDefaultController, WritableStream,
 };
 
+#[cfg(feature = "brotli-compression-stream")]
 pub(crate) const BROTLI_BUFFER_SIZE: usize = 4096;
+#[cfg(feature = "brotli-compression-stream")]
 const BROTLI_QUALITIY_LEVEL: u32 = 5;
+#[cfg(feature = "brotli-compression-stream")]
 const BROTLI_WINDOW_SIZE: u32 = 22;
 
 /// <https://compression.spec.whatwg.org/#compressionstream>
@@ -53,13 +58,16 @@ pub(crate) struct CompressionStream {
 }
 
 impl CompressionStream {
-    fn new_inherited(transform: &TransformStream, format: CompressionFormat) -> CompressionStream {
-        CompressionStream {
+    fn new_inherited(
+        transform: &TransformStream,
+        format: CompressionFormat,
+    ) -> Fallible<CompressionStream> {
+        Ok(CompressionStream {
             reflector_: Reflector::new(),
             transform: Dom::from_ref(transform),
             format,
-            context: RefCell::new(CompressionContext::new(format)),
-        }
+            context: RefCell::new(CompressionContext::new(format)?),
+        })
     }
 
     fn new_with_proto(
@@ -68,13 +76,13 @@ impl CompressionStream {
         proto: Option<SafeHandleObject>,
         transform: &TransformStream,
         format: CompressionFormat,
-    ) -> DomRoot<CompressionStream> {
-        reflect_dom_object_with_proto(
+    ) -> Fallible<DomRoot<CompressionStream>> {
+        Ok(reflect_dom_object_with_proto(
             cx,
-            Box::new(CompressionStream::new_inherited(transform, format)),
+            Box::new(CompressionStream::new_inherited(transform, format)?),
             global,
             proto,
-        )
+        ))
     }
 }
 
@@ -93,7 +101,7 @@ impl CompressionStreamMethods<crate::DomTypeHolder> for CompressionStream {
         // Step 5. Set this’s transform to a new TransformStream.
         let transform = TransformStream::new_with_proto(cx, global, None);
         let compression_stream =
-            CompressionStream::new_with_proto(cx, global, proto, &transform, format);
+            CompressionStream::new_with_proto(cx, global, proto, &transform, format)?;
 
         // Step 3. Let transformAlgorithm be an algorithm which takes a chunk argument and runs the
         // compress and enqueue a chunk algorithm with this and chunk.
@@ -203,6 +211,7 @@ pub(crate) fn compress_flush_and_enqueue(
 
 /// An enum grouping encoders of differenct compression algorithms.
 enum Encoder {
+    #[cfg(feature = "brotli-compression-stream")]
     Brotli(Box<BrotliEncoder<Vec<u8>>>),
     Deflate(ZlibEncoder<Vec<u8>>),
     DeflateRaw(DeflateEncoder<Vec<u8>>),
@@ -210,9 +219,10 @@ enum Encoder {
 }
 
 impl MallocSizeOf for Encoder {
-    #[expect(unsafe_code)]
+    #[cfg_attr(feature = "brotli-compression-stream", expect(unsafe_code))]
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         match self {
+            #[cfg(feature = "brotli-compression-stream")]
             Encoder::Brotli(encoder) => unsafe { ops.malloc_size_of(&**encoder) },
             Encoder::Deflate(encoder) => encoder.size_of(ops),
             Encoder::DeflateRaw(encoder) => encoder.size_of(ops),
@@ -229,14 +239,19 @@ struct CompressionContext {
 }
 
 impl CompressionContext {
-    fn new(format: CompressionFormat) -> CompressionContext {
+    fn new(format: CompressionFormat) -> Fallible<CompressionContext> {
         let encoder = match format {
+            #[cfg(feature = "brotli-compression-stream")]
             CompressionFormat::Brotli => Encoder::Brotli(Box::new(BrotliEncoder::new(
                 Vec::new(),
                 BROTLI_BUFFER_SIZE,
                 BROTLI_QUALITIY_LEVEL,
                 BROTLI_WINDOW_SIZE,
             ))),
+            #[cfg(not(feature = "brotli-compression-stream"))]
+            CompressionFormat::Brotli => {
+                return Err(Error::Operation(Some("Brotli not supported".into())));
+            },
             CompressionFormat::Deflate => {
                 Encoder::Deflate(ZlibEncoder::new(Vec::new(), Compression::default()))
             },
@@ -247,13 +262,14 @@ impl CompressionContext {
                 Encoder::Gzip(GzEncoder::new(Vec::new(), Compression::default()))
             },
         };
-        CompressionContext { encoder }
+        Ok(CompressionContext { encoder })
     }
 
     fn compress(&mut self, chunk: &[u8]) -> Result<Vec<u8>, io::Error> {
         let mut result = Vec::new();
 
         match &mut self.encoder {
+            #[cfg(feature = "brotli-compression-stream")]
             Encoder::Brotli(encoder) => {
                 encoder.write_all(chunk)?;
                 encoder.flush()?;
@@ -283,6 +299,7 @@ impl CompressionContext {
         let mut result = Vec::new();
 
         match &mut self.encoder {
+            #[cfg(feature = "brotli-compression-stream")]
             Encoder::Brotli(encoder) => {
                 let encoder = std::mem::replace(
                     encoder.borrow_mut(),

--- a/components/script/dom/stream/decompressionstream.rs
+++ b/components/script/dom/stream/decompressionstream.rs
@@ -259,7 +259,7 @@ impl DecompressionContext {
             },
             #[cfg(not(feature = "brotli-compression-stream"))]
             CompressionFormat::Brotli => {
-                return Err(Error::Operation(Some("Brotli not supported".into())));
+                return Err(Error::NotSupported(Some("Brotli not supported".into())));
             },
             CompressionFormat::Deflate => Decoder::Deflate(ZlibDecoder::new(Vec::new())),
             CompressionFormat::Deflate_raw => Decoder::DeflateRaw(DeflateDecoder::new(Vec::new())),

--- a/components/script/dom/stream/decompressionstream.rs
+++ b/components/script/dom/stream/decompressionstream.rs
@@ -6,6 +6,7 @@ use std::cell::RefCell;
 use std::io::{self, Write};
 use std::ptr;
 
+#[cfg(feature = "brotli-compression-stream")]
 use brotli::DecompressorWriter as BrotliDecoder;
 use dom_struct::dom_struct;
 use flate2::write::{DeflateDecoder, GzDecoder, ZlibDecoder};
@@ -22,7 +23,9 @@ use crate::dom::bindings::codegen::Bindings::DecompressionStreamBinding::Decompr
 use crate::dom::bindings::conversions::ToJSValConvertible;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::root::{Dom, DomRoot};
-use crate::dom::stream::compressionstream::{BROTLI_BUFFER_SIZE, convert_chunk_to_vec};
+#[cfg(feature = "brotli-compression-stream")]
+use crate::dom::stream::compressionstream::BROTLI_BUFFER_SIZE;
+use crate::dom::stream::compressionstream::convert_chunk_to_vec;
 use crate::dom::stream::transformstreamdefaultcontroller::TransformerType;
 use crate::dom::types::{
     GlobalScope, ReadableStream, TransformStream, TransformStreamDefaultController, WritableStream,
@@ -48,13 +51,13 @@ impl DecompressionStream {
     fn new_inherited(
         transform: &TransformStream,
         format: CompressionFormat,
-    ) -> DecompressionStream {
-        DecompressionStream {
+    ) -> Fallible<DecompressionStream> {
+        Ok(DecompressionStream {
             reflector_: Reflector::new(),
             transform: Dom::from_ref(transform),
             format,
-            context: RefCell::new(DecompressionContext::new(format)),
-        }
+            context: RefCell::new(DecompressionContext::new(format)?),
+        })
     }
 
     fn new_with_proto(
@@ -63,13 +66,13 @@ impl DecompressionStream {
         proto: Option<SafeHandleObject>,
         transform: &TransformStream,
         format: CompressionFormat,
-    ) -> DomRoot<DecompressionStream> {
-        reflect_dom_object_with_proto(
+    ) -> Fallible<DomRoot<DecompressionStream>> {
+        Ok(reflect_dom_object_with_proto(
             cx,
-            Box::new(DecompressionStream::new_inherited(transform, format)),
+            Box::new(DecompressionStream::new_inherited(transform, format)?),
             global,
             proto,
-        )
+        ))
     }
 }
 
@@ -88,7 +91,7 @@ impl DecompressionStreamMethods<crate::DomTypeHolder> for DecompressionStream {
         // Step 5. Set this’s transform to a new TransformStream.
         let transform = TransformStream::new_with_proto(cx, global, None);
         let decompression_stream =
-            DecompressionStream::new_with_proto(cx, global, proto, &transform, format);
+            DecompressionStream::new_with_proto(cx, global, proto, &transform, format)?;
 
         // Step 3. Let transformAlgorithm be an algorithm which takes a chunk argument and runs the
         // decompress and enqueue a chunk algorithm with this and chunk.
@@ -218,6 +221,7 @@ pub(crate) fn decompress_flush_and_enqueue(
 
 /// An enum grouping decoders of differenct compression algorithms.
 enum Decoder {
+    #[cfg(feature = "brotli-compression-stream")]
     Brotli(Box<BrotliDecoder<Vec<u8>>>),
     Deflate(ZlibDecoder<Vec<u8>>),
     DeflateRaw(DeflateDecoder<Vec<u8>>),
@@ -225,9 +229,10 @@ enum Decoder {
 }
 
 impl MallocSizeOf for Decoder {
-    #[expect(unsafe_code)]
+    #[cfg_attr(feature = "brotli-compression-stream", expect(unsafe_code))]
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         match self {
+            #[cfg(feature = "brotli-compression-stream")]
             Decoder::Brotli(decoder) => unsafe { ops.malloc_size_of(&**decoder) },
             Decoder::Deflate(decoder) => decoder.size_of(ops),
             Decoder::DeflateRaw(decoder) => decoder.size_of(ops),
@@ -245,25 +250,31 @@ struct DecompressionContext {
 }
 
 impl DecompressionContext {
-    fn new(format: CompressionFormat) -> DecompressionContext {
+    fn new(format: CompressionFormat) -> Fallible<DecompressionContext> {
         let decoder = match format {
+            #[cfg(feature = "brotli-compression-stream")]
             CompressionFormat::Brotli => {
                 Decoder::Brotli(Box::new(BrotliDecoder::new(Vec::new(), BROTLI_BUFFER_SIZE)))
+            },
+            #[cfg(not(feature = "brotli-compression-stream"))]
+            CompressionFormat::Brotli => {
+                return Err(Error::Operation(Some("Brotli not supported".into())));
             },
             CompressionFormat::Deflate => Decoder::Deflate(ZlibDecoder::new(Vec::new())),
             CompressionFormat::Deflate_raw => Decoder::DeflateRaw(DeflateDecoder::new(Vec::new())),
             CompressionFormat::Gzip => Decoder::Gzip(GzDecoder::new(Vec::new())),
         };
-        DecompressionContext {
+        Ok(DecompressionContext {
             decoder,
             is_ended: false,
-        }
+        })
     }
 
     fn decompress(&mut self, mut chunk: &[u8]) -> Result<Vec<u8>, io::Error> {
         let mut result = Vec::new();
 
         match &mut self.decoder {
+            #[cfg(feature = "brotli-compression-stream")]
             Decoder::Brotli(decoder) => {
                 while !chunk.is_empty() {
                     let written = decoder.write(chunk)?;
@@ -321,6 +332,7 @@ impl DecompressionContext {
         let mut result = Vec::new();
 
         match &mut self.decoder {
+            #[cfg(feature = "brotli-compression-stream")]
             Decoder::Brotli(decoder) => {
                 if decoder.close().is_ok() {
                     self.is_ended = true;

--- a/components/script/dom/stream/decompressionstream.rs
+++ b/components/script/dom/stream/decompressionstream.rs
@@ -60,6 +60,7 @@ impl DecompressionStream {
         })
     }
 
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))] // reflect will only be called on the box which is fine
     fn new_with_proto(
         cx: &mut js::context::JSContext,
         global: &GlobalScope,

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -23,12 +23,16 @@ default = ["bundled", "clipboard", "js_jit"]
 #  configuration with `--no-default-features` build
 #
 # A convenience feature to enable all default web features servo has.
-default_web_features = ["clipboard", "webgpu", "webxr"]
+default_web_features = ["brotli-compression-stream", "clipboard", "webgpu", "webxr"]
 # Bundle required resources in the binary.
 bundled = ["baked-in-resources", "bundled_freetype"]
 
 # Individual features below this line.
 background_hang_monitor = ["servo-background-hang-monitor/sampler"]
+
+# Allow brotli to be used for compression and decompression in TransportStream JavaScript API
+brotli-compression-stream = ["script/brotli-compression-stream"]
+
 # This is slightly magical, but this will also work on ohos, where `servo-default-resource` is not added,
 # which makes `baked-in-resources a no-op (as intended) on ohos (and perhaps other platforms in the future).
 baked-in-resources = ["dep:servo-default-resources"]


### PR DESCRIPTION
This guards brotli Transport Stream compression and decompression with a feature flag. If the feature flag is not enabled and transport stream is in brotli we throw a DOMException.

This saves roughly 1Mb in production-stripped binary.

Testing: The default is still to include brotli.
Fixes: https://github.com/servo/servo/issues/47190
