### PR TITLE
serviceworker: start implementing cache interface with in-mem only backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9198,7 +9198,6 @@ dependencies = [
  "serde",
  "servo-base",
  "servo-malloc-size-of",
- "servo-net-traits",
  "servo-profile-traits",
  "servo-url",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9198,6 +9198,7 @@ dependencies = [
  "serde",
  "servo-base",
  "servo-malloc-size-of",
+ "servo-net-traits",
  "servo-profile-traits",
  "servo-url",
  "uuid",

--- a/components/script/dom/fetch/request.rs
+++ b/components/script/dom/fetch/request.rs
@@ -73,7 +73,7 @@ impl Request {
         }
     }
 
-    fn new(
+    pub(crate) fn new(
         cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/serviceworker/cache.rs
+++ b/components/script/dom/serviceworker/cache.rs
@@ -134,6 +134,10 @@ impl Cache {
                 // Step 5.4.3: Resolve promise with a frozen array created from requestList, in realm.
                 promise.resolve_native(cx, &request_list);
             },
+            CacheStorageThreadResponse::DeleteCacheResult(_result) => debug_assert!(
+                false,
+                "Unexpected DeleteCacheResult response in Cache handle_response."
+            ),
             CacheStorageThreadResponse::HasCacheResult(_result) => debug_assert!(
                 false,
                 "Unexpected HasCacheResult response in Cache handle_response."

--- a/components/script/dom/serviceworker/cache.rs
+++ b/components/script/dom/serviceworker/cache.rs
@@ -95,9 +95,14 @@ impl Cache {
         let response = match response {
             Some(response) => response,
             None => {
-                if self.pending_promises.borrow_mut().pop_front().is_none() {
+                let Some(promise) = self.pending_promises.borrow_mut().pop_front() else {
                     error!("No pending promise for Cache response.");
-                }
+                    return;
+                };
+                promise.reject_error(
+                    cx,
+                    Error::Operation(Some("No response from Cache backend.".to_string())),
+                );
                 return;
             },
         };

--- a/components/script/dom/serviceworker/cache.rs
+++ b/components/script/dom/serviceworker/cache.rs
@@ -11,9 +11,8 @@ use js::context::JSContext;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use script_bindings::root::DomRoot;
 use servo_base::generic_channel::{GenericCallback, GenericSend};
-use servo_url::{ImmutableOrigin, ServoUrl};
+use servo_url::ServoUrl;
 use storage_traits::cache_storage::{CacheStorageThreadMessage, CacheStorageThreadResponse};
-use storage_traits::client_storage::{StorageIdentifier, StorageProxyMap, StorageType};
 
 use crate::dom::Promise;
 use crate::dom::bindings::codegen::Bindings::CacheBinding::CacheMethods;
@@ -156,7 +155,7 @@ impl CacheMethods<crate::DomTypeHolder> for Cache {
         &self,
         cx: &mut JSContext,
         request: Option<RequestOrUSVString>,
-        options: &CacheQueryOptions,
+        _options: &CacheQueryOptions,
     ) -> Rc<Promise> {
         // Step 1: Let r be null.
         let mut r: Option<DomRoot<Request>> = None;
@@ -190,6 +189,9 @@ impl CacheMethods<crate::DomTypeHolder> for Cache {
                 r = Some(request);
             }
         }
+
+        // TODO: use r in the backend.
+        let _ = r;
 
         // Step 5: Run these substeps in parallel:
         let callback = self.get_or_setup_callback();

--- a/components/script/dom/serviceworker/cache.rs
+++ b/components/script/dom/serviceworker/cache.rs
@@ -1,0 +1,211 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::rc::Rc;
+
+use dom_struct::dom_struct;
+use js::context::JSContext;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::root::DomRoot;
+use servo_base::generic_channel::{GenericCallback, GenericSend};
+use servo_url::{ImmutableOrigin, ServoUrl};
+use storage_traits::cache_storage::{CacheStorageThreadMessage, CacheStorageThreadResponse};
+use storage_traits::client_storage::{StorageIdentifier, StorageProxyMap, StorageType};
+
+use crate::dom::Promise;
+use crate::dom::bindings::codegen::Bindings::CacheBinding::CacheMethods;
+use crate::dom::bindings::codegen::GenericBindings::CacheBinding::CacheQueryOptions;
+use crate::dom::bindings::codegen::UnionTypes::RequestOrUSVString;
+use crate::dom::bindings::error::Error;
+use crate::dom::bindings::refcounted::Trusted;
+use crate::dom::bindings::reflector::DomGlobal;
+use crate::dom::bindings::str::DOMString;
+use crate::dom::fetch::request::Request;
+use crate::dom::globalscope::GlobalScope;
+
+/// <https://w3c.github.io/ServiceWorker/#cache>
+#[dom_struct]
+pub(crate) struct Cache {
+    reflector_: Reflector,
+
+    /// The name used to identify
+    /// <https://w3c.github.io/ServiceWorker/#dfn-relevant-request-response-list>
+    name: DOMString,
+
+    #[no_trace]
+    #[ignore_malloc_size_of = "GenericCallback"]
+    callback: RefCell<Option<GenericCallback<CacheStorageThreadResponse>>>,
+
+    // Dequeue of pending promises for backend operations.
+    #[conditional_malloc_size_of]
+    pending_promises: RefCell<VecDeque<Rc<Promise>>>,
+}
+
+impl Cache {
+    fn new_inherited(name: DOMString) -> Cache {
+        Cache {
+            reflector_: Reflector::new(),
+            name,
+            callback: Default::default(),
+            pending_promises: Default::default(),
+        }
+    }
+
+    pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope, name: DOMString) -> DomRoot<Cache> {
+        reflect_dom_object_with_cx(Box::new(Cache::new_inherited(name)), global, cx)
+    }
+
+    /// Setup the callback to the backend service, if this hasn't been done already.
+    pub(crate) fn get_or_setup_callback(&self) -> GenericCallback<CacheStorageThreadResponse> {
+        if let Some(cb) = self.callback.borrow().as_ref() {
+            return cb.clone();
+        }
+
+        let global = self.global();
+        let response_listener = Trusted::new(self);
+
+        let task_source = global
+            .task_manager()
+            .dom_manipulation_task_source()
+            .to_sendable();
+        let callback = GenericCallback::new(move |message| {
+            let response_listener = response_listener.clone();
+            let response = match message {
+                Ok(inner) => Some(inner),
+                Err(err) => {
+                    error!("Error in Cache callback {:?}.", err);
+                    None
+                },
+            };
+            task_source.queue(task!(set_request_result_to_database: move |cx| {
+                let cache = response_listener.root();
+                cache.handle_response(cx, response)
+            }));
+        })
+        .expect("Could not create Cache callback");
+
+        *self.callback.borrow_mut() = Some(callback.clone());
+
+        callback
+    }
+
+    fn handle_response(&self, cx: &mut JSContext, response: Option<CacheStorageThreadResponse>) {
+        let response = match response {
+            Some(response) => response,
+            None => {
+                if self.pending_promises.borrow_mut().pop_front().is_none() {
+                    error!("No pending promise for Cache response.");
+                }
+                return;
+            },
+        };
+        match response {
+            // <https://w3c.github.io/ServiceWorker/#cache-keys>
+            CacheStorageThreadResponse::KeysResult(results) => {
+                // Step 5.4: Queue a task,
+                // on promise’s relevant settings object’s responsible event loop using the DOM manipulation task source,
+                // to perform the following steps:
+                // Note: we are inside the task.
+
+                // Step 5.4.1: Let requestList be a list.
+                let mut request_list: Vec<DomRoot<Request>> = Vec::new();
+
+                let Some(promise) = self.pending_promises.borrow_mut().pop_front() else {
+                    debug_assert!(false, "No pending promise for Cache KeysResult response.");
+                    return;
+                };
+
+                // Step 5.4.2: For each request of requests:
+                // Step 5.4.2.1: Add a new Request object associated with request
+                // and a new associated Headers object whose guard is "immutable" to requestList.
+                for url in results.unwrap_or_default() {
+                    let Ok(url) = ServoUrl::parse(&url) else {
+                        promise.reject_error(cx, Error::Type(c"Invalid URL".to_owned()));
+                        return;
+                    };
+                    let request = Request::new(cx, &self.global(), None, url);
+                    // TODO: associate request with a header.
+                    request_list.push(request);
+                }
+
+                // Step 5.4.3: Resolve promise with a frozen array created from requestList, in realm.
+                promise.resolve_native(cx, &request_list);
+            },
+            CacheStorageThreadResponse::HasCacheResult(_result) => debug_assert!(
+                false,
+                "Unexpected HasCacheResult response in Cache handle_response."
+            ),
+            CacheStorageThreadResponse::OpenCacheResult { .. } => debug_assert!(
+                false,
+                "Unexpected OpenCacheResult response in Cache handle_response."
+            ),
+        }
+    }
+}
+
+impl CacheMethods<crate::DomTypeHolder> for Cache {
+    /// <https://w3c.github.io/ServiceWorker/#dom-cache-keys>
+    fn Keys(
+        &self,
+        cx: &mut JSContext,
+        request: Option<RequestOrUSVString>,
+        options: &CacheQueryOptions,
+    ) -> Rc<Promise> {
+        // Step 1: Let r be null.
+        let mut r: Option<DomRoot<Request>> = None;
+
+        // Step 3: Let realm be this’s relevant realm.
+        // Note: the global is used as the realm; step re-ordered to make it available in Step 2.
+        let global = self.global();
+
+        // Step 4: Let promise be a new promise.
+        // Note: step re-ordered to make it available in Step 2.
+        let promise = Promise::new(cx, &global);
+
+        // Step 2: If the optional argument request is not omitted, then:
+        if let Some(request) = request {
+            // Step 2.1: If request is a Request object, then:
+            if let RequestOrUSVString::Request(request) = request {
+                // Step 2.1.1: Set r to request.
+                r = Some(request);
+            // Step 2.2: Else if request is a string, then:
+            } else if let RequestOrUSVString::USVString(request_string) = request {
+                // Step 2.2.1: Set r to the associated request of the result of
+                // invoking the initial value of Request as
+                // constructor with request as its argument.
+                let Ok(url) = ServoUrl::parse(&request_string) else {
+                    // If this throws an exception, return a promise rejected with that exception.
+                    // Note: only the url parse can error.
+                    promise.reject_error(cx, Error::Type(c"Invalid URL".to_owned()));
+                    return promise;
+                };
+                let request = Request::new(cx, &global, None, url);
+                r = Some(request);
+            }
+        }
+
+        // Step 5: Run these substeps in parallel:
+        let callback = self.get_or_setup_callback();
+        if global
+            .storage_threads()
+            .send(CacheStorageThreadMessage::Keys {
+                cache_name: self.name.to_string(),
+                callback,
+                origin: global.origin().immutable().clone(),
+            })
+            .is_err()
+        {
+            promise.reject_error(cx, Error::Operation(None));
+            return promise;
+        }
+
+        self.pending_promises
+            .borrow_mut()
+            .push_back(promise.clone());
+
+        promise
+    }
+}

--- a/components/script/dom/serviceworker/cache.rs
+++ b/components/script/dom/serviceworker/cache.rs
@@ -204,7 +204,10 @@ impl CacheMethods<crate::DomTypeHolder> for Cache {
             })
             .is_err()
         {
-            promise.reject_error(cx, Error::Operation(None));
+            promise.reject_error(
+                cx,
+                Error::Operation(Some("Could not run the parallel steps.".to_string())),
+            );
             return promise;
         }
 

--- a/components/script/dom/serviceworker/cachestorage.rs
+++ b/components/script/dom/serviceworker/cachestorage.rs
@@ -62,7 +62,7 @@ impl CacheStorage {
 
         let task_source = global
             .task_manager()
-            .database_access_task_source()
+            .dom_manipulation_task_source()
             .to_sendable();
         let callback = GenericCallback::new(move |message| {
             let response_listener = response_listener.clone();
@@ -129,6 +129,10 @@ impl CacheStorage {
                 let cache = Cache::new(cx, &self.global(), DOMString::from(cache_name));
                 promise.resolve_native(cx, &cache);
             },
+            CacheStorageThreadResponse::KeysResult(_) => debug_assert!(
+                false,
+                "Unexpected KeysResult response in CacheStorage handle_response."
+            ),
         }
     }
 }

--- a/components/script/dom/serviceworker/cachestorage.rs
+++ b/components/script/dom/serviceworker/cachestorage.rs
@@ -110,7 +110,7 @@ impl CacheStorage {
                         Error::Operation(Some(
                             result
                                 .err()
-                                .unwrap_or_else(|| format!("HasCacheResult error")),
+                                .unwrap_or_else(|| "HasCacheResult error".to_string()),
                         )),
                     );
                     return;
@@ -134,7 +134,7 @@ impl CacheStorage {
                         Error::Operation(Some(
                             result
                                 .err()
-                                .unwrap_or_else(|| format!("OpenCacheResult error")),
+                                .unwrap_or_else(|| "OpenCacheResult error".to_string()),
                         )),
                     );
                     return;
@@ -155,7 +155,7 @@ impl CacheStorage {
                         Error::Operation(Some(
                             result
                                 .err()
-                                .unwrap_or_else(|| format!("DeleteCacheResult error")),
+                                .unwrap_or_else(|| "DeleteCacheResult error".to_string()),
                         )),
                     );
                     return;

--- a/components/script/dom/serviceworker/cachestorage.rs
+++ b/components/script/dom/serviceworker/cachestorage.rs
@@ -96,9 +96,9 @@ impl CacheStorage {
             },
         };
         match response {
-            // https://w3c.github.io/ServiceWorker/#cache-storage-has
+            // <https://w3c.github.io/ServiceWorker/#cache-storage-has>
             // the steps resolving the promise with the result.
-            // Note: spec forgets to queue a task see https://github.com/w3c/ServiceWorker/issues/1831
+            // Note: spec forgets to queue a task see <https://github.com/w3c/ServiceWorker/issues/1831>
             CacheStorageThreadResponse::HasCacheResult(result) => {
                 let Some(promise) = self.pending_promises.borrow_mut().pop_front() else {
                     debug_assert!(false, "No pending promise for HasCacheResult response.");
@@ -114,7 +114,7 @@ impl CacheStorage {
                 // Note: promise resolved with the result obtained in parallel.
                 promise.resolve_native(cx, &has_cache);
             },
-            // https://w3c.github.io/ServiceWorker/#cache-storage-open
+            // <https://w3c.github.io/ServiceWorker/#cache-storage-open>
             // the steps resolving the promise with the result.
             CacheStorageThreadResponse::OpenCacheResult { opened, cache_name } => {
                 let Some(promise) = self.pending_promises.borrow_mut().pop_front() else {
@@ -128,6 +128,18 @@ impl CacheStorage {
                 // Resolve promise with a new Cache object that represents value.
                 let cache = Cache::new(cx, &self.global(), DOMString::from(cache_name));
                 promise.resolve_native(cx, &cache);
+            },
+            // <https://w3c.github.io/ServiceWorker/#dom-cachestorage-delete>
+            CacheStorageThreadResponse::DeleteCacheResult(result) => {
+                let Some(promise) = self.pending_promises.borrow_mut().pop_front() else {
+                    debug_assert!(false, "No pending promise for DeleteCacheResult response.");
+                    return;
+                };
+                let Ok(deleted) = result else {
+                    promise.reject_error(cx, Error::Operation(Some(result.err().unwrap())));
+                    return;
+                };
+                promise.resolve_native(cx, &deleted);
             },
             CacheStorageThreadResponse::KeysResult(_) => debug_assert!(
                 false,
@@ -237,6 +249,43 @@ impl CacheStorageMethods<crate::DomTypeHolder> for CacheStorage {
             .borrow_mut()
             .push_back(promise.clone());
 
+        // Step 3: Return promise.
+        promise
+    }
+
+    /// <https://w3c.github.io/ServiceWorker/#dom-cachestorage-delete>
+    fn Delete(&self, cx: &mut JSContext, cache_name: DOMString) -> Rc<Promise> {
+        // Step 1: Let promise be the result of running the algorithm specified in has(cacheName) method with cacheName.
+        // Step 2: Return the result of reacting to promise with a fulfillment handler that,
+        // when called with argument cacheExists, performs the following substeps:
+        // Step 2.1: If cacheExists is false, then
+        // Step 2.1.1: Return false.
+        // Note: we skip the promise, and will run the equivalent steps directly in the backend.
+
+        // Step 2.2: Let cacheJobPromise be a new promise.
+        let global = self.global();
+        let promise = Promise::new(cx, &global);
+
+        // Step 3: Run the following substeps in parallel:
+        let callback = self.get_or_setup_callback();
+        if global
+            .storage_threads()
+            .send(CacheStorageThreadMessage::DeleteCache {
+                cache_name: cache_name.to_string(),
+                callback,
+                origin: global.origin().immutable().clone(),
+            })
+            .is_err()
+        {
+            promise.reject_error(cx, Error::Operation(None));
+            return promise;
+        }
+
+        self.pending_promises
+            .borrow_mut()
+            .push_back(promise.clone());
+
+        // Step 4: Return cacheJobPromise.
         promise
     }
 }

--- a/components/script/dom/serviceworker/cachestorage.rs
+++ b/components/script/dom/serviceworker/cachestorage.rs
@@ -318,7 +318,7 @@ impl CacheStorageMethods<crate::DomTypeHolder> for CacheStorage {
                 cache_name: cache_name.to_string(),
                 callback,
                 proxy: proxy_map,
-                origin: origin,
+                origin,
             })
             .is_err()
         {

--- a/components/script/dom/serviceworker/cachestorage.rs
+++ b/components/script/dom/serviceworker/cachestorage.rs
@@ -189,10 +189,14 @@ fn relevant_name_to_cache_map(
         )
         .recv();
     let Ok(response) = message else {
-        return Err(Error::Operation(None));
+        return Err(Error::Operation(Some(
+            "Could not obtain a local storage bottle map.".to_string(),
+        )));
     };
     let Ok(proxy_map) = response else {
-        return Err(Error::Operation(None));
+        return Err(Error::Operation(Some(
+            "Could not obtain a local storage bottle map.".to_string(),
+        )));
     };
     Ok(proxy_map)
 }
@@ -225,7 +229,10 @@ impl CacheStorageMethods<crate::DomTypeHolder> for CacheStorage {
             })
             .is_err()
         {
-            promise.reject_error(cx, Error::Operation(None));
+            promise.reject_error(
+                cx,
+                Error::Operation(Some("Could not run the parallel steps.".to_string())),
+            );
             return promise;
         }
 
@@ -262,7 +269,10 @@ impl CacheStorageMethods<crate::DomTypeHolder> for CacheStorage {
             })
             .is_err()
         {
-            promise.reject_error(cx, Error::Operation(None));
+            promise.reject_error(
+                cx,
+                Error::Operation(Some("Could not run the parallel steps.".to_string())),
+            );
             return promise;
         }
 

--- a/components/script/dom/serviceworker/cachestorage.rs
+++ b/components/script/dom/serviceworker/cachestorage.rs
@@ -105,7 +105,14 @@ impl CacheStorage {
                     return;
                 };
                 let Ok(has_cache) = result else {
-                    promise.reject_error(cx, Error::Operation(Some(result.err().unwrap())));
+                    promise.reject_error(
+                        cx,
+                        Error::Operation(Some(
+                            result
+                                .err()
+                                .unwrap_or_else(|| format!("HasCacheResult error")),
+                        )),
+                    );
                     return;
                 };
                 // Step 2.1:For each key → value of the relevant name to cache map:
@@ -116,13 +123,20 @@ impl CacheStorage {
             },
             // <https://w3c.github.io/ServiceWorker/#cache-storage-open>
             // the steps resolving the promise with the result.
-            CacheStorageThreadResponse::OpenCacheResult { opened, cache_name } => {
+            CacheStorageThreadResponse::OpenCacheResult { result, cache_name } => {
                 let Some(promise) = self.pending_promises.borrow_mut().pop_front() else {
                     debug_assert!(false, "No pending promise for OpenCacheResult response.");
                     return;
                 };
-                let Ok(opened) = opened else {
-                    promise.reject_error(cx, Error::Operation(Some(opened.err().unwrap())));
+                if result.is_err() {
+                    promise.reject_error(
+                        cx,
+                        Error::Operation(Some(
+                            result
+                                .err()
+                                .unwrap_or_else(|| format!("OpenCacheResult error")),
+                        )),
+                    );
                     return;
                 };
                 // Resolve promise with a new Cache object that represents value.
@@ -136,7 +150,14 @@ impl CacheStorage {
                     return;
                 };
                 let Ok(deleted) = result else {
-                    promise.reject_error(cx, Error::Operation(Some(result.err().unwrap())));
+                    promise.reject_error(
+                        cx,
+                        Error::Operation(Some(
+                            result
+                                .err()
+                                .unwrap_or_else(|| format!("DeleteCacheResult error")),
+                        )),
+                    );
                     return;
                 };
                 promise.resolve_native(cx, &deleted);

--- a/components/script/dom/serviceworker/cachestorage.rs
+++ b/components/script/dom/serviceworker/cachestorage.rs
@@ -22,8 +22,9 @@ use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::serviceworker::cache::Cache;
 
-/// <https://w3c.github.io/ServiceWorker/#cachestorage-interface>
+/// <https://w3c.github.io/ServiceWorker/#cachestorage>
 #[dom_struct]
 pub(crate) struct CacheStorage {
     reflector_: Reflector,
@@ -115,6 +116,33 @@ impl CacheStorage {
                     error!("No pending promise for HasCacheResult response.");
                 }
             },
+            // https://w3c.github.io/ServiceWorker/#cache-storage-open
+            // the steps resolving the promise with the result.
+            CacheStorageThreadResponse::OpenCacheResult { opened, cache_name } => {
+                let promise = self.pending_promises.borrow_mut().pop_front();
+                if let Some(promise) = promise {
+                    match opened {
+                        Ok(opened) => {
+                            if opened {
+                                // Resolve promise with a new Cache object that represents value.
+                                let cache =
+                                    Cache::new(cx, &self.global(), DOMString::from(cache_name));
+                                promise.resolve_native(cx, &cache);
+                            } else {
+                                // reject promise with a QuotaExceededError and abort these steps.
+                                // Note: just a generic error for now, no quota checks exist storage side at this point.
+                                promise.reject_error(
+                                    cx,
+                                    Error::Operation(Some("Failed to open cache".to_string())),
+                                );
+                            }
+                        },
+                        Err(err) => promise.reject_error(cx, Error::Operation(Some(err))),
+                    }
+                } else {
+                    error!("No pending promise for OpenCacheResult response.");
+                }
+            },
         }
     }
 }
@@ -171,6 +199,43 @@ impl CacheStorageMethods<crate::DomTypeHolder> for CacheStorage {
                 callback,
                 proxy: proxy_map,
                 origin,
+            })
+            .is_err()
+        {
+            promise.reject_error(cx, Error::Operation(None));
+            return promise;
+        }
+
+        self.pending_promises
+            .borrow_mut()
+            .push_back(promise.clone());
+
+        promise
+    }
+
+    /// <https://w3c.github.io/ServiceWorker/#dom-cachestorage-open>
+    fn Open(&self, cx: &mut JSContext, cache_name: DOMString) -> Rc<Promise> {
+        // Step 1: Let promise be a new promise.
+        let global = self.global();
+        let promise = Promise::new(cx, &global);
+
+        // Step 2: Run the following substeps in parallel:
+        let callback = self.get_or_setup_callback();
+        let proxy_map =
+            match relevant_name_to_cache_map(&global, global.origin().immutable().clone()) {
+                Ok(proxy_map) => proxy_map,
+                Err(err) => {
+                    promise.reject_error(cx, err);
+                    return promise;
+                },
+            };
+        if global
+            .storage_threads()
+            .send(CacheStorageThreadMessage::OpenCache {
+                cache_name: cache_name.to_string(),
+                callback,
+                proxy: proxy_map,
+                origin: global.origin().immutable().clone(),
             })
             .is_err()
         {

--- a/components/script/dom/serviceworker/cachestorage.rs
+++ b/components/script/dom/serviceworker/cachestorage.rs
@@ -100,48 +100,34 @@ impl CacheStorage {
             // the steps resolving the promise with the result.
             // Note: spec forgets to queue a task see https://github.com/w3c/ServiceWorker/issues/1831
             CacheStorageThreadResponse::HasCacheResult(result) => {
-                let promise = self.pending_promises.borrow_mut().pop_front();
-                if let Some(promise) = promise {
-                    match result {
-                        Ok(has_cache) => {
-                            // Step 2.1:For each key → value of the relevant name to cache map:
-                            // Step 2.1.1: If cacheName matches key, resolve promise with true and abort these steps.
-                            // Step 2.2: Resolve promise with false.
-                            // Note: promise resolved with the result obtained in parallel.
-                            promise.resolve_native(cx, &has_cache);
-                        },
-                        Err(err) => promise.reject_error(cx, Error::Operation(Some(err))),
-                    }
-                } else {
-                    error!("No pending promise for HasCacheResult response.");
-                }
+                let Some(promise) = self.pending_promises.borrow_mut().pop_front() else {
+                    debug_assert!(false, "No pending promise for HasCacheResult response.");
+                    return;
+                };
+                let Ok(has_cache) = result else {
+                    promise.reject_error(cx, Error::Operation(Some(result.err().unwrap())));
+                    return;
+                };
+                // Step 2.1:For each key → value of the relevant name to cache map:
+                // Step 2.1.1: If cacheName matches key, resolve promise with true and abort these steps.
+                // Step 2.2: Resolve promise with false.
+                // Note: promise resolved with the result obtained in parallel.
+                promise.resolve_native(cx, &has_cache);
             },
             // https://w3c.github.io/ServiceWorker/#cache-storage-open
             // the steps resolving the promise with the result.
             CacheStorageThreadResponse::OpenCacheResult { opened, cache_name } => {
-                let promise = self.pending_promises.borrow_mut().pop_front();
-                if let Some(promise) = promise {
-                    match opened {
-                        Ok(opened) => {
-                            if opened {
-                                // Resolve promise with a new Cache object that represents value.
-                                let cache =
-                                    Cache::new(cx, &self.global(), DOMString::from(cache_name));
-                                promise.resolve_native(cx, &cache);
-                            } else {
-                                // reject promise with a QuotaExceededError and abort these steps.
-                                // Note: just a generic error for now, no quota checks exist storage side at this point.
-                                promise.reject_error(
-                                    cx,
-                                    Error::Operation(Some("Failed to open cache".to_string())),
-                                );
-                            }
-                        },
-                        Err(err) => promise.reject_error(cx, Error::Operation(Some(err))),
-                    }
-                } else {
-                    error!("No pending promise for OpenCacheResult response.");
-                }
+                let Some(promise) = self.pending_promises.borrow_mut().pop_front() else {
+                    debug_assert!(false, "No pending promise for OpenCacheResult response.");
+                    return;
+                };
+                let Ok(opened) = opened else {
+                    promise.reject_error(cx, Error::Operation(Some(opened.err().unwrap())));
+                    return;
+                };
+                // Resolve promise with a new Cache object that represents value.
+                let cache = Cache::new(cx, &self.global(), DOMString::from(cache_name));
+                promise.resolve_native(cx, &cache);
             },
         }
     }

--- a/components/script/dom/serviceworker/cachestorage.rs
+++ b/components/script/dom/serviceworker/cachestorage.rs
@@ -89,9 +89,14 @@ impl CacheStorage {
         let response = match response {
             Some(response) => response,
             None => {
-                if self.pending_promises.borrow_mut().pop_front().is_none() {
+                let Some(promise) = self.pending_promises.borrow_mut().pop_front() else {
                     error!("No pending promise for CacheStorage response.");
-                }
+                    return;
+                };
+                promise.reject_error(
+                    cx,
+                    Error::Operation(Some("No response from CacheStorage backend.".to_string())),
+                );
                 return;
             },
         };
@@ -251,21 +256,21 @@ impl CacheStorageMethods<crate::DomTypeHolder> for CacheStorage {
 
         // Step 2: Run the following substeps in parallel:
         let callback = self.get_or_setup_callback();
-        let proxy_map =
-            match relevant_name_to_cache_map(&global, global.origin().immutable().clone()) {
-                Ok(proxy_map) => proxy_map,
-                Err(err) => {
-                    promise.reject_error(cx, err);
-                    return promise;
-                },
-            };
+        let origin = global.origin().immutable().clone();
+        let proxy_map = match relevant_name_to_cache_map(&global, origin.clone()) {
+            Ok(proxy_map) => proxy_map,
+            Err(err) => {
+                promise.reject_error(cx, err);
+                return promise;
+            },
+        };
         if global
             .storage_threads()
             .send(CacheStorageThreadMessage::OpenCache {
                 cache_name: cache_name.to_string(),
                 callback,
                 proxy: proxy_map,
-                origin: global.origin().immutable().clone(),
+                origin,
             })
             .is_err()
         {
@@ -299,12 +304,21 @@ impl CacheStorageMethods<crate::DomTypeHolder> for CacheStorage {
 
         // Step 3: Run the following substeps in parallel:
         let callback = self.get_or_setup_callback();
+        let origin = global.origin().immutable().clone();
+        let proxy_map = match relevant_name_to_cache_map(&global, origin.clone()) {
+            Ok(proxy_map) => proxy_map,
+            Err(err) => {
+                promise.reject_error(cx, err);
+                return promise;
+            },
+        };
         if global
             .storage_threads()
             .send(CacheStorageThreadMessage::DeleteCache {
                 cache_name: cache_name.to_string(),
                 callback,
-                origin: global.origin().immutable().clone(),
+                proxy: proxy_map,
+                origin: origin,
             })
             .is_err()
         {

--- a/components/script/dom/serviceworker/cachestorage.rs
+++ b/components/script/dom/serviceworker/cachestorage.rs
@@ -298,7 +298,10 @@ impl CacheStorageMethods<crate::DomTypeHolder> for CacheStorage {
             })
             .is_err()
         {
-            promise.reject_error(cx, Error::Operation(None));
+            promise.reject_error(
+                cx,
+                Error::Operation(Some("Could not run the parallel steps.".to_string())),
+            );
             return promise;
         }
 

--- a/components/script/dom/serviceworker/mod.rs
+++ b/components/script/dom/serviceworker/mod.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 pub(crate) use self::serviceworker::*;
+pub(crate) mod cache;
 pub(crate) mod cachestorage;
 pub(crate) mod client;
 pub(crate) mod extendableevent;

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -98,7 +98,7 @@ DOMInterfaces = {
 },
 
 'CacheStorage': {
-    'cx': ['Has', 'Open'],
+    'cx': ['Has', 'Open', 'Delete'],
 },
 
 'Cache': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -98,7 +98,11 @@ DOMInterfaces = {
 },
 
 'CacheStorage': {
-    'cx': ['Has'],
+    'cx': ['Has', 'Open'],
+},
+
+'Cache': {
+    'cx': ['Keys'],
 },
 
 'CanvasRenderingContext2D': {

--- a/components/script_bindings/webidls/Cache.webidl
+++ b/components/script_bindings/webidls/Cache.webidl
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://w3c.github.io/ServiceWorker/#cache
+[Pref="dom_serviceworker_enabled", SecureContext, Exposed=(Window,Worker)]
+interface Cache {
+  // [NewObject] Promise<FrozenArray<Request>> keys(optional RequestInfo request, optional CacheQueryOptions options = {});
+  // Workaround until FrozenArray get implemented.
+  [NewObject] Promise<sequence<Request>> keys(optional RequestInfo request, optional CacheQueryOptions options = {});
+};
+
+dictionary CacheQueryOptions {
+  boolean ignoreSearch = false;
+  boolean ignoreMethod = false;
+  boolean ignoreVary = false;
+};

--- a/components/script_bindings/webidls/CacheStorage.webidl
+++ b/components/script_bindings/webidls/CacheStorage.webidl
@@ -6,4 +6,5 @@
 [Pref="dom_serviceworker_enabled", SecureContext, Exposed=(Window,Worker)]
 interface CacheStorage {
   [NewObject] Promise<boolean> has(DOMString cacheName);
+  [NewObject] Promise<Cache> open(DOMString cacheName);
 };

--- a/components/script_bindings/webidls/CacheStorage.webidl
+++ b/components/script_bindings/webidls/CacheStorage.webidl
@@ -7,4 +7,5 @@
 interface CacheStorage {
   [NewObject] Promise<boolean> has(DOMString cacheName);
   [NewObject] Promise<Cache> open(DOMString cacheName);
+  [NewObject] Promise<boolean> delete(DOMString cacheName);
 };

--- a/components/shared/storage/Cargo.toml
+++ b/components/shared/storage/Cargo.toml
@@ -21,4 +21,3 @@ serde = { workspace = true }
 servo-base = { workspace = true }
 servo-url = { workspace = true }
 uuid = { workspace = true, features = ["serde"] }
-net_traits = { workspace = true }

--- a/components/shared/storage/Cargo.toml
+++ b/components/shared/storage/Cargo.toml
@@ -21,3 +21,4 @@ serde = { workspace = true }
 servo-base = { workspace = true }
 servo-url = { workspace = true }
 uuid = { workspace = true, features = ["serde"] }
+net_traits = { workspace = true }

--- a/components/shared/storage/cache_storage.rs
+++ b/components/shared/storage/cache_storage.rs
@@ -62,10 +62,21 @@ pub enum CacheStorageThreadMessage {
         proxy: StorageProxyMap,
         origin: ImmutableOrigin,
     },
+    /// <https://w3c.github.io/ServiceWorker/#cache-storage-open>
+    OpenCache {
+        cache_name: String,
+        callback: GenericCallback<CacheStorageThreadResponse>,
+        proxy: StorageProxyMap,
+        origin: ImmutableOrigin,
+    },
     Exit(GenericSender<()>),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum CacheStorageThreadResponse {
     HasCacheResult(Result<bool, String>),
+    OpenCacheResult {
+        opened: Result<bool, String>,
+        cache_name: String,
+    },
 }

--- a/components/shared/storage/cache_storage.rs
+++ b/components/shared/storage/cache_storage.rs
@@ -5,6 +5,7 @@
 use std::ops::{Deref, DerefMut};
 
 use malloc_size_of_derive::MallocSizeOf;
+use net_traits::request::Request;
 use serde::{Deserialize, Serialize};
 use servo_base::generic_channel::{GenericCallback, GenericSender};
 use servo_url::ImmutableOrigin;
@@ -69,6 +70,12 @@ pub enum CacheStorageThreadMessage {
         proxy: StorageProxyMap,
         origin: ImmutableOrigin,
     },
+    /// <https://w3c.github.io/ServiceWorker/#cache-keys>
+    Keys {
+        cache_name: String,
+        callback: GenericCallback<CacheStorageThreadResponse>,
+        origin: ImmutableOrigin,
+    },
     Exit(GenericSender<()>),
 }
 
@@ -79,4 +86,5 @@ pub enum CacheStorageThreadResponse {
         opened: Result<bool, String>,
         cache_name: String,
     },
+    KeysResult(Result<Vec<String>, String>),
 }

--- a/components/shared/storage/cache_storage.rs
+++ b/components/shared/storage/cache_storage.rs
@@ -5,7 +5,6 @@
 use std::ops::{Deref, DerefMut};
 
 use malloc_size_of_derive::MallocSizeOf;
-use net_traits::request::Request;
 use serde::{Deserialize, Serialize};
 use servo_base::generic_channel::{GenericCallback, GenericSender};
 use servo_url::ImmutableOrigin;
@@ -88,7 +87,7 @@ pub enum CacheStorageThreadMessage {
 pub enum CacheStorageThreadResponse {
     HasCacheResult(Result<bool, String>),
     OpenCacheResult {
-        opened: Result<bool, String>,
+        result: Result<(), String>,
         cache_name: String,
     },
     KeysResult(Result<Vec<String>, String>),

--- a/components/shared/storage/cache_storage.rs
+++ b/components/shared/storage/cache_storage.rs
@@ -76,6 +76,11 @@ pub enum CacheStorageThreadMessage {
         callback: GenericCallback<CacheStorageThreadResponse>,
         origin: ImmutableOrigin,
     },
+    DeleteCache {
+        cache_name: String,
+        callback: GenericCallback<CacheStorageThreadResponse>,
+        origin: ImmutableOrigin,
+    },
     Exit(GenericSender<()>),
 }
 
@@ -87,4 +92,5 @@ pub enum CacheStorageThreadResponse {
         cache_name: String,
     },
     KeysResult(Result<Vec<String>, String>),
+    DeleteCacheResult(Result<bool, String>),
 }

--- a/components/shared/storage/cache_storage.rs
+++ b/components/shared/storage/cache_storage.rs
@@ -78,6 +78,7 @@ pub enum CacheStorageThreadMessage {
     DeleteCache {
         cache_name: String,
         callback: GenericCallback<CacheStorageThreadResponse>,
+        proxy: StorageProxyMap,
         origin: ImmutableOrigin,
     },
     Exit(GenericSender<()>),

--- a/components/storage/cache_storage.rs
+++ b/components/storage/cache_storage.rs
@@ -53,13 +53,12 @@ impl CacheStorageEngine for MemCacheStorageEngine {
 
     /// <https://w3c.github.io/ServiceWorker/#cache-storage-has>
     /// The parallel steps.
-    fn has_cache(&mut self, _cache_name: &str) -> Result<bool, CacheStorageError<Self::Error>> {
-        // TODO: implement.
+    fn has_cache(&mut self, cache_name: &str) -> Result<bool, CacheStorageError<Self::Error>> {
         // Step 2.1:For each key → value of the relevant name to cache map:
         // Step 2.1.1: If cacheName matches key, resolve promise with true and abort these steps.
         // Step 2.2: Resolve promise with false.
         // Note: promise resolved in the callback in CacheStorage.
-        Ok(false)
+        Ok(self.name_to_cache_map.contains_key(cache_name))
     }
 
     /// <https://w3c.github.io/ServiceWorker/#cache-storage-open>

--- a/components/storage/cache_storage.rs
+++ b/components/storage/cache_storage.rs
@@ -140,7 +140,7 @@ impl CacheStorageEngine for MemCacheStorageEngine {
         // Step 5.2.1: For each requestResponse of the relevant request response list:
         let Some(relevant_cache) = self
             .name_to_cache_map
-            .get(&(origin.clone(), cache_name.to_string()))
+            .get(&(origin, cache_name.to_string()))
         else {
             return Err(CacheStorageError::Internal(()));
         };

--- a/components/storage/cache_storage.rs
+++ b/components/storage/cache_storage.rs
@@ -29,6 +29,9 @@ trait CacheStorageEngine {
         cache_name: String,
         proxy_map: &StorageProxyMap,
     ) -> Result<bool, CacheStorageError<Self::Error>>;
+
+    /// <https://w3c.github.io/ServiceWorker/#cache-keys>
+    fn keys(&mut self, cache_name: &str) -> Result<Vec<String>, CacheStorageError<Self::Error>>;
 }
 
 /// <https://w3c.github.io/ServiceWorker/#dfn-request-response-list>
@@ -95,6 +98,28 @@ impl CacheStorageEngine for MemCacheStorageEngine {
         // Step 2.4: Resolve promise with a new Cache object that represents cache.
         // Note: promise resolved in script.
         Ok(true)
+    }
+
+    /// <https://w3c.github.io/ServiceWorker/#cache-keys>
+    /// The parallel steps.
+    fn keys(&mut self, cache_name: &str) -> Result<Vec<String>, CacheStorageError<Self::Error>> {
+        // Step 5.1: Let requests be an empty list.
+        let mut requests: Vec<String> = Vec::new();
+
+        // Step 5.2: If the optional argument request is omitted, then:
+        // Step 5.2.1: For each requestResponse of the relevant request response list:
+        let Some(relevant_cache) = self.name_to_cache_map.get(cache_name) else {
+            return Err(CacheStorageError::Internal(()));
+        };
+        // Step 5.2.2: Add requestResponse’s request to requests.
+        for (request, _response) in &relevant_cache.list {
+            requests.push(request.url().to_string());
+        }
+
+        // Step 5.3: Else:
+        // Note: implementing this steps depends on Query Cache; todo.
+
+        Ok(requests)
     }
 }
 
@@ -198,6 +223,21 @@ where
                         .is_err()
                     {
                         error!("Failed to send response to script for OpenCache message.");
+                    }
+                },
+                CacheStorageThreadMessage::Keys {
+                    cache_name,
+                    callback,
+                    origin: _,
+                } => {
+                    let result = self.engine.keys(&cache_name);
+                    if callback
+                        .send(CacheStorageThreadResponse::KeysResult(
+                            result.map_err(|e| format!("{:?}", e)),
+                        ))
+                        .is_err()
+                    {
+                        error!("Failed to send response to script for Keys message.");
                     }
                 },
                 CacheStorageThreadMessage::Exit(sender) => {

--- a/components/storage/cache_storage.rs
+++ b/components/storage/cache_storage.rs
@@ -5,6 +5,10 @@
 use std::fmt::Debug;
 use std::path::PathBuf;
 use std::thread;
+use std::collections::HashMap;
+
+use net_traits::request::Request;
+use net_traits::response::Response;
 
 use log::error;
 use servo_base::generic_channel::{self, GenericReceiver, GenericSender};
@@ -20,9 +24,19 @@ trait CacheStorageEngine {
     fn has_cache(&mut self, cache_name: &str) -> Result<bool, CacheStorageError<Self::Error>>;
 }
 
-pub struct DummyCacheStorageEngine;
+/// <https://w3c.github.io/ServiceWorker/#dfn-request-response-list>
+pub struct RequestResponseList {
+    /// A list of tuples consisting of a request (a request) and a response (a response)
+    pub list: Vec<(Request, Response)>,
+}
 
-impl CacheStorageEngine for DummyCacheStorageEngine {
+pub struct MemCacheStorageEngine {
+
+    /// <https://w3c.github.io/ServiceWorker/#dfn-name-to-cache-map>
+    name_to_cache_map: HashMap<String, RequestResponseList>,
+}
+
+impl CacheStorageEngine for MemCacheStorageEngine {
     type Error = ();
 
     /// <https://w3c.github.io/ServiceWorker/#cache-storage-has>
@@ -67,8 +81,15 @@ impl CacheStorageThreadFactory for CacheStorageThreadHandle {
             .spawn(move || {
                 // Keep temp_dir alive while the thread runs.
                 let _ = temp_dir;
-                let engine = DummyCacheStorageEngine;
-                CacheStorageThread::new(sender_clone, generic_receiver, engine).start();
+                let engine = MemCacheStorageEngine {
+                    name_to_cache_map: Default::default(),
+                };
+                let mut cache_storage_thread = CacheStorageThread::new(
+                    sender_clone,
+                    generic_receiver,
+                    engine,
+                );
+                cache_storage_thread.start();
             })
             .expect("Thread spawning failed");
 

--- a/components/storage/cache_storage.rs
+++ b/components/storage/cache_storage.rs
@@ -2,26 +2,33 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::path::PathBuf;
 use std::thread;
-use std::collections::HashMap;
-
-use net_traits::request::Request;
-use net_traits::response::Response;
 
 use log::error;
+use net_traits::request::Request;
+use net_traits::response::Response;
 use servo_base::generic_channel::{self, GenericReceiver, GenericSender};
 use storage_traits::cache_storage::{
     CacheStorageError, CacheStorageThreadHandle, CacheStorageThreadMessage,
     CacheStorageThreadResponse,
 };
+use storage_traits::client_storage::StorageProxyMap;
 
 trait CacheStorageEngine {
     type Error: Debug;
 
     /// <https://w3c.github.io/ServiceWorker/#cache-storage-has>
     fn has_cache(&mut self, cache_name: &str) -> Result<bool, CacheStorageError<Self::Error>>;
+
+    /// <https://w3c.github.io/ServiceWorker/#cache-storage-open>
+    fn open_cache(
+        &mut self,
+        cache_name: String,
+        proxy_map: &StorageProxyMap,
+    ) -> Result<bool, CacheStorageError<Self::Error>>;
 }
 
 /// <https://w3c.github.io/ServiceWorker/#dfn-request-response-list>
@@ -31,7 +38,6 @@ pub struct RequestResponseList {
 }
 
 pub struct MemCacheStorageEngine {
-
     /// <https://w3c.github.io/ServiceWorker/#dfn-name-to-cache-map>
     name_to_cache_map: HashMap<String, RequestResponseList>,
 }
@@ -48,6 +54,47 @@ impl CacheStorageEngine for MemCacheStorageEngine {
         // Step 2.2: Resolve promise with false.
         // Note: promise resolved in the callback in CacheStorage.
         Ok(false)
+    }
+
+    /// <https://w3c.github.io/ServiceWorker/#cache-storage-open>
+    /// The parallel steps.
+    fn open_cache(
+        &mut self,
+        cache_name: String,
+        proxy_map: &StorageProxyMap,
+    ) -> Result<bool, CacheStorageError<Self::Error>> {
+        // Step 2.1: For each key → value of the relevant name to cache map:
+        for key in self.name_to_cache_map.keys() {
+            if key == &cache_name {
+                // Step 2.1.1: If cacheName matches key, then:
+                // Resolve promise with a new Cache object that represents value.
+                // Note: promise resolved in script.
+
+                // Step 2.1.2: Abort these steps.
+                return Ok(true);
+            }
+        }
+
+        // Step 2.2: Let cache be a new request response list.
+        let cache = RequestResponseList { list: Vec::new() };
+
+        // Step 2.3: Set the relevant name to cache map[cacheName] to cache.
+        // If this cache write operation failed due to exceeding the granted quota limit,
+        // reject promise with a QuotaExceededError and abort these steps.
+        // Note: there are no quota checks storage side at this point.
+        if proxy_map
+            .handle
+            .create_database(proxy_map.bottle_id, cache_name.clone())
+            .recv()
+            .is_err()
+        {
+            return Err(CacheStorageError::Internal(()));
+        };
+        self.name_to_cache_map.insert(cache_name.to_string(), cache);
+
+        // Step 2.4: Resolve promise with a new Cache object that represents cache.
+        // Note: promise resolved in script.
+        Ok(true)
     }
 }
 
@@ -84,11 +131,8 @@ impl CacheStorageThreadFactory for CacheStorageThreadHandle {
                 let engine = MemCacheStorageEngine {
                     name_to_cache_map: Default::default(),
                 };
-                let mut cache_storage_thread = CacheStorageThread::new(
-                    sender_clone,
-                    generic_receiver,
-                    engine,
-                );
+                let mut cache_storage_thread =
+                    CacheStorageThread::new(sender_clone, generic_receiver, engine);
                 cache_storage_thread.start();
             })
             .expect("Thread spawning failed");
@@ -137,6 +181,23 @@ where
                         .is_err()
                     {
                         error!("Failed to send response to script for HasCache message.");
+                    }
+                },
+                CacheStorageThreadMessage::OpenCache {
+                    cache_name,
+                    callback,
+                    proxy,
+                    origin: _,
+                } => {
+                    let result = self.engine.open_cache(cache_name.clone(), &proxy);
+                    if callback
+                        .send(CacheStorageThreadResponse::OpenCacheResult {
+                            opened: result.map(|_| false).map_err(|e| format!("{:?}", e)),
+                            cache_name,
+                        })
+                        .is_err()
+                    {
+                        error!("Failed to send response to script for OpenCache message.");
                     }
                 },
                 CacheStorageThreadMessage::Exit(sender) => {

--- a/components/storage/cache_storage.rs
+++ b/components/storage/cache_storage.rs
@@ -11,6 +11,7 @@ use log::error;
 use net_traits::request::Request;
 use net_traits::response::Response;
 use servo_base::generic_channel::{self, GenericReceiver, GenericSender};
+use servo_url::ImmutableOrigin;
 use storage_traits::cache_storage::{
     CacheStorageError, CacheStorageThreadHandle, CacheStorageThreadMessage,
     CacheStorageThreadResponse,
@@ -21,20 +22,34 @@ trait CacheStorageEngine {
     type Error: Debug;
 
     /// <https://w3c.github.io/ServiceWorker/#cache-storage-has>
-    fn has_cache(&mut self, cache_name: &str) -> Result<bool, CacheStorageError<Self::Error>>;
+    fn has_cache(
+        &mut self,
+        origin: ImmutableOrigin,
+        cache_name: &str,
+    ) -> Result<bool, CacheStorageError<Self::Error>>;
 
     /// <https://w3c.github.io/ServiceWorker/#cache-storage-open>
     fn open_cache(
         &mut self,
+        origin: ImmutableOrigin,
         cache_name: String,
         proxy_map: &StorageProxyMap,
     ) -> Result<(), CacheStorageError<Self::Error>>;
 
     /// <https://w3c.github.io/ServiceWorker/#cache-keys>
-    fn keys(&mut self, cache_name: &str) -> Result<Vec<String>, CacheStorageError<Self::Error>>;
+    fn keys(
+        &mut self,
+        origin: ImmutableOrigin,
+        cache_name: &str,
+    ) -> Result<Vec<String>, CacheStorageError<Self::Error>>;
 
     /// <https://w3c.github.io/ServiceWorker/#dom-cachestorage-delete>
-    fn delete_cache(&mut self, cache_name: &str) -> Result<bool, CacheStorageError<Self::Error>>;
+    fn delete_cache(
+        &mut self,
+        origin: ImmutableOrigin,
+        cache_name: &str,
+        proxy_map: &StorageProxyMap,
+    ) -> Result<bool, CacheStorageError<Self::Error>>;
 }
 
 /// <https://w3c.github.io/ServiceWorker/#dfn-request-response-list>
@@ -45,7 +60,7 @@ pub struct RequestResponseList {
 
 pub struct MemCacheStorageEngine {
     /// <https://w3c.github.io/ServiceWorker/#dfn-name-to-cache-map>
-    name_to_cache_map: HashMap<String, RequestResponseList>,
+    name_to_cache_map: HashMap<(ImmutableOrigin, String), RequestResponseList>,
 }
 
 impl CacheStorageEngine for MemCacheStorageEngine {
@@ -53,31 +68,38 @@ impl CacheStorageEngine for MemCacheStorageEngine {
 
     /// <https://w3c.github.io/ServiceWorker/#cache-storage-has>
     /// The parallel steps.
-    fn has_cache(&mut self, cache_name: &str) -> Result<bool, CacheStorageError<Self::Error>> {
+    fn has_cache(
+        &mut self,
+        origin: ImmutableOrigin,
+        cache_name: &str,
+    ) -> Result<bool, CacheStorageError<Self::Error>> {
         // Step 2.1:For each key → value of the relevant name to cache map:
         // Step 2.1.1: If cacheName matches key, resolve promise with true and abort these steps.
         // Step 2.2: Resolve promise with false.
         // Note: promise resolved in the callback in CacheStorage.
-        Ok(self.name_to_cache_map.contains_key(cache_name))
+        Ok(self
+            .name_to_cache_map
+            .contains_key(&(origin, cache_name.to_string())))
     }
 
     /// <https://w3c.github.io/ServiceWorker/#cache-storage-open>
     /// The parallel steps.
     fn open_cache(
         &mut self,
+        origin: ImmutableOrigin,
         cache_name: String,
         proxy_map: &StorageProxyMap,
     ) -> Result<(), CacheStorageError<Self::Error>> {
         // Step 2.1: For each key → value of the relevant name to cache map:
-        for key in self.name_to_cache_map.keys() {
-            if key == &cache_name {
-                // Step 2.1.1: If cacheName matches key, then:
-                // Resolve promise with a new Cache object that represents value.
-                // Note: promise resolved in script.
-
-                // Step 2.1.2: Abort these steps.
-                return Ok(());
-            }
+        // Step 2.1.1: If cacheName matches key, then:
+        // Resolve promise with a new Cache object that represents value.
+        // Note: promise resolved in script.
+        if self
+            .name_to_cache_map
+            .contains_key(&(origin.clone(), cache_name.clone()))
+        {
+            // Step 2.1.2: Abort these steps.
+            return Ok(());
         }
 
         // Step 2.2: Let cache be a new request response list.
@@ -87,15 +109,17 @@ impl CacheStorageEngine for MemCacheStorageEngine {
         // If this cache write operation failed due to exceeding the granted quota limit,
         // reject promise with a QuotaExceededError and abort these steps.
         // Note: there are no quota checks storage side at this point.
-        if proxy_map
+        let Ok(response) = proxy_map
             .handle
             .create_database(proxy_map.bottle_id, cache_name.clone())
             .recv()
-            .is_err()
-        {
+        else {
             return Err(CacheStorageError::Internal(()));
         };
-        self.name_to_cache_map.insert(cache_name, cache);
+        if response.is_err() {
+            return Err(CacheStorageError::Internal(()));
+        }
+        self.name_to_cache_map.insert((origin, cache_name), cache);
 
         // Step 2.4: Resolve promise with a new Cache object that represents cache.
         // Note: promise resolved in script.
@@ -104,13 +128,20 @@ impl CacheStorageEngine for MemCacheStorageEngine {
 
     /// <https://w3c.github.io/ServiceWorker/#cache-keys>
     /// The parallel steps.
-    fn keys(&mut self, cache_name: &str) -> Result<Vec<String>, CacheStorageError<Self::Error>> {
+    fn keys(
+        &mut self,
+        origin: ImmutableOrigin,
+        cache_name: &str,
+    ) -> Result<Vec<String>, CacheStorageError<Self::Error>> {
         // Step 5.1: Let requests be an empty list.
         let mut requests: Vec<String> = Vec::new();
 
         // Step 5.2: If the optional argument request is omitted, then:
         // Step 5.2.1: For each requestResponse of the relevant request response list:
-        let Some(relevant_cache) = self.name_to_cache_map.get(cache_name) else {
+        let Some(relevant_cache) = self
+            .name_to_cache_map
+            .get(&(origin.clone(), cache_name.to_string()))
+        else {
             return Err(CacheStorageError::Internal(()));
         };
         // Step 5.2.2: Add requestResponse’s request to requests.
@@ -126,7 +157,12 @@ impl CacheStorageEngine for MemCacheStorageEngine {
 
     /// <https://w3c.github.io/ServiceWorker/#dom-cachestorage-delete>
     /// The "running the algorithm specified in has" part, and the parallel steps.
-    fn delete_cache(&mut self, cache_name: &str) -> Result<bool, CacheStorageError<Self::Error>> {
+    fn delete_cache(
+        &mut self,
+        origin: ImmutableOrigin,
+        cache_name: &str,
+        proxy: &StorageProxyMap,
+    ) -> Result<bool, CacheStorageError<Self::Error>> {
         // Step 1: Let promise be the result of running the algorithm specified in has(cacheName) method with cacheName.
         // Step 2: Return the result of reacting to promise with a fulfillment handler that,
         // when called with argument cacheExists,
@@ -139,7 +175,23 @@ impl CacheStorageEngine for MemCacheStorageEngine {
 
         // Step 2.3: Run the following substeps in parallel:
         // Step 2.3.1: Remove the relevant name to cache map[cacheName].
-        let has = self.name_to_cache_map.remove(cache_name).is_some();
+        let has = self
+            .name_to_cache_map
+            .remove(&(origin, cache_name.to_string()))
+            .is_some();
+
+        if has {
+            let Ok(response) = proxy
+                .handle
+                .delete_database(proxy.bottle_id, cache_name.to_string())
+                .recv()
+            else {
+                return Err(CacheStorageError::Internal(()));
+            };
+            if response.is_err() {
+                return Err(CacheStorageError::Internal(()));
+            }
+        }
 
         // Step 2.3.2: Resolve promise with true.
         // Note: promise resolved in script.
@@ -220,12 +272,12 @@ where
                     cache_name,
                     callback,
                     proxy: _,
-                    origin: _,
+                    origin,
                 } => {
-                    let result = self.engine.has_cache(&cache_name);
+                    let result = self.engine.has_cache(origin.clone(), &cache_name);
                     if callback
                         .send(CacheStorageThreadResponse::HasCacheResult(
-                            result.map(|_| false).map_err(|e| format!("{:?}", e)),
+                            result.map_err(|e| format!("{:?}", e)),
                         ))
                         .is_err()
                     {
@@ -236,12 +288,14 @@ where
                     cache_name,
                     callback,
                     proxy,
-                    origin: _,
+                    origin,
                 } => {
-                    let result = self.engine.open_cache(cache_name.clone(), &proxy);
+                    let result = self
+                        .engine
+                        .open_cache(origin.clone(), cache_name.clone(), &proxy);
                     if callback
                         .send(CacheStorageThreadResponse::OpenCacheResult {
-                            result: result.map(|_| ()).map_err(|e| format!("{:?}", e)),
+                            result: result.map_err(|e| format!("{:?}", e)),
                             cache_name,
                         })
                         .is_err()
@@ -252,9 +306,9 @@ where
                 CacheStorageThreadMessage::Keys {
                     cache_name,
                     callback,
-                    origin: _,
+                    origin,
                 } => {
-                    let result = self.engine.keys(&cache_name);
+                    let result = self.engine.keys(origin.clone(), &cache_name);
                     if callback
                         .send(CacheStorageThreadResponse::KeysResult(
                             result.map_err(|e| format!("{:?}", e)),
@@ -267,12 +321,15 @@ where
                 CacheStorageThreadMessage::DeleteCache {
                     cache_name,
                     callback,
-                    origin: _,
+                    proxy,
+                    origin,
                 } => {
-                    let result = self.engine.delete_cache(&cache_name);
+                    let result = self
+                        .engine
+                        .delete_cache(origin.clone(), &cache_name, &proxy);
                     if callback
                         .send(CacheStorageThreadResponse::DeleteCacheResult(
-                            result.map(|_| false).map_err(|e| format!("{:?}", e)),
+                            result.map_err(|e| format!("{:?}", e)),
                         ))
                         .is_err()
                     {

--- a/components/storage/cache_storage.rs
+++ b/components/storage/cache_storage.rs
@@ -32,6 +32,9 @@ trait CacheStorageEngine {
 
     /// <https://w3c.github.io/ServiceWorker/#cache-keys>
     fn keys(&mut self, cache_name: &str) -> Result<Vec<String>, CacheStorageError<Self::Error>>;
+
+    /// <https://w3c.github.io/ServiceWorker/#dom-cachestorage-delete>
+    fn delete_cache(&mut self, cache_name: &str) -> Result<bool, CacheStorageError<Self::Error>>;
 }
 
 /// <https://w3c.github.io/ServiceWorker/#dfn-request-response-list>
@@ -120,6 +123,28 @@ impl CacheStorageEngine for MemCacheStorageEngine {
         // Note: implementing this steps depends on Query Cache; todo.
 
         Ok(requests)
+    }
+
+    /// <https://w3c.github.io/ServiceWorker/#dom-cachestorage-delete>
+    /// The "running the algorithm specified in has" part, and the parallel steps.
+    fn delete_cache(&mut self, cache_name: &str) -> Result<bool, CacheStorageError<Self::Error>> {
+        // Step 1: Let promise be the result of running the algorithm specified in has(cacheName) method with cacheName.
+        // Step 2: Return the result of reacting to promise with a fulfillment handler that,
+        // when called with argument cacheExists, 
+        // performs the following substeps:
+        // Note: skipping th promise here.
+
+        // Step 2.1: If cacheExists is false, then:
+        // Step 2.1.1: Resolve promise with false.
+        // Note: done below using return value from `is_some`.
+
+        // Step 2.3: Run the following substeps in parallel:
+        // Step 2.3.1: Remove the relevant name to cache map[cacheName].
+        let has = self.name_to_cache_map.remove(cache_name).is_some();
+
+        // Step 2.3.2: Resolve promise with true.
+        // Note: promise resolved in script.
+        Ok(has)
     }
 }
 
@@ -238,6 +263,21 @@ where
                         .is_err()
                     {
                         error!("Failed to send response to script for Keys message.");
+                    }
+                },
+                CacheStorageThreadMessage::DeleteCache {
+                    cache_name,
+                    callback,
+                    origin: _,
+                } => {
+                    let result = self.engine.delete_cache(&cache_name);
+                    if callback
+                        .send(CacheStorageThreadResponse::DeleteCacheResult(
+                            result.map(|_| false).map_err(|e| format!("{:?}", e)),
+                        ))
+                        .is_err()
+                    {
+                        error!("Failed to send response to script for DeleteCache message.");
                     }
                 },
                 CacheStorageThreadMessage::Exit(sender) => {

--- a/components/storage/cache_storage.rs
+++ b/components/storage/cache_storage.rs
@@ -96,7 +96,7 @@ impl CacheStorageEngine for MemCacheStorageEngine {
         {
             return Err(CacheStorageError::Internal(()));
         };
-        self.name_to_cache_map.insert(cache_name.to_string(), cache);
+        self.name_to_cache_map.insert(cache_name, cache);
 
         // Step 2.4: Resolve promise with a new Cache object that represents cache.
         // Note: promise resolved in script.

--- a/components/storage/cache_storage.rs
+++ b/components/storage/cache_storage.rs
@@ -28,7 +28,7 @@ trait CacheStorageEngine {
         &mut self,
         cache_name: String,
         proxy_map: &StorageProxyMap,
-    ) -> Result<bool, CacheStorageError<Self::Error>>;
+    ) -> Result<(), CacheStorageError<Self::Error>>;
 
     /// <https://w3c.github.io/ServiceWorker/#cache-keys>
     fn keys(&mut self, cache_name: &str) -> Result<Vec<String>, CacheStorageError<Self::Error>>;
@@ -68,7 +68,7 @@ impl CacheStorageEngine for MemCacheStorageEngine {
         &mut self,
         cache_name: String,
         proxy_map: &StorageProxyMap,
-    ) -> Result<bool, CacheStorageError<Self::Error>> {
+    ) -> Result<(), CacheStorageError<Self::Error>> {
         // Step 2.1: For each key → value of the relevant name to cache map:
         for key in self.name_to_cache_map.keys() {
             if key == &cache_name {
@@ -77,7 +77,7 @@ impl CacheStorageEngine for MemCacheStorageEngine {
                 // Note: promise resolved in script.
 
                 // Step 2.1.2: Abort these steps.
-                return Ok(true);
+                return Ok(());
             }
         }
 
@@ -100,7 +100,7 @@ impl CacheStorageEngine for MemCacheStorageEngine {
 
         // Step 2.4: Resolve promise with a new Cache object that represents cache.
         // Note: promise resolved in script.
-        Ok(true)
+        Ok(())
     }
 
     /// <https://w3c.github.io/ServiceWorker/#cache-keys>
@@ -130,7 +130,7 @@ impl CacheStorageEngine for MemCacheStorageEngine {
     fn delete_cache(&mut self, cache_name: &str) -> Result<bool, CacheStorageError<Self::Error>> {
         // Step 1: Let promise be the result of running the algorithm specified in has(cacheName) method with cacheName.
         // Step 2: Return the result of reacting to promise with a fulfillment handler that,
-        // when called with argument cacheExists, 
+        // when called with argument cacheExists,
         // performs the following substeps:
         // Note: skipping th promise here.
 
@@ -242,7 +242,7 @@ where
                     let result = self.engine.open_cache(cache_name.clone(), &proxy);
                     if callback
                         .send(CacheStorageThreadResponse::OpenCacheResult {
-                            opened: result.map(|_| false).map_err(|e| format!("{:?}", e)),
+                            result: result.map(|_| ()).map_err(|e| format!("{:?}", e)),
                             cache_name,
                         })
                         .is_err()

--- a/python/tidy/error_message_exceptions.txt
+++ b/python/tidy/error_message_exceptions.txt
@@ -77,7 +77,6 @@
 ./components/script/dom/performance/performanceobserver.rs 4
 ./components/script/dom/range/range.rs 20
 ./components/script/dom/selection.rs 14
-./components/script/dom/serviceworker/cachestorage.rs 3
 ./components/script/dom/serviceworker/extendableevent.rs 1
 ./components/script/dom/serviceworker/serviceworker.rs 1
 ./components/script/dom/serviceworker/serviceworkercontainer.rs 2

--- a/tests/wpt/meta/service-workers/cache-storage/cache-abort.https.any.js.ini
+++ b/tests/wpt/meta/service-workers/cache-storage/cache-abort.https.any.js.ini
@@ -1,22 +1,16 @@
 [cache-abort.https.any.html]
   expected: ERROR
-  [put() on an already-aborted request should reject with AbortError]
+  [put() followed by abort after headers received should reject with AbortError]
     expected: FAIL
 
-  [put() synchronously followed by abort should reject with AbortError]
-    expected: NOTRUN
-
-  [put() followed by abort after headers received should reject with AbortError]
-    expected: NOTRUN
-
   [add() on an already-aborted request should reject with AbortError]
-    expected: NOTRUN
+    expected: FAIL
 
   [add() synchronously followed by abort should reject with AbortError]
-    expected: NOTRUN
+    expected: FAIL
 
   [add() followed by abort after headers received should reject with AbortError]
-    expected: NOTRUN
+    expected: TIMEOUT
 
   [addAll() on an already-aborted request should reject with AbortError]
     expected: NOTRUN
@@ -29,24 +23,18 @@
 
 
 [cache-abort.https.any.worker.html]
-  expected: ERROR
-  [put() on an already-aborted request should reject with AbortError]
+  expected: TIMEOUT
+  [put() followed by abort after headers received should reject with AbortError]
     expected: FAIL
 
-  [put() synchronously followed by abort should reject with AbortError]
-    expected: NOTRUN
-
-  [put() followed by abort after headers received should reject with AbortError]
-    expected: NOTRUN
-
   [add() on an already-aborted request should reject with AbortError]
-    expected: NOTRUN
+    expected: FAIL
 
   [add() synchronously followed by abort should reject with AbortError]
-    expected: NOTRUN
+    expected: FAIL
 
   [add() followed by abort after headers received should reject with AbortError]
-    expected: NOTRUN
+    expected: TIMEOUT
 
   [addAll() on an already-aborted request should reject with AbortError]
     expected: NOTRUN
@@ -59,24 +47,18 @@
 
 
 [cache-abort.https.any.sharedworker.html]
-  expected: ERROR
-  [put() on an already-aborted request should reject with AbortError]
+  expected: TIMEOUT
+  [put() followed by abort after headers received should reject with AbortError]
     expected: FAIL
 
-  [put() synchronously followed by abort should reject with AbortError]
-    expected: NOTRUN
-
-  [put() followed by abort after headers received should reject with AbortError]
-    expected: NOTRUN
-
   [add() on an already-aborted request should reject with AbortError]
-    expected: NOTRUN
+    expected: FAIL
 
   [add() synchronously followed by abort should reject with AbortError]
-    expected: NOTRUN
+    expected: FAIL
 
   [add() followed by abort after headers received should reject with AbortError]
-    expected: NOTRUN
+    expected: TIMEOUT
 
   [addAll() on an already-aborted request should reject with AbortError]
     expected: NOTRUN
@@ -89,4 +71,24 @@
 
 
 [cache-abort.https.any.serviceworker.html]
-  expected: ERROR
+  expected: TIMEOUT
+  [put() followed by abort after headers received should reject with AbortError]
+    expected: FAIL
+
+  [add() on an already-aborted request should reject with AbortError]
+    expected: FAIL
+
+  [add() synchronously followed by abort should reject with AbortError]
+    expected: FAIL
+
+  [add() followed by abort after headers received should reject with AbortError]
+    expected: TIMEOUT
+
+  [addAll() on an already-aborted request should reject with AbortError]
+    expected: NOTRUN
+
+  [addAll() synchronously followed by abort should reject with AbortError]
+    expected: NOTRUN
+
+  [addAll() followed by abort after headers received should reject with AbortError]
+    expected: NOTRUN

--- a/tests/wpt/meta/service-workers/cache-storage/cache-add.https.any.js.ini
+++ b/tests/wpt/meta/service-workers/cache-storage/cache-add.https.any.js.ini
@@ -1,208 +1,270 @@
 [cache-add.https.any.worker.html]
-  expected: ERROR
   [Cache.add called with no arguments]
     expected: FAIL
 
   [Cache.add called with relative URL specified as a string]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add called with non-HTTP/HTTPS URL]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add called with Request object]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add called with POST request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add called twice with the same Request object]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add with request with null body (not consumed)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add with 206 response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with 206 response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with opaque-filtered 206 response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add with request that results in a status of 404]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add with request that results in a status of 500]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with no arguments]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with a mix of valid and undefined arguments]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with an empty array]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with string URL arguments]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with Request arguments]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with a mix of succeeding and failing requests]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll called with the same Request object specified twice]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll should succeed when entries differ by vary header]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll should reject when entries are duplicate by vary header]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll should reject when one entry has a vary header matching another entry]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [cache-add.https.any.sharedworker.html]
-  expected: ERROR
   [Cache.add called with no arguments]
     expected: FAIL
 
   [Cache.add called with relative URL specified as a string]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add called with non-HTTP/HTTPS URL]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add called with Request object]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add called with POST request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add called twice with the same Request object]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add with request with null body (not consumed)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add with 206 response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with 206 response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with opaque-filtered 206 response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add with request that results in a status of 404]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add with request that results in a status of 500]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with no arguments]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with a mix of valid and undefined arguments]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with an empty array]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with string URL arguments]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with Request arguments]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with a mix of succeeding and failing requests]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll called with the same Request object specified twice]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll should succeed when entries differ by vary header]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll should reject when entries are duplicate by vary header]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll should reject when one entry has a vary header matching another entry]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [cache-add.https.any.serviceworker.html]
-  expected: ERROR
-
-[cache-add.https.any.html]
-  expected: ERROR
   [Cache.add called with no arguments]
     expected: FAIL
 
   [Cache.add called with relative URL specified as a string]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add called with non-HTTP/HTTPS URL]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add called with Request object]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add called with POST request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add called twice with the same Request object]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add with request with null body (not consumed)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add with 206 response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with 206 response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with opaque-filtered 206 response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add with request that results in a status of 404]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.add with request that results in a status of 500]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with no arguments]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with a mix of valid and undefined arguments]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with an empty array]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with string URL arguments]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with Request arguments]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll with a mix of succeeding and failing requests]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll called with the same Request object specified twice]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll should succeed when entries differ by vary header]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll should reject when entries are duplicate by vary header]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.addAll should reject when one entry has a vary header matching another entry]
-    expected: NOTRUN
+    expected: FAIL
+
+
+[cache-add.https.any.html]
+  [Cache.add called with no arguments]
+    expected: FAIL
+
+  [Cache.add called with relative URL specified as a string]
+    expected: FAIL
+
+  [Cache.add called with non-HTTP/HTTPS URL]
+    expected: FAIL
+
+  [Cache.add called with Request object]
+    expected: FAIL
+
+  [Cache.add called with POST request]
+    expected: FAIL
+
+  [Cache.add called twice with the same Request object]
+    expected: FAIL
+
+  [Cache.add with request with null body (not consumed)]
+    expected: FAIL
+
+  [Cache.add with 206 response]
+    expected: FAIL
+
+  [Cache.addAll with 206 response]
+    expected: FAIL
+
+  [Cache.addAll with opaque-filtered 206 response]
+    expected: FAIL
+
+  [Cache.add with request that results in a status of 404]
+    expected: FAIL
+
+  [Cache.add with request that results in a status of 500]
+    expected: FAIL
+
+  [Cache.addAll with no arguments]
+    expected: FAIL
+
+  [Cache.addAll with a mix of valid and undefined arguments]
+    expected: FAIL
+
+  [Cache.addAll with an empty array]
+    expected: FAIL
+
+  [Cache.addAll with string URL arguments]
+    expected: FAIL
+
+  [Cache.addAll with Request arguments]
+    expected: FAIL
+
+  [Cache.addAll with a mix of succeeding and failing requests]
+    expected: FAIL
+
+  [Cache.addAll called with the same Request object specified twice]
+    expected: FAIL
+
+  [Cache.addAll should succeed when entries differ by vary header]
+    expected: FAIL
+
+  [Cache.addAll should reject when entries are duplicate by vary header]
+    expected: FAIL
+
+  [Cache.addAll should reject when one entry has a vary header matching another entry]
+    expected: FAIL

--- a/tests/wpt/meta/service-workers/cache-storage/cache-delete.https.any.js.ini
+++ b/tests/wpt/meta/service-workers/cache-storage/cache-delete.https.any.js.ini
@@ -1,82 +1,102 @@
 [cache-delete.https.any.serviceworker.html]
-  expected: ERROR
-
-[cache-delete.https.any.worker.html]
-  expected: ERROR
   [Cache.delete with no arguments]
     expected: FAIL
 
   [Cache.delete called with a string URL]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.delete called with a Request object]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.delete called with a HEAD request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.delete supports ignoreVary]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.delete with a non-existent entry]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.delete with ignoreSearch option (request with search parameters)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.delete with ignoreSearch option (when it is specified as false)]
-    expected: NOTRUN
+    expected: FAIL
+
+
+[cache-delete.https.any.worker.html]
+  [Cache.delete with no arguments]
+    expected: FAIL
+
+  [Cache.delete called with a string URL]
+    expected: FAIL
+
+  [Cache.delete called with a Request object]
+    expected: FAIL
+
+  [Cache.delete called with a HEAD request]
+    expected: FAIL
+
+  [Cache.delete supports ignoreVary]
+    expected: FAIL
+
+  [Cache.delete with a non-existent entry]
+    expected: FAIL
+
+  [Cache.delete with ignoreSearch option (request with search parameters)]
+    expected: FAIL
+
+  [Cache.delete with ignoreSearch option (when it is specified as false)]
+    expected: FAIL
 
 
 [cache-delete.https.any.sharedworker.html]
-  expected: ERROR
   [Cache.delete with no arguments]
     expected: FAIL
 
   [Cache.delete called with a string URL]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.delete called with a Request object]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.delete called with a HEAD request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.delete supports ignoreVary]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.delete with a non-existent entry]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.delete with ignoreSearch option (request with search parameters)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.delete with ignoreSearch option (when it is specified as false)]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [cache-delete.https.any.html]
-  expected: ERROR
   [Cache.delete with no arguments]
     expected: FAIL
 
   [Cache.delete called with a string URL]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.delete called with a Request object]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.delete called with a HEAD request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.delete supports ignoreVary]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.delete with a non-existent entry]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.delete with ignoreSearch option (request with search parameters)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.delete with ignoreSearch option (when it is specified as false)]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/service-workers/cache-storage/cache-keys-attributes-for-service-worker.https.html.ini
+++ b/tests/wpt/meta/service-workers/cache-storage/cache-keys-attributes-for-service-worker.https.html.ini
@@ -1,6 +1,7 @@
 [cache-keys-attributes-for-service-worker.https.html]
+  expected: TIMEOUT
   [Request.IsReloadNavigation should persist.]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Request.IsHistoryNavigation should persist.]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/service-workers/cache-storage/cache-keys.https.any.js.ini
+++ b/tests/wpt/meta/service-workers/cache-storage/cache-keys.https.any.js.ini
@@ -104,51 +104,44 @@
 
 
 [cache-keys.https.any.html]
-  expected: ERROR
-  [Cache.keys() called on an empty cache]
+  [Cache.keys with no matching entries]
     expected: FAIL
 
-  [Cache.keys with no matching entries]
-    expected: NOTRUN
-
   [Cache.keys with URL]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with Request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with new Request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with ignoreSearch option (request with no search parameters)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with ignoreSearch option (request with search parameters)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys supports ignoreMethod]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys supports ignoreVary]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with URL containing fragment]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with string fragment "http" as query]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys without parameters]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with explicitly undefined request]
-    expected: NOTRUN
-
-  [Cache.keys with explicitly undefined request and empty options]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys without parameters and VARY entries]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with a HEAD Request]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/service-workers/cache-storage/cache-keys.https.any.js.ini
+++ b/tests/wpt/meta/service-workers/cache-storage/cache-keys.https.any.js.ini
@@ -1,106 +1,133 @@
 [cache-keys.https.any.sharedworker.html]
-  expected: ERROR
-  [Cache.keys() called on an empty cache]
+  [Cache.keys with no matching entries]
     expected: FAIL
 
-  [Cache.keys with no matching entries]
-    expected: NOTRUN
-
   [Cache.keys with URL]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with Request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with new Request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with ignoreSearch option (request with no search parameters)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with ignoreSearch option (request with search parameters)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys supports ignoreMethod]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys supports ignoreVary]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with URL containing fragment]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with string fragment "http" as query]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys without parameters]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with explicitly undefined request]
-    expected: NOTRUN
-
-  [Cache.keys with explicitly undefined request and empty options]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys without parameters and VARY entries]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with a HEAD Request]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [cache-keys.https.any.serviceworker.html]
-  expected: ERROR
-
-[cache-keys.https.any.worker.html]
-  expected: ERROR
-  [Cache.keys() called on an empty cache]
+  [Cache.keys with no matching entries]
     expected: FAIL
 
-  [Cache.keys with no matching entries]
-    expected: NOTRUN
-
   [Cache.keys with URL]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with Request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with new Request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with ignoreSearch option (request with no search parameters)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with ignoreSearch option (request with search parameters)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys supports ignoreMethod]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys supports ignoreVary]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with URL containing fragment]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with string fragment "http" as query]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys without parameters]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with explicitly undefined request]
-    expected: NOTRUN
-
-  [Cache.keys with explicitly undefined request and empty options]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys without parameters and VARY entries]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.keys with a HEAD Request]
-    expected: NOTRUN
+    expected: FAIL
+
+
+[cache-keys.https.any.worker.html]
+  [Cache.keys with no matching entries]
+    expected: FAIL
+
+  [Cache.keys with URL]
+    expected: FAIL
+
+  [Cache.keys with Request]
+    expected: FAIL
+
+  [Cache.keys with new Request]
+    expected: FAIL
+
+  [Cache.keys with ignoreSearch option (request with no search parameters)]
+    expected: FAIL
+
+  [Cache.keys with ignoreSearch option (request with search parameters)]
+    expected: FAIL
+
+  [Cache.keys supports ignoreMethod]
+    expected: FAIL
+
+  [Cache.keys supports ignoreVary]
+    expected: FAIL
+
+  [Cache.keys with URL containing fragment]
+    expected: FAIL
+
+  [Cache.keys with string fragment "http" as query]
+    expected: FAIL
+
+  [Cache.keys without parameters]
+    expected: FAIL
+
+  [Cache.keys with explicitly undefined request]
+    expected: FAIL
+
+  [Cache.keys without parameters and VARY entries]
+    expected: FAIL
+
+  [Cache.keys with a HEAD Request]
+    expected: FAIL
 
 
 [cache-keys.https.any.html]

--- a/tests/wpt/meta/service-workers/cache-storage/cache-match.https.any.js.ini
+++ b/tests/wpt/meta/service-workers/cache-storage/cache-match.https.any.js.ini
@@ -1,235 +1,306 @@
 [cache-match.https.any.sharedworker.html]
-  expected: ERROR
   [Cache.match with no matching entries]
     expected: FAIL
 
   [Cache.match with URL]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with Request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with multiple cache hits]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with new Request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with HEAD]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with ignoreSearch option (request with no search parameters)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with ignoreSearch option (request with search parameter)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match supports ignoreMethod]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match supports ignoreVary]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match does not support cacheName option]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with URL containing fragment]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with string fragment "http" as query]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with responses containing "Vary" header]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with Request and Response objects with different URLs]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match invoked multiple times for the same Request/Response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match blob should be sliceable]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with POST Request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with a non-2xx Response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with a network error Response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache produces large Responses that can be cloned and read correctly.]
-    expected: NOTRUN
+    expected: FAIL
 
   [cors-exposed header should be stored correctly.]
-    expected: NOTRUN
+    expected: FAIL
 
   [MIME type should be set from content-header correctly.]
-    expected: NOTRUN
+    expected: FAIL
 
   [MIME type should reflect Content-Type headers of response.]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match ignores vary headers on opaque response.]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [cache-match.https.any.serviceworker.html]
-  expected: ERROR
-
-[cache-match.https.any.html]
-  expected: ERROR
   [Cache.match with no matching entries]
     expected: FAIL
 
   [Cache.match with URL]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with Request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with multiple cache hits]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with new Request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with HEAD]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with ignoreSearch option (request with no search parameters)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with ignoreSearch option (request with search parameter)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match supports ignoreMethod]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match supports ignoreVary]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match does not support cacheName option]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with URL containing fragment]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with string fragment "http" as query]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with responses containing "Vary" header]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with Request and Response objects with different URLs]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match invoked multiple times for the same Request/Response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match blob should be sliceable]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with POST Request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with a non-2xx Response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with a network error Response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache produces large Responses that can be cloned and read correctly.]
-    expected: NOTRUN
+    expected: FAIL
 
   [cors-exposed header should be stored correctly.]
-    expected: NOTRUN
+    expected: FAIL
 
   [MIME type should be set from content-header correctly.]
-    expected: NOTRUN
+    expected: FAIL
 
   [MIME type should reflect Content-Type headers of response.]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match ignores vary headers on opaque response.]
-    expected: NOTRUN
+    expected: FAIL
+
+
+[cache-match.https.any.html]
+  [Cache.match with no matching entries]
+    expected: FAIL
+
+  [Cache.match with URL]
+    expected: FAIL
+
+  [Cache.match with Request]
+    expected: FAIL
+
+  [Cache.match with multiple cache hits]
+    expected: FAIL
+
+  [Cache.match with new Request]
+    expected: FAIL
+
+  [Cache.match with HEAD]
+    expected: FAIL
+
+  [Cache.match with ignoreSearch option (request with no search parameters)]
+    expected: FAIL
+
+  [Cache.match with ignoreSearch option (request with search parameter)]
+    expected: FAIL
+
+  [Cache.match supports ignoreMethod]
+    expected: FAIL
+
+  [Cache.match supports ignoreVary]
+    expected: FAIL
+
+  [Cache.match does not support cacheName option]
+    expected: FAIL
+
+  [Cache.match with URL containing fragment]
+    expected: FAIL
+
+  [Cache.match with string fragment "http" as query]
+    expected: FAIL
+
+  [Cache.match with responses containing "Vary" header]
+    expected: FAIL
+
+  [Cache.match with Request and Response objects with different URLs]
+    expected: FAIL
+
+  [Cache.match invoked multiple times for the same Request/Response]
+    expected: FAIL
+
+  [Cache.match blob should be sliceable]
+    expected: FAIL
+
+  [Cache.match with POST Request]
+    expected: FAIL
+
+  [Cache.match with a non-2xx Response]
+    expected: FAIL
+
+  [Cache.match with a network error Response]
+    expected: FAIL
+
+  [Cache produces large Responses that can be cloned and read correctly.]
+    expected: FAIL
+
+  [cors-exposed header should be stored correctly.]
+    expected: FAIL
+
+  [MIME type should be set from content-header correctly.]
+    expected: FAIL
+
+  [MIME type should reflect Content-Type headers of response.]
+    expected: FAIL
+
+  [Cache.match ignores vary headers on opaque response.]
+    expected: FAIL
 
 
 [cache-match.https.any.worker.html]
-  expected: ERROR
   [Cache.match with no matching entries]
     expected: FAIL
 
   [Cache.match with URL]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with Request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with multiple cache hits]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with new Request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with HEAD]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with ignoreSearch option (request with no search parameters)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with ignoreSearch option (request with search parameter)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match supports ignoreMethod]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match supports ignoreVary]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match does not support cacheName option]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with URL containing fragment]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with string fragment "http" as query]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with responses containing "Vary" header]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with Request and Response objects with different URLs]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match invoked multiple times for the same Request/Response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match blob should be sliceable]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with POST Request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with a non-2xx Response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match with a network error Response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache produces large Responses that can be cloned and read correctly.]
-    expected: NOTRUN
+    expected: FAIL
 
   [cors-exposed header should be stored correctly.]
-    expected: NOTRUN
+    expected: FAIL
 
   [MIME type should be set from content-header correctly.]
-    expected: NOTRUN
+    expected: FAIL
 
   [MIME type should reflect Content-Type headers of response.]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match ignores vary headers on opaque response.]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/service-workers/cache-storage/cache-matchAll.https.any.js.ini
+++ b/tests/wpt/meta/service-workers/cache-storage/cache-matchAll.https.any.js.ini
@@ -1,154 +1,198 @@
 [cache-matchAll.https.any.serviceworker.html]
-  expected: ERROR
-
-[cache-matchAll.https.any.worker.html]
-  expected: ERROR
   [Cache.matchAll with no matching entries]
     expected: FAIL
 
   [Cache.matchAll with URL]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with Request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with new Request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with HEAD]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with ignoreSearch option (request with no search parameters)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with ignoreSearch option (request with search parameters)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll supports ignoreMethod]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll supports ignoreVary]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with URL containing fragment]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with string fragment "http" as query]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll without parameters]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with explicitly undefined request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with explicitly undefined request and empty options]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with responses containing "Vary" header]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with multiple vary pairs]
-    expected: NOTRUN
+    expected: FAIL
+
+
+[cache-matchAll.https.any.worker.html]
+  [Cache.matchAll with no matching entries]
+    expected: FAIL
+
+  [Cache.matchAll with URL]
+    expected: FAIL
+
+  [Cache.matchAll with Request]
+    expected: FAIL
+
+  [Cache.matchAll with new Request]
+    expected: FAIL
+
+  [Cache.matchAll with HEAD]
+    expected: FAIL
+
+  [Cache.matchAll with ignoreSearch option (request with no search parameters)]
+    expected: FAIL
+
+  [Cache.matchAll with ignoreSearch option (request with search parameters)]
+    expected: FAIL
+
+  [Cache.matchAll supports ignoreMethod]
+    expected: FAIL
+
+  [Cache.matchAll supports ignoreVary]
+    expected: FAIL
+
+  [Cache.matchAll with URL containing fragment]
+    expected: FAIL
+
+  [Cache.matchAll with string fragment "http" as query]
+    expected: FAIL
+
+  [Cache.matchAll without parameters]
+    expected: FAIL
+
+  [Cache.matchAll with explicitly undefined request]
+    expected: FAIL
+
+  [Cache.matchAll with explicitly undefined request and empty options]
+    expected: FAIL
+
+  [Cache.matchAll with responses containing "Vary" header]
+    expected: FAIL
+
+  [Cache.matchAll with multiple vary pairs]
+    expected: FAIL
 
 
 [cache-matchAll.https.any.sharedworker.html]
-  expected: ERROR
   [Cache.matchAll with no matching entries]
     expected: FAIL
 
   [Cache.matchAll with URL]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with Request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with new Request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with HEAD]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with ignoreSearch option (request with no search parameters)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with ignoreSearch option (request with search parameters)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll supports ignoreMethod]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll supports ignoreVary]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with URL containing fragment]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with string fragment "http" as query]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll without parameters]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with explicitly undefined request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with explicitly undefined request and empty options]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with responses containing "Vary" header]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with multiple vary pairs]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [cache-matchAll.https.any.html]
-  expected: ERROR
   [Cache.matchAll with no matching entries]
     expected: FAIL
 
   [Cache.matchAll with URL]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with Request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with new Request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with HEAD]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with ignoreSearch option (request with no search parameters)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with ignoreSearch option (request with search parameters)]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll supports ignoreMethod]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll supports ignoreVary]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with URL containing fragment]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with string fragment "http" as query]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll without parameters]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with explicitly undefined request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with explicitly undefined request and empty options]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with responses containing "Vary" header]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.matchAll with multiple vary pairs]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/service-workers/cache-storage/cache-put.https.any.js.ini
+++ b/tests/wpt/meta/service-workers/cache-storage/cache-put.https.any.js.ini
@@ -1,253 +1,330 @@
 [cache-put.https.any.sharedworker.html]
-  expected: ERROR
   [Cache.put called with simple Request and Response]
     expected: FAIL
 
   [Cache.put called with Request and Response from fetch()]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with Request without a body]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with Response without a body]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a Response containing an empty URL]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with an empty response body]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with synthetic 206 response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with HTTP 206 response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with opaque-filtered HTTP 206 response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with HTTP 500 response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put called twice with matching Requests and different Responses]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put called multiple times with request URLs that differ only by a fragment]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a string request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with an invalid response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a non-HTTP/HTTPS request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a relative URL]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a non-GET request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a null response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a POST request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a used response body]
-    expected: NOTRUN
+    expected: FAIL
 
   [getReader() after Cache.put]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a VARY:* Response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with an embedded VARY:* Response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a VARY:* opaque response should not reject]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put should store Response.redirect() correctly]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put called with simple Request and blob Response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put called with simple Request and form data Response]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [cache-put.https.any.html]
-  expected: ERROR
   [Cache.put called with simple Request and Response]
     expected: FAIL
 
   [Cache.put called with Request and Response from fetch()]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with Request without a body]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with Response without a body]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a Response containing an empty URL]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with an empty response body]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with synthetic 206 response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with HTTP 206 response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with opaque-filtered HTTP 206 response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with HTTP 500 response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put called twice with matching Requests and different Responses]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put called multiple times with request URLs that differ only by a fragment]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a string request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with an invalid response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a non-HTTP/HTTPS request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a relative URL]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a non-GET request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a null response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a POST request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a used response body]
-    expected: NOTRUN
+    expected: FAIL
 
   [getReader() after Cache.put]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a VARY:* Response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with an embedded VARY:* Response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a VARY:* opaque response should not reject]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put should store Response.redirect() correctly]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put called with simple Request and blob Response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put called with simple Request and form data Response]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [cache-put.https.any.serviceworker.html]
-  expected: ERROR
-
-[cache-put.https.any.worker.html]
-  expected: ERROR
   [Cache.put called with simple Request and Response]
     expected: FAIL
 
   [Cache.put called with Request and Response from fetch()]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with Request without a body]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with Response without a body]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a Response containing an empty URL]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with an empty response body]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with synthetic 206 response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with HTTP 206 response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with opaque-filtered HTTP 206 response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with HTTP 500 response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put called twice with matching Requests and different Responses]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put called multiple times with request URLs that differ only by a fragment]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a string request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with an invalid response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a non-HTTP/HTTPS request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a relative URL]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a non-GET request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a null response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a POST request]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a used response body]
-    expected: NOTRUN
+    expected: FAIL
 
   [getReader() after Cache.put]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a VARY:* Response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with an embedded VARY:* Response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put with a VARY:* opaque response should not reject]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put should store Response.redirect() correctly]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put called with simple Request and blob Response]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.put called with simple Request and form data Response]
-    expected: NOTRUN
+    expected: FAIL
+
+
+[cache-put.https.any.worker.html]
+  [Cache.put called with simple Request and Response]
+    expected: FAIL
+
+  [Cache.put called with Request and Response from fetch()]
+    expected: FAIL
+
+  [Cache.put with Request without a body]
+    expected: FAIL
+
+  [Cache.put with Response without a body]
+    expected: FAIL
+
+  [Cache.put with a Response containing an empty URL]
+    expected: FAIL
+
+  [Cache.put with an empty response body]
+    expected: FAIL
+
+  [Cache.put with synthetic 206 response]
+    expected: FAIL
+
+  [Cache.put with HTTP 206 response]
+    expected: FAIL
+
+  [Cache.put with opaque-filtered HTTP 206 response]
+    expected: FAIL
+
+  [Cache.put with HTTP 500 response]
+    expected: FAIL
+
+  [Cache.put called twice with matching Requests and different Responses]
+    expected: FAIL
+
+  [Cache.put called multiple times with request URLs that differ only by a fragment]
+    expected: FAIL
+
+  [Cache.put with a string request]
+    expected: FAIL
+
+  [Cache.put with an invalid response]
+    expected: FAIL
+
+  [Cache.put with a non-HTTP/HTTPS request]
+    expected: FAIL
+
+  [Cache.put with a relative URL]
+    expected: FAIL
+
+  [Cache.put with a non-GET request]
+    expected: FAIL
+
+  [Cache.put with a null response]
+    expected: FAIL
+
+  [Cache.put with a POST request]
+    expected: FAIL
+
+  [Cache.put with a used response body]
+    expected: FAIL
+
+  [getReader() after Cache.put]
+    expected: FAIL
+
+  [Cache.put with a VARY:* Response]
+    expected: FAIL
+
+  [Cache.put with an embedded VARY:* Response]
+    expected: FAIL
+
+  [Cache.put with a VARY:* opaque response should not reject]
+    expected: FAIL
+
+  [Cache.put should store Response.redirect() correctly]
+    expected: FAIL
+
+  [Cache.put called with simple Request and blob Response]
+    expected: FAIL
+
+  [Cache.put called with simple Request and form data Response]
+    expected: FAIL

--- a/tests/wpt/meta/service-workers/cache-storage/cache-storage-buckets.https.any.js.ini
+++ b/tests/wpt/meta/service-workers/cache-storage/cache-storage-buckets.https.any.js.ini
@@ -15,7 +15,12 @@
 
 
 [cache-storage-buckets.https.any.serviceworker.html]
-  expected: ERROR
+  [caches from different buckets have different contents]
+    expected: FAIL
+
+  [cache.open promise is rejected when bucket is gone]
+    expected: FAIL
+
 
 [cache-storage-buckets.https.any.worker.html]
   [caches from different buckets have different contents]

--- a/tests/wpt/meta/service-workers/cache-storage/cache-storage-keys.https.any.js.ini
+++ b/tests/wpt/meta/service-workers/cache-storage/cache-storage-keys.https.any.js.ini
@@ -1,5 +1,7 @@
 [cache-storage-keys.https.any.serviceworker.html]
-  expected: ERROR
+  [CacheStorage keys]
+    expected: FAIL
+
 
 [cache-storage-keys.https.any.html]
   [CacheStorage keys]

--- a/tests/wpt/meta/service-workers/cache-storage/cache-storage-match.https.any.js.ini
+++ b/tests/wpt/meta/service-workers/cache-storage/cache-storage-match.https.any.js.ini
@@ -1,109 +1,138 @@
 [cache-storage-match.https.any.html]
-  expected: ERROR
   [CacheStorageMatch with no cache name provided]
     expected: FAIL
 
   [CacheStorageMatch from one of many caches]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch from one of many caches by name]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch a string request]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch a HEAD request]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch with no cached entry]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch with no caches available but name provided]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch with empty cache name provided]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch supports ignoreSearch]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match supports ignoreMethod]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch supports ignoreVary]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [cache-storage-match.https.any.sharedworker.html]
-  expected: ERROR
   [CacheStorageMatch with no cache name provided]
     expected: FAIL
 
   [CacheStorageMatch from one of many caches]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch from one of many caches by name]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch a string request]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch a HEAD request]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch with no cached entry]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch with no caches available but name provided]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch with empty cache name provided]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch supports ignoreSearch]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match supports ignoreMethod]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch supports ignoreVary]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [cache-storage-match.https.any.serviceworker.html]
-  expected: ERROR
-
-[cache-storage-match.https.any.worker.html]
-  expected: ERROR
   [CacheStorageMatch with no cache name provided]
     expected: FAIL
 
   [CacheStorageMatch from one of many caches]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch from one of many caches by name]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch a string request]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch a HEAD request]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch with no cached entry]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch with no caches available but name provided]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch with empty cache name provided]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch supports ignoreSearch]
-    expected: NOTRUN
+    expected: FAIL
 
   [Cache.match supports ignoreMethod]
-    expected: NOTRUN
+    expected: FAIL
 
   [CacheStorageMatch supports ignoreVary]
-    expected: NOTRUN
+    expected: FAIL
+
+
+[cache-storage-match.https.any.worker.html]
+  [CacheStorageMatch with no cache name provided]
+    expected: FAIL
+
+  [CacheStorageMatch from one of many caches]
+    expected: FAIL
+
+  [CacheStorageMatch from one of many caches by name]
+    expected: FAIL
+
+  [CacheStorageMatch a string request]
+    expected: FAIL
+
+  [CacheStorageMatch a HEAD request]
+    expected: FAIL
+
+  [CacheStorageMatch with no cached entry]
+    expected: FAIL
+
+  [CacheStorageMatch with no caches available but name provided]
+    expected: FAIL
+
+  [CacheStorageMatch with empty cache name provided]
+    expected: FAIL
+
+  [CacheStorageMatch supports ignoreSearch]
+    expected: FAIL
+
+  [Cache.match supports ignoreMethod]
+    expected: FAIL
+
+  [CacheStorageMatch supports ignoreVary]
+    expected: FAIL

--- a/tests/wpt/meta/service-workers/cache-storage/cache-storage.https.any.js.ini
+++ b/tests/wpt/meta/service-workers/cache-storage/cache-storage.https.any.js.ini
@@ -34,31 +34,10 @@
   expected: ERROR
 
 [cache-storage.https.any.html]
-  [CacheStorage.open]
-    expected: FAIL
-
   [CacheStorage.delete dooms, but does not delete immediately]
     expected: FAIL
 
-  [CacheStorage.open with an empty name]
-    expected: FAIL
-
-  [CacheStorage.open with no arguments]
-    expected: FAIL
-
-  [CacheStorage.has with existing cache]
-    expected: FAIL
-
-  [CacheStorage.has with nonexistent cache]
-    expected: FAIL
-
   [CacheStorage.open with existing cache]
-    expected: FAIL
-
-  [CacheStorage.delete with existing cache]
-    expected: FAIL
-
-  [CacheStorage.delete with nonexistent cache]
     expected: FAIL
 
   [CacheStorage names are DOMStrings not USVStrings]

--- a/tests/wpt/meta/service-workers/cache-storage/cache-storage.https.any.js.ini
+++ b/tests/wpt/meta/service-workers/cache-storage/cache-storage.https.any.js.ini
@@ -1,29 +1,8 @@
 [cache-storage.https.any.worker.html]
-  [CacheStorage.open]
-    expected: FAIL
-
   [CacheStorage.delete dooms, but does not delete immediately]
     expected: FAIL
 
-  [CacheStorage.open with an empty name]
-    expected: FAIL
-
-  [CacheStorage.open with no arguments]
-    expected: FAIL
-
-  [CacheStorage.has with existing cache]
-    expected: FAIL
-
-  [CacheStorage.has with nonexistent cache]
-    expected: FAIL
-
   [CacheStorage.open with existing cache]
-    expected: FAIL
-
-  [CacheStorage.delete with existing cache]
-    expected: FAIL
-
-  [CacheStorage.delete with nonexistent cache]
     expected: FAIL
 
   [CacheStorage names are DOMStrings not USVStrings]
@@ -31,7 +10,15 @@
 
 
 [cache-storage.https.any.serviceworker.html]
-  expected: ERROR
+  [CacheStorage.delete dooms, but does not delete immediately]
+    expected: FAIL
+
+  [CacheStorage.open with existing cache]
+    expected: FAIL
+
+  [CacheStorage names are DOMStrings not USVStrings]
+    expected: FAIL
+
 
 [cache-storage.https.any.html]
   [CacheStorage.delete dooms, but does not delete immediately]
@@ -45,31 +32,10 @@
 
 
 [cache-storage.https.any.sharedworker.html]
-  [CacheStorage.open]
-    expected: FAIL
-
   [CacheStorage.delete dooms, but does not delete immediately]
     expected: FAIL
 
-  [CacheStorage.open with an empty name]
-    expected: FAIL
-
-  [CacheStorage.open with no arguments]
-    expected: FAIL
-
-  [CacheStorage.has with existing cache]
-    expected: FAIL
-
-  [CacheStorage.has with nonexistent cache]
-    expected: FAIL
-
   [CacheStorage.open with existing cache]
-    expected: FAIL
-
-  [CacheStorage.delete with existing cache]
-    expected: FAIL
-
-  [CacheStorage.delete with nonexistent cache]
     expected: FAIL
 
   [CacheStorage names are DOMStrings not USVStrings]

--- a/tests/wpt/meta/service-workers/cache-storage/common.https.window.js.ini
+++ b/tests/wpt/meta/service-workers/cache-storage/common.https.window.js.ini
@@ -1,3 +1,4 @@
 [common.https.window.html]
+  expected: TIMEOUT
   [Window sees cache puts by Worker]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/service-workers/cache-storage/credentials.https.html.ini
+++ b/tests/wpt/meta/service-workers/cache-storage/credentials.https.html.ini
@@ -1,3 +1,4 @@
 [credentials.https.html]
+  expected: TIMEOUT
   [Cache API matching includes credentials]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/service-workers/cache-storage/cross-partition.https.tentative.html.ini
+++ b/tests/wpt/meta/service-workers/cache-storage/cross-partition.https.tentative.html.ini
@@ -7,7 +7,7 @@
     expected: FAIL
 
   [CacheStorage caches shouldn't be shared with a cross-partition shared worker]
-    expected: TIMEOUT
+    expected: FAIL
 
   [CacheStorage caches shouldn't be shared with a cross-partition service worker]
-    expected: NOTRUN
+    expected: TIMEOUT

--- a/tests/wpt/meta/service-workers/cache-storage/sandboxed-iframes.https.html.ini
+++ b/tests/wpt/meta/service-workers/cache-storage/sandboxed-iframes.https.html.ini
@@ -1,6 +1,3 @@
 [sandboxed-iframes.https.html]
-  [Sandboxed iframe with allow-same-origin is allowed access]
-    expected: FAIL
-
   [Sandboxed iframe without allow-same-origin is denied access]
     expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14521,7 +14521,7 @@
      ]
     ],
     "interfaces.https.html": [
-     "c2f50ff3984b553a116252ac5bf376e9a2f4814e",
+     "3c6c27bb8ccd8d46da0dcc6784f3fd1c32e53c97",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
@@ -34,6 +34,7 @@ test_interfaces([
   "BiquadFilterNode",
   "Blob",
   "BroadcastChannel",
+  "Cache",
   "CacheStorage",
   "CanvasGradient",
   "CanvasRenderingContext2D",


### PR DESCRIPTION
Implement the the basics of a service worker in-mem only cache with the ability to open and delete caches and read their keys (which are always empty for now).

Testing: SW suite is not turned on, but locally I can confirm that the "Cache.keys() called on an empty cache" passes. I have also ran and updated expectations for the entire cache-storage sub suite. 
Fixes: N/A

Part of: https://github.com/servo/servo/issues/36538
