### PR TITLE
base: Switch all occurences in generic_channel to use fn use_ipc instead of checking options

### DIFF
--- a/components/shared/base/generic_channel/lazy_callback.rs
+++ b/components/shared/base/generic_channel/lazy_callback.rs
@@ -24,7 +24,6 @@ use malloc_size_of::{MallocSizeOf as MallocSizeOfTrait, MallocSizeOfOps};
 use malloc_size_of_derive::MallocSizeOf;
 use serde::de::VariantAccess;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use servo_config::opts;
 
 use crate::generic_channel::{GenericCallback, SendError, SendResult, use_ipc};
 
@@ -275,7 +274,7 @@ pub fn lazy_callback<T>() -> (LazyCallback<T>, CallbackSetter<T>)
 where
     T: Serialize + for<'de> Deserialize<'de> + Send + 'static,
 {
-    if opts::get().multiprocess || opts::get().force_ipc {
+    if use_ipc() {
         lazy_callback_ipc()
     } else {
         lazy_callback_inprocess()

--- a/components/shared/base/generic_channel/shared_memory.rs
+++ b/components/shared/base/generic_channel/shared_memory.rs
@@ -10,7 +10,8 @@ use ipc_channel::ipc::IpcSharedMemory;
 use malloc_size_of::MallocSizeOf;
 use serde::de::VariantAccess;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use servo_config::opts;
+
+use crate::generic_channel::use_ipc;
 
 #[derive(Clone)]
 pub struct GenericSharedMemory(GenericSharedMemoryVariant);
@@ -50,7 +51,7 @@ impl MallocSizeOf for GenericSharedMemory {
 
 impl GenericSharedMemory {
     pub fn from_bytes(bytes: &[u8]) -> Self {
-        if servo_config::opts::get().multiprocess || servo_config::opts::get().force_ipc {
+        if use_ipc() {
             GenericSharedMemory(GenericSharedMemoryVariant::Ipc(
                 IpcSharedMemory::from_bytes(bytes),
             ))
@@ -62,7 +63,7 @@ impl GenericSharedMemory {
     }
 
     pub fn from_byte(data: u8, length: usize) -> Self {
-        if servo_config::opts::get().multiprocess || servo_config::opts::get().force_ipc {
+        if use_ipc() {
             GenericSharedMemory(GenericSharedMemoryVariant::Ipc(IpcSharedMemory::from_byte(
                 data, length,
             )))
@@ -80,7 +81,7 @@ impl GenericSharedMemory {
     /// allocating a new Arc. Prefer over `Self::from_bytes` if ownership is
     /// transferred.
     pub fn from_vec(bytes: Vec<u8>) -> Self {
-        if servo_config::opts::get().multiprocess || servo_config::opts::get().force_ipc {
+        if use_ipc() {
             GenericSharedMemory(GenericSharedMemoryVariant::Ipc(
                 IpcSharedMemory::from_bytes(&bytes),
             ))
@@ -93,7 +94,7 @@ impl GenericSharedMemory {
     ///
     /// In single-process mode this allows creating shared memory without copying.
     pub fn from_arc_vec(arc: Arc<Vec<u8>>) -> Self {
-        if servo_config::opts::get().multiprocess || servo_config::opts::get().force_ipc {
+        if use_ipc() {
             GenericSharedMemory(GenericSharedMemoryVariant::Ipc(
                 IpcSharedMemory::from_bytes(&arc),
             ))
@@ -145,7 +146,7 @@ impl Serialize for GenericSharedMemory {
                 s.serialize_newtype_variant("GenericSharedMemory", 0, "Ipc", memory)
             },
             GenericSharedMemoryVariant::InProcess(arc) => {
-                if opts::get().multiprocess || opts::get().force_ipc {
+                if use_ipc() {
                     return Err(serde::ser::Error::custom(
                         "Arc<Vec<u8>> found in multiprocess mode!",
                     ));
@@ -184,7 +185,7 @@ impl<'de> serde::de::Visitor<'de> for GenericSharedMemoryVisitor {
                 .newtype_variant::<IpcSharedMemory>()
                 .map(|receiver| GenericSharedMemory(GenericSharedMemoryVariant::Ipc(receiver))),
             GenericSharedMemoryVariantNames::InProcess => {
-                if opts::get().multiprocess || servo_config::opts::get().force_ipc {
+                if use_ipc() {
                     return Err(serde::de::Error::custom(
                         "Arc data found in multiprocess mode!",
                     ));


### PR DESCRIPTION
This switches GenericSharedMemory and LazyCallback to use the use_ipc() function for deciding instead of manually checkking opts and prefs.

Testing: This is just a refactor so does not need special tests.
