### PR TITLE
script: use a trait for the WorkletThreadPool

### DIFF
--- a/components/script/dom/testing/testworklet.rs
+++ b/components/script/dom/testing/testworklet.rs
@@ -89,7 +89,7 @@ impl TestWorkletMethods<crate::DomTypeHolder> for TestWorklet {
             let test_worklet_global_scope = global_scope
                 .downcast::<TestWorkletGlobalScope>()
                 .expect("TestWorklet's task should be run only on TestWorkletGlobalScope.");
-            let value = test_worklet_global_scope.lookup_value(key);
+            let value = test_worklet_global_scope.lookup_value(key.as_str());
             let _ = sender.send(value);
         };
 

--- a/components/script/dom/testing/testworklet.rs
+++ b/components/script/dom/testing/testworklet.rs
@@ -89,7 +89,7 @@ impl TestWorkletMethods<crate::DomTypeHolder> for TestWorklet {
             let test_worklet_global_scope = global_scope
                 .downcast::<TestWorkletGlobalScope>()
                 .expect("TestWorklet's task should be run only on TestWorkletGlobalScope.");
-            let value = test_worklet_global_scope.lookup_value(key.as_str());
+            let value = test_worklet_global_scope.lookup_value(&key);
             let _ = sender.send(value);
         };
 

--- a/components/script/dom/testing/testworklet.rs
+++ b/components/script/dom/testing/testworklet.rs
@@ -5,13 +5,15 @@
 // check-tidy: no specs after this line
 use std::rc::Rc;
 
+use crossbeam_channel::unbounded;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::realm::CurrentRealm;
 use js::rust::HandleObject;
+use script_bindings::inheritance::Castable;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
-use crate::dom::WorkletThreadPool;
+use crate::dom::{GlobalScope, StatelessWorkletThreadPool};
 use crate::dom::bindings::codegen::Bindings::TestWorkletBinding::TestWorkletMethods;
 use crate::dom::bindings::codegen::Bindings::WorkletBinding::Worklet_Binding::WorkletMethods;
 use crate::dom::bindings::codegen::Bindings::WorkletBinding::WorkletOptions;
@@ -19,6 +21,7 @@ use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::promise::Promise;
+use crate::dom::types::{TestWorkletGlobalScope, WorkletGlobalScope};
 use crate::dom::window::Window;
 use crate::dom::worklet::Worklet;
 use crate::dom::workletglobalscope::WorkletGlobalScopeType;
@@ -47,7 +50,7 @@ impl TestWorklet {
             cx,
             window,
             WorkletGlobalScopeType::Test,
-            Box::new(|| Rc::new(WorkletThreadPool::spawn(worklet_global_scope_init))),
+            Box::new(|| Rc::new(StatelessWorkletThreadPool::spawn(worklet_global_scope_init))),
         );
         reflect_dom_object_with_proto(
             cx,
@@ -76,12 +79,33 @@ impl TestWorkletMethods<crate::DomTypeHolder> for TestWorklet {
         self.worklet.AddModule(realm, module_url, options)
     }
 
+    // TODO:
+    // - do stuff of testworkletglobalscope:73 in a closure
+    // - downcast global_scope to test_worklet_global_scope
+    // - pass the closure to the primary_sender to execute
+
     fn Lookup(&self, key: DOMString) -> Option<DOMString> {
         let id = self.worklet.worklet_id();
 
-        self.worklet
-            .worklet_thread_pool()
-            .test_worklet_lookup(id, String::from(key))
-            .map(DOMString::from)
+        let key = String::from(key);
+        let (tx, rx) = unbounded::<Option<String>>();
+
+        let lookup_task = move |global_scope: &WorkletGlobalScope|  {
+            let test_worklet_global_scope = global_scope.downcast::<TestWorkletGlobalScope>().expect("");
+            let pending = test_worklet_global_scope.lookup_table().borrow().get(&key).cloned();
+            tx.send(pending);
+        };
+
+        self.worklet.worklet_thread_pool().run_task(id, Box::new(lookup_task));
+
+        match rx.recv() {
+            Ok(val) => {
+                val.map(DOMString::from)
+            },
+            Err(err) => {
+                error!("Test Worklet died? {}", err);
+                None
+            }
+        }
     }
 }

--- a/components/script/dom/testing/testworklet.rs
+++ b/components/script/dom/testing/testworklet.rs
@@ -88,14 +88,14 @@ impl TestWorkletMethods<crate::DomTypeHolder> for TestWorklet {
         let lookup_task = move |_cx: &mut JSContext, global_scope: &WorkletGlobalScope| {
             let test_worklet_global_scope = global_scope
                 .downcast::<TestWorkletGlobalScope>()
-                .expect("Could not downcast &WorkletGlobalScope to &TestWorkletGlobalScope.");
+                .expect("TestWorklet's task should be run only on TestWorkletGlobalScope.");
             let value = test_worklet_global_scope.lookup_value(key);
             let _ = sender.send(value);
         };
 
         self.worklet
             .worklet_thread_pool()
-            .run_task(id, Box::new(lookup_task));
+            .perform_a_worklet_task(id, Box::new(lookup_task));
 
         match receiver.recv() {
             Ok(value) => value.map(DOMString::from),

--- a/components/script/dom/testing/testworklet.rs
+++ b/components/script/dom/testing/testworklet.rs
@@ -13,7 +13,7 @@ use js::rust::HandleObject;
 use script_bindings::inheritance::Castable;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
-use crate::dom::{GlobalScope, StatelessWorkletThreadPool};
+use crate::dom::StatelessWorkletThreadPool;
 use crate::dom::bindings::codegen::Bindings::TestWorkletBinding::TestWorkletMethods;
 use crate::dom::bindings::codegen::Bindings::WorkletBinding::Worklet_Binding::WorkletMethods;
 use crate::dom::bindings::codegen::Bindings::WorkletBinding::WorkletOptions;
@@ -79,33 +79,30 @@ impl TestWorkletMethods<crate::DomTypeHolder> for TestWorklet {
         self.worklet.AddModule(realm, module_url, options)
     }
 
-    // TODO:
-    // - do stuff of testworkletglobalscope:73 in a closure
-    // - downcast global_scope to test_worklet_global_scope
-    // - pass the closure to the primary_sender to execute
-
     fn Lookup(&self, key: DOMString) -> Option<DOMString> {
         let id = self.worklet.worklet_id();
 
+        let (sender, receiver) = unbounded();
         let key = String::from(key);
-        let (tx, rx) = unbounded::<Option<String>>();
 
-        let lookup_task = move |global_scope: &WorkletGlobalScope|  {
-            let test_worklet_global_scope = global_scope.downcast::<TestWorkletGlobalScope>().expect("");
-            let pending = test_worklet_global_scope.lookup_table().borrow().get(&key).cloned();
-            tx.send(pending);
+        let lookup_task = move |_cx: &mut JSContext, global_scope: &WorkletGlobalScope| {
+            let test_worklet_global_scope = global_scope
+                .downcast::<TestWorkletGlobalScope>()
+                .expect("Could not downcast &WorkletGlobalScope to &TestWorkletGlobalScope.");
+            let value = test_worklet_global_scope.lookup_value(key);
+            let _ = sender.send(value);
         };
 
-        self.worklet.worklet_thread_pool().run_task(id, Box::new(lookup_task));
+        self.worklet
+            .worklet_thread_pool()
+            .run_task(id, Box::new(lookup_task));
 
-        match rx.recv() {
-            Ok(val) => {
-                val.map(DOMString::from)
-            },
+        match receiver.recv() {
+            Ok(value) => value.map(DOMString::from),
             Err(err) => {
                 error!("Test Worklet died? {}", err);
                 None
-            }
+            },
         }
     }
 }

--- a/components/script/dom/testing/testworkletglobalscope.rs
+++ b/components/script/dom/testing/testworkletglobalscope.rs
@@ -65,7 +65,7 @@ impl TestWorkletGlobalScope {
         TestWorkletGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(cx, &global.origin(), global)
     }
 
-    /// Get a value on the `lookup_table` using a key.
+    /// Get the value associated with the given key.
     pub fn lookup_value(&self, key: String) -> Option<String> {
         self.lookup_table.borrow().get(&key).cloned()
     }

--- a/components/script/dom/testing/testworkletglobalscope.rs
+++ b/components/script/dom/testing/testworkletglobalscope.rs
@@ -66,14 +66,8 @@ impl TestWorkletGlobalScope {
         TestWorkletGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(cx, &global.origin(), global)
     }
 
-    pub(crate) fn perform_a_worklet_task(&self, task: TestWorkletTask) {
-        match task {
-            TestWorkletTask::Lookup(key, sender) => {
-                debug!("Looking up key {}.", key);
-                let result = self.lookup_table.borrow().get(&key).cloned();
-                let _ = sender.send(result);
-            },
-        }
+    pub fn lookup_table(&self) -> &DomRefCell<HashMap<String, String>> {
+        &self.lookup_table
     }
 }
 

--- a/components/script/dom/testing/testworkletglobalscope.rs
+++ b/components/script/dom/testing/testworkletglobalscope.rs
@@ -66,8 +66,8 @@ impl TestWorkletGlobalScope {
     }
 
     /// Get the value associated with the given key.
-    pub fn lookup_value(&self, key: String) -> Option<String> {
-        self.lookup_table.borrow().get(&key).cloned()
+    pub fn lookup_value(&self, key: &str) -> Option<String> {
+        self.lookup_table.borrow().get(key).cloned()
     }
 }
 

--- a/components/script/dom/testing/testworkletglobalscope.rs
+++ b/components/script/dom/testing/testworkletglobalscope.rs
@@ -7,7 +7,6 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
-use crossbeam_channel::Sender;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
@@ -66,8 +65,9 @@ impl TestWorkletGlobalScope {
         TestWorkletGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(cx, &global.origin(), global)
     }
 
-    pub fn lookup_table(&self) -> &DomRefCell<HashMap<String, String>> {
-        &self.lookup_table
+    /// Get a value on the `lookup_table` using a key.
+    pub fn lookup_value(&self, key: String) -> Option<String> {
+        self.lookup_table.borrow().get(&key).cloned()
     }
 }
 
@@ -78,11 +78,6 @@ impl TestWorkletGlobalScopeMethods<crate::DomTypeHolder> for TestWorkletGlobalSc
             .borrow_mut()
             .insert(String::from(key), String::from(value));
     }
-}
-
-/// Tasks which can be performed by test worklets.
-pub(crate) enum TestWorkletTask {
-    Lookup(String, Sender<Option<String>>),
 }
 
 impl HasOrigin for TestWorkletGlobalScope {

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -110,7 +110,7 @@ use time::Duration as TimeDuration;
 use webrender_api::ExternalScrollId;
 use webrender_api::units::{DeviceIntSize, DevicePixel, LayoutPixel, LayoutPoint};
 
-use crate::dom::WorkletThreadPool;
+use crate::dom::StatelessWorkletThreadPool;
 use crate::dom::bindings::codegen::Bindings::AnimationFrameProviderBinding::FrameRequestCallback;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::{
     DocumentMethods, DocumentReadyState, NamedPropertyValue,
@@ -736,7 +736,7 @@ impl Window {
             cx,
             self,
             WorkletGlobalScopeType::Paint,
-            Box::new(|| Rc::new(WorkletThreadPool::spawn(worklet_global_scope_init))),
+            Box::new(|| Rc::new(StatelessWorkletThreadPool::spawn(worklet_global_scope_init))),
         )
     }
 

--- a/components/script/dom/worklet/paintworkletglobalscope.rs
+++ b/components/script/dom/worklet/paintworkletglobalscope.rs
@@ -357,139 +357,140 @@ impl PaintWorkletGlobalScope {
     }
 
     fn painter(&self, name: Atom) -> Box<dyn Painter> {
-        // Rather annoyingly we have to use a mutex here to make the painter Sync.
-        struct WorkletPainter {
-            name: Atom,
-            executor: Mutex<WorkletExecutor>,
-        }
-        impl SpeculativePainter for WorkletPainter {
-            fn speculatively_draw_a_paint_image(
-                &self,
-                properties: Vec<(Atom, String)>,
-                arguments: Vec<String>,
-            ) {
-                let name = self.name.clone();
-
-                let speculatively_draw_a_paint_image_task =
-                    move |cx: &mut JSContext, global_scope: &WorkletGlobalScope| {
-                        let paint_worklet_global_scope = global_scope.downcast::<PaintWorkletGlobalScope>().expect("PaintWorklet's task should be run only on PaintWorkletGlobalScope.");
-
-                        let should_speculate = (*paint_worklet_global_scope.cached_name.borrow() !=
-                            name) ||
-                            (*paint_worklet_global_scope.cached_properties.borrow() !=
-                                properties) ||
-                            (*paint_worklet_global_scope.cached_arguments.borrow() != arguments);
-                        if should_speculate {
-                            let size = paint_worklet_global_scope.cached_size.get();
-                            let device_pixel_ratio =
-                                paint_worklet_global_scope.cached_device_pixel_ratio.get();
-                            let map = StylePropertyMapReadOnly::from_iter(
-                                cx,
-                                paint_worklet_global_scope.upcast(),
-                                properties.iter().cloned(),
-                            );
-                            let result = paint_worklet_global_scope.draw_a_paint_image(
-                                cx,
-                                &name,
-                                size,
-                                device_pixel_ratio,
-                                &map,
-                                &arguments,
-                            );
-                            if (result.image_key.is_some()) &&
-                                (result.missing_image_urls.is_empty())
-                            {
-                                paint_worklet_global_scope.set_cached_paint_image(
-                                    name,
-                                    size,
-                                    device_pixel_ratio,
-                                    properties,
-                                    arguments,
-                                    result,
-                                );
-                            }
-                        }
-                    };
-
-                self.executor
-                    .lock()
-                    .expect("Locking a painter.")
-                    .schedule_a_worklet_task(Box::new(speculatively_draw_a_paint_image_task));
-            }
-        }
-        impl Painter for WorkletPainter {
-            fn draw_a_paint_image(
-                &self,
-                size: Size2D<f32, CSSPixel>,
-                device_pixel_ratio: Scale<f32, CSSPixel, DevicePixel>,
-                properties: Vec<(Atom, String)>,
-                arguments: Vec<String>,
-            ) -> Result<DrawAPaintImageResult, PaintWorkletError> {
-                let name = self.name.clone();
-                let (sender, receiver) = unbounded();
-
-                let draw_a_paint_image_task =
-                    move |cx: &mut JSContext, global_scope: &WorkletGlobalScope| {
-                        let paint_worklet_global_scope = global_scope.downcast::<PaintWorkletGlobalScope>().expect("PaintWorklet's task should be run only on PaintWorkletGlobalScope.");
-
-                        let cache_hit = paint_worklet_global_scope.has_cached_paint_image(
-                            &name,
-                            size,
-                            device_pixel_ratio,
-                            &properties,
-                            &arguments,
-                        );
-                        let result = if cache_hit {
-                            debug!("Cache hit on paint worklet {}!", name);
-                            paint_worklet_global_scope.cached_result.borrow().clone()
-                        } else {
-                            debug!("Cache miss on paint worklet {}!", name);
-                            let map = StylePropertyMapReadOnly::from_iter(
-                                cx,
-                                paint_worklet_global_scope.upcast(),
-                                properties.iter().cloned(),
-                            );
-                            let result = paint_worklet_global_scope.draw_a_paint_image(
-                                cx,
-                                &name,
-                                size,
-                                device_pixel_ratio,
-                                &map,
-                                &arguments,
-                            );
-                            if (result.image_key.is_some()) &&
-                                (result.missing_image_urls.is_empty())
-                            {
-                                paint_worklet_global_scope.set_cached_paint_image(
-                                    name,
-                                    size,
-                                    device_pixel_ratio,
-                                    properties,
-                                    arguments,
-                                    result.clone(),
-                                );
-                            }
-                            result
-                        };
-                        let _ = sender.send(result);
-                    };
-
-                self.executor
-                    .lock()
-                    .expect("Locking a painter.")
-                    .schedule_a_worklet_task(Box::new(draw_a_paint_image_task));
-
-                let timeout = pref!(dom_worklet_timeout_ms) as u64;
-
-                receiver
-                    .recv_timeout(Duration::from_millis(timeout))
-                    .map_err(PaintWorkletError::from)
-            }
-        }
         Box::new(WorkletPainter {
             name,
             executor: Mutex::new(self.worklet_global.executor()),
         })
+    }
+}
+
+// Rather annoyingly we have to use a mutex here to make the painter Sync.
+struct WorkletPainter {
+    name: Atom,
+    executor: Mutex<WorkletExecutor>,
+}
+
+impl SpeculativePainter for WorkletPainter {
+    fn speculatively_draw_a_paint_image(
+        &self,
+        properties: Vec<(Atom, String)>,
+        arguments: Vec<String>,
+    ) {
+        let name = self.name.clone();
+
+        let speculatively_draw_a_paint_image_task =
+            move |cx: &mut JSContext, global_scope: &WorkletGlobalScope| {
+                let paint_worklet_global_scope = global_scope
+                    .downcast::<PaintWorkletGlobalScope>()
+                    .expect("PaintWorklet's task should be run only on PaintWorkletGlobalScope.");
+
+                let should_speculate = (*paint_worklet_global_scope.cached_name.borrow() != name) ||
+                    (*paint_worklet_global_scope.cached_properties.borrow() != properties) ||
+                    (*paint_worklet_global_scope.cached_arguments.borrow() != arguments);
+                if should_speculate {
+                    let size = paint_worklet_global_scope.cached_size.get();
+                    let device_pixel_ratio =
+                        paint_worklet_global_scope.cached_device_pixel_ratio.get();
+                    let map = StylePropertyMapReadOnly::from_iter(
+                        cx,
+                        paint_worklet_global_scope.upcast(),
+                        properties.iter().cloned(),
+                    );
+                    let result = paint_worklet_global_scope.draw_a_paint_image(
+                        cx,
+                        &name,
+                        size,
+                        device_pixel_ratio,
+                        &map,
+                        &arguments,
+                    );
+                    if (result.image_key.is_some()) && (result.missing_image_urls.is_empty()) {
+                        paint_worklet_global_scope.set_cached_paint_image(
+                            name,
+                            size,
+                            device_pixel_ratio,
+                            properties,
+                            arguments,
+                            result,
+                        );
+                    }
+                }
+            };
+
+        self.executor
+            .lock()
+            .expect("Locking a painter.")
+            .schedule_a_worklet_task(Box::new(speculatively_draw_a_paint_image_task));
+    }
+}
+
+impl Painter for WorkletPainter {
+    fn draw_a_paint_image(
+        &self,
+        size: Size2D<f32, CSSPixel>,
+        device_pixel_ratio: Scale<f32, CSSPixel, DevicePixel>,
+        properties: Vec<(Atom, String)>,
+        arguments: Vec<String>,
+    ) -> Result<DrawAPaintImageResult, PaintWorkletError> {
+        let name = self.name.clone();
+        let (sender, receiver) = unbounded();
+
+        let draw_a_paint_image_task =
+            move |cx: &mut JSContext, global_scope: &WorkletGlobalScope| {
+                let paint_worklet_global_scope = global_scope
+                    .downcast::<PaintWorkletGlobalScope>()
+                    .expect("PaintWorklet's task should be run only on PaintWorkletGlobalScope.");
+
+                let cache_hit = paint_worklet_global_scope.has_cached_paint_image(
+                    &name,
+                    size,
+                    device_pixel_ratio,
+                    &properties,
+                    &arguments,
+                );
+                let result = if cache_hit {
+                    debug!("Cache hit on paint worklet {}!", name);
+                    paint_worklet_global_scope.cached_result.borrow().clone()
+                } else {
+                    debug!("Cache miss on paint worklet {}!", name);
+                    let map = StylePropertyMapReadOnly::from_iter(
+                        cx,
+                        paint_worklet_global_scope.upcast(),
+                        properties.iter().cloned(),
+                    );
+                    let result = paint_worklet_global_scope.draw_a_paint_image(
+                        cx,
+                        &name,
+                        size,
+                        device_pixel_ratio,
+                        &map,
+                        &arguments,
+                    );
+                    if (result.image_key.is_some()) && (result.missing_image_urls.is_empty()) {
+                        paint_worklet_global_scope.set_cached_paint_image(
+                            name,
+                            size,
+                            device_pixel_ratio,
+                            properties,
+                            arguments,
+                            result.clone(),
+                        );
+                    }
+                    result
+                };
+                let _ = sender.send(result);
+            };
+
+        self.executor
+            .lock()
+            .expect("Locking a painter.")
+            .schedule_a_worklet_task(Box::new(draw_a_paint_image_task));
+
+        let timeout = pref!(dom_worklet_timeout_ms) as u64;
+
+        receiver
+            .recv_timeout(Duration::from_millis(timeout))
+            .map_err(PaintWorkletError::from)
     }
 }
 

--- a/components/script/dom/worklet/paintworkletglobalscope.rs
+++ b/components/script/dom/worklet/paintworkletglobalscope.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
-use crossbeam_channel::{Sender, unbounded};
+use crossbeam_channel::unbounded;
 use dom_struct::dom_struct;
 use euclid::{Scale, Size2D};
 use js::context::JSContext;
@@ -135,122 +135,6 @@ impl PaintWorkletGlobalScope {
         self.image_cache.clone()
     }
 
-    pub(crate) fn perform_a_worklet_task(&self, cx: &mut JSContext, task: PaintWorkletTask) {
-        match task {
-            PaintWorkletTask::DrawAPaintImage(
-                name,
-                size,
-                device_pixel_ratio,
-                properties,
-                arguments,
-                sender,
-            ) => {
-                let cache_hit = self.has_cached_paint_image(
-                    &name,
-                    size,
-                    device_pixel_ratio,
-                    &properties,
-                    &arguments,
-                );
-
-                let result = if cache_hit {
-                    debug!("Cache hit on paint worklet {}!", name);
-                    self.cached_result.borrow().clone()
-                } else {
-                    debug!("Cache miss on paint worklet {}!", name);
-                    let map = StylePropertyMapReadOnly::from_iter(
-                        cx,
-                        self.upcast(),
-                        properties.iter().cloned(),
-                    );
-                    let result = self.draw_a_paint_image(
-                        cx,
-                        &name,
-                        size,
-                        device_pixel_ratio,
-                        &map,
-                        &arguments,
-                    );
-                    if (result.image_key.is_some()) && (result.missing_image_urls.is_empty()) {
-                        self.set_cached_paint_image(
-                            name,
-                            size,
-                            device_pixel_ratio,
-                            properties,
-                            arguments,
-                            result.clone(),
-                        );
-                    }
-                    result
-                };
-                let _ = sender.send(result);
-            },
-            PaintWorkletTask::SpeculativelyDrawAPaintImage(name, properties, arguments) => {
-                let should_speculate = (*self.cached_name.borrow() != name) ||
-                    (*self.cached_properties.borrow() != properties) ||
-                    (*self.cached_arguments.borrow() != arguments);
-                if should_speculate {
-                    let size = self.cached_size.get();
-                    let device_pixel_ratio = self.cached_device_pixel_ratio.get();
-                    let map = StylePropertyMapReadOnly::from_iter(
-                        cx,
-                        self.upcast(),
-                        properties.iter().cloned(),
-                    );
-                    let result = self.draw_a_paint_image(
-                        cx,
-                        &name,
-                        size,
-                        device_pixel_ratio,
-                        &map,
-                        &arguments,
-                    );
-                    if (result.image_key.is_some()) && (result.missing_image_urls.is_empty()) {
-                        self.set_cached_paint_image(
-                            name,
-                            size,
-                            device_pixel_ratio,
-                            properties,
-                            arguments,
-                            result,
-                        );
-                    }
-                }
-            },
-        }
-    }
-
-    fn has_cached_paint_image(
-        &self,
-        name: &Atom,
-        size: Size2D<f32, CSSPixel>,
-        device_pixel_ratio: Scale<f32, CSSPixel, DevicePixel>,
-        properties: &[(Atom, String)],
-        arguments: &[String],
-    ) -> bool {
-        (&*self.cached_name.borrow() == name) &&
-            (self.cached_size.get() == size) &&
-            (self.cached_device_pixel_ratio.get() == device_pixel_ratio) &&
-            (*self.cached_properties.borrow() == properties) &&
-            (*self.cached_arguments.borrow() == arguments)
-    }
-
-    fn set_cached_paint_image(
-        &self,
-        name: Atom,
-        size: Size2D<f32, CSSPixel>,
-        device_pixel_ratio: Scale<f32, CSSPixel, DevicePixel>,
-        properties: Vec<(Atom, String)>,
-        arguments: Vec<String>,
-        result: DrawAPaintImageResult,
-    ) {
-        *self.cached_name.borrow_mut() = name;
-        self.cached_size.set(size);
-        self.cached_device_pixel_ratio.set(device_pixel_ratio);
-        *self.cached_properties.borrow_mut() = properties;
-        *self.cached_arguments.borrow_mut() = arguments;
-        *self.cached_result.borrow_mut() = result;
-    }
 
     /// <https://drafts.css-houdini.org/css-paint-api/#draw-a-paint-image>
     fn draw_a_paint_image(
@@ -441,75 +325,176 @@ impl PaintWorkletGlobalScope {
         }
     }
 
-    // fn painter(&self, name: Atom) -> Box<dyn Painter> {
-    //     // Rather annoyingly we have to use a mutex here to make the painter Sync.
-    //     struct WorkletPainter {
-    //         name: Atom,
-    //         executor: Mutex<WorkletExecutor>,
-    //     }
-    //     impl SpeculativePainter for WorkletPainter {
-    //         fn speculatively_draw_a_paint_image(
-    //             &self,
-    //             properties: Vec<(Atom, String)>,
-    //             arguments: Vec<String>,
-    //         ) {
-    //             let name = self.name.clone();
-    //             let task =
-    //                 PaintWorkletTask::SpeculativelyDrawAPaintImage(name, properties, arguments);
-    //             self.executor
-    //                 .lock()
-    //                 .expect("Locking a painter.")
-    //                 .schedule_a_worklet_task(WorkletTask::Paint(task));
-    //         }
-    //     }
-    //     impl Painter for WorkletPainter {
-    //         fn draw_a_paint_image(
-    //             &self,
-    //             size: Size2D<f32, CSSPixel>,
-    //             device_pixel_ratio: Scale<f32, CSSPixel, DevicePixel>,
-    //             properties: Vec<(Atom, String)>,
-    //             arguments: Vec<String>,
-    //         ) -> Result<DrawAPaintImageResult, PaintWorkletError> {
-    //             let name = self.name.clone();
-    //             let (sender, receiver) = unbounded();
-    //             let task = PaintWorkletTask::DrawAPaintImage(
-    //                 name,
-    //                 size,
-    //                 device_pixel_ratio,
-    //                 properties,
-    //                 arguments,
-    //                 sender,
-    //             );
-    //             self.executor
-    //                 .lock()
-    //                 .expect("Locking a painter.")
-    //                 .schedule_a_worklet_task(WorkletTask::Paint(task));
-    //
-    //             let timeout = pref!(dom_worklet_timeout_ms) as u64;
-    //
-    //             receiver
-    //                 .recv_timeout(Duration::from_millis(timeout))
-    //                 .map_err(PaintWorkletError::from)
-    //         }
-    //     }
-    //     Box::new(WorkletPainter {
-    //         name,
-    //         executor: Mutex::new(self.worklet_global.executor()),
-    //     })
-    // }
-}
+    fn painter(&self, name: Atom) -> Box<dyn Painter> {
+        // Rather annoyingly we have to use a mutex here to make the painter Sync.
+        struct WorkletPainter {
+            name: Atom,
+            executor: Mutex<WorkletExecutor>,
+        }
 
-/// Tasks which can be peformed by a paint worklet
-pub(crate) enum PaintWorkletTask {
-    DrawAPaintImage(
-        Atom,
-        Size2D<f32, CSSPixel>,
-        Scale<f32, CSSPixel, DevicePixel>,
-        Vec<(Atom, String)>,
-        Vec<String>,
-        Sender<DrawAPaintImageResult>,
-    ),
-    SpeculativelyDrawAPaintImage(Atom, Vec<(Atom, String)>, Vec<String>),
+        impl WorkletPainter {
+        }
+
+        impl SpeculativePainter for WorkletPainter {
+            fn speculatively_draw_a_paint_image(
+                &self,
+                properties: Vec<(Atom, String)>,
+                arguments: Vec<String>,
+            ) {
+                let name = self.name.clone();
+
+                let speculatively_draw_a_paint_image_task =
+                    move |cx: &mut JSContext, global_scope: &WorkletGlobalScope| {
+                        let paint_worklet_global_scope = global_scope.downcast::<PaintWorkletGlobalScope>().expect("Could not downcast &WorkletGlobalScope to &PaintWorkletGlobalScope.");
+
+                        let should_speculate = (*paint_worklet_global_scope.cached_name.borrow() !=
+                            name) ||
+                            (*paint_worklet_global_scope.cached_properties.borrow() !=
+                                properties) ||
+                            (*paint_worklet_global_scope.cached_arguments.borrow() != arguments);
+                        if should_speculate {
+                            let size = paint_worklet_global_scope.cached_size.get();
+                            let device_pixel_ratio =
+                                paint_worklet_global_scope.cached_device_pixel_ratio.get();
+                            let map = StylePropertyMapReadOnly::from_iter(
+                                cx,
+                                paint_worklet_global_scope.upcast(),
+                                properties.iter().cloned(),
+                            );
+                            let result = paint_worklet_global_scope.draw_a_paint_image(
+                                cx,
+                                &name,
+                                size,
+                                device_pixel_ratio,
+                                &map,
+                                &arguments,
+                            );
+                            if (result.image_key.is_some()) &&
+                                (result.missing_image_urls.is_empty())
+                            {
+                                paint_worklet_global_scope.set_cached_paint_image(
+                                    name,
+                                    size,
+                                    device_pixel_ratio,
+                                    properties,
+                                    arguments,
+                                    result,
+                                );
+                            }
+                        }
+                    };
+
+                self.executor
+                    .lock()
+                    .expect("Locking a painter.")
+                    .schedule_a_worklet_task(Box::new(speculatively_draw_a_paint_image_task));
+            }
+        }
+        impl Painter for WorkletPainter {
+            fn draw_a_paint_image(
+                &self,
+                size: Size2D<f32, CSSPixel>,
+                device_pixel_ratio: Scale<f32, CSSPixel, DevicePixel>,
+                properties: Vec<(Atom, String)>,
+                arguments: Vec<String>,
+            ) -> Result<DrawAPaintImageResult, PaintWorkletError> {
+                let name = self.name.clone();
+                let (sender, receiver) = unbounded();
+
+                let draw_a_paint_image_task =
+                    move |cx: &mut JSContext, global_scope: &WorkletGlobalScope| {
+                        let paint_worklet_global_scope = global_scope.downcast::<PaintWorkletGlobalScope>().expect("Could not downcast &WorkletGlobalScope to &PaintWorkletGlobalScope.");
+
+                        let cache_hit = paint_worklet_global_scope.has_cached_paint_image(
+                            &name,
+                            size,
+                            device_pixel_ratio,
+                            &properties,
+                            &arguments,
+                        );
+                        let result = if cache_hit {
+                            debug!("Cache hit on paint worklet {}!", name);
+                            paint_worklet_global_scope.cached_result.borrow().clone()
+                        } else {
+                            debug!("Cache miss on paint worklet {}!", name);
+                            let map = StylePropertyMapReadOnly::from_iter(
+                                cx,
+                                paint_worklet_global_scope.upcast(),
+                                properties.iter().cloned(),
+                            );
+                            let result = paint_worklet_global_scope.draw_a_paint_image(
+                                cx,
+                                &name,
+                                size,
+                                device_pixel_ratio,
+                                &map,
+                                &arguments,
+                            );
+                            if (result.image_key.is_some()) &&
+                                (result.missing_image_urls.is_empty())
+                            {
+                                paint_worklet_global_scope.set_cached_paint_image(
+                                    name,
+                                    size,
+                                    device_pixel_ratio,
+                                    properties,
+                                    arguments,
+                                    result.clone(),
+                                );
+                            }
+                            result
+                        };
+                        let _ = sender.send(result);
+                    };
+
+                self.executor
+                    .lock()
+                    .expect("Locking a painter.")
+                    .schedule_a_worklet_task(Box::new(draw_a_paint_image_task));
+
+                let timeout = pref!(dom_worklet_timeout_ms) as u64;
+
+                receiver
+                    .recv_timeout(Duration::from_millis(timeout))
+                    .map_err(PaintWorkletError::from)
+            }
+        }
+        Box::new(WorkletPainter {
+            name,
+            executor: Mutex::new(self.worklet_global.executor()),
+        })
+    }
+    fn has_cached_paint_image(
+        &self,
+        name: &Atom,
+        size: Size2D<f32, CSSPixel>,
+        device_pixel_ratio: Scale<f32, CSSPixel, DevicePixel>,
+        properties: &[(Atom, String)],
+        arguments: &[String],
+    ) -> bool {
+        (&*self.cached_name.borrow() == name) &&
+            (self.cached_size.get() == size) &&
+            (self.cached_device_pixel_ratio.get() == device_pixel_ratio) &&
+            (*self.cached_properties.borrow() == properties) &&
+            (*self.cached_arguments.borrow() == arguments)
+    }
+
+    fn set_cached_paint_image(
+        &self,
+        name: Atom,
+        size: Size2D<f32, CSSPixel>,
+        device_pixel_ratio: Scale<f32, CSSPixel, DevicePixel>,
+        properties: Vec<(Atom, String)>,
+        arguments: Vec<String>,
+        result: DrawAPaintImageResult,
+    ) {
+        *self.cached_name.borrow_mut() = name;
+        self.cached_size.set(size);
+        self.cached_device_pixel_ratio.set(device_pixel_ratio);
+        *self.cached_properties.borrow_mut() = properties;
+        *self.cached_arguments.borrow_mut() = arguments;
+        *self.cached_result.borrow_mut() = result;
+    }
 }
 
 /// A paint definition
@@ -584,7 +569,7 @@ impl PaintWorkletGlobalScopeMethods<crate::DomTypeHolder> for PaintWorkletGlobal
         // Step 4-6.
         let property_names: Vec<String> =
             get_property(cx, paint_obj.handle(), c"inputProperties", ())?.unwrap_or_default();
-        // let properties = property_names.into_iter().map(Atom::from).collect();
+        let properties = property_names.into_iter().map(Atom::from).collect();
 
         // Step 7-9.
         let input_arguments: Vec<String> =
@@ -642,9 +627,9 @@ impl PaintWorkletGlobalScopeMethods<crate::DomTypeHolder> for PaintWorkletGlobal
 
         // Inform layout that there is a registered paint worklet.
         // TODO: layout will end up getting this message multiple times.
-        // let painter = self.painter(name.clone());
-        // self.worklet_global
-        //     .register_paint_worklet(name, properties, painter);
+        let painter = self.painter(name.clone());
+        self.worklet_global
+            .register_paint_worklet(name, properties, painter);
 
         Ok(())
     }

--- a/components/script/dom/worklet/paintworkletglobalscope.rs
+++ b/components/script/dom/worklet/paintworkletglobalscope.rs
@@ -135,7 +135,6 @@ impl PaintWorkletGlobalScope {
         self.image_cache.clone()
     }
 
-
     /// <https://drafts.css-houdini.org/css-paint-api/#draw-a-paint-image>
     fn draw_a_paint_image(
         &self,
@@ -332,9 +331,6 @@ impl PaintWorkletGlobalScope {
             executor: Mutex<WorkletExecutor>,
         }
 
-        impl WorkletPainter {
-        }
-
         impl SpeculativePainter for WorkletPainter {
             fn speculatively_draw_a_paint_image(
                 &self,
@@ -345,7 +341,7 @@ impl PaintWorkletGlobalScope {
 
                 let speculatively_draw_a_paint_image_task =
                     move |cx: &mut JSContext, global_scope: &WorkletGlobalScope| {
-                        let paint_worklet_global_scope = global_scope.downcast::<PaintWorkletGlobalScope>().expect("Could not downcast &WorkletGlobalScope to &PaintWorkletGlobalScope.");
+                        let paint_worklet_global_scope = global_scope.downcast::<PaintWorkletGlobalScope>().expect("PaintWorklet's task should be run only on PaintWorkletGlobalScope.");
 
                         let should_speculate = (*paint_worklet_global_scope.cached_name.borrow() !=
                             name) ||
@@ -403,7 +399,7 @@ impl PaintWorkletGlobalScope {
 
                 let draw_a_paint_image_task =
                     move |cx: &mut JSContext, global_scope: &WorkletGlobalScope| {
-                        let paint_worklet_global_scope = global_scope.downcast::<PaintWorkletGlobalScope>().expect("Could not downcast &WorkletGlobalScope to &PaintWorkletGlobalScope.");
+                        let paint_worklet_global_scope = global_scope.downcast::<PaintWorkletGlobalScope>().expect("PaintWorklet's task should be run only on PaintWorkletGlobalScope.");
 
                         let cache_hit = paint_worklet_global_scope.has_cached_paint_image(
                             &name,

--- a/components/script/dom/worklet/paintworkletglobalscope.rs
+++ b/components/script/dom/worklet/paintworkletglobalscope.rs
@@ -135,6 +135,38 @@ impl PaintWorkletGlobalScope {
         self.image_cache.clone()
     }
 
+    fn has_cached_paint_image(
+        &self,
+        name: &Atom,
+        size: Size2D<f32, CSSPixel>,
+        device_pixel_ratio: Scale<f32, CSSPixel, DevicePixel>,
+        properties: &[(Atom, String)],
+        arguments: &[String],
+    ) -> bool {
+        (&*self.cached_name.borrow() == name) &&
+            (self.cached_size.get() == size) &&
+            (self.cached_device_pixel_ratio.get() == device_pixel_ratio) &&
+            (*self.cached_properties.borrow() == properties) &&
+            (*self.cached_arguments.borrow() == arguments)
+    }
+
+    fn set_cached_paint_image(
+        &self,
+        name: Atom,
+        size: Size2D<f32, CSSPixel>,
+        device_pixel_ratio: Scale<f32, CSSPixel, DevicePixel>,
+        properties: Vec<(Atom, String)>,
+        arguments: Vec<String>,
+        result: DrawAPaintImageResult,
+    ) {
+        *self.cached_name.borrow_mut() = name;
+        self.cached_size.set(size);
+        self.cached_device_pixel_ratio.set(device_pixel_ratio);
+        *self.cached_properties.borrow_mut() = properties;
+        *self.cached_arguments.borrow_mut() = arguments;
+        *self.cached_result.borrow_mut() = result;
+    }
+
     /// <https://drafts.css-houdini.org/css-paint-api/#draw-a-paint-image>
     fn draw_a_paint_image(
         &self,
@@ -330,7 +362,6 @@ impl PaintWorkletGlobalScope {
             name: Atom,
             executor: Mutex<WorkletExecutor>,
         }
-
         impl SpeculativePainter for WorkletPainter {
             fn speculatively_draw_a_paint_image(
                 &self,
@@ -459,37 +490,6 @@ impl PaintWorkletGlobalScope {
             name,
             executor: Mutex::new(self.worklet_global.executor()),
         })
-    }
-    fn has_cached_paint_image(
-        &self,
-        name: &Atom,
-        size: Size2D<f32, CSSPixel>,
-        device_pixel_ratio: Scale<f32, CSSPixel, DevicePixel>,
-        properties: &[(Atom, String)],
-        arguments: &[String],
-    ) -> bool {
-        (&*self.cached_name.borrow() == name) &&
-            (self.cached_size.get() == size) &&
-            (self.cached_device_pixel_ratio.get() == device_pixel_ratio) &&
-            (*self.cached_properties.borrow() == properties) &&
-            (*self.cached_arguments.borrow() == arguments)
-    }
-
-    fn set_cached_paint_image(
-        &self,
-        name: Atom,
-        size: Size2D<f32, CSSPixel>,
-        device_pixel_ratio: Scale<f32, CSSPixel, DevicePixel>,
-        properties: Vec<(Atom, String)>,
-        arguments: Vec<String>,
-        result: DrawAPaintImageResult,
-    ) {
-        *self.cached_name.borrow_mut() = name;
-        self.cached_size.set(size);
-        self.cached_device_pixel_ratio.set(device_pixel_ratio);
-        *self.cached_properties.borrow_mut() = properties;
-        *self.cached_arguments.borrow_mut() = arguments;
-        *self.cached_result.borrow_mut() = result;
     }
 }
 

--- a/components/script/dom/worklet/paintworkletglobalscope.rs
+++ b/components/script/dom/worklet/paintworkletglobalscope.rs
@@ -50,7 +50,7 @@ use crate::dom::css::stylepropertymapreadonly::StylePropertyMapReadOnly;
 use crate::dom::paintrenderingcontext2d::PaintRenderingContext2D;
 use crate::dom::paintsize::PaintSize;
 use crate::dom::worklet::WorkletExecutor;
-use crate::dom::workletglobalscope::{WorkletGlobalScope, WorkletGlobalScopeInit, WorkletTask};
+use crate::dom::workletglobalscope::{WorkletGlobalScope, WorkletGlobalScopeInit};
 use crate::runtime::microtask::MicrotaskQueue;
 
 /// <https://drafts.css-houdini.org/css-paint-api/#paintworkletglobalscope>
@@ -441,62 +441,62 @@ impl PaintWorkletGlobalScope {
         }
     }
 
-    fn painter(&self, name: Atom) -> Box<dyn Painter> {
-        // Rather annoyingly we have to use a mutex here to make the painter Sync.
-        struct WorkletPainter {
-            name: Atom,
-            executor: Mutex<WorkletExecutor>,
-        }
-        impl SpeculativePainter for WorkletPainter {
-            fn speculatively_draw_a_paint_image(
-                &self,
-                properties: Vec<(Atom, String)>,
-                arguments: Vec<String>,
-            ) {
-                let name = self.name.clone();
-                let task =
-                    PaintWorkletTask::SpeculativelyDrawAPaintImage(name, properties, arguments);
-                self.executor
-                    .lock()
-                    .expect("Locking a painter.")
-                    .schedule_a_worklet_task(WorkletTask::Paint(task));
-            }
-        }
-        impl Painter for WorkletPainter {
-            fn draw_a_paint_image(
-                &self,
-                size: Size2D<f32, CSSPixel>,
-                device_pixel_ratio: Scale<f32, CSSPixel, DevicePixel>,
-                properties: Vec<(Atom, String)>,
-                arguments: Vec<String>,
-            ) -> Result<DrawAPaintImageResult, PaintWorkletError> {
-                let name = self.name.clone();
-                let (sender, receiver) = unbounded();
-                let task = PaintWorkletTask::DrawAPaintImage(
-                    name,
-                    size,
-                    device_pixel_ratio,
-                    properties,
-                    arguments,
-                    sender,
-                );
-                self.executor
-                    .lock()
-                    .expect("Locking a painter.")
-                    .schedule_a_worklet_task(WorkletTask::Paint(task));
-
-                let timeout = pref!(dom_worklet_timeout_ms) as u64;
-
-                receiver
-                    .recv_timeout(Duration::from_millis(timeout))
-                    .map_err(PaintWorkletError::from)
-            }
-        }
-        Box::new(WorkletPainter {
-            name,
-            executor: Mutex::new(self.worklet_global.executor()),
-        })
-    }
+    // fn painter(&self, name: Atom) -> Box<dyn Painter> {
+    //     // Rather annoyingly we have to use a mutex here to make the painter Sync.
+    //     struct WorkletPainter {
+    //         name: Atom,
+    //         executor: Mutex<WorkletExecutor>,
+    //     }
+    //     impl SpeculativePainter for WorkletPainter {
+    //         fn speculatively_draw_a_paint_image(
+    //             &self,
+    //             properties: Vec<(Atom, String)>,
+    //             arguments: Vec<String>,
+    //         ) {
+    //             let name = self.name.clone();
+    //             let task =
+    //                 PaintWorkletTask::SpeculativelyDrawAPaintImage(name, properties, arguments);
+    //             self.executor
+    //                 .lock()
+    //                 .expect("Locking a painter.")
+    //                 .schedule_a_worklet_task(WorkletTask::Paint(task));
+    //         }
+    //     }
+    //     impl Painter for WorkletPainter {
+    //         fn draw_a_paint_image(
+    //             &self,
+    //             size: Size2D<f32, CSSPixel>,
+    //             device_pixel_ratio: Scale<f32, CSSPixel, DevicePixel>,
+    //             properties: Vec<(Atom, String)>,
+    //             arguments: Vec<String>,
+    //         ) -> Result<DrawAPaintImageResult, PaintWorkletError> {
+    //             let name = self.name.clone();
+    //             let (sender, receiver) = unbounded();
+    //             let task = PaintWorkletTask::DrawAPaintImage(
+    //                 name,
+    //                 size,
+    //                 device_pixel_ratio,
+    //                 properties,
+    //                 arguments,
+    //                 sender,
+    //             );
+    //             self.executor
+    //                 .lock()
+    //                 .expect("Locking a painter.")
+    //                 .schedule_a_worklet_task(WorkletTask::Paint(task));
+    //
+    //             let timeout = pref!(dom_worklet_timeout_ms) as u64;
+    //
+    //             receiver
+    //                 .recv_timeout(Duration::from_millis(timeout))
+    //                 .map_err(PaintWorkletError::from)
+    //         }
+    //     }
+    //     Box::new(WorkletPainter {
+    //         name,
+    //         executor: Mutex::new(self.worklet_global.executor()),
+    //     })
+    // }
 }
 
 /// Tasks which can be peformed by a paint worklet
@@ -584,7 +584,7 @@ impl PaintWorkletGlobalScopeMethods<crate::DomTypeHolder> for PaintWorkletGlobal
         // Step 4-6.
         let property_names: Vec<String> =
             get_property(cx, paint_obj.handle(), c"inputProperties", ())?.unwrap_or_default();
-        let properties = property_names.into_iter().map(Atom::from).collect();
+        // let properties = property_names.into_iter().map(Atom::from).collect();
 
         // Step 7-9.
         let input_arguments: Vec<String> =
@@ -642,9 +642,9 @@ impl PaintWorkletGlobalScopeMethods<crate::DomTypeHolder> for PaintWorkletGlobal
 
         // Inform layout that there is a registered paint worklet.
         // TODO: layout will end up getting this message multiple times.
-        let painter = self.painter(name.clone());
-        self.worklet_global
-            .register_paint_worklet(name, properties, painter);
+        // let painter = self.painter(name.clone());
+        // self.worklet_global
+        //     .register_paint_worklet(name, properties, painter);
 
         Ok(())
     }

--- a/components/script/dom/worklet/worklet.rs
+++ b/components/script/dom/worklet/worklet.rs
@@ -47,7 +47,6 @@ use crate::dom::bindings::str::USVString;
 use crate::dom::bindings::trace::{JSTraceable, RootedTraceableBox};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
-#[cfg(feature = "testbinding")]
 use crate::dom::window::Window;
 use crate::dom::workletglobalscope::{
     WorkletGlobalScope, WorkletGlobalScopeInit, WorkletGlobalScopeType,

--- a/components/script/dom/worklet/worklet.rs
+++ b/components/script/dom/worklet/worklet.rs
@@ -265,7 +265,7 @@ pub trait WorkletThreadPool: JSTraceable {
     fn exit_worklet(&self, worklet_id: WorkletId);
     fn wake_threads(&self);
     /// Send a `WorkletTask` to a Worklet thread to execute.
-    fn run_task(&self, worklet_id: WorkletId, worklet_task: WorkletTask);
+    fn perform_a_worklet_task(&self, worklet_id: WorkletId, worklet_task: WorkletTask);
 }
 
 /// Worklets execute in a dedicated thread pool.
@@ -432,7 +432,7 @@ impl WorkletThreadPool for StatelessWorkletThreadPool {
     }
 
     /// Send a `WorkletTask` to the "Primary Worklet Thread" to execute.
-    fn run_task(&self, worklet_id: WorkletId, worklet_task: WorkletTask) {
+    fn perform_a_worklet_task(&self, worklet_id: WorkletId, worklet_task: WorkletTask) {
         let msg = WorkletData::Task(worklet_id, worklet_task);
         let _ = self.primary_sender.send(msg);
     }

--- a/components/script/dom/worklet/worklet.rs
+++ b/components/script/dom/worklet/worklet.rs
@@ -251,7 +251,7 @@ pub trait WorkletThreadPool: JSTraceable {
     /// If all of the threads load successfully, the promise is resolved.
     /// If any of the threads fails to load, the promise is rejected.
     /// NOTE: The method implements the Step 6 of AddModule
-    /// <https://html.spec.whatwg.org/multipage/worklets.html#dom-worklet-addmodule>
+    /// <https://html.spec.whatwg.org/multipage/#dom-worklet-addmodule>
     #[allow(clippy::too_many_arguments)]
     fn fetch_and_invoke_a_worklet_script(
         &self,

--- a/components/script/dom/worklet/worklet.rs
+++ b/components/script/dom/worklet/worklet.rs
@@ -48,7 +48,6 @@ use crate::dom::bindings::trace::{JSTraceable, RootedTraceableBox};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 #[cfg(feature = "testbinding")]
-use crate::dom::testworkletglobalscope::TestWorkletTask;
 use crate::dom::window::Window;
 use crate::dom::workletglobalscope::{
     WorkletGlobalScope, WorkletGlobalScopeInit, WorkletGlobalScopeType,
@@ -139,8 +138,7 @@ impl Worklet {
 
     pub(crate) fn worklet_thread_pool(&self) -> Rc<dyn WorkletThreadPool> {
         self.droppable_field.is_thread_pool_initialized.set(true);
-
-        return self.droppable_field.thread_pool.clone()
+        self.droppable_field.thread_pool.clone()
     }
 
     #[cfg(feature = "testbinding")]
@@ -266,6 +264,7 @@ pub trait WorkletThreadPool: JSTraceable {
     );
     fn exit_worklet(&self, worklet_id: WorkletId);
     fn wake_threads(&self);
+    /// Send a `WorkletTask` to a Worklet thread to execute.
     fn run_task(&self, worklet_id: WorkletId, worklet_task: WorkletTask);
 }
 
@@ -432,13 +431,15 @@ impl WorkletThreadPool for StatelessWorkletThreadPool {
         let _ = self.primary_sender.send(WorkletData::WakeUp);
     }
 
+    /// Send a `WorkletTask` to the "Primary Worklet Thread" to execute.
     fn run_task(&self, worklet_id: WorkletId, worklet_task: WorkletTask) {
         let msg = WorkletData::Task(worklet_id, worklet_task);
         let _ = self.primary_sender.send(msg);
     }
 }
 
-type WorkletTask = Box<dyn FnOnce(&WorkletGlobalScope) + Send>;
+// A boxed closure sent to the "Primary Worklet Thread" to execute Worklet tasks.
+type WorkletTask = Box<dyn FnOnce(&mut JSContext, &WorkletGlobalScope) + Send>;
 
 /// The data messages sent to worklet threads
 enum WorkletData {
@@ -868,10 +869,15 @@ impl WorkletThread {
         );
     }
 
-    /// Perform a task.
-    fn perform_a_worklet_task(&self, cx: &mut JSContext, worklet_id: WorkletId, task: WorkletTask) {
+    /// Execute a `WorkletTask`.
+    fn perform_a_worklet_task(
+        &self,
+        cx: &mut JSContext,
+        worklet_id: WorkletId,
+        worklet_task: WorkletTask,
+    ) {
         match self.global_scopes.get(&worklet_id) {
-            Some(global) => task(global),
+            Some(global) => worklet_task(cx, global),
             None => warn!("No such worklet as {:?}.", worklet_id),
         }
     }

--- a/components/script/dom/worklet/worklet.rs
+++ b/components/script/dom/worklet/worklet.rs
@@ -247,6 +247,10 @@ impl PendingTasksStruct {
 }
 
 pub trait WorkletThreadPool: JSTraceable {
+    /// Loads a worklet module into every thread in this thread pool.
+    /// If all of the threads load successfully, the promise is resolved.
+    /// If any of the threads fails to load, the promise is rejected.
+    /// <https://html.spec.whatwg.org/multipage/#fetch-a-worklet-script-graph>
     #[allow(clippy::too_many_arguments)]
     fn fetch_and_invoke_a_worklet_script(
         &self,
@@ -262,13 +266,18 @@ pub trait WorkletThreadPool: JSTraceable {
         promise: &Rc<Promise>,
         inherited_secure_context: Option<bool>,
     );
+    /// Request that the [`WorkletGlobalScope`] associated with the [`WorkletId`] be removed from all the threads in the thread pool.
     fn exit_worklet(&self, worklet_id: WorkletId);
+    /// Signal all the threads in the pool that there may be control messages to process.
     fn wake_threads(&self);
-    /// Send a `WorkletTask` to a Worklet thread to execute.
+    /// Queue a [`WorkletTask`] for execution on this [`WorkletThreadPool`]. The task will be executed in the context of the [`WorkletGlobalScope`] represented by the [`WorketId`].
     fn perform_a_worklet_task(&self, worklet_id: WorkletId, worklet_task: WorkletTask);
 }
 
-/// Worklets execute in a dedicated thread pool.
+/// The `StatelessWorkletThreadPool` executes the associated
+/// [`WorkletTask`]s in a dedicated thread pool with the assumption that
+/// the tasks are idempotent. This is useful for the paint worklet, for
+/// example.
 ///
 /// The goal is to ensure that there is a primary worklet thread,
 /// which is able to responsively execute worklet code. In particular,
@@ -371,10 +380,6 @@ impl StatelessWorkletThreadPool {
 }
 
 impl WorkletThreadPool for StatelessWorkletThreadPool {
-    /// Loads a worklet module into every worklet thread.
-    /// If all of the threads load successfully, the promise is resolved.
-    /// If any of the threads fails to load, the promise is rejected.
-    /// <https://drafts.css-houdini.org/worklets/#fetch-and-invoke-a-worklet-script>
     #[allow(clippy::too_many_arguments)]
     fn fetch_and_invoke_a_worklet_script(
         &self,
@@ -431,14 +436,14 @@ impl WorkletThreadPool for StatelessWorkletThreadPool {
         let _ = self.primary_sender.send(WorkletData::WakeUp);
     }
 
-    /// Send a `WorkletTask` to the "Primary Worklet Thread" to execute.
+    /// Queue the [`WorkletTask`] for execution on the primary thread.
     fn perform_a_worklet_task(&self, worklet_id: WorkletId, worklet_task: WorkletTask) {
         let msg = WorkletData::Task(worklet_id, worklet_task);
         let _ = self.primary_sender.send(msg);
     }
 }
 
-// A boxed closure sent to the "Primary Worklet Thread" to execute Worklet tasks.
+/// A task which can be performed in the context of a [`WorkletGlobalScope`].
 type WorkletTask = Box<dyn FnOnce(&mut JSContext, &WorkletGlobalScope) + Send>;
 
 /// The data messages sent to worklet threads
@@ -869,7 +874,7 @@ impl WorkletThread {
         );
     }
 
-    /// Execute a `WorkletTask`.
+    /// Run the steps for the `WorkletTask` for a given Worklet.
     fn perform_a_worklet_task(
         &self,
         cx: &mut JSContext,

--- a/components/script/dom/worklet/worklet.rs
+++ b/components/script/dom/worklet/worklet.rs
@@ -250,7 +250,8 @@ pub trait WorkletThreadPool: JSTraceable {
     /// Loads a worklet module into every thread in this thread pool.
     /// If all of the threads load successfully, the promise is resolved.
     /// If any of the threads fails to load, the promise is rejected.
-    /// <https://html.spec.whatwg.org/multipage/#fetch-a-worklet-script-graph>
+    /// NOTE: The method implements the Step 6 of AddModule
+    /// <https://html.spec.whatwg.org/multipage/worklets.html#dom-worklet-addmodule>
     #[allow(clippy::too_many_arguments)]
     fn fetch_and_invoke_a_worklet_script(
         &self,
@@ -266,11 +267,15 @@ pub trait WorkletThreadPool: JSTraceable {
         promise: &Rc<Promise>,
         inherited_secure_context: Option<bool>,
     );
-    /// Request that the [`WorkletGlobalScope`] associated with the [`WorkletId`] be removed from all the threads in the thread pool.
+    /// Request that the [`WorkletGlobalScope`] associated with the [`WorkletId`]
+    /// be removed from all the threads in the thread pool.
     fn exit_worklet(&self, worklet_id: WorkletId);
-    /// Signal all the threads in the pool that there may be control messages to process.
+    /// Signal all the threads in the pool that there may be control messages to
+    /// process.
     fn wake_threads(&self);
-    /// Queue a [`WorkletTask`] for execution on this [`WorkletThreadPool`]. The task will be executed in the context of the [`WorkletGlobalScope`] represented by the [`WorketId`].
+    /// Queue a [`WorkletTask`] for execution on this [`WorkletThreadPool`].
+    /// The task will be executed in the context of the [`WorkletGlobalScope`]
+    /// represented by the [`WorketId`].
     fn perform_a_worklet_task(&self, worklet_id: WorkletId, worklet_task: WorkletTask);
 }
 

--- a/components/script/dom/worklet/worklet.rs
+++ b/components/script/dom/worklet/worklet.rs
@@ -51,7 +51,7 @@ use crate::dom::promise::Promise;
 use crate::dom::testworkletglobalscope::TestWorkletTask;
 use crate::dom::window::Window;
 use crate::dom::workletglobalscope::{
-    WorkletGlobalScope, WorkletGlobalScopeInit, WorkletGlobalScopeType, WorkletTask,
+    WorkletGlobalScope, WorkletGlobalScopeInit, WorkletGlobalScopeType,
 };
 use crate::messaging::{CommonScriptMsg, MainThreadScriptMsg, ScriptEventLoopSender};
 use crate::modules::script_module::fetch_a_module_script_graph;
@@ -75,7 +75,7 @@ struct DroppableField {
     /// NOTE: Do not access the `thread_pool` field directly, instead use the
     /// `Worklet::worklet_thread_pool` method to access the Thread Pool.
     #[ignore_malloc_size_of = "Difficult to measure memory usage of Rc<...> types"]
-    thread_pool: LazyCellWithBoxedInitializer<Rc<WorkletThreadPool>>,
+    thread_pool: LazyCellWithBoxedInitializer<Rc<dyn WorkletThreadPool>>,
 
     /// NOTE: The `is_thread_pool_initialized` field is a temporary workaround because
     /// using the `LazyCell::get()` method requires Rust version >1.94.0 and is not
@@ -105,7 +105,7 @@ impl Worklet {
     fn new_inherited(
         window: &Window,
         global_type: WorkletGlobalScopeType,
-        thread_pool_constructor: Box<dyn FnOnce() -> Rc<WorkletThreadPool>>,
+        thread_pool_constructor: Box<dyn FnOnce() -> Rc<dyn WorkletThreadPool>>,
     ) -> Worklet {
         Worklet {
             reflector: Reflector::new(),
@@ -123,7 +123,7 @@ impl Worklet {
         cx: &mut JSContext,
         window: &Window,
         global_type: WorkletGlobalScopeType,
-        thread_pool_constructor: Box<dyn FnOnce() -> Rc<WorkletThreadPool>>,
+        thread_pool_constructor: Box<dyn FnOnce() -> Rc<dyn WorkletThreadPool>>,
     ) -> DomRoot<Worklet> {
         debug!("Creating worklet {:?}.", global_type);
         reflect_dom_object_with_cx(
@@ -137,9 +137,10 @@ impl Worklet {
         )
     }
 
-    pub(crate) fn worklet_thread_pool(&self) -> &WorkletThreadPool {
+    pub(crate) fn worklet_thread_pool(&self) -> Rc<dyn WorkletThreadPool> {
         self.droppable_field.is_thread_pool_initialized.set(true);
-        &self.droppable_field.thread_pool
+
+        return self.droppable_field.thread_pool.clone()
     }
 
     #[cfg(feature = "testbinding")]
@@ -247,6 +248,27 @@ impl PendingTasksStruct {
     }
 }
 
+pub trait WorkletThreadPool: JSTraceable {
+    #[allow(clippy::too_many_arguments)]
+    fn fetch_and_invoke_a_worklet_script(
+        &self,
+        pipeline_id: PipelineId,
+        worklet_id: WorkletId,
+        global_type: WorkletGlobalScopeType,
+        origin: ImmutableOrigin,
+        base_url: ServoUrl,
+        script_url: ServoUrl,
+        policy_container: PolicyContainer,
+        credentials: RequestCredentials,
+        pending_tasks_struct: PendingTasksStruct,
+        promise: &Rc<Promise>,
+        inherited_secure_context: Option<bool>,
+    );
+    fn exit_worklet(&self, worklet_id: WorkletId);
+    fn wake_threads(&self);
+    fn run_task(&self, worklet_id: WorkletId, worklet_task: WorkletTask);
+}
+
 /// Worklets execute in a dedicated thread pool.
 ///
 /// The goal is to ensure that there is a primary worklet thread,
@@ -297,7 +319,7 @@ impl PendingTasksStruct {
 /// by a backup thread, not by the primary thread.
 
 #[derive(Clone, JSTraceable)]
-pub(crate) struct WorkletThreadPool {
+pub(crate) struct StatelessWorkletThreadPool {
     // Channels to send data messages to the three roles.
     #[no_trace]
     primary_sender: Sender<WorkletData>,
@@ -314,7 +336,7 @@ pub(crate) struct WorkletThreadPool {
     control_sender_2: Sender<WorkletControl>,
 }
 
-impl Drop for WorkletThreadPool {
+impl Drop for StatelessWorkletThreadPool {
     fn drop(&mut self) {
         let _ = self.cold_backup_sender.send(WorkletData::Quit);
         let _ = self.hot_backup_sender.send(WorkletData::Quit);
@@ -322,10 +344,10 @@ impl Drop for WorkletThreadPool {
     }
 }
 
-impl WorkletThreadPool {
+impl StatelessWorkletThreadPool {
     /// Create a new thread pool and spawn the threads.
     /// When the thread pool is dropped, the threads will be asked to quit.
-    pub(crate) fn spawn(global_init: WorkletGlobalScopeInit) -> WorkletThreadPool {
+    pub(crate) fn spawn(global_init: WorkletGlobalScopeInit) -> StatelessWorkletThreadPool {
         let primary_role = WorkletThreadRole::new(false, false);
         let hot_backup_role = WorkletThreadRole::new(true, false);
         let cold_backup_role = WorkletThreadRole::new(false, true);
@@ -338,7 +360,7 @@ impl WorkletThreadPool {
             cold_backup_sender: cold_backup_sender.clone(),
             global_init,
         };
-        WorkletThreadPool {
+        StatelessWorkletThreadPool {
             primary_sender,
             hot_backup_sender,
             cold_backup_sender,
@@ -347,7 +369,9 @@ impl WorkletThreadPool {
             control_sender_2: WorkletThread::spawn(cold_backup_role, init, 2),
         }
     }
+}
 
+impl WorkletThreadPool for StatelessWorkletThreadPool {
     /// Loads a worklet module into every worklet thread.
     /// If all of the threads load successfully, the promise is resolved.
     /// If any of the threads fails to load, the promise is rejected.
@@ -390,7 +414,7 @@ impl WorkletThreadPool {
         self.wake_threads();
     }
 
-    pub(crate) fn exit_worklet(&self, worklet_id: WorkletId) {
+    fn exit_worklet(&self, worklet_id: WorkletId) {
         for sender in &[
             &self.control_sender_0,
             &self.control_sender_1,
@@ -401,22 +425,20 @@ impl WorkletThreadPool {
         self.wake_threads();
     }
 
-    /// For testing.
-    #[cfg(feature = "testbinding")]
-    pub(crate) fn test_worklet_lookup(&self, id: WorkletId, key: String) -> Option<String> {
-        let (sender, receiver) = unbounded();
-        let msg = WorkletData::Task(id, WorkletTask::Test(TestWorkletTask::Lookup(key, sender)));
-        let _ = self.primary_sender.send(msg);
-        receiver.recv().expect("Test worklet has died?")
-    }
-
     fn wake_threads(&self) {
         // If any of the threads are blocked waiting on data, wake them up.
         let _ = self.cold_backup_sender.send(WorkletData::WakeUp);
         let _ = self.hot_backup_sender.send(WorkletData::WakeUp);
         let _ = self.primary_sender.send(WorkletData::WakeUp);
     }
+
+    fn run_task(&self, worklet_id: WorkletId, worklet_task: WorkletTask) {
+        let msg = WorkletData::Task(worklet_id, worklet_task);
+        let _ = self.primary_sender.send(msg);
+    }
 }
+
+type WorkletTask = Box<dyn FnOnce(&WorkletGlobalScope) + Send>;
 
 /// The data messages sent to worklet threads
 enum WorkletData {
@@ -849,7 +871,7 @@ impl WorkletThread {
     /// Perform a task.
     fn perform_a_worklet_task(&self, cx: &mut JSContext, worklet_id: WorkletId, task: WorkletTask) {
         match self.global_scopes.get(&worklet_id) {
-            Some(global) => global.perform_a_worklet_task(cx, task),
+            Some(global) => task(global),
             None => warn!("No such worklet as {:?}.", worklet_id),
         }
     }

--- a/components/script/dom/worklet/workletglobalscope.rs
+++ b/components/script/dom/worklet/workletglobalscope.rs
@@ -198,21 +198,6 @@ impl WorkletGlobalScope {
         self.executor.clone()
     }
 
-    /// Perform a worklet task
-    pub(crate) fn perform_a_worklet_task(&self, cx: &mut JSContext, task: WorkletTask) {
-        match task {
-            #[cfg(feature = "testbinding")]
-            WorkletTask::Test(task) => match self.downcast::<TestWorkletGlobalScope>() {
-                Some(global) => global.perform_a_worklet_task(task),
-                None => warn!("This is not a test worklet."),
-            },
-            WorkletTask::Paint(task) => match self.downcast::<PaintWorkletGlobalScope>() {
-                Some(global) => global.perform_a_worklet_task(cx, task),
-                None => warn!("This is not a paint worklet."),
-            },
-        }
-    }
-
     pub(crate) fn task_manager(&self) -> Rc<TaskManager> {
         self.task_manager.clone()
     }
@@ -280,9 +265,3 @@ pub(crate) enum WorkletGlobalScopeType {
     Paint,
 }
 
-/// A task which can be performed in the context of a worklet global.
-pub(crate) enum WorkletTask {
-    #[cfg(feature = "testbinding")]
-    Test(TestWorkletTask),
-    Paint(PaintWorkletTask),
-}

--- a/components/script/dom/worklet/workletglobalscope.rs
+++ b/components/script/dom/worklet/workletglobalscope.rs
@@ -28,9 +28,9 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::trace::CustomTraceable;
 use crate::dom::bindings::utils::define_all_exposed_interfaces;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::paintworkletglobalscope::{PaintWorkletGlobalScope, PaintWorkletTask};
+use crate::dom::paintworkletglobalscope::PaintWorkletGlobalScope;
 #[cfg(feature = "testbinding")]
-use crate::dom::testworkletglobalscope::{TestWorkletGlobalScope, TestWorkletTask};
+use crate::dom::testworkletglobalscope::TestWorkletGlobalScope;
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::identityhub::IdentityHub;
 use crate::dom::worklet::WorkletExecutor;
@@ -264,4 +264,3 @@ pub(crate) enum WorkletGlobalScopeType {
     /// A paint worklet
     Paint,
 }
-


### PR DESCRIPTION
This PR is a part of refactoring Worklet for implementing AudioWorklet

- Create a WorkletThreadPool trait, which allows for a stateful and a stateless WorkletThreadPool.
- Change the existing mechanism of executing tasks on the WorkletThreadPool
  - Use a boxed closure to send the Worklet tasks to the Primary Worklet Thread

Testing: existing worklet WPT covers the changes

