### PR TITLE
script: Rename MAC-related structs in WebCrypto

### DIFF
--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -4004,7 +4004,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for KmacImportParams {
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-KmacKeyAlgorithm>
 #[derive(Clone, MallocSizeOf)]
-pub(crate) struct SubtleKmacKeyAlgorithm {
+pub(crate) struct KmacKeyAlgorithm {
     /// <https://w3c.github.io/webcrypto/#dom-keyalgorithm-name>
     name: CryptoAlgorithm,
 
@@ -4012,7 +4012,7 @@ pub(crate) struct SubtleKmacKeyAlgorithm {
     length: u32,
 }
 
-impl ToJSValConvertible for SubtleKmacKeyAlgorithm {
+impl ToJSValConvertible for KmacKeyAlgorithm {
     #[expect(unsafe_code)]
     fn safe_to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
         rooted!(&in(cx) let mut object = unsafe { JS_NewObject(cx, ptr::null()) });
@@ -4031,19 +4031,19 @@ impl ToJSValConvertible for SubtleKmacKeyAlgorithm {
     }
 }
 
-impl TryFrom<SerializableKmacKeyAlgorithm> for SubtleKmacKeyAlgorithm {
+impl TryFrom<SerializableKmacKeyAlgorithm> for KmacKeyAlgorithm {
     type Error = ();
 
     fn try_from(value: SerializableKmacKeyAlgorithm) -> Result<Self, Self::Error> {
-        Ok(SubtleKmacKeyAlgorithm {
+        Ok(KmacKeyAlgorithm {
             name: CryptoAlgorithm::from_str(&value.name).map_err(|_| ())?,
             length: value.length,
         })
     }
 }
 
-impl From<&SubtleKmacKeyAlgorithm> for SerializableKmacKeyAlgorithm {
-    fn from(value: &SubtleKmacKeyAlgorithm) -> Self {
+impl From<&KmacKeyAlgorithm> for SerializableKmacKeyAlgorithm {
+    fn from(value: &KmacKeyAlgorithm) -> Self {
         SerializableKmacKeyAlgorithm {
             name: value.name.as_str().into(),
             length: value.length,
@@ -4305,7 +4305,7 @@ pub(crate) enum KeyAlgorithmAndDerivatives {
     EcKeyAlgorithm(EcKeyAlgorithm),
     AesKeyAlgorithm(AesKeyAlgorithm),
     HmacKeyAlgorithm(HmacKeyAlgorithm),
-    KmacKeyAlgorithm(SubtleKmacKeyAlgorithm),
+    KmacKeyAlgorithm(KmacKeyAlgorithm),
 }
 
 impl KeyAlgorithmAndDerivatives {

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3954,7 +3954,7 @@ impl From<&SubtleKangarooTwelveParams> for SerializableKangarooTwelveParams {
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-KmacKeyGenParams>
 #[derive(Clone, MallocSizeOf)]
-struct SubtleKmacKeyGenParams {
+struct KmacKeyGenParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -3962,7 +3962,7 @@ struct SubtleKmacKeyGenParams {
     length: Option<u32>,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleKmacKeyGenParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for KmacKeyGenParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -3970,7 +3970,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleKmacKeyGenParams {
         cx: &mut js::context::JSContext,
         algorithm_name: CryptoAlgorithm,
     ) -> Result<Self, Self::Error> {
-        Ok(SubtleKmacKeyGenParams {
+        Ok(KmacKeyGenParams {
             name: algorithm_name,
             length: get_property(cx, object, c"length", ConversionBehavior::EnforceRange)?,
         })
@@ -5562,7 +5562,7 @@ enum GenerateKeyAlgorithm {
     MlDsa(Algorithm),
     AesOcb(AesKeyGenParams),
     ChaCha20Poly1305(Algorithm),
-    Kmac(SubtleKmacKeyGenParams),
+    Kmac(KmacKeyGenParams),
 }
 
 impl NormalizedAlgorithm for GenerateKeyAlgorithm {

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3979,7 +3979,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for KmacKeyGenParams {
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-KmacImportParams>
 #[derive(Clone, MallocSizeOf)]
-struct SubtleKmacImportParams {
+struct KmacImportParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -3987,7 +3987,7 @@ struct SubtleKmacImportParams {
     length: Option<u32>,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleKmacImportParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for KmacImportParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -3995,7 +3995,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleKmacImportParams {
         cx: &mut js::context::JSContext,
         algorithm_name: CryptoAlgorithm,
     ) -> Result<Self, Self::Error> {
-        Ok(SubtleKmacImportParams {
+        Ok(KmacImportParams {
             name: algorithm_name,
             length: get_property(cx, object, c"length", ConversionBehavior::EnforceRange)?,
         })
@@ -5788,7 +5788,7 @@ enum ImportKeyAlgorithm {
     MlDsa(Algorithm),
     AesOcb(Algorithm),
     ChaCha20Poly1305(Algorithm),
-    Kmac(SubtleKmacImportParams),
+    Kmac(KmacImportParams),
     Argon2(Algorithm),
 }
 
@@ -6230,7 +6230,7 @@ enum GetKeyLengthAlgorithm {
     Pbkdf2(Algorithm),
     AesOcb(AesDerivedKeyParams),
     ChaCha20Poly1305(Algorithm),
-    Kmac(SubtleKmacImportParams),
+    Kmac(KmacImportParams),
     Argon2(Algorithm),
 }
 

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3611,7 +3611,7 @@ impl From<&HmacKeyAlgorithm> for SerializableHmacKeyAlgorithm {
 
 /// <https://w3c.github.io/webcrypto/#dfn-HmacKeyGenParams>
 #[derive(Clone, MallocSizeOf)]
-struct SubtleHmacKeyGenParams {
+struct HmacKeyGenParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -3622,7 +3622,7 @@ struct SubtleHmacKeyGenParams {
     length: Option<u32>,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleHmacKeyGenParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for HmacKeyGenParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -3632,7 +3632,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleHmacKeyGenParams {
     ) -> Result<Self, Self::Error> {
         let hash = get_required_parameter(cx, object, c"hash", ())?;
 
-        Ok(SubtleHmacKeyGenParams {
+        Ok(HmacKeyGenParams {
             name: algorithm_name,
             hash: normalize_algorithm::<DigestOperation>(cx, &hash)?,
             length: get_property(cx, object, c"length", ConversionBehavior::EnforceRange)?,
@@ -5557,7 +5557,7 @@ enum GenerateKeyAlgorithm {
     AesCbc(AesKeyGenParams),
     AesGcm(AesKeyGenParams),
     AesKw(AesKeyGenParams),
-    Hmac(SubtleHmacKeyGenParams),
+    Hmac(HmacKeyGenParams),
     MlKem(Algorithm),
     MlDsa(Algorithm),
     AesOcb(AesKeyGenParams),

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3518,7 +3518,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for AesGcmParams {
 
 /// <https://w3c.github.io/webcrypto/#dfn-HmacImportParams>
 #[derive(Clone, MallocSizeOf)]
-struct SubtleHmacImportParams {
+struct HmacImportParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -3529,7 +3529,7 @@ struct SubtleHmacImportParams {
     length: Option<u32>,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleHmacImportParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for HmacImportParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -3539,7 +3539,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleHmacImportParams {
     ) -> Result<Self, Self::Error> {
         let hash = get_required_parameter(cx, object, c"hash", ())?;
 
-        Ok(SubtleHmacImportParams {
+        Ok(HmacImportParams {
             name: algorithm_name,
             hash: normalize_algorithm::<DigestOperation>(cx, &hash)?,
             length: get_property(cx, object, c"length", ConversionBehavior::EnforceRange)?,
@@ -5781,7 +5781,7 @@ enum ImportKeyAlgorithm {
     AesCbc(Algorithm),
     AesGcm(Algorithm),
     AesKw(Algorithm),
-    Hmac(SubtleHmacImportParams),
+    Hmac(HmacImportParams),
     Hkdf(Algorithm),
     Pbkdf2(Algorithm),
     MlKem(Algorithm),
@@ -6225,7 +6225,7 @@ enum GetKeyLengthAlgorithm {
     AesCbc(AesDerivedKeyParams),
     AesGcm(AesDerivedKeyParams),
     AesKw(AesDerivedKeyParams),
-    Hmac(SubtleHmacImportParams),
+    Hmac(HmacImportParams),
     Hkdf(Algorithm),
     Pbkdf2(Algorithm),
     AesOcb(AesDerivedKeyParams),

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -4052,7 +4052,7 @@ impl From<&KmacKeyAlgorithm> for SerializableKmacKeyAlgorithm {
 }
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-KmacParams>
-struct SubtleKmacParams {
+struct KmacParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -4063,7 +4063,7 @@ struct SubtleKmacParams {
     customization: Option<Vec<u8>>,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleKmacParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for KmacParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -4071,7 +4071,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleKmacParams {
         cx: &mut js::context::JSContext,
         algorithm_name: CryptoAlgorithm,
     ) -> Result<Self, Self::Error> {
-        Ok(SubtleKmacParams {
+        Ok(KmacParams {
             name: algorithm_name,
             output_length: get_required_parameter(
                 cx,
@@ -5063,7 +5063,7 @@ enum SignAlgorithm {
     Ed448(SubtleEd448Params),
     Hmac(Algorithm),
     MlDsa(SubtleContextParams),
-    Kmac(SubtleKmacParams),
+    Kmac(KmacParams),
 }
 
 impl NormalizedAlgorithm for SignAlgorithm {
@@ -5152,7 +5152,7 @@ enum VerifyAlgorithm {
     Ed448(SubtleEd448Params),
     Hmac(Algorithm),
     MlDsa(SubtleContextParams),
-    Kmac(SubtleKmacParams),
+    Kmac(KmacParams),
 }
 
 impl NormalizedAlgorithm for VerifyAlgorithm {

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3549,7 +3549,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for HmacImportParams {
 
 /// <https://w3c.github.io/webcrypto/#dfn-HmacKeyAlgorithm>
 #[derive(Clone, MallocSizeOf)]
-pub(crate) struct SubtleHmacKeyAlgorithm {
+pub(crate) struct HmacKeyAlgorithm {
     /// <https://w3c.github.io/webcrypto/#dom-keyalgorithm-name>
     name: CryptoAlgorithm,
 
@@ -3560,7 +3560,7 @@ pub(crate) struct SubtleHmacKeyAlgorithm {
     length: u32,
 }
 
-impl ToJSValConvertible for SubtleHmacKeyAlgorithm {
+impl ToJSValConvertible for HmacKeyAlgorithm {
     #[expect(unsafe_code)]
     fn safe_to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
         rooted!(&in(cx) let mut object = unsafe { JS_NewObject(cx, ptr::null()) });
@@ -3587,11 +3587,11 @@ impl ToJSValConvertible for SubtleHmacKeyAlgorithm {
     }
 }
 
-impl TryFrom<SerializableHmacKeyAlgorithm> for SubtleHmacKeyAlgorithm {
+impl TryFrom<SerializableHmacKeyAlgorithm> for HmacKeyAlgorithm {
     type Error = ();
 
     fn try_from(value: SerializableHmacKeyAlgorithm) -> Result<Self, Self::Error> {
-        Ok(SubtleHmacKeyAlgorithm {
+        Ok(HmacKeyAlgorithm {
             name: CryptoAlgorithm::from_str(&value.name).map_err(|_| ())?,
             hash: value.hash.try_into()?,
             length: value.length,
@@ -3599,8 +3599,8 @@ impl TryFrom<SerializableHmacKeyAlgorithm> for SubtleHmacKeyAlgorithm {
     }
 }
 
-impl From<&SubtleHmacKeyAlgorithm> for SerializableHmacKeyAlgorithm {
-    fn from(value: &SubtleHmacKeyAlgorithm) -> Self {
+impl From<&HmacKeyAlgorithm> for SerializableHmacKeyAlgorithm {
+    fn from(value: &HmacKeyAlgorithm) -> Self {
         SerializableHmacKeyAlgorithm {
             name: value.name.as_str().into(),
             hash: (&value.hash).into(),
@@ -4304,7 +4304,7 @@ pub(crate) enum KeyAlgorithmAndDerivatives {
     RsaHashedKeyAlgorithm(RsaHashedKeyAlgorithm),
     EcKeyAlgorithm(EcKeyAlgorithm),
     AesKeyAlgorithm(AesKeyAlgorithm),
-    HmacKeyAlgorithm(SubtleHmacKeyAlgorithm),
+    HmacKeyAlgorithm(HmacKeyAlgorithm),
     KmacKeyAlgorithm(SubtleKmacKeyAlgorithm),
 }
 

--- a/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
@@ -18,8 +18,8 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
-    NormalizedAlgorithm, HmacImportParams, HmacKeyAlgorithm, HmacKeyGenParams,
+    CryptoAlgorithm, ExportedKey, HmacImportParams, HmacKeyAlgorithm, HmacKeyGenParams,
+    JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives, NormalizedAlgorithm,
 };
 
 /// <https://w3c.github.io/webcrypto/#hmac-operations-sign>

--- a/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
@@ -19,7 +19,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
-    NormalizedAlgorithm, HmacImportParams, SubtleHmacKeyAlgorithm, SubtleHmacKeyGenParams,
+    NormalizedAlgorithm, HmacImportParams, HmacKeyAlgorithm, SubtleHmacKeyGenParams,
 };
 
 /// <https://w3c.github.io/webcrypto/#hmac-operations-sign>
@@ -139,7 +139,7 @@ pub(crate) fn generate_key(
     // Step 10. Set the name attribute of hash to equal the name member of the hash member of
     // normalizedAlgorithm.
     // Step 11. Set the hash attribute of algorithm to hash.
-    let algorithm = SubtleHmacKeyAlgorithm {
+    let algorithm = HmacKeyAlgorithm {
         name: CryptoAlgorithm::Hmac,
         hash: normalized_algorithm.hash.clone(),
         length,
@@ -339,7 +339,7 @@ pub(crate) fn import_key(
     // Step 11. Set the name attribute of algorithm to "HMAC".
     // Step 12. Set the length attribute of algorithm to length.
     // Step 13. Set the hash attribute of algorithm to hash.
-    let algorithm = SubtleHmacKeyAlgorithm {
+    let algorithm = HmacKeyAlgorithm {
         name: CryptoAlgorithm::Hmac,
         hash: hash.clone(),
         length,

--- a/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
@@ -19,7 +19,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
-    NormalizedAlgorithm, HmacImportParams, HmacKeyAlgorithm, SubtleHmacKeyGenParams,
+    NormalizedAlgorithm, HmacImportParams, HmacKeyAlgorithm, HmacKeyGenParams,
 };
 
 /// <https://w3c.github.io/webcrypto/#hmac-operations-sign>
@@ -89,7 +89,7 @@ pub(crate) fn verify(key: &CryptoKey, message: &[u8], signature: &[u8]) -> Resul
 pub(crate) fn generate_key(
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleHmacKeyGenParams,
+    normalized_algorithm: &HmacKeyGenParams,
     extractable: bool,
     usages: Vec<KeyUsage>,
 ) -> Result<DomRoot<CryptoKey>, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
@@ -19,7 +19,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
-    NormalizedAlgorithm, SubtleHmacImportParams, SubtleHmacKeyAlgorithm, SubtleHmacKeyGenParams,
+    NormalizedAlgorithm, HmacImportParams, SubtleHmacKeyAlgorithm, SubtleHmacKeyGenParams,
 };
 
 /// <https://w3c.github.io/webcrypto/#hmac-operations-sign>
@@ -168,7 +168,7 @@ pub(crate) fn generate_key(
 pub(crate) fn import_key(
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleHmacImportParams,
+    normalized_algorithm: &HmacImportParams,
     format: KeyFormat,
     key_data: &[u8],
     extractable: bool,
@@ -444,7 +444,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
 
 /// <https://w3c.github.io/webcrypto/#hmac-operations-get-key-length>
 pub(crate) fn get_key_length(
-    normalized_derived_key_algorithm: &SubtleHmacImportParams,
+    normalized_derived_key_algorithm: &HmacImportParams,
 ) -> Result<Option<u32>, Error> {
     // Step 1.
     let length = match normalized_derived_key_algorithm.length {

--- a/components/script/dom/webcrypto/subtlecrypto/kmac_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/kmac_operation.rs
@@ -20,7 +20,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
-    SubtleKmacImportParams, SubtleKmacKeyAlgorithm, KmacKeyGenParams, SubtleKmacParams,
+    KmacImportParams, SubtleKmacKeyAlgorithm, KmacKeyGenParams, SubtleKmacParams,
 };
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#kmac-operations-sign>
@@ -235,7 +235,7 @@ pub(crate) fn generate_key(
 pub(crate) fn import_key(
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleKmacImportParams,
+    normalized_algorithm: &KmacImportParams,
     format: KeyFormat,
     key_data: &[u8],
     extractable: bool,
@@ -473,7 +473,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#kmac-operations-get-key-length>
 pub(crate) fn get_key_length(
-    normalized_algorithm: &SubtleKmacImportParams,
+    normalized_algorithm: &KmacImportParams,
 ) -> Result<Option<u32>, Error> {
     // Step 1.
     // If the length member of normalizedAlgorithm is present:

--- a/components/script/dom/webcrypto/subtlecrypto/kmac_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/kmac_operation.rs
@@ -20,7 +20,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
-    KmacImportParams, SubtleKmacKeyAlgorithm, KmacKeyGenParams, SubtleKmacParams,
+    KmacImportParams, KmacKeyAlgorithm, KmacKeyGenParams, SubtleKmacParams,
 };
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#kmac-operations-sign>
@@ -213,7 +213,7 @@ pub(crate) fn generate_key(
     // Step 10. Set the [[algorithm]] internal slot of key to algorithm.
     // Step 11. Set the [[extractable]] internal slot of key to be extractable.
     // Step 12. Set the [[usages]] internal slot of key to be the normalized value of usages.
-    let algorithm = SubtleKmacKeyAlgorithm {
+    let algorithm = KmacKeyAlgorithm {
         name: normalized_algorithm.name,
         length,
     };
@@ -378,7 +378,7 @@ pub(crate) fn import_key(
             *last_byte &= mask;
         }
     }
-    let algorithm = SubtleKmacKeyAlgorithm {
+    let algorithm = KmacKeyAlgorithm {
         name: normalized_algorithm.name,
         length,
     };

--- a/components/script/dom/webcrypto/subtlecrypto/kmac_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/kmac_operation.rs
@@ -20,12 +20,12 @@ use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
-    KmacImportParams, KmacKeyAlgorithm, KmacKeyGenParams, SubtleKmacParams,
+    KmacImportParams, KmacKeyAlgorithm, KmacKeyGenParams, KmacParams,
 };
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#kmac-operations-sign>
 pub(crate) fn sign(
-    normalized_algorithm: &SubtleKmacParams,
+    normalized_algorithm: &KmacParams,
     key: &CryptoKey,
     message: &[u8],
 ) -> Result<Vec<u8>, Error> {
@@ -86,7 +86,7 @@ pub(crate) fn sign(
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#kmac-operations-verify>
 pub(crate) fn verify(
-    normalized_algorithm: &SubtleKmacParams,
+    normalized_algorithm: &KmacParams,
     key: &CryptoKey,
     message: &[u8],
     signature: &[u8],

--- a/components/script/dom/webcrypto/subtlecrypto/kmac_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/kmac_operation.rs
@@ -20,7 +20,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
-    SubtleKmacImportParams, SubtleKmacKeyAlgorithm, SubtleKmacKeyGenParams, SubtleKmacParams,
+    SubtleKmacImportParams, SubtleKmacKeyAlgorithm, KmacKeyGenParams, SubtleKmacParams,
 };
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#kmac-operations-sign>
@@ -152,7 +152,7 @@ pub(crate) fn verify(
 pub(crate) fn generate_key(
     cx: &mut JSContext,
     global: &GlobalScope,
-    normalized_algorithm: &SubtleKmacKeyGenParams,
+    normalized_algorithm: &KmacKeyGenParams,
     extractable: bool,
     usages: Vec<KeyUsage>,
 ) -> Result<DomRoot<CryptoKey>, Error> {


### PR DESCRIPTION
Rename the following structs:

`SubtleHmacImportParams` to `HmacImportParams`
`SubtleHmacKeyAlgorithm` to `HmacKeyAlgorithm`
`SubtleHmacKeyGenParams` to `HmacKeyGenParams`
`SubtleKmacKeyGenParams` to `KmacKeyGenParams`
`SubtleKmacImportParams` to `KmacImportParams`
`SubtleKmacKeyAlgorithm` to `KmacKeyAlgorithm`
`SubtleKmacParams` to `KmacParams`

This is part of #46948 in order to replace the generated binding types with custom binding types for WebCrypto.

Testing: It compiles.
Part-of: #46948
