### PR TITLE
script: Remove last mentions of `_and_cx`

### DIFF
--- a/components/script/dom/animations/animation.rs
+++ b/components/script/dom/animations/animation.rs
@@ -40,7 +40,7 @@ impl Animation {
         }
     }
 
-    fn new_with_proto_and_cx(
+    fn new_with_proto(
         cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
@@ -49,7 +49,7 @@ impl Animation {
     }
 
     pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<Self> {
-        Self::new_with_proto_and_cx(cx, global, None)
+        Self::new_with_proto(cx, global, None)
     }
 
     /// <https://drafts.csswg.org/web-animations-1/#animation-set-the-timeline-of-an-animation>

--- a/components/script/dom/animations/keyframeeffect.rs
+++ b/components/script/dom/animations/keyframeeffect.rs
@@ -79,7 +79,7 @@ impl KeyframeEffect {
         }
     }
 
-    fn new_with_proto_and_cx(
+    fn new_with_proto(
         cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
@@ -88,7 +88,7 @@ impl KeyframeEffect {
     }
 
     pub(crate) fn new(cx: &mut JSContext, window: &Window) -> DomRoot<Self> {
-        Self::new_with_proto_and_cx(cx, window, None)
+        Self::new_with_proto(cx, window, None)
     }
 }
 


### PR DESCRIPTION
While all reflect versions of `_and_cx` were already removed, there were two remaining specific functions in two structs.

Testing: it compiles