### PR TITLE
wpt: Enable srcdoc referrer-policy tests.

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -252,14 +252,6 @@ skip: true
   skip: false
 [referrer-policy]
   skip: false
-  [gen]
-    skip: false
-    [srcdoc-inherit.http-rp]
-      skip: true
-    [srcdoc-inherit.meta]
-      skip: true
-    [srcdoc.meta]
-      skip: true
 [reporting]
   skip: false
 [resize-observer]

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.http-rp/no-referrer-when-downgrade/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.http-rp/no-referrer-when-downgrade/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.http-rp/no-referrer/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.http-rp/no-referrer/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects omitted for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects omitted for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects omitted for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects omitted for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.http-rp/origin-when-cross-origin/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.http-rp/origin-when-cross-origin/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects origin for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.http-rp/origin/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.http-rp/origin/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects origin for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.http-rp/same-origin/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.http-rp/same-origin/svg-a-tag.http.html.ini
@@ -1,0 +1,9 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects omitted for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects omitted for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.http-rp/strict-origin-when-cross-origin/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.http-rp/strict-origin-when-cross-origin/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects origin for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.http-rp/strict-origin/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.http-rp/strict-origin/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects origin for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.http-rp/unsafe-url/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.http-rp/unsafe-url/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.http-rp/unset/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.http-rp/unset/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects origin for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/always/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/always/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/default/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/default/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects origin for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/never/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/never/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects omitted for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects omitted for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects omitted for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects omitted for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/no-referrer-when-downgrade/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/no-referrer-when-downgrade/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/no-referrer/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/no-referrer/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects omitted for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects omitted for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects omitted for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects omitted for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/origin-when-cross-origin/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/origin-when-cross-origin/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects origin for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/origin-when-crossorigin/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/origin-when-crossorigin/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects origin for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/origin/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/origin/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects origin for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/same-origin/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/same-origin/svg-a-tag.http.html.ini
@@ -1,0 +1,9 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects omitted for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects omitted for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/strict-origin-when-cross-origin/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/strict-origin-when-cross-origin/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects origin for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/strict-origin/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/strict-origin/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects origin for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/unsafe-url/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/unsafe-url/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/unset/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc-inherit.meta/unset/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects origin for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/always/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/always/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/default/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/default/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects origin for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/never/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/never/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects omitted for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects omitted for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects omitted for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects omitted for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/no-referrer-when-downgrade/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/no-referrer-when-downgrade/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/no-referrer/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/no-referrer/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects omitted for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects omitted for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects omitted for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects omitted for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/origin-when-cross-origin/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/origin-when-cross-origin/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects origin for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/origin-when-crossorigin/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/origin-when-crossorigin/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects origin for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/origin/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/origin/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects origin for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/same-origin/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/same-origin/svg-a-tag.http.html.ini
@@ -1,0 +1,9 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects omitted for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects omitted for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/strict-origin-when-cross-origin/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/strict-origin-when-cross-origin/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects origin for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/strict-origin/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/strict-origin/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects origin for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects origin for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/unsafe-url/svg-a-tag.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/gen/srcdoc.meta/unsafe-url/svg-a-tag.http.html.ini
@@ -1,0 +1,12 @@
+[svg-a-tag.http.html]
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to cross-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to cross-https origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-http origin and no-redirect redirection from http context.]
+    expected: FAIL
+
+  [Referrer Policy: Expects stripped-referrer for svg-a-tag to same-https origin and no-redirect redirection from http context.]
+    expected: FAIL


### PR DESCRIPTION
Since we now have much more consistent about:srcdoc support, the tests no longer exhibit the strange failures that made us disable them years ago.

Testing: new tests are running.
Fixes: #24731
