### PR TITLE
constellation: Queue session history traversals

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -160,11 +160,12 @@ use servo_canvas_traits::canvas::{CanvasId, CanvasMsg};
 use servo_config::{opts, pref};
 use servo_constellation_traits::{
     AuxiliaryWebViewCreationRequest, AuxiliaryWebViewCreationResponse, ConstellationInterest,
-    DocumentState, EmbedderToConstellationMessage, IFrameLoadInfo, IFrameLoadInfoWithData,
-    IFrameSizeMsg, LoadData, LogEntry, MessagePortMsg, NavigationHistoryBehavior, PaintMetricEvent,
-    PortMessageTask, PortTransferInfo, RemoteFocusOperation, SWManagerSenders,
-    ScreenshotReadinessResponse, ScriptToConstellationMessage, ScrollStateUpdate,
-    ServiceWorkerAlgorithm, ServiceWorkerManagerFactory, ServiceWorkerMsg,
+    DocumentState, EmbedderToConstellationMessage, HistoryTraversalSource, IFrameLoadInfo,
+    IFrameLoadInfoWithData, IFrameSizeMsg, LoadData, LogEntry, MessagePortMsg,
+    NavigationHistoryBehavior, PaintMetricEvent, PortMessageTask, PortTransferInfo,
+    RemoteFocusOperation, SWManagerSenders, ScreenshotReadinessResponse,
+    ScriptToConstellationMessage, ScrollStateUpdate, ServiceWorkerAlgorithm,
+    ServiceWorkerManagerFactory, ServiceWorkerMsg, SessionHistoryTraversalRequest,
     StructuredSerializedData, TargetSnapshotParams, TraversalDirection, UserContentManagerAction,
     WindowSizeType, WorkerAnimationFrameTick,
 };
@@ -186,7 +187,7 @@ use crate::browsingcontext::{
     AllBrowsingContextsIterator, BrowsingContext, FullyActiveBrowsingContextsIterator,
     NewBrowsingContextInfo,
 };
-use crate::constellation_webview::ConstellationWebView;
+use crate::constellation_webview::{ConstellationWebView, OngoingHistoryTraversalRequest};
 use crate::event_loop::EventLoop;
 use crate::pipeline::Pipeline;
 use crate::process_manager::ProcessManager;
@@ -792,6 +793,7 @@ where
             // This is for testing the hardening of the constellation.
             self.maybe_close_random_pipeline();
             self.handle_request();
+            self.finish_completed_session_history_traversal_requests();
             self.clean_up_finished_script_event_loops();
         }
         self.handle_shutdown();
@@ -1379,15 +1381,8 @@ where
                     .send(ConstellationToEmbedderMsg::WebViewBlurred);
             },
             // Handle a forward or back request
-            EmbedderToConstellationMessage::TraverseHistory(
-                webview_id,
-                direction,
-                traversal_id,
-            ) => {
-                self.handle_traverse_history_msg(webview_id, direction);
-                self.constellation_to_embedder_proxy.send(
-                    ConstellationToEmbedderMsg::HistoryTraversalComplete(webview_id, traversal_id),
-                );
+            EmbedderToConstellationMessage::TraverseHistory(request) => {
+                self.handle_traverse_session_history_msg(request);
             },
             EmbedderToConstellationMessage::ChangeViewportDetails(
                 webview_id,
@@ -1803,8 +1798,8 @@ where
                 self.handle_navigated_to_fragment(source_pipeline_id, new_url, replacement_enabled);
             },
             // Handle a forward or back request
-            ScriptToConstellationMessage::TraverseHistory(direction) => {
-                self.handle_traverse_history_msg(webview_id, direction);
+            ScriptToConstellationMessage::TraverseHistory(request) => {
+                self.handle_traverse_session_history_msg(request);
             },
             // Handle a push history state request.
             ScriptToConstellationMessage::PushHistoryState(history_state_id, url) => {
@@ -3326,8 +3321,22 @@ where
         // Step 5. Remove traversable from the user agent's top-level traversable set.
         let browsing_context =
             self.close_browsing_context(browsing_context_id, ExitPipelineMode::Normal);
+
+        // Any queued history traversal requests are never going to finish at this point,
+        // so notify the embedder that they are now finished.
+        let webview = self.webviews.remove(&webview_id);
+        if let Some(mut webview) = webview {
+            if let Some(ongoing_request) = webview.ongoing_history_traversal_request {
+                self.notify_embedder_of_completed_session_history_traversal_request(
+                    &ongoing_request.traversal_request,
+                );
+            }
+            for request in webview.session_history_traversal_request_queue.drain(..) {
+                self.notify_embedder_of_completed_session_history_traversal_request(&request);
+            }
+        }
+
         // Step 4. Remove traversable from the user interface (e.g., close or hide its tab in a tabbed browser).
-        self.webviews.remove(&webview_id);
         self.constellation_to_embedder_proxy
             .send(ConstellationToEmbedderMsg::WebViewClosed(webview_id));
 
@@ -4313,29 +4322,54 @@ where
         }
     }
 
+    /// Step 4 of <https://html.spec.whatwg.org/multipage/#traverse-the-history-by-a-delta>
+    ///
+    /// This change appends a session history traversal to the session history traversal queue,
+    /// which is stored as [`ConstellationWebView::history_traversal_request_queue`].
+    ///
+    /// See also: <https://html.spec.whatwg.org/multipage/#tn-session-history-traversal-queue>
     #[servo_tracing::instrument(skip_all)]
-    fn handle_traverse_history_msg(
+    fn handle_traverse_session_history_msg(
         &mut self,
-        webview_id: WebViewId,
-        direction: TraversalDirection,
+        traversal_request: SessionHistoryTraversalRequest,
     ) {
+        let webview_id = traversal_request.webview_id;
+        let Some(webview) = self.webviews.get_mut(&webview_id) else {
+            self.notify_embedder_of_completed_session_history_traversal_request(&traversal_request);
+            return warn!("Ignoring history traversal in non-existent WebView ({webview_id:?}).");
+        };
+
+        webview
+            .session_history_traversal_request_queue
+            .push_back(traversal_request);
+        self.apply_queued_session_history_traversal_requests(webview_id);
+    }
+
+    /// Apply the given [`HistoryTraversalRequest`], triggering the session history navigation.
+    /// Return the same [`HistoryTraversalRequest`] when it completes immediately or is out
+    /// of range, otherwise return `None` when it is still pending.
+    fn apply_session_history_traversal_request(
+        &mut self,
+        traversal_request: SessionHistoryTraversalRequest,
+    ) -> Option<SessionHistoryTraversalRequest> {
         let mut browsing_context_changes = FxHashMap::<BrowsingContextId, NeedsToReload>::default();
         let mut pipeline_changes =
             FxHashMap::<PipelineId, (Option<HistoryStateId>, ServoUrl)>::default();
         let mut url_to_load = FxHashMap::<PipelineId, ServoUrl>::default();
+        let webview_id = traversal_request.webview_id;
+
         {
             let Some(webview) = self.webviews.get_mut(&webview_id) else {
-                return warn!(
-                    "Ignoring history traversal in non-existent WebView ({webview_id:?})."
-                );
+                warn!("Ignoring history traversal in non-existent WebView ({webview_id:?}).");
+                return Some(traversal_request);
             };
 
-            match direction {
+            match traversal_request.direction {
                 TraversalDirection::Forward(forward) => {
                     let future_length = webview.session_history.future.len();
-
                     if future_length < forward {
-                        return warn!("Cannot traverse that far into the future.");
+                        warn!("Cannot traverse that far into the future.");
+                        return Some(traversal_request);
                     }
 
                     for diff in webview
@@ -4390,9 +4424,9 @@ where
                 },
                 TraversalDirection::Back(back) => {
                     let past_length = webview.session_history.past.len();
-
                     if past_length < back {
-                        return warn!("Cannot traverse that far into the past.");
+                        warn!("Cannot traverse that far into the past.");
+                        return Some(traversal_request);
                     }
 
                     for diff in webview
@@ -4448,31 +4482,139 @@ where
             }
         }
 
-        for (browsing_context_id, mut pipeline_reloader) in browsing_context_changes.drain() {
-            if let NeedsToReload::Yes(pipeline_id, ref mut load_data) = pipeline_reloader &&
-                let Some(url) = url_to_load.get(&pipeline_id)
-            {
-                load_data.url = url.clone();
-            }
-            self.update_browsing_context(browsing_context_id, pipeline_reloader);
-        }
+        let pipelines_awaiting_activation: FxHashSet<_> = browsing_context_changes
+            .drain()
+            .filter_map(|(browsing_context_id, mut pipeline_reloader)| {
+                if let NeedsToReload::Yes(pipeline_id, ref mut load_data) = pipeline_reloader &&
+                    let Some(url) = url_to_load.get(&pipeline_id)
+                {
+                    load_data.url = url.clone();
+                }
+                self.activate_history_entry_in_browsing_context(
+                    browsing_context_id,
+                    pipeline_reloader,
+                )
+            })
+            .collect();
 
         for (pipeline_id, (history_state_id, url)) in pipeline_changes.drain() {
-            self.update_pipeline(pipeline_id, history_state_id, url);
+            self.update_pipeline_history_state(pipeline_id, history_state_id, url);
         }
 
         self.notify_history_changed(webview_id);
-
         self.trim_history(webview_id);
         self.set_frame_tree_for_webview(webview_id);
+
+        // The traversal finishes immediately when we are traversing within the same document
+        // or between already live pipelines. Note that the script event loop may still be
+        // completing these navigations asynchronously.
+        if pipelines_awaiting_activation.is_empty() {
+            return Some(traversal_request);
+        }
+
+        let Some(webview) = self.webviews.get_mut(&webview_id) else {
+            return Some(traversal_request);
+        };
+        webview.ongoing_history_traversal_request = Some(OngoingHistoryTraversalRequest {
+            traversal_request,
+            pipelines_awaiting_activation,
+        });
+        None
     }
 
+    /// Finish any completed ongoing history traversal request from any active
+    /// [`ConstellationWebView`] and trigger (and possibly finish) any other queued history
+    /// traversals on that same `WebView` until there are no remaining completed ongoing history
+    /// traversal requests.
+    fn finish_completed_session_history_traversal_requests(&mut self) {
+        while let Some(traversal_request) =
+            self.take_next_completed_session_history_traversal_request()
+        {
+            self.notify_embedder_of_completed_session_history_traversal_request(&traversal_request);
+            self.apply_queued_session_history_traversal_requests(traversal_request.webview_id);
+        }
+    }
+
+    /// If any [`ConstellationWebView`] has a completed ongoing history traversal request, return
+    /// it. Otherwise, `None` is returned.
+    fn take_next_completed_session_history_traversal_request(
+        &mut self,
+    ) -> Option<SessionHistoryTraversalRequest> {
+        if self
+            .webviews
+            .values()
+            .all(|webview| webview.ongoing_history_traversal_request.is_none())
+        {
+            return None;
+        }
+
+        let pipelines_with_pending_changes = self
+            .pending_changes
+            .iter()
+            .map(|change| change.new_pipeline_id)
+            .collect::<FxHashSet<_>>();
+        self.webviews.values_mut().find_map(|webview| {
+            webview.maybe_finish_ongoing_session_history_traversal_request(
+                &pipelines_with_pending_changes,
+            )
+        })
+    }
+
+    /// Notify the embedder that the given [`HistoryTraversalRequest`] is complete, if it was
+    /// triggered by the embedder.
+    fn notify_embedder_of_completed_session_history_traversal_request(
+        &self,
+        traversal_request: &SessionHistoryTraversalRequest,
+    ) {
+        if traversal_request.source == HistoryTraversalSource::Embedder {
+            self.constellation_to_embedder_proxy.send(
+                ConstellationToEmbedderMsg::HistoryTraversalComplete(
+                    traversal_request.webview_id,
+                    traversal_request.id.clone(),
+                ),
+            );
+        }
+    }
+
+    /// If the [`ConstellationWebView`] with the given [`WebViewId`] does not have any
+    /// ongoing traversal history request, apply the next queued request, if one exists.
+    fn apply_next_queued_session_history_traversal_request(
+        &mut self,
+        webview_id: WebViewId,
+    ) -> Option<SessionHistoryTraversalRequest> {
+        let webview = self.webviews.get_mut(&webview_id)?;
+        if webview.ongoing_history_traversal_request.is_some() {
+            return None;
+        }
+
+        let traversal_request = webview
+            .session_history_traversal_request_queue
+            .pop_front()?;
+        self.apply_session_history_traversal_request(traversal_request)
+    }
+
+    /// If the [`ConstellationWebView`] with the given [`WebViewId`] does not have any ongoing
+    /// traversal history request, apply the next queued request and potentially finish it
+    /// until there is either an ongoing history request or no more queued requests.
+    fn apply_queued_session_history_traversal_requests(&mut self, webview_id: WebViewId) {
+        while let Some(traversal_request) =
+            self.apply_next_queued_session_history_traversal_request(webview_id)
+        {
+            self.notify_embedder_of_completed_session_history_traversal_request(&traversal_request);
+        }
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#activate-history-entry>
+    ///
+    /// Activate the history entry indicated by the given [`NeedsToReload`]. Returns the
+    /// [`PipelineId`] of the pipeline if the constellation is waiting for it to reload
+    /// and `None` otherwise.
     #[servo_tracing::instrument(skip_all)]
-    fn update_browsing_context(
+    fn activate_history_entry_in_browsing_context(
         &mut self,
         browsing_context_id: BrowsingContextId,
         new_reloader: NeedsToReload,
-    ) {
+    ) -> Option<PipelineId> {
         let new_pipeline_id = match new_reloader {
             NeedsToReload::No(pipeline_id) => pipeline_id,
             NeedsToReload::Yes(pipeline_id, mut load_data) => {
@@ -4503,7 +4645,10 @@ where
                         ctx.is_private,
                         ctx.throttled,
                     ),
-                    None => return warn!("No browsing context to traverse!"),
+                    None => {
+                        warn!("No browsing context to traverse!");
+                        return None;
+                    },
                 };
                 let opener = match self.pipelines.get(&old_pipeline_id) {
                     Some(pipeline) => pipeline.opener,
@@ -4535,7 +4680,7 @@ where
                     new_browsing_context_info: None,
                     viewport_details,
                 });
-                return;
+                return Some(new_pipeline_id);
             },
         };
 
@@ -4551,7 +4696,8 @@ where
                     )
                 },
                 None => {
-                    return warn!("{}: Closed during traversal", browsing_context_id);
+                    warn!("{browsing_context_id}: Closed during traversal");
+                    return None;
                 },
             };
 
@@ -4592,10 +4738,12 @@ where
             );
             self.send_message_to_pipeline(parent_pipeline_id, msg, "Child traversed after closure");
         }
+
+        None
     }
 
     #[servo_tracing::instrument(skip_all)]
-    fn update_pipeline(
+    fn update_pipeline_history_state(
         &mut self,
         pipeline_id: PipelineId,
         history_state_id: Option<HistoryStateId>,
@@ -5511,6 +5659,7 @@ where
         // If it is found, remove it from the pending changes, and make it
         // the active document of its frame.
         let change = self.pending_changes.swap_remove(pending_index);
+        let webview_id = change.webview_id;
 
         self.send_screenshot_readiness_requests_to_pipelines();
 
@@ -5535,12 +5684,13 @@ where
             let msg = ScriptThreadMessage::UpdatePipelineId(
                 parent_pipeline_id,
                 change.browsing_context_id,
-                change.webview_id,
+                webview_id,
                 pipeline_id,
                 UpdatePipelineIdReason::Navigation,
             );
             let _ = parent_pipeline.event_loop.send(msg);
         }
+
         self.change_session_history(change);
     }
 

--- a/components/constellation/constellation_webview.rs
+++ b/components/constellation/constellation_webview.rs
@@ -2,14 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::collections::VecDeque;
+
 use embedder_traits::user_contents::UserContentManagerId;
 use embedder_traits::{InputEvent, MouseLeftViewportEvent, Theme};
 use euclid::Point2D;
 use log::warn;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use script_traits::{ConstellationInputEvent, ScriptThreadMessage};
 use servo_base::Epoch;
 use servo_base::id::{BrowsingContextId, PipelineId, WebViewId};
+use servo_constellation_traits::SessionHistoryTraversalRequest;
 use style_traits::CSSPixel;
 
 use crate::browsingcontext::BrowsingContext;
@@ -42,6 +45,16 @@ pub(crate) struct ConstellationWebView {
 
     /// The joint session history for this webview.
     pub session_history: JointSessionHistory,
+
+    /// <https://html.spec.whatwg.org/multipage/#tn-session-history-traversal-queue>
+    ///
+    /// A queue of traversals that should be applied sequentially. The next item from
+    /// the queue is applied once [`Self::ongoing_history_traversal_request`] has finished.
+    pub session_history_traversal_request_queue: VecDeque<SessionHistoryTraversalRequest>,
+
+    /// The currently running session history traversal. This will be completed once all
+    /// `Pipeline`s in a traversal become active or their load fails for some other reason.
+    pub ongoing_history_traversal_request: Option<OngoingHistoryTraversalRequest>,
 
     /// The [`UserContentManagerId`] for all pipelines in this `WebView`. This is `Some`
     /// if the embedder has set a `UserContentManager` using the WebViewBuilder API and
@@ -76,6 +89,8 @@ impl ConstellationWebView {
             hovered_browsing_context_id: None,
             last_mouse_move_point: Default::default(),
             session_history: JointSessionHistory::new(),
+            session_history_traversal_request_queue: Default::default(),
+            ongoing_history_traversal_request: None,
             theme: Theme::Light,
             accessibility_active: false,
         }
@@ -188,4 +203,42 @@ impl ConstellationWebView {
             ));
         true
     }
+
+    /// If there is an ongoing history traversal request that is waiting on documents to
+    /// reload, check to see if none of its pipelines are awaiting activation. If that's the
+    /// case unset the ongoing request and return it.
+    pub(crate) fn maybe_finish_ongoing_session_history_traversal_request(
+        &mut self,
+        pipelines_with_pending_changes: &FxHashSet<PipelineId>,
+    ) -> Option<SessionHistoryTraversalRequest> {
+        let ongoing_history_traversal_request = self.ongoing_history_traversal_request.as_mut()?;
+        ongoing_history_traversal_request
+            .pipelines_awaiting_activation
+            .retain(|pipeline_id| pipelines_with_pending_changes.contains(pipeline_id));
+
+        if !ongoing_history_traversal_request
+            .pipelines_awaiting_activation
+            .is_empty()
+        {
+            return None;
+        }
+        Some(
+            self.ongoing_history_traversal_request
+                .take()
+                .expect("Guaranteed above")
+                .traversal_request,
+        )
+    }
+}
+
+/// A [`HistoryTraversalRequest`] that is in progress because it is waiting
+/// for documents that need reloading.
+pub(crate) struct OngoingHistoryTraversalRequest {
+    /// The [`HistoryTraversalRequest`] that spawned this series of navigations.
+    pub traversal_request: SessionHistoryTraversalRequest,
+    /// The ids of all the `Pipeline`s that needed reloading for this traversal.
+    /// Multiple pipelines can be traversed if the top-level document contained
+    /// `<iframe>`s / browsing contexts. The traversal is only done when all of
+    /// the pipelines are ready or have failed to load.
+    pub pipelines_awaiting_activation: FxHashSet<PipelineId>,
 }

--- a/components/script/dom/window/history.rs
+++ b/components/script/dom/window/history.rs
@@ -16,7 +16,8 @@ use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::generic_channel::GenericSend;
 use servo_base::id::HistoryStateId;
 use servo_constellation_traits::{
-    ScriptToConstellationMessage, StructuredSerializedData, TraversalDirection,
+    HistoryTraversalSource, ScriptToConstellationMessage, SessionHistoryTraversalRequest,
+    StructuredSerializedData, TraversalDirection,
 };
 use servo_url::ServoUrl;
 
@@ -74,12 +75,17 @@ impl History {
         if !self.window.Document().is_fully_active() {
             return Err(Error::Security(None));
         }
-        let msg = ScriptToConstellationMessage::TraverseHistory(direction);
         let _ = self
             .window
             .as_global_scope()
             .script_to_constellation_chan()
-            .send(msg);
+            .send(ScriptToConstellationMessage::TraverseHistory(
+                SessionHistoryTraversalRequest::new(
+                    self.window.webview_id(),
+                    direction,
+                    HistoryTraversalSource::Script,
+                ),
+            ));
         Ok(())
     }
 

--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -92,10 +92,10 @@ use servo_canvas_traits::webgl::WebGLPipeline;
 use servo_config::opts::{self, DiagnosticsLoggingOption};
 use servo_config::{pref, prefs};
 use servo_constellation_traits::{
-    LoadData, LoadOrigin, NavigationHistoryBehavior, RemoteFocusOperation,
+    HistoryTraversalSource, LoadData, LoadOrigin, NavigationHistoryBehavior, RemoteFocusOperation,
     ScreenshotReadinessResponse, ScriptToConstellationChan, ScriptToConstellationMessage,
-    ScrollStateUpdate, StructuredSerializedData, TargetSnapshotParams, TraversalDirection,
-    WindowSizeType,
+    ScrollStateUpdate, SessionHistoryTraversalRequest, StructuredSerializedData,
+    TargetSnapshotParams, TraversalDirection, WindowSizeType,
 };
 use servo_url::{ImmutableOrigin, MutableOrigin, OriginSnapshot, ServoUrl};
 use storage_traits::StorageThreads;
@@ -4258,12 +4258,19 @@ impl ScriptThread {
         // The constellation only needs to know the WebView ID for navigation,
         // but actors don't keep track of it. Infer WebView ID from pipeline ID instead.
         if let Some(document) = self.documents.borrow().find_document(pipeline_id) {
+            let webview_id = document.webview_id();
             self.senders
                 .pipeline_to_constellation_sender
                 .send((
-                    document.webview_id(),
+                    webview_id,
                     pipeline_id,
-                    ScriptToConstellationMessage::TraverseHistory(direction),
+                    ScriptToConstellationMessage::TraverseHistory(
+                        SessionHistoryTraversalRequest::new(
+                            webview_id,
+                            direction,
+                            HistoryTraversalSource::Script,
+                        ),
+                    ),
                 ))
                 .unwrap();
         }

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -25,7 +25,10 @@ use servo_base::Epoch;
 use servo_base::generic_channel::GenericSender;
 use servo_base::id::WebViewId;
 use servo_config::pref;
-use servo_constellation_traits::{EmbedderToConstellationMessage, TraversalDirection};
+use servo_constellation_traits::{
+    EmbedderToConstellationMessage, HistoryTraversalSource, SessionHistoryTraversalRequest,
+    TraversalDirection,
+};
 use servo_geometry::DeviceIndependentPixel;
 use servo_url::ServoUrl;
 use style_traits::CSSPixel;
@@ -563,14 +566,16 @@ impl WebView {
     /// [`WebViewDelegate::notify_traversal_complete`] callback to determine when the
     /// traversal is complete.
     pub fn go_back(&self, amount: usize) -> TraversalId {
-        let traversal_id = TraversalId::new();
-        self.inner().servo.constellation_proxy().send(
-            EmbedderToConstellationMessage::TraverseHistory(
-                self.id(),
-                TraversalDirection::Back(amount),
-                traversal_id.clone(),
-            ),
+        let request = SessionHistoryTraversalRequest::new(
+            self.id(),
+            TraversalDirection::Back(amount),
+            HistoryTraversalSource::Embedder,
         );
+        let traversal_id = request.id.clone();
+        self.inner()
+            .servo
+            .constellation_proxy()
+            .send(EmbedderToConstellationMessage::TraverseHistory(request));
         traversal_id
     }
 
@@ -589,14 +594,16 @@ impl WebView {
     /// [`WebViewDelegate::notify_traversal_complete`] callback to determine when the
     /// traversal is complete.
     pub fn go_forward(&self, amount: usize) -> TraversalId {
-        let traversal_id = TraversalId::new();
-        self.inner().servo.constellation_proxy().send(
-            EmbedderToConstellationMessage::TraverseHistory(
-                self.id(),
-                TraversalDirection::Forward(amount),
-                traversal_id.clone(),
-            ),
+        let request = SessionHistoryTraversalRequest::new(
+            self.id(),
+            TraversalDirection::Forward(amount),
+            HistoryTraversalSource::Embedder,
         );
+        let traversal_id = request.id.clone();
+        self.inner()
+            .servo
+            .constellation_proxy()
+            .send(EmbedderToConstellationMessage::TraverseHistory(request));
         traversal_id
     }
 

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -47,7 +47,8 @@ use webgpu_traits::{WebGPU, WebGPUAdapterResponse};
 
 use crate::structured_data::{BroadcastChannelMsg, StructuredSerializedData};
 use crate::{
-    LogEntry, MessagePortMsg, PortMessageTask, PortTransferInfo, TraversalDirection, WindowSizeType,
+    LogEntry, MessagePortMsg, PortMessageTask, PortTransferInfo, SessionHistoryTraversalRequest,
+    WindowSizeType,
 };
 
 pub type ScriptToConstellationSender =
@@ -758,7 +759,7 @@ pub enum ScriptToConstellationMessage {
     /// Inform the constellation that a fragment was navigated to and whether or not it was a replacement navigation.
     NavigatedToFragment(ServoUrl, NavigationHistoryBehavior),
     /// HTMLIFrameElement Forward or Back traversal.
-    TraverseHistory(TraversalDirection),
+    TraverseHistory(SessionHistoryTraversalRequest),
     /// Inform the constellation of a pushed history state.
     PushHistoryState(HistoryStateId, ServoUrl),
     /// Inform the constellation of a replaced history state.

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -50,7 +50,7 @@ pub enum EmbedderToConstellationMessage {
     /// Request to load a page, with optionally additional data in [`URLRequest`].
     LoadUrl(WebViewId, UrlRequest),
     /// Request to traverse the joint session history of the provided browsing context.
-    TraverseHistory(WebViewId, TraversalDirection, TraversalId),
+    TraverseHistory(SessionHistoryTraversalRequest),
     /// Inform the Constellation that a `WebView`'s [`ViewportDetails`] have changed.
     ChangeViewportDetails(WebViewId, ViewportDetails, WindowSizeType),
     /// Inform the constellation of a theme change.
@@ -173,6 +173,46 @@ pub enum TraversalDirection {
     Forward(usize),
     /// Travel backward the given number of documents.
     Back(usize),
+}
+
+/// The source of a [`HistoryTraversalRequest`].
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum HistoryTraversalSource {
+    /// The traversal was triggered from the embedder, which means it is expecting
+    /// a notification when the request has completed.
+    Embedder,
+    /// The traversal was triggered from the script event loop.
+    Script,
+}
+
+/// A history traversal request.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SessionHistoryTraversalRequest {
+    /// An identifier that uniquely identifies this [`HistoryTraversalRequest`].
+    pub id: TraversalId,
+    /// The `WebView` that should be traversed.
+    pub webview_id: WebViewId,
+    /// The direction and number of steps that should be traversed.
+    pub direction: TraversalDirection,
+    /// The [`HistoryTraversalSource`] of this [`HistoryTraversalRequest`].
+    pub source: HistoryTraversalSource,
+}
+
+impl SessionHistoryTraversalRequest {
+    /// Create a new [`HistoryTraversalRequest`] either due to an embedder API call
+    /// or a script-initiated history traversal.
+    pub fn new(
+        webview_id: WebViewId,
+        direction: TraversalDirection,
+        source: HistoryTraversalSource,
+    ) -> Self {
+        Self {
+            id: TraversalId::new(),
+            webview_id,
+            direction,
+            source,
+        }
+    }
 }
 
 /// A task on the <https://html.spec.whatwg.org/multipage/#port-message-queue>

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -362,13 +362,13 @@ pub struct ScreenMetrics {
 }
 
 /// An opaque identifier for a single history traversal operation.
-#[derive(Clone, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct TraversalId(String);
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct TraversalId(Uuid);
 
 impl TraversalId {
     #[expect(clippy::new_without_default)]
     pub fn new() -> Self {
-        Self(Uuid::new_v4().to_string())
+        Self(Uuid::new_v4())
     }
 }
 


### PR DESCRIPTION
Instead of running history traversals (moving backward and forward in
the session history) immediately, only run each traversal after the
previous one has finished. Traversals may not finish immediately if a
page needs to be reloaded due to being a sufficient distance away in the
back-forward list to not be cached or because an `unload` handler ran.

This fixes issues with intermittency when running history navigation
tests. Previously, history traversals were run immediately (instead of
being queued) which could lead to nondeterminate navigation outcomes.

Testing: This should eliminate test flakiness on the CI.
Fixes: #21383.
