### PR TITLE
constellation: Move `pending_viewport_changes` to `ConstellationWebView`

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -508,10 +508,6 @@ pub struct Constellation<STF, SWF> {
     /// [`ImageCacheFactoryImpl`].
     pub(crate) image_cache_factory: Arc<ImageCacheFactoryImpl>,
 
-    /// Pending viewport changes for browsing contexts that are not
-    /// yet known to the constellation.
-    pending_viewport_changes: HashMap<BrowsingContextId, ViewportDetails>,
-
     /// A map from `UserContentManagerId` to the `UserContents` for that manager.
     /// Multiple `WebView`s can share the same `UserContentManager` and any mutations
     /// to the `UserContents` need to be forwared to all the `ScriptThread`s that host
@@ -735,7 +731,6 @@ where
                     image_cache_factory: Arc::new(ImageCacheFactoryImpl::new(
                         broken_image_icon_data,
                     )),
-                    pending_viewport_changes: Default::default(),
                     user_contents_for_manager_id: Default::default(),
                 };
 
@@ -1148,6 +1143,11 @@ where
         inherited_secure_context: Option<bool>,
         throttled: bool,
     ) {
+        let Some(webview) = self.webviews.get_mut(&webview_id) else {
+            println!("Adding BrowsingContext for unknown WebView: {webview_id:?}");
+            return;
+        };
+
         debug!("{browsing_context_id}: Creating new browsing context");
         let bc_group_id = match self
             .browsing_context_group_set
@@ -1172,9 +1172,8 @@ where
         };
 
         // Override the viewport details if we have a pending change for that browsing context.
-        let viewport_details = self
-            .pending_viewport_changes
-            .remove(&browsing_context_id)
+        let viewport_details = webview
+            .take_pending_viewport_details(&browsing_context_id)
             .unwrap_or(viewport_details);
         let browsing_context = BrowsingContext::new(
             bc_group_id,
@@ -5790,6 +5789,11 @@ where
         size_type: WindowSizeType,
         browsing_context_id: BrowsingContextId,
     ) {
+        let Some(webview) = self.webviews.get_mut(&webview_id) else {
+            warn!("Resizing browsing context for unkown WebView: {webview_id:?}");
+            return;
+        };
+
         if let Some(browsing_context) = self.browsing_contexts.get_mut(&browsing_context_id) {
             browsing_context.viewport_details = new_viewport_details;
             // Send Resize (or ResizeInactive) messages to each pipeline in the frame tree.
@@ -5817,25 +5821,22 @@ where
                 }
             }
         } else {
-            self.pending_viewport_changes
-                .insert(browsing_context_id, new_viewport_details);
+            webview.add_viewport_details(browsing_context_id, new_viewport_details);
         }
 
         // Send resize message to any pending pipelines that aren't loaded yet.
-        if let Some(webview) = self.webviews.get(&webview_id) {
-            for change in &webview.pending_changes {
-                let pipeline_id = change.new_pipeline_id;
-                let Some(pipeline) = self.pipelines.get(&pipeline_id) else {
-                    warn!("Pending pipeline is closed: {pipeline_id}");
-                    continue;
-                };
-                if pipeline.browsing_context_id == browsing_context_id {
-                    let _ = pipeline.event_loop.send(ScriptThreadMessage::Resize(
-                        pipeline.id,
-                        new_viewport_details,
-                        size_type,
-                    ));
-                }
+        for change in &webview.pending_changes {
+            let pipeline_id = change.new_pipeline_id;
+            let Some(pipeline) = self.pipelines.get(&pipeline_id) else {
+                warn!("Pending pipeline is closed: {pipeline_id}");
+                continue;
+            };
+            if pipeline.browsing_context_id == browsing_context_id {
+                let _ = pipeline.event_loop.send(ScriptThreadMessage::Resize(
+                    pipeline.id,
+                    new_viewport_details,
+                    size_type,
+                ));
             }
         }
     }
@@ -5898,18 +5899,17 @@ where
             exit_mode,
         );
 
-        let _ = self.pending_viewport_changes.remove(&browsing_context_id);
+        let Some(webview) = self.webviews.get_mut(&webview_id) else {
+            warn!("Closing BrowsingContext in unknown WebView: {webview_id:?}");
+            return self.browsing_contexts.remove(&browsing_context_id);
+        };
+
+        webview.close_browsing_context(browsing_context_id);
 
         let Some(browsing_context) = self.browsing_contexts.remove(&browsing_context_id) else {
             warn!("fn close_browsing_context: {browsing_context_id}: Closing twice");
             return None;
         };
-
-        if let Some(webview) = self.webviews.get_mut(&browsing_context.webview_id) {
-            webview
-                .session_history
-                .remove_entries_for_browsing_context(browsing_context_id);
-        }
 
         if let Some(parent_pipeline_id) = browsing_context.parent_pipeline_id {
             match self.pipelines.get_mut(&parent_pipeline_id) {
@@ -5919,28 +5919,19 @@ where
                 Some(parent_pipeline) => {
                     parent_pipeline.remove_child(browsing_context_id);
 
-                    // If `browsing_context_id` has focus, focus the parent
-                    // browsing context
-                    if let Some(webview) = self.webviews.get_mut(&browsing_context.webview_id) {
-                        if webview.focused_browsing_context_id == browsing_context_id {
-                            trace!(
-                                "About-to-be-closed browsing context {} is currently focused, so \
+                    // If `browsing_context_id` has focus, focus the parent browsing context
+                    if webview.focused_browsing_context_id == browsing_context_id {
+                        trace!(
+                            "About-to-be-closed browsing context {} is currently focused, so \
                                 focusing its parent {}",
-                                browsing_context_id, parent_pipeline.browsing_context_id
-                            );
-                            webview.focused_browsing_context_id =
-                                parent_pipeline.browsing_context_id;
-                        }
-                    } else {
-                        warn!(
-                            "Browsing context {} contains a reference to \
-                                a non-existent top-level browsing context {}",
-                            browsing_context_id, browsing_context.webview_id
+                            browsing_context_id, parent_pipeline.browsing_context_id
                         );
+                        webview.focused_browsing_context_id = parent_pipeline.browsing_context_id;
                     }
                 },
             };
         }
+
         debug!("{}: Closed", browsing_context_id);
         Some(browsing_context)
     }

--- a/components/constellation/constellation_webview.rs
+++ b/components/constellation/constellation_webview.rs
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 
 use embedder_traits::user_contents::UserContentManagerId;
-use embedder_traits::{InputEvent, MouseLeftViewportEvent, Theme};
+use embedder_traits::{InputEvent, MouseLeftViewportEvent, Theme, ViewportDetails};
 use euclid::{Point2D, Size2D};
 use log::{debug, warn};
 use paint_api::{PaintMessage, PaintProxy};
@@ -66,6 +66,10 @@ pub(crate) struct ConstellationWebView {
     /// `Pipeline`s in a traversal become active or their load fails for some other reason.
     pub ongoing_history_traversal_request: Option<OngoingHistoryTraversalRequest>,
 
+    /// Pending viewport changes for browsing contexts that are not
+    /// yet known to the constellation.
+    pending_viewport_details: HashMap<BrowsingContextId, ViewportDetails>,
+
     /// The [`UserContentManagerId`] for all pipelines in this `WebView`. This is `Some`
     /// if the embedder has set a `UserContentManager` using the WebViewBuilder API and
     /// it is `None` otherwise.
@@ -107,6 +111,7 @@ impl ConstellationWebView {
             session_history: JointSessionHistory::new(),
             session_history_traversal_request_queue: Default::default(),
             ongoing_history_traversal_request: None,
+            pending_viewport_details: Default::default(),
             theme: Theme::Light,
             accessibility_active: false,
             screenshot_readiness_requests: Default::default(),
@@ -219,6 +224,12 @@ impl ConstellationWebView {
                 event,
             ));
         true
+    }
+
+    pub(crate) fn close_browsing_context(&mut self, browsing_context_id: BrowsingContextId) {
+        self.take_pending_viewport_details(&browsing_context_id);
+        self.session_history
+            .remove_entries_for_browsing_context(browsing_context_id);
     }
 
     /// If there is an ongoing history traversal request that is waiting on documents to
@@ -400,6 +411,22 @@ impl ConstellationWebView {
 
                 false
             });
+    }
+
+    pub(crate) fn add_viewport_details(
+        &mut self,
+        browsing_context_id: BrowsingContextId,
+        viewport_details: ViewportDetails,
+    ) {
+        self.pending_viewport_details
+            .insert(browsing_context_id, viewport_details);
+    }
+
+    pub(crate) fn take_pending_viewport_details(
+        &mut self,
+        browsing_context_id: &BrowsingContextId,
+    ) -> Option<ViewportDetails> {
+        self.pending_viewport_details.remove(browsing_context_id)
     }
 }
 


### PR DESCRIPTION
This is another change in a series of work to try to reduce the amount
of `HashMap` access in `Constellation`. This moves
`pending_viewport_changes` to `ConstellationWebView` and renames it to
`pending_viewport_details`.


Testing: This shouldn't change behavior so is covered by existing tests.
Fixes: This is part of #47294.
