### PR TITLE
script: Rename EC-related and AES-related structs in WebCrypto

### DIFF
--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3210,7 +3210,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for EcKeyGenParams {
 
 /// <https://w3c.github.io/webcrypto/#dfn-EcKeyAlgorithm>
 #[derive(Clone, MallocSizeOf)]
-pub(crate) struct SubtleEcKeyAlgorithm {
+pub(crate) struct EcKeyAlgorithm {
     /// <https://w3c.github.io/webcrypto/#dom-keyalgorithm-name>
     name: CryptoAlgorithm,
 
@@ -3218,7 +3218,7 @@ pub(crate) struct SubtleEcKeyAlgorithm {
     named_curve: String,
 }
 
-impl ToJSValConvertible for SubtleEcKeyAlgorithm {
+impl ToJSValConvertible for EcKeyAlgorithm {
     #[expect(unsafe_code)]
     fn safe_to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
         rooted!(&in(cx) let mut object = unsafe { JS_NewObject(cx, ptr::null()) });
@@ -3238,19 +3238,19 @@ impl ToJSValConvertible for SubtleEcKeyAlgorithm {
     }
 }
 
-impl TryFrom<SerializableEcKeyAlgorithm> for SubtleEcKeyAlgorithm {
+impl TryFrom<SerializableEcKeyAlgorithm> for EcKeyAlgorithm {
     type Error = ();
 
     fn try_from(value: SerializableEcKeyAlgorithm) -> Result<Self, Self::Error> {
-        Ok(SubtleEcKeyAlgorithm {
+        Ok(EcKeyAlgorithm {
             name: CryptoAlgorithm::from_str(&value.name).map_err(|_| ())?,
             named_curve: value.named_curve,
         })
     }
 }
 
-impl From<&SubtleEcKeyAlgorithm> for SerializableEcKeyAlgorithm {
-    fn from(value: &SubtleEcKeyAlgorithm) -> Self {
+impl From<&EcKeyAlgorithm> for SerializableEcKeyAlgorithm {
+    fn from(value: &EcKeyAlgorithm) -> Self {
         SerializableEcKeyAlgorithm {
             name: value.name.as_str().into(),
             named_curve: value.named_curve.clone(),
@@ -4302,7 +4302,7 @@ impl ExportedKey {
 pub(crate) enum KeyAlgorithmAndDerivatives {
     KeyAlgorithm(KeyAlgorithm),
     RsaHashedKeyAlgorithm(RsaHashedKeyAlgorithm),
-    EcKeyAlgorithm(SubtleEcKeyAlgorithm),
+    EcKeyAlgorithm(EcKeyAlgorithm),
     AesKeyAlgorithm(SubtleAesKeyAlgorithm),
     HmacKeyAlgorithm(SubtleHmacKeyAlgorithm),
     KmacKeyAlgorithm(SubtleKmacKeyAlgorithm),

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3400,7 +3400,7 @@ impl From<&AesKeyAlgorithm> for SerializableAesKeyAlgorithm {
 
 /// <https://w3c.github.io/webcrypto/#dfn-AesKeyGenParams>
 #[derive(Clone, MallocSizeOf)]
-struct SubtleAesKeyGenParams {
+struct AesKeyGenParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -3408,7 +3408,7 @@ struct SubtleAesKeyGenParams {
     length: u16,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleAesKeyGenParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for AesKeyGenParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -3416,7 +3416,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleAesKeyGenParams {
         cx: &mut js::context::JSContext,
         algorithm_name: CryptoAlgorithm,
     ) -> Result<Self, Self::Error> {
-        Ok(SubtleAesKeyGenParams {
+        Ok(AesKeyGenParams {
             name: algorithm_name,
             length: get_required_parameter(
                 cx,
@@ -5553,14 +5553,14 @@ enum GenerateKeyAlgorithm {
     X25519(Algorithm),
     Ed448(Algorithm),
     X448(Algorithm),
-    AesCtr(SubtleAesKeyGenParams),
-    AesCbc(SubtleAesKeyGenParams),
-    AesGcm(SubtleAesKeyGenParams),
-    AesKw(SubtleAesKeyGenParams),
+    AesCtr(AesKeyGenParams),
+    AesCbc(AesKeyGenParams),
+    AesGcm(AesKeyGenParams),
+    AesKw(AesKeyGenParams),
     Hmac(SubtleHmacKeyGenParams),
     MlKem(Algorithm),
     MlDsa(Algorithm),
-    AesOcb(SubtleAesKeyGenParams),
+    AesOcb(AesKeyGenParams),
     ChaCha20Poly1305(Algorithm),
     Kmac(SubtleKmacKeyGenParams),
 }

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3153,7 +3153,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for RsaOaepParams {
 
 /// <https://w3c.github.io/webcrypto/#dfn-EcdsaParams>
 #[derive(Clone, MallocSizeOf)]
-struct SubtleEcdsaParams {
+struct EcdsaParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -3161,7 +3161,7 @@ struct SubtleEcdsaParams {
     hash: DigestAlgorithm,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleEcdsaParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for EcdsaParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -3171,7 +3171,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleEcdsaParams {
     ) -> Result<Self, Self::Error> {
         let hash = get_required_parameter(cx, object, c"hash", ())?;
 
-        Ok(SubtleEcdsaParams {
+        Ok(EcdsaParams {
             name: algorithm_name,
             hash: normalize_algorithm::<DigestOperation>(cx, &hash)?,
         })
@@ -5058,7 +5058,7 @@ impl Operation for SignOperation {
 enum SignAlgorithm {
     RsassaPkcs1V1_5(Algorithm),
     RsaPss(RsaPssParams),
-    Ecdsa(SubtleEcdsaParams),
+    Ecdsa(EcdsaParams),
     Ed25519(Algorithm),
     Ed448(SubtleEd448Params),
     Hmac(Algorithm),
@@ -5147,7 +5147,7 @@ impl Operation for VerifyOperation {
 enum VerifyAlgorithm {
     RsassaPkcs1V1_5(Algorithm),
     RsaPss(RsaPssParams),
-    Ecdsa(SubtleEcdsaParams),
+    Ecdsa(EcdsaParams),
     Ed25519(Algorithm),
     Ed448(SubtleEd448Params),
     Hmac(Algorithm),

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3290,7 +3290,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for EcKeyImportParams {
 
 /// <https://w3c.github.io/webcrypto/#dfn-EcdhKeyDeriveParams>
 #[derive(Clone, MallocSizeOf)]
-struct SubtleEcdhKeyDeriveParams {
+struct EcdhKeyDeriveParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -3298,7 +3298,7 @@ struct SubtleEcdhKeyDeriveParams {
     public: Trusted<CryptoKey>,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleEcdhKeyDeriveParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for EcdhKeyDeriveParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -3308,7 +3308,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleEcdhKeyDeriveParams {
     ) -> Result<Self, Self::Error> {
         let public = get_required_parameter::<DomRoot<CryptoKey>>(cx, object, c"public", ())?;
 
-        Ok(SubtleEcdhKeyDeriveParams {
+        Ok(EcdhKeyDeriveParams {
             name: algorithm_name,
             public: Trusted::new(&public),
         })
@@ -5367,9 +5367,9 @@ impl Operation for DeriveBitsOperation {
 /// Normalized algorithm for the "deriveBits" operation, used as output of
 /// <https://w3c.github.io/webcrypto/#dfn-normalize-an-algorithm>
 enum DeriveBitsAlgorithm {
-    Ecdh(SubtleEcdhKeyDeriveParams),
-    X25519(SubtleEcdhKeyDeriveParams),
-    X448(SubtleEcdhKeyDeriveParams),
+    Ecdh(EcdhKeyDeriveParams),
+    X25519(EcdhKeyDeriveParams),
+    X448(EcdhKeyDeriveParams),
     Hkdf(SubtleHkdfParams),
     Pbkdf2(SubtlePbkdf2Params),
     Argon2(SubtleArgon2Params),

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3485,7 +3485,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for AesCbcParams {
 
 /// <https://w3c.github.io/webcrypto/#dfn-AesGcmParams>
 #[derive(Clone, MallocSizeOf)]
-struct SubtleAesGcmParams {
+struct AesGcmParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -3499,7 +3499,7 @@ struct SubtleAesGcmParams {
     tag_length: Option<u8>,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleAesGcmParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for AesGcmParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -3507,7 +3507,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleAesGcmParams {
         cx: &mut js::context::JSContext,
         algorithm_name: CryptoAlgorithm,
     ) -> Result<Self, Self::Error> {
-        Ok(SubtleAesGcmParams {
+        Ok(AesGcmParams {
             name: algorithm_name,
             iv: get_required_buffer_source(cx, object, c"iv")?,
             additional_data: get_optional_buffer_source(cx, object, c"additionalData")?,
@@ -4885,7 +4885,7 @@ enum EncryptAlgorithm {
     RsaOaep(RsaOaepParams),
     AesCtr(AesCtrParams),
     AesCbc(AesCbcParams),
-    AesGcm(SubtleAesGcmParams),
+    AesGcm(AesGcmParams),
     AesOcb(SubtleAeadParams),
     ChaCha20Poly1305(SubtleAeadParams),
 }
@@ -4972,7 +4972,7 @@ enum DecryptAlgorithm {
     RsaOaep(RsaOaepParams),
     AesCtr(AesCtrParams),
     AesCbc(AesCbcParams),
-    AesGcm(SubtleAesGcmParams),
+    AesGcm(AesGcmParams),
     AesOcb(SubtleAeadParams),
     ChaCha20Poly1305(SubtleAeadParams),
 }

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3260,7 +3260,7 @@ impl From<&EcKeyAlgorithm> for SerializableEcKeyAlgorithm {
 
 /// <https://w3c.github.io/webcrypto/#dfn-EcKeyImportParams>
 #[derive(Clone, MallocSizeOf)]
-struct SubtleEcKeyImportParams {
+struct EcKeyImportParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -3268,7 +3268,7 @@ struct SubtleEcKeyImportParams {
     named_curve: String,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleEcKeyImportParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for EcKeyImportParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -3276,7 +3276,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleEcKeyImportParams {
         cx: &mut js::context::JSContext,
         algorithm_name: CryptoAlgorithm,
     ) -> Result<Self, Self::Error> {
-        Ok(SubtleEcKeyImportParams {
+        Ok(EcKeyImportParams {
             name: algorithm_name,
             named_curve: String::from(get_required_parameter::<DOMString>(
                 cx,
@@ -5771,8 +5771,8 @@ enum ImportKeyAlgorithm {
     RsassaPkcs1V1_5(RsaHashedImportParams),
     RsaPss(RsaHashedImportParams),
     RsaOaep(RsaHashedImportParams),
-    Ecdsa(SubtleEcKeyImportParams),
-    Ecdh(SubtleEcKeyImportParams),
+    Ecdsa(EcKeyImportParams),
+    Ecdh(EcKeyImportParams),
     Ed25519(Algorithm),
     X25519(Algorithm),
     Ed448(Algorithm),

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3351,7 +3351,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for AesCtrParams {
 
 /// <https://w3c.github.io/webcrypto/#dfn-AesKeyAlgorithm>
 #[derive(Clone, MallocSizeOf)]
-pub(crate) struct SubtleAesKeyAlgorithm {
+pub(crate) struct AesKeyAlgorithm {
     /// <https://w3c.github.io/webcrypto/#dom-keyalgorithm-name>
     name: CryptoAlgorithm,
 
@@ -3359,7 +3359,7 @@ pub(crate) struct SubtleAesKeyAlgorithm {
     length: u16,
 }
 
-impl ToJSValConvertible for SubtleAesKeyAlgorithm {
+impl ToJSValConvertible for AesKeyAlgorithm {
     #[expect(unsafe_code)]
     fn safe_to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
         rooted!(&in(cx) let mut object = unsafe { JS_NewObject(cx, ptr::null()) });
@@ -3378,19 +3378,19 @@ impl ToJSValConvertible for SubtleAesKeyAlgorithm {
     }
 }
 
-impl TryFrom<SerializableAesKeyAlgorithm> for SubtleAesKeyAlgorithm {
+impl TryFrom<SerializableAesKeyAlgorithm> for AesKeyAlgorithm {
     type Error = ();
 
     fn try_from(value: SerializableAesKeyAlgorithm) -> Result<Self, Self::Error> {
-        Ok(SubtleAesKeyAlgorithm {
+        Ok(AesKeyAlgorithm {
             name: CryptoAlgorithm::from_str(&value.name).map_err(|_| ())?,
             length: value.length,
         })
     }
 }
 
-impl From<&SubtleAesKeyAlgorithm> for SerializableAesKeyAlgorithm {
-    fn from(value: &SubtleAesKeyAlgorithm) -> Self {
+impl From<&AesKeyAlgorithm> for SerializableAesKeyAlgorithm {
+    fn from(value: &AesKeyAlgorithm) -> Self {
         SerializableAesKeyAlgorithm {
             name: value.name.as_str().into(),
             length: value.length,
@@ -4303,7 +4303,7 @@ pub(crate) enum KeyAlgorithmAndDerivatives {
     KeyAlgorithm(KeyAlgorithm),
     RsaHashedKeyAlgorithm(RsaHashedKeyAlgorithm),
     EcKeyAlgorithm(EcKeyAlgorithm),
-    AesKeyAlgorithm(SubtleAesKeyAlgorithm),
+    AesKeyAlgorithm(AesKeyAlgorithm),
     HmacKeyAlgorithm(SubtleHmacKeyAlgorithm),
     KmacKeyAlgorithm(SubtleKmacKeyAlgorithm),
 }

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -4825,9 +4825,9 @@ fn normalize_algorithm<Op: Operation>(
 // implement the [`Operation`] trait for it. The associated type [`RegisteredAlgorithm`] of
 // [`Operation`]  is set to the [`EncryptAlgorithm`] enum, whose variants are cryptographic
 // algorithms that support the "encrypt" operation. The variant [`EncryptAlgorithm::AesCtr`] has an
-// inner type [`AesCtrParams`] since the desired input IDL dictionary type for "encrypt"
-// operation of AES-CTR algorithm is the `AesCtrParams` dictionary. The [`EncryptAlgorithm`] enum
-// also implements the [`NormalizedAlgorithm`] trait accordingly.
+// inner type [`AesCtrParams`] since the desired input IDL dictionary type for "encrypt" operation
+// of AES-CTR algorithm is the `AesCtrParams` dictionary. The [`EncryptAlgorithm`] enum also
+// implements the [`NormalizedAlgorithm`] trait accordingly.
 //
 // The algorithm registrations are specified in:
 // RSASSA-PKCS1-v1_5: <https://w3c.github.io/webcrypto/#rsassa-pkcs1-registration>

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3430,7 +3430,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for AesKeyGenParams {
 
 /// <https://w3c.github.io/webcrypto/#dfn-AesDerivedKeyParams>
 #[derive(Clone, MallocSizeOf)]
-struct SubtleAesDerivedKeyParams {
+struct AesDerivedKeyParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -3438,7 +3438,7 @@ struct SubtleAesDerivedKeyParams {
     length: u16,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleAesDerivedKeyParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for AesDerivedKeyParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -3446,7 +3446,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleAesDerivedKeyParams {
         cx: &mut js::context::JSContext,
         algorithm_name: CryptoAlgorithm,
     ) -> Result<Self, Self::Error> {
-        Ok(SubtleAesDerivedKeyParams {
+        Ok(AesDerivedKeyParams {
             name: algorithm_name,
             length: get_required_parameter(
                 cx,
@@ -6221,14 +6221,14 @@ impl Operation for GetKeyLengthOperation {
 /// Normalized algorithm for the "get key length" operation, used as output of
 /// <https://w3c.github.io/webcrypto/#dfn-normalize-an-algorithm>
 enum GetKeyLengthAlgorithm {
-    AesCtr(SubtleAesDerivedKeyParams),
-    AesCbc(SubtleAesDerivedKeyParams),
-    AesGcm(SubtleAesDerivedKeyParams),
-    AesKw(SubtleAesDerivedKeyParams),
+    AesCtr(AesDerivedKeyParams),
+    AesCbc(AesDerivedKeyParams),
+    AesGcm(AesDerivedKeyParams),
+    AesKw(AesDerivedKeyParams),
     Hmac(SubtleHmacImportParams),
     Hkdf(Algorithm),
     Pbkdf2(Algorithm),
-    AesOcb(SubtleAesDerivedKeyParams),
+    AesOcb(AesDerivedKeyParams),
     ChaCha20Poly1305(Algorithm),
     Kmac(SubtleKmacImportParams),
     Argon2(Algorithm),

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3180,7 +3180,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for EcdsaParams {
 
 /// <https://w3c.github.io/webcrypto/#dfn-EcKeyGenParams>
 #[derive(Clone, MallocSizeOf)]
-struct SubtleEcKeyGenParams {
+struct EcKeyGenParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -3188,7 +3188,7 @@ struct SubtleEcKeyGenParams {
     named_curve: String,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleEcKeyGenParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for EcKeyGenParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -3196,7 +3196,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleEcKeyGenParams {
         cx: &mut js::context::JSContext,
         algorithm_name: CryptoAlgorithm,
     ) -> Result<Self, Self::Error> {
-        Ok(SubtleEcKeyGenParams {
+        Ok(EcKeyGenParams {
             name: algorithm_name,
             named_curve: String::from(get_required_parameter::<DOMString>(
                 cx,
@@ -5547,8 +5547,8 @@ enum GenerateKeyAlgorithm {
     RsassaPkcs1V1_5(RsaHashedKeyGenParams),
     RsaPss(RsaHashedKeyGenParams),
     RsaOaep(RsaHashedKeyGenParams),
-    Ecdsa(SubtleEcKeyGenParams),
-    Ecdh(SubtleEcKeyGenParams),
+    Ecdsa(EcKeyGenParams),
+    Ecdh(EcKeyGenParams),
     Ed25519(Algorithm),
     X25519(Algorithm),
     Ed448(Algorithm),

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3460,7 +3460,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for AesDerivedKeyParams {
 
 /// <https://w3c.github.io/webcrypto/#dfn-AesCbcParams>
 #[derive(Clone, MallocSizeOf)]
-struct SubtleAesCbcParams {
+struct AesCbcParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -3468,7 +3468,7 @@ struct SubtleAesCbcParams {
     iv: Vec<u8>,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleAesCbcParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for AesCbcParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -3476,7 +3476,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleAesCbcParams {
         cx: &mut js::context::JSContext,
         algorithm_name: CryptoAlgorithm,
     ) -> Result<Self, Self::Error> {
-        Ok(SubtleAesCbcParams {
+        Ok(AesCbcParams {
             name: algorithm_name,
             iv: get_required_buffer_source(cx, object, c"iv")?,
         })
@@ -4884,7 +4884,7 @@ impl Operation for EncryptOperation {
 enum EncryptAlgorithm {
     RsaOaep(RsaOaepParams),
     AesCtr(AesCtrParams),
-    AesCbc(SubtleAesCbcParams),
+    AesCbc(AesCbcParams),
     AesGcm(SubtleAesGcmParams),
     AesOcb(SubtleAeadParams),
     ChaCha20Poly1305(SubtleAeadParams),
@@ -4971,7 +4971,7 @@ impl Operation for DecryptOperation {
 enum DecryptAlgorithm {
     RsaOaep(RsaOaepParams),
     AesCtr(AesCtrParams),
-    AesCbc(SubtleAesCbcParams),
+    AesCbc(AesCbcParams),
     AesGcm(SubtleAesGcmParams),
     AesOcb(SubtleAeadParams),
     ChaCha20Poly1305(SubtleAeadParams),

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3317,7 +3317,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for EcdhKeyDeriveParams {
 
 /// <https://w3c.github.io/webcrypto/#dfn-AesCtrParams>
 #[derive(Clone, MallocSizeOf)]
-struct SubtleAesCtrParams {
+struct AesCtrParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -3328,7 +3328,7 @@ struct SubtleAesCtrParams {
     length: u8,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleAesCtrParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for AesCtrParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -3336,7 +3336,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleAesCtrParams {
         cx: &mut js::context::JSContext,
         algorithm_name: CryptoAlgorithm,
     ) -> Result<Self, Self::Error> {
-        Ok(SubtleAesCtrParams {
+        Ok(AesCtrParams {
             name: algorithm_name,
             counter: get_required_buffer_source(cx, object, c"counter")?,
             length: get_required_parameter(
@@ -4825,7 +4825,7 @@ fn normalize_algorithm<Op: Operation>(
 // implement the [`Operation`] trait for it. The associated type [`RegisteredAlgorithm`] of
 // [`Operation`]  is set to the [`EncryptAlgorithm`] enum, whose variants are cryptographic
 // algorithms that support the "encrypt" operation. The variant [`EncryptAlgorithm::AesCtr`] has an
-// inner type [`SubtleAesCtrParams`] since the desired input IDL dictionary type for "encrypt"
+// inner type [`AesCtrParams`] since the desired input IDL dictionary type for "encrypt"
 // operation of AES-CTR algorithm is the `AesCtrParams` dictionary. The [`EncryptAlgorithm`] enum
 // also implements the [`NormalizedAlgorithm`] trait accordingly.
 //
@@ -4883,7 +4883,7 @@ impl Operation for EncryptOperation {
 /// <https://w3c.github.io/webcrypto/#dfn-normalize-an-algorithm>
 enum EncryptAlgorithm {
     RsaOaep(RsaOaepParams),
-    AesCtr(SubtleAesCtrParams),
+    AesCtr(AesCtrParams),
     AesCbc(SubtleAesCbcParams),
     AesGcm(SubtleAesGcmParams),
     AesOcb(SubtleAeadParams),
@@ -4970,7 +4970,7 @@ impl Operation for DecryptOperation {
 /// <https://w3c.github.io/webcrypto/#dfn-normalize-an-algorithm>
 enum DecryptAlgorithm {
     RsaOaep(RsaOaepParams),
-    AesCtr(SubtleAesCtrParams),
+    AesCtr(AesCtrParams),
     AesCbc(SubtleAesCbcParams),
     AesGcm(SubtleAesGcmParams),
     AesOcb(SubtleAeadParams),

--- a/components/script/dom/webcrypto/subtlecrypto/aes_cbc_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_cbc_operation.rs
@@ -16,7 +16,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
 use crate::dom::subtlecrypto::{
-    ExportedKey, SubtleAesCbcParams, SubtleAesDerivedKeyParams, SubtleAesKeyGenParams, aes_common,
+    ExportedKey, SubtleAesCbcParams, SubtleAesDerivedKeyParams, AesKeyGenParams, aes_common,
 };
 
 /// <https://w3c.github.io/webcrypto/#aes-cbc-operations-encrypt>
@@ -133,7 +133,7 @@ pub(crate) fn decrypt(
 pub(crate) fn generate_key(
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleAesKeyGenParams,
+    normalized_algorithm: &AesKeyGenParams,
     extractable: bool,
     usages: Vec<KeyUsage>,
 ) -> Result<DomRoot<CryptoKey>, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/aes_cbc_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_cbc_operation.rs
@@ -16,7 +16,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
 use crate::dom::subtlecrypto::{
-    ExportedKey, AesCbcParams, AesDerivedKeyParams, AesKeyGenParams, aes_common,
+    AesCbcParams, AesDerivedKeyParams, AesKeyGenParams, ExportedKey, aes_common,
 };
 
 /// <https://w3c.github.io/webcrypto/#aes-cbc-operations-encrypt>

--- a/components/script/dom/webcrypto/subtlecrypto/aes_cbc_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_cbc_operation.rs
@@ -16,12 +16,12 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
 use crate::dom::subtlecrypto::{
-    ExportedKey, SubtleAesCbcParams, AesDerivedKeyParams, AesKeyGenParams, aes_common,
+    ExportedKey, AesCbcParams, AesDerivedKeyParams, AesKeyGenParams, aes_common,
 };
 
 /// <https://w3c.github.io/webcrypto/#aes-cbc-operations-encrypt>
 pub(crate) fn encrypt(
-    normalized_algorithm: &SubtleAesCbcParams,
+    normalized_algorithm: &AesCbcParams,
     key: &CryptoKey,
     plaintext: &[u8],
 ) -> Result<Vec<u8>, Error> {
@@ -69,7 +69,7 @@ pub(crate) fn encrypt(
 
 /// <https://w3c.github.io/webcrypto/#aes-cbc-operations-decrypt>
 pub(crate) fn decrypt(
-    normalized_algorithm: &SubtleAesCbcParams,
+    normalized_algorithm: &AesCbcParams,
     key: &CryptoKey,
     ciphertext: &[u8],
 ) -> Result<Vec<u8>, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/aes_cbc_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_cbc_operation.rs
@@ -16,7 +16,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
 use crate::dom::subtlecrypto::{
-    ExportedKey, SubtleAesCbcParams, SubtleAesDerivedKeyParams, AesKeyGenParams, aes_common,
+    ExportedKey, SubtleAesCbcParams, AesDerivedKeyParams, AesKeyGenParams, aes_common,
 };
 
 /// <https://w3c.github.io/webcrypto/#aes-cbc-operations-encrypt>
@@ -174,7 +174,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
 
 /// <https://w3c.github.io/webcrypto/#aes-cbc-operations-get-key-length>
 pub(crate) fn get_key_length(
-    normalized_derived_key_algorithm: &SubtleAesDerivedKeyParams,
+    normalized_derived_key_algorithm: &AesDerivedKeyParams,
 ) -> Result<Option<u32>, Error> {
     aes_common::get_key_length(normalized_derived_key_algorithm)
 }

--- a/components/script/dom/webcrypto/subtlecrypto/aes_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_common.rs
@@ -18,7 +18,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
-    SubtleAesDerivedKeyParams, AesKeyAlgorithm, SubtleAesKeyGenParams,
+    SubtleAesDerivedKeyParams, AesKeyAlgorithm, AesKeyGenParams,
 };
 
 #[expect(clippy::enum_variant_names)]
@@ -42,7 +42,7 @@ pub(crate) fn generate_key(
     aes_algorithm: AesAlgorithm,
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleAesKeyGenParams,
+    normalized_algorithm: &AesKeyGenParams,
     extractable: bool,
     usages: Vec<KeyUsage>,
 ) -> Result<DomRoot<CryptoKey>, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/aes_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_common.rs
@@ -18,7 +18,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
-    SubtleAesDerivedKeyParams, SubtleAesKeyAlgorithm, SubtleAesKeyGenParams,
+    SubtleAesDerivedKeyParams, AesKeyAlgorithm, SubtleAesKeyGenParams,
 };
 
 #[expect(clippy::enum_variant_names)]
@@ -138,7 +138,7 @@ pub(crate) fn generate_key(
             CryptoAlgorithm::AesOcb
         },
     };
-    let algorithm = SubtleAesKeyAlgorithm {
+    let algorithm = AesKeyAlgorithm {
         name: algorithm_name,
         length: normalized_algorithm.length,
     };
@@ -480,7 +480,7 @@ pub(crate) fn import_key(
             )));
         },
     };
-    let algorithm = SubtleAesKeyAlgorithm {
+    let algorithm = AesKeyAlgorithm {
         name: match &aes_algorithm {
             AesAlgorithm::AesCtr => {
                 // Step 6. Set the name attribute of algorithm to "AES-CTR".

--- a/components/script/dom/webcrypto/subtlecrypto/aes_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_common.rs
@@ -18,7 +18,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
-    SubtleAesDerivedKeyParams, AesKeyAlgorithm, AesKeyGenParams,
+    AesDerivedKeyParams, AesKeyAlgorithm, AesKeyGenParams,
 };
 
 #[expect(clippy::enum_variant_names)]
@@ -757,7 +757,7 @@ pub(crate) fn export_key(
 /// <https://w3c.github.io/webcrypto/#aes-kw-operations-get-key-length>
 /// <https://wicg.github.io/webcrypto-modern-algos/#aes-ocb-operations-get-key-length>
 pub(crate) fn get_key_length(
-    normalized_derived_key_algorithm: &SubtleAesDerivedKeyParams,
+    normalized_derived_key_algorithm: &AesDerivedKeyParams,
 ) -> Result<Option<u32>, Error> {
     // Step 1. If the length member of normalizedDerivedKeyAlgorithm is not 128, 192 or 256, then
     // throw an OperationError.

--- a/components/script/dom/webcrypto/subtlecrypto/aes_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_common.rs
@@ -17,8 +17,8 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
-    AesDerivedKeyParams, AesKeyAlgorithm, AesKeyGenParams,
+    AesDerivedKeyParams, AesKeyAlgorithm, AesKeyGenParams, CryptoAlgorithm, ExportedKey,
+    JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
 };
 
 #[expect(clippy::enum_variant_names)]

--- a/components/script/dom/webcrypto/subtlecrypto/aes_ctr_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_ctr_operation.rs
@@ -16,7 +16,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
 use crate::dom::subtlecrypto::{
-    ExportedKey, AesCtrParams, SubtleAesDerivedKeyParams, SubtleAesKeyGenParams, aes_common,
+    ExportedKey, AesCtrParams, SubtleAesDerivedKeyParams, AesKeyGenParams, aes_common,
 };
 
 /// Use aes::Ctr128BE by default. According to the WebCrypto API specification, the counter MUST be
@@ -147,7 +147,7 @@ pub(crate) fn decrypt(
 pub(crate) fn generate_key(
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleAesKeyGenParams,
+    normalized_algorithm: &AesKeyGenParams,
     extractable: bool,
     usages: Vec<KeyUsage>,
 ) -> Result<DomRoot<CryptoKey>, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/aes_ctr_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_ctr_operation.rs
@@ -16,7 +16,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
 use crate::dom::subtlecrypto::{
-    ExportedKey, SubtleAesCtrParams, SubtleAesDerivedKeyParams, SubtleAesKeyGenParams, aes_common,
+    ExportedKey, AesCtrParams, SubtleAesDerivedKeyParams, SubtleAesKeyGenParams, aes_common,
 };
 
 /// Use aes::Ctr128BE by default. According to the WebCrypto API specification, the counter MUST be
@@ -25,7 +25,7 @@ type Ctr<T> = Ctr128BE<T>;
 
 /// <https://w3c.github.io/webcrypto/#aes-ctr-operations-encrypt>
 pub(crate) fn encrypt(
-    normalized_algorithm: &SubtleAesCtrParams,
+    normalized_algorithm: &AesCtrParams,
     key: &CryptoKey,
     plaintext: &[u8],
 ) -> Result<Vec<u8>, Error> {
@@ -85,7 +85,7 @@ pub(crate) fn encrypt(
 
 /// <https://w3c.github.io/webcrypto/#aes-ctr-operations-decrypt>
 pub(crate) fn decrypt(
-    normalized_algorithm: &SubtleAesCtrParams,
+    normalized_algorithm: &AesCtrParams,
     key: &CryptoKey,
     ciphertext: &[u8],
 ) -> Result<Vec<u8>, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/aes_ctr_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_ctr_operation.rs
@@ -16,7 +16,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
 use crate::dom::subtlecrypto::{
-    ExportedKey, AesCtrParams, SubtleAesDerivedKeyParams, AesKeyGenParams, aes_common,
+    ExportedKey, AesCtrParams, AesDerivedKeyParams, AesKeyGenParams, aes_common,
 };
 
 /// Use aes::Ctr128BE by default. According to the WebCrypto API specification, the counter MUST be
@@ -188,7 +188,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
 
 /// <https://w3c.github.io/webcrypto/#aes-ctr-operations-get-key-length>
 pub(crate) fn get_key_length(
-    normalized_derived_key_algorithm: &SubtleAesDerivedKeyParams,
+    normalized_derived_key_algorithm: &AesDerivedKeyParams,
 ) -> Result<Option<u32>, Error> {
     aes_common::get_key_length(normalized_derived_key_algorithm)
 }

--- a/components/script/dom/webcrypto/subtlecrypto/aes_ctr_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_ctr_operation.rs
@@ -16,7 +16,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
 use crate::dom::subtlecrypto::{
-    ExportedKey, AesCtrParams, AesDerivedKeyParams, AesKeyGenParams, aes_common,
+    AesCtrParams, AesDerivedKeyParams, AesKeyGenParams, ExportedKey, aes_common,
 };
 
 /// Use aes::Ctr128BE by default. According to the WebCrypto API specification, the counter MUST be

--- a/components/script/dom/webcrypto/subtlecrypto/aes_gcm_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_gcm_operation.rs
@@ -18,7 +18,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
 use crate::dom::subtlecrypto::{
-    ExportedKey, AesDerivedKeyParams, AesGcmParams, AesKeyGenParams, aes_common,
+    AesDerivedKeyParams, AesGcmParams, AesKeyGenParams, ExportedKey, aes_common,
 };
 
 /// <https://w3c.github.io/webcrypto/#aes-gcm-operations-encrypt>

--- a/components/script/dom/webcrypto/subtlecrypto/aes_gcm_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_gcm_operation.rs
@@ -18,7 +18,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
 use crate::dom::subtlecrypto::{
-    ExportedKey, SubtleAesDerivedKeyParams, SubtleAesGcmParams, SubtleAesKeyGenParams, aes_common,
+    ExportedKey, SubtleAesDerivedKeyParams, SubtleAesGcmParams, AesKeyGenParams, aes_common,
 };
 
 /// <https://w3c.github.io/webcrypto/#aes-gcm-operations-encrypt>
@@ -463,7 +463,7 @@ where
 pub(crate) fn generate_key(
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleAesKeyGenParams,
+    normalized_algorithm: &AesKeyGenParams,
     extractable: bool,
     usages: Vec<KeyUsage>,
 ) -> Result<DomRoot<CryptoKey>, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/aes_gcm_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_gcm_operation.rs
@@ -18,12 +18,12 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
 use crate::dom::subtlecrypto::{
-    ExportedKey, AesDerivedKeyParams, SubtleAesGcmParams, AesKeyGenParams, aes_common,
+    ExportedKey, AesDerivedKeyParams, AesGcmParams, AesKeyGenParams, aes_common,
 };
 
 /// <https://w3c.github.io/webcrypto/#aes-gcm-operations-encrypt>
 pub(crate) fn encrypt(
-    normalized_algorithm: &SubtleAesGcmParams,
+    normalized_algorithm: &AesGcmParams,
     key: &CryptoKey,
     plaintext: &[u8],
 ) -> Result<Vec<u8>, Error> {
@@ -236,7 +236,7 @@ where
 
 /// <https://w3c.github.io/webcrypto/#aes-gcm-operations-decrypt>
 pub(crate) fn decrypt(
-    normalized_algorithm: &SubtleAesGcmParams,
+    normalized_algorithm: &AesGcmParams,
     key: &CryptoKey,
     ciphertext: &[u8],
 ) -> Result<Vec<u8>, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/aes_gcm_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_gcm_operation.rs
@@ -18,7 +18,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
 use crate::dom::subtlecrypto::{
-    ExportedKey, SubtleAesDerivedKeyParams, SubtleAesGcmParams, AesKeyGenParams, aes_common,
+    ExportedKey, AesDerivedKeyParams, SubtleAesGcmParams, AesKeyGenParams, aes_common,
 };
 
 /// <https://w3c.github.io/webcrypto/#aes-gcm-operations-encrypt>
@@ -504,7 +504,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
 
 /// <https://w3c.github.io/webcrypto/#aes-gcm-operations-get-key-length>
 pub(crate) fn get_key_length(
-    normalized_derived_key_algorithm: &SubtleAesDerivedKeyParams,
+    normalized_derived_key_algorithm: &AesDerivedKeyParams,
 ) -> Result<Option<u32>, Error> {
     aes_common::get_key_length(normalized_derived_key_algorithm)
 }

--- a/components/script/dom/webcrypto/subtlecrypto/aes_kw_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_kw_operation.rs
@@ -14,7 +14,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
 use crate::dom::subtlecrypto::{
-    ExportedKey, SubtleAesDerivedKeyParams, SubtleAesKeyGenParams, aes_common,
+    ExportedKey, SubtleAesDerivedKeyParams, AesKeyGenParams, aes_common,
 };
 
 /// <https://w3c.github.io/webcrypto/#aes-kw-operations-wrap-key>
@@ -100,7 +100,7 @@ pub(crate) fn unwrap_key(key: &CryptoKey, ciphertext: &[u8]) -> Result<Vec<u8>, 
 pub(crate) fn generate_key(
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleAesKeyGenParams,
+    normalized_algorithm: &AesKeyGenParams,
     extractable: bool,
     usages: Vec<KeyUsage>,
 ) -> Result<DomRoot<CryptoKey>, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/aes_kw_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_kw_operation.rs
@@ -13,9 +13,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
-use crate::dom::subtlecrypto::{
-    ExportedKey, AesDerivedKeyParams, AesKeyGenParams, aes_common,
-};
+use crate::dom::subtlecrypto::{AesDerivedKeyParams, AesKeyGenParams, ExportedKey, aes_common};
 
 /// <https://w3c.github.io/webcrypto/#aes-kw-operations-wrap-key>
 pub(crate) fn wrap_key(key: &CryptoKey, plaintext: &[u8]) -> Result<Vec<u8>, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/aes_kw_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_kw_operation.rs
@@ -14,7 +14,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
 use crate::dom::subtlecrypto::{
-    ExportedKey, SubtleAesDerivedKeyParams, AesKeyGenParams, aes_common,
+    ExportedKey, AesDerivedKeyParams, AesKeyGenParams, aes_common,
 };
 
 /// <https://w3c.github.io/webcrypto/#aes-kw-operations-wrap-key>
@@ -141,7 +141,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
 
 /// <https://w3c.github.io/webcrypto/#aes-kw-operations-get-key-length>
 pub(crate) fn get_key_length(
-    normalized_derived_key_algorithm: &SubtleAesDerivedKeyParams,
+    normalized_derived_key_algorithm: &AesDerivedKeyParams,
 ) -> Result<Option<u32>, Error> {
     aes_common::get_key_length(normalized_derived_key_algorithm)
 }

--- a/components/script/dom/webcrypto/subtlecrypto/aes_ocb_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_ocb_operation.rs
@@ -22,7 +22,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
 use crate::dom::subtlecrypto::{
-    ExportedKey, SubtleAeadParams, AesDerivedKeyParams, AesKeyGenParams, aes_common,
+    AesDerivedKeyParams, AesKeyGenParams, ExportedKey, SubtleAeadParams, aes_common,
 };
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#aes-ocb-operations-encrypt>

--- a/components/script/dom/webcrypto/subtlecrypto/aes_ocb_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_ocb_operation.rs
@@ -22,7 +22,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
 use crate::dom::subtlecrypto::{
-    ExportedKey, SubtleAeadParams, SubtleAesDerivedKeyParams, SubtleAesKeyGenParams, aes_common,
+    ExportedKey, SubtleAeadParams, SubtleAesDerivedKeyParams, AesKeyGenParams, aes_common,
 };
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#aes-ocb-operations-encrypt>
@@ -475,7 +475,7 @@ where
 pub(crate) fn generate_key(
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleAesKeyGenParams,
+    normalized_algorithm: &AesKeyGenParams,
     extractable: bool,
     usages: Vec<KeyUsage>,
 ) -> Result<DomRoot<CryptoKey>, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/aes_ocb_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_ocb_operation.rs
@@ -22,7 +22,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
 use crate::dom::subtlecrypto::{
-    ExportedKey, SubtleAeadParams, SubtleAesDerivedKeyParams, AesKeyGenParams, aes_common,
+    ExportedKey, SubtleAeadParams, AesDerivedKeyParams, AesKeyGenParams, aes_common,
 };
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#aes-ocb-operations-encrypt>
@@ -516,7 +516,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#aes-ocb-operations-get-key-length>
 pub(crate) fn get_key_length(
-    normalized_derived_key_algorithm: &SubtleAesDerivedKeyParams,
+    normalized_derived_key_algorithm: &AesDerivedKeyParams,
 ) -> Result<Option<u32>, Error> {
     aes_common::get_key_length(normalized_derived_key_algorithm)
 }

--- a/components/script/dom/webcrypto/subtlecrypto/ec_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ec_common.rs
@@ -20,9 +20,9 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    CryptoAlgorithm, ExportedKey, JwkStringField, KeyAlgorithmAndDerivatives, NAMED_CURVE_P256,
-    NAMED_CURVE_P384, NAMED_CURVE_P521, SUPPORTED_CURVES, EcKeyAlgorithm,
-    EcKeyGenParams, EcKeyImportParams,
+    CryptoAlgorithm, EcKeyAlgorithm, EcKeyGenParams, EcKeyImportParams, ExportedKey,
+    JwkStringField, KeyAlgorithmAndDerivatives, NAMED_CURVE_P256, NAMED_CURVE_P384,
+    NAMED_CURVE_P521, SUPPORTED_CURVES,
 };
 use crate::dom::webcrypto::subtlecrypto::JsonWebKeyExt;
 

--- a/components/script/dom/webcrypto/subtlecrypto/ec_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ec_common.rs
@@ -22,7 +22,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, JwkStringField, KeyAlgorithmAndDerivatives, NAMED_CURVE_P256,
     NAMED_CURVE_P384, NAMED_CURVE_P521, SUPPORTED_CURVES, EcKeyAlgorithm,
-    EcKeyGenParams, SubtleEcKeyImportParams,
+    EcKeyGenParams, EcKeyImportParams,
 };
 use crate::dom::webcrypto::subtlecrypto::JsonWebKeyExt;
 
@@ -212,7 +212,7 @@ pub(crate) fn import_key(
     ec_algorithm: EcAlgorithm,
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleEcKeyImportParams,
+    normalized_algorithm: &EcKeyImportParams,
     format: KeyFormat,
     key_data: &[u8],
     extractable: bool,

--- a/components/script/dom/webcrypto/subtlecrypto/ec_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ec_common.rs
@@ -21,7 +21,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, JwkStringField, KeyAlgorithmAndDerivatives, NAMED_CURVE_P256,
-    NAMED_CURVE_P384, NAMED_CURVE_P521, SUPPORTED_CURVES, SubtleEcKeyAlgorithm,
+    NAMED_CURVE_P384, NAMED_CURVE_P521, SUPPORTED_CURVES, EcKeyAlgorithm,
     EcKeyGenParams, SubtleEcKeyImportParams,
 };
 use crate::dom::webcrypto::subtlecrypto::JsonWebKeyExt;
@@ -124,7 +124,7 @@ pub(crate) fn generate_key(
     // Step 4. Let algorithm be a new EcKeyAlgorithm object.
     // Step 6. Set the namedCurve attribute of algorithm to equal the namedCurve member of
     // normalizedAlgorithm.
-    let algorithm = SubtleEcKeyAlgorithm {
+    let algorithm = EcKeyAlgorithm {
         name: match ec_algorithm {
             EcAlgorithm::Ecdsa => {
                 // Step 5. Set the name attribute of algorithm to "ECDSA".
@@ -315,7 +315,7 @@ pub(crate) fn import_key(
             // Step 2.14. Let algorithm be a new EcKeyAlgorithm.
             // Step 2.16. Set the namedCurve attribute of algorithm to namedCurve.
             // Step 2.17. Set the [[algorithm]] internal slot of key to algorithm.
-            let algorithm = SubtleEcKeyAlgorithm {
+            let algorithm = EcKeyAlgorithm {
                 name: match ec_algorithm {
                     EcAlgorithm::Ecdsa => {
                         // Step 2.15. Set the name attribute of algorithm to "ECDSA".
@@ -444,7 +444,7 @@ pub(crate) fn import_key(
             // Step 2.14. Let algorithm be a new EcKeyAlgorithm.
             // Step 2.16. Set the namedCurve attribute of algorithm to namedCurve.
             // Step 2.17. Set the [[algorithm]] internal slot of key to algorithm.
-            let algorithm = SubtleEcKeyAlgorithm {
+            let algorithm = EcKeyAlgorithm {
                 name: match ec_algorithm {
                     EcAlgorithm::Ecdsa => {
                         // Step 2.15. Set the name attribute of algorithm to "ECDSA".
@@ -733,7 +733,7 @@ pub(crate) fn import_key(
             // Step 2.11. Let algorithm be a new instance of an EcKeyAlgorithm object.
             // Step 2.13. Set the namedCurve attribute of algorithm to namedCurve.
             // Step 2.14. Set the [[algorithm]] internal slot of key to algorithm.
-            let algorithm = SubtleEcKeyAlgorithm {
+            let algorithm = EcKeyAlgorithm {
                 name: match ec_algorithm {
                     EcAlgorithm::Ecdsa => {
                         // Step 2.12. Set the name attribute of algorithm to "ECDSA".
@@ -836,7 +836,7 @@ pub(crate) fn import_key(
             // Step 2.4. Let algorithm be a new EcKeyAlgorithm object.
             // Step 2.6. Set the namedCurve attribute of algorithm to equal the namedCurve member
             // of normalizedAlgorithm.
-            let algorithm = SubtleEcKeyAlgorithm {
+            let algorithm = EcKeyAlgorithm {
                 name: match ec_algorithm {
                     EcAlgorithm::Ecdsa => {
                         // Step 2.5. Set the name attribute of algorithm to "ECDSA".

--- a/components/script/dom/webcrypto/subtlecrypto/ec_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ec_common.rs
@@ -22,7 +22,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, JwkStringField, KeyAlgorithmAndDerivatives, NAMED_CURVE_P256,
     NAMED_CURVE_P384, NAMED_CURVE_P521, SUPPORTED_CURVES, SubtleEcKeyAlgorithm,
-    SubtleEcKeyGenParams, SubtleEcKeyImportParams,
+    EcKeyGenParams, SubtleEcKeyImportParams,
 };
 use crate::dom::webcrypto::subtlecrypto::JsonWebKeyExt;
 
@@ -38,7 +38,7 @@ pub(crate) fn generate_key(
     ec_algorithm: EcAlgorithm,
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleEcKeyGenParams,
+    normalized_algorithm: &EcKeyGenParams,
     extractable: bool,
     usages: Vec<KeyUsage>,
 ) -> Result<CryptoKeyPair, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/ecdh_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ecdh_operation.rs
@@ -23,14 +23,14 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::ec_common::EcAlgorithm;
 use crate::dom::subtlecrypto::{
     ExportedKey, KeyAlgorithmAndDerivatives, NAMED_CURVE_P256, NAMED_CURVE_P384, NAMED_CURVE_P521,
-    SubtleEcKeyGenParams, SubtleEcKeyImportParams, SubtleEcdhKeyDeriveParams, ec_common,
+    EcKeyGenParams, SubtleEcKeyImportParams, SubtleEcdhKeyDeriveParams, ec_common,
 };
 
 /// <https://w3c.github.io/webcrypto/#ecdh-operations-generate-key>
 pub(crate) fn generate_key(
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleEcKeyGenParams,
+    normalized_algorithm: &EcKeyGenParams,
     extractable: bool,
     usages: Vec<KeyUsage>,
 ) -> Result<CryptoKeyPair, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/ecdh_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ecdh_operation.rs
@@ -22,8 +22,8 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::ec_common::EcAlgorithm;
 use crate::dom::subtlecrypto::{
-    ExportedKey, KeyAlgorithmAndDerivatives, NAMED_CURVE_P256, NAMED_CURVE_P384, NAMED_CURVE_P521,
-    EcKeyGenParams, EcKeyImportParams, EcdhKeyDeriveParams, ec_common,
+    EcKeyGenParams, EcKeyImportParams, EcdhKeyDeriveParams, ExportedKey,
+    KeyAlgorithmAndDerivatives, NAMED_CURVE_P256, NAMED_CURVE_P384, NAMED_CURVE_P521, ec_common,
 };
 
 /// <https://w3c.github.io/webcrypto/#ecdh-operations-generate-key>
@@ -241,9 +241,7 @@ pub(crate) fn get_public_key(
 /// Given a normalizedAlgorithm (an EcdhKeyDeriveParams dictionary), return the length of the secret
 /// derived by the named curve specified by the `named_curve` member of the `[[algorithm]]` slot of
 /// the `public` member of normalizedAlgorithm.
-pub(crate) fn secret_length(
-    normalized_algorithm: &EcdhKeyDeriveParams,
-) -> Result<u32, Error> {
+pub(crate) fn secret_length(normalized_algorithm: &EcdhKeyDeriveParams) -> Result<u32, Error> {
     let public_key = normalized_algorithm.public.root();
     let KeyAlgorithmAndDerivatives::EcKeyAlgorithm(algorithm) = public_key.algorithm() else {
         return Err(Error::Operation(Some(

--- a/components/script/dom/webcrypto/subtlecrypto/ecdh_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ecdh_operation.rs
@@ -23,7 +23,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::ec_common::EcAlgorithm;
 use crate::dom::subtlecrypto::{
     ExportedKey, KeyAlgorithmAndDerivatives, NAMED_CURVE_P256, NAMED_CURVE_P384, NAMED_CURVE_P521,
-    EcKeyGenParams, EcKeyImportParams, SubtleEcdhKeyDeriveParams, ec_common,
+    EcKeyGenParams, EcKeyImportParams, EcdhKeyDeriveParams, ec_common,
 };
 
 /// <https://w3c.github.io/webcrypto/#ecdh-operations-generate-key>
@@ -46,7 +46,7 @@ pub(crate) fn generate_key(
 
 /// <https://w3c.github.io/webcrypto/#ecdh-operations-derive-bits>
 pub(crate) fn derive_bits(
-    normalized_algorithm: &SubtleEcdhKeyDeriveParams,
+    normalized_algorithm: &EcdhKeyDeriveParams,
     key: &CryptoKey,
     length: Option<u32>,
 ) -> Result<Vec<u8>, Error> {
@@ -242,7 +242,7 @@ pub(crate) fn get_public_key(
 /// derived by the named curve specified by the `named_curve` member of the `[[algorithm]]` slot of
 /// the `public` member of normalizedAlgorithm.
 pub(crate) fn secret_length(
-    normalized_algorithm: &SubtleEcdhKeyDeriveParams,
+    normalized_algorithm: &EcdhKeyDeriveParams,
 ) -> Result<u32, Error> {
     let public_key = normalized_algorithm.public.root();
     let KeyAlgorithmAndDerivatives::EcKeyAlgorithm(algorithm) = public_key.algorithm() else {

--- a/components/script/dom/webcrypto/subtlecrypto/ecdh_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ecdh_operation.rs
@@ -23,7 +23,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::ec_common::EcAlgorithm;
 use crate::dom::subtlecrypto::{
     ExportedKey, KeyAlgorithmAndDerivatives, NAMED_CURVE_P256, NAMED_CURVE_P384, NAMED_CURVE_P521,
-    EcKeyGenParams, SubtleEcKeyImportParams, SubtleEcdhKeyDeriveParams, ec_common,
+    EcKeyGenParams, EcKeyImportParams, SubtleEcdhKeyDeriveParams, ec_common,
 };
 
 /// <https://w3c.github.io/webcrypto/#ecdh-operations-generate-key>
@@ -203,7 +203,7 @@ pub(crate) fn derive_bits(
 pub(crate) fn import_key(
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleEcKeyImportParams,
+    normalized_algorithm: &EcKeyImportParams,
     format: KeyFormat,
     key_data: &[u8],
     extractable: bool,

--- a/components/script/dom/webcrypto/subtlecrypto/ecdsa_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ecdsa_operation.rs
@@ -19,8 +19,8 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::ec_common::EcAlgorithm;
 use crate::dom::subtlecrypto::{
-    ExportedKey, KeyAlgorithmAndDerivatives, NAMED_CURVE_P256, NAMED_CURVE_P384, NAMED_CURVE_P521,
-    EcKeyGenParams, EcKeyImportParams, EcdsaParams, ec_common,
+    EcKeyGenParams, EcKeyImportParams, EcdsaParams, ExportedKey, KeyAlgorithmAndDerivatives,
+    NAMED_CURVE_P256, NAMED_CURVE_P384, NAMED_CURVE_P521, ec_common,
 };
 
 /// <https://w3c.github.io/webcrypto/#ecdsa-operations-sign>

--- a/components/script/dom/webcrypto/subtlecrypto/ecdsa_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ecdsa_operation.rs
@@ -20,12 +20,12 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::ec_common::EcAlgorithm;
 use crate::dom::subtlecrypto::{
     ExportedKey, KeyAlgorithmAndDerivatives, NAMED_CURVE_P256, NAMED_CURVE_P384, NAMED_CURVE_P521,
-    SubtleEcKeyGenParams, SubtleEcKeyImportParams, SubtleEcdsaParams, ec_common,
+    SubtleEcKeyGenParams, SubtleEcKeyImportParams, EcdsaParams, ec_common,
 };
 
 /// <https://w3c.github.io/webcrypto/#ecdsa-operations-sign>
 pub(crate) fn sign(
-    normalized_algorithm: &SubtleEcdsaParams,
+    normalized_algorithm: &EcdsaParams,
     key: &CryptoKey,
     message: &[u8],
 ) -> Result<Vec<u8>, Error> {
@@ -120,7 +120,7 @@ pub(crate) fn sign(
 
 /// <https://w3c.github.io/webcrypto/#ecdsa-operations-verify>
 pub(crate) fn verify(
-    normalized_algorithm: &SubtleEcdsaParams,
+    normalized_algorithm: &EcdsaParams,
     key: &CryptoKey,
     message: &[u8],
     signature: &[u8],

--- a/components/script/dom/webcrypto/subtlecrypto/ecdsa_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ecdsa_operation.rs
@@ -20,7 +20,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::ec_common::EcAlgorithm;
 use crate::dom::subtlecrypto::{
     ExportedKey, KeyAlgorithmAndDerivatives, NAMED_CURVE_P256, NAMED_CURVE_P384, NAMED_CURVE_P521,
-    SubtleEcKeyGenParams, SubtleEcKeyImportParams, EcdsaParams, ec_common,
+    EcKeyGenParams, SubtleEcKeyImportParams, EcdsaParams, ec_common,
 };
 
 /// <https://w3c.github.io/webcrypto/#ecdsa-operations-sign>
@@ -222,7 +222,7 @@ pub(crate) fn verify(
 pub(crate) fn generate_key(
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleEcKeyGenParams,
+    normalized_algorithm: &EcKeyGenParams,
     extractable: bool,
     usages: Vec<KeyUsage>,
 ) -> Result<CryptoKeyPair, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/ecdsa_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ecdsa_operation.rs
@@ -20,7 +20,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::ec_common::EcAlgorithm;
 use crate::dom::subtlecrypto::{
     ExportedKey, KeyAlgorithmAndDerivatives, NAMED_CURVE_P256, NAMED_CURVE_P384, NAMED_CURVE_P521,
-    EcKeyGenParams, SubtleEcKeyImportParams, EcdsaParams, ec_common,
+    EcKeyGenParams, EcKeyImportParams, EcdsaParams, ec_common,
 };
 
 /// <https://w3c.github.io/webcrypto/#ecdsa-operations-sign>
@@ -240,7 +240,7 @@ pub(crate) fn generate_key(
 pub(crate) fn import_key(
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleEcKeyImportParams,
+    normalized_algorithm: &EcKeyImportParams,
     format: KeyFormat,
     key_data: &[u8],
     extractable: bool,

--- a/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
@@ -19,8 +19,8 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithm,
-    KeyAlgorithmAndDerivatives, EcdhKeyDeriveParams,
+    CryptoAlgorithm, EcdhKeyDeriveParams, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithm,
+    KeyAlgorithmAndDerivatives,
 };
 
 /// `id-X25519` object identifier defined in [RFC8410]

--- a/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
@@ -20,7 +20,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithm,
-    KeyAlgorithmAndDerivatives, SubtleEcdhKeyDeriveParams,
+    KeyAlgorithmAndDerivatives, EcdhKeyDeriveParams,
 };
 
 /// `id-X25519` object identifier defined in [RFC8410]
@@ -32,7 +32,7 @@ pub(crate) const SECRET_LENGTH: usize = 32;
 
 /// <https://w3c.github.io/webcrypto/#x25519-operations-derive-bits>
 pub(crate) fn derive_bits(
-    normalized_algorithm: &SubtleEcdhKeyDeriveParams,
+    normalized_algorithm: &EcdhKeyDeriveParams,
     key: &CryptoKey,
     length: Option<u32>,
 ) -> Result<Vec<u8>, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/x448_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/x448_operation.rs
@@ -21,7 +21,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithm,
-    KeyAlgorithmAndDerivatives, SubtleEcdhKeyDeriveParams,
+    KeyAlgorithmAndDerivatives, EcdhKeyDeriveParams,
 };
 
 /// `id-X448` object identifier defined in [RFC8410]
@@ -32,7 +32,7 @@ pub(crate) const SECRET_LENGTH: usize = 56;
 
 /// <https://wicg.github.io/webcrypto-secure-curves/#x448>
 pub(crate) fn derive_bits(
-    normalized_algorithm: &SubtleEcdhKeyDeriveParams,
+    normalized_algorithm: &EcdhKeyDeriveParams,
     key: &CryptoKey,
     length: Option<u32>,
 ) -> Result<Vec<u8>, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/x448_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/x448_operation.rs
@@ -20,8 +20,8 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithm,
-    KeyAlgorithmAndDerivatives, EcdhKeyDeriveParams,
+    CryptoAlgorithm, EcdhKeyDeriveParams, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithm,
+    KeyAlgorithmAndDerivatives,
 };
 
 /// `id-X448` object identifier defined in [RFC8410]


### PR DESCRIPTION
Rename the following structs:

`SubtleEcdsaParams` to `EcdsaParams`
`SubtleEcKeyGenParams` to `EcKeyGenParams`
`SubtleEcKeyAlgorithm` to `EcKeyAlgorithm`
`SubtleEcKeyImportParams` to ` EcKeyImportParams`
`SubtleEcdhKeyDeriveParams` to ` EcdhKeyDeriveParams`
`SubtleAesCtrParams` to `AesCtrParams`
`SubtleAesKeyAlgorithm` to `AesKeyAlgorithm`
`SubtleAesKeyGenParams` to `AesKeyGenParams`
`SubtleAesDerivedKeyParams` to `AesDerivedKeyParams`
`SubtleAesCbcParams` to `AesCbcParams`
`SubtleAesGcmParams` to `AesGcmParams`

This is part of #46948 in order to replace the generated binding types with custom binding types for WebCrypto.

Testing: It compiles.
Part-of: #46948