### PR TITLE
ohos: Use clang-19 instead of the SDK clang-15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5244,9 +5244,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "560c5ff6e8c30ecbe7f004a87cb3caeb0567093e0e09cffc637b4fe20e5896d5"
+version = "0.23.1"
+source = "git+https://github.com/jschwe/mozjs?branch=update_ohos_build#fc6dccf30050912b0389fa22112c12e20864a373"
 dependencies = [
  "bindgen",
  "cc",
@@ -5259,9 +5258,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "140.14.0-0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec80275168074746f8dd14e3f451836aecb9f6b8af03610e35e0d49f2b4126f"
+version = "140.14.0-1"
+source = "git+https://github.com/jschwe/mozjs?branch=update_ohos_build#fc6dccf30050912b0389fa22112c12e20864a373"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5245,7 +5245,8 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.23.1"
-source = "git+https://github.com/jschwe/mozjs?branch=update_ohos_build#fc6dccf30050912b0389fa22112c12e20864a373"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b0250ec78781bceb8c3bf523771654583e4db2625e815138bc65fa2b1ec7fe"
 dependencies = [
  "bindgen",
  "cc",
@@ -5259,7 +5260,8 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "140.14.0-1"
-source = "git+https://github.com/jschwe/mozjs?branch=update_ohos_build#fc6dccf30050912b0389fa22112c12e20864a373"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cb5edb8729da5f2b09939fcad2559ba1c54e55d222f14d485b88c7d645890d5"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ inventory = "0.3.24"
 ipc-channel = "0.22"
 itertools = "0.15"
 jni = "0.22"
-js = { package = "mozjs", version = "=0.23.1", default-features = false, features = ["intl", "libz-sys"], git = "https://github.com/jschwe/mozjs", branch = "update_ohos_build" }
+js = { package = "mozjs", version = "=0.23.1", default-features = false, features = ["intl", "libz-sys"] }
 k12 = "0.5"
 keccak = "0.2"
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ inventory = "0.3.24"
 ipc-channel = "0.22"
 itertools = "0.15"
 jni = "0.22"
-js = { package = "mozjs", version = "=0.23", default-features = false, features = ["intl", "libz-sys"] }
+js = { package = "mozjs", version = "=0.23.1", default-features = false, features = ["intl", "libz-sys"], git = "https://github.com/jschwe/mozjs", branch = "update_ohos_build" }
 k12 = "0.5"
 keccak = "0.2"
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -257,9 +257,15 @@ class PackageCommands(CommandBase):
             ohos_libs_dir = path.join(ohos_target_dir, "entry", "libs", abi_string)
             os.makedirs(ohos_libs_dir)
             # The libservoshell.so binary that was built needs to be copied
-            # into the app folder heirarchy where hvigor expects it.
+            # into the app folder hierarchy where hvigor expects it.
             print(f"Copying {binary_path} to {ohos_libs_dir}")
             shutil.copy(binary_path, ohos_libs_dir)
+            # This includes `libc++` and in the future also potentially sanitizer libraries
+            # and maybe could also include shared library dependencies from our build, if
+            # we support building some dependencies as shared libraries in the future.
+            for runtime_library in self.target.runtime_libraries():
+                print(f"Copying {runtime_library} to {ohos_libs_dir}")
+                shutil.copy(runtime_library, ohos_libs_dir)
             try:
                 with cd(ohos_target_dir):
                     print("Calling", hvigor_command)

--- a/python/servo/platform/build_target.py
+++ b/python/servo/platform/build_target.py
@@ -335,10 +335,10 @@ class OpenHarmonyTarget(CrossBuildTarget):
             sys.exit(1)
         command = ["cargo", "ohos", "env", "--format", "json", "--target", self.triple()]
         try:
-            output = subprocess.run(command, check=True, capture_output=True, encoding="utf8", env=input_env).stdout
-        except subprocess.CalledProcessError as exception:
-            print(exception.stderr, end="", file=sys.stderr)
-            print("Failed to determine the OpenHarmony toolchain environment via `cargo ohos env`.", file=sys.stderr)
+            # `cargo-ohos` prints status information to `stderr`, so don't intercept that.
+            output = subprocess.run(command, check=True, stdout=subprocess.PIPE, encoding="utf8", env=input_env).stdout
+        except subprocess.CalledProcessError:
+            print("Error: Failed to determine the OpenHarmony toolchain environment via `cargo ohos env`.", file=sys.stderr)
             sys.exit(1)
         try:
             ohos_env = json.loads(output)

--- a/python/servo/platform/build_target.py
+++ b/python/servo/platform/build_target.py
@@ -333,7 +333,7 @@ class OpenHarmonyTarget(CrossBuildTarget):
             print(f"Building for OpenHarmony requires `cargo-ohos`: {error_msg}", file=sys.stderr)
             print("Please rerun `./mach bootstrap --ohos`.", file=sys.stderr)
             sys.exit(1)
-        command = ["cargo", "ohos", "env", "--format", "json", "--target", self.triple()]
+        command = ["cargo", "ohos", "env", "--format", "json", "--download-prebuilt=19", "--target", self.triple()]
         try:
             # `cargo-ohos` prints status information to `stderr`, so don't intercept that.
             output = subprocess.run(command, check=True, stdout=subprocess.PIPE, encoding="utf8", env=input_env).stdout

--- a/python/servo/platform/build_target.py
+++ b/python/servo/platform/build_target.py
@@ -291,7 +291,9 @@ class OpenHarmonyTarget(CrossBuildTarget):
     # will bump the schema version in cargo-ohos.
     CARGO_OHOS_EXPECTED_SCHEMA_VERSION = 1
     # Pin a cargo-ohos semver version for bootstrap
-    REQUESTED_CARGO_OHOS_VERSION = "0.3"
+    REQUESTED_CARGO_OHOS_VERSION = "0.3.2"
+
+    cargo_ohos_info: Optional[dict[str, Any]] = None
 
     @classmethod
     def is_cargo_ohos_compatible(cls) -> Tuple[bool, Optional[str]]:
@@ -328,6 +330,10 @@ class OpenHarmonyTarget(CrossBuildTarget):
         return (True, None)
 
     def get_cargo_ohos_env(self, input_env: dict[str, str]) -> dict[str, Any]:
+        # `input_env` is mainly the environment from outside, and we won't be
+        # calling this with different input_envs.
+        if self.cargo_ohos_info is not None:
+            return self.cargo_ohos_info
         (compatible, error_msg) = self.is_cargo_ohos_compatible()
         if not compatible:
             print(f"Building for OpenHarmony requires `cargo-ohos`: {error_msg}", file=sys.stderr)
@@ -338,7 +344,10 @@ class OpenHarmonyTarget(CrossBuildTarget):
             # `cargo-ohos` prints status information to `stderr`, so don't intercept that.
             output = subprocess.run(command, check=True, stdout=subprocess.PIPE, encoding="utf8", env=input_env).stdout
         except subprocess.CalledProcessError:
-            print("Error: Failed to determine the OpenHarmony toolchain environment via `cargo ohos env`.", file=sys.stderr)
+            print(
+                "Error: Failed to determine the OpenHarmony toolchain environment via `cargo ohos env`.",
+                file=sys.stderr,
+            )
             sys.exit(1)
         try:
             ohos_env = json.loads(output)
@@ -350,7 +359,12 @@ class OpenHarmonyTarget(CrossBuildTarget):
             # This shouldn't happen if cargo-ohos releases follow semver, but still better
             # to check.
             raise RuntimeError("Unexpected schema-version mismatch.")
+        # Cargo prefers `CARGO_ENCODED_RUSTFLAGS` if set, but mach currently uses `RUSTFLAGS`
+        # instead, so we remove this from the environment. It probably would make sense to migrate
+        # mach towards also using the encoded form.
+        ohos_env["env"].pop("CARGO_ENCODED_RUSTFLAGS")
 
+        self.cargo_ohos_info = ohos_env
         return ohos_env
 
     def configure_build_environment(self, env: dict[str, str], config: dict[str, Any], topdir: pathlib.Path) -> None:
@@ -385,11 +399,6 @@ class OpenHarmonyTarget(CrossBuildTarget):
                 file=sys.stderr,
             )
             sys.exit(1)
-
-        # Cargo prefers `CARGO_ENCODED_RUSTFLAGS` if set, but mach currently uses `RUSTFLAGS`
-        # instead, so we remove this from the environment. It probably would make sense to migrate
-        # mach towards also using the encoded form.
-        del ohos_env["CARGO_ENCODED_RUSTFLAGS"]
 
         env.update(ohos_env)
         # `cargo ohos` currently doesn't set RUSTFLAGS in the environment (since it uses the encoded rustflags),
@@ -467,6 +476,13 @@ class OpenHarmonyTarget(CrossBuildTarget):
             # If a non-SDK LLVM is used with cargo-ohos, then these flags will not be set.
             env["TARGET_CFLAGS"] = env.get("TARGET_CFLAGS", "") + " " + " ".join(san_compile_flags)
             env["TARGET_CXXFLAGS"] = env.get("TARGET_CXXFLAGS", "") + " " + " ".join(san_compile_flags)
+
+    def runtime_libraries(self) -> List[pathlib.Path]:
+        if self.cargo_ohos_info is None:
+            # This shouldn't be possible, but if it does, then `build_env()` is not called on some path.
+            raise RuntimeError("Internal Error: cargo_ohos_info field not initialized yet")
+        required_libraries = self.cargo_ohos_info["runtime_libraries"]
+        return [pathlib.Path(lib["path"]) for lib in required_libraries]
 
     def binary_name(self) -> str:
         return "libservoshell.so"


### PR DESCRIPTION
Spidermonkey 153 will require clang-19 or newer, and there happens to be a prebuilt (preview) version available for ohos.  This PR updates servo (and mozjs via the companion PR) to use clang-19 in advance, so we update independently of the mozjs ESR update. `cargo ohos --download-prebuilt=19` (currenlty only 19 is supported) will download the prebuilt llvm toolchain the first time (by default cached in XDG_CACHE_HOME) and handle setting all the required environment variables to use the custom LLMV together with the SDK sysroot.  Servo will not be using the SDKs `libc++_shared.so`, since SM uses some C++ features which the clang-15 SDK version does not support yet. This has a slightly negative effect on the binary size, since we need to bundle the custom LLVM libc++ (different namespace, so symbols won't conflict). 

As of now this does break ASAN / TSAN on ohos, since the `compiler_rt` in the prebuilt clang version that was available seems to be defective. This can be fixed in a follow-up by switching from a prebuilt to compiling a newer version from source (which can then be hosted via the same mirror mechanism cargo ohos already uses to download the prebuilt).

Testing: We run servoshell on HarmonyOS devices in CI, so this is covered by existing tests
Fixes: #47332