### PR TITLE
net: Add AuthCache and Cookie Storage to memory reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8408,6 +8408,7 @@ dependencies = [
  "app_units",
  "atomic_refcell",
  "content-security-policy",
+ "cookie 0.18.2",
  "crossbeam-channel",
  "data-url",
  "encoding_rs",

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -15,6 +15,7 @@ path = "lib.rs"
 [dependencies]
 app_units = { workspace = true }
 atomic_refcell = { workspace = true }
+cookie = { workspace = true }
 content-security-policy = { workspace = true }
 crossbeam-channel = { workspace = true }
 data-url = { workspace = true }

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -54,6 +54,7 @@ use std::ops::{Range, RangeInclusive};
 use std::rc::Rc;
 use std::sync::{Arc, OnceLock};
 
+use cookie::Cookie;
 use resvg::usvg::fontdb::Source;
 use resvg::usvg::{self, tiny_skia_path};
 use style::properties::ComputedValues;
@@ -1167,6 +1168,14 @@ impl MallocSizeOf for http::HeaderMap {
         self.iter()
             .map(|entry| entry.0.size_of(ops) + entry.1.size_of(ops))
             .sum()
+    }
+}
+
+impl<'a> MallocSizeOf for Cookie<'a> {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        // While the cookie storage can be more efficient by using the same striing it is unlikely that the values have this property.
+        // We take the string that is probably allocated in cookie an allocate it here to get the correct heap size.
+        self.value().to_owned().size_of(ops)
     }
 }
 

--- a/components/net/cookie.rs
+++ b/components/net/cookie.rs
@@ -11,6 +11,7 @@ use std::time::SystemTime;
 
 use cookie::Cookie;
 use log::{Level, debug, log_enabled};
+use malloc_size_of_derive::MallocSizeOf;
 use net_traits::CookieSource;
 use net_traits::pub_domains::is_pub_domain;
 use nom::branch::alt;
@@ -26,7 +27,7 @@ use time::{Date, Duration, Month, OffsetDateTime, Time};
 /// A stored cookie that wraps the definition in cookie-rs. This is used to implement
 /// various behaviours defined in the spec that rely on an associated request URL,
 /// which cookie-rs and hyper's header parsing do not support.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 pub struct ServoCookie {
     #[serde(
         deserialize_with = "hyper_serde::deserialize",

--- a/components/net/cookie_storage.rs
+++ b/components/net/cookie_storage.rs
@@ -14,6 +14,7 @@ use std::time::SystemTime;
 use cookie::Cookie;
 use itertools::Itertools;
 use log::info;
+use malloc_size_of_derive::MallocSizeOf;
 use net_traits::pub_domains::reg_suffix;
 use net_traits::{CookieSource, SiteDescriptor};
 use serde::{Deserialize, Serialize};
@@ -21,7 +22,7 @@ use servo_url::ServoUrl;
 
 use crate::cookie::ServoCookie;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 pub struct CookieStorage {
     version: u32,
     cookies_map: HashMap<String, Vec<ServoCookie>>,

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -133,6 +133,16 @@ impl HttpState {
                 kind: ReportKind::ExplicitJemallocHeapSize,
                 size: self.hsts_list.read().size_of(ops),
             },
+            Report {
+                path: path!["auth cache", suffix],
+                kind: ReportKind::ExplicitJemallocHeapSize,
+                size: self.auth_cache.read().size_of(ops),
+            },
+            Report {
+                path: path!["cookie storage", suffix],
+                kind: ReportKind::ExplicitJemallocHeapSize,
+                size: self.cookie_jar.read().size_of(ops),
+            },
         ]
     }
 

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -19,6 +19,7 @@ use embedder_traits::GenericEmbedderProxy;
 use hyper_serde::Serde;
 use ipc_channel::ipc::IpcSender;
 use log::{debug, trace, warn};
+use malloc_size_of_derive::MallocSizeOf;
 use net_traits::blob_url_store::{BlobTokenCommunicator, parse_blob_url};
 use net_traits::filemanager_thread::FileTokenCheck;
 use net_traits::pub_domains::public_suffix_list_size_of;
@@ -684,7 +685,7 @@ impl ResourceChannelManager {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 pub struct AuthCacheEntry {
     pub user_name: String,
     pub password: String,
@@ -699,7 +700,7 @@ impl Default for AuthCache {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 pub struct AuthCache {
     pub version: u32,
     pub entries: HashMap<String, AuthCacheEntry>,


### PR DESCRIPTION
This adds auth cache and cookie storage to memory reporting.
Because the cookie storage is complicated we only have a lower approximation for it by only looking at how much the value would have to be allocated.

Testing: Memory reporting does not have automatic tests. Tested manually.
