### PR TITLE
script: Avoid double adjustment of Selection ranges during `contenteditable` node movement

### DIFF
--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -157,88 +157,73 @@ where
         .active_range()
         .expect("Must always have an active range");
 
-    // Relevant only in the case where we have a single text node that is partially/fully selected.
-    // In that case, the spec algorithm would update the selection to the parent of the text node.
-    // However, this then breaks the algorithm to compute "effectively contained" nodes. To remedy
-    // that, we record the values here and reset them as part of step 2.
-    let end_offsets_if_previously_selected_single_text_node = if active_range.start_container() ==
-        active_range.end_container() &&
-        active_range.start_container().is::<Text>()
-    {
-        Some((
-            active_range.start_container(),
-            active_range.start_offset(),
-            active_range.end_offset(),
-        ))
-    } else {
-        None
-    };
+    // Selection is currently implemented as a live range (not great!), which means that
+    // we need to record the old boundary point (container and offset) before actually
+    // performing the move operation and then apply the editing spec's range update
+    // algorithm to this original boundary point.
+    let start_container = active_range.start_container();
+    let start_offset = active_range.start_offset();
+    let end_container = active_range.end_container();
+    let end_offset = active_range.end_offset();
+
+    let should_adjust_start = node.is_inclusive_ancestor_of(&start_container);
+    let should_adjust_end = node.is_inclusive_ancestor_of(&end_container);
 
     if move_(cx).is_err() {
         unreachable!("Must always be able to move");
     }
 
-    // Step 2. If a boundary point's node is the same as or a descendant of node, leave it unchanged,
-    // so it moves to the new location.
-    //
-    // From the spec:
-    // > This is actually implicit, but I state it anyway for completeness.
-    //
-    // However, this is not actually implicit. The caveat here are text nodes that are
-    // partially/fully selected. In these cases, we shouldn't update the offsets to the new parent,
-    // but instead retain them on the original text node. Therefore, if that's the case,
-    // update them here and immediately return.
-    if let Some((selected_text_node, previous_start_offset, previous_end_offset)) =
-        end_offsets_if_previously_selected_single_text_node
-    {
-        active_range.set_start(&selected_text_node, previous_start_offset);
-        active_range.set_end(&selected_text_node, previous_end_offset);
-        return;
-    }
-
     let new_parent = node.GetParentNode().expect("Must always have a new parent");
     let new_index = node.index();
 
-    let mut start_node = active_range.start_container();
-    let mut start_offset = active_range.start_offset();
-    let mut end_node = active_range.end_container();
-    let mut end_offset = active_range.end_offset();
-
-    // Step 3. If a boundary point's node is new parent and its offset is greater than new index, add one to its offset.
-    if start_node == new_parent && start_offset > new_index {
-        start_offset += 1;
-    }
-    if end_node == new_parent && end_offset > new_index {
-        end_offset += 1;
-    }
-
-    if let Some(old_parent) = old_parent {
-        // Step 4. If a boundary point's node is old parent and its offset is old index or old index + 1,
-        // set its node to new parent and add new index − old index to its offset.
-        if start_node == old_parent && (start_offset == old_index || start_offset == old_index + 1)
-        {
-            start_node = new_parent.clone();
-            start_offset += new_index;
-            start_offset -= old_index;
-        }
-        if end_node == old_parent && (end_offset == old_index || end_offset == old_index + 1) {
-            end_node = new_parent;
-            end_offset += new_index;
-            end_offset -= old_index;
+    let adjust_boundary_point = |mut container, mut offset, should_adjust: bool| {
+        // Step 2. If a boundary point's node is the same as or a descendant of node, leave it
+        // unchanged, so it moves to the new location.
+        //
+        // From the spec:
+        // > This is actually implicit, but I state it anyway for completeness.
+        //
+        // However, this does not seem to be implicit for text nodes that are partially/fully
+        // selected. In these cases, we shouldn't update the offsets to the new parent, but
+        // instead retain them on the original text node. Therefore, if that's the case,
+        // update them here and immediately return.
+        if !should_adjust {
+            return (container, offset);
         }
 
-        // Step 5. If a boundary point's node is old parent and its offset is greater than old index + 1,
-        // subtract one from its offset.
-        if start_node == old_parent && (start_offset > old_index + 1) {
-            start_offset -= 1;
+        // Step 3. If a boundary point's node is new parent and its offset is greater than new
+        // index, add one to its offset.
+        if container == new_parent && offset > new_index {
+            offset += 1;
         }
-        if end_node == old_parent && (end_offset > old_index + 1) {
-            end_offset -= 1;
-        }
-    }
 
-    active_range.set_start(&start_node, start_offset);
-    active_range.set_end(&end_node, end_offset);
+        if let Some(old_parent) = old_parent.as_ref() {
+            // Step 4. If a boundary point's node is old parent and its offset is old
+            // index or old index + 1, set its node to new parent and add new index −
+            // old index to its offset.
+            if container == *old_parent && (offset == old_index || offset == old_index + 1) {
+                container = new_parent.clone();
+                offset += new_index;
+                offset -= old_index;
+            }
+
+            // Step 5. If a boundary point's node is old parent and its offset is
+            // greater than old index + 1, subtract one from its offset.
+            if container == *old_parent && (offset > old_index + 1) {
+                offset -= 1;
+            }
+        }
+
+        (container, offset)
+    };
+
+    let (new_start_container, new_start_offset) =
+        adjust_boundary_point(start_container, start_offset, should_adjust_start);
+    let (new_end_container, new_end_offset) =
+        adjust_boundary_point(end_container, end_offset, should_adjust_end);
+
+    active_range.set_start(&new_start_container, new_start_offset);
+    active_range.set_end(&new_end_container, new_end_offset);
 }
 
 /// <https://w3c.github.io/editing/docs/execCommand/#allowed-child>

--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -166,8 +166,8 @@ where
     let end_container = active_range.end_container();
     let end_offset = active_range.end_offset();
 
-    let should_adjust_start = node.is_inclusive_ancestor_of(&start_container);
-    let should_adjust_end = node.is_inclusive_ancestor_of(&end_container);
+    let should_adjust_start = !node.is_inclusive_ancestor_of(&start_container);
+    let should_adjust_end = !node.is_inclusive_ancestor_of(&end_container);
 
     if move_(cx).is_err() {
         unreachable!("Must always be able to move");

--- a/tests/wpt/meta/editing/run/backcolor.html.ini
+++ b/tests/wpt/meta/editing/run/backcolor.html.ini
@@ -53,12 +53,6 @@
   [[["backcolor","#00FFFF"\]\] "fo[o<span style=background-color:tan>bar</span>b\]az" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["backcolor","#00FFFF"\]\] "foo[<span style=background-color:tan>b\]ar</span>baz" queryCommandValue("backcolor") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["backcolor","#00FFFF"\]\] "foo[<span style=background-color:tan>b\]ar</span>baz" queryCommandValue("backcolor") after]
-    expected: FAIL
-
   [[["backcolor","#00FFFF"\]\] "<p style=\\"background-color: rgb(0, 255, 255)\\">foo[bar\]baz</p>" compare innerHTML]
     expected: FAIL
 
@@ -69,4 +63,7 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["backcolor","#00FFFF"\]\] "<p>[foo<p><br><p>bar\]" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["backcolor","#00FFFF"\]\] "{ <span contenteditable=\\"false\\">A</span> ; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span> }" compare innerHTML]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/bold.html.ini
+++ b/tests/wpt/meta/editing/run/bold.html.ini
@@ -1,41 +1,11 @@
 [bold.html?1001-2000]
-  [[["stylewithcss","true"\],["bold",""\]\] "<b>{<p>foo</p><p>bar</p>}<p>baz</p></b>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["bold",""\]\] "<b>{<p>foo</p><p>bar</p>}<p>baz</p></b>" compare innerHTML]
-    expected: FAIL
-
   [[["bold",""\]\] "foo [bar <b>baz\] qoz</b> quz sic" queryCommandIndeterm("bold") before]
     expected: FAIL
 
   [[["bold",""\]\] "foo bar <b>baz [qoz</b> quz\] sic" queryCommandIndeterm("bold") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["bold",""\]\] "foo[<span style=\\"font-weight: 400\\">bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["bold",""\]\] "foo[<span style=\\"font-weight: 400\\">bar\]</span>baz" queryCommandState("bold") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["bold",""\]\] "foo[<span style=\\"font-weight: 400\\">bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["bold",""\]\] "foo[<span style=\\"font-weight: 400\\">bar\]</span>baz" queryCommandState("bold") after]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["bold",""\]\] "<span style=\\"font-weight: 900\\">foo[bar\]baz</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["bold",""\]\] "{<span style=\\"font-weight: 100\\">foobar\]baz</span>" queryCommandState("bold") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["bold",""\]\] "{<span style=\\"font-weight: 100\\">foobar\]baz</span>" queryCommandState("bold") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["bold",""\]\] "{<span style=\\"font-weight: 400\\">foobar\]baz</span>" queryCommandState("bold") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["bold",""\]\] "{<span style=\\"font-weight: 400\\">foobar\]baz</span>" queryCommandState("bold") after]
     expected: FAIL
 
   [[["bold",""\]\] "{<span style=\\"font-weight: 900\\">foobar\]baz</span>" compare innerHTML]
@@ -111,6 +81,9 @@
   [[["stylewithcss","false"\],["bold",""\]\] "abc<i>[def\]</i>ghi" compare innerHTML]
     expected: FAIL
 
+  [[["stylewithcss","false"\],["bold",""\]\] "{ <span contenteditable=\\"false\\">A</span> ; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span> }" compare innerHTML]
+    expected: FAIL
+
 
 [bold.html?2001-3000]
   [[["bold",""\]\] "<span style=\\"font-weight: 900\\">foo[barbaz</span>}" compare innerHTML]
@@ -144,12 +117,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["bold",""\]\] "{<h3>foo</h3><b>bar</b>}" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["bold",""\]\] "foo<span style=\\"font-weight: normal\\"><b>{bar}</b></span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["bold",""\]\] "foo<span style=\\"font-weight: normal\\"><b>{bar}</b></span>baz" compare innerHTML]
     expected: FAIL
 
   [[["bold",""\]\] "fo[o<b>b\]ar</b>baz" queryCommandIndeterm("bold") before]

--- a/tests/wpt/meta/editing/run/createlink.html.ini
+++ b/tests/wpt/meta/editing/run/createlink.html.ini
@@ -5,9 +5,6 @@
   [[["createlink","http://www.google.com/"\]\] "<p>[foo<p><br><p>bar\]" compare innerHTML]
     expected: FAIL
 
-  [[["createlink","http://www.google.com/"\]\] "[foo<a href=http://www.google.com/>bar\]</a>baz" compare innerHTML]
-    expected: FAIL
-
   [[["createlink","http://www.google.com/"\]\] "<a href=otherurl>foo[bar\]baz</a>" compare innerHTML]
     expected: FAIL
 
@@ -15,9 +12,6 @@
     expected: FAIL
 
   [[["createlink","http://www.google.com/"\]\] "{<a href=otherurl>foobar\]baz</a>" compare innerHTML]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\]\] "[foo<a href=otherurl>bar\]</a>baz" compare innerHTML]
     expected: FAIL
 
   [[["createlink","http://www.google.com/"\]\] "<a href=otherurl><b>foo[bar\]baz</b></a>" compare innerHTML]

--- a/tests/wpt/meta/editing/run/fontname.html.ini
+++ b/tests/wpt/meta/editing/run/fontname.html.ini
@@ -46,6 +46,9 @@
   [[["stylewithcss","true"\],["fontname","sans-serif"\]\] "fo[o<pre>b\]ar</pre>" queryCommandState("stylewithcss") before]
     expected: FAIL
 
+  [[["stylewithcss","false"\],["fontname","sans-serif"\]\] "{ <span contenteditable=\\"false\\">A</span> ; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span> }" compare innerHTML]
+    expected: FAIL
+
 
 [fontname.html?1001-2000]
   [[["stylewithcss","false"\],["fontname","sans-serif"\]\] "[foo<pre>bar</pre>baz\]" queryCommandValue("fontname") after]
@@ -78,9 +81,6 @@
   [[["stylewithcss","true"\],["fontname","sans-serif"\]\] "foo<tt>{<br></tt>b\]ar" queryCommandValue("fontname") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontname","sans-serif"\]\] "foo<tt>{<br></tt>b\]ar" queryCommandValue("fontname") after]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontname","sans-serif"\]\] "foo<tt>{<br></tt>b\]ar" compare innerHTML]
     expected: FAIL
 
@@ -88,9 +88,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontname","sans-serif"\]\] "foo<tt>{<br></tt>b\]ar" queryCommandValue("fontname") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontname","sans-serif"\]\] "foo<tt>{<br></tt>b\]ar" queryCommandValue("fontname") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontname","sans-serif"\]\] "fo[o<span style=font-family:monospace>b\]ar</span>baz" compare innerHTML]
@@ -111,13 +108,7 @@
   [[["stylewithcss","true"\],["fontname","sans-serif"\]\] "foo[<span style=font-family:monospace>b\]ar</span>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontname","sans-serif"\]\] "foo[<span style=font-family:monospace>b\]ar</span>baz" queryCommandValue("fontname") after]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontname","sans-serif"\]\] "foo[<span style=font-family:monospace>b\]ar</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontname","sans-serif"\]\] "foo[<span style=font-family:monospace>b\]ar</span>baz" queryCommandValue("fontname") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontname","sans-serif"\]\] "foo<span style=font-family:monospace>ba[r</span>\]baz" compare innerHTML]

--- a/tests/wpt/meta/editing/run/fontsize.html.ini
+++ b/tests/wpt/meta/editing/run/fontsize.html.ini
@@ -315,8 +315,5 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "fo[o<font size=2>bar</font>b\]az" queryCommandState("stylewithcss") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[<font size=2>b\]ar</font>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[<font size=2>b\]ar</font>baz" queryCommandValue("fontsize") after]
+  [[["stylewithcss","false"\],["fontsize","5"\]\] "{ <span contenteditable=\\"false\\">A</span> ; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span> }" compare innerHTML]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/forecolor.html.ini
+++ b/tests/wpt/meta/editing/run/forecolor.html.ini
@@ -390,13 +390,7 @@
   [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "foo[<font color=brown>b\]ar</font>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "foo[<font color=brown>b\]ar</font>baz" queryCommandValue("forecolor") after]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["forecolor","#0000FF"\]\] "foo[<font color=brown>b\]ar</font>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["forecolor","#0000FF"\]\] "foo[<font color=brown>b\]ar</font>baz" queryCommandValue("forecolor") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "foo<font color=brown>ba[r</font>\]baz" compare innerHTML]
@@ -420,13 +414,7 @@
   [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "foo{<font color=brown>bar</font>}baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "foo{<font color=brown>bar</font>}baz" queryCommandValue("forecolor") after]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["forecolor","#0000FF"\]\] "foo{<font color=brown>bar</font>}baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["forecolor","#0000FF"\]\] "foo{<font color=brown>bar</font>}baz" queryCommandValue("forecolor") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "<font color=brown>fo[o</font><span style=color:brown>b\]ar</span>" compare innerHTML]
@@ -493,4 +481,7 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["forecolor","#0000FF"\]\] "<font color=brown>fo[o</font><span style=color:brown>b\]ar</span>" queryCommandIndeterm("forecolor") before]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["foreColor","#ff0000"\]\] "{ <span contenteditable=\\"false\\">A</span> ; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span> }" compare innerHTML]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/hilitecolor.html.ini
+++ b/tests/wpt/meta/editing/run/hilitecolor.html.ini
@@ -56,12 +56,6 @@
   [[["hilitecolor","#00FFFF"\]\] "fo[o<span style=background-color:tan>bar</span>b\]az" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["hilitecolor","#00FFFF"\]\] "foo[<span style=background-color:tan>b\]ar</span>baz" queryCommandValue("hilitecolor") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["hilitecolor","#00FFFF"\]\] "foo[<span style=background-color:tan>b\]ar</span>baz" queryCommandValue("hilitecolor") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["hilitecolor","#00FFFF"\]\] "<font size=6>[foo\]</font>" compare innerHTML]
     expected: FAIL
 
@@ -96,4 +90,7 @@
     expected: FAIL
 
   [[["hilitecolor","#00FFFF"\]\] "<p style=\\"background-color: aqua\\">foo[bar\]baz</p>" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["hilitecolor","#00FFFF"\]\] "{ <span contenteditable=\\"false\\">A</span> ; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span> }" compare innerHTML]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/insertparagraph.html.ini
+++ b/tests/wpt/meta/editing/run/insertparagraph.html.ini
@@ -525,18 +525,6 @@
   [[["defaultparagraphseparator","div"\],["insertparagraph",""\],["inserttext","d"\]\] "<div>abc</div><p>[def\]</p>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\],["inserttext","d"\]\] "<ol><li>[abc\]</li></ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\],["inserttext","d"\]\] "<ol><li>abc</li><li>[def\]</li></ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\],["inserttext","d"\]\] "<ol><li>abc</li><li>[def\]</li><li>ghi</li></ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\],["inserttext","a"\]\] "<ol><li>[abc\]</li><li>def</li></ol>" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<h3>[abc\]</h3>" compare innerHTML]
     expected: FAIL
 

--- a/tests/wpt/meta/editing/run/italic.html.ini
+++ b/tests/wpt/meta/editing/run/italic.html.ini
@@ -85,6 +85,9 @@
   [[["stylewithcss","false"\],["italic",""\]\] "<span style=font-style:italic>fo[o</span><span style=font-style:oblique>b\]ar</span>" queryCommandState("italic") after]
     expected: FAIL
 
+  [[["stylewithcss","false"\],["italic",""\]\] "{ <span contenteditable=\\"false\\">A</span> ; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span> }" compare innerHTML]
+    expected: FAIL
+
 
 [italic.html?1001-2000]
   [[["stylewithcss","true"\],["italic",""\]\] "fo[o<dfn>bar</dfn>b\]az" queryCommandIndeterm("italic") before]
@@ -178,12 +181,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "foo<span style=\\"font-style: oblique\\">b[a\]r</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<i>{<p>foo</p><p>bar</p>}<p>baz</p></i>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<i>{<p>foo</p><p>bar</p>}<p>baz</p></i>" compare innerHTML]
     expected: FAIL
 
   [[["italic",""\]\] "foo [bar <i>baz\] qoz</i> quz sic" queryCommandIndeterm("italic") before]

--- a/tests/wpt/meta/editing/run/strikethrough.html.ini
+++ b/tests/wpt/meta/editing/run/strikethrough.html.ini
@@ -38,32 +38,11 @@
   [[["stylewithcss","false"\],["strikethrough",""\]\] "<s>fo[o</s><del>b\]ar</del>" compare innerHTML]
     expected: FAIL
 
+  [[["stylewithcss","false"\],["strikethrough",""\]\] "{ <span contenteditable=\\"false\\">A</span> ; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span> }" compare innerHTML]
+    expected: FAIL
+
 
 [strikethrough.html?1001-2000]
-  [[["stylewithcss","true"\],["strikethrough",""\]\] "<strike>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</strike>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "<strike>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</strike>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["strikethrough",""\]\] "<strike>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</strike>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "<strike>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</strike>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["strikethrough",""\]\] "<strike>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</strike>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "<strike>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</strike>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["strikethrough",""\]\] "<strike>foo[b<i>ar\]ba</i>z</strike>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "<strike>foo[b<i>ar\]ba</i>z</strike>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["strikethrough",""\]\] "foo<ins>[bar\]</ins>baz" compare innerHTML]
     expected: FAIL
 
@@ -125,30 +104,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["strikethrough",""\]\] "<strike>foo[bar\]baz</strike>" queryCommandState("strikethrough") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["strikethrough",""\]\] "<strike>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</strike>" queryCommandState("strikethrough") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "<strike>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</strike>" queryCommandState("strikethrough") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["strikethrough",""\]\] "<strike>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</strike>" queryCommandState("strikethrough") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "<strike>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</strike>" queryCommandState("strikethrough") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["strikethrough",""\]\] "<strike>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</strike>" queryCommandState("strikethrough") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "<strike>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</strike>" queryCommandState("strikethrough") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["strikethrough",""\]\] "<strike>foo[b<i>ar\]ba</i>z</strike>" queryCommandState("strikethrough") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "<strike>foo[b<i>ar\]ba</i>z</strike>" queryCommandState("strikethrough") after]
     expected: FAIL
 
   [[["strikethrough",""\]\] "foo<s>ba[r</s>b\]az" compare innerHTML]
@@ -214,30 +169,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["strikethrough",""\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("stylewithcss") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["strikethrough",""\]\] "<s>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</s>" queryCommandState("strikethrough") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "<s>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</s>" queryCommandState("strikethrough") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["strikethrough",""\]\] "<s>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</s>" queryCommandState("strikethrough") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "<s>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</s>" queryCommandState("strikethrough") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["strikethrough",""\]\] "<s>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</s>" queryCommandState("strikethrough") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "<s>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</s>" queryCommandState("strikethrough") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["strikethrough",""\]\] "<s>foo[b<i>ar\]ba</i>z</s>" queryCommandState("strikethrough") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "<s>foo[b<i>ar\]ba</i>z</s>" queryCommandState("strikethrough") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["strikethrough",""\]\] "<s>foo[bar\]baz</s>" compare innerHTML]

--- a/tests/wpt/meta/editing/run/subscript.html.ini
+++ b/tests/wpt/meta/editing/run/subscript.html.ini
@@ -59,9 +59,6 @@
   [[["stylewithcss","false"\],["subscript",""\]\] "foo<sup>b<sub>[a\]</sub>r</sup>baz" queryCommandIndeterm("subscript") before]
     expected: FAIL
 
-  [[["subscript",""\]\] "fo[o<sub>b\]ar</sub>baz" compare innerHTML]
-    expected: FAIL
-
   [[["subscript",""\]\] "fo[o<sub>b\]ar</sub>baz" queryCommandIndeterm("subscript") before]
     expected: FAIL
 
@@ -69,9 +66,6 @@
     expected: FAIL
 
   [[["subscript",""\]\] "fo[o<sub>bar</sub>b\]az" queryCommandIndeterm("subscript") before]
-    expected: FAIL
-
-  [[["subscript",""\]\] "<sub>fo[o</sub><sup>b\]ar</sup>" compare innerHTML]
     expected: FAIL
 
   [[["subscript",""\]\] "<sub>fo[o</sub><sup>b\]ar</sup>" queryCommandIndeterm("subscript") before]
@@ -108,4 +102,7 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["subscript",""\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("stylewithcss") before]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["subscript",""\]\] "{ <span contenteditable=\\"false\\">A</span> ; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span> }" compare innerHTML]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/superscript.html.ini
+++ b/tests/wpt/meta/editing/run/superscript.html.ini
@@ -59,9 +59,6 @@
   [[["stylewithcss","false"\],["superscript",""\]\] "foo<sup>b<sub>[a\]</sub>r</sup>baz" queryCommandIndeterm("superscript") before]
     expected: FAIL
 
-  [[["superscript",""\]\] "fo[o<sup>b\]ar</sup>baz" compare innerHTML]
-    expected: FAIL
-
   [[["superscript",""\]\] "fo[o<sup>b\]ar</sup>baz" queryCommandIndeterm("superscript") before]
     expected: FAIL
 
@@ -69,9 +66,6 @@
     expected: FAIL
 
   [[["superscript",""\]\] "fo[o<sup>bar</sup>b\]az" queryCommandIndeterm("superscript") before]
-    expected: FAIL
-
-  [[["superscript",""\]\] "<sup>fo[o</sup><sub>b\]ar</sub>" compare innerHTML]
     expected: FAIL
 
   [[["superscript",""\]\] "<sup>fo[o</sup><sub>b\]ar</sub>" queryCommandIndeterm("superscript") before]
@@ -108,4 +102,7 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["superscript",""\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("stylewithcss") before]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["superscript",""\]\] "{ <span contenteditable=\\"false\\">A</span> ; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span> }" compare innerHTML]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/underline.html.ini
+++ b/tests/wpt/meta/editing/run/underline.html.ini
@@ -11,30 +11,6 @@
   [[["stylewithcss","false"\],["underline",""\]\] "<p>[foo<p><br><p>bar\]" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</u>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</u>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</u>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</u>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</u>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</u>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<i>ar\]ba</i>z</u>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<i>ar\]ba</i>z</u>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo<s>[bar\]</s>baz" compare innerHTML]
     expected: FAIL
 
@@ -45,30 +21,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("stylewithcss") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</u>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</u>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</u>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<i>ar\]ba</i>z</u>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</u>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</u>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</u>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<i>ar\]ba</i>z</u>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "foo<s>[bar\]</s>baz" compare innerHTML]
@@ -109,10 +61,7 @@
   [[["stylewithcss","true"\],["underline",""\]\] "foo<u>[bar\]</u>baz" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<ins>fo[o</ins><u>b\]ar</u>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<ins>fo[o</ins><u>b\]ar</u>" queryCommandState("underline") after]
+  [[["stylewithcss","false"\],["underline",""\]\] "{ <span contenteditable=\\"false\\">A</span> ; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span> }" compare innerHTML]
     expected: FAIL
 
 

--- a/tests/wpt/tests/editing/crashtests/updating-selection-offsets-after-insertHorizontalRule.html
+++ b/tests/wpt/tests/editing/crashtests/updating-selection-offsets-after-insertHorizontalRule.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/47333">
+<script>
+function main() {
+  window.getSelection().selectAllChildren(div);
+  document.execCommand("removeFormat");
+  document.execCommand("insertHorizontalRule");
+}
+</script>
+<body onload="main()" contenteditable="">
+<div id="div"><b>


### PR DESCRIPTION
The editing specification has a different way of updating selection
ranges than the typical live range update method in the `insert` and
`remove` algorithms. Because selections are currently represented as
live ranges (something that will change soon), this means that the
adjustment was being applied twice: once by the live range update and
then once by the `contenteditable` code's range fixup. This change makes
it so that the `contenteditable` fixup runs against the original
selection boundaries, meaning that the final fixup is done only once.

Testing: This change adds a WPT crash test.
Fixes: #47333.
