### PR TITLE
script: Simplify internal slots of `CryptoKey`

### DIFF
--- a/components/script/dom/webcrypto/cryptokey.rs
+++ b/components/script/dom/webcrypto/cryptokey.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::Cell;
 use std::str::FromStr;
 
 use dom_struct::dom_struct;
@@ -12,7 +11,6 @@ use js::jsapi::{Heap, JSObject, Value};
 use js::rust::MutableHandleObject;
 use malloc_size_of::MallocSizeOf;
 use rustc_hash::FxHashMap;
-use script_bindings::cell::{DomRefCell, Ref};
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::id::{CryptoKeyId, CryptoKeyIndex};
 use servo_constellation_traits::{SerializableCryptoKey, SerializableCryptoKeyHandle};
@@ -87,7 +85,7 @@ pub(crate) struct CryptoKey {
     key_type: KeyType,
 
     /// <https://w3c.github.io/webcrypto/#dfn-CryptoKey-slot-extractable>
-    extractable: Cell<bool>,
+    extractable: bool,
 
     /// <https://w3c.github.io/webcrypto/#dfn-CryptoKey-slot-algorithm>
     ///
@@ -103,7 +101,7 @@ pub(crate) struct CryptoKey {
     /// <https://w3c.github.io/webcrypto/#dfn-CryptoKey-slot-usages>
     ///
     /// The contents of the [[usages]] internal slot shall be of type Sequence<KeyUsage>.
-    usages: DomRefCell<Vec<KeyUsage>>,
+    usages: Vec<KeyUsage>,
 
     /// <https://w3c.github.io/webcrypto/#dfn-CryptoKey-slot-usages_cached>
     #[ignore_malloc_size_of = "Defined in mozjs"]
@@ -125,10 +123,10 @@ impl CryptoKey {
         CryptoKey {
             reflector_: Reflector::new(),
             key_type,
-            extractable: Cell::new(extractable),
+            extractable,
             algorithm,
             algorithm_cached: Heap::default(),
-            usages: DomRefCell::new(usages),
+            usages,
             usages_cached: Heap::default(),
             handle,
         }
@@ -176,8 +174,8 @@ impl CryptoKey {
         &self.algorithm
     }
 
-    pub(crate) fn usages(&self) -> Ref<'_, Vec<KeyUsage>> {
-        self.usages.borrow()
+    pub(crate) fn usages(&self) -> &[KeyUsage] {
+        &self.usages
     }
 
     pub(crate) fn handle(&self) -> &Handle {
@@ -196,7 +194,7 @@ impl CryptoKeyMethods<crate::DomTypeHolder> for CryptoKey {
     fn Extractable(&self) -> bool {
         // Reflects the [[extractable]] internal slot, which indicates whether or not the raw
         // keying material may be exported by the application.
-        self.extractable.get()
+        self.extractable
     }
 
     /// <https://w3c.github.io/webcrypto/#dom-cryptokey-algorithm>
@@ -228,11 +226,10 @@ impl Serializable for CryptoKey {
         // Step 5. Set serialized.[[Handle]] to the [[handle]] internal slot of value.
         let serialized = SerializableCryptoKey {
             key_type: self.key_type.as_str().into(),
-            extractable: self.extractable.get(),
+            extractable: self.extractable,
             algorithm: (&self.algorithm).into(),
             usages: self
                 .usages
-                .borrow()
                 .iter()
                 .map(|usage| usage.as_str().into())
                 .collect(),

--- a/components/script/dom/webcrypto/subtlecrypto/aes_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_common.rs
@@ -730,7 +730,7 @@ pub(crate) fn export_key(
             }
 
             // Step 2.5. Set the key_ops attribute of jwk to equal the usages attribute of key.
-            jwk.set_key_ops(&key.usages());
+            jwk.set_key_ops(key.usages());
 
             // Step 2.6. Set the ext attribute of jwk to equal the [[extractable]] internal slot of
             // key.

--- a/components/script/dom/webcrypto/subtlecrypto/chacha20_poly1305_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/chacha20_poly1305_operation.rs
@@ -376,7 +376,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             jwk.alg = Some(DOMString::from("C20P"));
 
             // Step 2.5. Set the key_ops attribute of jwk to equal the usages attribute of key.
-            jwk.set_key_ops(&key.usages());
+            jwk.set_key_ops(key.usages());
 
             // Step 2.6. Set the ext attribute of jwk to equal the [[extractable]] internal slot of
             // key.

--- a/components/script/dom/webcrypto/subtlecrypto/ec_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ec_common.rs
@@ -1146,7 +1146,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             }
 
             // Step 3.4. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.set_key_ops(&key.usages());
+            jwk.set_key_ops(key.usages());
 
             // Step 3.4. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());

--- a/components/script/dom/webcrypto/subtlecrypto/ed25519_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ed25519_operation.rs
@@ -579,7 +579,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             }
 
             // Step 3.7. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.set_key_ops(&key.usages());
+            jwk.set_key_ops(key.usages());
 
             // Step 3.8. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());

--- a/components/script/dom/webcrypto/subtlecrypto/ed448_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ed448_operation.rs
@@ -683,7 +683,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             }
 
             // Step 3.7. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.set_key_ops(&key.usages());
+            jwk.set_key_ops(key.usages());
 
             // Step 3.8. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());

--- a/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
@@ -424,7 +424,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             jwk.alg = Some(DOMString::from(hash_algorithm));
 
             // Step 4.7. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.set_key_ops(&key.usages());
+            jwk.set_key_ops(key.usages());
 
             // Step 4.8. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());

--- a/components/script/dom/webcrypto/subtlecrypto/kmac_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/kmac_operation.rs
@@ -450,7 +450,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             }
 
             // Step 4.6. Set the key_ops attribute of jwk to equal the usages attribute of key.
-            jwk.set_key_ops(&key.usages());
+            jwk.set_key_ops(key.usages());
 
             // Step 4.7. Set the ext attribute of jwk to equal the [[extractable]] internal slot of
             // key.

--- a/components/script/dom/webcrypto/subtlecrypto/ml_dsa_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ml_dsa_operation.rs
@@ -1153,7 +1153,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             }
 
             // Step 3.7. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.set_key_ops(&key.usages());
+            jwk.set_key_ops(key.usages());
 
             // Step 3.8. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());

--- a/components/script/dom/webcrypto/subtlecrypto/ml_kem_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ml_kem_operation.rs
@@ -1289,7 +1289,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             }
 
             // Step 2.7. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.set_key_ops(&key.usages());
+            jwk.set_key_ops(key.usages());
 
             // Step 2.8. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());

--- a/components/script/dom/webcrypto/subtlecrypto/rsa_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsa_common.rs
@@ -968,7 +968,7 @@ pub(crate) fn export_key(
             }
 
             // Step 3.7. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.set_key_ops(&key.usages());
+            jwk.set_key_ops(key.usages());
 
             // Step 3.8. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());

--- a/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
@@ -680,7 +680,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             }
 
             // Step 3.6. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.set_key_ops(&key.usages());
+            jwk.set_key_ops(key.usages());
 
             // Step 3.7. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());

--- a/components/script/dom/webcrypto/subtlecrypto/x448_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/x448_operation.rs
@@ -711,7 +711,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             }
 
             // Step 3.6. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.set_key_ops(&key.usages());
+            jwk.set_key_ops(key.usages());
 
             // Step 3.7. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());


### PR DESCRIPTION
After #47178, the [[extractable]] and [[usages]] internal slots of the `CryptoKey` interface will not change after the key creation. We can take away the `Cell` from the [[extractable]] internal slot and `DomRefCell` from the [[usages]] internal slot to simplify the code.

Testing: Refactoring. Existing tests suffice.
