### PR TITLE
android: Remove uninvoked `onRedrawing` callback

### DIFF
--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
@@ -299,9 +299,6 @@ class MainActivity : ComponentActivity(), Servo.Client {
         canGoForwardState.value = canGoForward
     }
 
-    override fun onRedrawing(redrawing: Boolean) {
-    }
-
     public override fun onPause() {
         servoView.onPause()
         super.onPause()

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.kt
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.kt
@@ -156,8 +156,6 @@ class Servo(
 
         fun onHistoryChanged(canGoBack: Boolean, canGoForward: Boolean)
 
-        fun onRedrawing(redrawing: Boolean)
-
         fun onImeShow()
 
         fun onImeHide()
@@ -218,10 +216,6 @@ class Servo(
 
         override fun onHistoryChanged(canGoBack: Boolean, canGoForward: Boolean) {
             runCallback.inUIThread { client.onHistoryChanged(canGoBack, canGoForward) }
-        }
-
-        override fun onRedrawing(redrawing: Boolean) {
-            runCallback.inUIThread { client.onRedrawing(redrawing) }
         }
 
         override fun onMediaSessionMetadata(title: String, artist: String, album: String) {


### PR DESCRIPTION
The native code never calls this callback, and even if it did, the Android-side just ignores this.

Testing: There are no automated tests for Android.