### PR TITLE
script: Fix computation of contained nodes in range

### DIFF
--- a/components/script/dom/execcommand/commands/indent.rs
+++ b/components/script/dom/execcommand/commands/indent.rs
@@ -9,7 +9,6 @@ use script_bindings::codegen::GenericBindings::NodeBinding::NodeMethods;
 use script_bindings::inheritance::Castable;
 
 use crate::dom::NodeTraits;
-use crate::dom::bindings::codegen::Bindings::RangeBinding::RangeMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::element::{AdjacentPosition, Element};
@@ -19,7 +18,6 @@ use crate::dom::execcommand::contenteditable::node::{
 use crate::dom::html::htmllielement::HTMLLIElement;
 use crate::dom::html::htmlolistelement::HTMLOListElement;
 use crate::dom::html::htmlulistelement::HTMLUListElement;
-use crate::dom::iterators::ShadowIncluding;
 use crate::dom::node::Node;
 use crate::dom::selection::Selection;
 use crate::dom::text::Text;
@@ -199,11 +197,7 @@ pub(crate) fn execute_indent_command(
     //         if node is editable and is an allowed child of "div" or "ol"
     //         and if the last member of node list (if any) is not an ancestor of node,
     //         append node to node list.
-    for node in new_range
-        .CommonAncestorContainer()
-        .traverse_preorder(ShadowIncluding::No)
-        .filter(|node| new_range.contains(node))
-    {
+    for node in new_range.contained_nodes() {
         if node.is_editable() &&
             (is_allowed_child(
                 NodeOrString::Node(node.clone()),

--- a/components/script/dom/execcommand/commands/insertparagraph.rs
+++ b/components/script/dom/execcommand/commands/insertparagraph.rs
@@ -351,9 +351,7 @@ pub(crate) fn execute_insert_paragraph_command(
         unreachable!("Must always be able to insert");
     }
     // Step 26. Let contained nodes be all nodes contained in new line range.
-    let Ok(contained_nodes) = new_line_range.contained_children() else {
-        unreachable!("Must always have contained children");
-    };
+    let contained_nodes: Vec<DomRoot<Node>> = new_line_range.contained_nodes().collect();
     // Step 27. Let frag be the result of calling extractContents() on new line range.
     let Ok(frag) = new_line_range.ExtractContents(cx) else {
         unreachable!("Must always be able to extract");
@@ -362,7 +360,7 @@ pub(crate) fn execute_insert_paragraph_command(
     // Step 28. Unset the id attribute (if any) of each Element descendant of frag
     // that is not in contained nodes.
     for descendant in frag_as_node.traverse_preorder(ShadowIncluding::No) {
-        if !contained_nodes.contained_children.contains(&descendant) &&
+        if !contained_nodes.contains(&descendant) &&
             let Some(descendant) = descendant.downcast::<Element>()
         {
             descendant.remove_attribute_by_name(cx, &local_name!("id"));

--- a/components/script/dom/execcommand/contenteditable/range.rs
+++ b/components/script/dom/execcommand/contenteditable/range.rs
@@ -100,6 +100,12 @@ impl Range {
         }
     }
 
+    pub(crate) fn contained_nodes(&self) -> impl Iterator<Item = DomRoot<Node>> {
+        self.CommonAncestorContainer()
+            .traverse_preorder(ShadowIncluding::No)
+            .filter(|node| self.contains(node))
+    }
+
     /// <https://w3c.github.io/editing/docs/execCommand/#block-extend>
     pub(crate) fn block_extend(&self, cx: &mut JSContext, document: &Document) -> DomRoot<Range> {
         // Step 1. Let start node, start offset, end node,

--- a/components/script/dom/execcommand/contenteditable/selection.rs
+++ b/components/script/dom/execcommand/contenteditable/selection.rs
@@ -365,10 +365,7 @@ impl Selection {
         // Step 24. For each node contained in the active range, append node to node list if the
         // last member of node list (if any) is not an ancestor of node; node is editable;
         // and node is not a thead, tbody, tfoot, tr, th, or td.
-        let Ok(contained_children) = active_range.contained_children() else {
-            unreachable!("Must always have contained children");
-        };
-        for node in contained_children.contained_children {
+        for node in active_range.contained_nodes() {
             // This type is only used to tell the compiler how to handle the type of `node_list.last()`.
             // It is not allowed to add a `& DomRoot<Node>` annotation, as test-tidy disallows that.
             // However, if we omit the type, the compiler doesn't know what it is, since we also

--- a/tests/wpt/meta/editing/run/delete.html.ini
+++ b/tests/wpt/meta/editing/run/delete.html.ini
@@ -1,7 +1,4 @@
 [delete.html?6001-7000]
-  [[["delete",""\]\] "<p>fo[o<ol><li>bar<li>b\]az</ol><p>quz" compare innerHTML]
-    expected: FAIL
-
   [[["delete",""\]\] "<b>foo [&nbsp;</b>bar\]" compare innerHTML]
     expected: FAIL
 
@@ -48,15 +45,6 @@
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<ol><li><p>foo[</ol><p>bar\]<ol><li>baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<ol><li>foo</ol><p>[bar<ol><li>\]baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["delete",""\]\] "<ol><li>foo</ol><p>[bar<ol><li><p>\]baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["delete",""\]\] "<ol><li>foo</ol><p>[bar<ol><li><p>\]baz</ol>" compare innerHTML]
     expected: FAIL
 
   [[["delete",""\]\] "<ol><ol><li>foo[</ol><li>bar</ol>baz\]<ol><li>quz</ol>" compare innerHTML]
@@ -223,18 +211,6 @@
   [[["stylewithcss","false"\],["delete",""\]\] "<div style=color:blue><p style=color:green>foo</div>[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["delete",""\]\] "<p>[foo<span style=color:#aBcDeF>bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["delete",""\]\] "<p>[foo<span style=color:#aBcDeF>bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["delete",""\]\] "<p>{foo<span style=color:#aBcDeF>bar}</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["delete",""\]\] "<p>{foo<span style=color:#aBcDeF>bar}</span>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span>baz\]" compare innerHTML]
     expected: FAIL
 
@@ -247,19 +223,7 @@
   [[["stylewithcss","false"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>{bar</span>baz}" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span><span style=color:#fEdCbA>baz\]</span>quz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span><span style=color:#fEdCbA>baz\]</span>quz" compare innerHTML]
-    expected: FAIL
-
   [[["delete",""\]\] "<p>foo</p><p>{bar</p>}<p>baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo</p>{<p>bar}</p><p>baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo</p>{<p>bar}</p><p>baz</p>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo<p style=text-decoration:line-through>[\]bar" queryCommandState("stylewithcss") after]
@@ -319,18 +283,6 @@
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo<br><br>{<p>\]bar</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<table><tbody><tr><th>fo[o<th>bar<th>b\]az<tr><td>quz<td>qoz<td>qiz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<table><tbody><tr><th>[foo<th>bar<th>baz\]<tr><td>quz<td>qoz<td>qiz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<table><tbody><tr><th>[foo<th>bar<th>baz<tr><td>quz<td>qoz<td>qiz\]</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<table><tbody><tr><td>foo<td>ba[r<tr><td>baz<td>quz<tr><td>q\]oz<td>qiz</table>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo[bar<p style=color:blue>baz\]quz" queryCommandState("stylewithcss") before]
@@ -620,16 +572,7 @@
   [[["delete",""\]\] "<div style=white-space:nowrap>foo\\n\\n[\]bar</div>" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\]\] "<div contenteditable=\\"false\\"><custom-element contenteditable=\\"\\"><p>[ab</p><p>c\]d</p></custom-element></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<div contenteditable=\\"false\\"><custom-element contenteditable=\\"\\"><p>a[b</p><p>cd\]</p></custom-element></div>" compare innerHTML]
-    expected: FAIL
-
   [[["delete",""\]\] "<div contenteditable=\\"false\\"><custom-element contenteditable=\\"\\"><p><b>[ab</b></p><p><i>c\]d</i></p></custom-element></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<div contenteditable=\\"false\\"><custom-element contenteditable=\\"\\"><p><b>a[b</b></p><p><i>cd\]</i></p></custom-element></div>" compare innerHTML]
     expected: FAIL
 
   [[["delete",""\]\] "<p>abc</p><ul contenteditable=\\"false\\"><li>def</li></ul><p>[\]ghi</p>" compare innerHTML]
@@ -707,24 +650,6 @@
   [[["styleWithCSS","false"\],["delete",""\]\] "<span style=\\"color:rgb(0, 0, 255)\\">foo<br></span><p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span></p>" queryCommandValue("foreColor") after]
     expected: FAIL
 
-  [[["delete",""\]\] "<ul><li>[abc</li><li>def\]</li></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<ul><ol><li>[abc</li></ol><li>def\]</li></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<ul><ul><li>[abc</li></ul><li>def\]</li></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<ul><li>[abc</li><ul><li>def\]</li></ul></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<ul><ul><li>[abc</li></ul><ul><li>def\]</li></ul></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<ul><ol><li>[abc</li></ol><ul><li>def\]</li></ul></ul>" compare innerHTML]
-    expected: FAIL
-
   [[["delete",""\]\] "<ul><li><span>[abc</span></li><li>def\]</li></ul>" compare innerHTML]
     expected: FAIL
 
@@ -734,31 +659,10 @@
   [[["delete",""\]\] "<ul><li><span>[abc</span></li><li><span>def\]</span></li></ul>" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\]\] "<ul><li> [abc</li><li>def\]</li></ul>" compare innerHTML]
-    expected: FAIL
-
   [[["delete",""\]\] "<ul><li>[abc</li><li>def\] </li></ul>" compare innerHTML]
     expected: FAIL
 
   [[["delete",""\]\] "<ul><li> [abc</li><li>def\] </li></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<ul>\\n<li>[abc</li><li>def\]</li></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<ul><li>[abc</li><li>def\]</li>\\n</ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<ul>\\n<li>[abc</li><li>def\]</li>\\n</ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<ol><li>[abc</li></ol><ul><li>def\]</li></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<ol><li> [abc</li></ol><ul><li>def\]</li></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<ol>\\n<li>[abc</li></ol><ul><li>def\]</li></ul>" compare innerHTML]
     expected: FAIL
 
   [[["delete",""\]\] "{<ul><li>abc<span>def</span>ghi</li><li>jkl<span>opq</span>rst</li></ul>}" compare innerHTML]

--- a/tests/wpt/meta/editing/run/forwarddelete.html.ini
+++ b/tests/wpt/meta/editing/run/forwarddelete.html.ini
@@ -99,24 +99,6 @@
   [[["styleWithCSS","false"\],["forwarddelete",""\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo[\]<br></span></p><span style=\\"color:rgb(255, 0, 0)\\">bar</span>" compare innerHTML]
     expected: FAIL
 
-  [[["forwarddelete",""\]\] "<ul><li>[abc</li><li>def\]</li></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<ul><ol><li>[abc</li></ol><li>def\]</li></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<ul><ul><li>[abc</li></ul><li>def\]</li></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<ul><li>[abc</li><ul><li>def\]</li></ul></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<ul><ul><li>[abc</li></ul><ul><li>def\]</li></ul></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<ul><ol><li>[abc</li></ol><ul><li>def\]</li></ul></ul>" compare innerHTML]
-    expected: FAIL
-
   [[["forwarddelete",""\]\] "<ul><li><span>[abc</span></li><li>def\]</li></ul>" compare innerHTML]
     expected: FAIL
 
@@ -126,31 +108,10 @@
   [[["forwarddelete",""\]\] "<ul><li><span>[abc</span></li><li><span>def\]</span></li></ul>" compare innerHTML]
     expected: FAIL
 
-  [[["forwarddelete",""\]\] "<ul><li> [abc</li><li>def\]</li></ul>" compare innerHTML]
-    expected: FAIL
-
   [[["forwarddelete",""\]\] "<ul><li>[abc</li><li>def\] </li></ul>" compare innerHTML]
     expected: FAIL
 
   [[["forwarddelete",""\]\] "<ul><li> [abc</li><li>def\] </li></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<ul>\\n<li>[abc</li><li>def\]</li></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<ul><li>[abc</li><li>def\]</li>\\n</ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<ul>\\n<li>[abc</li><li>def\]</li>\\n</ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<ol><li>[abc</li></ol><ul><li>def\]</li></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<ol><li> [abc</li></ol><ul><li>def\]</li></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<ol>\\n<li>[abc</li></ol><ul><li>def\]</li></ul>" compare innerHTML]
     expected: FAIL
 
   [[["forwarddelete",""\]\] "{<ul><li>abc<span>def</span>ghi</li><li>jkl<span>opq</span>rst</li></ul>}" compare innerHTML]
@@ -382,18 +343,6 @@
   [[["stylewithcss","false"\],["forwarddelete",""\]\] "<div style=color:blue><p style=color:green>foo[\]</div>bar" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["forwarddelete",""\]\] "<p>[foo<span style=color:#aBcDeF>bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["forwarddelete",""\]\] "<p>[foo<span style=color:#aBcDeF>bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["forwarddelete",""\]\] "<p>{foo<span style=color:#aBcDeF>bar}</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["forwarddelete",""\]\] "<p>{foo<span style=color:#aBcDeF>bar}</span>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["forwarddelete",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span>baz\]" compare innerHTML]
     expected: FAIL
 
@@ -406,19 +355,7 @@
   [[["stylewithcss","false"\],["forwarddelete",""\]\] "<p>foo<span style=color:#aBcDeF>{bar</span>baz}" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["forwarddelete",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span><span style=color:#fEdCbA>baz\]</span>quz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["forwarddelete",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span><span style=color:#fEdCbA>baz\]</span>quz" compare innerHTML]
-    expected: FAIL
-
   [[["forwarddelete",""\]\] "<p>foo</p><p>{bar</p>}<p>baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["forwarddelete",""\]\] "<p>foo</p>{<p>bar}</p><p>baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["forwarddelete",""\]\] "<p>foo</p>{<p>bar}</p><p>baz</p>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["forwarddelete",""\]\] "<p style=color:blue>foo[\]</p>bar" queryCommandState("stylewithcss") before]
@@ -480,9 +417,6 @@
     expected: FAIL
 
   [[["forwarddelete",""\]\] "<ol><li>foo</ol>[bar<ol><li>\]baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<ol><li>foo</ol><p>[bar<ol><li>\]baz</ol>" compare innerHTML]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["forwarddelete",""\]\] "<ol><li>foo</ol><p>[bar<ol><li><p>\]baz</ol>" compare innerHTML]
@@ -626,16 +560,7 @@
   [[["forwarddelete",""\]\] "<p contenteditable=\\"false\\"><unknown-element contenteditable>[abc\]</unknown-element></p>" compare innerHTML]
     expected: FAIL
 
-  [[["forwarddelete",""\]\] "<div contenteditable=\\"false\\"><custom-element contenteditable=\\"\\"><p>[ab</p><p>c\]d</p></custom-element></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<div contenteditable=\\"false\\"><custom-element contenteditable=\\"\\"><p>a[b</p><p>cd\]</p></custom-element></div>" compare innerHTML]
-    expected: FAIL
-
   [[["forwarddelete",""\]\] "<div contenteditable=\\"false\\"><custom-element contenteditable=\\"\\"><p><b>[ab</b></p><p><i>c\]d</i></p></custom-element></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<div contenteditable=\\"false\\"><custom-element contenteditable=\\"\\"><p><b>a[b</b></p><p><i>cd\]</i></p></custom-element></div>" compare innerHTML]
     expected: FAIL
 
   [[["forwarddelete",""\]\] "<p>abc[\]</p><ul contenteditable=\\"false\\"><li>def</li></ul><p>ghi</p>" compare innerHTML]
@@ -722,21 +647,6 @@
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["forwarddelete",""\]\] "foo<br><br>{<p>\]bar</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<table><tbody><tr><th>fo[o<th>bar<th>b\]az<tr><td>quz<td>qoz<td>qiz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<table><tbody><tr><th>[foo<th>bar<th>baz\]<tr><td>quz<td>qoz<td>qiz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<table><tbody><tr><th>[foo<th>bar<th>baz<tr><td>quz<td>qoz<td>qiz\]</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<table><tbody><tr><td>foo<td>ba[r<tr><td>baz<td>quz<tr><td>q\]oz<td>qiz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<p>fo[o<ol><li>bar<li>b\]az</ol><p>quz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["forwarddelete",""\]\] "<p>foo[bar<p style=color:blue>baz\]quz" queryCommandState("stylewithcss") before]

--- a/tests/wpt/meta/editing/run/insertimage.html.ini
+++ b/tests/wpt/meta/editing/run/insertimage.html.ini
@@ -11,18 +11,6 @@
   [[["insertimage","/img/lion.svg"\]\] "foo{<span style=color:#aBcDeF>bar</span>}baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["insertimage","/img/lion.svg"\]\] "[foo<span style=color:#aBcDeF>bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["insertimage","/img/lion.svg"\]\] "[foo<span style=color:#aBcDeF>bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["insertimage","/img/lion.svg"\]\] "{foo<span style=color:#aBcDeF>bar}</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["insertimage","/img/lion.svg"\]\] "{foo<span style=color:#aBcDeF>bar}</span>baz" compare innerHTML]
-    expected: FAIL
-
   [[["insertimage","/img/lion.svg"\]\] "foo<span style=color:#aBcDeF>[bar</span>baz\]" compare innerHTML]
     expected: FAIL
 
@@ -54,12 +42,6 @@
     expected: FAIL
 
   [[["insertimage","/img/lion.svg"\]\] "<b>foo[bar</b><i>baz\]quz</i>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertimage","/img/lion.svg"\]\] "<div><p>foo<p>[bar<p>baz\]</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertimage","/img/lion.svg"\]\] "<div><p>foo<p>[bar<p>baz\]</div>" compare innerHTML]
     expected: FAIL
 
   [[["insertimage","/img/lion.svg"\]\] "<p>foo[</p>\]bar" compare innerHTML]

--- a/tests/wpt/meta/editing/run/insertparagraph.html.ini
+++ b/tests/wpt/meta/editing/run/insertparagraph.html.ini
@@ -133,30 +133,6 @@
   [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<p>foo<span style=color:#aBcDeF>{bar}</span>baz" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<p>[foo<span style=color:#aBcDeF>bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<p>[foo<span style=color:#aBcDeF>bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "<p>[foo<span style=color:#aBcDeF>bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "<p>[foo<span style=color:#aBcDeF>bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<p>{foo<span style=color:#aBcDeF>bar}</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<p>{foo<span style=color:#aBcDeF>bar}</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "<p>{foo<span style=color:#aBcDeF>bar}</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "<p>{foo<span style=color:#aBcDeF>bar}</span>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span>baz\]" compare innerHTML]
     expected: FAIL
 
@@ -179,18 +155,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "<p>foo<span style=color:#aBcDeF>{bar</span>baz}" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span><span style=color:#fEdCbA>baz\]</span>quz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span><span style=color:#fEdCbA>baz\]</span>quz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span><span style=color:#fEdCbA>baz\]</span>quz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span><span style=color:#fEdCbA>baz\]</span>quz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "<p>foo<span style=color:#aBcDeF>[bar\]</span>baz" queryCommandState("stylewithcss") after]
@@ -645,9 +609,6 @@
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "<table><tr><td>[foo<td>bar\]<tr><td>baz<td>quz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertparagraph",""\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<tr><td>baz<td>quz</table>" compare innerHTML]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<table><tr><td>fo[o</table>b\]ar" compare innerHTML]


### PR DESCRIPTION
`Range::contained_children` only iterates the direct children of range. Instead, we should iterate over all nodes within the range. This was spotted while working on `indent` and the same fix applies for `delete-the-selection`.

Part of #25005

Testing: new WPT passes