### PR TITLE
android: Add basic Compose UI abstraction for library

### DIFF
--- a/support/android/apk/gradle/libs.versions.toml
+++ b/support/android/apk/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ android-sdk-min = "29"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.13.0" }
+androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version = "1.12.0" }
 androidx-material3-compose = { module = "androidx.compose.material3:material3", version = "1.4.0" }
 androidx-material3-compose-adaptive = { module = "androidx.compose.material3.adaptive:adaptive", version = "1.2.0" }
 androidx-preference = { module = "androidx.preference:preference-ktx", version = "1.2.1" }

--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.getSystemService
 import androidx.preference.PreferenceManager
 import androidx.window.core.layout.WindowSizeClass
@@ -177,8 +176,8 @@ class MainActivity : ComponentActivity(), Servo.Client {
                     }
                 },
             ) { innerPadding ->
-                AndroidView(
-                    factory = { _ -> servoView },
+                Servo(
+                    servoView = servoView,
                     modifier = Modifier.padding(innerPadding),
                 )
                 BackHandler(enabled = canGoBackState.value) {

--- a/support/android/apk/servoview/build.gradle.kts
+++ b/support/android/apk/servoview/build.gradle.kts
@@ -2,6 +2,7 @@ import java.util.regex.Pattern
 
 plugins {
     alias(libs.plugins.android.library)
+    alias(libs.plugins.compose)
 }
 
 android {
@@ -175,4 +176,8 @@ project.afterEvaluate {
             variant.assembleProvider.get().finalizedBy(copyAndRenameAARTask)
         }
     }
+}
+
+dependencies {
+    implementation(libs.androidx.compose.foundation)
 }

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.kt
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.kt
@@ -9,6 +9,20 @@ import android.content.Context
 import android.util.Size
 import android.view.KeyEvent
 import android.view.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+
+@Composable
+fun Servo(
+    servoView: ServoView,
+    modifier: Modifier = Modifier,
+) {
+    AndroidView(
+        factory = { _ -> servoView },
+        modifier = modifier,
+    )
+}
 
 class Servo(
     args: String?,


### PR DESCRIPTION
`Servo` acts as the starting point for the introduction of a native Compose UI library component. It is currently a simple abstraction over `ServoView`, but with time, it will absorb everything `ServoView` does.

It's named `Servo` due to that being the convention in Compose UI, for example, in Android Views it was called `TextView` whereas in Compose UI the equivalent component is called `Text`.

Testing: There are no automated tests for Android.
Fixes: Part of https://github.com/servo/servo/issues/33742.