### PR TITLE
script: abstract the cache logic of `PaintWorklet`'s Worklet Tasks

### DIFF
--- a/components/script/dom/worklet/paintworkletglobalscope.rs
+++ b/components/script/dom/worklet/paintworkletglobalscope.rs
@@ -145,11 +145,14 @@ impl PaintWorkletGlobalScope {
                 arguments,
                 sender,
             ) => {
-                let cache_hit = (*self.cached_name.borrow() == name) &&
-                    (self.cached_size.get() == size) &&
-                    (self.cached_device_pixel_ratio.get() == device_pixel_ratio) &&
-                    (*self.cached_properties.borrow() == properties) &&
-                    (*self.cached_arguments.borrow() == arguments);
+                let cache_hit = self.has_cached_paint_image(
+                    &name,
+                    size,
+                    device_pixel_ratio,
+                    &properties,
+                    &arguments,
+                );
+
                 let result = if cache_hit {
                     debug!("Cache hit on paint worklet {}!", name);
                     self.cached_result.borrow().clone()
@@ -169,12 +172,14 @@ impl PaintWorkletGlobalScope {
                         &arguments,
                     );
                     if (result.image_key.is_some()) && (result.missing_image_urls.is_empty()) {
-                        *self.cached_name.borrow_mut() = name;
-                        self.cached_size.set(size);
-                        self.cached_device_pixel_ratio.set(device_pixel_ratio);
-                        *self.cached_properties.borrow_mut() = properties;
-                        *self.cached_arguments.borrow_mut() = arguments;
-                        *self.cached_result.borrow_mut() = result.clone();
+                        self.set_cached_paint_image(
+                            name,
+                            size,
+                            device_pixel_ratio,
+                            properties,
+                            arguments,
+                            result.clone(),
+                        );
                     }
                     result
                 };
@@ -209,6 +214,38 @@ impl PaintWorkletGlobalScope {
                 }
             },
         }
+    }
+
+    fn has_cached_paint_image(
+        &self,
+        name: &Atom,
+        size: Size2D<f32, CSSPixel>,
+        device_pixel_ratio: Scale<f32, CSSPixel, DevicePixel>,
+        properties: &[(Atom, String)],
+        arguments: &[String],
+    ) -> bool {
+        (&*self.cached_name.borrow() == name) &&
+            (self.cached_size.get() == size) &&
+            (self.cached_device_pixel_ratio.get() == device_pixel_ratio) &&
+            (*self.cached_properties.borrow() == properties) &&
+            (*self.cached_arguments.borrow() == arguments)
+    }
+
+    fn set_cached_paint_image(
+        &self,
+        name: Atom,
+        size: Size2D<f32, CSSPixel>,
+        device_pixel_ratio: Scale<f32, CSSPixel, DevicePixel>,
+        properties: Vec<(Atom, String)>,
+        arguments: Vec<String>,
+        result: DrawAPaintImageResult,
+    ) {
+        *self.cached_name.borrow_mut() = name;
+        self.cached_size.set(size);
+        self.cached_device_pixel_ratio.set(device_pixel_ratio);
+        *self.cached_properties.borrow_mut() = properties;
+        *self.cached_arguments.borrow_mut() = arguments;
+        *self.cached_result.borrow_mut() = result;
     }
 
     /// <https://drafts.css-houdini.org/css-paint-api/#draw-a-paint-image>

--- a/components/script/dom/worklet/paintworkletglobalscope.rs
+++ b/components/script/dom/worklet/paintworkletglobalscope.rs
@@ -206,10 +206,14 @@ impl PaintWorkletGlobalScope {
                         &arguments,
                     );
                     if (result.image_key.is_some()) && (result.missing_image_urls.is_empty()) {
-                        *self.cached_name.borrow_mut() = name;
-                        *self.cached_properties.borrow_mut() = properties;
-                        *self.cached_arguments.borrow_mut() = arguments;
-                        *self.cached_result.borrow_mut() = result;
+                        self.set_cached_paint_image(
+                            name,
+                            size,
+                            device_pixel_ratio,
+                            properties,
+                            arguments,
+                            result,
+                        );
                     }
                 }
             },


### PR DESCRIPTION
Simplifies the cache logic of `PaintWorkletTask::DrawAPaintImage` and `PaintWorkletTask::SpeculativelyDrawAPaintImage`,

Add and use two cache helper methods:
1. `has_cached_paint_image`
2. `set_cached_paint_image`

Testing: no testing requires as this patch is a refactor and does not change existing logic
