### PR TITLE
constellation: Move `pending_changes` to `ConstellationWebView`

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -433,13 +433,6 @@ pub struct Constellation<STF, SWF> {
     /// The Id counter for BrowsingContextGroup.
     browsing_context_group_next_id: u32,
 
-    /// When a navigation is performed, we do not immediately update
-    /// the session history, instead we ask the event loop to begin loading
-    /// the new document, and do not update the browsing context until the
-    /// document is active. Between starting the load and it activating,
-    /// we store a `SessionHistoryChange` object for the navigation in progress.
-    pending_changes: Vec<SessionHistoryChange>,
-
     /// Pipeline IDs are namespaced in order to avoid name collisions,
     /// and the namespaces are allocated by the constellation.
     next_pipeline_namespace_id: Cell<PipelineNamespaceId>,
@@ -717,7 +710,6 @@ where
                     pipelines: Default::default(),
                     worker_animation_frame_providers: Default::default(),
                     browsing_contexts: Default::default(),
-                    pending_changes: vec![],
                     next_pipeline_namespace_id: Cell::new(FIRST_CONTENT_PIPELINE_NAMESPACE_ID),
                     time_profiler_chan: state.time_profiler_chan,
                     mem_profiler_chan: state.mem_profiler_chan.clone(),
@@ -1216,18 +1208,6 @@ where
         {
             parent.add_child(browsing_context_id);
         }
-    }
-
-    fn add_pending_change(&mut self, change: SessionHistoryChange) {
-        debug!(
-            "adding pending session history change with {}",
-            if change.replace.is_some() {
-                "replacement"
-            } else {
-                "no replacement"
-            },
-        );
-        self.pending_changes.push(change);
     }
 
     /// Handles loading pages, navigation, and granting access to `Paint`.
@@ -1787,7 +1767,7 @@ where
                 );
             },
             ScriptToConstellationMessage::AbortLoadUrl => {
-                self.handle_abort_load_url_msg(source_pipeline_id);
+                self.handle_abort_load_url_msg(webview_id, source_pipeline_id);
             },
             // A page loaded has completed all parsing, script, and reflow messages have been sent.
             ScriptToConstellationMessage::LoadComplete => {
@@ -1814,7 +1794,7 @@ where
             },
             // Notification that the new document is ready to become active
             ScriptToConstellationMessage::ActivateDocument => {
-                self.handle_activate_document_msg(source_pipeline_id);
+                self.handle_activate_document_msg(webview_id, source_pipeline_id);
             },
             // Update pipeline url after redirections
             ScriptToConstellationMessage::SetFinalUrl(final_url) => {
@@ -1863,7 +1843,8 @@ where
                 self.handle_set_throttled_complete(source_pipeline_id, throttled);
             },
             ScriptToConstellationMessage::RemoveIFrame(browsing_context_id, response_sender) => {
-                let removed_pipeline_ids = self.handle_remove_iframe_msg(browsing_context_id);
+                let removed_pipeline_ids =
+                    self.handle_remove_iframe_msg(webview_id, browsing_context_id);
                 if let Err(e) = response_sender.send(removed_pipeline_ids) {
                     warn!("Error replying to remove iframe ({})", e);
                 }
@@ -2011,7 +1992,7 @@ where
                 }
             },
             ScriptToConstellationMessage::IFrameSizes(iframe_sizes) => {
-                self.handle_iframe_size_msg(iframe_sizes)
+                self.handle_iframe_size_msg(webview_id, iframe_sizes)
             },
             ScriptToConstellationMessage::ReportMemory(sender) => {
                 // get memory report and send it back.
@@ -2657,27 +2638,36 @@ where
         self.send_message_to_all_background_hang_monitors(BackgroundHangMonitorControlMsg::Exit);
 
         // Close the top-level browsing contexts
-        let browsing_context_ids: Vec<BrowsingContextId> = self
+        let browsing_context_ids: Vec<_> = self
             .browsing_contexts
             .values()
             .filter(|browsing_context| browsing_context.is_top_level())
-            .map(|browsing_context| browsing_context.id)
+            .map(|browsing_context| (browsing_context.webview_id, browsing_context.id))
             .collect();
-        for browsing_context_id in browsing_context_ids {
+        for (webview_id, browsing_context_id) in browsing_context_ids {
             debug!(
                 "{}: Removing top-level browsing context",
                 browsing_context_id
             );
-            self.close_browsing_context(browsing_context_id, ExitPipelineMode::Normal);
+            self.close_browsing_context(webview_id, browsing_context_id, ExitPipelineMode::Normal);
         }
 
         // Close any pending changes and pipelines
-        while let Some(pending) = self.pending_changes.pop() {
+        let pending_changes: Vec<_> = self
+            .webviews
+            .values_mut()
+            .flat_map(|webview| webview.pending_changes.drain(..))
+            .collect();
+        for pending in pending_changes {
             debug!(
                 "{}: Removing pending browsing context",
                 pending.browsing_context_id
             );
-            self.close_browsing_context(pending.browsing_context_id, ExitPipelineMode::Normal);
+            self.close_browsing_context(
+                pending.webview_id,
+                pending.browsing_context_id,
+                ExitPipelineMode::Normal,
+            );
             debug!("{}: Removing pending pipeline", pending.new_pipeline_id);
             self.close_pipeline(
                 pending.new_pipeline_id,
@@ -2687,14 +2677,20 @@ where
         }
 
         // In case there are browsing contexts which weren't attached, we close them.
-        let browsing_context_ids: Vec<BrowsingContextId> =
-            self.browsing_contexts.keys().cloned().collect();
-        for browsing_context_id in browsing_context_ids {
+        let browsing_context_ids: Vec<_> = self
+            .browsing_contexts
+            .iter()
+            .map(|(browsing_context_id, browsing_context)| {
+                (*browsing_context_id, browsing_context.webview_id)
+            })
+            .collect();
+
+        for (browsing_context_id, webview_id) in browsing_context_ids {
             debug!(
                 "{}: Removing detached browsing context",
                 browsing_context_id
             );
-            self.close_browsing_context(browsing_context_id, ExitPipelineMode::Normal);
+            self.close_browsing_context(webview_id, browsing_context_id, ExitPipelineMode::Normal);
         }
 
         // In case there are pipelines which weren't attached to the pipeline tree, we close them.
@@ -3029,6 +3025,7 @@ where
         let opener = pipeline.opener;
 
         self.close_browsing_context_children(
+            webview_id,
             browsing_context_id,
             DiscardBrowsingContext::No,
             ExitPipelineMode::Force,
@@ -3070,7 +3067,11 @@ where
             TargetSnapshotParams::default(),
             None,
         );
-        self.add_pending_change(SessionHistoryChange {
+
+        let Some(webview) = self.webviews.get_mut(&webview_id) else {
+            return warn!("Adding pending change to unknown WebView: {webview_id:?}");
+        };
+        webview.add_pending_change(SessionHistoryChange {
             webview_id,
             browsing_context_id,
             new_pipeline_id,
@@ -3258,10 +3259,22 @@ where
 
         // Register this new top-level browsing context id as a webview and set
         // its focused browsing context to be itself.
-        self.webviews.insert(
+        let mut new_webview =
+            ConstellationWebView::new(webview_id, browsing_context_id, user_content_manager_id);
+        new_webview.add_pending_change(SessionHistoryChange {
             webview_id,
-            ConstellationWebView::new(webview_id, browsing_context_id, user_content_manager_id),
-        );
+            browsing_context_id,
+            new_pipeline_id: pipeline_id,
+            replace: None,
+            new_browsing_context_info: Some(NewBrowsingContextInfo {
+                parent_pipeline_id: None,
+                is_private,
+                inherited_secure_context: None,
+                throttled,
+            }),
+            viewport_details,
+        });
+        self.webviews.insert(webview_id, new_webview);
 
         // https://html.spec.whatwg.org/multipage/#creating-a-new-browsing-context-group
         let mut new_bc_group: BrowsingContextGroup = Default::default();
@@ -3285,23 +3298,9 @@ where
             TargetSnapshotParams::default(),
             None,
         );
-        self.add_pending_change(SessionHistoryChange {
-            webview_id,
-            browsing_context_id,
-            new_pipeline_id: pipeline_id,
-            replace: None,
-            new_browsing_context_info: Some(NewBrowsingContextInfo {
-                parent_pipeline_id: None,
-                is_private,
-                inherited_secure_context: None,
-                throttled,
-            }),
-            viewport_details,
-        });
 
-        let painter_id = PainterId::from(webview_id);
         self.system_font_service
-            .prefetch_font_keys_for_painter(painter_id);
+            .prefetch_font_keys_for_painter(PainterId::from(webview_id));
     }
 
     #[servo_tracing::instrument(skip_all)]
@@ -3311,7 +3310,7 @@ where
         let browsing_context_id = BrowsingContextId::from(webview_id);
         // Step 5. Remove traversable from the user agent's top-level traversable set.
         let browsing_context =
-            self.close_browsing_context(browsing_context_id, ExitPipelineMode::Normal);
+            self.close_browsing_context(webview_id, browsing_context_id, ExitPipelineMode::Normal);
 
         // Any queued history traversal requests are never going to finish at this point,
         // so notify the embedder that they are now finished.
@@ -3362,14 +3361,14 @@ where
     }
 
     #[servo_tracing::instrument(skip_all)]
-    fn handle_iframe_size_msg(&mut self, iframe_sizes: Vec<IFrameSizeMsg>) {
+    fn handle_iframe_size_msg(&mut self, webview_id: WebViewId, iframe_sizes: Vec<IFrameSizeMsg>) {
         for IFrameSizeMsg {
             browsing_context_id,
             size,
             type_,
         } in iframe_sizes
         {
-            self.resize_browsing_context(size, type_, browsing_context_id);
+            self.resize_browsing_context(webview_id, size, type_, browsing_context_id);
         }
     }
 
@@ -3424,10 +3423,10 @@ where
         }
     }
 
-    // The script thread associated with pipeline_id has loaded a URL in an
-    // iframe via script. This will result in a new pipeline being spawned and
-    // a child being added to the parent browsing context. This message is never
-    // the result of a page navigation.
+    /// The script thread associated with pipeline_id has loaded a URL in an
+    /// iframe via script. This will result in a new pipeline being spawned and
+    /// a child being added to the parent browsing context. This message is never
+    /// the result of a page navigation.
     #[servo_tracing::instrument(skip_all)]
     fn handle_script_loaded_url_in_iframe_msg(&mut self, load_info: IFrameLoadInfoWithData) {
         let IFrameLoadInfo {
@@ -3502,7 +3501,7 @@ where
         // TODO(servo#30571) revert to debug_assert_eq!() once underlying bug is fixed
         #[cfg(debug_assertions)]
         if !(browsing_context_size == load_info.viewport_details) {
-            log::warn!(
+            warn!(
                 "debug assertion failed! browsing_context_size == load_info.viewport_details.initial_viewport"
             );
         }
@@ -3521,15 +3520,20 @@ where
             target_snapshot_params,
             name,
         );
-        self.add_pending_change(SessionHistoryChange {
-            webview_id,
-            browsing_context_id,
-            new_pipeline_id,
-            replace,
-            // Browsing context for iframe already exists.
-            new_browsing_context_info: None,
-            viewport_details: load_info.viewport_details,
-        });
+
+        if let Some(webview) = self.webviews.get_mut(&webview_id) {
+            webview.add_pending_change(SessionHistoryChange {
+                webview_id,
+                browsing_context_id,
+                new_pipeline_id,
+                replace,
+                // Browsing context for iframe already exists.
+                new_browsing_context_info: None,
+                viewport_details: load_info.viewport_details,
+            });
+        } else {
+            warn!("Could not find WebView for script-loaded iframe: ({webview_id:?})");
+        }
     }
 
     #[servo_tracing::instrument(skip_all)]
@@ -3577,20 +3581,25 @@ where
 
         assert!(!self.pipelines.contains_key(&new_pipeline_id));
         self.pipelines.insert(new_pipeline_id, pipeline);
-        self.add_pending_change(SessionHistoryChange {
-            webview_id,
-            browsing_context_id,
-            new_pipeline_id,
-            replace: None,
-            // Browsing context for iframe doesn't exist yet.
-            new_browsing_context_info: Some(NewBrowsingContextInfo {
-                parent_pipeline_id: Some(parent_pipeline_id),
-                is_private,
-                inherited_secure_context: is_parent_secure,
-                throttled: is_parent_throttled,
-            }),
-            viewport_details: load_info.viewport_details,
-        });
+
+        if let Some(webview) = self.webviews.get_mut(&webview_id) {
+            webview.add_pending_change(SessionHistoryChange {
+                webview_id,
+                browsing_context_id,
+                new_pipeline_id,
+                replace: None,
+                // Browsing context for iframe doesn't exist yet.
+                new_browsing_context_info: Some(NewBrowsingContextInfo {
+                    parent_pipeline_id: Some(parent_pipeline_id),
+                    is_private,
+                    inherited_secure_context: is_parent_secure,
+                    throttled: is_parent_throttled,
+                }),
+                viewport_details: load_info.viewport_details,
+            });
+        } else {
+            warn!("Could not find WebView for new iframe: ({webview_id:?})");
+        }
     }
 
     #[servo_tracing::instrument(skip_all)]
@@ -3664,27 +3673,13 @@ where
 
         assert!(!self.pipelines.contains_key(&new_pipeline_id));
         self.pipelines.insert(new_pipeline_id, pipeline);
-        self.webviews.insert(
+
+        let mut new_webview = ConstellationWebView::new(
             new_webview_id,
-            ConstellationWebView::new(
-                new_webview_id,
-                new_browsing_context_id,
-                user_content_manager_id,
-            ),
+            new_browsing_context_id,
+            user_content_manager_id,
         );
-
-        // https://html.spec.whatwg.org/multipage/#bcg-append
-        let Some(opener) = self.browsing_contexts.get(&opener_browsing_context_id) else {
-            return warn!("Trying to append an unknown auxiliary to a browsing context group");
-        };
-        let Some(bc_group) = self.browsing_context_group_set.get_mut(&opener.bc_group_id) else {
-            return warn!("Trying to add a top-level to an unknown group.");
-        };
-        bc_group
-            .top_level_browsing_context_set
-            .insert(new_webview_id);
-
-        self.add_pending_change(SessionHistoryChange {
+        new_webview.add_pending_change(SessionHistoryChange {
             webview_id: new_webview_id,
             browsing_context_id: new_browsing_context_id,
             new_pipeline_id,
@@ -3698,6 +3693,18 @@ where
             }),
             viewport_details,
         });
+        self.webviews.insert(new_webview_id, new_webview);
+
+        // https://html.spec.whatwg.org/multipage/#bcg-append
+        let Some(opener) = self.browsing_contexts.get(&opener_browsing_context_id) else {
+            return warn!("Trying to append an unknown auxiliary to a browsing context group");
+        };
+        let Some(bc_group) = self.browsing_context_group_set.get_mut(&opener.bc_group_id) else {
+            return warn!("Trying to add a top-level to an unknown group.");
+        };
+        bc_group
+            .top_level_browsing_context_set
+            .insert(new_webview_id);
     }
 
     #[servo_tracing::instrument(skip_all)]
@@ -4181,11 +4188,13 @@ where
             },
             None => {
                 // Make sure no pending page would be overridden.
-                for change in &self.pending_changes {
-                    if change.browsing_context_id == browsing_context_id {
-                        // id that sent load msg is being changed already; abort
-                        return None;
-                    }
+                if let Some(webview) = self.webviews.get(&webview_id) &&
+                    webview.pending_changes.iter().any(|pending_change| {
+                        pending_change.browsing_context_id == browsing_context_id
+                    })
+                {
+                    // id that sent load msg is being changed already; abort
+                    return None;
                 }
 
                 if self.get_activity(source_id) == DocumentActivity::Inactive {
@@ -4221,39 +4230,45 @@ where
                     target_snapshot_params,
                     None,
                 );
-                self.add_pending_change(SessionHistoryChange {
-                    webview_id,
-                    browsing_context_id,
-                    new_pipeline_id,
-                    replace,
-                    // `load_url` is always invoked on an existing browsing context.
-                    new_browsing_context_info: None,
-                    viewport_details,
-                });
+
+                if let Some(webview) = self.webviews.get_mut(&webview_id) {
+                    webview.add_pending_change(SessionHistoryChange {
+                        webview_id,
+                        browsing_context_id,
+                        new_pipeline_id,
+                        replace,
+                        // `load_url` is always invoked on an existing browsing context.
+                        new_browsing_context_info: None,
+                        viewport_details,
+                    });
+                } else {
+                    warn!("Could not find WebView for URL load: ({webview_id:?})");
+                }
+
                 self.paint_proxy
                     .send(PaintMessage::EnableLCPCalculation(webview_id));
+
                 Some(new_pipeline_id)
             },
         }
     }
 
     #[servo_tracing::instrument(skip_all)]
-    fn handle_abort_load_url_msg(&mut self, new_pipeline_id: PipelineId) {
-        let pending_index = self
-            .pending_changes
-            .iter()
-            .rposition(|change| change.new_pipeline_id == new_pipeline_id);
-
-        // If it is found, remove it from the pending changes.
-        if let Some(pending_index) = pending_index {
-            self.pending_changes.remove(pending_index);
-            self.close_pipeline(
-                new_pipeline_id,
-                DiscardBrowsingContext::No,
-                ExitPipelineMode::Normal,
-            );
+    fn handle_abort_load_url_msg(&mut self, webview_id: WebViewId, new_pipeline_id: PipelineId) {
+        if self
+            .webviews
+            .get_mut(&webview_id)
+            .and_then(|webview| webview.remove_pending_change_for_pipeline(new_pipeline_id))
+            .is_none()
+        {
+            return;
         }
 
+        self.close_pipeline(
+            new_pipeline_id,
+            DiscardBrowsingContext::No,
+            ExitPipelineMode::Normal,
+        );
         self.send_screenshot_readiness_requests_to_pipelines();
     }
 
@@ -4518,37 +4533,14 @@ where
     /// traversals on that same `WebView` until there are no remaining completed ongoing history
     /// traversal requests.
     fn finish_completed_session_history_traversal_requests(&mut self) {
-        while let Some(traversal_request) =
-            self.take_next_completed_session_history_traversal_request()
+        while let Some(traversal_request) = self
+            .webviews
+            .values_mut()
+            .find_map(|webview| webview.maybe_finish_ongoing_session_history_traversal_request())
         {
             self.notify_embedder_of_completed_session_history_traversal_request(&traversal_request);
             self.apply_queued_session_history_traversal_requests(traversal_request.webview_id);
         }
-    }
-
-    /// If any [`ConstellationWebView`] has a completed ongoing history traversal request, return
-    /// it. Otherwise, `None` is returned.
-    fn take_next_completed_session_history_traversal_request(
-        &mut self,
-    ) -> Option<SessionHistoryTraversalRequest> {
-        if self
-            .webviews
-            .values()
-            .all(|webview| webview.ongoing_history_traversal_request.is_none())
-        {
-            return None;
-        }
-
-        let pipelines_with_pending_changes = self
-            .pending_changes
-            .iter()
-            .map(|change| change.new_pipeline_id)
-            .collect::<FxHashSet<_>>();
-        self.webviews.values_mut().find_map(|webview| {
-            webview.maybe_finish_ongoing_session_history_traversal_request(
-                &pipelines_with_pending_changes,
-            )
-        })
     }
 
     /// Notify the embedder that the given [`HistoryTraversalRequest`] is complete, if it was
@@ -4662,7 +4654,12 @@ where
                     TargetSnapshotParams::default(),
                     None,
                 );
-                self.add_pending_change(SessionHistoryChange {
+
+                let webview = self
+                    .webviews
+                    .get_mut(&webview_id)
+                    .expect("WebView for history traversal should always exist at this point");
+                webview.add_pending_change(SessionHistoryChange {
                     webview_id,
                     browsing_context_id,
                     new_pipeline_id,
@@ -5122,13 +5119,14 @@ where
     #[servo_tracing::instrument(skip_all)]
     fn handle_remove_iframe_msg(
         &mut self,
+        webview_id: WebViewId,
         browsing_context_id: BrowsingContextId,
     ) -> Vec<PipelineId> {
         let result = self
             .all_descendant_browsing_contexts_iter(browsing_context_id)
             .flat_map(|browsing_context| browsing_context.pipelines.iter().cloned())
             .collect();
-        self.close_browsing_context(browsing_context_id, ExitPipelineMode::Normal);
+        self.close_browsing_context(webview_id, browsing_context_id, ExitPipelineMode::Normal);
         result
     }
 
@@ -5635,22 +5633,18 @@ where
     }
 
     #[servo_tracing::instrument(skip_all)]
-    fn handle_activate_document_msg(&mut self, pipeline_id: PipelineId) {
+    fn handle_activate_document_msg(&mut self, webview_id: WebViewId, pipeline_id: PipelineId) {
         debug!("{}: Document ready to activate", pipeline_id);
 
-        // Find the pending change whose new pipeline id is pipeline_id.
-        let Some(pending_index) = self
-            .pending_changes
-            .iter()
-            .rposition(|change| change.new_pipeline_id == pipeline_id)
+        // Find the pending change whose new pipeline id is pipeline_id. If it is found, remove
+        // it from the pending changes, and make it the active document of its frame.
+        let Some(change) = self
+            .webviews
+            .get_mut(&webview_id)
+            .and_then(|webview| webview.remove_pending_change_for_pipeline(pipeline_id))
         else {
             return;
         };
-
-        // If it is found, remove it from the pending changes, and make it
-        // the active document of its frame.
-        let change = self.pending_changes.swap_remove(pending_index);
-        let webview_id = change.webview_id;
 
         self.send_screenshot_readiness_requests_to_pipelines();
 
@@ -5699,7 +5693,12 @@ where
         );
 
         let browsing_context_id = BrowsingContextId::from(webview_id);
-        self.resize_browsing_context(new_viewport_details, size_type, browsing_context_id);
+        self.resize_browsing_context(
+            webview_id,
+            new_viewport_details,
+            size_type,
+            browsing_context_id,
+        );
     }
 
     /// Called when the window exits from fullscreen mode
@@ -5722,7 +5721,11 @@ where
 
     fn send_screenshot_readiness_requests_to_pipelines(&mut self) {
         // If there are pending loads, wait for those to complete.
-        if !self.pending_changes.is_empty() {
+        if self
+            .webviews
+            .values()
+            .any(ConstellationWebView::has_pending_change)
+        {
             return;
         }
 
@@ -5871,6 +5874,7 @@ where
     #[servo_tracing::instrument(skip_all)]
     fn resize_browsing_context(
         &mut self,
+        webview_id: WebViewId,
         new_viewport_details: ViewportDetails,
         size_type: WindowSizeType,
         browsing_context_id: BrowsingContextId,
@@ -5907,18 +5911,20 @@ where
         }
 
         // Send resize message to any pending pipelines that aren't loaded yet.
-        for change in &self.pending_changes {
-            let pipeline_id = change.new_pipeline_id;
-            let Some(pipeline) = self.pipelines.get(&pipeline_id) else {
-                warn!("{}: Pending pipeline is closed", pipeline_id);
-                continue;
-            };
-            if pipeline.browsing_context_id == browsing_context_id {
-                let _ = pipeline.event_loop.send(ScriptThreadMessage::Resize(
-                    pipeline.id,
-                    new_viewport_details,
-                    size_type,
-                ));
+        if let Some(webview) = self.webviews.get(&webview_id) {
+            for change in &webview.pending_changes {
+                let pipeline_id = change.new_pipeline_id;
+                let Some(pipeline) = self.pipelines.get(&pipeline_id) else {
+                    warn!("Pending pipeline is closed: {pipeline_id}");
+                    continue;
+                };
+                if pipeline.browsing_context_id == browsing_context_id {
+                    let _ = pipeline.event_loop.send(ScriptThreadMessage::Resize(
+                        pipeline.id,
+                        new_viewport_details,
+                        size_type,
+                    ));
+                }
             }
         }
     }
@@ -5968,12 +5974,14 @@ where
     #[servo_tracing::instrument(skip_all)]
     fn close_browsing_context(
         &mut self,
+        webview_id: WebViewId,
         browsing_context_id: BrowsingContextId,
         exit_mode: ExitPipelineMode,
     ) -> Option<BrowsingContext> {
         debug!("{}: Closing", browsing_context_id);
 
         self.close_browsing_context_children(
+            webview_id,
             browsing_context_id,
             DiscardBrowsingContext::Yes,
             exit_mode,
@@ -6030,21 +6038,30 @@ where
     #[servo_tracing::instrument(skip_all)]
     fn close_browsing_context_children(
         &mut self,
+        webview_id: WebViewId,
         browsing_context_id: BrowsingContextId,
         dbc: DiscardBrowsingContext,
         exit_mode: ExitPipelineMode,
     ) {
         debug!("{}: Closing browsing context children", browsing_context_id);
+
         // Store information about the pipelines to be closed. Then close the
         // pipelines, before removing ourself from the browsing_contexts hash map. This
         // ordering is vital - so that if close_pipeline() ends up closing
         // any child browsing contexts, they can be removed from the parent browsing context correctly.
-        let mut pipelines_to_close: Vec<PipelineId> = self
-            .pending_changes
-            .iter()
-            .filter(|change| change.browsing_context_id == browsing_context_id)
-            .map(|change| change.new_pipeline_id)
-            .collect();
+        let mut pipelines_to_close: Vec<_> = {
+            let Some(webview) = self.webviews.get(&webview_id) else {
+                return warn!(
+                    "Couldnot find WebView for closing browsing context id: {webview_id:?}"
+                );
+            };
+            webview
+                .pending_changes
+                .iter()
+                .filter(|change| change.browsing_context_id == browsing_context_id)
+                .map(|change| change.new_pipeline_id)
+                .collect()
+        };
 
         if let Some(browsing_context) = self.browsing_contexts.get(&browsing_context_id) {
             pipelines_to_close.extend(&browsing_context.pipelines)
@@ -6112,13 +6129,15 @@ where
         debug!("{}: Closing", pipeline_id);
 
         // Sever connection to browsing context
-        let browsing_context_id = self
+        let Some((webview_id, browsing_context_id)) = self
             .pipelines
             .get(&pipeline_id)
-            .map(|pipeline| pipeline.browsing_context_id);
-        if let Some(browsing_context) = browsing_context_id
-            .and_then(|browsing_context_id| self.browsing_contexts.get_mut(&browsing_context_id))
-        {
+            .map(|pipeline| (pipeline.webview_id, pipeline.browsing_context_id))
+        else {
+            return warn!("Tried closing unknown pipeline: {pipeline_id:?}");
+        };
+
+        if let Some(browsing_context) = self.browsing_contexts.get_mut(&browsing_context_id) {
             browsing_context.pipelines.remove(&pipeline_id);
         }
 
@@ -6138,7 +6157,7 @@ where
 
         // Remove any child browsing contexts
         for child_browsing_context in &browsing_contexts_to_close {
-            self.close_browsing_context(*child_browsing_context, exit_mode);
+            self.close_browsing_context(webview_id, *child_browsing_context, exit_mode);
         }
 
         // Note, we don't remove the pipeline now, we wait for the message to come back from
@@ -6148,12 +6167,8 @@ where
         };
 
         // Remove this pipeline from pending changes if it hasn't loaded yet.
-        let pending_index = self
-            .pending_changes
-            .iter()
-            .position(|change| change.new_pipeline_id == pipeline_id);
-        if let Some(pending_index) = pending_index {
-            self.pending_changes.remove(pending_index);
+        if let Some(webview) = self.webviews.get_mut(&webview_id) {
+            webview.remove_pending_change_for_pipeline(pipeline_id);
         }
 
         // Inform script and paint that this pipeline has exited.
@@ -6186,9 +6201,9 @@ where
             let Some(pipeline) = self.pipelines.get(pipeline_id)
         {
             if self
-                .pending_changes
-                .iter()
-                .any(|change| change.new_pipeline_id == pipeline.id) &&
+                .webviews
+                .values()
+                .any(|webview| webview.pipeline_is_pending(pipeline.id)) &&
                 probability <= rng.random::<f32>()
             {
                 // We tend not to close pending pipelines, as that almost always

--- a/components/constellation/constellation_webview.rs
+++ b/components/constellation/constellation_webview.rs
@@ -7,7 +7,7 @@ use std::collections::VecDeque;
 use embedder_traits::user_contents::UserContentManagerId;
 use embedder_traits::{InputEvent, MouseLeftViewportEvent, Theme};
 use euclid::Point2D;
-use log::warn;
+use log::{debug, warn};
 use rustc_hash::{FxHashMap, FxHashSet};
 use script_traits::{ConstellationInputEvent, ScriptThreadMessage};
 use servo_base::Epoch;
@@ -17,7 +17,7 @@ use style_traits::CSSPixel;
 
 use crate::browsingcontext::BrowsingContext;
 use crate::pipeline::Pipeline;
-use crate::session_history::JointSessionHistory;
+use crate::session_history::{JointSessionHistory, SessionHistoryChange};
 
 /// The `Constellation`'s view of a `WebView` in the embedding layer. This tracks all of the
 /// `Constellation` state for this `WebView`.
@@ -27,8 +27,16 @@ pub(crate) struct ConstellationWebView {
 
     /// The [`PipelineId`] of the currently active pipeline at the top level of this WebView.
     pub active_top_level_pipeline_id: Option<PipelineId>,
+
     /// A counter for changes to [`Self::active_top_level_pipeline_id`].
     pub active_top_level_pipeline_epoch: Epoch,
+
+    /// When a navigation is performed, we do not immediately update
+    /// the session history, instead we ask the event loop to begin loading
+    /// the new document, and do not update the browsing context until the
+    /// document is active. Between starting the load and it activating,
+    /// we store a `SessionHistoryChange` object for the navigation in progress.
+    pub pending_changes: Vec<SessionHistoryChange>,
 
     /// The currently focused browsing context in this webview for key events.
     /// The focused pipeline is the current entry of the focused browsing
@@ -85,6 +93,7 @@ impl ConstellationWebView {
             user_content_manager_id,
             active_top_level_pipeline_id: None,
             active_top_level_pipeline_epoch: Epoch::default(),
+            pending_changes: Default::default(),
             focused_browsing_context_id,
             hovered_browsing_context_id: None,
             last_mouse_move_point: Default::default(),
@@ -209,9 +218,14 @@ impl ConstellationWebView {
     /// case unset the ongoing request and return it.
     pub(crate) fn maybe_finish_ongoing_session_history_traversal_request(
         &mut self,
-        pipelines_with_pending_changes: &FxHashSet<PipelineId>,
     ) -> Option<SessionHistoryTraversalRequest> {
         let ongoing_history_traversal_request = self.ongoing_history_traversal_request.as_mut()?;
+
+        let pipelines_with_pending_changes = self
+            .pending_changes
+            .iter()
+            .map(|change| change.new_pipeline_id)
+            .collect::<FxHashSet<_>>();
         ongoing_history_traversal_request
             .pipelines_awaiting_activation
             .retain(|pipeline_id| pipelines_with_pending_changes.contains(pipeline_id));
@@ -228,6 +242,39 @@ impl ConstellationWebView {
                 .expect("Guaranteed above")
                 .traversal_request,
         )
+    }
+
+    pub(crate) fn has_pending_change(&self) -> bool {
+        !self.pending_changes.is_empty()
+    }
+
+    pub(crate) fn pipeline_is_pending(&self, pipeline_id: PipelineId) -> bool {
+        self.pending_changes
+            .iter()
+            .any(|pending_change| pending_change.new_pipeline_id == pipeline_id)
+    }
+
+    pub(crate) fn add_pending_change(&mut self, change: SessionHistoryChange) {
+        debug!(
+            "adding pending session history change with {}",
+            if change.replace.is_some() {
+                "replacement"
+            } else {
+                "no replacement"
+            },
+        );
+        self.pending_changes.push(change);
+    }
+
+    pub(crate) fn remove_pending_change_for_pipeline(
+        &mut self,
+        pipeline_id: PipelineId,
+    ) -> Option<SessionHistoryChange> {
+        let pending_index = self
+            .pending_changes
+            .iter()
+            .rposition(|change| change.new_pipeline_id == pipeline_id)?;
+        Some(self.pending_changes.swap_remove(pending_index))
     }
 }
 


### PR DESCRIPTION
This makes dealing with pending changes a bit more complicated, but once
more members of `Constellation` are moved to `ConstellationWebView`,
this should become simpler.

Testing: This should not change observable behavior so should be covered by existing tests.
Fixes: This is part of #47294.
