### PR TITLE
wpt: Make domInteractive timing tests fail better.

### DIFF
--- a/tests/wpt/tests/navigation-timing/dom-interactive-image-document.html
+++ b/tests/wpt/tests/navigation-timing/dom-interactive-image-document.html
@@ -20,6 +20,6 @@
     <body>
         <h1>Description</h1>
         <p>This tests that a image document has positive-value domInteractive.</p>
-        <iframe src="../images/smiley.png" onload="frameLoaded()"></iframe>
+        <iframe src="../images/smiley.png" onload="t.step(frameLoaded)"></iframe>
     </body>
 </html>

--- a/tests/wpt/tests/navigation-timing/dom-interactive-media-document.html
+++ b/tests/wpt/tests/navigation-timing/dom-interactive-media-document.html
@@ -20,6 +20,6 @@
     <body>
         <h1>Description</h1>
         <p>This tests that a media document has positive-value domInteractive.</p>
-        <iframe src="../media/A4.webm" onload="frameLoaded()"></iframe>
+        <iframe src="../media/A4.webm" onload="t.step(frameLoaded)"></iframe>
     </body>
 </html>


### PR DESCRIPTION
Assertions should only run inside of the WPT step functions, or else the test fails with confusing ERROR/NOTRUN codes.