### PR TITLE
script: Make inserttext handle surrogate pairs correctly.

### DIFF
--- a/components/script/dom/execcommand/commands/inserttext.rs
+++ b/components/script/dom/execcommand/commands/inserttext.rs
@@ -44,6 +44,11 @@ pub(crate) fn execute_insert_text_command(
     }
 
     // Step 3. If value's length is greater than one:
+    // NOTE: In theory, the 'spec' wants us to do insertText for every UTF-16 code unit. We do it for every UTF-8
+    //       character instead, as that lets us avoid having to deal with inbetween states where we should have
+    //       inserted one half of a surrogate pair, which would temporarily make the text in the node invalid UTF-8.
+    //       This shouldn't cause any issues since none of the per-character handling cares about half a surrogate pair
+    //       and the events that a MutationObserver sees aren't per-character in other browsers.
     if value.str().chars().nth(1).is_some() {
         // Step 3.1. For each code unit el in value, take the action for the insertText command, with value equal to el.
         for el in value.str().chars() {
@@ -121,7 +126,11 @@ pub(crate) fn execute_insert_text_command(
         }
 
         // Step 13.3. Call extend(node, offset + 1) on the context object's selection.
-        if selection.Extend(cx, &node, offset + 1).is_err() {
+        // Note: We're doing this per UTF-8 character instead of per UTF-16 code unit.
+        if selection
+            .Extend(cx, &node, offset + (value.len_utf16().0 as u32))
+            .is_err()
+        {
             unreachable!("Must always be able to extend the selection");
         }
 
@@ -149,7 +158,11 @@ pub(crate) fn execute_insert_text_command(
         }
 
         // Step 14.5. Call extend(text, 1) on the context object's selection.
-        if selection.Extend(cx, text, 1).is_err() {
+        // Note: We're doing this per UTF-8 character instead of per UTF-16 code unit.
+        if selection
+            .Extend(cx, text, value.len_utf16().0 as u32)
+            .is_err()
+        {
             unreachable!("Must always be able to extend the selection");
         }
 

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -275,7 +275,7 @@ impl std::fmt::Debug for DOMStringType {
 ///
 /// The hypothesis is that it does not matter much how exactly those values are
 /// transformed, because  passing unpaired surrogates into the DOM is very rare.
-/// Instead Servo withh replace the unpaired surrogate by a U+FFFD replacement
+/// Instead Servo will replace the unpaired surrogate by a U+FFFD replacement
 /// character.
 ///
 /// Currently, the lack of crash reports about this issue provides some

--- a/tests/wpt/tests/editing/other/insert-text-with-surrogate-pairs.html
+++ b/tests/wpt/tests/editing/other/insert-text-with-surrogate-pairs.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<head>
+  <meta charset="UTF-8">
+  <link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+  <script src=/resources/testharness.js></script>
+  <script src=/resources/testharnessreport.js></script>
+</head>
+<body>
+  <div contenteditable="true" id="editable"></div>
+  <script>
+    test(() => {
+      document.getSelection().selectAllChildren(editable);
+      document.execCommand("inserttext", false, "🏆");
+      assert_equals(editable.textContent, "🏆", "Surrogate pair should survive insertText");
+    }, "Surrogate pair should survive insertText");
+  </script>
+</body>


### PR DESCRIPTION
Any characters that are longer than one UTF-16 code unit weren't inserted correctly before this. Now they are.

The note about MutationObserver in my comment is referring to other browsers specifically, because we do generate one mutation event per character here. I'm not sure if that's just because no browser implements this spec verbatim or if maybe mutation events need to or could be aggregated somehow somewhere, but it's a discrepancy to be aware of, I guess. I would say that this could have performance implications if any JavaScript wants to act upon these events in some major way, but Firefox generates exactly 0 characterData mutation events from `insertText`, so I'd hope that there's no websites that depend on any of this behavior.
Edit: Firefox actually only generates 0 characterData mutation events when `inserttext` has to create a new text node.

Also, Ladybird, as the only other browser to implement this spec somewhat verbatim, ends up emitting mutation events per character as well (or rather per UTF-16 code unit), but they generate 2 for each character for some reason. No idea why.

Testing: Added a new WPT tests that verifies that this works.
