### PR TITLE
layout: Truncate in place for each accessibility label

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -846,7 +846,9 @@ impl AccessibilityNode {
                 },
             }
         }
-        Some(text.trim().to_owned())
+        let trimmed_len = text.trim().len();
+        text.truncate(trimmed_len);
+        Some(text)
     }
 
     fn print(&self, print_tree: &mut PrintTree) {


### PR DESCRIPTION
`trim` returns a slice. We truncate in place to avoid one owned String creation.

Testing: No behaviour change. Covered by existing tests.