### PR TITLE
layout: Advance ancestor pointer when style data is missing in containing_block_for_node

### DIFF
--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -810,6 +810,12 @@ fn containing_block_for_node<'a>(node: ServoLayoutNode<'a>) -> Option<ServoLayou
     #[expect(unsafe_code)]
     while let Some(ancestor) = unsafe { current_ancestor.dangerous_flat_tree_parent() } {
         let Some((ancestor_style, ancestor_flags)) = style_and_flags_for_node(&ancestor) else {
+            // The ancestor has no layout data (e.g. it belongs to a `BrowsingContext`
+            // that has just been discarded/closed, which happens routinely on pages
+            // with many ad/consent iframes such as aol.co.uk). Without advancing
+            // `current_ancestor` here, `dangerous_flat_tree_parent()` returns the
+            // same ancestor forever, spinning this loop at 100% CPU indefinitely.
+            current_ancestor = ancestor;
             continue;
         };
 


### PR DESCRIPTION
## Problem

We discovered that sites which create and destroy a high volume of iframe
components in quick succession were hanging the `ScriptThread` entirely —
the browser becomes unresponsive and CPU sits pegged at ~100% indefinitely.

We first noticed this on **aol.co.uk** and **dailymail.co.uk**, both of
which pump a steady stream of ad iframes into the DOM and tear them down
just as rapidly. It only shows up with
`--enable-experimental-web-platform-features` enabled, since that's what
gates `IntersectionObserver` (which is still experimental in Servo).

We haven't been able to reliably reproduce this offline in an isolated test
page — it seems to depend on genuine timing between iframe/pipeline teardown
and a queued intersection-observation task, which is hard to force
deterministically without the real churn of ads and network traffic these
sites generate.

Digging into it, the hang is in `containing_block_for_node()`
(`components/layout/query.rs`). It walks up the flat tree looking for the
nearest containing ancestor via `dangerous_flat_tree_parent()`. When an
ancestor has no layout data available (its `BrowsingContext`/pipeline is
mid-teardown), the loop hits `continue` — but without advancing
`current_ancestor` first. The next iteration asks for the parent of the
exact same node again, gets the exact same ancestor back, and never makes
progress. It just spins forever.

This gets hit via `IntersectionObserver`'s
`update_intersection_observations_steps`, which queries a node's containing
block without forcing a fresh reflow. On these ad-heavy pages, an observed
node's ancestor can lose its layout data mid-query exactly because its
pipeline is being torn down at that moment — landing right in this stuck
branch.

## Fix

Advance `current_ancestor = ancestor;` before the `continue`, so the walk
keeps moving up the tree even when a given ancestor's layout data isn't
available yet.

## Testing

- `./mach test-tidy` passes.
- Verified directly against the reported case: ran
  `servoshell --headless --enable-experimental-web-platform-features https://www.aol.co.uk/`
  and watched CPU. Without the fix, CPU sustains ~90-100% indefinitely and
  the page never becomes responsive. With the fix, CPU spikes briefly during
  load and settles down normally within ~20s, same as any other page.
- We tried building a synthetic WPT crashtest around rapid iframe
  creation/removal + `IntersectionObserver.observe()` to reproduce this in
  isolation, but couldn't get it to reliably hang without the fix — the bug
  seems to need real timing between pipeline teardown and a concurrent
  intersection-observation pass that a synthetic same-tick DOM test doesn't
  trigger reliably. Open to suggestions from reviewers on how to pin this
  down as an automated regression test (e.g. a lower-level unit test around
  `containing_block_for_node` with a mocked ancestor that has no layout
  data).
