### PR TITLE
fonts: Do not copy FontDescriptor needlesly

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -364,7 +364,7 @@ impl Font {
     }
 
     /// A unique identifier for the font, allowing comparison.
-    pub fn identifier(&self) -> FontIdentifier {
+    pub fn identifier(&self) -> AtomicRef<'_, FontIdentifier> {
         self.template.identifier()
     }
 
@@ -395,7 +395,7 @@ impl Font {
             return Ok(data_and_index);
         }
 
-        let FontIdentifier::Local(local_font_identifier) = self.identifier() else {
+        let FontIdentifier::Local(local_font_identifier) = &*self.identifier() else {
             unreachable!("All web fonts should already have initialized data");
         };
         let Some(data_and_index) = local_font_identifier.font_data_and_index() else {

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -280,7 +280,7 @@ impl FontContext {
             };
 
         let cache_key = FontCacheKey {
-            font_identifier: font_template.identifier(),
+            font_identifier: font_template.identifier().to_owned(),
             font_descriptor: font_descriptor.clone(),
         };
 
@@ -374,9 +374,10 @@ impl FontContext {
         font: &Font,
         painter_id: PainterId,
     ) -> FontInstanceKey {
-        match font.template.identifier() {
+        let font_template_identifier = font.template.identifier();
+        match &*font_template_identifier {
             FontIdentifier::Local(_) => self.system_font_service_proxy.get_system_font_instance(
-                font.template.identifier(),
+                font.template.identifier().to_owned(),
                 font.descriptor.pt_size,
                 font.webrender_font_instance_flags(),
                 font.variations().to_owned(),

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -2562,7 +2562,7 @@ impl UnshapedTextRun<'_> {
         }
 
         match (&self.font, other_font) {
-            (Some(font_a), Some(font_b)) => font_a.identifier() == font_b.identifier(),
+            (Some(font_a), Some(font_b)) => *font_a.identifier() == *font_b.identifier(),
             (None, None) => true,
             _ => false,
         }
@@ -2611,7 +2611,7 @@ impl UnshapedTextRun<'_> {
             .collect();
 
         let identifier = font.identifier();
-        let font_data = match &identifier {
+        let font_data = match &*identifier {
             FontIdentifier::Local(_) => None,
             FontIdentifier::Web(_) | FontIdentifier::ArrayBuffer(_) => {
                 Some(font.font_data_and_index().ok()?)
@@ -2619,7 +2619,7 @@ impl UnshapedTextRun<'_> {
         }
         .cloned();
         let canvas_font = CanvasFont {
-            identifier,
+            identifier: identifier.to_owned(),
             data: font_data,
         };
 

--- a/components/shared/fonts/font_template.rs
+++ b/components/shared/fonts/font_template.rs
@@ -273,9 +273,9 @@ impl FontTemplate {
 
 pub trait FontTemplateRefMethods {
     /// Get the descriptor.
-    fn descriptor(&self) -> FontTemplateDescriptor;
+    fn descriptor(&self) -> AtomicRef<'_, FontTemplateDescriptor>;
     /// Get the [`FontIdentifier`] for this template.
-    fn identifier(&self) -> FontIdentifier;
+    fn identifier(&self) -> AtomicRef<'_, FontIdentifier>;
     /// Returns true if the given descriptor matches the one in this [`FontTemplate`].
     fn matches_font_descriptor(&self, descriptor_to_match: &FontDescriptor) -> bool;
     /// Calculate the distance from this [`FontTemplate`]s descriptor and return it
@@ -290,12 +290,16 @@ pub trait FontTemplateRefMethods {
 }
 
 impl FontTemplateRefMethods for FontTemplateRef {
-    fn descriptor(&self) -> FontTemplateDescriptor {
-        self.borrow().descriptor.clone()
+    fn descriptor(&self) -> AtomicRef<'_, FontTemplateDescriptor> {
+        AtomicRef::map(self.borrow(), |font_template_ref| {
+            &font_template_ref.descriptor
+        })
     }
 
-    fn identifier(&self) -> FontIdentifier {
-        self.borrow().identifier.clone()
+    fn identifier(&self) -> AtomicRef<'_, FontIdentifier> {
+        AtomicRef::map(self.borrow(), |font_template_ref| {
+            &font_template_ref.identifier
+        })
     }
 
     fn matches_font_descriptor(&self, descriptor_to_match: &FontDescriptor) -> bool {


### PR DESCRIPTION
Previously, FontTemplateRef::descriptor and identifier cloned the value. This just returns the AtomicRef with some call sites using to_owned() but not all. This should save some amount of work, especially for methods such as descriptor_difference.

This saves 0.4% in a 308ms slice on script thread.

Testing: Refactor so no extra test is needed.
