### PR TITLE
script: Return `0` as`loadTime` value for all LCP Entries

### DIFF
--- a/components/script/dom/performance/largestcontentfulpaint.rs
+++ b/components/script/dom/performance/largestcontentfulpaint.rs
@@ -25,7 +25,7 @@ use crate::dom::node::Node;
 pub(crate) struct LargestContentfulPaint {
     entry: PerformanceEntry,
     #[no_trace]
-    load_time: CrossProcessInstant,
+    load_time: Option<CrossProcessInstant>,
     #[no_trace]
     render_time: CrossProcessInstant,
     size: usize,
@@ -47,7 +47,7 @@ impl LargestContentfulPaint {
                 Some(render_time),
                 Duration::ZERO,
             ),
-            load_time: CrossProcessInstant::epoch(),
+            load_time: None,
             render_time,
             size,
             url: url.map(|u| DOMString::from(u.as_str())).unwrap_or_default(),
@@ -83,7 +83,7 @@ impl LargestContentfulPaintMethods<crate::DomTypeHolder> for LargestContentfulPa
     fn LoadTime(&self, cx: &mut JSContext) -> DOMHighResTimeStamp {
         self.global()
             .performance(cx)
-            .to_dom_high_res_time_stamp(self.load_time)
+            .maybe_to_dom_high_res_time_stamp(self.load_time)
     }
 
     /// <https://www.w3.org/TR/largest-contentful-paint/#dom-largestcontentfulpaint-rendertime>

--- a/tests/wpt/meta/largest-contentful-paint/first-letter-background.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/first-letter-background.html.ini
@@ -1,3 +1,0 @@
-[first-letter-background.html]
-  [Largest Contentful Paint: first-letter is observable.]
-    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/larger-text.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/larger-text.html.ini
@@ -1,3 +1,0 @@
-[larger-text.html]
-  [Largest Contentful Paint: largest text is reported.]
-    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/observe-css-generated-text.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/observe-css-generated-text.html.ini
@@ -1,9 +1,3 @@
 [observe-css-generated-text.html]
-  [CSS generated text is observable as a LargestContentfulPaint candidate]
-    expected: FAIL
-
-  [Text generated with CSS using content:attr() is observable as a LargestContentfulPaint candidate]
-    expected: FAIL
-
   [CSS generated text on a inline element is observable as a LargestContentfulPaint candidate]
     expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/observe-mathml.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/observe-mathml.html.ini
@@ -1,3 +1,0 @@
-[observe-mathml.html]
-  [Element rendered by MathML is observable]
-    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/observe-random-namespace.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/observe-random-namespace.html.ini
@@ -1,3 +1,0 @@
-[observe-random-namespace.html]
-  [Element created with different namespace is observable]
-    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/observe-text.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/observe-text.html.ini
@@ -1,3 +1,0 @@
-[observe-text.html]
-  [Text element is observable as a LargestContentfulPaint candidate.]
-    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/text-fragment-union.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/text-fragment-union.html.ini
@@ -1,3 +1,0 @@
-[text-fragment-union.html]
-  [Text fragment union: wrapped text LCP size reflects the union of all line boxes.]
-    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/text-with-display-style.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/text-with-display-style.html.ini
@@ -1,3 +1,0 @@
-[text-with-display-style.html]
-  [Text with display style is observable.]
-    expected: FAIL


### PR DESCRIPTION
As per the spec loadTime for Text is 0. 
> [Step 5.8.6](https://www.w3.org/TR/largest-contentful-paint/#compute-a-new-largest-contentful-paint-candidate). [loadTime](https://www.w3.org/TR/largest-contentful-paint/#largest-contentful-paint-candidate-loadtime) set to 0.

Hence, returning `None` will pass Text releated WPTs.

Testing: Additional WPT Passed 
Fixes: Part of #47315

