### PR TITLE
script: Fix borrow hazard in stream and rtcp

### DIFF
--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -1020,6 +1020,8 @@ impl ReadableByteStreamController {
                     .transfer_array_buffer(cx)
                     .expect("TransferArrayBuffer failed")
             };
+
+            drop(pending_pull_intos);
             // Set firstPendingPullInto’s buffer to ! TransferArrayBuffer(firstPendingPullInto’s buffer).
 
             self.pending_pull_intos

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -342,7 +342,7 @@ impl ReadableByteStreamController {
 
                 // If controller.[[pendingPullIntos]] is not empty,
                 {
-                    let mut pending_pull_intos = self.pending_pull_intos.borrow_mut();
+                    let mut pending_pull_intos = self.pending_pull_intos.safe_borrow_mut(cx);
                     if !pending_pull_intos.is_empty() {
                         // Append pullIntoDescriptor to controller.[[pendingPullIntos]].
                         pending_pull_intos.push(*pull_into_descriptor.into_box());
@@ -432,7 +432,7 @@ impl ReadableByteStreamController {
                 // Append pullIntoDescriptor to controller.[[pendingPullIntos]].
                 {
                     self.pending_pull_intos
-                        .borrow_mut()
+                        .safe_borrow_mut(cx)
                         .push(*pull_into_descriptor.into_box());
                 }
                 // Perform ! ReadableStreamAddReadIntoRequest(stream, readIntoRequest).
@@ -456,13 +456,13 @@ impl ReadableByteStreamController {
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-respond>
     pub(crate) fn respond(&self, cx: &mut JSContext, bytes_written: u64) -> Fallible<()> {
-        {
+        let heap_buffer = {
             // Assert: controller.[[pendingPullIntos]] is not empty.
-            let mut pending_pull_intos = self.pending_pull_intos.borrow_mut();
+            let pending_pull_intos = self.pending_pull_intos.borrow();
             assert!(!pending_pull_intos.is_empty());
 
             // Let firstDescriptor be controller.[[pendingPullIntos]][0].
-            let first_descriptor = pending_pull_intos.first_mut().unwrap();
+            let first_descriptor = pending_pull_intos.first().unwrap();
 
             // Let state be controller.[[stream]].[[state]].
             let stream = self.stream.get().unwrap();
@@ -495,13 +495,17 @@ impl ReadableByteStreamController {
                 }
             }
 
-            // Set firstDescriptor’s buffer to ! TransferArrayBuffer(firstDescriptor’s buffer).
-            first_descriptor.buffer = *first_descriptor
+            first_descriptor
                 .buffer
                 .transfer_array_buffer(cx)
                 .expect("TransferArrayBuffer failed")
-                .into_box();
-        }
+        };
+        // Set firstDescriptor’s buffer to ! TransferArrayBuffer(firstDescriptor’s buffer).
+        self.pending_pull_intos
+            .safe_borrow_mut(cx)
+            .first_mut()
+            .unwrap()
+            .buffer = *(heap_buffer.into_box());
 
         // Perform ? ReadableByteStreamControllerRespondInternal(controller, bytesWritten).
         self.respond_internal(cx, bytes_written)
@@ -697,16 +701,17 @@ impl ReadableByteStreamController {
         view: &HeapBufferSource<ArrayBufferViewU8>,
     ) -> Fallible<()> {
         let view_byte_length;
-        {
+
+        let view = {
             // Assert: controller.[[pendingPullIntos]] is not empty.
-            let mut pending_pull_intos = self.pending_pull_intos.borrow_mut();
+            let pending_pull_intos = self.pending_pull_intos.borrow();
             assert!(!pending_pull_intos.is_empty());
 
             // Assert: ! IsDetachedBuffer(view.[[ViewedArrayBuffer]]) is false.
             assert!(!view.is_detached_buffer(cx));
 
             // Let firstDescriptor be controller.[[pendingPullIntos]][0].
-            let first_descriptor = pending_pull_intos.first_mut().unwrap();
+            let first_descriptor = pending_pull_intos.first().unwrap();
 
             // Let state be controller.[[stream]].[[state]].
             let stream = self.stream.get().unwrap();
@@ -762,12 +767,15 @@ impl ReadableByteStreamController {
             // Let viewByteLength be view.[[ByteLength]].
             view_byte_length = view.byte_length();
 
-            // Set firstDescriptor’s buffer to ? TransferArrayBuffer(view.[[ViewedArrayBuffer]]).
-            first_descriptor.buffer = *view
-                .get_array_buffer_view_buffer(cx)
+            view.get_array_buffer_view_buffer(cx)
                 .transfer_array_buffer(cx)?
-                .into_box();
-        }
+        };
+        // Set firstDescriptor’s buffer to ? TransferArrayBuffer(view.[[ViewedArrayBuffer]]).
+        self.pending_pull_intos
+            .safe_borrow_mut(cx)
+            .first_mut()
+            .unwrap()
+            .buffer = *view.into_box();
 
         // Perform ? ReadableByteStreamControllerRespondInternal(controller, viewByteLength).
         self.respond_internal(cx, view_byte_length as u64)
@@ -993,11 +1001,12 @@ impl ReadableByteStreamController {
         let transferred_buffer = buffer.transfer_array_buffer(cx)?;
 
         // If controller.[[pendingPullIntos]] is not empty,
-        {
-            let mut pending_pull_intos = self.pending_pull_intos.borrow_mut();
-            if !pending_pull_intos.is_empty() {
+
+        let pending_pull_intos = self.pending_pull_intos.borrow();
+        if !pending_pull_intos.is_empty() {
+            let heap_buffer = {
                 // Let firstPendingPullInto be controller.[[pendingPullIntos]][0].
-                let first_descriptor = pending_pull_intos.first_mut().unwrap();
+                let first_descriptor = pending_pull_intos.first().unwrap();
                 // If ! IsDetachedBuffer(firstPendingPullInto’s buffer) is true, throw a TypeError exception.
                 if first_descriptor.buffer.is_detached_buffer(cx) {
                     return Err(Error::Type(c"buffer is detached".to_owned()));
@@ -1006,22 +1015,31 @@ impl ReadableByteStreamController {
                 // Perform ! ReadableByteStreamControllerInvalidateBYOBRequest(controller).
                 self.invalidate_byob_request();
 
-                // Set firstPendingPullInto’s buffer to ! TransferArrayBuffer(firstPendingPullInto’s buffer).
-                first_descriptor.buffer = *first_descriptor
+                first_descriptor
                     .buffer
                     .transfer_array_buffer(cx)
                     .expect("TransferArrayBuffer failed")
-                    .into_box();
+            };
+            // Set firstPendingPullInto’s buffer to ! TransferArrayBuffer(firstPendingPullInto’s buffer).
 
-                // If firstPendingPullInto’s reader type is "none",
-                if first_descriptor.reader_type.is_none() {
-                    // needed to drop the borrow and avoid BorrowMutError
-                    drop(pending_pull_intos);
+            self.pending_pull_intos
+                .safe_borrow_mut(cx)
+                .first_mut()
+                .unwrap()
+                .buffer = *heap_buffer.into_box();
 
-                    // perform ? ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue(
-                    // controller, firstPendingPullInto).
-                    self.enqueue_detached_pull_into_to_queue(cx)?;
-                }
+            // If firstPendingPullInto’s reader type is "none",
+            if self
+                .pending_pull_intos
+                .borrow()
+                .first()
+                .unwrap()
+                .reader_type
+                .is_none()
+            {
+                // perform ? ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue(
+                // controller, firstPendingPullInto).
+                self.enqueue_detached_pull_into_to_queue(cx)?;
             }
         }
 
@@ -1285,12 +1303,11 @@ impl ReadableByteStreamController {
         }
 
         // Let queue be controller.[[queue]].
-        let mut queue = self.queue.borrow_mut();
-
         // While totalBytesToCopyRemaining > 0,
         while total_bytes_to_copy_remaining > 0 {
             // Let headOfQueue be queue[0].
-            let head_of_queue = queue.front_mut().unwrap();
+            let queue = self.queue.borrow();
+            let head_of_queue = queue.front().unwrap();
 
             // Let bytesToCopy be min(totalBytesToCopyRemaining, headOfQueue’s byte length).
             let bytes_to_copy = total_bytes_to_copy_remaining.min(head_of_queue.byte_length);
@@ -1328,11 +1345,17 @@ impl ReadableByteStreamController {
                 bytes_to_copy,
             );
 
+            let head_of_queue_byte_length = head_of_queue.byte_length;
+            // Remove the borrow on self.queue
+            drop(queue);
+
             // If headOfQueue’s byte length is bytesToCopy,
-            if head_of_queue.byte_length == bytes_to_copy {
+            if head_of_queue_byte_length == bytes_to_copy {
                 // Remove queue[0].
-                queue.pop_front().unwrap();
+                self.queue.safe_borrow_mut(cx).pop_front().unwrap();
             } else {
+                let mut queue = self.queue.safe_borrow_mut(cx);
+                let head_of_queue = queue.front_mut().unwrap();
                 // Set headOfQueue’s byte offset to headOfQueue’s byte offset + bytesToCopy.
                 head_of_queue.byte_offset += bytes_to_copy;
 
@@ -1875,7 +1898,7 @@ impl ReadableByteStreamController {
 
                     // Append pullIntoDescriptor to this.[[pendingPullIntos]].
                     self.pending_pull_intos
-                        .borrow_mut()
+                        .safe_borrow_mut(cx)
                         .push(PullIntoDescriptor {
                             buffer: *buffer.into_box(),
                             buffer_byte_length: auto_allocate_chunk_size,

--- a/components/script/dom/webrtc/rtcpeerconnection.rs
+++ b/components/script/dom/webrtc/rtcpeerconnection.rs
@@ -650,7 +650,7 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
             .networking_task_source()
             .to_sendable();
         self.controller
-            .borrow_mut()
+            .borrow()
             .as_ref()
             .unwrap()
             .set_local_description(
@@ -693,7 +693,7 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
             .networking_task_source()
             .to_sendable();
         self.controller
-            .borrow_mut()
+            .borrow()
             .as_ref()
             .unwrap()
             .set_remote_description(


### PR DESCRIPTION
This fixes some borrow hazards in rtcpeerconnection where the mutable borrow was unneeded.
Additionally, we transform readablebytestreamcontroller to use safe_borrow_mut (wshen cx is available). We fix multiple borrow hazards in this file.

We include the fix for rtcp because it is very minor.

Testing: safe_borrow_mut prevents us ffrom introducing new borrow hazards and errors in refactoring should be caught by WPT tests.
