### PR TITLE
script: Restrict navigator.servo to about:memory.

### DIFF
--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -214,7 +214,7 @@ impl ServoInternalsHelpers for ServoInternals {
         let mut realm = CurrentRealm::assert(cx);
         let global_scope = GlobalScope::from_current_realm(&mut realm);
         let url = global_scope.get_url();
-        (url.scheme() == "about" && url.as_str() != "about:blank") ||
+        url.as_str() == "about:memory" ||
             ScriptThread::is_servo_privileged(url) ||
             prefs::get().expose_servointernals_globally
     }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -15036,6 +15036,13 @@
       {}
      ]
     ],
+    "servo_internals.html": [
+     "39a8f6f0f7da1dd398062ea25ca14fc6dcb2b82f",
+     [
+      null,
+      {}
+     ]
+    ],
     "sigsegv.html": [
      "51b9192c23e91d12befb3457a1fb19e59e96f803",
      [

--- a/tests/wpt/mozilla/tests/mozilla/servo_internals.html
+++ b/tests/wpt/mozilla/tests/mozilla/servo_internals.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<head>
+<title>Verify that navigator.servo is inaccessible in content-accessible about: documents</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  let t1 = async_test("navigator.servo in about:blank");
+  let t2 = async_test("navigator.servo in about:srcdoc");
+  let t3 = async_test("navigator.servo in javascript:");
+  let t4 = async_test("about:memory always cross-origin");
+  var tests = [t1, t2, t3, t4];
+  function report(test_index, result) {
+      let this_test = tests[test_index];
+      this_test.step(() => {
+          assert_false(result);
+          this_test.done();
+      });
+  }
+
+  function test_frame(index, frame) {
+      report(index, "servo" in frame.contentWindow.navigator);
+  }
+
+  function test_cross_origin(index, frame) {
+      let this_test = tests[index];
+      this_test.step(() => {
+          assert_throws_dom("SECURITY_ERR", () => "servo" in frame.contentWindow.navigator, "Can't access navigator in cross-origin");
+          this_test.done();
+      });
+  }
+
+</script>
+<iframe onload="test_frame(0, this)"></iframe>
+<iframe srcdoc="<script>parent.report(1, 'servo' in navigator)</script>"></iframe>
+<iframe src="javascript:parent.report(2, 'servo' in navigator);''"></iframe>
+<iframe src="about:memory" onload="test_cross_origin(3, this)"></iframe>


### PR DESCRIPTION
The previous check was too lenient and allowed documents created from srcdoc iframes.

Testing: New WPT test added.