### PR TITLE
webgl: Add feature guard

### DIFF
--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -20,6 +20,7 @@ gamepad = ["embedder_traits/gamepad"]
 tracing = ["dep:tracing", "servo-canvas/tracing"]
 vello = ["servo-canvas/vello"]
 webgpu = ["dep:webgpu", "dep:webgpu_traits", "script_traits/webgpu"]
+webgl = []
 
 [lints.clippy]
 unwrap_used = "deny"

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -465,6 +465,7 @@ pub struct Constellation<STF, SWF> {
     phantom: PhantomData<(STF, SWF)>,
 
     /// Entry point to create and get channels to a WebGLThread.
+    #[cfg(feature = "webgl")]
     pub(crate) webgl_threads: Option<WebGLThreads>,
 
     /// The XR device registry
@@ -580,6 +581,7 @@ pub struct InitialConstellationState {
     pub webrender_external_image_id_manager: WebRenderExternalImageIdManager,
 
     /// Entry point to create and get channels to a WebGLThread.
+    #[cfg(feature = "webgl")]
     pub webgl_threads: Option<WebGLThreads>,
 
     /// The XR device registry
@@ -733,6 +735,7 @@ where
                         warn!("Randomly closing pipelines using seed {random_pipeline_closure_seed:?}.");
                         (rng, probability)
                     }),
+                    #[cfg(feature = "webgl")]
                     webgl_threads: state.webgl_threads,
                     webxr_registry: state.webxr_registry,
                     canvas: OnceCell::new(),

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -157,8 +157,6 @@ use servo_bluetooth_traits::BluetoothRequest;
 use servo_canvas::canvas_paint_thread::CanvasPaintThread;
 use servo_canvas_traits::ConstellationCanvasMsg;
 use servo_canvas_traits::canvas::{CanvasId, CanvasMsg};
-#[cfg(feature = "webgl")]
-use servo_canvas_traits::webgl::WebGLThreads;
 use servo_config::{opts, pref};
 use servo_constellation_traits::{
     AuxiliaryWebViewCreationRequest, AuxiliaryWebViewCreationResponse, ConstellationInterest,
@@ -467,7 +465,7 @@ pub struct Constellation<STF, SWF> {
 
     /// Entry point to create and get channels to a WebGLThread.
     #[cfg(feature = "webgl")]
-    pub(crate) webgl_threads: Option<WebGLThreads>,
+    pub(crate) webgl_threads: Option<servo_canvas_traits::webgl::WebGLThreads>,
 
     /// The XR device registry
     pub(crate) webxr_registry: Option<webxr_api::Registry>,
@@ -583,7 +581,7 @@ pub struct InitialConstellationState {
 
     /// Entry point to create and get channels to a WebGLThread.
     #[cfg(feature = "webgl")]
-    pub webgl_threads: Option<WebGLThreads>,
+    pub webgl_threads: Option<servo_canvas_traits::webgl::WebGLThreads>,
 
     /// The XR device registry
     pub webxr_registry: Option<webxr_api::Registry>,

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -157,6 +157,7 @@ use servo_bluetooth_traits::BluetoothRequest;
 use servo_canvas::canvas_paint_thread::CanvasPaintThread;
 use servo_canvas_traits::ConstellationCanvasMsg;
 use servo_canvas_traits::canvas::{CanvasId, CanvasMsg};
+#[cfg(feature = "webgl")]
 use servo_canvas_traits::webgl::WebGLThreads;
 use servo_config::{opts, pref};
 use servo_constellation_traits::{

--- a/components/constellation/event_loop.rs
+++ b/components/constellation/event_loop.rs
@@ -103,6 +103,7 @@ impl EventLoop {
             constellation_to_script_receiver: script_port,
             pipeline_namespace_id: constellation.next_pipeline_namespace_id(),
             cross_process_paint_api: constellation.paint_proxy.cross_process_paint_api.clone(),
+            #[cfg(feature = "webgl")]
             webgl_chan: constellation
                 .webgl_threads
                 .as_ref()

--- a/components/paint/Cargo.toml
+++ b/components/paint/Cargo.toml
@@ -16,8 +16,9 @@ path = "lib.rs"
 [features]
 default = []
 tracing = ["dep:tracing"]
+webgl = ["dep:webgl"]
 webgpu = ["dep:webgpu"]
-webxr = ["dep:webxr", "dep:webxr-api"]
+webxr = ["webgl", "dep:webxr", "dep:webxr-api"]
 
 [lints.clippy]
 unwrap_used = "deny"

--- a/components/paint/Cargo.toml
+++ b/components/paint/Cargo.toml
@@ -50,7 +50,7 @@ stylo_traits = { workspace = true }
 surfman = { workspace = true }
 timers = { workspace = true }
 tracing = { workspace = true, optional = true }
-webgl = { workspace = true }
+webgl = { workspace = true, optional = true }
 webgpu = { workspace = true, optional = true }
 webrender = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/paint/lib.rs
+++ b/components/paint/lib.rs
@@ -29,6 +29,7 @@ mod render_notifier;
 mod screenshot;
 mod touch;
 mod web_content_animation;
+#[cfg(feature = "webgl")]
 mod webrender_external_images;
 mod webview_renderer;
 

--- a/components/paint/paint.rs
+++ b/components/paint/paint.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::env;
 use std::fs::create_dir_all;
 use std::rc::Rc;
+#[cfg(feature = "webgl")]
 use std::thread::JoinHandle;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -19,7 +20,9 @@ use embedder_traits::{
 };
 use euclid::{Scale, Size2D};
 use image::RgbaImage;
-use log::{debug, warn};
+#[cfg(feature = "webgl")]
+use log::warn;
+use log::debug;
 use paint_api::rendering_context::RenderingContext;
 use paint_api::{
     PaintMessage, PaintProxy, PainterSurfmanDetails, PainterSurfmanDetailsMap,
@@ -32,14 +35,19 @@ use profile_traits::path;
 use profile_traits::time::{self as profile_time};
 use servo_base::generic_channel::{self, GenericSender, RoutedReceiver};
 use servo_base::id::{PainterId, PipelineId, WebViewId};
+#[cfg(feature = "webgl")]
 use servo_canvas_traits::webgl::{WebGLContextId, WebGLThreads};
 use servo_config::pref;
 use servo_constellation_traits::EmbedderToConstellationMessage;
 use servo_geometry::DeviceIndependentPixel;
 use style_traits::CSSPixel;
+#[cfg(feature = "webgl")]
 use surfman::Device;
+#[cfg(feature = "webgl")]
 use surfman::chains::SwapChains;
+#[cfg(feature = "webgl")]
 use webgl::WebGLComm;
+#[cfg(feature = "webgl")]
 use webgl::webgl_thread::WebGLContextBusyMap;
 #[cfg(feature = "webgpu")]
 use webgpu::canvas_context::WebGpuExternalImageMap;
@@ -115,15 +123,19 @@ pub struct Paint {
     /// A [`HashMap`] of `WebGLContextId` to a usage count. This count indicates when
     /// WebRender is still rendering the context. This is used to ensure properly clean
     /// up of all Surfman `Surface`s.
+    #[cfg(feature = "webgl")]
     pub(crate) busy_webgl_contexts_map: WebGLContextBusyMap,
 
     /// The [`WebGLThreads`] for this renderer.
+    #[cfg(feature = "webgl")]
     webgl_threads: WebGLThreads,
 
     /// A [`JoinHandle`] for joining the WebGL thread once the exit message is sent.
+    #[cfg(feature = "webgl")]
     webgl_join_handle: Cell<Option<JoinHandle<()>>>,
 
     /// The shared [`SwapChains`] used by [`WebGLThreads`] for this renderer.
+    #[cfg(feature = "webgl")]
     pub(crate) swap_chains: SwapChains<WebGLContextId, Device>,
 
     /// The channel on which messages can be sent to the time profiler.
@@ -173,26 +185,30 @@ impl Paint {
 
         let webrender_external_image_id_manager = WebRenderExternalImageIdManager::default();
         let painter_surfman_details_map = PainterSurfmanDetailsMap::default();
-        let WebGLComm {
-            webgl_threads,
-            swap_chains,
-            busy_webgl_context_map,
-            #[cfg(feature = "webxr")]
-            webxr_layer_grand_manager,
-            join_handle: webgl_join_handle,
-        } = WebGLComm::new(
-            state.paint_proxy.cross_process_paint_api.clone(),
-            webrender_external_image_id_manager.clone(),
-            painter_surfman_details_map.clone(),
-        );
 
-        // Create the WebXR main thread
-        #[cfg(feature = "webxr")]
-        let webxr_main_thread = webxr::MainThreadRegistry::new(
-            state.event_loop_waker.clone(),
-            webxr_layer_grand_manager,
-        )
-        .expect("Failed to create WebXR device registry");
+        #[cfg(feature = "webgl")]
+        {
+            let WebGLComm {
+                webgl_threads,
+                swap_chains,
+                busy_webgl_context_map,
+                #[cfg(feature = "webxr")]
+                webxr_layer_grand_manager,
+                join_handle: webgl_join_handle,
+            } = WebGLComm::new(
+                state.paint_proxy.cross_process_paint_api.clone(),
+                webrender_external_image_id_manager.clone(),
+                painter_surfman_details_map.clone(),
+            );
+
+            // Create the WebXR main thread
+            #[cfg(feature = "webxr")]
+            let webxr_main_thread = webxr::MainThreadRegistry::new(
+                state.event_loop_waker.clone(),
+                webxr_layer_grand_manager,
+            )
+            .expect("Failed to create WebXR device registry");
+        }
 
         Rc::new(RefCell::new(Paint {
             painters: Default::default(),
@@ -202,12 +218,16 @@ impl Paint {
             paint_receiver: state.receiver,
             embedder_to_constellation_sender: state.embedder_to_constellation_sender.clone(),
             webrender_external_image_id_manager,
+            #[cfg(feature = "webgl")]
             webgl_threads,
+            #[cfg(feature = "webgl")]
             webgl_join_handle: Cell::new(Some(webgl_join_handle)),
+            #[cfg(feature = "webgl")]
             swap_chains,
             time_profiler_chan: state.time_profiler_chan,
             _mem_profiler_registration: registration,
             painter_surfman_details_map,
+            #[cfg(feature = "webgl")]
             busy_webgl_contexts_map: busy_webgl_context_map,
             #[cfg(feature = "webxr")]
             webxr_main_thread: RefCell::new(webxr_main_thread),
@@ -262,6 +282,7 @@ impl Paint {
         // devices after `clear_painter_resources` is called.
         self.painter_surfman_details_map.remove(painter_id);
 
+        #[cfg(feature = "webgl")]
         if !self.webgl_threads.clear_painter_resources(painter_id) {
             warn!("Could not clear {painter_id:?} resources in WebGLThread");
         }
@@ -306,6 +327,7 @@ impl Paint {
         self.painter(painter_id).rendering_context.size2d()
     }
 
+    #[cfg(feature = "webgl")]
     pub fn webgl_threads(&self) -> WebGLThreads {
         self.webgl_threads.clone()
     }
@@ -347,11 +369,14 @@ impl Paint {
         // another thread from finishing (i.e. SetFrameTree).
         while self.paint_receiver.try_recv().is_ok() {}
 
-        self.webgl_threads.exit();
-        if let Some(webgl_join_handle) = self.webgl_join_handle.take() &&
-            webgl_join_handle.join().is_err()
+        #[cfg(feature = "webgl")]
         {
-            warn!("Could not join WebGLThread.");
+            self.webgl_threads.exit();
+            if let Some(webgl_join_handle) = self.webgl_join_handle.take() &&
+                webgl_join_handle.join().is_err()
+            {
+                warn!("Could not join WebGLThread.");
+            }
         }
 
         // Tell the profiler, memory profiler, and scrolling timer to shut down.

--- a/components/paint/paint.rs
+++ b/components/paint/paint.rs
@@ -20,9 +20,9 @@ use embedder_traits::{
 };
 use euclid::{Scale, Size2D};
 use image::RgbaImage;
+use log::debug;
 #[cfg(feature = "webgl")]
 use log::warn;
-use log::debug;
 use paint_api::rendering_context::RenderingContext;
 use paint_api::{
     PaintMessage, PaintProxy, PainterSurfmanDetails, PainterSurfmanDetailsMap,

--- a/components/paint/paint.rs
+++ b/components/paint/paint.rs
@@ -185,30 +185,27 @@ impl Paint {
 
         let webrender_external_image_id_manager = WebRenderExternalImageIdManager::default();
         let painter_surfman_details_map = PainterSurfmanDetailsMap::default();
-
         #[cfg(feature = "webgl")]
-        {
-            let WebGLComm {
-                webgl_threads,
-                swap_chains,
-                busy_webgl_context_map,
-                #[cfg(feature = "webxr")]
-                webxr_layer_grand_manager,
-                join_handle: webgl_join_handle,
-            } = WebGLComm::new(
-                state.paint_proxy.cross_process_paint_api.clone(),
-                webrender_external_image_id_manager.clone(),
-                painter_surfman_details_map.clone(),
-            );
-
-            // Create the WebXR main thread
+        let WebGLComm {
+            webgl_threads,
+            swap_chains,
+            busy_webgl_context_map,
             #[cfg(feature = "webxr")]
-            let webxr_main_thread = webxr::MainThreadRegistry::new(
-                state.event_loop_waker.clone(),
-                webxr_layer_grand_manager,
-            )
-            .expect("Failed to create WebXR device registry");
-        }
+            webxr_layer_grand_manager,
+            join_handle: webgl_join_handle,
+        } = WebGLComm::new(
+            state.paint_proxy.cross_process_paint_api.clone(),
+            webrender_external_image_id_manager.clone(),
+            painter_surfman_details_map.clone(),
+        );
+
+        // Create the WebXR main thread.
+        #[cfg(feature = "webxr")]
+        let webxr_main_thread = webxr::MainThreadRegistry::new(
+            state.event_loop_waker.clone(),
+            webxr_layer_grand_manager,
+        )
+        .expect("Failed to create WebXR device registry");
 
         Rc::new(RefCell::new(Paint {
             painters: Default::default(),

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -63,6 +63,7 @@ use crate::refresh_driver::{AnimationRefreshDriverObserver, BaseRefreshDriver};
 use crate::render_notifier::RenderNotifier;
 use crate::screenshot::ScreenshotTaker;
 use crate::web_content_animation::WebContentAnimator;
+#[cfg(feature = "webgl")]
 use crate::webrender_external_images::WebGLExternalImages;
 use crate::webview_renderer::{PinchZoomResult, ScrollResult, UnknownWebView, WebViewRenderer};
 
@@ -165,13 +166,16 @@ impl Painter {
         let mut external_image_handlers = Box::new(WebRenderExternalImageHandlers::new(id_manager));
 
         // Set WebRender external image handler for WebGL textures.
-        let image_handler = Box::new(WebGLExternalImages::new(
-            paint.webgl_threads(),
-            rendering_context.clone(),
-            paint.swap_chains.clone(),
-            paint.busy_webgl_contexts_map.clone(),
-        ));
-        external_image_handlers.set_handler(image_handler, WebRenderImageHandlerType::WebGl);
+        #[cfg(feature = "webgl")]
+        {
+            let image_handler = Box::new(WebGLExternalImages::new(
+                paint.webgl_threads(),
+                rendering_context.clone(),
+                paint.swap_chains.clone(),
+                paint.busy_webgl_contexts_map.clone(),
+            ));
+            external_image_handlers.set_handler(image_handler, WebRenderImageHandlerType::WebGl);
+        }
 
         #[cfg(feature = "webgpu")]
         external_image_handlers.set_handler(

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -28,6 +28,7 @@ profilemozjs = ['js/profilemozjs']
 testbinding = ["script_bindings/testbinding"]
 tracing = ["dep:tracing", "script_bindings/tracing"]
 webgl_backtrace = ["servo-canvas-traits/webgl_backtrace"]
+webgl = ["script_bindings/webgl"]
 webgpu = [
     "dep:script_webgpu",
     "dep:webgpu_traits",

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -28,7 +28,11 @@ profilemozjs = ['js/profilemozjs']
 testbinding = ["script_bindings/testbinding"]
 tracing = ["dep:tracing", "script_bindings/tracing"]
 webgl_backtrace = ["servo-canvas-traits/webgl_backtrace"]
-webgl = ["script_bindings/webgl"]
+webgl = [
+    "script_bindings/webgl",
+    "script_traits/webgl",
+    "servo-constellation-traits/webgl",
+]
 webgpu = [
     "dep:script_webgpu",
     "dep:webgpu_traits",
@@ -37,7 +41,7 @@ webgpu = [
     "script_bindings/webgpu",
     "script_traits/webgpu",
 ]
-webxr = ["gamepad", "webxr-api", "script_bindings/webxr"]
+webxr = ["webgl", "gamepad", "webxr-api", "script_bindings/webxr"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(crown)'] }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -29,6 +29,7 @@ testbinding = ["script_bindings/testbinding"]
 tracing = ["dep:tracing", "script_bindings/tracing"]
 webgl_backtrace = ["servo-canvas-traits/webgl_backtrace"]
 webgl = [
+    "dep:mozangle",
     "script_bindings/webgl",
     "script_traits/webgl",
     "servo-constellation-traits/webgl",
@@ -191,4 +192,4 @@ xpath = { workspace = true }
 zeroize = { workspace = true }
 
 [target.'cfg(not(target_os = "ios"))'.dependencies]
-mozangle = { workspace = true }
+mozangle = { workspace = true, optional = true }

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -716,6 +716,7 @@ impl CanvasState {
                         self.state.borrow().transform,
                     ));
                 },
+                #[cfg(feature = "webgl")]
                 OffscreenRenderingContext::WebGL(ref context) => {
                     let Some(snapshot) = context.get_image_data() else {
                         return Ok(());
@@ -731,7 +732,7 @@ impl CanvasState {
                         self.state.borrow().transform,
                     ));
                 },
-
+                #[cfg(feature = "webgl")]
                 OffscreenRenderingContext::WebGL2(ref context) => {
                     let Some(snapshot) = context.get_image_data() else {
                         return Ok(());
@@ -859,6 +860,7 @@ impl CanvasState {
                                 self.state.borrow().transform,
                             ));
                         },
+                        #[cfg(feature = "webgl")]
                         OffscreenRenderingContext::WebGL(ref context) => {
                             let Some(snapshot) = context.get_image_data() else {
                                 return Ok(());
@@ -875,6 +877,7 @@ impl CanvasState {
                             ));
                         },
 
+                        #[cfg(feature = "webgl")]
                         OffscreenRenderingContext::WebGL2(ref context) => {
                             let Some(snapshot) = context.get_image_data() else {
                                 return Ok(());

--- a/components/script/dom/canvas/canvas_context.rs
+++ b/components/script/dom/canvas/canvas_context.rs
@@ -14,14 +14,12 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::node::{Node, NodeTraits};
 #[cfg(feature = "webgpu")]
 use crate::dom::types::GPUCanvasContext;
-#[cfg(feature = "webgl")]
-use crate::dom::types::{
-    WebGL2RenderingContext, WebGLRenderingContext,
-};
 use crate::dom::types::{
     CanvasRenderingContext2D, HTMLCanvasElement, ImageBitmapRenderingContext, OffscreenCanvas,
     OffscreenCanvasRenderingContext2D,
 };
+#[cfg(feature = "webgl")]
+use crate::dom::types::{WebGL2RenderingContext, WebGLRenderingContext};
 
 /// Non rooted variant of [`crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas`]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]

--- a/components/script/dom/canvas/canvas_context.rs
+++ b/components/script/dom/canvas/canvas_context.rs
@@ -14,9 +14,13 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::node::{Node, NodeTraits};
 #[cfg(feature = "webgpu")]
 use crate::dom::types::GPUCanvasContext;
+#[cfg(feature = "webgl")]
+use crate::dom::types::{
+    WebGL2RenderingContext, WebGLRenderingContext,
+};
 use crate::dom::types::{
     CanvasRenderingContext2D, HTMLCanvasElement, ImageBitmapRenderingContext, OffscreenCanvas,
-    OffscreenCanvasRenderingContext2D, WebGL2RenderingContext, WebGLRenderingContext,
+    OffscreenCanvasRenderingContext2D,
 };
 
 /// Non rooted variant of [`crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas`]
@@ -168,7 +172,9 @@ pub(crate) enum RenderingContext {
     Placeholder(Dom<OffscreenCanvas>),
     Context2d(Dom<CanvasRenderingContext2D>),
     BitmapRenderer(Dom<ImageBitmapRenderingContext>),
+    #[cfg(feature = "webgl")]
     WebGL(Dom<WebGLRenderingContext>),
+    #[cfg(feature = "webgl")]
     WebGL2(Dom<WebGL2RenderingContext>),
     #[cfg(feature = "webgpu")]
     WebGPU(Dom<GPUCanvasContext>),
@@ -182,7 +188,9 @@ impl RenderingContext {
             },
             RenderingContext::Context2d(context) => context.set_image_key(image_key),
             RenderingContext::BitmapRenderer(context) => context.set_image_key(image_key),
+            #[cfg(feature = "webgl")]
             RenderingContext::WebGL(context) => context.set_image_key(image_key),
+            #[cfg(feature = "webgl")]
             RenderingContext::WebGL2(context) => context.set_image_key(image_key),
             #[cfg(feature = "webgpu")]
             RenderingContext::WebGPU(context) => context.set_image_key(image_key),
@@ -200,7 +208,9 @@ impl CanvasContext for RenderingContext {
             RenderingContext::Placeholder(offscreen_canvas) => offscreen_canvas.context()?.canvas(),
             RenderingContext::Context2d(context) => context.canvas(),
             RenderingContext::BitmapRenderer(context) => context.canvas(),
+            #[cfg(feature = "webgl")]
             RenderingContext::WebGL(context) => context.canvas(),
+            #[cfg(feature = "webgl")]
             RenderingContext::WebGL2(context) => context.canvas(),
             #[cfg(feature = "webgpu")]
             RenderingContext::WebGPU(context) => context.canvas(),
@@ -216,7 +226,9 @@ impl CanvasContext for RenderingContext {
             },
             RenderingContext::Context2d(context) => context.resize(),
             RenderingContext::BitmapRenderer(context) => context.resize(),
+            #[cfg(feature = "webgl")]
             RenderingContext::WebGL(context) => context.resize(),
+            #[cfg(feature = "webgl")]
             RenderingContext::WebGL2(context) => context.resize(),
             #[cfg(feature = "webgpu")]
             RenderingContext::WebGPU(context) => context.resize(),
@@ -232,7 +244,9 @@ impl CanvasContext for RenderingContext {
             },
             RenderingContext::Context2d(context) => context.reset_bitmap(),
             RenderingContext::BitmapRenderer(context) => context.reset_bitmap(),
+            #[cfg(feature = "webgl")]
             RenderingContext::WebGL(context) => context.reset_bitmap(),
+            #[cfg(feature = "webgl")]
             RenderingContext::WebGL2(context) => context.reset_bitmap(),
             #[cfg(feature = "webgpu")]
             RenderingContext::WebGPU(context) => context.reset_bitmap(),
@@ -246,7 +260,9 @@ impl CanvasContext for RenderingContext {
             },
             RenderingContext::Context2d(context) => context.get_image_data(),
             RenderingContext::BitmapRenderer(context) => context.get_image_data(),
+            #[cfg(feature = "webgl")]
             RenderingContext::WebGL(context) => context.get_image_data(),
+            #[cfg(feature = "webgl")]
             RenderingContext::WebGL2(context) => context.get_image_data(),
             #[cfg(feature = "webgpu")]
             RenderingContext::WebGPU(context) => context.get_image_data(),
@@ -260,7 +276,9 @@ impl CanvasContext for RenderingContext {
                 .is_none_or(|context| context.origin_is_clean()),
             RenderingContext::Context2d(context) => context.origin_is_clean(),
             RenderingContext::BitmapRenderer(context) => context.origin_is_clean(),
+            #[cfg(feature = "webgl")]
             RenderingContext::WebGL(context) => context.origin_is_clean(),
+            #[cfg(feature = "webgl")]
             RenderingContext::WebGL2(context) => context.origin_is_clean(),
             #[cfg(feature = "webgpu")]
             RenderingContext::WebGPU(context) => context.origin_is_clean(),
@@ -275,7 +293,9 @@ impl CanvasContext for RenderingContext {
                 .unwrap_or_default(),
             RenderingContext::Context2d(context) => context.size(),
             RenderingContext::BitmapRenderer(context) => context.size(),
+            #[cfg(feature = "webgl")]
             RenderingContext::WebGL(context) => context.size(),
+            #[cfg(feature = "webgl")]
             RenderingContext::WebGL2(context) => context.size(),
             #[cfg(feature = "webgpu")]
             RenderingContext::WebGPU(context) => context.size(),
@@ -291,7 +311,9 @@ impl CanvasContext for RenderingContext {
             },
             RenderingContext::Context2d(context) => context.mark_as_dirty(),
             RenderingContext::BitmapRenderer(context) => context.mark_as_dirty(),
+            #[cfg(feature = "webgl")]
             RenderingContext::WebGL(context) => context.mark_as_dirty(),
+            #[cfg(feature = "webgl")]
             RenderingContext::WebGL2(context) => context.mark_as_dirty(),
             #[cfg(feature = "webgpu")]
             RenderingContext::WebGPU(context) => context.mark_as_dirty(),
@@ -305,7 +327,9 @@ impl CanvasContext for RenderingContext {
                 .is_some_and(|context| context.onscreen()),
             RenderingContext::Context2d(context) => context.onscreen(),
             RenderingContext::BitmapRenderer(context) => context.onscreen(),
+            #[cfg(feature = "webgl")]
             RenderingContext::WebGL(context) => context.onscreen(),
+            #[cfg(feature = "webgl")]
             RenderingContext::WebGL2(context) => context.onscreen(),
             #[cfg(feature = "webgpu")]
             RenderingContext::WebGPU(context) => context.onscreen(),
@@ -319,7 +343,9 @@ impl CanvasContext for RenderingContext {
 pub(crate) enum OffscreenRenderingContext {
     Context2d(Dom<OffscreenCanvasRenderingContext2D>),
     BitmapRenderer(Dom<ImageBitmapRenderingContext>),
+    #[cfg(feature = "webgl")]
     WebGL(Dom<WebGLRenderingContext>),
+    #[cfg(feature = "webgl")]
     WebGL2(Dom<WebGL2RenderingContext>),
     // #[cfg(feature = "webgpu")]
     // WebGPU(Dom<GPUCanvasContext>),
@@ -335,7 +361,9 @@ impl CanvasContext for OffscreenRenderingContext {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.canvas(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.canvas(),
+            #[cfg(feature = "webgl")]
             OffscreenRenderingContext::WebGL(context) => context.canvas(),
+            #[cfg(feature = "webgl")]
             OffscreenRenderingContext::WebGL2(context) => context.canvas(),
             OffscreenRenderingContext::Detached => None,
         }
@@ -345,7 +373,9 @@ impl CanvasContext for OffscreenRenderingContext {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.resize(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.resize(),
+            #[cfg(feature = "webgl")]
             OffscreenRenderingContext::WebGL(context) => context.resize(),
+            #[cfg(feature = "webgl")]
             OffscreenRenderingContext::WebGL2(context) => context.resize(),
             OffscreenRenderingContext::Detached => {},
         }
@@ -355,7 +385,9 @@ impl CanvasContext for OffscreenRenderingContext {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.reset_bitmap(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.reset_bitmap(),
+            #[cfg(feature = "webgl")]
             OffscreenRenderingContext::WebGL(context) => context.reset_bitmap(),
+            #[cfg(feature = "webgl")]
             OffscreenRenderingContext::WebGL2(context) => context.reset_bitmap(),
             OffscreenRenderingContext::Detached => {},
         }
@@ -365,7 +397,9 @@ impl CanvasContext for OffscreenRenderingContext {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.get_image_data(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.get_image_data(),
+            #[cfg(feature = "webgl")]
             OffscreenRenderingContext::WebGL(context) => context.get_image_data(),
+            #[cfg(feature = "webgl")]
             OffscreenRenderingContext::WebGL2(context) => context.get_image_data(),
             OffscreenRenderingContext::Detached => None,
         }
@@ -375,7 +409,9 @@ impl CanvasContext for OffscreenRenderingContext {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.origin_is_clean(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.origin_is_clean(),
+            #[cfg(feature = "webgl")]
             OffscreenRenderingContext::WebGL(context) => context.origin_is_clean(),
+            #[cfg(feature = "webgl")]
             OffscreenRenderingContext::WebGL2(context) => context.origin_is_clean(),
             OffscreenRenderingContext::Detached => true,
         }
@@ -385,7 +421,9 @@ impl CanvasContext for OffscreenRenderingContext {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.size(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.size(),
+            #[cfg(feature = "webgl")]
             OffscreenRenderingContext::WebGL(context) => context.size(),
+            #[cfg(feature = "webgl")]
             OffscreenRenderingContext::WebGL2(context) => context.size(),
             OffscreenRenderingContext::Detached => Size2D::default(),
         }
@@ -395,7 +433,9 @@ impl CanvasContext for OffscreenRenderingContext {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.mark_as_dirty(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.mark_as_dirty(),
+            #[cfg(feature = "webgl")]
             OffscreenRenderingContext::WebGL(context) => context.mark_as_dirty(),
+            #[cfg(feature = "webgl")]
             OffscreenRenderingContext::WebGL2(context) => context.mark_as_dirty(),
             OffscreenRenderingContext::Detached => {},
         }
@@ -405,7 +445,9 @@ impl CanvasContext for OffscreenRenderingContext {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.onscreen(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.onscreen(),
+            #[cfg(feature = "webgl")]
             OffscreenRenderingContext::WebGL(context) => context.onscreen(),
+            #[cfg(feature = "webgl")]
             OffscreenRenderingContext::WebGL2(context) => context.onscreen(),
             OffscreenRenderingContext::Detached => false,
         }

--- a/components/script/dom/canvas/imagedata.rs
+++ b/components/script/dom/canvas/imagedata.rs
@@ -16,6 +16,7 @@ use pixels::{Snapshot, SnapshotAlphaMode, SnapshotPixelFormat};
 use rustc_hash::FxHashMap;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use script_bindings::trace::RootedTraceableBox;
+#[cfg(feature = "webgl")]
 use servo_base::generic_channel::GenericSharedMemory;
 use servo_base::id::{ImageDataId, ImageDataIndex};
 use servo_constellation_traits::SerializableImageData;
@@ -216,6 +217,7 @@ impl ImageData {
     }
 
     #[expect(unsafe_code)]
+    #[cfg(feature = "webgl")]
     pub(crate) fn to_shared_memory(&self, no_gc: &NoGC) -> GenericSharedMemory {
         // This is safe because we copy the slice content
         GenericSharedMemory::from_bytes(unsafe { self.as_slice(no_gc) })

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -26,6 +26,7 @@ use crate::dom::bindings::codegen::Bindings::OffscreenCanvasBinding::{
     ImageEncodeOptions, OffscreenCanvasMethods,
     OffscreenRenderingContext as RootedOffscreenRenderingContext, OffscreenRenderingContextId,
 };
+#[cfg(feature = "webgl")]
 use crate::dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLContextAttributes;
 use crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas as RootedHTMLCanvasElementOrOffscreenCanvas;
 use crate::dom::bindings::conversions::ConversionResult;
@@ -43,7 +44,9 @@ use crate::dom::imagebitmap::ImageBitmap;
 use crate::dom::imagebitmaprenderingcontext::ImageBitmapRenderingContext;
 use crate::dom::offscreencanvasrenderingcontext2d::OffscreenCanvasRenderingContext2D;
 use crate::dom::promise::Promise;
+#[cfg(feature = "webgl")]
 use crate::dom::types::{WebGLRenderingContext, Window};
+#[cfg(feature = "webgl")]
 use crate::dom::webgl::webgl2renderingcontext::WebGL2RenderingContext;
 
 /// <https://html.spec.whatwg.org/multipage/#offscreencanvas>
@@ -101,6 +104,7 @@ impl OffscreenCanvas {
         )
     }
 
+    #[cfg(feature = "webgl")]
     #[expect(unsafe_code)]
     fn get_gl_attributes(
         cx: &mut js::context::JSContext,
@@ -201,6 +205,7 @@ impl OffscreenCanvas {
         Some(context)
     }
 
+    #[cfg(feature = "webgl")]
     // <https://html.spec.whatwg.org/multipage/#offscreen-context-type-webgl>
     pub(crate) fn get_or_init_webgl_context(
         &self,
@@ -236,6 +241,7 @@ impl OffscreenCanvas {
             })
     }
 
+    #[cfg(feature = "webgl")]
     // <https://html.spec.whatwg.org/multipage/#offscreen-context-type-webgl>
     fn get_or_init_webgl2_context(
         &self,
@@ -404,15 +410,19 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
             OffscreenRenderingContextId::Bitmaprenderer => Ok(self
                 .get_or_init_bitmaprenderer_context(cx)
                 .map(RootedOffscreenRenderingContext::ImageBitmapRenderingContext)),
+            #[cfg(feature = "webgl")]
             OffscreenRenderingContextId::Webgl => Ok(self
                 .get_or_init_webgl_context(cx, options)
                 .map(RootedOffscreenRenderingContext::WebGLRenderingContext)),
+            #[cfg(feature = "webgl")]
             OffscreenRenderingContextId::Experimental_webgl => Ok(self
                 .get_or_init_webgl_context(cx, options)
                 .map(RootedOffscreenRenderingContext::WebGLRenderingContext)),
+            #[cfg(feature = "webgl")]
             OffscreenRenderingContextId::Webgl2 => Ok(self
                 .get_or_init_webgl2_context(cx, options)
                 .map(RootedOffscreenRenderingContext::WebGL2RenderingContext)),
+            #[cfg(feature = "webgl")]
             OffscreenRenderingContextId::Experimental_webgl2 => Ok(self
                 .get_or_init_webgl2_context(cx, options)
                 .map(RootedOffscreenRenderingContext::WebGL2RenderingContext)),

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -7,20 +7,26 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
+#[cfg(feature = "webgl")]
 use js::error::throw_type_error;
 use js::realm::CurrentRealm;
 use js::rust::{HandleObject, HandleValue};
 use pixels::{EncodedImageType, Snapshot};
 use rustc_hash::FxHashMap;
 use script_bindings::cell::{DomRefCell, Ref};
+#[cfg(feature = "webgl")]
 use script_bindings::inheritance::Castable;
-use script_bindings::reflector::{DomObject, reflect_dom_object_with_proto};
+#[cfg(feature = "webgl")]
+use script_bindings::reflector::DomObject;
+use script_bindings::reflector::reflect_dom_object_with_proto;
 use script_bindings::weakref::WeakRef;
 use servo_base::id::{OffscreenCanvasId, OffscreenCanvasIndex};
+#[cfg(feature = "webgl")]
 use servo_canvas_traits::webgl::{GLContextAttributes, WebGLVersion};
 use servo_constellation_traits::{BlobImpl, TransferableOffscreenCanvas};
 
 use crate::canvas_context::{CanvasContext, OffscreenRenderingContext};
+#[cfg(feature = "webgl")]
 use crate::conversions::Convert;
 use crate::dom::bindings::codegen::Bindings::OffscreenCanvasBinding::{
     ImageEncodeOptions, OffscreenCanvasMethods,
@@ -29,6 +35,7 @@ use crate::dom::bindings::codegen::Bindings::OffscreenCanvasBinding::{
 #[cfg(feature = "webgl")]
 use crate::dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLContextAttributes;
 use crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas as RootedHTMLCanvasElementOrOffscreenCanvas;
+#[cfg(feature = "webgl")]
 use crate::dom::bindings::conversions::ConversionResult;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -2357,14 +2357,11 @@ impl Document {
             return;
         }
 
-        self.queue_document_completion(
-            #[cfg(feature = "webgl")]
-            cx,
-        );
+        self.queue_document_completion(cx);
     }
 
     /// Step 9 of <https://html.spec.whatwg.org/multipage/#the-end>
-    fn queue_document_completion(&self, #[cfg(feature = "webgl")] cx: &mut JSContext) {
+    fn queue_document_completion(&self, cx: &mut JSContext) {
         self.loader.borrow_mut().inhibit_events();
 
         // The rest will ever run only once per document.

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -2357,11 +2357,14 @@ impl Document {
             return;
         }
 
-        self.queue_document_completion(cx);
+        self.queue_document_completion(
+            #[cfg(feature = "webgl")]
+            cx,
+        );
     }
 
     /// Step 9 of <https://html.spec.whatwg.org/multipage/#the-end>
-    fn queue_document_completion(&self, cx: &mut JSContext) {
+    fn queue_document_completion(&self, #[cfg(feature = "webgl")] cx: &mut JSContext) {
         self.loader.borrow_mut().inhibit_events();
 
         // The rest will ever run only once per document.

--- a/components/script/dom/html/embedded_content/htmlcanvaselement.rs
+++ b/components/script/dom/html/embedded_content/htmlcanvaselement.rs
@@ -59,7 +59,9 @@ use crate::dom::node::virtualmethods::VirtualMethods;
 use crate::dom::node::{Node, NodeDamage, NodeTraits};
 use crate::dom::offscreencanvas::OffscreenCanvas;
 use crate::dom::values::UNSIGNED_LONG_MAX;
+#[cfg(feature = "webgl")]
 use crate::dom::webgl::webgl2renderingcontext::WebGL2RenderingContext;
+#[cfg(feature = "webgl")]
 use crate::dom::webgl::webglrenderingcontext::WebGLRenderingContext;
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::gpucanvascontext::GPUCanvasContext;
@@ -206,7 +208,9 @@ impl HTMLCanvasElement {
             RenderingContext::Placeholder(..) => None,
             RenderingContext::Context2d(..) => get_image_key(),
             RenderingContext::BitmapRenderer(..) => get_image_key(),
+            #[cfg(feature = "webgl")]
             RenderingContext::WebGL(..) => get_image_key(),
+            #[cfg(feature = "webgl")]
             RenderingContext::WebGL2(..) => get_image_key(),
             #[cfg(feature = "webgpu")]
             RenderingContext::WebGPU(..) => get_image_key(),
@@ -267,6 +271,7 @@ impl HTMLCanvasElement {
         Some(context)
     }
 
+    #[cfg(feature = "webgl")]
     fn get_or_init_webgl_context(
         &self,
         cx: &mut js::context::JSContext,
@@ -291,6 +296,7 @@ impl HTMLCanvasElement {
         Some(context)
     }
 
+    #[cfg(feature = "webgl")]
     fn get_or_init_webgl2_context(
         &self,
         cx: &mut js::context::JSContext,

--- a/components/script/dom/html/embedded_content/htmlcanvaselement.rs
+++ b/components/script/dom/html/embedded_content/htmlcanvaselement.rs
@@ -9,15 +9,18 @@ use dom_struct::dom_struct;
 use euclid::default::Size2D;
 use html5ever::{LocalName, Prefix, local_name, ns};
 use js::context::NoGC;
+#[cfg(feature = "webgl")]
 use js::error::throw_type_error;
 use js::rust::{HandleObject, HandleValue};
 use layout_api::HTMLCanvasData;
 use pixels::{EncodedImageType, Snapshot};
 use rustc_hash::FxHashMap;
 use script_bindings::cell::{DomRefCell, Ref};
+#[cfg(feature = "webgl")]
 use script_bindings::reflector::DomObject;
 use script_bindings::weakref::WeakRef;
 use servo_base::Epoch;
+#[cfg(feature = "webgl")]
 use servo_canvas_traits::webgl::{GLContextAttributes, WebGLVersion};
 use servo_constellation_traits::BlobImpl;
 #[cfg(feature = "webgpu")]
@@ -28,6 +31,7 @@ use style::attr::AttrValue;
 use webrender_api::ImageKey;
 
 use crate::canvas_context::{CanvasContext, RenderingContext};
+#[cfg(feature = "webgl")]
 use crate::conversions::Convert;
 use crate::dom::bindings::callback::ExceptionHandling;
 use crate::dom::bindings::codegen::Bindings::HTMLCanvasElementBinding::{
@@ -37,6 +41,7 @@ use crate::dom::bindings::codegen::Bindings::MediaStreamBinding::MediaStreamMeth
 #[cfg(feature = "webgl")]
 use crate::dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLContextAttributes;
 use crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas as RootedHTMLCanvasElementOrOffscreenCanvas;
+#[cfg(feature = "webgl")]
 use crate::dom::bindings::conversions::ConversionResult;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::inheritance::Castable;

--- a/components/script/dom/html/embedded_content/htmlcanvaselement.rs
+++ b/components/script/dom/html/embedded_content/htmlcanvaselement.rs
@@ -34,6 +34,7 @@ use crate::dom::bindings::codegen::Bindings::HTMLCanvasElementBinding::{
     BlobCallback, HTMLCanvasElementMethods, RenderingContext as RootedRenderingContext,
 };
 use crate::dom::bindings::codegen::Bindings::MediaStreamBinding::MediaStreamMethods;
+#[cfg(feature = "webgl")]
 use crate::dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLContextAttributes;
 use crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas as RootedHTMLCanvasElementOrOffscreenCanvas;
 use crate::dom::bindings::conversions::ConversionResult;
@@ -359,6 +360,7 @@ impl HTMLCanvasElement {
             })
     }
 
+    #[cfg(feature = "webgl")]
     #[expect(unsafe_code)]
     fn get_gl_attributes(
         cx: &mut js::context::JSContext,
@@ -418,7 +420,9 @@ impl HTMLCanvasElement {
             RenderingContext::Placeholder(..) => false,
             RenderingContext::Context2d(context) => context.update_rendering(epoch),
             RenderingContext::BitmapRenderer(context) => context.update_rendering(epoch),
+            #[cfg(feature = "webgl")]
             RenderingContext::WebGL(context) => context.update_rendering(epoch),
+            #[cfg(feature = "webgl")]
             RenderingContext::WebGL2(context) => context.base_context().update_rendering(epoch),
             #[cfg(feature = "webgpu")]
             RenderingContext::WebGPU(context) => context.update_rendering(epoch),
@@ -501,9 +505,11 @@ impl HTMLCanvasElementMethods<crate::DomTypeHolder> for HTMLCanvasElement {
             "bitmaprenderer" => self
                 .get_or_init_bitmaprenderer_context(cx)
                 .map(RootedRenderingContext::ImageBitmapRenderingContext),
+            #[cfg(feature = "webgl")]
             "webgl" | "experimental-webgl" => self
                 .get_or_init_webgl_context(cx, options)
                 .map(RootedRenderingContext::WebGLRenderingContext),
+            #[cfg(feature = "webgl")]
             "webgl2" | "experimental-webgl2" => self
                 .get_or_init_webgl2_context(cx, options)
                 .map(RootedRenderingContext::WebGL2RenderingContext),
@@ -727,6 +733,7 @@ impl VirtualMethods for HTMLCanvasElement {
     }
 }
 
+#[cfg(feature = "webgl")]
 impl Convert<GLContextAttributes> for WebGLContextAttributes {
     fn convert(self) -> GLContextAttributes {
         GLContextAttributes {

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -773,6 +773,7 @@ macro_rules! window_event_handlers(
     );
 );
 
+#[cfg(feature = "webgl")]
 macro_rules! handle_potential_webgl_error {
     ($context:expr, $call:expr, $return_on_error:expr) => {
         match $call {

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -337,8 +337,11 @@ pub(crate) mod values;
 pub(crate) mod visualviewport;
 pub(crate) mod wakelock;
 pub(crate) use self::wakelock::*;
+#[cfg(feature = "webgl")]
 pub(crate) mod webgl;
+#[cfg(feature = "webgl")]
 pub(crate) use self::webgl::extensions::ext::*;
+#[cfg(feature = "webgl")]
 pub(crate) use self::webgl::*;
 #[cfg(feature = "webxr")]
 mod webxr;

--- a/components/script/dom/serviceworker/serviceworkerregistration.rs
+++ b/components/script/dom/serviceworker/serviceworkerregistration.rs
@@ -124,12 +124,13 @@ impl ServiceWorkerRegistration {
             pipeline_id: global.pipeline_id(),
         };
 
+        #[cfg(feature = "webgl")]
         let webgl_chan = global
             .downcast::<Window>()
             .and_then(|window| window.webgl_chan_value());
         let worker_id = WorkerId(Uuid::new_v4());
         let devtools_chan = global.devtools_chan().cloned();
-        let init = prepare_workerscope_init(global, None, Some(worker_id), webgl_chan);
+        let init = prepare_workerscope_init(global, None, Some(worker_id), #[cfg(feature = "webgl")] webgl_chan);
         let browsing_context_id = global
             .downcast::<Window>()
             .map(|w: &Window| w.window_proxy().browsing_context_id())

--- a/components/script/dom/serviceworker/serviceworkerregistration.rs
+++ b/components/script/dom/serviceworker/serviceworkerregistration.rs
@@ -130,7 +130,13 @@ impl ServiceWorkerRegistration {
             .and_then(|window| window.webgl_chan_value());
         let worker_id = WorkerId(Uuid::new_v4());
         let devtools_chan = global.devtools_chan().cloned();
-        let init = prepare_workerscope_init(global, None, Some(worker_id), #[cfg(feature = "webgl")] webgl_chan);
+        let init = prepare_workerscope_init(
+            global,
+            None,
+            Some(worker_id),
+            #[cfg(feature = "webgl")]
+            webgl_chan,
+        );
         let browsing_context_id = global
             .downcast::<Window>()
             .map(|w: &Window| w.window_proxy().browsing_context_id())

--- a/components/script/dom/webgl/webglshader.rs
+++ b/components/script/dom/webgl/webglshader.rs
@@ -18,18 +18,21 @@ use servo_canvas_traits::webgl::{
     GLLimits, GlType, WebGLCommand, WebGLError, WebGLResult, WebGLSLVersion, WebGLShaderId,
     WebGLVersion, webgl_channel,
 };
+#[cfg(feature = "webgl")]
+use {
+    crate::dom::webgl::extensions::WebGLExtensions,
+    crate::dom::webgl::extensions::extfragdepth::EXTFragDepth,
+    crate::dom::webgl::extensions::extshadertexturelod::EXTShaderTextureLod,
+    crate::dom::webgl::extensions::oesstandardderivatives::OESStandardDerivatives,
+    crate::dom::webgl::webglobject::WebGLObject,
+    crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext},
+    crate::dom::webglrenderingcontext::capture_webgl_backtrace,
+};
 
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
-use crate::dom::webgl::extensions::WebGLExtensions;
-use crate::dom::webgl::extensions::extfragdepth::EXTFragDepth;
-use crate::dom::webgl::extensions::extshadertexturelod::EXTShaderTextureLod;
-use crate::dom::webgl::extensions::oesstandardderivatives::OESStandardDerivatives;
-use crate::dom::webgl::webglobject::WebGLObject;
-use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
-use crate::dom::webglrenderingcontext::capture_webgl_backtrace;
 
 #[derive(Clone, Copy, Debug, JSTraceable, MallocSizeOf, PartialEq)]
 pub(crate) enum ShaderCompilationStatus {

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -3663,7 +3663,7 @@ impl Window {
             .unwrap();
     }
 
-    #[cfg(feature = "webxr")]
+    #[cfg(all(feature = "webgl", feature = "webxr"))]
     pub(crate) fn in_immersive_xr_session(&self) -> bool {
         self.navigator
             .get()
@@ -3672,7 +3672,7 @@ impl Window {
             .is_some_and(|xr| xr.pending_or_active_session())
     }
 
-    #[cfg(not(feature = "webxr"))]
+    #[cfg(all(feature = "webgl", not(feature = "webxr")))]
     pub(crate) fn in_immersive_xr_session(&self) -> bool {
         false
     }

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -3663,7 +3663,7 @@ impl Window {
             .unwrap();
     }
 
-    #[cfg(all(feature = "webgl", feature = "webxr"))]
+    #[cfg(feature = "webxr")]
     pub(crate) fn in_immersive_xr_session(&self) -> bool {
         self.navigator
             .get()

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -392,6 +392,7 @@ pub(crate) struct Window {
 
     /// A handle for communicating messages to the WebGL thread, if available.
     #[no_trace]
+    #[cfg(feature = "webgl")]
     webgl_chan: Option<WebGLChan>,
 
     #[ignore_malloc_size_of = "defined in webxr"]
@@ -687,11 +688,13 @@ impl Window {
         &self.error_reporter
     }
 
+    #[cfg(feature = "webgl")]
     pub(crate) fn webgl_chan(&self) -> Option<WebGLChan> {
         self.webgl_chan.clone()
     }
 
     // TODO: rename the function to webgl_chan after the existing `webgl_chan` function is removed.
+    #[cfg(feature = "webgl")]
     pub(crate) fn webgl_chan_value(&self) -> Option<WebGLChan> {
         self.webgl_chan.clone()
     }
@@ -3879,6 +3882,7 @@ impl Window {
         creation_url: ServoUrl,
         top_level_creation_url: ServoUrl,
         navigation_start: CrossProcessInstant,
+        #[cfg(feature = "webgl")]
         webgl_chan: Option<WebGLChan>,
         #[cfg(feature = "webxr")] webxr_registry: Option<webxr_api::Registry>,
         paint_api: CrossProcessPaintApi,
@@ -3951,6 +3955,7 @@ impl Window {
             media_query_lists: DOMTracker::new(),
             #[cfg(feature = "bluetooth")]
             test_runner: Default::default(),
+            #[cfg(feature = "webgl")]
             webgl_chan,
             #[cfg(feature = "webxr")]
             webxr_registry,

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -81,6 +81,7 @@ use servo_base::generic_channel::{self, GenericCallback, GenericSender};
 use servo_base::id::{BrowsingContextId, PipelineId, WebViewId};
 #[cfg(feature = "bluetooth")]
 use servo_bluetooth_traits::BluetoothRequest;
+#[cfg(feature = "webgl")]
 use servo_canvas_traits::webgl::WebGLChan;
 use servo_config::pref;
 use servo_constellation_traits::{
@@ -3882,8 +3883,7 @@ impl Window {
         creation_url: ServoUrl,
         top_level_creation_url: ServoUrl,
         navigation_start: CrossProcessInstant,
-        #[cfg(feature = "webgl")]
-        webgl_chan: Option<WebGLChan>,
+        #[cfg(feature = "webgl")] webgl_chan: Option<WebGLChan>,
         #[cfg(feature = "webxr")] webxr_registry: Option<webxr_api::Registry>,
         paint_api: CrossProcessPaintApi,
         unminify_js: bool,

--- a/components/script/dom/workers/sharedworker.rs
+++ b/components/script/dom/workers/sharedworker.rs
@@ -588,6 +588,7 @@ impl SharedWorkerMethods<crate::DomTypeHolder> for SharedWorker {
             global,
             Some(devtools_sender),
             Some(worker_id),
+            #[cfg(feature = "webgl")]
             window.webgl_chan_value(),
         );
 

--- a/components/script/dom/workers/worker.rs
+++ b/components/script/dom/workers/worker.rs
@@ -240,11 +240,17 @@ impl WorkerMethods<crate::DomTypeHolder> for Worker {
             }
         }
 
+        #[cfg(feature = "webgl")]
         let webgl_chan = global
             .downcast::<Window>()
             .and_then(|window| window.webgl_chan_value());
-        let init =
-            prepare_workerscope_init(global, Some(devtools_sender), Some(worker_id), webgl_chan);
+        let init = prepare_workerscope_init(
+            global,
+            Some(devtools_sender),
+            Some(worker_id),
+            #[cfg(feature = "webgl")]
+            webgl_chan,
+        );
         let animation_frame_provider_supported = global
             .downcast::<DedicatedWorkerGlobalScope>()
             .map(|worker| worker.animation_frame_provider_supported_flag())

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -36,6 +36,7 @@ use script_bindings::trace::CustomTraceable;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_base::generic_channel::{GenericSend, GenericSender, RoutedReceiver};
 use servo_base::id::{PipelineId, PipelineNamespace};
+#[cfg(feature = "webgl")]
 use servo_canvas_traits::webgl::WebGLChan;
 use servo_constellation_traits::WorkerGlobalScopeInit;
 use servo_url::{MutableOrigin, ServoUrl};
@@ -103,7 +104,7 @@ pub(crate) fn prepare_workerscope_init(
     global: &GlobalScope,
     devtools_sender: Option<GenericSender<DevtoolScriptControlMsg>>,
     worker_id: Option<WorkerId>,
-    webgl_chan: Option<WebGLChan>,
+    #[cfg(feature = "webgl")] webgl_chan: Option<WebGLChan>,
 ) -> WorkerGlobalScopeInit {
     // An AnimationFrameProvider provider is considered supported if any of the following are true:
     // - provider is a Window.
@@ -132,6 +133,7 @@ pub(crate) fn prepare_workerscope_init(
         origin: global.origin().immutable().clone(),
         inherited_secure_context: Some(global.is_secure_context()),
         unminify_js: global.unminify_js(),
+        #[cfg(feature = "webgl")]
         webgl_chan,
     }
 }

--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -87,6 +87,7 @@ use servo_base::id::{
 };
 use servo_base::threadboost::{BoostAffinity, ThreadPriority};
 use servo_base::{Epoch, generic_channel};
+#[cfg(feature = "webgl")]
 use servo_canvas_traits::webgl::WebGLPipeline;
 use servo_config::opts::{self, DiagnosticsLoggingOption};
 use servo_config::{pref, prefs};

--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -334,6 +334,7 @@ pub struct ScriptThread {
 
     /// A handle to the WebGL thread
     #[no_trace]
+    #[cfg(feature = "webgl")]
     webgl_chan: Option<WebGLPipeline>,
 
     /// The WebXR device registry
@@ -984,6 +985,7 @@ impl ScriptThread {
                     closed_pipelines: DomRefCell::new(FxHashSet::default()),
                     mutation_observers: Default::default(),
                     system_font_service: Arc::new(state.system_font_service.to_proxy()),
+                    #[cfg(feature = "webgl")]
                     webgl_chan: state.webgl_chan,
                     #[cfg(feature = "webxr")]
                     webxr_registry: state.webxr_registry,
@@ -3501,6 +3503,7 @@ impl ScriptThread {
             // is another nested iframe in a frame).
             final_url.clone(),
             incomplete.navigation_start,
+            #[cfg(feature = "webgl")]
             self.webgl_chan.as_ref().map(|chan| chan.channel()),
             #[cfg(feature = "webxr")]
             self.webxr_registry.clone(),

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -73,6 +73,7 @@ gamepad = []
 testbinding = []
 tracing = ["dep:tracing"]
 webgpu = []
+webgl = []
 webxr = ["webxr-api"]
 
 [lints.rust]

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -74,7 +74,7 @@ testbinding = []
 tracing = ["dep:tracing"]
 webgpu = []
 webgl = []
-webxr = ["webxr-api"]
+webxr = ["gamepad", "webgl", "webxr-api"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(crown)'] }

--- a/components/script_bindings/codegen/run.py
+++ b/components/script_bindings/codegen/run.py
@@ -17,6 +17,8 @@ SCRIPT_PATH = os.path.abspath(os.path.dirname(__file__))
 SCRIPT_BINDINGS_ROOT = os.path.abspath(os.path.join(SCRIPT_PATH, ".."))
 
 FILTER_PATTERN = re.compile("// skip-unless ([A-Z_]+)\n")
+CONDITIONAL_BLOCK_START_PATTERN = re.compile(r"\s*// skip-unless ([A-Z_]+) begin\n")
+CONDITIONAL_BLOCK_END_PATTERN = re.compile(r"\s*// skip-unless ([A-Z_]+) end\n")
 
 if TYPE_CHECKING:
     from configuration import Configuration
@@ -51,6 +53,7 @@ def main() -> None:
                 if not os.environ.get(env_var):
                     continue
 
+            contents = filter_conditional_blocks(contents)
             parser.parse(contents, filename)
 
     add_css_properties_attributes(css_properties_json, parser)
@@ -111,6 +114,25 @@ def make_dir(path: str)-> str:
     if not os.path.exists(path):
         os.makedirs(path)
     return path
+
+
+def filter_conditional_blocks(contents: str) -> str:
+    """Remove `skip-unless` blocks whose Cargo feature is disabled."""
+    enabled = [True]
+    filtered_contents = []
+
+    for line in contents.splitlines(keepends=True):
+        if match := CONDITIONAL_BLOCK_START_PATTERN.fullmatch(line):
+            enabled.append(enabled[-1] and bool(os.environ.get(match.group(1))))
+            continue
+        if CONDITIONAL_BLOCK_END_PATTERN.fullmatch(line):
+            enabled.pop()
+            continue
+        if enabled[-1]:
+            filtered_contents.append(line)
+
+    assert len(enabled) == 1, "Unterminated skip-unless block"
+    return "".join(filtered_contents)
 
 
 def generate(config: Configuration, name: str, filename: str) -> None:

--- a/components/script_bindings/codegen/run.py
+++ b/components/script_bindings/codegen/run.py
@@ -123,6 +123,7 @@ def filter_conditional_blocks(contents: str) -> str:
 
     for line in contents.splitlines(keepends=True):
         if match := CONDITIONAL_BLOCK_START_PATTERN.fullmatch(line):
+            # Cargo exposes enabled features as CARGO_FEATURE_* to build scripts.
             enabled.append(enabled[-1] and bool(os.environ.get(match.group(1))))
             continue
         if CONDITIONAL_BLOCK_END_PATTERN.fullmatch(line):

--- a/components/script_bindings/webidls/ANGLEInstancedArrays.webidl
+++ b/components/script_bindings/webidls/ANGLEInstancedArrays.webidl
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
 /*
  * WebGL IDL definitions from the Khronos specification:
  * https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/

--- a/components/script_bindings/webidls/EXTBlendMinmax.webidl
+++ b/components/script_bindings/webidls/EXTBlendMinmax.webidl
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
 /*
  * WebGL IDL definitions scraped from the Khronos specification:
  * https://www.khronos.org/registry/webgl/extensions/EXT_blend_minmax/

--- a/components/script_bindings/webidls/EXTColorBufferHalfFloat.webidl
+++ b/components/script_bindings/webidls/EXTColorBufferHalfFloat.webidl
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
 /*
  * WebGL IDL definitions from the Khronos specification:
  * https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/

--- a/components/script_bindings/webidls/EXTFragDepth.webidl
+++ b/components/script_bindings/webidls/EXTFragDepth.webidl
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
 /*
  * WebGL IDL definitions from the Khronos specification:
  * https://www.khronos.org/registry/webgl/extensions/EXT_frag_depth/

--- a/components/script_bindings/webidls/EXTShaderTextureLod.webidl
+++ b/components/script_bindings/webidls/EXTShaderTextureLod.webidl
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
 /*
  * WebGL IDL definitions scraped from the Khronos specification:
  * https://www.khronos.org/registry/webgl/extensions/EXT_shader_texture_lod/

--- a/components/script_bindings/webidls/EXTTextureFilterAnisotropic.webidl
+++ b/components/script_bindings/webidls/EXTTextureFilterAnisotropic.webidl
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
 /*
  * WebGL IDL definitions from the Khronos specification:
  * https://www.khronos.org/registry/webgl/extensions/EXT_texture_filter_anisotropic/

--- a/components/script_bindings/webidls/HTMLCanvasElement.webidl
+++ b/components/script_bindings/webidls/HTMLCanvasElement.webidl
@@ -5,8 +5,10 @@
 // https://html.spec.whatwg.org/multipage/#htmlcanvaselement
 typedef (CanvasRenderingContext2D
   or ImageBitmapRenderingContext
+  // skip-unless CARGO_FEATURE_WEBGL begin
   or WebGLRenderingContext
   or WebGL2RenderingContext
+  // skip-unless CARGO_FEATURE_WEBGL end
   or GPUCanvasContext) RenderingContext;
 
 [Exposed=Window]

--- a/components/script_bindings/webidls/OESElementIndexUint.webidl
+++ b/components/script_bindings/webidls/OESElementIndexUint.webidl
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
 /*
  * WebGL IDL definitions from the Khronos specification:
  * https://www.khronos.org/registry/webgl/extensions/OES_element_index_uint/

--- a/components/script_bindings/webidls/OESStandardDerivatives.webidl
+++ b/components/script_bindings/webidls/OESStandardDerivatives.webidl
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
 /*
  * WebGL IDL definitions from the Khronos specification:
  * https://www.khronos.org/registry/webgl/extensions/OES_standard_derivatives/

--- a/components/script_bindings/webidls/OESTextureFloat.webidl
+++ b/components/script_bindings/webidls/OESTextureFloat.webidl
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
 /*
  * WebGL IDL definitions from the Khronos specification:
  * https://www.khronos.org/registry/webgl/extensions/OES_texture_float/

--- a/components/script_bindings/webidls/OESTextureFloatLinear.webidl
+++ b/components/script_bindings/webidls/OESTextureFloatLinear.webidl
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
 /*
  * WebGL IDL definitions from the Khronos specification:
  * https://www.khronos.org/registry/webgl/extensions/OES_texture_float_linear/

--- a/components/script_bindings/webidls/OESTextureHalfFloat.webidl
+++ b/components/script_bindings/webidls/OESTextureHalfFloat.webidl
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
 /*
  * WebGL IDL definitions from the Khronos specification:
  * https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float/

--- a/components/script_bindings/webidls/OESTextureHalfFloatLinear.webidl
+++ b/components/script_bindings/webidls/OESTextureHalfFloatLinear.webidl
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
 /*
  * WebGL IDL definitions from the Khronos specification:
  * https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float_linear/

--- a/components/script_bindings/webidls/OESVertexArrayObject.webidl
+++ b/components/script_bindings/webidls/OESVertexArrayObject.webidl
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
 /*
  * WebGL IDL definitions from the Khronos specification:
  * https://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/

--- a/components/script_bindings/webidls/OffscreenCanvas.webidl
+++ b/components/script_bindings/webidls/OffscreenCanvas.webidl
@@ -5,15 +5,27 @@
 // https://html.spec.whatwg.org/multipage/#the-offscreencanvas-interface
 typedef (OffscreenCanvasRenderingContext2D
   or ImageBitmapRenderingContext
+  // skip-unless CARGO_FEATURE_WEBGL begin
   or WebGLRenderingContext
-  or WebGL2RenderingContext) OffscreenRenderingContext;
+  or WebGL2RenderingContext
+  // skip-unless CARGO_FEATURE_WEBGL end
+) OffscreenRenderingContext;
 
 dictionary ImageEncodeOptions {
   DOMString type = "image/png";
   unrestricted double quality;
 };
 
-enum OffscreenRenderingContextId { "2d", "bitmaprenderer", "webgl", "webgl2", "experimental-webgl", "experimental-webgl2" };
+enum OffscreenRenderingContextId {
+  "2d",
+  "bitmaprenderer",
+  // skip-unless CARGO_FEATURE_WEBGL begin
+  "webgl",
+  "webgl2",
+  "experimental-webgl",
+  "experimental-webgl2"
+  // skip-unless CARGO_FEATURE_WEBGL end
+};
 
 [Exposed=(Window,Worker), Transferable, Pref="dom_offscreen_canvas_enabled"]
 interface OffscreenCanvas : EventTarget {

--- a/components/script_bindings/webidls/WEBGLColorBufferFloat.webidl
+++ b/components/script_bindings/webidls/WEBGLColorBufferFloat.webidl
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
+
 /*
  * WebGL IDL definitions from the Khronos specification:
  * https://www.khronos.org/registry/webgl/extensions/WEBGL_color_buffer_float/

--- a/components/script_bindings/webidls/WEBGLCompressedTextureETC1.webidl
+++ b/components/script_bindings/webidls/WEBGLCompressedTextureETC1.webidl
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
+
 /*
  * WebGL IDL definitions from the Khronos specification:
  * https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc1/

--- a/components/script_bindings/webidls/WEBGLCompressedTextureS3TC.webidl
+++ b/components/script_bindings/webidls/WEBGLCompressedTextureS3TC.webidl
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
+
 /*
  * WebGL IDL definitions from the Khronos specification:
  * https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/

--- a/components/script_bindings/webidls/WebGL2RenderingContext.webidl
+++ b/components/script_bindings/webidls/WebGL2RenderingContext.webidl
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
+
 //
 // WebGL IDL definitions scraped from the Khronos specification:
 // https://www.khronos.org/registry/webgl/specs/latest/

--- a/components/script_bindings/webidls/WebGLActiveInfo.webidl
+++ b/components/script_bindings/webidls/WebGLActiveInfo.webidl
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
+
 //
 // WebGL IDL definitions scraped from the Khronos specification:
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.7

--- a/components/script_bindings/webidls/WebGLBuffer.webidl
+++ b/components/script_bindings/webidls/WebGLBuffer.webidl
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
+
 //
 // WebGL IDL definitions scraped from the Khronos specification:
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.4

--- a/components/script_bindings/webidls/WebGLContextEvent.webidl
+++ b/components/script_bindings/webidls/WebGLContextEvent.webidl
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
 
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15
 [Exposed=Window]

--- a/components/script_bindings/webidls/WebGLFramebuffer.webidl
+++ b/components/script_bindings/webidls/WebGLFramebuffer.webidl
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
+
 //
 // WebGL IDL definitions scraped from the Khronos specification:
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.7

--- a/components/script_bindings/webidls/WebGLObject.webidl
+++ b/components/script_bindings/webidls/WebGLObject.webidl
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
+
 //
 // WebGL IDL definitions scraped from the Khronos specification:
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.3

--- a/components/script_bindings/webidls/WebGLProgram.webidl
+++ b/components/script_bindings/webidls/WebGLProgram.webidl
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
+
 //
 // WebGL IDL definitions scraped from the Khronos specification:
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.6

--- a/components/script_bindings/webidls/WebGLQuery.webidl
+++ b/components/script_bindings/webidls/WebGLQuery.webidl
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
+
 //
 // WebGL IDL definitions scraped from the Khronos specification:
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.8

--- a/components/script_bindings/webidls/WebGLRenderbuffer.webidl
+++ b/components/script_bindings/webidls/WebGLRenderbuffer.webidl
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
+
 //
 // WebGL IDL definitions scraped from the Khronos specification:
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.5

--- a/components/script_bindings/webidls/WebGLRenderingContext.webidl
+++ b/components/script_bindings/webidls/WebGLRenderingContext.webidl
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
+
 //
 // WebGL IDL definitions scraped from the Khronos specification:
 // https://www.khronos.org/registry/webgl/specs/latest/

--- a/components/script_bindings/webidls/WebGLSampler.webidl
+++ b/components/script_bindings/webidls/WebGLSampler.webidl
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
+
 //
 // WebGL IDL definitions scraped from the Khronos specification:
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.8

--- a/components/script_bindings/webidls/WebGLShader.webidl
+++ b/components/script_bindings/webidls/WebGLShader.webidl
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
+
 //
 // WebGL IDL definitions scraped from the Khronos specification:
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.8

--- a/components/script_bindings/webidls/WebGLShaderPrecisionFormat.webidl
+++ b/components/script_bindings/webidls/WebGLShaderPrecisionFormat.webidl
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
+
 //
 // WebGL IDL definitions scraped from the Khronos specification:
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.7

--- a/components/script_bindings/webidls/WebGLSync.webidl
+++ b/components/script_bindings/webidls/WebGLSync.webidl
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
+
 //
 // WebGL IDL definitions scraped from the Khronos specification:
 // https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.14

--- a/components/script_bindings/webidls/WebGLTexture.webidl
+++ b/components/script_bindings/webidls/WebGLTexture.webidl
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
 //
 // WebGL IDL definitions scraped from the Khronos specification:
 // https://www.khronos.org/registry/webgl/specs/latest/#5.9

--- a/components/script_bindings/webidls/WebGLTransformFeedback.webidl
+++ b/components/script_bindings/webidls/WebGLTransformFeedback.webidl
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
 //
 // WebGL IDL definitions scraped from the Khronos specification:
 // https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.15

--- a/components/script_bindings/webidls/WebGLUniformLocation.webidl
+++ b/components/script_bindings/webidls/WebGLUniformLocation.webidl
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
 //
 // WebGL IDL definitions scraped from the Khronos specification:
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.10

--- a/components/script_bindings/webidls/WebGLVertexArrayObject.webidl
+++ b/components/script_bindings/webidls/WebGLVertexArrayObject.webidl
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
 //
 // WebGL IDL definitions scraped from the Khronos specification:
 // https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.17

--- a/components/script_bindings/webidls/WebGLVertexArrayObjectOES.webidl
+++ b/components/script_bindings/webidls/WebGLVertexArrayObjectOES.webidl
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// skip-unless CARGO_FEATURE_WEBGL
 /*
  * WebGL IDL definitions scraped from the Khronos specification:
  * https://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -23,11 +23,7 @@ default = ["bundled", "clipboard", "js_jit"]
 #  configuration with `--no-default-features` build
 #
 # A convenience feature to enable all default web features servo has.
-<<<<<<< HEAD
 default_web_features = ["brotli-compression-stream", "clipboard", "webgpu", "webxr"]
-=======
-default_web_features = ["clipboard", "webgpu"] # , "webxr"
->>>>>>> ae9a00ce520 (wip: more feature guards after bindgen fix (address warnings))
 # Bundle required resources in the binary.
 bundled = ["baked-in-resources", "bundled_freetype"]
 

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -79,6 +79,10 @@ webgl_backtrace = [
     "webgl/webgl_backtrace",
     "servo-canvas-traits/webgl_backtrace",
 ]
+webgl = [
+    "dep:webgl",
+    "script/webgl",
+]
 webgpu = [
     "dep:webgpu",
     "script/webgpu",
@@ -87,6 +91,7 @@ webgpu = [
     "servo-constellation-traits/webgpu",
 ]
 webxr = [
+    "webgl",
     "dep:webxr",
     "dep:webxr-api",
     "paint/webxr",
@@ -150,7 +155,7 @@ surfman = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true, optional = true }
 url = { workspace = true }
-webgl = { workspace = true, default-features = false }
+webgl = { workspace = true, default-features = false, optional = true }
 webgpu = { workspace = true, optional = true }
 webrender = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -96,6 +96,7 @@ webgpu = [
 ]
 webxr = [
     "webgl",
+    "gamepad",
     "dep:webxr",
     "dep:webxr-api",
     "paint/webxr",

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -85,7 +85,11 @@ webgl_backtrace = [
 ]
 webgl = [
     "dep:webgl",
+    "paint/webgl",
     "script/webgl",
+    "script_traits/webgl",
+    "servo-constellation/webgl",
+    "servo-constellation-traits/webgl",
 ]
 webgpu = [
     "dep:webgpu",

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -23,7 +23,11 @@ default = ["bundled", "clipboard", "js_jit"]
 #  configuration with `--no-default-features` build
 #
 # A convenience feature to enable all default web features servo has.
+<<<<<<< HEAD
 default_web_features = ["brotli-compression-stream", "clipboard", "webgpu", "webxr"]
+=======
+default_web_features = ["clipboard", "webgpu"] # , "webxr"
+>>>>>>> ae9a00ce520 (wip: more feature guards after bindgen fix (address warnings))
 # Bundle required resources in the binary.
 bundled = ["baked-in-resources", "bundled_freetype"]
 

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -59,7 +59,7 @@ js_backtrace = ["script/js_backtrace"]
 js_jit = ["script/js_jit"]
 media-gstreamer = ["servo-media-gstreamer", "gstreamer"]
 native-bluetooth = ["servo-bluetooth/native-bluetooth"]
-no-wgl = ["mozangle/egl", "mozangle/build_dlls", "surfman/sm-angle-default", "paint_api/no-wgl"]
+no-wgl = ["dep:mozangle", "mozangle/egl", "mozangle/build_dlls", "surfman/sm-angle-default", "paint_api/no-wgl"]
 profilemozjs = ["script/profilemozjs"]
 testbinding = ["script/testbinding"]
 tracing = [
@@ -125,7 +125,7 @@ layout = { workspace = true }
 layout_api = { workspace = true }
 log = { workspace = true }
 media = { workspace = true }
-mozangle = { workspace = true }
+mozangle = { workspace = true, optional = true }
 net = { workspace = true }
 net_traits = { workspace = true }
 paint = { workspace = true }

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -1236,6 +1236,7 @@ fn create_constellation(
         webxr_registry: Some(paint.webxr_main_thread_registry()),
         #[cfg(not(feature = "webxr"))]
         webxr_registry: None,
+        #[cfg(feature = "webgl")]
         webgl_threads: Some(paint.webgl_threads()),
         webrender_external_image_id_manager: paint.webrender_external_image_id_manager(),
         #[cfg(feature = "webgpu")]

--- a/components/shared/constellation/Cargo.toml
+++ b/components/shared/constellation/Cargo.toml
@@ -16,6 +16,7 @@ path = "lib.rs"
 [features]
 bluetooth = []
 webgpu = ["dep:webgpu_traits", "dep:wgpu-core"]
+webgl = []
 
 [dependencies]
 base64 = { workspace = true }

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -546,6 +546,7 @@ pub struct WorkerGlobalScopeInit {
     /// Unminify Javascript.
     pub unminify_js: bool,
     /// Handle for communicating messages to the WebGL thread, if available.
+    #[cfg(feature = "webgl")]
     pub webgl_chan: Option<WebGLChan>,
 }
 

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -36,6 +36,7 @@ use servo_base::id::{
     ServiceWorkerRegistrationId, WebViewId,
 };
 use servo_canvas_traits::canvas::{CanvasId, CanvasMsg};
+#[cfg(feature = "webgl")]
 use servo_canvas_traits::webgl::WebGLChan;
 use servo_url::{ImmutableOrigin, OriginSnapshot, ServoUrl};
 use storage_traits::StorageThreads;

--- a/components/shared/script/Cargo.toml
+++ b/components/shared/script/Cargo.toml
@@ -15,6 +15,7 @@ path = "lib.rs"
 
 [features]
 bluetooth = ["servo-bluetooth-traits"]
+webgl = []
 webgpu = ["dep:webgpu_traits"]
 
 [dependencies]

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -414,6 +414,7 @@ pub struct InitialScriptState {
     /// The ID of the pipeline namespace for this script thread.
     pub pipeline_namespace_id: PipelineNamespaceId,
     /// A channel to the WebGL thread used in this pipeline.
+    #[cfg(feature = "webgl")]
     pub webgl_chan: Option<WebGLPipeline>,
     /// The XR device registry
     pub webxr_registry: Option<webxr_api::Registry>,

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -40,6 +40,7 @@ use servo_base::id::{
 };
 #[cfg(feature = "bluetooth")]
 use servo_bluetooth_traits::BluetoothRequest;
+#[cfg(feature = "webgl")]
 use servo_canvas_traits::webgl::WebGLPipeline;
 use servo_config::prefs::PrefValue;
 use servo_constellation_traits::{

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -48,7 +48,7 @@ default = ["default_without_allocator", "servo-allocator/use-jemalloc"]
 default_without_allocator = ["bundled", "default_web_features", "max_log_level", "js_jit"]
 # Default web features should be kept in sync with the list in servo/Cargo.toml.
 # We also need to enable our own features, since we also have `cfg` gated code here.
-default_web_features = ["servo/default_web_features", "gamepad", "webgpu"] # ,"webxr"
+default_web_features = ["servo/default_web_features", "gamepad", "webgpu" ,"webxr"]
 # Bundle required resources in the binary.
 bundled = ["servo/bundled"]
 

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -48,7 +48,7 @@ default = ["default_without_allocator", "servo-allocator/use-jemalloc"]
 default_without_allocator = ["bundled", "default_web_features", "max_log_level", "js_jit"]
 # Default web features should be kept in sync with the list in servo/Cargo.toml.
 # We also need to enable our own features, since we also have `cfg` gated code here.
-default_web_features = ["servo/default_web_features", "gamepad", "webgpu", "webxr"]
+default_web_features = ["servo/default_web_features", "gamepad", "webgpu"] # ,"webxr"
 # Bundle required resources in the binary.
 bundled = ["servo/bundled"]
 
@@ -70,6 +70,7 @@ tracing-hitrace = ["tracing", "dep:hitrace"]
 tracing-perfetto = ["tracing", "dep:tracing-perfetto"]
 vello = ["servo/vello"]
 webgl_backtrace = ["servo/webgl_backtrace"]
+webgl = ["servo/webgl"]
 webgpu = ["servo/webgpu"]
 webxr = ["servo/webxr"]
 

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -48,7 +48,7 @@ default = ["default_without_allocator", "servo-allocator/use-jemalloc"]
 default_without_allocator = ["bundled", "default_web_features", "max_log_level", "js_jit"]
 # Default web features should be kept in sync with the list in servo/Cargo.toml.
 # We also need to enable our own features, since we also have `cfg` gated code here.
-default_web_features = ["servo/default_web_features", "gamepad", "webgpu" ,"webxr"]
+default_web_features = ["servo/default_web_features", "gamepad", "webgpu", "webxr"]
 # Bundle required resources in the binary.
 bundled = ["servo/bundled"]
 


### PR DESCRIPTION
Add webgl feature guard, so that we can build without it.

Testing: has no automated tests, but can verify by building without the webgl using `./mach build --no-default-features --features bundled,gamepad,webgpu,max_log_level,js_jit`
Fixes: https://github.com/servo/servo/issues/47184

This PR does a lot of small changes:
- adds `webgl = []` as features to script, servoshell, servo, constellation, paint
- adds a lot of `#[cfg(feature = "webgl")]`
- make webxr depend on webgl `webxr = ["webgl",` (as previouslty webgl was non optional)
- adds `// skip-unless CARGO_FEATURE_WEBGL` to the `.webdl`'s

The .webdl part was tricky as it had:
```
typedef (OffscreenCanvasRenderingContext2D
  or ImageBitmapRenderingContext
  or WebGLRenderingContext
  or WebGL2RenderingContext
) OffscreenRenderingContext;
```
and as the WebGLRenderingContext is now optional, I had to introduce 

```
typedef (OffscreenCanvasRenderingContext2D
  or ImageBitmapRenderingContext
  // skip-unless CARGO_FEATURE_WEBGL begin
  or WebGLRenderingContext
  or WebGL2RenderingContext
  // skip-unless CARGO_FEATURE_WEBGL end
) OffscreenRenderingContext;
```

I though about making it a separate PR, but I guess it should stay here, as the separate PR would need a working example anyway.

---

I made sure that this would still compile with and without webgl, and currently webxr forces webgl as a dependency 