### PR TITLE
script: Small unminify-js clean-up

### DIFF
--- a/components/script/dom/globalscope/script_execution.rs
+++ b/components/script/dom/globalscope/script_execution.rs
@@ -90,7 +90,7 @@ impl GlobalScope {
             let mut script_source = ScriptSource {
                 source,
                 external,
-                url: url.clone(),
+                url: &url,
             };
             unminify_js(&mut script_source, unminified_js_dir);
             transform_str_to_source_text(&script_source.source)

--- a/components/script/dom/globalscope/script_execution.rs
+++ b/components/script/dom/globalscope/script_execution.rs
@@ -30,11 +30,9 @@ use crate::dom::bindings::error::{Error, ErrorInfo, ErrorResult, report_pending_
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
-use crate::modules::script_module::{
-    ModuleScript, ModuleSource, ModuleTree, RethrowError, ScriptFetchOptions,
-};
+use crate::modules::script_module::{ModuleScript, ModuleTree, RethrowError, ScriptFetchOptions};
 use crate::realms::enter_auto_realm;
-use crate::unminify::unminify_js;
+use crate::unminify::{ScriptSource, unminify_js};
 
 /// <https://html.spec.whatwg.org/multipage/#classic-script>
 #[derive(JSTraceable, MallocSizeOf)]
@@ -88,14 +86,13 @@ impl GlobalScope {
         line_number: u32,
         external: bool,
     ) -> ClassicScript {
-        let mut source = if self.unminified_js_dir().is_some() {
-            let mut script_source = ModuleSource {
+        let mut source = if let Some(unminified_js_dir) = self.unminified_js_dir() {
+            let mut script_source = ScriptSource {
                 source,
-                unminified_dir: self.unminified_js_dir(),
                 external,
                 url: url.clone(),
             };
-            unminify_js(&mut script_source);
+            unminify_js(&mut script_source, unminified_js_dir);
             transform_str_to_source_text(&script_source.source)
         } else {
             transform_str_to_source_text(&source)

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -390,7 +390,7 @@ impl FetchResponseListener for ClassicContext {
         if let Some(window) = global.downcast::<Window>() &&
             let Some(script_source) = window.local_script_source()
         {
-            substitute_with_local_script(script_source, &mut source_text, final_url.clone());
+            substitute_with_local_script(script_source, &mut source_text, &final_url);
         }
 
         // Step 5.6. Let mutedErrors be true if response was CORS-cross-origin, and false otherwise.
@@ -1403,7 +1403,11 @@ impl HTMLScriptElementMethods<crate::DomTypeHolder> for HTMLScriptElement {
     }
 }
 
-pub fn substitute_with_local_script(script_source: &str, script: &mut Cow<'_, str>, url: ServoUrl) {
+pub fn substitute_with_local_script(
+    script_source: &str,
+    script: &mut Cow<'_, str>,
+    url: &ServoUrl,
+) {
     let mut path = PathBuf::from(script_source);
     path = path.join(&url[url::Position::BeforeHost..url::Position::AfterPath]);
     debug!("Attempting to read script stored at: {:?}", path);

--- a/components/script/modules/script_module.rs
+++ b/components/script/modules/script_module.rs
@@ -291,7 +291,7 @@ impl ModuleTree {
             let mut module_source = ScriptSource {
                 source,
                 external,
-                url: url.clone(),
+                url,
             };
             unminify_js(&mut module_source, unminified_js_dir);
             transform_str_to_source_text(&module_source.source)

--- a/components/script/modules/script_module.rs
+++ b/components/script/modules/script_module.rs
@@ -763,7 +763,7 @@ impl FetchResponseListener for ModuleContext {
                 if let Some(window) = global.downcast::<Window>() &&
                     let Some(script_souce) = window.local_script_source()
                 {
-                    substitute_with_local_script(script_souce, &mut source_text, final_url.clone());
+                    substitute_with_local_script(script_souce, &mut source_text, &final_url);
                 }
 
                 let module_tree = Rc::new(ModuleTree::create_a_javascript_module_script(

--- a/components/script/modules/script_module.rs
+++ b/components/script/modules/script_module.rs
@@ -82,6 +82,7 @@ use crate::modules::module_loading::{
 use crate::realms::enter_auto_realm;
 use crate::script_runtime::IntroductionType;
 use crate::tasks::task::NonSendTaskBox;
+use crate::unminify::{ScriptSource, unminify_js};
 
 pub(crate) fn gen_type_error(
     cx: &mut JSContext,
@@ -245,35 +246,6 @@ impl ModuleTree {
     }
 }
 
-pub(crate) struct ModuleSource<'a> {
-    pub source: Cow<'a, str>,
-    pub unminified_dir: Option<String>,
-    pub external: bool,
-    pub url: ServoUrl,
-}
-
-impl<'a> crate::unminify::ScriptSource for ModuleSource<'a> {
-    fn unminified_dir(&self) -> Option<String> {
-        self.unminified_dir.clone()
-    }
-
-    fn extract_bytes(&self) -> &[u8] {
-        self.source.as_bytes()
-    }
-
-    fn rewrite_source(&mut self, source: String) {
-        self.source = source.into();
-    }
-
-    fn url(&self) -> ServoUrl {
-        self.url.clone()
-    }
-
-    fn is_external(&self) -> bool {
-        self.external
-    }
-}
-
 impl ModuleTree {
     #[expect(unsafe_code)]
     #[expect(clippy::too_many_arguments)]
@@ -315,14 +287,13 @@ impl ModuleTree {
             line_number,
         );
 
-        let mut source = if global.unminified_js_dir().is_some() {
-            let mut module_source = ModuleSource {
+        let mut source = if let Some(unminified_js_dir) = global.unminified_js_dir() {
+            let mut module_source = ScriptSource {
                 source,
-                unminified_dir: global.unminified_js_dir(),
                 external,
                 url: url.clone(),
             };
-            crate::unminify::unminify_js(&mut module_source);
+            unminify_js(&mut module_source, unminified_js_dir);
             transform_str_to_source_text(&module_source.source)
         } else {
             transform_str_to_source_text(&source)

--- a/components/script/unminify.rs
+++ b/components/script/unminify.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::borrow::Cow;
 use std::env;
 use std::fs::{File, create_dir_all};
 use std::io::{Error, ErrorKind, Read, Seek, Write};
@@ -12,12 +13,10 @@ use servo_url::ServoUrl;
 use tempfile::NamedTempFile;
 use uuid::Uuid;
 
-pub(crate) trait ScriptSource {
-    fn unminified_dir(&self) -> Option<String>;
-    fn extract_bytes(&self) -> &[u8];
-    fn rewrite_source(&mut self, source: String);
-    fn url(&self) -> ServoUrl;
-    fn is_external(&self) -> bool;
+pub(crate) struct ScriptSource<'a> {
+    pub source: Cow<'a, str>,
+    pub url: ServoUrl,
+    pub external: bool,
 }
 
 pub(crate) fn create_temp_files() -> Option<(NamedTempFile, File)> {
@@ -100,13 +99,9 @@ pub fn create_output_file(
     File::create(path)
 }
 
-pub(crate) fn unminify_js(script: &mut dyn ScriptSource) {
-    let Some(unminified_dir) = script.unminified_dir() else {
-        return;
-    };
-
+pub(crate) fn unminify_js(script: &mut ScriptSource, unminified_js_dir: String) {
     if let Some((mut input, mut output)) = create_temp_files() {
-        input.write_all(script.extract_bytes()).unwrap();
+        input.write_all(script.source.as_bytes()).unwrap();
 
         if execute_js_beautify(
             input.path(),
@@ -116,12 +111,12 @@ pub(crate) fn unminify_js(script: &mut dyn ScriptSource) {
             let mut script_content = String::new();
             output.seek(std::io::SeekFrom::Start(0)).unwrap();
             output.read_to_string(&mut script_content).unwrap();
-            script.rewrite_source(script_content);
+            script.source = script_content.into();
         }
     }
 
-    match create_output_file(unminified_dir, &script.url(), Some(script.is_external())) {
-        Ok(mut file) => file.write_all(script.extract_bytes()).unwrap(),
+    match create_output_file(unminified_js_dir, &script.url, Some(script.external)) {
+        Ok(mut file) => file.write_all(script.source.as_bytes()).unwrap(),
         Err(why) => warn!("Could not store script {:?}", why),
     }
 }

--- a/components/script/unminify.rs
+++ b/components/script/unminify.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 
 pub(crate) struct ScriptSource<'a> {
     pub source: Cow<'a, str>,
-    pub url: ServoUrl,
+    pub url: &'a ServoUrl,
     pub external: bool,
 }
 
@@ -115,7 +115,7 @@ pub(crate) fn unminify_js(script: &mut ScriptSource, unminified_js_dir: String) 
         }
     }
 
-    match create_output_file(unminified_js_dir, &script.url, Some(script.external)) {
+    match create_output_file(unminified_js_dir, script.url, Some(script.external)) {
         Ok(mut file) => file.write_all(script.source.as_bytes()).unwrap(),
         Err(why) => warn!("Could not store script {:?}", why),
     }

--- a/tests/unit/script/unminify.rs
+++ b/tests/unit/script/unminify.rs
@@ -62,7 +62,7 @@ fn replace_script_with_query_string() {
     }
 
     let mut script = Cow::from("fail");
-    substitute_with_local_script(&format!("{}", dir.path().display()), &mut script, url);
+    substitute_with_local_script(&format!("{}", dir.path().display()), &mut script, &url);
     assert_eq!(script, "pass");
 }
 
@@ -78,6 +78,6 @@ fn replace_script_without_query_string() {
     }
 
     let mut script = Cow::from("fail");
-    substitute_with_local_script(&format!("{}", dir.path().display()), &mut script, url);
+    substitute_with_local_script(&format!("{}", dir.path().display()), &mut script, &url);
     assert_eq!(script, "pass");
 }


### PR DESCRIPTION
The trait‑object parameter for `unminify_js` was mainly needed when we had `ScriptOrigin`.
Currently for both classic scripts and modules we are using `ModuleSource`, so convert `ScriptSource` to a helper struct.

Testing: This is a simple refactor, `--unminify-js` shouldn't show any behavioural changes
