### PR TITLE
script: Implement `outdent` editing command

### DIFF
--- a/components/script/dom/execcommand/basecommand.rs
+++ b/components/script/dom/execcommand/basecommand.rs
@@ -37,6 +37,7 @@ use crate::dom::execcommand::commands::insertlinebreak::execute_insert_line_brea
 use crate::dom::execcommand::commands::insertparagraph::execute_insert_paragraph_command;
 use crate::dom::execcommand::commands::inserttext::execute_insert_text_command;
 use crate::dom::execcommand::commands::italic::execute_italic_command;
+use crate::dom::execcommand::commands::outdent::execute_outdent_command;
 use crate::dom::execcommand::commands::removeformat::execute_removeformat_command;
 use crate::dom::execcommand::commands::strikethrough::execute_strikethrough_command;
 use crate::dom::execcommand::commands::stylewithcss::execute_style_with_css_command;
@@ -763,6 +764,7 @@ impl CommandName {
             },
             CommandName::InsertText => execute_insert_text_command(cx, document, selection, value),
             CommandName::Italic => execute_italic_command(cx, document, selection),
+            CommandName::Outdent => execute_outdent_command(cx, document, selection),
             CommandName::RemoveFormat => execute_removeformat_command(cx, document, selection),
             CommandName::Strikethrough => execute_strikethrough_command(cx, document, selection),
             CommandName::StyleWithCss => execute_style_with_css_command(document, value),

--- a/components/script/dom/execcommand/commands/delete.rs
+++ b/components/script/dom/execcommand/commands/delete.rs
@@ -17,6 +17,7 @@ use crate::dom::html::htmlanchorelement::HTMLAnchorElement;
 use crate::dom::html::htmlbrelement::HTMLBRElement;
 use crate::dom::html::htmlhrelement::HTMLHRElement;
 use crate::dom::html::htmlimageelement::HTMLImageElement;
+use crate::dom::html::htmllielement::HTMLLIElement;
 use crate::dom::html::htmltableelement::HTMLTableElement;
 use crate::dom::selection::Selection;
 use crate::dom::text::Text;
@@ -159,9 +160,13 @@ pub(crate) fn execute_delete_command(
         offset == 0
     {
         // Step 7.1. Let items be a list of all lis that are ancestors of node.
-        // TODO
+        let items = node
+            .ancestors()
+            .filter(|ancestor| ancestor.is::<HTMLLIElement>());
         // Step 7.2. Normalize sublists of each item in items.
-        // TODO
+        for item in items {
+            item.normalize_sublists(cx);
+        }
         // Step 7.3. Record the values of the one-node list consisting of node, and let values be the result.
         let values = record_the_values(vec![node.clone()]);
         // Step 7.4. Split the parent of the one-node list consisting of node.

--- a/components/script/dom/execcommand/commands/indent.rs
+++ b/components/script/dom/execcommand/commands/indent.rs
@@ -21,7 +21,7 @@ use crate::dom::node::Node;
 use crate::dom::selection::Selection;
 
 // <https://w3c.github.io/editing/docs/execCommand/#indent>
-pub(crate) fn indent(cx: &mut JSContext, document: &Document, node_list: Vec<DomRoot<Node>>) {
+pub(crate) fn indent(cx: &mut JSContext, context_object: &Document, node_list: Vec<DomRoot<Node>>) {
     // Step 1. If node list is empty, do nothing and abort these steps.
     if node_list.is_empty() {
         return;
@@ -83,7 +83,7 @@ pub(crate) fn indent(cx: &mut JSContext, document: &Document, node_list: Vec<Dom
 
     // Step 5. Fix disallowed ancestors of new parent.
     if let Some(new_parent) = new_parent {
-        new_parent.fix_disallowed_ancestors(cx, document);
+        new_parent.fix_disallowed_ancestors(cx, context_object);
     }
 }
 

--- a/components/script/dom/execcommand/commands/indent.rs
+++ b/components/script/dom/execcommand/commands/indent.rs
@@ -8,19 +8,17 @@ use js::context::JSContext;
 use script_bindings::codegen::GenericBindings::NodeBinding::NodeMethods;
 use script_bindings::inheritance::Castable;
 
-use crate::dom::NodeTraits;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
-use crate::dom::element::{AdjacentPosition, Element};
+use crate::dom::element::Element;
 use crate::dom::execcommand::contenteditable::node::{
-    NodeOrString, is_allowed_child, move_preserving_ranges, wrap_node_list,
+    NodeOrString, is_allowed_child, wrap_node_list,
 };
 use crate::dom::html::htmllielement::HTMLLIElement;
 use crate::dom::html::htmlolistelement::HTMLOListElement;
 use crate::dom::html::htmlulistelement::HTMLUListElement;
 use crate::dom::node::Node;
 use crate::dom::selection::Selection;
-use crate::dom::text::Text;
 
 // <https://w3c.github.io/editing/docs/execCommand/#indent>
 pub(crate) fn indent(cx: &mut JSContext, document: &Document, node_list: Vec<DomRoot<Node>>) {
@@ -89,77 +87,6 @@ pub(crate) fn indent(cx: &mut JSContext, document: &Document, node_list: Vec<Dom
     }
 }
 
-/// <https://w3c.github.io/editing/docs/execCommand/#normalize-sublists>
-pub(crate) fn normalize_sublists(cx: &mut JSContext, item: DomRoot<Node>) {
-    let item_element = item
-        .downcast::<Element>()
-        .expect("item should be an element");
-
-    // Step 1. If item is not an li or it is not editable or its parent is not editable, abort these steps.
-    if !item.is::<HTMLLIElement>() ||
-        !item.is_editable() ||
-        !item
-            .GetParentElement()
-            .is_some_and(|parent| parent.upcast::<Node>().is_editable())
-    {
-        return;
-    }
-
-    // Step 2. Let new item be null.
-    let mut new_item: Option<DomRoot<Element>> = None;
-
-    // Step 3. While item has an ol or ul child:
-    while item
-        .child_elements()
-        .any(|child| child.is::<HTMLOListElement>() || child.is::<HTMLUListElement>())
-    {
-        // Step 3.1. Let child be the last child of item.
-        let child = item.GetLastChild().expect("Must have a last child here.");
-
-        // Step 3.2. If child is an ol or ul, or new item is null and child is a Text node whose data consists of zero of more space characters:
-        if child.is::<HTMLOListElement>() ||
-            child.is::<HTMLUListElement>() ||
-            (new_item.is_none() &&
-                child
-                    .downcast::<Text>()
-                    .is_some_and(|text| text.data().bytes().all(|byte| byte == b' ')))
-        {
-            // Step 3.2.1. Set new item to null.
-            new_item = None;
-
-            // Step 3.2.2. Insert child into the parent of item immediately following item, preserving ranges.
-            move_preserving_ranges(cx, &child, |cx| {
-                item_element
-                    .insert_adjacent(cx, AdjacentPosition::AfterEnd, &child)
-                    .map(|elem| elem.expect("Should have inserted"))
-            });
-
-            continue;
-        }
-        // Step 3.3. Otherwise:
-        // Step 3.3.1. If new item is null,
-        //             let new item be the result of calling createElement("li") on the ownerDocument of item,
-        //             then insert new item into the parent of item immediately after item.
-        if new_item.is_none() {
-            new_item = Some(item.owner_document().create_element(cx, "li"));
-            item_element
-                .insert_adjacent(cx, AdjacentPosition::AfterEnd, &child)
-                .expect("Insertion should always work here.");
-        }
-
-        // Step 3.3.2. Insert child into new item as its first child, preserving ranges.
-        move_preserving_ranges(cx, &child, |cx| {
-            new_item
-                .as_ref()
-                .expect("Must have new item here")
-                .downcast::<Element>()
-                .expect("New item must be able to support children")
-                .insert_adjacent(cx, AdjacentPosition::AfterBegin, &child)
-                .map(|elem| elem.expect("Should have inserted"))
-        });
-    }
-}
-
 /// <https://w3c.github.io/editing/docs/execCommand/#the-indent-command>
 pub(crate) fn execute_indent_command(
     cx: &mut JSContext,
@@ -179,7 +106,7 @@ pub(crate) fn execute_indent_command(
 
     // Step 2. For each item in items, normalize sublists of item.
     for item in items {
-        normalize_sublists(cx, item);
+        item.normalize_sublists(cx);
     }
 
     // Normalizing sublists probably messes up the range
@@ -234,7 +161,7 @@ pub(crate) fn execute_indent_command(
         if let Some(sibling) = sibling &&
             sibling.is::<HTMLLIElement>()
         {
-            normalize_sublists(cx, sibling);
+            sibling.normalize_sublists(cx);
         }
     }
 

--- a/components/script/dom/execcommand/commands/mod.rs
+++ b/components/script/dom/execcommand/commands/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod insertlinebreak;
 pub(crate) mod insertparagraph;
 pub(crate) mod inserttext;
 pub(crate) mod italic;
+pub(crate) mod outdent;
 pub(crate) mod removeformat;
 pub(crate) mod strikethrough;
 pub(crate) mod stylewithcss;

--- a/components/script/dom/execcommand/commands/outdent.rs
+++ b/components/script/dom/execcommand/commands/outdent.rs
@@ -1,0 +1,367 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::collections::HashSet;
+
+use html5ever::local_name;
+use js::context::JSContext;
+use script_bindings::codegen::GenericBindings::CSSStyleDeclarationBinding::CSSStyleDeclarationMethods;
+use script_bindings::codegen::GenericBindings::NodeBinding::NodeMethods;
+use script_bindings::inheritance::Castable;
+use script_bindings::root::DomSlice;
+
+use crate::dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
+use crate::dom::bindings::root::{Dom, DomRoot};
+use crate::dom::document::Document;
+use crate::dom::element::Element;
+use crate::dom::execcommand::commands::indent::indent;
+use crate::dom::execcommand::contenteditable::node::{
+    record_the_values, restore_the_values, split_the_parent,
+};
+use crate::dom::html::htmlbrelement::HTMLBRElement;
+use crate::dom::html::htmlelement::HTMLElement;
+use crate::dom::html::htmllielement::HTMLLIElement;
+use crate::dom::html::htmlolistelement::HTMLOListElement;
+use crate::dom::html::htmlulistelement::HTMLUListElement;
+use crate::dom::iterators::ShadowIncluding;
+use crate::dom::node::Node;
+use crate::dom::selection::Selection;
+
+/// <https://w3c.github.io/editing/docs/execCommand/#outdent>
+pub(crate) fn outdent(cx: &mut JSContext, context_object: &Document, node: &DomRoot<Node>) {
+    // Step 1. If node is not editable, abort these steps.
+    if !node.is_editable() {
+        return;
+    }
+
+    // Step 2. If node is a simple indentation element, remove node, preserving its descendants.
+    //         Then abort these steps.
+    if node
+        .downcast::<Element>()
+        .is_some_and(|element| element.is_simple_indentation_element())
+    {
+        node.remove_preserving_its_descendants(cx);
+        return;
+    }
+
+    // Step 3. If node is an indentation element:
+    if let Some(node_as_element) = node.downcast::<Element>() &&
+        node_as_element.is_indentation_element()
+    {
+        // Step 3.1. Unset the dir attribute of node, if any.
+        node_as_element.remove_attribute_by_name(cx, &local_name!("dir"));
+
+        // Step 3.2. Unset the margin, padding, and border CSS properties of node.
+        if let Some(node_as_html_element) = node_as_element.downcast::<HTMLElement>() {
+            let _ = node_as_html_element
+                .Style(cx)
+                .RemoveProperty(cx, "margin".into());
+            let _ = node_as_html_element
+                .Style(cx)
+                .RemoveProperty(cx, "padding".into());
+            let _ = node_as_html_element
+                .Style(cx)
+                .RemoveProperty(cx, "border".into());
+        }
+
+        // Step 3.3. Set the tag name of node to "div".
+        node_as_element.set_the_tag_name(cx, "div");
+
+        // Step 3.4. Abort these steps.
+        return;
+    }
+
+    // Step 4. Let current ancestor be node's parent.
+    let mut current_ancestor = node.GetParentNode();
+
+    // Step 5. Let ancestor list be a list of nodes, initially empty.
+    let mut ancestor_list: Vec<DomRoot<Node>> = vec![];
+
+    // Step 6. While current ancestor is an editable Element that is neither a simple indentation
+    //         element nor an ol nor a ul, append current ancestor to ancestor list and then set
+    //         current ancestor to its parent.
+    while let Some(ancestor) = current_ancestor.clone() &&
+        ancestor.is_editable() &&
+        !ancestor
+            .downcast::<Element>()
+            .is_some_and(|element| element.is_simple_indentation_element()) &&
+        !ancestor.is::<HTMLOListElement>() &&
+        !ancestor.is::<HTMLUListElement>()
+    {
+        current_ancestor = ancestor.GetParentNode();
+        ancestor_list.push(ancestor);
+    }
+
+    // Step 7. If current ancestor is not an editable simple indentation element:
+    if !current_ancestor.as_ref().is_some_and(|ancestor| {
+        ancestor.is_editable() &&
+            ancestor
+                .downcast::<Element>()
+                .is_some_and(|element| element.is_simple_indentation_element())
+    }) {
+        // Step 7.1. Let current ancestor be node's parent.
+        current_ancestor = node.GetParentNode();
+
+        // Step 7.2. Let ancestor list be the empty list.
+        ancestor_list.clear();
+
+        // Step 7.3. While current ancestor is an editable Element that is neither an indentation
+        //           element nor an ol nor a ul, append current ancestor to ancestor list and then
+        //           set current ancestor to its parent.
+        while let Some(ancestor) = current_ancestor.clone() &&
+            ancestor.is_editable() &&
+            !ancestor
+                .downcast::<Element>()
+                .is_some_and(|element| element.is_indentation_element()) &&
+            !ancestor.is::<HTMLOListElement>() &&
+            !ancestor.is::<HTMLUListElement>()
+        {
+            current_ancestor = ancestor.GetParentNode();
+            ancestor_list.push(ancestor);
+        }
+    }
+
+    // Step 8. If node is an ol or ul and current ancestor is not an editable indentation element:
+    if let Some(node_as_element) = node.downcast::<Element>() &&
+        (node.is::<HTMLOListElement>() || node.is::<HTMLUListElement>()) &&
+        !current_ancestor.as_ref().is_some_and(|ancestor| {
+            ancestor.is_editable() &&
+                ancestor
+                    .downcast::<Element>()
+                    .is_some_and(|element| element.is_indentation_element())
+        })
+    {
+        // Step 8.1. Unset the reversed, start, and type attributes of node, if any are set.
+        node_as_element.remove_attribute_by_name(cx, &local_name!("reversed"));
+        node_as_element.remove_attribute_by_name(cx, &local_name!("start"));
+        node_as_element.remove_attribute_by_name(cx, &local_name!("type"));
+
+        // Step 8.2. Let children be the children of node.
+        let children = node.children();
+
+        // Step 8.3. If node has attributes, and its parent is not an ol or ul, set the tag name of node to "div".
+        if !node_as_element.attrs().borrow().is_empty() &&
+            !node.GetParentElement().is_some_and(|parent| {
+                parent.is::<HTMLOListElement>() || parent.is::<HTMLUListElement>()
+            })
+        {
+            node_as_element.set_the_tag_name(cx, "div");
+        }
+        // Step 8.4. Otherwise:
+        else {
+            // Step 8.4.1. Record the values of node's children, and let values be the result.
+            let values = record_the_values(node.children().collect());
+
+            // Step 8.4.2. Remove node, preserving its descendants.
+            node.remove_preserving_its_descendants(cx);
+
+            // Step 8.4.3. Restore the values from values.
+            restore_the_values(cx, values);
+        }
+
+        // Step 8.5. Fix disallowed ancestors of each member of children.
+        for child in children {
+            child.fix_disallowed_ancestors(cx, context_object);
+        }
+
+        // Step 8.6. Abort these steps.
+        return;
+    }
+
+    // Step 9. If current ancestor is not an editable indentation element, abort these steps.
+    if !current_ancestor.as_ref().is_some_and(|ancestor| {
+        ancestor.is_editable() &&
+            ancestor
+                .downcast::<Element>()
+                .is_some_and(|element| element.is_indentation_element())
+    }) {
+        return;
+    }
+
+    // Step 10. Append current ancestor to ancestor list.
+    ancestor_list.push(
+        current_ancestor
+            .clone()
+            .expect("Should have an ancestor here."),
+    );
+
+    // Step 11. Let original ancestor be current ancestor.
+    let original_ancestor = current_ancestor;
+
+    // Step 12. While ancestor list is not empty:
+    while !ancestor_list.is_empty() {
+        // Step 12.1. Let current ancestor be the last member of ancestor list.
+        // Step 12.2. Remove the last member from ancestor list.
+        let current_ancestor_ref = ancestor_list.pop();
+
+        // Step 12.3. Let target be the child of current ancestor that is equal to either node or
+        //            the last member of ancestor list.
+        let target = current_ancestor_ref
+            .expect("Must always have an ancestor here.")
+            .children()
+            .find(|child| child == node || Some(child) == ancestor_list.last())
+            .expect("Must be able to find a target here.");
+
+        // Step 12.4. If target is an inline node that is not a br, and its nextSibling is a br,
+        //            remove target's nextSibling from its parent.
+        if target.is_inline_node() &&
+            let Some(next_br_sibling) = target.GetNextSibling() &&
+            next_br_sibling.is::<HTMLBRElement>()
+        {
+            next_br_sibling.remove_self(cx);
+        }
+
+        // Step 12.5. Let preceding siblings be the precedings siblings of target, and let
+        //            following siblings be the followings siblings of target.
+        let preceding_siblings = target.preceding_siblings().collect();
+        let following_siblings = target.following_siblings().collect();
+
+        // Step 12.6. Indent preceding siblings.
+        indent(cx, context_object, preceding_siblings);
+
+        // Step 12.7. Indent following siblings.
+        indent(cx, context_object, following_siblings);
+    }
+
+    // Step 13. Outdent original ancestor.
+    outdent(
+        cx,
+        context_object,
+        &original_ancestor.expect("Should have an ancestor here."),
+    );
+}
+
+/// <https://w3c.github.io/editing/docs/execCommand/#the-outdent-command>
+pub(crate) fn execute_outdent_command(
+    cx: &mut JSContext,
+    document: &Document,
+    selection: &Selection,
+) -> bool {
+    let mut active_range = selection
+        .active_range(cx)
+        .expect("Must always have an active range.");
+    // Step 1. Let items be a list of all lis that are inclusive ancestors of the active range's start and/or end node.
+    let items: HashSet<DomRoot<Node>> = active_range
+        .start_container()
+        .ancestors()
+        .chain(active_range.end_container().ancestors())
+        .filter(|ancestor| ancestor.is::<HTMLLIElement>())
+        .collect();
+
+    // Step 2. For each item in items, normalize sublists of item.
+    for item in items {
+        item.normalize_sublists(cx);
+    }
+
+    // Normalizing sublists probably messes up the range
+    active_range = selection
+        .active_range(cx)
+        .expect("Must always have an active range.");
+
+    // Step 3. Block-extend the active range, and let new range be the result.
+    let new_range = active_range.block_extend(cx, document);
+
+    // Step 4. Let node list be a list of nodes, initially empty.
+    rooted_vec!(let mut node_list);
+
+    // Step 5. For each node node contained in new range,
+    //         append node to node list if the last member of node list (if any)
+    //         is not an ancestor of node; node is editable;
+    //         and either node has no editable descendants, or is an ol or ul,
+    //         or is an li whose parent is an ol or ul.
+    for node in new_range.contained_nodes() {
+        if !node_list
+            .last()
+            .is_some_and(|last: &Dom<Node>| last.is_ancestor_of(&node)) &&
+            node.is_editable() &&
+            (!node
+                .traverse_preorder(ShadowIncluding::No)
+                .any(|node| node.is_editable()) ||
+                node.is::<HTMLOListElement>() ||
+                node.is::<HTMLUListElement>() ||
+                (node.is::<HTMLLIElement>() &&
+                    node.GetParentElement().is_some_and(|parent| {
+                        parent.is::<HTMLOListElement>() || parent.is::<HTMLUListElement>()
+                    })))
+        {
+            node_list.push(node.as_traced());
+        }
+    }
+
+    // Step 6. While node list is not empty:
+    let mut node_list_iter = node_list.iter().peekable();
+    while node_list_iter.peek().is_some() {
+        // Step 6.1. While the first member of node list is an ol or ul or is not the child of an
+        //           ol or ul, outdent it and remove it from node list.
+        while node_list_iter.peek().is_some_and(|first| {
+            (first.is::<HTMLOListElement>() || first.is::<HTMLUListElement>()) &&
+                !first.GetParentElement().is_some_and(|parent| {
+                    parent.is::<HTMLOListElement>() || parent.is::<HTMLUListElement>()
+                })
+        }) {
+            // We just walk the iterator instead of continuously removing things from node list.
+            outdent(
+                cx,
+                document,
+                &node_list_iter
+                    .next()
+                    .expect("Should have a node here.")
+                    .as_rooted(),
+            );
+        }
+
+        // Step 6.2. If node list is empty, break from these substeps.
+        if !node_list_iter.peek().is_some() {
+            break;
+        }
+
+        // Step 6.3. Let sublist be a list of nodes, initially empty.
+        rooted_vec!(let mut sublist);
+
+        // Step 6.4. Remove the first member of node list and append it to sublist.
+        sublist.push(
+            node_list_iter
+                .next()
+                .expect("Must always have a next item")
+                .clone(),
+        );
+
+        // Step 6.5. While the first member of node list is the nextSibling of the last member of
+        //           sublist, and the first member of node list is not an ol or ul, remove the
+        //           first member of node list and append it to sublist.
+        while node_list_iter.peek().is_some_and(|node| {
+            sublist
+                .last()
+                .expect("Must always have last element here.")
+                .GetNextSibling()
+                .is_some_and(|next_sibling| next_sibling == node.as_rooted()) &&
+                !node.is::<HTMLOListElement>() &&
+                !node.is::<HTMLUListElement>()
+        }) {
+            sublist.push(
+                node_list_iter
+                    .next()
+                    .expect("Must always have a next item")
+                    .clone(),
+            );
+        }
+
+        // Step 6.6. Record the values of sublist, and let values be the result.
+        let values = record_the_values(sublist.iter().map(|node| node.as_rooted()).collect());
+
+        // Step 6.7. Split the parent of sublist.
+        split_the_parent(cx, sublist.r());
+
+        // Step 6.8. Fix disallowed ancestors of each member of sublist.
+        for node in sublist.iter() {
+            node.fix_disallowed_ancestors(cx, document);
+        }
+
+        // Step 6.9. Restore the values from values.
+        restore_the_values(cx, values);
+    }
+
+    // Step 7. Return true.
+    true
+}

--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -23,7 +23,7 @@ use crate::dom::bindings::inheritance::NodeTypeId;
 use crate::dom::bindings::root::{DomRoot, DomSlice};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::characterdata::CharacterData;
-use crate::dom::element::Element;
+use crate::dom::element::{AdjacentPosition, Element};
 use crate::dom::execcommand::basecommand::{CommandName, CssPropertyName};
 use crate::dom::execcommand::commands::forecolor::serialize_to_simple_color;
 use crate::dom::html::htmlanchorelement::HTMLAnchorElement;
@@ -31,6 +31,8 @@ use crate::dom::html::htmlbrelement::HTMLBRElement;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmlimageelement::HTMLImageElement;
 use crate::dom::html::htmllielement::HTMLLIElement;
+use crate::dom::html::htmlolistelement::HTMLOListElement;
+use crate::dom::html::htmlulistelement::HTMLUListElement;
 use crate::dom::iterators::ShadowIncluding;
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::text::Text;
@@ -1728,6 +1730,77 @@ impl Node {
         }
         // Step 5. Restore the values from values.
         restore_the_values(cx, values);
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#normalize-sublists>
+    pub(crate) fn normalize_sublists(&self, cx: &mut JSContext) {
+        let item_element = self
+            .downcast::<Element>()
+            .expect("item should be an element.");
+
+        // Step 1. If item is not an li or it is not editable or its parent is not editable, abort these steps.
+        if !self.is::<HTMLLIElement>() ||
+            !self.is_editable() ||
+            !self
+                .GetParentElement()
+                .is_some_and(|parent| parent.upcast::<Node>().is_editable())
+        {
+            return;
+        }
+
+        // Step 2. Let new item be null.
+        let mut new_item: Option<DomRoot<Element>> = None;
+
+        // Step 3. While item has an ol or ul child:
+        while self
+            .child_elements()
+            .any(|child| child.is::<HTMLOListElement>() || child.is::<HTMLUListElement>())
+        {
+            // Step 3.1. Let child be the last child of item.
+            let child = self.GetLastChild().expect("Must have a last child here.");
+
+            // Step 3.2. If child is an ol or ul, or new item is null and child is a Text node whose data consists of zero of more space characters:
+            if child.is::<HTMLOListElement>() ||
+                child.is::<HTMLUListElement>() ||
+                (new_item.is_none() &&
+                    child
+                        .downcast::<Text>()
+                        .is_some_and(|text| text.data().bytes().all(|byte| byte == b' ')))
+            {
+                // Step 3.2.1. Set new item to null.
+                new_item = None;
+
+                // Step 3.2.2. Insert child into the parent of item immediately following item, preserving ranges.
+                move_preserving_ranges(cx, &child, |cx| {
+                    item_element
+                        .insert_adjacent(cx, AdjacentPosition::AfterEnd, &child)
+                        .map(|elem| elem.expect("Should have inserted"))
+                });
+
+                continue;
+            }
+            // Step 3.3. Otherwise:
+            // Step 3.3.1. If new item is null,
+            //             let new item be the result of calling createElement("li") on the ownerDocument of item,
+            //             then insert new item into the parent of item immediately after item.
+            if new_item.is_none() {
+                new_item = Some(self.owner_document().create_element(cx, "li"));
+                item_element
+                    .insert_adjacent(cx, AdjacentPosition::AfterEnd, &child)
+                    .expect("Insertion should always work here.");
+            }
+
+            // Step 3.3.2. Insert child into new item as its first child, preserving ranges.
+            move_preserving_ranges(cx, &child, |cx| {
+                new_item
+                    .as_ref()
+                    .expect("Must have new item here")
+                    .downcast::<Element>()
+                    .expect("New item must be able to support children")
+                    .insert_adjacent(cx, AdjacentPosition::AfterBegin, &child)
+                    .map(|elem| elem.expect("Should have inserted"))
+            });
+        }
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#collapsed-block-prop>

--- a/components/script/dom/execcommand/execcommands.rs
+++ b/components/script/dom/execcommand/execcommands.rs
@@ -168,6 +168,7 @@ impl Document {
             "insertparagraph" => CommandName::InsertParagraph,
             "inserttext" => CommandName::InsertText,
             "italic" => CommandName::Italic,
+            "outdent" => CommandName::Outdent,
             "removeformat" => CommandName::RemoveFormat,
             "strikethrough" => CommandName::Strikethrough,
             "stylewithcss" => CommandName::StyleWithCss,

--- a/tests/wpt/meta/editing/event.html.ini
+++ b/tests/wpt/meta/editing/event.html.ini
@@ -97,9 +97,3 @@
 
   [Command justifyRight, value "quasit": input event]
     expected: FAIL
-
-  [Command outdent, value "": input event]
-    expected: FAIL
-
-  [Command outdent, value "quasit": input event]
-    expected: FAIL

--- a/tests/wpt/meta/editing/other/exec-command-with-text-editor.tentative.html.ini
+++ b/tests/wpt/meta/editing/other/exec-command-with-text-editor.tentative.html.ini
@@ -59,9 +59,6 @@
   [In <input type="password">, execCommand("redo", false, null), a[b\]c): The command should be enabled]
     expected: FAIL
 
-  [In <input type="password">, execCommand("outdent", false, null), a[b\]c): The command should be supported]
-    expected: FAIL
-
   [In <input type="password">, execCommand("inserthtml", false, <b>inserted</b>), a[b\]c): The command should be supported]
     expected: FAIL
 
@@ -141,9 +138,6 @@
     expected: FAIL
 
   [In <input type="password"> in contenteditable, execCommand("redo", false, null), a[b\]c): The command should be enabled]
-    expected: FAIL
-
-  [In <input type="password"> in contenteditable, execCommand("outdent", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <input type="password"> in contenteditable, execCommand("inserthtml", false, <b>inserted</b>), a[b\]c): The command should be supported]
@@ -539,6 +533,21 @@
   [In <input type="password"> in contenteditable, execCommand("indent", false, null), a[b\]c): input.target should be undefined]
     expected: FAIL
 
+  [In <input type="password"> in contenteditable, execCommand("outdent", false, null), a[b\]c): The command should not be enabled]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("outdent", false, null), a[b\]c): execCommand() should return false]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("outdent", false, null), a[b\]c): should not fire beforeinput event]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("outdent", false, null), a[b\]c): input.inputType should be undefined]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("outdent", false, null), a[b\]c): input.target should be undefined]
+    expected: FAIL
+
 
 [exec-command-with-text-editor.tentative.html?type=text]
   [In <input type="text">, execCommand("cut", false, null), ab[\]c): The command should be supported]
@@ -599,9 +608,6 @@
     expected: FAIL
 
   [In <input type="text">, execCommand("redo", false, null), a[b\]c): The command should be enabled]
-    expected: FAIL
-
-  [In <input type="text">, execCommand("outdent", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <input type="text">, execCommand("inserthtml", false, <b>inserted</b>), a[b\]c): The command should be supported]
@@ -683,9 +689,6 @@
     expected: FAIL
 
   [In <input type="text"> in contenteditable, execCommand("redo", false, null), a[b\]c): The command should be enabled]
-    expected: FAIL
-
-  [In <input type="text"> in contenteditable, execCommand("outdent", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <input type="text"> in contenteditable, execCommand("inserthtml", false, <b>inserted</b>), a[b\]c): The command should be supported]
@@ -1081,6 +1084,21 @@
   [In <input type="text"> in contenteditable, execCommand("indent", false, null), a[b\]c): input.target should be undefined]
     expected: FAIL
 
+  [In <input type="text"> in contenteditable, execCommand("outdent", false, null), a[b\]c): The command should not be enabled]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("outdent", false, null), a[b\]c): execCommand() should return false]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("outdent", false, null), a[b\]c): should not fire beforeinput event]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("outdent", false, null), a[b\]c): input.inputType should be undefined]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("outdent", false, null), a[b\]c): input.target should be undefined]
+    expected: FAIL
+
 
 [exec-command-with-text-editor.tentative.html?type=textarea]
   [In <textarea>, execCommand("cut", false, null), ab[\]c): The command should be supported]
@@ -1141,9 +1159,6 @@
     expected: FAIL
 
   [In <textarea>, execCommand("redo", false, null), a[b\]c): The command should be enabled]
-    expected: FAIL
-
-  [In <textarea>, execCommand("outdent", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <textarea>, execCommand("inserthtml", false, <b>inserted</b>), a[b\]c): The command should be supported]
@@ -1231,9 +1246,6 @@
     expected: FAIL
 
   [In <textarea> in contenteditable, execCommand("redo", false, null), a[b\]c): The command should be enabled]
-    expected: FAIL
-
-  [In <textarea> in contenteditable, execCommand("outdent", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <textarea> in contenteditable, execCommand("inserthtml", false, <b>inserted</b>), a[b\]c): The command should be supported]
@@ -1681,4 +1693,19 @@
     expected: FAIL
 
   [In <textarea> in contenteditable, execCommand("insertlinebreak", false, null), a[b\]c): input.target should be [object HTMLTextAreaElement\]]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("outdent", false, null), a[b\]c): The command should not be enabled]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("outdent", false, null), a[b\]c): execCommand() should return false]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("outdent", false, null), a[b\]c): should not fire beforeinput event]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("outdent", false, null), a[b\]c): input.inputType should be undefined]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("outdent", false, null), a[b\]c): input.target should be undefined]
     expected: FAIL

--- a/tests/wpt/meta/editing/other/restoration.html.ini
+++ b/tests/wpt/meta/editing/other/restoration.html.ini
@@ -11,12 +11,6 @@
   [insertunorderedlist  starting not bold]
     expected: FAIL
 
-  [outdent  starting bold]
-    expected: FAIL
-
-  [outdent  starting not bold]
-    expected: FAIL
-
   [justifyleft  starting bold]
     expected: FAIL
 

--- a/tests/wpt/meta/editing/run/multitest.html.ini
+++ b/tests/wpt/meta/editing/run/multitest.html.ini
@@ -1,10 +1,4 @@
 [multitest.html?7001-8000]
-  [[["forecolor","#0000FF"\],["outdent",""\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["forecolor","#0000FF"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["forecolor","#0000FF"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -204,12 +198,6 @@
     expected: FAIL
 
   [[["hilitecolor","#00FFFF"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyright") after]
-    expected: FAIL
-
-  [[["hilitecolor","#00FFFF"\],["outdent",""\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["hilitecolor","#00FFFF"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["superscript",""\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -487,12 +475,6 @@
   [[["bold",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyright") after]
     expected: FAIL
 
-  [[["bold",""\],["outdent",""\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["bold",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["bold",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -714,12 +696,6 @@
   [[["italic",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyright") after]
     expected: FAIL
 
-  [[["italic",""\],["outdent",""\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["italic",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["italic",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -939,12 +915,6 @@
   [[["strikethrough",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyright") after]
     expected: FAIL
 
-  [[["strikethrough",""\],["outdent",""\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["strikethrough",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["strikethrough",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -1137,12 +1107,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyright") after]
-    expected: FAIL
-
-  [[["fontsize","4"\],["outdent",""\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["fontsize","4"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1456,12 +1420,6 @@
   [[["createlink","http://www.google.com/"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyright") after]
     expected: FAIL
 
-  [[["createlink","http://www.google.com/"\],["outdent",""\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["fontname","sans-serif"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -1676,12 +1634,6 @@
     expected: FAIL
 
   [[["fontname","sans-serif"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyright") after]
-    expected: FAIL
-
-  [[["fontname","sans-serif"\],["outdent",""\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["fontname","sans-serif"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["fontname","sans-serif"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -1936,12 +1888,6 @@
     expected: FAIL
 
   [[["subscript",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyright") after]
-    expected: FAIL
-
-  [[["subscript",""\],["outdent",""\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["subscript",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["superscript",""\],["delete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -2814,12 +2760,6 @@
   [[["superscript",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyright") after]
     expected: FAIL
 
-  [[["superscript",""\],["outdent",""\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["superscript",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["underline",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
@@ -3034,12 +2974,6 @@
     expected: FAIL
 
   [[["underline",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyright") after]
-    expected: FAIL
-
-  [[["underline",""\],["outdent",""\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["underline",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["underline",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
@@ -3285,12 +3219,6 @@
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyright") after]
-    expected: FAIL
-
-  [[["backcolor","#00FFFF"\],["outdent",""\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["backcolor","#00FFFF"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]

--- a/tests/wpt/meta/editing/run/outdent.html.ini
+++ b/tests/wpt/meta/editing/run/outdent.html.ini
@@ -1,428 +1,113 @@
 [outdent.html?1001-2000]
-  [[["outdent",""\]\] "<ol><li>foo<ol><li>[bar\]<li>baz</ol><li>quz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ol><li>foo<ol><li>[bar\]<li>baz</ol><li>quz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ol><li>foo<ol><li>bar<li>[baz\]</ol><li>quz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ol><li>foo<ol><li>bar<li>[baz\]</ol><li>quz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ol><li>foo</li><ol><li>[bar\]<li>baz</ol><li>quz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ol><li>foo</li><ol><li>[bar\]<li>baz</ol><li>quz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ol><li>foo</li><ol data-start=0 data-end=1><li>bar<li>baz</ol><li>quz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ol><li>foo</li><ol data-start=0 data-end=1><li>bar<li>baz</ol><li>quz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ol><li>foo</li><ol><li>bar<li>[baz\]</ol><li>quz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ol><li>foo</li><ol><li>bar<li>[baz\]</ol><li>quz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ol><li>foo</li><ol data-start=1 data-end=2><li>bar<li>baz</ol><li>quz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ol><li>foo</li><ol data-start=1 data-end=2><li>bar<li>baz</ol><li>quz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ol><li>foo<ol><li>b[a\]r</ol><li>baz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["outdent",""\]\] "<ol><li>foo<ol><li>b[a\]r</ol><li>baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ol><li>foo</li><ol><li>b[a\]r</ol><li>baz</ol>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["outdent",""\]\] "<ol><li>foo</li><ol><li>b[a\]r</ol><li>baz</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["outdent",""\]\] "<ol><li>foo{<ol><li>bar</ol>}<li>baz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["outdent",""\]\] "<ol><li>foo{<ol><li>bar</ol>}<li>baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ol><li>foo</li>{<ol><li>bar</ol>}<li>baz</ol>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["outdent",""\]\] "<ol><li>foo</li>{<ol><li>bar</ol>}<li>baz</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>[foo\]<ol><li>bar</ol><li>baz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>[foo\]<ol><li>bar</ol><li>baz</ol>" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>[foo\]<ol><li>bar</ol><li>baz</ol>" queryCommandValue("defaultparagraphseparator") before]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>[foo\]<ol><li>bar</ol><li>baz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>[foo\]<ol><li>bar</ol><li>baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>[foo\]</li><ol><li>bar</ol><li>baz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>[foo\]</li><ol><li>bar</ol><li>baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>[foo\]</li><ol><li>bar</ol><li>baz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>[foo\]</li><ol><li>bar</ol><li>baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>foo<li>[bar\]<ol><li>baz</ol><li>quz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>foo<li>[bar\]<ol><li>baz</ol><li>quz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>foo<li>[bar\]<ol><li>baz</ol><li>quz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>foo<li>[bar\]<ol><li>baz</ol><li>quz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>foo<li>[bar\]</li><ol><li>baz</ol><li>quz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>foo<li>[bar\]</li><ol><li>baz</ol><li>quz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>foo<li>[bar\]</li><ol><li>baz</ol><li>quz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>foo<li>[bar\]</li><ol><li>baz</ol><li>quz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>foo<ol><li>bar<li>baz</ol><li>[quz\]</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>foo<ol><li>bar<li>baz</ol><li>[quz\]</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>foo<ol><li>bar<li>baz</ol><li>[quz\]</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>foo<ol><li>bar<li>baz</ol><li>[quz\]</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>foo</li><ol><li>bar<li>baz</ol><li>[quz\]</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>foo</li><ol><li>bar<li>baz</ol><li>[quz\]</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>foo</li><ol><li>bar<li>baz</ol><li>[quz\]</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>foo</li><ol><li>bar<li>baz</ol><li>[quz\]</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>foo<li>b[ar<li>baz\]</ol>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>foo<li>b[ar<li>baz\]</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>foo<li>b[ar<li>baz\]</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>foo<li>b[ar<li>baz\]</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>[foo<ol><li>bar\]</ol><li>baz</ol>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>[foo<ol><li>bar\]</ol><li>baz</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>[foo<ol><li>bar\]</ol><li>baz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>[foo<ol><li>bar\]</ol><li>baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>[foo</li><ol><li>bar\]</ol><li>baz</ol>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>[foo</li><ol><li>bar\]</ol><li>baz</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>[foo</li><ol><li>bar\]</ol><li>baz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>[foo</li><ol><li>bar\]</ol><li>baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>foo<ol><li>b[ar</ol><li>b\]az</ol>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>foo<ol><li>b[ar</ol><li>b\]az</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>foo<ol><li>b[ar</ol><li>b\]az</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>foo<ol><li>b[ar</ol><li>b\]az</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>foo</li><ol><li>b[ar</ol><li>b\]az</ol>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>foo</li><ol><li>b[ar</ol><li>b\]az</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>foo</li><ol><li>b[ar</ol><li>b\]az</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>foo</li><ol><li>b[ar</ol><li>b\]az</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>[foo<ol><li>bar</ol><li>baz\]</ol><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>[foo<ol><li>bar</ol><li>baz\]</ol><p>extra" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>[foo<ol><li>bar</ol><li>baz\]</ol><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>[foo<ol><li>bar</ol><li>baz\]</ol><p>extra" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>[foo</li><ol><li>bar</ol><li>baz\]</ol><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>[foo</li><ol><li>bar</ol><li>baz\]</ol><p>extra" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>[foo</li><ol><li>bar</ol><li>baz\]</ol><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>[foo</li><ol><li>bar</ol><li>baz\]</ol><p>extra" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>[foo\]<ol><li>bar</ol>baz</ol>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>[foo\]<ol><li>bar</ol>baz</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>[foo\]<ol><li>bar</ol>baz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>[foo\]<ol><li>bar</ol>baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ol><li>foo<ol><li>[bar\]</ol>baz</ol>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["outdent",""\]\] "<ol><li>foo<ol><li>[bar\]</ol>baz</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>foo<ol><li>bar</ol>[baz\]</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>foo<ol><li>bar</ol>[baz\]</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>foo<ol><li>bar</ol>[baz\]</ol>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>foo<ol><li>bar</ol>[baz\]</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>[foo<ol><li>bar\]</ol>baz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>[foo<ol><li>bar\]</ol>baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>[foo<ol><li>bar\]</ol>baz</ol>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>[foo<ol><li>bar\]</ol>baz</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "foo<ol start=5><li>[bar\]</ol>baz": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "foo<ol start=5><li>[bar\]</ol>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "foo<ol start=5><li>[bar\]</ol>baz": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "foo<ol start=5><li>[bar\]</ol>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "foo<ol id=abc><li>[bar\]</ol>baz": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "foo<ol id=abc><li>[bar\]</ol>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "foo<ol id=abc><li>[bar\]</ol>baz": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "foo<ol id=abc><li>[bar\]</ol>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "foo<ol style=color:blue><li>[bar\]</ol>baz": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "foo<ol style=color:blue><li>[bar\]</ol>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "foo<ol style=color:blue><li>[bar\]</ol>baz": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "foo<ol style=color:blue><li>[bar\]</ol>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "foo<ol><li value=5>[bar\]</ol>baz": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "foo<ol><li value=5>[bar\]</ol>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "foo<ol><li value=5>[bar\]</ol>baz": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "foo<ol><li value=5>[bar\]</ol>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "foo<ol><li id=abc>[bar\]</ol>baz": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "foo<ol><li id=abc>[bar\]</ol>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "foo<ol><li id=abc>[bar\]</ol>baz": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "foo<ol><li id=abc>[bar\]</ol>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "foo<ol><li style=color:blue>[bar\]</ol>baz": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "foo<ol><li style=color:blue>[bar\]</ol>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "foo<ol><li style=color:blue>[bar\]</ol>baz": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "foo<ol><li style=color:blue>[bar\]</ol>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ol><li>foo</li><ol><li value=5>[bar\]</ol></ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["outdent",""\]\] "<ol><li>foo</li><ol><li value=5>[bar\]</ol></ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ul><li>foo</li><ol><li value=5>[bar\]</ol></ul>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["outdent",""\]\] "<ul><li>foo</li><ol><li value=5>[bar\]</ol></ul>" compare innerHTML]
     expected: FAIL
 
-  [[["outdent",""\]\] "<ol><li>foo</li><ol start=5><li>[bar\]</ol><li>baz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["outdent",""\]\] "<ol><li>foo</li><ol start=5><li>[bar\]</ol><li>baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ol><li>foo</li><ol id=abc><li>[bar\]</ol><li>baz</ol>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["outdent",""\]\] "<ol><li>foo</li><ol id=abc><li>[bar\]</ol><li>baz</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["outdent",""\]\] "<ol><li>foo</li><ol style=color:blue><li>[bar\]</ol><li>baz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["outdent",""\]\] "<ol><li>foo</li><ol style=color:blue><li>[bar\]</ol><li>baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["outdent",""\]\] "<ol><li>foo</li><ol style=color:blue><li>[bar\]</ol><li>baz</ol>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["outdent",""\]\] "<ol><li>foo</li><ol style=color:blue><li>[bar\]</ol><li>baz</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["outdent",""\]\] "<ol><li>foo</li><ol style=text-indent:1em><li>[bar\]</ol><li>baz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["outdent",""\]\] "<ol><li>foo</li><ol style=text-indent:1em><li>[bar\]</ol><li>baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["outdent",""\]\] "<ol><li>foo</li><ol style=text-indent:1em><li>[bar\]</ol><li>baz</ol>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["outdent",""\]\] "<ol><li>foo</li><ol style=text-indent:1em><li>[bar\]</ol><li>baz</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["outdent",""\]\] "<ol><li>foo</li><ol start=5><li>[bar<li>baz\]</ol><li>quz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["outdent",""\]\] "<ol><li>foo</li><ol start=5><li>[bar<li>baz\]</ol><li>quz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ol><li>foo</li><ol id=abc><li>[bar<li>baz\]</ol><li>quz</ol>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["outdent",""\]\] "<ol><li>foo</li><ol id=abc><li>[bar<li>baz\]</ol><li>quz</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["outdent",""\]\] "<ol><li>foo</li><ol style=color:blue><li>[bar<li>baz\]</ol><li>quz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["outdent",""\]\] "<ol><li>foo</li><ol style=color:blue><li>[bar<li>baz\]</ol><li>quz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["outdent",""\]\] "<ol><li>foo</li><ol style=color:blue><li>[bar<li>baz\]</ol><li>quz</ol>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["outdent",""\]\] "<ol><li>foo</li><ol style=color:blue><li>[bar<li>baz\]</ol><li>quz</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["outdent",""\]\] "<ol><li>foo</li><ol style=text-indent:1em><li>[bar<li>baz\]</ol><li>quz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["outdent",""\]\] "<ol><li>foo</li><ol style=text-indent:1em><li>[bar<li>baz\]</ol><li>quz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["outdent",""\]\] "<ol><li>foo</li><ol style=text-indent:1em><li>[bar<li>baz\]</ol><li>quz</ol>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["outdent",""\]\] "<ol><li>foo</li><ol style=text-indent:1em><li>[bar<li>baz\]</ol><li>quz</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["outdent",""\]\] "<blockquote><ol><li>[foo\]</ol></blockquote><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["outdent",""\]\] "<blockquote><ol><li>[foo\]</ol></blockquote><p>extra" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<blockquote>foo<ol><li>[bar\]</ol>baz</blockquote><p>extra": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["outdent",""\]\] "<blockquote>foo<ol><li>[bar\]</ol>baz</blockquote><p>extra" compare innerHTML]
@@ -433,385 +118,157 @@
 
 
 [outdent.html?1-1000]
-  [[["outdent",""\]\] "<blockquote><p>foo[bar\]</p><p>baz</p></blockquote><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["outdent",""\]\] "<blockquote><p>foo[bar\]</p><p>baz</p></blockquote><p>extra" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<blockquote><p>foo[bar</p><p>b\]az</p></blockquote><p>extra": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["outdent",""\]\] "<blockquote><p>foo[bar</p><p>b\]az</p></blockquote><p>extra" compare innerHTML]
     expected: FAIL
 
-  [[["outdent",""\]\] "<blockquote><p>foo[bar\]</p></blockquote><p>baz</p><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["outdent",""\]\] "<blockquote><p>foo[bar\]</p></blockquote><p>baz</p><p>extra" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<blockquote><p>foo[bar</p></blockquote><p>b\]az</p><p>extra": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["outdent",""\]\] "<blockquote><p>foo[bar</p></blockquote><p>b\]az</p><p>extra" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["outdent",""\]\] "<blockquote style=\\"margin-right: 0px;\\" dir=\\"ltr\\"><p>foo[bar\]</p><p>baz</p></blockquote><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["outdent",""\]\] "<blockquote style=\\"margin-right: 0px;\\" dir=\\"ltr\\"><p>foo[bar\]</p><p>baz</p></blockquote><p>extra" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["outdent",""\]\] "<blockquote style=\\"margin-right: 0px;\\" dir=\\"ltr\\"><p>foo[bar\]</p><p>baz</p></blockquote><p>extra": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["outdent",""\]\] "<blockquote style=\\"margin-right: 0px;\\" dir=\\"ltr\\"><p>foo[bar\]</p><p>baz</p></blockquote><p>extra" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["outdent",""\]\] "<blockquote style=\\"margin-right: 0px;\\" dir=\\"ltr\\"><p>foo[bar</p><p>b\]az</p></blockquote><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["outdent",""\]\] "<blockquote style=\\"margin-right: 0px;\\" dir=\\"ltr\\"><p>foo[bar</p><p>b\]az</p></blockquote><p>extra" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["outdent",""\]\] "<blockquote style=\\"margin-right: 0px;\\" dir=\\"ltr\\"><p>foo[bar</p><p>b\]az</p></blockquote><p>extra": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["outdent",""\]\] "<blockquote style=\\"margin-right: 0px;\\" dir=\\"ltr\\"><p>foo[bar</p><p>b\]az</p></blockquote><p>extra" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["outdent",""\]\] "<blockquote style=\\"margin-right: 0px;\\" dir=\\"ltr\\"><p>foo[bar\]</p></blockquote><p>baz</p><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["outdent",""\]\] "<blockquote style=\\"margin-right: 0px;\\" dir=\\"ltr\\"><p>foo[bar\]</p></blockquote><p>baz</p><p>extra" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["outdent",""\]\] "<blockquote style=\\"margin-right: 0px;\\" dir=\\"ltr\\"><p>foo[bar\]</p></blockquote><p>baz</p><p>extra": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["outdent",""\]\] "<blockquote style=\\"margin-right: 0px;\\" dir=\\"ltr\\"><p>foo[bar\]</p></blockquote><p>baz</p><p>extra" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["outdent",""\]\] "<blockquote style=\\"margin-right: 0px;\\" dir=\\"ltr\\"><p>foo[bar</p></blockquote><p>b\]az</p><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["outdent",""\]\] "<blockquote style=\\"margin-right: 0px;\\" dir=\\"ltr\\"><p>foo[bar</p></blockquote><p>b\]az</p><p>extra" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["outdent",""\]\] "<blockquote style=\\"margin-right: 0px;\\" dir=\\"ltr\\"><p>foo[bar</p></blockquote><p>b\]az</p><p>extra": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["outdent",""\]\] "<blockquote style=\\"margin-right: 0px;\\" dir=\\"ltr\\"><p>foo[bar</p></blockquote><p>b\]az</p><p>extra" compare innerHTML]
     expected: FAIL
 
-  [[["outdent",""\]\] "<p style=\\"margin-left: 40px\\">foo[bar\]</p><p style=\\"margin-left: 40px\\">baz</p><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<p style=\\"margin-left: 40px\\">foo[bar</p><p style=\\"margin-left: 40px\\">b\]az</p><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<p style=\\"margin-left: 40px\\">foo[bar\]</p><p>baz</p><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<p style=\\"margin-left: 40px\\">foo[bar</p><p>b\]az</p><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar\]</p><p>baz</p></blockquote><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar\]</p><p>baz</p></blockquote><p>extra" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar\]</p><p>baz</p></blockquote><p>extra": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar\]</p><p>baz</p></blockquote><p>extra" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar\]</p><p>baz</p></blockquote><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar\]</p><p>baz</p></blockquote><p>extra" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar\]</p><p>baz</p></blockquote><p>extra": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar\]</p><p>baz</p></blockquote><p>extra" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar</p><p>b\]az</p></blockquote><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar</p><p>b\]az</p></blockquote><p>extra" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar</p><p>b\]az</p></blockquote><p>extra": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar</p><p>b\]az</p></blockquote><p>extra" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar</p><p>b\]az</p></blockquote><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar</p><p>b\]az</p></blockquote><p>extra" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar</p><p>b\]az</p></blockquote><p>extra": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar</p><p>b\]az</p></blockquote><p>extra" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar\]</p></blockquote><p>baz</p><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar\]</p></blockquote><p>baz</p><p>extra" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar\]</p></blockquote><p>baz</p><p>extra": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar\]</p></blockquote><p>baz</p><p>extra" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar\]</p></blockquote><p>baz</p><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar\]</p></blockquote><p>baz</p><p>extra" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar\]</p></blockquote><p>baz</p><p>extra": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar\]</p></blockquote><p>baz</p><p>extra" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar</p></blockquote><p>b\]az</p><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar</p></blockquote><p>b\]az</p><p>extra" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar</p></blockquote><p>b\]az</p><p>extra": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar</p></blockquote><p>b\]az</p><p>extra" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar</p></blockquote><p>b\]az</p><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar</p></blockquote><p>b\]az</p><p>extra" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar</p></blockquote><p>b\]az</p><p>extra": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote class=\\"webkit-indent-blockquote\\" style=\\"margin: 0 0 0 40px; border: none; padding: 0px;\\"><p>foo[bar</p></blockquote><p>b\]az</p><p>extra" compare innerHTML]
     expected: FAIL
 
-  [[["outdent",""\]\] "<blockquote><blockquote>foo[bar\]baz</blockquote></blockquote>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["outdent",""\]\] "<blockquote><blockquote>foo[bar\]baz</blockquote></blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<blockquote><blockquote data-abc=def>foo[bar\]baz</blockquote></blockquote>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["outdent",""\]\] "<blockquote><blockquote data-abc=def>foo[bar\]baz</blockquote></blockquote>" compare innerHTML]
     expected: FAIL
 
-  [[["outdent",""\]\] "<blockquote data-abc=def><blockquote>foo[bar\]baz</blockquote></blockquote>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["outdent",""\]\] "<blockquote data-abc=def><blockquote>foo[bar\]baz</blockquote></blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<blockquote><div>foo[bar\]baz</div></blockquote>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["outdent",""\]\] "<blockquote><div>foo[bar\]baz</div></blockquote>" compare innerHTML]
     expected: FAIL
 
-  [[["outdent",""\]\] "<blockquote><div id=abc>foo[bar\]baz</div></blockquote>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["outdent",""\]\] "<blockquote><div id=abc>foo[bar\]baz</div></blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote id=abc>foo[bar\]baz</blockquote>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote id=abc>foo[bar\]baz</blockquote>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote id=abc>foo[bar\]baz</blockquote>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote id=abc>foo[bar\]baz</blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote style=\\"color: blue\\">foo[bar\]baz</blockquote>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote style=\\"color: blue\\">foo[bar\]baz</blockquote>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote style=\\"color: blue\\">foo[bar\]baz</blockquote>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote style=\\"color: blue\\">foo[bar\]baz</blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<blockquote><blockquote><p>foo[bar\]<p>baz</blockquote></blockquote>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["outdent",""\]\] "<blockquote><blockquote><p>foo[bar\]<p>baz</blockquote></blockquote>" compare innerHTML]
     expected: FAIL
 
-  [[["outdent",""\]\] "<blockquote><blockquote data-abc=def><p>foo[bar\]<p>baz</blockquote></blockquote>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["outdent",""\]\] "<blockquote><blockquote data-abc=def><p>foo[bar\]<p>baz</blockquote></blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<blockquote data-abc=def><blockquote><p>foo[bar\]<p>baz</blockquote></blockquote>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["outdent",""\]\] "<blockquote data-abc=def><blockquote><p>foo[bar\]<p>baz</blockquote></blockquote>" compare innerHTML]
     expected: FAIL
 
-  [[["outdent",""\]\] "<blockquote><div><p>foo[bar\]<p>baz</div></blockquote>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["outdent",""\]\] "<blockquote><div><p>foo[bar\]<p>baz</div></blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<blockquote><div id=abc><p>foo[bar\]<p>baz</div></blockquote>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["outdent",""\]\] "<blockquote><div id=abc><p>foo[bar\]<p>baz</div></blockquote>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote id=abc><p>foo[bar\]<p>baz</blockquote>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote id=abc><p>foo[bar\]<p>baz</blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote id=abc><p>foo[bar\]<p>baz</blockquote>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote id=abc><p>foo[bar\]<p>baz</blockquote>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote style=\\"color: blue\\"><p>foo[bar\]<p>baz</blockquote>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote style=\\"color: blue\\"><p>foo[bar\]<p>baz</blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote style=\\"color: blue\\"><p>foo[bar\]<p>baz</blockquote>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote style=\\"color: blue\\"><p>foo[bar\]<p>baz</blockquote>" compare innerHTML]
     expected: FAIL
 
-  [[["outdent",""\]\] "<blockquote><p><b>foo[bar\]</b><p>baz</blockquote>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["outdent",""\]\] "<blockquote><p><b>foo[bar\]</b><p>baz</blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<blockquote><p><strong>foo[bar\]</strong><p>baz</blockquote>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["outdent",""\]\] "<blockquote><p><strong>foo[bar\]</strong><p>baz</blockquote>" compare innerHTML]
     expected: FAIL
 
-  [[["outdent",""\]\] "<blockquote><p><span>foo[bar\]</span><p>baz</blockquote>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["outdent",""\]\] "<blockquote><p><span>foo[bar\]</span><p>baz</blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<blockquote><blockquote style=\\"color: blue\\"><p>foo[bar\]</blockquote><p>baz</blockquote>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["outdent",""\]\] "<blockquote><blockquote style=\\"color: blue\\"><p>foo[bar\]</blockquote><p>baz</blockquote>" compare innerHTML]
     expected: FAIL
 
-  [[["outdent",""\]\] "<blockquote style=\\"color: blue\\"><blockquote><p>foo[bar\]</blockquote><p>baz</blockquote>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["outdent",""\]\] "<blockquote style=\\"color: blue\\"><blockquote><p>foo[bar\]</blockquote><p>baz</blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>foo<li>[bar\]<li>baz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>foo<li>[bar\]<li>baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>foo<li>[bar\]<li>baz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>foo<li>[bar\]<li>baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol data-start=1 data-end=2><li>foo<li>bar<li>baz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol data-start=1 data-end=2><li>foo<li>bar<li>baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol data-start=1 data-end=2><li>foo<li>bar<li>baz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol data-start=1 data-end=2><li>foo<li>bar<li>baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ol><li>foo</ol>[bar\]": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>[foo\]<br>bar<li>baz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>[foo\]<br>bar<li>baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>[foo\]<br>bar<li>baz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>[foo\]<br>bar<li>baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>foo<br>[bar\]<li>baz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>foo<br>[bar\]<li>baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>foo<br>[bar\]<li>baz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>foo<br>[bar\]<li>baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li><div>[foo\]</div>bar<li>baz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li><div>[foo\]</div>bar<li>baz</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li><div>[foo\]</div>bar<li>baz</ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li><div>[foo\]</div>bar<li>baz</ol>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["outdent",""\]\] "<blockquote style=\\"margin-right: 0px;\\" dir=\\"ltr\\"><p>foo[bar\]</p><p>baz</p></blockquote><p>extra" queryCommandState("stylewithcss") before]
@@ -819,239 +276,71 @@
 
 
 [outdent.html?2001-last]
-  [[["outdent",""\]\] "<blockquote><ol><li>foo</li><ol><li>[bar\]</ol><li>baz</ol></blockquote><p>extra": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["outdent",""\]\] "<blockquote><ol><li>foo</li><ol><li>[bar\]</ol><li>baz</ol></blockquote><p>extra" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ol><li><h1>[foo\]</h1></ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ol><li><h1>[foo\]</h1></ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ol><li><xmp>[foo\]</xmp></li></ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ol><li><xmp>[foo\]</xmp></li></ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote><ol><li>foo<div><ol><li>[bar\]</ol></div><li>baz</ol></blockquote>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote><ol><li>foo<div><ol><li>[bar\]</ol></div><li>baz</ol></blockquote>" compare innerHTML]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<blockquote><ol><li>foo<div><ol><li>[bar\]</ol></div><li>baz</ol></blockquote>" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote><ol><li>foo<div><ol><li>[bar\]</ol></div><li>baz</ol></blockquote>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<blockquote><ol><li>foo<div><ol><li>[bar\]</ol></div><li>baz</ol></blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<blockquote> <p>[foo\]</p></blockquote>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["outdent",""\]\] "<blockquote> <p>[foo\]</p></blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<blockquote><p>[foo\]</p> </blockquote>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["outdent",""\]\] "<blockquote><p>[foo\]</p> </blockquote>" compare innerHTML]
     expected: FAIL
 
-  [[["outdent",""\]\] "<blockquote> <p>[foo\]</p> </blockquote>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["outdent",""\]\] "<blockquote> <p>[foo\]</p> </blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol> <li>[foo\]</li></ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol> <li>[foo\]</li></ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol> <li>[foo\]</li></ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol> <li>[foo\]</li></ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>[foo\]</li> </ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>[foo\]</li> </ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>[foo\]</li> </ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>[foo\]</li> </ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol> <li>[foo\]</li> </ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol> <li>[foo\]</li> </ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol> <li>[foo\]</li> </ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol> <li>[foo\]</li> </ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ul> <li>[foo\]</li></ul>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ul> <li>[foo\]</li></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ul> <li>[foo\]</li></ul>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ul> <li>[foo\]</li></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ul><li>[foo\]</li> </ul>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ul><li>[foo\]</li> </ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ul><li>[foo\]</li> </ul>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ul><li>[foo\]</li> </ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ul> <li>[foo\]</li> </ul>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ul> <li>[foo\]</li> </ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ul> <li>[foo\]</li> </ul>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ul> <li>[foo\]</li> </ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<blockquote> <p>[foo\]</p> <p>bar</p> <p>baz</p></blockquote>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["outdent",""\]\] "<blockquote> <p>[foo\]</p> <p>bar</p> <p>baz</p></blockquote>" compare innerHTML]
     expected: FAIL
 
-  [[["outdent",""\]\] "<blockquote> <p>foo</p> <p>[bar\]</p> <p>baz</p></blockquote>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["outdent",""\]\] "<blockquote> <p>foo</p> <p>[bar\]</p> <p>baz</p></blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<blockquote> <p>foo</p> <p>bar</p> <p>[baz\]</p></blockquote>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["outdent",""\]\] "<blockquote> <p>foo</p> <p>bar</p> <p>[baz\]</p></blockquote>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol> <li>[foo\]</li> <li>bar</li> <li>baz</li></ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol> <li>[foo\]</li> <li>bar</li> <li>baz</li></ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol> <li>[foo\]</li> <li>bar</li> <li>baz</li></ol>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol> <li>[foo\]</li> <li>bar</li> <li>baz</li></ol>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol> <li>foo</li> <li>[bar\]</li> <li>baz</li></ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol> <li>foo</li> <li>[bar\]</li> <li>baz</li></ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol> <li>foo</li> <li>[bar\]</li> <li>baz</li></ol>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol> <li>foo</li> <li>[bar\]</li> <li>baz</li></ol>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol> <li>foo</li> <li>bar</li> <li>[baz\]</li></ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol> <li>foo</li> <li>bar</li> <li>[baz\]</li></ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol> <li>foo</li> <li>bar</li> <li>[baz\]</li></ol>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol> <li>foo</li> <li>bar</li> <li>[baz\]</li></ol>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ul> <li>[foo\]</li> <li>bar</li> <li>baz</li></ul>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ul> <li>[foo\]</li> <li>bar</li> <li>baz</li></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ul> <li>[foo\]</li> <li>bar</li> <li>baz</li></ul>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ul> <li>[foo\]</li> <li>bar</li> <li>baz</li></ul>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ul> <li>foo</li> <li>[bar\]</li> <li>baz</li></ul>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ul> <li>foo</li> <li>[bar\]</li> <li>baz</li></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ul> <li>foo</li> <li>[bar\]</li> <li>baz</li></ul>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ul> <li>foo</li> <li>[bar\]</li> <li>baz</li></ul>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ul> <li>foo</li> <li>bar</li> <li>[baz\]</li></ul>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ul> <li>foo</li> <li>bar</li> <li>[baz\]</li></ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ul> <li>foo</li> <li>bar</li> <li>[baz\]</li></ul>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ul> <li>foo</li> <li>bar</li> <li>[baz\]</li></ul>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>[\]a<table><tr><td><br></table></ol>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["outdent",""\]\] "<ol><li>[\]a<table><tr><td><br></table></ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>[\]a<table><tr><td><br></table></ol>": execCommand("outdent", false, "") return value]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["outdent",""\]\] "<ol><li>[\]a<table><tr><td><br></table></ol>" compare innerHTML]
     expected: FAIL
 
-  [[["outdent",""\]\] "<blockquote><span>foo<br>[bar\]</span></blockquote>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
   [[["outdent",""\]\] "<blockquote><span>foo<br>[bar\]</span></blockquote>" compare innerHTML]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ul><ul><li><span style=\\"color:rgb(255, 0, 0)\\">[\]foo</span></li></ul></ul>": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["outdent",""\]\] "<ul><ul><li><span style=\\"color:rgb(255, 0, 0)\\">[\]foo</span></li></ul></ul>" compare innerHTML]
     expected: FAIL


### PR DESCRIPTION
This implements the `outdent` command.

Testing: More WPT passes

There is some interesting behavior that's still making some of the test fail though. Consider this setup:
```html
<!DOCTYPE html>
<div contenteditable="true">
  <ol>
    <li>foo
    <ol>
      <li id="target">bar
    </ol>
    <li>baz
  </ol>
</div>
<script>
  document.getSelection().collapse(target.firstChild, 1);
  document.getSelection().extend(target.firstChild, 2);
  document.execCommand("outdent");
</script>
```
Here we're trying to outdent an LI inside of a list.
WPT asserts, that the entire nested OL should just be gotten rid of. This makes sense and matches Chrome. (Firefox also removes the OL but then additionally merges the LI with the preceding one)

But from what I can tell, the spec as written accomplishes none of that:
The outdent command first block-extends the range (step 3), which means that it now wraps the inner LI.
Then, (step 5) it makes a list of all 'leaf' nodes in the range. (A leaf node being one with no further editable children, or, alternatively, an OL or UL or **correctly parented LI**)
In our example, *node list* contains only the LI now.
And now, (step 6.1) the spec specifically does not outdent children of OL/UL elements... which includes our LI.
So `outdent` is never called.

Not sure what to make of this yet, but I'll investigate it a bit more to see how the WPT tests ended up that way. (and maybe go and compare homework with Ladybird to see if they ended up doing anything different here.)