### PR TITLE
ohos: Better keyboard support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12485,9 +12485,9 @@ dependencies = [
 
 [[package]]
 name = "xcomponent-sys"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f3d0f0bc477f9a5e25bcdede5520c27faa2b39d505f867d836f43f99189add"
+checksum = "50ea5fc2cd5a198d7ceaf9b50985a966459dd50cdc7d95fbc8d085a721080113"
 dependencies = [
  "arkui-sys",
  "keyboard-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -289,7 +289,7 @@ wio = "0.2"
 wr_malloc_size_of = "0.2.2"
 x25519-dalek = { version = "3.0", features = ["getrandom", "static_secrets", "zeroize"] }
 x448 = { version = "=0.14.0-pre.12", features = ["static_secrets"] }
-xcomponent-sys = "0.3.6"
+xcomponent-sys = "0.4.0"
 xml = "1.1"
 xml5ever = "0.39"
 yuv = { version = "0.8.14", features = ["rayon"] }

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -120,7 +120,7 @@ ohos-vsync = { workspace = true }
 ohos-window-sys = { workspace = true }
 ohos-sys-opaque-types = { workspace = true }
 ohos-window-manager-sys = { workspace = true, features = ["api-14"] }
-xcomponent-sys = { workspace = true, features = ["api-14", "keyboard-types"] }
+xcomponent-sys = { workspace = true, features = ["api-20", "keyboard-types"] }
 
 [target.'cfg(any(target_os = "android", target_env = "ohos"))'.dependencies]
 nix = { workspace = true, features = ["fs"] }

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -613,6 +613,13 @@ impl App {
         }
     }
 
+    pub fn key_event(&self, event: keyboard_types::KeyboardEvent) {
+        if let Some(webview) = self.active_or_newest_webview() {
+            webview.notify_input_event(InputEvent::Keyboard(KeyboardEvent::new(event)));
+            self.spin_event_loop();
+        }
+    }
+
     pub fn ime_insert_text(&self, text: String) {
         // In OHOS, we get empty text after the intended text.
         if text.is_empty() {

--- a/ports/servoshell/egl/ohos/mod.rs
+++ b/ports/servoshell/egl/ohos/mod.rs
@@ -64,7 +64,7 @@ use std::ptr::NonNull;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, Sender};
-use std::sync::{LazyLock, Once, OnceLock, mpsc};
+use std::sync::{LazyLock, Mutex, Once, OnceLock, mpsc};
 use std::{fs, thread};
 
 use euclid::{Point2D, Rect, Scale, Size2D};
@@ -89,9 +89,12 @@ use servo::{
     self, DevicePixel, EventLoopWaker, InputMethodControl, InputMethodType, LoadStatus,
     MediaSessionPlaybackState, PrefValue, SelectElement, WebViewId, Zero,
 };
+use xcomponent_sys::keyboard_types_compat::{KeyEventConverter, ModifierState};
 use xcomponent_sys::{
     OH_NativeXComponent, OH_NativeXComponent_Callback, OH_NativeXComponent_GetKeyEvent,
-    OH_NativeXComponent_GetKeyEventAction, OH_NativeXComponent_GetKeyEventCode,
+    OH_NativeXComponent_GetKeyEventAction, OH_NativeXComponent_GetKeyEventCapsLockState,
+    OH_NativeXComponent_GetKeyEventCode, OH_NativeXComponent_GetKeyEventModifierKeyStates,
+    OH_NativeXComponent_GetKeyEventNumLockState, OH_NativeXComponent_GetKeyEventScrollLockState,
     OH_NativeXComponent_GetTouchEvent, OH_NativeXComponent_GetXComponentOffset,
     OH_NativeXComponent_GetXComponentSize, OH_NativeXComponent_KeyAction,
     OH_NativeXComponent_KeyCode, OH_NativeXComponent_KeyEvent,
@@ -124,6 +127,8 @@ static PROMPT_TOAST: OnceLock<
     ThreadsafeFunction<String, (), String, napi_ohos::Status, false, false, PROMPT_QUEUE_SIZE>,
 > = OnceLock::new();
 static NEXT_WINDOW_ID: AtomicU64 = AtomicU64::new(0);
+
+static KEY_EVENT_CONVERTER: Mutex<KeyEventConverter> = Mutex::new(KeyEventConverter::new());
 
 static SERVO_CHANNEL: OnceLock<Sender<ServoAction>> = OnceLock::new();
 
@@ -371,8 +376,7 @@ pub(super) enum ServoAction {
         y: f32,
         pointer_id: i32,
     },
-    KeyUp(Key),
-    KeyDown(Key),
+    KeyEvent(keyboard_types::KeyboardEvent),
     InsertText(String),
     ImeDeleteForward(usize),
     ImeDeleteBackward(usize),
@@ -407,8 +411,7 @@ impl std::fmt::Debug for ServoAction {
                 .field("y", y)
                 .field("pointer_id", pointer_id)
                 .finish(),
-            Self::KeyUp(arg0) => f.debug_tuple("KeyUp").field(arg0).finish(),
-            Self::KeyDown(arg0) => f.debug_tuple("KeyDown").field(arg0).finish(),
+            Self::KeyEvent(_) => f.debug_struct("KeyEvent").finish(),
             Self::InsertText(arg0) => f.debug_tuple("InsertText").field(arg0).finish(),
             Self::ImeDeleteForward(arg0) => f.debug_tuple("ImeDeleteForward").field(arg0).finish(),
             Self::ImeDeleteBackward(arg0) => {
@@ -467,8 +470,7 @@ impl ServoAction {
                 y,
                 pointer_id,
             } => Self::dispatch_touch_event(servo, *kind, *x, *y, *pointer_id),
-            KeyUp(k) => servo.key_up(k.clone()),
-            KeyDown(k) => servo.key_down(k.clone()),
+            KeyEvent(k) => servo.key_event(k.clone()),
             InsertText(text) => servo.ime_insert_text(text.clone()),
             ImeDeleteForward(len) => {
                 for _ in 0..*len {
@@ -755,6 +757,11 @@ extern "C" fn on_dispatch_touch_event_cb(component: *mut OH_NativeXComponent, wi
 }
 
 extern "C" fn on_dispatch_key_event(xc: *mut OH_NativeXComponent, _window: *mut c_void) {
+    // See <https://docs.rs/arkui-sys/latest/arkui_sys/ui_input_event/struct.ArkUI_ModifierKeyName.html#impl-ArkUI_ModifierKeyName>
+    const MODIFIER_KEY_CTRL: u64 = 1;
+    const MODIFIER_KEY_SHIFT: u64 = 2;
+    const MODIFIER_KEY_ALT: u64 = 4;
+
     info!("DispatchKeyEvent");
     let mut event: *mut OH_NativeXComponent_KeyEvent = core::ptr::null_mut();
     let res = unsafe { OH_NativeXComponent_GetKeyEvent(xc, &mut event as *mut *mut _) };
@@ -768,22 +775,40 @@ extern "C" fn on_dispatch_key_event(xc: *mut OH_NativeXComponent, _window: *mut 
     let res = unsafe { OH_NativeXComponent_GetKeyEventCode(event, &mut keycode as *mut _) };
     assert_eq!(res, 0);
 
-    // Simplest possible impl, just for testing purposes
-    let code: keyboard_types::Code = keycode.into();
-    // There currently doesn't seem to be an API to query keymap / keyboard layout, so
-    // we don't even bother implementing modifier support for now, since we expect to be using the
-    // IME most of the time anyway. We can revisit this when someone has an OH device with a
-    // physical keyboard.
-    let char = code.to_string();
-    let key = Key::Character(char);
-    match action {
-        OH_NativeXComponent_KeyAction::OH_NATIVEXCOMPONENT_KEY_ACTION_UP => {
-            call(ServoAction::KeyUp(key)).expect("Call failed")
+    let mut modifier_bits: u64 = 0;
+    let res =
+        unsafe { OH_NativeXComponent_GetKeyEventModifierKeyStates(event, &raw mut modifier_bits) };
+    if res != 0 {
+        warn!("GetKeyEventModifierKeyStates failed with {res}");
+    }
+    let mut caps_lock = false;
+    let mut num_lock = false;
+    let mut scroll_lock = false;
+    unsafe {
+        OH_NativeXComponent_GetKeyEventCapsLockState(event, &raw mut caps_lock);
+        OH_NativeXComponent_GetKeyEventNumLockState(event, &raw mut num_lock);
+        OH_NativeXComponent_GetKeyEventScrollLockState(event, &raw mut scroll_lock);
+    }
+    let modifiers = ModifierState {
+        shift: modifier_bits & MODIFIER_KEY_SHIFT != 0,
+        ctrl: modifier_bits & MODIFIER_KEY_CTRL != 0,
+        alt: modifier_bits & MODIFIER_KEY_ALT != 0,
+        meta: None,
+        caps_lock,
+        num_lock,
+        scroll_lock,
+    };
+
+    let converted = KEY_EVENT_CONVERTER
+        .lock()
+        .unwrap()
+        .convert(action, keycode, modifiers);
+    match converted {
+        Some(key_event) => {
+            debug!("Dispatching key event {key_event:?}");
+            call(ServoAction::KeyEvent(key_event)).expect("Call failed")
         },
-        OH_NativeXComponent_KeyAction::OH_NATIVEXCOMPONENT_KEY_ACTION_DOWN => {
-            call(ServoAction::KeyDown(key)).expect("Call failed")
-        },
-        _ => error!("Unknown key action {:?}", action),
+        None => error!("Unknown key action {:?}", action),
     }
 }
 

--- a/support/openharmony/entry/src/main/ets/pages/Index.ets
+++ b/support/openharmony/entry/src/main/ets/pages/Index.ets
@@ -122,6 +122,7 @@ struct Index {
           TabContent() {
             XComponent(this.xComponentAttrs)
               .focusable(true)
+              .focusOnTouch(true)
           }.tabBar(this.tabBuilder(String(item), index))
         })
       }.barHeight(40)


### PR DESCRIPTION
For physical keyboards we need to translate the OH KeyEventCode into a KeyEvent with a Unicode character, taking into account keyboard state (like shift or caps lock).
Since OH still doesn't have a keyboard layout API, this is greatly simplified due to only needing to support US keyboard layout. The actual conversion is handled in the xcomponent-sys crate.

This now allows typing with a real (US-layout) keyboard to work as expected on OpenHarmony.

Testing: This is not covered by any automatic tests, and I also didn't find an API that allows simulating raw keyboard events (`hdc shell uinput` seems to behave differently to a raw keyboard). This was manually tested on a dayu-200 developer board with a keyboard attached.

