### PR TITLE
deps: Update h2 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3625,9 +3625,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
This updates the h2 dependency so we don't get flagged by cargo deny.

Testing: Not needed for semver compatible.
