### PR TITLE
base: Do not use default features for `flate2`, `peniko`, and `resvg`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2709,6 +2709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
+ "libz-sys",
  "miniz_oxide",
 ]
 
@@ -10898,7 +10899,6 @@ checksum = "977d0a4abdef933f424a99fe09f95576e089b90aebc6f016a3bc813762493e91"
 dependencies = [
  "base64 0.23.1",
  "data-url",
- "flate2",
  "fontdb",
  "harfrust",
  "imagesize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ encoding_rs = { version = "0.8", features = ["serde"] }
 env_filter = "0.1.4"
 env_logger = "0.11"
 euclid = "0.22"
-flate2 = "1.1"
+flate2 = { version = "1.1", default-features = false, features = ["libz-sys"] }
 font-types = "0.12"
 fontconfig_sys = { package = "yeslogic-fontconfig-sys", version = "6" }
 fontsan = { version = "0.7", default-features = false, features = ["libz-sys", "wuff"] }
@@ -210,7 +210,7 @@ raw-window-handle = "0.6"
 rayon = "1"
 read-fonts = "0.41.0"
 regex = "1.12"
-resvg = "0.48.1"
+resvg = { version = "0.48.1", default-features = false, features = ["text", "system-fonts", "memmap-fonts", "raster-images"] }
 rsa = "=0.10.0-rc.18"
 rusqlite = { version = "0.38", features = ["bundled"] }
 rustc-demangle = "0.1"


### PR DESCRIPTION
This PR removes some unused features bringing down compile size by an unnoticable fraction.
Additionally, we enforce the usage of libz-rs iin mozjs and flate2.

Testing: Compilation is the test.
