### PR TITLE
Layout: Get Element Role Using AccessKit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8575,6 +8575,7 @@ dependencies = [
 name = "servo-layout-api"
 version = "0.6.0"
 dependencies = [
+ "accesskit",
  "app_units",
  "atomic_refcell",
  "bitflags 2.13.1",
@@ -9136,6 +9137,7 @@ dependencies = [
 name = "servo-script"
 version = "0.6.0"
 dependencies = [
+ "accesskit",
  "aes",
  "aes-gcm",
  "aes-kw",

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -458,7 +458,10 @@ impl AccessibilityTree {
 
         (id, node_ref)
     }
-
+    pub(crate) fn accesskit_node_for_dom_node(self, dom_node: &ServoLayoutNode) -> Option<accesskit::Node> {
+        let node = dom_node.node_for_dom_node(dom_node)?;
+        node.accesskit_node.clone()
+    }
     fn get_or_create_node_with_id(
         &mut self,
         id: NodeId,

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -458,17 +458,23 @@ impl AccessibilityTree {
 
         (id, node_ref)
     }
-    
-    fn node_for_dom_node(&self, dom_node: &ServoLayoutNode) -> Option<ArcRefCell<AccessibilityNode>> {
+
+    fn node_for_dom_node(
+        &self,
+        dom_node: &ServoLayoutNode,
+    ) -> Option<ArcRefCell<AccessibilityNode>> {
         let id = self.existing_id_for_opaque(dom_node.opaque())?;
         Some(self.node_for_id(id)?)
     }
-    
-    pub(crate) fn accesskit_node_for_dom_node(&self, dom_node: &ServoLayoutNode) -> Option<accesskit::Node> {
+
+    pub(crate) fn accesskit_node_for_dom_node(
+        &self,
+        dom_node: &ServoLayoutNode,
+    ) -> Option<accesskit::Node> {
         let node = self.node_for_dom_node(dom_node)?;
         Some(node.borrow().accesskit_node.clone())
     }
-    
+
     fn get_or_create_node_with_id(
         &mut self,
         id: NodeId,

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -460,8 +460,8 @@ impl AccessibilityTree {
     }
     
     fn node_for_dom_node(&self, dom_node: &ServoLayoutNode) -> Option<ArcRefCell<AccessibilityNode>> {
-        let node = self.existing_id_for_opaque(dom_node.opaque())?;
-        Some(self.node_for_id(node)?)
+        let id = self.existing_id_for_opaque(dom_node.opaque())?;
+        Some(self.node_for_id(id)?)
     }
     
     pub(crate) fn accesskit_node_for_dom_node(&self, dom_node: &ServoLayoutNode) -> Option<accesskit::Node> {

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -459,7 +459,12 @@ impl AccessibilityTree {
         (id, node_ref)
     }
     
-    pub(crate) fn accesskit_node_for_dom_node(&mut self, dom_node: &ServoLayoutNode) -> Option<accesskit::Node> {
+    fn node_for_dom_node(&self, dom_node: &ServoLayoutNode) -> Option<ArcRefCell<AccessibilityNode>> {
+        let node = self.existing_id_for_opaque(dom_node.opaque())?;
+        Some(self.node_for_id(node)?)
+    }
+    
+    pub(crate) fn accesskit_node_for_dom_node(&self, dom_node: &ServoLayoutNode) -> Option<accesskit::Node> {
         let node = self.node_for_dom_node(dom_node)?;
         Some(node.borrow().accesskit_node.clone())
     }

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -458,10 +458,12 @@ impl AccessibilityTree {
 
         (id, node_ref)
     }
-    pub(crate) fn accesskit_node_for_dom_node(self, dom_node: &ServoLayoutNode) -> Option<accesskit::Node> {
-        let node = dom_node.node_for_dom_node(dom_node)?;
-        node.accesskit_node.clone()
+    
+    pub(crate) fn accesskit_node_for_dom_node(&mut self, dom_node: &ServoLayoutNode) -> Option<accesskit::Node> {
+        let node = self.node_for_dom_node(dom_node)?;
+        Some(node.borrow().accesskit_node.clone())
     }
+    
     fn get_or_create_node_with_id(
         &mut self,
         id: NodeId,

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -10,7 +10,7 @@ use std::ffi::c_void;
 use std::fmt::Debug;
 use std::rc::Rc;
 use std::sync::{Arc, LazyLock};
-
+use accesskit::Node;
 use app_units::Au;
 use bitflags::bitflags;
 use embedder_traits::{
@@ -521,6 +521,15 @@ impl Layout for LayoutThread {
 
             process_resolved_style_request(self, &shared_style_context, node, &pseudo, &property_id)
         })
+    }
+
+    fn query_accesskit_node(&self, node: TrustedNodeAddress) -> Option<Node> {
+        // TODO: enable accessibility pref accessibility_enabled (in prefernces)
+        // & set_accessibility_active (see: alice's comment on GH)
+        let node = unsafe { ServoLayoutNode::new(&node) };
+        let mut accessibility_tree = self.accessibility_tree.borrow_mut();
+        let mut accessibility_tree = accessibility_tree.as_mut()?;
+        accessibility_tree.accesskit_node_for_dom_node(&node)
     }
 
     #[servo_tracing::instrument(skip_all)]
@@ -1994,7 +2003,9 @@ impl ReflowPhases {
                 QueryMsg::PaddingQuery |
                 QueryMsg::ResolvedFontStyleQuery |
                 QueryMsg::ScrollParentQuery |
-                QueryMsg::StyleQuery => Self::empty(),
+                QueryMsg::StyleQuery |
+                QueryMsg::AccessKitNodeQuery => Self::empty(),
+
             },
             ReflowGoal::UpdateScrollNode(..) | ReflowGoal::UpdateTheRendering => {
                 Self::StackingContextTreeConstruction | Self::DisplayListConstruction

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -524,12 +524,12 @@ impl Layout for LayoutThread {
     }
 
     fn query_accesskit_node(&self, node: TrustedNodeAddress) -> Option<Node> {
-        // TODO: enable accessibility pref accessibility_enabled (in prefernces)
-        // & set_accessibility_active (see: alice's comment on GH)
-        let node = unsafe { ServoLayoutNode::new(&node) };
-        let mut accessibility_tree = self.accessibility_tree.borrow_mut();
-        let mut accessibility_tree = accessibility_tree.as_mut()?;
-        accessibility_tree.accesskit_node_for_dom_node(&node)
+        with_layout_state (|| {
+            let node = unsafe { ServoLayoutNode::new(&node) };
+            let mut accessibility_tree = self.accessibility_tree.borrow_mut();
+            let accessibility_tree = accessibility_tree.as_mut()?;
+            accessibility_tree.accesskit_node_for_dom_node(&node)
+        })
     }
 
     #[servo_tracing::instrument(skip_all)]

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -10,6 +10,7 @@ use std::ffi::c_void;
 use std::fmt::Debug;
 use std::rc::Rc;
 use std::sync::{Arc, LazyLock};
+
 use accesskit::Node;
 use app_units::Au;
 use bitflags::bitflags;
@@ -2005,7 +2006,6 @@ impl ReflowPhases {
                 QueryMsg::ScrollParentQuery |
                 QueryMsg::StyleQuery |
                 QueryMsg::AccessKitNodeQuery => Self::empty(),
-
             },
             ReflowGoal::UpdateScrollNode(..) | ReflowGoal::UpdateTheRendering => {
                 Self::StackingContextTreeConstruction | Self::DisplayListConstruction

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -524,10 +524,10 @@ impl Layout for LayoutThread {
     }
 
     fn query_accesskit_node(&self, node: TrustedNodeAddress) -> Option<Node> {
-        with_layout_state (|| {
+        with_layout_state(|| {
             let node = unsafe { ServoLayoutNode::new(&node) };
-            let mut accessibility_tree = self.accessibility_tree.borrow_mut();
-            let accessibility_tree = accessibility_tree.as_mut()?;
+            let accessibility_tree = self.accessibility_tree.borrow();
+            let accessibility_tree = accessibility_tree.as_ref()?;
             accessibility_tree.accesskit_node_for_dom_node(&node)
         })
     }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -83,9 +83,9 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(crown)'] }
 
 [dependencies]
 accesskit = { workspace = true }
-aes = { workspace = true }
-aes-gcm = { workspace = true }
-aes-kw = { workspace = true }
+aes = { workspace = true, optional = true }
+aes-gcm = { workspace = true, optional = true }
+aes-kw = { workspace = true, optional = true }
 app_units = { workspace = true }
 argon2 = { workspace = true, optional = true }
 arrayvec = { workspace = true }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -82,9 +82,10 @@ webxr = ["webgl", "gamepad", "webxr-api", "script_bindings/webxr"]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(crown)'] }
 
 [dependencies]
-aes = { workspace = true, optional = true }
-aes-gcm = { workspace = true, optional = true }
-aes-kw = { workspace = true, optional = true }
+accesskit = { workspace = true }
+aes = { workspace = true }
+aes-gcm = { workspace = true }
+aes-kw = { workspace = true }
 app_units = { workspace = true }
 argon2 = { workspace = true, optional = true }
 arrayvec = { workspace = true }

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -5240,7 +5240,7 @@ impl Element {
             .accesskit_node_query(self.upcast::<Node>().to_trusted_node_address());
         let accesskit_node = accesskit_node?;
         let role = accesskit_node.role();
-        // TODO: Eventually will need mapping table that maps accesskit roles to aria roles
+        // TODO(#43734): Eventually will need mapping table that maps accesskit roles to aria roles
         let role_string = format!("{role:?}");
         Some(DOMString::from(role_string.to_lowercase()))
     }

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -5244,7 +5244,6 @@ impl Element {
         let role_string = format!("{role:?}");
         Some(DOMString::from(role_string.to_lowercase()))
     }
-
 }
 
 impl Element {

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -5237,11 +5237,12 @@ impl Element {
     pub(crate) fn get_computed_role(&self) -> Option<DOMString> {
         let accesskit_node = self
             .owner_window()
-            .accesskit_node_query(self.upcast::<Node>().to_trusted_node_address())?;
-
+            .accesskit_node_query(self.upcast::<Node>().to_trusted_node_address());
+        let accesskit_node = accesskit_node?;
         let role = accesskit_node.role();
         // TODO: Eventually will need mapping table that maps accesskit roles to aria roles
-        Some(DOMString::from(format!("{role:?}")))
+        let role_string = format!("{role:?}");
+        Some(DOMString::from(role_string.to_lowercase()))
     }
 
 }

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -5233,6 +5233,17 @@ impl Element {
         let document = self.owner_document();
         !document.is_fully_active() || (!self.is::<HTMLAnchorElement>() && !self.is_connected())
     }
+
+    pub(crate) fn get_computed_role(&self) -> Option<DOMString> {
+        let accesskit_node = self
+            .owner_window()
+            .accesskit_node_query(self.upcast::<Node>().to_trusted_node_address())?;
+
+        let role = accesskit_node.role();
+        // TODO: Eventually will need mapping table that maps accesskit roles to aria roles
+        Some(DOMString::from(format!("{role:?}")))
+    }
+
 }
 
 impl Element {

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -2715,7 +2715,8 @@ impl Window {
 
         let mut rooted_nodes_for_accessibility_integrity_check = None;
         let mut accessibility_damage = None;
-        if reflow_goal == ReflowGoal::UpdateTheRendering && self.layout().accessibility_active() {
+        if (reflow_goal == ReflowGoal::UpdateTheRendering || self.layout().force_accessibility_update())
+            && self.layout().accessibility_active() {
             rooted_nodes_for_accessibility_integrity_check =
                 document.rooted_nodes_for_accessibility_integrity_check();
             let mut accessibility_data = document.accessibility_data_mut();

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -2715,8 +2715,11 @@ impl Window {
 
         let mut rooted_nodes_for_accessibility_integrity_check = None;
         let mut accessibility_damage = None;
-        if (reflow_goal == ReflowGoal::UpdateTheRendering || self.layout().force_accessibility_update())
-            && self.layout().accessibility_active() {
+        let should_reflow = matches!(
+            reflow_goal,
+            ReflowGoal::UpdateTheRendering | ReflowGoal::LayoutQuery(QueryMsg::AccessKitNodeQuery)
+        );
+        if should_reflow && self.layout().accessibility_active() {
             rooted_nodes_for_accessibility_integrity_check =
                 document.rooted_nodes_for_accessibility_integrity_check();
             let mut accessibility_data = document.accessibility_data_mut();

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -3139,6 +3139,14 @@ impl Window {
         ))
     }
 
+    pub(crate) fn accesskit_node_query(
+        &self,
+        element: TrustedNodeAddress,
+    )-> Option<accesskit::Node> {
+        self.layout_reflow(QueryMsg::AccessKitNodeQuery);
+        self.layout.borrow().query_accesskit_node(element)
+    }
+
     /// If the given |browsing_context_id| refers to an `<iframe>` that is an element
     /// in this [`Window`] and that `<iframe>` has been laid out, return its size.
     /// Otherwise, return `None`.

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -3143,6 +3143,7 @@ impl Window {
         &self,
         element: TrustedNodeAddress,
     )-> Option<accesskit::Node> {
+        self.layout().set_needs_accessibility_update();
         self.layout_reflow(QueryMsg::AccessKitNodeQuery);
         self.layout.borrow().query_accesskit_node(element)
     }

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -3143,7 +3143,7 @@ impl Window {
         &self,
         element: TrustedNodeAddress,
     )-> Option<accesskit::Node> {
-        self.layout().set_needs_accessibility_update();
+        self.layout().set_force_accessibility_update();
         self.layout_reflow(QueryMsg::AccessKitNodeQuery);
         self.layout.borrow().query_accesskit_node(element)
     }

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -3146,7 +3146,7 @@ impl Window {
     pub(crate) fn accesskit_node_query(
         &self,
         element: TrustedNodeAddress,
-    )-> Option<accesskit::Node> {
+    ) -> Option<accesskit::Node> {
         self.layout().set_force_accessibility_update();
         self.layout_reflow(QueryMsg::AccessKitNodeQuery);
         self.layout.borrow().query_accesskit_node(element)

--- a/components/script/event_loop/webdriver_handlers.rs
+++ b/components/script/event_loop/webdriver_handlers.rs
@@ -1394,7 +1394,7 @@ pub(crate) fn handle_get_computed_role(
     node_id: String,
     reply: GenericSender<Result<Option<String>, ErrorStatus>>,
 ) {
-    if pref!(accessibility_enabled) {
+    if !pref!(accessibility_enabled) {
         return reply.send(Err(ErrorStatus::UnsupportedOperation)).unwrap();
     }
     reply

--- a/components/script/event_loop/webdriver_handlers.rs
+++ b/components/script/event_loop/webdriver_handlers.rs
@@ -1416,26 +1416,6 @@ pub(crate) fn handle_get_computed_role(
     }
 
 }
-// pub(crate) fn handle_computed_role(documents: &DocumentCollection,
-//                                    pipeline: PipelineId,
-//                                    reply: GenericSender<Option<String>>,) {
-//     // ... existing browsing context checks ...
-//
-//     // Activate accessibility and wait for the tree to be built
-//     let (sender, receiver) = generic_channel::channel().unwrap();
-//     self.send_message_to_embedder(WebDriverCommandMsg::SetAccessibilityActive(
-//         self.webview_id()?, true, sender
-//     ))?;
-//     wait_for_ipc_response_flatten(receiver)?;  // blocks until reflow done
-//
-//     // Now query
-//     let (sender, receiver) = generic_channel::channel().unwrap();
-//     let cmd = WebDriverScriptCommand::GetComputedRole(element.to_string(), sender);
-//     self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)?;
-//     Ok(WebDriverResponse::Generic(ValueResponse(
-//         serde_json::to_value(wait_for_ipc_response_flatten(receiver)?)?,
-//     )))
-// }
 
 pub(crate) fn handle_get_page_source(
     cx: &mut JSContext,

--- a/components/script/event_loop/webdriver_handlers.rs
+++ b/components/script/event_loop/webdriver_handlers.rs
@@ -34,6 +34,7 @@ use script_bindings::settings_stack::run_a_script;
 use servo_base::generic_channel::{self, GenericOneshotSender, GenericSend, GenericSender};
 use servo_base::id::{BrowsingContextId, PipelineId};
 use webdriver::error::ErrorStatus;
+use servo_config::pref;
 
 use crate::DomTypeHolder;
 use crate::dom::Promise;
@@ -520,6 +521,7 @@ fn clone_an_object(
                         JavaScriptEvaluationResultSerializationError::UnknownType,
                     ));
                 },
+
             },
             Err(error) => {
                 throw_dom_exception(cx, global_scope, error);
@@ -1392,16 +1394,48 @@ pub(crate) fn handle_get_computed_role(
     node_id: String,
     reply: GenericSender<Result<Option<String>, ErrorStatus>>,
 ) {
-    reply
-        .send(
-            get_known_element(documents, pipeline, node_id)
-                // FIXME: Actually compute the role instead of using WAI-ARIA role.
-                // <https://github.com/servo/servo/issues/43734>
-                // The logic can then be shared with devtools accessibility inspector.
-                .map(|element| element.get_computed_role().map(String::from)),
-        )
-        .unwrap();
+    if pref!(accessibility_enabled){
+        reply
+            .send(
+
+                get_known_element(documents, pipeline, node_id)
+                    // WIP: Actually compute the role instead of using WAI-ARIA role.
+                    // <https://github.com/servo/servo/issues/43734>
+                    // The logic can then be shared with devtools accessibility inspector.
+                    .map(|element| {
+                        let document = element.upcast::<Node>().owner_doc();
+                        let window = document.window();
+                        let epoch = document.current_rendering_epoch();
+                        window.layout().set_accessibility_active(true, epoch);
+                       element.get_computed_role().map(String::from)
+                    }),
+            )
+            .unwrap();
+    } else {
+        reply.send(Err(ErrorStatus::UnsupportedOperation)).unwrap()
+    }
+
 }
+// pub(crate) fn handle_computed_role(documents: &DocumentCollection,
+//                                    pipeline: PipelineId,
+//                                    reply: GenericSender<Option<String>>,) {
+//     // ... existing browsing context checks ...
+//
+//     // Activate accessibility and wait for the tree to be built
+//     let (sender, receiver) = generic_channel::channel().unwrap();
+//     self.send_message_to_embedder(WebDriverCommandMsg::SetAccessibilityActive(
+//         self.webview_id()?, true, sender
+//     ))?;
+//     wait_for_ipc_response_flatten(receiver)?;  // blocks until reflow done
+//
+//     // Now query
+//     let (sender, receiver) = generic_channel::channel().unwrap();
+//     let cmd = WebDriverScriptCommand::GetComputedRole(element.to_string(), sender);
+//     self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)?;
+//     Ok(WebDriverResponse::Generic(ValueResponse(
+//         serde_json::to_value(wait_for_ipc_response_flatten(receiver)?)?,
+//     )))
+// }
 
 pub(crate) fn handle_get_page_source(
     cx: &mut JSContext,

--- a/components/script/event_loop/webdriver_handlers.rs
+++ b/components/script/event_loop/webdriver_handlers.rs
@@ -31,6 +31,7 @@ use script_bindings::conversions::is_array_like;
 use script_bindings::num::Finite;
 use script_bindings::reflector::DomObject;
 use script_bindings::settings_stack::run_a_script;
+use servo_base::Epoch;
 use servo_base::generic_channel::{self, GenericOneshotSender, GenericSend, GenericSender};
 use servo_base::id::{BrowsingContextId, PipelineId};
 use servo_config::pref;
@@ -1405,8 +1406,9 @@ pub(crate) fn handle_get_computed_role(
                 .map(|element| {
                     let document = element.upcast::<Node>().owner_doc();
                     let window = document.window();
-                    let epoch = document.current_rendering_epoch();
-                    window.layout().set_accessibility_active(true, epoch);
+                    window
+                        .layout()
+                        .set_accessibility_active(true, Epoch::default());
                     element.get_computed_role().map(String::from)
                 }),
         )

--- a/components/script/event_loop/webdriver_handlers.rs
+++ b/components/script/event_loop/webdriver_handlers.rs
@@ -1394,27 +1394,25 @@ pub(crate) fn handle_get_computed_role(
     node_id: String,
     reply: GenericSender<Result<Option<String>, ErrorStatus>>,
 ) {
-    if pref!(accessibility_enabled){
-        reply
-            .send(
-
-                get_known_element(documents, pipeline, node_id)
-                    // WIP: Actually compute the role instead of using WAI-ARIA role.
-                    // <https://github.com/servo/servo/issues/43734>
-                    // The logic can then be shared with devtools accessibility inspector.
-                    .map(|element| {
-                        let document = element.upcast::<Node>().owner_doc();
-                        let window = document.window();
-                        let epoch = document.current_rendering_epoch();
-                        window.layout().set_accessibility_active(true, epoch);
-                       element.get_computed_role().map(String::from)
-                    }),
-            )
-            .unwrap();
-    } else {
-        reply.send(Err(ErrorStatus::UnsupportedOperation)).unwrap()
+    if pref!(accessibility_enabled) {
+        return reply.send(Err(ErrorStatus::UnsupportedOperation)).unwrap();
     }
+    reply
+        .send(
 
+            get_known_element(documents, pipeline, node_id)
+                // WIP: Actually compute the role instead of using WAI-ARIA role.
+                // <https://github.com/servo/servo/issues/43734>
+                // The logic can then be shared with devtools accessibility inspector.
+                .map(|element| {
+                    let document = element.upcast::<Node>().owner_doc();
+                    let window = document.window();
+                    let epoch = document.current_rendering_epoch();
+                    window.layout().set_accessibility_active(true, epoch);
+                   element.get_computed_role().map(String::from)
+                }),
+        )
+        .unwrap();
 }
 
 pub(crate) fn handle_get_page_source(

--- a/components/script/event_loop/webdriver_handlers.rs
+++ b/components/script/event_loop/webdriver_handlers.rs
@@ -1398,7 +1398,7 @@ pub(crate) fn handle_get_computed_role(
                 // FIXME: Actually compute the role instead of using WAI-ARIA role.
                 // <https://github.com/servo/servo/issues/43734>
                 // The logic can then be shared with devtools accessibility inspector.
-                .map(|element| element.GetRole().map(String::from)),
+                .map(|element| element.get_computed_role().map(String::from)),
         )
         .unwrap();
 }

--- a/components/script/event_loop/webdriver_handlers.rs
+++ b/components/script/event_loop/webdriver_handlers.rs
@@ -33,8 +33,8 @@ use script_bindings::reflector::DomObject;
 use script_bindings::settings_stack::run_a_script;
 use servo_base::generic_channel::{self, GenericOneshotSender, GenericSend, GenericSender};
 use servo_base::id::{BrowsingContextId, PipelineId};
-use webdriver::error::ErrorStatus;
 use servo_config::pref;
+use webdriver::error::ErrorStatus;
 
 use crate::DomTypeHolder;
 use crate::dom::Promise;
@@ -521,7 +521,6 @@ fn clone_an_object(
                         JavaScriptEvaluationResultSerializationError::UnknownType,
                     ));
                 },
-
             },
             Err(error) => {
                 throw_dom_exception(cx, global_scope, error);
@@ -1399,7 +1398,6 @@ pub(crate) fn handle_get_computed_role(
     }
     reply
         .send(
-
             get_known_element(documents, pipeline, node_id)
                 // WIP: Actually compute the role instead of using WAI-ARIA role.
                 // <https://github.com/servo/servo/issues/43734>
@@ -1409,7 +1407,7 @@ pub(crate) fn handle_get_computed_role(
                     let window = document.window();
                     let epoch = document.current_rendering_epoch();
                     window.layout().set_accessibility_active(true, epoch);
-                   element.get_computed_role().map(String::from)
+                    element.get_computed_role().map(String::from)
                 }),
         )
         .unwrap();

--- a/components/shared/layout/Cargo.toml
+++ b/components/shared/layout/Cargo.toml
@@ -14,6 +14,7 @@ name = "layout_api"
 path = "lib.rs"
 
 [dependencies]
+accesskit = { workspace = true }
 app_units = { workspace = true }
 atomic_refcell = { workspace = true }
 bitflags = { workspace = true }

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -555,11 +555,8 @@ pub enum QueryMsg {
     StyleQuery,
     TextIndexQuery,
     PaddingQuery,
-<<<<<<< HEAD
     FlushForUpdateTheRenderingQuery,
-=======
     AccessKitNodeQuery,
->>>>>>> 8928fe336c1 (wip)
 }
 
 /// The goal of a reflow request.

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -380,10 +380,7 @@ pub trait Layout {
         animation_timeline_value: f64,
     ) -> String;
 
-    fn query_accesskit_node(
-        &self,
-        node: TrustedNodeAddress,
-    ) -> Option<accesskit::Node>;
+    fn query_accesskit_node(&self, node: TrustedNodeAddress) -> Option<accesskit::Node>;
 
     fn query_resolved_font_style(
         &self,

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -379,6 +379,12 @@ pub trait Layout {
         animations: DocumentAnimationSet,
         animation_timeline_value: f64,
     ) -> String;
+
+    fn query_accesskit_node(
+        &self,
+        node: TrustedNodeAddress,
+    ) -> Option<accesskit::Node>;
+
     fn query_resolved_font_style(
         &self,
         node: TrustedNodeAddress,
@@ -549,7 +555,11 @@ pub enum QueryMsg {
     StyleQuery,
     TextIndexQuery,
     PaddingQuery,
+<<<<<<< HEAD
     FlushForUpdateTheRenderingQuery,
+=======
+    AccessKitNodeQuery,
+>>>>>>> 8928fe336c1 (wip)
 }
 
 /// The goal of a reflow request.

--- a/resources/wpt-prefs.json
+++ b/resources/wpt-prefs.json
@@ -2,5 +2,6 @@
   "dom_webxr_test": true,
   "editing_caret_blink_time": 0,
   "gfx_text_antialiasing_enabled": false,
-  "dom_testutils_enabled": true
+  "dom_testutils_enabled": true,
+  "accessibility_enabled": true
 }

--- a/tests/wpt/meta/webdriver/tests/classic/get_computed_role/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_computed_role/get.py.ini
@@ -2,5 +2,8 @@
   [test_no_browsing_context]
     expected: FAIL
 
-  [test_computed_roles[<article>foo</article>-article-article\]]
+  [test_computed_roles[<input role=searchbox>-input-searchbox\]]
+    expected: FAIL
+
+  [test_computed_roles[<img role=button tabindex=0>-img-button\]]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/get_computed_role/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_computed_role/get.py.ini
@@ -1,4 +1,3 @@
-prefs: [accessibility_enabled: true]
 [get.py]
   [test_no_browsing_context]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/get_computed_role/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_computed_role/get.py.ini
@@ -1,3 +1,4 @@
+prefs: [accessibility_enabled: true]
 [get.py]
   [test_no_browsing_context]
     expected: FAIL

--- a/tests/wpt/tests/webdriver/tests/classic/get_computed_role/get.py
+++ b/tests/wpt/tests/webdriver/tests/classic/get_computed_role/get.py
@@ -83,4 +83,5 @@ def test_computed_roles(session, inline, html, tag, expected):
     session.url = inline(html)
     element = session.find.css(tag, all=False)
     result = get_computed_role(session, element.id)
+#     print("RESULT:", result)
     assert_success(result, expected)

--- a/tests/wpt/tests/webdriver/tests/classic/get_computed_role/get.py
+++ b/tests/wpt/tests/webdriver/tests/classic/get_computed_role/get.py
@@ -83,5 +83,4 @@ def test_computed_roles(session, inline, html, tag, expected):
     session.url = inline(html)
     element = session.find.css(tag, all=False)
     result = get_computed_role(session, element.id)
-    print("RESULT:", result)
     assert_success(result, expected)

--- a/tests/wpt/tests/webdriver/tests/classic/get_computed_role/get.py
+++ b/tests/wpt/tests/webdriver/tests/classic/get_computed_role/get.py
@@ -83,5 +83,5 @@ def test_computed_roles(session, inline, html, tag, expected):
     session.url = inline(html)
     element = session.find.css(tag, all=False)
     result = get_computed_role(session, element.id)
-#     print("RESULT:", result)
+    print("RESULT:", result)
     assert_success(result, expected)


### PR DESCRIPTION
This is the first part to https://github.com/servo/servo/issues/43734.

A relationship between a DOM node and an AccessKit node is created to allow for querying the AccessKit node for the role.

We are passing the `get_computed_role` tests for `article`: https://github.com/servo/servo/blob/bc9a86f7bd57f19b89d533b6b1ed1b62f95f2a69/tests/wpt/tests/webdriver/tests/classic/get_computed_role/get.py#L78-L79