### PR TITLE
backport: script_webgpu: Enable webgpu feature on bindings

### DIFF
--- a/components/script_webgpu/Cargo.toml
+++ b/components/script_webgpu/Cargo.toml
@@ -23,7 +23,7 @@ dom_struct = { workspace = true }
 js = { workspace = true }
 log = { workspace = true }
 jstraceable_derive = { workspace = true }
-script_bindings = { workspace = true }
+script_bindings = { workspace = true, features = ["webgpu"] }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 webgpu_traits = { workspace = true }


### PR DESCRIPTION
script_webgpu requires the webgpu feature in bindings. This worked via feature unification for servo builds, but breaks when building script_webgpu individually.

This is a backport of https://github.com/servo/servo/pull/47262 to the release/v0.5 branch.

Testing: Simple backport, not required. Standalone builds of script_webgpu are not performed in CI.

