### PR TITLE
script_webgpu: Enable webgpu feature on bindings

### DIFF
--- a/components/script_webgpu/Cargo.toml
+++ b/components/script_webgpu/Cargo.toml
@@ -24,7 +24,7 @@ indexmap = { workspace = true }
 js = { workspace = true }
 jstraceable_derive = { workspace = true }
 log = { workspace = true }
-script_bindings = { workspace = true }
+script_bindings = { workspace = true, features = ["webgpu"] }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 num-traits = { workspace = true }


### PR DESCRIPTION
script_webgpu requires the webgpu feature in bindings. This worked via feature unification for servo builds, but breaks when building script_webgpu individually.

Testing: Building script_webgpu individually is not covered by automatic tests
Fixes: #47261