### PR TITLE
fonts: Add Windows support for `PlatformFont::copy_with_variations`

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -153,10 +153,7 @@ pub trait PlatformFontMethods: Sized {
         self,
         _font_identifer: &FontIdentifier,
         _variations: &[FontVariation],
-    ) -> Result<Self, &'static str> {
-        // TODO: Get rid of this default implementation once windows support is added.
-        Ok(self)
-    }
+    ) -> Result<Self, &'static str>;
 
     /// Get a [`FontTemplateDescriptor`] from a [`PlatformFont`]. This is used to get
     /// descriptors for web fonts.

--- a/components/fonts/platform/windows/font.rs
+++ b/components/fonts/platform/windows/font.rs
@@ -175,6 +175,13 @@ impl PlatformFont {
 
         Self::new(font_face, pt_size, variations)
     }
+
+    fn uses_synthetic_bold(&self) -> bool {
+        matches!(
+            self.face.simulations(),
+            FontSimulations::Bold | FontSimulations::BoldOblique
+        )
+    }
 }
 
 impl PlatformFontMethods for PlatformFont {
@@ -203,6 +210,19 @@ impl PlatformFontMethods for PlatformFont {
             .ok_or("Could not create Font from descriptor")?
             .create_font_face();
         Self::new_with_variations(font_face, pt_size, &[], synthetic_bold)
+    }
+
+    fn copy_with_variations(
+        self,
+        _: &FontIdentifier,
+        variations: &[FontVariation],
+    ) -> Result<Self, &'static str> {
+        Self::new_with_variations(
+            self.face.0.clone(),
+            Some(Au::from_f32_px(self.em_size * 16.)),
+            variations,
+            self.uses_synthetic_bold(),
+        )
     }
 
     fn descriptor(&self) -> FontTemplateDescriptor {
@@ -315,10 +335,7 @@ impl PlatformFontMethods for PlatformFont {
 
         // TODO: Add support for synthetic italics.
         // <https://github.com/servo/servo/issues/39637>
-        if matches!(
-            self.face.simulations(),
-            FontSimulations::Bold | FontSimulations::BoldOblique
-        ) {
+        if self.uses_synthetic_bold() {
             flags |= FontInstanceFlags::SYNTHETIC_BOLD;
         }
 


### PR DESCRIPTION
This adds an implementation of this method for Windows, effectively
renabling font variations for that platform.

Testing: Tests are not currently run for Windows, but this causes more web platform tests to run on that platform.

