### PR TITLE
input: rotate wheel direction if shift key is set

### DIFF
--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -1143,7 +1143,7 @@ impl WebViewRenderer {
             !result.contains(InputEventResult::DefaultPrevented)
         {
             // A scroll delta for a wheel event is the inverse of the wheel delta.
-            let scroll_delta = if !wheel_event.modifiers {
+            let scroll_delta = if !wheel_event.swap_axes {
                 DeviceVector2D::new(-wheel_event.delta.x as f32, -wheel_event.delta.y as f32)
             } else {
                 DeviceVector2D::new(-wheel_event.delta.y as f32, -wheel_event.delta.x as f32)

--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -1143,8 +1143,11 @@ impl WebViewRenderer {
             !result.contains(InputEventResult::DefaultPrevented)
         {
             // A scroll delta for a wheel event is the inverse of the wheel delta.
-            let scroll_delta =
-                DeviceVector2D::new(-wheel_event.delta.x as f32, -wheel_event.delta.y as f32);
+            let scroll_delta = if !wheel_event.modifiers {
+                DeviceVector2D::new(-wheel_event.delta.x as f32, -wheel_event.delta.y as f32)
+            } else {
+                DeviceVector2D::new(-wheel_event.delta.y as f32, -wheel_event.delta.x as f32)
+            };
             self.notify_scroll_event(Scroll::Delta(scroll_delta.into()), wheel_event.point);
         }
     }

--- a/components/servo/examples/winit_minimal.rs
+++ b/components/servo/examples/winit_minimal.rs
@@ -149,6 +149,7 @@ impl ApplicationHandler<WakerEvent> for App {
                                 mode,
                             },
                             DevicePoint::default().into(),
+                            /*modifier=*/ false,
                         )));
                     }
                 }

--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -340,16 +340,16 @@ pub struct WheelDelta {
 pub struct WheelEvent {
     pub delta: WheelDelta,
     pub point: WebViewPoint,
-    // Reverse x, y delta if modifiers is set (shift key in PC)
-    pub modifiers: bool,
+    // Swap x, y value on condition
+    pub swap_axes: bool,
 }
 
 impl WheelEvent {
-    pub fn new(delta: WheelDelta, point: WebViewPoint, modifiers: bool) -> Self {
+    pub fn new(delta: WheelDelta, point: WebViewPoint, swap_axes: bool) -> Self {
         WheelEvent {
             delta,
             point,
-            modifiers,
+            swap_axes,
         }
     }
 }

--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -340,11 +340,17 @@ pub struct WheelDelta {
 pub struct WheelEvent {
     pub delta: WheelDelta,
     pub point: WebViewPoint,
+    // Reverse x, y delta if modifiers is set (shift key in PC)
+    pub modifiers: bool,
 }
 
 impl WheelEvent {
-    pub fn new(delta: WheelDelta, point: WebViewPoint) -> Self {
-        WheelEvent { delta, point }
+    pub fn new(delta: WheelDelta, point: WebViewPoint, modifiers: bool) -> Self {
+        WheelEvent {
+            delta,
+            point,
+            modifiers,
+        }
     }
 }
 

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -879,7 +879,8 @@ impl Handler {
                 mode: WheelMode::DeltaPixel,
             };
             let point = WebViewPoint::Page(Point2D::new(x as f32, y as f32));
-            let input_event = InputEvent::Wheel(WheelEvent::new(delta, point));
+            let input_event =
+                InputEvent::Wheel(WheelEvent::new(delta, point, /*modifier=*/ false));
 
             self.send_blocking_input_event_to_embedder(input_event);
 

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -686,6 +686,7 @@ impl HeadedWindow {
                     webview.notify_input_event(InputEvent::Wheel(WheelEvent::new(
                         delta,
                         point.into(),
+                        self.modifiers_state.get().shift_key(),
                     )));
                 },
                 WindowEvent::Touch(touch) => {


### PR DESCRIPTION
As described in issue47235, hold shift and scroll the wheel change the y direction wheel to x direction.
Since Servo handle the wheel event in both x, y direction (maybe a 2D scroll exist), I designed to switch the x, y direction if shift key is held.

Testing: 
No wpt tests cover this behavior to my knowledge. I have run `./mach try` on my [Github Action](https://github.com/yodalee/servo/actions/runs/32156566246/job/95783847630)
There is one unexpected result, which is intermittent result `/html/browsers/history/the-history-interface/traverse_the_history_4.html`

Fixes: #47235 