### PR TITLE
script: Remove already enabled prefs

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -128,8 +128,6 @@ pub struct Preferences {
     pub dom_webgpu_enabled: bool,
     /// List of comma-separated backends to be used by wgpu.
     pub dom_webgpu_wgpu_backend: String,
-    // feature: AbortController | #34866 | Web/API/AbortController
-    pub dom_abort_controller_enabled: bool,
     // feature: Adopted Stylesheet | #38132 | Web/API/Document/adoptedStyleSheets
     pub dom_adoptedstylesheet_enabled: bool,
     pub dom_allow_preloading_module_descendants: bool,
@@ -154,7 +152,6 @@ pub struct Preferences {
     ///
     /// See <https://github.com/servo/servo/pull/45301> for measurements.
     pub dom_canvas_msg_buffer_size: u64,
-    pub dom_clipboardevent_enabled: bool,
     pub dom_composition_event_enabled: bool,
     // feature: CookieStore | #37674 | Web/API/CookieStore
     pub dom_cookiestore_enabled: bool,
@@ -182,9 +179,6 @@ pub struct Preferences {
     // feature: IntersectionObserver | #35767 | Web/API/Intersection_Observer_API
     pub dom_intersection_observer_enabled: bool,
     pub dom_microdata_testing_enabled: bool,
-    pub dom_uievent_which_enabled: bool,
-    // feature: MutationObserver | #6633 | Web/API/MutationObserver
-    pub dom_mutation_observer_enabled: bool,
     // feature: Navigator.registerProtocolHandler() | #40615 | Web/API/Navigator/registerProtocolHandler
     pub dom_navigator_protocol_handlers_enabled: bool,
     // feature: Notification API | #34841 | Web/API/Notifications_API
@@ -434,7 +428,6 @@ impl Preferences {
             editing_caret_blink_time: 600,
             devtools_server_enabled: false,
             devtools_server_listen_address: String::new(),
-            dom_abort_controller_enabled: true,
             dom_adoptedstylesheet_enabled: false,
             dom_allow_preloading_module_descendants: false,
             dom_allow_scripts_to_close_windows: false,
@@ -445,7 +438,6 @@ impl Preferences {
             dom_canvas_text_enabled: true,
             dom_canvas_backend: String::new(),
             dom_canvas_msg_buffer_size: 16,
-            dom_clipboardevent_enabled: true,
             dom_composition_event_enabled: false,
             dom_cookiestore_enabled: false,
             dom_credential_management_enabled: false,
@@ -462,8 +454,6 @@ impl Preferences {
             dom_indexeddb_enabled: false,
             dom_intersection_observer_enabled: false,
             dom_microdata_testing_enabled: false,
-            dom_uievent_which_enabled: true,
-            dom_mutation_observer_enabled: true,
             dom_navigator_protocol_handlers_enabled: false,
             dom_notification_enabled: false,
             dom_parallel_css_parsing_enabled: true,

--- a/components/script/dom/event/uievent.rs
+++ b/components/script/dom/event/uievent.rs
@@ -9,7 +9,6 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::reflector::reflect_dom_object_with_proto;
-use servo_config::pref;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -203,10 +202,6 @@ impl UIEventMethods<crate::DomTypeHolder> for UIEvent {
 
     /// <https://w3c.github.io/uievents/#dom-uievent-which>
     fn Which(&self) -> u32 {
-        if pref!(dom_uievent_which_enabled) {
-            self.which.get()
-        } else {
-            0
-        }
+        self.which.get()
     }
 }

--- a/components/script_bindings/webidls/AbortController.webidl
+++ b/components/script_bindings/webidls/AbortController.webidl
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 // https://dom.spec.whatwg.org/#interface-abortcontroller
-[Exposed=*, Pref="dom_abort_controller_enabled"]
+[Exposed=*]
 interface AbortController {
   constructor();
 

--- a/components/script_bindings/webidls/AbortSignal.webidl
+++ b/components/script_bindings/webidls/AbortSignal.webidl
@@ -4,7 +4,7 @@
 
 // https://dom.spec.whatwg.org/#abortsignal
 
-[Exposed=*, Pref="dom_abort_controller_enabled"]
+[Exposed=*]
 interface AbortSignal : EventTarget {
   [NewObject] static AbortSignal abort(optional any reason);
   [Exposed=(Window,Worker), NewObject] static AbortSignal timeout([EnforceRange] unsigned long long milliseconds);

--- a/components/script_bindings/webidls/ClipboardEvent.webidl
+++ b/components/script_bindings/webidls/ClipboardEvent.webidl
@@ -4,7 +4,7 @@
 
 // https://w3c.github.io/clipboard-apis/
 
-[Exposed=Window, Pref="dom_clipboardevent_enabled"]
+[Exposed=Window]
 interface ClipboardEvent : Event {
   constructor (DOMString type, optional ClipboardEventInit eventInitDict = {});
   readonly attribute DataTransfer? clipboardData;

--- a/components/script_bindings/webidls/MutationObserver.webidl
+++ b/components/script_bindings/webidls/MutationObserver.webidl
@@ -7,7 +7,7 @@
  */
 
 // https://dom.spec.whatwg.org/#mutationobserver
-[Exposed=Window, Pref="dom_mutation_observer_enabled"]
+[Exposed=Window]
 interface MutationObserver {
     [Throws] constructor(MutationCallback callback);
     [Throws]

--- a/components/script_bindings/webidls/MutationRecord.webidl
+++ b/components/script_bindings/webidls/MutationRecord.webidl
@@ -7,7 +7,7 @@
  */
 
 // https://dom.spec.whatwg.org/#mutationrecord
-[Pref="dom_mutation_observer_enabled", Exposed=Window]
+[Exposed=Window]
 interface MutationRecord {
     readonly attribute DOMString type;
     [SameObject]

--- a/components/script_bindings/webidls/UIEvent.webidl
+++ b/components/script_bindings/webidls/UIEvent.webidl
@@ -32,6 +32,5 @@ partial interface UIEvent {
       long detailArg
     );
 
-    [Pref="dom_uievent_which_enabled"]
     readonly attribute unsigned long which;
 };

--- a/resources/resource_protocol/preferences.html
+++ b/resources/resource_protocol/preferences.html
@@ -52,7 +52,7 @@
       const prefs = {
           "experimental": [],
           "http-cache": ["network_http_cache_disabled"],
-          "more-experimental": ["dom_abort_controller_enabled"],
+          "more-experimental": [],
           "user-agent": ["user_agent"],
       };
 


### PR DESCRIPTION
These prefs were all enabled and the corresponding issue was already closed as completed. Therefore, remove these preferences and consider them feature complete.

Testing: it compiles
