### PR TITLE
fonts: Fix line height calculation on windows

### DIFF
--- a/components/fonts/platform/windows/font.rs
+++ b/components/fonts/platform/windows/font.rs
@@ -256,7 +256,10 @@ impl PlatformFontMethods for PlatformFont {
 
         // anything that we calculate and don't just pull out of self.face.metrics
         // is pulled out here for clarity
-        let leading = dm.ascent - dm.capHeight;
+        // Values may be negative, so we convert to signed integers, see
+        // <https://learn.microsoft.com/en-us/windows/win32/api/dwrite/ns-dwrite-dwrite_font_metrics>
+        let leading = i32::from(dm.lineGap);
+        let line_height = i32::from(dm.ascent) + i32::from(dm.descent) + leading;
 
         let zero_horizontal_advance = self
             .glyph_index('0')
@@ -283,14 +286,14 @@ impl PlatformFontMethods for PlatformFont {
             underline_offset: au_from_du_s(dm.underlinePosition as i32),
             strikeout_size: au_from_du(dm.strikethroughThickness as i32),
             strikeout_offset: au_from_du_s(dm.strikethroughPosition as i32),
-            leading: au_from_du_s(leading as i32),
+            leading: au_from_du_s(leading),
             x_height: au_from_du_s(dm.xHeight as i32),
             em_size: au_from_em(self.em_size as f64),
             ascent: au_from_du_s(dm.ascent as i32),
             descent: au_from_du_s(dm.descent as i32),
             max_advance,
             average_advance,
-            line_gap: au_from_du_s((dm.ascent + dm.descent + dm.lineGap as u16) as i32),
+            line_gap: au_from_du_s(line_height),
             zero_horizontal_advance,
             ic_horizontal_advance,
             space_advance,


### PR DESCRIPTION
Negative values are allowed for lineGap, so we should do calculation with signed arithmetic. To quote the docs:

> The line gap in font design units. Recommended additional white space to add between lines
> to improve legibility. The recommended line spacing (baseline-to-baseline distance) is the
> sum of ascent, descent, and lineGap. The line gap is usually positive or zero but can be
> negative, in which case the recommended line spacing is less than the height of the character
> alignment box.

Testing: We don't run wpt-tests on windows in CI. Local testing of `css/css-fonts` showed the following diff: https://github.com/servo/servo/commit/f0b62e5904d34057bb1185629a0e6f24beacd9e2. Fixing the crashes in the `font-stretch` test cases.  `font-size-zero-2` appears to be flaky.
Fixes: #47367