### PR TITLE
servoshell: Update deprecated keycodes

### DIFF
--- a/ports/servoshell/desktop/keyutils.rs
+++ b/ports/servoshell/desktop/keyutils.rs
@@ -299,7 +299,7 @@ impl FromWinitKeyEvent for Key {
             WinitNamedKey::SplitScreenToggle => Key::Named(NamedKey::SplitScreenToggle),
             WinitNamedKey::Standby => Key::Named(NamedKey::Standby),
             WinitNamedKey::Subtitle => Key::Named(NamedKey::Subtitle),
-            WinitNamedKey::Super => Key::Named(NamedKey::Super),
+            WinitNamedKey::Super => Key::Named(NamedKey::Meta),
             WinitNamedKey::Symbol => Key::Named(NamedKey::Symbol),
             WinitNamedKey::SymbolLock => Key::Named(NamedKey::SymbolLock),
             WinitNamedKey::TV => Key::Named(NamedKey::TV),


### PR DESCRIPTION
This updates servoshell's key event interpretation so that the macOS Command key and the Windows Logo key correspond to 'Meta'. Previously, this was causing servoshell to interpret these as 'Super', which is unlike other browsers' behaviour such as Chrome, which interpret these keys as 'Meta'.

Here is the documentation from winit regarding the 'Super' key:
https://docs.rs/winit/latest/winit/keyboard/enum.NamedKey.html#variant.Super

Testing: servoshell does not have testing at this layer.
Fixes: #41306



