### PR TITLE
net: use serde_bytes to serialize ResponseBody

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8784,6 +8784,7 @@ dependencies = [
  "rustc-hash 2.1.3",
  "rustls-pki-types",
  "serde",
+ "serde_bytes",
  "servo-base",
  "servo-config",
  "servo-default-resources",

--- a/components/shared/net/Cargo.toml
+++ b/components/shared/net/Cargo.toml
@@ -44,6 +44,7 @@ resvg = { workspace = true }
 rustc-hash = { workspace = true }
 rustls-pki-types = { workspace = true }
 serde = { workspace = true }
+serde_bytes = { workspace = true }
 servo-base = { workspace = true }
 servo-config = { workspace = true }
 servo-url = { workspace = true }

--- a/components/shared/net/response.rs
+++ b/components/shared/net/response.rs
@@ -46,7 +46,9 @@ pub enum TerminationReason {
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
 pub enum ResponseBody {
     Empty, // XXXManishearth is this necessary, or is Done(vec![]) enough?
+    #[serde(with = "serde_bytes")]
     Receiving(Vec<u8>),
+    #[serde(with = "serde_bytes")]
     Done(Vec<u8>),
 }
 


### PR DESCRIPTION
That enables postcard to use the more efficient serialize_bytes and deserialize_bytes methods.

Testing: optimization covered by existing tests.