### PR TITLE
layout: Consider Text as LCP candidate

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1175,6 +1175,19 @@ impl Fragment {
         // > target has a text node child, representing non-empty text, and the node’s used opacity is greater than zero.
         builder.mark_is_contentful();
 
+        // Accumulate this text fragment for LCP by the containing element's tag
+        if let Some(tag) = state.containing_element_tag &&
+            pref!(largest_contentful_paint_enabled)
+        {
+            let transform = builder
+                .paint_info
+                .scroll_tree
+                .cumulative_node_to_root_transform(state.spatial_id);
+            builder
+                .paint_timing_handler
+                .accumulate_text_rect(tag, rect.to_webrender(), transform);
+        }
+
         for text_decoration in state.text_decorations.iter() {
             if text_decoration
                 .line

--- a/components/layout/display_list/paint_timing_handler.rs
+++ b/components/layout/display_list/paint_timing_handler.rs
@@ -105,11 +105,6 @@ impl PaintTimingHandler {
         natural_width: Option<Au>,
         natural_height: Option<Au>,
     ) {
-        if let Some(node) = tag.map(|tag| tag.node) &&
-            !self.reported_image_nodes.insert(node)
-        {
-            return;
-        }
         self.painted_images.push(PendingImageRecord {
             tag,
             bounds,
@@ -259,6 +254,19 @@ impl PaintTimingHandler {
 
         // Step 4. For each record of paintedImages:
         for record in std::mem::take(&mut self.painted_images) {
+            // > From: <https://www.w3.org/TR/largest-contentful-paint/#sec-report-largest-contentful-paint>
+            // > Note: Each pending image record in paintedImages and text
+            // > element in paintedTextNodes will only be reported exactly
+            // > once, from mark paint timing, for the first paint where the
+            // > element is considered paintable (i.e. has opacity and
+            // > visibility) and contentful (i.e. image resource or blocking
+            // > fonts are sufficiently loaded).
+            // TODO(shubhamg13): Move to mark_paint_timing
+            if let Some(node) = record.tag.map(|tag| tag.node) &&
+                !self.reported_image_nodes.insert(node)
+            {
+                return;
+            }
             // Step 4.1. Let imageElement be record’s element.
 
             // TODO Step 4.2. If imageElement is not exposed for paint timing,

--- a/components/layout/display_list/paint_timing_handler.rs
+++ b/components/layout/display_list/paint_timing_handler.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use app_units::Au;
 use euclid::Rect;
@@ -35,6 +35,25 @@ struct PendingImageRecord {
     natural_height: Option<Au>,
 }
 
+/// <https://w3c.github.io/paint-timing/#sec-recording-paint-timing>
+/// > Each Element has a set of owned text nodes, which is an ordered set of
+/// > Text nodes, initially empty.
+///
+/// This struct corresponds to an Element for accumulating set of owned text
+/// nodes by nearest ancestor box fragment's tag during display list building.
+struct TextRecord {
+    /// The tag of containing box fragment these texts belongs to.
+    tag: Tag,
+    /// <https://w3c.github.io/paint-timing/#set-of-owned-text-nodes>
+    /// Collection of border_boxes of all Text nodes accumulated
+    border_boxes: Vec<LayoutRect>,
+}
+
+enum LCPCandidateType<'a> {
+    Image(&'a PendingImageRecord),
+    Text,
+}
+
 pub(crate) struct PaintTimingHandler {
     /// The rect of viewport.
     viewport_rect: LayoutRect,
@@ -53,6 +72,10 @@ pub(crate) struct PaintTimingHandler {
     reported_image_nodes: HashSet<OpaqueNode>,
     /// <https://w3c.github.io/paint-timing/#paintedImages>
     painted_images: Vec<PendingImageRecord>,
+    /// The set of text nodes that have been reported as LCP candidates.
+    reported_text_nodes: HashSet<OpaqueNode>,
+    /// <https://w3c.github.io/paint-timing/#paintedTextNodes>
+    painted_text_nodes: HashMap<OpaqueNode, TextRecord>,
 }
 
 impl PaintTimingHandler {
@@ -66,6 +89,8 @@ impl PaintTimingHandler {
             viewport_rect: LayoutRect::from_size(viewport_size),
             reported_image_nodes: HashSet::new(),
             painted_images: Vec::new(),
+            reported_text_nodes: HashSet::new(),
+            painted_text_nodes: HashMap::new(),
         }
     }
 
@@ -96,6 +121,24 @@ impl PaintTimingHandler {
         });
     }
 
+    pub(crate) fn accumulate_text_rect(
+        &mut self,
+        tag: Tag,
+        rect: LayoutRect,
+        transform: FastLayoutTransform,
+    ) {
+        let border_box = transform_f32_rectangle(rect.to_rect(), transform)
+            .unwrap_or_default()
+            .to_box2d();
+        self.painted_text_nodes
+            .entry(tag.node)
+            .and_modify(|record| record.border_boxes.push(border_box))
+            .or_insert(TextRecord {
+                tag,
+                border_boxes: vec![border_box],
+            });
+    }
+
     // Returns true if has non-zero width and height values.
     pub(crate) fn check_bounding_rect(&self, bounds: LayoutRect, clip_rect: LayoutRect) -> bool {
         let clipped_rect = bounds
@@ -113,19 +156,15 @@ impl PaintTimingHandler {
     /// <https://www.w3.org/TR/largest-contentful-paint/#sec-effective-visual-size>
     fn effective_visual_size(
         &self,
-        bounds: LayoutRect,
-        clip_rect: LayoutRect,
         intersection_rect: LayoutRect,
-        transform: FastLayoutTransform,
-        natural_width: Option<Au>,
-        natural_height: Option<Au>,
+        candidate_type: LCPCandidateType<'_>,
     ) -> Option<f32> {
         // Step 1. Let width be intersectionRect's width, rounded up to the
         // nearest integer.
         // Step 2. Let height be intersectionRect's height, rounded up to the
         // nearest integer.
         // Step 3. Let size be width * height.
-        let size = intersection_rect.area();
+        let mut size = intersection_rect.area();
 
         // Step 4. Let root be document's browsing context's top-level browsing
         // context's active document.
@@ -141,58 +180,64 @@ impl PaintTimingHandler {
         }
 
         // Step 8: If imageRequest is not null, run the following steps to
-        // adjust for image position and upscaling:
-        // Note: This is handled by check for [showing_broken_image_icon] earlier
+        // adjust for image position and upscaling.
+        // Note: This is skipped for Text aka the case of null request from specs
+        if let LCPCandidateType::Image(record) = candidate_type {
+            // TODO Step 8.1: If imageRequest's response's content length in bytes
+            // is less than size * 0.004, then return null. (Not Implemented)
 
-        // TODO Step 8.1: If imageRequest's response's content length in bytes
-        // is less than size * 0.004, then return null. (Not Implemented)
+            // Step 8.2: Let concreteDimensions be imageRequest's concrete object
+            // size within element.
+            // Step 8.3: Let visibleDimensions be concreteDimensions, adjusted for
+            // positioning by object-position or background-position and element's
+            // content box.
+            // Note: bounds are already adjusted for positioning and content box
+            let visible_dimensions = record
+                .bounds
+                .intersection(&record.clip_rect)
+                .unwrap_or(LayoutRect::zero());
 
-        // Step 8.2: Let concreteDimensions be imageRequest's concrete object
-        // size within element.
-        // Step 8.3: Let visibleDimensions be concreteDimensions, adjusted for
-        // positioning by object-position or background-position and element's
-        // content box.
-        // Note: bounds are already adjusted for positioning and content box
-        let visible_dimensions = bounds
-            .intersection(&clip_rect)
-            .unwrap_or(LayoutRect::zero());
+            // Step 8.4: Let clientContentRect be the smallest DOMRectReadOnly
+            // containing visibleDimensions with element's transforms applied.
+            let client_content_rect =
+                transform_f32_rectangle(visible_dimensions.to_rect(), record.transform)
+                    .unwrap_or_default();
 
-        // Step 8.4: Let clientContentRect be the smallest DOMRectReadOnly
-        // containing visibleDimensions with element's transforms applied.
-        let client_content_rect =
-            transform_f32_rectangle(visible_dimensions.to_rect(), transform).unwrap_or_default();
+            // Step 8.5: Let intersectingClientContentRect be the intersection of
+            // clientContentRect with intersectionRect.
+            let intersecting_client_content_rect = client_content_rect
+                .intersection(&intersection_rect.to_rect())
+                .unwrap_or(Rect::zero());
 
-        // Step 8.5: Let intersectingClientContentRect be the intersection of
-        // clientContentRect with intersectionRect.
-        let intersecting_client_content_rect = client_content_rect
-            .intersection(&intersection_rect.to_rect())
-            .unwrap_or(Rect::zero());
+            // Step 8.6: Set width to intersectingClientContentRect's width,
+            // rounded up to the nearest integer.
+            // Step 8.7: Set height to intersectingClientContentRect's height,
+            // rounded up to the nearest integer.
+            // Step 8.8: Set size to width * height.
+            size = intersecting_client_content_rect.area();
 
-        // Step 8.6: Set width to intersectingClientContentRect's width,
-        // rounded up to the nearest integer.
-        // Step 8.7: Set height to intersectingClientContentRect's height,
-        // rounded up to the nearest integer.
-        // Step 8.8: Set size to width * height.
-        let mut size = intersecting_client_content_rect.area();
+            // Step 8.9: Let naturalArea be imageRequest's natural width * imageRequest's natural height.
+            if let (Some(natural_width), Some(natural_height)) =
+                (record.natural_width, record.natural_height)
+            {
+                let natural_area = natural_width.to_f32_px() * natural_height.to_f32_px();
 
-        // Step 8.9: Let naturalArea be imageRequest's natural width * imageRequest's natural height.
-        if let (Some(natural_width), Some(natural_height)) = (natural_width, natural_height) {
-            let natural_area = natural_width.to_f32_px() * natural_height.to_f32_px();
+                // Step 8.10: If naturalArea is 0, then return null.
+                if natural_area == 0.0 {
+                    return None;
+                }
+                // Step 8.11: Let boundingClientArea be clientContentRect's width *
+                // clientContentRect's height.
+                let bounding_client_area =
+                    client_content_rect.width() * client_content_rect.height();
 
-            // Step 8.10: If naturalArea is 0, then return null.
-            if natural_area == 0.0 {
-                return None;
-            }
-            // Step 8.11: Let boundingClientArea be clientContentRect's width *
-            // clientContentRect's height.
-            let bounding_client_area = client_content_rect.width() * client_content_rect.height();
+                // Step 8.12: Let scaleFactor be boundingClientArea / naturalArea.
+                let scale_factor = bounding_client_area / natural_area;
 
-            // Step 8.12: Let scaleFactor be boundingClientArea / naturalArea.
-            let scale_factor = bounding_client_area / natural_area;
-
-            // Step 8.13: If scaleFactor is greater than 1, then divide size by scaleFactor.
-            if scale_factor > 1.0 {
-                size /= scale_factor;
+                // Step 8.13: If scaleFactor is greater than 1, then divide size by scaleFactor.
+                if scale_factor > 1.0 {
+                    size /= scale_factor;
+                }
             }
         }
 
@@ -230,14 +275,8 @@ impl PaintTimingHandler {
 
             // Step 4.4. Let result be the effective visual size of imageElement
             // given intersectionRect and record's request.
-            let result = self.effective_visual_size(
-                record.bounds,
-                record.clip_rect,
-                intersection_rect,
-                record.transform,
-                record.natural_width,
-                record.natural_height,
-            );
+            let result =
+                self.effective_visual_size(intersection_rect, LCPCandidateType::Image(&record));
 
             // Step 4.5. If result is null, continue.
             let Some(result) = result else {
@@ -263,7 +302,60 @@ impl PaintTimingHandler {
             new_candidate_tag = record.tag;
         }
 
-        // TODO Step 5. For each textNode of paintedTextNodes,
+        // Step 5. For each textNode of paintedTextNodes,
+        for (node, record) in std::mem::take(&mut self.painted_text_nodes) {
+            // > From: <https://www.w3.org/TR/largest-contentful-paint/#sec-report-largest-contentful-paint>
+            // > Note: Each pending image record in paintedImages and text
+            // > element in paintedTextNodes will only be reported exactly
+            // > once, from mark paint timing, for the first paint where the
+            // > element is considered paintable (i.e. has opacity and
+            // > visibility) and contentful (i.e. image resource or blocking
+            // > fonts are sufficiently loaded).
+            // TODO(shubhamg13): Move to mark_paint_timing
+            if !self.reported_text_nodes.insert(node) {
+                continue;
+            }
+            // TODO Step 5.1. If textNode is not exposed for paint timing,
+            // given document, continue.
+            // TODO Step 5.2. If textNode has alpha channel value <=0 or
+            // opacity value <=0:
+            // Step 5.3. Let intersectionRect be the union of the border boxes of
+            // all Text nodes in textNode’s set of owned text nodes,
+            // intersected with the visual viewport.
+            let intersection_rect = record
+                .border_boxes
+                .into_iter()
+                .reduce(|a, b| a.union(&b))
+                .unwrap_or_default()
+                .intersection(&self.viewport_rect)
+                .unwrap_or_default();
+            // Step 5.4. Let result be the effective visual size of textNode
+            // given intersectionRect and null.
+            let result = self.effective_visual_size(intersection_rect, LCPCandidateType::Text);
+
+            // Step 5.5. If result is null, continue.
+            let Some(result) = result else {
+                continue;
+            };
+            // Step 5.6. If result's size is less than or equal to
+            // largestSize, continue.
+            if result <= largest_size {
+                continue;
+            }
+
+            // Step 5.7. Set largestSize to result’s size.
+            largest_size = result;
+
+            // Step 5.8. Set newCandidate to be a new largest contentful paint candidate ...
+            let uuid = self.lcp_next_uuid;
+            self.lcp_next_uuid += 1;
+            new_candidate = Some(LCPCandidate::new(
+                LCPCandidateID(uuid),
+                result as usize,
+                None,
+            ));
+            new_candidate_tag = Some(record.tag);
+        }
 
         // Step 6. If newCandidate is not null and currentSize is greater than 0:
         // TODO Step 6.1. If newCandidate’s width minus currentCandidate’s

--- a/components/layout/display_list/paint_traversal.rs
+++ b/components/layout/display_list/paint_traversal.rs
@@ -14,7 +14,7 @@ use crate::display_list::{
 };
 use crate::fragment_tree::{
     BoxFragment, BoxFragmentWithStyle, Fragment, FragmentFlags, IFrameFragment, ImageFragment,
-    PositioningFragment, TextFragment,
+    PositioningFragment, Tag, TextFragment,
 };
 use crate::geom::{PhysicalPoint, PhysicalRect};
 
@@ -535,6 +535,10 @@ pub(crate) struct TraversalState {
     pub clip_id: ClipId,
     pub origin: PhysicalPoint<Au>,
     pub text_decorations: Rc<Vec<FragmentTextDecoration>>,
+    /// The tag of the nearest ancestor box fragment that has a tag.
+    /// Used for text LCP candidate grouping — all text fragments within
+    /// a single element are unioned before computing effective visual size.
+    pub containing_element_tag: Option<Tag>,
 }
 
 impl TraversalState {
@@ -582,6 +586,7 @@ impl TraversalState {
                 .unwrap_or(self.spatial_id),
             clip_id: box_fragment.generated_clip_id().unwrap_or(self.clip_id),
             text_decorations,
+            containing_element_tag: box_fragment.base.tag.or(self.containing_element_tag),
         }
     }
 
@@ -601,6 +606,7 @@ impl TraversalState {
             spatial_id: self.spatial_id,
             clip_id: self.clip_id,
             text_decorations: self.text_decorations.clone(),
+            containing_element_tag: self.containing_element_tag,
         }
     }
 
@@ -610,6 +616,7 @@ impl TraversalState {
             spatial_id: stacking_context.scroll_tree_node_id,
             clip_id: stacking_context.clip_id,
             text_decorations: stacking_context.text_decorations.clone(),
+            containing_element_tag: self.containing_element_tag,
         }
     }
 }

--- a/tests/wpt/meta/largest-contentful-paint/element-only-when-fully-active.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/element-only-when-fully-active.html.ini
@@ -1,4 +1,0 @@
-[element-only-when-fully-active.html]
-  expected: TIMEOUT
-  [Only expose element attribute for fully active documents]
-    expected: NOTRUN

--- a/tests/wpt/meta/largest-contentful-paint/first-paint-equals-lcp-text.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/first-paint-equals-lcp-text.html.ini
@@ -1,4 +1,0 @@
-[first-paint-equals-lcp-text.html]
-  expected: TIMEOUT
-  [FCP and LCP are the same when there is a single text element in the page.]
-    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/image-full-viewport.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/image-full-viewport.html.ini
@@ -1,4 +1,0 @@
-[image-full-viewport.html]
-  expected: TIMEOUT
-  [The intersectionRect of an img element overflowing is computed correctly]
-    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/initially-invisible-images.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/initially-invisible-images.html.ini
@@ -1,2 +1,4 @@
 [initially-invisible-images.html]
   expected: ERROR
+  [Image visibility: out-of-viewport images are observable by LargestContentfulPaint once they become visible.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/larger-text.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/larger-text.html.ini
@@ -1,4 +1,3 @@
 [larger-text.html]
-  expected: ERROR
   [Largest Contentful Paint: largest text is reported.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/larger-text.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/larger-text.html.ini
@@ -1,4 +1,4 @@
 [larger-text.html]
-  expected: TIMEOUT
+  expected: ERROR
   [Largest Contentful Paint: largest text is reported.]
     expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/modified-text-not-reconsidered.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/modified-text-not-reconsidered.html.ini
@@ -1,3 +1,0 @@
-[modified-text-not-reconsidered.html]
-  [Text element should not be reconsidered as LCP after text content changes.]
-    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/observe-mathml.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/observe-mathml.html.ini
@@ -1,4 +1,3 @@
 [observe-mathml.html]
-  expected: TIMEOUT
   [Element rendered by MathML is observable]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/observe-random-namespace.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/observe-random-namespace.html.ini
@@ -1,4 +1,3 @@
 [observe-random-namespace.html]
-  expected: TIMEOUT
   [Element created with different namespace is observable]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/observe-text.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/observe-text.html.ini
@@ -1,4 +1,3 @@
 [observe-text.html]
-  expected: TIMEOUT
   [Text element is observable as a LargestContentfulPaint candidate.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/performance-entry-sequence.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/performance-entry-sequence.html.ini
@@ -1,4 +1,0 @@
-[performance-entry-sequence.html]
-  expected: TIMEOUT
-  [Exactly one LargestContentfulPaint entry is emitted per frame when a new candidate is rendered]
-    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/text-fragment-union.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/text-fragment-union.html.ini
@@ -1,4 +1,3 @@
 [text-fragment-union.html]
-  expected: ERROR
   [Text fragment union: wrapped text LCP size reflects the union of all line boxes.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/text-fragment-union.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/text-fragment-union.html.ini
@@ -1,4 +1,4 @@
 [text-fragment-union.html]
-  expected: TIMEOUT
+  expected: ERROR
   [Text fragment union: wrapped text LCP size reflects the union of all line boxes.]
     expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/text-with-display-style.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/text-with-display-style.html.ini
@@ -1,4 +1,3 @@
 [text-with-display-style.html]
-  expected: TIMEOUT
   [Text with display style is observable.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/toJSON.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/toJSON.html.ini
@@ -1,4 +1,0 @@
-[toJSON.html]
-  expected: TIMEOUT
-  [Test toJSON() in LargestContentfulPaint.]
-    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/transparent-text-with-shadow.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/transparent-text-with-shadow.html.ini
@@ -1,4 +1,0 @@
-[transparent-text-with-shadow.html]
-  expected: TIMEOUT
-  [Transparent text with shadow decoration should not be excluded from LCP.]
-    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/transparent-text-with-text-stroke.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/transparent-text-with-text-stroke.html.ini
@@ -1,4 +1,0 @@
-[transparent-text-with-text-stroke.html]
-  expected: TIMEOUT
-  [Transparent text with text stroke decoration should not be excluded from LCP.]
-    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/transparent-text.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/transparent-text.html.ini
@@ -1,0 +1,3 @@
+[transparent-text.html]
+  [Transparent text should not be LCP.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/update-on-style-change.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/update-on-style-change.html.ini
@@ -1,4 +1,0 @@
-[update-on-style-change.html]
-  expected: TIMEOUT
-  [LargestContentfulPaint entries should NOT be emitted for updates to previous LargestContentfulPaint elements.]
-    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/web-font-styled-text-resize-swap-after-interaction.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/web-font-styled-text-resize-swap-after-interaction.html.ini
@@ -1,4 +1,3 @@
 [web-font-styled-text-resize-swap-after-interaction.html]
-  expected: TIMEOUT
   [LCP should be not updated if the web font styled text resize occurs after an interaction happens]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/tests/largest-contentful-paint/larger-text.html
+++ b/tests/wpt/tests/largest-contentful-paint/larger-text.html
@@ -47,7 +47,7 @@
 
       await new Promise(resolve => {
         new PerformanceObserver(
-          (entryList, observer) => {
+          t.step_func((entryList, observer) => {
             entryList.getEntries().forEach(entry => {
               // The tiny images or text1 could be reported as LCP if it is rendered before text2.
               if (entry.id !== 'text2')
@@ -85,8 +85,9 @@
               observer.disconnect();
 
               resolve();
+              })
             })
-          }).observe({ type: 'largest-contentful-paint', buffered: true });
+          ).observe({ type: 'largest-contentful-paint', buffered: true });
       });
     }, 'Largest Contentful Paint: largest text is reported.');
   </script>

--- a/tests/wpt/tests/largest-contentful-paint/observe-text.html
+++ b/tests/wpt/tests/largest-contentful-paint/observe-text.html
@@ -24,13 +24,15 @@ p {
           'startTime should be equal to renderTime to the precision of 1 millisecond.');
 
         // PaintTimingMixin
-        assert_greater_than_equal(entry.paintTime, beforeRender, 'paintTime should represent the time when the UA started painting');
+        if ("paintTime" in entry && entry.paintTime !== null) {
+          assert_greater_than_equal(entry.paintTime, beforeRender, 'paintTime should represent the time when the UA started painting');
 
-        if ("presentationTime" in entry && entry.presentationTime !== null) {
-          assert_greater_than(entry.presentationTime, entry.paintTime);
-          assert_equals(entry.presentationTime, entry.renderTime);
-        } else {
-          assert_equals(entry.renderTime, entry.paintTime);
+          if ("presentationTime" in entry && entry.presentationTime !== null) {
+            assert_greater_than(entry.presentationTime, entry.paintTime);
+            assert_equals(entry.presentationTime, entry.renderTime);
+          } else {
+            assert_equals(entry.renderTime, entry.paintTime);
+          }
         }
         assert_equals(entry.duration, 0);
         // Some lower bound: height of at least 12 px.

--- a/tests/wpt/tests/largest-contentful-paint/text-fragment-union.html
+++ b/tests/wpt/tests/largest-contentful-paint/text-fragment-union.html
@@ -21,7 +21,8 @@
     document.body.appendChild(div);
 
     await new Promise(resolve => {
-      new PerformanceObserver((entryList, observer) => {
+      new PerformanceObserver(
+        t.step_func((entryList, observer) => {
         for (const entry of entryList.getEntries()) {
           if (entry.id !== 'multi-line-text') continue;
 
@@ -47,7 +48,7 @@
           observer.disconnect();
           resolve();
         }
-      }).observe({type: 'largest-contentful-paint', buffered: true});
+      })).observe({type: 'largest-contentful-paint', buffered: true});
     });
   }, 'Text fragment union: wrapped text LCP size reflects the union of all line boxes.');
 </script>


### PR DESCRIPTION
Since the spec says, for text nodes we need to do union of border box per element.

-  Adding `containing_element_tag` for making this union.
 - Adding `TextRecord` to store `TextNodes` related to an `Element`.
 

> Note: Please view using `Hide whitespace` option.

Testing: More WPT Passed
- Added a specific test to verify union logic of rect - size calculation is correct in WPT 
  - `tests/wpt/tests/largest-contentful-paint/text-fragment-union.html`- web-platform-tests/wpt#61873
  - (_TODO: set loadTime to zero for text, other failing tests will also pass #47315_)



Fixes: Part of #42000