### PR TITLE
script: Reland loading state machine for documents

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -1458,6 +1458,35 @@ impl Document {
         }
     }
 
+    /// Set the `readyState` of this [`Document`] to `loading` for the purposes of the
+    /// "initialize a document object" part of the specification.
+    ///
+    /// See <https://html.spec.whatwg.org/multipage/#initialise-the-document-object>.
+    pub(crate) fn set_document_readiness_to_loading_for_initialization(&self) {
+        // https://html.spec.whatwg.org/multipage/#initialise-the-document-object
+        // > such initial about:blank Document are never created by this algorithm
+        // TODO(47417): Once "creating a new browsing context" properly exists, remove this check
+        if self.is_initial_about_blank() {
+            return;
+        }
+
+        // From <https://w3c.github.io/navigation-timing/#dom-performancetiming-domloading>:
+        // > This attribute must return the time immediately before the user agent sets the
+        // > current document readiness to "loading".
+        update_with_current_instant(&self.navigation_timing.dom_loading);
+
+        if self.window.is_top_level() {
+            let webview_id = self.webview_id();
+            self.send_to_embedder(EmbedderMsg::NotifyLoadStatusChanged(
+                webview_id,
+                LoadStatus::Started,
+            ));
+            self.send_to_embedder(EmbedderMsg::Status(webview_id, None));
+        }
+
+        self.ready_state.set(DocumentReadyState::Loading);
+    }
+
     /// <https://html.spec.whatwg.org/multipage/#update-the-current-document-readiness>
     pub(crate) fn update_the_current_document_readiness(
         &self,
@@ -1477,21 +1506,7 @@ impl Document {
         // global object.
         // Note: Handled implicitly by update_with_current_instant.
         match state {
-            DocumentReadyState::Loading => {
-                // From <https://w3c.github.io/navigation-timing/#dom-performancetiming-domloading>:
-                // > This attribute must return the time immediately before the user agent sets the
-                // > current document readiness to "loading".
-                update_with_current_instant(&self.navigation_timing.dom_loading);
-
-                let webview_id = self.webview_id();
-                self.send_to_embedder(EmbedderMsg::NotifyLoadStatusChanged(
-                    webview_id,
-                    LoadStatus::Started,
-                ));
-                self.send_to_embedder(EmbedderMsg::Status(webview_id, None));
-                // We should not fire a `readystatechange` event for the initial loading state
-                return;
-            },
+            DocumentReadyState::Loading => {},
             DocumentReadyState::Complete => {
                 // This isn't part of the specification, but it's useful to have it here to
                 // avoid code duplication.
@@ -3939,8 +3954,6 @@ impl Document {
             QuirksMode::NoQuirks
         };
 
-        let navigation_timing = Rc::new(NavigationTiming::default());
-
         Document {
             node: Node::new_document_node(),
             document_or_shadow_root: DocumentOrShadowRoot::new(window),
@@ -4017,7 +4030,7 @@ impl Document {
             active_parser_was_aborted: Cell::new(false),
             fired_unload: Cell::new(false),
             responsive_images: Default::default(),
-            navigation_timing,
+            navigation_timing: Default::default(),
             resource_fetch_timing: RefCell::new(None),
             completely_loaded: Cell::new(false),
             script_and_layout_blockers: Cell::new(0),

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -2379,9 +2379,8 @@ impl Document {
         // The initial about:blank document passes through
         // https://html.spec.whatwg.org/multipage/#creating-a-new-browsing-context
         // instead of the steps used by other documents.
-        if self.is_initial_about_blank() {
-            return;
-        }
+        assert!(!self.is_initial_about_blank());
+
         self.loader.borrow_mut().inhibit_events();
 
         // The rest will ever run only once per document.
@@ -2490,8 +2489,14 @@ impl Document {
     }
 
     pub(crate) fn start_the_end_loading_phase(&self) {
-        self.current_the_end_loading_phase
-            .set(TheEndLoadingPhase::ProcessingDeferredScripts);
+        if self.is_initial_about_blank() {
+            // TODO(47417): Once "creating a new browsing context" properly exists, remove this check
+            self.current_the_end_loading_phase
+                .set(TheEndLoadingPhase::Done);
+        } else {
+            self.current_the_end_loading_phase
+                .set(TheEndLoadingPhase::ProcessingDeferredScripts);
+        }
     }
 
     // https://html.spec.whatwg.org/multipage/#pending-parsing-blocking-script
@@ -3758,12 +3763,6 @@ struct DocumentSizes {
     other_nodes_size: usize,
 }
 
-#[derive(MallocSizeOf, PartialEq)]
-pub(crate) enum DocumentSource {
-    FromParser,
-    NotFromParser,
-}
-
 impl<'dom> LayoutDom<'dom, Document> {
     #[inline]
     pub(crate) fn is_html_document_for_layout(&self) -> bool {
@@ -3878,7 +3877,6 @@ impl Document {
         content_type: Option<Mime>,
         last_modified: Option<String>,
         activity: DocumentActivity,
-        source: DocumentSource,
         doc_loader: DocumentLoader,
         referrer: Option<String>,
         status_code: Option<u16>,
@@ -3894,12 +3892,6 @@ impl Document {
         image_cache: StdArc<dyn ImageCache>,
     ) -> Document {
         let url = url.unwrap_or_else(|| ServoUrl::parse("about:blank").unwrap());
-
-        let ready_state = if source == DocumentSource::FromParser {
-            DocumentReadyState::Loading
-        } else {
-            DocumentReadyState::Complete
-        };
 
         let frame_type = match window.is_top_level() {
             true => TimerMetadataFrameType::RootWindow,
@@ -3982,7 +3974,9 @@ impl Document {
             shared_style_locks,
             stylesheets: DomRefCell::new(DocumentStylesheetSet::new()),
             stylesheet_list: MutNullableDom::new(None),
-            ready_state: Cell::new(ready_state),
+            // https://html.spec.whatwg.org/multipage/dom.html#current-document-readiness
+            // > Each Document has a current document readiness, a string, initially "complete".
+            ready_state: Cell::new(DocumentReadyState::Complete),
             current_script: Default::default(),
             current_the_end_loading_phase: Default::default(),
             pending_parsing_blocking_script: Default::default(),
@@ -4202,7 +4196,6 @@ impl Document {
         content_type: Option<Mime>,
         last_modified: Option<String>,
         activity: DocumentActivity,
-        source: DocumentSource,
         doc_loader: DocumentLoader,
         referrer: Option<String>,
         status_code: Option<u16>,
@@ -4228,7 +4221,6 @@ impl Document {
             content_type,
             last_modified,
             activity,
-            source,
             doc_loader,
             referrer,
             status_code,
@@ -4257,7 +4249,6 @@ impl Document {
         content_type: Option<Mime>,
         last_modified: Option<String>,
         activity: DocumentActivity,
-        source: DocumentSource,
         doc_loader: DocumentLoader,
         referrer: Option<String>,
         status_code: Option<u16>,
@@ -4284,7 +4275,6 @@ impl Document {
                 content_type,
                 last_modified,
                 activity,
-                source,
                 doc_loader,
                 referrer,
                 status_code,
@@ -4488,7 +4478,6 @@ impl Document {
                     None,
                     None,
                     DocumentActivity::Inactive,
-                    DocumentSource::NotFromParser,
                     DocumentLoader::new(&self.loader()),
                     None,
                     None,
@@ -5261,7 +5250,6 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             None,
             None,
             DocumentActivity::Inactive,
-            DocumentSource::NotFromParser,
             docloader,
             None,
             None,
@@ -5314,7 +5302,6 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             Some(content_type),
             None,
             DocumentActivity::Inactive,
-            DocumentSource::FromParser,
             loader,
             None,
             None,
@@ -5369,7 +5356,6 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             Some(content_type),
             None,
             DocumentActivity::Inactive,
-            DocumentSource::FromParser,
             loader,
             None,
             None,

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -435,9 +435,6 @@ pub(crate) struct Document {
     stylesheets: DomRefCell<DocumentStylesheetSet<ServoStylesheetInDocument>>,
     stylesheet_list: MutNullableDom<StyleSheetList>,
     ready_state: Cell<DocumentReadyState>,
-    /// Whether the DOMContentLoaded event has already been dispatched.
-    /// TODO(43149): Remove when document replacement is implemented
-    domcontentloaded_dispatched: Cell<bool>,
     /// The script element that is currently executing.
     current_script: MutNullableDom<HTMLScriptElement>,
     #[no_trace]
@@ -1481,7 +1478,12 @@ impl Document {
         // Note: Handled implicitly by update_with_current_instant.
         match state {
             DocumentReadyState::Loading => {
-                unreachable!("Loading is an initial state, so we never transition to it.")
+                let webview_id = self.webview_id();
+                window.send_to_embedder(EmbedderMsg::NotifyLoadStatusChanged(
+                    webview_id,
+                    LoadStatus::Started,
+                ));
+                window.send_to_embedder(EmbedderMsg::Status(webview_id, None));
             },
             DocumentReadyState::Complete => {
                 // This isn't part of the specification, but it's useful to have it here to
@@ -2180,36 +2182,6 @@ impl Document {
             _ => {},
         }
 
-        // START TODO(43149): Remove when document replacement is implemented
-
-        // Step 4 is in another castle, namely at the end of
-        // process_deferred_scripts.
-
-        // Step 5 can be found in asap_script_loaded and
-        // asap_in_order_script_loaded.
-
-        let loader = self.loader.borrow();
-
-        // Servo measures when the top-level content (not iframes) is loaded.
-        if self
-            .navigation_timing
-            .top_level_dom_complete
-            .get()
-            .is_none() &&
-            loader.is_only_blocked_by_iframes()
-        {
-            update_with_current_instant(&self.navigation_timing.top_level_dom_complete);
-        }
-
-        if loader.is_blocked() || loader.events_inhibited() {
-            // Step 6.
-            return;
-        }
-
-        ScriptThread::mark_document_with_no_blocked_loads(self);
-
-        // END TODO(43149): Remove when document replacement is implemented
-
         // Step 8. Spin the event loop until there is nothing that delays the load event in the Document.
         let document = Trusted::new(self);
         self.owner_global()
@@ -2402,43 +2374,14 @@ impl Document {
         }
     }
 
-    // https://html.spec.whatwg.org/multipage/#the-end
-    // TODO(43149): Remove when document replacement is implemented
-    pub(crate) fn maybe_queue_document_completion(&self, cx: &mut JSContext) {
+    /// Step 9 of <https://html.spec.whatwg.org/multipage/#the-end>
+    fn queue_document_completion(&self, cx: &mut JSContext) {
         // The initial about:blank document passes through
         // https://html.spec.whatwg.org/multipage/#creating-a-new-browsing-context
         // instead of the steps used by other documents.
         if self.is_initial_about_blank() {
             return;
         }
-
-        // https://html.spec.whatwg.org/multipage/#delaying-load-events-mode
-        let is_in_delaying_load_events_mode = match self.window.undiscarded_window_proxy() {
-            Some(window_proxy) => window_proxy.is_delaying_load_events_mode(),
-            None => false,
-        };
-
-        // Note: if the document is not fully active, layout will have exited already,
-        // and this method will panic.
-        // The underlying problem might actually be that layout exits while it should be kept alive.
-        // See https://github.com/servo/servo/issues/22507
-        let not_ready_for_load = self.loader.borrow().is_blocked() ||
-            !self.is_fully_active() ||
-            is_in_delaying_load_events_mode ||
-            // In case we have already aborted this document and receive a
-            // a subsequent message to load the document
-            self.loader.borrow().events_inhibited();
-
-        if not_ready_for_load {
-            // Step 6.
-            return;
-        }
-
-        self.queue_document_completion(cx);
-    }
-
-    /// Step 9 of <https://html.spec.whatwg.org/multipage/#the-end>
-    fn queue_document_completion(&self, cx: &mut JSContext) {
         self.loader.borrow_mut().inhibit_events();
 
         // The rest will ever run only once per document.
@@ -2459,7 +2402,7 @@ impl Document {
                 }
 
                 // Step 9.1. Update the current document readiness to "complete".
-                document.update_the_current_document_readiness(cx,DocumentReadyState::Complete);
+                document.update_the_current_document_readiness(cx, DocumentReadyState::Complete);
 
                 // Step 9.2. If the Document object's browsing context is null, then abort these steps.
                 if document.browsing_context().is_none() {
@@ -2696,20 +2639,8 @@ impl Document {
         if self.deferred_scripts.is_empty() {
             self.current_the_end_loading_phase
                 .set(TheEndLoadingPhase::ProcessingAsSoonAsPossibleScripts);
-            // TODO(43149): Use `dispatch_dom_content_loaded` when document replacement is implemented
-            self.maybe_dispatch_dom_content_loaded();
+            self.dispatch_dom_content_loaded();
         }
-    }
-
-    /// Step 6. of <https://html.spec.whatwg.org/multipage/#the-end>
-    pub(crate) fn maybe_dispatch_dom_content_loaded(&self) {
-        // TODO(43149): Remove when document replacement is implemented
-        if self.domcontentloaded_dispatched.get() {
-            return;
-        }
-        self.domcontentloaded_dispatched.set(true);
-
-        self.dispatch_dom_content_loaded();
     }
 
     /// Step 6 of <https://html.spec.whatwg.org/multipage/#the-end>
@@ -2793,7 +2724,7 @@ impl Document {
     }
 
     /// Step 8 of <https://html.spec.whatwg.org/multipage/#the-end>
-    pub(crate) fn wait_until_load_blockers_have_resolved(&self, _cx: &mut JSContext) {
+    pub(crate) fn wait_until_load_blockers_have_resolved(&self, cx: &mut JSContext) {
         if self.current_the_end_loading_phase.get() !=
             TheEndLoadingPhase::WaitingForLoadEventBlockers
         {
@@ -2822,8 +2753,7 @@ impl Document {
 
         self.current_the_end_loading_phase
             .set(TheEndLoadingPhase::Done);
-        // TODO(43149): Add when document replacement is implemented
-        // self.queue_document_completion(cx);
+        self.queue_document_completion(cx);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#destroy-a-document-and-its-descendants>
@@ -3965,10 +3895,10 @@ impl Document {
     ) -> Document {
         let url = url.unwrap_or_else(|| ServoUrl::parse("about:blank").unwrap());
 
-        let (ready_state, domcontentloaded_dispatched) = if source == DocumentSource::FromParser {
-            (DocumentReadyState::Loading, false)
+        let ready_state = if source == DocumentSource::FromParser {
+            DocumentReadyState::Loading
         } else {
-            (DocumentReadyState::Complete, true)
+            DocumentReadyState::Complete
         };
 
         let frame_type = match window.is_top_level() {
@@ -4053,7 +3983,6 @@ impl Document {
             stylesheets: DomRefCell::new(DocumentStylesheetSet::new()),
             stylesheet_list: MutNullableDom::new(None),
             ready_state: Cell::new(ready_state),
-            domcontentloaded_dispatched: Cell::new(domcontentloaded_dispatched),
             current_script: Default::default(),
             current_the_end_loading_phase: Default::default(),
             pending_parsing_blocking_script: Default::default(),

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -1478,12 +1478,19 @@ impl Document {
         // Note: Handled implicitly by update_with_current_instant.
         match state {
             DocumentReadyState::Loading => {
+                // From <https://w3c.github.io/navigation-timing/#dom-performancetiming-domloading>:
+                // > This attribute must return the time immediately before the user agent sets the
+                // > current document readiness to "loading".
+                update_with_current_instant(&self.navigation_timing.dom_loading);
+
                 let webview_id = self.webview_id();
-                window.send_to_embedder(EmbedderMsg::NotifyLoadStatusChanged(
+                self.send_to_embedder(EmbedderMsg::NotifyLoadStatusChanged(
                     webview_id,
                     LoadStatus::Started,
                 ));
-                window.send_to_embedder(EmbedderMsg::Status(webview_id, None));
+                self.send_to_embedder(EmbedderMsg::Status(webview_id, None));
+                // We should not fire a `readystatechange` event for the initial loading state
+                return;
             },
             DocumentReadyState::Complete => {
                 // This isn't part of the specification, but it's useful to have it here to
@@ -3932,13 +3939,7 @@ impl Document {
             QuirksMode::NoQuirks
         };
 
-        // From <https://w3c.github.io/navigation-timing/#dom-performancetiming-domloading>:
-        // > This attribute must return the time immediately before the user agent sets the
-        // > current document readiness to "loading".
         let navigation_timing = Rc::new(NavigationTiming::default());
-        if ready_state == DocumentReadyState::Loading {
-            update_with_current_instant(&navigation_timing.dom_loading);
-        }
 
         Document {
             node: Node::new_document_node(),
@@ -3974,7 +3975,7 @@ impl Document {
             shared_style_locks,
             stylesheets: DomRefCell::new(DocumentStylesheetSet::new()),
             stylesheet_list: MutNullableDom::new(None),
-            // https://html.spec.whatwg.org/multipage/dom.html#current-document-readiness
+            // https://html.spec.whatwg.org/multipage/#current-document-readiness
             // > Each Document has a current document readiness, a string, initially "complete".
             ready_state: Cell::new(DocumentReadyState::Complete),
             current_script: Default::default(),
@@ -6723,7 +6724,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         // Handled when creating the parser in step 16
 
         // Step 18. Update the current document readiness of document to "loading".
-        self.ready_state.set(DocumentReadyState::Loading);
+        self.update_the_current_document_readiness(cx, DocumentReadyState::Loading);
 
         // Step 19. Return document.
         Ok(DomRoot::from_ref(self))

--- a/components/script/dom/document/domimplementation.rs
+++ b/components/script/dom/document/domimplementation.rs
@@ -20,7 +20,7 @@ use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
-use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLDocument};
+use crate::dom::document::{Document, HasBrowsingContext, IsHTMLDocument};
 use crate::dom::documenttype::DocumentType;
 use crate::dom::element::{CustomElementCreationMode, ElementCreator};
 use crate::dom::node::Node;
@@ -111,7 +111,6 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
             Some(content_type),
             None,
             DocumentActivity::Inactive,
-            DocumentSource::NotFromParser,
             loader,
             Some(self.document.insecure_requests_policy()),
             self.document.has_trustworthy_ancestor_or_current_origin(),
@@ -179,7 +178,6 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
             None,
             None,
             DocumentActivity::Inactive,
-            DocumentSource::NotFromParser,
             loader,
             None,
             None,

--- a/components/script/dom/document/domparser.rs
+++ b/components/script/dom/document/domparser.rs
@@ -17,7 +17,7 @@ use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::codegen::UnionTypes::TrustedHTMLOrString;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::root::{Dom, DomRoot};
-use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLDocument};
+use crate::dom::document::{Document, HasBrowsingContext, IsHTMLDocument};
 use crate::dom::servoparser::ServoParser;
 use crate::dom::trustedtypes::trustedhtml::TrustedHTML;
 use crate::dom::window::Window;
@@ -100,7 +100,6 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                     Some(content_type),
                     None,
                     DocumentActivity::Inactive,
-                    DocumentSource::FromParser,
                     loader,
                     None,
                     None,
@@ -139,7 +138,6 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                     Some(content_type),
                     None,
                     DocumentActivity::Inactive,
-                    DocumentSource::FromParser,
                     loader,
                     None,
                     None,

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -91,7 +91,7 @@ use crate::dom::css::stylesheetlist::StyleSheetListOwner;
 use crate::dom::customelementregistry::{
     CallbackReaction, CustomElementRegistry, try_upgrade_element,
 };
-use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLDocument};
+use crate::dom::document::{Document, HasBrowsingContext, IsHTMLDocument};
 use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::documenttype::DocumentType;
 use crate::dom::element::{CustomElementCreationMode, Element, ElementCreator};
@@ -3124,7 +3124,6 @@ impl Node {
                     None,
                     None,
                     DocumentActivity::Inactive,
-                    DocumentSource::NotFromParser,
                     loader,
                     None,
                     document.status_code(),

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -65,7 +65,7 @@ use crate::dom::characterdata::CharacterData;
 use crate::dom::comment::Comment;
 use crate::dom::csp::{Violation, parse_csp_list_from_metadata};
 use crate::dom::customelementregistry::{CustomElementReactionStack, CustomElementRegistry};
-use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLDocument};
+use crate::dom::document::{Document, HasBrowsingContext, IsHTMLDocument};
 use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::documenttype::DocumentType;
 use crate::dom::domstringlist::DOMStringList;
@@ -257,7 +257,6 @@ impl ServoParser {
             None,
             None,
             DocumentActivity::Inactive,
-            DocumentSource::FromParser,
             loader,
             None,
             None,

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1019,8 +1019,13 @@ impl ParserContext {
     /// <https://html.spec.whatwg.org/multipage/#initialise-the-document-object>
     fn initialize_document_object(&self, cx: &mut JSContext, document: &Document) {
         // Step 9. Let document be a new Document, with
+        // policy container: navigationParams's policy container
         document.set_policy_container(self.navigation_params.policy_container.clone());
+        // active sandboxing flag: set navigationParams's final sandboxing flag set
         document.set_active_sandboxing_flag_set(self.navigation_params.final_sandboxing_flag_set);
+        // current document readiness: "loading"
+        document.set_document_readiness_to_loading_for_initialization();
+        // about base URL: navigationParams's about base URL
         document.set_about_base_url(self.navigation_params.about_base_url.clone());
         // Step 11. Set document's internal ancestor origin objects list to the result of
         // running the internal ancestor origin objects list creation steps given
@@ -1314,7 +1319,6 @@ impl ParserContext {
         debug_assert_eq!(document.ReadyState(), DocumentReadyState::Complete);
 
         document.set_current_parser(None);
-        document.start_the_end_loading_phase();
         document.finish_load(LoadType::PageSource(self.url.clone()), cx);
 
         document.notify_embedder_of_load_completion();

--- a/components/script/dom/window/windowproxy.rs
+++ b/components/script/dom/window/windowproxy.rs
@@ -900,7 +900,10 @@ impl WindowProxy {
         if let Some(frame_element) = self.frame_element() {
             let parent_document = frame_element.owner_document();
             // Step 4. Assert: parentDoc is fully active.
-            assert!(parent_document.is_fully_active());
+            // TODO(47417): Once "creating a new browsing context" properly exists, remove this check
+            if !parent_document.is_fully_active() {
+                return None;
+            }
             Some((
                 parent_document.origin().snapshot(),
                 parent_document

--- a/components/script/dom/window/windowproxy.rs
+++ b/components/script/dom/window/windowproxy.rs
@@ -423,11 +423,6 @@ impl WindowProxy {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#delaying-load-events-mode>
-    pub(crate) fn is_delaying_load_events_mode(&self) -> bool {
-        self.delaying_load_events_mode.get()
-    }
-
-    /// <https://html.spec.whatwg.org/multipage/#delaying-load-events-mode>
     pub(crate) fn start_delaying_load_events_mode(&self) {
         self.delaying_load_events_mode.set(true);
     }
@@ -435,11 +430,6 @@ impl WindowProxy {
     /// <https://html.spec.whatwg.org/multipage/#delaying-load-events-mode>
     pub(crate) fn stop_delaying_load_events_mode(&self) {
         self.delaying_load_events_mode.set(false);
-        if let Some(document) = self.document() &&
-            !document.loader().events_inhibited()
-        {
-            ScriptThread::mark_document_with_no_blocked_loads(&document);
-        }
     }
 
     // https://html.spec.whatwg.org/multipage/#disowned-its-opener

--- a/components/script/dom/xml/xmldocument.rs
+++ b/components/script/dom/xml/xmldocument.rs
@@ -24,7 +24,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::customelementregistry::CustomElementReactionStack;
-use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLDocument};
+use crate::dom::document::{Document, HasBrowsingContext, IsHTMLDocument};
 use crate::dom::location::Location;
 use crate::dom::node::Node;
 use crate::dom::window::Window;
@@ -47,7 +47,6 @@ impl XMLDocument {
         content_type: Option<Mime>,
         last_modified: Option<String>,
         activity: DocumentActivity,
-        source: DocumentSource,
         doc_loader: DocumentLoader,
         inherited_insecure_requests_policy: Option<InsecureRequestsPolicy>,
         has_trustworthy_ancestor_origin: bool,
@@ -66,7 +65,6 @@ impl XMLDocument {
                 content_type,
                 last_modified,
                 activity,
-                source,
                 doc_loader,
                 None,
                 None,
@@ -95,7 +93,6 @@ impl XMLDocument {
         content_type: Option<Mime>,
         last_modified: Option<String>,
         activity: DocumentActivity,
-        source: DocumentSource,
         doc_loader: DocumentLoader,
         inherited_insecure_requests_policy: Option<InsecureRequestsPolicy>,
         has_trustworthy_ancestor_origin: bool,
@@ -113,7 +110,6 @@ impl XMLDocument {
                 content_type,
                 last_modified,
                 activity,
-                source,
                 doc_loader,
                 inherited_insecure_requests_policy,
                 has_trustworthy_ancestor_origin,

--- a/components/script/dom/xmlhttprequest/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest/xmlhttprequest.rs
@@ -60,7 +60,7 @@ use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::{ByteString, DOMString, USVString, is_token};
 use crate::dom::blob::{Blob, normalize_type_string};
 use crate::dom::csp::{GlobalCspReporting, Violation};
-use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLDocument};
+use crate::dom::document::{Document, HasBrowsingContext, IsHTMLDocument};
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
@@ -1567,7 +1567,6 @@ impl XMLHttpRequest {
             content_type,
             None,
             DocumentActivity::Inactive,
-            DocumentSource::FromParser,
             docloader,
             None,
             None,

--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -344,11 +344,6 @@ pub struct ScriptThread {
     #[cfg(feature = "webxr")]
     webxr_registry: Option<webxr_api::Registry>,
 
-    /// A list of pipelines containing documents that finished loading all their blocking
-    /// resources during a turn of the event loop.
-    /// TODO(43149): Remove when document replacement is implemented
-    docs_with_no_blocking_loads: DomRefCell<FxHashSet<Dom<Document>>>,
-
     /// <https://html.spec.whatwg.org/multipage/#custom-element-reactions-stack>
     custom_element_reaction_stack: Rc<CustomElementReactionStack>,
 
@@ -555,15 +550,6 @@ impl ScriptThread {
 
     pub(crate) fn shared_style_locks(&self) -> &SharedRwLocks {
         &self.shared_style_locks
-    }
-
-    pub(crate) fn mark_document_with_no_blocked_loads(doc: &Document) {
-        with_script_thread(|script_thread| {
-            script_thread
-                .docs_with_no_blocking_loads
-                .borrow_mut()
-                .insert(Dom::from_ref(doc));
-        })
     }
 
     pub(crate) fn page_headers_available(
@@ -978,7 +964,6 @@ impl ScriptThread {
                     webgl_chan: state.webgl_chan,
                     #[cfg(feature = "webxr")]
                     webxr_registry: state.webxr_registry,
-                    docs_with_no_blocking_loads: Default::default(),
                     custom_element_reaction_stack: Rc::new(CustomElementReactionStack::new()),
                     paint_api: state.cross_process_paint_api,
                     profile_script_events: opts
@@ -1514,20 +1499,6 @@ impl ScriptThread {
             window
                 .upcast::<GlobalScope>()
                 .perform_a_dom_garbage_collection_checkpoint();
-        }
-
-        // TODO(43149): Remove when document replacement is implemented
-        {
-            // https://html.spec.whatwg.org/multipage/#the-end step 6
-            {
-                let docs = self.docs_with_no_blocking_loads.borrow();
-                for document in docs.iter() {
-                    let mut realm = enter_auto_realm(cx, &**document);
-                    let cx = &mut realm.current_realm();
-                    document.maybe_queue_document_completion(cx);
-                }
-            }
-            self.docs_with_no_blocking_loads.borrow_mut().clear();
         }
 
         let built_any_display_lists =
@@ -3661,20 +3632,7 @@ impl ScriptThread {
             image_cache,
         );
 
-        // Only send loading-related messages if this document is actually in the loading state.
-        // `about:blank` documents should never be in that state when starting.
-        if !incomplete.load_data.is_initial_about_blank {
-            debug_assert_eq!(document.ReadyState(), DocumentReadyState::Loading);
-            if window.is_top_level() {
-                window.send_to_embedder(EmbedderMsg::NotifyLoadStatusChanged(
-                    incomplete.webview_id,
-                    LoadStatus::Started,
-                ));
-                window.send_to_embedder(EmbedderMsg::Status(incomplete.webview_id, None));
-            }
-        } else {
-            debug_assert_eq!(document.ReadyState(), DocumentReadyState::Complete);
-        }
+        document.set_ready_state(cx, DocumentReadyState::Loading);
 
         // Step 8. Let loadTimingInfo be a new document load timing info with its
         //   navigation start time set to navigationParams's response's timing

--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -113,9 +113,7 @@ use url::Position;
 #[cfg(feature = "webgpu")]
 use webgpu_traits::{WebGPUDevice, WebGPUMsg};
 
-use crate::dom::bindings::codegen::Bindings::DocumentBinding::{
-    DocumentMethods, DocumentReadyState,
-};
+use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use crate::dom::bindings::codegen::Bindings::NavigatorBinding::NavigatorMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::conversions::{
@@ -3622,13 +3620,6 @@ impl ScriptThread {
             incomplete.pipeline_id,
             image_cache,
         );
-
-        // https://html.spec.whatwg.org/multipage/#initialise-the-document-object
-        // > such initial about:blank Document are never created by this algorithm
-        // TODO(47417): Once "creating a new browsing context" properly exists, remove this check
-        if !document.is_initial_about_blank() {
-            document.update_the_current_document_readiness(cx, DocumentReadyState::Loading);
-        }
 
         // Step 8. Let loadTimingInfo be a new document load timing info with its
         //   navigation start time set to navigationParams's response's timing

--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -129,9 +129,7 @@ use crate::dom::customelementregistry::{
     CallbackReaction, CustomElementDefinition, CustomElementReactionStack,
 };
 use crate::dom::document::focus::FocusableArea;
-use crate::dom::document::{
-    Document, DocumentSource, HasBrowsingContext, IsHTMLDocument, RenderingUpdateReason,
-};
+use crate::dom::document::{Document, HasBrowsingContext, IsHTMLDocument, RenderingUpdateReason};
 use crate::dom::element::Element;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmliframeelement::{HTMLIFrameElement, IframeContext, ProcessingMode};
@@ -3592,12 +3590,6 @@ impl ScriptThread {
             .as_ref()
             .map(|referrer| referrer.clone().into_string());
 
-        let document_source = if incomplete.load_data.is_initial_about_blank {
-            DocumentSource::NotFromParser
-        } else {
-            DocumentSource::FromParser
-        };
-
         // Step 9. Let document be a new Document, with
         // - content type: contentType
         // - origin: navigationParams's origin
@@ -3617,7 +3609,6 @@ impl ScriptThread {
             content_type,
             last_modified,
             incomplete.activity,
-            document_source,
             loader,
             referrer,
             Some(metadata.status.raw_code()),
@@ -3632,7 +3623,12 @@ impl ScriptThread {
             image_cache,
         );
 
-        document.set_ready_state(cx, DocumentReadyState::Loading);
+        // https://html.spec.whatwg.org/multipage/document-lifecycle.html#initialise-the-document-object
+        // > such initial about:blank Document are never created by this algorithm
+        // TODO(47417): Once "creating a new browsing context" properly exists, remove this check
+        if !document.is_initial_about_blank() {
+            document.set_ready_state(cx, DocumentReadyState::Loading);
+        }
 
         // Step 8. Let loadTimingInfo be a new document load timing info with its
         //   navigation start time set to navigationParams's response's timing

--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -42,8 +42,8 @@ use devtools_traits::{
 use embedder_traits::user_contents::{UserContentManagerId, UserContents, UserScript};
 use embedder_traits::{
     EmbedderControlId, EmbedderControlResponse, EmbedderMsg, FocusSequenceNumber,
-    InputEventOutcome, JavaScriptEvaluationError, JavaScriptEvaluationId, LoadStatus,
-    MediaSessionActionType, Theme, ViewportDetails, WebDriverScriptCommand,
+    InputEventOutcome, JavaScriptEvaluationError, JavaScriptEvaluationId, MediaSessionActionType,
+    Theme, ViewportDetails, WebDriverScriptCommand,
 };
 use encoding_rs::Encoding;
 use fonts::{FontContext, SystemFontServiceProxy, WebFontLoadEvent};
@@ -3623,11 +3623,11 @@ impl ScriptThread {
             image_cache,
         );
 
-        // https://html.spec.whatwg.org/multipage/document-lifecycle.html#initialise-the-document-object
+        // https://html.spec.whatwg.org/multipage/#initialise-the-document-object
         // > such initial about:blank Document are never created by this algorithm
         // TODO(47417): Once "creating a new browsing context" properly exists, remove this check
         if !document.is_initial_about_blank() {
-            document.set_ready_state(cx, DocumentReadyState::Loading);
+            document.update_the_current_document_readiness(cx, DocumentReadyState::Loading);
         }
 
         // Step 8. Let loadTimingInfo be a new document load timing info with its

--- a/tests/wpt/meta/css/selectors/invalidation/media-loading-pseudo-classes-in-has.sub.html.ini
+++ b/tests/wpt/meta/css/selectors/invalidation/media-loading-pseudo-classes-in-has.sub.html.ini
@@ -1,4 +1,5 @@
 [media-loading-pseudo-classes-in-has.sub.html]
+  expected: ERROR
   [Test :has(:stalled) invalidation]
     expected: FAIL
 

--- a/tests/wpt/meta/fetch/api/redirect/redirect-keepalive.https.any.js.ini
+++ b/tests/wpt/meta/fetch/api/redirect/redirect-keepalive.https.any.js.ini
@@ -1,4 +1,0 @@
-[redirect-keepalive.https.any.html]
-  expected: TIMEOUT
-  [[keepalive\][iframe\][load\] mixed content redirect; setting up]
-    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/history-traversal/srcdoc/consecutive-srcdoc.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/history-traversal/srcdoc/consecutive-srcdoc.html.ini
@@ -1,6 +1,7 @@
 [consecutive-srcdoc.html]
+  expected: TIMEOUT
   [changing srcdoc does a replace navigation since the URL is still about:srcdoc]
     expected: FAIL
 
   [changing srcdoc to about:srcdoc#yo then another srcdoc does two push navigations and we can navigate back]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/history-traversal/srcdoc/consecutive-srcdoc.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/history-traversal/srcdoc/consecutive-srcdoc.html.ini
@@ -1,7 +1,6 @@
 [consecutive-srcdoc.html]
-  expected: TIMEOUT
   [changing srcdoc does a replace navigation since the URL is still about:srcdoc]
     expected: FAIL
 
   [changing srcdoc to about:srcdoc#yo then another srcdoc does two push navigations and we can navigate back]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/013.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/013.html.ini
@@ -1,3 +1,0 @@
-[013.html]
-  [Link with onclick navigation to javascript url with delayed document.write and href navigation ]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/014.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/014.html.ini
@@ -1,3 +1,0 @@
-[014.html]
-  [ Link with javascript onclick form submission script order ]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/015.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/015.html.ini
@@ -1,3 +1,0 @@
-[015.html]
-  [ Link with javascript onclick and href script order ]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-assign.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-assign.html.ini
@@ -1,4 +1,3 @@
 [location-assign.html]
-  expected: TIMEOUT
   [Replace before load, triggered by location.assign()]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-setter.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-setter.html.ini
@@ -1,10 +1,10 @@
 [location-setter.html]
   expected: TIMEOUT
   [href]
-    expected: TIMEOUT
+    expected: FAIL
 
   [search]
-    expected: NOTRUN
+    expected: FAIL
 
   [hash]
-    expected: NOTRUN
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-setter.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-setter.html.ini
@@ -1,10 +1,10 @@
 [location-setter.html]
   expected: TIMEOUT
   [href]
-    expected: FAIL
+    expected: TIMEOUT
 
   [search]
-    expected: FAIL
+    expected: NOTRUN
 
   [hash]
-    expected: TIMEOUT
+    expected: NOTRUN

--- a/tests/wpt/meta/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/location-set-and-document-open.html.ini
+++ b/tests/wpt/meta/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/location-set-and-document-open.html.ini
@@ -1,0 +1,3 @@
+[location-set-and-document-open.html]
+  [Location sets should cancel current navigation and prevent later document.open() from doing anything]
+    expected: FAIL

--- a/tests/wpt/meta/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/location-set-and-document-open.html.ini
+++ b/tests/wpt/meta/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/location-set-and-document-open.html.ini
@@ -1,3 +1,0 @@
-[location-set-and-document-open.html]
-  [Location sets should cancel current navigation and prevent later document.open() from doing anything]
-    expected: FAIL

--- a/tests/wpt/meta/resource-timing/nested-context-navigations-iframe.html.ini
+++ b/tests/wpt/meta/resource-timing/nested-context-navigations-iframe.html.ini
@@ -1,8 +1,5 @@
 [nested-context-navigations-iframe.html]
   expected: TIMEOUT
-  [Test that iframe navigations are not observable by the parent, even after history navigations by the parent]
-    expected: TIMEOUT
-
   [Test that crossorigin iframe navigations are not observable by the parent, even after history navigations by the parent]
     expected: NOTRUN
 
@@ -26,3 +23,6 @@
 
   [Test that cross-site iframe refreshes are not observable by the parent]
     expected: NOTRUN
+
+  [Test that iframe navigations are not observable by the parent, even after history navigations by the parent]
+    expected: TIMEOUT

--- a/tests/wpt/meta/resource-timing/test_resource_timing.https.html.ini
+++ b/tests/wpt/meta/resource-timing/test_resource_timing.https.html.ini
@@ -29,9 +29,6 @@
   [PerformanceEntry has correct protocol attribute (link)]
     expected: FAIL
 
-  [PerformanceEntry has correct name, initiatorType, startTime, and duration (script)]
-    expected: FAIL
-
   [PerformanceEntry has correct order of timing attributes (script)]
     expected: FAIL
 

--- a/tests/wpt/meta/trusted-types/inheriting-csp-for-local-schemes.html.ini
+++ b/tests/wpt/meta/trusted-types/inheriting-csp-for-local-schemes.html.ini
@@ -1,25 +1,12 @@
 [inheriting-csp-for-local-schemes.html]
-  expected: TIMEOUT
   [require-trusted-types-for directive should be inherited in local data frames]
-    expected: TIMEOUT
+    expected: FAIL
 
   [trusted-types directive should be inherited in local data frames]
-    expected: NOTRUN
+    expected: FAIL
 
   [require-trusted-types-for directive should be inherited in local blob frames]
-    expected: NOTRUN
+    expected: FAIL
 
   [trusted-types directive should be inherited in local blob frames]
-    expected: NOTRUN
-
-  [require-trusted-types-for directive should be inherited in local about:blank frames]
-    expected: NOTRUN
-
-  [trusted-types directive should be inherited in local about:blank frames]
-    expected: NOTRUN
-
-  [require-trusted-types-for directive should not be inherited in local blank.html frames]
-    expected: NOTRUN
-
-  [trusted-types directive should not be inherited in local blank.html frames]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/trusted-types-navigation.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-navigation.html.ini
@@ -50,21 +50,14 @@
 
 
 [trusted-types-navigation.html?31-35]
-  expected: TIMEOUT
   [Navigate a window via form-submission with javascript:-urls w/ a default policy throwing an exception in enforcing mode.]
-    expected: NOTRUN
+    expected: FAIL
 
   [Navigate a window via form-submission with javascript:-urls w/ a default policy throwing an exception in report-only mode.]
-    expected: NOTRUN
+    expected: FAIL
 
   [Navigate a window via form-submission with javascript:-urls w/ a default policy making the URL invalid in enforcing mode.]
-    expected: NOTRUN
-
-  [Navigate a frame via form-submission with javascript:-urls w/ default policy in report-only mode.]
-    expected: NOTRUN
-
-  [Navigate a frame via form-submission with javascript:-urls in report-only mode.]
-    expected: TIMEOUT
+    expected: FAIL
 
 
 [trusted-types-navigation.html?36-last]
@@ -73,19 +66,6 @@
 
 
 [trusted-types-navigation.html?26-30]
-  expected: TIMEOUT
-  [Navigate a window via form-submission with javascript:-urls w/ default policy in report-only mode.]
-    expected: NOTRUN
-
-  [Navigate a frame via form-submission with javascript:-urls w/ default policy in enforcing mode.]
-    expected: NOTRUN
-
-  [Navigate a frame via form-submission with javascript:-urls in enforcing mode.]
-    expected: NOTRUN
-
-  [Navigate a window via form-submission with javascript:-urls in report-only mode.]
-    expected: TIMEOUT
-
 
 [trusted-types-navigation.html?06-10]
   expected: TIMEOUT
@@ -103,15 +83,11 @@
 
 
 [trusted-types-navigation.html?11-15]
-  expected: TIMEOUT
   [Navigate a window via anchor with javascript:-urls w/ a default policy making the URL invalid in enforcing mode.]
     expected: FAIL
 
   [Navigate a window via anchor with javascript:-urls w/ a default policy making the URL invalid in report-only mode.]
     expected: FAIL
-
-  [Navigate a window via area with javascript:-urls in report-only mode.]
-    expected: TIMEOUT
 
 
 [trusted-types-navigation.html?16-20]
@@ -134,12 +110,3 @@
 
 
 [trusted-types-navigation.html?01-05]
-  expected: TIMEOUT
-  [Navigate a window via anchor with javascript:-urls in report-only mode.]
-    expected: TIMEOUT
-
-  [Navigate a window via anchor with javascript:-urls w/ default policy in report-only mode.]
-    expected: NOTRUN
-
-  [Navigate a frame via anchor with javascript:-urls in enforcing mode.]
-    expected: NOTRUN


### PR DESCRIPTION
This is a reland of #46059 which now reliably works thanks to the changes in #46975. The tests that I updated I all verified locally that they run correct with `--repeat-until-unexpected` for at least 20 runs.

Testing: new WPT passes
Fixes: Part of #46859