### PR TITLE
fonts: Resolve ties during web font matching by cascade order of `@font-face` rules

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -508,7 +508,7 @@ impl Font {
     #[servo_tracing::instrument(name = "Font::shape_text", skip_all)]
     pub fn shape_text(&self, text: &str, options: &ShapingOptions) -> Arc<ShapedText> {
         let font_features =
-            compute_used_font_features(options, self.template.borrow().font_face_rule.as_ref())
+            compute_used_font_features(options, self.template.borrow().font_face_rule.as_deref())
                 .collect();
         let lookup_key = ShapeCacheEntry {
             text: text.to_owned(),
@@ -719,7 +719,7 @@ impl Font {
         self.template
             .font_face_rule()
             .and_then(|font_face_rule| {
-                AtomicRef::filter_map(font_face_rule, |rule| rule.font_family.as_ref())
+                AtomicRef::filter_map(font_face_rule, |rule| rule.descriptors.font_family.as_ref())
             })
             .map(|font_family| font_family.name.clone())
             .or_else(|| {
@@ -1169,7 +1169,9 @@ fn compute_variations(
     if let Some(font_face_rule) = &font_face_rule {
         // Step 6. If the font is defined via an @font-face rule, the font variations implied by the font-variation-settings
         // descriptor in the @font-face rule are applied.
-        if let Some(variation_settings) = font_face_rule.font_variation_settings.as_ref() {
+        if let Some(variation_settings) =
+            font_face_rule.descriptors.font_variation_settings.as_ref()
+        {
             variation_settings
                 .0
                 .iter()
@@ -1208,7 +1210,7 @@ fn compute_variations(
     if variation_axes.intersects(VariationAxes::ITAL | VariationAxes::SLNT) {
         let clamped_font_style = font_face_rule
             .as_ref()
-            .and_then(|descriptor| descriptor.font_style.as_ref())
+            .and_then(|font_face_rule| font_face_rule.descriptors.font_style.as_ref())
             .map(|font_style_range| {
                 let computed_font_style_range =
                     font_style_range.compute().expect("never returns None");

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -331,7 +331,7 @@ impl FontContext {
                 matching_templates.sort_unstable_by_key(|template| {
                     template
                         .font_face_rule()
-                        .map(|rule| rule.cascade_index)
+                        .map(|rule| rule.cascade_index.load(Ordering::SeqCst))
                         .unwrap_or(usize::MAX)
                 });
                 matching_templates
@@ -778,10 +778,13 @@ impl FontContextWebFontMethods for Arc<FontContext> {
             self.remove_single_font_face_rule(removed_rule, &mut self.web_fonts.write());
         }
 
-        if !difference.removed_font_faces.is_empty() {
-            // We modified the list of available fonts, so invalidate resolved font groups.
+        if !difference.removed_font_faces.is_empty() || difference.cascade_index_of_any_rule_changed
+        {
+            // Font matching may now yield different results, so invalidate resolved font groups.
             self.resolved_font_groups.write().clear();
+        }
 
+        if !difference.removed_font_faces.is_empty() {
             // Ensure that we clean up any WebRender resources on the next display list update.
             self.have_removed_web_fonts.store(true, Ordering::Relaxed);
         }
@@ -1572,8 +1575,13 @@ impl KnownFontFaceRules {
                 } else {
                     number_of_unchanged_rules += 1;
 
-                    // FIXME: We need to update the cascade index of this entry and potentially trigger a reflow
-                    // if it changed.
+                    let previous_cascade_index_of_this_rule = known_font_faces_for_family
+                        [index_of_existing_entry_for_this_rule]
+                        .font_face_rule_entry
+                        .cascade_index
+                        .swap(cascade_index, Ordering::SeqCst);
+                    difference.cascade_index_of_any_rule_changed |=
+                        previous_cascade_index_of_this_rule != cascade_index;
                     known_font_faces_for_family[index_of_existing_entry_for_this_rule].generation =
                         self.generation;
                 }
@@ -1584,7 +1592,7 @@ impl KnownFontFaceRules {
             } else {
                 // This is a new rule that does not conflict with anything that previously existed, so insert it.
                 let font_face_rule_entry = ServoArc::new(FontFaceRuleInfo {
-                    cascade_index,
+                    cascade_index: AtomicUsize::new(cascade_index),
                     descriptors: borrowed_rule.descriptors.clone(),
                     rule: rule_with_origin.rule,
                 });

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -1571,6 +1571,9 @@ impl KnownFontFaceRules {
                         .push(stale_rule.font_face_rule_entry);
                 } else {
                     number_of_unchanged_rules += 1;
+
+                    // FIXME: We need to update the cascade index of this entry and potentially trigger a reflow
+                    // if it changed.
                     known_font_faces_for_family[index_of_existing_entry_for_this_rule].generation =
                         self.generation;
                 }

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -734,20 +734,20 @@ impl FontContextWebFontMethods for Arc<FontContext> {
         callback: StylesheetWebFontLoadFinishedCallback,
         document_context: &WebFontDocumentContext,
     ) {
-        let Some(sources) = font_face_rule.descriptors.src.clone() else {
+        let Some(sources) = font_face_rule.descriptors.src.as_ref() else {
             return;
         };
 
         let css_font_face_descriptors = CSSFontFaceDescriptors::from(&font_face_rule.descriptors);
 
         let initiator = FontFaceRuleInitiator {
-            font_face_rule,
+            font_face_rule: font_face_rule.clone(),
             callback: callback.clone(),
         };
 
         self.start_loading_one_web_font(
             Some(webview_id),
-            &sources,
+            sources,
             css_font_face_descriptors,
             WebFontLoadInitiator::Stylesheet(Box::new(initiator)),
             document_context,

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use app_units::Au;
 use content_security_policy::Violation;
 use fonts_traits::{
-    CSSFontFaceDescriptors, FontDescriptor, FontFaceRuleWithOrigin, FontIdentifier, FontTemplate,
+    CSSFontFaceDescriptors, FontDescriptor, FontFaceRuleInfo, FontIdentifier, FontTemplate,
     FontTemplateRef, FontTemplateRefMethods, StylesheetWebFontLoadFinishedCallback,
     WebFontLoadEvent, WebFontSetDifference,
 };
@@ -44,7 +44,7 @@ use style::font_face::{
 use style::properties::generated::font_face::Descriptors as FontFaceRuleDescriptors;
 use style::properties::style_structs::Font as FontStyleStruct;
 use style::shared_lock::StylesheetGuards;
-use style::stylesheets::LockedFontFaceRule;
+use style::stylesheets::{FontFaceRule, LockedFontFaceRule, Origin};
 use style::stylist::Stylist;
 use style::values::computed::FontVariantAlternates;
 use style::values::computed::font::{FamilyName, FontFamilyNameSyntax, SingleFontFamily};
@@ -325,7 +325,17 @@ impl FontContext {
             .read()
             .families
             .get(&family_name.name.clone().into())
-            .map(|templates| templates.find_for_descriptor(Some(descriptor_to_match)))
+            .map(|templates| {
+                let mut matching_templates =
+                    templates.find_for_descriptor(Some(descriptor_to_match));
+                matching_templates.sort_unstable_by_key(|template| {
+                    template
+                        .font_face_rule()
+                        .map(|rule| rule.cascade_index)
+                        .unwrap_or(usize::MAX)
+                });
+                matching_templates
+            })
     }
 
     /// Try to find matching templates in this [`FontContext`], first looking in the list of web fonts and
@@ -582,16 +592,13 @@ impl FontContext {
     /// Returns true iff a `@font-face` rule is part of the active set.
     ///
     /// A font face rule might be removed from this set if its stylesheet is removed for example.
-    pub(crate) fn is_font_face_rule_active(
-        &self,
-        target_rule: &ServoArc<LockedFontFaceRule>,
-    ) -> bool {
+    pub(crate) fn is_font_active(&self, web_font: &ServoArc<FontFaceRuleInfo>) -> bool {
         self.known_font_face_rules
             .lock()
             .contents
             .values()
             .flat_map(|bucket| bucket.iter())
-            .any(|known_rule| ServoArc::ptr_eq(&known_rule.rule_with_origin.rule, target_rule))
+            .any(|known_web_font| ServoArc::ptr_eq(&known_web_font.font_face_rule_entry, web_font))
     }
 }
 
@@ -634,10 +641,7 @@ impl WebFontDownloadState {
         let family_name = self.css_font_face_descriptors.family_name.clone();
         match self.initiator {
             WebFontLoadInitiator::Stylesheet(initiator) => {
-                if !self
-                    .font_context
-                    .is_font_face_rule_active(&initiator.created_by)
-                {
+                if !self.font_context.is_font_active(&initiator.font_face_rule) {
                     // This font load was cancelled.
                     if self
                         .font_context
@@ -707,8 +711,7 @@ pub trait FontContextWebFontMethods {
     fn load_single_font_face_rule(
         &self,
         webview_id: WebViewId,
-        locked_font_face_rule: &FontFaceRuleWithOrigin,
-        guards: &StylesheetGuards<'_>,
+        font_face_rule: ServoArc<FontFaceRuleInfo>,
         callback: StylesheetWebFontLoadFinishedCallback,
         document_context: &WebFontDocumentContext,
     );
@@ -727,27 +730,24 @@ impl FontContextWebFontMethods for Arc<FontContext> {
     fn load_single_font_face_rule(
         &self,
         webview_id: WebViewId,
-        locked_font_face_rule: &FontFaceRuleWithOrigin,
-        guards: &StylesheetGuards<'_>,
+        font_face_rule: ServoArc<FontFaceRuleInfo>,
         callback: StylesheetWebFontLoadFinishedCallback,
         document_context: &WebFontDocumentContext,
     ) {
-        let font_face_rule = locked_font_face_rule.read_with(guards);
-        let Some(ref sources) = font_face_rule.descriptors.src else {
+        let Some(sources) = font_face_rule.descriptors.src.clone() else {
             return;
         };
 
-        let css_font_face_descriptors = font_face_rule.into();
+        let css_font_face_descriptors = CSSFontFaceDescriptors::from(&font_face_rule.descriptors);
 
         let initiator = FontFaceRuleInitiator {
-            created_by: locked_font_face_rule.rule.clone(),
-            font_face_rule: font_face_rule.descriptors.clone(),
+            font_face_rule,
             callback: callback.clone(),
         };
 
         self.start_loading_one_web_font(
             Some(webview_id),
-            sources,
+            &sources,
             css_font_face_descriptors,
             WebFontLoadInitiator::Stylesheet(Box::new(initiator)),
             document_context,
@@ -769,18 +769,13 @@ impl FontContextWebFontMethods for Arc<FontContext> {
         for added_rule in &difference.added_font_faces {
             self.load_single_font_face_rule(
                 webview_id,
-                added_rule,
-                guards,
+                added_rule.clone(),
                 callback.clone(),
                 document_context,
             );
         }
         for removed_rule in &difference.removed_font_faces {
-            let removed_rule = removed_rule.read_with(guards);
-            self.remove_single_font_face_rule(
-                &removed_rule.descriptors,
-                &mut self.web_fonts.write(),
-            );
+            self.remove_single_font_face_rule(removed_rule, &mut self.web_fonts.write());
         }
 
         if !difference.removed_font_faces.is_empty() {
@@ -821,7 +816,7 @@ impl FontContextWebFontMethods for Arc<FontContext> {
         for subscriber in subscribers {
             // See if the font load was cancelled in the meantime
             if let WebFontLoadInitiator::Stylesheet(stylesheet_initiator) = &subscriber.initiator &&
-                !self.is_font_face_rule_active(&stylesheet_initiator.created_by)
+                !self.is_font_active(&stylesheet_initiator.font_face_rule)
             {
                 // This font load was cancelled.
                 if self
@@ -833,7 +828,7 @@ impl FontContextWebFontMethods for Arc<FontContext> {
                     // has finished because this an opportunity to resolve document.fonts.ready.
                     (stylesheet_initiator.callback)(WebFontLoadEvent::UnblockedFontReadyPromise);
                 }
-                return;
+                continue;
             }
 
             self.process_next_web_font_source(subscriber);
@@ -912,10 +907,10 @@ impl FontContext {
     /// Returns `true` if any font templates were removed.
     fn remove_single_font_face_rule(
         &self,
-        font_face_rule: &FontFaceRuleDescriptors,
+        font_face_rule: &ServoArc<FontFaceRuleInfo>,
         font_store: &mut FontStore,
     ) -> bool {
-        let Some(family) = font_face_rule.font_family.as_ref() else {
+        let Some(family) = font_face_rule.descriptors.font_family.as_ref() else {
             return false;
         };
 
@@ -1239,14 +1234,8 @@ pub(crate) type ScriptWebFontLoadFinishedCallback =
 
 #[derive(MallocSizeOf)]
 pub(crate) struct FontFaceRuleInitiator {
-    /// A reference to the `@font-face` rule that created this web font load.
-    /// This is only used to identify the font in case it is
-    // TODO: It is awkward that we have to carry both the locked font face rule and the
-    // unlocked copy around. Perhaps the FontContext should have access to the shared
-    // lock in the future.
     #[conditional_malloc_size_of]
-    created_by: ServoArc<LockedFontFaceRule>,
-    font_face_rule: FontFaceRuleDescriptors,
+    font_face_rule: ServoArc<FontFaceRuleInfo>,
     #[ignore_malloc_size_of = "dyn Fn"]
     callback: StylesheetWebFontLoadFinishedCallback,
 }
@@ -1258,7 +1247,7 @@ pub(crate) enum WebFontLoadInitiator {
 }
 
 impl WebFontLoadInitiator {
-    pub(crate) fn font_face_rule(&self) -> Option<&FontFaceRuleDescriptors> {
+    pub(crate) fn font_face_rule(&self) -> Option<&ServoArc<FontFaceRuleInfo>> {
         match self {
             Self::Stylesheet(initiator) => Some(&initiator.font_face_rule),
             Self::Script(_) => None,
@@ -1470,8 +1459,29 @@ struct KnownFontFaceRules {
 
 #[derive(MallocSizeOf)]
 struct KnownFontFaceRule {
-    rule_with_origin: FontFaceRuleWithOrigin,
+    #[conditional_malloc_size_of]
+    font_face_rule_entry: ServoArc<FontFaceRuleInfo>,
     generation: bool,
+}
+
+#[derive(Clone, MallocSizeOf)]
+struct FontFaceRuleWithOrigin {
+    #[conditional_malloc_size_of]
+    rule: ServoArc<LockedFontFaceRule>,
+    origin: Origin,
+}
+
+impl FontFaceRuleWithOrigin {
+    fn new(rule: ServoArc<LockedFontFaceRule>, origin: Origin) -> Self {
+        Self { rule, origin }
+    }
+
+    fn read_with<'a>(&'a self, guards: &'a StylesheetGuards) -> &'a FontFaceRule {
+        match self.origin {
+            Origin::Author => self.rule.read_with(guards.author),
+            Origin::UserAgent | Origin::User => self.rule.read_with(guards.ua_or_user),
+        }
+    }
 }
 
 impl KnownFontFaceRules {
@@ -1500,7 +1510,7 @@ impl KnownFontFaceRules {
             .values()
             .map(|fonts_from_family| fonts_from_family.len())
             .sum();
-        for rule_with_origin in font_face_rules_in_cascade_order {
+        for (cascade_index, rule_with_origin) in font_face_rules_in_cascade_order.enumerate() {
             let borrowed_rule = rule_with_origin.read_with(guards);
 
             let Some(font_family) = borrowed_rule.descriptors.font_family.as_ref() else {
@@ -1522,9 +1532,9 @@ impl KnownFontFaceRules {
             let mut index_of_existing_entry_for_this_rule = None;
             for (index, known_font_face) in known_font_faces_for_family.iter().enumerate() {
                 // See if this is a entry for this @font-face that existed prior to the current update
-                if FontFaceRuleWithOrigin::ptr_eq(
-                    &known_font_face.rule_with_origin,
-                    &rule_with_origin,
+                if ServoArc::ptr_eq(
+                    &known_font_face.font_face_rule_entry.rule,
+                    &rule_with_origin.rule,
                 ) {
                     index_of_existing_entry_for_this_rule = Some(index);
                 }
@@ -1540,10 +1550,7 @@ impl KnownFontFaceRules {
                     continue;
                 }
                 if font_face_rules_conflict(
-                    &known_font_face
-                        .rule_with_origin
-                        .read_with(guards)
-                        .descriptors,
+                    &known_font_face.font_face_rule_entry.descriptors,
                     &borrowed_rule.descriptors,
                 ) {
                     conflicting_declaration_with_higher_priority_exists = true;
@@ -1561,7 +1568,7 @@ impl KnownFontFaceRules {
                         known_font_faces_for_family.remove(index_of_existing_entry_for_this_rule);
                     difference
                         .removed_font_faces
-                        .push(stale_rule.rule_with_origin);
+                        .push(stale_rule.font_face_rule_entry);
                 } else {
                     number_of_unchanged_rules += 1;
                     known_font_faces_for_family[index_of_existing_entry_for_this_rule].generation =
@@ -1573,9 +1580,16 @@ impl KnownFontFaceRules {
                 continue;
             } else {
                 // This is a new rule that does not conflict with anything that previously existed, so insert it.
-                difference.added_font_faces.push(rule_with_origin.clone());
+                let font_face_rule_entry = ServoArc::new(FontFaceRuleInfo {
+                    cascade_index,
+                    descriptors: borrowed_rule.descriptors.clone(),
+                    rule: rule_with_origin.rule,
+                });
+                difference
+                    .added_font_faces
+                    .push(font_face_rule_entry.clone());
                 known_font_faces_for_family.push(KnownFontFaceRule {
-                    rule_with_origin,
+                    font_face_rule_entry,
                     generation: self.generation,
                 });
             }
@@ -1595,7 +1609,7 @@ impl KnownFontFaceRules {
                 .for_each(|removed_rule| {
                     difference
                         .removed_font_faces
-                        .push(removed_rule.rule_with_origin);
+                        .push(removed_rule.font_face_rule_entry);
                 });
 
             !known_font_faces_for_family.is_empty()

--- a/components/fonts/font_store.rs
+++ b/components/fonts/font_store.rs
@@ -7,13 +7,13 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use fonts_traits::{
-    FontDescriptor, FontIdentifier, FontTemplate, FontTemplateRef, FontTemplateRefMethods,
-    IsOblique, LowercaseFontFamilyName,
+    FontDescriptor, FontFaceRuleInfo, FontIdentifier, FontTemplate, FontTemplateRef,
+    FontTemplateRefMethods, IsOblique, LowercaseFontFamilyName,
 };
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use parking_lot::RwLock;
-use style::properties::generated::font_face::Descriptors as FontFaceRuleDescriptors;
+use servo_arc::Arc as ServoArc;
 use style::values::computed::{FontStyle, FontWeight};
 
 #[derive(Default, MallocSizeOf)]
@@ -80,7 +80,7 @@ impl SimpleFamily {
         preference.iter().find_map(|template| (*template).clone())
     }
 
-    fn remove_templates_for_font_face_rule(&mut self, font_face_rule: &FontFaceRuleDescriptors) {
+    fn remove_templates_for_font_face_rule(&mut self, font_face_rule: &ServoArc<FontFaceRuleInfo>) {
         let remove_if_template_matches = |template: &mut Option<FontTemplateRef>| {
             if template.as_ref().is_some_and(|template| {
                 template
@@ -242,7 +242,7 @@ impl FontTemplates {
     /// Returns true if any templates were removed.
     pub(crate) fn remove_template_for_font_face_rule(
         &mut self,
-        removed_rule: &FontFaceRuleDescriptors,
+        removed_rule: &ServoArc<FontFaceRuleInfo>,
     ) -> bool {
         let old_length = self.templates.len();
         self.templates

--- a/components/fonts/shapers/mod.rs
+++ b/components/fonts/shapers/mod.rs
@@ -6,11 +6,11 @@ mod harfbuzz;
 
 use app_units::Au;
 use euclid::default::Point2D;
+use fonts_traits::FontFaceRuleInfo;
 pub(crate) use harfbuzz::Shaper;
 use read_fonts::types::Tag;
 use rustc_hash::FxHashMap;
 use style::computed_values::font_variant_position::T as FontVariantPosition;
-use style::properties::generated::font_face::Descriptors as FontFaceRuleDescriptors;
 use style::values::computed::{FontVariantEastAsian, FontVariantLigatures, FontVariantNumeric};
 
 use crate::{
@@ -77,7 +77,7 @@ pub(crate) trait GlyphShapingResult {
 /// <https://drafts.csswg.org/css-fonts-4/#apply-font-matching-variations>.
 pub(crate) fn compute_used_font_features(
     options: &ShapingOptions,
-    font_face_rule: Option<&FontFaceRuleDescriptors>,
+    font_face_rule: Option<&FontFaceRuleInfo>,
 ) -> impl Iterator<Item = (Tag, u32)> {
     let mut features = FxHashMap::default();
 
@@ -93,7 +93,7 @@ pub(crate) fn compute_used_font_features(
     // Step 7. If the font is defined via an @font-face rule, the font features implied
     // by the font-feature-settings descriptor in the @font-face rule are applied.
     if let Some(font_feature_settings) =
-        font_face_rule.and_then(|rule| rule.font_feature_settings.as_ref())
+        font_face_rule.and_then(|rule| rule.descriptors.font_feature_settings.as_ref())
     {
         for feature_setting in font_feature_settings.0.iter() {
             add_feature(

--- a/components/script/dom/css/fontface.rs
+++ b/components/script/dom/css/fontface.rs
@@ -8,17 +8,16 @@ use std::rc::Rc;
 use cssparser::{Parser, ParserInput};
 use dom_struct::dom_struct;
 use fonts::{
-    FontContext, FontContextWebFontMethods, FontFaceRuleWithOrigin, FontTemplate,
-    LowercaseFontFamilyName,
+    FontContext, FontContextWebFontMethods, FontFaceRuleInfo, FontTemplate, LowercaseFontFamilyName,
 };
 use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use servo_arc::Arc as ServoArc;
 use style::error_reporting::ParseErrorReporter;
 use style::font_face::SourceList;
 use style::properties::font_face::Descriptors;
-use style::shared_lock::StylesheetGuards;
 use style::stylesheets::{CssRuleType, FontFaceRule, UrlExtraData};
 use style_traits::{ParsingMode, ToCss};
 
@@ -75,7 +74,8 @@ pub struct FontFace {
     ///
     /// [css-connected]: https://drafts.csswg.org/css-font-loading/#css-connected
     #[no_trace]
-    css_font_face_rule: DomRefCell<Option<FontFaceRuleWithOrigin>>,
+    #[conditional_malloc_size_of]
+    css_font_face_rule: DomRefCell<Option<ServoArc<FontFaceRuleInfo>>>,
 }
 
 /// Given the various font face descriptors, construct the equivalent `@font-face` css rule as a
@@ -293,7 +293,7 @@ impl FontFace {
         descriptors: FontFaceDescriptors,
         src: Option<SourceList>,
         font_status_promise: Rc<Promise>,
-        font_face_rule: FontFaceRuleWithOrigin,
+        font_face_rule: ServoArc<FontFaceRuleInfo>,
     ) -> Self {
         Self {
             reflector: Reflector::new(),
@@ -312,11 +312,9 @@ impl FontFace {
     pub(crate) fn new_for_web_font(
         cx: &mut JSContext,
         global: &GlobalScope,
-        font_face_rule: FontFaceRuleWithOrigin,
-        guards: &StylesheetGuards,
+        font_face_rule: ServoArc<FontFaceRuleInfo>,
     ) -> Option<DomRoot<Self>> {
-        let new_web_font_ref = font_face_rule.read_with(guards);
-        let Some(family_name) = new_web_font_ref
+        let Some(family_name) = font_face_rule
             .descriptors
             .font_family
             .as_ref()
@@ -330,7 +328,7 @@ impl FontFace {
         // > The FontFace object corresponding to a @font-face rule has its family, style, weight, stretch,
         // > unicodeRange, variant, and featureSettings attributes set to the same value as the corresponding
         // > descriptors in the @font-face rule.
-        let descriptors = serialize_parsed_descriptors(&new_web_font_ref.descriptors);
+        let descriptors = serialize_parsed_descriptors(&font_face_rule.descriptors);
 
         let font_status_promise = Promise::new(cx, global);
         Some(reflect_dom_object_with_proto(
@@ -338,7 +336,7 @@ impl FontFace {
             Box::new(Self::new_inherited_for_web_font(
                 family_name,
                 descriptors,
-                new_web_font_ref.descriptors.src.clone(),
+                font_face_rule.descriptors.src.clone(),
                 font_status_promise,
                 font_face_rule,
             )),
@@ -363,16 +361,11 @@ impl FontFace {
     /// `@font-face` rule.
     ///
     /// [css-connected]: https://drafts.csswg.org/css-font-loading/#css-connected
-    pub(crate) fn is_connected_to_font_face_rule(
-        &self,
-        target_rule: &FontFaceRuleWithOrigin,
-    ) -> bool {
+    pub(crate) fn is_connected_to_font_face_rule(&self, target_rule: &FontFaceRuleInfo) -> bool {
         self.css_font_face_rule
             .borrow()
             .as_ref()
-            .is_some_and(|connected_rule| {
-                FontFaceRuleWithOrigin::ptr_eq(connected_rule, target_rule)
-            })
+            .is_some_and(|connected_rule| ServoArc::ptr_eq(&connected_rule.rule, &target_rule.rule))
     }
 
     /// Step 3 of <https://drafts.csswg.org/css-font-loading/#font-face-constructor>

--- a/components/script/dom/css/fontfaceset.rs
+++ b/components/script/dom/css/fontfaceset.rs
@@ -6,7 +6,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
-use fonts::FontFaceRuleWithOrigin;
+use fonts::FontFaceRuleInfo;
 use js::context::JSContext;
 use js::gc::Handle;
 use js::jsapi::Value;
@@ -19,6 +19,7 @@ use script_bindings::codegen::GenericBindings::FontFaceBinding::{
 };
 use script_bindings::like::Setlike;
 use script_bindings::reflector::reflect_dom_object_with_proto;
+use servo_arc::Arc as ServoArc;
 
 use crate::dom::bindings::codegen::Bindings::FontFaceSetBinding::FontFaceSetMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
@@ -162,7 +163,7 @@ impl FontFaceSet {
     /// [css-connected]: https://drafts.csswg.org/css-font-loading/#css-connected
     pub(crate) fn notify_font_face_rules_removed(
         &self,
-        removed_font_face_rules: &[FontFaceRuleWithOrigin],
+        removed_font_face_rules: &[ServoArc<FontFaceRuleInfo>],
     ) {
         let entries = self.set_entries.borrow_mut();
         for removed_font_face_rule in removed_font_face_rules {

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -98,7 +98,6 @@ use style::error_reporting::{ContextualParseError, ParseErrorReporter};
 use style::properties::PropertyId;
 use style::properties::style_structs::Font;
 use style::selector_parser::PseudoElement;
-use style::shared_lock::StylesheetGuards;
 use style::str::HTML_SPACE_CHARACTERS;
 use style::stylesheets::UrlExtraData;
 use style_traits::CSSPixel;
@@ -3720,14 +3719,8 @@ impl Window {
         if !changed_web_fonts.added_font_faces.is_empty() {
             fonts.switch_to_loading(cx);
 
-            let shared_locks = document.shared_style_locks();
-            let guards = StylesheetGuards {
-                author: &shared_locks.author.read(),
-                ua_or_user: &shared_locks.ua_or_user.read(),
-            };
             for new_web_font in changed_web_fonts.added_font_faces {
-                if let Some(font_face) =
-                    FontFace::new_for_web_font(cx, self.upcast(), new_web_font, &guards)
+                if let Some(font_face) = FontFace::new_for_web_font(cx, self.upcast(), new_web_font)
                 {
                     fonts.add(cx, font_face);
                 }

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -3710,7 +3710,11 @@ impl Window {
         let fonts = document.Fonts(cx);
         if !changed_web_fonts.removed_font_faces.is_empty() {
             fonts.notify_font_face_rules_removed(&changed_web_fonts.removed_font_faces);
+        }
 
+        if !changed_web_fonts.removed_font_faces.is_empty() ||
+            changed_web_fonts.cascade_index_of_any_rule_changed
+        {
             // TODO: This should only dirty nodes that are rendered using any of the removed
             // web fonts!
             document.dirty_all_nodes(cx.no_gc());

--- a/components/shared/fonts/font_template.rs
+++ b/components/shared/fonts/font_template.rs
@@ -9,13 +9,13 @@ use std::sync::Arc;
 use atomic_refcell::{AtomicRef, AtomicRefCell};
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
+use servo_arc::Arc as ServoArc;
 use style::computed_values::font_stretch::T as FontStretch;
 use style::computed_values::font_style::T as FontStyle;
 use style::font_face::{ComputedFontStretchRange, ComputedFontStyleRange, ComputedFontWeightRange};
-use style::properties::generated::font_face::Descriptors as FontFaceRuleDescriptors;
 use style::values::computed::font::FontWeight;
 
-use crate::{CSSFontFaceDescriptors, FontDescriptor, FontIdentifier};
+use crate::{CSSFontFaceDescriptors, FontDescriptor, FontFaceRuleInfo, FontIdentifier};
 
 /// A reference to a [`FontTemplate`] with shared ownership and mutability.
 #[derive(Clone, Debug, MallocSizeOf)]
@@ -144,7 +144,8 @@ pub struct FontTemplate {
     /// If this font is a web font, this is a reference to the `@font-face` rule that
     /// created it.
     #[serde(skip)]
-    pub font_face_rule: Option<FontFaceRuleDescriptors>,
+    #[conditional_malloc_size_of]
+    pub font_face_rule: Option<ServoArc<FontFaceRuleInfo>>,
 }
 
 impl Debug for FontTemplate {
@@ -161,7 +162,7 @@ impl FontTemplate {
     pub fn new(
         identifier: FontIdentifier,
         descriptor: FontTemplateDescriptor,
-        font_face_rule: Option<FontFaceRuleDescriptors>,
+        font_face_rule: Option<ServoArc<FontFaceRuleInfo>>,
     ) -> FontTemplate {
         FontTemplate {
             identifier,
@@ -176,7 +177,7 @@ impl FontTemplate {
     pub fn new_for_local_web_font(
         local_template: FontTemplateRef,
         css_font_template_descriptors: &CSSFontFaceDescriptors,
-        font_face_rule: Option<FontFaceRuleDescriptors>,
+        font_face_rule: Option<ServoArc<FontFaceRuleInfo>>,
     ) -> Result<FontTemplate, &'static str> {
         let mut alias_template = local_template.borrow().clone();
         alias_template
@@ -190,10 +191,10 @@ impl FontTemplate {
         &self.identifier
     }
 
-    pub fn is_defined_by_font_face_rule(&self, rule: &FontFaceRuleDescriptors) -> bool {
+    pub fn is_defined_by_font_face_rule(&self, rule: &ServoArc<FontFaceRuleInfo>) -> bool {
         self.font_face_rule
             .as_ref()
-            .is_some_and(|defining_rule| defining_rule == rule)
+            .is_some_and(|defining_rule| ServoArc::ptr_eq(rule, defining_rule))
     }
 }
 
@@ -212,7 +213,7 @@ pub trait FontTemplateRefMethods {
     fn char_in_unicode_range(&self, character: char) -> bool;
 
     /// Return the `@font-face` rule that defined this template, if any.
-    fn font_face_rule(&self) -> Option<AtomicRef<'_, FontFaceRuleDescriptors>>;
+    fn font_face_rule(&self) -> Option<AtomicRef<'_, ServoArc<FontFaceRuleInfo>>>;
 }
 
 impl FontTemplateRefMethods for FontTemplateRef {
@@ -245,7 +246,7 @@ impl FontTemplateRefMethods for FontTemplateRef {
             .is_none_or(|ranges| ranges.iter().any(|range| range.contains(&character)))
     }
 
-    fn font_face_rule(&self) -> Option<AtomicRef<'_, FontFaceRuleDescriptors>> {
+    fn font_face_rule(&self) -> Option<AtomicRef<'_, ServoArc<FontFaceRuleInfo>>> {
         AtomicRef::filter_map(self.borrow(), |template| template.font_face_rule.as_ref())
     }
 }

--- a/components/shared/fonts/lib.rs
+++ b/components/shared/fonts/lib.rs
@@ -20,8 +20,8 @@ use num_derive::{NumOps, One, Zero};
 use serde::{Deserialize, Serialize};
 use servo_arc::Arc as ServoArc;
 use servo_base::generic_channel::GenericSharedMemory;
-use style::shared_lock::StylesheetGuards;
-use style::stylesheets::{FontFaceRule, LockedFontFaceRule, Origin};
+use style::font_face::Descriptors;
+use style::stylesheets::LockedFontFaceRule;
 pub use system_font_service_proxy::*;
 use webrender_api::euclid::num::One;
 
@@ -180,9 +180,9 @@ pub enum FontDataError {
 #[derive(Clone, Default)]
 pub struct WebFontSetDifference {
     /// A list of `@font-face` rules that were added in this update.
-    pub added_font_faces: Vec<FontFaceRuleWithOrigin>,
+    pub added_font_faces: Vec<ServoArc<FontFaceRuleInfo>>,
     /// A list of `@font-face` rules that were removed in this update.
-    pub removed_font_faces: Vec<FontFaceRuleWithOrigin>,
+    pub removed_font_faces: Vec<ServoArc<FontFaceRuleInfo>>,
 }
 
 impl WebFontSetDifference {
@@ -193,25 +193,13 @@ impl WebFontSetDifference {
 }
 
 #[derive(Clone, MallocSizeOf)]
-pub struct FontFaceRuleWithOrigin {
+pub struct FontFaceRuleInfo {
+    /// The index of this `@font-face` in the cascade, relative to all
+    /// other `@font-face` rules.
+    pub cascade_index: usize,
+    /// The descriptors on the `@font-face` rule.
+    pub descriptors: Descriptors,
+    /// The CSS rule that created this `@font-face`.
     #[conditional_malloc_size_of]
     pub rule: ServoArc<LockedFontFaceRule>,
-    origin: Origin,
-}
-
-impl FontFaceRuleWithOrigin {
-    pub fn new(rule: ServoArc<LockedFontFaceRule>, origin: Origin) -> Self {
-        Self { rule, origin }
-    }
-
-    pub fn ptr_eq(first: &Self, second: &Self) -> bool {
-        ServoArc::ptr_eq(&first.rule, &second.rule)
-    }
-
-    pub fn read_with<'a>(&'a self, guards: &'a StylesheetGuards) -> &'a FontFaceRule {
-        match self.origin {
-            Origin::Author => self.rule.read_with(guards.author),
-            Origin::UserAgent | Origin::User => self.rule.read_with(guards.ua_or_user),
-        }
-    }
 }

--- a/components/shared/fonts/lib.rs
+++ b/components/shared/fonts/lib.rs
@@ -11,6 +11,7 @@ mod system_font_service_proxy;
 
 use std::ops::{Deref, Range};
 use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
 
 pub use font_descriptor::*;
 pub use font_identifier::*;
@@ -183,6 +184,10 @@ pub struct WebFontSetDifference {
     pub added_font_faces: Vec<ServoArc<FontFaceRuleInfo>>,
     /// A list of `@font-face` rules that were removed in this update.
     pub removed_font_faces: Vec<ServoArc<FontFaceRuleInfo>>,
+    /// Whether the cascade index of any `@font-face` rule changed during this update.
+    ///
+    /// This can cause different fonts to be selected during font matching.
+    pub cascade_index_of_any_rule_changed: bool,
 }
 
 impl WebFontSetDifference {
@@ -192,11 +197,11 @@ impl WebFontSetDifference {
     }
 }
 
-#[derive(Clone, MallocSizeOf)]
+#[derive(MallocSizeOf)]
 pub struct FontFaceRuleInfo {
     /// The index of this `@font-face` in the cascade, relative to all
     /// other `@font-face` rules.
-    pub cascade_index: usize,
+    pub cascade_index: AtomicUsize,
     /// The descriptors on the `@font-face` rule.
     pub descriptors: Descriptors,
     /// The CSS rule that created this `@font-face`.


### PR DESCRIPTION
Currently when multiple web fonts tie during font matching then whichever one loaded first wins. This causes obvious intermittent behaviour, and we should instead prefer the one that comes first in the CSS cascade.

This change also stores `@font-face` related info in a single `FontFaceRuleInfo` struct that is shared between the DOM `FontFace` objects, the font templates and everything that wants to know about the rule. Doing this cleans up the code significantly and makes removing `@font-face` rules easier, as they now can compare the `@font-face` pointer in `O(1)` instead of comparing each individual descriptor.

This PR does not yet update the cascade index of a web font as stylesheets are inserted or removed. I intend to do that in a followup.

Fixes https://github.com/servo/servo/issues/46029
Fixes https://github.com/servo/servo/issues/20684
Part of https://github.com/servo/servo/issues/46859
