### PR TITLE
script: Improve spec compliance of `Document::set_ready_state`

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -1425,35 +1425,58 @@ impl Document {
             .map(|element| DomRoot::from_ref(&**element))
     }
 
-    // https://html.spec.whatwg.org/multipage/#current-document-readiness
-    pub(crate) fn set_ready_state(&self, cx: &mut JSContext, state: DocumentReadyState) {
+    pub(crate) fn notify_embedder_of_load_completion(&self) {
+        if self.window().is_top_level() {
+            self.send_to_embedder(EmbedderMsg::NotifyLoadStatusChanged(
+                self.webview_id(),
+                LoadStatus::Complete,
+            ));
+        }
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#update-the-current-document-readiness>
+    pub(crate) fn update_the_current_document_readiness(
+        &self,
+        cx: &mut JSContext,
+        state: DocumentReadyState,
+    ) {
+        // Step 1. If document's current document readiness equals readinessValue, then return.
+        if self.ready_state.get() == state {
+            return;
+        }
+
+        // Step 2. Set document's current document readiness to readinessValue.
+        self.ready_state.set(state);
+
+        // Step 3. If document is associated with an HTML parser:
+        // Step 3.1: Let now be the current high resolution time given document's relevant
+        // global object.
+        // Note: Handled implicitly by update_with_current_instant.
         match state {
             DocumentReadyState::Loading => {
-                if self.window().is_top_level() {
-                    self.send_to_embedder(EmbedderMsg::NotifyLoadStatusChanged(
-                        self.webview_id(),
-                        LoadStatus::Started,
-                    ));
-                    self.send_to_embedder(EmbedderMsg::Status(self.webview_id(), None));
-                    update_with_current_instant(&self.navigation_timing.dom_loading);
-                }
+                unreachable!("Loading is an initial state, so we never transition to it.")
             },
             DocumentReadyState::Complete => {
-                if self.window().is_top_level() {
-                    self.send_to_embedder(EmbedderMsg::NotifyLoadStatusChanged(
-                        self.webview_id(),
-                        LoadStatus::Complete,
-                    ));
-                }
+                // This isn't part of the specification, but it's useful to have it here to
+                // avoid code duplication.
+                self.notify_embedder_of_load_completion();
+
+                // Step 3.2: If readinessValue is "complete", and document's load timing info's
+                // DOM complete time is 0, then set document's load timing info's DOM complete
+                // time to now.
+                // Note: "check for zero" is handled by `.update_with_current_instant`.
                 update_with_current_instant(&self.navigation_timing.dom_complete);
             },
             DocumentReadyState::Interactive => {
+                // Step 3.3: Otherwise, if readinessValue is "interactive", and document's load timing
+                // info's DOM interactive time is 0, then set document's load timing info's DOM
+                // interactive time to now.
+                // Note: "check for zero" is handled by `.update_with_current_instant`.
                 update_with_current_instant(&self.navigation_timing.dom_interactive)
             },
         };
 
-        self.ready_state.set(state);
-
+        // Step 4. Fire an event named readystatechange at document.
         self.upcast::<EventTarget>()
             .fire_event(cx, atom!("readystatechange"));
     }
@@ -2409,7 +2432,7 @@ impl Document {
                 }
 
                 // Step 9.1. Update the current document readiness to "complete".
-                document.set_ready_state(cx,DocumentReadyState::Complete);
+                document.update_the_current_document_readiness(cx,DocumentReadyState::Complete);
 
                 // Step 9.2. If the Document object's browsing context is null, then abort these steps.
                 if document.browsing_context().is_none() {
@@ -3862,6 +3885,14 @@ impl Document {
             QuirksMode::NoQuirks
         };
 
+        // From <https://w3c.github.io/navigation-timing/#dom-performancetiming-domloading>:
+        // > This attribute must return the time immediately before the user agent sets the
+        // > current document readiness to "loading".
+        let navigation_timing = Rc::new(NavigationTiming::default());
+        if ready_state == DocumentReadyState::Loading {
+            update_with_current_instant(&navigation_timing.dom_loading);
+        }
+
         Document {
             node: Node::new_document_node(),
             document_or_shadow_root: DocumentOrShadowRoot::new(window),
@@ -3935,7 +3966,7 @@ impl Document {
             active_parser_was_aborted: Cell::new(false),
             fired_unload: Cell::new(false),
             responsive_images: Default::default(),
-            navigation_timing: Default::default(),
+            navigation_timing,
             resource_fetch_timing: RefCell::new(None),
             completely_loaded: Cell::new(false),
             script_and_layout_blockers: Cell::new(0),
@@ -5252,7 +5283,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         sanitizer.sanitize(cx, document.upcast(), false)?;
 
         // Step 7. Return document.
-        document.set_ready_state(cx, DocumentReadyState::Complete);
+        document.update_the_current_document_readiness(cx, DocumentReadyState::Complete);
         Ok(document)
     }
 

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -156,7 +156,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                 // Step switch-1. Create an XML parser parser, associated with document,
                 // and with XML scripting support disabled.
                 ServoParser::parse_xml_document(cx, &document, Some(compliant_string), url, None);
-                document.set_ready_state(cx, DocumentReadyState::Complete);
+                document.update_the_current_document_readiness(cx, DocumentReadyState::Complete);
                 document
             },
         };

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -487,7 +487,7 @@ impl ServoParser {
 
         // Step 2.
         self.document
-            .set_ready_state(cx, DocumentReadyState::Interactive);
+            .update_the_current_document_readiness(cx, DocumentReadyState::Interactive);
 
         // Step 3.
         self.tokenizer.end(cx);
@@ -495,7 +495,7 @@ impl ServoParser {
 
         // Step 4.
         self.document
-            .set_ready_state(cx, DocumentReadyState::Complete);
+            .update_the_current_document_readiness(cx, DocumentReadyState::Complete);
     }
 
     pub(crate) fn get_current_line(&self) -> u32 {
@@ -765,7 +765,7 @@ impl ServoParser {
         self.tokenizer.end(cx);
         // Step 3. Update the current document readiness to "interactive".
         self.document
-            .set_ready_state(cx, DocumentReadyState::Interactive);
+            .update_the_current_document_readiness(cx, DocumentReadyState::Interactive);
         // Step 4. Pop all the nodes off the stack of open elements.
         self.document.set_current_parser(None);
         // Step 5. While the list of scripts that will execute when the document has finished parsing is not empty:
@@ -1289,11 +1289,21 @@ impl ParserContext {
             .queue_entry(performance_entry.upcast::<PerformanceEntry>());
     }
 
-    fn finish_synchronous_load(&self, cx: &mut JSContext, document: &Document) {
-        document.set_ready_state(cx, DocumentReadyState::Complete);
+    fn finish_synchronous_load_for_initial_about_blank(
+        &self,
+        cx: &mut JSContext,
+        document: &Document,
+    ) {
+        // Synchronous loads for initial `about:blank` always start in the `Complete` state
+        // which is why we do not notify the embedder of completion via
+        // `Document::update_the_current_document_readiness`.
+        debug_assert_eq!(document.ReadyState(), DocumentReadyState::Complete);
+
         document.set_current_parser(None);
         document.start_the_end_loading_phase();
         document.finish_load(LoadType::PageSource(self.url.clone()), cx);
+
+        document.notify_embedder_of_load_completion();
     }
 }
 
@@ -1612,7 +1622,7 @@ impl FetchResponseListener for ParserContext {
         }
 
         if document.is_initial_about_blank() {
-            self.finish_synchronous_load(cx, &document);
+            self.finish_synchronous_load_for_initial_about_blank(cx, &document);
         }
     }
 

--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -42,8 +42,8 @@ use devtools_traits::{
 use embedder_traits::user_contents::{UserContentManagerId, UserContents, UserScript};
 use embedder_traits::{
     EmbedderControlId, EmbedderControlResponse, EmbedderMsg, FocusSequenceNumber,
-    InputEventOutcome, JavaScriptEvaluationError, JavaScriptEvaluationId, MediaSessionActionType,
-    Theme, ViewportDetails, WebDriverScriptCommand,
+    InputEventOutcome, JavaScriptEvaluationError, JavaScriptEvaluationId, LoadStatus,
+    MediaSessionActionType, Theme, ViewportDetails, WebDriverScriptCommand,
 };
 use encoding_rs::Encoding;
 use fonts::{FontContext, SystemFontServiceProxy, WebFontLoadEvent};
@@ -3651,7 +3651,20 @@ impl ScriptThread {
             image_cache,
         );
 
-        document.set_ready_state(cx, DocumentReadyState::Loading);
+        // Only send loading-related messages if this document is actually in the loading state.
+        // `about:blank` documents should never be in that state when starting.
+        if !incomplete.load_data.is_initial_about_blank {
+            debug_assert_eq!(document.ReadyState(), DocumentReadyState::Loading);
+            if window.is_top_level() {
+                window.send_to_embedder(EmbedderMsg::NotifyLoadStatusChanged(
+                    incomplete.webview_id,
+                    LoadStatus::Started,
+                ));
+                window.send_to_embedder(EmbedderMsg::Status(incomplete.webview_id, None));
+            }
+        } else {
+            debug_assert_eq!(document.ReadyState(), DocumentReadyState::Complete);
+        }
 
         // Step 8. Let loadTimingInfo be a new document load timing info with its
         //   navigation start time set to navigationParams's response's timing

--- a/tests/wpt/meta/navigation-timing/test-timing-attributes-order.html.ini
+++ b/tests/wpt/meta/navigation-timing/test-timing-attributes-order.html.ini
@@ -5,9 +5,6 @@
   [window.performance.timing.responseStart > 0]
     expected: FAIL
 
-  [window.performance.timing.domLoading > 0]
-    expected: FAIL
-
   [window.performance.timing.unloadEventStart > 0]
     expected: FAIL
 


### PR DESCRIPTION
This changes makes some minor changes to `Document::set_ready_state` to
make it match the specification steps for
"update-the-current-document-readiness". Notably, because `Document`'s
can start in the `Loaded` state, to match the specification that work
has to be done by the caller. This should guard against times when
`set_ready_state` is called more than once for the same state, which
will be useful when implementing full support for `WebView::stop`.

One very minor behavioral improvement: `about:blank` documents now do
not transition from `Complete` to `Loading`.

Testing: This causes one WPT subtest to start passing.
