### PR TITLE
script: Use safe variants of `throw_range_error` and `throw_type_error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2539,7 +2539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3106,7 +3106,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5244,9 +5244,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.21.3"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29596ccede272dfd26a6377d65be42dc8da3d6f41916d29a9ce8a7945b0a235b"
+checksum = "267f2f944b93c97cb8759d4ce1fd1d18705a80879212bc8976cf70e2f4d2f6d4"
 dependencies = [
  "bindgen",
  "cc",
@@ -5259,9 +5259,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "140.13.0-3"
+version = "140.13.0-4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7f303ebd1ccc07f1748a8ed9048df7dd88e23ac706b63fb89af82c80145fa8"
+checksum = "427a26f5b4ce14f66f5e59cdbde6588a4cc831c0f3ce3acd39b517ecd66422a1"
 dependencies = [
  "bindgen",
  "cc",
@@ -6249,7 +6249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7373,7 +7373,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7430,7 +7430,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10187,7 +10187,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11863,7 +11863,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ inventory = "0.3.24"
 ipc-channel = "0.22"
 itertools = "0.15"
 jni = "0.22"
-js = { package = "mozjs", version = "=0.21.3", default-features = false, features = ["intl", "libz-sys"] }
+js = { package = "mozjs", version = "=0.21.5", default-features = false, features = ["intl", "libz-sys"] }
 k12 = "0.5"
 keccak = "0.2"
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -13,7 +13,7 @@ use backtrace::Backtrace;
 use embedder_traits::JavaScriptErrorInfo;
 use js::context::JSContext;
 use js::conversions::{ToJSValConvertible, jsstr_to_string};
-use js::error::{throw_range_error, throw_type_error};
+use js::error::{throw_range_error_safe, throw_type_error_safe};
 use js::gc::{HandleObject, HandleValue, MutableHandleValue};
 use js::jsapi::ExceptionStackBehavior;
 #[cfg(feature = "js_backtrace")]
@@ -79,12 +79,12 @@ pub(crate) fn throw_dom_exception(cx: &mut JSContext, global: &GlobalScope, resu
 
         Err(JsEngineError::Type(message)) => unsafe {
             assert!(!JS_IsExceptionPending(cx));
-            throw_type_error(cx.raw_cx(), &message);
+            throw_type_error_safe(cx, &message);
         },
 
         Err(JsEngineError::Range(message)) => unsafe {
             assert!(!JS_IsExceptionPending(cx));
-            throw_range_error(cx.raw_cx(), &message);
+            throw_range_error_safe(cx, &message);
         },
 
         Err(JsEngineError::JSFailed) => unsafe {

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
 #[cfg(feature = "webgl")]
-use js::error::throw_type_error;
+use js::error::throw_type_error_safe;
 use js::realm::CurrentRealm;
 use js::rust::{HandleObject, HandleValue};
 use pixels::{EncodedImageType, Snapshot};
@@ -112,23 +112,20 @@ impl OffscreenCanvas {
     }
 
     #[cfg(feature = "webgl")]
-    #[expect(unsafe_code)]
     fn get_gl_attributes(
         cx: &mut js::context::JSContext,
         options: HandleValue,
     ) -> Option<GLContextAttributes> {
-        unsafe {
-            match WebGLContextAttributes::new(cx, options) {
-                Ok(ConversionResult::Success(attrs)) => Some(attrs.convert()),
-                Ok(ConversionResult::Failure(error)) => {
-                    throw_type_error(cx.raw_cx(), &error);
-                    None
-                },
-                _ => {
-                    debug!("Unexpected error on conversion of WebGLContextAttributes");
-                    None
-                },
-            }
+        match WebGLContextAttributes::new(cx, options) {
+            Ok(ConversionResult::Success(attrs)) => Some(attrs.convert()),
+            Ok(ConversionResult::Failure(error)) => {
+                throw_type_error_safe(cx, &error);
+                None
+            },
+            _ => {
+                debug!("Unexpected error on conversion of WebGLContextAttributes");
+                None
+            },
         }
     }
 

--- a/components/script/dom/html/embedded_content/htmlcanvaselement.rs
+++ b/components/script/dom/html/embedded_content/htmlcanvaselement.rs
@@ -10,7 +10,7 @@ use euclid::default::Size2D;
 use html5ever::{LocalName, Prefix, local_name, ns};
 use js::context::NoGC;
 #[cfg(feature = "webgl")]
-use js::error::throw_type_error;
+use js::error::throw_type_error_safe;
 use js::rust::{HandleObject, HandleValue};
 use layout_api::HTMLCanvasData;
 use pixels::{EncodedImageType, Snapshot};
@@ -366,23 +366,20 @@ impl HTMLCanvasElement {
     }
 
     #[cfg(feature = "webgl")]
-    #[expect(unsafe_code)]
     fn get_gl_attributes(
         cx: &mut js::context::JSContext,
         options: HandleValue,
     ) -> Option<GLContextAttributes> {
-        unsafe {
-            match WebGLContextAttributes::new(cx, options) {
-                Ok(ConversionResult::Success(attrs)) => Some(attrs.convert()),
-                Ok(ConversionResult::Failure(error)) => {
-                    throw_type_error(cx.raw_cx(), &error);
-                    None
-                },
-                _ => {
-                    debug!("Unexpected error on conversion of WebGLContextAttributes");
-                    None
-                },
-            }
+        match WebGLContextAttributes::new(cx, options) {
+            Ok(ConversionResult::Success(attrs)) => Some(attrs.convert()),
+            Ok(ConversionResult::Failure(error)) => {
+                throw_type_error_safe(cx, &error);
+                None
+            },
+            _ => {
+                debug!("Unexpected error on conversion of WebGLContextAttributes");
+                None
+            },
         }
     }
 

--- a/components/script/dom/stream/bytelengthqueuingstrategy.rs
+++ b/components/script/dom/stream/bytelengthqueuingstrategy.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use js::error::throw_type_error;
+use js::error::throw_type_error_safe;
 use js::gc::{HandleValue, MutableHandleValue};
 use js::jsapi::CallArgs;
 use js::jsval::{JSVal, UndefinedValue};
@@ -96,12 +96,10 @@ fn byte_length_queuing_strategy_size(cx: &mut js::context::JSContext, args: Call
     // https://tc39.es/ecma262/#sec-getv
     // Let O be ? ToObject(V).
     if chunk.is_undefined() || chunk.is_null() {
-        unsafe {
-            throw_type_error(
-                cx.raw_cx(),
-                c"ByteLengthQueuingStrategy size called with undefined or nulll",
-            )
-        };
+        throw_type_error_safe(
+            cx,
+            c"ByteLengthQueuingStrategy size called with undefined or nulll",
+        );
         return false;
     }
 

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -484,7 +484,7 @@ class CGMethodCall(CGThing):
             if requiredArgs > 0:
                 code = (
                     f"if argc < {requiredArgs} {{\n"
-                    f"    throw_type_error(cx.raw_cx(), c\"Not enough arguments to {methodName}.\");\n"
+                    f"    throw_type_error_safe(cx, c\"Not enough arguments to {methodName}.\");\n"
                     "    return false;\n"
                     "}")
                 self.cgRoot.prepend(
@@ -663,7 +663,7 @@ class CGMethodCall(CGThing):
             else:
                 # Just throw; we have no idea what we're supposed to
                 # do with this.
-                caseBody.append(CGGeneric("throw_type_error(cx.raw_cx(), c\"Could not convert JavaScript argument\");\n"
+                caseBody.append(CGGeneric("throw_type_error_safe(cx, c\"Could not convert JavaScript argument\");\n"
                                           "return false;"))
 
             argCountCases.append(CGCase(str(argCount),
@@ -675,7 +675,7 @@ class CGMethodCall(CGThing):
         overloadCGThings.append(
             CGSwitch("argcount",
                      argCountCases,
-                     CGGeneric(f"throw_type_error(cx.raw_cx(), c\"Not enough arguments to {methodName}.\");\n"
+                     CGGeneric(f"throw_type_error_safe(cx, c\"Not enough arguments to {methodName}.\");\n"
                                "return false;")))
         # XXXjdm Avoid unreachable statement warnings
         # overloadCGThings.append(
@@ -823,7 +823,7 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
         exceptionCode = "return false;\n"
 
     if failureCode is None:
-        failOrPropagate = f"throw_type_error(cx.raw_cx(), error.as_ref());\n{exceptionCode}"
+        failOrPropagate = f"throw_type_error_safe(cx, error.as_ref());\n{exceptionCode}"
     else:
         failOrPropagate = failureCode
 
@@ -837,14 +837,14 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
         return CGWrapper(
             CGGeneric(
                 failureCode
-                or (f'throw_type_error(cx.raw_cx(), c"{firstCap(sourceDescription)} is not an object.");\n'
+                or (f'throw_type_error_safe(cx, c"{firstCap(sourceDescription)} is not an object.");\n'
                     f'{exceptionCode}')),
             post="\n")
 
     def onFailureNotCallable(failureCode: str | None) -> CGGeneric:
         return CGGeneric(
             failureCode
-            or (f'throw_type_error(cx.raw_cx(), c"{firstCap(sourceDescription)} is not callable.");\n'
+            or (f'throw_type_error_safe(cx, c"{firstCap(sourceDescription)} is not callable.");\n'
                 f'{exceptionCode}'))
 
     # A helper function for handling default values.
@@ -1025,7 +1025,7 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
 
         if failureCode is None:
             unwrapFailureCode = (
-                f'throw_type_error(cx.raw_cx(), c"{sourceDescription} does not '
+                f'throw_type_error_safe(cx, c"{sourceDescription} does not '
                 f'implement interface {descriptor.interface.identifier.name}.");\n'
                 f'{exceptionCode}')
         else:
@@ -1058,7 +1058,7 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
     if is_typed_array(type):
         if failureCode is None:
             unwrapFailureCode = (
-                f'throw_type_error(cx.raw_cx(), c"{sourceDescription} is not a typed array.");\n'
+                f'throw_type_error_safe(cx, c"{sourceDescription} is not a typed array.");\n'
                 f'{exceptionCode}'
             )
         else:
@@ -1185,7 +1185,7 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
         # pyrefly: ignore  # missing-attribute
         enum = type.inner.identifier.name
         if invalidEnumValueFatal:
-            handleInvalidEnumValueCode = failureCode or f"throw_type_error(cx.raw_cx(), error.as_ref()); {exceptionCode}"
+            handleInvalidEnumValueCode = failureCode or f"throw_type_error_safe(cx, error.as_ref()); {exceptionCode}"
         else:
             handleInvalidEnumValueCode = "return true;"
 
@@ -1226,7 +1226,7 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
             else:
                 template = conversion
         else:
-            template = CGIfElseWrapper("IsCallable(${val}.get().to_object())",
+            template = CGIfElseWrapper("unsafe { IsCallable(${val}.get().to_object()) }",
                                        conversion,
                                        onFailureNotCallable(failureCode)).define()
             template = wrapObjectTemplate(
@@ -2866,7 +2866,7 @@ class CGGeneric(CGThing):
 
 class CGCallbackTempRoot(CGGeneric):
     def __init__(self, name: str) -> None:
-        CGGeneric.__init__(self, f"{name.replace('<D>', '::<D>')}::new(cx, ${{val}}.get().to_object())")
+        CGGeneric.__init__(self, f"unsafe {{ {name.replace('<D>', '::<D>')}::new(cx, ${{val}}.get().to_object()) }}")
 
 
 def getAllTypes(
@@ -4880,7 +4880,7 @@ class CGStaticSetter(CGAbstractStaticBindingMethod):
         checkForArg = CGGeneric(
             "let args = CallArgs::from_vp(vp, argc);\n"
             "if argc == 0 {\n"
-            f'    throw_type_error(cx.raw_cx(), c"Not enough arguments to {self.attr.identifier.name} setter.");\n'
+            f'    throw_type_error_safe(cx, c"Not enough arguments to {self.attr.identifier.name} setter.");\n'
             "    return false;\n"
             "}")
         call = CGSetterCall(["&global"], self.attr.type, nativeName, self.descriptor,
@@ -4911,7 +4911,7 @@ if !JS_GetProperty(cx, HandleObject::from_raw(obj), {str_to_cstr_ptr(attrName)},
     return false;
 }}
 if !v.is_object() {{
-    throw_type_error(cx.raw_cx(), c"Value.{attrName} is not an object.");
+    throw_type_error_safe(cx, c"Value.{attrName} is not an object.");
     return false;
 }}
 rooted!(&in(cx) let target_obj = v.to_object());
@@ -6342,7 +6342,7 @@ class CGProxyNamedDeleter(CGProxyNamedOperation):
                 f'    let {argName} = match jsid_to_string(cx, id) {{\n'
                 "        Some(val) => val,\n"
                 "        None => {\n"
-                "            throw_type_error(cx.raw_cx(), c\"Not a string-convertible JSID\");\n"
+                "            throw_type_error_safe(cx, c\"Not a string-convertible JSID\");\n"
                 "            return false;\n"
                 "        }\n"
                 "    };\n"
@@ -7734,7 +7734,7 @@ impl{self.generic} Clone for {self.makeClassName(self.dictionary)}{self.genericS
                 f"    match {self.makeModuleName(d.parent)}::{self.makeClassName(d.parent)}::new(cx, val)? {{\n"
                 "        ConversionResult::Success(v) => v,\n"
                 "        ConversionResult::Failure(error) => {\n"
-                "            throw_type_error(cx.raw_cx(), error.as_ref());\n"
+                "            throw_type_error_safe(cx, error.as_ref());\n"
                 "            return Err(());\n"
                 "        }\n"
                 "    }\n"
@@ -7784,15 +7784,11 @@ impl{self.generic} Clone for {self.makeClassName(self.dictionary)}{self.genericS
         initParent = f"parent: {initParent},\n" if initParent else ""
         memberInits = CGList([memberInit(member) for member in self.memberInfo])
 
-        unsafe_if_necessary = "unsafe"
-        if not initParent and not memberInits:
-            unsafe_if_necessary = ""
         return (
             f"impl{self.generic} {selfName}{self.genericSuffix} {{\n"
             f"{CGIndenter(CGGeneric(self.makeEmpty()), indentLevel=4).define()}\n"
             "    pub fn new(cx: &mut JSContext, val: HandleValue) \n"
             f"                      -> Result<ConversionResult<{actualType}>, ()> {{\n"
-            f"        {unsafe_if_necessary} {{\n"
             "            let object = if val.get().is_null_or_undefined() {\n"
             "                ptr::null_mut()\n"
             "            } else if val.get().is_object() {\n"
@@ -7807,7 +7803,6 @@ impl{self.generic} Clone for {self.makeClassName(self.dictionary)}{self.genericS
             f"{CGIndenter(CGGeneric(postInitial), indentLevel=8).define()}"
             "            Ok(ConversionResult::Success(dictionary))\n"
             "        }\n"
-            "    }\n"
             "}\n"
             "\n"
             f"impl{self.generic} FromJSValConvertible for {actualType} {{\n"
@@ -7872,7 +7867,7 @@ impl{self.generic} Clone for {self.makeClassName(self.dictionary)}{self.genericS
         assert (member.defaultValue is None) == (default is None)
         if not member.optional:
             assert default is None
-            default = (f'throw_type_error(cx.raw_cx(), c"Missing required member \\"{member.identifier.name}\\".");\n'
+            default = (f'throw_type_error_safe(cx, c"Missing required member \\"{member.identifier.name}\\".");\n'
                        "return Err(());")
         elif not default:
             default = "None"
@@ -9056,7 +9051,7 @@ class CGIterableMethodGenerator(CGGeneric):
             CGGeneric.__init__(self, fill(
                 """
                 if !IsCallable(arg0) {
-                  throw_type_error(cx.raw_cx(), c"Argument 1 of ${ifaceName}.forEach is not callable.");
+                  throw_type_error_safe(cx, c"Argument 1 of ${ifaceName}.forEach is not callable.");
                   return false;
                 }
                 rooted!(&in(cx) let arg0 = ObjectValue(arg0));

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -8,7 +8,7 @@ use js::context::JSContext;
 use js::conversions::{
     ConversionResult, FromJSValConvertible, ToJSValConvertible, jsstr_to_string,
 };
-use js::error::throw_type_error;
+use js::error::throw_type_error_safe;
 use js::glue::{
     GetProxyHandlerExtra, GetProxyReservedSlot, IsProxyHandlerFamily, IsWrapper, JS_GetReservedSlot,
 };
@@ -156,7 +156,7 @@ impl FromJSValConvertible for ByteString {
             let char_vec = slice::from_raw_parts(chars, length);
 
             if char_vec.iter().any(|&c| c > 0xFF) {
-                throw_type_error(cx.raw_cx(), c"Invalid ByteString");
+                throw_type_error_safe(cx, c"Invalid ByteString");
                 Err(())
             } else {
                 Ok(ConversionResult::Success(ByteString::new(
@@ -404,19 +404,14 @@ impl<T: Float + FromJSValConvertible<Config = ()>> FromJSValConvertible for Fini
             ConversionResult::Success(v) => v,
             ConversionResult::Failure(error) => {
                 // FIXME(emilio): Why throwing instead of propagating the error?
-                unsafe { throw_type_error(cx.raw_cx(), &error) };
+                throw_type_error_safe(cx, &error);
                 return Err(());
             },
         };
         match Finite::new(result) {
             Some(v) => Ok(ConversionResult::Success(v)),
             None => {
-                unsafe {
-                    throw_type_error(
-                        cx.raw_cx(),
-                        c"this argument is not a finite floating-point value",
-                    )
-                };
+                throw_type_error_safe(cx, c"this argument is not a finite floating-point value");
                 Err(())
             },
         }

--- a/components/script_bindings/error.rs
+++ b/components/script_bindings/error.rs
@@ -5,7 +5,7 @@
 use std::ffi::CString;
 
 use js::context::JSContext;
-use js::error::throw_type_error;
+use js::error::throw_type_error_safe;
 use js::rust::wrappers2::JS_IsExceptionPending;
 
 use crate::codegen::PrototypeList::proto_id_to_name;
@@ -104,7 +104,7 @@ pub fn throw_invalid_this(cx: &mut JSContext, proto_id: u16) {
         .to_vec();
     vec.extend_from_slice(proto_id_to_name(proto_id).as_bytes());
     let error = CString::new(vec).expect("WebIDL name should not contain nul byte");
-    unsafe { throw_type_error(cx.raw_cx(), &error) };
+    throw_type_error_safe(cx, &error);
 }
 
 pub fn throw_constructor_without_new(cx: &mut JSContext, name: &str) {
@@ -112,7 +112,7 @@ pub fn throw_constructor_without_new(cx: &mut JSContext, name: &str) {
     let mut error = name.as_bytes().to_vec();
     error.extend_from_slice(b" constructor: 'new' is required");
     let error = CString::new(error).expect("WebIDL name should not contain nul byte");
-    unsafe { throw_type_error(cx.raw_cx(), &error) };
+    throw_type_error_safe(cx, &error);
 }
 
 #[macro_export]

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -11,7 +11,7 @@ pub(crate) mod base {
     pub(crate) use js::conversions::{
         ConversionBehavior, ConversionResult, FromJSValConvertible, ToJSValConvertible,
     };
-    pub(crate) use js::error::throw_type_error;
+    pub(crate) use js::error::throw_type_error_safe;
     pub(crate) use js::gc::RootedVec;
     pub(crate) use js::jsapi::{
         HandleValue as RawHandleValue, HandleValueArray, Heap, IsCallable, JSObject, Value,

--- a/components/script_bindings/interface.rs
+++ b/components/script_bindings/interface.rs
@@ -8,7 +8,7 @@ use std::convert::TryFrom;
 use std::ffi::CStr;
 use std::ptr::{self, NonNull};
 
-use js::error::throw_type_error;
+use js::error::throw_type_error_safe;
 use js::glue::UncheckedUnwrapObject;
 use js::jsapi::JS::CompartmentIterResult;
 use js::jsapi::{
@@ -544,7 +544,9 @@ unsafe extern "C" fn invalid_constructor(
     _argc: libc::c_uint,
     _vp: *mut JSVal,
 ) -> bool {
-    throw_type_error(cx, c"Illegal constructor.");
+    // SAFETY: it is safe to construct a JSContext from engine hook.
+    let mut cx = unsafe { js::context::JSContext::from_ptr(NonNull::new(cx).unwrap()) };
+    throw_type_error_safe(&mut cx, c"Illegal constructor.");
     false
 }
 
@@ -553,7 +555,9 @@ unsafe extern "C" fn non_new_constructor(
     _argc: libc::c_uint,
     _vp: *mut JSVal,
 ) -> bool {
-    throw_type_error(cx, c"This constructor needs to be called with `new`.");
+    // SAFETY: it is safe to construct a JSContext from engine hook.
+    let mut cx = unsafe { js::context::JSContext::from_ptr(NonNull::new(cx).unwrap()) };
+    throw_type_error_safe(&mut cx, c"This constructor needs to be called with `new`.");
     false
 }
 


### PR DESCRIPTION
By switching to `throw_type_error_safe`, the unsafe blocks that wrapped dictionary types creation are no longer required. For the handful of cases where a callback is part of a dictionary, the unsafe blocks are now narrowed to the single function. 
Companion PR of https://github.com/servo/mozjs/pull/797

Testing: It compiles
