### PR TITLE
LTS 0.1 mozjs ESR update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2995,9 +2995,9 @@ dependencies = [
 
 [[package]]
 name = "glslopt"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba4741358604ca0848c27ecc069d68e62e11cde81e38aac1da3c54b79ab5adf"
+checksum = "a9c406272113953698f579ad93ec5e909eae0b5f84f6839238b185081d0df04d"
 dependencies = [
  "cc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3453,9 +3453,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3793,22 +3793,21 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.12",
+ "h2 0.4.17",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -3821,7 +3820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper 1.11.0",
  "hyper-util",
  "log",
  "rustls",
@@ -3844,12 +3843,12 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.11.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -6246,12 +6245,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "piper"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7427,7 +7420,7 @@ dependencies = [
  "gstreamer",
  "http 1.4.0",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.11.0",
  "image",
  "ipc-channel",
  "keyboard-types",
@@ -7920,7 +7913,7 @@ dependencies = [
  "cookie 0.18.1",
  "headers 0.4.1",
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper 1.11.0",
  "mime",
  "serde",
  "serde_bytes",
@@ -8301,7 +8294,7 @@ dependencies = [
  "headers 0.4.1",
  "http 1.4.0",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.11.0",
  "hyper-rustls",
  "hyper-util",
  "imsz",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1830,7 +1830,7 @@ dependencies = [
 
 [[package]]
 name = "deny_public_fields_tests"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "servo-deny-public-fields",
 ]
@@ -4902,7 +4902,7 @@ dependencies = [
 
 [[package]]
 name = "malloc_size_of_tests"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "servo-malloc-size-of",
  "servo_arc",
@@ -6477,7 +6477,7 @@ dependencies = [
 
 [[package]]
 name = "profile_tests"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "ipc-channel",
  "servo-config",
@@ -7175,7 +7175,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script_tests"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "encoding_rs",
  "euclid",
@@ -7405,7 +7405,7 @@ dependencies = [
 
 [[package]]
 name = "servo"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -7480,7 +7480,7 @@ dependencies = [
 
 [[package]]
 name = "servo-allocator"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "backtrace",
  "libc",
@@ -7493,7 +7493,7 @@ dependencies = [
 
 [[package]]
 name = "servo-background-hang-monitor"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "backtrace",
  "crossbeam-channel",
@@ -7510,7 +7510,7 @@ dependencies = [
 
 [[package]]
 name = "servo-background-hang-monitor-api"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "serde",
  "servo-base",
@@ -7518,7 +7518,7 @@ dependencies = [
 
 [[package]]
 name = "servo-base"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "accesskit",
  "crossbeam-channel",
@@ -7542,7 +7542,7 @@ dependencies = [
 
 [[package]]
 name = "servo-bluetooth"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bitflags 2.11.0",
  "blurmock",
@@ -7560,7 +7560,7 @@ dependencies = [
 
 [[package]]
 name = "servo-bluetooth-traits"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "regex",
  "serde",
@@ -7570,7 +7570,7 @@ dependencies = [
 
 [[package]]
 name = "servo-canvas"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bytemuck",
  "crossbeam-channel",
@@ -7598,7 +7598,7 @@ dependencies = [
 
 [[package]]
 name = "servo-canvas-traits"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -7618,7 +7618,7 @@ dependencies = [
 
 [[package]]
 name = "servo-config"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -7628,7 +7628,7 @@ dependencies = [
 
 [[package]]
 name = "servo-config-macro"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7638,7 +7638,7 @@ dependencies = [
 
 [[package]]
 name = "servo-constellation"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "accesskit",
  "backtrace",
@@ -7684,7 +7684,7 @@ dependencies = [
 
 [[package]]
 name = "servo-constellation-traits"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "content-security-policy",
  "encoding_rs",
@@ -7718,14 +7718,14 @@ dependencies = [
 
 [[package]]
 name = "servo-default-resources"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "servo-embedder-traits",
 ]
 
 [[package]]
 name = "servo-deny-public-fields"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "syn",
  "synstructure",
@@ -7733,7 +7733,7 @@ dependencies = [
 
 [[package]]
 name = "servo-devtools"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "atomic_refcell",
  "base64 0.22.1",
@@ -7761,7 +7761,7 @@ dependencies = [
 
 [[package]]
 name = "servo-devtools-traits"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "http 1.4.0",
  "malloc_size_of_derive",
@@ -7777,7 +7777,7 @@ dependencies = [
 
 [[package]]
 name = "servo-dom-struct"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7786,7 +7786,7 @@ dependencies = [
 
 [[package]]
 name = "servo-embedder-traits"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "accesskit",
  "bitflags 2.11.0",
@@ -7818,7 +7818,7 @@ dependencies = [
 
 [[package]]
 name = "servo-fonts"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "app_units",
  "bitflags 2.11.0",
@@ -7873,7 +7873,7 @@ dependencies = [
 
 [[package]]
 name = "servo-fonts-traits"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "atomic_refcell",
  "dwrote",
@@ -7896,7 +7896,7 @@ dependencies = [
 
 [[package]]
 name = "servo-geometry"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "app_units",
  "euclid",
@@ -7908,7 +7908,7 @@ dependencies = [
 
 [[package]]
 name = "servo-hyper-serde"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "cookie 0.18.1",
  "headers 0.4.1",
@@ -7923,7 +7923,7 @@ dependencies = [
 
 [[package]]
 name = "servo-jstraceable-derive"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -7932,7 +7932,7 @@ dependencies = [
 
 [[package]]
 name = "servo-layout"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -7986,7 +7986,7 @@ dependencies = [
 
 [[package]]
 name = "servo-layout-api"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -8018,7 +8018,7 @@ dependencies = [
 
 [[package]]
 name = "servo-malloc-size-of"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "accountable-refcell",
  "app_units",
@@ -8058,7 +8058,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "once_cell",
  "servo-media-audio",
@@ -8070,7 +8070,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-audio"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "byte-slice-cast",
  "euclid",
@@ -8092,7 +8092,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-auto"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "servo-media-dummy",
  "servo-media-gstreamer",
@@ -8100,7 +8100,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-derive"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8109,7 +8109,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-dummy"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "ipc-channel",
  "servo-media",
@@ -8122,7 +8122,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-examples"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "euclid",
  "rand 0.9.5",
@@ -8134,7 +8134,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "byte-slice-cast",
  "glib",
@@ -8166,7 +8166,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "gstreamer",
  "gstreamer-video",
@@ -8175,7 +8175,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render-android"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8188,7 +8188,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render-unix"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8203,7 +8203,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-player"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "ipc-channel",
  "malloc_size_of_derive",
@@ -8216,7 +8216,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-streams"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "malloc_size_of_derive",
  "servo-malloc-size-of",
@@ -8225,7 +8225,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-thread"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "euclid",
  "ipc-channel",
@@ -8242,7 +8242,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-traits"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "malloc_size_of_derive",
  "servo-malloc-size-of",
@@ -8250,7 +8250,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-webrtc"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "log",
  "servo-media-streams",
@@ -8259,7 +8259,7 @@ dependencies = [
 
 [[package]]
 name = "servo-metrics"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "malloc_size_of_derive",
  "servo-base",
@@ -8273,7 +8273,7 @@ dependencies = [
 
 [[package]]
 name = "servo-net"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-compression",
  "async-recursion",
@@ -8344,7 +8344,7 @@ dependencies = [
 
 [[package]]
 name = "servo-net-traits"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "content-security-policy",
  "cookie 0.18.1",
@@ -8384,7 +8384,7 @@ dependencies = [
 
 [[package]]
 name = "servo-paint"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bitflags 2.11.0",
  "crossbeam-channel",
@@ -8424,7 +8424,7 @@ dependencies = [
 
 [[package]]
 name = "servo-paint-api"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bitflags 2.11.0",
  "crossbeam-channel",
@@ -8459,7 +8459,7 @@ dependencies = [
 
 [[package]]
 name = "servo-pixels"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "criterion",
  "euclid",
@@ -8474,7 +8474,7 @@ dependencies = [
 
 [[package]]
 name = "servo-profile"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "libc",
  "log",
@@ -8492,7 +8492,7 @@ dependencies = [
 
 [[package]]
 name = "servo-profile-traits"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "crossbeam-channel",
  "ipc-channel",
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "accountable-refcell",
  "aes",
@@ -8647,7 +8647,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script-bindings"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bitflags 2.11.0",
  "crossbeam-channel",
@@ -8686,7 +8686,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script-traits"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "accesskit",
  "crossbeam-channel",
@@ -8721,7 +8721,7 @@ dependencies = [
 
 [[package]]
 name = "servo-storage"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "libc",
  "log",
@@ -8748,7 +8748,7 @@ dependencies = [
 
 [[package]]
 name = "servo-storage-traits"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "malloc_size_of_derive",
  "serde",
@@ -8761,7 +8761,7 @@ dependencies = [
 
 [[package]]
 name = "servo-timers"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "crossbeam-channel",
  "malloc_size_of_derive",
@@ -8770,7 +8770,7 @@ dependencies = [
 
 [[package]]
 name = "servo-tracing"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -8780,7 +8780,7 @@ dependencies = [
 
 [[package]]
 name = "servo-url"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "encoding_rs",
  "malloc_size_of_derive",
@@ -8793,7 +8793,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webdriver-server"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "base64 0.22.1",
  "cookie 0.18.1",
@@ -8819,7 +8819,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgl"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -8843,7 +8843,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgpu"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "arrayvec",
  "euclid",
@@ -8861,7 +8861,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgpu-traits"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "arrayvec",
  "malloc_size_of_derive",
@@ -8876,7 +8876,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webxr"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -8894,7 +8894,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webxr-api"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "euclid",
  "ipc-channel",
@@ -8909,7 +8909,7 @@ dependencies = [
 
 [[package]]
 name = "servo-xpath"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "log",
  "malloc_size_of_derive",
@@ -8929,7 +8929,7 @@ dependencies = [
 
 [[package]]
 name = "servoshell"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "accesskit",
  "android_logger",
@@ -9322,7 +9322,7 @@ dependencies = [
 
 [[package]]
 name = "style_tests"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "app_units",
  "cssparser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5078,9 +5078,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.15.16"
+version = "0.15.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99f453559a827f30c1a60db68d95e0149d141031f2483334682a4ffd47ebf2f1"
+checksum = "f987be645c2865dbd1d08b6ff2727aec1f6ee278051096913972b1ba69ed25c6"
 dependencies = [
  "bindgen",
  "cc",
@@ -5093,9 +5093,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "140.12.0-1-lts"
+version = "140.14.0-0-lts"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ad338ebb43b9faa0d8268d88d662eeda8774812c5401c1a26a50b56ab5f5a9c"
+checksum = "378a0092e9ce43e847ce08d0ed65e4a25bb8ec80064db0f6c645d782befb44a2"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ default-members = ["ports/servoshell"]
 exclude = [".cargo", "support/crown"]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 authors = ["The Servo Project Developers"]
 repository = "https://github.com/servo/servo"
 # A generic description for packages that don't have a meaningful description yet.
@@ -230,70 +230,70 @@ xml5ever = "0.39"
 # be listed here, between the `Begin` and `End` comments, so that we can easily find and
 # update the version requirements when bumping the workspace version.
 # Begin workspace-version dependencies - Don't change this comment, we grep for it in scripts!
-deny_public_fields = { package = "servo-deny-public-fields", version = "=0.1.2", path = "components/deny_public_fields" }
-devtools = { package = "servo-devtools", version = "=0.1.2", path = "components/devtools" }
-devtools_traits = { package = "servo-devtools-traits", version = "=0.1.2", path = "components/shared/devtools" }
-dom_struct = { package = "servo-dom-struct", version = "=0.1.2", path = "components/dom_struct" }
-embedder_traits = { package = "servo-embedder-traits", version = "=0.1.2", path = "components/shared/embedder" }
-fonts = { package = "servo-fonts", version = "=0.1.2", path = "components/fonts" }
-fonts_traits = { package = "servo-fonts-traits", version = "=0.1.2", path = "components/shared/fonts" }
-hyper_serde = { package = "servo-hyper-serde", version = "=0.1.2", path = "components/hyper_serde" }
-jstraceable_derive = { package = "servo-jstraceable-derive", version = "=0.1.2", path = "components/jstraceable_derive" }
-layout = { package = "servo-layout", version = "=0.1.2", path = "components/layout" }
-layout_api = { package = "servo-layout-api", version = "=0.1.2", path = "components/shared/layout" }
-malloc_size_of = { package = "servo-malloc-size-of", version = "=0.1.2", path = "components/malloc_size_of" }
-media = { package = "servo-media-thread", version = "=0.1.2", path = "components/media/media-thread" }
-metrics = { package = "servo-metrics", version = "=0.1.2", path = "components/metrics" }
-net = { package = "servo-net", version = "=0.1.2", path = "components/net" }
-net_traits = { package = "servo-net-traits", version = "=0.1.2", path = "components/shared/net" }
-paint = { package = "servo-paint", version = "=0.1.2", path = "components/paint" }
-paint_api = { package = "servo-paint-api", version = "=0.1.2", path = "components/shared/paint" }
-pixels = { package = "servo-pixels", version = "=0.1.2", path = "components/pixels" }
-profile = { package = "servo-profile", version = "=0.1.2", path = "components/profile" }
-profile_traits = { package = "servo-profile-traits", version = "=0.1.2", path = "components/shared/profile" }
-script = { package = "servo-script", version = "=0.1.2", path = "components/script" }
-script_bindings = { package = "servo-script-bindings", version = "=0.1.2", path = "components/script_bindings" }
-script_traits = { package = "servo-script-traits", version = "=0.1.2", path = "components/shared/script" }
-servo = { version = "=0.1.2", path = "components/servo", default-features = false }
-servo-allocator = { version = "=0.1.2", path = "components/allocator" }
-servo-background-hang-monitor = { version = "=0.1.2", path = "components/background_hang_monitor" }
-servo-background-hang-monitor-api = { version = "=0.1.2", path = "components/shared/background_hang_monitor" }
-servo-base = { version = "=0.1.2", path = "components/shared/base" }
-servo-bluetooth = { version = "=0.1.2", path = "components/bluetooth" }
-servo-bluetooth-traits = { version = "=0.1.2", path = "components/shared/bluetooth" }
-servo-canvas = { version = "=0.1.2", path = "components/canvas" }
-servo-canvas-traits = { version = "=0.1.2", path = "components/shared/canvas" }
-servo-config = { version = "=0.1.2", path = "components/config" }
-servo-config-macro = { version = "=0.1.2", path = "components/config/macro" }
-servo-constellation = { version = "=0.1.2", path = "components/constellation" }
-servo-constellation-traits = { version = "=0.1.2", path = "components/shared/constellation" }
-servo-default-resources = { version = "=0.1.2", path = "components/default-resources" }
-servo-geometry = { version = "=0.1.2", path = "components/geometry" }
-servo-media = { version = "=0.1.2", path = "components/media/servo-media" }
-servo-media-audio = { version = "=0.1.2", path = "components/media/audio" }
-servo-media-auto = { version = "=0.1.2", path = "components/media/backends/auto" }
-servo-media-derive = { version = "=0.1.2", path = "components/media/servo-media-derive" }
-servo-media-dummy = { version = "=0.1.2", path = "components/media/backends/dummy" }
-servo-media-gstreamer = { version = "=0.1.2", path = "components/media/backends/gstreamer" }
-servo-media-gstreamer-render = { version = "=0.1.2", path = "components/media/backends/gstreamer/render" }
-servo-media-gstreamer-render-android = { version = "=0.1.2", path = "components/media/backends/gstreamer/render-android" }
-servo-media-gstreamer-render-unix = { version = "=0.1.2", path = "components/media/backends/gstreamer/render-unix" }
-servo-media-player = { version = "=0.1.2", path = "components/media/player" }
-servo-media-streams = { version = "=0.1.2", path = "components/media/streams" }
-servo-media-traits = { version = "=0.1.2", path = "components/media/traits" }
-servo-media-webrtc = { version = "=0.1.2", path = "components/media/webrtc" }
-servo-tracing = { version = "=0.1.2", path = "components/servo_tracing" }
-servo-url = { version = "=0.1.2", path = "components/url" }
-storage = { package = "servo-storage", version = "=0.1.2", path = "components/storage" }
-storage_traits = { package = "servo-storage-traits", version = "=0.1.2", path = "components/shared/storage" }
-timers = { package = "servo-timers", version = "=0.1.2", path = "components/timers" }
-webdriver_server = { package = "servo-webdriver-server", version = "=0.1.2", path = "components/webdriver_server" }
-webgl = { package = "servo-webgl", version = "=0.1.2", path = "components/webgl", default-features = false }
-webgpu = { package = "servo-webgpu", version = "=0.1.2", path = "components/webgpu" }
-webgpu_traits = { package = "servo-webgpu-traits", version = "=0.1.2", path = "components/shared/webgpu" }
-webxr = { package = "servo-webxr", version = "=0.1.2", path = "components/webxr" }
-webxr-api = { package = "servo-webxr-api", version = "=0.1.2", path = "components/shared/webxr" }
-xpath = { package = "servo-xpath", version = "=0.1.2", path = "components/xpath" }
+deny_public_fields = { package = "servo-deny-public-fields", version = "=0.1.3", path = "components/deny_public_fields" }
+devtools = { package = "servo-devtools", version = "=0.1.3", path = "components/devtools" }
+devtools_traits = { package = "servo-devtools-traits", version = "=0.1.3", path = "components/shared/devtools" }
+dom_struct = { package = "servo-dom-struct", version = "=0.1.3", path = "components/dom_struct" }
+embedder_traits = { package = "servo-embedder-traits", version = "=0.1.3", path = "components/shared/embedder" }
+fonts = { package = "servo-fonts", version = "=0.1.3", path = "components/fonts" }
+fonts_traits = { package = "servo-fonts-traits", version = "=0.1.3", path = "components/shared/fonts" }
+hyper_serde = { package = "servo-hyper-serde", version = "=0.1.3", path = "components/hyper_serde" }
+jstraceable_derive = { package = "servo-jstraceable-derive", version = "=0.1.3", path = "components/jstraceable_derive" }
+layout = { package = "servo-layout", version = "=0.1.3", path = "components/layout" }
+layout_api = { package = "servo-layout-api", version = "=0.1.3", path = "components/shared/layout" }
+malloc_size_of = { package = "servo-malloc-size-of", version = "=0.1.3", path = "components/malloc_size_of" }
+media = { package = "servo-media-thread", version = "=0.1.3", path = "components/media/media-thread" }
+metrics = { package = "servo-metrics", version = "=0.1.3", path = "components/metrics" }
+net = { package = "servo-net", version = "=0.1.3", path = "components/net" }
+net_traits = { package = "servo-net-traits", version = "=0.1.3", path = "components/shared/net" }
+paint = { package = "servo-paint", version = "=0.1.3", path = "components/paint" }
+paint_api = { package = "servo-paint-api", version = "=0.1.3", path = "components/shared/paint" }
+pixels = { package = "servo-pixels", version = "=0.1.3", path = "components/pixels" }
+profile = { package = "servo-profile", version = "=0.1.3", path = "components/profile" }
+profile_traits = { package = "servo-profile-traits", version = "=0.1.3", path = "components/shared/profile" }
+script = { package = "servo-script", version = "=0.1.3", path = "components/script" }
+script_bindings = { package = "servo-script-bindings", version = "=0.1.3", path = "components/script_bindings" }
+script_traits = { package = "servo-script-traits", version = "=0.1.3", path = "components/shared/script" }
+servo = { version = "=0.1.3", path = "components/servo", default-features = false }
+servo-allocator = { version = "=0.1.3", path = "components/allocator" }
+servo-background-hang-monitor = { version = "=0.1.3", path = "components/background_hang_monitor" }
+servo-background-hang-monitor-api = { version = "=0.1.3", path = "components/shared/background_hang_monitor" }
+servo-base = { version = "=0.1.3", path = "components/shared/base" }
+servo-bluetooth = { version = "=0.1.3", path = "components/bluetooth" }
+servo-bluetooth-traits = { version = "=0.1.3", path = "components/shared/bluetooth" }
+servo-canvas = { version = "=0.1.3", path = "components/canvas" }
+servo-canvas-traits = { version = "=0.1.3", path = "components/shared/canvas" }
+servo-config = { version = "=0.1.3", path = "components/config" }
+servo-config-macro = { version = "=0.1.3", path = "components/config/macro" }
+servo-constellation = { version = "=0.1.3", path = "components/constellation" }
+servo-constellation-traits = { version = "=0.1.3", path = "components/shared/constellation" }
+servo-default-resources = { version = "=0.1.3", path = "components/default-resources" }
+servo-geometry = { version = "=0.1.3", path = "components/geometry" }
+servo-media = { version = "=0.1.3", path = "components/media/servo-media" }
+servo-media-audio = { version = "=0.1.3", path = "components/media/audio" }
+servo-media-auto = { version = "=0.1.3", path = "components/media/backends/auto" }
+servo-media-derive = { version = "=0.1.3", path = "components/media/servo-media-derive" }
+servo-media-dummy = { version = "=0.1.3", path = "components/media/backends/dummy" }
+servo-media-gstreamer = { version = "=0.1.3", path = "components/media/backends/gstreamer" }
+servo-media-gstreamer-render = { version = "=0.1.3", path = "components/media/backends/gstreamer/render" }
+servo-media-gstreamer-render-android = { version = "=0.1.3", path = "components/media/backends/gstreamer/render-android" }
+servo-media-gstreamer-render-unix = { version = "=0.1.3", path = "components/media/backends/gstreamer/render-unix" }
+servo-media-player = { version = "=0.1.3", path = "components/media/player" }
+servo-media-streams = { version = "=0.1.3", path = "components/media/streams" }
+servo-media-traits = { version = "=0.1.3", path = "components/media/traits" }
+servo-media-webrtc = { version = "=0.1.3", path = "components/media/webrtc" }
+servo-tracing = { version = "=0.1.3", path = "components/servo_tracing" }
+servo-url = { version = "=0.1.3", path = "components/url" }
+storage = { package = "servo-storage", version = "=0.1.3", path = "components/storage" }
+storage_traits = { package = "servo-storage-traits", version = "=0.1.3", path = "components/shared/storage" }
+timers = { package = "servo-timers", version = "=0.1.3", path = "components/timers" }
+webdriver_server = { package = "servo-webdriver-server", version = "=0.1.3", path = "components/webdriver_server" }
+webgl = { package = "servo-webgl", version = "=0.1.3", path = "components/webgl", default-features = false }
+webgpu = { package = "servo-webgpu", version = "=0.1.3", path = "components/webgpu" }
+webgpu_traits = { package = "servo-webgpu-traits", version = "=0.1.3", path = "components/shared/webgpu" }
+webxr = { package = "servo-webxr", version = "=0.1.3", path = "components/webxr" }
+webxr-api = { package = "servo-webxr-api", version = "=0.1.3", path = "components/shared/webxr" }
+xpath = { package = "servo-xpath", version = "=0.1.3", path = "components/xpath" }
 # End workspace-version dependencies - Don't change this comment, we grep for it in scripts!
 
 # RSA key generation could be very slow without compilation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ indexmap = { version = "2.11.4", features = ["std"] }
 inventory = { version = "0.3.24" }
 ipc-channel = "0.21"
 itertools = "0.14"
-js = { package = "mozjs", version = "=0.15.16", default-features = false, features = ["libz-sys", "intl"] }
+js = { package = "mozjs", version = "=0.15.18", default-features = false, features = ["libz-sys", "intl"] }
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.12", features = ["euclid"] }
 libc = "0.2"

--- a/deny.toml
+++ b/deny.toml
@@ -56,6 +56,10 @@ ignore = [
     # `rustybuzz` is unmaintained. Switch to harfrust.
     # However, this is a dependecy of `resvg`, there's nothing we can do.
     "RUSTSEC-2026-0206",
+    # Addressed by updating `h2` to 0.4.16 or newer. We still pull in an
+    # older version via `webdriver`, but the vulnerability should not
+    # be exploitable from that path.
+    "RUSTSEC-2026-0258",
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
Updates spidermonkey to the latest ESR version, fix a build issue by updating glslopt and address a cargo-deny flagged vulnerability. See the individual commits.

Testing: Covered by existing tests

