### PR TITLE
script: Rename remaining dictionary structs in WebCrypto

### DIFF
--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3742,7 +3742,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for ContextParams {
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-AeadParams>
 #[derive(Clone, MallocSizeOf)]
-struct SubtleAeadParams {
+struct AeadParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -3756,7 +3756,7 @@ struct SubtleAeadParams {
     tag_length: Option<u8>,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleAeadParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for AeadParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -3764,7 +3764,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleAeadParams {
         cx: &mut js::context::JSContext,
         algorithm_name: CryptoAlgorithm,
     ) -> Result<Self, Self::Error> {
-        Ok(SubtleAeadParams {
+        Ok(AeadParams {
             name: algorithm_name,
             iv: get_required_buffer_source(cx, object, c"iv")?,
             additional_data: get_optional_buffer_source(cx, object, c"additionalData")?,
@@ -4924,8 +4924,8 @@ enum EncryptAlgorithm {
     AesCtr(AesCtrParams),
     AesCbc(AesCbcParams),
     AesGcm(AesGcmParams),
-    AesOcb(SubtleAeadParams),
-    ChaCha20Poly1305(SubtleAeadParams),
+    AesOcb(AeadParams),
+    ChaCha20Poly1305(AeadParams),
 }
 
 impl NormalizedAlgorithm for EncryptAlgorithm {
@@ -5011,8 +5011,8 @@ enum DecryptAlgorithm {
     AesCtr(AesCtrParams),
     AesCbc(AesCbcParams),
     AesGcm(AesGcmParams),
-    AesOcb(SubtleAeadParams),
-    ChaCha20Poly1305(SubtleAeadParams),
+    AesOcb(AeadParams),
+    ChaCha20Poly1305(AeadParams),
 }
 
 impl NormalizedAlgorithm for DecryptAlgorithm {

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3837,7 +3837,7 @@ impl From<&CShakeParams> for SerializableCShakeParams {
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-TurboShakeParams>
 #[derive(Clone, MallocSizeOf)]
-struct SubtleTurboShakeParams {
+struct TurboShakeParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -3848,7 +3848,7 @@ struct SubtleTurboShakeParams {
     domain_separation: Option<u8>,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleTurboShakeParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for TurboShakeParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -3856,7 +3856,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleTurboShakeParams {
         cx: &mut js::context::JSContext,
         algorithm_name: CryptoAlgorithm,
     ) -> Result<Self, Self::Error> {
-        Ok(SubtleTurboShakeParams {
+        Ok(TurboShakeParams {
             name: algorithm_name,
             output_length: get_required_parameter(
                 cx,
@@ -3874,11 +3874,11 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleTurboShakeParams {
     }
 }
 
-impl TryFrom<SerializableTurboShakeParams> for SubtleTurboShakeParams {
+impl TryFrom<SerializableTurboShakeParams> for TurboShakeParams {
     type Error = ();
 
     fn try_from(value: SerializableTurboShakeParams) -> Result<Self, Self::Error> {
-        Ok(SubtleTurboShakeParams {
+        Ok(TurboShakeParams {
             name: CryptoAlgorithm::from_str(&value.name).map_err(|_| ())?,
             output_length: value.output_length,
             domain_separation: value.domain_separation,
@@ -3886,8 +3886,8 @@ impl TryFrom<SerializableTurboShakeParams> for SubtleTurboShakeParams {
     }
 }
 
-impl From<&SubtleTurboShakeParams> for SerializableTurboShakeParams {
-    fn from(value: &SubtleTurboShakeParams) -> Self {
+impl From<&TurboShakeParams> for SerializableTurboShakeParams {
+    fn from(value: &TurboShakeParams) -> Self {
         SerializableTurboShakeParams {
             name: value.name.as_str().into(),
             output_length: value.output_length,
@@ -5288,7 +5288,7 @@ enum DigestAlgorithm {
     Sha(Algorithm),
     Sha3(Algorithm),
     CShake(CShakeParams),
-    TurboShake(SubtleTurboShakeParams),
+    TurboShake(TurboShakeParams),
     KangarooTwelve(SubtleKangarooTwelveParams),
 }
 

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -363,7 +363,7 @@ impl SubtleCrypto {
     fn resolve_promise_with_encapsulated_bits(
         &self,
         promise: Rc<Promise>,
-        encapsulated_bits: SubtleEncapsulatedBits,
+        encapsulated_bits: EncapsulatedBits,
     ) {
         let trusted_promise = TrustedPromise::new(promise);
         self.global().task_manager().crypto_task_source().queue(
@@ -4191,7 +4191,7 @@ impl ToJSValConvertible for EncapsulatedKey {
 }
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-EncapsulatedBits>
-struct SubtleEncapsulatedBits {
+struct EncapsulatedBits {
     /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-EncapsulatedBits-sharedKey>
     shared_key: Option<Zeroizing<Vec<u8>>>,
 
@@ -4199,7 +4199,7 @@ struct SubtleEncapsulatedBits {
     ciphertext: Option<Vec<u8>>,
 }
 
-impl ToJSValConvertible for SubtleEncapsulatedBits {
+impl ToJSValConvertible for EncapsulatedBits {
     #[expect(unsafe_code)]
     fn safe_to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
         rooted!(&in(cx) let mut object = unsafe { JS_NewObject(cx, ptr::null()) });
@@ -6406,7 +6406,7 @@ impl NormalizedAlgorithm for EncapsulateAlgorithm {
 }
 
 impl EncapsulateAlgorithm {
-    fn encapsulate(&self, key: &CryptoKey) -> Result<SubtleEncapsulatedBits, Error> {
+    fn encapsulate(&self, key: &CryptoKey) -> Result<EncapsulatedBits, Error> {
         match self {
             EncapsulateAlgorithm::MlKem(algorithm) => ml_kem_operation::encapsulate(algorithm, key),
         }

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3677,7 +3677,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for HkdfParams {
 
 /// <https://w3c.github.io/webcrypto/#dfn-Pbkdf2Params>
 #[derive(Clone, MallocSizeOf)]
-pub(crate) struct SubtlePbkdf2Params {
+pub(crate) struct Pbkdf2Params {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -3691,7 +3691,7 @@ pub(crate) struct SubtlePbkdf2Params {
     hash: DigestAlgorithm,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtlePbkdf2Params {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for Pbkdf2Params {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -3701,7 +3701,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtlePbkdf2Params {
     ) -> Result<Self, Self::Error> {
         let hash = get_required_parameter(cx, object, c"hash", ())?;
 
-        Ok(SubtlePbkdf2Params {
+        Ok(Pbkdf2Params {
             name: algorithm_name,
             salt: get_required_buffer_source(cx, object, c"salt")?,
             iterations: get_required_parameter(
@@ -5409,7 +5409,7 @@ enum DeriveBitsAlgorithm {
     X25519(EcdhKeyDeriveParams),
     X448(EcdhKeyDeriveParams),
     Hkdf(HkdfParams),
-    Pbkdf2(SubtlePbkdf2Params),
+    Pbkdf2(Pbkdf2Params),
     Argon2(SubtleArgon2Params),
 }
 

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3775,7 +3775,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for AeadParams {
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-CShakeParams>
 #[derive(Clone, MallocSizeOf)]
-struct SubtleCShakeParams {
+struct CShakeParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -3789,7 +3789,7 @@ struct SubtleCShakeParams {
     customization: Option<Vec<u8>>,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleCShakeParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for CShakeParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -3797,7 +3797,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleCShakeParams {
         cx: &mut js::context::JSContext,
         algorithm_name: CryptoAlgorithm,
     ) -> Result<Self, Self::Error> {
-        Ok(SubtleCShakeParams {
+        Ok(CShakeParams {
             name: algorithm_name,
             output_length: get_required_parameter(
                 cx,
@@ -3811,11 +3811,11 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleCShakeParams {
     }
 }
 
-impl TryFrom<SerializableCShakeParams> for SubtleCShakeParams {
+impl TryFrom<SerializableCShakeParams> for CShakeParams {
     type Error = ();
 
     fn try_from(value: SerializableCShakeParams) -> Result<Self, Self::Error> {
-        Ok(SubtleCShakeParams {
+        Ok(CShakeParams {
             name: CryptoAlgorithm::from_str(&value.name).map_err(|_| ())?,
             output_length: value.output_length,
             function_name: value.function_name,
@@ -3824,8 +3824,8 @@ impl TryFrom<SerializableCShakeParams> for SubtleCShakeParams {
     }
 }
 
-impl From<&SubtleCShakeParams> for SerializableCShakeParams {
-    fn from(value: &SubtleCShakeParams) -> Self {
+impl From<&CShakeParams> for SerializableCShakeParams {
+    fn from(value: &CShakeParams) -> Self {
         SerializableCShakeParams {
             name: value.name.as_str().into(),
             output_length: value.output_length,
@@ -5287,7 +5287,7 @@ impl Operation for DigestOperation {
 enum DigestAlgorithm {
     Sha(Algorithm),
     Sha3(Algorithm),
-    CShake(SubtleCShakeParams),
+    CShake(CShakeParams),
     TurboShake(SubtleTurboShakeParams),
     KangarooTwelve(SubtleKangarooTwelveParams),
 }

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3642,7 +3642,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for HmacKeyGenParams {
 
 /// <https://w3c.github.io/webcrypto/#dfn-HkdfParams>
 #[derive(Clone, MallocSizeOf)]
-pub(crate) struct SubtleHkdfParams {
+pub(crate) struct HkdfParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -3656,7 +3656,7 @@ pub(crate) struct SubtleHkdfParams {
     info: Vec<u8>,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleHkdfParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for HkdfParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -3666,7 +3666,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleHkdfParams {
     ) -> Result<Self, Self::Error> {
         let hash = get_required_parameter(cx, object, c"hash", ())?;
 
-        Ok(SubtleHkdfParams {
+        Ok(HkdfParams {
             name: algorithm_name,
             hash: normalize_algorithm::<DigestOperation>(cx, &hash)?,
             salt: get_required_buffer_source(cx, object, c"salt")?,
@@ -5408,7 +5408,7 @@ enum DeriveBitsAlgorithm {
     Ecdh(EcdhKeyDeriveParams),
     X25519(EcdhKeyDeriveParams),
     X448(EcdhKeyDeriveParams),
-    Hkdf(SubtleHkdfParams),
+    Hkdf(HkdfParams),
     Pbkdf2(SubtlePbkdf2Params),
     Argon2(SubtleArgon2Params),
 }

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3717,7 +3717,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for Pbkdf2Params {
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-ContextParams>
 #[derive(Clone, MallocSizeOf)]
-struct SubtleContextParams {
+struct ContextParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -3725,7 +3725,7 @@ struct SubtleContextParams {
     context: Option<Vec<u8>>,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleContextParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for ContextParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -3733,7 +3733,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleContextParams {
         cx: &mut js::context::JSContext,
         algorithm_name: CryptoAlgorithm,
     ) -> Result<Self, Self::Error> {
-        Ok(SubtleContextParams {
+        Ok(ContextParams {
             name: algorithm_name,
             context: get_optional_buffer_source(cx, object, c"context")?,
         })
@@ -5100,7 +5100,7 @@ enum SignAlgorithm {
     Ed25519(Algorithm),
     Ed448(SubtleEd448Params),
     Hmac(Algorithm),
-    MlDsa(SubtleContextParams),
+    MlDsa(ContextParams),
     Kmac(KmacParams),
 }
 
@@ -5189,7 +5189,7 @@ enum VerifyAlgorithm {
     Ed25519(Algorithm),
     Ed448(SubtleEd448Params),
     Hmac(Algorithm),
-    MlDsa(SubtleContextParams),
+    MlDsa(ContextParams),
     Kmac(KmacParams),
 }
 

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3898,7 +3898,7 @@ impl From<&TurboShakeParams> for SerializableTurboShakeParams {
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-KangarooTwelveParams>
 #[derive(Clone, MallocSizeOf)]
-struct SubtleKangarooTwelveParams {
+struct KangarooTwelveParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -3909,7 +3909,7 @@ struct SubtleKangarooTwelveParams {
     customization: Option<Vec<u8>>,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleKangarooTwelveParams {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for KangarooTwelveParams {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -3917,7 +3917,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleKangarooTwelveParams {
         cx: &mut js::context::JSContext,
         algorithm_name: CryptoAlgorithm,
     ) -> Result<Self, Self::Error> {
-        Ok(SubtleKangarooTwelveParams {
+        Ok(KangarooTwelveParams {
             name: algorithm_name,
             output_length: get_required_parameter(
                 cx,
@@ -3930,11 +3930,11 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleKangarooTwelveParams {
     }
 }
 
-impl TryFrom<SerializableKangarooTwelveParams> for SubtleKangarooTwelveParams {
+impl TryFrom<SerializableKangarooTwelveParams> for KangarooTwelveParams {
     type Error = ();
 
     fn try_from(value: SerializableKangarooTwelveParams) -> Result<Self, Self::Error> {
-        Ok(SubtleKangarooTwelveParams {
+        Ok(KangarooTwelveParams {
             name: CryptoAlgorithm::from_str(&value.name).map_err(|_| ())?,
             output_length: value.output_length,
             customization: value.customization,
@@ -3942,8 +3942,8 @@ impl TryFrom<SerializableKangarooTwelveParams> for SubtleKangarooTwelveParams {
     }
 }
 
-impl From<&SubtleKangarooTwelveParams> for SerializableKangarooTwelveParams {
-    fn from(value: &SubtleKangarooTwelveParams) -> Self {
+impl From<&KangarooTwelveParams> for SerializableKangarooTwelveParams {
+    fn from(value: &KangarooTwelveParams) -> Self {
         SerializableKangarooTwelveParams {
             name: value.name.as_str().into(),
             output_length: value.output_length,
@@ -5289,7 +5289,7 @@ enum DigestAlgorithm {
     Sha3(Algorithm),
     CShake(CShakeParams),
     TurboShake(TurboShakeParams),
-    KangarooTwelve(SubtleKangarooTwelveParams),
+    KangarooTwelve(KangarooTwelveParams),
 }
 
 impl NormalizedAlgorithm for DigestAlgorithm {

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -4086,7 +4086,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for KmacParams {
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-Argon2Params>
 #[derive(Clone, MallocSizeOf)]
-struct SubtleArgon2Params {
+struct Argon2Params {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
     name: CryptoAlgorithm,
 
@@ -4112,7 +4112,7 @@ struct SubtleArgon2Params {
     associated_data: Option<Vec<u8>>,
 }
 
-impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleArgon2Params {
+impl<'a> TryFromWithCxAndName<HandleObject<'a>> for Argon2Params {
     type Error = Error;
 
     fn try_from_with_cx_and_name(
@@ -4120,7 +4120,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleArgon2Params {
         cx: &mut js::context::JSContext,
         algorithm_name: CryptoAlgorithm,
     ) -> Result<Self, Self::Error> {
-        Ok(SubtleArgon2Params {
+        Ok(Argon2Params {
             name: algorithm_name,
             nonce: get_required_buffer_source(cx, object, c"nonce")?,
             parallelism: get_required_parameter(
@@ -5410,7 +5410,7 @@ enum DeriveBitsAlgorithm {
     X448(EcdhKeyDeriveParams),
     Hkdf(HkdfParams),
     Pbkdf2(Pbkdf2Params),
-    Argon2(SubtleArgon2Params),
+    Argon2(Argon2Params),
 }
 
 impl NormalizedAlgorithm for DeriveBitsAlgorithm {

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -346,7 +346,7 @@ impl SubtleCrypto {
     fn resolve_promise_with_encapsulated_key(
         &self,
         promise: Rc<Promise>,
-        encapsulated_key: SubtleEncapsulatedKey,
+        encapsulated_key: EncapsulatedKey,
     ) {
         let trusted_promise = TrustedPromise::new(promise);
         self.global().task_manager().crypto_task_source().queue(
@@ -1830,7 +1830,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
 
                 // Step 16. Let encapsulatedKey be a new EncapsulatedKey dictionary with sharedKey
                 // set to sharedKey and ciphertext set to the ciphertext field of encapsulatedBits.
-                let encapsulated_key = SubtleEncapsulatedKey {
+                let encapsulated_key = EncapsulatedKey {
                     shared_key: Some(Trusted::new(&shared_key)),
                     ciphertext:encapsulated_bits.ciphertext,
                 };
@@ -4149,7 +4149,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for Argon2Params {
 }
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-EncapsulatedKey>
-struct SubtleEncapsulatedKey {
+struct EncapsulatedKey {
     /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-EncapsulatedKey-sharedKey>
     shared_key: Option<Trusted<CryptoKey>>,
 
@@ -4157,7 +4157,7 @@ struct SubtleEncapsulatedKey {
     ciphertext: Option<Vec<u8>>,
 }
 
-impl ToJSValConvertible for SubtleEncapsulatedKey {
+impl ToJSValConvertible for EncapsulatedKey {
     #[expect(unsafe_code)]
     fn safe_to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
         rooted!(&in(cx) let mut object = unsafe { JS_NewObject(cx, ptr::null()) });

--- a/components/script/dom/webcrypto/subtlecrypto/aes_ocb_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_ocb_operation.rs
@@ -22,12 +22,12 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
 use crate::dom::subtlecrypto::{
-    AesDerivedKeyParams, AesKeyGenParams, ExportedKey, SubtleAeadParams, aes_common,
+    AesDerivedKeyParams, AesKeyGenParams, ExportedKey, AeadParams, aes_common,
 };
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#aes-ocb-operations-encrypt>
 pub(crate) fn encrypt(
-    normalized_algorithm: &SubtleAeadParams,
+    normalized_algorithm: &AeadParams,
     key: &CryptoKey,
     plaintext: &[u8],
 ) -> Result<Vec<u8>, Error> {
@@ -244,7 +244,7 @@ where
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#aes-ocb-operations-decrypt>
 pub(crate) fn decrypt(
-    normalized_algorithm: &SubtleAeadParams,
+    normalized_algorithm: &AeadParams,
     key: &CryptoKey,
     ciphertext: &[u8],
 ) -> Result<Vec<u8>, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/aes_ocb_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_ocb_operation.rs
@@ -22,7 +22,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
 use crate::dom::subtlecrypto::{
-    AesDerivedKeyParams, AesKeyGenParams, ExportedKey, AeadParams, aes_common,
+    AeadParams, AesDerivedKeyParams, AesKeyGenParams, ExportedKey, aes_common,
 };
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#aes-ocb-operations-encrypt>

--- a/components/script/dom/webcrypto/subtlecrypto/argon2_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/argon2_operation.rs
@@ -12,12 +12,12 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    Algorithm, CryptoAlgorithm, KeyAlgorithm, KeyAlgorithmAndDerivatives, SubtleArgon2Params,
+    Algorithm, CryptoAlgorithm, KeyAlgorithm, KeyAlgorithmAndDerivatives, Argon2Params,
 };
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#argon2-operations-derive-bits>
 pub(crate) fn derive_bits(
-    normalized_algorithm: &SubtleArgon2Params,
+    normalized_algorithm: &Argon2Params,
     key: &CryptoKey,
     length: Option<u32>,
 ) -> Result<Vec<u8>, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/argon2_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/argon2_operation.rs
@@ -12,7 +12,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    Algorithm, CryptoAlgorithm, KeyAlgorithm, KeyAlgorithmAndDerivatives, Argon2Params,
+    Algorithm, Argon2Params, CryptoAlgorithm, KeyAlgorithm, KeyAlgorithmAndDerivatives,
 };
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#argon2-operations-derive-bits>

--- a/components/script/dom/webcrypto/subtlecrypto/chacha20_poly1305_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/chacha20_poly1305_operation.rs
@@ -18,12 +18,12 @@ use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithm,
-    KeyAlgorithmAndDerivatives, SubtleAeadParams,
+    KeyAlgorithmAndDerivatives, AeadParams,
 };
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#chacha20-poly1305-operations-encrypt>
 pub(crate) fn encrypt(
-    normalized_algorithm: &SubtleAeadParams,
+    normalized_algorithm: &AeadParams,
     key: &CryptoKey,
     plaintext: &[u8],
 ) -> Result<Vec<u8>, Error> {
@@ -84,7 +84,7 @@ pub(crate) fn encrypt(
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#chacha20-poly1305-operations-decrypt>
 pub(crate) fn decrypt(
-    normalized_algorithm: &SubtleAeadParams,
+    normalized_algorithm: &AeadParams,
     key: &CryptoKey,
     ciphertext: &[u8],
 ) -> Result<Vec<u8>, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/chacha20_poly1305_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/chacha20_poly1305_operation.rs
@@ -17,8 +17,8 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithm,
-    KeyAlgorithmAndDerivatives, AeadParams,
+    AeadParams, CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithm,
+    KeyAlgorithmAndDerivatives,
 };
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#chacha20-poly1305-operations-encrypt>

--- a/components/script/dom/webcrypto/subtlecrypto/cshake_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/cshake_operation.rs
@@ -6,7 +6,7 @@ use cshake::digest::{ExtendableOutput, Update};
 use cshake::{CShake128, CShake256};
 
 use crate::dom::bindings::error::Error;
-use crate::dom::subtlecrypto::{CryptoAlgorithm, CShakeParams};
+use crate::dom::subtlecrypto::{CShakeParams, CryptoAlgorithm};
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#cshake-operations-digest>
 pub(crate) fn digest(

--- a/components/script/dom/webcrypto/subtlecrypto/cshake_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/cshake_operation.rs
@@ -6,11 +6,11 @@ use cshake::digest::{ExtendableOutput, Update};
 use cshake::{CShake128, CShake256};
 
 use crate::dom::bindings::error::Error;
-use crate::dom::subtlecrypto::{CryptoAlgorithm, SubtleCShakeParams};
+use crate::dom::subtlecrypto::{CryptoAlgorithm, CShakeParams};
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#cshake-operations-digest>
 pub(crate) fn digest(
-    normalized_algorithm: &SubtleCShakeParams,
+    normalized_algorithm: &CShakeParams,
     message: &[u8],
 ) -> Result<Vec<u8>, Error> {
     // Step 1. Let outputLength be the outputLength member of normalizedAlgorithm.

--- a/components/script/dom/webcrypto/subtlecrypto/hkdf_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/hkdf_operation.rs
@@ -14,8 +14,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    CryptoAlgorithm, KeyAlgorithm, KeyAlgorithmAndDerivatives, NormalizedAlgorithm,
-    HkdfParams,
+    CryptoAlgorithm, HkdfParams, KeyAlgorithm, KeyAlgorithmAndDerivatives, NormalizedAlgorithm,
 };
 
 /// <https://w3c.github.io/webcrypto/#hkdf-operations-derive-bits>

--- a/components/script/dom/webcrypto/subtlecrypto/hkdf_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/hkdf_operation.rs
@@ -15,12 +15,12 @@ use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, KeyAlgorithm, KeyAlgorithmAndDerivatives, NormalizedAlgorithm,
-    SubtleHkdfParams,
+    HkdfParams,
 };
 
 /// <https://w3c.github.io/webcrypto/#hkdf-operations-derive-bits>
 pub(crate) fn derive_bits(
-    normalized_algorithm: &SubtleHkdfParams,
+    normalized_algorithm: &HkdfParams,
     key: &CryptoKey,
     length: Option<u32>,
 ) -> Result<Vec<u8>, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/kangarootwelve_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/kangarootwelve_operation.rs
@@ -5,11 +5,11 @@
 use k12::{CustomRefKt128, CustomRefKt256, ExtendableOutput, Update};
 
 use crate::dom::bindings::error::Error;
-use crate::dom::subtlecrypto::{CryptoAlgorithm, SubtleKangarooTwelveParams};
+use crate::dom::subtlecrypto::{CryptoAlgorithm, KangarooTwelveParams};
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#kangarootwelve-operations-digest>
 pub(crate) fn digest(
-    normalized_algorithm: &SubtleKangarooTwelveParams,
+    normalized_algorithm: &KangarooTwelveParams,
     message: &[u8],
 ) -> Result<Vec<u8>, Error> {
     // Step 1. Let outputLength be the outputLength member of normalizedAlgorithm.

--- a/components/script/dom/webcrypto/subtlecrypto/ml_dsa_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ml_dsa_operation.rs
@@ -21,12 +21,12 @@ use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     Algorithm, CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithm,
-    KeyAlgorithmAndDerivatives, SubtleContextParams,
+    KeyAlgorithmAndDerivatives, ContextParams,
 };
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#ml-dsa-operations-sign>
 pub(crate) fn sign(
-    normalized_algorithm: &SubtleContextParams,
+    normalized_algorithm: &ContextParams,
     key: &CryptoKey,
     message: &[u8],
 ) -> Result<Vec<u8>, Error> {
@@ -98,7 +98,7 @@ pub(crate) fn sign(
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#ml-dsa-operations-verify>
 pub(crate) fn verify(
-    normalized_algorithm: &SubtleContextParams,
+    normalized_algorithm: &ContextParams,
     key: &CryptoKey,
     message: &[u8],
     signature: &[u8],

--- a/components/script/dom/webcrypto/subtlecrypto/ml_dsa_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ml_dsa_operation.rs
@@ -20,8 +20,8 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    Algorithm, CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithm,
-    KeyAlgorithmAndDerivatives, ContextParams,
+    Algorithm, ContextParams, CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField,
+    KeyAlgorithm, KeyAlgorithmAndDerivatives,
 };
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#ml-dsa-operations-sign>

--- a/components/script/dom/webcrypto/subtlecrypto/ml_kem_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ml_kem_operation.rs
@@ -20,8 +20,8 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    Algorithm, CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithm,
-    KeyAlgorithmAndDerivatives, EncapsulatedBits,
+    Algorithm, CryptoAlgorithm, EncapsulatedBits, ExportedKey, JsonWebKeyExt, JwkStringField,
+    KeyAlgorithm, KeyAlgorithmAndDerivatives,
 };
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#ml-kem-operations-encapsulate>

--- a/components/script/dom/webcrypto/subtlecrypto/ml_kem_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ml_kem_operation.rs
@@ -21,14 +21,14 @@ use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     Algorithm, CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithm,
-    KeyAlgorithmAndDerivatives, SubtleEncapsulatedBits,
+    KeyAlgorithmAndDerivatives, EncapsulatedBits,
 };
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#ml-kem-operations-encapsulate>
 pub(crate) fn encapsulate(
     normalized_algorithm: &Algorithm,
     key: &CryptoKey,
-) -> Result<SubtleEncapsulatedBits, Error> {
+) -> Result<EncapsulatedBits, Error> {
     // Step 1. If the [[type]] internal slot of key is not "public", then throw an
     // InvalidAccessError.
     if key.Type() != KeyType::Public {
@@ -87,7 +87,7 @@ pub(crate) fn encapsulate(
     // containing sharedKey.
     // Step 8. Set the ciphertext attribute of result to the result of creating an ArrayBuffer
     // containing ciphertext.
-    let result = SubtleEncapsulatedBits {
+    let result = EncapsulatedBits {
         shared_key: Some(shared_key.into()),
         ciphertext: Some(ciphertext),
     };

--- a/components/script/dom/webcrypto/subtlecrypto/pbkdf2_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/pbkdf2_operation.rs
@@ -15,12 +15,12 @@ use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, KeyAlgorithm, KeyAlgorithmAndDerivatives, NormalizedAlgorithm,
-    SubtlePbkdf2Params,
+    Pbkdf2Params,
 };
 
 /// <https://w3c.github.io/webcrypto/#pbkdf2-operations-derive-bits>
 pub(crate) fn derive_bits(
-    normalized_algorithm: &SubtlePbkdf2Params,
+    normalized_algorithm: &Pbkdf2Params,
     key: &CryptoKey,
     length: Option<u32>,
 ) -> Result<Vec<u8>, Error> {

--- a/components/script/dom/webcrypto/subtlecrypto/pbkdf2_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/pbkdf2_operation.rs
@@ -14,8 +14,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::cryptokey::{CryptoKey, Handle, KeyUsageVecHelper};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    CryptoAlgorithm, KeyAlgorithm, KeyAlgorithmAndDerivatives, NormalizedAlgorithm,
-    Pbkdf2Params,
+    CryptoAlgorithm, KeyAlgorithm, KeyAlgorithmAndDerivatives, NormalizedAlgorithm, Pbkdf2Params,
 };
 
 /// <https://w3c.github.io/webcrypto/#pbkdf2-operations-derive-bits>

--- a/components/script/dom/webcrypto/subtlecrypto/turboshake_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/turboshake_operation.rs
@@ -6,11 +6,11 @@ use keccak::{Keccak, State1600};
 use sponge_cursor::SpongeCursor;
 
 use crate::dom::bindings::error::Error;
-use crate::dom::subtlecrypto::{CryptoAlgorithm, SubtleTurboShakeParams};
+use crate::dom::subtlecrypto::{CryptoAlgorithm, TurboShakeParams};
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#turboshake-operations-digest>
 pub(crate) fn digest(
-    normalized_algorithm: &SubtleTurboShakeParams,
+    normalized_algorithm: &TurboShakeParams,
     message: &[u8],
 ) -> Result<Vec<u8>, Error> {
     // Step 1. Let outputLength be the outputLength member of normalizedAlgorithm.


### PR DESCRIPTION
Rename the following structs:

`SubtleHkdfParams` to `HkdfParams`
`SubtlePbkdf2Params` to `Pbkdf2Params`
`SubtleContextParams` to `ContextParams`
`SubtleAeadParams` to `AeadParams`
`SubtleCShakeParams` to `CShakeParams`
`SubtleTurboShakeParams` to `TurboShakeParams`
`SubtleKangarooTwelveParams` to `KangarooTwelveParams`
`SubtleArgon2Params` to `Argon2Params`
`SubtleEncapsulatedKey` to `EncapsulatedKey`
`SubtleEncapsulatedBits` to `EncapsulatedBits`

This is part of #46948 in order to replace the generated binding types with custom binding types for WebCrypto.

Testing: It compiles.
Part-of: #46948