### PR TITLE
net: Skip needless clone of response bodies if devtools are off

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -2357,12 +2357,15 @@ async fn http_network_fetch(
                     ResponseBody::Receiving(ref mut body) => std::mem::take(body),
                     _ => vec![],
                 };
-                let devtools_response_body = completed_body.clone();
+                // If devtools is disabled avoid cloning, since the result would
+                // be unused anyway.
+                let devtools_response_body =
+                    devtools_chan.is_some().then(|| completed_body.clone());
                 *body = ResponseBody::Done(completed_body);
                 send_response_values_to_devtools(
                     Some(headers),
                     status,
-                    Some(devtools_response_body),
+                    devtools_response_body,
                     CacheState::None,
                     &devtools_request,
                     devtools_chan,


### PR DESCRIPTION
`send_response_values_to_devtools` is also called from send_response_to_devtools, and there it seems we have at least one user that wants to pass in a Vec (without needing to clone), so I'm not sure how to avoid the clone otherwise.

Testing: No behavior change

