### PR TITLE
net: Shrink `completed_body` allocation when finishing HTTP load

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -2353,10 +2353,12 @@ async fn http_network_fetch(
             .and_then(move |res_body| {
                 debug!("successfully finished response for {:?}", url1);
                 let mut body = res_body.lock();
-                let completed_body = match *body {
+                let mut completed_body = match *body {
                     ResponseBody::Receiving(ref mut body) => std::mem::take(body),
                     _ => vec![],
                 };
+                // This allocation may be retained by the http-cache.
+                completed_body.shrink_to_fit();
                 // If devtools is disabled avoid cloning, since the result would
                 // be unused anyway.
                 let devtools_response_body =


### PR DESCRIPTION
The responses are cached by our HTTP cache, so shrinking the allocation can save memory by discarding excess capacity. Not all responses are cached, but currently we don't have a way to determine if it is retained by the HTTP cache or not, and it's unclear if adding such a mechanic would save work compared to just always shrinking.  The network loading process already contains a series of potential re-allocations (by growing the `Vec`), so adding another potential reallocation to shrink should be fine.

Testing: No behavior change.

