### PR TITLE
script: Update `JSPrincipals` in `Window` when `Origin` is replaced

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -1092,6 +1092,7 @@ impl Document {
     /// TODO: Remove this when we create documents after processing headers
     pub(crate) fn mark_as_internal(&self) {
         *self.origin.borrow_mut() = MutableOrigin::new(ImmutableOrigin::new_opaque());
+        self.window().update_jsprincipals_from_document(self);
     }
 
     pub(crate) fn set_protocol_handler_automation_mode(&self, mode: CustomHandlersAutomationMode) {

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -36,7 +36,10 @@ use fonts::{
 use js::context::{JSContext, NoGC};
 use js::conversions::ToJSValConvertible;
 use js::glue::DumpJSStack;
-use js::jsapi::{GCReason, Heap, JSContext as RawJSContext, JSObject, JSPROP_ENUMERATE};
+use js::jsapi::{
+    GCReason, GetObjectRealmOrNull, Heap, JSContext as RawJSContext, JSObject, JSPROP_ENUMERATE,
+    SetRealmPrincipals,
+};
 use js::jsval::{NullValue, UndefinedValue};
 use js::realm::{AutoRealm, CurrentRealm};
 use js::rust::wrappers2::{JS_DefineProperty, JS_GC};
@@ -71,6 +74,7 @@ use script_bindings::codegen::GenericBindings::WindowBinding::ScrollToOptions;
 use script_bindings::dom::UnrootedDom;
 use script_bindings::interfaces::{HasOrigin, WindowHelpers};
 use script_bindings::like::Setlike;
+use script_bindings::principals::ServoJSPrincipals;
 use script_bindings::reflector::DomObject;
 use script_bindings::root::Root;
 use script_traits::{ConstellationInputEvent, ScriptThreadMessage};
@@ -3310,6 +3314,20 @@ impl Window {
         );
         assert!(document.window() == self);
         self.document.set(Some(document));
+        self.update_jsprincipals_from_document(document);
+    }
+
+    /// The `JSPrincipals` object inside a [`Window`] stores a mutable origin used for
+    /// same-origin checks within SpiderMonkey. When the entire origin of a [`Window`]'s
+    /// [`Document`] object is replaced or the [`Document`] object itself is replaced with a
+    /// [`Document`] with a different origin, the `JSPrincipals` stored inside the [`Window`]
+    /// also needs to change. This ensures that same origin checks are done against the correct
+    /// origin.
+    #[expect(unsafe_code)]
+    pub(crate) fn update_jsprincipals_from_document(&self, document: &Document) {
+        let realm = unsafe { GetObjectRealmOrNull(self.reflector().get_jsobject().get()) };
+        let new_principals = ServoJSPrincipals::new::<crate::DomTypeHolder>(&document.origin());
+        unsafe { SetRealmPrincipals(realm, new_principals.as_raw()) };
     }
 
     pub(crate) fn load_data_for_document(

--- a/components/script_bindings/principals.rs
+++ b/components/script_bindings/principals.rs
@@ -20,6 +20,9 @@ use crate::interfaces::DomHelpers;
 pub struct ServoJSPrincipals(NonNull<JSPrincipals>);
 
 impl ServoJSPrincipals {
+    /// Crate a new [`ServoJSPrincipals`] with the given [`MutableOrigin`]. Note that the
+    /// resulting value will hold a **shared** mutable reference to `origin`, so any changes to
+    /// `origin`'s `host` will be reflected in the return value's internal state.
     pub fn new<D: DomTypes>(origin: &MutableOrigin) -> Self {
         unsafe {
             let private: Box<MutableOrigin> = Box::new(origin.clone());

--- a/tests/wpt/meta/html/browsers/history/the-location-interface/location-prototype-setting-cross-origin-domain.sub.html.ini
+++ b/tests/wpt/meta/html/browsers/history/the-location-interface/location-prototype-setting-cross-origin-domain.sub.html.ini
@@ -1,9 +1,3 @@
 [location-prototype-setting-cross-origin-domain.sub.html]
-  [Cross-origin via document.domain: the prototype is null]
-    expected: FAIL
-
-  [Cross-origin via document.domain: setting the prototype to an empty object via __proto__ should throw a "SecurityError" DOMException]
-    expected: FAIL
-
   [Cross-origin via document.domain: setting the prototype to its original value via __proto__ should throw a "SecurityError" since it ends up in CrossOriginGetOwnProperty]
     expected: FAIL

--- a/tests/wpt/meta/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-no-child-yes-same.sub.https.html.ini
+++ b/tests/wpt/meta/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-no-child-yes-same.sub.https.html.ini
@@ -4,6 +4,3 @@
 
   [child: originAgentCluster must equal false]
     expected: FAIL
-
-  [setting document.domain must give sync access]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-yes-child-no-same.sub.https.html.ini
+++ b/tests/wpt/meta/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-yes-child-no-same.sub.https.html.ini
@@ -4,6 +4,3 @@
 
   [parent: originAgentCluster must equal true]
     expected: FAIL
-
-  [setting document.domain must give sync access]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-yes-child-yes-same.sub.https.html.ini
+++ b/tests/wpt/meta/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-yes-child-yes-same.sub.https.html.ini
@@ -4,6 +4,3 @@
 
   [parent: originAgentCluster must equal true]
     expected: FAIL
-
-  [setting document.domain must give sync access]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-no-1-no-same-2-yes-port.sub.https.html.ini
+++ b/tests/wpt/meta/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-no-1-no-same-2-yes-port.sub.https.html.ini
@@ -16,7 +16,3 @@
 
   [After: parent to child: setting document.domain must not give sync access]
     expected: FAIL
-
-  [Before: parent to child: setting document.domain must give sync access]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-no-1-no-same-2-yes-subdomain.sub.https.html.ini
+++ b/tests/wpt/meta/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-no-1-no-same-2-yes-subdomain.sub.https.html.ini
@@ -16,7 +16,3 @@
 
   [After: parent to child: setting document.domain must not give sync access]
     expected: FAIL
-
-  [Before: parent to child: setting document.domain must give sync access]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-yes-1-no-same-2-no-port.sub.https.html.ini
+++ b/tests/wpt/meta/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-yes-1-no-same-2-no-port.sub.https.html.ini
@@ -16,7 +16,3 @@
 
   [After: parent to child: setting document.domain must not give sync access]
     expected: FAIL
-
-  [Before: parent to child: setting document.domain must give sync access]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-yes-1-no-same-2-no-subdomain.sub.https.html.ini
+++ b/tests/wpt/meta/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-yes-1-no-same-2-no-subdomain.sub.https.html.ini
@@ -16,7 +16,3 @@
 
   [After: parent to child: setting document.domain must not give sync access]
     expected: FAIL
-
-  [Before: parent to child: setting document.domain must give sync access]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-no-openee-yes-same.sub.https.html.ini
+++ b/tests/wpt/meta/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-no-openee-yes-same.sub.https.html.ini
@@ -7,6 +7,3 @@
 
   [openee: originAgentCluster must equal false]
     expected: FAIL
-
-  [setting document.domain must give sync access]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-yes-openee-no-same.sub.https.html.ini
+++ b/tests/wpt/meta/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-yes-openee-no-same.sub.https.html.ini
@@ -7,6 +7,3 @@
 
   [openee: originAgentCluster must equal true]
     expected: FAIL
-
-  [setting document.domain must give sync access]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-yes-openee-yes-same.sub.https.html.ini
+++ b/tests/wpt/meta/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-yes-openee-yes-same.sub.https.html.ini
@@ -7,6 +7,3 @@
 
   [openee: originAgentCluster must equal true]
     expected: FAIL
-
-  [setting document.domain must give sync access]
-    expected: FAIL

--- a/tests/wpt/mozilla/meta/mozilla/cross-origin-objects/security-check.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/cross-origin-objects/security-check.html.ini
@@ -13,6 +13,3 @@
 
   [`this` is cross-site, `this`'s class is cross-origin, `this` provides a cross-origin callable operation of that name, `this` implements the operation]
     expected: FAIL
-
-  [`this` is same-origin + document.domain, `this`'s class is cross-origin, `this` doesn't provide a cross-origin callable operation of that name, `this` implements the operation]
-    expected: FAIL


### PR DESCRIPTION
The `JSPrincipals` stored in the `Window` object is used for same-origin
checks in `is_platform_object_same_value`. When created it holds a
shared mutable cell with the `Document`'s origin. Yet, there are two
places in Servo where the `Origin` associated with a `Window` change
entirely (meaning the shared cell underneath it changes):

1. During Document replacement
2. When a Document is marked as internal

For same-origin checks to process properly, the shared cell stored in
the `Window` needs to reflect the one in the `Document`. This change
makes it so that the `JSPrincipals` is updated at those moments.

Testing: This change causes a bunch of WPT subtests to start passing.
Fixes: #47436.
