### PR TITLE
script: Use `MouseButton` in events and add `MouseButtons`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9123,6 +9123,7 @@ name = "servo-script-traits"
 version = "0.5.0"
 dependencies = [
  "accesskit",
+ "bitflags 2.13.1",
  "crossbeam-channel",
  "euclid",
  "keyboard-types",

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -110,7 +110,7 @@ use embedder_traits::{
     AnimationState, EmbedderControlId, EmbedderControlResponse, EmbedderProxy, FocusSequenceNumber,
     GenericEmbedderProxy, InputEvent, InputEventAndId, InputEventOutcome, JSValue,
     JavaScriptEvaluationError, JavaScriptEvaluationId, KeyboardEvent, MediaSessionActionType,
-    MediaSessionEvent, MediaSessionPlaybackState, MouseButton, MouseButtonAction, MouseButtonEvent,
+    MediaSessionEvent, MediaSessionPlaybackState, MouseButtonAction, MouseButtonEvent,
     NewWebViewDetails, PaintHitTestResult, Theme, ViewportDetails, WakeLockDelegate, WakeLockType,
     WebDriverCommandMsg, WebDriverLoadStatus, WebDriverScriptCommand,
 };
@@ -137,8 +137,8 @@ use rand::seq::IndexedRandom;
 use rand::{RngExt, SeedableRng, make_rng};
 use rustc_hash::{FxHashMap, FxHashSet};
 use script_traits::{
-    ConstellationInputEvent, DiscardBrowsingContext, DocumentActivity, NewPipelineInfo,
-    ProgressiveWebMetricType, ScriptThreadMessage, UpdatePipelineIdReason,
+    ConstellationInputEvent, DiscardBrowsingContext, DocumentActivity, MouseButtons,
+    NewPipelineInfo, ProgressiveWebMetricType, ScriptThreadMessage, UpdatePipelineIdReason,
 };
 use servo_background_hang_monitor::HangMonitorRegister;
 use servo_base::generic_channel::{
@@ -478,7 +478,7 @@ pub struct Constellation<STF, SWF> {
 
     /// Bitmask which indicates which combination of mouse buttons are
     /// currently being pressed.
-    pressed_mouse_buttons: u16,
+    pressed_mouse_buttons: MouseButtons,
 
     /// The currently activated keyboard modifiers.
     active_keyboard_modifiers: Modifiers,
@@ -739,7 +739,7 @@ where
                     webxr_registry: state.webxr_registry,
                     canvas: OnceCell::new(),
                     pending_approval_navigations: Default::default(),
-                    pressed_mouse_buttons: 0,
+                    pressed_mouse_buttons: MouseButtons::empty(),
                     active_keyboard_modifiers: Modifiers::empty(),
                     hard_fail,
                     active_media_session: None,
@@ -3116,24 +3116,15 @@ where
     }
 
     fn update_pressed_mouse_buttons(&mut self, event: &MouseButtonEvent) {
-        // This value is ultimately used for a DOM mouse event, and the specification says that
-        // the pressed buttons should be represented as a bitmask with values defined at
-        // <https://w3c.github.io/uievents/#dom-mouseevent-buttons>.
-        let button_as_bitmask = match event.button {
-            MouseButton::Left => 1,
-            MouseButton::Right => 2,
-            MouseButton::Middle => 4,
-            MouseButton::Back => 8,
-            MouseButton::Forward => 16,
-            MouseButton::Other(_) => return,
+        let Ok(buttons) = MouseButtons::try_from(event.button) else {
+            return;
         };
-
         match event.action {
             MouseButtonAction::Down => {
-                self.pressed_mouse_buttons |= button_as_bitmask;
+                self.pressed_mouse_buttons |= buttons;
             },
             MouseButtonAction::Up => {
-                self.pressed_mouse_buttons &= !(button_as_bitmask);
+                self.pressed_mouse_buttons &= !(buttons);
             },
         }
     }

--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -715,7 +715,7 @@ impl WebViewRenderer {
 
     /// <http://w3c.github.io/touch-events/#mouse-events>
     fn simulate_mouse_click(&mut self, render_api: &RenderApi, point: DevicePoint) {
-        let button = MouseButton::Left;
+        let button = MouseButton::Primary;
         self.dispatch_input_event_with_hit_testing(
             render_api,
             InputEvent::MouseMove(MouseMoveEvent::new_compatibility_for_touch(point.into())).into(),

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -40,7 +40,7 @@ use script_bindings::match_domstring_ascii;
 use script_bindings::num::Finite;
 use script_bindings::root::{Dom, DomRoot, DomSlice};
 use script_bindings::str::DOMString;
-use script_traits::ConstellationInputEvent;
+use script_traits::{ConstellationInputEvent, MouseButtons};
 use servo_base::generic_channel::GenericCallback;
 use servo_config::pref;
 use servo_constellation_traits::{KeyboardScroll, ScriptToConstellationMessage};
@@ -173,7 +173,7 @@ pub(crate) struct DocumentEventHandler {
     /// The number of mouse buttons currently being pressed. This is used to ensure
     /// that `pointerup` and `pointerdown` events are only sent when transitioning from
     /// having no mouse buttons pressed to having any and vice-versa.
-    mouse_buttons_down: Cell<u32>,
+    mouse_buttons_down_count: Cell<u32>,
     /// The element that is currently hovered by the cursor.
     current_hover_target: MutNullableDom<Element>,
     /// The element that was most recently activated during a mouse button press or touch
@@ -219,7 +219,7 @@ impl DocumentEventHandler {
             coalesced_wheel_event_ids: Default::default(),
             click_counting_info: Default::default(),
             last_mouse_button_down_point: Default::default(),
-            mouse_buttons_down: Cell::new(0),
+            mouse_buttons_down_count: Cell::new(0),
             current_hover_target: Default::default(),
             current_active_element: Default::default(),
             most_recently_clicked_element: Default::default(),
@@ -871,7 +871,7 @@ impl DocumentEventHandler {
     fn handle_native_mouse_button_event(
         &self,
         cx: &mut JSContext,
-        event: MouseButtonEvent,
+        mouse_button_event: MouseButtonEvent,
         input_event: &ConstellationInputEvent,
     ) {
         let flags = if input_event.primary_button_is_pressed() {
@@ -887,13 +887,13 @@ impl DocumentEventHandler {
 
         debug!(
             "{:?}: at {:?}",
-            event.action, hit_test_result.point_in_frame
+            mouse_button_event.action, hit_test_result.point_in_frame
         );
 
         // Set the sequential focus navigation starting point for any mouse button down event, no
         // matter if the target is not a node.
         let document = self.window.Document();
-        if event.action == MouseButtonAction::Down {
+        if mouse_button_event.action == MouseButtonAction::Down {
             document
                 .focus_handler()
                 .set_sequential_focus_navigation_starting_point(&hit_test_result.node);
@@ -908,17 +908,17 @@ impl DocumentEventHandler {
         };
 
         let node = element.upcast::<Node>();
-        debug!("{:?} on {:?}", event.action, node.debug_str());
+        debug!("{:?} on {:?}", mouse_button_event.action, node.debug_str());
 
         // <https://html.spec.whatwg.org/multipage/#selector-active>
         // > If the element is being actively pointed at the element is being activated.
         // Disabled elements can also be activated, so this must happen before the
         // early return below.
-        if event.button == MouseButton::Left {
-            if event.action == MouseButtonAction::Down {
+        if mouse_button_event.button == MouseButton::Primary {
+            if mouse_button_event.action == MouseButtonAction::Down {
                 self.set_active_element(&element);
             }
-            if event.action == MouseButtonAction::Up {
+            if mouse_button_event.action == MouseButtonAction::Up {
                 self.unset_active_element();
             }
         }
@@ -930,7 +930,7 @@ impl DocumentEventHandler {
             return;
         }
 
-        let mouse_event_type = match event.action {
+        let mouse_event_type = match mouse_button_event.action {
             embedder_traits::MouseButtonAction::Up => atom!("mouseup"),
             embedder_traits::MouseButtonAction::Down => atom!("mousedown"),
         };
@@ -941,16 +941,19 @@ impl DocumentEventHandler {
         // UIEvent.detail: indicates the current click count incremented by one. For
         // example, if no click happened before the mousedown, detail will contain
         // the value 1
-        if event.action == MouseButtonAction::Down {
+        if mouse_button_event.action == MouseButtonAction::Down {
             self.click_counting_info
                 .safe_borrow_mut(cx.no_gc())
-                .reset_click_count_if_necessary(event.button, hit_test_result.point_in_frame);
+                .reset_click_count_if_necessary(
+                    mouse_button_event.button,
+                    hit_test_result.point_in_frame,
+                );
         }
 
         let mouse_event = MouseEvent::for_platform_button_event(
             cx,
             mouse_event_type,
-            event,
+            mouse_button_event,
             input_event.pressed_mouse_buttons,
             &self.window,
             &hit_test_result,
@@ -958,13 +961,13 @@ impl DocumentEventHandler {
             self.click_counting_info.borrow().count + 1,
         );
 
-        match event.action {
+        match mouse_button_event.action {
             MouseButtonAction::Down => {
                 self.last_mouse_button_down_point
                     .set(Some(hit_test_result.point_in_frame));
 
                 // Step 6. Dispatch pointerdown event.
-                let mouse_buttons_down = self.mouse_buttons_down.get();
+                let mouse_buttons_down = self.mouse_buttons_down_count.get();
                 let pointer_event_name = if mouse_buttons_down == 0 {
                     // From <https://w3c.github.io/pointerevents/#dfn-pointerdown>
                     // > The user agent MUST fire a pointer event named pointerdown when a pointer enters
@@ -995,7 +998,7 @@ impl DocumentEventHandler {
                     .unwrap_or_else(|| DomRoot::from_ref(node.upcast::<EventTarget>()));
 
                 // Increment button count before firing so setPointerCapture works in handler.
-                self.mouse_buttons_down.set(mouse_buttons_down + 1);
+                self.mouse_buttons_down_count.set(mouse_buttons_down + 1);
 
                 pointer_event.upcast::<Event>().fire(cx, &pointer_target);
 
@@ -1024,14 +1027,14 @@ impl DocumentEventHandler {
 
                 // Step 9. If mbutton is the secondary mouse button, then
                 // Maybe show context menu with native, target.
-                if let MouseButton::Right = event.button {
+                if let MouseButton::Secondary = mouse_button_event.button {
                     self.maybe_show_context_menu(cx, node.upcast(), &hit_test_result, input_event);
                 }
             },
             // https://w3c.github.io/pointerevents/#dfn-handle-native-mouse-up
             MouseButtonAction::Up => {
                 // Step 6. Dispatch pointerup event.
-                let mouse_buttons_down = self.mouse_buttons_down.get();
+                let mouse_buttons_down = self.mouse_buttons_down_count.get();
                 let pointer_event_name = if mouse_buttons_down == 1 {
                     // From <https://w3c.github.io/pointerevents/#dfn-pointerup>:
                     // > The user agent MUST fire a pointer event named pointerup when a pointer leaves
@@ -1065,7 +1068,7 @@ impl DocumentEventHandler {
 
                 // Decrement button count after firing event, so setPointerCapture/releasePointerCapture
                 // work during the pointerup handler (pointer is still "active").
-                self.mouse_buttons_down
+                self.mouse_buttons_down_count
                     .set(mouse_buttons_down.saturating_sub(1));
 
                 // Process pending pointer capture after decrementing button count, but skip
@@ -1090,11 +1093,14 @@ impl DocumentEventHandler {
                 // even when those events are not fired.
                 self.click_counting_info
                     .safe_borrow_mut(cx.no_gc())
-                    .increment_click_count(event.button, hit_test_result.point_in_frame);
+                    .increment_click_count(
+                        mouse_button_event.button,
+                        hit_test_result.point_in_frame,
+                    );
 
                 self.maybe_trigger_click_for_mouse_button_down_event(
                     cx,
-                    event,
+                    mouse_button_event,
                     input_event,
                     &hit_test_result,
                     &element,
@@ -1113,7 +1119,7 @@ impl DocumentEventHandler {
         hit_test_result: &HitTestResult,
         element: &Element,
     ) {
-        if event.button != MouseButton::Left {
+        if event.button != MouseButton::Primary {
             return;
         }
 
@@ -1196,7 +1202,7 @@ impl DocumentEventHandler {
                 .point_relative_to_initial_containing_block
                 .to_i32(),
             input_event.active_keyboard_modifiers,
-            2i16, // button, right mouse button
+            MouseButton::Secondary,
             input_event.pressed_mouse_buttons,
             None,                     // related_target
             None,                     // point_in_target
@@ -1683,7 +1689,7 @@ impl DocumentEventHandler {
                 .point_relative_to_initial_containing_block
                 .to_i32(),
             input_event.active_keyboard_modifiers,
-            0i16,
+            MouseButton::Primary,
             input_event.pressed_mouse_buttons,
             None,
             None,
@@ -2528,7 +2534,7 @@ impl DocumentEventHandler {
     pub(crate) fn is_active_pointer(&self, pointer_id: i32) -> bool {
         if pointer_id == PointerId::Mouse as i32 {
             // Mouse is active when buttons are down
-            self.mouse_buttons_down.get() > 0
+            self.mouse_buttons_down_count.get() > 0
         } else {
             // Touch pointers are tracked in active_pointer_ids
             self.active_pointer_ids
@@ -2660,8 +2666,8 @@ impl DocumentEventHandler {
             Point2D::new(0, 0),
             Point2D::new(0, 0),
             Modifiers::empty(),
-            0,
-            0,
+            MouseButton::Primary,
+            MouseButtons::empty(),
             None,
             None,
             pointer_id,
@@ -2698,6 +2704,13 @@ impl DocumentEventHandler {
         target: &Element,
         related_target: Option<&Element>,
     ) {
+        // TODO: This is wrong when the button pressed is not the primary one.
+        let mouse_buttons = if self.mouse_buttons_down_count.get() != 0 {
+            MouseButtons::Primary
+        } else {
+            MouseButtons::empty()
+        };
+
         let pointer_event = PointerEvent::new(
             cx,
             &self.window,
@@ -2710,8 +2723,8 @@ impl DocumentEventHandler {
             Point2D::new(0, 0),
             Point2D::new(0, 0),
             Modifiers::empty(),
-            -1, // button: -1 for boundary events
-            self.mouse_buttons_down.get() as u16,
+            MouseButton::None,
+            mouse_buttons,
             related_target.map(|el| el.upcast::<EventTarget>()),
             None,
             pointer_id,

--- a/components/script/dom/event/mouseevent.rs
+++ b/components/script/dom/event/mouseevent.rs
@@ -7,6 +7,7 @@ use std::default::Default;
 use std::f64::consts::PI;
 
 use dom_struct::dom_struct;
+use embedder_traits::MouseButton;
 use euclid::Point2D;
 use js::context::JSContext;
 use js::rust::HandleObject;
@@ -15,7 +16,7 @@ use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::dom::MutNullableDom;
 use script_bindings::match_domstring_ascii;
 use script_bindings::reflector::reflect_dom_object_with_proto;
-use script_traits::ConstellationInputEvent;
+use script_traits::{ConstellationInputEvent, MouseButtons};
 use servo_base::text::Utf32CodeUnits;
 use style::Atom;
 use style_traits::CSSPixel;
@@ -75,10 +76,12 @@ pub(crate) struct MouseEvent {
     modifiers: Cell<Modifiers>,
 
     /// <https://w3c.github.io/uievents/#dom-mouseevent-button>
-    button: Cell<i16>,
+    #[no_trace]
+    button: Cell<MouseButton>,
 
     /// <https://w3c.github.io/uievents/#dom-mouseevent-buttons>
-    buttons: Cell<u16>,
+    #[no_trace]
+    buttons: Cell<MouseButtons>,
 
     #[no_trace]
     point_in_target: Cell<Option<Point2D<f32, CSSPixel>>>,
@@ -101,8 +104,8 @@ impl MouseEvent {
             client_point: Cell::new(Default::default()),
             page_point: Cell::new(Default::default()),
             modifiers: Cell::new(Modifiers::empty()),
-            button: Cell::new(0),
-            buttons: Cell::new(0),
+            button: Cell::new(MouseButton::Primary),
+            buttons: Cell::new(MouseButtons::empty()),
             point_in_target: Cell::new(None),
             dom_position_container: MutNullableDom::default(),
             dom_position_offset: Cell::new(None),
@@ -134,8 +137,8 @@ impl MouseEvent {
         client_point: Point2D<i32, CSSPixel>,
         page_point: Point2D<i32, CSSPixel>,
         modifiers: Modifiers,
-        button: i16,
-        buttons: u16,
+        button: MouseButton,
+        buttons: MouseButtons,
         related_target: Option<&EventTarget>,
         point_in_target: Option<Point2D<f32, CSSPixel>>,
         dom_position_for_selection: Option<&(DomRoot<Node>, Utf32CodeUnits)>,
@@ -175,8 +178,8 @@ impl MouseEvent {
         client_point: Point2D<i32, CSSPixel>,
         page_point: Point2D<i32, CSSPixel>,
         modifiers: Modifiers,
-        button: i16,
-        buttons: u16,
+        button: MouseButton,
+        buttons: MouseButtons,
         related_target: Option<&EventTarget>,
         point_in_target: Option<Point2D<f32, CSSPixel>>,
         dom_position_for_selection: Option<&(DomRoot<Node>, Utf32CodeUnits)>,
@@ -214,8 +217,8 @@ impl MouseEvent {
         client_point: Point2D<i32, CSSPixel>,
         page_point: Point2D<i32, CSSPixel>,
         modifiers: Modifiers,
-        button: i16,
-        buttons: u16,
+        button: MouseButton,
+        buttons: MouseButtons,
         related_target: Option<&EventTarget>,
         point_in_target: Option<Point2D<f32, CSSPixel>>,
         dom_position_for_selection: Option<&(DomRoot<Node>, Utf32CodeUnits)>,
@@ -236,9 +239,11 @@ impl MouseEvent {
         self.buttons.set(buttons);
         self.upcast::<Event>().set_related_target(related_target);
         self.point_in_target.set(point_in_target);
-        // Legacy mapping per spec: left/middle/right => 1/2/3 (button + 1), else 0.
-        let w = if button >= 0 { (button as u32) + 1 } else { 0 };
-        self.uievent.set_which(w);
+
+        // From <https://w3c.github.io/uievents/#dom-uievent-which>:
+        // > For MouseEvents, this contains a value equal to the value stored in button+1.
+        self.uievent.set_which((i16::from(button) + 1) as u32);
+
         if let Some((node, offset)) = dom_position_for_selection {
             self.dom_position_container.set(Some(node));
             self.dom_position_offset.set(Some(*offset));
@@ -279,7 +284,7 @@ impl MouseEvent {
                 .point_relative_to_initial_containing_block
                 .to_i32(),
             input_event.active_keyboard_modifiers,
-            0i16,
+            MouseButton::Primary,
             input_event.pressed_mouse_buttons,
             None,
             None,
@@ -305,7 +310,7 @@ impl MouseEvent {
         cx: &mut JSContext,
         event_type: Atom,
         event: embedder_traits::MouseButtonEvent,
-        pressed_mouse_buttons: u16,
+        pressed_mouse_buttons: MouseButtons,
         window: &Window,
         hit_test_result: &HitTestResult,
         modifiers: Modifiers,
@@ -328,7 +333,7 @@ impl MouseEvent {
             client_point,
             page_point,
             modifiers,
-            event.button.into(),
+            event.button,
             pressed_mouse_buttons,
             None,
             Some(hit_test_result.point_in_node),
@@ -355,16 +360,16 @@ impl MouseEvent {
         let is_pointer_up = &*event_type == "pointerup";
 
         // Pressure is 0.5 when button is down, 0.0 when up
-        let pressure = if is_pointer_down || (is_pointer_move && self.Buttons() != 0) {
+        let pressure = if is_pointer_down || (is_pointer_move && !self.buttons.get().is_empty()) {
             0.5
         } else {
             0.0
         };
 
         let button = if is_pointer_down || is_pointer_up {
-            self.Button()
+            self.button.get()
         } else {
-            -1
+            MouseButton::None
         };
 
         // https://w3c.github.io/pointerevents/#dfn-attributes-and-default-actions
@@ -388,7 +393,7 @@ impl MouseEvent {
             Point2D::new(self.PageX(), self.PageY()),
             self.modifiers.get(),
             button,
-            self.Buttons(),
+            self.buttons.get(),
             self.GetRelatedTarget().as_deref(),
             self.point_in_target.get(),
             PointerId::Mouse as i32, // Mouse pointer ID is always -1
@@ -446,8 +451,8 @@ impl MouseEvent {
             Point2D::new(self.ClientX(), self.ClientY()),
             Point2D::new(self.PageX(), self.PageY()),
             self.modifiers.get(),
-            -1, // button: -1 for hover events (no button pressed)
-            self.Buttons(),
+            MouseButton::None,
+            self.buttons.get(),
             self.GetRelatedTarget().as_deref(),
             self.point_in_target.get(),
             PointerId::Mouse as i32, // Mouse pointer ID is always -1
@@ -510,8 +515,8 @@ impl MouseEventMethods<crate::DomTypeHolder> for MouseEvent {
             Point2D::new(init.clientX, init.clientY),
             page_point,
             init.parent.modifiers(),
-            init.button,
-            init.buttons,
+            init.button.into(),
+            MouseButtons::from_bits_retain(init.buttons),
             init.relatedTarget.as_deref(),
             None,
             None,
@@ -650,12 +655,12 @@ impl MouseEventMethods<crate::DomTypeHolder> for MouseEvent {
 
     /// <https://w3c.github.io/pointerevents/#dom-mouseevent-button>
     fn Button(&self) -> i16 {
-        self.button.get()
+        self.button.get().into()
     }
 
     /// <https://w3c.github.io/pointerevents/#dom-mouseevent-buttons>
     fn Buttons(&self) -> u16 {
-        self.buttons.get()
+        self.buttons.get().bits()
     }
 
     /// <https://w3c.github.io/pointerevents/#dom-mouseevent-relatedtarget>
@@ -720,7 +725,7 @@ impl MouseEventMethods<crate::DomTypeHolder> for MouseEvent {
         }
         self.modifiers.set(modifiers);
 
-        self.button.set(button_arg);
+        self.button.set(button_arg.into());
         self.upcast::<Event>()
             .set_related_target(related_target_arg);
 

--- a/components/script/dom/event/pointerevent.rs
+++ b/components/script/dom/event/pointerevent.rs
@@ -5,12 +5,14 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
+use embedder_traits::MouseButton;
 use euclid::Point2D;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use keyboard_types::Modifiers;
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_traits::MouseButtons;
 use style::Atom;
 use style_traits::CSSPixel;
 
@@ -94,8 +96,8 @@ impl PointerEvent {
         client_point: Point2D<i32, CSSPixel>,
         page_point: Point2D<i32, CSSPixel>,
         modifiers: Modifiers,
-        button: i16,
-        buttons: u16,
+        button: MouseButton,
+        buttons: MouseButtons,
         related_target: Option<&EventTarget>,
         point_in_target: Option<Point2D<f32, CSSPixel>>,
         pointer_id: i32,
@@ -161,8 +163,8 @@ impl PointerEvent {
         client_point: Point2D<i32, CSSPixel>,
         page_point: Point2D<i32, CSSPixel>,
         modifiers: Modifiers,
-        button: i16,
-        buttons: u16,
+        button: MouseButton,
+        buttons: MouseButtons,
         related_target: Option<&EventTarget>,
         point_in_target: Option<Point2D<f32, CSSPixel>>,
         pointer_id: i32,
@@ -250,8 +252,8 @@ impl PointerEventMethods<crate::DomTypeHolder> for PointerEvent {
             Point2D::new(init.parent.clientX, init.parent.clientY),
             page_point,
             init.parent.parent.modifiers(),
-            init.parent.button,
-            init.parent.buttons,
+            init.parent.button.into(),
+            MouseButtons::from_bits_retain(init.parent.buttons),
             init.parent.relatedTarget.as_deref(),
             None,
             init.pointerId,

--- a/components/script/dom/event/wheelevent.rs
+++ b/components/script/dom/event/wheelevent.rs
@@ -5,11 +5,13 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
+use embedder_traits::MouseButton;
 use euclid::Point2D;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use keyboard_types::Modifiers;
 use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_traits::MouseButtons;
 use style::Atom;
 use style_traits::CSSPixel;
 
@@ -67,8 +69,8 @@ impl WheelEvent {
         client_point: Point2D<i32, CSSPixel>,
         page_point: Point2D<i32, CSSPixel>,
         modifiers: Modifiers,
-        button: i16,
-        buttons: u16,
+        button: MouseButton,
+        buttons: MouseButtons,
         related_target: Option<&EventTarget>,
         point_in_target: Option<Point2D<f32, CSSPixel>>,
         delta_x: Finite<f64>,
@@ -114,8 +116,8 @@ impl WheelEvent {
         client_point: Point2D<i32, CSSPixel>,
         page_point: Point2D<i32, CSSPixel>,
         modifiers: Modifiers,
-        button: i16,
-        buttons: u16,
+        button: MouseButton,
+        buttons: MouseButtons,
         related_target: Option<&EventTarget>,
         point_in_target: Option<Point2D<f32, CSSPixel>>,
         delta_x: Finite<f64>,
@@ -159,8 +161,8 @@ impl WheelEvent {
         client_point: Point2D<i32, CSSPixel>,
         page_point: Point2D<i32, CSSPixel>,
         modifiers: Modifiers,
-        button: i16,
-        buttons: u16,
+        button: MouseButton,
+        buttons: MouseButtons,
         related_target: Option<&EventTarget>,
         point_in_target: Option<Point2D<f32, CSSPixel>>,
         delta_x: Finite<f64>,
@@ -226,8 +228,8 @@ impl WheelEventMethods<crate::DomTypeHolder> for WheelEvent {
             Point2D::new(init.parent.clientX, init.parent.clientY),
             Point2D::new(page_point.x, page_point.y),
             init.parent.parent.modifiers(),
-            init.parent.button,
-            init.parent.buttons,
+            init.parent.button.into(),
+            MouseButtons::from_bits_retain(init.parent.buttons),
             init.parent.relatedTarget.as_deref(),
             None,
             init.deltaX,

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -17,7 +17,7 @@ use app_units::Au;
 use bitflags::bitflags;
 use devtools_traits::NodeInfo;
 use dom_struct::dom_struct;
-use embedder_traits::UntrustedNodeAddress;
+use embedder_traits::{MouseButton, UntrustedNodeAddress};
 use euclid::default::Size2D;
 use euclid::{Point2D, Rect};
 use html5ever::serialize::HtmlSerializer;
@@ -41,7 +41,7 @@ use script_bindings::reflector::{
     DomObject, DomObjectWrap, WeakReferenceableDomObjectWrap, reflect_dom_object_with_proto,
     reflect_weak_referenceable_dom_object_with_proto,
 };
-use script_traits::DocumentActivity;
+use script_traits::{DocumentActivity, MouseButtons};
 use servo_base::id::PipelineId;
 use servo_config::pref;
 use smallvec::SmallVec;
@@ -608,8 +608,8 @@ impl Node {
             Point2D::zero(),                    // coordinates uninitialized
             Point2D::zero(),                    // coordinates uninitialized
             Modifiers::empty(),                 // empty modifiers
-            0,                                  // button, left mouse button
-            0,                                  // buttons
+            MouseButton::Primary,               // button, primary mouse button
+            MouseButtons::empty(),              // buttons
             None,                               // related_target
             None,                               // point_in_target
             PointerId::NonPointerDevice as i32, // pointer_id

--- a/components/script/dom/touch/touch.rs
+++ b/components/script/dom/touch/touch.rs
@@ -5,6 +5,7 @@
 use std::f64::consts::PI;
 
 use dom_struct::dom_struct;
+use embedder_traits::MouseButton;
 use euclid::Point2D;
 use js::context::JSContext;
 use js::rust::HandleObject;
@@ -12,6 +13,7 @@ use script_bindings::inheritance::Castable;
 use script_bindings::reflector::{
     Reflector, reflect_dom_object_with_cx, reflect_dom_object_with_proto,
 };
+use script_traits::MouseButtons;
 
 use crate::dom::bindings::codegen::Bindings::TouchBinding::{TouchInit, TouchMethods};
 use crate::dom::bindings::num::Finite;
@@ -142,21 +144,21 @@ impl Touch {
             event_type == "pointerout" ||
             event_type == "pointerleave"
         {
-            -1
+            MouseButton::None
         } else {
-            0
+            MouseButton::Primary
         };
 
-        // Buttons: 1 if a button is pressed during the event, 0 otherwise
+        // Buttons: Primary if a button is pressed during the event, empty otherwise.
         // For touch: button is pressed during over/enter/down/move, not during up/cancel/out/leave
         let buttons = if event_type == "pointermove" ||
             event_type == "pointerover" ||
             event_type == "pointerenter" ||
             event_type == "pointerdown"
         {
-            1
+            MouseButtons::Primary
         } else {
-            0
+            MouseButtons::empty()
         };
 
         // For enter/leave events, they don't bubble and are not cancelable

--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -181,12 +181,12 @@ pub(crate) fn click_at_point(webview: &WebView, point: DevicePoint) {
     webview.notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(point)));
     webview.notify_input_event(InputEvent::MouseButton(MouseButtonEvent::new(
         MouseButtonAction::Down,
-        MouseButton::Left,
+        MouseButton::Primary,
         point,
     )));
     webview.notify_input_event(InputEvent::MouseButton(MouseButtonEvent::new(
         MouseButtonAction::Up,
-        MouseButton::Left,
+        MouseButton::Primary,
         point,
     )));
 }

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -55,12 +55,12 @@ fn open_context_menu_at_point(webview: &WebView, point: DevicePoint) {
     webview.notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(point)));
     webview.notify_input_event(InputEvent::MouseButton(MouseButtonEvent::new(
         MouseButtonAction::Down,
-        MouseButton::Right,
+        MouseButton::Secondary,
         point,
     )));
     webview.notify_input_event(InputEvent::MouseButton(MouseButtonEvent::new(
         MouseButtonAction::Up,
-        MouseButton::Right,
+        MouseButton::Secondary,
         point,
     )));
 }

--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -162,23 +162,28 @@ impl MouseButtonEvent {
 }
 
 /// The types of mouse buttons.
+///
+/// <https://w3c.github.io/pointerevents/#the-button-property>
 #[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
 pub enum MouseButton {
-    Left,
-    Middle,
-    Right,
+    #[doc(hidden)]
+    None,
+    Primary,
+    Auxiliary,
+    Secondary,
     Back,
     Forward,
     Other(u16),
 }
 
-impl<T: Into<u64>> From<T> for MouseButton {
+impl<T: Into<i128>> From<T> for MouseButton {
     fn from(value: T) -> Self {
         let value = value.into();
         match value {
-            0 => MouseButton::Left,
-            1 => MouseButton::Middle,
-            2 => MouseButton::Right,
+            -1 => MouseButton::None,
+            0 => MouseButton::Primary,
+            1 => MouseButton::Auxiliary,
+            2 => MouseButton::Secondary,
             3 => MouseButton::Back,
             4 => MouseButton::Forward,
             _ => MouseButton::Other(value as u16),
@@ -189,9 +194,10 @@ impl<T: Into<u64>> From<T> for MouseButton {
 impl From<MouseButton> for i16 {
     fn from(value: MouseButton) -> Self {
         match value {
-            MouseButton::Left => 0,
-            MouseButton::Middle => 1,
-            MouseButton::Right => 2,
+            MouseButton::None => -1,
+            MouseButton::Primary => 0,
+            MouseButton::Auxiliary => 1,
+            MouseButton::Secondary => 2,
             MouseButton::Back => 3,
             MouseButton::Forward => 4,
             MouseButton::Other(value) => value as i16,

--- a/components/shared/script/Cargo.toml
+++ b/components/shared/script/Cargo.toml
@@ -20,6 +20,7 @@ webgpu = ["dep:webgpu_traits"]
 
 [dependencies]
 accesskit = { workspace = true }
+bitflags = { workspace = true }
 crossbeam-channel = { workspace = true }
 devtools_traits = { workspace = true }
 embedder_traits = { workspace = true }

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -11,17 +11,19 @@
 
 use std::fmt;
 
+use bitflags::bitflags;
 use crossbeam_channel::RecvTimeoutError;
 use devtools_traits::ScriptToDevtoolsControlMsg;
 use embedder_traits::user_contents::{UserContentManagerId, UserContents};
 use embedder_traits::{
     EmbedderControlId, EmbedderControlResponse, FocusSequenceNumber, InputEventAndId,
-    JavaScriptEvaluationId, MediaSessionActionType, PaintHitTestResult, ScriptToEmbedderChan,
-    Theme, ViewportDetails, WebDriverScriptCommand,
+    JavaScriptEvaluationId, MediaSessionActionType, MouseButton, PaintHitTestResult,
+    ScriptToEmbedderChan, Theme, ViewportDetails, WebDriverScriptCommand,
 };
 use euclid::{Scale, Size2D};
 use fonts_traits::{SystemFontServiceProxySender, WebFontLoadEvent};
 use keyboard_types::Modifiers;
+use malloc_size_of::malloc_size_of_is_0;
 use malloc_size_of_derive::MallocSizeOf;
 use media::WindowGLContext;
 use net_traits::ResourceThreads;
@@ -356,6 +358,52 @@ pub enum DocumentState {
     Pending,
 }
 
+bitflags! {
+    #[derive(Clone, Copy, Default, Debug, Deserialize, Eq, PartialEq, Serialize)]
+    /// <https://w3c.github.io/pointerevents/#dom-mouseevent-buttons>
+    pub struct MouseButtons: u16 {
+        /// > 1 MUST indicate the primary button of the device (in general, the left
+        /// > button or the only button on single-button devices, used to activate a user
+        /// > interface control or select text).
+        const Primary = 1;
+        /// > 2 MUST indicate the secondary button (in general, the right button, often
+        /// > used to display a context menu), if present.
+        const Secondary = 2;
+        /// > 4 MUST indicate the auxiliary button (in general, the middle button, often
+        /// > combined with a mouse wheel).
+        const Auxiliary = 4;
+        /// The 'back' button:
+        ///
+        /// > Some pointing devices provide or simulate more buttons. To represent such
+        /// > buttons, the value MUST be doubled for each successive button (in the binary
+        /// > series 8, 16, 32, ... ).
+        const Back = 8;
+        /// The 'forward' button:
+        ///
+        /// > Some pointing devices provide or simulate more buttons. To represent such
+        /// > buttons, the value MUST be doubled for each successive button (in the binary
+        /// > series 8, 16, 32, ... ).
+        const Forward = 16;
+    }
+}
+
+malloc_size_of_is_0!(MouseButtons);
+
+impl TryFrom<MouseButton> for MouseButtons {
+    type Error = ();
+
+    fn try_from(button: MouseButton) -> Result<Self, Self::Error> {
+        match button {
+            MouseButton::Primary => Ok(Self::Primary),
+            MouseButton::Secondary => Ok(Self::Secondary),
+            MouseButton::Auxiliary => Ok(Self::Auxiliary),
+            MouseButton::Back => Ok(Self::Back),
+            MouseButton::Forward => Ok(Self::Forward),
+            MouseButton::None | MouseButton::Other(_) => Err(()),
+        }
+    }
+}
+
 /// Input events from the embedder that are sent via the `Constellation`` to the `ScriptThread`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ConstellationInputEvent {
@@ -363,7 +411,7 @@ pub struct ConstellationInputEvent {
     pub hit_test_result: Option<PaintHitTestResult>,
     /// The pressed mouse button state of the constellation when this input
     /// event was triggered.
-    pub pressed_mouse_buttons: u16,
+    pub pressed_mouse_buttons: MouseButtons,
     /// The currently active keyboard modifiers.
     pub active_keyboard_modifiers: Modifiers,
     /// The [`InputEventAndId`] itself.
@@ -371,11 +419,9 @@ pub struct ConstellationInputEvent {
 }
 
 impl ConstellationInputEvent {
-    /// Returns whether `pressed_mouse_buttons` includes the primarry button
+    /// Returns whether `pressed_mouse_buttons` includes the primary button
     pub fn primary_button_is_pressed(&self) -> bool {
-        /// <https://w3c.github.io/pointerevents/#dom-mouseevent-buttons>
-        const PRIMARY_BUTTON_MASK: u16 = 1;
-        (self.pressed_mouse_buttons & PRIMARY_BUTTON_MASK) != 0
+        self.pressed_mouse_buttons.contains(MouseButtons::Primary)
     }
 }
 

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -275,9 +275,9 @@ impl HeadedWindow {
         }
 
         let mouse_button = match &button {
-            MouseButton::Left => ServoMouseButton::Left,
-            MouseButton::Right => ServoMouseButton::Right,
-            MouseButton::Middle => ServoMouseButton::Middle,
+            MouseButton::Left => ServoMouseButton::Primary,
+            MouseButton::Right => ServoMouseButton::Secondary,
+            MouseButton::Middle => ServoMouseButton::Auxiliary,
             MouseButton::Back => ServoMouseButton::Back,
             MouseButton::Forward => ServoMouseButton::Forward,
             MouseButton::Other(value) => ServoMouseButton::Other(*value),

--- a/ports/servoshell/egl/android/mod.rs
+++ b/ports/servoshell/egl/android/mod.rs
@@ -594,8 +594,8 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_click(
     env.with_env(|env| -> jni::errors::Result<_> {
         debug!("click");
         call(env, |s| {
-            s.mouse_down(x, y, MouseButton::Left);
-            s.mouse_up(x, y, MouseButton::Left);
+            s.mouse_down(x, y, MouseButton::Primary);
+            s.mouse_up(x, y, MouseButton::Primary);
         });
         Ok(())
     })


### PR DESCRIPTION
Instead of storing raw numbers in DOM input events, store `MouseButton`
and `MouseButtons` (a new `bitflags`). This reduces quite a bit the
amount of magic numbers thoughout the codebase and makes various bits of
code easier to reason about.

In addition, `MouseButton` names are renamed according to what they
represent internally (e.g. `Primary` instead of `Left`). This is an API
change.

Testing: This should not change observable behavior so should be covered by existing tests.
