### PR TITLE
net: Store memory cache to disk on shutdown

### DIFF
--- a/components/net/async_runtime.rs
+++ b/components/net/async_runtime.rs
@@ -82,7 +82,7 @@ where
 }
 
 /// Spawn a blocking task using the handle to the runtime.
-pub fn spawn_blocking_task<F, R>(task: F) -> F::Output
+pub fn spawn_blocking_task<F>(task: F) -> F::Output
 where
     F: Future,
 {

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -174,7 +174,7 @@ type QuickCachePlaceholderGuard<'a> = PlaceholderGuard<
 >;
 
 /// Is this state assigned to the private or public side.
-#[derive(Debug, MallocSizeOf, PartialEq)]
+#[derive(Clone, Debug, MallocSizeOf, PartialEq)]
 pub enum HttpCacheAssignment {
     /// Public Cache State, possibly stored to disk.
     Public,
@@ -187,10 +187,14 @@ pub enum HttpCacheAssignment {
 /// by the number of entries per given url. We evict currently a whole url.
 /// The cache makes extensive use of `Arc::unwrap_or_clone or` and `Arc::into_inner`
 /// to modify the cached entries. This is ok because `CachedResource` are cheap to clone
+///
+/// If the [`DiskCache`] is enabled, evicted elements will first land in the DiskCache. We check the DiskCache for a
+/// cache hit per request.
 pub struct HttpCache {
     /// cached responses.
     entries: QuickCache,
     disk_cache: Option<std::sync::Arc<DiskCache>>,
+    cache_assignment: HttpCacheAssignment,
 }
 
 impl MallocSizeOf for HttpCache {
@@ -208,11 +212,11 @@ impl MallocSizeOf for HttpCache {
 
 impl HttpCache {
     /// Create a new HttpCache with [`HttpCacheAssignment`]
-    pub fn new(assignment: HttpCacheAssignment) -> Self {
+    pub fn new(cache_assignment: HttpCacheAssignment) -> Self {
         let size = pref!(network_http_cache_size)
             .try_into()
             .expect("http_cache_size needs to fit into u64");
-        let (disk_cache, lifecycle) = DiskCache::new(assignment);
+        let (disk_cache, lifecycle) = DiskCache::new(cache_assignment.clone());
         let memory_cache = Cache::with(
             size,
             size as u64,
@@ -224,6 +228,24 @@ impl HttpCache {
         Self {
             entries: memory_cache,
             disk_cache,
+            cache_assignment,
+        }
+    }
+
+    /// Stores all entries from the memory cache to the disk cache.
+    /// This should be only used for shutdown as it leaves the relationship between the memory and disk cache
+    pub async fn shutdown(&self) {
+        log::error!(
+            "DISK CACHE IS {:?}, assignment {:?}",
+            self.disk_cache.is_some(),
+            self.cache_assignment
+        );
+        if let Some(disk_cache) = &self.disk_cache &&
+            self.cache_assignment == HttpCacheAssignment::Public
+        {
+            for (key, entry) in self.entries.iter() {
+                let _ = disk_cache.store(key, entry).await;
+            }
         }
     }
 }

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -235,17 +235,14 @@ impl HttpCache {
     /// Stores all entries from the memory cache to the disk cache.
     /// This should be only used for shutdown as it leaves the relationship between the memory and disk cache
     pub async fn shutdown(&self) {
-        log::error!(
-            "DISK CACHE IS {:?}, assignment {:?}",
-            self.disk_cache.is_some(),
-            self.cache_assignment
-        );
         if let Some(disk_cache) = &self.disk_cache &&
             self.cache_assignment == HttpCacheAssignment::Public
         {
             for (key, entry) in self.entries.iter() {
                 let _ = disk_cache.store(key, entry).await;
             }
+        } else {
+            log::debug!("No disk cache enabled. Not saving memory cache.");
         }
     }
 }

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -75,7 +75,7 @@ use tokio_stream::wrappers::ReceiverStream;
 #[cfg(feature = "tracing")]
 use tracing::Instrument;
 
-use crate::async_runtime::spawn_task;
+use crate::async_runtime::{self, spawn_task};
 use crate::connector::{
     CertificateErrorOverrideManager, ServoClient, TlsHandshakeInfo, create_tls_config,
 };
@@ -159,6 +159,13 @@ impl HttpState {
                 sender,
             ));
         receiver.await.ok()?
+    }
+
+    /// Shuts down the cache, potentially storing elements.
+    pub(crate) fn shutdown(&self) {
+        async_runtime::spawn_blocking_task(async move {
+            self.http_cache.shutdown().await;
+        });
     }
 }
 

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -670,8 +670,10 @@ impl ResourceChannelManager {
                     let hsts = http_state.hsts_list.read();
                     servo_base::write_json_to_file(&*hsts, config_dir, "hsts_list.json");
                 }
+
                 self.resource_manager.exit();
 
+                http_state.shutdown();
                 let _ = sender.send(());
                 return false;
             },

--- a/components/net/test_util.rs
+++ b/components/net/test_util.rs
@@ -95,9 +95,7 @@ where
     let listener = StdTcpListener::bind("0.0.0.0:0").unwrap();
     listener.set_nonblocking(true).unwrap();
     let listener =
-        spawn_blocking_task::<_, TcpListener>(
-            async move { TcpListener::from_std(listener).unwrap() },
-        );
+        spawn_blocking_task::<_>(async move { TcpListener::from_std(listener).unwrap() });
 
     let url_string = format!("http://localhost:{}", listener.local_addr().unwrap().port());
     let url = UrlWithBlobClaim::new(ServoUrl::parse(&url_string).unwrap(), None);
@@ -190,9 +188,7 @@ where
     let listener = StdTcpListener::bind("[::0]:0").unwrap();
     listener.set_nonblocking(true).unwrap();
     let listener =
-        spawn_blocking_task::<_, TcpListener>(
-            async move { TcpListener::from_std(listener).unwrap() },
-        );
+        spawn_blocking_task::<_>(async move { TcpListener::from_std(listener).unwrap() });
 
     let url_string = format!("http://localhost:{}", listener.local_addr().unwrap().port());
     let url = UrlWithBlobClaim::new(ServoUrl::parse(&url_string).unwrap(), None);

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -213,7 +213,7 @@ fn test_fetch_blob() {
         expected: bytes.to_vec(),
     };
 
-    spawn_blocking_task::<_, Response>(methods::fetch(request, &mut target, &context));
+    spawn_blocking_task::<_>(methods::fetch(request, &mut target, &context));
 
     let fetch_response = receiver.recv().unwrap();
     assert!(!fetch_response.is_network_error());

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -1625,7 +1625,7 @@ fn test_fetch_compressed_response_update_count() {
         sender: Some(sender),
         update_count: 0,
     };
-    let response_update_count = spawn_blocking_task::<_, Response>(async move {
+    let response_update_count = spawn_blocking_task::<_>(async move {
         methods::fetch(request, &mut target, &mut new_fetch_context(None, None)).await;
         receiver.await.unwrap()
     });

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -167,7 +167,7 @@ fn fetch_with_context(request: Request, mut context: &mut FetchContext) -> Respo
     let mut target = FetchResponseCollector {
         sender: Some(sender),
     };
-    spawn_blocking_task::<_, Response>(async move {
+    spawn_blocking_task::<_>(async move {
         methods::fetch(request, &mut target, &mut context).await;
         receiver.await.unwrap()
     })
@@ -179,7 +179,7 @@ fn fetch_with_cors_cache(request: Request, cache: &mut CorsCache) -> Response {
         sender: Some(sender),
     };
     let mut fetch_context = new_fetch_context(None, None);
-    spawn_blocking_task::<_, Response>(async move {
+    spawn_blocking_task::<_>(async move {
         methods::fetch_with_cors_cache(request, cache, &mut target, &mut fetch_context).await;
         receiver.await.unwrap()
     })


### PR DESCRIPTION
Need to do performance measurements.

This stores the memory cache to disk on shutdown if the disk cache is enabled.

On start of the browser the entries will be automatically promoted to the memory cache if used.

We also remove the second type parameter from async_runtime::spawn_blocking as it is not needed.

Testing: No automated test exist but this was manually verified.
