### PR TITLE
script: Pass `JSContext` to `Selection::active_range`

### DIFF
--- a/components/script/dom/execcommand/basecommand.rs
+++ b/components/script/dom/execcommand/basecommand.rs
@@ -372,7 +372,7 @@ impl CommandName {
         let Some(selection) = document.GetSelection(cx) else {
             return false;
         };
-        let Some(active_range) = selection.active_range() else {
+        let Some(active_range) = selection.active_range(cx) else {
             return false;
         };
         let mut at_least_two_different_effective_values = false;
@@ -423,7 +423,7 @@ impl CommandName {
                     return None;
                 }
                 let selection = document.GetSelection(cx)?;
-                let active_range = selection.active_range()?;
+                let active_range = selection.active_range(cx)?;
                 let mut at_least_one_child_is_formattable = false;
                 let mut all_children_have_matching_command_values = true;
                 active_range.for_each_effectively_contained_child(|node| {
@@ -471,7 +471,7 @@ impl CommandName {
                 // > the effective command value of the active range's start node;
                 // > or if that is null, the empty string.
                 let selection = document.GetSelection(cx)?;
-                let active_range = selection.active_range()?;
+                let active_range = selection.active_range(cx)?;
 
                 active_range
                     .first_formattable_contained_node(cx.no_gc())
@@ -773,7 +773,7 @@ impl CommandName {
         // > After taking the action, if the active range is collapsed,
         // > it must restore states and values from the recorded list.
         if let Some(active_range) = selection
-            .active_range()
+            .active_range(cx)
             .filter(|active_range| active_range.collapsed())
         {
             active_range.restore_states_and_values(cx, selection, document, overrides);

--- a/components/script/dom/execcommand/commands/createlink.rs
+++ b/components/script/dom/execcommand/commands/createlink.rs
@@ -30,7 +30,7 @@ pub(crate) fn execute_createlink_command(
     // is an ancestor of some node effectively contained in the active range,
     // set that a element's href attribute to value.
     let active_range = selection
-        .active_range()
+        .active_range(cx)
         .expect("Must always have an active range");
     active_range.for_each_effectively_contained_child(|node| {
         for ancestor in node.inclusive_ancestors(ShadowIncluding::No) {

--- a/components/script/dom/execcommand/commands/delete.rs
+++ b/components/script/dom/execcommand/commands/delete.rs
@@ -28,7 +28,7 @@ pub(crate) fn execute_delete_command(
     selection: &Selection,
 ) -> bool {
     let active_range = selection
-        .active_range()
+        .active_range(cx)
         .expect("Must always have an active range");
     // Step 1. If the active range is not collapsed, delete the selection and return true.
     if !active_range.collapsed() {

--- a/components/script/dom/execcommand/commands/fontsize.rs
+++ b/components/script/dom/execcommand/commands/fontsize.rs
@@ -125,7 +125,7 @@ pub(crate) fn value_for_fontsize_command(
 ) -> Option<DOMString> {
     // Step 1. If the active range is null, return the empty string.
     let selection = document.GetSelection(cx)?;
-    let active_range = selection.active_range()?;
+    let active_range = selection.active_range(cx)?;
     // Step 2. Let pixel size be the effective command value of the first formattable
     // node that is effectively contained in the active range, or if there is no such node,
     // the effective command value of the active range's start node,

--- a/components/script/dom/execcommand/commands/forwarddelete.rs
+++ b/components/script/dom/execcommand/commands/forwarddelete.rs
@@ -23,7 +23,7 @@ pub(crate) fn execute_forward_delete_command(
 ) -> bool {
     // Step 1. If the active range is not collapsed, delete the selection and return true.
     let active_range = selection
-        .active_range()
+        .active_range(cx)
         .expect("Must always have an active range");
     if !active_range.collapsed() {
         selection.delete_the_selection(

--- a/components/script/dom/execcommand/commands/indent.rs
+++ b/components/script/dom/execcommand/commands/indent.rs
@@ -167,7 +167,7 @@ pub(crate) fn execute_indent_command(
     selection: &Selection,
 ) -> bool {
     let mut active_range = selection
-        .active_range()
+        .active_range(cx)
         .expect("Must always have an active range.");
     // Step 1. Let items be a list of all lis that are inclusive ancestors of the active range's start and/or end node.
     let items: HashSet<DomRoot<Node>> = active_range
@@ -184,7 +184,7 @@ pub(crate) fn execute_indent_command(
 
     // Normalizing sublists probably messes up the range
     active_range = selection
-        .active_range()
+        .active_range(cx)
         .expect("Must always have an active range.");
 
     // Step 3. Block-extend the active range, and let new range be the result.

--- a/components/script/dom/execcommand/commands/inserthorizontalrule.rs
+++ b/components/script/dom/execcommand/commands/inserthorizontalrule.rs
@@ -22,7 +22,7 @@ pub(crate) fn execute_insert_horizontal_rule_command(
 ) -> bool {
     // Step 1. Let start node, start offset, end node, and end offset be the active range's start and end nodes and offsets.
     let mut active_range = selection
-        .active_range()
+        .active_range(cx)
         .expect("Must always have an active range");
     let mut start_node = active_range.start_container();
     let mut start_offset = active_range.start_offset();
@@ -70,7 +70,7 @@ pub(crate) fn execute_insert_horizontal_rule_command(
     );
 
     active_range = selection
-        .active_range()
+        .active_range(cx)
         .expect("Must always have an active range");
 
     // Step 7. If the active range's start node is neither editable nor an editing host, return true.
@@ -93,7 +93,7 @@ pub(crate) fn execute_insert_horizontal_rule_command(
             unreachable!("Should always be able to collapse the selection.");
         }
         active_range = selection
-            .active_range()
+            .active_range(cx)
             .expect("Must always have an active range");
     }
 
@@ -114,7 +114,7 @@ pub(crate) fn execute_insert_horizontal_rule_command(
             unreachable!("Should always be able to collapse the selection.");
         }
         active_range = selection
-            .active_range()
+            .active_range(cx)
             .expect("Must always have an active range");
     }
 

--- a/components/script/dom/execcommand/commands/insertimage.rs
+++ b/components/script/dom/execcommand/commands/insertimage.rs
@@ -39,7 +39,7 @@ pub(crate) fn execute_insert_image_command(
 
     // Step 3. Let range be the active range.
     let range = selection
-        .active_range()
+        .active_range(cx)
         .expect("Must always have an active range");
 
     // Step 4. If the active range's start node is neither editable nor an editing host, return true.

--- a/components/script/dom/execcommand/commands/insertparagraph.rs
+++ b/components/script/dom/execcommand/commands/insertparagraph.rs
@@ -39,7 +39,7 @@ pub(crate) fn execute_insert_paragraph_command(
     );
     // Step 3. Let node and offset be the active range's start node and offset.
     let active_range = selection
-        .active_range()
+        .active_range(cx)
         .expect("Must always have an active range");
     let mut node = active_range.start_container();
     let mut offset = active_range.start_offset();

--- a/components/script/dom/execcommand/commands/inserttext.rs
+++ b/components/script/dom/execcommand/commands/inserttext.rs
@@ -37,7 +37,7 @@ pub(crate) fn execute_insert_text_command(
 
     // Step 2. If the active range's start node is neither editable nor an editing host, return true.
     let mut active_range = selection
-        .active_range()
+        .active_range(cx)
         .expect("Must always have an active range.");
     if !active_range.start_container().is_editable_or_editing_host() {
         return true;
@@ -104,7 +104,7 @@ pub(crate) fn execute_insert_text_command(
 
     // Step 12. Let (node, offset) be the active range's start.
     active_range = selection
-        .active_range()
+        .active_range(cx)
         .expect("Must always have an active range.");
     node = active_range.start_container();
     offset = active_range.start_offset();
@@ -135,7 +135,7 @@ pub(crate) fn execute_insert_text_command(
         }
 
         active_range = selection
-            .active_range()
+            .active_range(cx)
             .expect("Must always have an active range.");
     }
     // Step 14. Otherwise:
@@ -167,7 +167,7 @@ pub(crate) fn execute_insert_text_command(
         }
 
         active_range = selection
-            .active_range()
+            .active_range(cx)
             .expect("Must always have an active range.");
     }
 

--- a/components/script/dom/execcommand/commands/removeformat.rs
+++ b/components/script/dom/execcommand/commands/removeformat.rs
@@ -65,7 +65,7 @@ pub(crate) fn execute_removeformat_command(
 ) -> bool {
     // Step 1. Let elements to remove be a list of every removeFormat candidate effectively contained in the active range.
     let active_range = selection
-        .active_range()
+        .active_range(cx)
         .expect("Must always have an active range");
     let mut elements = vec![];
     active_range.for_each_effectively_contained_child(|node| {

--- a/components/script/dom/execcommand/commands/unlink.rs
+++ b/components/script/dom/execcommand/commands/unlink.rs
@@ -18,7 +18,7 @@ pub(crate) fn execute_unlink_command(cx: &mut JSContext, selection: &Selection) 
     // Step 1. Let hyperlinks be a list of every a element that has an href attribute
     // and is contained in the active range or is an ancestor of one of its boundary points.
     let active_range = selection
-        .active_range()
+        .active_range(cx)
         .expect("Must always have an active range");
     let mut hyperlinks = vec![];
     active_range.for_each_effectively_contained_child(|node| {

--- a/components/script/dom/execcommand/contenteditable/htmlelement.rs
+++ b/components/script/dom/execcommand/contenteditable/htmlelement.rs
@@ -190,7 +190,7 @@ impl HTMLElement {
         // case, we should maintain the selection as it were, by not creating
         // a new range.
         if selection
-            .active_range()
+            .active_range(cx)
             .is_some_and(|active| active == range)
         {
             return;

--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -154,7 +154,7 @@ where
         .GetSelection(cx)
         .expect("Must always have a selection");
     let active_range = selection
-        .active_range()
+        .active_range(cx)
         .expect("Must always have an active range");
 
     // Selection is currently implemented as a live range (not great!), which means that
@@ -657,7 +657,7 @@ where
         if let Some(range) = first_in_node_list
             .owner_document()
             .GetSelection(cx)
-            .and_then(|selection| selection.active_range())
+            .and_then(|selection| selection.active_range(cx))
         {
             let parent_of_new_parent = new_parent.GetParentNode().expect("Must have a parent");
             let start_container = range.start_container();

--- a/components/script/dom/execcommand/contenteditable/selection.rs
+++ b/components/script/dom/execcommand/contenteditable/selection.rs
@@ -172,7 +172,7 @@ impl Selection {
         direction: SelectionDeleteDirection,
     ) {
         // Step 1. If the active range is null, abort these steps and do nothing.
-        let Some(active_range) = self.active_range() else {
+        let Some(active_range) = self.active_range(cx) else {
             return;
         };
 
@@ -777,7 +777,7 @@ impl Selection {
         context_object: &Document,
     ) {
         let active_range = self
-            .active_range()
+            .active_range(cx)
             .expect("Must always have an active range");
 
         // Step 1. Let command be the current command.

--- a/components/script/dom/execcommand/execcommands.rs
+++ b/components/script/dom/execcommand/execcommands.rs
@@ -35,14 +35,14 @@ fn is_command_listed_in_miscellaneous_section(command_name: CommandName) -> bool
     )
 }
 
-fn bump_selection_out_of_invalid_node(selection: &Selection) -> Result<(), ()> {
+fn bump_selection_out_of_invalid_node(cx: &mut JSContext, selection: &Selection) -> Result<(), ()> {
     // Note: Here we make sure that if the selection range starts or ends inside of an HTML
     //       comment or PI, we get it out of there before trying to edit things. Trying to
     //       perform text editing inside of these nodes doesn't make any sense anyways and
     //       some commands aren't prepared to handle that. Picking the boundary point right
     //       before the problematic node is vaguely consistent with other browsers.
     let active_range = selection
-        .active_range()
+        .active_range(cx)
         .expect("Must always have an active range");
     if let start_container = active_range.start_container() &&
         (start_container.is::<Comment>() || start_container.is::<ProcessingInstruction>())
@@ -119,7 +119,7 @@ impl Document {
             return Some(selection);
         }
         // > The other commands defined here are enabled if the active range is not null,
-        let range = selection.active_range()?;
+        let range = selection.active_range(cx)?;
         // > its start node is either editable or an editing host,
         let start_container_editing_host = range.start_container().editing_host_of()?;
         // > the editing host of its start node is not an EditContext editing host,
@@ -279,7 +279,7 @@ impl DocumentExecCommandSupport for Document {
             // of the active range's start node and end node, and is not the ancestor of any editing host
             // that is an inclusive ancestor of the active range's start node and end node.
             let Some(affected_editing_host) = selection
-                .active_range()
+                .active_range(cx)
                 .expect("Must always have an active range")
                 .CommonAncestorContainer()
                 .editing_host_of()
@@ -318,7 +318,7 @@ impl DocumentExecCommandSupport for Document {
             // of the active range's start node and end node, and is not the ancestor of any editing host
             // that is an inclusive ancestor of the active range's start node and end node.
             selection
-                .active_range()
+                .active_range(cx)
                 .expect("Must always have an active range")
                 .CommonAncestorContainer()
                 .editing_host_of()
@@ -327,7 +327,7 @@ impl DocumentExecCommandSupport for Document {
         };
 
         if affected_editing_host.is_some() &&
-            bump_selection_out_of_invalid_node(&selection).is_err()
+            bump_selection_out_of_invalid_node(cx, &selection).is_err()
         {
             return false;
         }

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -256,7 +256,7 @@ impl Selection {
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#active-range>
-    pub(crate) fn active_range(&self) -> Option<DomRoot<Range>> {
+    pub(crate) fn active_range(&self, _cx: &mut JSContext) -> Option<DomRoot<Range>> {
         // > The active range is the range of the selection given by calling
         // > getSelection() on the context object. (Thus the active range may be null.)
         self.range.get()


### PR DESCRIPTION
This is mechanical change which starts passing a `cx` argument to
`Selection::active_range`. In order to properly support DOM selection,
it needs to be a composed tree range, with the live range (the result of
`Selection#getActiveRange` and `Selection::active_range` being a
lazily-initialized live range cache cofined to a single tree's
boundaries (not crossing shadow roots). This is a prepatory change and
the argument will be used by PR to follow.

Testing: This does not change behavior, so is covered by existing tests.
