### PR TITLE
script: Optimize TurboSHAKE support in WebCrypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7622,12 +7622,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
-name = "seq-macro"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8979,6 +8973,7 @@ dependencies = [
  "ipc-channel",
  "itertools 0.15.0",
  "k12",
+ "keccak",
  "keyboard-types",
  "libc",
  "log",
@@ -9008,7 +9003,6 @@ dependencies = [
  "rsa",
  "rustc-hash 2.1.3",
  "selectors",
- "seq-macro",
  "serde",
  "serde_json",
  "servo-background-hang-monitor-api",
@@ -9051,6 +9045,7 @@ dependencies = [
  "sha2 0.11.0",
  "sha3 0.12.0",
  "smallvec",
+ "sponge-cursor",
  "strum",
  "stylo",
  "stylo_atoms",
@@ -9062,7 +9057,6 @@ dependencies = [
  "tendril",
  "time",
  "tracing",
- "turboshake",
  "unicode-bidi",
  "unicode-script",
  "url",
@@ -10723,17 +10717,6 @@ dependencies = [
  "rustls-pki-types",
  "sha1 0.11.0",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "turboshake"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f892c6904b0bd5a9241eac848347abcbbbd2b9f3892bad23ac3e6efab8d6f06a"
-dependencies = [
- "digest 0.11.3",
- "keccak",
- "sponge-cursor",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ itertools = "0.15"
 jni = "0.22"
 js = { package = "mozjs", version = "=0.21.3", default-features = false, features = ["intl", "libz-sys"] }
 k12 = "0.5"
+keccak = "0.2"
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.13.1", features = ["euclid"] }
 libc = "0.2"
@@ -220,7 +221,6 @@ rustls-platform-verifier = "0.7.0"
 sea-query = { version = "1.0.1", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = "0.8.0"
 selectors = { git = "https://github.com/servo/stylo", rev = "f6d1d525db9a7fb1aa0842926458e63faa4f44c7" }
-seq-macro = "0.3.6"
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
@@ -234,6 +234,7 @@ signal-hook-registry = "1.4.8"
 skrifa = "0.44.0"
 smallvec = { version = "1.15", features = ["serde", "union"] }
 speexdsp-resampler = "0.1.0"
+sponge-cursor = "0.1"
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
 stylo = { git = "https://github.com/servo/stylo", rev = "f6d1d525db9a7fb1aa0842926458e63faa4f44c7" }
@@ -262,7 +263,6 @@ tracing = "0.1.44"
 tracing-perfetto = "0.1.5"
 tracing-subscriber = "0.3.23"
 tungstenite = "0.30"
-turboshake = "0.7"
 unicode-bidi = "0.3.18"
 unicode-properties = { version = "0.1.4", features = ["emoji"] }
 unicode-script = "0.5"

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -97,6 +97,7 @@ js = { workspace = true }
 jstraceable_derive = { workspace = true }
 k12 = { workspace = true }
 keyboard-types = { workspace = true }
+keccak = { workspace = true }
 layout_api = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
@@ -134,7 +135,6 @@ script_bindings = { workspace = true }
 script_webgpu = { workspace = true, optional = true }
 script_traits = { workspace = true }
 selectors = { workspace = true }
-seq-macro = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
 servo-background-hang-monitor-api = { workspace = true }
@@ -153,6 +153,7 @@ sha1 = { workspace = true }
 sha2 = { workspace = true }
 sha3 = { workspace = true }
 smallvec = { workspace = true }
+sponge-cursor = { workspace = true }
 storage_traits = { workspace = true }
 strum = { workspace = true }
 stylo = { workspace = true }
@@ -166,7 +167,6 @@ tendril = { workspace = true }
 time = { workspace = true }
 timers = { workspace = true }
 tracing = { workspace = true, optional = true }
-turboshake = { workspace = true }
 unicode-bidi = { workspace = true }
 unicode-script = { workspace = true }
 url = { workspace = true }

--- a/components/script/dom/webcrypto/subtlecrypto/turboshake_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/turboshake_operation.rs
@@ -2,9 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use seq_macro::seq;
-use turboshake::digest::{ExtendableOutput, Update};
-use turboshake::{CTurboShake128, CTurboShake256};
+use keccak::{Keccak, State1600};
+use sponge_cursor::SpongeCursor;
 
 use crate::dom::bindings::error::Error;
 use crate::dom::subtlecrypto::{CryptoAlgorithm, SubtleTurboShakeParams};
@@ -51,24 +50,12 @@ pub(crate) fn digest(
     let mut result = vec![0u8; output_length as usize / 8];
     match normalized_algorithm.name {
         CryptoAlgorithm::TurboShake128 => {
-            seq!(DS in 0x01..=0x7f {
-                match domain_separation {
-                    #(
-                        DS => hash_message::<CTurboShake128<DS>>(message, &mut result),
-                    )*
-                    _ => unreachable!("Step 4 guarantees domainSeparation lies in 0x01..=0x7f"),
-                }
-            });
+            let hasher = TurboShake::<168>::new(domain_separation)?;
+            hasher.hash(message, &mut result);
         },
         CryptoAlgorithm::TurboShake256 => {
-            seq!(DS in 0x01..=0x7f {
-                match domain_separation {
-                    #(
-                        DS => hash_message::<CTurboShake256<DS>>(message, &mut result),
-                    )*
-                    _ => unreachable!("Step 4 guarantees domainSeparation lies in 0x01..=0x7f"),
-                }
-            });
+            let hasher = TurboShake::<136>::new(domain_separation)?;
+            hasher.hash(message, &mut result);
         },
         algorithm_name => {
             return Err(Error::NotSupported(Some(format!(
@@ -82,8 +69,53 @@ pub(crate) fn digest(
     Ok(result)
 }
 
-fn hash_message<T: ExtendableOutput + Update + Default>(message: &[u8], result: &mut [u8]) {
-    let mut hasher = T::default();
-    hasher.update(message);
-    hasher.finalize_xof_into(result);
+/// Keccak rounds for TurboSHAKE
+const ROUNDS: usize = 12;
+
+/// TurboSHAKE hasher. RATE must be either 168 for TurboSHAKE128 or 136 for TurboSHAKE256.
+struct TurboShake<const RATE: usize> {
+    state: State1600,
+    cursor: SpongeCursor<RATE>,
+    keccak: Keccak,
+    domain_separation: u8,
+}
+
+impl<const RATE: usize> TurboShake<RATE> {
+    fn new(domain_separation: u8) -> Result<TurboShake<RATE>, Error> {
+        if RATE != 168 && RATE != 136 {
+            return Err(Error::NotSupported(Some(
+                "Invalid sponge cursor rate for TurboSHAKE".into(),
+            )));
+        }
+        if domain_separation == 0x00 || domain_separation > 0x7f {
+            return Err(Error::NotSupported(Some(
+                "Invalid TurboSHAKE domain separation".into(),
+            )));
+        }
+        Ok(TurboShake {
+            state: Default::default(),
+            cursor: Default::default(),
+            keccak: Default::default(),
+            domain_separation,
+        })
+    }
+
+    fn hash(mut self, message: &[u8], result: &mut [u8]) {
+        // Digest message
+        self.keccak.with_p1600::<ROUNDS>(|p1600| {
+            self.cursor.absorb_u64_le(&mut self.state, p1600, message);
+        });
+
+        // Finalize
+        let position = self.cursor.pos();
+        self.state[position / 8] ^= (self.domain_separation as u64) << (8 * (position % 8));
+        self.state[RATE / 8 - 1] ^= 1 << 63;
+
+        // Read result
+        self.cursor = Default::default();
+        self.keccak.with_p1600::<ROUNDS>(|p1600| {
+            self.cursor
+                .squeeze_read_u64_le(&mut self.state, p1600, result);
+        });
+    }
 }

--- a/components/script/dom/webcrypto/subtlecrypto/turboshake_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/turboshake_operation.rs
@@ -102,16 +102,25 @@ impl<const RATE: usize> TurboShake<RATE> {
 
     fn hash(mut self, message: &[u8], result: &mut [u8]) {
         // Digest message
+        //
+        // Reference implementation from RustCrypto:
+        // <https://docs.rs/turboshake/0.7.1/src/turboshake/lib.rs.html#60-64>
         self.keccak.with_p1600::<ROUNDS>(|p1600| {
             self.cursor.absorb_u64_le(&mut self.state, p1600, message);
         });
 
         // Finalize
+        //
+        // Reference implementation from RustCrypto:
+        // <https://docs.rs/turboshake/0.7.1/src/turboshake/lib.rs.html#67-91>
         let position = self.cursor.pos();
         self.state[position / 8] ^= (self.domain_separation as u64) << (8 * (position % 8));
         self.state[RATE / 8 - 1] ^= 1 << 63;
 
         // Read result
+        //
+        // Reference implementation from RustCrypto:
+        // <https://docs.rs/turboshake/0.7.1/src/turboshake/lib.rs.html#161-165>
         self.cursor = Default::default();
         self.keccak.with_p1600::<ROUNDS>(|p1600| {
             self.cursor


### PR DESCRIPTION
The TurboSHAKE algorithm provided by the `turboshake` crate (current latest stable version: 0.7.1) takes the domain separation parameter as a const generic, which requires to be known as compile time. However, the WebCrypto API allows users set it at runtime. Our current implementation maps the user-provided value to const generic via the `seq!`, which results in large `match` blocks and instantiating the generic many times.

In this patch, we replace the `turboshake` crate with our own TurboSHAKE implementation, which takes the domain separation as a usual function parameter at runtime. The implementation is equivalent to combining `turboshake::TurboShake` and `turboshake::TurboShakeReader` (https://docs.rs/turboshake/0.7.1/turboshake/struct.TurboShake.html and https://docs.rs/turboshake/0.7.1/turboshake/struct.TurboShakeReader.html). Since it is also based on the `keccak` and `sponge-cursor` crate, so it should have the similar performance as the `turboshake` crate.

This helps us get rid of the large expanded `match` blocks and the multiple instantiations of the generic function. We already import the `keccak` and `sponge-cursor` crate as dependencies of `sha3`, so we are not actually adding dependencies. Furthermore, we can drop `turboshake` and `seq-macro` from our dependency tree.

This reduces the binary size by around 300KB in release mode.

Testing: Refactoring. Existing tests suffice.
Fixes: #47202