### PR TITLE
script: Make paint timing unit test wait for performance observer.

### DIFF
--- a/components/servo/tests/performance_paint_timing.rs
+++ b/components/servo/tests/performance_paint_timing.rs
@@ -94,11 +94,51 @@ fn verify_first_paint(servo_test: &ServoTest, data_url: &str, expected_fp: i32) 
         .url(Url::parse(data_url).unwrap())
         .build();
 
-    let _ = evaluate_javascript(
+    let store_result = evaluate_javascript(
         &servo_test,
         webview.clone(),
-        "await new Promise(requestAnimationFrame);",
+        "paintEntries = false;
+         finishedCallbacks = false;
+         const observer = new PerformanceObserver((list) => {
+           paintEntries = true;
+         });
+         observer.observe({ type: 'paint', buffered: true });",
     );
+    assert_eq!(store_result, Ok(JSValue::Undefined));
+
+    if expected_fp == 0 {
+        let frame_store_result = evaluate_javascript(
+            &servo_test,
+            webview.clone(),
+            "frameCallbacks = 0;
+             maxFrameCallbacks = 10;
+             function frame() {
+               requestAnimationFrame(() => {
+                 frameCallbacks++;
+                 if (frameCallbacks < maxFrameCallbacks) {
+                   frame();
+                 } else {
+                    finishedCallbacks = true;
+                 }
+               });
+             }
+             frame();",
+        );
+        assert_eq!(frame_store_result, Ok(JSValue::Undefined));
+    }
+
+    loop {
+        let entries_available = evaluate_javascript(
+            &servo_test,
+            webview.clone(),
+            "paintEntries || finishedCallbacks;",
+        )
+        .expect("error evaluating JS");
+
+        if entries_available == JSValue::Boolean(true) {
+            break;
+        }
+    }
 
     let paint_entries = evaluate_javascript(
         &servo_test,


### PR DESCRIPTION
The existing code tried to wait for requestAnimationFrame but always failed to execute instead. We now guarantee that the performance entries exist before asserting their contents.

Testing: modifying existing tests.
Fixes: #47156
