### PR TITLE
backport: ci: Handle token expiry in crates.io publish by exiting early

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,10 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       id-token: write
+    env:
+      SERVO_CRATES_IO_SLEEP_AFTER_PUBLISH_SECONDS: "30"
+      SERVO_CRATES_IO_VERIFY_PUBLISHED_TIMEOUT_SECONDS: "300"
+      SERVO_CRATES_IO_VERIFY_PUBLISHED_INTERVAL_SECONDS: "10"
     steps:
       - uses: actions/checkout@v6
       - uses: rust-lang/crates-io-auth-action@v1
@@ -118,14 +122,24 @@ jobs:
       - name: Publish to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-          SERVO_CRATES_IO_SLEEP_AFTER_PUBLISH_SECONDS: "30"
-          SERVO_CRATES_IO_VERIFY_PUBLISHED_TIMEOUT_SECONDS: "300"
-          SERVO_CRATES_IO_VERIFY_PUBLISHED_INTERVAL_SECONDS: "10"
         # Verification requires building, which is incredibly slow and also increases our attack surface.
         # If we decide for an extra verification, we should add a seperate job before this one, which
         # does a `dry-run` publish without any elevated permissions.
         run: |
           python3 etc/ci/publish_crates_io.py --no-verify
+      # For a whole workspace publish the above step will run into the token expiry,
+      # which the script handles by exiting (code 0) before the predicted expiry.
+      # Other failures, will still cause the workflow to fail
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth2
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth2.outputs.token }}
+        # Since we assume 2 tries (2*25 minutes) should be enough to publish our workspace,
+        # add `--fail-on-timeout` so the workflow fails if the assumption is violated
+        # Otherwise this does exactly the same as the above publish step.
+        run: |
+          python3 etc/ci/publish_crates_io.py --no-verify --fail-on-timeout
 
   build-win:
     # This job is only useful when run on upstream servo.

--- a/etc/ci/publish_crates_io.py
+++ b/etc/ci/publish_crates_io.py
@@ -28,6 +28,9 @@ SLEEP_AFTER_PUBLISH_SECONDS = int(os.environ.get("SERVO_CRATES_IO_SLEEP_AFTER_PU
 VERIFY_PUBLISHED_TIMEOUT_SECONDS = int(os.environ.get("SERVO_CRATES_IO_VERIFY_PUBLISHED_TIMEOUT_SECONDS", "300"))
 VERIFY_PUBLISHED_INTERVAL_SECONDS = int(os.environ.get("SERVO_CRATES_IO_VERIFY_PUBLISHED_INTERVAL_SECONDS", "10"))
 API_TIMEOUT_SECONDS = int(os.environ.get("SERVO_CRATES_IO_API_TIMEOUT_SECONDS", "30"))
+# The trusted publishing token is valid for 30 minutes. Add some slack, so we can exit early
+# before the token expires.
+MAX_RUNTIME_SECONDS = int(os.environ.get("SERVO_CRATES_IO_MAX_RUNTIME_SECONDS", str(25 * 60)))
 
 
 @dataclass(frozen=True)
@@ -40,6 +43,10 @@ class WorkspacePackage:
 
 def log(message: str) -> None:
     print(message, file=sys.stderr, flush=True)
+
+
+def runtime_limit_reached(start_time: float) -> bool:
+    return time.monotonic() - start_time >= MAX_RUNTIME_SECONDS
 
 
 def parse_args() -> argparse.Namespace:
@@ -58,6 +65,11 @@ def parse_args() -> argparse.Namespace:
         "--dry-run",
         action="store_true",
         help="Print the resolved publish order without querying crates.io or publishing.",
+    )
+    parser.add_argument(
+        "--fail-on-timeout",
+        action="store_true",
+        help="Exit with a non-zero status if the max runtime limit is reached.",
     )
     return parser.parse_args()
 
@@ -187,8 +199,12 @@ def publish_package(
     subprocess.run(command, cwd=WORKSPACE_ROOT, check=True)
 
 
-def publish_packages(args: argparse.Namespace, packages: Iterable[WorkspacePackage]) -> None:
+def publish_packages(args: argparse.Namespace, packages: Iterable[WorkspacePackage], start_time: float) -> bool:
     for package in packages:
+        if runtime_limit_reached(start_time):
+            log(f"reached runtime limit of {MAX_RUNTIME_SECONDS}s; stopping before publishing {package.name}")
+            return True
+
         if crates_io_version_exists(package.name, package.version):
             log(f"skipping {package.name} {package.version}; already on crates.io")
             continue
@@ -202,9 +218,12 @@ def publish_packages(args: argparse.Namespace, packages: Iterable[WorkspacePacka
         # try and wait until the new version appears on crates.io.
         wait_until_published(package)
 
+    return False
+
 
 def main() -> int:
     args = parse_args()
+    start_time = time.monotonic()
 
     metadata = load_metadata()
     packages = collect_packages(metadata)
@@ -222,7 +241,9 @@ def main() -> int:
     if args.dry_run:
         return 0
 
-    publish_packages(args, ordered_packages)
+    timed_out = publish_packages(args, ordered_packages, start_time)
+    if timed_out and args.fail_on_timeout:
+        return 1
     return 0
 
 


### PR DESCRIPTION
Backports #45633 to make the release workflow more reliable. 

Testing: Tested already on main, where it has been working fine.

(cherry picked from commit f2351d6f517b1d8e9838bc7513f0cd58f4a78e11)

---------------

Since our publish token for trusted publishing is only valid for 30 minutes, and a full publish can take longer than that, the simplest solution is just to re-authenticate and continue publishing. To avoid re-authenticating if a failure is due to another reason, the script attempts to exit before the token expires. In theory it would be better to attempt to detect if there is still work left before running the second auth + publish step, but I don't think thats trivial, and the workflow should be simple to audit, so leaving it at always retry (unless non-zero exit code) seems fine to me.







