### PR TITLE
Revert "layout: Truncate in place for each accessibility label"

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -846,9 +846,7 @@ impl AccessibilityNode {
                 },
             }
         }
-        let trimmed_len = text.trim().len();
-        text.truncate(trimmed_len);
-        Some(text)
+        Some(text.trim().to_owned())
     }
 
     fn print(&self, print_tree: &mut PrintTree) {


### PR DESCRIPTION
Revert servo/servo#47440 as it wrongly keeps the leading whitespace.