### PR TITLE
script: Reduce codegen-units to 16 to avoid ICE

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -381,6 +381,14 @@ xpath = { package = "servo-xpath", version = "=0.5.0", path = "components/xpath"
 [profile.dev.package.crypto-bigint]
 opt-level = 3
 
+[profile.dev.package.servo-script]
+# On windows builds the default 256 codegen units cause the script rlib file
+# to exceed 4 GB, whichs causes build errors due to
+# https://github.com/rust-lang/rust/issues/151184.
+# Reducing the codegen-units seems to significantly decrease the rlib size and
+# avoids the issue.
+codegen-units = 16
+
 # Force tikv-jemalloc-sys to build with at least -O1.
 # This can help with build environments that force _FORTIFY_SOURCE, such as Nix.
 # More details: <https://github.com/tikv/jemallocator/issues/108>


### PR DESCRIPTION
With the default amount of codegen-units (256) the `rlib` size of script increases beyond 4GB, which seems to hit a limit of the COFF format, and causes an ICE in rustc.
`codegen-units = 16` fixed the issue, and resulted in an rlib of ~1.2GB, which is well below 4GB.
The alternative would have been to reduce debug-info.

Testing: Not covered by automatic tests. Perform a debug build on a windows machine to validate.

