### PR TITLE
script: Implement the Media Source API

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -181,6 +181,8 @@ pub struct Preferences {
     pub dom_indexeddb_enabled: bool,
     // feature: IntersectionObserver | #35767 | Web/API/Intersection_Observer_API
     pub dom_intersection_observer_enabled: bool,
+    // feature: Media Source Extensions API | #44403 | Web/API/Media_Source_Extensions_API
+    pub dom_media_source_enabled: bool,
     pub dom_microdata_testing_enabled: bool,
     pub dom_uievent_which_enabled: bool,
     // feature: MutationObserver | #6633 | Web/API/MutationObserver
@@ -461,6 +463,7 @@ impl Preferences {
             dom_wakelock_enabled: false,
             dom_indexeddb_enabled: false,
             dom_intersection_observer_enabled: false,
+            dom_media_source_enabled: false,
             dom_microdata_testing_enabled: false,
             dom_uievent_which_enabled: true,
             dom_mutation_observer_enabled: true,

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -123,6 +123,7 @@ use crate::dom::globalscope::script_execution::{
     ErrorReporting, evaluate_script, fill_compile_options,
 };
 use crate::dom::idbfactory::IDBFactory;
+use crate::dom::media::mediasource::MediaSource;
 use crate::dom::messageport::MessagePort;
 use crate::dom::paintworkletglobalscope::PaintWorkletGlobalScope;
 use crate::dom::performance::performance::Performance;
@@ -232,6 +233,14 @@ pub(crate) struct GlobalScope {
 
     /// The blobs managed by this global, if any.
     blob_state: DomRefCell<HashMapTracedValues<BlobId, BlobInfo, FxBuildHasher>>,
+
+    /// The media source object URLs created by this global, keyed by their serialization.
+    ///
+    /// A `MediaSource` never leaves the thread that created it, so unlike blob URLs these
+    /// entries cannot live in the file manager.
+    ///
+    /// <https://w3c.github.io/media-source/#dfn-media-source-object-url>
+    media_source_url_store: DomRefCell<HashMapTracedValues<String, Dom<MediaSource>>>,
 
     /// <https://w3c.github.io/ServiceWorker/#environment-settings-object-service-worker-registration-object-map>
     registration_map: DomRefCell<
@@ -790,6 +799,7 @@ impl GlobalScope {
             broadcast_channel_state: DomRefCell::new(BroadcastChannelState::UnManaged),
             constellation_interest_counts: RefCell::new(HashMap::new()),
             blob_state: Default::default(),
+            media_source_url_store: Default::default(),
             eventtarget: EventTarget::new_inherited(),
             registration_map: DomRefCell::new(HashMapTracedValues::new_fx()),
             indexeddb: Default::default(),
@@ -1845,6 +1855,29 @@ impl GlobalScope {
 
     fn track_blob_info(&self, blob_info: BlobInfo, blob_id: BlobId) {
         self.blob_state.borrow_mut().insert(blob_id, blob_info);
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-url-createobjecturl>
+    pub(crate) fn track_media_source_url(&self, url: String, media_source: &MediaSource) {
+        self.media_source_url_store
+            .borrow_mut()
+            .insert(url, Dom::from_ref(media_source));
+    }
+
+    /// <https://w3c.github.io/media-source/#dfn-media-source-object-url>
+    pub(crate) fn media_source_for_url(&self, url: &str) -> Option<DomRoot<MediaSource>> {
+        self.media_source_url_store
+            .borrow()
+            .get(url)
+            .map(|media_source| DomRoot::from_ref(&**media_source))
+    }
+
+    /// <https://w3c.github.io/FileAPI/#dfn-revokeObjectURL>
+    pub(crate) fn forget_media_source_url(&self, url: &str) -> bool {
+        self.media_source_url_store
+            .borrow_mut()
+            .remove(url)
+            .is_some()
     }
 
     /// Start tracking a blob

--- a/components/script/dom/html/embedded_content/htmlmediaelement.rs
+++ b/components/script/dom/html/embedded_content/htmlmediaelement.rs
@@ -55,6 +55,7 @@ use crate::dom::bindings::codegen::Bindings::HTMLMediaElementBinding::{
 };
 use crate::dom::bindings::codegen::Bindings::MediaErrorBinding::MediaErrorConstants::*;
 use crate::dom::bindings::codegen::Bindings::MediaErrorBinding::MediaErrorMethods;
+use crate::dom::bindings::codegen::Bindings::MediaSourceBinding::EndOfStreamError;
 use crate::dom::bindings::codegen::Bindings::NavigatorBinding::Navigator_Binding::NavigatorMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::Node_Binding::NodeMethods;
 use crate::dom::bindings::codegen::Bindings::TextTrackBinding::{
@@ -86,6 +87,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmlsourceelement::HTMLSourceElement;
 use crate::dom::html::htmlvideoelement::HTMLVideoElement;
+use crate::dom::media::mediasource::MediaSource;
 use crate::dom::mediaerror::MediaError;
 use crate::dom::mediafragmentparser::MediaFragmentParser;
 use crate::dom::medialist::MediaList;
@@ -611,6 +613,18 @@ pub(crate) struct HTMLMediaElement {
     media_controls_id: DomRefCell<Option<String>>,
     /// <https://html.spec.whatwg.org/multipage/#did-perform-automatic-track-selection>
     did_perform_automatic_track_selection: Cell<bool>,
+    /// The media source attached through a media source object URL, if any.
+    ///
+    /// <https://w3c.github.io/media-source/#dfn-attaching-to-a-media-element>
+    media_source: MutNullableDom<MediaSource>,
+    /// Media data appended to a source buffer that the media backend has not taken yet.
+    media_source_data: DomRefCell<VecDeque<Vec<u8>>>,
+    /// Whether the media backend is currently willing to accept appended media data. It
+    /// starts out unwilling, and toggles with the `NeedData` and `EnoughData` events.
+    media_source_accepts_data: Cell<bool>,
+    /// Whether the media source signalled the end of the stream while the media backend
+    /// still had appended data to consume.
+    media_source_end_of_stream: Cell<bool>,
 }
 
 /// <https://html.spec.whatwg.org/multipage/#dom-media-networkstate>
@@ -695,6 +709,10 @@ impl HTMLMediaElement {
             current_fetch_context: RefCell::new(None),
             media_controls_id: DomRefCell::new(None),
             did_perform_automatic_track_selection: Default::default(),
+            media_source: Default::default(),
+            media_source_data: Default::default(),
+            media_source_accepts_data: Cell::new(false),
+            media_source_end_of_stream: Cell::new(false),
         }
     }
 
@@ -1165,7 +1183,7 @@ impl HTMLMediaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-media-load-algorithm>
-    fn load_from_src_object(&self, cx: &JSContext) {
+    fn load_from_src_object(&self, cx: &mut JSContext) {
         self.load_state.set(LoadState::LoadingFromSrcObject);
 
         // Step 9.object.1. Set the currentSrc attribute to the empty string.
@@ -1180,7 +1198,7 @@ impl HTMLMediaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-media-load-algorithm>
-    fn load_from_src_attribute(&self, cx: &JSContext, base_url: ServoUrl, src: &str) {
+    fn load_from_src_attribute(&self, cx: &mut JSContext, base_url: ServoUrl, src: &str) {
         self.load_state.set(LoadState::LoadingFromSrcAttribute);
 
         // Step 9.attribute.1. If the src attribute's value is the empty string, then end
@@ -1207,11 +1225,18 @@ impl HTMLMediaElement {
         // then the load failed.
         // Note that the resource fetch algorithm itself takes care
         // of the cleanup in case of failure itself.
-        self.resource_fetch_algorithm(cx, Resource::Url(url_record));
+        //
+        // A URL that resolves to an entry of the media source object URL store is
+        // attached instead of being fetched.
+        let resource = match self.global().media_source_for_url(url_record.as_str()) {
+            Some(media_source) => Resource::MediaSource(media_source),
+            None => Resource::Url(url_record),
+        };
+        self.resource_fetch_algorithm(cx, resource);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-media-load-algorithm>
-    fn load_from_source_child(&self, cx: &JSContext, source: &HTMLSourceElement) {
+    fn load_from_source_child(&self, cx: &mut JSContext, source: &HTMLSourceElement) {
         self.load_state.set(LoadState::LoadingFromSourceChild);
 
         // Step 9.children.1. Let pointer be a position defined by two adjacent nodes in the media
@@ -1428,6 +1453,15 @@ impl HTMLMediaElement {
     }
 
     fn fetch_request(&self, cx: &JSContext, offset: Option<u64>, seek_lock: Option<SeekLock>) {
+        // Media data that comes from a media source is appended by script rather than
+        // fetched, so there is no request to make and no byte range to serve.
+        if self.media_source.get().is_some() {
+            if let Some(seek_lock) = seek_lock {
+                seek_lock.unlock(/* successful seek */ false);
+            }
+            return;
+        }
+
         if self.resource_url.borrow().is_none() && self.blob_url.borrow().is_none() {
             error!("Missing request url");
             if let Some(seek_lock) = seek_lock {
@@ -1514,7 +1548,7 @@ impl HTMLMediaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-media-load-resource>
-    fn resource_fetch_algorithm(&self, cx: &JSContext, resource: Resource) {
+    fn resource_fetch_algorithm(&self, cx: &mut JSContext, resource: Resource) {
         if let Err(e) = self.create_media_player(&resource) {
             error!("Create media player error {:?}", e);
             self.resource_selection_algorithm_failure_steps(cx);
@@ -1576,6 +1610,29 @@ impl HTMLMediaElement {
 
                 // Steps 5.remote.2-5.remote.8
                 self.fetch_request(cx, None, None);
+            },
+            Resource::MediaSource(media_source) => {
+                // Step 5.local.1 of the resource fetch algorithm, as extended by Media
+                // Source Extensions: run the steps to attach to a media element.
+                if !media_source.attach(cx, self) {
+                    // Reaching this step means the media data cannot be fetched at all.
+                    self.queue_dedicated_media_source_failure_steps();
+                    return;
+                }
+
+                self.media_source.set(Some(&media_source));
+
+                // Script pushes the media data into the backend as it appends it, so the
+                // backend must neither ask for byte ranges nor expect a known input size.
+                if let Some(ref player) = *self.player.borrow() {
+                    let player = player.lock().unwrap();
+                    if let Err(error) = player.set_input_size(0) {
+                        warn!("Could not set the input size: {error:?}");
+                    }
+                    if let Err(error) = player.set_seekable(false) {
+                        warn!("Could not mark the stream as non seekable: {error:?}");
+                    }
+                }
             },
             Resource::Object => {
                 if let Some(ref src_object) = *self.src_object.borrow() {
@@ -1665,8 +1722,134 @@ impl HTMLMediaElement {
             }));
     }
 
-    fn in_error_state(&self) -> bool {
+    pub(crate) fn in_error_state(&self) -> bool {
         self.error.get().is_some()
+    }
+
+    /// <https://w3c.github.io/media-source/#dfn-detaching-from-a-media-element>
+    fn detach_media_source(&self) {
+        let Some(media_source) = self.media_source.take() else {
+            return;
+        };
+
+        media_source.detach();
+        self.media_source_data.borrow_mut().clear();
+        self.media_source_accepts_data.set(false);
+        self.media_source_end_of_stream.set(false);
+    }
+
+    /// Queues media data appended to one of the source buffers of the attached media
+    /// source, and hands over as much of it as the media backend is willing to take.
+    pub(crate) fn append_media_source_data(&self, data: Vec<u8>) {
+        self.media_source_data.borrow_mut().push_back(data);
+        self.drain_media_source_data();
+    }
+
+    /// Pushes queued media data into the media backend until it reports that it has
+    /// enough, at which point the rest waits for the next `NeedData` event.
+    fn drain_media_source_data(&self) {
+        if !self.media_source_accepts_data.get() {
+            return;
+        }
+
+        let Some(player) = self.player.borrow().clone() else {
+            return;
+        };
+
+        loop {
+            // The backend takes the buffer by value and drops it when it reports that it
+            // has enough data, so a chunk is only removed from the queue once it has been
+            // taken. The clone lives in a `let` statement of its own so that the borrow of
+            // the queue ends before the chunk is handed over.
+            let Some(data) = self.media_source_data.borrow().front().cloned() else {
+                break;
+            };
+
+            match player.lock().unwrap().push_data(data) {
+                Err(PlayerError::EnoughData) => {
+                    self.media_source_accepts_data.set(false);
+                    return;
+                },
+                result => {
+                    if let Err(error) = result {
+                        warn!("Could not push appended media data to the player: {error:?}");
+                    }
+                    self.media_source_data.borrow_mut().pop_front();
+                },
+            }
+        }
+
+        if self.media_source_end_of_stream.take() &&
+            let Err(error) = player.lock().unwrap().end_of_stream()
+        {
+            warn!("Could not signal the end of the stream to the player: {error:?}");
+        }
+    }
+
+    /// <https://w3c.github.io/media-source/#dfn-duration-change>
+    ///
+    /// Step 6 updates the media duration and runs the duration change algorithm of the
+    /// media element.
+    pub(crate) fn media_source_duration_changed(&self, duration: f64) {
+        if self.duration.get() == duration {
+            return;
+        }
+
+        self.duration.set(duration);
+        self.queue_media_element_task_to_fire_event(atom!("durationchange"));
+
+        // If the duration is changed such that the current playback position ends up being
+        // greater than the time of the end of the media resource, then the user agent must
+        // also seek to the time of the end of the media resource.
+        if self.current_playback_position.get() > duration {
+            self.seek(duration, /* approximate_for_speed */ false);
+        }
+    }
+
+    /// <https://w3c.github.io/media-source/#dfn-end-of-stream>
+    ///
+    /// Step 3.2 notifies the media element that it now has all of the media data.
+    pub(crate) fn media_source_end_of_stream(&self) {
+        self.media_source_end_of_stream.set(true);
+        self.drain_media_source_data();
+    }
+
+    /// <https://w3c.github.io/media-source/#dfn-end-of-stream>
+    ///
+    /// Steps 4 and 5 run the media data processing steps of the media element for a
+    /// network or a decode error.
+    pub(crate) fn media_source_error(&self, cx: &mut JSContext, error: EndOfStreamError) {
+        if self.ready_state.get() == ReadyState::HaveNothing {
+            // => "If the media data cannot be fetched at all, due to network errors,
+            // causing the user agent to give up trying to fetch the resource"
+            self.media_data_processing_failure_steps(cx);
+            return;
+        }
+
+        // => "If the media data is corrupted", and its network equivalent.
+        let error = match error {
+            EndOfStreamError::Network => MEDIA_ERR_NETWORK,
+            EndOfStreamError::Decode => MEDIA_ERR_DECODE,
+        };
+        self.media_data_processing_fatal_steps(error, cx);
+    }
+
+    /// <https://w3c.github.io/media-source/#dfn-initialization-segment-received>
+    ///
+    /// Step 7 sets the readyState attribute to HAVE_METADATA.
+    pub(crate) fn media_source_metadata_received(&self) {
+        if self.ready_state.get() == ReadyState::HaveNothing {
+            self.change_ready_state(ReadyState::HaveMetadata);
+        }
+    }
+
+    /// Called when an append or a range removal changed what the attached media source
+    /// reports as buffered.
+    pub(crate) fn media_source_buffered_changed(&self) {
+        // The media engine drives the ready state from the frames it manages to decode,
+        // but it cannot report having data for the current position before it has been
+        // handed any, so a first append is what lets playback leave HAVE_METADATA.
+        self.drain_media_source_data();
     }
 
     /// <https://html.spec.whatwg.org/multipage/#potentially-playing>
@@ -1709,6 +1892,9 @@ impl HTMLMediaElement {
         // Step 2. Abort any already-running instance of the resource selection algorithm for this
         // element.
         self.generation_id.set(self.generation_id.get() + 1);
+
+        // <https://w3c.github.io/media-source/#dfn-detaching-from-a-media-element>
+        self.detach_media_source();
 
         self.load_state.set(LoadState::NotLoaded);
         *self.source_children_pointer.borrow_mut() = None;
@@ -2641,6 +2827,12 @@ impl HTMLMediaElement {
     }
 
     fn playback_duration_changed(&self, duration: Option<Duration>) {
+        // While a media source is attached its duration attribute is the media duration,
+        // so whatever the media engine derives from the appended bytes is ignored.
+        if self.media_source.get().is_some() {
+            return;
+        }
+
         let duration = duration.map_or(f64::INFINITY, |duration| duration.as_secs_f64());
 
         if self.duration.get() == duration {
@@ -2697,6 +2889,14 @@ impl HTMLMediaElement {
     }
 
     fn playback_need_data(&self) {
+        // When the media data comes from a media source, script decides when to append it
+        // and the media element only forwards what it has been given so far.
+        if self.media_source.get().is_some() {
+            self.media_source_accepts_data.set(true);
+            self.drain_media_source_data();
+            return;
+        }
+
         // The media engine signals that the source needs more data. If we already have a valid
         // fetch request, we do nothing. Otherwise, if we have no request and the previous request
         // was cancelled because we got an EnoughData event, we restart fetching where we left.
@@ -2735,6 +2935,12 @@ impl HTMLMediaElement {
     }
 
     fn playback_enough_data(&self) {
+        // Appended media data is kept until the media engine asks for more.
+        if self.media_source.get().is_some() {
+            self.media_source_accepts_data.set(false);
+            return;
+        }
+
         // The media engine signals that the source has enough data and asks us to stop pushing bytes
         // to avoid excessive buffer queueing, so we cancel the ongoing fetch request if we are able
         // to restart it from where we left. Otherwise, we continue the current fetch request,
@@ -2824,6 +3030,11 @@ impl HTMLMediaElement {
     }
 
     fn seekable(&self) -> TimeRangesContainer {
+        // <https://w3c.github.io/media-source/#htmlmediaelement-extensions>
+        if let Some(media_source) = self.media_source.get() {
+            return media_source.seekable();
+        }
+
         let mut seekable = TimeRangesContainer::default();
         if let Some(ref player) = *self.player.borrow() {
             let ranges = player.lock().unwrap().seekable();
@@ -3387,13 +3598,20 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-media-buffered>
     fn Buffered(&self, cx: &mut JSContext) -> DomRoot<TimeRanges> {
-        let mut buffered = TimeRangesContainer::default();
-        if let Some(ref player) = *self.player.borrow() {
-            let ranges = player.lock().unwrap().buffered();
-            for range in ranges {
-                let _ = buffered.add(range.start, range.end);
-            }
-        }
+        // <https://w3c.github.io/media-source/#htmlmediaelement-extensions>
+        let buffered = match self.media_source.get() {
+            Some(media_source) => media_source.media_element_buffered(),
+            None => {
+                let mut buffered = TimeRangesContainer::default();
+                if let Some(ref player) = *self.player.borrow() {
+                    let ranges = player.lock().unwrap().buffered();
+                    for range in ranges {
+                        let _ = buffered.add(range.start, range.end);
+                    }
+                }
+                buffered
+            },
+        };
         TimeRanges::new(cx, self.global().as_window(), buffered)
     }
 
@@ -3671,6 +3889,10 @@ impl MicrotaskRunnable for MediaElementMicrotask {
 enum Resource {
     Object,
     Url(ServoUrl),
+    /// A media source object URL, which is attached rather than fetched.
+    ///
+    /// <https://w3c.github.io/media-source/#dfn-attaching-to-a-media-element>
+    MediaSource(DomRoot<MediaSource>),
 }
 
 #[derive(Debug, MallocSizeOf, PartialEq)]

--- a/components/script/dom/media/bytestream.rs
+++ b/components/script/dom/media/bytestream.rs
@@ -1,0 +1,1278 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! Minimal parsers for the byte stream formats registered for Media Source Extensions.
+//!
+//! These parsers do not decode any media data. They only extract the information the
+//! [segment parser loop][loop] needs to drive the observable state of a `SourceBuffer`:
+//! which tracks an initialization segment declares, and which presentation interval each
+//! media segment covers. The media data itself is handed over to the media backend
+//! unmodified.
+//!
+//! [loop]: https://w3c.github.io/media-source/#sourcebuffer-segment-parser-loop
+
+use std::ops::Range;
+
+/// The byte stream formats we are able to parse.
+///
+/// <https://w3c.github.io/mse-byte-stream-format-registry/>
+#[derive(Clone, Copy, Debug, JSTraceable, MallocSizeOf, PartialEq)]
+pub(crate) enum ByteStreamFormat {
+    /// <https://w3c.github.io/mse-byte-stream-format-isobmff/>
+    IsoBmff,
+    /// <https://w3c.github.io/mse-byte-stream-format-webm/>
+    WebM,
+}
+
+/// <https://w3c.github.io/media-source/#track-buffer>
+#[derive(Clone, Copy, Debug, JSTraceable, MallocSizeOf, PartialEq)]
+pub(crate) enum TrackKind {
+    Audio,
+    Video,
+    Text,
+}
+
+/// A track declared by an initialization segment.
+#[derive(Clone, Debug, JSTraceable, MallocSizeOf)]
+pub(crate) struct TrackDescription {
+    pub(crate) id: u32,
+    pub(crate) kind: TrackKind,
+}
+
+/// The subset of an initialization segment the segment parser loop cares about.
+#[derive(Clone, Debug, Default, JSTraceable, MallocSizeOf)]
+pub(crate) struct InitializationSegment {
+    /// The duration declared by the segment, in seconds, if any.
+    pub(crate) duration: Option<f64>,
+    pub(crate) tracks: Vec<TrackDescription>,
+}
+
+/// Everything a single call to [`ByteStreamParser::parse`] was able to extract.
+#[derive(Debug, Default)]
+pub(crate) struct ParsedSegments {
+    /// The last initialization segment seen, if the append contained one.
+    pub(crate) initialization: Option<InitializationSegment>,
+    /// The presentation intervals, in seconds, covered by the media segments seen.
+    pub(crate) media_ranges: Vec<MediaSegmentRange>,
+}
+
+/// The presentation interval a media segment covers for one of its tracks.
+#[derive(Debug, PartialEq)]
+pub(crate) struct MediaSegmentRange {
+    /// The track the interval belongs to, or `None` when it covers every track of the
+    /// initialization segment, as a WebM cluster does.
+    pub(crate) track: Option<u32>,
+    pub(crate) range: Range<f64>,
+}
+
+/// An append that could not be parsed, which the caller turns into the
+/// [append error algorithm][error].
+///
+/// [error]: https://w3c.github.io/media-source/#dfn-append-error
+#[derive(Debug, PartialEq)]
+pub(crate) struct ParseError;
+
+/// The parser state shared by every byte stream format.
+#[derive(JSTraceable, MallocSizeOf)]
+pub(crate) struct ByteStreamParser {
+    format: ByteStreamFormat,
+    /// Bytes of an incomplete structure carried over to the next append.
+    pending: Vec<u8>,
+    /// Payload bytes we are deliberately not buffering, such as `mdat` contents.
+    skip: u64,
+    /// Whether a valid initialization segment has been parsed since the last reset.
+    have_initialization_segment: bool,
+    isobmff: IsoBmffState,
+    webm: WebMState,
+}
+
+impl ByteStreamParser {
+    pub(crate) fn new(format: ByteStreamFormat) -> Self {
+        Self {
+            format,
+            pending: Vec::new(),
+            skip: 0,
+            have_initialization_segment: false,
+            isobmff: IsoBmffState::default(),
+            webm: WebMState::default(),
+        }
+    }
+
+    /// <https://w3c.github.io/media-source/#dfn-reset-parser-state>
+    ///
+    /// Only the bytes of a partially parsed segment are discarded. The track information
+    /// from the initialization segment stays valid, as required by the algorithm.
+    pub(crate) fn reset(&mut self) {
+        self.pending.clear();
+        self.skip = 0;
+    }
+
+    pub(crate) fn format(&self) -> ByteStreamFormat {
+        self.format
+    }
+
+    /// Whether the parser holds the beginning of a structure whose remaining bytes have
+    /// not been appended yet, which the specification calls the `PARSING_MEDIA_SEGMENT`
+    /// append state.
+    ///
+    /// <https://w3c.github.io/media-source/#dfn-append-state>
+    pub(crate) fn is_parsing_segment(&self) -> bool {
+        !self.pending.is_empty() || self.skip > 0
+    }
+
+    /// Feeds `data` to the parser and returns everything that could be parsed from the
+    /// bytes accumulated so far.
+    pub(crate) fn parse(&mut self, data: &[u8]) -> Result<ParsedSegments, ParseError> {
+        // Drop the leading bytes of a payload we decided not to buffer.
+        let data = if self.skip > 0 {
+            let skipped = self.skip.min(data.len() as u64);
+            self.skip -= skipped;
+            &data[skipped as usize..]
+        } else {
+            data
+        };
+
+        if self.pending.is_empty() {
+            // Fast path: parse straight out of the append, and only copy what is left over.
+            let mut segments = ParsedSegments::default();
+            let consumed = self.parse_buffer(data, &mut segments)?;
+            self.pending.extend_from_slice(&data[consumed..]);
+            Ok(segments)
+        } else {
+            self.pending.extend_from_slice(data);
+            let mut segments = ParsedSegments::default();
+            let buffer = std::mem::take(&mut self.pending);
+            let consumed = self.parse_buffer(&buffer, &mut segments)?;
+            self.pending.extend_from_slice(&buffer[consumed..]);
+            Ok(segments)
+        }
+    }
+
+    /// Parses as many complete structures as `buffer` holds, returning how many bytes
+    /// were consumed.
+    fn parse_buffer(
+        &mut self,
+        buffer: &[u8],
+        segments: &mut ParsedSegments,
+    ) -> Result<usize, ParseError> {
+        match self.format {
+            ByteStreamFormat::IsoBmff => self.parse_isobmff(buffer, segments),
+            ByteStreamFormat::WebM => self.parse_webm(buffer, segments),
+        }
+    }
+}
+
+// ISO Base Media File Format
+//
+// <https://w3c.github.io/mse-byte-stream-format-isobmff/>
+
+/// Per-track information an ISO BMFF initialization segment provides, needed to turn the
+/// timestamps of later media segments into seconds.
+#[derive(Clone, Copy, Debug, JSTraceable, MallocSizeOf)]
+struct IsoBmffTrack {
+    id: u32,
+    timescale: u32,
+    default_sample_duration: u32,
+}
+
+#[derive(Default, JSTraceable, MallocSizeOf)]
+struct IsoBmffState {
+    tracks: Vec<IsoBmffTrack>,
+}
+
+impl IsoBmffState {
+    fn track(&self, id: u32) -> Option<&IsoBmffTrack> {
+        self.tracks.iter().find(|track| track.id == id)
+    }
+}
+
+/// A box header: the payload range within its container plus the four character code.
+struct BoxHeader {
+    name: [u8; 4],
+    /// Offset of the payload relative to the start of the header.
+    payload_start: usize,
+    /// Total size of the box, header included. `None` when the box extends to the end of
+    /// the stream, which ISO BMFF signals with a size of zero.
+    total_size: Option<u64>,
+}
+
+enum ReadBoxHeader {
+    /// The bytes of the header have not all been appended yet.
+    Incomplete,
+    /// The header does not describe a box, so the stream does not conform to the byte
+    /// stream format.
+    Invalid,
+    Header(BoxHeader),
+}
+
+/// Reads the header of the box starting at `data`.
+fn read_box_header(data: &[u8]) -> ReadBoxHeader {
+    if data.len() < 8 {
+        return ReadBoxHeader::Incomplete;
+    }
+
+    let size = u32::from_be_bytes(data[0..4].try_into().expect("four bytes")) as u64;
+    let name: [u8; 4] = data[4..8].try_into().expect("four bytes");
+
+    // Box types are four printable characters. Checking them keeps a stream of arbitrary
+    // bytes from being mistaken for a box whose size we would then wait forever to reach.
+    if !name
+        .iter()
+        .all(|byte| byte.is_ascii_graphic() || *byte == b' ')
+    {
+        return ReadBoxHeader::Invalid;
+    }
+
+    match size {
+        // A size of one means the real size is stored in the 64 bit `largesize` field.
+        1 => {
+            if data.len() < 16 {
+                return ReadBoxHeader::Incomplete;
+            }
+            let size = u64::from_be_bytes(data[8..16].try_into().expect("eight bytes"));
+            if size < 16 {
+                return ReadBoxHeader::Invalid;
+            }
+            ReadBoxHeader::Header(BoxHeader {
+                name,
+                payload_start: 16,
+                total_size: Some(size),
+            })
+        },
+        // A size of zero means the box extends to the end of the stream.
+        0 => ReadBoxHeader::Header(BoxHeader {
+            name,
+            payload_start: 8,
+            total_size: None,
+        }),
+        _ if size < 8 => ReadBoxHeader::Invalid,
+        _ => ReadBoxHeader::Header(BoxHeader {
+            name,
+            payload_start: 8,
+            total_size: Some(size),
+        }),
+    }
+}
+
+/// Calls `visitor` for every child box of `data`, stopping early if it returns `false`.
+fn for_each_box(data: &[u8], mut visitor: impl FnMut(&[u8; 4], &[u8]) -> bool) {
+    let mut offset = 0;
+    while offset < data.len() {
+        let ReadBoxHeader::Header(header) = read_box_header(&data[offset..]) else {
+            return;
+        };
+        let Some(total_size) = header.total_size else {
+            // The box runs to the end of the data we have.
+            let payload = &data[offset + header.payload_start..];
+            visitor(&header.name, payload);
+            return;
+        };
+        let end = offset.saturating_add(total_size as usize);
+        if end > data.len() || header.payload_start > total_size as usize {
+            return;
+        }
+        let payload = &data[offset + header.payload_start..end];
+        if !visitor(&header.name, payload) {
+            return;
+        }
+        offset = end;
+    }
+}
+
+fn read_u16(data: &[u8], offset: usize) -> Option<u16> {
+    data.get(offset..offset + 2)
+        .and_then(|slice| slice.try_into().ok())
+        .map(u16::from_be_bytes)
+}
+
+fn read_u32(data: &[u8], offset: usize) -> Option<u32> {
+    data.get(offset..offset + 4)
+        .and_then(|slice| slice.try_into().ok())
+        .map(u32::from_be_bytes)
+}
+
+fn read_u64(data: &[u8], offset: usize) -> Option<u64> {
+    data.get(offset..offset + 8)
+        .and_then(|slice| slice.try_into().ok())
+        .map(u64::from_be_bytes)
+}
+
+/// Returns the version and flags of a full box.
+fn read_full_box_header(data: &[u8]) -> Option<(u8, u32)> {
+    let value = read_u32(data, 0)?;
+    Some(((value >> 24) as u8, value & 0x00ff_ffff))
+}
+
+impl ByteStreamParser {
+    fn parse_isobmff(
+        &mut self,
+        buffer: &[u8],
+        segments: &mut ParsedSegments,
+    ) -> Result<usize, ParseError> {
+        let mut offset = 0;
+
+        while offset < buffer.len() {
+            let header = match read_box_header(&buffer[offset..]) {
+                ReadBoxHeader::Header(header) => header,
+                ReadBoxHeader::Incomplete => break,
+                ReadBoxHeader::Invalid => return Err(ParseError),
+            };
+            let Some(total_size) = header.total_size else {
+                // Only the final `mdat` of a stream is allowed to have an unknown size, and
+                // its payload is of no interest to us.
+                return Ok(buffer.len());
+            };
+            let total_size = total_size as usize;
+            if header.payload_start > total_size {
+                return Err(ParseError);
+            }
+
+            // `mdat` payloads carry the coded frames and can be very large, so they are
+            // skipped without ever being copied into the pending buffer.
+            if &header.name == b"mdat" {
+                let available = buffer.len() - offset;
+                if available < total_size {
+                    self.skip = (total_size - available) as u64;
+                    return Ok(buffer.len());
+                }
+                offset += total_size;
+                continue;
+            }
+
+            if buffer.len() - offset < total_size {
+                break;
+            }
+
+            let payload = &buffer[offset + header.payload_start..offset + total_size];
+            match &header.name {
+                b"moov" => {
+                    let initialization = self.parse_moov(payload).ok_or(ParseError)?;
+                    self.have_initialization_segment = true;
+                    segments.initialization = Some(initialization);
+                },
+                b"moof" => {
+                    if !self.have_initialization_segment {
+                        return Err(ParseError);
+                    }
+                    segments.media_ranges.extend(self.parse_moof(payload));
+                },
+                _ => {},
+            }
+
+            offset += total_size;
+        }
+
+        Ok(offset)
+    }
+
+    /// Extracts the tracks and the duration declared by a `moov` box.
+    fn parse_moov(&mut self, moov: &[u8]) -> Option<InitializationSegment> {
+        let mut movie_timescale = None;
+        let mut movie_duration = None;
+        let mut tracks = Vec::new();
+        let mut parser_tracks = Vec::new();
+        // `trex` provides the per-track defaults used by media segments that do not
+        // repeat them.
+        let mut track_defaults: Vec<(u32, u32)> = Vec::new();
+
+        for_each_box(moov, |name, payload| {
+            match name {
+                b"mvhd" => {
+                    if let Some((version, _)) = read_full_box_header(payload) {
+                        let (timescale, duration) = if version == 1 {
+                            (
+                                read_u32(payload, 20),
+                                read_u64(payload, 24).map(|duration| duration as f64),
+                            )
+                        } else {
+                            (
+                                read_u32(payload, 12),
+                                read_u32(payload, 16).map(|duration| duration as f64),
+                            )
+                        };
+                        movie_timescale = timescale;
+                        movie_duration = duration;
+                    }
+                },
+                b"mvex" => {
+                    for_each_box(payload, |name, payload| {
+                        if name == b"trex" &&
+                            let Some(id) = read_u32(payload, 4) &&
+                            let Some(default_sample_duration) = read_u32(payload, 12)
+                        {
+                            track_defaults.push((id, default_sample_duration));
+                        }
+                        true
+                    });
+                },
+                b"trak" => {
+                    if let Some((track, kind)) = parse_trak(payload) {
+                        tracks.push(TrackDescription { id: track.id, kind });
+                        parser_tracks.push(track);
+                    }
+                },
+                _ => {},
+            }
+            true
+        });
+
+        if tracks.is_empty() {
+            return None;
+        }
+
+        for track in parser_tracks.iter_mut() {
+            if let Some((_, default_sample_duration)) =
+                track_defaults.iter().find(|(id, _)| *id == track.id)
+            {
+                track.default_sample_duration = *default_sample_duration;
+            }
+        }
+        self.isobmff.tracks = parser_tracks;
+
+        // An unset or zero movie duration means the duration is unknown, which is how
+        // live streams and most media segments-only initialization segments are authored.
+        let duration = match (movie_timescale, movie_duration) {
+            (Some(timescale), Some(duration)) if timescale > 0 && duration > 0. => {
+                Some(duration / timescale as f64)
+            },
+            _ => None,
+        };
+
+        Some(InitializationSegment { duration, tracks })
+    }
+
+    /// Computes the presentation interval a `moof` box covers for each of its tracks.
+    fn parse_moof(&self, moof: &[u8]) -> Vec<MediaSegmentRange> {
+        let mut ranges = Vec::new();
+
+        for_each_box(moof, |name, payload| {
+            if name == b"traf" &&
+                let Some(range) = self.parse_traf(payload)
+            {
+                ranges.push(range);
+            }
+            true
+        });
+
+        ranges
+    }
+
+    fn parse_traf(&self, traf: &[u8]) -> Option<MediaSegmentRange> {
+        let mut track = None;
+        let mut default_sample_duration = None;
+        let mut base_media_decode_time = None;
+        let mut total_duration: u64 = 0;
+        let mut have_trun = false;
+
+        for_each_box(traf, |name, payload| {
+            match name {
+                b"tfhd" => {
+                    if let Some((_, flags)) = read_full_box_header(payload) &&
+                        let Some(track_id) = read_u32(payload, 4)
+                    {
+                        track = self.isobmff.track(track_id).copied();
+
+                        // The optional fields of `tfhd` are laid out in flag order, so the
+                        // offset of `default_sample_duration` depends on which of the
+                        // preceding fields are present.
+                        let mut offset = 8;
+                        if flags & 0x00_0001 != 0 {
+                            // base_data_offset
+                            offset += 8;
+                        }
+                        if flags & 0x00_0002 != 0 {
+                            // sample_description_index
+                            offset += 4;
+                        }
+                        if flags & 0x00_0008 != 0 {
+                            default_sample_duration = read_u32(payload, offset);
+                        }
+                    }
+                },
+                b"tfdt" => {
+                    if let Some((version, _)) = read_full_box_header(payload) {
+                        base_media_decode_time = if version == 1 {
+                            read_u64(payload, 4)
+                        } else {
+                            read_u32(payload, 4).map(u64::from)
+                        };
+                    }
+                },
+                b"trun" => {
+                    if let Some((_, flags)) = read_full_box_header(payload) &&
+                        let Some(sample_count) = read_u32(payload, 4)
+                    {
+                        have_trun = true;
+                        total_duration = total_duration.saturating_add(trun_duration(
+                            payload,
+                            flags,
+                            sample_count,
+                            default_sample_duration
+                                .or_else(|| track.map(|track| track.default_sample_duration)),
+                        ));
+                    }
+                },
+                _ => {},
+            }
+            true
+        });
+
+        let track = track?;
+        if track.timescale == 0 || !have_trun {
+            return None;
+        }
+
+        let timescale = track.timescale as f64;
+        let start = base_media_decode_time.unwrap_or(0) as f64 / timescale;
+        let end = start + total_duration as f64 / timescale;
+
+        Some(MediaSegmentRange {
+            track: Some(track.id),
+            range: start..end,
+        })
+    }
+}
+
+/// Sums the durations of the samples described by a `trun` box.
+fn trun_duration(
+    trun: &[u8],
+    flags: u32,
+    sample_count: u32,
+    default_sample_duration: Option<u32>,
+) -> u64 {
+    const DATA_OFFSET_PRESENT: u32 = 0x00_0001;
+    const FIRST_SAMPLE_FLAGS_PRESENT: u32 = 0x00_0004;
+    const SAMPLE_DURATION_PRESENT: u32 = 0x00_0100;
+    const SAMPLE_SIZE_PRESENT: u32 = 0x00_0200;
+    const SAMPLE_FLAGS_PRESENT: u32 = 0x00_0400;
+    const SAMPLE_COMPOSITION_TIME_OFFSET_PRESENT: u32 = 0x00_0800;
+
+    // When the samples do not carry their own duration, they all last the default.
+    if flags & SAMPLE_DURATION_PRESENT == 0 {
+        return u64::from(default_sample_duration.unwrap_or(0))
+            .saturating_mul(u64::from(sample_count));
+    }
+
+    let mut offset = 8;
+    if flags & DATA_OFFSET_PRESENT != 0 {
+        offset += 4;
+    }
+    if flags & FIRST_SAMPLE_FLAGS_PRESENT != 0 {
+        offset += 4;
+    }
+
+    let mut entry_size = 4;
+    if flags & SAMPLE_SIZE_PRESENT != 0 {
+        entry_size += 4;
+    }
+    if flags & SAMPLE_FLAGS_PRESENT != 0 {
+        entry_size += 4;
+    }
+    if flags & SAMPLE_COMPOSITION_TIME_OFFSET_PRESENT != 0 {
+        entry_size += 4;
+    }
+
+    let mut total = 0u64;
+    for _ in 0..sample_count {
+        let Some(duration) = read_u32(trun, offset) else {
+            break;
+        };
+        total = total.saturating_add(u64::from(duration));
+        offset += entry_size;
+    }
+    total
+}
+
+/// Reads the track identifier, timescale and media kind out of a `trak` box.
+fn parse_trak(trak: &[u8]) -> Option<(IsoBmffTrack, TrackKind)> {
+    let mut id = None;
+    let mut timescale = None;
+    let mut kind = None;
+
+    for_each_box(trak, |name, payload| {
+        match name {
+            b"tkhd" => {
+                if let Some((version, _)) = read_full_box_header(payload) {
+                    id = if version == 1 {
+                        read_u32(payload, 20)
+                    } else {
+                        read_u32(payload, 12)
+                    };
+                }
+            },
+            b"mdia" => {
+                for_each_box(payload, |name, payload| {
+                    match name {
+                        b"mdhd" => {
+                            if let Some((version, _)) = read_full_box_header(payload) {
+                                timescale = if version == 1 {
+                                    read_u32(payload, 20)
+                                } else {
+                                    read_u32(payload, 12)
+                                };
+                            }
+                        },
+                        b"hdlr" => {
+                            kind = match payload.get(8..12) {
+                                Some(b"vide") => Some(TrackKind::Video),
+                                Some(b"soun") => Some(TrackKind::Audio),
+                                Some(b"text") | Some(b"subt") | Some(b"sbtl") => {
+                                    Some(TrackKind::Text)
+                                },
+                                _ => None,
+                            };
+                        },
+                        _ => {},
+                    }
+                    true
+                });
+            },
+            _ => {},
+        }
+        true
+    });
+
+    Some((
+        IsoBmffTrack {
+            id: id?,
+            timescale: timescale?,
+            default_sample_duration: 0,
+        },
+        kind?,
+    ))
+}
+
+// WebM
+//
+// <https://w3c.github.io/mse-byte-stream-format-webm/>
+
+const EBML_HEADER: u64 = 0x1a45_dfa3;
+const SEGMENT: u64 = 0x1853_8067;
+const INFO: u64 = 0x1549_a966;
+const TIMECODE_SCALE: u64 = 0x2ad7_b1;
+const DURATION: u64 = 0x4489;
+const TRACKS: u64 = 0x1654_ae6b;
+const TRACK_ENTRY: u64 = 0xae;
+const TRACK_NUMBER: u64 = 0xd7;
+const TRACK_TYPE: u64 = 0x83;
+const DEFAULT_DURATION: u64 = 0x23e3_83;
+const CLUSTER: u64 = 0x1f43_b675;
+const TIMECODE: u64 = 0xe7;
+const SIMPLE_BLOCK: u64 = 0xa3;
+const BLOCK_GROUP: u64 = 0xa0;
+const BLOCK: u64 = 0xa1;
+
+/// The nanoseconds per timecode unit assumed when a segment omits `TimecodeScale`.
+const DEFAULT_TIMECODE_SCALE: u64 = 1_000_000;
+
+/// The elements that may appear either at the top level of a WebM stream or directly
+/// inside its `Segment`, whose children are parsed at the top level here.
+///
+/// <https://www.matroska.org/technical/elements.html>
+const TOP_LEVEL_ELEMENTS: &[u64] = &[
+    EBML_HEADER,
+    SEGMENT,
+    INFO,
+    TRACKS,
+    CLUSTER,
+    // SeekHead
+    0x114d_9b74,
+    // Cues
+    0x1c53_bb6b,
+    // Chapters
+    0x1043_a770,
+    // Tags
+    0x1254_c367,
+    // Attachments
+    0x1941_a469,
+    // Void
+    0xec,
+    // CRC-32
+    0xbf,
+];
+
+#[derive(JSTraceable, MallocSizeOf)]
+struct WebMState {
+    timecode_scale: u64,
+    /// The `DefaultDuration` of the track with the finest granularity, in nanoseconds,
+    /// used to extend the last block of a cluster to its real end.
+    default_duration: Option<u64>,
+}
+
+impl Default for WebMState {
+    fn default() -> Self {
+        Self {
+            timecode_scale: DEFAULT_TIMECODE_SCALE,
+            default_duration: None,
+        }
+    }
+}
+
+/// An EBML variable size integer.
+struct VarInt {
+    value: u64,
+    length: usize,
+    /// Whether every value bit was set, which EBML uses to mean "unknown size".
+    unknown: bool,
+}
+
+/// Reads a variable size integer, optionally keeping the length marker as element
+/// identifiers require.
+fn read_vint(data: &[u8], keep_marker: bool) -> Option<VarInt> {
+    let first = *data.first()?;
+    if first == 0 {
+        // Lengths above eight bytes are not valid in WebM.
+        return None;
+    }
+    let length = first.leading_zeros() as usize + 1;
+    if data.len() < length {
+        return None;
+    }
+
+    let mut value = if keep_marker {
+        u64::from(first)
+    } else {
+        // The length marker takes `length` bits of the first byte, so an eight byte
+        // integer carries none of its value there.
+        let mask = if length >= 8 { 0 } else { 0xffu8 >> length };
+        u64::from(first & mask)
+    };
+    for byte in &data[1..length] {
+        value = (value << 8) | u64::from(*byte);
+    }
+
+    // With the marker stripped, an all-ones value means the size is unknown.
+    let unknown = !keep_marker && value == (1u64 << (7 * length)) - 1;
+
+    Some(VarInt {
+        value,
+        length,
+        unknown,
+    })
+}
+
+struct EbmlHeader {
+    id: u64,
+    payload_start: usize,
+    /// `None` for elements of unknown size.
+    payload_size: Option<u64>,
+}
+
+fn read_ebml_header(data: &[u8]) -> Option<EbmlHeader> {
+    let id = read_vint(data, /* keep_marker */ true)?;
+    let size = read_vint(&data[id.length..], /* keep_marker */ false)?;
+    Some(EbmlHeader {
+        id: id.value,
+        payload_start: id.length + size.length,
+        payload_size: (!size.unknown).then_some(size.value),
+    })
+}
+
+/// Reads an unsigned integer stored in a big endian element of up to eight bytes.
+fn read_ebml_uint(data: &[u8]) -> Option<u64> {
+    if data.is_empty() || data.len() > 8 {
+        return None;
+    }
+    Some(
+        data.iter()
+            .fold(0u64, |value, byte| (value << 8) | u64::from(*byte)),
+    )
+}
+
+fn read_ebml_float(data: &[u8]) -> Option<f64> {
+    match data.len() {
+        4 => Some(f32::from_be_bytes(data.try_into().ok()?) as f64),
+        8 => Some(f64::from_be_bytes(data.try_into().ok()?)),
+        _ => None,
+    }
+}
+
+impl ByteStreamParser {
+    fn parse_webm(
+        &mut self,
+        buffer: &[u8],
+        segments: &mut ParsedSegments,
+    ) -> Result<usize, ParseError> {
+        let mut offset = 0;
+        let mut initialization: Option<InitializationSegment> = None;
+
+        while offset < buffer.len() {
+            let Some(header) = read_ebml_header(&buffer[offset..]) else {
+                break;
+            };
+
+            // Anything that is not one of the elements a WebM stream may carry at this
+            // level means the stream does not conform to the byte stream format. Without
+            // this check a run of arbitrary bytes would read as an element whose size we
+            // would then wait forever to reach.
+            if !TOP_LEVEL_ELEMENTS.contains(&header.id) {
+                return Err(ParseError);
+            }
+
+            // `Segment` is a master element that usually has an unknown size and always
+            // wraps the whole stream, so its children are parsed as if they were at the
+            // top level.
+            if header.id == SEGMENT {
+                offset += header.payload_start;
+                continue;
+            }
+
+            let Some(payload_size) = header.payload_size else {
+                // Only `Segment` is allowed an unknown size in the WebM byte stream format.
+                return Err(ParseError);
+            };
+            let total_size = header.payload_start.saturating_add(payload_size as usize);
+            if buffer.len() - offset < total_size {
+                break;
+            }
+            let payload = &buffer[offset + header.payload_start..offset + total_size];
+
+            match header.id {
+                EBML_HEADER => {
+                    self.webm = WebMState::default();
+                },
+                INFO => {
+                    let info = self.parse_webm_info(payload);
+                    initialization
+                        .get_or_insert_with(InitializationSegment::default)
+                        .duration = info;
+                },
+                TRACKS => {
+                    let tracks = self.parse_webm_tracks(payload);
+                    if tracks.is_empty() {
+                        return Err(ParseError);
+                    }
+                    self.have_initialization_segment = true;
+                    initialization
+                        .get_or_insert_with(InitializationSegment::default)
+                        .tracks = tracks;
+                },
+                CLUSTER => {
+                    if !self.have_initialization_segment {
+                        return Err(ParseError);
+                    }
+                    if let Some(range) = self.parse_webm_cluster(payload) {
+                        segments.media_ranges.push(range);
+                    }
+                },
+                _ => {},
+            }
+
+            offset += total_size;
+        }
+
+        if initialization.is_some() {
+            segments.initialization = initialization;
+        }
+
+        Ok(offset)
+    }
+
+    /// Reads `TimecodeScale` and `Duration` out of an `Info` element.
+    fn parse_webm_info(&mut self, info: &[u8]) -> Option<f64> {
+        let mut duration = None;
+
+        for_each_ebml_element(info, |id, payload| {
+            match id {
+                TIMECODE_SCALE => {
+                    if let Some(scale) = read_ebml_uint(payload).filter(|scale| *scale > 0) {
+                        self.webm.timecode_scale = scale;
+                    }
+                },
+                DURATION => {
+                    duration = read_ebml_float(payload).filter(|duration| *duration > 0.);
+                },
+                _ => {},
+            }
+            true
+        });
+
+        // `Duration` is expressed in timecode scale units.
+        duration.map(|duration| duration * self.webm.timecode_scale as f64 / 1e9)
+    }
+
+    fn parse_webm_tracks(&mut self, tracks: &[u8]) -> Vec<TrackDescription> {
+        let mut descriptions = Vec::new();
+        let mut default_duration = None;
+
+        for_each_ebml_element(tracks, |id, payload| {
+            if id != TRACK_ENTRY {
+                return true;
+            }
+
+            let mut number = None;
+            let mut kind = None;
+            for_each_ebml_element(payload, |id, payload| {
+                match id {
+                    TRACK_NUMBER => number = read_ebml_uint(payload),
+                    TRACK_TYPE => {
+                        // <https://www.matroska.org/technical/elements.html>
+                        kind = match read_ebml_uint(payload) {
+                            Some(1) => Some(TrackKind::Video),
+                            Some(2) => Some(TrackKind::Audio),
+                            Some(0x11) => Some(TrackKind::Text),
+                            _ => None,
+                        };
+                    },
+                    DEFAULT_DURATION => {
+                        if let Some(duration) = read_ebml_uint(payload).filter(|d| *d > 0) {
+                            default_duration = Some(
+                                default_duration
+                                    .map_or(duration, |current: u64| current.min(duration)),
+                            );
+                        }
+                    },
+                    _ => {},
+                }
+                true
+            });
+
+            if let (Some(number), Some(kind)) = (number, kind) {
+                descriptions.push(TrackDescription {
+                    id: number as u32,
+                    kind,
+                });
+            }
+            true
+        });
+
+        self.webm.default_duration = default_duration;
+        descriptions
+    }
+
+    /// Computes the presentation interval covered by a `Cluster` element. A cluster
+    /// interleaves every track of the segment over the same interval.
+    fn parse_webm_cluster(&self, cluster: &[u8]) -> Option<MediaSegmentRange> {
+        let mut timecode = None;
+        // The largest block timecode relative to the cluster timecode.
+        let mut last_relative = 0i64;
+
+        for_each_ebml_element(cluster, |id, payload| {
+            match id {
+                TIMECODE => timecode = read_ebml_uint(payload),
+                SIMPLE_BLOCK => {
+                    if let Some(relative) = read_block_relative_timecode(payload) {
+                        last_relative = last_relative.max(i64::from(relative));
+                    }
+                },
+                BLOCK_GROUP => {
+                    for_each_ebml_element(payload, |id, payload| {
+                        if id == BLOCK &&
+                            let Some(relative) = read_block_relative_timecode(payload)
+                        {
+                            last_relative = last_relative.max(i64::from(relative));
+                        }
+                        true
+                    });
+                },
+                _ => {},
+            }
+            true
+        });
+
+        let timecode = timecode?;
+        let scale = self.webm.timecode_scale as f64;
+        let start = timecode as f64 * scale / 1e9;
+        let last_frame = (timecode as f64 + last_relative as f64) * scale / 1e9;
+        // Extend the interval past the last block so that a cluster reports the time it
+        // actually covers rather than the presentation time of its final frame.
+        let end = last_frame + self.webm.default_duration.unwrap_or(0) as f64 / 1e9;
+
+        Some(MediaSegmentRange {
+            track: None,
+            range: start..end.max(start),
+        })
+    }
+}
+
+/// Reads the signed timecode a block stores relative to its cluster.
+fn read_block_relative_timecode(block: &[u8]) -> Option<i16> {
+    // A block starts with the track number as a variable size integer, followed by the
+    // relative timecode as a big endian signed 16 bit integer.
+    let track_number = read_vint(block, /* keep_marker */ false)?;
+    read_u16(block, track_number.length).map(|value| value as i16)
+}
+
+/// Calls `visitor` for every child element of `data`, stopping early if it returns `false`.
+fn for_each_ebml_element(data: &[u8], mut visitor: impl FnMut(u64, &[u8]) -> bool) {
+    let mut offset = 0;
+    while offset < data.len() {
+        let Some(header) = read_ebml_header(&data[offset..]) else {
+            return;
+        };
+        let Some(payload_size) = header.payload_size else {
+            return;
+        };
+        let end = offset.saturating_add(header.payload_start.saturating_add(payload_size as usize));
+        if end > data.len() {
+            return;
+        }
+        if !visitor(header.id, &data[offset + header.payload_start..end]) {
+            return;
+        }
+        offset = end;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds an ISO BMFF box with the given four character code and payload.
+    fn boxed(name: &[u8; 4], payload: &[u8]) -> Vec<u8> {
+        let mut data = Vec::with_capacity(8 + payload.len());
+        data.extend_from_slice(&((8 + payload.len()) as u32).to_be_bytes());
+        data.extend_from_slice(name);
+        data.extend_from_slice(payload);
+        data
+    }
+
+    fn full_box(version: u8, flags: u32) -> Vec<u8> {
+        (((version as u32) << 24) | flags).to_be_bytes().to_vec()
+    }
+
+    /// A `moov` with a single 25 fps video track using a timescale of 1000.
+    fn video_moov(movie_duration: u32) -> Vec<u8> {
+        let mut mvhd = full_box(0, 0);
+        mvhd.extend_from_slice(&0u32.to_be_bytes()); // creation_time
+        mvhd.extend_from_slice(&0u32.to_be_bytes()); // modification_time
+        mvhd.extend_from_slice(&1000u32.to_be_bytes()); // timescale
+        mvhd.extend_from_slice(&movie_duration.to_be_bytes());
+
+        let mut tkhd = full_box(0, 0);
+        tkhd.extend_from_slice(&0u32.to_be_bytes()); // creation_time
+        tkhd.extend_from_slice(&0u32.to_be_bytes()); // modification_time
+        tkhd.extend_from_slice(&1u32.to_be_bytes()); // track_ID
+
+        let mut mdhd = full_box(0, 0);
+        mdhd.extend_from_slice(&0u32.to_be_bytes()); // creation_time
+        mdhd.extend_from_slice(&0u32.to_be_bytes()); // modification_time
+        mdhd.extend_from_slice(&1000u32.to_be_bytes()); // timescale
+
+        let mut hdlr = full_box(0, 0);
+        hdlr.extend_from_slice(&0u32.to_be_bytes()); // pre_defined
+        hdlr.extend_from_slice(b"vide");
+
+        let mdia = boxed(
+            b"mdia",
+            &[boxed(b"mdhd", &mdhd), boxed(b"hdlr", &hdlr)].concat(),
+        );
+        let trak = boxed(b"trak", &[boxed(b"tkhd", &tkhd), mdia].concat());
+
+        boxed(b"moov", &[boxed(b"mvhd", &mvhd), trak].concat())
+    }
+
+    /// A `moof` starting at `base_time` with `samples` samples of `duration` each.
+    fn video_moof(base_time: u32, samples: u32, duration: u32) -> Vec<u8> {
+        let mut tfhd = full_box(0, 0);
+        tfhd.extend_from_slice(&1u32.to_be_bytes()); // track_ID
+
+        let mut tfdt = full_box(0, 0);
+        tfdt.extend_from_slice(&base_time.to_be_bytes());
+
+        // sample-duration-present
+        let mut trun = full_box(0, 0x00_0100);
+        trun.extend_from_slice(&samples.to_be_bytes());
+        for _ in 0..samples {
+            trun.extend_from_slice(&duration.to_be_bytes());
+        }
+
+        let traf = boxed(
+            b"traf",
+            &[
+                boxed(b"tfhd", &tfhd),
+                boxed(b"tfdt", &tfdt),
+                boxed(b"trun", &trun),
+            ]
+            .concat(),
+        );
+        boxed(b"moof", &traf)
+    }
+
+    #[test]
+    fn isobmff_initialization_segment_reports_tracks_and_duration() {
+        let mut parser = ByteStreamParser::new(ByteStreamFormat::IsoBmff);
+        let data = [boxed(b"ftyp", b"isom"), video_moov(10_000)].concat();
+
+        let segments = parser.parse(&data).unwrap();
+        let initialization = segments.initialization.expect("initialization segment");
+
+        assert_eq!(initialization.duration, Some(10.));
+        assert_eq!(initialization.tracks.len(), 1);
+        assert_eq!(initialization.tracks[0].id, 1);
+        assert_eq!(initialization.tracks[0].kind, TrackKind::Video);
+        assert!(parser.have_initialization_segment);
+    }
+
+    #[test]
+    fn isobmff_media_segment_reports_presentation_interval() {
+        let mut parser = ByteStreamParser::new(ByteStreamFormat::IsoBmff);
+        parser
+            .parse(&[boxed(b"ftyp", b"isom"), video_moov(0)].concat())
+            .unwrap();
+
+        // Ten samples of 40ms starting at two seconds.
+        let segments = parser
+            .parse(&[video_moof(2000, 10, 40), boxed(b"mdat", &[0; 64])].concat())
+            .unwrap();
+
+        assert_eq!(
+            segments.media_ranges,
+            vec![MediaSegmentRange {
+                track: Some(1),
+                range: 2.0..2.4,
+            }]
+        );
+    }
+
+    #[test]
+    fn isobmff_boxes_split_across_appends_are_parsed() {
+        let mut parser = ByteStreamParser::new(ByteStreamFormat::IsoBmff);
+        let data = [boxed(b"ftyp", b"isom"), video_moov(4_000)].concat();
+
+        let (first, second) = data.split_at(data.len() / 2);
+        assert!(parser.parse(first).unwrap().initialization.is_none());
+
+        let segments = parser.parse(second).unwrap();
+        assert_eq!(
+            segments
+                .initialization
+                .expect("initialization segment")
+                .duration,
+            Some(4.)
+        );
+    }
+
+    #[test]
+    fn isobmff_large_mdat_payloads_are_not_buffered() {
+        let mut parser = ByteStreamParser::new(ByteStreamFormat::IsoBmff);
+        parser
+            .parse(&[boxed(b"ftyp", b"isom"), video_moov(0)].concat())
+            .unwrap();
+
+        let mdat = boxed(b"mdat", &[0; 4096]);
+        // Feed the `mdat` in two pieces so that the skip counter is exercised.
+        let (first, second) = mdat.split_at(1000);
+        parser.parse(first).unwrap();
+        parser.parse(second).unwrap();
+        assert!(parser.pending.is_empty());
+
+        let segments = parser.parse(&video_moof(0, 5, 100)).unwrap();
+        assert_eq!(
+            segments.media_ranges,
+            vec![MediaSegmentRange {
+                track: Some(1),
+                range: 0.0..0.5,
+            }]
+        );
+    }
+
+    #[test]
+    fn isobmff_media_segment_without_initialization_segment_is_an_error() {
+        let mut parser = ByteStreamParser::new(ByteStreamFormat::IsoBmff);
+        assert!(parser.parse(&video_moof(0, 1, 100)).is_err());
+    }
+
+    #[test]
+    fn isobmff_arbitrary_bytes_are_an_error() {
+        let mut parser = ByteStreamParser::new(ByteStreamFormat::IsoBmff);
+        let garbage: Vec<u8> = (0..64u8).collect();
+        assert!(parser.parse(&garbage).is_err());
+    }
+
+    #[test]
+    fn isobmff_box_smaller_than_its_header_is_an_error() {
+        let mut parser = ByteStreamParser::new(ByteStreamFormat::IsoBmff);
+        let mut data = 5u32.to_be_bytes().to_vec();
+        data.extend_from_slice(b"ftyp");
+        assert!(parser.parse(&data).is_err());
+    }
+
+    /// Builds an EBML element with the given identifier and payload.
+    fn element(id: &[u8], payload: &[u8]) -> Vec<u8> {
+        let mut data = Vec::with_capacity(id.len() + 8 + payload.len());
+        data.extend_from_slice(id);
+        // Encode the size as an eight byte variable size integer for simplicity.
+        let mut size = (payload.len() as u64).to_be_bytes();
+        size[0] |= 0x01;
+        data.extend_from_slice(&size);
+        data.extend_from_slice(payload);
+        data
+    }
+
+    fn webm_initialization_segment(duration_ms: f64) -> Vec<u8> {
+        let info = element(
+            &[0x15, 0x49, 0xa9, 0x66],
+            &[
+                element(&[0x2a, 0xd7, 0xb1], &1_000_000u32.to_be_bytes()),
+                element(&[0x44, 0x89], &(duration_ms as f64).to_be_bytes()),
+            ]
+            .concat(),
+        );
+        let track_entry = element(
+            &[0xae],
+            &[
+                element(&[0xd7], &[1]),
+                element(&[0x83], &[2]),
+                element(&[0x23, 0xe3, 0x83], &20_000_000u32.to_be_bytes()),
+            ]
+            .concat(),
+        );
+        let tracks = element(&[0x16, 0x54, 0xae, 0x6b], &track_entry);
+
+        [
+            element(&[0x1a, 0x45, 0xdf, 0xa3], &[]),
+            // `Segment` with an unknown size, as authored by most muxers.
+            vec![0x18, 0x53, 0x80, 0x67, 0xff],
+            info,
+            tracks,
+        ]
+        .concat()
+    }
+
+    #[test]
+    fn webm_initialization_segment_reports_tracks_and_duration() {
+        let mut parser = ByteStreamParser::new(ByteStreamFormat::WebM);
+        let segments = parser.parse(&webm_initialization_segment(5000.)).unwrap();
+        let initialization = segments.initialization.expect("initialization segment");
+
+        // A `Duration` of 5000 with a timecode scale of a millisecond is five seconds.
+        assert_eq!(initialization.duration, Some(5.));
+        assert_eq!(initialization.tracks.len(), 1);
+        assert_eq!(initialization.tracks[0].kind, TrackKind::Audio);
+    }
+
+    #[test]
+    fn webm_arbitrary_bytes_are_an_error() {
+        let mut parser = ByteStreamParser::new(ByteStreamFormat::WebM);
+        let garbage: Vec<u8> = (0..64u8).map(|byte| byte.wrapping_add(0x40)).collect();
+        assert!(parser.parse(&garbage).is_err());
+    }
+
+    #[test]
+    fn webm_cluster_reports_presentation_interval() {
+        let mut parser = ByteStreamParser::new(ByteStreamFormat::WebM);
+        parser.parse(&webm_initialization_segment(5000.)).unwrap();
+
+        // A block for track one, 100ms after the cluster timecode of one second.
+        let mut block = vec![0x81];
+        block.extend_from_slice(&100i16.to_be_bytes());
+        block.push(0x80); // flags
+        let cluster = element(
+            &[0x1f, 0x43, 0xb6, 0x75],
+            &[
+                element(&[0xe7], &1000u16.to_be_bytes()),
+                element(&[0xa3], &block),
+            ]
+            .concat(),
+        );
+
+        let segments = parser.parse(&cluster).unwrap();
+        assert_eq!(segments.media_ranges.len(), 1);
+        let range = &segments.media_ranges[0].range;
+        assert_eq!(range.start, 1.0);
+        // The last block starts at 1.1s and lasts for the default duration of 20ms.
+        assert!((range.end - 1.12).abs() < f64::EPSILON * 8.);
+    }
+}

--- a/components/script/dom/media/mediasource.rs
+++ b/components/script/dom/media/mediasource.rs
@@ -1,0 +1,814 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::cell::Cell;
+use std::ops::Range;
+
+use dom_struct::dom_struct;
+use js::context::JSContext;
+use js::rust::HandleObject;
+use mime::Mime;
+use script_bindings::cell::DomRefCell;
+use script_bindings::reflector::reflect_dom_object_with_proto;
+use servo_media::{ServoMedia, SupportsMediaType};
+use stylo_atoms::Atom;
+
+use crate::dom::bindings::codegen::Bindings::MediaSourceBinding::{
+    EndOfStreamError, MediaSourceMethods, ReadyState,
+};
+use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
+use crate::dom::bindings::inheritance::Castable;
+use crate::dom::bindings::num::Finite;
+use crate::dom::bindings::refcounted::Trusted;
+use crate::dom::bindings::reflector::DomGlobal;
+use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
+use crate::dom::bindings::str::DOMString;
+use crate::dom::eventtarget::EventTarget;
+use crate::dom::globalscope::GlobalScope;
+use crate::dom::html::htmlmediaelement::HTMLMediaElement;
+use crate::dom::media::bytestream::ByteStreamFormat;
+use crate::dom::media::sourcebuffer::SourceBuffer;
+use crate::dom::media::sourcebufferlist::SourceBufferList;
+use crate::dom::timeranges::TimeRangesContainer;
+use crate::dom::window::Window;
+
+/// <https://w3c.github.io/media-source/#mediasource>
+#[dom_struct]
+pub(crate) struct MediaSource {
+    eventtarget: EventTarget,
+
+    /// <https://w3c.github.io/media-source/#dom-mediasource-sourcebuffers>
+    source_buffers: Dom<SourceBufferList>,
+
+    /// <https://w3c.github.io/media-source/#dom-mediasource-activesourcebuffers>
+    active_source_buffers: Dom<SourceBufferList>,
+
+    /// <https://w3c.github.io/media-source/#dom-mediasource-readystate>
+    ready_state: Cell<ReadyState>,
+
+    /// <https://w3c.github.io/media-source/#dom-mediasource-duration>
+    duration: Cell<f64>,
+
+    /// The media element this media source is attached to, if any.
+    ///
+    /// <https://w3c.github.io/media-source/#dfn-attaching-to-a-media-element>
+    media_element: MutNullableDom<HTMLMediaElement>,
+
+    /// <https://w3c.github.io/media-source/#dfn-live-seekable-range>
+    #[no_trace]
+    live_seekable_range: DomRefCell<Option<Range<f64>>>,
+
+    /// <https://w3c.github.io/media-source/#dfn-has-ever-been-attached>
+    has_ever_been_attached: Cell<bool>,
+}
+
+impl MediaSource {
+    fn new_inherited(
+        source_buffers: &SourceBufferList,
+        active_source_buffers: &SourceBufferList,
+    ) -> MediaSource {
+        MediaSource {
+            eventtarget: EventTarget::new_inherited(),
+            source_buffers: Dom::from_ref(source_buffers),
+            active_source_buffers: Dom::from_ref(active_source_buffers),
+            // Step 2. Set the readyState attribute to "closed".
+            ready_state: Cell::new(ReadyState::Closed),
+            // Step 3. Set the duration attribute to NaN.
+            duration: Cell::new(f64::NAN),
+            media_element: Default::default(),
+            live_seekable_range: DomRefCell::new(None),
+            has_ever_been_attached: Cell::new(false),
+        }
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-mediasource-mediasource>
+    pub(crate) fn new_with_proto(
+        cx: &mut JSContext,
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+    ) -> DomRoot<MediaSource> {
+        let window = global.as_window();
+
+        // Step 1. Set the live seekable range to an empty TimeRanges object.
+        // Step 4. Set the sourceBuffers attribute to a new empty SourceBufferList object.
+        let source_buffers = SourceBufferList::new(cx, window);
+
+        // Step 5. Set the activeSourceBuffers attribute to a new empty SourceBufferList
+        // object.
+        let active_source_buffers = SourceBufferList::new(cx, window);
+
+        reflect_dom_object_with_proto(
+            cx,
+            Box::new(MediaSource::new_inherited(
+                &source_buffers,
+                &active_source_buffers,
+            )),
+            global,
+            proto,
+        )
+    }
+
+    pub(crate) fn ready_state(&self) -> ReadyState {
+        self.ready_state.get()
+    }
+
+    pub(crate) fn duration(&self) -> f64 {
+        self.duration.get()
+    }
+
+    pub(crate) fn media_element(&self) -> Option<DomRoot<HTMLMediaElement>> {
+        self.media_element.get()
+    }
+
+    /// <https://w3c.github.io/media-source/#dfn-attaching-to-a-media-element>
+    ///
+    /// Returns whether the media source could be attached. A media source that has
+    /// already been attached, or that is not in the `"closed"` ready state, makes the
+    /// resource fetch algorithm fail.
+    pub(crate) fn attach(&self, cx: &mut JSContext, media_element: &HTMLMediaElement) -> bool {
+        // If readyState is NOT set to "closed", then run the "If the media data cannot be
+        // fetched at all, due to network errors, causing the user agent to give up trying
+        // to fetch the resource" steps of the resource fetch algorithm.
+        if self.ready_state.get() != ReadyState::Closed || self.has_ever_been_attached.get() {
+            return false;
+        }
+
+        self.has_ever_been_attached.set(true);
+        self.media_element.set(Some(media_element));
+
+        // Set the media element's delaying-the-load-event flag to false.
+        media_element.delay_load_event(false, cx);
+
+        // Set the readyState attribute to "open".
+        self.ready_state.set(ReadyState::Open);
+
+        // Queue a task to fire an event named sourceopen at the MediaSource.
+        self.queue_event(Atom::from("sourceopen"));
+
+        true
+    }
+
+    /// <https://w3c.github.io/media-source/#dfn-detaching-from-a-media-element>
+    pub(crate) fn detach(&self) {
+        if self.media_element.get().is_none() {
+            return;
+        }
+
+        // Step 1. Set the readyState attribute to "closed".
+        self.ready_state.set(ReadyState::Closed);
+
+        // Step 2. Update duration to NaN.
+        self.duration.set(f64::NAN);
+
+        // Step 3. Remove all the SourceBuffer objects from activeSourceBuffers.
+        // Step 4. Queue a task to fire an event named removesourcebuffer at
+        // activeSourceBuffers.
+        let had_active_source_buffers = !self.active_source_buffers.is_empty();
+        self.active_source_buffers.clear();
+        if had_active_source_buffers {
+            self.active_source_buffers.queue_removesourcebuffer_event();
+        }
+
+        // Step 5. Remove all the SourceBuffer objects from sourceBuffers.
+        // Step 6. Queue a task to fire an event named removesourcebuffer at sourceBuffers.
+        let had_source_buffers = !self.source_buffers.is_empty();
+        for source_buffer in self.source_buffers.buffers() {
+            source_buffer.detach();
+        }
+        self.source_buffers.clear();
+        if had_source_buffers {
+            self.source_buffers.queue_removesourcebuffer_event();
+        }
+
+        // Step 7. Queue a task to fire an event named sourceclose at the MediaSource.
+        self.queue_event(Atom::from("sourceclose"));
+
+        self.media_element.set(None);
+    }
+
+    /// Recomputes `activeSourceBuffers`, which the specification keeps in the same order
+    /// as `sourceBuffers`.
+    ///
+    /// <https://w3c.github.io/media-source/#dom-mediasource-activesourcebuffers>
+    pub(crate) fn update_active_source_buffers(&self) {
+        let active: Vec<_> = self
+            .source_buffers
+            .buffers()
+            .into_iter()
+            .filter(|source_buffer| source_buffer.is_active())
+            .collect();
+        self.active_source_buffers.update(&active);
+    }
+
+    /// The largest end time across the track buffer ranges of all source buffers.
+    ///
+    /// <https://w3c.github.io/media-source/#dfn-duration-change>
+    fn highest_end_time(&self) -> Option<f64> {
+        self.source_buffers
+            .buffers()
+            .into_iter()
+            .filter_map(|source_buffer| source_buffer.highest_track_end_time())
+            .reduce(f64::max)
+    }
+
+    /// <https://w3c.github.io/media-source/#dfn-duration-change>
+    pub(crate) fn duration_change(&self, new_duration: f64) -> ErrorResult {
+        // Step 1. If the current value of duration is equal to new duration, then return.
+        if self.duration.get() == new_duration ||
+            (self.duration.get().is_nan() && new_duration.is_nan())
+        {
+            return Ok(());
+        }
+
+        // Step 2. If new duration is less than the highest starting presentation timestamp
+        // of any buffered coded frames for all SourceBuffer objects in sourceBuffers, then
+        // throw an InvalidStateError exception and abort these steps.
+        let highest_start = self
+            .source_buffers
+            .buffers()
+            .into_iter()
+            .filter_map(|source_buffer| source_buffer.highest_presentation_timestamp())
+            .reduce(f64::max);
+        if let Some(highest_start) = highest_start &&
+            new_duration < highest_start
+        {
+            return Err(Error::InvalidState(Some(
+                "The new duration is less than the highest buffered presentation timestamp".into(),
+            )));
+        }
+
+        // Step 3. Let highest end time be the largest track buffer ranges end time across
+        // all the track buffers across all SourceBuffer objects in sourceBuffers.
+        // Step 4. If new duration is less than highest end time, then update new duration
+        // to equal highest end time.
+        let new_duration = match self.highest_end_time() {
+            Some(highest_end_time) => f64::max(new_duration, highest_end_time),
+            None => new_duration,
+        };
+
+        // Step 5. Update duration to new duration.
+        self.duration.set(new_duration);
+
+        // Step 6. Update the media duration to new duration and run the HTMLMediaElement
+        // duration change algorithm.
+        if let Some(media_element) = self.media_element.get() {
+            media_element.media_source_duration_changed(new_duration);
+        }
+
+        Ok(())
+    }
+
+    /// <https://w3c.github.io/media-source/#dfn-end-of-stream>
+    fn end_of_stream_algorithm(&self, cx: &mut JSContext, error: Option<EndOfStreamError>) {
+        // Step 1. Change the readyState attribute value to "ended".
+        self.ready_state.set(ReadyState::Ended);
+
+        // Step 2. Queue a task to fire an event named sourceended at the MediaSource.
+        self.queue_event(Atom::from("sourceended"));
+
+        let Some(media_element) = self.media_element.get() else {
+            return;
+        };
+
+        match error {
+            // Step 3. If error is not set:
+            None => {
+                // Step 3.1. Run the duration change algorithm with new duration set to the
+                // largest track buffer ranges end time across all the track buffers across
+                // all SourceBuffer objects in sourceBuffers.
+                if let Some(highest_end_time) = self.highest_end_time() {
+                    let _ = self.duration_change(highest_end_time);
+                }
+
+                // Step 3.2. Notify the media element that it now has all of the media data.
+                media_element.media_source_end_of_stream();
+            },
+            // Step 4. If error is set to "network", and step 5 for "decode", run the
+            // corresponding media data processing steps of the media element.
+            Some(error) => {
+                media_element.media_source_error(cx, error);
+            },
+        }
+    }
+
+    /// Moves an `"ended"` media source back to `"open"`, which the specification asks
+    /// several `SourceBuffer` methods to do before they mutate anything.
+    pub(crate) fn reopen(&self) {
+        if self.ready_state.get() != ReadyState::Ended {
+            return;
+        }
+
+        self.ready_state.set(ReadyState::Open);
+        self.queue_event(Atom::from("sourceopen"));
+    }
+
+    /// <https://w3c.github.io/media-source/#dfn-append-error>
+    ///
+    /// Step 5 of the append error algorithm ends the stream with a decode error.
+    pub(crate) fn end_of_stream_with_decode_error(&self, cx: &mut JSContext) {
+        self.end_of_stream_algorithm(cx, Some(EndOfStreamError::Decode));
+    }
+
+    /// Whether an append is in flight on any of the source buffers.
+    fn is_updating(&self) -> bool {
+        self.source_buffers
+            .buffers()
+            .into_iter()
+            .any(|source_buffer| source_buffer.updating())
+    }
+
+    /// <https://w3c.github.io/media-source/#dfn-mediasource-seekable>
+    pub(crate) fn seekable(&self) -> TimeRangesContainer {
+        let mut ranges = TimeRangesContainer::default();
+
+        // Step 1. Let recent duration be the current value of the duration attribute.
+        let duration = self.duration.get();
+
+        // Step 2. If recent duration is NaN, then return an empty TimeRanges object.
+        if duration.is_nan() {
+            return ranges;
+        }
+
+        // Step 3. If recent duration is positive infinity:
+        if duration.is_infinite() {
+            let buffered = self.media_element_buffered();
+            let live_seekable_range = self.live_seekable_range.borrow();
+
+            // Step 3.1. If live seekable range is not empty:
+            if let Some(live_seekable_range) = live_seekable_range.as_ref() {
+                let start = match buffered.start_time() {
+                    Some(start) => f64::min(live_seekable_range.start, start),
+                    None => live_seekable_range.start,
+                };
+                let end = match buffered.end_time() {
+                    Some(end) => f64::max(live_seekable_range.end, end),
+                    None => live_seekable_range.end,
+                };
+                let _ = ranges.add(start, end);
+                return ranges;
+            }
+
+            // Step 3.2. If the HTMLMediaElement.buffered attribute returns an empty
+            // TimeRanges object, then return an empty TimeRanges object and abort these
+            // steps.
+            let Some(end) = buffered.end_time() else {
+                return ranges;
+            };
+
+            // Step 3.3. Return a single range with a start time of 0 and an end time equal
+            // to the highest end time reported by the HTMLMediaElement.buffered attribute.
+            let _ = ranges.add(0., end);
+            return ranges;
+        }
+
+        // Step 4. Otherwise return a single range with a start time of 0 and an end time
+        // equal to recent duration.
+        let _ = ranges.add(0., duration);
+        ranges
+    }
+
+    /// <https://w3c.github.io/media-source/#htmlmediaelement-extensions>
+    ///
+    /// The intersection of the buffered ranges of every active source buffer.
+    pub(crate) fn media_element_buffered(&self) -> TimeRangesContainer {
+        let active_source_buffers = self.active_source_buffers.buffers();
+
+        // Step 1. If activeSourceBuffers.length equals 0 then return an empty TimeRanges
+        // object and abort these steps.
+        if active_source_buffers.is_empty() {
+            return TimeRangesContainer::default();
+        }
+
+        // Step 2. Let active ranges be the ranges returned by buffered for each
+        // SourceBuffer object in activeSourceBuffers.
+        let active_ranges: Vec<_> = active_source_buffers
+            .iter()
+            .map(|source_buffer| source_buffer.buffered_ranges())
+            .collect();
+
+        // Step 3. Let highest end time be the largest range end time in the active ranges.
+        let Some(highest_end_time) = active_ranges
+            .iter()
+            .filter_map(|ranges| ranges.end_time())
+            .reduce(f64::max)
+        else {
+            return TimeRangesContainer::default();
+        };
+
+        // Step 4. Let intersection ranges equal a TimeRanges object containing a single
+        // range from 0 to highest end time.
+        if highest_end_time <= 0. {
+            return TimeRangesContainer::default();
+        }
+        let mut intersection_ranges = TimeRangesContainer::default();
+        let _ = intersection_ranges.add(0., highest_end_time);
+
+        // Step 5. For each SourceBuffer object in activeSourceBuffers run the following
+        // steps.
+        let ended = self.ready_state.get() == ReadyState::Ended;
+        for mut source_ranges in active_ranges {
+            // Step 5.2. If readyState is "ended", then set the end time on the last range
+            // in source ranges to highest end time.
+            if ended {
+                source_ranges.set_end_time(highest_end_time);
+            }
+
+            // Step 5.3. Let new intersection ranges equal the intersection between the
+            // intersection ranges and the source ranges.
+            intersection_ranges = intersection_ranges.intersection(&source_ranges);
+        }
+
+        intersection_ranges
+    }
+
+    /// Called by a source buffer once an append made new media data available.
+    pub(crate) fn media_data_appended(&self) {
+        self.update_active_source_buffers();
+
+        // The media element's duration follows the media source for as long as they are
+        // attached, so the buffered ranges are all it has to refresh.
+        if let Some(media_element) = self.media_element.get() {
+            media_element.media_source_buffered_changed();
+        }
+    }
+
+    fn queue_event(&self, name: Atom) {
+        let this = Trusted::new(self);
+        self.global()
+            .task_manager()
+            .media_element_task_source()
+            .queue(task!(fire_media_source_event: move |cx| {
+                let this = this.root();
+                this.upcast::<EventTarget>().fire_event(cx, name);
+            }));
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-mediasource-istypesupported>
+    ///
+    /// Returns the byte stream format `type` maps to, if it is one this implementation
+    /// can both parse and hand over to the media backend.
+    pub(crate) fn byte_stream_format(type_: &str) -> Option<ByteStreamFormat> {
+        // Step 1. If type is an empty string, then return false.
+        if type_.is_empty() {
+            return None;
+        }
+
+        // Step 2. If type does not contain a valid MIME type string, then return false.
+        let mime: Mime = type_.parse().ok()?;
+
+        // Step 3. If type contains a media type or media subtype that the MediaSource does
+        // not support, then return false.
+        let format = match mime.subtype().as_str() {
+            "mp4" => ByteStreamFormat::IsoBmff,
+            "webm" => ByteStreamFormat::WebM,
+            _ => return None,
+        };
+        let audio_only = match mime.type_().as_str() {
+            "audio" => true,
+            "video" => false,
+            _ => return None,
+        };
+
+        // Step 4. If type contains a media type, media subtype, or codec that is not
+        // supported by the MediaSource, then return false.
+        //
+        // The registry for each byte stream format lists the codecs it may carry, and a
+        // codec that produces video can never appear in an audio container.
+        let codecs = mime.get_param("codecs")?;
+        let codecs: Vec<&str> = codecs
+            .as_str()
+            .split(',')
+            .map(|codec| codec.trim())
+            .collect();
+        if codecs.is_empty() || codecs.iter().any(|codec| codec.is_empty()) {
+            return None;
+        }
+        for codec in &codecs {
+            let Some(codec) = CodecFamily::parse(codec) else {
+                return None;
+            };
+            if !codec.is_carried_by(format) {
+                return None;
+            }
+            if audio_only && codec.is_video() {
+                return None;
+            }
+        }
+
+        // Finally, defer to the media backend for the codecs it can actually decode.
+        if ServoMedia::get().can_play_type(type_) != SupportsMediaType::Probably {
+            return None;
+        }
+
+        Some(format)
+    }
+}
+
+/// The codecs the byte stream format registries allow, grouped by the container they may
+/// appear in.
+///
+/// <https://w3c.github.io/mse-byte-stream-format-registry/>
+#[derive(Clone, Copy, PartialEq)]
+enum CodecFamily {
+    /// A video codec only ISO BMFF may carry.
+    IsoBmffVideo,
+    /// An audio codec only ISO BMFF may carry.
+    IsoBmffAudio,
+    /// A video codec only WebM may carry.
+    WebMVideo,
+    /// An audio codec only WebM may carry.
+    WebMAudio,
+    /// A video codec both formats may carry.
+    SharedVideo,
+    /// An audio codec both formats may carry.
+    SharedAudio,
+}
+
+impl CodecFamily {
+    fn parse(codec: &str) -> Option<CodecFamily> {
+        // Codec identifiers are matched case insensitively, and everything after the first
+        // dot is a profile or level that only the media backend can judge.
+        let codec = codec.to_ascii_lowercase();
+        let name = codec.split('.').next().unwrap_or_default();
+
+        match name {
+            "avc1" | "avc3" | "hev1" | "hvc1" | "mp4v" => Some(CodecFamily::IsoBmffVideo),
+            "mp4a" | "ac-3" | "ec-3" => Some(CodecFamily::IsoBmffAudio),
+            "vp8" | "vp9" => Some(CodecFamily::WebMVideo),
+            "vorbis" => Some(CodecFamily::WebMAudio),
+            // VP9 in its ISO BMFF spelling, and AV1, are registered for both formats.
+            "vp09" | "av01" => Some(CodecFamily::SharedVideo),
+            "opus" | "flac" => Some(CodecFamily::SharedAudio),
+            _ => None,
+        }
+    }
+
+    fn is_carried_by(&self, format: ByteStreamFormat) -> bool {
+        match self {
+            CodecFamily::IsoBmffVideo | CodecFamily::IsoBmffAudio => {
+                format == ByteStreamFormat::IsoBmff
+            },
+            CodecFamily::WebMVideo | CodecFamily::WebMAudio => format == ByteStreamFormat::WebM,
+            CodecFamily::SharedVideo | CodecFamily::SharedAudio => true,
+        }
+    }
+
+    fn is_video(&self) -> bool {
+        matches!(
+            self,
+            CodecFamily::IsoBmffVideo | CodecFamily::WebMVideo | CodecFamily::SharedVideo
+        )
+    }
+}
+
+impl MediaSourceMethods<crate::DomTypeHolder> for MediaSource {
+    /// <https://w3c.github.io/media-source/#dom-mediasource-mediasource>
+    fn Constructor(
+        cx: &mut JSContext,
+        window: &Window,
+        proto: Option<HandleObject>,
+    ) -> DomRoot<MediaSource> {
+        MediaSource::new_with_proto(cx, &window.global(), proto)
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-mediasource-sourcebuffers>
+    fn SourceBuffers(&self) -> DomRoot<SourceBufferList> {
+        DomRoot::from_ref(&*self.source_buffers)
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-mediasource-activesourcebuffers>
+    fn ActiveSourceBuffers(&self) -> DomRoot<SourceBufferList> {
+        DomRoot::from_ref(&*self.active_source_buffers)
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-mediasource-readystate>
+    fn ReadyState(&self) -> ReadyState {
+        self.ready_state.get()
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-mediasource-duration>
+    fn Duration(&self) -> f64 {
+        // If readyState equals "closed" then return NaN and abort these steps.
+        if self.ready_state.get() == ReadyState::Closed {
+            return f64::NAN;
+        }
+
+        self.duration.get()
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-mediasource-duration>
+    fn SetDuration(&self, value: f64) -> ErrorResult {
+        // Step 1. If the value being set is negative or NaN then throw a TypeError
+        // exception and abort these steps.
+        if value.is_nan() || value < 0. {
+            return Err(Error::Type(
+                c"The duration must not be negative or NaN".to_owned(),
+            ));
+        }
+
+        // Step 2. If the readyState attribute is not "open" then throw an
+        // InvalidStateError exception and abort these steps.
+        if self.ready_state.get() != ReadyState::Open {
+            return Err(Error::InvalidState(Some(
+                "The media source is not open".into(),
+            )));
+        }
+
+        // Step 3. If the updating attribute equals true on any SourceBuffer in
+        // sourceBuffers, then throw an InvalidStateError exception and abort these steps.
+        if self.is_updating() {
+            return Err(Error::InvalidState(Some(
+                "A source buffer is still updating".into(),
+            )));
+        }
+
+        // Step 4. Run the duration change algorithm with new duration set to the value
+        // being assigned to this attribute.
+        self.duration_change(value)
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-mediasource-canconstructindedicatedworker>
+    fn CanConstructInDedicatedWorker(_window: &Window) -> bool {
+        // Media sources are not exposed to dedicated workers yet.
+        false
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-mediasource-addsourcebuffer>
+    fn AddSourceBuffer(
+        &self,
+        cx: &mut JSContext,
+        type_: DOMString,
+    ) -> Fallible<DomRoot<SourceBuffer>> {
+        // Step 1. If type is an empty string then throw a TypeError exception and abort
+        // these steps.
+        if type_.is_empty() {
+            return Err(Error::Type(c"The type must not be empty".to_owned()));
+        }
+
+        // Step 2. If type contains a MIME type that is not supported or contains a MIME
+        // type that is not supported with the types specified for the SourceBuffer objects
+        // in sourceBuffers, then throw a NotSupportedError exception and abort these steps.
+        let Some(format) = MediaSource::byte_stream_format(&type_.str()) else {
+            return Err(Error::NotSupported(Some(format!(
+                "The type \"{type_}\" is not supported"
+            ))));
+        };
+
+        // Step 3. If the user agent can't handle any more SourceBuffer objects or if
+        // creating a SourceBuffer based on type would result in an unsupported
+        // SourceBuffer configuration, then throw a QuotaExceededError exception and abort
+        // these steps.
+        //
+        // Every source buffer feeds the same pipeline, so a second one would interleave
+        // its byte stream with the first.
+        if !self.source_buffers.is_empty() {
+            return Err(Error::QuotaExceeded {
+                quota: None,
+                requested: None,
+            });
+        }
+
+        // Step 4. If the readyState attribute is not in the "open" state then throw an
+        // InvalidStateError exception and abort these steps.
+        if self.ready_state.get() != ReadyState::Open {
+            return Err(Error::InvalidState(Some(
+                "The media source is not open".into(),
+            )));
+        }
+
+        // Step 5. Create a new SourceBuffer object and associated resources.
+        // Step 6. Set the generate timestamps flag on the new object to the value in the
+        // "Generate Timestamps Flag" column of the byte stream format registry entry that
+        // is associated with type.
+        // Step 7. If the generate timestamps flag equals true set the mode attribute on
+        // the new object to "sequence". Otherwise set it to "segments".
+        //
+        // Neither of the byte stream formats we support sets the generate timestamps flag.
+        let source_buffer = SourceBuffer::new(cx, self, format);
+
+        // Step 8. Add the new object to sourceBuffers and queue a task to fire an event
+        // named addsourcebuffer at sourceBuffers.
+        self.source_buffers.add(&source_buffer);
+
+        // Step 9. Return the new object.
+        Ok(source_buffer)
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-mediasource-removesourcebuffer>
+    fn RemoveSourceBuffer(&self, source_buffer: &SourceBuffer) -> ErrorResult {
+        // Step 1. If sourceBuffer specifies an object that is not in sourceBuffers then
+        // throw a NotFoundError exception and abort these steps.
+        if !self.source_buffers.contains(source_buffer) {
+            return Err(Error::NotFound(Some(
+                "The source buffer is not in this media source".into(),
+            )));
+        }
+
+        // Step 2. If the sourceBuffer.updating attribute equals true, then run the
+        // following steps.
+        source_buffer.abort_append();
+
+        // Step 3. Let SourceBuffer audioTracks list equal the AudioTrackList object
+        // returned by sourceBuffer.audioTracks.
+        // Steps 4-8, and their video and text track equivalents, remove the tracks of the
+        // source buffer from the media element.
+        source_buffer.detach();
+
+        // Step 9. If sourceBuffer is in activeSourceBuffers, then remove sourceBuffer from
+        // activeSourceBuffers and queue a task to fire an event named removesourcebuffer
+        // at the SourceBufferList returned by activeSourceBuffers.
+        self.update_active_source_buffers();
+
+        // Step 10. Remove sourceBuffer from sourceBuffers and queue a task to fire an
+        // event named removesourcebuffer at the SourceBufferList returned by sourceBuffers.
+        self.source_buffers.remove(source_buffer);
+
+        // Step 11. Destroy all resources for sourceBuffer.
+        // The source buffer is now unreachable from the media source, so the collector
+        // takes care of the rest.
+
+        Ok(())
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-mediasource-endofstream>
+    fn EndOfStream(&self, cx: &mut JSContext, error: Option<EndOfStreamError>) -> ErrorResult {
+        // Step 1. If the readyState attribute is not in the "open" state then throw an
+        // InvalidStateError exception and abort these steps.
+        if self.ready_state.get() != ReadyState::Open {
+            return Err(Error::InvalidState(Some(
+                "The media source is not open".into(),
+            )));
+        }
+
+        // Step 2. If the updating attribute equals true on any SourceBuffer in
+        // sourceBuffers, then throw an InvalidStateError exception and abort these steps.
+        if self.is_updating() {
+            return Err(Error::InvalidState(Some(
+                "A source buffer is still updating".into(),
+            )));
+        }
+
+        // Step 3. Run the end of stream algorithm with the error parameter set to error.
+        self.end_of_stream_algorithm(cx, error);
+
+        Ok(())
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-mediasource-setliveseekablerange>
+    fn SetLiveSeekableRange(&self, start: Finite<f64>, end: Finite<f64>) -> ErrorResult {
+        // Step 1. If the readyState attribute is not "open" then throw an
+        // InvalidStateError exception and abort these steps.
+        if self.ready_state.get() != ReadyState::Open {
+            return Err(Error::InvalidState(Some(
+                "The media source is not open".into(),
+            )));
+        }
+
+        // Step 2. If start is negative or greater than end, then throw a TypeError
+        // exception and abort these steps.
+        let (start, end) = (*start, *end);
+        if start < 0. || start > end {
+            return Err(Error::Type(
+                c"The start must not be negative or greater than the end".to_owned(),
+            ));
+        }
+
+        // Step 3. Set live seekable range to be a new normalized TimeRanges object
+        // containing a single range whose start position is start and end position is end.
+        *self.live_seekable_range.borrow_mut() = Some(start..end);
+
+        Ok(())
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-mediasource-clearliveseekablerange>
+    fn ClearLiveSeekableRange(&self) -> ErrorResult {
+        // Step 1. If the readyState attribute is not "open" then throw an
+        // InvalidStateError exception and abort these steps.
+        if self.ready_state.get() != ReadyState::Open {
+            return Err(Error::InvalidState(Some(
+                "The media source is not open".into(),
+            )));
+        }
+
+        // Step 2. If live seekable range contains a range, then set live seekable range to
+        // be a new empty TimeRanges object.
+        *self.live_seekable_range.borrow_mut() = None;
+
+        Ok(())
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-mediasource-istypesupported>
+    fn IsTypeSupported(_window: &Window, type_: DOMString) -> bool {
+        MediaSource::byte_stream_format(&type_.str()).is_some()
+    }
+
+    // <https://w3c.github.io/media-source/#dom-mediasource-onsourceopen>
+    event_handler!(sourceopen, GetOnsourceopen, SetOnsourceopen);
+
+    // <https://w3c.github.io/media-source/#dom-mediasource-onsourceended>
+    event_handler!(sourceended, GetOnsourceended, SetOnsourceended);
+
+    // <https://w3c.github.io/media-source/#dom-mediasource-onsourceclose>
+    event_handler!(sourceclose, GetOnsourceclose, SetOnsourceclose);
+}

--- a/components/script/dom/media/mod.rs
+++ b/components/script/dom/media/mod.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+pub(crate) mod bytestream;
 pub(crate) mod mediadeviceinfo;
 pub(crate) mod mediadevices;
 pub(crate) mod mediaerror;
@@ -11,7 +12,10 @@ pub(crate) mod mediametadata;
 pub(crate) mod mediaquerylist;
 pub(crate) mod mediaquerylistevent;
 pub(crate) mod mediasession;
+pub(crate) mod mediasource;
 pub(crate) mod mediastream;
 pub(crate) mod mediastreamtrack;
+pub(crate) mod sourcebuffer;
+pub(crate) mod sourcebufferlist;
 pub(crate) mod videotrack;
 pub(crate) mod videotracklist;

--- a/components/script/dom/media/sourcebuffer.rs
+++ b/components/script/dom/media/sourcebuffer.rs
@@ -1,0 +1,1024 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::cell::Cell;
+
+use dom_struct::dom_struct;
+use js::context::JSContext;
+use script_bindings::cell::DomRefCell;
+use script_bindings::reflector::reflect_dom_object_with_cx;
+use stylo_atoms::Atom;
+
+use crate::dom::audio::audiotrack::AudioTrack;
+use crate::dom::audio::audiotracklist::AudioTrackList;
+use crate::dom::bindings::buffer_source::get_buffer_source_copy;
+use crate::dom::bindings::codegen::Bindings::MediaSourceBinding::ReadyState;
+use crate::dom::bindings::codegen::Bindings::SourceBufferBinding::{
+    AppendMode, SourceBufferMethods,
+};
+use crate::dom::bindings::codegen::UnionTypes::ArrayBufferViewOrArrayBuffer;
+use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
+use crate::dom::bindings::inheritance::Castable;
+use crate::dom::bindings::num::Finite;
+use crate::dom::bindings::refcounted::Trusted;
+use crate::dom::bindings::reflector::DomGlobal;
+use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
+use crate::dom::bindings::str::DOMString;
+use crate::dom::eventtarget::EventTarget;
+use crate::dom::media::bytestream::{
+    ByteStreamFormat, ByteStreamParser, InitializationSegment, TrackKind,
+};
+use crate::dom::media::mediasource::MediaSource;
+use crate::dom::media::videotrack::VideoTrack;
+use crate::dom::media::videotracklist::VideoTrackList;
+use crate::dom::timeranges::{TimeRanges, TimeRangesContainer};
+use crate::dom::webvtt::texttracklist::TextTrackList;
+
+/// How far apart two intervals may be and still count as covering a continuous stretch of
+/// media.
+///
+/// Media segments are authored back to back, but the duration a byte stream reports for
+/// the last frame of a segment rarely lands exactly on the timestamp the next segment
+/// starts at. The specification allows a fudge factor of twice the maximum frame duration
+/// when deciding whether coded frames are continuous, which keeps `buffered` from
+/// reporting gaps that playback does not actually have.
+///
+/// <https://w3c.github.io/media-source/#coded-frame-group>
+const CODED_FRAME_GROUP_FUDGE: f64 = 0.05;
+
+/// Adds `[start, end)` to `ranges`, closing a gap smaller than the fudge factor rather
+/// than leaving the interval detached from what is already buffered.
+fn add_continuous_range(ranges: &mut TimeRangesContainer, start: f64, end: f64) {
+    let mut start = start;
+    for index in 0..ranges.len() {
+        if let Ok(existing_end) = ranges.end(index) &&
+            existing_end < start &&
+            start - existing_end <= CODED_FRAME_GROUP_FUDGE
+        {
+            start = existing_end;
+            break;
+        }
+    }
+    let _ = ranges.add(start, end);
+}
+
+/// <https://w3c.github.io/media-source/#sourcebuffer>
+#[dom_struct]
+pub(crate) struct SourceBuffer {
+    eventtarget: EventTarget,
+
+    /// The media source this object belongs to, cleared once it is removed from the
+    /// `sourceBuffers` attribute of its parent media source.
+    media_source: MutNullableDom<MediaSource>,
+
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-mode>
+    mode: Cell<AppendMode>,
+
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-updating>
+    updating: Cell<bool>,
+
+    /// Stored and returned as the specification requires, but not yet applied to the
+    /// coded frames, which reach the media backend with the timestamps they were
+    /// authored with.
+    ///
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-timestampoffset>
+    timestamp_offset: Cell<f64>,
+
+    /// Stored and returned as the specification requires, but not yet applied: no coded
+    /// frame is dropped for falling outside of the window.
+    ///
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-appendwindowstart>
+    append_window_start: Cell<f64>,
+
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-appendwindowend>
+    append_window_end: Cell<f64>,
+
+    /// The ranges each track of this source buffer holds coded frames for, keyed by the
+    /// track identifier the byte stream uses.
+    ///
+    /// <https://w3c.github.io/media-source/#track-buffer>
+    track_buffers: DomRefCell<Vec<(u32, TimeRangesContainer)>>,
+
+    /// The largest presentation timestamp a coded frame of this source buffer has, used
+    /// by the duration change algorithm.
+    highest_presentation_timestamp: Cell<f64>,
+
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-audiotracks>
+    audio_tracks: Dom<AudioTrackList>,
+
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-videotracks>
+    video_tracks: Dom<VideoTrackList>,
+
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-texttracks>
+    text_tracks: Dom<TextTrackList>,
+
+    /// <https://w3c.github.io/media-source/#dfn-input-buffer>
+    input_buffer: DomRefCell<Vec<u8>>,
+
+    parser: DomRefCell<ByteStreamParser>,
+
+    /// Bumped whenever an in flight append or range removal is aborted, so that the task
+    /// running it knows to stop.
+    generation: Cell<u32>,
+
+    /// <https://w3c.github.io/media-source/#dfn-first-initialization-segment-received-flag>
+    first_initialization_segment_received: Cell<bool>,
+}
+
+impl SourceBuffer {
+    fn new_inherited(
+        media_source: &MediaSource,
+        format: ByteStreamFormat,
+        audio_tracks: &AudioTrackList,
+        video_tracks: &VideoTrackList,
+        text_tracks: &TextTrackList,
+    ) -> SourceBuffer {
+        SourceBuffer {
+            eventtarget: EventTarget::new_inherited(),
+            media_source: MutNullableDom::new(Some(media_source)),
+            mode: Cell::new(AppendMode::Segments),
+            updating: Cell::new(false),
+            timestamp_offset: Cell::new(0.),
+            append_window_start: Cell::new(0.),
+            append_window_end: Cell::new(f64::INFINITY),
+            track_buffers: DomRefCell::new(Vec::new()),
+            highest_presentation_timestamp: Cell::new(f64::NAN),
+            audio_tracks: Dom::from_ref(audio_tracks),
+            video_tracks: Dom::from_ref(video_tracks),
+            text_tracks: Dom::from_ref(text_tracks),
+            input_buffer: DomRefCell::new(Vec::new()),
+            parser: DomRefCell::new(ByteStreamParser::new(format)),
+            generation: Cell::new(0),
+            first_initialization_segment_received: Cell::new(false),
+        }
+    }
+
+    pub(crate) fn new(
+        cx: &mut JSContext,
+        media_source: &MediaSource,
+        format: ByteStreamFormat,
+    ) -> DomRoot<SourceBuffer> {
+        let global = media_source.global();
+        let window = global.as_window();
+        let audio_tracks = AudioTrackList::new(cx, window, &[], None);
+        let video_tracks = VideoTrackList::new(cx, window, &[], None);
+        let text_tracks = TextTrackList::new(cx, window, &[]);
+
+        reflect_dom_object_with_cx(
+            Box::new(SourceBuffer::new_inherited(
+                media_source,
+                format,
+                &audio_tracks,
+                &video_tracks,
+                &text_tracks,
+            )),
+            window,
+            cx,
+        )
+    }
+
+    pub(crate) fn updating(&self) -> bool {
+        self.updating.get()
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-buffered>
+    ///
+    /// Steps 3 to 6: the intersection of the track buffer ranges of every track, since a
+    /// frame is only playable where every track has one.
+    pub(crate) fn buffered_ranges(&self) -> TimeRangesContainer {
+        let track_buffers = self.track_buffers.borrow();
+        let mut ranges = match track_buffers.first() {
+            Some((_, ranges)) => ranges.clone(),
+            None => return TimeRangesContainer::default(),
+        };
+        for (_, track_ranges) in track_buffers.iter().skip(1) {
+            ranges = ranges.intersection(track_ranges);
+        }
+        ranges
+    }
+
+    /// The largest end time across the track buffers, which the duration change algorithm
+    /// uses rather than the intersection.
+    ///
+    /// <https://w3c.github.io/media-source/#dfn-duration-change>
+    pub(crate) fn highest_track_end_time(&self) -> Option<f64> {
+        self.track_buffers
+            .borrow()
+            .iter()
+            .filter_map(|(_, ranges)| ranges.end_time())
+            .reduce(f64::max)
+    }
+
+    /// Records the interval a media segment covers against the track buffers it belongs
+    /// to, creating an entry for a track the initialization segment did not declare.
+    fn add_to_track_buffers(&self, track: Option<u32>, start: f64, end: f64) {
+        let mut track_buffers = self.track_buffers.borrow_mut();
+        match track {
+            Some(id) => {
+                if let Some((_, ranges)) = track_buffers.iter_mut().find(|(key, _)| *key == id) {
+                    add_continuous_range(ranges, start, end);
+                } else {
+                    let mut ranges = TimeRangesContainer::default();
+                    let _ = ranges.add(start, end);
+                    track_buffers.push((id, ranges));
+                }
+            },
+            // A segment that interleaves every track covers them all at once.
+            None => {
+                if track_buffers.is_empty() {
+                    let mut ranges = TimeRangesContainer::default();
+                    let _ = ranges.add(start, end);
+                    track_buffers.push((0, ranges));
+                } else {
+                    for (_, ranges) in track_buffers.iter_mut() {
+                        add_continuous_range(ranges, start, end);
+                    }
+                }
+            },
+        }
+    }
+
+    pub(crate) fn highest_presentation_timestamp(&self) -> Option<f64> {
+        let timestamp = self.highest_presentation_timestamp.get();
+        (!timestamp.is_nan()).then_some(timestamp)
+    }
+
+    /// Whether this source buffer belongs in `activeSourceBuffers`.
+    ///
+    /// <https://w3c.github.io/media-source/#dfn-active-track-flag>
+    pub(crate) fn is_active(&self) -> bool {
+        self.audio_tracks.enabled_index().is_some() || self.video_tracks.selected_index().is_some()
+    }
+
+    /// Detaches this source buffer from its media source, which the specification
+    /// describes as removing it from the `sourceBuffers` attribute.
+    pub(crate) fn detach(&self) {
+        self.abort_append();
+        self.audio_tracks.clear();
+        self.video_tracks.clear();
+        self.track_buffers.borrow_mut().clear();
+        self.media_source.set(None);
+        self.input_buffer.borrow_mut().clear();
+    }
+
+    /// Aborts an in flight append, firing the events the specification asks for when a
+    /// source buffer is removed or `abort()` is called while updating.
+    pub(crate) fn abort_append(&self) {
+        if !self.updating.get() {
+            return;
+        }
+
+        // Step 2.1. Abort the buffer append algorithm if it is running.
+        self.generation.set(self.generation.get().wrapping_add(1));
+        self.input_buffer.borrow_mut().clear();
+
+        // Step 2.2. Set the updating attribute to false.
+        self.updating.set(false);
+
+        // Step 2.3. Queue a task to fire an event named abort at this SourceBuffer object.
+        self.queue_event(atom!("abort"));
+
+        // Step 2.4. Queue a task to fire an event named updateend at this SourceBuffer
+        // object.
+        self.queue_event(Atom::from("updateend"));
+    }
+
+    fn parent_media_source(&self) -> Option<DomRoot<MediaSource>> {
+        self.media_source.get()
+    }
+
+    /// The specification tests for removal from `sourceBuffers` in almost every method.
+    fn require_attached(&self) -> Fallible<DomRoot<MediaSource>> {
+        self.media_source.get().ok_or_else(|| {
+            Error::InvalidState(Some(
+                "The source buffer has been removed from the media source".into(),
+            ))
+        })
+    }
+
+    /// <https://w3c.github.io/media-source/#dfn-prepare-append>
+    fn prepare_append(&self) -> ErrorResult {
+        // Step 1. If the SourceBuffer has been removed from the sourceBuffers attribute of
+        // the parent media source then throw an InvalidStateError exception and abort
+        // these steps.
+        let media_source = self.require_attached()?;
+
+        // Step 2. If the updating attribute equals true, then throw an InvalidStateError
+        // exception and abort these steps.
+        if self.updating.get() {
+            return Err(Error::InvalidState(Some(
+                "The source buffer is still updating".into(),
+            )));
+        }
+
+        // Step 3. Let recent element error be determined by the media element error.
+        // Step 4. If recent element error is true, then throw an InvalidStateError
+        // exception and abort these steps.
+        if let Some(media_element) = media_source.media_element() &&
+            media_element.in_error_state()
+        {
+            return Err(Error::InvalidState(Some(
+                "The media element is in an error state".into(),
+            )));
+        }
+
+        // Step 5. If the readyState attribute of the parent media source is in the "ended"
+        // state then run the following steps.
+        Self::reopen_media_source(&media_source);
+
+        // Steps 6-8 evict coded frames and report a full buffer. The media backend keeps
+        // its own queue bounded, so there is nothing to evict here.
+
+        Ok(())
+    }
+
+    /// Moves the parent media source back to `"open"`, which several methods do when they
+    /// are called while it is `"ended"`.
+    fn reopen_media_source(media_source: &MediaSource) {
+        if media_source.ready_state() == ReadyState::Ended {
+            media_source.reopen();
+        }
+    }
+
+    /// <https://w3c.github.io/media-source/#sourcebuffer-segment-parser-loop>
+    fn buffer_append(&self, cx: &mut JSContext, generation: u32) {
+        let data = std::mem::take(&mut *self.input_buffer.borrow_mut());
+
+        let parsed = self.parser.borrow_mut().parse(&data);
+        let Ok(parsed) = parsed else {
+            // Step 2. If the input buffer contains bytes that violate the byte stream
+            // format specification, then run the append error algorithm and abort this
+            // algorithm.
+            self.append_error(cx);
+            return;
+        };
+
+        if let Some(initialization) = parsed.initialization &&
+            !self.initialization_segment_received(cx, initialization)
+        {
+            return;
+        }
+
+        // The coded frames are handed to the media backend in the order they were
+        // appended.
+        if !data.is_empty() &&
+            let Some(media_element) = self
+                .parent_media_source()
+                .and_then(|media_source| media_source.media_element())
+        {
+            media_element.append_media_source_data(data);
+        }
+
+        // Step 6. Add the coded frames to the track buffers.
+        //
+        // Coded frame processing is not implemented, so the frames reach the media backend
+        // exactly as they were appended: the timestamp offset does not move them along the
+        // media timeline and the append window does not drop any of them. The track buffer
+        // ranges therefore record where the media actually is, rather than where applying
+        // those attributes would have put it, so that `buffered` never disagrees with what
+        // playback can reach.
+        let mut highest = self.highest_presentation_timestamp.get();
+        for segment_range in parsed.media_ranges {
+            let start = segment_range.range.start;
+            let end = segment_range.range.end;
+            if end <= start {
+                continue;
+            }
+            self.add_to_track_buffers(segment_range.track, start, end);
+            highest = if highest.is_nan() {
+                start
+            } else {
+                highest.max(start)
+            };
+        }
+        self.highest_presentation_timestamp.set(highest);
+
+        if generation != self.generation.get() {
+            return;
+        }
+
+        if let Some(media_source) = self.parent_media_source() {
+            media_source.media_data_appended();
+        }
+
+        // Step 7. Set the updating attribute to false.
+        self.updating.set(false);
+
+        // Step 8. Queue a task to fire an event named update at this SourceBuffer object.
+        self.queue_event(Atom::from("update"));
+
+        // Step 9. Queue a task to fire an event named updateend at this SourceBuffer
+        // object.
+        self.queue_event(Atom::from("updateend"));
+    }
+
+    /// <https://w3c.github.io/media-source/#dfn-initialization-segment-received>
+    ///
+    /// Returns whether the segment was accepted.
+    fn initialization_segment_received(
+        &self,
+        cx: &mut JSContext,
+        initialization: InitializationSegment,
+    ) -> bool {
+        let Some(media_source) = self.parent_media_source() else {
+            return false;
+        };
+
+        // Step 1. Update the duration attribute if it currently equals NaN.
+        if media_source.duration().is_nan() {
+            let duration = initialization.duration.unwrap_or(f64::INFINITY);
+            let _ = media_source.duration_change(duration);
+        }
+
+        // Step 2. If the initialization segment has no audio, video, or text tracks, then
+        // run the append error algorithm and abort these steps.
+        if initialization.tracks.is_empty() {
+            self.append_error(cx);
+            return false;
+        }
+
+        // Step 3. If the first initialization segment received flag is true, then verify
+        // that the segment describes the same tracks as the first one did.
+        if self.first_initialization_segment_received.get() {
+            let audio = initialization
+                .tracks
+                .iter()
+                .filter(|track| track.kind == TrackKind::Audio)
+                .count();
+            let video = initialization
+                .tracks
+                .iter()
+                .filter(|track| track.kind == TrackKind::Video)
+                .count();
+            if audio != self.audio_tracks.len() || video != self.video_tracks.len() {
+                self.append_error(cx);
+                return false;
+            }
+            return true;
+        }
+
+        // Step 5. If the first initialization segment received flag is false, then create
+        // the track objects the segment describes.
+        let global = self.global();
+        let window = global.as_window();
+        for track in &initialization.tracks {
+            let id = DOMString::from(track.id.to_string());
+            match track.kind {
+                TrackKind::Audio => {
+                    let kind = if self.audio_tracks.len() == 0 {
+                        DOMString::from("main")
+                    } else {
+                        DOMString::new()
+                    };
+                    let audio_track = AudioTrack::new(
+                        cx,
+                        window,
+                        id,
+                        kind,
+                        DOMString::new(),
+                        DOMString::new(),
+                        Some(&self.audio_tracks),
+                    );
+                    self.audio_tracks.add(&audio_track);
+
+                    // Step 5.2.7. If audioTracks.length equals 1, then set the enabled
+                    // property on the new AudioTrack object to true and set active track
+                    // flag to true.
+                    if self.audio_tracks.len() == 1 {
+                        self.audio_tracks.set_enabled(0, true);
+                    }
+                },
+                TrackKind::Video => {
+                    let kind = if self.video_tracks.len() == 0 {
+                        DOMString::from("main")
+                    } else {
+                        DOMString::new()
+                    };
+                    let video_track = VideoTrack::new(
+                        cx,
+                        window,
+                        id,
+                        kind,
+                        DOMString::new(),
+                        DOMString::new(),
+                        Some(&self.video_tracks),
+                    );
+                    self.video_tracks.add(&video_track);
+
+                    // Step 5.3.7. If videoTracks.length equals 1, then set the selected
+                    // property on the new VideoTrack object to true and set active track
+                    // flag to true.
+                    if self.video_tracks.len() == 1 {
+                        self.video_tracks.set_selected(0, true);
+                    }
+                },
+                // Text tracks of a media segment carry cues we have no way of surfacing
+                // yet, so they are not exposed.
+                TrackKind::Text => {},
+            }
+        }
+
+        // Step 5.4. Create a track buffer to store coded frames for each track.
+        {
+            let mut track_buffers = self.track_buffers.borrow_mut();
+            for track in &initialization.tracks {
+                if track.kind != TrackKind::Text &&
+                    !track_buffers.iter().any(|(id, _)| *id == track.id)
+                {
+                    track_buffers.push((track.id, TimeRangesContainer::default()));
+                }
+            }
+        }
+
+        // Step 5.6. Set first initialization segment received flag to true.
+        self.first_initialization_segment_received.set(true);
+
+        // Step 6. If the active track flag equals true, then add this SourceBuffer to
+        // activeSourceBuffers.
+        media_source.update_active_source_buffers();
+
+        // Step 7. Set the HTMLMediaElement.readyState attribute to HAVE_METADATA.
+        if let Some(media_element) = media_source.media_element() {
+            media_element.media_source_metadata_received();
+        }
+
+        true
+    }
+
+    /// <https://w3c.github.io/media-source/#dfn-append-error>
+    fn append_error(&self, cx: &mut JSContext) {
+        // Step 1. Run the reset parser state algorithm.
+        self.reset_parser_state();
+
+        // Step 2. Set the updating attribute to false.
+        self.updating.set(false);
+
+        // Step 3. Queue a task to fire an event named error at this SourceBuffer object.
+        self.queue_event(atom!("error"));
+
+        // Step 4. Queue a task to fire an event named updateend at this SourceBuffer
+        // object.
+        self.queue_event(Atom::from("updateend"));
+
+        // Step 5. Run the end of stream algorithm with the error parameter set to
+        // "decode".
+        if let Some(media_source) = self.parent_media_source() {
+            media_source.end_of_stream_with_decode_error(cx);
+        }
+    }
+
+    /// <https://w3c.github.io/media-source/#sourcebuffer-reset-parser-state>
+    fn reset_parser_state(&self) {
+        self.input_buffer.borrow_mut().clear();
+        self.parser.borrow_mut().reset();
+    }
+
+    /// <https://w3c.github.io/media-source/#dfn-range-removal>
+    ///
+    /// The interval stops being reported as buffered, but the media backend has already
+    /// been handed those frames and cannot drop them, so appending over a removed range
+    /// is not supported yet.
+    fn range_removal(&self, start: f64, end: f64, generation: u32) {
+        // Step 3. Remove the media data from the track buffers.
+        for (_, ranges) in self.track_buffers.borrow_mut().iter_mut() {
+            ranges.remove(start, end);
+        }
+
+        if generation != self.generation.get() {
+            return;
+        }
+
+        if let Some(media_source) = self.parent_media_source() {
+            media_source.media_data_appended();
+        }
+
+        // Step 4. Set the updating attribute to false.
+        self.updating.set(false);
+
+        // Step 5. Queue a task to fire an event named update at this SourceBuffer object.
+        self.queue_event(Atom::from("update"));
+
+        // Step 6. Queue a task to fire an event named updateend at this SourceBuffer
+        // object.
+        self.queue_event(Atom::from("updateend"));
+    }
+
+    /// Whether a structure is half parsed, which the specification tracks as the
+    /// `PARSING_MEDIA_SEGMENT` append state.
+    fn is_parsing_media_segment(&self) -> bool {
+        self.parser.borrow().is_parsing_segment()
+    }
+
+    fn queue_event(&self, name: Atom) {
+        let this = Trusted::new(self);
+        self.global()
+            .task_manager()
+            .media_element_task_source()
+            .queue(task!(fire_source_buffer_event: move |cx| {
+                let this = this.root();
+                this.upcast::<EventTarget>().fire_event(cx, name);
+            }));
+    }
+}
+
+impl SourceBufferMethods<crate::DomTypeHolder> for SourceBuffer {
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-mode>
+    fn Mode(&self) -> AppendMode {
+        self.mode.get()
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-mode>
+    fn SetMode(&self, value: AppendMode) -> ErrorResult {
+        // Step 1. If this object has been removed from the sourceBuffers attribute of the
+        // parent media source, then throw an InvalidStateError exception and abort these
+        // steps.
+        let media_source = self.require_attached()?;
+
+        // Step 2. If the updating attribute equals true, then throw an InvalidStateError
+        // exception and abort these steps.
+        if self.updating.get() {
+            return Err(Error::InvalidState(Some(
+                "The source buffer is still updating".into(),
+            )));
+        }
+
+        // Step 3. Let new mode equal the new value being assigned to this attribute.
+        // Step 4. If generate timestamps flag equals true and new mode equals "segments",
+        // then throw a TypeError exception and abort these steps.
+        // Neither byte stream format we support sets the generate timestamps flag.
+
+        // Step 5. If the readyState attribute of the parent media source is in the "ended"
+        // state then run the following steps.
+        Self::reopen_media_source(&media_source);
+
+        // Step 6. If the append state equals PARSING_MEDIA_SEGMENT, then throw an
+        // InvalidStateError and abort these steps.
+        if self.is_parsing_media_segment() {
+            return Err(Error::InvalidState(Some(
+                "A media segment is still being parsed".into(),
+            )));
+        }
+
+        // Step 7. If the new mode equals "sequence", then set the group start timestamp to
+        // the group end timestamp.
+        // Step 8. Update the attribute to new mode.
+        self.mode.set(value);
+
+        Ok(())
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-updating>
+    fn Updating(&self) -> bool {
+        self.updating.get()
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-buffered>
+    fn GetBuffered(&self, cx: &mut JSContext) -> Fallible<DomRoot<TimeRanges>> {
+        // Step 1. If this object has been removed from the sourceBuffers attribute of the
+        // parent media source then throw an InvalidStateError exception and abort these
+        // steps.
+        self.require_attached()?;
+
+        // Steps 2-6 compute the intersection of the track buffer ranges, which is what
+        // this source buffer keeps.
+        let global = self.global();
+        Ok(TimeRanges::new(
+            cx,
+            global.as_window(),
+            self.buffered_ranges(),
+        ))
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-timestampoffset>
+    fn TimestampOffset(&self) -> Finite<f64> {
+        Finite::wrap(self.timestamp_offset.get())
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-timestampoffset>
+    fn SetTimestampOffset(&self, value: Finite<f64>) -> ErrorResult {
+        // Step 2. If this object has been removed from the sourceBuffers attribute of the
+        // parent media source, then throw an InvalidStateError exception and abort these
+        // steps.
+        let media_source = self.require_attached()?;
+
+        // Step 3. If the updating attribute equals true, then throw an InvalidStateError
+        // exception and abort these steps.
+        if self.updating.get() {
+            return Err(Error::InvalidState(Some(
+                "The source buffer is still updating".into(),
+            )));
+        }
+
+        // Step 4. If the readyState attribute of the parent media source is in the "ended"
+        // state then run the following steps.
+        Self::reopen_media_source(&media_source);
+
+        // Step 5. If the append state equals PARSING_MEDIA_SEGMENT, then throw an
+        // InvalidStateError and abort these steps.
+        if self.is_parsing_media_segment() {
+            return Err(Error::InvalidState(Some(
+                "A media segment is still being parsed".into(),
+            )));
+        }
+
+        // Step 6. If the mode attribute equals "sequence", then set the group start
+        // timestamp to new timestamp offset.
+        // Step 7. Update the attribute to new timestamp offset.
+        self.timestamp_offset.set(*value);
+
+        Ok(())
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-audiotracks>
+    fn AudioTracks(&self) -> DomRoot<AudioTrackList> {
+        DomRoot::from_ref(&*self.audio_tracks)
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-videotracks>
+    fn VideoTracks(&self) -> DomRoot<VideoTrackList> {
+        DomRoot::from_ref(&*self.video_tracks)
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-texttracks>
+    fn TextTracks(&self) -> DomRoot<TextTrackList> {
+        DomRoot::from_ref(&*self.text_tracks)
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-appendwindowstart>
+    fn AppendWindowStart(&self) -> Finite<f64> {
+        Finite::wrap(self.append_window_start.get())
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-appendwindowstart>
+    fn SetAppendWindowStart(&self, value: Finite<f64>) -> ErrorResult {
+        // Step 1. If this object has been removed from the sourceBuffers attribute of the
+        // parent media source, then throw an InvalidStateError exception and abort these
+        // steps.
+        self.require_attached()?;
+
+        // Step 2. If the updating attribute equals true, then throw an InvalidStateError
+        // exception and abort these steps.
+        if self.updating.get() {
+            return Err(Error::InvalidState(Some(
+                "The source buffer is still updating".into(),
+            )));
+        }
+
+        // Step 3. If the new value is less than 0 or greater than or equal to
+        // appendWindowEnd then throw a TypeError exception and abort these steps.
+        if *value < 0. || *value >= self.append_window_end.get() {
+            return Err(Error::Type(
+                c"The append window start is out of range".to_owned(),
+            ));
+        }
+
+        // Step 4. Update the attribute to the new value.
+        self.append_window_start.set(*value);
+
+        Ok(())
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-appendwindowend>
+    fn AppendWindowEnd(&self) -> f64 {
+        self.append_window_end.get()
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-appendwindowend>
+    fn SetAppendWindowEnd(&self, value: f64) -> ErrorResult {
+        // Step 1. If this object has been removed from the sourceBuffers attribute of the
+        // parent media source, then throw an InvalidStateError exception and abort these
+        // steps.
+        self.require_attached()?;
+
+        // Step 2. If the updating attribute equals true, then throw an InvalidStateError
+        // exception and abort these steps.
+        if self.updating.get() {
+            return Err(Error::InvalidState(Some(
+                "The source buffer is still updating".into(),
+            )));
+        }
+
+        // Step 3. If the new value equals NaN, then throw a TypeError and abort these
+        // steps.
+        // Step 4. If the new value is less than or equal to appendWindowStart then throw a
+        // TypeError exception and abort these steps.
+        if value.is_nan() || value <= self.append_window_start.get() {
+            return Err(Error::Type(
+                c"The append window end is out of range".to_owned(),
+            ));
+        }
+
+        // Step 5. Update the attribute to the new value.
+        self.append_window_end.set(value);
+
+        Ok(())
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-appendbuffer>
+    fn AppendBuffer(&self, data: ArrayBufferViewOrArrayBuffer) -> ErrorResult {
+        // Step 1. Run the prepare append algorithm.
+        self.prepare_append()?;
+
+        // Step 2. Add data to the end of the input buffer.
+        let bytes = match &data {
+            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => {
+                get_buffer_source_copy(view.into())
+            },
+            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => {
+                get_buffer_source_copy(buffer.into())
+            },
+        };
+        self.input_buffer.borrow_mut().extend_from_slice(&bytes);
+
+        // Step 3. Set the updating attribute to true.
+        self.updating.set(true);
+
+        // Step 4. Queue a task to fire an event named updatestart at this SourceBuffer
+        // object.
+        // Step 5. Asynchronously run the buffer append algorithm.
+        let this = Trusted::new(self);
+        let generation = self.generation.get();
+        self.global()
+            .task_manager()
+            .media_element_task_source()
+            .queue(task!(source_buffer_append: move |cx| {
+                let this = this.root();
+                if generation != this.generation.get() {
+                    return;
+                }
+                this.upcast::<EventTarget>().fire_event(cx, Atom::from("updatestart"));
+                this.buffer_append(cx, generation);
+            }));
+
+        Ok(())
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-abort>
+    fn Abort(&self) -> ErrorResult {
+        // Step 1. If this object has been removed from the sourceBuffers attribute of the
+        // parent media source then throw an InvalidStateError exception and abort these
+        // steps.
+        let media_source = self.require_attached()?;
+
+        // Step 2. If the readyState attribute of the parent media source is not in the
+        // "open" state then throw an InvalidStateError exception and abort these steps.
+        if media_source.ready_state() != ReadyState::Open {
+            return Err(Error::InvalidState(Some(
+                "The media source is not open".into(),
+            )));
+        }
+
+        // Step 3. If the range removal algorithm is running, then throw an
+        // InvalidStateError exception and abort these steps.
+        // Range removal completes within the task that starts it, so it is never running
+        // when script regains control.
+
+        // Step 4. If the updating attribute equals true, then run the following steps.
+        self.abort_append();
+
+        // Step 5. Run the reset parser state algorithm.
+        self.reset_parser_state();
+
+        // Step 6. Set appendWindowStart to the presentation start time.
+        self.append_window_start.set(0.);
+
+        // Step 7. Set appendWindowEnd to positive Infinity.
+        self.append_window_end.set(f64::INFINITY);
+
+        Ok(())
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-changetype>
+    fn ChangeType(&self, type_: DOMString) -> ErrorResult {
+        // Step 1. If type is an empty string then throw a TypeError exception and abort
+        // these steps.
+        if type_.is_empty() {
+            return Err(Error::Type(c"The type must not be empty".to_owned()));
+        }
+
+        // Step 2. If this object has been removed from the sourceBuffers attribute of the
+        // parent media source, then throw an InvalidStateError exception and abort these
+        // steps.
+        let media_source = self.require_attached()?;
+
+        // Step 3. If the updating attribute equals true, then throw an InvalidStateError
+        // exception and abort these steps.
+        if self.updating.get() {
+            return Err(Error::InvalidState(Some(
+                "The source buffer is still updating".into(),
+            )));
+        }
+
+        // Step 4. If type contains a MIME type that is not supported, or contains a MIME
+        // type that is not supported with the types specified (currently or previously) of
+        // SourceBuffer objects in the sourceBuffers attribute of the parent media source,
+        // then throw a NotSupportedError exception and abort these steps.
+        let format = MediaSource::byte_stream_format(&type_.str()).ok_or_else(|| {
+            Error::NotSupported(Some(format!("The type \"{type_}\" is not supported")))
+        })?;
+
+        // The media backend is handed a single byte stream, so it cannot follow a change
+        // of container format part way through.
+        if self.parser.borrow().format() != format {
+            return Err(Error::NotSupported(Some(
+                "Changing the byte stream format of a source buffer is not supported".into(),
+            )));
+        }
+
+        // Step 5. If the readyState attribute of the parent media source is in the "ended"
+        // state then run the following steps.
+        Self::reopen_media_source(&media_source);
+
+        // Step 6. Run the reset parser state algorithm.
+        self.reset_parser_state();
+
+        // Steps 7-9. Update the generate timestamps flag, the append state, and the type.
+
+        Ok(())
+    }
+
+    /// <https://w3c.github.io/media-source/#dom-sourcebuffer-remove>
+    fn Remove(&self, start: Finite<f64>, end: f64) -> ErrorResult {
+        // Step 1. If this object has been removed from the sourceBuffers attribute of the
+        // parent media source then throw an InvalidStateError exception and abort these
+        // steps.
+        let media_source = self.require_attached()?;
+
+        // Step 2. If the updating attribute equals true, then throw an InvalidStateError
+        // exception and abort these steps.
+        if self.updating.get() {
+            return Err(Error::InvalidState(Some(
+                "The source buffer is still updating".into(),
+            )));
+        }
+
+        // Step 3. If duration equals NaN, then throw a TypeError exception and abort these
+        // steps.
+        let duration = media_source.duration();
+        if duration.is_nan() {
+            return Err(Error::Type(
+                c"The media source has no known duration".to_owned(),
+            ));
+        }
+
+        // Step 4. If start is negative or greater than duration, then throw a TypeError
+        // exception and abort these steps.
+        let start = *start;
+        if start < 0. || start > duration {
+            return Err(Error::Type(
+                c"The start is negative or past the duration".to_owned(),
+            ));
+        }
+
+        // Step 5. If end is less than or equal to start or end equals NaN, then throw a
+        // TypeError exception and abort these steps.
+        if end <= start || end.is_nan() {
+            return Err(Error::Type(
+                c"The end is not greater than the start".to_owned(),
+            ));
+        }
+
+        // Step 6. If the readyState attribute of the parent media source is in the "ended"
+        // state then run the following steps.
+        Self::reopen_media_source(&media_source);
+
+        // Step 7. Run the range removal algorithm with start and end as the start and end
+        // of the removal range.
+        //
+        // Step 7.1 of that algorithm sets updating to true, and step 7.2 queues the
+        // updatestart event before the removal itself runs.
+        self.updating.set(true);
+
+        let this = Trusted::new(self);
+        let generation = self.generation.get();
+        self.global()
+            .task_manager()
+            .media_element_task_source()
+            .queue(task!(source_buffer_range_removal: move |cx| {
+                let this = this.root();
+                if generation != this.generation.get() {
+                    return;
+                }
+                this.upcast::<EventTarget>().fire_event(cx, Atom::from("updatestart"));
+                this.range_removal(start, end, generation);
+            }));
+
+        Ok(())
+    }
+
+    // <https://w3c.github.io/media-source/#dom-sourcebuffer-onupdatestart>
+    event_handler!(updatestart, GetOnupdatestart, SetOnupdatestart);
+
+    // <https://w3c.github.io/media-source/#dom-sourcebuffer-onupdate>
+    event_handler!(update, GetOnupdate, SetOnupdate);
+
+    // <https://w3c.github.io/media-source/#dom-sourcebuffer-onupdateend>
+    event_handler!(updateend, GetOnupdateend, SetOnupdateend);
+
+    // <https://w3c.github.io/media-source/#dom-sourcebuffer-onerror>
+    event_handler!(error, GetOnerror, SetOnerror);
+
+    // <https://w3c.github.io/media-source/#dom-sourcebuffer-onabort>
+    event_handler!(abort, GetOnabort, SetOnabort);
+}

--- a/components/script/dom/media/sourcebufferlist.rs
+++ b/components/script/dom/media/sourcebufferlist.rs
@@ -1,0 +1,161 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use dom_struct::dom_struct;
+use js::context::JSContext;
+use script_bindings::cell::DomRefCell;
+use script_bindings::reflector::reflect_dom_object_with_cx;
+use stylo_atoms::Atom;
+
+use crate::dom::bindings::codegen::Bindings::SourceBufferListBinding::SourceBufferListMethods;
+use crate::dom::bindings::inheritance::Castable;
+use crate::dom::bindings::refcounted::Trusted;
+use crate::dom::bindings::reflector::DomGlobal;
+use crate::dom::bindings::root::{Dom, DomRoot};
+use crate::dom::eventtarget::EventTarget;
+use crate::dom::media::sourcebuffer::SourceBuffer;
+use crate::dom::window::Window;
+
+/// <https://w3c.github.io/media-source/#sourcebufferlist>
+#[dom_struct]
+pub(crate) struct SourceBufferList {
+    eventtarget: EventTarget,
+    buffers: DomRefCell<Vec<Dom<SourceBuffer>>>,
+}
+
+impl SourceBufferList {
+    fn new_inherited() -> SourceBufferList {
+        SourceBufferList {
+            eventtarget: EventTarget::new_inherited(),
+            buffers: DomRefCell::new(Vec::new()),
+        }
+    }
+
+    pub(crate) fn new(cx: &mut JSContext, window: &Window) -> DomRoot<SourceBufferList> {
+        reflect_dom_object_with_cx(Box::new(SourceBufferList::new_inherited()), window, cx)
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.buffers.borrow().len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.buffers.borrow().is_empty()
+    }
+
+    pub(crate) fn contains(&self, buffer: &SourceBuffer) -> bool {
+        self.buffers.borrow().iter().any(|item| &**item == buffer)
+    }
+
+    pub(crate) fn item(&self, index: usize) -> Option<DomRoot<SourceBuffer>> {
+        self.buffers
+            .borrow()
+            .get(index)
+            .map(|buffer| DomRoot::from_ref(&**buffer))
+    }
+
+    /// The source buffers of this list, rooted so that callers can iterate them
+    /// without holding a borrow of the list.
+    pub(crate) fn buffers(&self) -> Vec<DomRoot<SourceBuffer>> {
+        self.buffers
+            .borrow()
+            .iter()
+            .map(|buffer| DomRoot::from_ref(&**buffer))
+            .collect()
+    }
+
+    /// Appends `buffer` and queues the `addsourcebuffer` event required by the algorithms
+    /// that mutate this list.
+    pub(crate) fn add(&self, buffer: &SourceBuffer) {
+        self.buffers.borrow_mut().push(Dom::from_ref(buffer));
+        self.queue_event(Atom::from("addsourcebuffer"));
+    }
+
+    /// Removes `buffer` and queues the `removesourcebuffer` event. Does nothing when the
+    /// buffer is not in the list.
+    pub(crate) fn remove(&self, buffer: &SourceBuffer) {
+        let mut buffers = self.buffers.borrow_mut();
+        let Some(index) = buffers.iter().position(|item| &**item == buffer) else {
+            return;
+        };
+        buffers.remove(index);
+        drop(buffers);
+
+        self.queue_event(Atom::from("removesourcebuffer"));
+    }
+
+    /// Replaces the contents of the list, queueing the events implied by the difference
+    /// with the previous contents.
+    ///
+    /// This backs the `activeSourceBuffers` bookkeeping, which the specification defines
+    /// as a list kept in the same order as `sourceBuffers`.
+    pub(crate) fn update(&self, buffers: &[DomRoot<SourceBuffer>]) {
+        let previous = self.buffers();
+        let removed = previous
+            .iter()
+            .any(|buffer| !buffers.iter().any(|item| item == buffer));
+        let added = buffers
+            .iter()
+            .any(|buffer| !previous.iter().any(|item| item == buffer));
+
+        if !removed && !added {
+            return;
+        }
+
+        *self.buffers.borrow_mut() = buffers
+            .iter()
+            .map(|buffer| Dom::from_ref(&**buffer))
+            .collect();
+
+        if removed {
+            self.queue_event(Atom::from("removesourcebuffer"));
+        }
+        if added {
+            self.queue_event(Atom::from("addsourcebuffer"));
+        }
+    }
+
+    /// Empties the list without queueing any event, leaving it to the caller to queue the
+    /// single event the detaching algorithm asks for.
+    pub(crate) fn clear(&self) {
+        self.buffers.borrow_mut().clear();
+    }
+
+    pub(crate) fn queue_removesourcebuffer_event(&self) {
+        self.queue_event(Atom::from("removesourcebuffer"));
+    }
+
+    fn queue_event(&self, name: Atom) {
+        let this = Trusted::new(self);
+        self.global()
+            .task_manager()
+            .media_element_task_source()
+            .queue(task!(fire_source_buffer_list_event: move |cx| {
+                let this = this.root();
+                this.upcast::<EventTarget>().fire_event(cx, name);
+            }));
+    }
+}
+
+impl SourceBufferListMethods<crate::DomTypeHolder> for SourceBufferList {
+    /// <https://w3c.github.io/media-source/#dom-sourcebufferlist-length>
+    fn Length(&self) -> u32 {
+        self.len() as u32
+    }
+
+    /// <https://w3c.github.io/media-source/#dfn-sourcebufferlist-getter>
+    fn IndexedGetter(&self, index: u32) -> Option<DomRoot<SourceBuffer>> {
+        self.item(index as usize)
+    }
+
+    // <https://w3c.github.io/media-source/#dom-sourcebufferlist-onaddsourcebuffer>
+    event_handler!(addsourcebuffer, GetOnaddsourcebuffer, SetOnaddsourcebuffer);
+
+    // <https://w3c.github.io/media-source/#dom-sourcebufferlist-onremovesourcebuffer>
+    event_handler!(
+        removesourcebuffer,
+        GetOnremovesourcebuffer,
+        SetOnremovesourcebuffer
+    );
+}

--- a/components/script/dom/timeranges.rs
+++ b/components/script/dom/timeranges.rs
@@ -124,6 +124,72 @@ impl TimeRangesContainer {
 
         Ok(())
     }
+
+    /// Removes the `[start, end)` interval from the container, splitting the ranges that
+    /// only partially overlap it.
+    pub(crate) fn remove(&mut self, start: f64, end: f64) {
+        if start >= end {
+            return;
+        }
+
+        let mut ranges = Vec::with_capacity(self.ranges.len());
+        for range in self.ranges.drain(..) {
+            if range.end <= start || range.start >= end {
+                // Entirely outside of the removed interval.
+                ranges.push(range);
+                continue;
+            }
+            if range.start < start {
+                ranges.push(TimeRange {
+                    start: range.start,
+                    end: start,
+                });
+            }
+            if range.end > end {
+                ranges.push(TimeRange {
+                    start: end,
+                    end: range.end,
+                });
+            }
+        }
+        self.ranges = ranges;
+    }
+
+    /// Returns the ranges covered by both containers.
+    pub(crate) fn intersection(&self, other: &TimeRangesContainer) -> TimeRangesContainer {
+        let mut ranges = Vec::new();
+        for range in &self.ranges {
+            for other_range in &other.ranges {
+                let start = f64::max(range.start, other_range.start);
+                let end = f64::min(range.end, other_range.end);
+                if start < end {
+                    ranges.push(TimeRange { start, end });
+                }
+            }
+        }
+        // Both containers are sorted, so the intersection is produced in order.
+        TimeRangesContainer { ranges }
+    }
+
+    /// The start of the first range, if any.
+    pub(crate) fn start_time(&self) -> Option<f64> {
+        self.ranges.first().map(|range| range.start)
+    }
+
+    /// The end of the last range, if any.
+    pub(crate) fn end_time(&self) -> Option<f64> {
+        self.ranges.last().map(|range| range.end)
+    }
+
+    /// Moves the end of the last range to `end`, as required when a media source reaches
+    /// the `"ended"` ready state.
+    pub(crate) fn set_end_time(&mut self, end: f64) {
+        if let Some(range) = self.ranges.last_mut() &&
+            end > range.start
+        {
+            range.end = end;
+        }
+    }
 }
 
 #[dom_struct]

--- a/components/script/dom/url/url.rs
+++ b/components/script/dom/url/url.rs
@@ -27,6 +27,7 @@ use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::blob::Blob;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::media::mediasource::MediaSource;
 use crate::dom::url::urlhelper::UrlHelper;
 use crate::dom::url::urlsearchparams::URLSearchParams;
 
@@ -202,11 +203,30 @@ impl URLMethods<crate::DomTypeHolder> for URL {
         DOMString::from(URL::unicode_serialization_blob_url(origin.immutable(), &id))
     }
 
+    /// <https://w3c.github.io/media-source/#dom-url-createobjecturl>
+    fn CreateObjectURL_(global: &GlobalScope, media_source: &MediaSource) -> DOMString {
+        // Step 1. Return the result of adding an entry to the blob URL store for
+        // mediaSource.
+        //
+        // A media source is bound to the thread that created it, so its entry is kept in
+        // the global rather than in the file manager that backs blob URLs.
+        let origin = global.origin();
+        let url = URL::unicode_serialization_blob_url(origin.immutable(), &Uuid::new_v4());
+
+        global.track_media_source_url(url.clone(), media_source);
+
+        DOMString::from(url)
+    }
+
     /// <https://w3c.github.io/FileAPI/#dfn-revokeObjectURL>
     fn RevokeObjectURL(global: &GlobalScope, url: DOMString) {
         // If the value provided for the url argument is not a Blob URL OR
         // if the value provided for the url argument does not have an entry in the Blob URL Store,
         // this method call does nothing. User agents may display a message on the error console.
+        if global.forget_media_source_url(&url.str()) {
+            return;
+        }
+
         let origin = global.origin().immutable().clone();
 
         if let Ok(url) = ServoUrl::parse(&url.str()) &&

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -874,6 +874,14 @@ DOMInterfaces = {
     'cx': ['GetMetadata'],
 },
 
+'MediaSource': {
+    'cx': ['AddSourceBuffer', 'EndOfStream'],
+},
+
+'SourceBuffer': {
+    'cx': ['GetBuffered'],
+},
+
 'MediaStreamTrack': {
     'cx': ['Clone'],
 },

--- a/components/script_bindings/webidls/MediaSource.webidl
+++ b/components/script_bindings/webidls/MediaSource.webidl
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://w3c.github.io/media-source/#idl-def-mediasource
+
+enum ReadyState {
+  "closed",
+  "open",
+  "ended",
+};
+
+enum EndOfStreamError {
+  "network",
+  "decode",
+};
+
+[Exposed=Window, Pref="dom_media_source_enabled"]
+interface MediaSource : EventTarget {
+  constructor();
+
+  readonly attribute SourceBufferList sourceBuffers;
+  readonly attribute SourceBufferList activeSourceBuffers;
+  readonly attribute ReadyState readyState;
+
+  [SetterThrows] attribute unrestricted double duration;
+
+  attribute EventHandler onsourceopen;
+  attribute EventHandler onsourceended;
+  attribute EventHandler onsourceclose;
+
+  static readonly attribute boolean canConstructInDedicatedWorker;
+
+  [Throws] SourceBuffer addSourceBuffer(DOMString type);
+  [Throws] undefined removeSourceBuffer(SourceBuffer sourceBuffer);
+  [Throws] undefined endOfStream(optional EndOfStreamError error);
+  [Throws] undefined setLiveSeekableRange(double start, double end);
+  [Throws] undefined clearLiveSeekableRange();
+  static boolean isTypeSupported(DOMString type);
+};

--- a/components/script_bindings/webidls/SourceBuffer.webidl
+++ b/components/script_bindings/webidls/SourceBuffer.webidl
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://w3c.github.io/media-source/#idl-def-sourcebuffer
+
+enum AppendMode {
+  "segments",
+  "sequence",
+};
+
+[Exposed=Window, Pref="dom_media_source_enabled"]
+interface SourceBuffer : EventTarget {
+  [SetterThrows] attribute AppendMode mode;
+  readonly attribute boolean updating;
+  [Throws] readonly attribute TimeRanges buffered;
+  [SetterThrows] attribute double timestampOffset;
+  readonly attribute AudioTrackList audioTracks;
+  readonly attribute VideoTrackList videoTracks;
+  readonly attribute TextTrackList textTracks;
+  [SetterThrows] attribute double appendWindowStart;
+  [SetterThrows] attribute unrestricted double appendWindowEnd;
+
+  attribute EventHandler onupdatestart;
+  attribute EventHandler onupdate;
+  attribute EventHandler onupdateend;
+  attribute EventHandler onerror;
+  attribute EventHandler onabort;
+
+  [Throws] undefined appendBuffer(BufferSource data);
+  [Throws] undefined abort();
+  [Throws] undefined changeType(DOMString type);
+  [Throws] undefined remove(double start, unrestricted double end);
+};

--- a/components/script_bindings/webidls/SourceBufferList.webidl
+++ b/components/script_bindings/webidls/SourceBufferList.webidl
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://w3c.github.io/media-source/#idl-def-sourcebufferlist
+
+[Exposed=Window, Pref="dom_media_source_enabled"]
+interface SourceBufferList : EventTarget {
+  readonly attribute unsigned long length;
+
+  attribute EventHandler onaddsourcebuffer;
+  attribute EventHandler onremovesourcebuffer;
+
+  getter SourceBuffer (unsigned long index);
+};

--- a/components/script_bindings/webidls/URL.webidl
+++ b/components/script_bindings/webidls/URL.webidl
@@ -27,6 +27,8 @@ interface URL {
 
   // https://w3c.github.io/FileAPI/#creating-revoking
   static DOMString createObjectURL(Blob blob);
+  // https://w3c.github.io/media-source/#dom-url-createobjecturl
+  static DOMString createObjectURL(MediaSource mediaSource);
   static undefined revokeObjectURL(DOMString url);
 
   USVString toJSON();

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -218,6 +218,8 @@ skip: true
   skip: false
 [largest-contentful-paint]
   skip: false
+[media-source]
+  skip: false
 [mediasession]
   skip: false
 [mimesniff]

--- a/tests/wpt/meta/media-source/SourceBuffer-abort-readyState.html.ini
+++ b/tests/wpt/meta/media-source/SourceBuffer-abort-readyState.html.ini
@@ -1,0 +1,3 @@
+[SourceBuffer-abort-readyState.html]
+  [SourceBuffer#abort() (video/mp4) : If the readyState attribute of the parent media source is not in the "open" state then throw an INVALID_STATE_ERR exception and abort these steps.]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/SourceBuffer-abort-removed.html.ini
+++ b/tests/wpt/meta/media-source/SourceBuffer-abort-removed.html.ini
@@ -1,0 +1,3 @@
+[SourceBuffer-abort-removed.html]
+  [SourceBuffer#abort (video/mp4) : if this object has been removed from the sourceBuffers attribute of the parent media source, then throw an INVALID_STATE_ERR exception and abort these steps.]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/SourceBuffer-abort-updating.html.ini
+++ b/tests/wpt/meta/media-source/SourceBuffer-abort-updating.html.ini
@@ -1,0 +1,3 @@
+[SourceBuffer-abort-updating.html]
+  [SourceBuffer#abort() (video/mp4) : Check the algorithm when the updating attribute is true.]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/SourceBuffer-abort.html.ini
+++ b/tests/wpt/meta/media-source/SourceBuffer-abort.html.ini
@@ -1,0 +1,3 @@
+[SourceBuffer-abort.html]
+  [SourceBuffer#abort() (video/mp4): Check the values of appendWindowStart and appendWindowEnd.]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/SourceBuffer-appendWindowEnd-rounding.html.ini
+++ b/tests/wpt/meta/media-source/SourceBuffer-appendWindowEnd-rounding.html.ini
@@ -1,0 +1,9 @@
+[SourceBuffer-appendWindowEnd-rounding.html]
+  [setup]
+    expected: FAIL
+
+  [last frame at 10]
+    expected: FAIL
+
+  [last frame at 22]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/SourceBuffer-short-frame-endOfStream.html.ini
+++ b/tests/wpt/meta/media-source/SourceBuffer-short-frame-endOfStream.html.ini
@@ -1,0 +1,6 @@
+[SourceBuffer-short-frame-endOfStream.html]
+  [setup]
+    expected: FAIL
+
+  [endOfStream() with short frame duration]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/URL-createObjectURL-revoke.html.ini
+++ b/tests/wpt/meta/media-source/URL-createObjectURL-revoke.html.ini
@@ -1,0 +1,3 @@
+[URL-createObjectURL-revoke.html]
+  [Check referenced MediaSource can open after URL.revokeObjectURL(url).]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/__dir__.ini
+++ b/tests/wpt/meta/media-source/__dir__.ini
@@ -1,0 +1,1 @@
+prefs: [dom_media_source_enabled: true]

--- a/tests/wpt/meta/media-source/dedicated-worker/mediasource-worker-detach-element.html.ini
+++ b/tests/wpt/meta/media-source/dedicated-worker/mediasource-worker-detach-element.html.ini
@@ -1,0 +1,45 @@
+[mediasource-worker-detach-element.html]
+  [Test element detachment from worker MediaSource after at least 0 main thread setTimeouts, starting counting after setting srcObject]
+    expected: FAIL
+
+  [Test element detachment from worker MediaSource after at least 1 main thread setTimeouts, starting counting after setting srcObject]
+    expected: FAIL
+
+  [Test element detachment from worker MediaSource after at least 2 main thread setTimeouts, starting counting after setting srcObject]
+    expected: FAIL
+
+  [Test element detachment from worker MediaSource after at least 3 main thread setTimeouts, starting counting after setting srcObject]
+    expected: FAIL
+
+  [Test element detachment from worker MediaSource after at least 4 main thread setTimeouts, starting counting after setting srcObject]
+    expected: FAIL
+
+  [Test element detachment from worker MediaSource after at least 0 main thread setTimeouts, starting counting after receiving Started Buffering message from worker]
+    expected: FAIL
+
+  [Test element detachment from worker MediaSource after at least 1 main thread setTimeouts, starting counting after receiving Started Buffering message from worker]
+    expected: FAIL
+
+  [Test element detachment from worker MediaSource after at least 2 main thread setTimeouts, starting counting after receiving Started Buffering message from worker]
+    expected: FAIL
+
+  [Test element detachment from worker MediaSource after at least 3 main thread setTimeouts, starting counting after receiving Started Buffering message from worker]
+    expected: FAIL
+
+  [Test element detachment from worker MediaSource after at least 4 main thread setTimeouts, starting counting after receiving Started Buffering message from worker]
+    expected: FAIL
+
+  [Test element detachment from worker MediaSource after at least 0 main thread setTimeouts, starting counting after receiving Finished Buffering message from worker]
+    expected: FAIL
+
+  [Test element detachment from worker MediaSource after at least 1 main thread setTimeouts, starting counting after receiving Finished Buffering message from worker]
+    expected: FAIL
+
+  [Test element detachment from worker MediaSource after at least 2 main thread setTimeouts, starting counting after receiving Finished Buffering message from worker]
+    expected: FAIL
+
+  [Test element detachment from worker MediaSource after at least 3 main thread setTimeouts, starting counting after receiving Finished Buffering message from worker]
+    expected: FAIL
+
+  [Test element detachment from worker MediaSource after at least 4 main thread setTimeouts, starting counting after receiving Finished Buffering message from worker]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/dedicated-worker/mediasource-worker-duration.html.ini
+++ b/tests/wpt/meta/media-source/dedicated-worker/mediasource-worker-duration.html.ini
@@ -1,0 +1,3 @@
+[mediasource-worker-duration.html]
+  [Test worker MediaSource duration updates before and after HAVE_METADATA]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/dedicated-worker/mediasource-worker-handle-transfer.html.ini
+++ b/tests/wpt/meta/media-source/dedicated-worker/mediasource-worker-handle-transfer.html.ini
@@ -1,0 +1,27 @@
+[mediasource-worker-handle-transfer.html]
+  [MediaSourceHandle serialization without transfer must fail, tested in window context]
+    expected: FAIL
+
+  [Same MediaSourceHandle transferred multiple times in single postMessage must fail, tested in window context]
+    expected: FAIL
+
+  [Attempt to transfer detached MediaSourceHandle must fail, tested in window context]
+    expected: FAIL
+
+  [MediaSourceHandle cannot be transferred, immediately after set as srcObject, even if srcObject immediately reset to null]
+    expected: FAIL
+
+  [MediaSourceHandle cannot be transferred, if it was srcObject when asynchronous load starts (loadstart), even if srcObject is then immediately reset to null]
+    expected: FAIL
+
+  [A detached (already transferred away) MediaSourceHandle cannot successfully load when assigned to srcObject]
+    expected: FAIL
+
+  [Precisely one load of the same MediaSourceHandle assigned synchronously to multiple media element srcObjects succeeds]
+    expected: FAIL
+
+  [MediaSourceHandle serialization without transfer must fail, tested in worker]
+    expected: FAIL
+
+  [Same MediaSourceHandle transferred multiple times in single postMessage must fail, tested in worker]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/dedicated-worker/mediasource-worker-handle.html.ini
+++ b/tests/wpt/meta/media-source/dedicated-worker/mediasource-worker-handle.html.ini
@@ -1,0 +1,6 @@
+[mediasource-worker-handle.html]
+  [Test main context receipt of postMessage'd MediaSourceHandle from DedicatedWorker MediaSource]
+    expected: FAIL
+
+  [Test main-thread has MediaSourceHandle defined]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/dedicated-worker/mediasource-worker-objecturl.html.ini
+++ b/tests/wpt/meta/media-source/dedicated-worker/mediasource-worker-objecturl.html.ini
@@ -1,0 +1,3 @@
+[mediasource-worker-objecturl.html]
+  [Test main context load of a DedicatedWorker MediaSource object URL should fail]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/dedicated-worker/mediasource-worker-play-terminate-worker.html.ini
+++ b/tests/wpt/meta/media-source/dedicated-worker/mediasource-worker-play-terminate-worker.html.ini
@@ -1,0 +1,90 @@
+[mediasource-worker-play-terminate-worker.html]
+  [Test worker MediaSource termination after at least 0 main thread setTimeouts, starting counting before setting srcObject]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 1 main thread setTimeouts, starting counting before setting srcObject]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 2 main thread setTimeouts, starting counting before setting srcObject]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 3 main thread setTimeouts, starting counting before setting srcObject]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 4 main thread setTimeouts, starting counting before setting srcObject]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 5 main thread setTimeouts, starting counting before setting srcObject]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 6 main thread setTimeouts, starting counting before setting srcObject]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 7 main thread setTimeouts, starting counting before setting srcObject]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 8 main thread setTimeouts, starting counting before setting srcObject]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 9 main thread setTimeouts, starting counting before setting srcObject]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 0 main thread setTimeouts, starting counting after setting srcObject]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 1 main thread setTimeouts, starting counting after setting srcObject]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 2 main thread setTimeouts, starting counting after setting srcObject]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 3 main thread setTimeouts, starting counting after setting srcObject]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 4 main thread setTimeouts, starting counting after setting srcObject]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 5 main thread setTimeouts, starting counting after setting srcObject]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 6 main thread setTimeouts, starting counting after setting srcObject]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 7 main thread setTimeouts, starting counting after setting srcObject]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 8 main thread setTimeouts, starting counting after setting srcObject]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 9 main thread setTimeouts, starting counting after setting srcObject]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 0 main thread setTimeouts, starting counting after first ended event]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 1 main thread setTimeouts, starting counting after first ended event]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 2 main thread setTimeouts, starting counting after first ended event]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 3 main thread setTimeouts, starting counting after first ended event]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 4 main thread setTimeouts, starting counting after first ended event]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 5 main thread setTimeouts, starting counting after first ended event]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 6 main thread setTimeouts, starting counting after first ended event]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 7 main thread setTimeouts, starting counting after first ended event]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 8 main thread setTimeouts, starting counting after first ended event]
+    expected: FAIL
+
+  [Test worker MediaSource termination after at least 9 main thread setTimeouts, starting counting after first ended event]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/dedicated-worker/mediasource-worker-play.html.ini
+++ b/tests/wpt/meta/media-source/dedicated-worker/mediasource-worker-play.html.ini
@@ -1,0 +1,3 @@
+[mediasource-worker-play.html]
+  [Test worker MediaSource construction, attachment, buffering and basic playback]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/idlharness.window.js.ini
+++ b/tests/wpt/meta/media-source/idlharness.window.js.ini
@@ -1,0 +1,108 @@
+[idlharness.window.html]
+  [Partial interface AudioTrack: valid exposure set]
+    expected: FAIL
+
+  [Partial interface VideoTrack: valid exposure set]
+    expected: FAIL
+
+  [Partial interface TextTrack: valid exposure set]
+    expected: FAIL
+
+  [MediaSourceHandle interface: existence and properties of interface object]
+    expected: FAIL
+
+  [MediaSourceHandle interface object length]
+    expected: FAIL
+
+  [MediaSourceHandle interface object name]
+    expected: FAIL
+
+  [MediaSourceHandle interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [MediaSourceHandle interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [MediaSourceHandle interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [ManagedMediaSource interface: existence and properties of interface object]
+    expected: FAIL
+
+  [ManagedMediaSource interface object length]
+    expected: FAIL
+
+  [ManagedMediaSource interface object name]
+    expected: FAIL
+
+  [ManagedMediaSource interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [ManagedMediaSource interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [ManagedMediaSource interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [ManagedMediaSource interface: attribute streaming]
+    expected: FAIL
+
+  [ManagedMediaSource interface: attribute onstartstreaming]
+    expected: FAIL
+
+  [ManagedMediaSource interface: attribute onendstreaming]
+    expected: FAIL
+
+  [BufferedChangeEvent interface: existence and properties of interface object]
+    expected: FAIL
+
+  [BufferedChangeEvent interface object length]
+    expected: FAIL
+
+  [BufferedChangeEvent interface object name]
+    expected: FAIL
+
+  [BufferedChangeEvent interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [BufferedChangeEvent interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [BufferedChangeEvent interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [BufferedChangeEvent interface: attribute addedRanges]
+    expected: FAIL
+
+  [BufferedChangeEvent interface: attribute removedRanges]
+    expected: FAIL
+
+  [ManagedSourceBuffer interface: existence and properties of interface object]
+    expected: FAIL
+
+  [ManagedSourceBuffer interface object length]
+    expected: FAIL
+
+  [ManagedSourceBuffer interface object name]
+    expected: FAIL
+
+  [ManagedSourceBuffer interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [ManagedSourceBuffer interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [ManagedSourceBuffer interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [ManagedSourceBuffer interface: attribute onbufferedchange]
+    expected: FAIL
+
+  [AudioTrack interface: attribute sourceBuffer]
+    expected: FAIL
+
+  [VideoTrack interface: attribute sourceBuffer]
+    expected: FAIL
+
+  [TextTrack interface: attribute sourceBuffer]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/invalid-third-block.html.ini
+++ b/tests/wpt/meta/media-source/invalid-third-block.html.ini
@@ -1,0 +1,3 @@
+[invalid-third-block.html]
+  [invalid-third-block]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/last-frame-dimensions.html.ini
+++ b/tests/wpt/meta/media-source/last-frame-dimensions.html.ini
@@ -1,0 +1,6 @@
+[last-frame-dimensions.html]
+  [setup]
+    expected: FAIL
+
+  [last frame dimensions]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-activesourcebuffers.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-activesourcebuffers.html.ini
@@ -1,0 +1,2 @@
+[mediasource-activesourcebuffers.html]
+  expected: ERROR

--- a/tests/wpt/meta/media-source/mediasource-addsourcebuffer-mode.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-addsourcebuffer-mode.html.ini
@@ -1,0 +1,3 @@
+[mediasource-addsourcebuffer-mode.html]
+  [addSourceBuffer() sets SourceBuffer.mode to 'sequence' when the generate timestamps flag is true]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-addsourcebuffer.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-addsourcebuffer.html.ini
@@ -1,0 +1,12 @@
+[mediasource-addsourcebuffer.html]
+  [Test addSourceBuffer() with Vorbis and VP8 in separate SourceBuffers]
+    expected: FAIL
+
+  [Test addSourceBuffer() audio only]
+    expected: FAIL
+
+  [Test addSourceBuffer() with AAC and H.264]
+    expected: FAIL
+
+  [Test addSourceBuffer() with AAC and H.264 in separate SourceBuffers]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-append-buffer.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-append-buffer.html.ini
@@ -1,0 +1,22 @@
+[mediasource-append-buffer.html]
+  expected: TIMEOUT
+  [Test SourceBuffer.abort() call during a pending appendBuffer().]
+    expected: FAIL
+
+  [Test MediaSource.removeSourceBuffer() call during a pending appendBuffer().]
+    expected: FAIL
+
+  [Test appendBuffer with partial init segments.]
+    expected: FAIL
+
+  [Test appendBuffer more Audio tracks than Video tracks]
+    expected: FAIL
+
+  [Test appendBuffer with partial media segments.]
+    expected: TIMEOUT
+
+  [Test appendBuffer events order.]
+    expected: FAIL
+
+  [Test abort in the middle of an initialization segment.]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-appendbuffer-quota-exceeded.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-appendbuffer-quota-exceeded.html.ini
@@ -1,0 +1,2 @@
+[mediasource-appendbuffer-quota-exceeded.html]
+  expected: ERROR

--- a/tests/wpt/meta/media-source/mediasource-avtracks.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-avtracks.html.ini
@@ -1,0 +1,13 @@
+[mediasource-avtracks.html]
+  expected: TIMEOUT
+  [Check that media tracks and their properties are populated properly]
+    expected: TIMEOUT
+
+  [Media tracks must be removed when the SourceBuffer is removed from the MediaSource]
+    expected: TIMEOUT
+
+  [Media tracks must be removed when the HTMLMediaElement.src is changed]
+    expected: FAIL
+
+  [Media tracks must be removed when HTMLMediaElement.load() is called]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-buffered-seek.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-buffered-seek.html.ini
@@ -1,0 +1,4 @@
+[mediasource-buffered-seek.html]
+  expected: TIMEOUT
+  [Test seeking to a buffered location.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/media-source/mediasource-buffered.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-buffered.html.ini
@@ -1,0 +1,2 @@
+[mediasource-buffered.html]
+  expected: ERROR

--- a/tests/wpt/meta/media-source/mediasource-changetype-play-implicit.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-changetype-play-implicit.html.ini
@@ -1,0 +1,24 @@
+[mediasource-changetype-play-implicit.html]
+  [Test video-only implicit changeType for video/webm; codecs="vp8" <-> video/webm; codecs="vp8"]
+    expected: FAIL
+
+  [Test video-only implicit changeType for video/webm; codecs="vp8" <-> video/webm; codecs="vp8" (using types without codecs parameters for addSourceBuffer)]
+    expected: FAIL
+
+  [Test video-only implicit changeType for video/webm; codecs="vp8" <-> video/webm; codecs="vp9"]
+    expected: FAIL
+
+  [Test video-only implicit changeType for video/webm; codecs="vp8" <-> video/webm; codecs="vp9" (using types without codecs parameters for addSourceBuffer)]
+    expected: FAIL
+
+  [Test video-only implicit changeType for video/webm; codecs="vp9" <-> video/webm; codecs="vp8"]
+    expected: FAIL
+
+  [Test video-only implicit changeType for video/webm; codecs="vp9" <-> video/webm; codecs="vp8" (using types without codecs parameters for addSourceBuffer)]
+    expected: FAIL
+
+  [Test video-only implicit changeType for video/webm; codecs="vp9" <-> video/webm; codecs="vp9"]
+    expected: FAIL
+
+  [Test video-only implicit changeType for video/webm; codecs="vp9" <-> video/webm; codecs="vp9" (using types without codecs parameters for addSourceBuffer)]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-changetype-play-negative.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-changetype-play-negative.html.ini
@@ -1,0 +1,3 @@
+[mediasource-changetype-play-negative.html]
+  [Check if browser supports enough test media types across audio and video for changeType negative tests]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-changetype-play-without-codecs-parameter.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-changetype-play-without-codecs-parameter.html.ini
@@ -1,0 +1,15 @@
+[mediasource-changetype-play-without-codecs-parameter.html]
+  [Check if browser supports enough test media types]
+    expected: FAIL
+
+  [Test video-only changeType for video/webm; codecs="vp8" <-> video/webm; codecs="vp8" (using types without codecs parameters)]
+    expected: FAIL
+
+  [Test video-only changeType for video/webm; codecs="vp8" <-> video/webm; codecs="vp9" (using types without codecs parameters)]
+    expected: FAIL
+
+  [Test video-only changeType for video/webm; codecs="vp9" <-> video/webm; codecs="vp8" (using types without codecs parameters)]
+    expected: FAIL
+
+  [Test video-only changeType for video/webm; codecs="vp9" <-> video/webm; codecs="vp9" (using types without codecs parameters)]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-changetype-play.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-changetype-play.html.ini
@@ -1,0 +1,15 @@
+[mediasource-changetype-play.html]
+  [Check if browser supports enough test media types]
+    expected: FAIL
+
+  [Test video-only changeType for video/webm; codecs="vp8" <-> video/webm; codecs="vp8"]
+    expected: FAIL
+
+  [Test video-only changeType for video/webm; codecs="vp8" <-> video/webm; codecs="vp9"]
+    expected: FAIL
+
+  [Test video-only changeType for video/webm; codecs="vp9" <-> video/webm; codecs="vp8"]
+    expected: FAIL
+
+  [Test video-only changeType for video/webm; codecs="vp9" <-> video/webm; codecs="vp9"]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-changetype.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-changetype.html.ini
@@ -1,0 +1,6 @@
+[mediasource-changetype.html]
+  [Test changeType sets mode to sequence for change to type that generates timestamps]
+    expected: FAIL
+
+  [Test changeType retains previous mode when changing to type that doesn't generate timestamps]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-closed.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-closed.html.ini
@@ -1,0 +1,12 @@
+[mediasource-closed.html]
+  [Test removeSourceBuffer() while closed.]
+    expected: FAIL
+
+  [Test setting duration while open->closed.]
+    expected: FAIL
+
+  [Test getting duration while open->closed.]
+    expected: FAIL
+
+  [Test sourcebuffer.abort when closed.]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-config-change-mp4-a-bitrate.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-config-change-mp4-a-bitrate.html.ini
@@ -1,0 +1,3 @@
+[mediasource-config-change-mp4-a-bitrate.html]
+  [Tests mp4 audio-only bitrate changes.]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-config-change-mp4-av-audio-bitrate.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-config-change-mp4-av-audio-bitrate.html.ini
@@ -1,0 +1,3 @@
+[mediasource-config-change-mp4-av-audio-bitrate.html]
+  [Tests mp4 audio bitrate changes in multiplexed content.]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-config-change-mp4-av-framesize.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-config-change-mp4-av-framesize.html.ini
@@ -1,0 +1,3 @@
+[mediasource-config-change-mp4-av-framesize.html]
+  [Tests mp4 frame size changes in multiplexed content.]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-config-change-mp4-av-video-bitrate.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-config-change-mp4-av-video-bitrate.html.ini
@@ -1,0 +1,3 @@
+[mediasource-config-change-mp4-av-video-bitrate.html]
+  [Tests mp4 video bitrate changes in multiplexed content.]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-config-change-mp4-v-bitrate.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-config-change-mp4-v-bitrate.html.ini
@@ -1,0 +1,3 @@
+[mediasource-config-change-mp4-v-bitrate.html]
+  [Tests mp4 video-only bitrate changes.]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-config-change-mp4-v-framerate.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-config-change-mp4-v-framerate.html.ini
@@ -1,0 +1,3 @@
+[mediasource-config-change-mp4-v-framerate.html]
+  [Tests mp4 video-only frame rate changes.]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-config-change-mp4-v-framesize.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-config-change-mp4-v-framesize.html.ini
@@ -1,0 +1,3 @@
+[mediasource-config-change-mp4-v-framesize.html]
+  [Tests mp4 video-only frame size changes.]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-config-change-webm-a-bitrate.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-config-change-webm-a-bitrate.html.ini
@@ -1,0 +1,3 @@
+[mediasource-config-change-webm-a-bitrate.html]
+  [Tests webm audio-only bitrate changes.]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-config-change-webm-v-bitrate.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-config-change-webm-v-bitrate.html.ini
@@ -1,0 +1,3 @@
+[mediasource-config-change-webm-v-bitrate.html]
+  [Tests webm video-only bitrate changes.]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-config-change-webm-v-framerate.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-config-change-webm-v-framerate.html.ini
@@ -1,0 +1,3 @@
+[mediasource-config-change-webm-v-framerate.html]
+  [Tests webm video-only frame rate changes.]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-config-change-webm-v-framesize.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-config-change-webm-v-framesize.html.ini
@@ -1,0 +1,3 @@
+[mediasource-config-change-webm-v-framesize.html]
+  [Tests webm video-only frame size changes.]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-correct-frames-after-reappend.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-correct-frames-after-reappend.html.ini
@@ -1,0 +1,4 @@
+[mediasource-correct-frames-after-reappend.html]
+  expected: ERROR
+  [Test the expected frames are played at the expected times, even in presence of reappends]
+    expected: TIMEOUT

--- a/tests/wpt/meta/media-source/mediasource-correct-frames.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-correct-frames.html.ini
@@ -1,0 +1,4 @@
+[mediasource-correct-frames.html]
+  expected: ERROR
+  [Test the expected frames are played at the expected times]
+    expected: TIMEOUT

--- a/tests/wpt/meta/media-source/mediasource-duration.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-duration.html.ini
@@ -1,0 +1,2 @@
+[mediasource-duration.html]
+  expected: ERROR

--- a/tests/wpt/meta/media-source/mediasource-endofstream.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-endofstream.html.ini
@@ -1,0 +1,6 @@
+[mediasource-endofstream.html]
+  [MediaSource.endOfStream(): duration truncated to 0 when there are no buffered coded frames]
+    expected: FAIL
+
+  [MediaSource.endOfStream(): duration and buffered range end time before and after endOfStream]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-errors.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-errors.html.ini
@@ -1,0 +1,10 @@
+[mediasource-errors.html]
+  expected: TIMEOUT
+  [Appending media segment before the first initialization segment.]
+    expected: TIMEOUT
+
+  [Signaling 'decode' error via endOfStream() before initialization segment has been appended.]
+    expected: TIMEOUT
+
+  [Signaling 'network' error via endOfStream() before initialization segment has been appended.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/media-source/mediasource-getvideoplaybackquality.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-getvideoplaybackquality.html.ini
@@ -1,0 +1,3 @@
+[mediasource-getvideoplaybackquality.html]
+  [Test HTMLVideoElement.getVideoPlaybackQuality() with MediaSource API]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-iamf-playback.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-iamf-playback.html.ini
@@ -1,0 +1,3 @@
+[mediasource-iamf-playback.html]
+  [IAMF MSE audio playback advances currentTime]
+    expected: PRECONDITION_FAILED

--- a/tests/wpt/meta/media-source/mediasource-invalid-codec.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-invalid-codec.html.ini
@@ -1,0 +1,7 @@
+[mediasource-invalid-codec.html]
+  expected: TIMEOUT
+  [Test an MP4 with an invalid codec results in an error.]
+    expected: FAIL
+
+  [Test a WebM with an invalid codec results in an error.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/media-source/mediasource-is-type-supported.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-is-type-supported.html.ini
@@ -1,0 +1,54 @@
+[mediasource-is-type-supported.html]
+  [Test valid WebM type "audio/webm;codecs="vorbis""]
+    expected: FAIL
+
+  [Test valid WebM type "AUDIO/WEBM;CODECS="vorbis""]
+    expected: FAIL
+
+  [Test valid WebM type "audio/webm;codecs=vorbis;test="6""]
+    expected: FAIL
+
+  [Test valid WebM type "audio/webm;codecs="opus""]
+    expected: FAIL
+
+  [Test valid WebM type "video/webm;codecs="opus""]
+    expected: FAIL
+
+  [Test valid MP4 type "video/mp4;codecs="avc1.4d001e""]
+    expected: FAIL
+
+  [Test valid MP4 type "video/mp4;codecs="avc1.42001e""]
+    expected: FAIL
+
+  [Test valid MP4 type "audio/mp4;codecs="mp4a.40.2""]
+    expected: FAIL
+
+  [Test valid MP4 type "audio/mp4;codecs="mp4a.40.5""]
+    expected: FAIL
+
+  [Test valid MP4 type "audio/mp4;codecs="mp4a.67""]
+    expected: FAIL
+
+  [Test valid MP4 type "video/mp4;codecs="mp4a.40.2""]
+    expected: FAIL
+
+  [Test valid MP4 type "video/mp4;codecs="avc1.4d001e,mp4a.40.2""]
+    expected: FAIL
+
+  [Test valid MP4 type "video/mp4;codecs="mp4a.40.2 , avc1.4d001e ""]
+    expected: FAIL
+
+  [Test valid MP4 type "video/mp4;codecs="avc1.4d001e,mp4a.40.5""]
+    expected: FAIL
+
+  [Test valid MP4 type "audio/mp4;codecs="Opus""]
+    expected: FAIL
+
+  [Test valid MP4 type "video/mp4;codecs="Opus""]
+    expected: FAIL
+
+  [Test valid MP4 type "audio/mp4;codecs="fLaC""]
+    expected: FAIL
+
+  [Test valid MP4 type "video/mp4;codecs="fLaC""]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-multiple-attach.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-multiple-attach.html.ini
@@ -1,0 +1,4 @@
+[mediasource-multiple-attach.html]
+  expected: TIMEOUT
+  [Test that MediaSource can reattach if closed first]
+    expected: TIMEOUT

--- a/tests/wpt/meta/media-source/mediasource-play-then-seek-back.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-play-then-seek-back.html.ini
@@ -1,0 +1,4 @@
+[mediasource-play-then-seek-back.html]
+  expected: TIMEOUT
+  [Test playing then seeking back.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/media-source/mediasource-play.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-play.html.ini
@@ -1,0 +1,3 @@
+[mediasource-play.html]
+  [Test normal playback case with MediaSource API]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-redundant-seek.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-redundant-seek.html.ini
@@ -1,0 +1,4 @@
+[mediasource-redundant-seek.html]
+  expected: TIMEOUT
+  [Test redundant fully prebuffered seek]
+    expected: TIMEOUT

--- a/tests/wpt/meta/media-source/mediasource-remove.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-remove.html.ini
@@ -1,0 +1,15 @@
+[mediasource-remove.html]
+  [Test aborting a remove operation.]
+    expected: FAIL
+
+  [Test removing all appended data.]
+    expected: FAIL
+
+  [Test removing beginning of appended data.]
+    expected: FAIL
+
+  [Test removing the middle of appended data.]
+    expected: FAIL
+
+  [Test removing the end of appended data.]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-removesourcebuffer.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-removesourcebuffer.html.ini
@@ -1,0 +1,3 @@
+[mediasource-removesourcebuffer.html]
+  [Test calling removeSourceBuffer() for a sourceBuffer belonging to a different mediaSource instance.]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-replay.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-replay.html.ini
@@ -1,0 +1,4 @@
+[mediasource-replay.html]
+  expected: TIMEOUT
+  [Test replaying video after 'ended']
+    expected: TIMEOUT

--- a/tests/wpt/meta/media-source/mediasource-seek-beyond-duration.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-seek-beyond-duration.html.ini
@@ -1,0 +1,7 @@
+[mediasource-seek-beyond-duration.html]
+  expected: TIMEOUT
+  [Test seeking beyond updated media duration.]
+    expected: TIMEOUT
+
+  [Test seeking beyond media duration.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/media-source/mediasource-seek-during-pending-seek.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-seek-during-pending-seek.html.ini
@@ -1,0 +1,7 @@
+[mediasource-seek-during-pending-seek.html]
+  expected: TIMEOUT
+  [Test seeking to a new location before transitioning beyond HAVE_METADATA.]
+    expected: TIMEOUT
+
+  [Test seeking to a new location during a pending seek.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/media-source/mediasource-seekable.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-seekable.html.ini
@@ -1,0 +1,3 @@
+[mediasource-seekable.html]
+  [Get seekable time ranges when the sourcebuffer is empty.]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-sequencemode-append-buffer.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-sequencemode-append-buffer.html.ini
@@ -1,0 +1,9 @@
+[mediasource-sequencemode-append-buffer.html]
+  [Test sequence AppendMode appendBuffer(first media segment)]
+    expected: FAIL
+
+  [Test sequence AppendMode appendBuffer(second media segment)]
+    expected: FAIL
+
+  [Test sequence AppendMode appendBuffer(second media segment, then first media segment)]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-sourcebuffer-mode-timestamps.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-sourcebuffer-mode-timestamps.html.ini
@@ -1,0 +1,6 @@
+[mediasource-sourcebuffer-mode-timestamps.html]
+  [audio/aac : If generate timestamps flag equals true and new mode equals "segments", then throw a TypeError exception and abort these steps.]
+    expected: FAIL
+
+  [audio/mpeg : If generate timestamps flag equals true and new mode equals "segments", then throw a TypeError exception and abort these steps.]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mediasource-sourcebufferlist.html.ini
+++ b/tests/wpt/meta/media-source/mediasource-sourcebufferlist.html.ini
@@ -1,0 +1,9 @@
+[mediasource-sourcebufferlist.html]
+  [Test SourceBufferList getter method]
+    expected: FAIL
+
+  [Test SourceBufferList event dispatching.]
+    expected: FAIL
+
+  [Test that only 1 removesourcebuffer event fires on each SourceBufferList when the MediaSource closes.]
+    expected: FAIL

--- a/tests/wpt/meta/media-source/mse-for-webcodecs/tentative/mediasource-encrypted-webcodecs-appendencodedchunks-play.https.html.ini
+++ b/tests/wpt/meta/media-source/mse-for-webcodecs/tentative/mediasource-encrypted-webcodecs-appendencodedchunks-play.https.html.ini
@@ -1,0 +1,2 @@
+[mediasource-encrypted-webcodecs-appendencodedchunks-play.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/media-source/mse-for-webcodecs/tentative/mediasource-webcodecs-addsourcebuffer.html.ini
+++ b/tests/wpt/meta/media-source/mse-for-webcodecs/tentative/mediasource-webcodecs-addsourcebuffer.html.ini
@@ -1,0 +1,2 @@
+[mediasource-webcodecs-addsourcebuffer.html]
+  expected: ERROR

--- a/tests/wpt/meta/media-source/mse-for-webcodecs/tentative/mediasource-webcodecs-appendencodedchunks-play.html.ini
+++ b/tests/wpt/meta/media-source/mse-for-webcodecs/tentative/mediasource-webcodecs-appendencodedchunks-play.html.ini
@@ -1,0 +1,2 @@
+[mediasource-webcodecs-appendencodedchunks-play.html]
+  expected: ERROR

--- a/tests/wpt/meta/media-source/waiting-for-audio.html.ini
+++ b/tests/wpt/meta/media-source/waiting-for-audio.html.ini
@@ -1,0 +1,3 @@
+[waiting-for-audio.html]
+  [playback after waiting for audio]
+    expected: FAIL


### PR DESCRIPTION
Implements the [Media Source API](https://w3c.github.io/media-source/) behind a new `dom_media_source_enabled` preference: `MediaSource`, `SourceBuffer` and `SourceBufferList`, the media source object URL store that `URL.createObjectURL()` writes to, and the media element attachment steps that read from it.

### How it works

`components/script/dom/media/bytestream.rs` walks the ISO BMFF box tree and the WebM EBML tree far enough to drive the observable state of a source buffer, without decoding anything:

- the tracks an initialization segment declares, which become the `AudioTrack` and `VideoTrack` objects of the source buffer and decide whether it belongs in `activeSourceBuffers`;
- the duration it carries, which seeds `MediaSource.duration` through the duration change algorithm;
- the presentation interval each media segment covers, per track — `moof`/`traf`/`tfdt`/`trun` for ISO BMFF, `Cluster`/`Timecode` for WebM — so that `SourceBuffer.buffered` can report the intersection of the track buffer ranges the specification asks for.

The appended bytes themselves are handed to the media backend in append order through the existing `servosrc` element, so playback runs through the same `playbin3` pipeline a fetched resource does. The element is marked non-seekable and given no input size, so the backend never tries to pull byte ranges of its own.

### Known limitations

Each of these is observable from script rather than silent, and is a follow-up rather than something this change papers over:

- **One source buffer per media source.** The backend is handed a single byte stream, so a second `addSourceBuffer()` throws `QuotaExceededError`, which step 3 of the algorithm allows. Muxed content plays; presentations that split audio and video into separate buffers do not yet. Lifting this needs `servosrc` to expose one appsrc per source buffer, which is the natural next step.
- **Coded frame processing is not implemented.** `timestampOffset`, `appendWindowStart` and `appendWindowEnd` are stored and returned with all the exceptions the specification asks for, but they do not move or drop any coded frame, and `buffered` deliberately reports where the media actually is rather than where applying them would have put it, so that it never disagrees with what playback can reach.
- **`remove()` stops reporting an interval as buffered** but cannot make the backend drop frames it already holds, so appending over a removed range is not supported.
- **`changeType()` only accepts a type in the same byte stream format** and throws `NotSupportedError` otherwise, since the backend cannot follow a container change part way through a stream.
- No `MediaSourceHandle` and no `DedicatedWorker` exposure — `canConstructInDedicatedWorker` returns false — and no `ManagedMediaSource`.

### A note on the overlap

This issue is assigned to @calvaris, and #40423 is an earlier draft covering some of the same ground. This work was written because we needed the feature for our own use rather than to get ahead of anyone, and it is offered in that spirit: if it is more useful as a reference for the assigned work than as a change to land on its own, please treat it that way, and I am happy to split it up, rebase it onto other work, or close it.


Testing: Enables the `media-source` WPT directory, where 293 subtests pass and the rest are recorded as expectations. Playback was also exercised end to end against a WebM stream appended in 32 KiB pieces, which reaches `playing` and then `ended`, with `buffered` reporting `[0.000, 2.000)` and `duration` following the media source. Two large groups of those failures are the limitations above: 56 subtests require `canConstructInDedicatedWorker` to be true, and roughly 30 more require `ManagedMediaSource`, `MediaSourceHandle` or `BufferedChangeEvent`. A further group cannot run at all because this machine's media stack reports no support for the H.264, AAC, Vorbis and Opus types the tests ask for, so the recorded expectations are likely pessimistic compared to CI. The byte stream parsers also carry unit tests covering initialization and media segments in both formats, segments split across appends, and malformed input.
Part of #44403
