### PR TITLE
script: Fix handling of blobs for hyperlinks

### DIFF
--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -185,7 +185,7 @@ impl FileManager {
             FileManagerThreadMsg::ActivateBlobURL(id, sender, origin) => {
                 let _ = sender.send(self.store.set_blob_url_validity(true, &id, &origin));
             },
-            FileManagerThreadMsg::GetTokenForFile(id, _origin, sender) => {
+            FileManagerThreadMsg::GetTokenForFile(id, sender) => {
                 let token = match self.get_token_for_file(&id, false) {
                     FileTokenCheck::Required(token) => Some(token),
                     _ => None,

--- a/components/net/protocols/blob.rs
+++ b/components/net/protocols/blob.rs
@@ -43,7 +43,7 @@ impl ProtocolHandler for BlobProtocolHander {
             (token.file_id, token.origin.clone())
         } else {
             // FIXME: This should never happen, we should have acquired a token beforehand
-            let Ok((id, _)) = parse_blob_url(&url_and_blob_claim.url()) else {
+            let Ok(id) = parse_blob_url(&url_and_blob_claim.url()) else {
                 return Box::pin(ready(Response::network_error(
                     NetworkError::ResourceLoadError("Invalid blob URL".into()),
                 )));

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -809,7 +809,7 @@ impl CoreResourceManager {
             "blob" => {
                 if let Some(token) = request.current_url_with_blob_claim().token() {
                     (FileTokenCheck::Required(token.token), Some(token.file_id))
-                } else if let Ok((id, _)) = parse_blob_url(&url) {
+                } else if let Ok(id) = parse_blob_url(&url) {
                     // See https://github.com/servo/servo/issues/25226
                     log::warn!(
                         "Failed to claim blob URL entry of valid blob URL before passing it to `net`. This causes race conditions."

--- a/components/script/dom/document/document_embedder_controls.rs
+++ b/components/script/dom/document/document_embedder_controls.rs
@@ -10,7 +10,7 @@ use embedder_traits::{
     EmbedderControlRequest, EmbedderControlResponse, EmbedderMsg,
 };
 use euclid::{Point2D, Rect, Size2D};
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use net_traits::CoreResourceMsg;
 use net_traits::filemanager_thread::FileManagerThreadMsg;
 use rustc_hash::FxHashMap;
@@ -247,7 +247,7 @@ impl DocumentEmbedderControls {
         }
     }
 
-    pub(crate) fn show_context_menu(&self, hit_test_result: &HitTestResult) {
+    pub(crate) fn show_context_menu(&self, no_gc: &NoGC, hit_test_result: &HitTestResult) {
         {
             let mut visible_elements = self.visible_elements.borrow_mut();
             visible_elements.retain(|index, control_element| {
@@ -298,7 +298,7 @@ impl DocumentEmbedderControls {
         if let Some(anchor_element) = anchor_element.as_ref() {
             info.flags.insert(ContextMenuElementInformationFlags::Link);
             info.link_url = anchor_element
-                .full_href_url_for_user_interface()
+                .full_href_url_for_user_interface(no_gc)
                 .map(ServoUrl::into_url);
 
             items.extend(vec![
@@ -480,17 +480,17 @@ impl ContextMenuNodes {
                 };
 
                 let url_string = anchor_element
-                    .full_href_url_for_user_interface()
+                    .full_href_url_for_user_interface(cx.no_gc())
                     .as_ref()
                     .map(ServoUrl::to_string)
-                    .unwrap_or_else(|| String::from(anchor_element.Href()));
+                    .unwrap_or_else(|| String::from(anchor_element.Href(cx.no_gc())));
                 set_clipboard_text(url_string);
             },
             ContextMenuAction::OpenLinkInNewWebView => {
                 let Some(anchor_element) = &self.anchor_element else {
                     return;
                 };
-                if let Some(url) = anchor_element.full_href_url_for_user_interface() {
+                if let Some(url) = anchor_element.full_href_url_for_user_interface(cx.no_gc()) {
                     open_url_in_new_webview(cx, url);
                 };
             },

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -21,7 +21,7 @@ use embedder_traits::{
     GamepadEvent as EmbedderGamepadEvent, GamepadSupportedHapticEffects, GamepadUpdateType,
 };
 use euclid::{Point2D, Vector2D};
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use keyboard_types::{Code, Key, KeyState, Modifiers, NamedKey};
 use layout_api::{HitTestFlags, ScrollContainerQueryFlags, node_id_from_scroll_id};
 use rustc_hash::FxHashMap;
@@ -758,10 +758,14 @@ impl DocumentEventHandler {
         // Send mousemove event. Routed to the capture target when capture is active.
         mouse_event.upcast::<Event>().fire(cx, &pointer_target);
 
-        self.update_current_hover_target_and_status(Some(new_target));
+        self.update_current_hover_target_and_status(cx.no_gc(), Some(new_target));
     }
 
-    fn update_current_hover_target_and_status(&self, new_hover_target: Option<DomRoot<Element>>) {
+    fn update_current_hover_target_and_status(
+        &self,
+        no_gc: &NoGC,
+        new_hover_target: Option<DomRoot<Element>>,
+    ) {
         let current_hover_target = self.current_hover_target.get();
         if current_hover_target == new_hover_target {
             return;
@@ -779,7 +783,7 @@ impl DocumentEventHandler {
                 .find_map(DomRoot::downcast::<HTMLAnchorElement>)
         {
             let status = anchor
-                .full_href_url_for_user_interface()
+                .full_href_url_for_user_interface(no_gc)
                 .map(|url| url.to_string());
             self.window
                 .send_to_embedder(EmbedderMsg::Status(self.window.webview_id(), status));
@@ -1221,7 +1225,7 @@ impl DocumentEventHandler {
             self.window
                 .Document()
                 .embedder_controls()
-                .show_context_menu(hit_test_result);
+                .show_context_menu(cx.no_gc(), hit_test_result);
         };
     }
 

--- a/components/script/dom/globalscope/origin.rs
+++ b/components/script/dom/globalscope/origin.rs
@@ -75,7 +75,7 @@ impl Origin {
 
         // <https://html.spec.whatwg.org/multipage/#api-for-a-and-area-elements:extract-an-origin>
         if let Ok(anchor_obj) = root_from_handlevalue::<HTMLAnchorElement>(cx, value) {
-            anchor_obj.reinitialize_url();
+            anchor_obj.reinitialize_url(cx.no_gc());
             if let Some(ref url) = *anchor_obj.get_url().borrow() {
                 return Some(url.origin());
             }
@@ -84,7 +84,7 @@ impl Origin {
 
         // <https://html.spec.whatwg.org/multipage/#api-for-a-and-area-elements:extract-an-origin>
         if let Ok(area_obj) = root_from_handlevalue::<HTMLAreaElement>(cx, value) {
-            area_obj.reinitialize_url();
+            area_obj.reinitialize_url(cx.no_gc());
             if let Some(ref url) = *area_obj.get_url().borrow() {
                 return Some(url.origin());
             }

--- a/components/script/dom/html/embedded_content/htmlareaelement.rs
+++ b/components/script/dom/html/embedded_content/htmlareaelement.rs
@@ -10,10 +10,10 @@ use cssparser::match_ignore_ascii_case;
 use dom_struct::dom_struct;
 use euclid::default::Point2D;
 use html5ever::{LocalName, Prefix, local_name};
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::rust::HandleObject;
+use net_traits::blob_url_store::UrlWithBlobClaim;
 use script_bindings::cell::DomRefCell;
-use servo_url::ServoUrl;
 use style::attr::AttrValue;
 use stylo_atoms::Atom;
 use stylo_dom::ElementState;
@@ -269,7 +269,7 @@ pub(crate) struct HTMLAreaElement {
     #[no_trace]
     relations: Cell<LinkRelations>,
     #[no_trace]
-    url: DomRefCell<Option<ServoUrl>>,
+    url: DomRefCell<Option<UrlWithBlobClaim>>,
 }
 
 impl HTMLAreaElement {
@@ -323,7 +323,7 @@ impl HTMLAreaElement {
 }
 
 impl HyperlinkElement for HTMLAreaElement {
-    fn get_url(&self) -> &DomRefCell<Option<ServoUrl>> {
+    fn get_url(&self) -> &DomRefCell<Option<UrlWithBlobClaim>> {
         &self.url
     }
 }
@@ -353,6 +353,12 @@ impl VirtualMethods for HTMLAreaElement {
             .unwrap()
             .attribute_mutated(cx, attr, mutation);
 
+        self.attribute_mutated_for_hyperlinks(cx.no_gc(), attr, mutation);
+
+        // https://html.spec.whatwg.org/multipage/#introduction-2
+        // > Similarly, for a and area elements with an href attribute and a rel attribute,
+        // > links must be created for the keywords of the rel attribute
+        // > as defined for those keywords in the link types section.
         match *attr.local_name() {
             local_name!("href") => self
                 .upcast::<Element>()
@@ -407,23 +413,21 @@ impl HTMLAreaElementMethods<crate::DomTypeHolder> for HTMLAreaElement {
     make_setter!(SetReferrerPolicy, "referrerpolicy");
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-href>
-    fn Href(&self) -> USVString {
-        self.get_href()
+    fn Href(&self, no_gc: &NoGC) -> USVString {
+        self.get_href(no_gc)
     }
 
-    /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-href>
-    fn SetHref(&self, cx: &mut JSContext, value: USVString) {
-        self.set_href(cx, value);
-    }
+    // https://html.spec.whatwg.org/multipage/#dom-hyperlink-href
+    make_url_setter!(SetHref, "href");
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-origin>
-    fn Origin(&self) -> USVString {
-        self.get_origin()
+    fn Origin(&self, no_gc: &NoGC) -> USVString {
+        self.get_origin(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-protocol>
-    fn Protocol(&self) -> USVString {
-        self.get_protocol()
+    fn Protocol(&self, no_gc: &NoGC) -> USVString {
+        self.get_protocol(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-protocol>
@@ -432,8 +436,8 @@ impl HTMLAreaElementMethods<crate::DomTypeHolder> for HTMLAreaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-password>
-    fn Password(&self) -> USVString {
-        self.get_password()
+    fn Password(&self, no_gc: &NoGC) -> USVString {
+        self.get_password(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-password>
@@ -442,8 +446,8 @@ impl HTMLAreaElementMethods<crate::DomTypeHolder> for HTMLAreaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-hash>
-    fn Hash(&self) -> USVString {
-        self.get_hash()
+    fn Hash(&self, no_gc: &NoGC) -> USVString {
+        self.get_hash(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-hash>
@@ -452,8 +456,8 @@ impl HTMLAreaElementMethods<crate::DomTypeHolder> for HTMLAreaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-host>
-    fn Host(&self) -> USVString {
-        self.get_host()
+    fn Host(&self, no_gc: &NoGC) -> USVString {
+        self.get_host(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-host>
@@ -462,8 +466,8 @@ impl HTMLAreaElementMethods<crate::DomTypeHolder> for HTMLAreaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-hostname>
-    fn Hostname(&self) -> USVString {
-        self.get_hostname()
+    fn Hostname(&self, no_gc: &NoGC) -> USVString {
+        self.get_hostname(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-hostname>
@@ -472,8 +476,8 @@ impl HTMLAreaElementMethods<crate::DomTypeHolder> for HTMLAreaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-port>
-    fn Port(&self) -> USVString {
-        self.get_port()
+    fn Port(&self, no_gc: &NoGC) -> USVString {
+        self.get_port(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-port>
@@ -482,8 +486,8 @@ impl HTMLAreaElementMethods<crate::DomTypeHolder> for HTMLAreaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-pathname>
-    fn Pathname(&self) -> USVString {
-        self.get_pathname()
+    fn Pathname(&self, no_gc: &NoGC) -> USVString {
+        self.get_pathname(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-pathname>
@@ -492,8 +496,8 @@ impl HTMLAreaElementMethods<crate::DomTypeHolder> for HTMLAreaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-search>
-    fn Search(&self) -> USVString {
-        self.get_search()
+    fn Search(&self, no_gc: &NoGC) -> USVString {
+        self.get_search(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-search>
@@ -502,8 +506,8 @@ impl HTMLAreaElementMethods<crate::DomTypeHolder> for HTMLAreaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-username>
-    fn Username(&self) -> USVString {
-        self.get_username()
+    fn Username(&self, no_gc: &NoGC) -> USVString {
+        self.get_username(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-username>

--- a/components/script/dom/html/htmlanchorelement.rs
+++ b/components/script/dom/html/htmlanchorelement.rs
@@ -7,8 +7,9 @@ use std::default::Default;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name};
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::rust::HandleObject;
+use net_traits::blob_url_store::UrlWithBlobClaim;
 use num_traits::ToPrimitive;
 use script_bindings::cell::DomRefCell;
 use servo_url::ServoUrl;
@@ -44,7 +45,7 @@ pub(crate) struct HTMLAnchorElement {
     #[no_trace]
     relations: Cell<LinkRelations>,
     #[no_trace]
-    url: DomRefCell<Option<ServoUrl>>,
+    url: DomRefCell<Option<UrlWithBlobClaim>>,
 }
 
 impl HTMLAnchorElement {
@@ -80,16 +81,19 @@ impl HTMLAnchorElement {
 
     /// Get the full URL of the `href` attribute of this `<a>` element, returning `None` if
     /// the URL could not be joined with the `Document` URL.
-    pub(crate) fn full_href_url_for_user_interface(&self) -> Option<ServoUrl> {
+    pub(crate) fn full_href_url_for_user_interface(&self, no_gc: &NoGC) -> Option<ServoUrl> {
         if !self.upcast::<Element>().has_attribute(&local_name!("href")) {
             return None;
         }
-        self.owner_document().base_url().join(&self.Href()).ok()
+        self.owner_document()
+            .base_url()
+            .join(&self.Href(no_gc))
+            .ok()
     }
 }
 
 impl HyperlinkElement for HTMLAnchorElement {
-    fn get_url(&self) -> &DomRefCell<Option<ServoUrl>> {
+    fn get_url(&self) -> &DomRefCell<Option<UrlWithBlobClaim>> {
         &self.url
     }
 }
@@ -119,6 +123,12 @@ impl VirtualMethods for HTMLAnchorElement {
             .unwrap()
             .attribute_mutated(cx, attr, mutation);
 
+        self.attribute_mutated_for_hyperlinks(cx.no_gc(), attr, mutation);
+
+        // https://html.spec.whatwg.org/multipage/#introduction-2
+        // > Similarly, for a and area elements with an href attribute and a rel attribute,
+        // > links must be created for the keywords of the rel attribute
+        // > as defined for those keywords in the link types section.
         match *attr.local_name() {
             local_name!("href") => self
                 .upcast::<Element>()
@@ -218,23 +228,21 @@ impl HTMLAnchorElementMethods<crate::DomTypeHolder> for HTMLAnchorElement {
     make_setter!(SetTarget, "target");
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-href>
-    fn Href(&self) -> USVString {
-        self.get_href()
+    fn Href(&self, no_gc: &NoGC) -> USVString {
+        self.get_href(no_gc)
     }
 
-    /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-href>
-    fn SetHref(&self, cx: &mut JSContext, value: USVString) {
-        self.set_href(cx, value);
-    }
+    // https://html.spec.whatwg.org/multipage/#dom-hyperlink-href
+    make_url_setter!(SetHref, "href");
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-origin>
-    fn Origin(&self) -> USVString {
-        self.get_origin()
+    fn Origin(&self, no_gc: &NoGC) -> USVString {
+        self.get_origin(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-protocol>
-    fn Protocol(&self) -> USVString {
-        self.get_protocol()
+    fn Protocol(&self, no_gc: &NoGC) -> USVString {
+        self.get_protocol(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-protocol>
@@ -243,8 +251,8 @@ impl HTMLAnchorElementMethods<crate::DomTypeHolder> for HTMLAnchorElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-password>
-    fn Password(&self) -> USVString {
-        self.get_password()
+    fn Password(&self, no_gc: &NoGC) -> USVString {
+        self.get_password(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-password>
@@ -253,8 +261,8 @@ impl HTMLAnchorElementMethods<crate::DomTypeHolder> for HTMLAnchorElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-hash>
-    fn Hash(&self) -> USVString {
-        self.get_hash()
+    fn Hash(&self, no_gc: &NoGC) -> USVString {
+        self.get_hash(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-hash>
@@ -263,8 +271,8 @@ impl HTMLAnchorElementMethods<crate::DomTypeHolder> for HTMLAnchorElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-host>
-    fn Host(&self) -> USVString {
-        self.get_host()
+    fn Host(&self, no_gc: &NoGC) -> USVString {
+        self.get_host(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-host>
@@ -273,8 +281,8 @@ impl HTMLAnchorElementMethods<crate::DomTypeHolder> for HTMLAnchorElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-hostname>
-    fn Hostname(&self) -> USVString {
-        self.get_hostname()
+    fn Hostname(&self, no_gc: &NoGC) -> USVString {
+        self.get_hostname(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-hostname>
@@ -283,8 +291,8 @@ impl HTMLAnchorElementMethods<crate::DomTypeHolder> for HTMLAnchorElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-port>
-    fn Port(&self) -> USVString {
-        self.get_port()
+    fn Port(&self, no_gc: &NoGC) -> USVString {
+        self.get_port(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-port>
@@ -293,8 +301,8 @@ impl HTMLAnchorElementMethods<crate::DomTypeHolder> for HTMLAnchorElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-pathname>
-    fn Pathname(&self) -> USVString {
-        self.get_pathname()
+    fn Pathname(&self, no_gc: &NoGC) -> USVString {
+        self.get_pathname(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-pathname>
@@ -303,8 +311,8 @@ impl HTMLAnchorElementMethods<crate::DomTypeHolder> for HTMLAnchorElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-search>
-    fn Search(&self) -> USVString {
-        self.get_search()
+    fn Search(&self, no_gc: &NoGC) -> USVString {
+        self.get_search(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-search>
@@ -313,8 +321,8 @@ impl HTMLAnchorElementMethods<crate::DomTypeHolder> for HTMLAnchorElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-username>
-    fn Username(&self) -> USVString {
-        self.get_username()
+    fn Username(&self, no_gc: &NoGC) -> USVString {
+        self.get_username(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-username>

--- a/components/script/dom/html/htmlhyperlinkelementutils.rs
+++ b/components/script/dom/html/htmlhyperlinkelementutils.rs
@@ -2,57 +2,64 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use html5ever::local_name;
-use js::context::JSContext;
+use html5ever::{local_name, ns};
+use js::context::{JSContext, NoGC};
+use net_traits::blob_url_store::UrlWithBlobClaim;
 use script_bindings::cell::DomRefCell;
-use servo_url::ServoUrl;
 
 use crate::dom::bindings::conversions::DerivedFrom;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::str::{DOMString, USVString};
-use crate::dom::element::Element;
+use crate::dom::element::attributes::storage::AttrRef;
+use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::node::NodeTraits;
 use crate::dom::urlhelper::UrlHelper;
+use crate::url::ensure_blob_referenced_by_url_is_kept_alive;
 
 pub(crate) trait HyperlinkElement {
-    fn get_url(&self) -> &DomRefCell<Option<ServoUrl>>;
+    fn get_url(&self) -> &DomRefCell<Option<UrlWithBlobClaim>>;
 }
 
 /// <https://html.spec.whatwg.org/multipage/#htmlhyperlinkelementutils>
 pub(crate) trait HyperlinkElementTraits {
-    fn get_hash(&self) -> USVString;
+    fn get_hash(&self, no_gc: &NoGC) -> USVString;
     fn set_hash(&self, cx: &mut JSContext, value: USVString);
-    fn get_host(&self) -> USVString;
+    fn get_host(&self, no_gc: &NoGC) -> USVString;
     fn set_host(&self, cx: &mut JSContext, value: USVString);
-    fn get_hostname(&self) -> USVString;
+    fn get_hostname(&self, no_gc: &NoGC) -> USVString;
     fn set_hostname(&self, cx: &mut JSContext, value: USVString);
-    fn get_href(&self) -> USVString;
-    fn set_href(&self, cx: &mut JSContext, value: USVString);
-    fn get_origin(&self) -> USVString;
-    fn get_password(&self) -> USVString;
+    fn get_href(&self, no_gc: &NoGC) -> USVString;
+    fn get_origin(&self, no_gc: &NoGC) -> USVString;
+    fn get_password(&self, no_gc: &NoGC) -> USVString;
     fn set_password(&self, cx: &mut JSContext, value: USVString);
-    fn get_pathname(&self) -> USVString;
+    fn get_pathname(&self, no_gc: &NoGC) -> USVString;
     fn set_pathname(&self, cx: &mut JSContext, value: USVString);
-    fn get_port(&self) -> USVString;
+    fn get_port(&self, no_gc: &NoGC) -> USVString;
     fn set_port(&self, cx: &mut JSContext, value: USVString);
-    fn get_protocol(&self) -> USVString;
+    fn get_protocol(&self, no_gc: &NoGC) -> USVString;
     fn set_protocol(&self, cx: &mut JSContext, value: USVString);
-    fn get_search(&self) -> USVString;
+    fn get_search(&self, no_gc: &NoGC) -> USVString;
     fn set_search(&self, cx: &mut JSContext, value: USVString);
-    fn get_username(&self) -> USVString;
-    fn set_url(&self);
+    fn get_username(&self, no_gc: &NoGC) -> USVString;
+    fn set_url(&self, no_gc: &NoGC);
     fn set_username(&self, cx: &mut JSContext, value: USVString);
-    fn update_href(&self, cx: &mut JSContext, url: &ServoUrl);
-    fn reinitialize_url(&self);
+    fn update_href(&self, cx: &mut JSContext, url: String);
+    fn reinitialize_url(&self, no_gc: &NoGC);
+    fn attribute_mutated_for_hyperlinks(
+        &self,
+        no_gc: &NoGC,
+        attr: AttrRef<'_>,
+        mutation: AttributeMutation,
+    );
 }
 
 impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> HyperlinkElementTraits
     for T
 {
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-hash>
-    fn get_hash(&self) -> USVString {
+    fn get_hash(&self, no_gc: &NoGC) -> USVString {
         // Step 1. Reinitialize url.
-        self.reinitialize_url();
+        self.reinitialize_url(no_gc);
 
         // Step 2. Let url be this's url.
         match *self.get_url().borrow() {
@@ -72,12 +79,12 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-hash>
     fn set_hash(&self, cx: &mut JSContext, value: USVString) {
         // Step 1. Reinitialize url.
-        self.reinitialize_url();
+        self.reinitialize_url(cx.no_gc());
 
         // Step 2. Let url be this's url.
         // Step 3. If url is null, then return.
-        {
-            let mut url = self.get_url().borrow_mut();
+        let url = {
+            let mut url = self.get_url().safe_borrow_mut(cx.no_gc());
             let Some(url) = url.as_mut() else {
                 return;
             };
@@ -91,18 +98,17 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
             // Step 5.4.  Basic URL parse input, with url as url and fragment state as state
             // override.
             UrlHelper::SetHash(url, value);
-        }
+            url.as_str().to_owned()
+        };
 
         // Step 6. Update href.
-        let url = self.get_url().borrow();
-        // Above we checked for not None
-        self.update_href(cx, url.as_ref().unwrap());
+        self.update_href(cx, url);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-host>
-    fn get_host(&self) -> USVString {
+    fn get_host(&self, no_gc: &NoGC) -> USVString {
         // Step 1. Reinitialize url.
-        self.reinitialize_url();
+        self.reinitialize_url(no_gc);
 
         // Step 2. Let url be this's url.
         match *self.get_url().borrow() {
@@ -124,11 +130,11 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-host>
     fn set_host(&self, cx: &mut JSContext, value: USVString) {
         // Step 1. Reinitialize url.
-        self.reinitialize_url();
+        self.reinitialize_url(cx.no_gc());
 
         // Step 2. Let url be this's url.
-        {
-            let mut url = self.get_url().borrow_mut();
+        let url = {
+            let mut url = self.get_url().safe_borrow_mut(cx.no_gc());
             let url = match url.as_mut() {
                 // Step 3. If url or url's host is null, return the empty string.
                 Some(ref url) if url.cannot_be_a_base() => return,
@@ -139,18 +145,17 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
             // Step 4. Basic URL parse the given value, with url as url and host state as state
             // override.
             UrlHelper::SetHost(url, value);
-        }
+            url.as_str().to_owned()
+        };
 
         // Step 5. Update href.
-        let url = self.get_url().borrow();
-        // Tested above for not None
-        self.update_href(cx, url.as_ref().unwrap());
+        self.update_href(cx, url);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-hostname>
-    fn get_hostname(&self) -> USVString {
+    fn get_hostname(&self, no_gc: &NoGC) -> USVString {
         // Step 1. Reinitialize url.
-        self.reinitialize_url();
+        self.reinitialize_url(no_gc);
 
         // Step 2. Let url be this's url.
         match *self.get_url().borrow() {
@@ -166,11 +171,11 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-hostname>
     fn set_hostname(&self, cx: &mut JSContext, value: USVString) {
         // Step 1. Reinitialize url.
-        self.reinitialize_url();
+        self.reinitialize_url(cx.no_gc());
 
         // Step 2. Let url be this's url.
-        {
-            let mut url = self.get_url().borrow_mut();
+        let url = {
+            let mut url = self.get_url().safe_borrow_mut(cx.no_gc());
             let url = match url.as_mut() {
                 // Step 3. If url is null or url has an opaque path, then return.
                 None => return,
@@ -181,18 +186,17 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
             // Step 4. Basic URL parse the given value, with url as url and hostname state as state
             // override.
             UrlHelper::SetHostname(url, value);
-        }
+            url.as_str().to_owned()
+        };
 
         // Step 5. Update href.
-        let url = self.get_url().borrow();
-        // tested above for not None
-        self.update_href(cx, url.as_ref().unwrap());
+        self.update_href(cx, url);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-href>
-    fn get_href(&self) -> USVString {
+    fn get_href(&self, no_gc: &NoGC) -> USVString {
         // Step 1. Reinitialize url.
-        self.reinitialize_url();
+        self.reinitialize_url(no_gc);
 
         // Step 2. Let url be this's url.
         USVString(match *self.get_url().borrow() {
@@ -209,18 +213,10 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
         })
     }
 
-    /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-href
-    fn set_href(&self, cx: &mut JSContext, value: USVString) {
-        self.upcast::<Element>()
-            .set_string_attribute(cx, &local_name!("href"), value.into());
-
-        self.set_url();
-    }
-
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-origin>
-    fn get_origin(&self) -> USVString {
+    fn get_origin(&self, no_gc: &NoGC) -> USVString {
         // Step 1. Reinitialize url.
-        self.reinitialize_url();
+        self.reinitialize_url(no_gc);
 
         USVString(match *self.get_url().borrow() {
             // Step 2. If this's url is null, return the empty string.
@@ -231,9 +227,9 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-password>
-    fn get_password(&self) -> USVString {
+    fn get_password(&self, no_gc: &NoGC) -> USVString {
         // Step 1. Reinitialize url.
-        self.reinitialize_url();
+        self.reinitialize_url(no_gc);
 
         // Step 2. Let url be this's url.
         match *self.get_url().borrow() {
@@ -247,11 +243,11 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-password>
     fn set_password(&self, cx: &mut JSContext, value: USVString) {
         // Step 1. Reinitialize url.
-        self.reinitialize_url();
+        self.reinitialize_url(cx.no_gc());
 
-        {
+        let url = {
             // Step 2. Let url be this's url.
-            let mut url = self.get_url().borrow_mut();
+            let mut url = self.get_url().safe_borrow_mut(cx.no_gc());
             let url = match url.as_mut() {
                 // Step 3. If url is null or url cannot have a username/password/port, then return.
                 None => return,
@@ -261,18 +257,17 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
 
             // Step 4. Set the password, given url and the given value.
             UrlHelper::SetPassword(url, value);
-        }
+            url.as_str().to_owned()
+        };
 
         // Step 5. Update href.
-        let url = self.get_url().borrow();
-        // Tested above for not None
-        self.update_href(cx, url.as_ref().unwrap());
+        self.update_href(cx, url);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-pathname>
-    fn get_pathname(&self) -> USVString {
+    fn get_pathname(&self, no_gc: &NoGC) -> USVString {
         // Step 1. Reinitialize url.
-        self.reinitialize_url();
+        self.reinitialize_url(no_gc);
 
         // Step 2. Let url be this's url.
         match *self.get_url().borrow() {
@@ -286,11 +281,11 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-pathname>
     fn set_pathname(&self, cx: &mut JSContext, value: USVString) {
         // Step 1. Reinitialize url.
-        self.reinitialize_url();
+        self.reinitialize_url(cx.no_gc());
 
         // Step 2. Let url be this's url.
-        {
-            let mut url = self.get_url().borrow_mut();
+        let url = {
+            let mut url = self.get_url().safe_borrow_mut(cx.no_gc());
             let url = match url.as_mut() {
                 // Step 3. If url is null or url has an opaque path, then return.
                 None => return,
@@ -301,17 +296,17 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
             // Step 4. Set url's path to the empty list.
             // Step 5. Basic URL parse the given value, with url as url and path start state as state override.
             UrlHelper::SetPathname(url, value);
-        }
+            url.as_str().to_owned()
+        };
 
         // Step 6. Update href.
-        let url = self.get_url().borrow();
-        self.update_href(cx, url.as_ref().unwrap());
+        self.update_href(cx, url);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-port>
-    fn get_port(&self) -> USVString {
+    fn get_port(&self, no_gc: &NoGC) -> USVString {
         // Step 1. Reinitialize url.
-        self.reinitialize_url();
+        self.reinitialize_url(no_gc);
 
         // Step 2. Let url be this's url.
         match *self.get_url().borrow() {
@@ -325,39 +320,40 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-port>
     fn set_port(&self, cx: &mut JSContext, value: USVString) {
         // Step 1. Reinitialize url.
-        self.reinitialize_url();
+        self.reinitialize_url(cx.no_gc());
 
         // Step 2. Let url be this's url.
-        {
-            let mut url = self.get_url().borrow_mut();
+        let url = {
+            let mut url = self.get_url().safe_borrow_mut(cx.no_gc());
             let url = match url.as_mut() {
-            // Step 3. If url is null or url cannot have a username/password/port, then return.
-            None => return,
-            Some(ref url)
+                // Step 3. If url is null or url cannot have a username/password/port, then return.
                 // https://url.spec.whatwg.org/#cannot-have-a-username-password-port
-                if url.host().is_none() || url.cannot_be_a_base() || url.scheme() == "file" =>
-            {
-                return;
-            },
-            Some(url) => url,
-        };
+                // > A URL cannot have a username/password/port if its host is
+                // > null or the empty string, or its scheme is "file".
+                None => return,
+                Some(ref url)
+                    if url.host().is_none() || url.cannot_be_a_base() || url.scheme() == "file" =>
+                {
+                    return;
+                },
+                Some(url) => url,
+            };
 
             // Step 4. If the given value is the empty string, then set url's port to null.
             // Step 5. Otherwise, basic URL parse the given value, with url as url and port state as
             // state override.
             UrlHelper::SetPort(url, value);
-        }
+            url.as_str().to_owned()
+        };
 
         // Step 6. Update href.
-        let url = self.get_url().borrow();
-        // Tested above for not None
-        self.update_href(cx, url.as_ref().unwrap());
+        self.update_href(cx, url);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-protocol>
-    fn get_protocol(&self) -> USVString {
+    fn get_protocol(&self, no_gc: &NoGC) -> USVString {
         // Step 1. Reinitialize url.
-        self.reinitialize_url();
+        self.reinitialize_url(no_gc);
 
         match *self.get_url().borrow() {
             // Step 2. If this's url is null, return ":".
@@ -370,10 +366,10 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-protocol>
     fn set_protocol(&self, cx: &mut JSContext, value: USVString) {
         // Step 1. Reinitialize url.
-        self.reinitialize_url();
+        self.reinitialize_url(cx.no_gc());
 
-        {
-            let mut url = self.get_url().borrow_mut();
+        let url = {
+            let mut url = self.get_url().safe_borrow_mut(cx.no_gc());
             let url = match url.as_mut() {
                 // Step 2. If this's url is null, then return.
                 None => return,
@@ -383,18 +379,17 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
             // Step 3. Basic URL parse the given value, followed by ":", with this's url as url and
             // scheme start state as state override.
             UrlHelper::SetProtocol(url, value);
-        }
+            url.as_str().to_owned()
+        };
 
         // Step 4. Update href.
-        let url = self.get_url().borrow();
-        // Tested above for not None
-        self.update_href(cx, url.as_ref().unwrap());
+        self.update_href(cx, url);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-search>
-    fn get_search(&self) -> USVString {
+    fn get_search(&self, no_gc: &NoGC) -> USVString {
         // Step 1. Reinitialize url.
-        self.reinitialize_url();
+        self.reinitialize_url(no_gc);
 
         // Step 2. Let url be this's url.
         match *self.get_url().borrow() {
@@ -410,11 +405,11 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-search>
     fn set_search(&self, cx: &mut JSContext, value: USVString) {
         // Step 1. Reinitialize url.
-        self.reinitialize_url();
+        self.reinitialize_url(cx.no_gc());
 
         // Step 2. Let url be this's url.
-        {
-            let mut url = self.get_url().borrow_mut();
+        let url = {
+            let mut url = self.get_url().safe_borrow_mut(cx.no_gc());
             let url = match url.as_mut() {
                 // Step 3. If url is null, terminate these steps.
                 None => return,
@@ -425,17 +420,17 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
             // Step 5. Otherwise:
             // Note: Inner steps are handled by UrlHelper::SetSearch
             UrlHelper::SetSearch(url, value);
-        }
+            url.as_str().to_owned()
+        };
 
         // Step 6. Update href.
-        let url = self.get_url().borrow();
-        self.update_href(cx, url.as_ref().unwrap());
+        self.update_href(cx, url);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-username>
-    fn get_username(&self) -> USVString {
+    fn get_username(&self, no_gc: &NoGC) -> USVString {
         // Step 1. Reinitialize url.
-        self.reinitialize_url();
+        self.reinitialize_url(no_gc);
 
         match *self.get_url().borrow() {
             // Step 2. If this's url is null, return the empty string.
@@ -446,9 +441,9 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-hyperlink-url-set>
-    fn set_url(&self) {
+    fn set_url(&self, no_gc: &NoGC) {
         // Step 1. Set this element's url to null.
-        *self.get_url().borrow_mut() = None;
+        *self.get_url().safe_borrow_mut(no_gc) = None;
 
         let attribute = self
             .upcast::<Element>()
@@ -460,6 +455,7 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
         };
 
         let document = self.owner_document();
+        let global = self.owner_global();
 
         // Step 3. Let url be the result of encoding-parsing a URL given this element's href content
         // attribute's value, relative to this element's node document.
@@ -467,18 +463,19 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
 
         // Step 4. If url is not failure, then set this element's url to url.
         if let Ok(url) = url {
-            *self.get_url().borrow_mut() = Some(url);
+            *self.get_url().safe_borrow_mut(no_gc) =
+                Some(ensure_blob_referenced_by_url_is_kept_alive(&global, url));
         }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-username>
     fn set_username(&self, cx: &mut JSContext, value: USVString) {
         // Step 1. Reinitialize url.
-        self.reinitialize_url();
+        self.reinitialize_url(cx.no_gc());
 
         // Step 2. Let url be this's url.
-        {
-            let mut url = self.get_url().borrow_mut();
+        let url = {
+            let mut url = self.get_url().safe_borrow_mut(cx.no_gc());
             let url = match url.as_mut() {
                 // Step 3. If url is null or url cannot have a username/password/port, then return.
                 None => return,
@@ -488,24 +485,26 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
 
             // Step 4. Set the username, given url and the given value.
             UrlHelper::SetUsername(url, value);
-        }
+            url.as_str().to_owned()
+        };
 
         // Step 5. Update href.
-        let url = self.get_url().borrow();
-        self.update_href(cx, url.as_ref().unwrap());
+        self.update_href(cx, url);
     }
 
-    /// <https://html.spec.whatwg.org/multipage/#update-href>
-    fn update_href(&self, cx: &mut JSContext, url: &ServoUrl) {
+    /// <https://html.spec.whatwg.org/multipage/#api-for-a-and-area-elements:update-href>
+    fn update_href(&self, cx: &mut JSContext, url: String) {
+        // > To update href for an HTMLAnchorElement or HTMLAreaElement element,
+        // > set the element's href content attribute's value to the element's url, serialized.
         self.upcast::<Element>().set_string_attribute(
             cx,
             &local_name!("href"),
-            DOMString::from(url.as_str()),
+            DOMString::from(url),
         );
     }
 
     /// <https://html.spec.whatwg.org/multipage/#reinitialise-url>
-    fn reinitialize_url(&self) {
+    fn reinitialize_url(&self, no_gc: &NoGC) {
         // Step 1. If the element's url is non-null, its scheme is "blob", and it has an opaque
         // path, then terminate these steps.
         match *self.get_url().borrow() {
@@ -514,6 +513,30 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
         }
 
         // Step 2. Set the url.
-        self.set_url();
+        self.set_url(no_gc);
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#api-for-a-and-area-elements:concept-element-attributes-change-ext>
+    fn attribute_mutated_for_hyperlinks(
+        &self,
+        no_gc: &NoGC,
+        attr: AttrRef<'_>,
+        mutation: AttributeMutation,
+    ) {
+        // Step 1. If namespace is not null, then return.
+        if attr.namespace() != &ns!() {
+            return;
+        }
+        // Step 2. If oldValue equals value, then return.
+        if mutation.old_value(attr) == mutation.new_value(attr).map(|value| value.to_string()) {
+            return;
+        }
+        // Step 3. If localName is href, then set the url given element.
+        if attr.local_name() == &local_name!("href") {
+            self.set_url(no_gc);
+        }
+        // Step 4. If localName is href, referrerpolicy, or rel,
+        // then consider speculative loads given element's node document.
+        // TODO
     }
 }

--- a/components/script/dom/url/url.rs
+++ b/components/script/dom/url/url.rs
@@ -211,7 +211,7 @@ impl URLMethods<crate::DomTypeHolder> for URL {
 
         if let Ok(url) = ServoUrl::parse(&url.str()) &&
             url.fragment().is_none() &&
-            let Ok((id, _)) = parse_blob_url(&url)
+            let Ok(id) = parse_blob_url(&url)
         {
             let resource_threads = global.resource_threads();
             let (tx, rx) = generic_channel::channel(global.time_profiler_chan().clone()).unwrap();

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -618,10 +618,12 @@ DOMInterfaces = {
 
 "HTMLAnchorElement": {
     "cx": ['RelList'],
+    'no_gc': ['Href', 'Origin', 'Protocol', 'Password', 'Hash', 'Host', 'Hostname', 'Port', 'Pathname', 'Search', 'Username'],
 },
 
 "HTMLAreaElement": {
     "cx": ['RelList'],
+    'no_gc': ['Href', 'Origin', 'Protocol', 'Password', 'Hash', 'Host', 'Hostname', 'Port', 'Pathname', 'Search', 'Username'],
 },
 
 "HTMLAudioElement": {

--- a/components/shared/net/blob_url_store.rs
+++ b/components/shared/net/blob_url_store.rs
@@ -50,12 +50,7 @@ pub struct BlobBuf {
 /// Parse URL as Blob URL scheme's definition
 ///
 /// <https://w3c.github.io/FileAPI/#url-intro>
-///
-/// FIXME: This function should never be used to obtain the origin of a blob url, because
-/// it doesn't consider [blob URL entries].
-///
-/// [blob URL entries]: https://url.spec.whatwg.org/#concept-url-blob-entry
-pub fn parse_blob_url(url: &ServoUrl) -> Result<(Uuid, ImmutableOrigin), &'static str> {
+pub fn parse_blob_url(url: &ServoUrl) -> Result<Uuid, &'static str> {
     if url.query().is_some() {
         return Err("URL should not contain a query");
     }
@@ -64,16 +59,7 @@ pub fn parse_blob_url(url: &ServoUrl) -> Result<(Uuid, ImmutableOrigin), &'stati
         return Err("Failed to split origin from uuid");
     };
 
-    // See https://url.spec.whatwg.org/#origin - "blob" case
-    let origin = Url::parse(url.path())
-        .ok()
-        .filter(|url| matches!(url.scheme(), "http" | "https" | "file"))
-        .map(|url| ImmutableOrigin::new(&url))
-        .unwrap_or(ImmutableOrigin::new_opaque());
-
-    let id = Uuid::from_str(uuid).map_err(|_| "Failed to parse UUID from path segment")?;
-
-    Ok((id, origin))
+    Uuid::from_str(uuid).map_err(|_| "Failed to parse UUID from path segment")
 }
 
 /// This type upholds the variant that if the URL is a valid `blob` URL, then it has
@@ -97,12 +83,32 @@ impl UrlWithBlobClaim {
         self.token.as_ref().map(|guard| guard.token.file_id)
     }
 
+    /// <https://url.spec.whatwg.org/#concept-url-origin>
     pub fn origin(&self) -> ImmutableOrigin {
-        if let Some(guard) = self.token.as_ref() {
-            return guard.token.origin.clone();
-        }
+        // > The origin of a URL url is the origin returned by running these steps,
+        // > switching on url’s scheme:
+        let url = &self.url;
+        if url.scheme() == "blob" {
+            // Step 1. If url’s blob URL entry is non-null,
+            // then return url’s blob URL entry’s environment’s origin.
+            if let Some(guard) = self.token.as_ref() {
+                return guard.token.origin.clone();
+            }
 
-        self.url.origin()
+            // Step 2. Let pathURL be the result of parsing the result of URL path serializing url.
+            Url::parse(url.path())
+                .ok()
+                // Step 4. If pathURL’s scheme is "http", "https", or "file",
+                // then return pathURL’s origin.
+                .filter(|url| matches!(url.scheme(), "http" | "https" | "file"))
+                .map(|url| ImmutableOrigin::new(&url))
+                // Step 3. If pathURL is failure, then return a new opaque origin.
+                // Step 5. Return a new opaque origin.
+                .unwrap_or(ImmutableOrigin::new_opaque())
+        } else {
+            // > Return the tuple origin (url’s scheme, url’s host, url’s port, null).
+            url.origin()
+        }
     }
 
     /// Constructs a [UrlWithBlobClaim] for URLs that are not `blob` URLs
@@ -274,13 +280,13 @@ impl<'a> BlobResolver<'a> {
         if url.scheme() != "blob" {
             return None;
         }
-        let (file_id, origin) = parse_blob_url(url)
+        let file_id = parse_blob_url(url)
             .inspect_err(|error| log::warn!("Failed to acquire token for {url}: {error}"))
             .ok()?;
         let (sender, receiver) = generic_channel::channel().unwrap();
         self.resource_threads
             .send(CoreResourceMsg::ToFileManager(
-                FileManagerThreadMsg::GetTokenForFile(file_id, origin, sender),
+                FileManagerThreadMsg::GetTokenForFile(file_id, sender),
             ))
             .ok()?;
         let reply = receiver.recv().ok()?;

--- a/components/shared/net/filemanager_thread.rs
+++ b/components/shared/net/filemanager_thread.rs
@@ -168,7 +168,7 @@ pub enum FileManagerThreadMsg {
         GenericSender<Result<(), BlobURLStoreError>>,
     ),
 
-    GetTokenForFile(Uuid, ImmutableOrigin, GenericSender<GetTokenForFileReply>),
+    GetTokenForFile(Uuid, GenericSender<GetTokenForFileReply>),
     RevokeTokenForFile(Uuid, Uuid),
 }
 

--- a/components/shared/net/tests/lib.rs
+++ b/components/shared/net/tests/lib.rs
@@ -242,8 +242,7 @@ fn test_reset_start_time() {
 fn parse_blob_url_with_opaque_origin() {
     let input = ServoUrl::parse("blob:null/93947d57-a49f-4b00-bdcc-fbf1ed8b60ab").unwrap();
     let expected_uuid = Uuid::from_str("93947d57-a49f-4b00-bdcc-fbf1ed8b60ab").unwrap();
-    let (uuid, origin) = parse_blob_url(&input).unwrap();
+    let uuid = parse_blob_url(&input).unwrap();
 
     assert_eq!(uuid, expected_uuid);
-    assert!(!origin.is_tuple(), "Origin is not opaque");
 }

--- a/tests/wpt/meta/url/a-element-origin-xhtml.xhtml.ini
+++ b/tests/wpt/meta/url/a-element-origin-xhtml.xhtml.ini
@@ -1,16 +1,4 @@
 [a-element-origin-xhtml.xhtml]
-  [Parsing origin: <blob:blob:https://example.org/> against <about:blank>]
-    expected: FAIL
-
-  [Parsing origin: <blob:ftp://host/path> against <about:blank>]
-    expected: FAIL
-
-  [Parsing origin: <blob:ws://example.org/> against <about:blank>]
-    expected: FAIL
-
-  [Parsing origin: <blob:wss://example.org/> against <about:blank>]
-    expected: FAIL
-
   [Parsing origin: <http://a.b.c.XN--pokxncvks> against <about:blank>]
     expected: FAIL
 

--- a/tests/wpt/meta/url/a-element-origin.html.ini
+++ b/tests/wpt/meta/url/a-element-origin.html.ini
@@ -1,16 +1,4 @@
 [a-element-origin.html]
-  [Parsing origin: <blob:blob:https://example.org/> against <about:blank>]
-    expected: FAIL
-
-  [Parsing origin: <blob:ftp://host/path> against <about:blank>]
-    expected: FAIL
-
-  [Parsing origin: <blob:ws://example.org/> against <about:blank>]
-    expected: FAIL
-
-  [Parsing origin: <blob:wss://example.org/> against <about:blank>]
-    expected: FAIL
-
   [Parsing origin: <http://a.b.c.XN--pokxncvks> against <about:blank>]
     expected: FAIL
 


### PR DESCRIPTION
There were several issues. First of all, setting a `href` attribute didn't trigger the appropriate mutation callback.

That uncovered an issue with handling of blobs, which are tested by `url/a-element-origin*` tests. These tests check that the logic for obtaining origins of blobs correctly handles the case where the blob URL is not actually a blob with UUID. E.g. `blob:blob:https://example.org/`. In this case, the origin is opaque, whereas before it would return `blob:https://example.org/`. That's because the origin was computed, then a UUID was attempted to be parsed from the URL (which fails) and then no token is generated.

Instead, we need to obtain the origin on the `UrlWithBlobClaim` whenever requested. This actually fully implements https://url.spec.whatwg.org/#concept-url-origin where it now handles the Blob URL entries. That's the token we attach to it, where the token has the origin of the document/global.

All of this needed `get_url()` for `<a>` and `<area>` to be a `UrlWithBlobClaim`. When I ported that over together with the mutation callback, I ran into double borrow issues. Therefore, I ported the `borrow_mut` to `safe_borrow_mut`, ensuring the `cx.no_gc` checks if no GC happens. Then, the `self.update_href(cx, url.as_ref().unwrap());` was no longer required, since that can be the serialization of the URL.

There's quite a bit going on in this PR, but mostly is mechanical since the same logic was used in all of these places.