### PR TITLE
script: Make inserttext not crash when inserting non-ASCII text

### DIFF
--- a/components/script/dom/execcommand/commands/inserttext.rs
+++ b/components/script/dom/execcommand/commands/inserttext.rs
@@ -44,7 +44,7 @@ pub(crate) fn execute_insert_text_command(
     }
 
     // Step 3. If value's length is greater than one:
-    if value.len() > 1 {
+    if value.str().chars().nth(1).is_some() {
         // Step 3.1. For each code unit el in value, take the action for the insertText command, with value equal to el.
         for el in value.str().chars() {
             execute_insert_text_command(cx, document, selection, DOMString::from(el.to_string()));

--- a/tests/wpt/meta/editing/run/inserttext.html.ini
+++ b/tests/wpt/meta/editing/run/inserttext.html.ini
@@ -289,7 +289,207 @@
 
 
 [inserttext.html?1001-2000]
-  expected: CRASH
+  [[["inserttext"," "\]\] "a@b<b>[\]c</b>" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","   "\]\] "foo[\]" compare innerHTML]
+    expected: FAIL
+
+  [[["defaultparagraphseparator","div"\],["inserttext","a"\]\] "<p>fo[o<p>b\]ar" compare innerHTML]
+    expected: FAIL
+
+  [[["defaultparagraphseparator","div"\],["inserttext","a"\]\] "<p>fo[o<p>b\]ar" queryCommandValue("defaultparagraphseparator") before]
+    expected: FAIL
+
+  [[["defaultparagraphseparator","p"\],["inserttext","a"\]\] "<p>fo[o<p>b\]ar" compare innerHTML]
+    expected: FAIL
+
+  [[["defaultparagraphseparator","div"\],["inserttext","a"\]\] "<p>fo[o<p>bar<p>b\]az" compare innerHTML]
+    expected: FAIL
+
+  [[["defaultparagraphseparator","p"\],["inserttext","a"\]\] "<p>fo[o<p>bar<p>b\]az" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "{}<br>" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "<p>{}<br>" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "<p><span>{}<br></span>" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "<p>foo<span style=color:#aBcDeF>[bar\]</span>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "<p>foo<span style=color:#aBcDeF>{bar}</span>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "<p>foo{<span style=color:#aBcDeF>bar</span>}baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["inserttext","a"\]\] "<p>[foo<span style=color:#aBcDeF>bar\]</span>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["inserttext","a"\]\] "<p>[foo<span style=color:#aBcDeF>bar\]</span>baz" queryCommandState("stylewithcss") before]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["inserttext","a"\]\] "<p>[foo<span style=color:#aBcDeF>bar\]</span>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["inserttext","a"\]\] "<p>{foo<span style=color:#aBcDeF>bar}</span>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["inserttext","a"\]\] "<p>{foo<span style=color:#aBcDeF>bar}</span>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "<p>foo<span style=color:#aBcDeF>[bar</span>baz\]" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "<p>foo<span style=color:#aBcDeF>{bar</span>baz}" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["inserttext","a"\]\] "<p>foo<span style=color:#aBcDeF>[bar</span><span style=color:#fEdCbA>baz\]</span>quz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["inserttext","a"\]\] "<p>foo<span style=color:#aBcDeF>[bar</span><span style=color:#fEdCbA>baz\]</span>quz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "foo<b>[bar\]</b>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "foo<i>[bar\]</i>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "foo<s>[bar\]</s>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "foo<sub>[bar\]</sub>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "foo<sup>[bar\]</sup>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "foo<u>[bar\]</u>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "foo<a href=http://www.google.com>[bar\]</a>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "foo<font face=sans-serif>[bar\]</font>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "foo<font size=4>[bar\]</font>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "foo<font color=#0000FF>[bar\]</font>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "foo<span style=background-color:#00FFFF>[bar\]</span>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "foo<a href=http://www.google.com><font color=blue>[bar\]</font></a>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "foo<font color=blue><a href=http://www.google.com>[bar\]</a></font>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "foo<a href=http://www.google.com><font color=brown>[bar\]</font></a>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "foo<font color=brown><a href=http://www.google.com>[bar\]</a></font>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "foo<a href=http://www.google.com><font color=black>[bar\]</font></a>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "foo<a href=http://www.google.com><u>[bar\]</u></a>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "foo<u><a href=http://www.google.com>[bar\]</a></u>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "foo<sub><font size=2>[bar\]</font></sub>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "foo<font size=2><sub>[bar\]</sub></font>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "foo<sub><font size=3>[bar\]</font></sub>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "foo<font size=3><sub>[bar\]</sub></font>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<b>bar\]</b>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<b>bar\]</b>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<i>bar\]</i>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<i>bar\]</i>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<s>bar\]</s>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<s>bar\]</s>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<sub>bar\]</sub>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<sub>bar\]</sub>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<sup>bar\]</sup>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<sup>bar\]</sup>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<u>bar\]</u>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<u>bar\]</u>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["inserttext","a"\]\] "[foo<a href=http://www.google.com>bar\]</a>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<font face=sans-serif>bar\]</font>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<font face=sans-serif>bar\]</font>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<font size=4>bar\]</font>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<font size=4>bar\]</font>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<font color=#0000FF>bar\]</font>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<font color=#0000FF>bar\]</font>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<span style=background-color:#00FFFF>bar\]</span>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<span style=background-color:#00FFFF>bar\]</span>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["inserttext","a"\]\] "[foo<a href=http://www.google.com><font color=blue>bar\]</font></a>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["inserttext","a"\]\] "[foo<a href=http://www.google.com><font color=blue>bar\]</font></a>baz" compare innerHTML]
+    expected: FAIL
+
 
 [inserttext.html?1-1000]
   [[["inserttext","a"\]\] "foo[bar\]baz" compare innerHTML]

--- a/tests/wpt/meta/editing/whitespaces/chrome-compat/inserttext.tentative.html.ini
+++ b/tests/wpt/meta/editing/whitespaces/chrome-compat/inserttext.tentative.html.ini
@@ -1,2 +1,495 @@
 [inserttext.tentative.html]
-  expected: CRASH
+  [execCommand("inserttext", false, " ") at "a&nbsp; [\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp; &nbsp; [\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp; &nbsp; &nbsp; [\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp; &nbsp; &nbsp; &nbsp; [\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; [\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp;[\]"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp; &nbsp;[\]"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp; &nbsp; &nbsp;[\]"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp; &nbsp; &nbsp; &nbsp;[\]"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;[\]"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;[\]"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "&nbsp; [\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "&nbsp; &nbsp; [\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "&nbsp; &nbsp; &nbsp; [\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "&nbsp; &nbsp; &nbsp; &nbsp; [\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; [\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp;[\] b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp; &nbsp;[\] b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp; &nbsp; &nbsp;[\] b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp; &nbsp; &nbsp; &nbsp;[\] b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;[\] b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;[\] b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a[\]&nbsp;&nbsp;b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp;[\]&nbsp;b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp;&nbsp;[\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a[\]&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp;[\]&nbsp;&nbsp;&nbsp;&nbsp;b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp;&nbsp;[\]&nbsp;&nbsp;&nbsp;b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp;&nbsp;&nbsp;[\]&nbsp;&nbsp;b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp;&nbsp;&nbsp;&nbsp;[\]&nbsp;b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a[\]&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp;[\]&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp;&nbsp;[\]&nbsp;&nbsp;&nbsp;&nbsp;b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp;&nbsp;&nbsp;[\]&nbsp;&nbsp;&nbsp;b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp;&nbsp;&nbsp;&nbsp;[\]&nbsp;&nbsp;b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[\]&nbsp;b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0") at "a&nbsp; [\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0") at "a&nbsp; &nbsp; [\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0") at "a&nbsp; &nbsp; &nbsp; [\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0") at "a&nbsp; &nbsp; &nbsp; &nbsp; [\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0") at "a&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; [\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span> [\]</span>b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>&nbsp; [\]</span>b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>&nbsp; &nbsp;[\]</span>b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>&nbsp; &nbsp; [\]</span>b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>&nbsp; &nbsp; &nbsp;[\]</span>b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b[\]</span>c"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp;[\]</span>c"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp;&nbsp;[\]</span>c"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp; &nbsp;[\]</span>c"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp; &nbsp;&nbsp;[\]</span>c"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp;[\]</span> c"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp; &nbsp;[\]</span> c"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b[\]</span>&nbsp;c"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp;[\]</span>&nbsp;c"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp;&nbsp;[\]</span>&nbsp;c"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp; &nbsp;[\]</span>&nbsp;c"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp; &nbsp;&nbsp;[\]</span>&nbsp;c"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b[\]</span><span>c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp;[\]</span><span>c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp;&nbsp;[\]</span><span>c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp; &nbsp;[\]</span><span>c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp; &nbsp;&nbsp;[\]</span><span>c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp;[\]</span><span> c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp; &nbsp;[\]</span><span> c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b[\]</span><span>&nbsp;c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp;[\]</span><span>&nbsp;c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp;&nbsp;[\]</span><span>&nbsp;c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp; &nbsp;[\]</span><span>&nbsp;c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp; &nbsp;&nbsp;[\]</span><span>&nbsp;c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b[\]</span><span><span>c</span></span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp;[\]</span><span><span>c</span></span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp;&nbsp;[\]</span><span><span>c</span></span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp; &nbsp;[\]</span><span><span>c</span></span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp; &nbsp;&nbsp;[\]</span><span><span>c</span></span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp;[\]</span><span><span> c</span></span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp; &nbsp;[\]</span><span><span> c</span></span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b[\]</span><span><span>&nbsp;c</span></span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp;[\]</span><span><span>&nbsp;c</span></span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp;&nbsp;[\]</span><span><span>&nbsp;c</span></span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp; &nbsp;[\]</span><span><span>&nbsp;c</span></span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span>b&nbsp; &nbsp;&nbsp;[\]</span><span><span>&nbsp;c</span></span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span><span>b[\]</span></span><span>c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span><span>b&nbsp;[\]</span></span><span>c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span><span>b&nbsp;&nbsp;[\]</span></span><span>c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span><span>b&nbsp; &nbsp;[\]</span></span><span>c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span><span>b&nbsp; &nbsp;&nbsp;[\]</span></span><span>c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span><span>b&nbsp;[\]</span></span><span> c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span><span>b&nbsp; &nbsp;[\]</span></span><span> c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span><span>b[\]</span></span><span>&nbsp;c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span><span>b&nbsp;[\]</span></span><span>&nbsp;c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span><span>b&nbsp;&nbsp;[\]</span></span><span>&nbsp;c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span><span>b&nbsp; &nbsp;[\]</span></span><span>&nbsp;c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a<span><span>b&nbsp; &nbsp;&nbsp;[\]</span></span><span>&nbsp;c</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "   ") at "a[\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "    ") at "a[\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "     ") at "a[\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "      ") at "a[\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "       ") at "a[\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "  ") at "a[\]"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "   ") at "a[\]"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "    ") at "a[\]"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "     ") at "a[\]"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "      ") at "a[\]"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "       ") at "a[\]"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0\\u00A0\\u00A0") at "a[\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0\\u00A0\\u00A0\\u00A0") at "a[\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0\\u00A0\\u00A0\\u00A0\\u00A0") at "a[\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0\\u00A0\\u00A0\\u00A0\\u00A0\\u00A0") at "a[\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0\\u00A0\\u00A0\\u00A0\\u00A0\\u00A0\\u00A0") at "a[\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0\\u00A0") at "a[\]"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0\\u00A0\\u00A0") at "a[\]"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0\\u00A0\\u00A0\\u00A0") at "a[\]"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0\\u00A0\\u00A0\\u00A0\\u00A0") at "a[\]"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0\\u00A0\\u00A0\\u00A0\\u00A0\\u00A0") at "a[\]"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0\\u00A0\\u00A0\\u00A0\\u00A0\\u00A0\\u00A0") at "a[\]"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a[\]<span style=white-space:pre>b</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp;[\]<span style=white-space:pre>b</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp;&nbsp;[\]<span style=white-space:pre>b</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp; &nbsp;[\]<span style=white-space:pre>b</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp; &nbsp;&nbsp;[\]<span style=white-space:pre>b</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a[\]<span style=white-space:pre> </span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp;[\]<span style=white-space:pre> </span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp;&nbsp;[\]<span style=white-space:pre> </span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp; &nbsp;[\]<span style=white-space:pre> </span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp; &nbsp;&nbsp;[\]<span style=white-space:pre> </span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a[\]<span style=white-space:pre>&nbsp;</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp;[\]<span style=white-space:pre>&nbsp;</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp;&nbsp;[\]<span style=white-space:pre>&nbsp;</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp; &nbsp;[\]<span style=white-space:pre>&nbsp;</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, " ") at "a&nbsp; &nbsp;&nbsp;[\]<span style=white-space:pre>&nbsp;</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0") at "a[\]<span style=white-space:pre>b</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0") at "a&nbsp;[\]<span style=white-space:pre>b</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0") at "a&nbsp;&nbsp;[\]<span style=white-space:pre>b</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0") at "a&nbsp; &nbsp;[\]<span style=white-space:pre>b</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0") at "a&nbsp; &nbsp;&nbsp;[\]<span style=white-space:pre>b</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0") at "a[\]<span style=white-space:pre> </span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0") at "a&nbsp;[\]<span style=white-space:pre> </span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0") at "a&nbsp;&nbsp;[\]<span style=white-space:pre> </span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0") at "a&nbsp; &nbsp;[\]<span style=white-space:pre> </span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0") at "a&nbsp; &nbsp;&nbsp;[\]<span style=white-space:pre> </span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0") at "a[\]<span style=white-space:pre>&nbsp;</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0") at "a&nbsp;[\]<span style=white-space:pre>&nbsp;</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0") at "a&nbsp;&nbsp;[\]<span style=white-space:pre>&nbsp;</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0") at "a&nbsp; &nbsp;[\]<span style=white-space:pre>&nbsp;</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "\\u00A0") at "a&nbsp; &nbsp;&nbsp;[\]<span style=white-space:pre>&nbsp;</span>"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "b") at "a[\]&nbsp;&nbsp;&nbsp;&nbsp;c"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "b") at "a&nbsp;[\]&nbsp;&nbsp;&nbsp;c"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "b") at "a&nbsp;&nbsp;&nbsp;[\]&nbsp;c"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, "b") at "a&nbsp;&nbsp;&nbsp;&nbsp;[\]c"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, ""): "a[\]&nbsp;|b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, ""): "a&nbsp;[\]|b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, ""): "a[\]|&nbsp;b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, ""): "a|[\]&nbsp;b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, ""): "a|&nbsp;[\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, ""): "a[\] |&nbsp;b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, ""): "a [\]|&nbsp;b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, ""): "a |[\]&nbsp;b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, ""): "a |&nbsp;[\]b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, ""): "a[\]&nbsp;|&nbsp;b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, ""): "a&nbsp;[\]|&nbsp;b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, ""): "a&nbsp;|[\]&nbsp;b"]
+    expected: FAIL
+
+  [execCommand("inserttext", false, ""): "a&nbsp;|&nbsp;[\]b"]
+    expected: FAIL


### PR DESCRIPTION
Fixes an infinite loop when inserting non-ASCII text with inserttext.

Testing: Less crashes. This uncovers some failures for autolinking and chrome-specific whitespace handling. Autolinking is just not implemented yet and the whitespace handling also has a bunch of failures in Safari and Ladybird. But both of these can be looked at in a subsequent PR.
Fixes: https://github.com/servo/servo/issues/47152
