### PR TITLE
constellation: Remove `ScriptToConstellationMessage::SetDocumentState`

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -160,14 +160,13 @@ use servo_canvas_traits::canvas::{CanvasId, CanvasMsg};
 use servo_config::{opts, pref};
 use servo_constellation_traits::{
     AuxiliaryWebViewCreationRequest, AuxiliaryWebViewCreationResponse, ConstellationInterest,
-    DocumentState, EmbedderToConstellationMessage, HistoryTraversalSource, IFrameLoadInfo,
-    IFrameLoadInfoWithData, IFrameSizeMsg, LoadData, LogEntry, MessagePortMsg,
-    NavigationHistoryBehavior, PaintMetricEvent, PortMessageTask, PortTransferInfo,
-    RemoteFocusOperation, SWManagerSenders, ScreenshotReadinessResponse,
-    ScriptToConstellationMessage, ScrollStateUpdate, ServiceWorkerAlgorithm,
-    ServiceWorkerManagerFactory, ServiceWorkerMsg, SessionHistoryTraversalRequest,
-    StructuredSerializedData, TargetSnapshotParams, TraversalDirection, UserContentManagerAction,
-    WindowSizeType, WorkerAnimationFrameTick,
+    EmbedderToConstellationMessage, HistoryTraversalSource, IFrameLoadInfo, IFrameLoadInfoWithData,
+    IFrameSizeMsg, LoadData, LogEntry, MessagePortMsg, NavigationHistoryBehavior, PaintMetricEvent,
+    PortMessageTask, PortTransferInfo, RemoteFocusOperation, SWManagerSenders,
+    ScreenshotReadinessResponse, ScriptToConstellationMessage, ScrollStateUpdate,
+    ServiceWorkerAlgorithm, ServiceWorkerManagerFactory, ServiceWorkerMsg,
+    SessionHistoryTraversalRequest, StructuredSerializedData, TargetSnapshotParams,
+    TraversalDirection, UserContentManagerAction, WindowSizeType, WorkerAnimationFrameTick,
 };
 use servo_url::{Host, ImmutableOrigin, ServoUrl};
 use storage_traits::StorageThreads;
@@ -447,9 +446,6 @@ pub struct Constellation<STF, SWF> {
     /// A [`GenericSender`] to notify navigation events to webdriver.
     webdriver_load_status_sender: Option<(GenericSender<WebDriverLoadStatus>, PipelineId)>,
 
-    /// Document states for loaded pipelines (used only when writing screenshots).
-    document_states: FxHashMap<PipelineId, DocumentState>,
-
     /// Are we shutting down?
     shutting_down: bool,
 
@@ -723,7 +719,6 @@ where
                     mem_profiler_chan: state.mem_profiler_chan.clone(),
                     phantom: PhantomData,
                     webdriver_load_status_sender: None,
-                    document_states: Default::default(),
                     #[cfg(feature = "webgpu")]
                     webrender_wgpu,
                     shutting_down: false,
@@ -1870,9 +1865,6 @@ where
             },
             ScriptToConstellationMessage::CreateCanvasPaintThread(size, response_sender) => {
                 self.handle_create_canvas_paint_thread_msg(size, response_sender)
-            },
-            ScriptToConstellationMessage::SetDocumentState(state) => {
-                self.document_states.insert(source_pipeline_id, state);
             },
             ScriptToConstellationMessage::LogEntry(event_loop_id, thread_name, entry) => {
                 self.handle_log_entry(event_loop_id, thread_name, entry);

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -177,7 +177,6 @@ mod from_script {
                 Self::ScriptNewIFrame(..) => target!("ScriptNewIFrame"),
                 Self::CreateAuxiliaryWebView(..) => target!("ScriptNewAuxiliary"),
                 Self::ActivateDocument => target!("ActivateDocument"),
-                Self::SetDocumentState(..) => target!("SetDocumentState"),
                 Self::SetFinalUrl(..) => target!("SetFinalUrl"),
                 Self::LogEntry(..) => target!("LogEntry"),
                 Self::DiscardDocument => target!("DiscardDocument"),

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -438,15 +438,6 @@ impl PartialEq for Job {
     }
 }
 
-/// Used to determine if a script has any pending asynchronous activity.
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
-pub enum DocumentState {
-    /// The document has been loaded and is idle.
-    Idle,
-    /// The document is either loading or waiting on an event.
-    Pending,
-}
-
 /// This trait allows creating a `ServiceWorkerManager` without depending on the `script`
 /// crate.
 pub trait ServiceWorkerManagerFactory {
@@ -779,8 +770,6 @@ pub enum ScriptToConstellationMessage {
     CreateAuxiliaryWebView(AuxiliaryWebViewCreationRequest),
     /// Mark a new document as active
     ActivateDocument,
-    /// Set the document state for a pipeline (used by screenshot / reftests)
-    SetDocumentState(DocumentState),
     /// Update the pipeline Url, which can change after redirections.
     SetFinalUrl(ServoUrl),
     /// A log entry, with the top-level browsing context id and thread name


### PR DESCRIPTION
This was part of the old screenshot architecture which is no more.
The message is not sent, so the related type and hash map are completely
unused and can be removed.

Testing: This does not change behavior so is covered by existing tests.
Fixes: This is part of #47294.
