### PR TITLE
servo: Wait for URL change notification in unit test.

### DIFF
--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -140,7 +140,7 @@ fn test_create_webview_http_custom_host() {
         .url(custom_url.clone().into_url())
         .build();
 
-    servo_test.spin(move || !delegate.load_status_changed.get());
+    servo_test.spin(move || !delegate.load_status_changed.get() || !delegate.url_changed.get()));
 
     let _ = server.close();
 

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -140,7 +140,7 @@ fn test_create_webview_http_custom_host() {
         .url(custom_url.clone().into_url())
         .build();
 
-    servo_test.spin(move || !delegate.load_status_changed.get() || !delegate.url_changed.get()));
+    servo_test.spin(move || !delegate.load_status_changed.get() || !delegate.url_changed.get());
 
     let _ = server.close();
 


### PR DESCRIPTION
The test asserts the current URL of the webview, but it doesn't always wait long enough for the URL to be updated. Both conditions are necessary because there is not a guaranteed ordering between the session history update and the load status update, since they are triggered by different threads.

Testing: Modifies an existing unit test.
Fixes: #47239
