### PR TITLE
script: Align live range update steps with specification

### DIFF
--- a/components/script/dom/bindings/weakref.rs
+++ b/components/script/dom/bindings/weakref.rs
@@ -119,15 +119,6 @@ pub(crate) struct WeakRefEntry<'a, T: WeakReferenceable> {
     index: &'a mut usize,
 }
 
-impl<'a, T: WeakReferenceable + 'a> WeakRefEntry<'a, T> {
-    /// Remove the entry from the underlying vector of weak references.
-    pub(crate) fn remove(self) -> WeakRef<T> {
-        let ref_ = self.vec.swap_remove(*self.index);
-        mem::forget(self);
-        ref_
-    }
-}
-
 impl<'a, T: WeakReferenceable + 'a> Deref for WeakRefEntry<'a, T> {
     type Target = WeakRef<T>;
 

--- a/components/script/dom/characterdata/characterdata.rs
+++ b/components/script/dom/characterdata/characterdata.rs
@@ -24,6 +24,7 @@ use crate::dom::cdatasection::CDATASection;
 use crate::dom::comment::Comment;
 use crate::dom::document::Document;
 use crate::dom::element::Element;
+use crate::dom::live_range_replace_data_steps;
 use crate::dom::mutationobserver::{Mutation, MutationObserver};
 use crate::dom::node::virtualmethods::vtable_for;
 use crate::dom::node::{ChildrenMutation, Node, NodeDamage};
@@ -120,10 +121,7 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
         *self.data.safe_borrow_mut(cx.no_gc()) = String::from(data.str());
         self.content_changed(cx);
 
-        let node = self.upcast::<Node>();
-        if let Some(weak_ranges) = node.weak_ranges_mut() {
-            weak_ranges.replace_code_units(node, 0, old_length, new_length);
-        }
+        live_range_replace_data_steps(self.upcast(), 0, old_length, new_length);
     }
 
     /// <https://dom.spec.whatwg.org/#dom-characterdata-length>
@@ -248,24 +246,9 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
         *self.data.safe_borrow_mut(cx.no_gc()) = new_data;
         self.content_changed(cx);
 
-        // Step 8: For each live range whose start node is node and start offset is
-        // greater than offset but less than or equal to offset + count: set its start
-        // offset to offset.
-        //
-        // Step 9: For each live range whose end node is node and end offset is greater
-        // than offset but less than or equal to offset + count: set its end offset to
-        // offset.
-        //
-        // Step 10: For each live range whose start node is node and start offset is
-        // greater than offset + count: increase its start offset by data’s length and
-        // decrease it by count.
-        //
-        // Step 11: For each live range whose end node is node and end offset is greater
-        // than offset + count: increase its end offset by data’s length and decrease it
-        // by count.
         let node = self.upcast::<Node>();
-        if let Some(weak_ranges) = node.weak_ranges_mut() {
-            weak_ranges.replace_code_units(
+        if node.has_live_ranges() {
+            live_range_replace_data_steps(
                 node,
                 offset,
                 count,

--- a/components/script/dom/characterdata/text.rs
+++ b/components/script/dom/characterdata/text.rs
@@ -18,6 +18,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::characterdata::CharacterData;
 use crate::dom::document::Document;
 use crate::dom::html::htmlslotelement::{HTMLSlotElement, Slottable};
+use crate::dom::live_range_text_split_steps;
 use crate::dom::node::Node;
 use crate::dom::window::Window;
 
@@ -73,47 +74,30 @@ impl TextMethods<crate::DomTypeHolder> for Text {
     /// <https://dom.spec.whatwg.org/#concept-text-split>
     fn SplitText(&self, cx: &mut JSContext, offset: u32) -> Fallible<DomRoot<Text>> {
         let cdata = self.upcast::<CharacterData>();
-        // Step 1.
+        // Step 1: Let length be node’s length.
         let length = cdata.Length();
+        // Step 2: If offset is greater than length, then throw an "IndexSizeError" DOMException.
         if offset > length {
-            // Step 2.
             return Err(Error::IndexSize(None));
         }
-        // Step 3.
+        // Step 3: Let count be length − offset.
         let count = length - offset;
-        // Step 4.
+        // Step 4: Let newData be the result of substringing data of node with offset and count.
         let new_data = cdata.SubstringData(offset, count).unwrap();
-        // Step 5.
+        // Step 5: Let newNode be the result of creating a text node given node’s node document and newData.
         let node = self.upcast::<Node>();
         let owner_doc = node.owner_doc();
         let new_node = owner_doc.CreateTextNode(cx, new_data);
-        // Step 6.
+        // Step 6: Let parent be node’s parent.
         let parent = node.GetParentNode();
+        // Step 7: If parent is non-null:
         if let Some(ref parent) = parent {
-            // Step 7.1.
+            // Step 7.1: Insert newNode into parent before node’s next sibling.
             parent
                 .InsertBefore(cx, new_node.upcast(), node.GetNextSibling().as_deref())
                 .unwrap();
-
-            // Step 7.2. For each live range whose start node is node and start offset is
-            // greater than offset, set its start node to newNode and decrease its start
-            // offset by offset.
-            //
-            // Step 7.3. For each live range whose end node is node and end offset is
-            // greater than offset, set its end node to newNode and decrease its end
-            // offset by offset.
-            if let Some(weak_ranges) = node.weak_ranges_mut() {
-                weak_ranges.move_to_following_text_sibling_above(node, offset, new_node.upcast());
-            }
-
-            // Step 7.4. For each live range whose start node is parent and start offset
-            // is equal to the index of node plus 1, increase its start offset by 1.
-            //
-            // Step 7.5. For each live range whose end node is parent and end offset is
-            // equal to the index of node plus 1, increase its end offset by 1.
-            if let Some(parent_weak_ranges) = parent.weak_ranges_mut() {
-                parent_weak_ranges.increment_at(parent, node.index() + 1);
-            }
+            // Steps 7.2-7.5: The live range update steps.
+            live_range_text_split_steps(parent, node, offset, new_node.upcast());
         }
         // Step 8.
         cdata.DeleteData(cx, offset, count).unwrap();

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -4053,10 +4053,11 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
                 if !sibling.is::<Text>() || sibling.is::<CDATASection>() {
                     break;
                 }
+
                 let sibling: DomRoot<CharacterData> =
                     DomRoot::downcast(children.next().expect("Guaranteed by the peek above"))
                         .expect("Guaranteed by check above");
-                new_data_length += sibling.Length();
+                new_data_length += sibling.data().len();
                 siblings_to_merge.push(sibling);
             }
 
@@ -4066,13 +4067,10 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
 
             // Step 3: Let data be the concatenation of the data of node’s contiguous
             // exclusive Text nodes (excluding itself), in tree order.
-            let data = siblings_to_merge.iter().fold(
-                String::with_capacity(new_data_length as usize),
-                |mut data, character_data| {
-                    data.push_str(character_data.data().as_str());
-                    data
-                },
-            );
+            let mut data = String::with_capacity(new_data_length);
+            for sibling in &siblings_to_merge {
+                data.push_str(sibling.data().as_str());
+            }
 
             // Step 4: Replace data of node with length, 0, and data.
             cdata.append_data(cx, &data);
@@ -4080,9 +4078,16 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
             // Step 5: Let currentNode be node’s next sibling.
             // Step 6: While currentNode is an exclusive Text node:
             // Note: Condition guaranteed by collection loop above.
-            for current_node in siblings_to_merge.iter() {
+            let first_sibling_index = LazyCell::new(|| node.index() + 1);
+            for (current_node_index, current_node) in siblings_to_merge.iter().enumerate() {
                 // Steps 6.1-6.4: The live range update steps.
-                live_range_normalization_steps(self, &node, current_node.upcast(), length);
+                live_range_normalization_steps(
+                    self,
+                    &node,
+                    current_node.upcast(),
+                    &|| *first_sibling_index + current_node_index as u32,
+                    length,
+                );
                 // Step 6.5:  Add currentNode’s length to length.
                 length += current_node.Length();
                 // Step 6.6 Set currentNode to its next sibling.

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -57,7 +57,6 @@ use uuid::Uuid;
 use xml5ever::{local_name, serialize as xml_serialize};
 
 use crate::conversions::Convert;
-use crate::dom::ChildrenMutation;
 use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use crate::dom::bindings::codegen::Bindings::CSSStyleDeclarationBinding::CSSStyleDeclarationMethods;
@@ -125,6 +124,10 @@ use crate::dom::shadowroot::{IsUserAgentWidget, ShadowRoot};
 use crate::dom::text::Text;
 use crate::dom::types::{CDATASection, KeyboardEvent, MouseEvent, ProcessingInstruction};
 use crate::dom::window::Window;
+use crate::dom::{
+    ChildrenMutation, Range, live_range_insert_steps, live_range_normalization_steps,
+    live_range_pre_remove_steps_for_parent, live_range_pre_remove_steps_for_removed_subtree,
+};
 use crate::drag::document_selection_drag::DocumentSelectionDragHandler;
 use crate::drag::drag_gesture::{DragGesture, DragHandler};
 use crate::event_loop::document_loader::DocumentLoader;
@@ -831,27 +834,27 @@ impl Node {
         self.children_count.get()
     }
 
-    pub(crate) fn weak_ranges_mut(&self) -> Option<RefMut<'_, WeakRangeVec>> {
-        let rare_data = self.rare_data.borrow_mut();
-        if rare_data.is_none() {
-            return None;
-        }
-        Some(RefMut::map(rare_data, |rare_data| {
-            &mut rare_data.as_mut().unwrap().weak_ranges
-        }))
-    }
-
     pub(crate) fn ensure_weak_ranges(&self) -> RefMut<'_, WeakRangeVec> {
         RefMut::map(self.ensure_rare_data(), |rare_data| {
             &mut rare_data.weak_ranges
         })
     }
 
-    pub(crate) fn weak_ranges_is_empty(&self) -> bool {
+    /// Whether or not this node has any live ranges.
+    pub(crate) fn has_live_ranges(&self) -> bool {
         self.rare_data
             .borrow()
             .as_ref()
-            .is_none_or(|data| data.weak_ranges.is_empty())
+            .is_some_and(|data| !data.weak_ranges.is_empty())
+    }
+
+    /// Return a `SmallVec` of all live ranges registered on this node.
+    pub(crate) fn live_ranges(&self) -> SmallVec<[DomRoot<Range>; 4]> {
+        let rare_data = self.rare_data.borrow();
+        let Some(rare_data) = &*rare_data else {
+            return Default::default();
+        };
+        rare_data.weak_ranges.live_ranges()
     }
 
     #[inline]
@@ -1457,7 +1460,8 @@ impl Node {
             .expect("old_parent should always be initialized");
 
         // Step 9. Run the live range pre-remove steps, given node.
-        let cached_index = Node::live_range_pre_remove_steps(node, &old_parent);
+        let mut cached_index = None;
+        live_range_pre_remove_steps_for_parent(node, &old_parent, &mut cached_index);
 
         // TODO Step 10. For each NodeIterator object iterator whose root’s node document is node’s
         // node document: run the NodeIterator pre-remove steps given node and iterator.
@@ -1530,14 +1534,9 @@ impl Node {
         }
 
         // Step 17. If child is non-null:
-        if let Some(child) = child &&
-            let Some(new_parent_ranges) = new_parent.weak_ranges_mut()
-        {
-            // Step 17.1. For each live range whose start node is newParent and start offset is
-            // greater than child’s index: increase its start offset by 1.
-            // Step 17.2. For each live range whose end node is newParent and end offset is greater
-            // than child’s index: increase its end offset by 1.
-            new_parent_ranges.increase_above(new_parent, child.index(), 1)
+        if let Some(child) = child {
+            // Steps 17.1-17.2: The live range move steps.
+            live_range_insert_steps(new_parent, child, 1);
         }
 
         // Step 18. Let newPreviousSibling be child’s previous sibling if child is non-null, and
@@ -2674,14 +2673,9 @@ impl Node {
         }
 
         // Step 5. If child is non-null:
-        //     1. For each live range whose start node is parent and start offset is
-        //        greater than child’s index, increase its start offset by count.
-        //     2. For each live range whose end node is parent and end offset is
-        //        greater than child’s index, increase its end offset by count.
-        if let Some(child) = child &&
-            let Some(parent_weak_ranges) = parent.weak_ranges_mut()
-        {
-            parent_weak_ranges.increase_above(parent, child.index(), count.try_into().unwrap());
+        if let Some(child) = child {
+            // Step 5.1. The live range insert steps.
+            live_range_insert_steps(parent, child, count.try_into().unwrap());
         }
 
         // Step 6. Let previousSibling be child’s previous sibling or parent’s last child if child is null.
@@ -2978,8 +2972,8 @@ impl Node {
         );
 
         // Step 3. Run the live range pre-remove steps.
-        // https://dom.spec.whatwg.org/#live-range-pre-remove-steps
-        let cached_index = Node::live_range_pre_remove_steps(node, parent);
+        let mut cached_index = None;
+        live_range_pre_remove_steps_for_parent(node, parent, &mut cached_index);
 
         // TODO: Step 4. Pre-removing steps for node iterators
 
@@ -3044,35 +3038,6 @@ impl Node {
             MutationObserver::queue_a_mutation_record(cx, parent, mutation);
         }
         parent.owner_doc().remove_script_and_layout_blocker(cx);
-    }
-
-    /// <https://dom.spec.whatwg.org/#live-range-pre-remove-steps>
-    fn live_range_pre_remove_steps(node: &Node, parent: &Node) -> Option<u32> {
-        if parent.weak_ranges_is_empty() {
-            return None;
-        }
-
-        // Step 1. Let parent be node’s parent.
-        // Step 2. Assert: parent is not null.
-        // NOTE: We already have the parent.
-
-        // Step 3. Let index be node’s index.
-        let index = node.index();
-
-        // Steps 4-5 are handled in Node::unbind_from_tree.
-
-        // Step 6. For each live range whose start node is parent and start offset is greater than index,
-        // decrease its start offset by 1.
-        // Step 7. For each live range whose end node is parent and end offset is greater than index,
-        // decrease its end offset by 1.
-        if let Some(parent_weak_ranges) = parent.weak_ranges_mut() {
-            parent_weak_ranges.decrease_above(parent, index, 1);
-        }
-
-        // Parent had ranges, we needed the index, let's keep track of
-        // it to avoid computing it for other ranges when calling
-        // unbind_from_tree recursively.
-        Some(index)
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-clone>
@@ -4057,36 +4022,82 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
 
     /// <https://dom.spec.whatwg.org/#dom-node-normalize>
     fn Normalize(&self, cx: &mut JSContext) {
-        let mut children = self.children().enumerate().peekable();
-        while let Some((_, node)) = children.next() {
-            if let Some(text) = node.downcast::<Text>() {
-                if text.is::<CDATASection>() {
-                    continue;
-                }
-                let cdata = text.upcast::<CharacterData>();
-                let mut length = cdata.Length();
-                if length == 0 {
-                    Node::remove(cx, &node, self, SuppressObserver::Unsuppressed);
-                    continue;
-                }
-                while children.peek().is_some_and(|(_, sibling)| {
-                    sibling.is::<Text>() && !sibling.is::<CDATASection>()
-                }) {
-                    let (index, sibling) = children.next().unwrap();
-                    if let Some(sibling_weak_ranges) = sibling.weak_ranges_mut() {
-                        sibling_weak_ranges
-                            .drain_to_preceding_text_sibling(&sibling, &node, length);
-                    }
-                    if let Some(weak_ranges) = self.weak_ranges_mut() {
-                        weak_ranges.move_to_text_child_at(self, index as u32, &node, length);
-                    }
-                    let sibling_cdata = sibling.downcast::<CharacterData>().unwrap();
-                    length += sibling_cdata.Length();
-                    cdata.append_data(cx, &sibling_cdata.data());
-                    Node::remove(cx, &sibling, self, SuppressObserver::Unsuppressed);
-                }
-            } else {
+        let mut children = self.children().peekable();
+        while let Some(node) = children.next() {
+            // The normalize() method steps are to run these steps for each descendant
+            // exclusive Text node node of this:
+            let Some(text) = node.downcast::<Text>() else {
                 node.Normalize(cx);
+                continue;
+            };
+            if text.is::<CDATASection>() {
+                continue;
+            }
+
+            // Step 1: Let length be node’s length.
+            let cdata = text.upcast::<CharacterData>();
+            let mut length = cdata.Length();
+
+            // Step 2: If length is zero, then remove node and continue with the next
+            // exclusive Text node, if any.
+            if length == 0 {
+                Node::remove(cx, &node, self, SuppressObserver::Unsuppressed);
+                continue;
+            }
+
+            // Collect siblings that need to be merged ahead of time so that we can
+            // avoid multiple mutation records.
+            let mut siblings_to_merge: SmallVec<[DomRoot<CharacterData>; 4]> = SmallVec::new();
+            let mut new_data_length = 0;
+            while let Some(sibling) = children.peek() {
+                if !sibling.is::<Text>() || sibling.is::<CDATASection>() {
+                    break;
+                }
+                let sibling: DomRoot<CharacterData> =
+                    DomRoot::downcast(children.next().expect("Guaranteed by the peek above"))
+                        .expect("Guaranteed by check above");
+                new_data_length += sibling.Length();
+                siblings_to_merge.push(sibling);
+            }
+
+            if siblings_to_merge.is_empty() {
+                continue;
+            }
+
+            // Step 3: Let data be the concatenation of the data of node’s contiguous
+            // exclusive Text nodes (excluding itself), in tree order.
+            let data = siblings_to_merge.iter().fold(
+                String::with_capacity(new_data_length as usize),
+                |mut data, character_data| {
+                    data.push_str(character_data.data().as_str());
+                    data
+                },
+            );
+
+            // Step 4: Replace data of node with length, 0, and data.
+            cdata.append_data(cx, &data);
+
+            // Step 5: Let currentNode be node’s next sibling.
+            // Step 6: While currentNode is an exclusive Text node:
+            // Note: Condition guaranteed by collection loop above.
+            for current_node in siblings_to_merge.iter() {
+                // Steps 6.1-6.4: The live range update steps.
+                live_range_normalization_steps(self, &node, current_node.upcast(), length);
+                // Step 6.5:  Add currentNode’s length to length.
+                length += current_node.Length();
+                // Step 6.6 Set currentNode to its next sibling.
+                // This is handled by the loop.
+            }
+
+            // Step 7: Remove node’s contiguous exclusive Text nodes (excluding itself),
+            // in tree order.
+            for current_node in siblings_to_merge.into_iter() {
+                Node::remove(
+                    cx,
+                    current_node.upcast(),
+                    self,
+                    SuppressObserver::Unsuppressed,
+                );
             }
         }
     }
@@ -4495,21 +4506,10 @@ impl VirtualMethods for Node {
             .content_and_heritage_changed(cx.no_gc(), self);
     }
 
-    // This handles the ranges mentioned in steps 2-3 when removing a node.
     /// <https://dom.spec.whatwg.org/#concept-node-remove>
     fn unbind_from_tree(&self, cx: &mut JSContext, context: &UnbindContext) {
         self.super_type().unwrap().unbind_from_tree(cx, context);
-
-        // Ranges should only drain to the parent from inclusive non-shadow
-        // including descendants. If we're in a shadow tree at this point then the
-        // unbind operation happened further up in the tree and we should not
-        // drain any ranges.
-        if !self.is_in_a_shadow_tree() &&
-            let Some(weak_ranges) = self.weak_ranges_mut() &&
-            !weak_ranges.is_empty()
-        {
-            weak_ranges.drain_to_parent(context.parent, context.index(), self);
-        }
+        live_range_pre_remove_steps_for_removed_subtree(self, context.parent, &|| context.index());
     }
 
     fn moving_steps(&self, cx: &mut JSContext, context: &MoveContext) {
@@ -4517,16 +4517,8 @@ impl VirtualMethods for Node {
             super_type.moving_steps(cx, context);
         }
 
-        // Ranges should only drain to the parent from inclusive non-shadow
-        // including descendants. If we're in a shadow tree at this point then the
-        // unbind operation happened further up in the tree and we should not
-        // drain any ranges.
-        if let Some(old_parent) = context.old_parent &&
-            !self.is_in_a_shadow_tree() &&
-            let Some(weak_ranges) = self.weak_ranges_mut() &&
-            !weak_ranges.is_empty()
-        {
-            weak_ranges.drain_to_parent(old_parent, context.index(), self);
+        if let Some(parent) = context.old_parent {
+            live_range_pre_remove_steps_for_removed_subtree(self, parent, &|| context.index());
         }
 
         self.owner_doc_unrooted(cx.no_gc())

--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -1407,26 +1407,26 @@ pub(crate) fn live_range_insert_steps(parent: &Node, child: &Node, count: u32) {
 /// having to iterate through those nodes twice, they are run when the inclusive
 /// descendants themselves are unbound from the tree.
 pub(crate) fn live_range_pre_remove_steps_for_removed_subtree(
-    node: &Node,
-    parent: &Node,
-    index: &dyn Fn() -> u32,
+    inclusive_descendant_of_removed_node: &Node, // "node" in the specification
+    parent_of_removed_node: &Node,               // "parent" in the specification
+    index_of_removed_node: &dyn Fn() -> u32,     // "index" in the specification
 ) {
     // The steps are only supposed to run on DOM tree inclusive descendants of the removal
     // root and elements in shadow trees are not, so they shouldn't run for them.
-    if node.is_in_a_shadow_tree() {
+    if inclusive_descendant_of_removed_node.is_in_a_shadow_tree() {
         return;
     }
-    for range in node.live_ranges() {
-        let index = index();
+    for range in inclusive_descendant_of_removed_node.live_ranges() {
+        let index = index_of_removed_node();
         // Step 4: For each live range whose start node is an inclusive descendant of
         // node, set its start to (parent, index).
-        if &*range.start_container() == node {
-            range.set_start(parent, index);
+        if &*range.start_container() == inclusive_descendant_of_removed_node {
+            range.set_start(parent_of_removed_node, index);
         }
         // Step 5: For each live range whose end node is an inclusive descendant of node,
         // set its end to (parent, index).
-        if &*range.end_container() == node {
-            range.set_end(parent, index);
+        if &*range.end_container() == inclusive_descendant_of_removed_node {
+            range.set_end(parent_of_removed_node, index);
         }
     }
 }
@@ -1458,12 +1458,15 @@ pub(crate) fn live_range_pre_remove_steps_for_parent(
 /// - `node`: The node that text is being merged into.
 /// - `current_node`: The node which has text being merged into `node` and will be
 ///   removed from the DOM.
-/// - `length`: The length of the text content that was merged into `node` from
-///   siblings before `current_node`.
+/// - `current_node_index`: The index of `current_node` in `parent`.
+/// - `length`: The length of the text content in `node`, its orginal length plus
+///   the length of all content that has already been merged from siblings before
+///   `current_node`.
 pub(crate) fn live_range_normalization_steps(
     parent: &Node,
     node: &Node,
     current_node: &Node,
+    current_node_index: &dyn Fn() -> u32,
     length: u32,
 ) {
     for range in current_node.live_ranges() {
@@ -1479,18 +1482,17 @@ pub(crate) fn live_range_normalization_steps(
         }
     }
 
-    let current_node_index = LazyCell::new(|| current_node.index());
     for range in parent.live_ranges() {
         // Step 6.3: For each live range whose start node is currentNode’s parent and
         // start offset is currentNode’s index: set its start node to node and its start
         // offset to length.
-        if &*range.start_container() == parent && range.start_offset() == *current_node_index {
+        if &*range.start_container() == parent && range.start_offset() == current_node_index() {
             range.set_start(node, length);
         }
         // Step 6.4: For each live range whose end node is currentNode’s parent and end
         // offset is currentNode’s index: set its end node to node and its end offset to
         // length.
-        if &*range.end_container() == parent && range.end_offset() == *current_node_index {
+        if &*range.end_container() == parent && range.end_offset() == current_node_index() {
             range.set_end(node, length);
         }
     }
@@ -1541,7 +1543,7 @@ pub(crate) fn live_range_replace_data_steps(
     }
 }
 
-/// <https://dom.spec.whatwg.org/#concept-text-split> steps 7.2-7.3.
+/// <https://dom.spec.whatwg.org/#concept-text-split> steps 7.2-7.5.
 pub(crate) fn live_range_text_split_steps(
     parent: &Node,
     node: &Node,

--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::RefCell;
+use std::cell::{LazyCell, RefCell};
 use std::cmp::{Ordering, PartialOrd};
 use std::iter;
 use std::rc::Rc;
@@ -16,6 +16,7 @@ use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
 use script_bindings::dom::UnrootedDom;
 use script_bindings::reflector::reflect_weak_referenceable_dom_object_with_proto;
+use smallvec::SmallVec;
 use style_traits::CSSPixel;
 
 use crate::dom::abstractrange::{AbstractRange, BoundaryPoint, bp_position};
@@ -1352,235 +1353,13 @@ impl WeakRangeVec {
         self.cell.borrow().is_empty()
     }
 
-    /// Used for steps 2.1-2. when inserting a node.
-    /// <https://dom.spec.whatwg.org/#concept-node-insert>
-    pub(crate) fn increase_above(&self, node: &Node, offset: u32, delta: u32) {
-        self.map_offset_above(node, offset, |offset| offset + delta);
-    }
-
-    /// Used for steps 4-5. when removing a node.
-    /// <https://dom.spec.whatwg.org/#concept-node-remove>
-    pub(crate) fn decrease_above(&self, node: &Node, offset: u32, delta: u32) {
-        self.map_offset_above(node, offset, |offset| offset - delta);
-    }
-
-    /// Used for steps 2-3. when removing a node.
-    ///
-    /// <https://dom.spec.whatwg.org/#concept-node-remove>
-    pub(crate) fn drain_to_parent(&self, parent: &Node, offset: u32, child: &Node) {
-        if self.is_empty() {
-            return;
+    /// Get a rooted version of the contents of this [`WeakRangeVec`]
+    pub(crate) fn live_ranges(&self) -> SmallVec<[DomRoot<Range>; 4]> {
+        let cell = self.cell.borrow();
+        if cell.is_empty() {
+            return Default::default();
         }
-
-        let ranges = &mut *self.cell.borrow_mut();
-
-        ranges.update(|entry| {
-            let range = entry.root().unwrap();
-            if range.start().node() == parent || range.end().node() == parent {
-                entry.remove();
-            }
-            if range.start().node() == child {
-                range.report_change();
-                range.start().set(parent, offset);
-            }
-            if range.end().node() == child {
-                range.report_change();
-                range.end().set(parent, offset);
-            }
-        });
-
-        parent
-            .ensure_weak_ranges()
-            .cell
-            .borrow_mut()
-            .extend(ranges.drain(..));
-    }
-
-    /// Used for steps 6.1-2. when normalizing a node.
-    /// <https://dom.spec.whatwg.org/#dom-node-normalize>
-    pub(crate) fn drain_to_preceding_text_sibling(&self, node: &Node, sibling: &Node, length: u32) {
-        if self.is_empty() {
-            return;
-        }
-
-        let ranges = &mut *self.cell.borrow_mut();
-
-        ranges.update(|entry| {
-            let range = entry.root().unwrap();
-            if range.start().node() == sibling || range.end().node() == sibling {
-                entry.remove();
-            }
-            if range.start().node() == node {
-                range.report_change();
-                range.start().set(sibling, range.start_offset() + length);
-            }
-            if range.end().node() == node {
-                range.report_change();
-                range.end().set(sibling, range.end_offset() + length);
-            }
-        });
-
-        sibling
-            .ensure_weak_ranges()
-            .cell
-            .borrow_mut()
-            .extend(ranges.drain(..));
-    }
-
-    /// Used for steps 6.3-4. when normalizing a node.
-    /// <https://dom.spec.whatwg.org/#dom-node-normalize>
-    pub(crate) fn move_to_text_child_at(
-        &self,
-        node: &Node,
-        offset: u32,
-        child: &Node,
-        new_offset: u32,
-    ) {
-        self.cell.borrow_mut().update(|entry| {
-            let range = entry.root().unwrap();
-
-            let node_is_start = range.start().node() == node;
-            let node_is_end = range.end().node() == node;
-
-            let move_start = node_is_start && range.start_offset() == offset;
-            let move_end = node_is_end && range.end_offset() == offset;
-
-            let remove_from_node =
-                move_start && (move_end || !node_is_end) || move_end && !node_is_start;
-
-            let already_in_child = range.start().node() == child || range.end().node() == child;
-            let push_to_child = !already_in_child && (move_start || move_end);
-
-            if remove_from_node {
-                let weak_range = entry.remove();
-                if push_to_child {
-                    child
-                        .ensure_weak_ranges()
-                        .cell
-                        .borrow_mut()
-                        .push(weak_range);
-                }
-            } else if push_to_child {
-                child
-                    .ensure_weak_ranges()
-                    .cell
-                    .borrow_mut()
-                    .push(WeakRef::new(&range));
-            }
-
-            if move_start {
-                range.report_change();
-                range.start().set(child, new_offset);
-            }
-            if move_end {
-                range.report_change();
-                range.end().set(child, new_offset);
-            }
-        });
-    }
-
-    /// Used for steps 8-11. when replacing character data.
-    /// <https://dom.spec.whatwg.org/#concept-cd-replace>
-    pub(crate) fn replace_code_units(
-        &self,
-        node: &Node,
-        offset: u32,
-        removed_code_units: u32,
-        added_code_units: u32,
-    ) {
-        self.map_offset_above(node, offset, |range_offset| {
-            if range_offset <= offset + removed_code_units {
-                offset
-            } else {
-                range_offset + added_code_units - removed_code_units
-            }
-        });
-    }
-
-    /// Used for steps 7.2-3. when splitting a text node.
-    /// <https://dom.spec.whatwg.org/#concept-text-split>
-    pub(crate) fn move_to_following_text_sibling_above(
-        &self,
-        node: &Node,
-        offset: u32,
-        sibling: &Node,
-    ) {
-        self.cell.borrow_mut().update(|entry| {
-            let range = entry.root().unwrap();
-            let start_offset = range.start_offset();
-            let end_offset = range.end_offset();
-
-            let node_is_start = range.start().node() == node;
-            let node_is_end = range.end().node() == node;
-
-            let move_start = node_is_start && start_offset > offset;
-            let move_end = node_is_end && end_offset > offset;
-
-            let remove_from_node =
-                move_start && (move_end || !node_is_end) || move_end && !node_is_start;
-
-            let already_in_sibling =
-                range.start().node() == sibling || range.end().node() == sibling;
-            let push_to_sibling = !already_in_sibling && (move_start || move_end);
-
-            if remove_from_node {
-                let weak_range = entry.remove();
-                if push_to_sibling {
-                    sibling
-                        .ensure_weak_ranges()
-                        .cell
-                        .borrow_mut()
-                        .push(weak_range);
-                }
-            } else if push_to_sibling {
-                sibling
-                    .ensure_weak_ranges()
-                    .cell
-                    .borrow_mut()
-                    .push(WeakRef::new(&range));
-            }
-
-            if move_start {
-                range.report_change();
-                range.start().set(sibling, start_offset - offset);
-            }
-            if move_end {
-                range.report_change();
-                range.end().set(sibling, end_offset - offset);
-            }
-        });
-    }
-
-    /// Used for steps 7.4-5. when splitting a text node.
-    /// <https://dom.spec.whatwg.org/#concept-text-split>
-    pub(crate) fn increment_at(&self, node: &Node, offset: u32) {
-        self.cell.borrow_mut().update(|entry| {
-            let range = entry.root().unwrap();
-            if range.start().node() == node && offset == range.start_offset() {
-                range.report_change();
-                range.start().set_offset(offset + 1);
-            }
-            if range.end().node() == node && offset == range.end_offset() {
-                range.report_change();
-                range.end().set_offset(offset + 1);
-            }
-        });
-    }
-
-    fn map_offset_above<F: FnMut(u32) -> u32>(&self, node: &Node, offset: u32, mut f: F) {
-        self.cell.borrow_mut().update(|entry| {
-            let range = entry.root().unwrap();
-            let start_offset = range.start_offset();
-            if range.start().node() == node && start_offset > offset {
-                range.report_change();
-                range.start().set_offset(f(start_offset));
-            }
-            let end_offset = range.end_offset();
-            if range.end().node() == node && end_offset > offset {
-                range.report_change();
-                range.end().set_offset(f(end_offset));
-            }
-        });
+        cell.iter().filter_map(|range| range.root()).collect()
     }
 
     pub(crate) fn push(&self, ref_: WeakRef<Range>) {
@@ -1598,5 +1377,204 @@ impl WeakRangeVec {
 unsafe impl JSTraceable for WeakRangeVec {
     unsafe fn trace(&self, _: *mut JSTracer) {
         self.cell.borrow_mut().retain_alive()
+    }
+}
+
+/// <https://dom.spec.whatwg.org/#concept-node-insert> steps 5.1-5.2
+/// and
+/// <https://dom.spec.whatwg.org/#move> steps 17.1-17.2.
+pub(crate) fn live_range_insert_steps(parent: &Node, child: &Node, count: u32) {
+    if parent.has_live_ranges() {
+        let child_index = LazyCell::new(|| child.index());
+        for range in parent.live_ranges() {
+            // Step 5.1: For each live range whose start node is parent and start offset is
+            // greater than child’s index: increase its start offset by count.
+            if &*range.start_container() == parent && range.start_offset() > *child_index {
+                range.set_start(parent, range.start_offset() + count);
+            }
+            // Step 5.2: For each live range whose end node is parent and end offset is
+            // greater than child’s index: increase its end offset by count.
+            if &*range.end_container() == parent && range.end_offset() > *child_index {
+                range.set_end(parent, range.end_offset() + count);
+            }
+        }
+    }
+}
+
+/// <https://dom.spec.whatwg.org/#live-range-pre-remove-steps> steps 4 and 5.
+///
+/// These steps are run on the inclusive descendants of a removed node, but to avoid
+/// having to iterate through those nodes twice, they are run when the inclusive
+/// descendants themselves are unbound from the tree.
+pub(crate) fn live_range_pre_remove_steps_for_removed_subtree(
+    node: &Node,
+    parent: &Node,
+    index: &dyn Fn() -> u32,
+) {
+    // The steps are only supposed to run on DOM tree inclusive descendants of the removal
+    // root and elements in shadow trees are not, so they shouldn't run for them.
+    if node.is_in_a_shadow_tree() {
+        return;
+    }
+    for range in node.live_ranges() {
+        let index = index();
+        // Step 4: For each live range whose start node is an inclusive descendant of
+        // node, set its start to (parent, index).
+        if &*range.start_container() == node {
+            range.set_start(parent, index);
+        }
+        // Step 5: For each live range whose end node is an inclusive descendant of node,
+        // set its end to (parent, index).
+        if &*range.end_container() == node {
+            range.set_end(parent, index);
+        }
+    }
+}
+
+/// <https://dom.spec.whatwg.org/#live-range-pre-remove-steps> steps 6 and 7.
+pub(crate) fn live_range_pre_remove_steps_for_parent(
+    node: &Node,
+    parent: &Node,
+    cached_node_index: &mut Option<u32>,
+) {
+    for range in parent.live_ranges() {
+        let node_index = *cached_node_index.get_or_insert_with(|| node.index());
+        // Step 6: For each live range whose start node is parent and start offset is
+        // greater than index, decrease its start offset by 1.
+        if &*range.start_container() == parent && range.start_offset() > node_index {
+            range.set_start(parent, range.start_offset() - 1);
+        }
+        // Step 7: For each live range whose end node is parent and end offset is greater than
+        // index, decrease its end offset by 1.
+        if &*range.end_container() == parent && range.end_offset() > node_index {
+            range.set_end(parent, range.end_offset() - 1);
+        }
+    }
+}
+
+/// <https://dom.spec.whatwg.org/#dom-node-normalize> Steps 6.1-6.4.
+///
+/// - `parent`: The parent of both other node arguments.
+/// - `node`: The node that text is being merged into.
+/// - `current_node`: The node which has text being merged into `node` and will be
+///   removed from the DOM.
+/// - `length`: The length of the text content that was merged into `node` from
+///   siblings before `current_node`.
+pub(crate) fn live_range_normalization_steps(
+    parent: &Node,
+    node: &Node,
+    current_node: &Node,
+    length: u32,
+) {
+    for range in current_node.live_ranges() {
+        // Step 6.1: For each live range whose start node is currentNode: add length to
+        // its start offset and set its start node to node.
+        if &*range.start_container() == current_node {
+            range.set_start(node, range.start_offset() + length);
+        }
+        // Step 6.2: For each live range whose end node is currentNode: add length to its
+        // end offset and set its end node to node.
+        if &*range.end_container() == current_node {
+            range.set_end(node, range.end_offset() + length);
+        }
+    }
+
+    let current_node_index = LazyCell::new(|| current_node.index());
+    for range in parent.live_ranges() {
+        // Step 6.3: For each live range whose start node is currentNode’s parent and
+        // start offset is currentNode’s index: set its start node to node and its start
+        // offset to length.
+        if &*range.start_container() == parent && range.start_offset() == *current_node_index {
+            range.set_start(node, length);
+        }
+        // Step 6.4: For each live range whose end node is currentNode’s parent and end
+        // offset is currentNode’s index: set its end node to node and its end offset to
+        // length.
+        if &*range.end_container() == parent && range.end_offset() == *current_node_index {
+            range.set_end(node, length);
+        }
+    }
+}
+
+/// <https://dom.spec.whatwg.org/#concept-cd-replace> steps 8-11.
+pub(crate) fn live_range_replace_data_steps(
+    node: &Node,
+    offset: u32,
+    removed_code_units: u32,
+    added_code_units: u32,
+) {
+    for range in node.live_ranges() {
+        // Step 8: For each live range whose start node is node and start offset is
+        // greater than offset but less than or equal to offset + count: set its start
+        // offset to offset.
+        let start_container = range.start_container();
+        let start_offset = range.start_offset();
+        if &*start_container == node &&
+            start_offset > offset &&
+            start_offset <= offset + removed_code_units
+        {
+            range.set_start(node, offset);
+        }
+        // Step 9: For each live range whose end node is node and end offset is
+        // greater than offset but less than or equal to offset + count: set its end
+        // offset to offset.
+        let end_container = range.end_container();
+        let end_offset = range.end_offset();
+        if &*end_container == node &&
+            end_offset > offset &&
+            end_offset <= offset + removed_code_units
+        {
+            range.set_end(node, offset);
+        }
+        // Step 10: For each live range whose start node is node and start offset is
+        // greater than offset + count: increase its start offset by data’s length and
+        // decrease it by count.
+        if &*start_container == node && start_offset > offset + removed_code_units {
+            range.set_start(node, start_offset + added_code_units - removed_code_units);
+        }
+        // Step 11: For each live range whose end node is node and end offset is
+        // greater than offset + count: increase its end offset by data’s length and
+        // decrease it by count.
+        if &*end_container == node && end_offset > offset + removed_code_units {
+            range.set_end(node, end_offset + added_code_units - removed_code_units);
+        }
+    }
+}
+
+/// <https://dom.spec.whatwg.org/#concept-text-split> steps 7.2-7.3.
+pub(crate) fn live_range_text_split_steps(
+    parent: &Node,
+    node: &Node,
+    offset: u32,
+    new_node: &Node,
+) {
+    for range in node.live_ranges() {
+        // Step 7.2. For each live range whose start node is node and start offset is
+        // greater than offset, set its start node to newNode and decrease its start
+        // offset by offset.
+        if &*range.start_container() == node && range.start_offset() > offset {
+            range.set_start(new_node, range.start_offset() - offset);
+        }
+        // Step 7.3. For each live range whose end node is node and end offset is
+        // greater than offset, set its end node to newNode and decrease its end
+        // offset by offset.
+        if &*range.end_container() == node && range.end_offset() > offset {
+            range.set_end(new_node, range.end_offset() - offset);
+        }
+    }
+
+    let node_index = LazyCell::new(|| node.index());
+    for range in parent.live_ranges() {
+        // Step 7.4. For each live range whose start node is parent and start offset
+        // is equal to the index of node plus 1, increase its start offset by 1.
+        if &*range.start_container() == parent && range.start_offset() == *node_index + 1 {
+            range.set_start(parent, range.start_offset() + 1);
+        }
+
+        // Step 7.5. For each live range whose end node is parent and end offset is
+        // equal to the index of node plus 1, increase its end offset by 1.
+        if &*range.end_container() == parent && range.end_offset() == *node_index + 1 {
+            range.set_end(parent, range.end_offset() + 1);
+        }
     }
 }

--- a/tests/wpt/tests/dom/ranges/Range-mutations-normalize.html
+++ b/tests/wpt/tests/dom/ranges/Range-mutations-normalize.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<title>Range mutation tests - normalize</title>
+ <link rel="help" href="https://dom.spec.whatwg.org/#dom-node-normalize">;
+<link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+<div id=log></div>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+    function createTestNode(t) {
+        // Create a node with adjacent 4 text children.
+        const parentNode = document.createElement("div");
+        parentNode.append(document.createElement("span"), "A", "BB", "CCC", "DDDD", document.createElement("span"));
+        document.body.append(parentNode);
+        t.add_cleanup(() => parentNode.remove());
+        return parentNode;
+    }
+
+    function normalizeTestNode(testNode) {
+        testNode.normalize();
+        assert_equals(testNode.childNodes.length, 3);
+        assert_equals(testNode.childNodes[1].data, "ABBCCCDDDD");
+    }
+
+    test(t => {
+        let testNode = createTestNode(t);
+        let range = document.createRange();
+        range.setStart(testNode.childNodes[1], 0);
+        range.setEnd(testNode.childNodes[4], 4);
+        normalizeTestNode(testNode);
+        assert_equals(range.startContainer, testNode.childNodes[1]);
+        assert_equals(range.startOffset, 0);
+        assert_equals(range.endContainer, testNode.childNodes[1]);
+        assert_equals(range.endOffset, 10);
+    }, "Live range updates properly when its boundaries span multiple merged text nodes");
+
+    test(t => {
+        let testNode = createTestNode(t);
+        let range = document.createRange();
+        range.setStart(testNode.childNodes[3], 2);
+        range.setEnd(testNode.childNodes[3], 2);
+
+        normalizeTestNode(testNode);
+
+        assert_equals(range.startContainer, testNode.childNodes[1]);
+        assert_equals(range.startOffset, 5);
+        assert_equals(range.endContainer, testNode.childNodes[1]);
+        assert_equals(range.endOffset, 5);
+    }, "Live range updates properly when collapsed into single merged text node in range of multiple")
+
+    test(t => {
+        let testNode = createTestNode(t);
+        let range = document.createRange();
+        range.setStart(testNode, 3);
+        range.setEnd(testNode, 4);
+
+        normalizeTestNode(testNode);
+
+        assert_equals(range.startContainer, testNode.childNodes[1]);
+        assert_equals(range.startOffset, 3);
+        assert_equals(range.endContainer, testNode.childNodes[1]);
+        assert_equals(range.endOffset, 6);
+    }, "Live range updates properly when its boundaries are initially indices to merged nodes")
+
+    test(t => {
+        let testNode = createTestNode(t);
+        let range1 = document.createRange();
+        let range2 = document.createRange();
+
+        range1.setStart(testNode, 0);
+        range1.setEnd(testNode, 0);
+        range2.setStart(testNode, 5);
+        range2.setEnd(testNode, 5);
+
+        normalizeTestNode(testNode);
+
+        assert_equals(range1.startContainer, testNode);
+        assert_equals(range1.startOffset, 0);
+        assert_equals(range1.endContainer, testNode);
+        assert_equals(range1.endOffset, 0);
+
+        assert_equals(range2.startContainer, testNode);
+        assert_equals(range2.startOffset, 2);
+        assert_equals(range2.endContainer, testNode);
+        assert_equals(range2.endOffset, 2);
+    }, "Live range updates properly when text nodes merged before and after them")
+</script>


### PR DESCRIPTION
This change reworks the live range update steps that show up in various
places in the specification so that they match what the specification
says. Now updates to live ranges use the existing `set_start` and
`set_end` APIs which simplify the code greatly as they already handle
updating the `Node`'s live range list. This is preparation work for
adding a new live-ish range type for selections (which will have a few
different requirements than a real DOM live range).

Improvements to spec compliance of `Node#normalize()`:
 - Instead of issuing one mutation record per merged node only issue a
   single one.
 - The change to the preserved node's data happens before the merged
   nodes' removal.
 - Indices for live range updates would be stale when merging more
   than two nodes.

Notes on performance:
 - This switches to accessing a rooted `SmallVec` of live ranges
   per-node. In cases where a node has 4 or fewer live ranges, this will
   not allocate, otherwise this adds a new vector allocation for an
   edge case.
 - The amount of rooting should be unchanged as the old code had to
   root all accessed `Range`'s anyway.
 - In some cases we avoid calculating node indices where they were
   before using `LazyCell`.

Testing: This change adds a new WPT test.
