### PR TITLE
wpt: Remove all skipped test files from include.ini

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -286,8 +286,6 @@ skip: true
   skip: false
 [user-timing]
   skip: false
-  [measure_associated_with_navigation_timing.html]
-    skip: true
 [wasm]
   skip: false
 [web-animations]

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -276,22 +276,6 @@ skip: true
     skip: false
   [transferable]
     skip: false
-    [service-worker.https.html]
-      skip: true
-    [shared-worker.html]
-      skip: true
-    [transform-stream-members.any.shadowrealm-in-dedicatedworker.html]
-      skip: true
-    [transform-stream-members.any.shadowrealm-in-shadowrealm.html]
-      skip: true
-    [transform-stream-members.any.shadowrealm-in-sharedworker.html]
-      skip: true
-    [transform-stream-members.any.shadowrealm-in-window.html]
-      skip: true
-    [transform-stream-members.https.any.shadowrealm-in-audioworklet.html]
-      skip: true
-    [transform-stream-members.https.any.shadowrealm-in-serviceworker.html]
-      skip: true
   [writable-streams]
     skip: false
   [transform-streams]

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -226,10 +226,6 @@ skip: true
   skip: false
 [navigation-timing]
   skip: false
-  [test-navigation-type-reload.html]
-    skip: true
-  [test-timing-reload.html]
-    skip: true
 [notifications]
   skip: false
 [old-tests]

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -267,19 +267,7 @@ skip: true
 [shadow-dom]
   skip: false
 [streams]
-  skip: true
-  [piping]
-    skip: false
-  [readable-streams]
-    skip: false
-  [readable-byte-streams]
-    skip: false
-  [transferable]
-    skip: false
-  [writable-streams]
-    skip: false
-  [transform-streams]
-    skip: false
+  skip: false
 [subresource-integrity]
   skip: false
 [svg]

--- a/tests/wpt/meta/streams/transferable/shared-worker.html.ini
+++ b/tests/wpt/meta/streams/transferable/shared-worker.html.ini
@@ -1,6 +1,0 @@
-[shared-worker.html]
-  [worker.postMessage should be able to transfer a ReadableStream]
-    expected: FAIL
-
-  [postMessage in a worker should be able to transfer a ReadableStream]
-    expected: FAIL


### PR DESCRIPTION
It's too easy to forget about these, since they never get run as part of our CI when listed in include.ini. It's better to file issues about tests that have intermittent results so they can benefit from our related tooling.

Testing: Now running more tests.