### PR TITLE
fonts: Replace AtomicRefCell with RwLock for resolving font variant alternates

### DIFF
--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -11,7 +11,6 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use app_units::Au;
-use atomic_refcell::AtomicRefCell;
 use content_security_policy::Violation;
 use fonts_traits::{
     CSSFontFaceDescriptors, FontDescriptor, FontFaceRuleWithOrigin, FontIdentifier, FontTemplate,
@@ -125,7 +124,7 @@ pub struct FontContext {
     known_font_face_rules: Mutex<KnownFontFaceRules>,
 
     /// A lazily-computed map of feature names from `@font-feature-value` rules.
-    font_feature_value_map: AtomicRefCell<Option<FontFeatureValueMap>>,
+    font_feature_value_map: RwLock<Option<FontFeatureValueMap>>,
 
     /// The number of fonts that are currently loading.
     number_of_loading_web_fonts: AtomicUsize,
@@ -1212,14 +1211,14 @@ impl FontContext {
         stylist: &Stylist,
     ) -> Option<FontFeatureValue> {
         // First, check if the map was initialized previously.
-        let read_guard = self.font_feature_value_map.borrow();
+        let read_guard = self.font_feature_value_map.read();
         if let Some(map) = &*read_guard {
             // This is the cheap case, we just need to read from the map
             map.lookup(family_name, kind, name)
         } else {
             // Map was not initialized yet - need to acquire a mutable guard and initialize it.
             drop(read_guard);
-            let mut write_guard = self.font_feature_value_map.borrow_mut();
+            let mut write_guard = self.font_feature_value_map.write();
             if let Some(map) = &*write_guard {
                 // We lost a race, some other thread initialized the map while we were waiting
                 // on the lock.
@@ -1239,7 +1238,7 @@ impl FontContext {
     }
 
     pub fn invalidate_font_feature_values_map(&self) {
-        self.font_feature_value_map.borrow_mut().take();
+        self.font_feature_value_map.write().take();
     }
 }
 


### PR DESCRIPTION
When upgrading the lock from a read lock to a write lock to initialize the map of font variant alternates then we need to wait until all other threads have also dropped their read guards, otherwise we run into panics. `AtomicRefCell` doesn't wait, causing https://github.com/servo/servo/issues/47352. Instead we can use to a `RwLock`.

I'm fairly sure I did initially used a RwLock when implementing `font-variant-alternates`, but apparently I switched to a `AtomicRefCell` at some point :/

Testing: This issue is intermittent and I don't think there's a way to test for it reliably.
Fixes: https://github.com/servo/servo/issues/47352