### PR TITLE
script: Don't mark script-created `<title>` elements as being actively parsed

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -5892,7 +5892,11 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             None => return,
         };
 
+        // > On setting, the steps corresponding to the first matching condition in the following list must be run:
+        // ↪ If the document element is an SVG svg element
         let node = if root.namespace() == &ns!(svg) && root.local_name() == &local_name!("svg") {
+            // Step 1. If there is an SVG title element that is a child of the document element,
+            // let element be the first such element.
             let elem = root
                 .upcast::<Node>()
                 .child_elements_unrooted(cx.no_gc())
@@ -5901,7 +5905,10 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                 });
             match elem {
                 Some(elem) => UnrootedDom::upcast::<Node>(elem).as_rooted(),
+                // Step 2. Otherwise:
                 None => {
+                    // Step 2.1 Let element be the result of creating an element given the document element's
+                    // node document, "title", and the SVG namespace.
                     let name = QualName::new(None, ns!(svg), local_name!("title"));
                     let elem = Element::create(
                         cx,
@@ -5912,6 +5919,8 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                         CustomElementCreationMode::Synchronous,
                         None,
                     );
+
+                    // Step 2.2 Insert element as the first child of the document element.
                     let parent = root.upcast::<Node>();
                     let child = elem.upcast::<Node>();
                     parent
@@ -5919,15 +5928,21 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                         .unwrap()
                 },
             }
-        } else if root.namespace() == &ns!(html) {
+        }
+        // ↪ If the document element is in the HTML namespace
+        else if root.namespace() == &ns!(html) {
             let elem = root
                 .upcast::<Node>()
                 .traverse_preorder_non_rooting(cx.no_gc(), ShadowIncluding::No)
                 .find(|node| node.is::<HTMLTitleElement>());
             match elem {
+                // Step 2. If the title element is non-null, let element be the title element.
                 Some(elem) => elem.as_rooted(),
+                // Step 3. Otherwise:
                 None => match self.GetHead() {
                     Some(head) => {
+                        // Step 3.1 Let element be the result of creating an element given the
+                        // document element's node document, "title", and the HTML namespace.
                         let name = QualName::new(None, ns!(html), local_name!("title"));
                         let elem = Element::create(
                             cx,
@@ -5938,17 +5953,27 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                             CustomElementCreationMode::Synchronous,
                             None,
                         );
+
+                        // Step 3.2 Append element to the head element.
                         head.upcast::<Node>()
                             .AppendChild(cx, elem.upcast())
                             .unwrap()
                     },
+                    // Step 1. If the title element is null and the head element is null, then return.
                     None => return,
                 },
             }
-        } else {
+        }
+        // ↪ Otherwise
+        else {
+            // Do nothing.
             return;
         };
 
+        // Step 3. of "↪ If the document element is an SVG svg element"
+        // Step 4. of "↪ If the document element is in the HTML namespace"
+        //
+        // > String replace all with the given value within element.
         node.set_text_content_for_element(cx, Some(title));
     }
 

--- a/components/script/dom/element/create.rs
+++ b/components/script/dom/element/create.rs
@@ -452,7 +452,7 @@ pub(crate) fn create_native_html_element(
         // https://html.spec.whatwg.org/multipage/#the-thead-element:concept-element-dom
         local_name!("thead") => make!(HTMLTableSectionElement),
         local_name!("time") => make!(HTMLTimeElement),
-        local_name!("title") => make!(HTMLTitleElement),
+        local_name!("title") => make!(HTMLTitleElement, creator),
         local_name!("tr") => make!(HTMLTableRowElement),
         local_name!("tt") => make!(HTMLElement),
         local_name!("track") => make!(HTMLTrackElement),

--- a/components/script/dom/html/documentmetadata/htmltitleelement.rs
+++ b/components/script/dom/html/documentmetadata/htmltitleelement.rs
@@ -9,6 +9,7 @@ use html5ever::{LocalName, Prefix};
 use js::context::JSContext;
 use js::rust::HandleObject;
 
+use crate::dom::ElementCreator;
 use crate::dom::bindings::codegen::Bindings::HTMLTitleElementBinding::HTMLTitleElementMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
@@ -21,7 +22,11 @@ use crate::dom::node::{BindContext, ChildrenMutation, Node};
 #[dom_struct]
 pub(crate) struct HTMLTitleElement {
     htmlelement: HTMLElement,
-    popped: Cell<bool>,
+    /// Whether this element is on the HTML parsers stack of open elements.
+    ///
+    /// While this is the case  we don't bother incrementally
+    /// updating the document title.
+    is_currently_being_parsed: Cell<bool>,
 }
 
 impl HTMLTitleElement {
@@ -29,10 +34,11 @@ impl HTMLTitleElement {
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
+        is_parser_created: bool,
     ) -> HTMLTitleElement {
         HTMLTitleElement {
             htmlelement: HTMLElement::new_inherited(local_name, prefix, document),
-            popped: Cell::new(false),
+            is_currently_being_parsed: Cell::new(is_parser_created),
         }
     }
 
@@ -42,11 +48,15 @@ impl HTMLTitleElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        creator: ElementCreator,
     ) -> DomRoot<HTMLTitleElement> {
         Node::reflect_node_with_proto(
             cx,
             Box::new(HTMLTitleElement::new_inherited(
-                local_name, prefix, document,
+                local_name,
+                prefix,
+                document,
+                creator.is_parser_created(),
             )),
             document,
             proto,
@@ -86,7 +96,7 @@ impl VirtualMethods for HTMLTitleElement {
 
         // Notify of title changes only after the initial full parsing
         // of the element.
-        if self.popped.get() {
+        if !self.is_currently_being_parsed.get() {
             self.notify_title_changed();
         }
     }
@@ -106,7 +116,7 @@ impl VirtualMethods for HTMLTitleElement {
             s.pop(cx);
         }
 
-        self.popped.set(true);
+        self.is_currently_being_parsed.set(false);
 
         // Initial notification of title change, once the full text
         // is available.

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -1171,3 +1171,52 @@ fn test_fullscreen() {
     let captured = delegate.clone();
     servo_test.spin(move || captured.fullscreen.get());
 }
+
+#[test]
+fn test_webview_title_updates_when_document_title_is_updated() {
+    let servo_test = ServoTest::new();
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let test_page = Url::parse(
+        "data:text/html,\
+        <script>document.title='Success';</script>",
+    )
+    .expect("Data URL failed to build");
+
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(test_page.clone())
+        .build();
+
+    // Wait for the page to load
+    let load_webview = webview.clone();
+    servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
+
+    assert_eq!(webview.page_title().as_deref(), Some("Success"));
+}
+
+#[test]
+fn test_webview_title_updates_when_title_element_is_created_from_javascript() {
+    let servo_test = ServoTest::new();
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let test_page = Url::parse(
+        "data:text/html,\
+        <body>\
+        <script>\
+        let title = document.createElement('title');\
+        title.textContent = 'Success';\
+        document.body.appendChild(title);\
+        </script>",
+    )
+    .expect("Data URL failed to build");
+
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(test_page.clone())
+        .build();
+
+    // Wait for the page to load
+    let load_webview = webview.clone();
+    servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
+
+    assert_eq!(webview.page_title().as_deref(), Some("Success"));
+}


### PR DESCRIPTION
While a `<title>` element is on the parsers stack of open elements we don't bother notifying the embedder about changes to its content, because it hasn't finished parsing yet. When a `<title>` element is created then we mark it as "parsing" and then when its popped from the stack of open elements then we unset that flag.

This is wrong for script-created title elements, because those are never parsed in the first place and thus the flag is never unset. This change forwards the `ElementCreator` to `HTMLTitleElement::new` so we can handle this correctly.

Testing: This change adds two tests
Fixes https://github.com/servo/servo/issues/47319