### PR TITLE
script: Convert Document/ShadowRoot.details_name_groups to safe_borrow_mut.

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -3610,9 +3610,12 @@ impl Document {
         Ok(())
     }
 
-    pub(crate) fn details_name_groups(&self) -> RefMut<'_, DetailsNameGroups> {
+    pub(crate) fn details_name_groups<'a: 'b, 'b>(
+        &'a self,
+        no_gc: &'b NoGC,
+    ) -> RefMut<'b, DetailsNameGroups> {
         RefMut::map(
-            self.details_name_groups.borrow_mut(),
+            self.details_name_groups.safe_borrow_mut(no_gc),
             |details_name_groups| details_name_groups.get_or_insert_default(),
         )
     }

--- a/components/script/dom/html/htmldetailselement.rs
+++ b/components/script/dom/html/htmldetailselement.rs
@@ -333,12 +333,12 @@ impl HTMLDetailsElement {
         // root of the tree is a document or shadow root, which is why this looks a bit more complicated.
         let other_open_member = if let Some(shadow_root) = self.containing_shadow_root() {
             shadow_root
-                .details_name_groups()
+                .details_name_groups(cx.no_gc())
                 .group_members_for(&name, self)
                 .find(|group_member| group_member.Open())
         } else if self.upcast::<Node>().is_in_a_document_tree() {
             self.owner_document()
-                .details_name_groups()
+                .details_name_groups(cx.no_gc())
                 .group_members_for(&name, self)
                 .find(|group_member| group_member.Open())
         } else {
@@ -418,24 +418,24 @@ impl VirtualMethods for HTMLDetailsElement {
             if let Some(shadow_root) = self.containing_shadow_root() {
                 if let Some(old_name) = old_name {
                     shadow_root
-                        .details_name_groups()
+                        .details_name_groups(cx.no_gc())
                         .unregister_details_element(old_name, self);
                 }
                 if matches!(mutation, AttributeMutation::Set(..)) {
                     shadow_root
-                        .details_name_groups()
+                        .details_name_groups(cx.no_gc())
                         .register_details_element(self);
                 }
             } else if self.upcast::<Node>().is_in_a_document_tree() {
                 let document = self.owner_document();
                 if let Some(old_name) = old_name {
                     document
-                        .details_name_groups()
+                        .details_name_groups(cx.no_gc())
                         .unregister_details_element(old_name, self);
                 }
                 if matches!(mutation, AttributeMutation::Set(..)) {
                     document
-                        .details_name_groups()
+                        .details_name_groups(cx.no_gc())
                         .register_details_element(self);
                 }
             }
@@ -511,14 +511,14 @@ impl VirtualMethods for HTMLDetailsElement {
             // If this is true then we can't have been in a document tree previously, so
             // we register ourselves.
             self.owner_document()
-                .details_name_groups()
+                .details_name_groups(cx.no_gc())
                 .register_details_element(self);
         }
 
         let was_already_in_shadow_tree = context.is_shadow_tree == IsShadowTree::Yes;
         if !was_already_in_shadow_tree && let Some(shadow_root) = self.containing_shadow_root() {
             shadow_root
-                .details_name_groups()
+                .details_name_groups(cx.no_gc())
                 .register_details_element(self);
         }
 
@@ -531,7 +531,7 @@ impl VirtualMethods for HTMLDetailsElement {
 
         if context.tree_is_in_a_document_tree && !self.upcast::<Node>().is_in_a_document_tree() {
             self.owner_document()
-                .details_name_groups()
+                .details_name_groups(cx.no_gc())
                 .unregister_details_element(self.Name(), self);
         }
 
@@ -541,7 +541,7 @@ impl VirtualMethods for HTMLDetailsElement {
             // If we used to be in a shadow root, but aren't anymore, then unregister this details
             // element.
             old_shadow_root
-                .details_name_groups()
+                .details_name_groups(cx.no_gc())
                 .unregister_details_element(self.Name(), self);
         }
     }

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -360,9 +360,12 @@ impl ShadowRoot {
         self.delegates_focus.set(delegates_focus);
     }
 
-    pub(crate) fn details_name_groups(&self) -> RefMut<'_, DetailsNameGroups> {
+    pub(crate) fn details_name_groups<'a: 'b, 'b>(
+        &'a self,
+        no_gc: &'b NoGC,
+    ) -> RefMut<'b, DetailsNameGroups> {
         RefMut::map(
-            self.details_name_groups.borrow_mut(),
+            self.details_name_groups.safe_borrow_mut(no_gc),
             |details_name_groups| details_name_groups.get_or_insert_default(),
         )
     }


### PR DESCRIPTION
Testing: Existing tests suffice.
Part of #40600
