### PR TITLE
url: Avoid allocation when serializing opaque origins

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -411,7 +411,11 @@ fn auth_from_cache(
     auth_cache: &RwLock<AuthCache>,
     origin: &ImmutableOrigin,
 ) -> Option<Authorization<Basic>> {
-    if let Some(auth_entry) = auth_cache.read().entries.get(&origin.ascii_serialization()) {
+    if let Some(auth_entry) = auth_cache
+        .read()
+        .entries
+        .get(origin.ascii_serialization().as_ref())
+    {
         let user_name = &auth_entry.user_name;
         let password = &auth_entry.password;
         Some(Authorization::basic(user_name, password))
@@ -1058,7 +1062,7 @@ fn tao_check(request: &Request, response: &Response) -> Result<(), ()> {
     // return success.
     if values
         .iter()
-        .any(|header_str| *header_str == request_origin.ascii_serialization())
+        .any(|header_str| *header_str == request_origin.ascii_serialization().as_ref())
     {
         return Ok(());
     }
@@ -1750,7 +1754,11 @@ async fn http_network_or_cache_fetch(
         };
         {
             let mut auth_cache = context.state.auth_cache.write();
-            let key = request.current_url().origin().ascii_serialization();
+            let key = request
+                .current_url()
+                .origin()
+                .ascii_serialization()
+                .into_owned();
             auth_cache.entries.insert(key, entry);
         }
 

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -1493,12 +1493,10 @@ fn test_if_auth_creds_not_in_url_but_in_cache_it_sets_it() {
         password: "test".to_owned(),
     };
 
-    context
-        .state
-        .auth_cache
-        .write()
-        .entries
-        .insert(url.origin().clone().ascii_serialization(), auth_entry);
+    context.state.auth_cache.write().entries.insert(
+        url.origin().clone().ascii_serialization().into_owned(),
+        auth_entry,
+    );
 
     let response = fetch_with_context(request, &mut context);
 
@@ -1643,7 +1641,7 @@ fn test_origin_serialization_compatibility() {
         let url = Url::parse(url_string).unwrap();
         let origin = ImmutableOrigin::new(&url);
         let serialized = format!("{}", serialize_origin(&origin));
-        assert_eq!(serialized, origin.ascii_serialization());
+        assert_eq!(serialized, origin.ascii_serialization().as_ref());
     };
 
     ensure_serialiations_match("https://example.com");

--- a/components/net/websocket_loader.rs
+++ b/components/net/websocket_loader.rs
@@ -57,7 +57,7 @@ pub fn create_handshake_request(
     let mut headers = HeaderMap::new();
     headers.insert(
         "Origin",
-        HeaderValue::from_str(&request.url.origin().ascii_serialization())?,
+        HeaderValue::from_str(request.url.origin().ascii_serialization().as_ref())?,
     );
 
     let host = format!(

--- a/components/script/dom/document/websocket.rs
+++ b/components/script/dom/document/websocket.rs
@@ -648,7 +648,7 @@ impl TaskOnce for MessageReceivedTask {
             ws.upcast(),
             &global,
             message.handle(),
-            Some(&ws.origin().ascii_serialization()),
+            Some(ws.origin().ascii_serialization().as_ref()),
             None,
             vec![],
         );

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -416,7 +416,7 @@ impl FetchResponseListener for EventSourceContext {
                 if (mime.type_(), mime.subtype()) != (mime::TEXT, mime::EVENT_STREAM) {
                     return self.fail_the_connection();
                 }
-                self.origin = meta.final_url.origin().ascii_serialization();
+                self.origin = meta.final_url.origin().ascii_serialization().into_owned();
                 // Step 15.4 announce the connection and interpret res's body line by line.
                 self.announce_the_connection();
             },

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -1396,7 +1396,7 @@ impl GlobalScope {
                                 destination.upcast(),
                                 &global,
                                 message.handle(),
-                                Some(&origin.ascii_serialization()),
+                                Some(origin.ascii_serialization().as_ref()),
                                 None,
                                 ports,
                             );
@@ -1566,7 +1566,7 @@ impl GlobalScope {
                             message_event_target,
                             self,
                             message_clone.handle(),
-                            Some(&origin.ascii_serialization()),
+                            Some(origin.ascii_serialization().as_ref()),
                             None,
                             ports,
                         );

--- a/components/script/dom/html/htmlhyperlinkelementutils.rs
+++ b/components/script/dom/html/htmlhyperlinkelementutils.rs
@@ -226,7 +226,7 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
             // Step 2. If this's url is null, return the empty string.
             None => "".to_owned(),
             // Step 3. Return the serialization of this's url's origin.
-            Some(ref url) => url.origin().ascii_serialization(),
+            Some(ref url) => url.origin().ascii_serialization().into_owned(),
         })
     }
 

--- a/components/script/dom/security/csp.rs
+++ b/components/script/dom/security/csp.rs
@@ -202,10 +202,11 @@ impl CspReporting for Option<CspList> {
             if let Some(container_element) = window_proxy.frame_element() {
                 let container_document = container_element.owner_document();
                 let parent_origin = Url::parse(
-                    &container_document
+                    container_document
                         .origin()
                         .immutable()
-                        .ascii_serialization(),
+                        .ascii_serialization()
+                        .as_ref(),
                 )
                 .expect("Must always be able to parse document origin");
                 parent_navigable_origins.push(parent_origin);

--- a/components/script/dom/serviceworker/serviceworkercontainer.rs
+++ b/components/script/dom/serviceworker/serviceworkercontainer.rs
@@ -211,7 +211,7 @@ impl ServiceWorkerContainer {
                         self.upcast(),
                         &global,
                         message_val.handle(),
-                        Some(&origin.ascii_serialization()),
+                        Some(origin.ascii_serialization().as_ref()),
                         None,
                         ports,
                     );

--- a/components/script/dom/url/url.rs
+++ b/components/script/dom/url/url.rs
@@ -105,7 +105,7 @@ impl URL {
         // Step 6. If serialized is "null", set it to an implementation-defined value.
         // Step 7. Append serialized to result.
         // N.B. We leave it as "null" right now.
-        result.push_str(&origin.ascii_serialization());
+        result.push_str(origin.ascii_serialization().as_ref());
 
         // Step 8. Append U+0024 SOLIDUS (/) to result.
         result.push('/');

--- a/components/script/dom/webrtc/rtcdatachannel.rs
+++ b/components/script/dom/webrtc/rtcdatachannel.rs
@@ -237,7 +237,7 @@ impl RTCDataChannel {
             self.upcast(),
             &global,
             message.handle(),
-            Some(&global.origin().immutable().ascii_serialization()),
+            Some(global.origin().immutable().ascii_serialization().as_ref()),
             None,
             vec![],
         );

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -2287,7 +2287,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-origin>
     fn Origin(&self) -> USVString {
-        USVString(self.origin().immutable().ascii_serialization())
+        USVString(self.origin().immutable().ascii_serialization().into_owned())
     }
 
     /// <https://w3c.github.io/selection-api/#dom-window-getselection>
@@ -4084,7 +4084,7 @@ impl Window {
                     this.upcast(),
                     this.upcast(),
                     message_clone.handle(),
-                    Some(&source_origin.ascii_serialization()),
+                    Some(source_origin.ascii_serialization().as_ref()),
                     Some(&*source),
                     ports,
                 );

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -933,7 +933,7 @@ impl DedicatedWorkerGlobalScope {
                 target,
                 scope.upcast(),
                 message.handle(),
-                Some(&msg.origin.ascii_serialization()),
+                Some(msg.origin.ascii_serialization().as_ref()),
                 None,
                 ports,
             );

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -1049,7 +1049,8 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
             self.upcast::<GlobalScope>()
                 .origin()
                 .immutable()
-                .ascii_serialization(),
+                .ascii_serialization()
+                .into_owned(),
         )
     }
 

--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -2739,12 +2739,13 @@ impl ScriptThread {
         id: PipelineId,
         result_sender: GenericSender<Option<String>>,
     ) {
-        let _ = result_sender.send(
-            self.documents
-                .borrow()
-                .find_document(id)
-                .map(|document| document.origin().immutable().ascii_serialization()),
-        );
+        let _ = result_sender.send(self.documents.borrow().find_document(id).map(|document| {
+            document
+                .origin()
+                .immutable()
+                .ascii_serialization()
+                .into_owned()
+        }));
     }
 
     // exit_fullscreen creates a new JS promise object, so we need to have entered a realm

--- a/components/storage/client_storage.rs
+++ b/components/storage/client_storage.rs
@@ -281,7 +281,10 @@ fn create_a_storage_shelf(
         "INSERT INTO shelves (shed_id, origin) VALUES (?1, ?2)
          ON CONFLICT(shed_id, origin) DO UPDATE SET origin = excluded.origin
          RETURNING id;",
-        [&shed.to_string(), &origin.ascii_serialization()],
+        [
+            &shed.to_string(),
+            &origin.ascii_serialization().into_owned(),
+        ],
         |row| row.get(0),
     )?;
 

--- a/components/storage/indexeddb/engines/sqlite.rs
+++ b/components/storage/indexeddb/engines/sqlite.rs
@@ -128,7 +128,7 @@ impl SqliteEngine {
             "INSERT INTO database (name, origin, version) VALUES (?, ?, ?)",
             params![
                 db_info.name.to_owned(),
-                db_info.origin.to_owned().ascii_serialization(),
+                db_info.origin.to_owned().ascii_serialization().into_owned(),
                 i64::from_ne_bytes(0_u64.to_ne_bytes())
             ],
         )?;

--- a/components/storage/tests/client_storage.rs
+++ b/components/storage/tests/client_storage.rs
@@ -169,7 +169,7 @@ fn test_repeated_local_obtain_reuses_same_logical_rows() {
     let shelf_count: i64 = registry
         .query_row(
             "SELECT COUNT(*) FROM shelves WHERE origin = ?1;",
-            [origin.ascii_serialization()],
+            [origin.ascii_serialization().into_owned()],
             |row| row.get(0),
         )
         .unwrap();
@@ -225,7 +225,7 @@ fn test_repeated_session_obtain_reuses_same_logical_rows() {
     let shelf_count: i64 = registry
         .query_row(
             "SELECT COUNT(*) FROM shelves WHERE origin = ?1;",
-            [origin.ascii_serialization()],
+            [origin.ascii_serialization().into_owned()],
             |row| row.get(0),
         )
         .unwrap();

--- a/components/storage/webstorage/mod.rs
+++ b/components/storage/webstorage/mod.rs
@@ -85,7 +85,7 @@ impl StorageOrigins {
     /// Returns `true` if a new origin descriptor was created, or `false` if
     /// one already existed.
     fn ensure_origin_descriptor(&mut self, origin: &ImmutableOrigin) -> bool {
-        let origin = origin.ascii_serialization();
+        let origin = origin.ascii_serialization().into_owned();
         match self.origin_descriptors.entry(origin.clone()) {
             Entry::Occupied(_) => false,
             Entry::Vacant(entry) => {

--- a/components/url/origin.rs
+++ b/components/url/origin.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::net::IpAddr;
 use std::rc::Rc;
@@ -193,8 +194,13 @@ impl ImmutableOrigin {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#ascii-serialisation-of-an-origin>
-    pub fn ascii_serialization(&self) -> String {
-        self.clone().into_url_origin().ascii_serialization()
+    pub fn ascii_serialization(&self) -> Cow<'_, str> {
+        match self {
+            ImmutableOrigin::Opaque(_) => Cow::Borrowed("null"),
+            ImmutableOrigin::Tuple(..) => {
+                Cow::Owned(self.clone().into_url_origin().ascii_serialization())
+            },
+        }
     }
 }
 


### PR DESCRIPTION
For opaque origin, we were cloning `ImmutableOrigin` + creating `Origin` + allocating String, which ends up just as "null": [see here](https://github.com/servo/rust-url/blob/00a6ce58d02f4e0d43c5ca0702c0bedb8b1ebf3a/url/src/origin.rs#L78-L80)

So we always return Cow instead.

Testing: Should not change behaviour. Existing tests.