### PR TITLE
media-examples should not depend on servo

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -307,10 +307,6 @@ jobs:
           jackd -d dummy &
           pulseaudio --start
           gst-inspect-1.0 | grep Total
-      - name: Set LIBCLANG_PATH env # needed for bindgen
-        shell: bash
-        if: ${{ runner.environment != 'self-hosted' }}
-        run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV
       - name: Run Examples
         run: |
           ls components/media/examples/examples/*.rs | xargs -I{} basename  {} .rs  | grep -v params_connect | RUST_BACKTRACE=1 GST_DEBUG=3 xargs -I{} cargo run -p servo-media-examples --example {}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8505,9 +8505,9 @@ name = "servo-media-examples"
 version = "0.5.0"
 dependencies = [
  "euclid",
+ "freetype-sys",
  "rand 0.10.2",
  "serde",
- "servo",
  "servo-media",
  "servo-media-auto",
  "servo-media-dummy",

--- a/components/media/examples/Cargo.toml
+++ b/components/media/examples/Cargo.toml
@@ -13,7 +13,7 @@ description.workspace = true
 euclid = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
-servo = { workspace = true, default-features = true }
+freetype-sys = { workspace = true, features = ["bundled"] } # used only to force bundled to make it standalone for CI
 servo-media = { workspace = true }
 servo-media-auto = { workspace = true }
 servo-media-dummy = { workspace = true }


### PR DESCRIPTION
If they do then we need to also compile mozjs in that job and we do not want that. This was done as a hacky way to buble down proper features on deps per https://github.com/servo/servo/pull/46233#discussion_r3839098127, but proper solution is to just enable bundled on freetype-sys.

Testing: CI
