### PR TITLE
media: Stop publishing `servo-media-examples`

### DIFF
--- a/components/media/examples/Cargo.toml
+++ b/components/media/examples/Cargo.toml
@@ -4,10 +4,10 @@ version.workspace = true
 authors.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 rust-version.workspace = true
 repository.workspace = true
 description.workspace = true
+publish = false
 
 [dependencies]
 euclid = { workspace = true }


### PR DESCRIPTION
This crate isn't meant to be published and is pretty much useless to end
users.

Testing: This just changes the build configuration, so no tests are necessary.
