### PR TITLE
android: Add button to dismiss alert

### DIFF
--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
@@ -262,6 +262,7 @@ class MainActivity : ComponentActivity(), Servo.Client {
     override fun onAlert(message: String) {
         AlertDialog.Builder(this)
             .setMessage(message)
+            .setPositiveButton(android.R.string.ok, null)
             .show()
     }
 


### PR DESCRIPTION
Adds an explicit button to dismiss dialogs that are created via an `alert()` in JavaScript. The dialog can already be dismissed by hitting the back button or clicking outside the dialog, but this is all very hidden. By adding an "OK" button, there is an explicit way to dismiss the dialog if the other two options weren't self-evident.

Both the presence of this button and the wording of this button was found on Firefox for Android, Chrome for Android, and Firefox for Linux.

|Before|After|
|---|---|
|<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/01bcf224-66bf-46d5-bac7-dae728abbfd6" />|<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/cb669796-8e73-4397-bc1e-9b1b035968c8" />|

Testing: There are no automated tests for Android.