### PR TITLE
script: Fix borrow hazard in PaintWorkletGlobalScope

### DIFF
--- a/components/script/dom/worklet/paintworkletglobalscope.rs
+++ b/components/script/dom/worklet/paintworkletglobalscope.rs
@@ -282,9 +282,9 @@ impl PaintWorkletGlobalScope {
     }
 
     #[expect(unsafe_code)]
-    /// Gets or creates the `self.paint_class_instances` given by `name`.
-    /// Returns None if the operation went normally.
-    /// Returns Some we have a pending exception.
+    /// Gets or creates the `self.paint_class_instances` given by `name` and inserts
+    /// the value into the provided `paint_instance` handle. Returns `Err` when this
+    /// fails.
     fn get_or_create_paint_instance(
         &self,
         cx: &mut JSContext,
@@ -292,12 +292,17 @@ impl PaintWorkletGlobalScope {
         name: Atom,
         class_constructor: HandleValue,
         size_in_dpx: Size2D<u32, DevicePixel>,
-    ) -> Option<DrawAPaintImageResult> {
+    ) -> Result<(), DrawAPaintImageResult> {
         if let Some(entry) = self.paint_class_instances.borrow().get(&name) {
             paint_instance.set(entry.get());
-            return None;
+            return Ok(());
         }
 
+        // Step of <https://drafts.css-houdini.org/css-paint-api/#invoke-a-paint-callback>
+        // 5.2 Let paintCtor be the class constructor on definition.
+        // 5.3 Let paintInstance be the result of Construct(paintCtor).
+        //     If construct throws an exception, set the definition’s constructor valid flag to false,
+        //     let the image output be an invalid image and abort all these steps.
         let args = HandleValueArray::empty();
         rooted!(&in(cx) let mut result = null_mut::<JSObject>());
         unsafe {
@@ -315,7 +320,7 @@ impl PaintWorkletGlobalScope {
                 .expect("Vanishing paint definition.")
                 .constructor_valid_flag
                 .set(false);
-            return Some(self.invalid_image(size_in_dpx, vec![]));
+            return Err(self.invalid_image(size_in_dpx, vec![]));
         }
         // Step 5.4
         let value = Box::<Heap<Value>>::default();
@@ -323,7 +328,7 @@ impl PaintWorkletGlobalScope {
         self.paint_class_instances
             .safe_borrow_mut(cx)
             .insert(name, value);
-        None
+        Ok(())
     }
 
     /// <https://drafts.css-houdini.org/css-paint-api/#invoke-a-paint-callback>
@@ -378,7 +383,7 @@ impl PaintWorkletGlobalScope {
         // the primary worklet thread.
         // https://github.com/servo/servo/issues/17377
         rooted!(&in(cx) let mut paint_instance = UndefinedValue());
-        if let Some(early_return) = self.get_or_create_paint_instance(
+        if let Err(early_return) = self.get_or_create_paint_instance(
             cx,
             paint_instance.handle_mut(),
             name.clone(),

--- a/components/script/dom/worklet/paintworkletglobalscope.rs
+++ b/components/script/dom/worklet/paintworkletglobalscope.rs
@@ -320,6 +320,7 @@ impl PaintWorkletGlobalScope {
                 .expect("Vanishing paint definition.")
                 .constructor_valid_flag
                 .set(false);
+            // 1.2 Let the image output be an invalid image and abort all these steps.
             return Err(self.invalid_image(size_in_dpx, vec![]));
         }
         // Step 5.4

--- a/components/script/dom/worklet/paintworkletglobalscope.rs
+++ b/components/script/dom/worklet/paintworkletglobalscope.rs
@@ -324,11 +324,11 @@ impl PaintWorkletGlobalScope {
             return Err(self.invalid_image(size_in_dpx, vec![]));
         }
         // Step 5.4
-        let value = Box::<Heap<Value>>::default();
-        value.set(paint_instance.get());
         self.paint_class_instances
             .safe_borrow_mut(cx)
-            .insert(name, value);
+            .entry(name)
+            .or_default()
+            .set(paint_instance.get());
         Ok(())
     }
 

--- a/components/script/dom/worklet/paintworkletglobalscope.rs
+++ b/components/script/dom/worklet/paintworkletglobalscope.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::Cell;
-use std::collections::hash_map::Entry;
 use std::ptr::{NonNull, null_mut};
 use std::rc::Rc;
 use std::sync::atomic::AtomicBool;
@@ -18,10 +17,10 @@ use js::context::JSContext;
 use js::jsapi::{HandleValueArray, Heap, IsCallable, IsConstructor, JSObject, Value};
 use js::jsval::{JSVal, ObjectValue, UndefinedValue};
 use js::realm::AutoRealm;
-use js::rust::HandleValue;
 use js::rust::wrappers2::{
     Call, Construct1, JS_ClearPendingException, JS_IsExceptionPending, NewArrayObject,
 };
+use js::rust::{HandleValue, MutableHandle};
 use net_traits::image_cache::ImageCache;
 use pixels::PixelFormat;
 use script_bindings::cell::DomRefCell;
@@ -282,6 +281,51 @@ impl PaintWorkletGlobalScope {
         )
     }
 
+    #[expect(unsafe_code)]
+    /// Gets or creates the `self.paint_class_instances` given by `name`.
+    /// Returns None if the operation went normally.
+    /// Returns Some we have a pending exception.
+    fn get_or_create_paint_instance(
+        &self,
+        cx: &mut JSContext,
+        mut paint_instance: MutableHandle<Value>,
+        name: Atom,
+        class_constructor: HandleValue,
+        size_in_dpx: Size2D<u32, DevicePixel>,
+    ) -> Option<DrawAPaintImageResult> {
+        if let Some(entry) = self.paint_class_instances.borrow().get(&name) {
+            paint_instance.set(entry.get());
+            return None;
+        }
+
+        let args = HandleValueArray::empty();
+        rooted!(&in(cx) let mut result = null_mut::<JSObject>());
+        unsafe {
+            Construct1(cx, class_constructor, &args, result.handle_mut());
+        }
+        paint_instance.set(ObjectValue(result.get()));
+        if unsafe { JS_IsExceptionPending(cx) } {
+            debug!("Paint constructor threw an exception {}.", name);
+            unsafe {
+                JS_ClearPendingException(cx);
+            }
+            self.paint_definitions
+                .safe_borrow_mut(cx)
+                .get_mut(&name)
+                .expect("Vanishing paint definition.")
+                .constructor_valid_flag
+                .set(false);
+            return Some(self.invalid_image(size_in_dpx, vec![]));
+        }
+        // Step 5.4
+        let value = Box::<Heap<Value>>::default();
+        value.set(paint_instance.get());
+        self.paint_class_instances
+            .safe_borrow_mut(cx)
+            .insert(name, value);
+        None
+    }
+
     /// <https://drafts.css-houdini.org/css-paint-api/#invoke-a-paint-callback>
     #[expect(clippy::too_many_arguments)]
     #[expect(unsafe_code)]
@@ -334,35 +378,15 @@ impl PaintWorkletGlobalScope {
         // the primary worklet thread.
         // https://github.com/servo/servo/issues/17377
         rooted!(&in(cx) let mut paint_instance = UndefinedValue());
-        match self.paint_class_instances.borrow_mut().entry(name.clone()) {
-            Entry::Occupied(entry) => paint_instance.set(entry.get().get()),
-            Entry::Vacant(entry) => {
-                // Step 5.2-5.3
-                let args = HandleValueArray::empty();
-                rooted!(&in(cx) let mut result = null_mut::<JSObject>());
-                unsafe {
-                    Construct1(cx, class_constructor.handle(), &args, result.handle_mut());
-                }
-                paint_instance.set(ObjectValue(result.get()));
-                if unsafe { JS_IsExceptionPending(cx) } {
-                    debug!("Paint constructor threw an exception {}.", name);
-                    unsafe {
-                        JS_ClearPendingException(cx);
-                    }
-                    self.paint_definitions
-                        .borrow_mut()
-                        .get_mut(name)
-                        .expect("Vanishing paint definition.")
-                        .constructor_valid_flag
-                        .set(false);
-                    return self.invalid_image(size_in_dpx, vec![]);
-                }
-                // Step 5.4
-                entry
-                    .insert(Box::<Heap<Value>>::default())
-                    .set(paint_instance.get());
-            },
-        };
+        if let Some(early_return) = self.get_or_create_paint_instance(
+            cx,
+            paint_instance.handle_mut(),
+            name.clone(),
+            class_constructor.handle(),
+            size_in_dpx,
+        ) {
+            return early_return;
+        }
 
         // TODO: Steps 6-7
         // Step 8


### PR DESCRIPTION
This handles a borrow hazard in PaintWorkletGlobalScope. Previously we kept a borrow_mut() (lives as long as entry()) open for the duration which contained a usage of &mut JSContext.

This code splits the querying of self.paint_class_instances into a separate function (with early returns) and switches to safe_borrow_mut to statically guarantee the abscence of borrow hazards.

Testing: safe_borrow_mut enforces the abscence of borrow hazards and WPT should find if there are other problems with the refactor.
