### PR TITLE
script: maybe_user_interacting_guard in EnqueuedPromiseCallback

### DIFF
--- a/components/script/microtask.rs
+++ b/components/script/microtask.rs
@@ -82,7 +82,11 @@ pub(crate) struct EnqueuedPromiseCallback {
 
 impl MicrotaskRunnable for EnqueuedPromiseCallback {
     fn handler(&self, cx: &mut JSContext) {
-        let _guard = ScriptThread::user_interacting_guard();
+        let _maybe_user_interacting_guard = if self.is_user_interacting {
+            Some(ScriptThread::user_interacting_guard())
+        } else {
+            None
+        };
         let mut realm = enter_auto_realm(cx, &*self.global);
         let cx = &mut realm;
         let _ = self

--- a/tests/wpt/meta/webxr/xrDevice_requestSession_immersive_no_gesture.https.html.ini
+++ b/tests/wpt/meta/webxr/xrDevice_requestSession_immersive_no_gesture.https.html.ini
@@ -1,3 +1,0 @@
-[xrDevice_requestSession_immersive_no_gesture.https.html]
-  [Requesting immersive session outside of a user gesture rejects]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/xrDevice_requestSession_requiredFeatures_unknown.https.html.ini
+++ b/tests/wpt/meta/webxr/xrDevice_requestSession_requiredFeatures_unknown.https.html.ini
@@ -1,0 +1,3 @@
+[xrDevice_requestSession_requiredFeatures_unknown.https.html]
+  [Tests requestSession rejects for unknown requiredFeatures]
+    expected: FAIL


### PR DESCRIPTION
I accidentality fixed this code in SM bump and then spent 2h to discover that we are doing this unconditionally, which is wrong. One test now fails (buggy webxr impl) but one does pass.

Testing: Covered by WPT tests 