### PR TITLE
layout/script: Let layout own LCP halting logic to preempt unnecessary compute

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -4237,9 +4237,6 @@ where
                     warn!("Could not find WebView for URL load: ({webview_id:?})");
                 }
 
-                self.paint_proxy
-                    .send(PaintMessage::EnableLCPCalculation(webview_id));
-
                 Some(new_pipeline_id)
             },
         }
@@ -4834,8 +4831,6 @@ where
             ScriptThreadMessage::Reload(pipeline_id),
             "Got reload event after closure",
         );
-        self.paint_proxy
-            .send(PaintMessage::EnableLCPCalculation(webview_id));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#window-post-message-steps>

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -235,7 +235,6 @@ impl DisplayListBuilder<'_> {
 
         PaintTraversal::traverse(&stacking_context_tree.root_stacking_context, &mut builder);
         builder.paint_dom_inspector_highlight();
-        builder.paint_timing_handler.mark_paint_timing();
 
         webrender_display_list_builder.end().1
     }

--- a/components/layout/display_list/paint_timing_handler.rs
+++ b/components/layout/display_list/paint_timing_handler.rs
@@ -356,8 +356,33 @@ impl PaintTimingHandler {
         // Note: We use flag lcp_candidate_updated for updating, needs revisit
     }
 
+    /// <https://www.w3.org/TR/largest-contentful-paint/#sec-report-largest-contentful-paint>
+    fn report_largest_contentful_paint(&mut self, halt_lcp: bool) {
+        // Step 1. Let window be document’s relevant global object.
+        // Step 2. If either of window’s has dispatched scroll event or has
+        // dispatched input event is true, return.
+        if halt_lcp {
+            return;
+        }
+
+        // Step 3. Let newCandidate be the result of computing a new largest
+        // contentful paint candidate given document, paintedImages,
+        // paintedTextNodes, and document’s current largest contentful paint
+        // candidate.
+        self.compute_new_lcp_candidate();
+
+        // Step 4. If newCandidate is null, return.
+        // Step 5. Set document’s current largest contentful paint candidate to
+        // newCandidate.
+        // TODO: Make it return and store here following specs.
+        // Step 6. Let entry be the result of creating a LargestContentfulPaint
+        // entry with newCandidate, paintTimingInfo, and document.
+        // Step 7. Queue the PerformanceEntry entry.
+        // Note: Step 6-7 are handled in script.
+    }
+
     /// <https://www.w3.org/TR/paint-timing/#mark-paint-timing>
-    pub(crate) fn mark_paint_timing(&mut self) {
+    pub(crate) fn mark_paint_timing(&mut self, halt_lcp: bool) {
         // > From: <https://www.w3.org/TR/largest-contentful-paint/#sec-report-largest-contentful-paint>
         // > Note: Each pending image record in paintedImages and text
         // > element in paintedTextNodes will only be reported exactly
@@ -373,7 +398,10 @@ impl PaintTimingHandler {
         self.painted_text_nodes
             .retain(|node, _record| self.reported_text_nodes.insert(*node));
 
-        self.compute_new_lcp_candidate();
+        // Step 10. Let flushPaintTimings be the following steps:
+        // Step 10.3. Report largest contentful paint given document,
+        // paintTimingInfo, paintedImages and paintedTextNodes.
+        self.report_largest_contentful_paint(halt_lcp);
     }
 
     pub(crate) fn did_lcp_candidate_update(&self) -> bool {

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1495,6 +1495,7 @@ impl LayoutThread {
             paint_timing_handler,
             reflow_statistics,
         );
+        paint_timing_handler.mark_paint_timing(reflow_request.halt_lcp);
         self.paint_api.send_display_list(
             self.webview_id,
             &stacking_context_tree.paint_info,

--- a/components/paint/largest_contentful_paint_calculator.rs
+++ b/components/paint/largest_contentful_paint_calculator.rs
@@ -3,23 +3,20 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use paint_api::largest_contentful_paint_candidate::{LCPCandidate, LargestContentfulPaint};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use servo_base::cross_process_instant::CrossProcessInstant;
-use servo_base::id::WebViewId;
 use webrender_api::PipelineId;
 
 /// Holds the [`LargestContentfulPaintsContainer`] for each pipeline.
 #[derive(Default)]
 pub(crate) struct LargestContentfulPaintCalculator {
     lcp_containers: FxHashMap<PipelineId, LargestContentfulPaintsContainer>,
-    disabled_webviews: FxHashSet<WebViewId>,
 }
 
 impl LargestContentfulPaintCalculator {
     pub(crate) fn new() -> Self {
         Self {
             lcp_containers: Default::default(),
-            disabled_webviews: Default::default(),
         }
     }
 
@@ -27,18 +24,12 @@ impl LargestContentfulPaintCalculator {
         &mut self,
         candidate: LCPCandidate,
         pipeline_id: PipelineId,
-        webview_id: &WebViewId,
     ) {
-        assert!(self.enabled_for_webview(webview_id));
         self.lcp_containers
             .entry(pipeline_id)
             .or_default()
             .lcp_candidates
             .push(candidate);
-    }
-
-    pub(crate) fn enabled_for_webview(&self, webview_id: &WebViewId) -> bool {
-        !self.disabled_webviews.contains(webview_id)
     }
 
     pub(crate) fn remove_lcp_candidates_for_pipeline(&mut self, pipeline_id: &PipelineId) {
@@ -53,15 +44,6 @@ impl LargestContentfulPaintCalculator {
         self.lcp_containers
             .get_mut(&pipeline_id)
             .and_then(|container| container.calculate_largest_contentful_paint(paint_time))
-    }
-
-    /// <https://www.w3.org/TR/largest-contentful-paint/#limitations>
-    pub(crate) fn disable_for_webview(&mut self, webview_id: WebViewId) {
-        self.disabled_webviews.insert(webview_id);
-    }
-
-    pub(crate) fn enable_for_webview(&mut self, webview_id: &WebViewId) {
-        self.disabled_webviews.remove(webview_id);
     }
 }
 

--- a/components/paint/paint.rs
+++ b/components/paint/paint.rs
@@ -587,11 +587,6 @@ impl Paint {
                     painter.append_lcp_candidate(lcp_candidate, webview_id, pipeline_id, epoch);
                 }
             },
-            PaintMessage::EnableLCPCalculation(webview_id) => {
-                if let Some(mut painter) = self.maybe_painter_mut(webview_id.into()) {
-                    painter.enable_lcp_calculation(&webview_id);
-                }
-            },
         }
     }
 

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -1237,7 +1237,6 @@ impl Painter {
         };
 
         self.send_root_pipeline_display_list();
-        self.lcp_calculator.enable_for_webview(&webview_id);
     }
 
     pub(crate) fn is_empty(&mut self) -> bool {
@@ -1345,10 +1344,7 @@ impl Painter {
                     InputEvent::MouseLeftViewport(_) => {
                         self.last_mouse_move_position = None;
                     },
-                    _ => {
-                        // Disable LCP calculation on any other input event except mouse moves.
-                        self.lcp_calculator.disable_for_webview(webview_id);
-                    },
+                    _ => {},
                 }
 
                 webview_renderer.notify_input_event(&self.webrender_api, &self.needs_repaint, event)
@@ -1364,16 +1360,6 @@ impl Painter {
         if let Some(webview_renderer) = self.webview_renderers.get_mut(&webview_id) {
             webview_renderer.notify_scroll_event(scroll, point);
         }
-        // Disable LCP calculation on any scroll event.
-        self.lcp_calculator.disable_for_webview(webview_id);
-    }
-
-    pub(crate) fn enable_lcp_calculation(&mut self, webview_id: &WebViewId) {
-        self.lcp_calculator.enable_for_webview(webview_id);
-    }
-
-    pub(crate) fn lcp_calculation_enabled_for_webview(&self, webview_id: &WebViewId) -> bool {
-        self.lcp_calculator.enabled_for_webview(webview_id)
     }
 
     pub(crate) fn adjust_pinch_zoom(
@@ -1508,19 +1494,14 @@ impl Painter {
         pipeline_id: PipelineId,
         epoch: Epoch,
     ) {
-        if self.lcp_calculation_enabled_for_webview(&webview_id) {
-            self.lcp_calculator.append_lcp_candidate(
-                lcp_candidate,
-                pipeline_id.into(),
-                &webview_id,
-            );
-            if let Some(webview_renderer) = self.webview_renderers.get_mut(&webview_id) {
-                webview_renderer
-                    .ensure_pipeline_details(pipeline_id)
-                    .largest_contentful_paint_metric
-                    .set(PaintMetricState::Seen(epoch.into(), false));
-            }
-        };
+        self.lcp_calculator
+            .append_lcp_candidate(lcp_candidate, pipeline_id.into());
+        if let Some(webview_renderer) = self.webview_renderers.get_mut(&webview_id) {
+            webview_renderer
+                .ensure_pipeline_details(pipeline_id)
+                .largest_contentful_paint_metric
+                .set(PaintMetricState::Seen(epoch.into(), false));
+        }
     }
 }
 

--- a/components/paint/tracing.rs
+++ b/components/paint/tracing.rs
@@ -54,7 +54,6 @@ mod from_constellation {
                 Self::DelayNewFrameForCanvas(..) => target!("DelayFramesForCanvas"),
                 Self::ScreenshotReadinessReponse(..) => target!("ScreenshotReadinessResponse"),
                 Self::SendLCPCandidate(..) => target!("SendLCPCandidate"),
-                Self::EnableLCPCalculation(..) => target!("EnableLCPCalculation"),
             }
         }
     }

--- a/components/script/dom/event/event.rs
+++ b/components/script/dom/event/event.rs
@@ -301,13 +301,21 @@ impl Event {
         legacy_target_override: bool,
         legacy_output_did_listeners_throw: Option<&Cell<bool>>,
     ) -> bool {
-        // > When a user interaction causes firing of an activation triggering input event in a Document document, the user agent
-        // > must perform the following activation notification steps before dispatching the event:
-        // <https://html.spec.whatwg.org/multipage/#user-activation-processing-model>
+        // From <https://html.spec.whatwg.org/multipage/#user-activation-processing-model>:
+        // > When a user interaction causes firing of an activation triggering
+        // > input event in a Document document, the user agent must perform
+        // > the following activation notification steps before dispatching the event:
         if self.is_an_activation_triggering_input_event() {
             // TODO: it is not quite clear what does the spec mean by in a `Document`. https://github.com/whatwg/html/issues/12126
             if let Some(document) = target.downcast::<Node>().map(|node| node.owner_doc()) {
                 UserActivation::handle_user_activation_notification(&document);
+            }
+            // From <https://w3c.github.io/event-timing/#set-event-timing-entry-duration>:
+            // Step 6.4. Set window’s has dispatched input event to true.
+            // Note: Spec refers use of interactionId for this,
+            // HTML "activation triggering input event" is a close approximation
+            if let Some(window) = target.global().downcast::<Window>() {
+                window.mark_has_dispatched_input_event();
             }
         }
 
@@ -319,6 +327,18 @@ impl Event {
 
         // Step 1. Set event’s dispatch flag.
         self.set_flags(EventFlags::Dispatch);
+
+        // From <https://www.w3.org/TR/largest-contentful-paint/#sec-modifications-DOM>
+        // > Right after step 1, we add the following step:
+        // > > If target’s relevant global object is a Window object, event’s
+        // > > type is scroll and its isTrusted is true, set target’s relevant
+        // > > global object’s has dispatched scroll event to true.
+        if let Some(window) = target.global().downcast::<Window>() &&
+            self.type_() == *"scroll" &&
+            self.is_trusted.get()
+        {
+            window.mark_has_dispatched_scroll_event();
+        }
 
         // Step 2. Let targetOverride be target, if legacy target override flag is not given,
         // and target’s associated Document otherwise.

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -502,6 +502,12 @@ pub(crate) struct Window {
     /// A flag to indicate whether the developer tools has requested
     /// live updates from the window.
     devtools_wants_updates: Cell<bool>,
+
+    /// <https://www.w3.org/TR/largest-contentful-paint/#has-dispatched-scroll-event>
+    has_dispatched_scroll_event: Cell<bool>,
+
+    /// <https://wicg.github.io/event-timing/#has-dispatched-input-event>
+    has_dispatched_input_event: Cell<bool>,
 }
 
 impl Window {
@@ -516,6 +522,16 @@ impl Window {
 
     pub(crate) fn as_global_scope(&self) -> &GlobalScope {
         self.upcast::<GlobalScope>()
+    }
+
+    /// <https://www.w3.org/TR/largest-contentful-paint/#has-dispatched-scroll-event>
+    pub(crate) fn mark_has_dispatched_scroll_event(&self) {
+        self.has_dispatched_scroll_event.set(true);
+    }
+
+    /// <https://wicg.github.io/event-timing/#has-dispatched-input-event>
+    pub(crate) fn mark_has_dispatched_input_event(&self) {
+        self.has_dispatched_input_event.set(true);
     }
 
     pub(crate) fn layout(&self) -> Ref<'_, Box<dyn Layout>> {
@@ -2744,6 +2760,8 @@ impl Window {
             animations: document.animations().sets.clone(),
             animating_images: document.image_animation_manager().animating_images(),
             highlighted_dom_node: document.highlighted_dom_node().map(|node| node.to_opaque()),
+            halt_lcp: self.has_dispatched_scroll_event.get() ||
+                self.has_dispatched_input_event.get(),
             document_context,
             accessibility_damage,
             rooted_nodes_for_accessibility_integrity_check,
@@ -4011,6 +4029,8 @@ impl Window {
             pending_media_query_evaluation: Default::default(),
             last_activation_timestamp: Cell::new(UserActivationTimestamp::PositiveInfinity),
             devtools_wants_updates: Default::default(),
+            has_dispatched_scroll_event: Cell::new(false),
+            has_dispatched_input_event: Cell::new(false),
         });
 
         WindowBinding::Wrap::<crate::DomTypeHolder>(cx, &origin, win)

--- a/components/servo/tests/largest_contentful_paint.rs
+++ b/components/servo/tests/largest_contentful_paint.rs
@@ -124,37 +124,67 @@ fn test_largest_contentful_paint_js_api_with_mouse_click_and_reload() {
         .url(Url::parse(DATA_URL_FOR_PAGE_WITH_SINGLE_RED_SQUARE).unwrap())
         .build();
 
-    // Simulate a user interaction before loading i.e before spinning event loop to disable LCP calculation for the WebView.
-    click_at_point(&webview, Point2D::new(1., 1.));
-
     show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
 
-    let lcp_script = "(async () => {
-        window.lcp = await new Promise(resolve => {
-            (new PerformanceObserver(entryList => {
-                resolve(entryList.getEntries()[0]);
-            }))
-            .observe({type: 'largest-contentful-paint', buffered: true});
-        })
-    })();";
-
-    if let Err(err) = evaluate_javascript(&servo_test, webview.clone(), lcp_script) {
-        panic!("Failed to evaluate LCP setup script: {:?}", err);
+    // Observe all largest-contentful-paint entries (buffered).
+    let observer_script = "
+        window.lcpEntries = [];
+        new PerformanceObserver(list => {
+            window.lcpEntries.push(...list.getEntries());
+        }).observe({type: 'largest-contentful-paint', buffered: true});
+    ";
+    if let Err(err) = evaluate_javascript(&servo_test, webview.clone(), observer_script) {
+        panic!("Failed to evaluate LCP observer script: {:?}", err);
     }
 
-    // Read from a global variable used to store the result since evaluate_javascript doesn't handle Promises
-    let lcp = evaluate_javascript(&servo_test, webview.clone(), "window.lcp;");
-    assert_eq!(lcp, Ok(JSValue::Undefined));
+    // The initial image should produce exactly one LCP entry.
+    let count = evaluate_javascript(&servo_test, webview.clone(), "window.lcpEntries.length;");
+    assert_eq!(count, Ok(JSValue::Number(1.0)));
 
-    // Reloading the WebView should re-enable LCP calculation.
+    // Simulate a click, which should halt LCP calculation.
+    click_at_point(&webview, Point2D::new(1., 1.));
+
+    // Append a larger image; it should not be reported because LCP is halted.
+    let append_image_script = r#"
+        window.image2Done = false;
+        (async () => {
+            const img = document.createElement('img');
+            img.id = 'image2';
+            img.style.width = '100px';
+            img.style.height = '100px';
+            img.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFElEQVR4nGP4z8DwnxjMMKqQvgoBksPHOas6/LEAAAAASUVORK5CYII=';
+            document.body.appendChild(img);
+            await new Promise(resolve => { img.addEventListener('load', resolve); });
+            await new Promise(resolve => requestAnimationFrame(() => resolve()));
+            window.image2Done = true;
+        })();
+    "#;
+    if let Err(err) = evaluate_javascript(&servo_test, webview.clone(), append_image_script) {
+        panic!("Failed to evaluate append image script: {:?}", err);
+    }
+
+    // Wait for the larger image to load and a rendering update to happen.
+    loop {
+        if evaluate_javascript(&servo_test, webview.clone(), "window.image2Done === true;") ==
+            Ok(JSValue::Boolean(true))
+        {
+            break;
+        }
+    }
+
+    // The LCP entry count should still be 1: the larger image was not reported.
+    let count = evaluate_javascript(&servo_test, webview.clone(), "window.lcpEntries.length;");
+    assert_eq!(count, Ok(JSValue::Number(1.0)));
+
+    // Reloading the WebView should re-enable LCP reporting.
     webview.reload();
     show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
 
-    if let Err(err) = evaluate_javascript(&servo_test, webview.clone(), lcp_script) {
-        panic!("Failed to evaluate LCP setup script: {:?}", err);
+    if let Err(err) = evaluate_javascript(&servo_test, webview.clone(), observer_script) {
+        panic!("Failed to evaluate LCP observer script: {:?}", err);
     }
 
-    // Read from a global variable used to store the result since evaluate_javascript doesn't handle Promises
-    let lcp = evaluate_javascript(&servo_test, webview.clone(), "window.lcp;");
-    assert_eq!(lcp, Ok(JSValue::Object(std::collections::HashMap::new())));
+    // After reload, it should produce exactly one LCP entry.
+    let count = evaluate_javascript(&servo_test, webview.clone(), "window.lcpEntries.length;");
+    assert_eq!(count, Ok(JSValue::Number(1.0)));
 }

--- a/components/servo/tests/largest_contentful_paint.rs
+++ b/components/servo/tests/largest_contentful_paint.rs
@@ -23,6 +23,32 @@ static DATA_URL_FOR_PAGE_WITH_SINGLE_RED_SQUARE: &str = "data:text/html,<!DOCTYP
 <div><img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAEklEQVQIW2P8z8AARAwMjDAGACwBA/+8RVWvAAAAAElFTkSuQmCC'\
 style='width: 50px; height: 50px;'></div>";
 
+// Observer script that buffers all largest-contentful-paint entries
+// into `window.lcpEntries`.
+static OBSERVER_SCRIPT: &str = "
+    window.lcpEntries = [];
+    new PerformanceObserver(list => {
+        window.lcpEntries.push(...list.getEntries());
+    }).observe({type: 'largest-contentful-paint', buffered: true});
+";
+
+// Script that appends a 100x100 image and sets `window.image2Done` once it has
+// been loaded and painted.
+static APPEND_LARGER_IMAGE_SCRIPT: &str = r#"
+    window.image2Done = false;
+    (async () => {
+        const img = document.createElement('img');
+        img.id = 'image2';
+        img.style.width = '100px';
+        img.style.height = '100px';
+        img.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFElEQVR4nGP4z8DwnxjMMKqQvgoBksPHOas6/LEAAAAASUVORK5CYII=';
+        document.body.appendChild(img);
+        await new Promise(resolve => { img.addEventListener('load', resolve); });
+        await new Promise(resolve => requestAnimationFrame(() => resolve()));
+        window.image2Done = true;
+    })();
+"#;
+
 #[test]
 fn test_largest_contentful_paint_js_api() {
     let servo_test = ServoTest::new_with_builder(|builder| {
@@ -40,22 +66,20 @@ fn test_largest_contentful_paint_js_api() {
     // Wait for the page to load and render before evaluating the LCP to ensure we don't miss LCP candidate.
     show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
 
-    let lcp_script = "(async () => {
-        window.lcp = await new Promise(resolve => {
-            (new PerformanceObserver(entryList => {
-                resolve(entryList.getEntries()[0]);
-            }))
-            .observe({type: 'largest-contentful-paint', buffered: true});
-        })
-    })();";
-
-    if let Err(err) = evaluate_javascript(&servo_test, webview.clone(), lcp_script) {
-        panic!("Failed to evaluate LCP setup script: {:?}", err);
+    if let Err(err) = evaluate_javascript(&servo_test, webview.clone(), OBSERVER_SCRIPT) {
+        panic!("Failed to evaluate LCP observer script: {:?}", err);
     }
 
-    // Read from a global variable used to store the result since evaluate_javascript doesn't handle Promises
-    let lcp = evaluate_javascript(&servo_test, webview.clone(), "window.lcp.toJSON();");
+    // The single image should produce exactly one LCP entry.
+    let count = evaluate_javascript(&servo_test, webview.clone(), "window.lcpEntries.length;");
+    assert_eq!(count, Ok(JSValue::Number(1.0)));
 
+    // Check the entry's fields.
+    let lcp = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "window.lcpEntries[0].toJSON();",
+    );
     if let Ok(JSValue::Object(obj)) = lcp {
         assert_eq!(obj.get("name"), Some(JSValue::String("".into())).as_ref());
         assert_eq!(obj.get("duration"), Some(JSValue::Number(0.0)).as_ref());
@@ -85,29 +109,44 @@ fn test_largest_contentful_paint_js_api_with_mouse_move() {
         .url(Url::parse(DATA_URL_FOR_PAGE_WITH_SINGLE_RED_SQUARE).unwrap())
         .build();
 
-    // Simulate a mouse move movement before loading the page aka before spinning the event loop.
+    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
+
+    if let Err(err) = evaluate_javascript(&servo_test, webview.clone(), OBSERVER_SCRIPT) {
+        panic!("Failed to evaluate LCP observer script: {:?}", err);
+    }
+
+    // The initial image should produce exactly one LCP entry.
+    let count = evaluate_javascript(&servo_test, webview.clone(), "window.lcpEntries.length;");
+    assert_eq!(count, Ok(JSValue::Number(1.0)));
+
+    // A mouse move is not an activation-triggering input event, so it should not
+    // halt LCP calculation.
     webview.notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(
         DevicePoint::new(10., 10.).into(),
     )));
 
-    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
-
-    let lcp_script = "(async () => {
-        window.lcp = await new Promise(resolve => {
-            (new PerformanceObserver(entryList => {
-                resolve(entryList.getEntries()[0]);
-            }))
-            .observe({type: 'largest-contentful-paint', buffered: true});
-        })
-    })();";
-
-    if let Err(err) = evaluate_javascript(&servo_test, webview.clone(), lcp_script) {
-        panic!("Failed to evaluate LCP setup script: {:?}", err);
+    // Append a larger image
+    if let Err(err) = evaluate_javascript(&servo_test, webview.clone(), APPEND_LARGER_IMAGE_SCRIPT)
+    {
+        panic!("Failed to evaluate append image script: {:?}", err);
     }
 
-    // Read from a global variable used to store the result since evaluate_javascript doesn't handle Promises
-    let lcp = evaluate_javascript(&servo_test, webview.clone(), "window.lcp;");
-    assert_eq!(lcp, Ok(JSValue::Object(std::collections::HashMap::new())));
+    // Wait for the larger image to load and a rendering update to happen.
+    loop {
+        if evaluate_javascript(&servo_test, webview.clone(), "window.image2Done === true;") ==
+            Ok(JSValue::Boolean(true))
+        {
+            break;
+        }
+    }
+
+    // Wait for the larger image's LCP entry to be reported.
+    loop {
+        let count = evaluate_javascript(&servo_test, webview.clone(), "window.lcpEntries.length;");
+        if count == Ok(JSValue::Number(2.0)) {
+            break;
+        }
+    }
 }
 
 #[test]
@@ -127,13 +166,7 @@ fn test_largest_contentful_paint_js_api_with_mouse_click_and_reload() {
     show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
 
     // Observe all largest-contentful-paint entries (buffered).
-    let observer_script = "
-        window.lcpEntries = [];
-        new PerformanceObserver(list => {
-            window.lcpEntries.push(...list.getEntries());
-        }).observe({type: 'largest-contentful-paint', buffered: true});
-    ";
-    if let Err(err) = evaluate_javascript(&servo_test, webview.clone(), observer_script) {
+    if let Err(err) = evaluate_javascript(&servo_test, webview.clone(), OBSERVER_SCRIPT) {
         panic!("Failed to evaluate LCP observer script: {:?}", err);
     }
 
@@ -145,21 +178,8 @@ fn test_largest_contentful_paint_js_api_with_mouse_click_and_reload() {
     click_at_point(&webview, Point2D::new(1., 1.));
 
     // Append a larger image; it should not be reported because LCP is halted.
-    let append_image_script = r#"
-        window.image2Done = false;
-        (async () => {
-            const img = document.createElement('img');
-            img.id = 'image2';
-            img.style.width = '100px';
-            img.style.height = '100px';
-            img.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFElEQVR4nGP4z8DwnxjMMKqQvgoBksPHOas6/LEAAAAASUVORK5CYII=';
-            document.body.appendChild(img);
-            await new Promise(resolve => { img.addEventListener('load', resolve); });
-            await new Promise(resolve => requestAnimationFrame(() => resolve()));
-            window.image2Done = true;
-        })();
-    "#;
-    if let Err(err) = evaluate_javascript(&servo_test, webview.clone(), append_image_script) {
+    if let Err(err) = evaluate_javascript(&servo_test, webview.clone(), APPEND_LARGER_IMAGE_SCRIPT)
+    {
         panic!("Failed to evaluate append image script: {:?}", err);
     }
 
@@ -180,7 +200,7 @@ fn test_largest_contentful_paint_js_api_with_mouse_click_and_reload() {
     webview.reload();
     show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
 
-    if let Err(err) = evaluate_javascript(&servo_test, webview.clone(), observer_script) {
+    if let Err(err) = evaluate_javascript(&servo_test, webview.clone(), OBSERVER_SCRIPT) {
         panic!("Failed to evaluate LCP observer script: {:?}", err);
     }
 

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -729,6 +729,10 @@ pub struct ReflowRequest {
     pub animating_images: Arc<RwLock<AnimatingImages>>,
     /// The node highlighted by the devtools, if any
     pub highlighted_dom_node: Option<OpaqueNode>,
+    /// Whether LCP computation should be halted for this reflow.
+    /// From <https://www.w3.org/TR/largest-contentful-paint/#limitations>:
+    /// > The LargestContentfulPaint ... algorithm halts ... inputs.
+    pub halt_lcp: bool,
     /// The current font context.
     pub document_context: WebFontDocumentContext,
     /// Damage to the accessibility tree from DOM mutations.

--- a/components/shared/paint/lib.rs
+++ b/components/shared/paint/lib.rs
@@ -187,8 +187,6 @@ pub enum PaintMessage {
     ScreenshotReadinessReponse(WebViewId, FxHashMap<PipelineId, Epoch>),
     /// The candidate of largest-contentful-paint
     SendLCPCandidate(LCPCandidate, WebViewId, PipelineId, Epoch),
-    /// Enable LCP calculation for the given WebView.
-    EnableLCPCalculation(WebViewId),
 }
 
 impl Debug for PaintMessage {


### PR DESCRIPTION
This PR spans over following changes
- Store the dispatched events in `window`
- Add `report_largest_contentful_paint`.
- Remove tracking via`disabled_webviews` container from paint.
- Implement halting according to specs

Testing: 
- Existing WPT Status Unchanged
- Updated unit tests
  - `test_largest_contentful_paint_js_api`
  - `test_largest_contentful_paint_js_api_with_mouse_move`
  - `test_largest_contentful_paint_js_api_with_mouse_click_and_reload`

Fixes: Part of #42000