### PR TITLE
script: Rename RSA-related structs in WebCrypto

### DIFF
--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3128,7 +3128,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for RsaPssParams {
 
 /// <https://w3c.github.io/webcrypto/#dfn-RsaOaepParams>
 #[derive(Clone, MallocSizeOf)]
-struct SubtleRsaOaepParams {
+struct RsaOaepParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -3136,7 +3136,7 @@ struct SubtleRsaOaepParams {
     label: Option<Vec<u8>>,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleRsaOaepParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for RsaOaepParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -3144,7 +3144,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleRsaOaepParams {
         cx: &mut js::context::JSContext,
         algorithm_name: CryptoAlgorithm,
     ) -> Result<Self, Self::Error> {
-        Ok(SubtleRsaOaepParams {
+        Ok(RsaOaepParams {
             name: algorithm_name,
             label: get_optional_buffer_source(cx, object, c"label")?,
         })
@@ -4882,7 +4882,7 @@ impl Operation for EncryptOperation {
 /// Normalized algorithm for the "encrypt" operation, used as output of
 /// <https://w3c.github.io/webcrypto/#dfn-normalize-an-algorithm>
 enum EncryptAlgorithm {
-    RsaOaep(SubtleRsaOaepParams),
+    RsaOaep(RsaOaepParams),
     AesCtr(SubtleAesCtrParams),
     AesCbc(SubtleAesCbcParams),
     AesGcm(SubtleAesGcmParams),
@@ -4969,7 +4969,7 @@ impl Operation for DecryptOperation {
 /// Normalized algorithm for the "decrypt" operation, used as output of
 /// <https://w3c.github.io/webcrypto/#dfn-normalize-an-algorithm>
 enum DecryptAlgorithm {
-    RsaOaep(SubtleRsaOaepParams),
+    RsaOaep(RsaOaepParams),
     AesCtr(SubtleAesCtrParams),
     AesCbc(SubtleAesCbcParams),
     AesGcm(SubtleAesGcmParams),

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -2934,7 +2934,7 @@ impl From<&KeyAlgorithm> for SerializableKeyAlgorithm {
 
 /// <https://w3c.github.io/webcrypto/#dfn-RsaHashedKeyGenParams>
 #[derive(Clone, MallocSizeOf)]
-pub(crate) struct SubtleRsaHashedKeyGenParams {
+pub(crate) struct RsaHashedKeyGenParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -2948,7 +2948,7 @@ pub(crate) struct SubtleRsaHashedKeyGenParams {
     hash: DigestAlgorithm,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleRsaHashedKeyGenParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for RsaHashedKeyGenParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -2958,7 +2958,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleRsaHashedKeyGenParams 
     ) -> Result<Self, Self::Error> {
         let hash = get_required_parameter(cx, object, c"hash", ())?;
 
-        Ok(SubtleRsaHashedKeyGenParams {
+        Ok(RsaHashedKeyGenParams {
             name: algorithm_name,
             modulus_length: get_required_parameter(
                 cx,
@@ -5544,9 +5544,9 @@ impl Operation for GenerateKeyOperation {
 /// Normalized algorithm for the "generateKey" operation, used as output of
 /// <https://w3c.github.io/webcrypto/#dfn-normalize-an-algorithm>
 enum GenerateKeyAlgorithm {
-    RsassaPkcs1V1_5(SubtleRsaHashedKeyGenParams),
-    RsaPss(SubtleRsaHashedKeyGenParams),
-    RsaOaep(SubtleRsaHashedKeyGenParams),
+    RsassaPkcs1V1_5(RsaHashedKeyGenParams),
+    RsaPss(RsaHashedKeyGenParams),
+    RsaOaep(RsaHashedKeyGenParams),
     Ecdsa(SubtleEcKeyGenParams),
     Ecdh(SubtleEcKeyGenParams),
     Ed25519(Algorithm),

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3071,7 +3071,7 @@ impl From<&RsaHashedKeyAlgorithm> for SerializableRsaHashedKeyAlgorithm {
 
 /// <https://w3c.github.io/webcrypto/#dfn-RsaHashedImportParams>
 #[derive(Clone, MallocSizeOf)]
-struct SubtleRsaHashedImportParams {
+struct RsaHashedImportParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -3079,7 +3079,7 @@ struct SubtleRsaHashedImportParams {
     hash: DigestAlgorithm,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleRsaHashedImportParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for RsaHashedImportParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -3089,7 +3089,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleRsaHashedImportParams 
     ) -> Result<Self, Self::Error> {
         let hash = get_required_parameter(cx, object, c"hash", ())?;
 
-        Ok(SubtleRsaHashedImportParams {
+        Ok(RsaHashedImportParams {
             name: algorithm_name,
             hash: normalize_algorithm::<DigestOperation>(cx, &hash)?,
         })
@@ -5768,9 +5768,9 @@ impl Operation for ImportKeyOperation {
 /// Normalized algorithm for the "importKey" operation, used as output of
 /// <https://w3c.github.io/webcrypto/#dfn-normalize-an-algorithm>
 enum ImportKeyAlgorithm {
-    RsassaPkcs1V1_5(SubtleRsaHashedImportParams),
-    RsaPss(SubtleRsaHashedImportParams),
-    RsaOaep(SubtleRsaHashedImportParams),
+    RsassaPkcs1V1_5(RsaHashedImportParams),
+    RsaPss(RsaHashedImportParams),
+    RsaOaep(RsaHashedImportParams),
     Ecdsa(SubtleEcKeyImportParams),
     Ecdh(SubtleEcKeyImportParams),
     Ed25519(Algorithm),

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3098,7 +3098,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for RsaHashedImportParams {
 
 /// <https://w3c.github.io/webcrypto/#dfn-RsaPssParams>
 #[derive(Clone, MallocSizeOf)]
-struct SubtleRsaPssParams {
+struct RsaPssParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -3106,7 +3106,7 @@ struct SubtleRsaPssParams {
     salt_length: u32,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleRsaPssParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for RsaPssParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -3114,7 +3114,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleRsaPssParams {
         cx: &mut js::context::JSContext,
         algorithm_name: CryptoAlgorithm,
     ) -> Result<Self, Self::Error> {
-        Ok(SubtleRsaPssParams {
+        Ok(RsaPssParams {
             name: algorithm_name,
             salt_length: get_required_parameter(
                 cx,
@@ -5057,7 +5057,7 @@ impl Operation for SignOperation {
 /// <https://w3c.github.io/webcrypto/#dfn-normalize-an-algorithm>
 enum SignAlgorithm {
     RsassaPkcs1V1_5(Algorithm),
-    RsaPss(SubtleRsaPssParams),
+    RsaPss(RsaPssParams),
     Ecdsa(SubtleEcdsaParams),
     Ed25519(Algorithm),
     Ed448(SubtleEd448Params),
@@ -5146,7 +5146,7 @@ impl Operation for VerifyOperation {
 /// <https://w3c.github.io/webcrypto/#dfn-normalize-an-algorithm>
 enum VerifyAlgorithm {
     RsassaPkcs1V1_5(Algorithm),
-    RsaPss(SubtleRsaPssParams),
+    RsaPss(RsaPssParams),
     Ecdsa(SubtleEcdsaParams),
     Ed25519(Algorithm),
     Ed448(SubtleEd448Params),

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -2981,7 +2981,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for RsaHashedKeyGenParams {
 
 /// <https://w3c.github.io/webcrypto/#dfn-RsaHashedKeyAlgorithm>
 #[derive(Clone, MallocSizeOf)]
-pub(crate) struct SubtleRsaHashedKeyAlgorithm {
+pub(crate) struct RsaHashedKeyAlgorithm {
     /// <https://w3c.github.io/webcrypto/#dom-keyalgorithm-name>
     name: CryptoAlgorithm,
 
@@ -2995,7 +2995,7 @@ pub(crate) struct SubtleRsaHashedKeyAlgorithm {
     hash: DigestAlgorithm,
 }
 
-impl ToJSValConvertible for SubtleRsaHashedKeyAlgorithm {
+impl ToJSValConvertible for RsaHashedKeyAlgorithm {
     #[expect(unsafe_code)]
     fn safe_to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
         rooted!(&in(cx) let mut object = unsafe { JS_NewObject(cx, ptr::null()) });
@@ -3045,11 +3045,11 @@ impl ToJSValConvertible for SubtleRsaHashedKeyAlgorithm {
     }
 }
 
-impl TryFrom<SerializableRsaHashedKeyAlgorithm> for SubtleRsaHashedKeyAlgorithm {
+impl TryFrom<SerializableRsaHashedKeyAlgorithm> for RsaHashedKeyAlgorithm {
     type Error = ();
 
     fn try_from(value: SerializableRsaHashedKeyAlgorithm) -> Result<Self, Self::Error> {
-        Ok(SubtleRsaHashedKeyAlgorithm {
+        Ok(RsaHashedKeyAlgorithm {
             name: CryptoAlgorithm::from_str(&value.name).map_err(|_| ())?,
             modulus_length: value.modulus_length,
             public_exponent: value.public_exponent,
@@ -3058,8 +3058,8 @@ impl TryFrom<SerializableRsaHashedKeyAlgorithm> for SubtleRsaHashedKeyAlgorithm 
     }
 }
 
-impl From<&SubtleRsaHashedKeyAlgorithm> for SerializableRsaHashedKeyAlgorithm {
-    fn from(value: &SubtleRsaHashedKeyAlgorithm) -> Self {
+impl From<&RsaHashedKeyAlgorithm> for SerializableRsaHashedKeyAlgorithm {
+    fn from(value: &RsaHashedKeyAlgorithm) -> Self {
         SerializableRsaHashedKeyAlgorithm {
             name: value.name.as_str().into(),
             modulus_length: value.modulus_length,
@@ -4301,7 +4301,7 @@ impl ExportedKey {
 #[expect(clippy::enum_variant_names)]
 pub(crate) enum KeyAlgorithmAndDerivatives {
     KeyAlgorithm(KeyAlgorithm),
-    RsaHashedKeyAlgorithm(SubtleRsaHashedKeyAlgorithm),
+    RsaHashedKeyAlgorithm(RsaHashedKeyAlgorithm),
     EcKeyAlgorithm(SubtleEcKeyAlgorithm),
     AesKeyAlgorithm(SubtleAesKeyAlgorithm),
     HmacKeyAlgorithm(SubtleHmacKeyAlgorithm),

--- a/components/script/dom/webcrypto/subtlecrypto/rsa_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsa_common.rs
@@ -24,7 +24,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, DigestOperation, ExportedKey, JsonWebKeyExt, JwkStringField,
     KeyAlgorithmAndDerivatives, NormalizedAlgorithm, RsaHashedKeyGenParams,
-    SubtleRsaHashedImportParams, RsaHashedKeyAlgorithm, normalize_algorithm,
+    RsaHashedImportParams, RsaHashedKeyAlgorithm, normalize_algorithm,
 };
 
 pub(crate) enum RsaAlgorithm {
@@ -197,7 +197,7 @@ pub(crate) fn import_key(
     rsa_algorithm: RsaAlgorithm,
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleRsaHashedImportParams,
+    normalized_algorithm: &RsaHashedImportParams,
     format: KeyFormat,
     key_data: &[u8],
     extractable: bool,

--- a/components/script/dom/webcrypto/subtlecrypto/rsa_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsa_common.rs
@@ -23,8 +23,8 @@ use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, DigestOperation, ExportedKey, JsonWebKeyExt, JwkStringField,
-    KeyAlgorithmAndDerivatives, NormalizedAlgorithm, RsaHashedKeyGenParams,
-    RsaHashedImportParams, RsaHashedKeyAlgorithm, normalize_algorithm,
+    KeyAlgorithmAndDerivatives, NormalizedAlgorithm, RsaHashedImportParams, RsaHashedKeyAlgorithm,
+    RsaHashedKeyGenParams, normalize_algorithm,
 };
 
 pub(crate) enum RsaAlgorithm {

--- a/components/script/dom/webcrypto/subtlecrypto/rsa_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsa_common.rs
@@ -24,7 +24,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, DigestOperation, ExportedKey, JsonWebKeyExt, JwkStringField,
     KeyAlgorithmAndDerivatives, NormalizedAlgorithm, RsaHashedKeyGenParams,
-    SubtleRsaHashedImportParams, SubtleRsaHashedKeyAlgorithm, normalize_algorithm,
+    SubtleRsaHashedImportParams, RsaHashedKeyAlgorithm, normalize_algorithm,
 };
 
 pub(crate) enum RsaAlgorithm {
@@ -105,7 +105,7 @@ pub(crate) fn generate_key(
     // Step 7. Set the publicExponent attribute of algorithm to equal the publicExponent attribute
     // of normalizedAlgorithm.
     // Step 8. Set the hash attribute of algorithm to equal the hash member of normalizedAlgorithm.
-    let algorithm = SubtleRsaHashedKeyAlgorithm {
+    let algorithm = RsaHashedKeyAlgorithm {
         name: match rsa_algorithm {
             // Step 5. Set the name attribute of algorithm to "RSASSA-PKCS1-v1_5".
             RsaAlgorithm::RsassaPkcs1v1_5 => CryptoAlgorithm::RsassaPkcs1V1_5,
@@ -633,7 +633,7 @@ pub(crate) fn import_key(
         ),
         _ => unreachable!(),
     };
-    let algorithm = SubtleRsaHashedKeyAlgorithm {
+    let algorithm = RsaHashedKeyAlgorithm {
         name: match &rsa_algorithm {
             RsaAlgorithm::RsassaPkcs1v1_5 => {
                 // Step 4. Set the name attribute of algorithm to "RSASSA-PKCS1-v1_5"

--- a/components/script/dom/webcrypto/subtlecrypto/rsa_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsa_common.rs
@@ -23,8 +23,8 @@ use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, DigestOperation, ExportedKey, JsonWebKeyExt, JwkStringField,
-    KeyAlgorithmAndDerivatives, NormalizedAlgorithm, SubtleRsaHashedImportParams,
-    SubtleRsaHashedKeyAlgorithm, SubtleRsaHashedKeyGenParams, normalize_algorithm,
+    KeyAlgorithmAndDerivatives, NormalizedAlgorithm, RsaHashedKeyGenParams,
+    SubtleRsaHashedImportParams, SubtleRsaHashedKeyAlgorithm, normalize_algorithm,
 };
 
 pub(crate) enum RsaAlgorithm {
@@ -40,7 +40,7 @@ pub(crate) fn generate_key(
     rsa_algorithm: RsaAlgorithm,
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleRsaHashedKeyGenParams,
+    normalized_algorithm: &RsaHashedKeyGenParams,
     extractable: bool,
     usages: Vec<KeyUsage>,
 ) -> Result<CryptoKeyPair, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/rsa_oaep_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsa_oaep_operation.rs
@@ -19,7 +19,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::rsa_common::{self, RsaAlgorithm};
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, KeyAlgorithmAndDerivatives, NormalizedAlgorithm,
-    SubtleRsaHashedImportParams, SubtleRsaHashedKeyGenParams, SubtleRsaOaepParams,
+    RsaHashedKeyGenParams, SubtleRsaHashedImportParams, SubtleRsaOaepParams,
 };
 
 /// <https://w3c.github.io/webcrypto/#rsa-oaep-operations-encrypt>
@@ -160,7 +160,7 @@ pub(crate) fn decrypt(
 pub(crate) fn generate_key(
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleRsaHashedKeyGenParams,
+    normalized_algorithm: &RsaHashedKeyGenParams,
     extractable: bool,
     usages: Vec<KeyUsage>,
 ) -> Result<CryptoKeyPair, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/rsa_oaep_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsa_oaep_operation.rs
@@ -19,12 +19,12 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::rsa_common::{self, RsaAlgorithm};
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, KeyAlgorithmAndDerivatives, NormalizedAlgorithm,
-    RsaHashedKeyGenParams, RsaHashedImportParams, SubtleRsaOaepParams,
+    RsaHashedKeyGenParams, RsaHashedImportParams, RsaOaepParams,
 };
 
 /// <https://w3c.github.io/webcrypto/#rsa-oaep-operations-encrypt>
 pub(crate) fn encrypt(
-    normalized_algorithm: &SubtleRsaOaepParams,
+    normalized_algorithm: &RsaOaepParams,
     key: &CryptoKey,
     plaintext: &[u8],
 ) -> Result<Vec<u8>, Error> {
@@ -90,7 +90,7 @@ pub(crate) fn encrypt(
 
 /// <https://w3c.github.io/webcrypto/#rsa-oaep-operations-decrypt>
 pub(crate) fn decrypt(
-    normalized_algorithm: &SubtleRsaOaepParams,
+    normalized_algorithm: &RsaOaepParams,
     key: &CryptoKey,
     ciphertext: &[u8],
 ) -> Result<Vec<u8>, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/rsa_oaep_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsa_oaep_operation.rs
@@ -19,7 +19,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::rsa_common::{self, RsaAlgorithm};
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, KeyAlgorithmAndDerivatives, NormalizedAlgorithm,
-    RsaHashedKeyGenParams, SubtleRsaHashedImportParams, SubtleRsaOaepParams,
+    RsaHashedKeyGenParams, RsaHashedImportParams, SubtleRsaOaepParams,
 };
 
 /// <https://w3c.github.io/webcrypto/#rsa-oaep-operations-encrypt>
@@ -178,7 +178,7 @@ pub(crate) fn generate_key(
 pub(crate) fn import_key(
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleRsaHashedImportParams,
+    normalized_algorithm: &RsaHashedImportParams,
     format: KeyFormat,
     key_data: &[u8],
     extractable: bool,

--- a/components/script/dom/webcrypto/subtlecrypto/rsa_oaep_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsa_oaep_operation.rs
@@ -19,7 +19,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::rsa_common::{self, RsaAlgorithm};
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, KeyAlgorithmAndDerivatives, NormalizedAlgorithm,
-    RsaHashedKeyGenParams, RsaHashedImportParams, RsaOaepParams,
+    RsaHashedImportParams, RsaHashedKeyGenParams, RsaOaepParams,
 };
 
 /// <https://w3c.github.io/webcrypto/#rsa-oaep-operations-encrypt>

--- a/components/script/dom/webcrypto/subtlecrypto/rsa_pss_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsa_pss_operation.rs
@@ -19,7 +19,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::rsa_common::{self, RsaAlgorithm};
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, KeyAlgorithmAndDerivatives, NormalizedAlgorithm,
-    SubtleRsaHashedImportParams, SubtleRsaHashedKeyGenParams, SubtleRsaPssParams,
+    RsaHashedKeyGenParams, SubtleRsaHashedImportParams, SubtleRsaPssParams,
 };
 
 /// <https://w3c.github.io/webcrypto/#rsa-pss-operations-sign>
@@ -178,7 +178,7 @@ pub(crate) fn verify(
 pub(crate) fn generate_key(
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleRsaHashedKeyGenParams,
+    normalized_algorithm: &RsaHashedKeyGenParams,
     extractable: bool,
     usages: Vec<KeyUsage>,
 ) -> Result<CryptoKeyPair, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/rsa_pss_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsa_pss_operation.rs
@@ -19,12 +19,12 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::rsa_common::{self, RsaAlgorithm};
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, KeyAlgorithmAndDerivatives, NormalizedAlgorithm,
-    RsaHashedKeyGenParams, RsaHashedImportParams, SubtleRsaPssParams,
+    RsaHashedKeyGenParams, RsaHashedImportParams, RsaPssParams,
 };
 
 /// <https://w3c.github.io/webcrypto/#rsa-pss-operations-sign>
 pub(crate) fn sign(
-    normalized_algorithm: &SubtleRsaPssParams,
+    normalized_algorithm: &RsaPssParams,
     key: &CryptoKey,
     message: &[u8],
 ) -> Result<Vec<u8>, Error> {
@@ -99,7 +99,7 @@ pub(crate) fn sign(
 
 /// <https://w3c.github.io/webcrypto/#rsa-pss-operations-verify>
 pub(crate) fn verify(
-    normalized_algorithm: &SubtleRsaPssParams,
+    normalized_algorithm: &RsaPssParams,
     key: &CryptoKey,
     message: &[u8],
     signature: &[u8],

--- a/components/script/dom/webcrypto/subtlecrypto/rsa_pss_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsa_pss_operation.rs
@@ -19,7 +19,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::rsa_common::{self, RsaAlgorithm};
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, KeyAlgorithmAndDerivatives, NormalizedAlgorithm,
-    RsaHashedKeyGenParams, RsaHashedImportParams, RsaPssParams,
+    RsaHashedImportParams, RsaHashedKeyGenParams, RsaPssParams,
 };
 
 /// <https://w3c.github.io/webcrypto/#rsa-pss-operations-sign>

--- a/components/script/dom/webcrypto/subtlecrypto/rsa_pss_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsa_pss_operation.rs
@@ -19,7 +19,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::rsa_common::{self, RsaAlgorithm};
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, KeyAlgorithmAndDerivatives, NormalizedAlgorithm,
-    RsaHashedKeyGenParams, SubtleRsaHashedImportParams, SubtleRsaPssParams,
+    RsaHashedKeyGenParams, RsaHashedImportParams, SubtleRsaPssParams,
 };
 
 /// <https://w3c.github.io/webcrypto/#rsa-pss-operations-sign>
@@ -196,7 +196,7 @@ pub(crate) fn generate_key(
 pub(crate) fn import_key(
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleRsaHashedImportParams,
+    normalized_algorithm: &RsaHashedImportParams,
     format: KeyFormat,
     key_data: &[u8],
     extractable: bool,

--- a/components/script/dom/webcrypto/subtlecrypto/rsassa_pkcs1_v1_5_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsassa_pkcs1_v1_5_operation.rs
@@ -19,7 +19,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::rsa_common::{self, RsaAlgorithm};
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, KeyAlgorithmAndDerivatives, NormalizedAlgorithm,
-    RsaHashedKeyGenParams, RsaHashedImportParams,
+    RsaHashedImportParams, RsaHashedKeyGenParams,
 };
 
 /// <https://w3c.github.io/webcrypto/#rsassa-pkcs1-operations-sign>

--- a/components/script/dom/webcrypto/subtlecrypto/rsassa_pkcs1_v1_5_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsassa_pkcs1_v1_5_operation.rs
@@ -19,7 +19,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::rsa_common::{self, RsaAlgorithm};
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, KeyAlgorithmAndDerivatives, NormalizedAlgorithm,
-    RsaHashedKeyGenParams, SubtleRsaHashedImportParams,
+    RsaHashedKeyGenParams, RsaHashedImportParams,
 };
 
 /// <https://w3c.github.io/webcrypto/#rsassa-pkcs1-operations-sign>
@@ -160,7 +160,7 @@ pub(crate) fn generate_key(
 pub(crate) fn import_key(
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleRsaHashedImportParams,
+    normalized_algorithm: &RsaHashedImportParams,
     format: KeyFormat,
     key_data: &[u8],
     extractable: bool,

--- a/components/script/dom/webcrypto/subtlecrypto/rsassa_pkcs1_v1_5_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsassa_pkcs1_v1_5_operation.rs
@@ -19,7 +19,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::rsa_common::{self, RsaAlgorithm};
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, KeyAlgorithmAndDerivatives, NormalizedAlgorithm,
-    SubtleRsaHashedImportParams, SubtleRsaHashedKeyGenParams,
+    RsaHashedKeyGenParams, SubtleRsaHashedImportParams,
 };
 
 /// <https://w3c.github.io/webcrypto/#rsassa-pkcs1-operations-sign>
@@ -142,7 +142,7 @@ pub(crate) fn verify(key: &CryptoKey, message: &[u8], signature: &[u8]) -> Resul
 pub(crate) fn generate_key(
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleRsaHashedKeyGenParams,
+    normalized_algorithm: &RsaHashedKeyGenParams,
     extractable: bool,
     usages: Vec<KeyUsage>,
 ) -> Result<CryptoKeyPair, Error> {


### PR DESCRIPTION
Rename the following structs:

`SubtleRsaHashedKeyGenParams` to `RsaHashedKeyGenParams`
`SubtleRsaHashedKeyAlgorithm` to `RsaHashedKeyAlgorithm`
`SubtleRsaHashedImportParams` to `RsaHashedImportParams`
`SubtleRsaPssParams` to `RsaPssParams`
`SubtleRsaOaepParams` to `RsaOaepParams`

This is part of #46948 in order to replace the generated binding types with custom binding types for WebCrypto.

Testing: It compiles.
Part-of: #46948