### PR TITLE
Parse the track url using `encoding_parse_a_url` in `htmltrackelement`

### DIFF
--- a/components/script/dom/html/embedded_content/htmltrackelement.rs
+++ b/components/script/dom/html/embedded_content/htmltrackelement.rs
@@ -275,7 +275,7 @@ impl VirtualMethods for HTMLTrackElement {
                     // Step 4. Set the element's track URL to trackURL if it is not failure;
                     // otherwise to the empty string.
                     *self.track_url.borrow_mut() = if !value.is_empty() {
-                        self.owner_document().encoding_parse_a_url(&value).ok()
+                        self.owner_document().encoding_parse_a_url(value).ok()
                     } else {
                         None
                     };

--- a/components/script/dom/html/embedded_content/htmltrackelement.rs
+++ b/components/script/dom/html/embedded_content/htmltrackelement.rs
@@ -275,7 +275,7 @@ impl VirtualMethods for HTMLTrackElement {
                     // Step 4. Set the element's track URL to trackURL if it is not failure;
                     // otherwise to the empty string.
                     *self.track_url.borrow_mut() = if !value.is_empty() {
-                        self.owner_document().base_url().join(value).ok()
+                        self.owner_document().encoding_parse_a_url(&value).ok()
                     } else {
                         None
                     };

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-default-load-timer-during-parser-block.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-default-load-timer-during-parser-block.html.ini
@@ -1,3 +1,3 @@
 [track-default-load-timer-during-parser-block.html]
   [Default text track delays readyState past HAVE_CURRENT_DATA when resource\n  selection runs while the parser is blocked inside the <video>]
-    expected: [PASS, FAIL]
+    expected: [FAIL]

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-default-load-timer-during-parser-block.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-default-load-timer-during-parser-block.html.ini
@@ -1,3 +1,3 @@
 [track-default-load-timer-during-parser-block.html]
   [Default text track delays readyState past HAVE_CURRENT_DATA when resource\n  selection runs while the parser is blocked inside the <video>]
-    expected: [FAIL]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-default-load-timer-during-parser-block.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-default-load-timer-during-parser-block.html.ini
@@ -1,3 +1,3 @@
 [track-default-load-timer-during-parser-block.html]
   [Default text track delays readyState past HAVE_CURRENT_DATA when resource\n  selection runs while the parser is blocked inside the <video>]
-    expected: FAIL
+    expected: [PASS, FAIL]


### PR DESCRIPTION
Testing: tests run as expected but `track-default-load-timer-during-parser-block.html` now passes sometimes.
Fixes: #47375
