### PR TITLE
script: Basic support for mapping 'role' attribute into the a11y tree.

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -12,13 +12,14 @@ use bitflags::bitflags;
 use layout_api::{AccessibilityDamage, LayoutElement, LayoutNode, LayoutNodeType};
 use log::trace;
 use rustc_hash::{FxHashMap, FxHashSet};
-use script::layout_dom::ServoLayoutNode;
+use script::layout_dom::{ServoLayoutElement, ServoLayoutNode};
 use servo_base::Epoch;
 use servo_base::print_tree::PrintTree;
 use servo_config::opts::{self, DiagnosticsLogging, DiagnosticsLoggingOption};
 use servo_config::pref;
+use style::Atom;
 use style::dom::OpaqueNode;
-use web_atoms::{LocalName, local_name};
+use web_atoms::{LocalName, local_name, ns};
 
 use crate::ArcRefCell;
 use crate::cell::WeakRefCell;
@@ -513,12 +514,25 @@ impl AccessibilityTree {
     }
 }
 
+/// <https://w3c.github.io/aria/#host_general_role>
+fn role_from_role_attribute(dom_element: &ServoLayoutElement<'_>) -> Option<Role> {
+    let role_attribute = dom_element.attribute(&ns!(), &local_name!("role"))?;
+    role_attribute
+        .as_tokens()
+        .iter()
+        .filter_map(|role_name_in_attribute| SUPPORTED_ARIA_ROLES.get(role_name_in_attribute))
+        .next()
+        .cloned()
+}
+
 fn role_from_dom_node(dom_node: &ServoLayoutNode<'_>) -> Role {
     if let Some(dom_element) = dom_node.as_element() {
-        let local_name = dom_element.local_name().to_ascii_lowercase();
-        *HTML_ELEMENT_ROLE_MAPPINGS
-            .get(&local_name)
-            .unwrap_or(&Role::GenericContainer)
+        role_from_role_attribute(&dom_element).unwrap_or_else(|| {
+            let local_name = dom_element.local_name().to_ascii_lowercase();
+            *HTML_ELEMENT_ROLE_MAPPINGS
+                .get(&local_name)
+                .unwrap_or(&Role::GenericContainer)
+        })
     } else if dom_node.type_id() == Some(LayoutNodeType::Text) {
         Role::TextRun
     } else {
@@ -772,7 +786,7 @@ impl AccessibilityNode {
         dom_damage: AccessibilityDamage,
     ) -> LocalAccessibilityDamage {
         let mut local_damage = LocalAccessibilityDamage::empty();
-        if !dom_damage.contains(AccessibilityDamage::Text) {
+        if !dom_damage.contains(AccessibilityDamage::Node) {
             return local_damage;
         }
         local_damage.insert(self.set_role(role_from_dom_node(dom_node)));
@@ -1166,6 +1180,55 @@ static HTML_ELEMENT_ROLE_MAPPINGS: LazyLock<FxHashMap<LocalName, Role>> = LazyLo
         (local_name!("main"), Role::Main),
         (local_name!("nav"), Role::Navigation),
         (local_name!("p"), Role::Paragraph),
+    ]
+    .into_iter()
+    .collect()
+});
+
+/// A map from role names allowed in the 'role' attribute of an HTML element to the corresponding
+/// [`Role`] in AccessKit.
+///
+/// This is currently just the roles that don't have any [supported][1] or [required][2] properties
+/// and also don't require an [accessible name][3].
+/// [1]: https://w3c.github.io/aria/#supportedState
+/// [2]: https://w3c.github.io/aria/#requiredState
+/// [3]: https://w3c.github.io/aria/#namefromauthor
+static SUPPORTED_ARIA_ROLES: LazyLock<FxHashMap<Atom, Role>> = LazyLock::new(|| {
+    [
+        (Atom::from("alert"), Role::Alert),
+        (Atom::from("banner"), Role::Banner),
+        (Atom::from("blockquote"), Role::Blockquote),
+        (Atom::from("caption"), Role::Caption),
+        (Atom::from("code"), Role::Code),
+        (Atom::from("complementary"), Role::Complementary),
+        (Atom::from("contentinfo"), Role::ContentInfo),
+        (Atom::from("definition"), Role::Definition),
+        (Atom::from("deletion"), Role::ContentDeletion),
+        (Atom::from("directory"), Role::Unknown),
+        (Atom::from("document"), Role::Document),
+        (Atom::from("emphasis"), Role::Emphasis),
+        (Atom::from("feed"), Role::Feed),
+        (Atom::from("figure"), Role::Figure),
+        (Atom::from("generic"), Role::GenericContainer),
+        (Atom::from("insertion"), Role::ContentInsertion),
+        (Atom::from("list"), Role::List),
+        (Atom::from("log"), Role::Log),
+        (Atom::from("main"), Role::Main),
+        (Atom::from("math"), Role::Math),
+        (Atom::from("navigation"), Role::Navigation),
+        (Atom::from("none"), Role::GenericContainer),
+        (Atom::from("note"), Role::Note),
+        (Atom::from("paragraph"), Role::Paragraph),
+        (Atom::from("presentation"), Role::GenericContainer),
+        (Atom::from("rowgroup"), Role::RowGroup),
+        (Atom::from("search"), Role::Search),
+        (Atom::from("status"), Role::Status),
+        (Atom::from("strong"), Role::Strong),
+        // (Atom::from("subscript"), Role::Subscript), // no corresponding accesskit role.
+        // (Atom::from("superscript"), Role::Superscript), // no corresponding accesskit role.
+        (Atom::from("term"), Role::Term),
+        (Atom::from("time"), Role::Time),
+        (Atom::from("timer"), Role::Timer),
     ]
     .into_iter()
     .collect()

--- a/components/script/dom/element/attributes/accessors.rs
+++ b/components/script/dom/element/attributes/accessors.rs
@@ -157,6 +157,22 @@ impl Element {
         }
     }
 
+    pub(crate) fn set_nullable_tokenlist_attribute(
+        &self,
+        cx: &mut JSContext,
+        local_name: &LocalName,
+        value: Option<DOMString>,
+    ) {
+        match value {
+            Some(string_value) => {
+                self.set_tokenlist_attribute(cx, local_name, string_value);
+            },
+            None => {
+                self.remove_attribute(cx, &ns!(), local_name);
+            },
+        }
+    }
+
     /// Returns true if any attribute in the tokenlist fulfill `f`. Equivalent to
     /// `get_tokenlist_attribute(name).iter().any(f)`.
     pub(crate) fn any_tokenlist_attribute(

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -25,7 +25,10 @@ use js::jsapi::{Heap, JSObject};
 use js::jsval::JSVal;
 use js::realm::CurrentRealm;
 use js::rust::HandleObject;
-use layout_api::{LayoutDamage, QueryMsg, ScrollContainerQueryFlags, StyleData, with_layout_state};
+use layout_api::{
+    AccessibilityDamage, LayoutDamage, QueryMsg, ScrollContainerQueryFlags, StyleData,
+    with_layout_state,
+};
 use net_traits::ReferrerPolicy;
 use net_traits::request::{CorsSettings, CredentialsMode};
 use script_bindings::cell::{DomRefCell, Ref, RefMut};
@@ -4229,7 +4232,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
 
     /// <https://w3c.github.io/aria/#ref-for-dom-ariamixin-role-1>
     fn SetRole(&self, cx: &mut JSContext, value: Option<DOMString>) {
-        self.set_nullable_string_attribute(cx, &local_name!("role"), value);
+        self.set_nullable_tokenlist_attribute(cx, &local_name!("role"), value);
     }
 
     fn GetAriaAtomic(&self) -> Option<DOMString> {
@@ -4786,6 +4789,10 @@ impl VirtualMethods for Element {
                 }
                 slottable.assign_a_slot(cx);
             },
+            local_name!("role") => {
+                self.upcast::<Node>()
+                    .add_pending_accessibility_damage(AccessibilityDamage::Node);
+            },
             _ => {
                 // FIXME(emilio): This is pretty dubious, and should be done in
                 // the relevant super-classes.
@@ -4834,7 +4841,7 @@ impl VirtualMethods for Element {
         match *name {
             local_name!("id") => AttrValue::Atom(value.into()),
             local_name!("name") => AttrValue::Atom(value.into()),
-            local_name!("class") | local_name!("part") => {
+            local_name!("class") | local_name!("part") | local_name!("role") => {
                 AttrValue::from_serialized_tokenlist(value.into())
             },
             local_name!("exportparts") => AttrValue::from_shadow_parts(value.into()),

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -686,7 +686,7 @@ impl Node {
         )
     }
 
-    fn add_pending_accessibility_damage(&self, damage: AccessibilityDamage) {
+    pub(crate) fn add_pending_accessibility_damage(&self, damage: AccessibilityDamage) {
         if !self.owner_doc().accessibility_active() {
             return;
         }
@@ -916,7 +916,7 @@ impl Node {
                     .dirty(no_gc, NodeDamage::ContentOrHeritage);
 
                 if damage == NodeDamage::Other {
-                    self.add_pending_accessibility_damage(AccessibilityDamage::Text);
+                    self.add_pending_accessibility_damage(AccessibilityDamage::Node);
                 }
             },
             NodeTypeId::Element(_) => self.downcast::<Element>().unwrap().restyle(no_gc, damage),

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -227,6 +227,18 @@ fn test_accessibility_basic_mapping() {
 }
 
 #[test]
+fn test_accessibility_basic_role_from_attribute() {
+    let url = "data:text/html,<!DOCTYPE html><div role='blockquote'></div>";
+    let (_servo_test, _delegate, _webview, tree) = build_webview_and_tree(url);
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let first_child = root
+        .children()
+        .next()
+        .expect("Root web area should have at least one child.");
+    assert_eq!(first_child.role(), Role::Blockquote);
+}
+
+#[test]
 fn test_accessibility_basic_name_from_contents() {
     let url = "data:text/html,<!DOCTYPE html><h1>Servo</h1>";
     let (_servo_test, _delegate, _webview, tree) = build_webview_and_tree(url);
@@ -393,6 +405,74 @@ fn test_accessibility_text_change() {
         h1.label(),
         Some("This is an h1, now with more text".to_owned())
     );
+}
+
+#[test]
+fn test_accessibility_role_mutations() {
+    let url = "data:text/html,<!DOCTYPE html>\
+        <div id='div1' role='emphasis'>Servo</div>\
+        <aside id='aside'>Aside</aside>\
+        <main id='main' role='status'>Main</main>";
+    let (servo_test, delegate, webview, mut tree) = build_webview_and_tree(url);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let children: Vec<accesskit_consumer::Node> = root.children().collect();
+    assert_eq!(children.len(), 3);
+    let div = children[0];
+    assert_eq!(
+        div.role(),
+        Role::Emphasis,
+        "<div> should respect author's override"
+    );
+    let aside = children[1];
+    assert_eq!(
+        aside.role(),
+        Role::Complementary,
+        "<aside> should default to implicit ARIA role"
+    );
+    let main = children[2];
+    assert_eq!(
+        main.role(),
+        Role::Status,
+        "<main> should respect author's override"
+    );
+
+    let _ = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "\
+            div1.role = 'blockquote';\
+            aside.role = 'presentation';\
+            main.role = null;\
+        ",
+    );
+
+    let mut updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
+    assert_eq!(updates.len(), 1);
+    let update = updates.pop().expect("Guaranteed by assert above");
+    assert_eq!(update.nodes.len(), 3);
+    assert_eq!(
+        update.nodes[0].1.role(),
+        Role::Main,
+        "<main> should fallback to implicit role when explicit role is removed"
+    );
+    assert_eq!(
+        update.nodes[1].1.role(),
+        Role::Blockquote,
+        "<div> should have the new explicit role"
+    );
+    assert_eq!(
+        update.nodes[2].1.role(),
+        Role::GenericContainer,
+        "<aside> should use the explicit role instead of the implicit role"
+    );
+    tree.update_and_process_changes(update, &mut NoOpChangeHandler);
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let children: Vec<accesskit_consumer::Node> = root.children().collect();
+    assert_eq!(children.len(), 3);
+    assert_eq!(children[0].role(), Role::Blockquote);
+    assert_eq!(children[1].role(), Role::GenericContainer);
+    assert_eq!(children[2].role(), Role::Main);
 }
 
 #[test]

--- a/components/shared/layout/layout_damage.rs
+++ b/components/shared/layout/layout_damage.rs
@@ -59,7 +59,7 @@ impl From<LayoutDamage> for RestyleDamage {
 bitflags! {
     #[derive(Clone, Copy, Default, Debug, Eq, PartialEq)]
     pub struct AccessibilityDamage: u16 {
-        const Text = 0b0001;
+        const Node = 0b0001;
         const Children = 0b0010;
         const Subtree = 0b0100;
         const Rebuild = 0b1111;


### PR DESCRIPTION
This patch
1. Fixes the way we parse the 'role' attribute of HTML elements to allow a list of role names as required by the specifiction.
2. Maps the role attribute of the element to an accesskit role. Support is limited to non-abstract roles that don't require an accessible name or properties and states other than the global supported states and properties.
3. Handles propagation of damage when the role attribute is mutated. Only the basic scenarios involving role changes are supported at the moment.

Part of #46242
Testing: New integration tests have been added.