### PR TITLE
script: Implement insertLineBreak command

### DIFF
--- a/components/script/dom/execcommand/basecommand.rs
+++ b/components/script/dom/execcommand/basecommand.rs
@@ -33,6 +33,7 @@ use crate::dom::execcommand::commands::hilitecolor::execute_hilitecolor_command;
 use crate::dom::execcommand::commands::indent::execute_indent_command;
 use crate::dom::execcommand::commands::inserthorizontalrule::execute_insert_horizontal_rule_command;
 use crate::dom::execcommand::commands::insertimage::execute_insert_image_command;
+use crate::dom::execcommand::commands::insertlinebreak::execute_insert_line_break_command;
 use crate::dom::execcommand::commands::insertparagraph::execute_insert_paragraph_command;
 use crate::dom::execcommand::commands::inserttext::execute_insert_text_command;
 use crate::dom::execcommand::commands::italic::execute_italic_command;
@@ -753,6 +754,9 @@ impl CommandName {
             },
             CommandName::InsertImage => {
                 execute_insert_image_command(cx, document, selection, value)
+            },
+            CommandName::InsertLineBreak => {
+                execute_insert_line_break_command(cx, document, selection)
             },
             CommandName::InsertParagraph => {
                 execute_insert_paragraph_command(cx, document, selection)

--- a/components/script/dom/execcommand/commands/inserthorizontalrule.rs
+++ b/components/script/dom/execcommand/commands/inserthorizontalrule.rs
@@ -124,7 +124,7 @@ pub(crate) fn execute_insert_horizontal_rule_command(
     // Step 11. Run insertNode(hr) on the active range.
     let hr_node = DomRoot::upcast(hr);
     if active_range.InsertNode(cx, &hr_node).is_err() {
-        unreachable!("The image should always be insertable.");
+        unreachable!("The node should always be insertable.");
     }
 
     // Step 12. Fix disallowed ancestors of hr.

--- a/components/script/dom/execcommand/commands/insertlinebreak.rs
+++ b/components/script/dom/execcommand/commands/insertlinebreak.rs
@@ -44,8 +44,8 @@ pub(crate) fn execute_insert_line_break_command(
     //         it, return true.
     if active_range.start_container().is::<Element>() &&
         !is_allowed_child(
-            NodeOrString::Node(active_range.start_container()),
             NodeOrString::String("br".to_owned()),
+            NodeOrString::Node(active_range.start_container()),
         )
     {
         return false;
@@ -55,13 +55,13 @@ pub(crate) fn execute_insert_line_break_command(
     //         of the active range's start node's parent, return true.
     if !active_range.start_container().is::<Element>() &&
         !is_allowed_child(
+            NodeOrString::String("br".to_owned()),
             NodeOrString::Node(
                 active_range
                     .start_container()
                     .GetParentNode()
                     .expect("Must always have a parent."),
             ),
-            NodeOrString::String("br".to_owned()),
         )
     {
         return false;

--- a/components/script/dom/execcommand/commands/insertlinebreak.rs
+++ b/components/script/dom/execcommand/commands/insertlinebreak.rs
@@ -110,7 +110,7 @@ pub(crate) fn execute_insert_line_break_command(
     }
 
     // Step 7. Let br be the result of calling createElement("br") on the context object.
-    let br = document.create_element(cx, "hr");
+    let br = document.create_element(cx, "br");
 
     // Step 8. Call insertNode(br) on the active range.
     let br_node = DomRoot::upcast(br);

--- a/components/script/dom/execcommand/commands/insertlinebreak.rs
+++ b/components/script/dom/execcommand/commands/insertlinebreak.rs
@@ -1,0 +1,136 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use js::context::JSContext;
+use script_bindings::codegen::GenericBindings::NodeBinding::NodeMethods;
+use script_bindings::codegen::GenericBindings::RangeBinding::RangeMethods;
+use script_bindings::codegen::GenericBindings::SelectionBinding::SelectionMethods;
+use script_bindings::inheritance::Castable;
+
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::document::Document;
+use crate::dom::element::Element;
+use crate::dom::execcommand::contenteditable::node::{NodeOrString, is_allowed_child};
+use crate::dom::execcommand::contenteditable::selection::SelectionDeletionStripWrappers;
+use crate::dom::selection::Selection;
+use crate::dom::text::Text;
+
+/// <https://w3c.github.io/editing/docs/execCommand/#the-insertlinebreak-command>
+pub(crate) fn execute_insert_line_break_command(
+    cx: &mut JSContext,
+    document: &Document,
+    selection: &Selection,
+) -> bool {
+    // Step 1. Delete the selection, with strip wrappers false.
+    selection.delete_the_selection(
+        cx,
+        document,
+        Default::default(),
+        SelectionDeletionStripWrappers::NoStrip,
+        Default::default(),
+    );
+
+    // Step 2. If the active range's start node is neither editable nor an editing host, return
+    //         true.
+    let mut active_range = selection
+        .active_range(cx)
+        .expect("Must always have an active range.");
+    if !active_range.start_container().is_editable_or_editing_host() {
+        return true;
+    }
+
+    // Step 3. If the active range's start node is an Element, and "br" is not an allowed child of
+    //         it, return true.
+    if active_range.start_container().is::<Element>() &&
+        !is_allowed_child(
+            NodeOrString::Node(active_range.start_container()),
+            NodeOrString::String("br".to_owned()),
+        )
+    {
+        return false;
+    }
+
+    // Step 4. If the active range's start node is not an Element, and "br" is not an allowed child
+    //         of the active range's start node's parent, return true.
+    if !active_range.start_container().is::<Element>() &&
+        !is_allowed_child(
+            NodeOrString::Node(
+                active_range
+                    .start_container()
+                    .GetParentNode()
+                    .expect("Must always have a parent."),
+            ),
+            NodeOrString::String("br".to_owned()),
+        )
+    {
+        return false;
+    }
+
+    // Step 5. If the active range's start node is a Text node and its start offset is zero, call
+    //         collapse() on the context object's selection, with first argument equal to the
+    //         active range's start node's parent and second argument equal to the active range's
+    //         start node's index.
+    if active_range.start_container().is::<Text>() && active_range.start_offset() == 0 {
+        if selection
+            .Collapse(
+                cx,
+                active_range.start_container().GetParentNode().as_deref(),
+                active_range.start_container().index(),
+            )
+            .is_err()
+        {
+            unreachable!("Should always be able to collapse the selection.");
+        }
+        active_range = selection
+            .active_range(cx)
+            .expect("Must always have an active range");
+    }
+
+    // Step 6. If the active range's start node is a Text node and its start offset is the length
+    //         of its start node, call collapse() on the context object's selection, with first
+    //         argument equal to the active range's start node's parent and second argument equal
+    //         to one plus the active range's start node's index.
+    if active_range.start_container().is::<Text>() &&
+        active_range.start_offset() == active_range.start_container().len()
+    {
+        if selection
+            .Collapse(
+                cx,
+                active_range.start_container().GetParentNode().as_deref(),
+                1 + active_range.start_container().index(),
+            )
+            .is_err()
+        {
+            unreachable!("Should always be able to collapse the selection.");
+        }
+        active_range = selection
+            .active_range(cx)
+            .expect("Must always have an active range");
+    }
+
+    // Step 7. Let br be the result of calling createElement("br") on the context object.
+    let br = document.create_element(cx, "hr");
+
+    // Step 8. Call insertNode(br) on the active range.
+    let br_node = DomRoot::upcast(br);
+    if active_range.InsertNode(cx, &br_node).is_err() {
+        unreachable!("The node should always be insertable.");
+    }
+
+    // Step 9. Call collapse() on the context object's selection, with br's parent as the first
+    //         argument and one plus br's index as the second argument.
+    if selection
+        .Collapse(cx, br_node.GetParentNode().as_deref(), 1 + br_node.index())
+        .is_err()
+    {
+        unreachable!("Should always be able to collapse the selection.");
+    }
+
+    // Step 10. If br is a collapsed line break, call createElement("br") on the context object and
+    //          let extra br be the result, then call insertNode(extra br) on the active range.
+    // TODO: Implement this.
+
+    // Step 11. Return true.
+    true
+}

--- a/components/script/dom/execcommand/commands/mod.rs
+++ b/components/script/dom/execcommand/commands/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod hilitecolor;
 pub(crate) mod indent;
 pub(crate) mod inserthorizontalrule;
 pub(crate) mod insertimage;
+pub(crate) mod insertlinebreak;
 pub(crate) mod insertparagraph;
 pub(crate) mod inserttext;
 pub(crate) mod italic;

--- a/components/script/dom/execcommand/execcommands.rs
+++ b/components/script/dom/execcommand/execcommands.rs
@@ -164,6 +164,7 @@ impl Document {
             "indent" => CommandName::Indent,
             "inserthorizontalrule" => CommandName::InsertHorizontalRule,
             "insertimage" => CommandName::InsertImage,
+            "insertlinebreak" => CommandName::InsertLineBreak,
             "insertparagraph" => CommandName::InsertParagraph,
             "inserttext" => CommandName::InsertText,
             "italic" => CommandName::Italic,

--- a/tests/wpt/meta/editing/event.html.ini
+++ b/tests/wpt/meta/editing/event.html.ini
@@ -62,12 +62,6 @@
   [Command insertImage, value "": input event]
     expected: FAIL
 
-  [Command insertLineBreak, value "": input event]
-    expected: FAIL
-
-  [Command insertLineBreak, value "quasit": input event]
-    expected: FAIL
-
   [Command insertOrderedList, value "": input event]
     expected: FAIL
 

--- a/tests/wpt/meta/editing/other/editing-div-outside-body.html.ini
+++ b/tests/wpt/meta/editing/other/editing-div-outside-body.html.ini
@@ -1,38 +1,23 @@
 [editing-div-outside-body.html?nothing]
-  [Test for execCommand("insertLineBreak", false, undefined) in "<div>ab[\]c</div>"]
-    expected: FAIL
-
   [Test for execCommand("insertHTML", false, "<hr>") in "<div>a[b\]c</div>"]
     expected: FAIL
 
 
 [editing-div-outside-body.html?html]
-  [Test for execCommand("insertLineBreak", false, undefined) in "<div>ab[\]c</div>"]
-    expected: FAIL
-
   [Test for execCommand("insertHTML", false, "<hr>") in "<div>a[b\]c</div>"]
     expected: FAIL
 
 
 [editing-div-outside-body.html?body]
-  [Test for execCommand("insertLineBreak", false, undefined) in "<div>ab[\]c</div>"]
-    expected: FAIL
-
   [Test for execCommand("insertHTML", false, "<hr>") in "<div>a[b\]c</div>"]
     expected: FAIL
 
 
 [editing-div-outside-body.html?designMode]
-  [Test for execCommand("insertLineBreak", false, undefined) in "<div>ab[\]c</div>"]
-    expected: FAIL
-
   [Test for execCommand("insertHTML", false, "<hr>") in "<div>a[b\]c</div>"]
     expected: FAIL
 
 
 [editing-div-outside-body.html?div-in-body]
-  [Test for execCommand("insertLineBreak", false, undefined) in "<div>ab[\]c</div>"]
-    expected: FAIL
-
   [Test for execCommand("insertHTML", false, "<hr>") in "<div>a[b\]c</div>"]
     expected: FAIL

--- a/tests/wpt/meta/editing/other/exec-command-with-text-editor.tentative.html.ini
+++ b/tests/wpt/meta/editing/other/exec-command-with-text-editor.tentative.html.ini
@@ -92,9 +92,6 @@
   [In <input type="password">, execCommand("insertunorderedlist", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
-  [In <input type="password">, execCommand("insertlinebreak", false, null), a[b\]c): The command should be supported]
-    expected: FAIL
-
   [In <input type="password">, execCommand("formatblock", false, div), a[b\]c): The command should be supported]
     expected: FAIL
 
@@ -177,9 +174,6 @@
     expected: FAIL
 
   [In <input type="password"> in contenteditable, execCommand("insertunorderedlist", false, null), a[b\]c): The command should be supported]
-    expected: FAIL
-
-  [In <input type="password"> in contenteditable, execCommand("insertlinebreak", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <input type="password"> in contenteditable, execCommand("formatblock", false, div), a[b\]c): The command should be supported]
@@ -640,9 +634,6 @@
   [In <input type="text">, execCommand("insertunorderedlist", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
-  [In <input type="text">, execCommand("insertlinebreak", false, null), a[b\]c): The command should be supported]
-    expected: FAIL
-
   [In <input type="text">, execCommand("formatblock", false, div), a[b\]c): The command should be supported]
     expected: FAIL
 
@@ -725,9 +716,6 @@
     expected: FAIL
 
   [In <input type="text"> in contenteditable, execCommand("insertunorderedlist", false, null), a[b\]c): The command should be supported]
-    expected: FAIL
-
-  [In <input type="text"> in contenteditable, execCommand("insertlinebreak", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <input type="text"> in contenteditable, execCommand("formatblock", false, div), a[b\]c): The command should be supported]
@@ -1191,9 +1179,6 @@
   [In <textarea>, execCommand("insertparagraph", false, null), a[b\]c): The command should be enabled]
     expected: FAIL
 
-  [In <textarea>, execCommand("insertlinebreak", false, null), a[b\]c): The command should be supported]
-    expected: FAIL
-
   [In <textarea>, execCommand("insertlinebreak", false, null), a[b\]c): The command should be enabled]
     expected: FAIL
 
@@ -1279,9 +1264,6 @@
     expected: FAIL
 
   [In <textarea> in contenteditable, execCommand("insertunorderedlist", false, null), a[b\]c): The command should be supported]
-    expected: FAIL
-
-  [In <textarea> in contenteditable, execCommand("insertlinebreak", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <textarea> in contenteditable, execCommand("insertlinebreak", false, null), a[b\]c): The command should be enabled]
@@ -1675,4 +1657,28 @@
     expected: FAIL
 
   [In <textarea> in contenteditable, execCommand("indent", false, null), a[b\]c): input.target should be undefined]
+    expected: FAIL
+
+  [In <textarea>, execCommand("insertlinebreak", false, null), a[b\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <textarea>, execCommand("insertlinebreak", false, null), a[b\]c): <textarea>.value should be "a\n[\]c"]
+    expected: FAIL
+
+  [In <textarea>, execCommand("insertlinebreak", false, null), a[b\]c): input.inputType should be insertLineBreak]
+    expected: FAIL
+
+  [In <textarea>, execCommand("insertlinebreak", false, null), a[b\]c): input.target should be [object HTMLTextAreaElement\]]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("insertlinebreak", false, null), a[b\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("insertlinebreak", false, null), a[b\]c): <textarea>.value should be "a\n[\]c"]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("insertlinebreak", false, null), a[b\]c): input.inputType should be insertLineBreak]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("insertlinebreak", false, null), a[b\]c): input.target should be [object HTMLTextAreaElement\]]
     expected: FAIL

--- a/tests/wpt/meta/editing/other/restoration.html.ini
+++ b/tests/wpt/meta/editing/other/restoration.html.ini
@@ -1,10 +1,4 @@
 [restoration.html]
-  [insertlinebreak  starting bold]
-    expected: FAIL
-
-  [insertlinebreak  starting not bold]
-    expected: FAIL
-
   [insertorderedlist  starting bold]
     expected: FAIL
 

--- a/tests/wpt/meta/editing/plaintext-only/insertLineBreak.html.ini
+++ b/tests/wpt/meta/editing/plaintext-only/insertLineBreak.html.ini
@@ -5,18 +5,6 @@
   [execCommand("insertLineBreak") when <p>{}<br></p>]
     expected: FAIL
 
-  [execCommand("insertLineBreak") when <p style="white-space:normal">A[\]B</p>]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <p style="white-space:pre">A[\]B</p>]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <p style="white-space:pre-line">A[\]B</p>]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <p style="white-space:pre-wrap">A[\]B</p>]
-    expected: FAIL
-
   [execCommand("insertLineBreak") when <ul><li>[\]AB</li></ul>]
     expected: FAIL
 
@@ -316,64 +304,16 @@
 
 
 [insertLineBreak.html?white-space=normal]
-  [execCommand("insertLineBreak") when A[\]B]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <p>{}<br></p>]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <p style="white-space:normal">A[\]B</p>]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <p style="white-space:pre">A[\]B</p>]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <p style="white-space:pre-line">A[\]B</p>]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <p style="white-space:pre-wrap">A[\]B</p>]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <ul><li>[\]AB</li></ul>]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <ul><li>A[\]B</li></ul>]
-    expected: FAIL
-
   [execCommand("insertLineBreak") when <ul><li>AB[\]</li></ul>]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <dl><dt>[\]AB</dt></dl>]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <dl><dt>A[\]B</dt></dl>]
     expected: FAIL
 
   [execCommand("insertLineBreak") when <dl><dt>AB[\]</dt></dl>]
     expected: FAIL
 
-  [execCommand("insertLineBreak") when <dl><dd>[\]AB</dd></dl>]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <dl><dd>A[\]B</dd></dl>]
-    expected: FAIL
-
   [execCommand("insertLineBreak") when <dl><dd>AB[\]</dd></dl>]
     expected: FAIL
 
-  [execCommand("insertLineBreak") when <table><tbody><tr><td>[\]AB</td></tr></tbody></table>]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <table><tbody><tr><td>A[\]B</td></tr></tbody></table>]
-    expected: FAIL
-
   [execCommand("insertLineBreak") when <table><tbody><tr><td>AB[\]</td></tr></tbody></table>]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <h1>[\]AB</h1>]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <h1>A[\]B</h1>]
     expected: FAIL
 
   [execCommand("insertLineBreak") when <h1>AB[\]</h1>]
@@ -637,18 +577,6 @@
     expected: FAIL
 
   [execCommand("insertLineBreak") when <p>{}<br></p>]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <p style="white-space:normal">A[\]B</p>]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <p style="white-space:pre">A[\]B</p>]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <p style="white-space:pre-line">A[\]B</p>]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <p style="white-space:pre-wrap">A[\]B</p>]
     expected: FAIL
 
   [execCommand("insertLineBreak") when <ul><li>[\]AB</li></ul>]
@@ -954,18 +882,6 @@
     expected: FAIL
 
   [execCommand("insertLineBreak") when <p>{}<br></p>]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <p style="white-space:normal">A[\]B</p>]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <p style="white-space:pre">A[\]B</p>]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <p style="white-space:pre-line">A[\]B</p>]
-    expected: FAIL
-
-  [execCommand("insertLineBreak") when <p style="white-space:pre-wrap">A[\]B</p>]
     expected: FAIL
 
   [execCommand("insertLineBreak") when <ul><li>[\]AB</li></ul>]

--- a/tests/wpt/meta/editing/plaintext-only/insertText.html.ini
+++ b/tests/wpt/meta/editing/plaintext-only/insertText.html.ini
@@ -62,19 +62,10 @@
   [Typing "a" when <p><b>[AB\]</b></p> and execCommand("insertParagraph")]
     expected: FAIL
 
-  [execCommand("insertText", false, "a") when <p><b>[\]AB</b></p> and execCommand("insertLineBreak")]
-    expected: FAIL
-
   [Typing "a" when <p><b>[\]AB</b></p> and execCommand("insertLineBreak")]
     expected: FAIL
 
-  [execCommand("insertText", false, "a") when <p><b>A[\]B</b></p> and execCommand("insertLineBreak")]
-    expected: FAIL
-
   [Typing "a" when <p><b>A[\]B</b></p> and execCommand("insertLineBreak")]
-    expected: FAIL
-
-  [execCommand("insertText", false, "a") when <p><b>AB[\]</b></p> and execCommand("insertLineBreak")]
     expected: FAIL
 
   [Typing "a" when <p><b>AB[\]</b></p> and execCommand("insertLineBreak")]

--- a/tests/wpt/meta/editing/run/insertlinebreak.html.ini
+++ b/tests/wpt/meta/editing/run/insertlinebreak.html.ini
@@ -1,35 +1,11 @@
 [insertlinebreak.html?1001-last]
-  [[["stylewithcss","true"\],["insertlinebreak",""\]\] "<p>[foo<span style=color:#aBcDeF>bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["insertlinebreak",""\]\] "<p>[foo<span style=color:#aBcDeF>bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["insertlinebreak",""\]\] "<p>{foo<span style=color:#aBcDeF>bar}</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["insertlinebreak",""\]\] "<p>{foo<span style=color:#aBcDeF>bar}</span>baz" compare innerHTML]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span>baz\]" compare innerHTML]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<p>foo<span style=color:#aBcDeF>{bar</span>baz}" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["insertlinebreak",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span><span style=color:#fEdCbA>baz\]</span>quz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["insertlinebreak",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span><span style=color:#fEdCbA>baz\]</span>quz" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ul contenteditable><li>{}<br></ul>" compare innerHTML]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<ul contenteditable><li>foo[\]</ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div contenteditable=false><ul contenteditable><li>{}<br></ul></div>" compare innerHTML]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div contenteditable=false><ul contenteditable><li>foo[\]</ul></div>" compare innerHTML]
@@ -71,78 +47,6 @@
   [[["insertlinebreak",""\]\] "<div><div>foo[\]</div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<address><p>[\]foo</address>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dt><p>[\]foo</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dd><p>[\]foo</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ol><li><p>[\]foo</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ul><li><p>[\]foo</ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<address><div>[\]foo</address>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dt><div>[\]foo</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dd><div>[\]foo</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ol><li><div>[\]foo</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ul><li><div>[\]foo</ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div><p>[\]foo</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div><div>[\]foo</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<address><p>foo[\]bar</address>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dt><p>foo[\]bar</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dd><p>foo[\]bar</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ol><li><p>foo[\]bar</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ul><li><p>foo[\]bar</ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<address><div>foo[\]bar</address>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dt><div>foo[\]bar</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dd><div>foo[\]bar</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ol><li><div>foo[\]bar</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ul><li><div>foo[\]bar</ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div><p>foo[\]bar</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div><div>foo[\]bar</div>" compare innerHTML]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<ol><li class=a id=x><p class=b id=y>foo[\]</ol>" compare innerHTML]
     expected: FAIL
 
@@ -152,52 +56,13 @@
   [[["insertlinebreak",""\]\] "<div class=a id=x><p class=b id=y>foo[\]</div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<ol><li class=a id=x><p class=b id=y>[\]foo</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div class=a id=x><div class=b id=y>[\]foo</div></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div class=a id=x><p class=b id=y>[\]foo</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ol><li class=a id=x><p class=b id=y>foo[\]bar</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div class=a id=x><div class=b id=y>foo[\]bar</div></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div class=a id=x><p class=b id=y>foo[\]bar</div>" compare innerHTML]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div>abc [\] </div>" compare innerHTML]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div>abc[\]  </div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div>[\] abc</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div>[\]  abc</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div> [\] abc</div>" compare innerHTML]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div>  [\]abc</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div style=display:flex><span>[\]abc</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div style=display:inline-flex><span>[\]abc</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div style=display:flex><span>a[\]bc</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div style=display:inline-flex><span>a[\]bc</span></div>" compare innerHTML]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div style=display:flex><span>abc[\]</span></div>" compare innerHTML]
@@ -222,18 +87,6 @@
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div style=display:inline-flex;white-space:pre><span>abc[\]</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div style=display:grid><span>[\]abc</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div style=display:inline-grid><span>[\]abc</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div style=display:grid><span>a[\]bc</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div style=display:inline-grid><span>a[\]bc</span></div>" compare innerHTML]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div style=display:grid><span>abc[\]</span></div>" compare innerHTML]
@@ -271,13 +124,7 @@
 
 
 [insertlinebreak.html?1-1000]
-  [[["insertlinebreak",""\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "fo[o<table><tr><td>b\]ar</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<table><tr><td>[foo<td>bar\]<tr><td>baz<td>quz</table>" compare innerHTML]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<tr><td>baz<td>quz</table>": execCommand("insertlinebreak", false, "") return value]
@@ -289,310 +136,52 @@
   [[["insertlinebreak",""\]\] "<table><tr><td>fo[o<td>b\]ar<td>baz</table>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "{<table><tr><td>foo</table>}" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<table><tr><td>[foo\]</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ol><li>[foo\]<li>bar</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ol><li>f[o\]o<li>bar</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "[\]foo" compare innerHTML]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "foo[\]" compare innerHTML]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<span>foo[\]</span>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "foo[\]<br>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<address>[\]foo</address>" compare innerHTML]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<address>foo[\]</address>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<address>foo[\]<br></address>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<address>foo[\]bar</address>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div>[\]foo</div>" compare innerHTML]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div>foo[\]</div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div>foo[\]<br></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div>foo[\]bar</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dt>[\]foo<dd>bar</dl>" compare innerHTML]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<dl><dt>foo[\]<dd>bar</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dt>foo[\]<br><dd>bar</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dt>foo[\]bar<dd>baz</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dt>foo<dd>[\]bar</dl>" compare innerHTML]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<dl><dt>foo<dd>bar[\]</dl>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<dl><dt>foo<dd>bar[\]<br></dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dt>foo<dd>bar[\]baz</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<h1>[\]foo</h1>" compare innerHTML]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<h1>foo[\]</h1>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<h1>foo[\]<br></h1>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<h1>foo[\]bar</h1>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ol><li>[\]foo</ol>" compare innerHTML]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<ol><li>foo[\]</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<ol><li>foo[\]<br></ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ol><li>foo[\]bar</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<p>[\]foo</p>" compare innerHTML]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<p>foo[\]</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<p>foo[\]<br></p>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<p>foo[\]bar</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<pre>[\]foo</pre>" compare innerHTML]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<pre>foo[\]</pre>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<pre>foo[\]<br></pre>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<pre>foo[\]bar</pre>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<pre>foo[\]<br><br></pre>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<pre>foo<br>{}<br></pre>" compare innerHTML]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<pre>foo&#10;[\]</pre>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<pre>foo[\]&#10;</pre>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<pre>foo&#10;[\]&#10;</pre>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<listing>foo[\]bar</listing>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ol><li>{}<br></li></ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "foo<ol><li>{}<br></li></ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ol><li>{}<br></li></ol>foo" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ol><li>foo<li>{}<br></ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ol><li>{}<br><li>bar</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ol><li>foo</li><ul><li>{}<br></ul></ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dt>{}<br></dt></dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dt>foo<dd>{}<br></dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dt>{}<br><dd>bar</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dt>foo<dd>bar<dl><dt>{}<br><dd>baz</dl></dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dt>foo<dd>bar<dl><dt>baz<dd>{}<br></dl></dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertlinebreak",""\]\] "<h1>foo[bar</h1><p>baz\]quz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertlinebreak",""\]\] "<h1>foo[bar</h1><p>baz\]quz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<p>foo[bar</p><h1>baz\]quz</h1>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<p>foo</p>{}<br>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "{}<br><p>foo</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<p>foo</p>{}<br><h1>bar</h1>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<h1>foo</h1>{}<br><p>bar</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<h1>foo</h1>{}<br><h2>bar</h2>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<p>foo</p><h1>[bar\]</h1><p>baz</p>" compare innerHTML]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<p>foo</p>{<h1>bar</h1>}<p>baz</p>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<table><tr><td>foo[\]bar</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<table><tr><td><p>foo[\]bar</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<blockquote>[\]foo</blockquote>" compare innerHTML]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<blockquote>foo[\]</blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<blockquote>foo[\]<br></blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<blockquote>foo[\]bar</blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<blockquote><p>[\]foo</blockquote>" compare innerHTML]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<blockquote><p>foo[\]</blockquote>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<blockquote><p>foo[\]bar</blockquote>" compare innerHTML]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<blockquote><p>foo[\]<p>bar</blockquote>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<blockquote><p>foo[\]bar<p>baz</blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<span>foo[\]bar</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<span>foo[\]bar</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<b>foo[\]bar</b>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<b>foo[\]bar</b>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<b>foo[\]</b>bar" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "foo<b>[\]bar</b>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<b>foo[\]</b><i>bar</i>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<b>foo</b>{}<i>bar</i>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<b id=x class=y>foo[\]bar</b>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<i><b>foo[\]bar</b>baz</i>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<p><b>foo[\]bar</b></p>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<p><b>[\]foo</b></p>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<p><b id=x class=y>foo[\]bar</b></p>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div><b>foo[\]bar</b></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<a href=foo>foo[\]bar</a>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<a href=foo>foo[\]bar</a>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<a href=foo>foo[\]</a>bar" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "foo<a href=foo>[\]bar</a>" compare innerHTML]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<p>foo[\]<!--bar-->" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<p><!--foo-->[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<p>foo<span style=color:#aBcDeF>[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<p>foo<span style=color:#aBcDeF>{bar}</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<p>foo{<span style=color:#aBcDeF>bar</span>}baz" compare innerHTML]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<xmp>foo[\]bar</xmp>": execCommand("insertlinebreak", false, "") return value]

--- a/tests/wpt/meta/editing/run/insertlinebreak.html.ini
+++ b/tests/wpt/meta/editing/run/insertlinebreak.html.ini
@@ -1,47 +1,23 @@
 [insertlinebreak.html?1001-last]
-  [[["stylewithcss","true"\],["insertlinebreak",""\]\] "<p>[foo<span style=color:#aBcDeF>bar\]</span>baz": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["insertlinebreak",""\]\] "<p>[foo<span style=color:#aBcDeF>bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["insertlinebreak",""\]\] "<p>[foo<span style=color:#aBcDeF>bar\]</span>baz": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["insertlinebreak",""\]\] "<p>[foo<span style=color:#aBcDeF>bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["insertlinebreak",""\]\] "<p>{foo<span style=color:#aBcDeF>bar}</span>baz": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["insertlinebreak",""\]\] "<p>{foo<span style=color:#aBcDeF>bar}</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["insertlinebreak",""\]\] "<p>{foo<span style=color:#aBcDeF>bar}</span>baz": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["insertlinebreak",""\]\] "<p>{foo<span style=color:#aBcDeF>bar}</span>baz" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span>baz\]": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<p>foo<span style=color:#aBcDeF>{bar</span>baz}": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<p>foo<span style=color:#aBcDeF>{bar</span>baz}" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["insertlinebreak",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span><span style=color:#fEdCbA>baz\]</span>quz": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["insertlinebreak",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span><span style=color:#fEdCbA>baz\]</span>quz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["insertlinebreak",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span><span style=color:#fEdCbA>baz\]</span>quz": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["insertlinebreak",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span><span style=color:#fEdCbA>baz\]</span>quz" compare innerHTML]
@@ -71,463 +47,232 @@
   [[["insertlinebreak",""\]\] "<div contenteditable=false><ul contenteditable><li>foo[\]</ul></div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<address><p>foo[\]</address>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<address><p>foo[\]</address>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dt><p>foo[\]</dl>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<dl><dt><p>foo[\]</dl>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<dl><dd><p>foo[\]</dl>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<dl><dd><p>foo[\]</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ol><li><p>foo[\]</ol>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<ol><li><p>foo[\]</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<ul><li><p>foo[\]</ul>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<ul><li><p>foo[\]</ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<address><div>foo[\]</address>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<address><div>foo[\]</address>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<dl><dt><div>foo[\]</dl>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<dl><dt><div>foo[\]</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dd><div>foo[\]</dl>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<dl><dd><div>foo[\]</dl>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<ol><li><div>foo[\]</ol>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<ol><li><div>foo[\]</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ul><li><div>foo[\]</ul>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<ul><li><div>foo[\]</ul>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div><p>foo[\]</div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div><p>foo[\]</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div><div>foo[\]</div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div><div>foo[\]</div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<address><p>[\]foo</address>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<address><p>[\]foo</address>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dt><p>[\]foo</dl>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<dl><dt><p>[\]foo</dl>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<dl><dd><p>[\]foo</dl>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<dl><dd><p>[\]foo</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ol><li><p>[\]foo</ol>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<ol><li><p>[\]foo</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<ul><li><p>[\]foo</ul>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<ul><li><p>[\]foo</ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<address><div>[\]foo</address>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<address><div>[\]foo</address>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<dl><dt><div>[\]foo</dl>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<dl><dt><div>[\]foo</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dd><div>[\]foo</dl>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<dl><dd><div>[\]foo</dl>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<ol><li><div>[\]foo</ol>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<ol><li><div>[\]foo</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ul><li><div>[\]foo</ul>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<ul><li><div>[\]foo</ul>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div><p>[\]foo</div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div><p>[\]foo</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div><div>[\]foo</div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div><div>[\]foo</div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<address><p>foo[\]bar</address>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<address><p>foo[\]bar</address>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dt><p>foo[\]bar</dl>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<dl><dt><p>foo[\]bar</dl>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<dl><dd><p>foo[\]bar</dl>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<dl><dd><p>foo[\]bar</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ol><li><p>foo[\]bar</ol>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<ol><li><p>foo[\]bar</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<ul><li><p>foo[\]bar</ul>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<ul><li><p>foo[\]bar</ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<address><div>foo[\]bar</address>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<address><div>foo[\]bar</address>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<dl><dt><div>foo[\]bar</dl>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<dl><dt><div>foo[\]bar</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dd><div>foo[\]bar</dl>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<dl><dd><div>foo[\]bar</dl>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<ol><li><div>foo[\]bar</ol>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<ol><li><div>foo[\]bar</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ul><li><div>foo[\]bar</ul>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<ul><li><div>foo[\]bar</ul>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div><p>foo[\]bar</div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div><p>foo[\]bar</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div><div>foo[\]bar</div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div><div>foo[\]bar</div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<ol><li class=a id=x><p class=b id=y>foo[\]</ol>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<ol><li class=a id=x><p class=b id=y>foo[\]</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div class=a id=x><div class=b id=y>foo[\]</div></div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div class=a id=x><div class=b id=y>foo[\]</div></div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div class=a id=x><p class=b id=y>foo[\]</div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div class=a id=x><p class=b id=y>foo[\]</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ol><li class=a id=x><p class=b id=y>[\]foo</ol>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<ol><li class=a id=x><p class=b id=y>[\]foo</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div class=a id=x><div class=b id=y>[\]foo</div></div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div class=a id=x><div class=b id=y>[\]foo</div></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div class=a id=x><p class=b id=y>[\]foo</div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div class=a id=x><p class=b id=y>[\]foo</div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<ol><li class=a id=x><p class=b id=y>foo[\]bar</ol>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<ol><li class=a id=x><p class=b id=y>foo[\]bar</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div class=a id=x><div class=b id=y>foo[\]bar</div></div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div class=a id=x><div class=b id=y>foo[\]bar</div></div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div class=a id=x><p class=b id=y>foo[\]bar</div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div class=a id=x><p class=b id=y>foo[\]bar</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div>abc [\] </div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div>abc [\] </div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div>abc[\]  </div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div>abc[\]  </div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div>[\] abc</div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div>[\] abc</div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div>[\]  abc</div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div>[\]  abc</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div> [\] abc</div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div> [\] abc</div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div>  [\]abc</div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div>  [\]abc</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div style=display:flex><span>[\]abc</span></div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div style=display:flex><span>[\]abc</span></div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div style=display:inline-flex><span>[\]abc</span></div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div style=display:inline-flex><span>[\]abc</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div style=display:flex><span>a[\]bc</span></div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div style=display:flex><span>a[\]bc</span></div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div style=display:inline-flex><span>a[\]bc</span></div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div style=display:inline-flex><span>a[\]bc</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div style=display:flex><span>abc[\]</span></div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div style=display:flex><span>abc[\]</span></div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div style=display:inline-flex><span>abc[\]</span></div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div style=display:inline-flex><span>abc[\]</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div style=display:flex;white-space:pre><span>[\]abc</span></div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div style=display:flex;white-space:pre><span>[\]abc</span></div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div style=display:inline-flex;white-space:pre><span>[\]abc</span></div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div style=display:inline-flex;white-space:pre><span>[\]abc</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div style=display:flex;white-space:pre><span>a[\]bc</span></div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div style=display:flex;white-space:pre><span>a[\]bc</span></div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div style=display:inline-flex;white-space:pre><span>a[\]bc</span></div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div style=display:inline-flex;white-space:pre><span>a[\]bc</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div style=display:flex;white-space:pre><span>abc[\]</span></div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div style=display:flex;white-space:pre><span>abc[\]</span></div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div style=display:inline-flex;white-space:pre><span>abc[\]</span></div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div style=display:inline-flex;white-space:pre><span>abc[\]</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div style=display:grid><span>[\]abc</span></div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div style=display:grid><span>[\]abc</span></div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div style=display:inline-grid><span>[\]abc</span></div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div style=display:inline-grid><span>[\]abc</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div style=display:grid><span>a[\]bc</span></div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div style=display:grid><span>a[\]bc</span></div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div style=display:inline-grid><span>a[\]bc</span></div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div style=display:inline-grid><span>a[\]bc</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div style=display:grid><span>abc[\]</span></div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div style=display:grid><span>abc[\]</span></div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div style=display:inline-grid><span>abc[\]</span></div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div style=display:inline-grid><span>abc[\]</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div style=display:grid;white-space:pre><span>[\]abc</span></div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div style=display:grid;white-space:pre><span>[\]abc</span></div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div style=display:inline-grid;white-space:pre><span>[\]abc</span></div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div style=display:inline-grid;white-space:pre><span>[\]abc</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div style=display:grid;white-space:pre><span>a[\]bc</span></div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div style=display:grid;white-space:pre><span>a[\]bc</span></div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div style=display:inline-grid;white-space:pre><span>a[\]bc</span></div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div style=display:inline-grid;white-space:pre><span>a[\]bc</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div style=display:grid;white-space:pre><span>abc[\]</span></div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div style=display:grid;white-space:pre><span>abc[\]</span></div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div style=display:inline-grid;white-space:pre><span>abc[\]</span></div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div style=display:inline-grid;white-space:pre><span>abc[\]</span></div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] " <span contenteditable=\\"false\\">A</span>[\] ; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span> ": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] " <span contenteditable=\\"false\\">A</span>[\] ; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span> " compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] " <span contenteditable=\\"false\\">A</span><br>[\]&nbsp;; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span> ": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] " <span contenteditable=\\"false\\">A</span><br>[\]&nbsp;; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span> " compare innerHTML]
@@ -538,13 +283,7 @@
 
 
 [insertlinebreak.html?1-1000]
-  [[["insertlinebreak",""\]\] "foo[bar\]baz": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "fo[o<table><tr><td>b\]ar</table>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "fo[o<table><tr><td>b\]ar</table>" compare innerHTML]
@@ -559,9 +298,6 @@
   [[["insertlinebreak",""\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<tr><td>baz<td>quz</table>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<tr><td>baz<td>quz</table>" compare innerHTML]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<table><tr><td>fo[o</table>b\]ar": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
@@ -572,9 +308,6 @@
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<table><tr><td>fo[o<td>b\]ar<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "{<table><tr><td>foo</table>}": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "{<table><tr><td>foo</table>}" compare innerHTML]
@@ -598,79 +331,40 @@
   [[["insertlinebreak",""\]\] "<ol><li>f[o\]o<li>bar</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "[\]foo": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "[\]foo" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "foo[\]": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "foo[\]" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<span>foo[\]</span>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<span>foo[\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "foo[\]<br>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "foo[\]<br>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<address>[\]foo</address>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<address>[\]foo</address>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<address>foo[\]</address>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<address>foo[\]</address>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<address>foo[\]<br></address>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<address>foo[\]<br></address>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<address>foo[\]bar</address>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<address>foo[\]bar</address>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div>[\]foo</div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div>[\]foo</div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div>foo[\]</div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div>foo[\]</div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div>foo[\]<br></div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div>foo[\]<br></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div>foo[\]bar</div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div>foo[\]bar</div>" compare innerHTML]
@@ -724,25 +418,13 @@
   [[["insertlinebreak",""\]\] "<dl><dt>foo<dd>bar[\]baz</dl>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<h1>[\]foo</h1>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<h1>[\]foo</h1>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<h1>foo[\]</h1>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<h1>foo[\]</h1>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<h1>foo[\]<br></h1>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<h1>foo[\]<br></h1>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<h1>foo[\]bar</h1>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<h1>foo[\]bar</h1>" compare innerHTML]
@@ -772,91 +454,43 @@
   [[["insertlinebreak",""\]\] "<ol><li>foo[\]bar</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<p>[\]foo</p>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<p>[\]foo</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<p>foo[\]</p>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<p>foo[\]</p>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<p>foo[\]<br></p>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<p>foo[\]<br></p>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<p>foo[\]bar</p>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<p>foo[\]bar</p>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<pre>[\]foo</pre>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<pre>[\]foo</pre>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<pre>foo[\]</pre>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<pre>foo[\]</pre>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<pre>foo[\]<br></pre>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<pre>foo[\]<br></pre>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<pre>foo[\]bar</pre>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<pre>foo[\]bar</pre>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<pre>foo[\]<br><br></pre>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<pre>foo[\]<br><br></pre>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<pre>foo<br>{}<br></pre>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<pre>foo<br>{}<br></pre>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<pre>foo&#10;[\]</pre>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<pre>foo&#10;[\]</pre>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<pre>foo[\]&#10;</pre>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<pre>foo[\]&#10;</pre>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<pre>foo&#10;[\]&#10;</pre>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<pre>foo&#10;[\]&#10;</pre>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<xmp>foo[\]bar</xmp>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<script>foo[\]bar</script>baz": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<listing>foo[\]bar</listing>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<listing>foo[\]bar</listing>" compare innerHTML]
@@ -928,61 +562,31 @@
   [[["insertlinebreak",""\]\] "<dl><dt>foo<dd>bar<dl><dt>baz<dd>{}<br></dl></dl>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["insertlinebreak",""\]\] "<h1>foo[bar</h1><p>baz\]quz</p>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["insertlinebreak",""\]\] "<h1>foo[bar</h1><p>baz\]quz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertlinebreak",""\]\] "<h1>foo[bar</h1><p>baz\]quz</p>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["insertlinebreak",""\]\] "<h1>foo[bar</h1><p>baz\]quz</p>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<p>foo[bar</p><h1>baz\]quz</h1>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<p>foo[bar</p><h1>baz\]quz</h1>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<p>foo</p>{}<br>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<p>foo</p>{}<br>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "{}<br><p>foo</p>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "{}<br><p>foo</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<p>foo</p>{}<br><h1>bar</h1>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<p>foo</p>{}<br><h1>bar</h1>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<h1>foo</h1>{}<br><p>bar</p>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<h1>foo</h1>{}<br><p>bar</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<h1>foo</h1>{}<br><h2>bar</h2>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<h1>foo</h1>{}<br><h2>bar</h2>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<p>foo</p><h1>[bar\]</h1><p>baz</p>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<p>foo</p><h1>[bar\]</h1><p>baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<p>foo</p>{<h1>bar</h1>}<p>baz</p>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<p>foo</p>{<h1>bar</h1>}<p>baz</p>" compare innerHTML]
@@ -994,200 +598,107 @@
   [[["insertlinebreak",""\]\] "<table><tr><td>foo[\]bar</table>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<table><tr><td><p>foo[\]bar</table>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<table><tr><td><p>foo[\]bar</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<blockquote>[\]foo</blockquote>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<blockquote>[\]foo</blockquote>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<blockquote>foo[\]</blockquote>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<blockquote>foo[\]</blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<blockquote>foo[\]<br></blockquote>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<blockquote>foo[\]<br></blockquote>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<blockquote>foo[\]bar</blockquote>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<blockquote>foo[\]bar</blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<blockquote><p>[\]foo</blockquote>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<blockquote><p>[\]foo</blockquote>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<blockquote><p>foo[\]</blockquote>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<blockquote><p>foo[\]</blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<blockquote><p>foo[\]bar</blockquote>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<blockquote><p>foo[\]bar</blockquote>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<blockquote><p>foo[\]<p>bar</blockquote>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<blockquote><p>foo[\]<p>bar</blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<blockquote><p>foo[\]bar<p>baz</blockquote>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<blockquote><p>foo[\]bar<p>baz</blockquote>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<span>foo[\]bar</span>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<span>foo[\]bar</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<span>foo[\]bar</span>baz": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<span>foo[\]bar</span>baz" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<b>foo[\]bar</b>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<b>foo[\]bar</b>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<b>foo[\]bar</b>baz": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<b>foo[\]bar</b>baz" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<b>foo[\]</b>bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<b>foo[\]</b>bar" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "foo<b>[\]bar</b>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "foo<b>[\]bar</b>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<b>foo[\]</b><i>bar</i>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<b>foo[\]</b><i>bar</i>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<b>foo</b>{}<i>bar</i>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<b>foo</b>{}<i>bar</i>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<b id=x class=y>foo[\]bar</b>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<b id=x class=y>foo[\]bar</b>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<i><b>foo[\]bar</b>baz</i>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<i><b>foo[\]bar</b>baz</i>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<p><b>foo[\]bar</b></p>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<p><b>foo[\]bar</b></p>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<p><b>[\]foo</b></p>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<p><b>[\]foo</b></p>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<p><b id=x class=y>foo[\]bar</b></p>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<p><b id=x class=y>foo[\]bar</b></p>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div><b>foo[\]bar</b></div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div><b>foo[\]bar</b></div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<a href=foo>foo[\]bar</a>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<a href=foo>foo[\]bar</a>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<a href=foo>foo[\]bar</a>baz": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<a href=foo>foo[\]bar</a>baz" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<a href=foo>foo[\]</a>bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<a href=foo>foo[\]</a>bar" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "foo<a href=foo>[\]bar</a>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "foo<a href=foo>[\]bar</a>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<p>foo[\]<!--bar-->": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<p>foo[\]<!--bar-->" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<p><!--foo-->[\]bar": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<p><!--foo-->[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<p>foo<span style=color:#aBcDeF>[bar\]</span>baz": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<p>foo<span style=color:#aBcDeF>[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<p>foo<span style=color:#aBcDeF>{bar}</span>baz": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<p>foo<span style=color:#aBcDeF>{bar}</span>baz" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<p>foo{<span style=color:#aBcDeF>bar</span>}baz": execCommand("insertlinebreak", false, "") return value]
+  [[["insertlinebreak",""\]\] "<p>foo{<span style=color:#aBcDeF>bar</span>}baz" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<p>foo{<span style=color:#aBcDeF>bar</span>}baz" compare innerHTML]
+  [[["insertlinebreak",""\]\] "<xmp>foo[\]bar</xmp>" compare innerHTML]
+    expected: FAIL
+
+  [[["insertlinebreak",""\]\] "<script>foo[\]bar</script>baz" compare innerHTML]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/insertlinebreak.html.ini
+++ b/tests/wpt/meta/editing/run/insertlinebreak.html.ini
@@ -23,25 +23,13 @@
   [[["stylewithcss","false"\],["insertlinebreak",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span><span style=color:#fEdCbA>baz\]</span>quz" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<ul contenteditable><li>{}<br></ul>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<ul contenteditable><li>{}<br></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ul contenteditable><li>foo[\]</ul>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<ul contenteditable><li>foo[\]</ul>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<div contenteditable=false><ul contenteditable><li>{}<br></ul></div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<div contenteditable=false><ul contenteditable><li>{}<br></ul></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<div contenteditable=false><ul contenteditable><li>foo[\]</ul></div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<div contenteditable=false><ul contenteditable><li>foo[\]</ul></div>" compare innerHTML]
@@ -289,22 +277,13 @@
   [[["insertlinebreak",""\]\] "fo[o<table><tr><td>b\]ar</table>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<table><tr><td>[foo<td>bar\]<tr><td>baz<td>quz</table>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<table><tr><td>[foo<td>bar\]<tr><td>baz<td>quz</table>" compare innerHTML]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<tr><td>baz<td>quz</table>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<table><tr><td>fo[o</table>b\]ar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<table><tr><td>fo[o</table>b\]ar" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<table><tr><td>fo[o<td>b\]ar<td>baz</table>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<table><tr><td>fo[o<td>b\]ar<td>baz</table>" compare innerHTML]
@@ -313,19 +292,10 @@
   [[["insertlinebreak",""\]\] "{<table><tr><td>foo</table>}" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<table><tr><td>[foo\]</table>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<table><tr><td>[foo\]</table>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<ol><li>[foo\]<li>bar</ol>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<ol><li>[foo\]<li>bar</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ol><li>f[o\]o<li>bar</ol>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<ol><li>f[o\]o<li>bar</ol>" compare innerHTML]
@@ -370,49 +340,25 @@
   [[["insertlinebreak",""\]\] "<div>foo[\]bar</div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<dl><dt>[\]foo<dd>bar</dl>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<dl><dt>[\]foo<dd>bar</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dt>foo[\]<dd>bar</dl>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<dl><dt>foo[\]<dd>bar</dl>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<dl><dt>foo[\]<br><dd>bar</dl>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<dl><dt>foo[\]<br><dd>bar</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dt>foo[\]bar<dd>baz</dl>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<dl><dt>foo[\]bar<dd>baz</dl>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<dl><dt>foo<dd>[\]bar</dl>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<dl><dt>foo<dd>[\]bar</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dt>foo<dd>bar[\]</dl>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<dl><dt>foo<dd>bar[\]</dl>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<dl><dt>foo<dd>bar[\]<br></dl>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<dl><dt>foo<dd>bar[\]<br></dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dt>foo<dd>bar[\]baz</dl>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<dl><dt>foo<dd>bar[\]baz</dl>" compare innerHTML]
@@ -430,25 +376,13 @@
   [[["insertlinebreak",""\]\] "<h1>foo[\]bar</h1>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<ol><li>[\]foo</ol>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<ol><li>[\]foo</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ol><li>foo[\]</ol>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<ol><li>foo[\]</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<ol><li>foo[\]<br></ol>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<ol><li>foo[\]<br></ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ol><li>foo[\]bar</ol>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<ol><li>foo[\]bar</ol>" compare innerHTML]
@@ -496,67 +430,34 @@
   [[["insertlinebreak",""\]\] "<listing>foo[\]bar</listing>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<ol><li>{}<br></li></ol>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<ol><li>{}<br></li></ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "foo<ol><li>{}<br></li></ol>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "foo<ol><li>{}<br></li></ol>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<ol><li>{}<br></li></ol>foo": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<ol><li>{}<br></li></ol>foo" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ol><li>foo<li>{}<br></ol>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<ol><li>foo<li>{}<br></ol>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<ol><li>{}<br><li>bar</ol>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<ol><li>{}<br><li>bar</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<ol><li>foo</li><ul><li>{}<br></ul></ol>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<ol><li>foo</li><ul><li>{}<br></ul></ol>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<dl><dt>{}<br></dt></dl>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<dl><dt>{}<br></dt></dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dt>foo<dd>{}<br></dl>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<dl><dt>foo<dd>{}<br></dl>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<dl><dt>{}<br><dd>bar</dl>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<dl><dt>{}<br><dd>bar</dl>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<dl><dt>foo<dd>bar<dl><dt>{}<br><dd>baz</dl></dl>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\]\] "<dl><dt>foo<dd>bar<dl><dt>{}<br><dd>baz</dl></dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<dl><dt>foo<dd>bar<dl><dt>baz<dd>{}<br></dl></dl>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<dl><dt>foo<dd>bar<dl><dt>baz<dd>{}<br></dl></dl>" compare innerHTML]
@@ -590,9 +491,6 @@
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<p>foo</p>{<h1>bar</h1>}<p>baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\]\] "<table><tr><td>foo[\]bar</table>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\]\] "<table><tr><td>foo[\]bar</table>" compare innerHTML]
@@ -697,8 +595,8 @@
   [[["insertlinebreak",""\]\] "<p>foo{<span style=color:#aBcDeF>bar</span>}baz" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<xmp>foo[\]bar</xmp>" compare innerHTML]
+  [[["insertlinebreak",""\]\] "<xmp>foo[\]bar</xmp>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
-  [[["insertlinebreak",""\]\] "<script>foo[\]bar</script>baz" compare innerHTML]
+  [[["insertlinebreak",""\]\] "<script>foo[\]bar</script>baz": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/multitest.html.ini
+++ b/tests/wpt/meta/editing/run/multitest.html.ini
@@ -44,13 +44,7 @@
   [[["hilitecolor","#00FFFF"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["hilitecolor","#00FFFF"\],["insertlinebreak",""\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["hilitecolor","#00FFFF"\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["hilitecolor","#00FFFF"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["hilitecolor","#00FFFF"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -331,13 +325,7 @@
   [[["bold",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["bold",""\],["insertlinebreak",""\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["bold",""\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["bold",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["bold",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -565,13 +553,7 @@
   [[["italic",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["italic",""\],["insertlinebreak",""\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["italic",""\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -801,13 +783,7 @@
   [[["strikethrough",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["strikethrough",""\],["insertlinebreak",""\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["strikethrough",""\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["strikethrough",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["strikethrough",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1010,13 +986,7 @@
   [[["fontsize","4"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontsize","4"\],["insertlinebreak",""\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1244,13 +1214,7 @@
   [[["forecolor","#0000FF"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["forecolor","#0000FF"\],["insertlinebreak",""\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["forecolor","#0000FF"\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forecolor","#0000FF"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["forecolor","#0000FF"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1567,13 +1531,7 @@
   [[["fontname","sans-serif"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontname","sans-serif"\],["insertlinebreak",""\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["fontname","sans-serif"\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontname","sans-serif"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["fontname","sans-serif"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1842,13 +1800,7 @@
   [[["subscript",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["subscript",""\],["insertlinebreak",""\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["subscript",""\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["subscript",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["subscript",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -2058,13 +2010,7 @@
   [[["superscript",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["superscript",""\],["insertlinebreak",""\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["superscript",""\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["superscript",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["superscript",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -2485,25 +2431,13 @@
   [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">de\]f</i></b>ghi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">de\]f</i></b>ghi</div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">de\]f</i></b>ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def\]</i></b>ghi</div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def\]</i></b>ghi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc[<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i><img src=\\"/img/lion.svg\\">def</i></b>\]ghi</div>" compare innerHTML]
@@ -2516,9 +2450,6 @@
     expected: FAIL
 
   [[["insertparagraph",""\],["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\],["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\],["inserttext","c"\],["inserttext","d"\],["inserttext","e"\]\] "<div>ab[c<b><i>de\]f</i></b>ghi</div>" compare innerHTML]
@@ -2539,16 +2470,10 @@
   [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i>de\]f</i></b>ghi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i>de\]f</i></b>ghi</div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<b><i>de\]f</i></b>ghi</div>" compare innerHTML]
     expected: FAIL
 
   [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<b><i>de\]f</i></b>ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<b><i>de\]f</i></b>ghi</div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<b><i>de\]f</i></b>ghi</div>" compare innerHTML]
@@ -2569,16 +2494,10 @@
   [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<s></s><b><i>de\]f</i></b>ghi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc[<s></s><b><i>de\]f</i></b>ghi</div>" compare innerHTML]
     expected: FAIL
 
   [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<s></s><b><i>de\]f</i></b>ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<s></s><b><i>de\]f</i></b>ghi</div>": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<s></s><b><i>de\]f</i></b>ghi</div>" compare innerHTML]
@@ -2985,13 +2904,7 @@
   [[["underline",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["underline",""\],["insertlinebreak",""\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["underline",""\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["underline",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -3245,13 +3158,7 @@
   [[["backcolor","#00FFFF"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["backcolor","#00FFFF"\],["insertlinebreak",""\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["backcolor","#00FFFF"\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["backcolor","#00FFFF"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -3467,13 +3374,7 @@
   [[["createlink","http://www.google.com/"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["createlink","http://www.google.com/"\],["insertlinebreak",""\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
-    expected: FAIL
-
   [[["createlink","http://www.google.com/"\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["createlink","http://www.google.com/"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -3624,4 +3525,7 @@
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("backcolor") after]
+    expected: FAIL
+
+  [[["backcolor","#00FFFF"\],["insertlinebreak",""\]\] "foo[\]bar" queryCommandValue("backcolor") after]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/multitest.html.ini
+++ b/tests/wpt/meta/editing/run/multitest.html.ini
@@ -44,12 +44,6 @@
   [[["hilitecolor","#00FFFF"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["hilitecolor","#00FFFF"\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["hilitecolor","#00FFFF"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
   [[["hilitecolor","#00FFFF"\],["insertorderedlist",""\]\] "foo[\]bar": execCommand("insertorderedlist", false, "") return value]
     expected: FAIL
 
@@ -325,9 +319,6 @@
   [[["bold",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["bold",""\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
   [[["bold",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -551,9 +542,6 @@
     expected: FAIL
 
   [[["italic",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["italic",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -783,9 +771,6 @@
   [[["strikethrough",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["strikethrough",""\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
   [[["strikethrough",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -984,9 +969,6 @@
 
 [multitest.html?6001-7000]
   [[["fontsize","4"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["fontsize","4"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1212,9 +1194,6 @@
     expected: FAIL
 
   [[["forecolor","#0000FF"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forecolor","#0000FF"\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["forecolor","#0000FF"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1531,9 +1510,6 @@
   [[["fontname","sans-serif"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontname","sans-serif"\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
   [[["fontname","sans-serif"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -1800,12 +1776,6 @@
   [[["subscript",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["subscript",""\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["subscript",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
   [[["subscript",""\],["insertorderedlist",""\]\] "foo[\]bar": execCommand("insertorderedlist", false, "") return value]
     expected: FAIL
 
@@ -2008,12 +1978,6 @@
     expected: FAIL
 
   [[["superscript",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["superscript",""\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["superscript",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["superscript",""\],["insertorderedlist",""\]\] "foo[\]bar": execCommand("insertorderedlist", false, "") return value]
@@ -2904,9 +2868,6 @@
   [[["underline",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["underline",""\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
   [[["underline",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -3158,9 +3119,6 @@
   [[["backcolor","#00FFFF"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["backcolor","#00FFFF"\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
   [[["backcolor","#00FFFF"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -3372,12 +3330,6 @@
     expected: FAIL
 
   [[["createlink","http://www.google.com/"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["createlink","http://www.google.com/"\],["insertorderedlist",""\]\] "foo[\]bar": execCommand("insertorderedlist", false, "") return value]

--- a/tests/wpt/meta/editing/whitespaces/chrome-compat/insertlinebreak.tentative.html.ini
+++ b/tests/wpt/meta/editing/whitespaces/chrome-compat/insertlinebreak.tentative.html.ini
@@ -1,7 +1,4 @@
 [insertlinebreak.tentative.html]
-  [execCommand("insertlinebreak", false, "") at "[\]a&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;b"]
-    expected: FAIL
-
   [execCommand("insertlinebreak", false, "") at "a[\]&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;b"]
     expected: FAIL
 


### PR DESCRIPTION
Implement the `insertLineBreak` command for contenteditable stuff.

Testing: More WPT passes

PS: Yes, I do still plan to get to writing `is_collapsed_line_break` at some point.
But for now, I want at least something implemented for every editing command. (at least all the ones that are relevant to keyboard input so that once regular DOM content becomes selectable, we can put in a thing that calls them upon user key presses. :) )