### PR TITLE
script: Small performance improvements in queue_a_mutation_record

### DIFF
--- a/components/script/dom/mutationobserver/mutationobserver.rs
+++ b/components/script/dom/mutationobserver/mutationobserver.rs
@@ -3,13 +3,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::LazyCell;
-use std::collections::HashMap;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Namespace, ns};
 use js::context::JSContext;
 use js::rust::HandleObject;
+use rustc_hash::FxHashMap;
 use script_bindings::callback::OwnerWindow;
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
@@ -112,12 +112,12 @@ impl MutationObserver {
             return;
         }
         // Step 1 Let interestedObservers be an empty map.
-        let mut interested_observers: HashMap<DomRoot<MutationObserver>, Option<DOMString>> =
-            HashMap::new();
+        let mut interested_observers: FxHashMap<DomRoot<MutationObserver>, Option<DOMString>> =
+            FxHashMap::default();
 
         // Step 2 Let nodes be the inclusive ancestors of target.
         // Step 3 For each node in nodes ...
-        for node in target.inclusive_ancestors(ShadowIncluding::No) {
+        for node in target.inclusive_ancestors_unrooted(cx.no_gc(), ShadowIncluding::No) {
             let registered = node.registered_mutation_observers();
             if registered.is_none() {
                 continue;
@@ -126,7 +126,7 @@ impl MutationObserver {
             // Step 3 ... and then for each registered of node’s registered observer list:
             for registered in &*registered.unwrap() {
                 // 3.2 "1": node is not target and options["subtree"] is false
-                if &*node != target && !registered.options.subtree {
+                if *node != target && !registered.options.subtree {
                     continue;
                 }
 


### PR DESCRIPTION
This contains two small optimizations:
- Use unrooted iterator as now we can statically guarantee that no GC happens.
- Switch normal HashMap to FxHashMap. DomRoot/Dom implements Hash by hashing the ptr, hence, there is no attack vector.

Testing: This is refactor and static guaranteed that no gc can happen.
