### PR TITLE
script_bindings: Add efficient ASCII case-insensitive match function for `DOMString`

### DIFF
--- a/components/script/dom/execcommand/commands/defaultparagraphseparator.rs
+++ b/components/script/dom/execcommand/commands/defaultparagraphseparator.rs
@@ -13,10 +13,12 @@ pub(crate) fn execute_default_paragraph_separator_command(
 ) -> bool {
     // > Let value be converted to ASCII lowercase. If value is then equal to "p" or "div",
     // > set the context object's default single-line container name to value, then return true. Otherwise, return false.
-    let value = match value.to_ascii_lowercase().as_str() {
-        "div" => DefaultSingleLineContainerName::Div,
-        "p" => DefaultSingleLineContainerName::Paragraph,
-        _ => return false,
+    let value = if value.eq_ignore_ascii_case("div") {
+        DefaultSingleLineContainerName::Div
+    } else if value.eq_ignore_ascii_case("p") {
+        DefaultSingleLineContainerName::Paragraph
+    } else {
+        return false;
     };
 
     document.set_default_single_line_container_name(value);

--- a/components/script/dom/execcommand/commands/stylewithcss.rs
+++ b/components/script/dom/execcommand/commands/stylewithcss.rs
@@ -9,7 +9,7 @@ use crate::dom::document::Document;
 pub(crate) fn execute_style_with_css_command(document: &Document, value: DOMString) -> bool {
     // > If value is an ASCII case-insensitive match for the string "false", set the CSS styling flag to false.
     // > Otherwise, set the CSS styling flag to true. Either way, return true.
-    let value = value.to_ascii_lowercase().as_str() != "false";
+    let value = !value.eq_ignore_ascii_case("false");
 
     document.set_css_styling_flag(value);
 

--- a/components/script/dom/html/documentmetadata/htmlmetaelement.rs
+++ b/components/script/dom/html/documentmetadata/htmlmetaelement.rs
@@ -75,10 +75,13 @@ impl HTMLMetaElement {
         // https://html.spec.whatwg.org/multipage/#attr-meta-http-equiv
         } else if !self.HttpEquiv().is_empty() {
             // TODO: Implement additional http-equiv candidates
-            match self.HttpEquiv().to_ascii_lowercase().as_str() {
-                "refresh" => self.declarative_refresh(),
-                "content-security-policy" => self.apply_csp_list(),
-                _ => {},
+            if self.HttpEquiv().eq_ignore_ascii_case("refresh") {
+                self.declarative_refresh();
+            } else if self
+                .HttpEquiv()
+                .eq_ignore_ascii_case("content-security-policy")
+            {
+                self.apply_csp_list();
             }
         }
     }

--- a/components/script/dom/html/form_controls/htmlbuttonelement.rs
+++ b/components/script/dom/html/form_controls/htmlbuttonelement.rs
@@ -263,20 +263,21 @@ impl HTMLButtonElement {
     }
 
     fn set_type(&self, cx: &mut JSContext, value: DOMString) {
-        let value = match value.to_ascii_lowercase().as_str() {
-            "reset" => ButtonType::Reset,
-            "button" => ButtonType::Button,
-            "submit" => ButtonType::Submit,
-            _ => {
-                let element = self.upcast::<Element>();
-                if element.has_attribute(&local_name!("command")) ||
-                    element.has_attribute(&local_name!("commandfor"))
-                {
-                    ButtonType::Button
-                } else {
-                    ButtonType::Submit
-                }
-            },
+        let value = if value.eq_ignore_ascii_case("reset") {
+            ButtonType::Reset
+        } else if value.eq_ignore_ascii_case("button") {
+            ButtonType::Button
+        } else if value.eq_ignore_ascii_case("submit") {
+            ButtonType::Submit
+        } else {
+            let element = self.upcast::<Element>();
+            if element.has_attribute(&local_name!("command")) ||
+                element.has_attribute(&local_name!("commandfor"))
+            {
+                ButtonType::Button
+            } else {
+                ButtonType::Submit
+            }
         };
         self.button_type.set(value);
         self.validity_state(cx)
@@ -308,11 +309,10 @@ impl HTMLButtonElement {
         if command.starts_with_str("--") {
             return CommandState::Custom;
         }
-        let value = command.to_ascii_lowercase();
-        if value == "close" {
+        if command.eq_ignore_ascii_case("close") {
             return CommandState::Close;
         }
-        if value == "show-modal" {
+        if command.eq_ignore_ascii_case("show-modal") {
             return CommandState::ShowModal;
         }
 
@@ -510,10 +510,10 @@ impl Activatable for HTMLButtonElement {
             }
             // Step 3.3 If element's type attribute is in the Auto state, then return.
             if button_type == ButtonType::Button &&
-                self.upcast::<Element>()
+                !self
+                    .upcast::<Element>()
                     .get_string_attribute(&local_name!("type"))
-                    .to_ascii_lowercase() !=
-                    "button"
+                    .eq_ignore_ascii_case("button")
             {
                 return;
             }

--- a/components/script/dom/html/form_controls/htmlinputelement.rs
+++ b/components/script/dom/html/form_controls/htmlinputelement.rs
@@ -1669,7 +1669,7 @@ impl HTMLInputElement {
             },
 
             // Step 5.9: Otherwise, if the field element is an input element whose type attribute is in the Hidden state and name is an ASCII case-insensitive match for "_charset_":
-            InputType::Hidden(_) if name.to_ascii_lowercase() == "_charset_" => {
+            InputType::Hidden(_) if name.eq_ignore_ascii_case("_charset_") => {
                 // Step 5.9.1: Let charset be the name of encoding.
                 let charset = match encoding {
                     None => DOMString::from("UTF-8"),

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -690,26 +690,25 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-contenteditable>
     fn SetContentEditable(&self, cx: &mut JSContext, value: DOMString) -> ErrorResult {
-        let lower_value = value.to_ascii_lowercase();
         let attr_name = &local_name!("contenteditable");
-        match lower_value.as_ref() {
+        if value.eq_ignore_ascii_case("inherit") {
             // > On setting, if the new value is an ASCII case-insensitive match for the string "inherit", then the content attribute must be removed,
-            "inherit" => {
-                self.element.remove_attribute_by_name(cx, attr_name);
-            },
+            self.element.remove_attribute_by_name(cx, attr_name);
+        } else if value.eq_ignore_ascii_case("true") ||
+            value.eq_ignore_ascii_case("false") ||
+            value.eq_ignore_ascii_case("plaintext-only")
+        {
             // > if the new value is an ASCII case-insensitive match for the string "true", then the content attribute must be set to the string "true",
             // > if the new value is an ASCII case-insensitive match for the string "plaintext-only", then the content attribute must be set to the string "plaintext-only",
             // > if the new value is an ASCII case-insensitive match for the string "false", then the content attribute must be set to the string "false",
-            "true" | "false" | "plaintext-only" => {
-                self.element
-                    .set_attribute(cx, attr_name, AttrValue::String(lower_value));
-            },
+            let lower_value = value.to_ascii_lowercase();
+            self.element
+                .set_attribute(cx, attr_name, AttrValue::String(lower_value));
+        } else {
             // > and otherwise the attribute setter must throw a "SyntaxError" DOMException.
-            _ => {
-                return Err(Error::Syntax(Some(
-                    "Invalid attribute for HTML element".into(),
-                )));
-            },
+            return Err(Error::Syntax(Some(
+                "Invalid attribute for HTML element".into(),
+            )));
         };
         Ok(())
     }

--- a/components/script/links.rs
+++ b/components/script/links.rs
@@ -295,7 +295,7 @@ impl LinkRelations {
         // Step 2. If element's link types do not include the opener keyword and
         //         target is an ASCII case-insensitive match for "_blank", then return true.
         let target_is_blank =
-            target_attribute_value.is_some_and(|target| target.to_ascii_lowercase() == "_blank");
+            target_attribute_value.is_some_and(|target| target.eq_ignore_ascii_case("_blank"));
         if !self.contains(Self::OPENER) && target_is_blank {
             return true;
         }
@@ -331,8 +331,10 @@ pub(crate) fn valid_navigable_target_name_or_keyword(target: &DOMString) -> bool
     if valid_navigable_target_name(target) {
         return true;
     }
-    let target = target.to_ascii_lowercase();
-    target == "_blank" || target == "_self" || target == "_parent" || target == "_top"
+    target.eq_ignore_ascii_case("_blank") ||
+        target.eq_ignore_ascii_case("_self") ||
+        target.eq_ignore_ascii_case("_parent") ||
+        target.eq_ignore_ascii_case("_top")
 }
 
 /// <https://html.spec.whatwg.org/multipage/#get-an-element%27s-target>

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -549,6 +549,20 @@ impl DOMString {
         self.str().contains(needle)
     }
 
+    /// Returns whether this [`DOMString`] is an ASCII case-insensitive match for `other`,
+    /// without allocating and copying temporaries.
+    ///
+    /// <https://infra.spec.whatwg.org/#ascii-case-insensitive>
+    pub fn eq_ignore_ascii_case(&self, other: &str) -> bool {
+        if other.is_ascii() {
+            self.encoded_bytes()
+                .bytes()
+                .eq_ignore_ascii_case(other.as_bytes())
+        } else {
+            self.str().eq_ignore_ascii_case(other)
+        }
+    }
+
     pub fn to_ascii_lowercase(&self) -> String {
         let conversion = match self.encoded_bytes() {
             EncodedBytes::Latin1(bytes) => {


### PR DESCRIPTION
There is actually [spec](https://infra.spec.whatwg.org/#ascii-case-insensitive) for this.
But it seems we always do the conversion manually in an inefficient way that allocates a new String.

Testing: Just an optimization without changing semantics.