### PR TITLE
script: Use global's active document's navigation timing for PerformanceTiming

### DIFF
--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -5,7 +5,6 @@
 use std::cell::Cell;
 use std::cmp::Ordering;
 use std::collections::VecDeque;
-use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
@@ -39,7 +38,6 @@ use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::structuredclone;
 use crate::dom::bindings::trace::RootedTraceableBox;
-use crate::dom::document::document::NavigationTiming;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::performance::performancetiming::PerformanceTiming;
@@ -169,9 +167,8 @@ impl Performance {
         cx: &mut JSContext,
         global: &GlobalScope,
         navigation_start: CrossProcessInstant,
-        navigation_timing: Rc<NavigationTiming>,
     ) -> DomRoot<Performance> {
-        let timing = PerformanceTiming::new(cx, global, navigation_timing);
+        let timing = PerformanceTiming::new(cx, global);
         let navigation = PerformanceNavigation::new(cx, global);
         reflect_dom_object_with_cx(
             Box::new(Performance::new_inherited(

--- a/components/script/dom/performance/performancetiming.rs
+++ b/components/script/dom/performance/performancetiming.rs
@@ -7,20 +7,21 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
+use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
+use script_bindings::inheritance::Castable;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use script_bindings::root::DomRoot;
 use servo_base::cross_process_instant::CrossProcessInstant;
 
 use crate::dom::bindings::codegen::Bindings::PerformanceTimingBinding::PerformanceTimingMethods;
+use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::document::document::NavigationTiming;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::window::Window;
 
 #[dom_struct]
 pub(crate) struct PerformanceTiming {
     reflector_: Reflector,
-    #[no_trace]
-    #[conditional_malloc_size_of]
-    navigation_timing: Rc<NavigationTiming>,
     /// <https://www.w3.org/TR/navigation-timing/#dom-performancetiming-redirectstart>
     redirect_start: Cell<u64>,
     /// <https://www.w3.org/TR/navigation-timing/#dom-performancetiming-redirectend>
@@ -46,10 +47,9 @@ pub(crate) struct PerformanceTiming {
 }
 
 impl PerformanceTiming {
-    pub(crate) fn new_inherited(navigation_timing: Rc<NavigationTiming>) -> PerformanceTiming {
+    pub(crate) fn new_inherited() -> PerformanceTiming {
         PerformanceTiming {
             reflector_: Reflector::new(),
-            navigation_timing,
             redirect_start: Default::default(),
             redirect_end: Default::default(),
             fetch_start: Default::default(),
@@ -64,41 +64,48 @@ impl PerformanceTiming {
         }
     }
 
-    pub(crate) fn new(
-        cx: &mut JSContext,
-        global: &GlobalScope,
-        navigation_timing: Rc<NavigationTiming>,
-    ) -> DomRoot<PerformanceTiming> {
-        reflect_dom_object_with_cx(
-            Box::new(PerformanceTiming::new_inherited(navigation_timing)),
-            global,
-            cx,
-        )
+    pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<PerformanceTiming> {
+        reflect_dom_object_with_cx(Box::new(PerformanceTiming::new_inherited()), global, cx)
     }
 
-    fn instant_to_millis(instant: &Cell<Option<CrossProcessInstant>>) -> u64 {
+    fn instant_to_millis(instant: Option<CrossProcessInstant>) -> u64 {
         // From <https://www.w3.org/TR/navigation-timing/#terminology>:
         // Throughout this work, time is measured in milliseconds since midnight of January 1, 1970 (UTC).
-        let instant = instant.get().unwrap_or(CrossProcessInstant::epoch());
+        let instant = instant.unwrap_or(CrossProcessInstant::epoch());
         let epoch = CrossProcessInstant::epoch();
         (instant - epoch).whole_milliseconds() as u64
+    }
+
+    fn navigation_timing(&self) -> Option<Rc<NavigationTiming>> {
+        self.global()
+            .downcast::<Window>()
+            .map(|window| window.Document().navigation_timing())
     }
 }
 
 impl PerformanceTimingMethods<crate::DomTypeHolder> for PerformanceTiming {
     /// <https://w3c.github.io/navigation-timing/#dom-performancetiming-navigationstart>
     fn NavigationStart(&self) -> u64 {
-        Self::instant_to_millis(&self.navigation_timing.navigation_start)
+        Self::instant_to_millis(
+            self.navigation_timing()
+                .and_then(|timing| timing.navigation_start.get()),
+        )
     }
 
     /// <https://w3c.github.io/navigation-timing/#dom-performancetiming-unloadeventstart
     fn UnloadEventStart(&self) -> u64 {
-        Self::instant_to_millis(&self.navigation_timing.unload_event_start)
+        Self::instant_to_millis(
+            self.navigation_timing()
+                .and_then(|timing| timing.unload_event_start.get()),
+        )
     }
 
     /// <https://w3c.github.io/navigation-timing/#dom-performancetiming-unloadeventend>
     fn UnloadEventEnd(&self) -> u64 {
-        Self::instant_to_millis(&self.navigation_timing.unload_event_end)
+        Self::instant_to_millis(
+            self.navigation_timing()
+                .and_then(|timing| timing.unload_event_end.get()),
+        )
     }
 
     /// <https://w3c.github.io/navigation-timing/#dom-performancetiming-redirectstart>
@@ -158,36 +165,57 @@ impl PerformanceTimingMethods<crate::DomTypeHolder> for PerformanceTiming {
 
     /// <https://w3c.github.io/navigation-timing/#dom-performancetiming-domloading>
     fn DomLoading(&self) -> u64 {
-        Self::instant_to_millis(&self.navigation_timing.dom_loading)
+        Self::instant_to_millis(
+            self.navigation_timing()
+                .and_then(|timing| timing.dom_loading.get()),
+        )
     }
 
     /// <https://w3c.github.io/navigation-timing/#dom-performancetiming-dominteractive>
     fn DomInteractive(&self) -> u64 {
-        Self::instant_to_millis(&self.navigation_timing.dom_interactive)
+        Self::instant_to_millis(
+            self.navigation_timing()
+                .and_then(|timing| timing.dom_interactive.get()),
+        )
     }
 
     /// <https://w3c.github.io/navigation-timing/#dom-performancetiming-domcontentloadedeventstart>
     fn DomContentLoadedEventStart(&self) -> u64 {
-        Self::instant_to_millis(&self.navigation_timing.dom_content_loaded_event_start)
+        Self::instant_to_millis(
+            self.navigation_timing()
+                .and_then(|timing| timing.dom_content_loaded_event_start.get()),
+        )
     }
 
     /// <https://w3c.github.io/navigation-timing/#dom-performancetiming-domcontentloadedeventend>
     fn DomContentLoadedEventEnd(&self) -> u64 {
-        Self::instant_to_millis(&self.navigation_timing.dom_content_loaded_event_end)
+        Self::instant_to_millis(
+            self.navigation_timing()
+                .and_then(|timing| timing.dom_content_loaded_event_end.get()),
+        )
     }
 
     /// <https://w3c.github.io/navigation-timing/#dom-performancetiming-domcomplete>
     fn DomComplete(&self) -> u64 {
-        Self::instant_to_millis(&self.navigation_timing.dom_complete)
+        Self::instant_to_millis(
+            self.navigation_timing()
+                .and_then(|timing| timing.dom_complete.get()),
+        )
     }
 
     /// <https://w3c.github.io/navigation-timing/#dom-performancetiming-loadeventstart>
     fn LoadEventStart(&self) -> u64 {
-        Self::instant_to_millis(&self.navigation_timing.load_event_start)
+        Self::instant_to_millis(
+            self.navigation_timing()
+                .and_then(|timing| timing.load_event_start.get()),
+        )
     }
 
     /// <https://w3c.github.io/navigation-timing/#dom-performancetiming-loadeventend>
     fn LoadEventEnd(&self) -> u64 {
-        Self::instant_to_millis(&self.navigation_timing.load_event_end)
+        Self::instant_to_millis(
+            self.navigation_timing()
+                .and_then(|timing| timing.load_event_end.get()),
+        )
     }
 }

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -1788,14 +1788,8 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     // https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/
     // NavigationTiming/Overview.html#sec-window.performance-attribute
     fn Performance(&self, cx: &mut JSContext) -> DomRoot<Performance> {
-        self.performance.or_init(|| {
-            Performance::new(
-                cx,
-                self.as_global_scope(),
-                self.navigation_start.get(),
-                self.Document().navigation_timing(),
-            )
-        })
+        self.performance
+            .or_init(|| Performance::new(cx, self.as_global_scope(), self.navigation_start.get()))
     }
 
     // https://html.spec.whatwg.org/multipage/#globaleventhandlers

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -1041,7 +1041,7 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
     fn Performance(&self, cx: &mut JSContext) -> DomRoot<Performance> {
         self.performance.or_init(|| {
             let global_scope = self.upcast::<GlobalScope>();
-            Performance::new(cx, global_scope, self.navigation_start, Default::default())
+            Performance::new(cx, global_scope, self.navigation_start)
         })
     }
 


### PR DESCRIPTION
#46975 exposes a case where the navigation timing information for documents in iframes is incorrect, because PerformanceTiming is initialized with the timing information for about:blank. We can avoid this by always returning timing information derived from the global's active document instead.

Testing: No behaviour change possible before #46975, and this change fixes failures exposed in that PR.
Part of #43149
