### PR TITLE
script: Use efficient `DOMString` ASCII case-insensitive match functions in more places

### DIFF
--- a/components/script/dom/event/eventtarget.rs
+++ b/components/script/dom/event/eventtarget.rs
@@ -484,13 +484,13 @@ impl EventTarget {
     /// <https://dom.spec.whatwg.org/#default-passive-value>
     fn default_passive_value(&self, ty: &Atom) -> bool {
         // Return true if all of the following are true:
-        let event_type = ty.to_ascii_lowercase();
+        let event_type = ty.trim_matches(HTML_SPACE_CHARACTERS);
 
         // type is one of "touchstart", "touchmove", "wheel", or "mousewheel"
-        let matches_event_type = matches!(
-            event_type.trim_matches(HTML_SPACE_CHARACTERS),
-            "touchstart" | "touchmove" | "wheel" | "mousewheel"
-        );
+        let matches_event_type = event_type.eq_ignore_ascii_case("touchstart") ||
+            event_type.eq_ignore_ascii_case("touchmove") ||
+            event_type.eq_ignore_ascii_case("wheel") ||
+            event_type.eq_ignore_ascii_case("mousewheel");
 
         if !matches_event_type {
             return false;

--- a/components/script/dom/html/documentmetadata/htmlmetaelement.rs
+++ b/components/script/dom/html/documentmetadata/htmlmetaelement.rs
@@ -64,12 +64,11 @@ impl HTMLMetaElement {
     fn process_attributes(&self, cx: &mut JSContext) {
         let element = self.upcast::<Element>();
         if let Some(ref name) = element.get_name() {
-            let name = name.to_ascii_lowercase();
             let name = name.trim_matches(HTML_SPACE_CHARACTERS);
-            if name == "referrer" {
+            if name.eq_ignore_ascii_case("referrer") {
                 self.apply_referrer();
             }
-            if name == "viewport" {
+            if name.eq_ignore_ascii_case("viewport") {
                 self.parse_and_send_viewport_if_necessary(cx);
             }
         // https://html.spec.whatwg.org/multipage/#attr-meta-http-equiv
@@ -89,10 +88,9 @@ impl HTMLMetaElement {
     fn process_referrer_attribute(&self) {
         let element = self.upcast::<Element>();
         if let Some(ref name) = element.get_name() {
-            let name = name.to_ascii_lowercase();
             let name = name.trim_matches(HTML_SPACE_CHARACTERS);
 
-            if name == "referrer" {
+            if name.eq_ignore_ascii_case("referrer") {
                 self.apply_referrer();
             }
         }
@@ -188,11 +186,13 @@ impl HTMLMetaElement {
                 // Step 2.2. If parsed is a valid CSS 'color-scheme' property value,
                 // then return parsed.
                 // TODO: Allow for more different themes than the ones that embedders can set
-                match content.to_ascii_lowercase().as_str() {
-                    "dark" => Some(Theme::Dark),
-                    "light" => Some(Theme::Light),
+                if content.eq_ignore_ascii_case("dark") {
+                    Some(Theme::Dark)
+                } else if content.eq_ignore_ascii_case("light") {
+                    Some(Theme::Light)
+                } else {
                     // Step 3. Return null.
-                    _ => None,
+                    None
                 }
             });
 

--- a/components/script/dom/html/form_controls/input_type/mod.rs
+++ b/components/script/dom/html/form_controls/input_type/mod.rs
@@ -197,30 +197,53 @@ impl InputActivationType {
 
 impl InputType {
     pub(crate) fn new_from_atom(value: &Atom) -> Self {
-        match value.to_ascii_lowercase() {
-            atom!("button") => InputType::Button(Default::default()),
-            atom!("checkbox") => InputType::Checkbox(Default::default()),
-            atom!("color") => InputType::Color(Default::default()),
-            atom!("date") => InputType::Date(Default::default()),
-            atom!("datetime-local") => InputType::DatetimeLocal(Default::default()),
-            atom!("email") => InputType::Email(Default::default()),
-            atom!("file") => InputType::File(Default::default()),
-            atom!("hidden") => InputType::Hidden(Default::default()),
-            atom!("image") => InputType::Image(Default::default()),
-            atom!("month") => InputType::Month(Default::default()),
-            atom!("number") => InputType::Number(Default::default()),
-            atom!("password") => InputType::Password(Default::default()),
-            atom!("radio") => InputType::Radio(Default::default()),
-            atom!("range") => InputType::Range(Default::default()),
-            atom!("reset") => InputType::Reset(Default::default()),
-            atom!("search") => InputType::Search(Default::default()),
-            atom!("submit") => InputType::Submit(Default::default()),
-            atom!("tel") => InputType::Tel(Default::default()),
-            atom!("text") => InputType::Text(Default::default()),
-            atom!("time") => InputType::Time(Default::default()),
-            atom!("url") => InputType::Url(Default::default()),
-            atom!("week") => InputType::Week(Default::default()),
-            _ => InputType::Text(Default::default()),
+        let value = value.as_ref();
+        if value.eq_ignore_ascii_case("button") {
+            InputType::Button(Default::default())
+        } else if value.eq_ignore_ascii_case("checkbox") {
+            InputType::Checkbox(Default::default())
+        } else if value.eq_ignore_ascii_case("color") {
+            InputType::Color(Default::default())
+        } else if value.eq_ignore_ascii_case("date") {
+            InputType::Date(Default::default())
+        } else if value.eq_ignore_ascii_case("datetime-local") {
+            InputType::DatetimeLocal(Default::default())
+        } else if value.eq_ignore_ascii_case("email") {
+            InputType::Email(Default::default())
+        } else if value.eq_ignore_ascii_case("file") {
+            InputType::File(Default::default())
+        } else if value.eq_ignore_ascii_case("hidden") {
+            InputType::Hidden(Default::default())
+        } else if value.eq_ignore_ascii_case("image") {
+            InputType::Image(Default::default())
+        } else if value.eq_ignore_ascii_case("month") {
+            InputType::Month(Default::default())
+        } else if value.eq_ignore_ascii_case("number") {
+            InputType::Number(Default::default())
+        } else if value.eq_ignore_ascii_case("password") {
+            InputType::Password(Default::default())
+        } else if value.eq_ignore_ascii_case("radio") {
+            InputType::Radio(Default::default())
+        } else if value.eq_ignore_ascii_case("range") {
+            InputType::Range(Default::default())
+        } else if value.eq_ignore_ascii_case("reset") {
+            InputType::Reset(Default::default())
+        } else if value.eq_ignore_ascii_case("search") {
+            InputType::Search(Default::default())
+        } else if value.eq_ignore_ascii_case("submit") {
+            InputType::Submit(Default::default())
+        } else if value.eq_ignore_ascii_case("tel") {
+            InputType::Tel(Default::default())
+        } else if value.eq_ignore_ascii_case("text") {
+            InputType::Text(Default::default())
+        } else if value.eq_ignore_ascii_case("time") {
+            InputType::Time(Default::default())
+        } else if value.eq_ignore_ascii_case("url") {
+            InputType::Url(Default::default())
+        } else if value.eq_ignore_ascii_case("week") {
+            InputType::Week(Default::default())
+        } else {
+            InputType::Text(Default::default())
         }
     }
 

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -1076,7 +1076,10 @@ impl HTMLScriptElement {
                 debug!("script language={}", lang);
                 let language = format!("text/{}", lang);
 
-                if SCRIPT_JS_MIMES.contains(&language.to_ascii_lowercase().as_str()) {
+                if SCRIPT_JS_MIMES
+                    .iter()
+                    .any(|mime| language.eq_ignore_ascii_case(mime))
+                {
                     Some(ScriptType::Classic)
                 } else {
                     None
@@ -1085,17 +1088,24 @@ impl HTMLScriptElement {
             (Some(ty), _) => {
                 debug!("script type={}", ty);
 
-                if ty.to_ascii_lowercase().trim_matches(HTML_SPACE_CHARACTERS) == "module" {
+                if ty
+                    .trim_matches(HTML_SPACE_CHARACTERS)
+                    .eq_ignore_ascii_case("module")
+                {
                     return Some(ScriptType::Module);
                 }
 
-                if ty.to_ascii_lowercase().trim_matches(HTML_SPACE_CHARACTERS) == "importmap" {
+                if ty
+                    .trim_matches(HTML_SPACE_CHARACTERS)
+                    .eq_ignore_ascii_case("importmap")
+                {
                     return Some(ScriptType::ImportMap);
                 }
 
-                if SCRIPT_JS_MIMES
-                    .contains(&ty.to_ascii_lowercase().trim_matches(HTML_SPACE_CHARACTERS))
-                {
+                if SCRIPT_JS_MIMES.iter().any(|mime| {
+                    ty.trim_matches(HTML_SPACE_CHARACTERS)
+                        .eq_ignore_ascii_case(mime)
+                }) {
                     Some(ScriptType::Classic)
                 } else {
                     None

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -115,8 +115,8 @@ impl Default for DOMStringType {
 
 impl DOMStringType {
     /// Warning:
-    /// This function does not checking and just returns the raw bytes of the string,
-    /// independently if they are  utf8 or latin1.
+    /// This function does not check and just returns the raw bytes of the string,
+    /// whether they are utf8 or latin1.
     /// The caller needs to take care that these make sense in context.
     fn as_raw_bytes(&self) -> &[u8] {
         match self {
@@ -587,7 +587,7 @@ impl DOMString {
                 }
             },
             EncodedBytes::Utf8(bytes) => unsafe {
-                // Save because we know it was a utf8 string
+                // Safe because we know it was a utf8 string
                 Some(str::from_utf8_unchecked(&bytes).to_ascii_lowercase())
             },
         };

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -150,12 +150,16 @@ impl ReferrerPolicy {
     pub fn from_with_legacy(value: &str) -> Self {
         // Step 5. If value is one of the values given in the first column of the following table,
         // then set value to the value given in the second column:
-        match value.to_ascii_lowercase().as_str() {
-            "never" => ReferrerPolicy::NoReferrer,
-            "default" => ReferrerPolicy::StrictOriginWhenCrossOrigin,
-            "always" => ReferrerPolicy::UnsafeUrl,
-            "origin-when-crossorigin" => ReferrerPolicy::OriginWhenCrossOrigin,
-            _ => ReferrerPolicy::from(value),
+        if value.eq_ignore_ascii_case("never") {
+            ReferrerPolicy::NoReferrer
+        } else if value.eq_ignore_ascii_case("default") {
+            ReferrerPolicy::StrictOriginWhenCrossOrigin
+        } else if value.eq_ignore_ascii_case("always") {
+            ReferrerPolicy::UnsafeUrl
+        } else if value.eq_ignore_ascii_case("origin-when-crossorigin") {
+            ReferrerPolicy::OriginWhenCrossOrigin
+        } else {
+            ReferrerPolicy::from(value)
         }
     }
 
@@ -174,16 +178,24 @@ impl ReferrerPolicy {
 impl From<&str> for ReferrerPolicy {
     /// <https://html.spec.whatwg.org/multipage/#referrer-policy-attribute>
     fn from(value: &str) -> Self {
-        match value.to_ascii_lowercase().as_str() {
-            "no-referrer" => ReferrerPolicy::NoReferrer,
-            "no-referrer-when-downgrade" => ReferrerPolicy::NoReferrerWhenDowngrade,
-            "origin" => ReferrerPolicy::Origin,
-            "same-origin" => ReferrerPolicy::SameOrigin,
-            "strict-origin" => ReferrerPolicy::StrictOrigin,
-            "strict-origin-when-cross-origin" => ReferrerPolicy::StrictOriginWhenCrossOrigin,
-            "origin-when-cross-origin" => ReferrerPolicy::OriginWhenCrossOrigin,
-            "unsafe-url" => ReferrerPolicy::UnsafeUrl,
-            _ => ReferrerPolicy::EmptyString,
+        if value.eq_ignore_ascii_case("no-referrer") {
+            ReferrerPolicy::NoReferrer
+        } else if value.eq_ignore_ascii_case("no-referrer-when-downgrade") {
+            ReferrerPolicy::NoReferrerWhenDowngrade
+        } else if value.eq_ignore_ascii_case("origin") {
+            ReferrerPolicy::Origin
+        } else if value.eq_ignore_ascii_case("same-origin") {
+            ReferrerPolicy::SameOrigin
+        } else if value.eq_ignore_ascii_case("strict-origin") {
+            ReferrerPolicy::StrictOrigin
+        } else if value.eq_ignore_ascii_case("strict-origin-when-cross-origin") {
+            ReferrerPolicy::StrictOriginWhenCrossOrigin
+        } else if value.eq_ignore_ascii_case("origin-when-cross-origin") {
+            ReferrerPolicy::OriginWhenCrossOrigin
+        } else if value.eq_ignore_ascii_case("unsafe-url") {
+            ReferrerPolicy::UnsafeUrl
+        } else {
+            ReferrerPolicy::EmptyString
         }
     }
 }

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -268,10 +268,10 @@ pub enum CorsSettings {
 impl CorsSettings {
     /// <https://html.spec.whatwg.org/multipage/#cors-settings-attribute>
     pub fn from_enumerated_attribute(value: &str) -> CorsSettings {
-        match value.to_ascii_lowercase().as_str() {
-            "anonymous" => CorsSettings::Anonymous,
-            "use-credentials" => CorsSettings::UseCredentials,
-            _ => CorsSettings::Anonymous,
+        if value.eq_ignore_ascii_case("use-credentials") {
+            CorsSettings::UseCredentials
+        } else {
+            CorsSettings::Anonymous
         }
     }
 }

--- a/components/shared/net/response.rs
+++ b/components/shared/net/response.rs
@@ -272,10 +272,9 @@ impl Response {
                 let headers = old_headers
                     .iter()
                     .filter(|(name, _)| {
-                        !matches!(
-                            &*name.as_str().to_ascii_lowercase(),
-                            "set-cookie" | "set-cookie2"
-                        )
+                        let name = name.as_str();
+                        !name.eq_ignore_ascii_case("set-cookie") &&
+                            !name.eq_ignore_ascii_case("set-cookie2")
                     })
                     .map(|(n, v)| (n.clone(), v.clone()))
                     .collect();
@@ -285,13 +284,26 @@ impl Response {
             ResponseType::Cors => {
                 let headers = old_headers
                     .iter()
-                    .filter(|(name, _)| match &*name.as_str().to_ascii_lowercase() {
-                        "cache-control" | "content-language" | "content-length" |
-                        "content-type" | "expires" | "last-modified" | "pragma" => true,
-                        "set-cookie" | "set-cookie2" => false,
-                        header => exposed_headers
-                            .iter()
-                            .any(|h| *header == h.as_str().to_ascii_lowercase()),
+                    .filter(|(name, _)| {
+                        let name = name.as_str();
+                        if name.eq_ignore_ascii_case("cache-control") ||
+                            name.eq_ignore_ascii_case("content-language") ||
+                            name.eq_ignore_ascii_case("content-length") ||
+                            name.eq_ignore_ascii_case("content-type") ||
+                            name.eq_ignore_ascii_case("expires") ||
+                            name.eq_ignore_ascii_case("last-modified") ||
+                            name.eq_ignore_ascii_case("pragma")
+                        {
+                            true
+                        } else if name.eq_ignore_ascii_case("set-cookie") ||
+                            name.eq_ignore_ascii_case("set-cookie2")
+                        {
+                            false
+                        } else {
+                            exposed_headers
+                                .iter()
+                                .any(|h| h.as_str().eq_ignore_ascii_case(name))
+                        }
                     })
                     .map(|(n, v)| (n.clone(), v.clone()))
                     .collect();


### PR DESCRIPTION
This extends #47285 by using it in more places.
Fix some typo/sentence in `domstring.rs`.

Testing: Covered by existing test.