### PR TITLE
mach: Simplify bootstrap

### DIFF
--- a/mach
+++ b/mach
@@ -45,11 +45,8 @@ def main(args):
     topdir = os.path.abspath(os.path.dirname(sys.argv[0]))
     sys.path.insert(0, os.path.join(topdir, "python"))
     import mach_bootstrap
-    if len(sys.argv) > 1 and sys.argv[1] == "bootstrap":
-        sys.exit(mach_bootstrap.bootstrap_command_only(topdir))
-    else:
-        mach = mach_bootstrap.bootstrap(topdir)
-        sys.exit(mach.run(sys.argv[1:]))
+    mach = mach_bootstrap.bootstrap(topdir)
+    sys.exit(mach.run(sys.argv[1:]))
 
 
 if __name__ == '__main__':

--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -103,28 +103,6 @@ def _is_windows() -> bool:
     return sys.platform == "win32"
 
 
-def bootstrap_command_only(topdir: str) -> int:
-    # We cannot import these modules until the virtual environment
-    # is active because they depend on modules installed via the
-    # virtual environment.
-    # pylint: disable=import-outside-toplevel
-    import servo.platform
-    import servo.util
-
-    try:
-        force = "-f" in sys.argv or "--force" in sys.argv
-        yes = "--yes" in sys.argv or "-y" in sys.argv
-        skip_platform = "--skip-platform" in sys.argv
-        skip_lints = "--skip-lints" in sys.argv
-        skip_nextest = "--skip-nextest" in sys.argv
-        servo.platform.get().bootstrap(force, yes, skip_platform, skip_lints, skip_nextest)
-    except NotImplementedError as exception:
-        print(exception)
-        return 1
-
-    return 0
-
-
 def bootstrap(topdir: str) -> "Mach":
     _ensure_case_insensitive_if_windows()
 

--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -49,9 +49,6 @@ class MachCommands(CommandBase):
         skip_lints: bool = False,
         skip_nextest: bool = False,
     ) -> int:
-        # Note: This entry point isn't actually invoked by ./mach bootstrap.
-        # ./mach bootstrap calls mach_bootstrap.bootstrap_command_only so that
-        # it can install dependencies without needing mach's dependencies
         try:
             servo.platform.get().bootstrap(force, yes, skip_platform, skip_lints, skip_nextest)
         except NotImplementedError as exception:


### PR DESCRIPTION
Since we switched to `uv`, `uv` is responsible for setting up the environment and `mach bootstrap` actually has the full environment available, so we don't need to duplicate the logic anymore.

Testing: `./mach bootstrap` is run on non-selfhosted CI runners. [Try run](https://github.com/jschwe/servo/actions/runs/32124284987) from my fork.

