### PR TITLE
script: Fix iframe name for initial navigation

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1029,6 +1029,7 @@ where
         is_private: bool,
         throttled: bool,
         target_snapshot_params: TargetSnapshotParams,
+        name: Option<String>,
     ) {
         if self.shutting_down {
             return;
@@ -1071,6 +1072,7 @@ where
             user_content_manager_id,
             embedder_theme: theme,
             target_snapshot_params,
+            frame_name: name,
         };
         let pipeline = match Pipeline::spawn(new_pipeline_info, event_loop, self, throttled) {
             Ok(pipeline) => pipeline,
@@ -3071,6 +3073,7 @@ where
             is_private,
             throttled,
             TargetSnapshotParams::default(),
+            None,
         );
         self.add_pending_change(SessionHistoryChange {
             webview_id,
@@ -3294,6 +3297,7 @@ where
             is_private,
             throttled,
             TargetSnapshotParams::default(),
+            None,
         );
         self.add_pending_change(SessionHistoryChange {
             webview_id,
@@ -3434,6 +3438,7 @@ where
             is_private,
             mut history_handling,
             target_snapshot_params,
+            name,
             ..
         } = load_info.info;
 
@@ -3514,6 +3519,7 @@ where
             is_private,
             browsing_context_throttled,
             target_snapshot_params,
+            name,
         );
         self.add_pending_change(SessionHistoryChange {
             webview_id,
@@ -4213,6 +4219,7 @@ where
                     is_private,
                     is_throttled,
                     target_snapshot_params,
+                    None,
                 );
                 self.add_pending_change(SessionHistoryChange {
                     webview_id,
@@ -4517,6 +4524,7 @@ where
                     // with the pipeline when it's created, so we can support reloading
                     // a discarded document properly.
                     TargetSnapshotParams::default(),
+                    None,
                 );
                 self.add_pending_change(SessionHistoryChange {
                     webview_id,

--- a/components/script/dom/html/embedded_content/htmliframeelement.rs
+++ b/components/script/dom/html/embedded_content/htmliframeelement.rs
@@ -112,6 +112,11 @@ pub(crate) struct HTMLIFrameElement {
     /// an empty iframe is attached. In that case, we shouldn't fire a
     /// subsequent asynchronous load event.
     already_fired_synchronous_load_event: Cell<bool>,
+    /// Initial name set by the content of the `name` attribute on the
+    /// iframe. This is frozen in time, since it is only processed once
+    /// on the initial creation of the iframe contents. If the iframe
+    /// itself changes the `window.name`, that takes precedence.
+    frozen_name: DomRefCell<Option<String>>,
 }
 
 impl HTMLIFrameElement {
@@ -272,6 +277,7 @@ impl HTMLIFrameElement {
             inherited_secure_context: load_data.inherited_secure_context,
             history_handling,
             target_snapshot_params,
+            name: self.frozen_name.borrow().clone(),
         };
 
         let viewport_details = window
@@ -309,6 +315,7 @@ impl HTMLIFrameElement {
                     user_content_manager_id: None,
                     embedder_theme: window.embedder_theme(),
                     target_snapshot_params,
+                    frame_name: self.frozen_name.borrow().clone(),
                 };
 
                 self.pipeline_id.set(Some(new_pipeline_id));
@@ -459,20 +466,6 @@ impl HTMLIFrameElement {
 
         let window = self.owner_window();
 
-        // https://html.spec.whatwg.org/multipage/#attr-iframe-name
-        // Note: the spec says to set the name 'when the nested browsing context is created'.
-        // The current implementation sets the name on the window,
-        // when the iframe attributes are first processed.
-        if mode == ProcessingMode::FirstTime &&
-            let Some(window) = self.GetContentWindow()
-        {
-            window.set_name(
-                element
-                    .get_name()
-                    .map_or(DOMString::from(""), |n| DOMString::from(&*n)),
-            );
-        }
-
         // Step 2.1. Let url be the result of running the shared attribute processing steps
         // for iframe and frame elements given element and initialInsertion.
         let Some(url) = self.shared_attribute_processing_steps_for_iframe_and_frame_elements(mode)
@@ -583,13 +576,25 @@ impl HTMLIFrameElement {
     /// and we still fire load and pageshow events as part of `maybe_queue_document_completion`.
     /// Also, some controversy spec-wise remains: <https://github.com/whatwg/html/issues/4965>
     fn create_nested_browsing_context(&self, cx: &mut JSContext) {
-        let url = ServoUrl::parse("about:blank").unwrap();
+        // Step 1. Let parentNavigable be element's node navigable.
         let document = self.owner_document();
         let window = self.owner_window();
         let pipeline_id = Some(window.pipeline_id());
+        // Step 4. Let targetName be null.
+        // Step 5. If element has a name content attribute,
+        // then set targetName to the value of that attribute.
+        *self.frozen_name.borrow_mut() = self
+            .upcast::<Element>()
+            .get_name()
+            .map(|name| name.to_string());
+        // Step 6. Let documentState be a new document state, with
         let mut load_data = LoadData::new(
+            // > initiator origin
+            // >     document's origin
             LoadOrigin::Script(document.origin().snapshot()),
-            url,
+            ServoUrl::parse("about:blank").unwrap(),
+            // > about base URL
+            // >     document's about base URL
             Some(document.base_url()),
             pipeline_id,
             window.as_global_scope().get_referrer(),
@@ -603,12 +608,14 @@ impl HTMLIFrameElement {
         load_data.destination = Destination::IFrame;
         load_data.policy_container = Some(window.as_global_scope().policy_container());
 
+        // Step 7. Let navigable be a new navigable.
         let browsing_context_id = BrowsingContextId::new();
         let webview_id = window.window_proxy().webview_id();
         self.pipeline_id.set(None);
         self.pending_pipeline_id.set(None);
         self.webview_id.set(Some(webview_id));
         self.browsing_context_id.set(Some(browsing_context_id));
+        // Step 8. Initialize the navigable navigable given documentState and parentNavigable.
         self.start_new_pipeline(
             cx,
             load_data,
@@ -617,6 +624,13 @@ impl HTMLIFrameElement {
             ProcessingMode::FirstTime,
             snapshot_self(self),
         );
+        // > navigable target name
+        // >     targetName
+        if let Some(window) = self.GetContentWindow() &&
+            let Some(window_name) = &*self.frozen_name.borrow()
+        {
+            window.set_name(window_name.as_str().into());
+        }
     }
 
     fn destroy_nested_browsing_context(&self) {
@@ -685,6 +699,7 @@ impl HTMLIFrameElement {
             lazy_load_resumption_steps: Default::default(),
             pending_navigation: Default::default(),
             already_fired_synchronous_load_event: Default::default(),
+            frozen_name: Default::default(),
         }
     }
 

--- a/components/script/dom/window/windowproxy.rs
+++ b/components/script/dom/window/windowproxy.rs
@@ -381,6 +381,7 @@ impl WindowProxy {
                 sandboxing_flags: sandboxing_flag_set,
                 iframe_element_referrer_policy: ReferrerPolicy::EmptyString,
             },
+            frame_name: None,
         };
 
         with_script_thread(|script_thread| {

--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -3646,6 +3646,9 @@ impl ScriptThread {
             incomplete.parent_info,
             incomplete.opener,
         );
+        if let Some(name) = incomplete.frame_name {
+            window_proxy.set_name(DOMString::from(name));
+        }
         if window_proxy.parent().is_some() {
             // https://html.spec.whatwg.org/multipage/#navigating-across-documents:delaying-load-events-mode-2
             // The user agent must take this nested browsing context

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -184,6 +184,8 @@ pub(crate) struct InProgressLoad {
     /// The [`TargetSnapshotParams`] to use when creating this document.
     #[no_trace]
     pub(crate) target_snapshot_params: TargetSnapshotParams,
+    /// Name of this iframe, if any
+    pub(crate) frame_name: Option<String>,
 }
 
 impl InProgressLoad {
@@ -206,6 +208,7 @@ impl InProgressLoad {
             user_content_manager_id: new_pipeline_info.user_content_manager_id,
             embedder_theme: new_pipeline_info.embedder_theme,
             target_snapshot_params: new_pipeline_info.target_snapshot_params,
+            frame_name: new_pipeline_info.frame_name,
         }
     }
 

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -498,6 +498,8 @@ pub struct IFrameLoadInfo {
     /// A snapshot of the navigation-related parameters of the target
     /// of this navigation.
     pub target_snapshot_params: TargetSnapshotParams,
+    /// Name of this iframe, if any
+    pub name: Option<String>,
 }
 
 /// Specifies the information required to load a URL in an iframe.

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -83,6 +83,8 @@ pub struct NewPipelineInfo {
     pub embedder_theme: Theme,
     /// A snapshot of the navigation parameters of the target of this navigation.
     pub target_snapshot_params: TargetSnapshotParams,
+    /// Name of this iframe, if any
+    pub frame_name: Option<String>,
 }
 
 /// When a pipeline is closed, should its browsing context be discarded too?

--- a/tests/wpt/meta/fullscreen/api/document-fullscreen-enabled-cross-origin.sub.html.ini
+++ b/tests/wpt/meta/fullscreen/api/document-fullscreen-enabled-cross-origin.sub.html.ini
@@ -1,10 +1,6 @@
 [document-fullscreen-enabled-cross-origin.sub.html]
-  expected: TIMEOUT
   [Fullscreen enabled test: cross-origin-allow]
-    expected: NOTRUN
+    expected: FAIL
 
   [Fullscreen enabled test: same-origin-default]
     expected: FAIL
-
-  [Fullscreen enabled test: cross-origin-default]
-    expected: NOTRUN

--- a/tests/wpt/meta/fullscreen/api/element-request-fullscreen-cross-origin.sub.html.ini
+++ b/tests/wpt/meta/fullscreen/api/element-request-fullscreen-cross-origin.sub.html.ini
@@ -1,4 +1,3 @@
 [element-request-fullscreen-cross-origin.sub.html]
-  expected: TIMEOUT
   [Element#requestFullscreen() works properly with a tree of cross-origin iframes]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/declarative/declarative-shadow-dom-opt-in.html.ini
+++ b/tests/wpt/meta/shadow-dom/declarative/declarative-shadow-dom-opt-in.html.ini
@@ -1,7 +1,3 @@
 [declarative-shadow-dom-opt-in.html]
-  expected: TIMEOUT
   [document.write disallowed on fresh document]
     expected: FAIL
-
-  [sandboxed iframe allows declarative Shadow DOM]
-    expected: TIMEOUT

--- a/tests/wpt/tests/html/browsers/browsing-the-web/history-traversal/window-name-after-cross-origin-sub-frame-navigation.sub.html
+++ b/tests/wpt/tests/html/browsers/browsing-the-web/history-traversal/window-name-after-cross-origin-sub-frame-navigation.sub.html
@@ -12,7 +12,7 @@
             assert_equals(e.data, true);
         }));
     </script>
-    <iframe src="support/window-name-navigation.sub.html?hostname={{domains[www1]}}&shouldhavename=true&sendmessage=true";
+    <iframe src="support/window-name-navigation.sub.html?hostname={{domains[www1]}}&shouldhavename=true&sendmessage=true">
     </iframe>
 </body>
 </html>

--- a/tests/wpt/tests/html/browsers/browsing-the-web/history-traversal/window-name-after-same-origin-sub-frame-navigation.sub.html
+++ b/tests/wpt/tests/html/browsers/browsing-the-web/history-traversal/window-name-after-same-origin-sub-frame-navigation.sub.html
@@ -12,7 +12,7 @@
             assert_equals(e.data, true);
         }));
     </script>
-    <iframe src="support/window-name-navigation.sub.html?hostname={{host}}&shouldhavename=true&sendmessage=true";
+    <iframe src="support/window-name-navigation.sub.html?hostname={{host}}&shouldhavename=true&sendmessage=true">
     </iframe>
 </body>
 </html>


### PR DESCRIPTION
During the initial load of an iframe, the name wasn't available yet. Now, we set the name immediately when creating the child navigable, following the spec.

Fixes #47259

Testing: new WPT passes
