### PR TITLE
http_loader: Improve preallocation heuristic

### DIFF
--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -1411,7 +1411,8 @@ impl RemoteWebFontDownloader {
                 DownloaderResponseResult::Finished
             },
             FetchResponseMsg::ProcessContentLength(_request_id, size) => {
-                self.response_data.reserve(size - self.response_data.len());
+                self.response_data
+                    .reserve(size.saturating_sub(self.response_data.len()));
                 DownloaderResponseResult::InProcess
             },
         }

--- a/components/net/decoder.rs
+++ b/components/net/decoder.rs
@@ -151,6 +151,11 @@ impl Decoder {
         }
     }
 
+    /// Returns true if the content is encoded
+    pub fn is_encoded(&self) -> bool {
+        !matches!(self.inner, Inner::PlainText(_))
+    }
+
     /// Constructs a Decoder from a hyper response.
     ///
     /// A decoder is just a wrapper around the hyper response that knows

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -2312,9 +2312,6 @@ async fn http_network_fetch(
         return Response::network_error(NetworkError::LoadCancelled);
     }
 
-    *response_body.lock() = ResponseBody::Receiving(vec![]);
-    let response_body2 = response_body.clone();
-
     if let Some(ref sender) = devtools_sender &&
         let Some(m) = msg
     {
@@ -2333,15 +2330,26 @@ async fn http_network_fetch(
     let headers = response.headers.clone();
     let devtools_chan = context.devtools_chan.clone();
 
-    if let Some(possible_length) = response_stream
+    let prealloc_size = if let Some(possible_length) = response_stream
         .headers()
         .get(http::header::CONTENT_LENGTH)
         .and_then(|header_value| header_value.to_str().ok())
         .and_then(|s| s.parse().ok())
         .map(|length| min(length, pref!(network_max_content_length) as usize))
     {
-        let _ = done_sender.send(Data::ContentLength(possible_length));
+        // For compressed content, we pre-allocate a multiple of the
+        // compressed size, assuming typical content will be highly compressed.
+        let multiplier = if response_stream.body().is_encoded() { 5 } else { 1 };
+        possible_length * multiplier
+    } else {
+        // We don't know the length, so we fallback to something to still
+        // avoid some reallocs.
+        4096
     }
+    .min(pref!(network_max_content_length) as usize);
+    let _ = done_sender.send(Data::ContentLength(prealloc_size));
+    *response_body.lock() = ResponseBody::Receiving(Vec::with_capacity(prealloc_size));
+    let response_body2 = response_body.clone();
 
     spawn_task(
         response_stream

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cmp::min;
 use std::collections::HashSet;
 use std::iter::FromIterator;
 use std::sync::Arc as StdArc;
@@ -2330,17 +2329,20 @@ async fn http_network_fetch(
     let headers = response.headers.clone();
     let devtools_chan = context.devtools_chan.clone();
 
-    let prealloc_size = if let Some(possible_length) = response_stream
+    let prealloc_size: usize = if let Some(possible_length) = response_stream
         .headers()
         .get(http::header::CONTENT_LENGTH)
         .and_then(|header_value| header_value.to_str().ok())
-        .and_then(|s| s.parse().ok())
-        .map(|length| min(length, pref!(network_max_content_length) as usize))
+        .and_then(|s| s.parse::<usize>().ok())
     {
         // For compressed content, we pre-allocate a multiple of the
         // compressed size, assuming typical content will be highly compressed.
-        let multiplier = if response_stream.body().is_encoded() { 5 } else { 1 };
-        possible_length * multiplier
+        let multiplier: usize = if response_stream.body().is_encoded() {
+            5
+        } else {
+            1
+        };
+        possible_length.saturating_mul(multiplier)
     } else {
         // We don't know the length, so we fallback to something to still
         // avoid some reallocs.

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -281,13 +281,14 @@ impl ImageBytes {
     }
 
     fn mark_complete(&mut self) -> Arc<Vec<u8>> {
-        let bytes = {
+        let mut bytes = {
             let own_bytes = match *self {
                 ImageBytes::InProgress(ref mut bytes) => bytes,
                 ImageBytes::Complete(_) => panic!("attempted modification of complete image bytes"),
             };
             mem::take(own_bytes)
         };
+        bytes.shrink_to_fit();
         let bytes = Arc::new(bytes);
         *self = ImageBytes::Complete(bytes.clone());
         bytes

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -303,7 +303,7 @@ impl ImageBytes {
 
     fn set_capacity(&mut self, size: usize) {
         match self {
-            ImageBytes::InProgress(items) => items.reserve(size - items.len()),
+            ImageBytes::InProgress(items) => items.reserve(size.saturating_sub(items.len())),
             ImageBytes::Complete(_) => error!("Want to set capacity on already completed image."),
         }
     }

--- a/components/script/css/stylesheet_loader.rs
+++ b/components/script/css/stylesheet_loader.rs
@@ -450,7 +450,7 @@ impl FetchResponseListener for StylesheetContext {
     }
 
     fn process_content_length(&mut self, _request_id: RequestId, size: usize) {
-        self.data.reserve(size - self.data.len());
+        self.data.reserve(size.saturating_sub(self.data.len()));
     }
 }
 

--- a/components/script/dom/html/document_metadata/processingoptions.rs
+++ b/components/script/dom/html/document_metadata/processingoptions.rs
@@ -528,7 +528,8 @@ impl FetchResponseListener for LinkFetchContext {
     }
 
     fn process_content_length(&mut self, _request_id: RequestId, size: usize) {
-        self.response_body.reserve(size - self.response_body.len());
+        self.response_body
+            .reserve(size.saturating_sub(self.response_body.len()));
     }
 }
 

--- a/components/script/dom/html/scripting/htmlscriptelement.rs
+++ b/components/script/dom/html/scripting/htmlscriptelement.rs
@@ -461,7 +461,7 @@ impl FetchResponseListener for ClassicContext {
     }
 
     fn process_content_length(&mut self, _request_id: RequestId, size: usize) {
-        self.data.reserve(size - self.data.len());
+        self.data.reserve(size.saturating_sub(self.data.len()));
     }
 }
 

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -279,7 +279,8 @@ impl FetchResponseListener for ScriptFetchContext {
     }
 
     fn process_content_length(&mut self, _request_id: RequestId, size: usize) {
-        self.body_bytes.reserve(size - self.body_bytes.len());
+        self.body_bytes
+            .reserve(size.saturating_sub(self.body_bytes.len()));
     }
 }
 

--- a/components/script/fetch/fetch.rs
+++ b/components/script/fetch/fetch.rs
@@ -904,7 +904,7 @@ pub(crate) fn load_whole_resource(
                 csp_violations_processor.process_csp_violations(cx, violations);
             },
             FetchResponseMsg::ProcessContentLength(_request_id, size) => {
-                buf.reserve(size - buf.len())
+                buf.reserve(size.saturating_sub(buf.len()))
             },
         }
     }

--- a/components/script/modules/script_module.rs
+++ b/components/script/modules/script_module.rs
@@ -793,7 +793,7 @@ impl FetchResponseListener for ModuleContext {
     }
 
     fn process_content_length(&mut self, _request_id: RequestId, size: usize) {
-        self.data.reserve(size - self.data.len());
+        self.data.reserve(size.saturating_sub(self.data.len()));
     }
 }
 


### PR DESCRIPTION
Reduce the amount of intermediate reallocations by preallocating more generously.
if we don't have any information, we at least preallocate something. If the content is compressed and we know the compressed content-length, we pre-allocate 5x, which should cover typical compressions ratios.
For the http-cache, the backing allocation will be shrunk once everything is received (see #47454).
Also change the calculation in fetch.rs to prevent underflow, if we do call the trait wrongly.
On typical pages this seems to avoid ~90% of the reallocs during fetching and does not seem to negatively affect memory usage.


Testing: No observable change, covered by existing tests

