### PR TITLE
script: No longer store `Selection` range as a live range

### DIFF
--- a/components/script/dom/characterdata/characterdata.rs
+++ b/components/script/dom/characterdata/characterdata.rs
@@ -129,11 +129,19 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
     fn SetData(&self, cx: &mut JSContext, data: DOMString) {
         self.queue_mutation_record(cx);
         let old_length = self.Length();
-        let new_length = Utf16CodeUnits::length_of(&data.str()).0 as u32;
         *self.data.safe_borrow_mut(cx.no_gc()) = String::from(data.str());
         self.content_changed(cx);
 
-        live_range_replace_data_steps(self.upcast(), 0, old_length, new_length);
+        let mut utf16_length = None;
+        let mut lazy_length = move || {
+            *utf16_length.get_or_insert_with(|| Utf16CodeUnits::length_of(&data.str()).0 as u32)
+        };
+
+        let node: &Node = self.upcast();
+        if let Some(selection) = node.owner_doc_unrooted(cx.no_gc()).selection() {
+            selection.replace_data_steps(node, 0, old_length, &mut lazy_length);
+        }
+        live_range_replace_data_steps(node, 0, old_length, &mut lazy_length);
     }
 
     /// <https://dom.spec.whatwg.org/#dom-characterdata-length>
@@ -259,13 +267,18 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
         self.content_changed(cx);
 
         let node = self.upcast::<Node>();
+
+        let mut utf16_length = None;
+        let mut lazy_length = move || {
+            *utf16_length.get_or_insert_with(|| Utf16CodeUnits::length_of(&arg.str()).0 as u32)
+        };
+
+        if let Some(selection) = node.owner_doc_unrooted(cx.no_gc()).selection() {
+            selection.replace_data_steps(node, offset, count, &mut lazy_length);
+        }
+
         if node.has_live_ranges() {
-            live_range_replace_data_steps(
-                node,
-                offset,
-                count,
-                Utf16CodeUnits::length_of(&arg.str()).0 as u32,
-            );
+            live_range_replace_data_steps(node, offset, count, &mut lazy_length);
         }
 
         // Step 12: If node is a ProcessingInstruction node and piAttributesAlreadyUpdated

--- a/components/script/dom/characterdata/text.rs
+++ b/components/script/dom/characterdata/text.rs
@@ -87,22 +87,27 @@ impl TextMethods<crate::DomTypeHolder> for Text {
         // Step 5: Let newNode be the result of creating a text node given node’s node document and newData.
         let node = self.upcast::<Node>();
         let owner_doc = node.owner_doc();
-        let new_node = owner_doc.CreateTextNode(cx, new_data);
+        let new_text_node = owner_doc.CreateTextNode(cx, new_data);
         // Step 6: Let parent be node’s parent.
         let parent = node.GetParentNode();
         // Step 7: If parent is non-null:
         if let Some(ref parent) = parent {
             // Step 7.1: Insert newNode into parent before node’s next sibling.
+            let new_node = new_text_node.upcast();
             parent
-                .InsertBefore(cx, new_node.upcast(), node.GetNextSibling().as_deref())
+                .InsertBefore(cx, new_node, node.GetNextSibling().as_deref())
                 .unwrap();
+
             // Steps 7.2-7.5: The live range update steps.
-            live_range_text_split_steps(parent, node, offset, new_node.upcast());
+            if let Some(selection) = owner_doc.selection() {
+                selection.text_split_steps(node, offset, parent, new_node);
+            }
+            live_range_text_split_steps(parent, node, offset, new_node);
         }
         // Step 8.
         cdata.DeleteData(cx, offset, count).unwrap();
         // Step 9.
-        Ok(new_node)
+        Ok(new_text_node)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-text-wholetext>

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -304,6 +304,7 @@ pub(crate) use self::resizeobserver::*;
 pub(crate) mod security;
 pub(crate) use self::security::*;
 pub(crate) mod selection;
+pub(crate) mod selection_range;
 pub(crate) mod serviceworker;
 pub(crate) use self::serviceworker::*;
 pub(crate) mod servointernals;

--- a/components/script/dom/node/layout_dom.rs
+++ b/components/script/dom/node/layout_dom.rs
@@ -15,7 +15,7 @@ use script_bindings::codegen::InheritTypes::{
     ElementTypeId, HTMLElementTypeId, SVGElementTypeId, SVGGraphicsElementTypeId,
 };
 use servo_base::id::{BrowsingContextId, PipelineId};
-use servo_base::text::{RangeAny, Utf32CodeUnits};
+use servo_base::text::{RangeAny, Utf16CodeUnits, Utf32CodeUnits};
 use servo_url::ServoUrl;
 use style::dom::OpaqueNode;
 use style::selector_parser::PseudoElement;
@@ -265,22 +265,19 @@ impl<'dom> LayoutDom<'dom, Node> {
 
         let text_node = self.downcast::<Text>()?;
         let text = text_node.upcast().data_for_layout();
-        let range = self
-            .owner_doc_for_layout()
-            .selection_for_layout()?
-            .range_for_layout()?
-            .unsafe_get();
-
-        let range_start = range.start();
-        let range_end = range.end();
+        let selection = self.owner_doc_for_layout().selection_for_layout()?;
+        let range = selection.range_for_layout();
 
         // Text nodes are always the same node when projected into the flat tree, so
         // it is fine to do the following check against the original unprojected nodes.
-        let is_start_node = unsafe { range_start.node().to_layout() } == *self;
-        let is_end_node = unsafe { range_end.node().to_layout() } == *self;
+        let range = range.as_ref()?;
+        let is_start_node = unsafe { range.start.container.to_layout() } == *self;
+        let is_end_node = unsafe { range.end.container.to_layout() } == *self;
 
-        let start = is_start_node.then(|| range_start.offset().to_utf32_code_units_in(&text));
-        let end = is_end_node.then(|| range_end.offset().to_utf32_code_units_in(&text));
+        let start = is_start_node
+            .then(|| Utf16CodeUnits(range.start.offset as usize).to_utf32_code_units_in(&text));
+        let end = is_end_node
+            .then(|| Utf16CodeUnits(range.end.offset as usize).to_utf32_code_units_in(&text));
         Some(RangeAny { start, end })
     }
 

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -4102,23 +4102,18 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
             // Note: Condition guaranteed by collection loop above.
             let first_sibling_index = LazyCell::new(|| node.index() + 1);
             for (current_node_index, current_node) in siblings_to_merge.iter().enumerate() {
+                let index = &|| *first_sibling_index + current_node_index as u32;
                 // Steps 6.1-6.4: The live range update steps.
-                if let Some(selection) = selection.as_ref() {
+                if let Some(selection) = &selection {
                     selection.normalization_steps(
                         self,
                         &node,
                         current_node.upcast(),
-                        &|| *first_sibling_index + current_node_index as u32,
+                        &index,
                         length,
                     );
                 }
-                live_range_normalization_steps(
-                    self,
-                    &node,
-                    current_node.upcast(),
-                    &|| *first_sibling_index + current_node_index as u32,
-                    length,
-                );
+                live_range_normalization_steps(self, &node, current_node.upcast(), &index, length);
                 // Step 6.5:  Add currentNode’s length to length.
                 length += current_node.Length();
                 // Step 6.6 Set currentNode to its next sibling.

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -1533,6 +1533,9 @@ impl Node {
         // Step 17. If child is non-null:
         if let Some(child) = child {
             // Steps 17.1-17.2: The live range move steps.
+            if let Some(selection) = new_parent.owner_document().selection() {
+                selection.insert_steps(new_parent, child, 1);
+            }
             live_range_insert_steps(new_parent, child, 1);
         }
 
@@ -2682,7 +2685,11 @@ impl Node {
         // Step 5. If child is non-null:
         if let Some(child) = child {
             // Step 5.1. The live range insert steps.
-            live_range_insert_steps(parent, child, count.try_into().unwrap());
+            let count = count.try_into().unwrap();
+            if let Some(selection) = parent.owner_document().selection() {
+                selection.insert_steps(parent, child, count);
+            }
+            live_range_insert_steps(parent, child, count);
         }
 
         // Step 6. Let previousSibling be child’s previous sibling or parent’s last child if child is null.
@@ -2982,6 +2989,9 @@ impl Node {
         let mut cached_index = None;
         {
             let mut lazy_index = || *cached_index.get_or_insert_with(|| node.index());
+            if let Some(selection) = node.owner_document().selection() {
+                selection.remove_steps_for_parent(parent, &mut lazy_index);
+            }
             live_range_pre_remove_steps_for_parent(parent, &mut lazy_index);
         }
 
@@ -4034,6 +4044,7 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
     /// <https://dom.spec.whatwg.org/#dom-node-normalize>
     fn Normalize(&self, cx: &mut JSContext) {
         let mut children = self.children().peekable();
+        let selection = self.owner_document().selection();
         while let Some(node) = children.next() {
             // The normalize() method steps are to run these steps for each descendant
             // exclusive Text node node of this:
@@ -4092,6 +4103,15 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
             let first_sibling_index = LazyCell::new(|| node.index() + 1);
             for (current_node_index, current_node) in siblings_to_merge.iter().enumerate() {
                 // Steps 6.1-6.4: The live range update steps.
+                if let Some(selection) = selection.as_ref() {
+                    selection.normalization_steps(
+                        self,
+                        &node,
+                        current_node.upcast(),
+                        &|| *first_sibling_index + current_node_index as u32,
+                        length,
+                    );
+                }
                 live_range_normalization_steps(
                     self,
                     &node,

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -4543,6 +4543,9 @@ impl VirtualMethods for Node {
 
         let mut cached_index = None;
         let mut lazy_index = || *cached_index.get_or_insert_with(|| context.index());
+        if let Some(selection) = self.owner_document().selection() {
+            selection.remove_steps_for_removed_subtree(self, context.parent, &mut lazy_index);
+        }
         live_range_pre_remove_steps_for_removed_subtree(self, context.parent, &mut lazy_index);
     }
 

--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -325,6 +325,10 @@ impl Range {
     }
 
     pub(crate) fn report_change(&self, notification: SelectionLiveRangeNotification) {
+        if notification.is_empty() {
+            return;
+        }
+
         self.associated_selections
             .borrow()
             .iter()

--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -43,7 +43,7 @@ use crate::dom::element::Element;
 use crate::dom::html::htmlscriptelement::HTMLScriptElement;
 use crate::dom::iterators::ShadowIncluding;
 use crate::dom::node::{Node, NodeTraits};
-use crate::dom::selection::Selection;
+use crate::dom::selection::{Selection, SelectionLiveRangeNotification};
 use crate::dom::text::Text;
 use crate::dom::trustedtypes::trustedhtml::TrustedHTML;
 use crate::dom::window::Window;
@@ -229,11 +229,11 @@ impl Range {
     /// <https://dom.spec.whatwg.org/#concept-range-bp-set>
     pub(crate) fn set_start(&self, node: &Node, offset: u32) {
         if self.set_start_without_reporting(node, offset) {
-            self.report_change();
+            self.report_change(SelectionLiveRangeNotification::Start);
         }
     }
 
-    fn set_start_without_reporting(&self, node: &Node, offset: u32) -> bool {
+    pub(crate) fn set_start_without_reporting(&self, node: &Node, offset: u32) -> bool {
         if self.start().node() == node && self.start_offset() == offset {
             return false;
         }
@@ -256,15 +256,14 @@ impl Range {
     /// <https://dom.spec.whatwg.org/#concept-range-bp-set>
     pub(crate) fn set_end(&self, node: &Node, offset: u32) {
         if self.set_end_without_reporting(node, offset) {
-            self.report_change();
+            self.report_change(SelectionLiveRangeNotification::End);
         }
     }
 
-    fn set_end_without_reporting(&self, node: &Node, offset: u32) -> bool {
+    pub(crate) fn set_end_without_reporting(&self, node: &Node, offset: u32) -> bool {
         if self.end().node() == node && self.end_offset() == offset {
             return false;
         }
-
         if self.end().node() != node {
             if self.end().node() == self.start().node() {
                 node.ensure_weak_ranges().push(WeakRef::new(self));
@@ -325,14 +324,12 @@ impl Range {
             .retain(|s| &**s != selection);
     }
 
-    fn report_change(&self) {
+    pub(crate) fn report_change(&self, notification: SelectionLiveRangeNotification) {
         self.associated_selections
             .borrow()
             .iter()
             .for_each(|selection| {
-                selection.queue_selectionchange_task();
-                selection.set_visible_selection_dirty();
-                selection.clear_command_overrides();
+                selection.update_from_live_range(self, notification);
             });
     }
 
@@ -346,11 +343,6 @@ impl Range {
 
     pub(crate) fn end(&self) -> &BoundaryPoint {
         self.abstract_range().end()
-    }
-
-    pub(crate) fn start_and_end_are_in_document_tree(&self) -> bool {
-        self.start_container().is_in_a_document_tree() &&
-            self.end_container().is_in_a_document_tree()
     }
 
     pub(crate) fn start_container(&self) -> DomRoot<Node> {
@@ -426,8 +418,7 @@ impl Range {
 
         // Step 3. Let bp be the boundary point (node, offset).
         // NOTE: We don't need this part.
-        let mut set_start = false;
-        let mut set_end = false;
+        let mut notification = SelectionLiveRangeNotification::empty();
         match start_or_end {
             // If these steps were invoked as "set the start"
             StartOrEnd::Start => {
@@ -437,11 +428,17 @@ impl Range {
                     bp_position(node, offset, &self.end_container(), self.end_offset()) ==
                         Ordering::Greater
                 {
-                    set_end = self.set_end_without_reporting(node, offset);
+                    notification.set(
+                        SelectionLiveRangeNotification::End,
+                        self.set_end_without_reporting(node, offset),
+                    );
                 }
 
                 // Step 4.2. Set range’s start to bp.
-                set_start = self.set_start_without_reporting(node, offset);
+                notification.set(
+                    SelectionLiveRangeNotification::Start,
+                    self.set_start_without_reporting(node, offset),
+                );
             },
             // If these steps were invoked as "set the end"
             StartOrEnd::End => {
@@ -451,18 +448,21 @@ impl Range {
                     bp_position(node, offset, &self.start_container(), self.start_offset()) ==
                         Ordering::Less
                 {
-                    set_start = self.set_start_without_reporting(node, offset);
+                    notification.set(
+                        SelectionLiveRangeNotification::Start,
+                        self.set_start_without_reporting(node, offset),
+                    );
                 }
 
                 // Step 4.2. Set range’s end to bp.
-                set_end = self.set_end_without_reporting(node, offset);
+                notification.set(
+                    SelectionLiveRangeNotification::End,
+                    self.set_end_without_reporting(node, offset),
+                );
             },
         }
 
-        if set_start || set_end {
-            self.report_change();
-        }
-
+        self.report_change(notification);
         Ok(())
     }
 }
@@ -480,7 +480,8 @@ impl std::fmt::Debug for Range {
     }
 }
 
-enum StartOrEnd {
+#[derive(Copy, Clone)]
+pub(crate) enum StartOrEnd {
     Start,
     End,
 }
@@ -1042,10 +1043,6 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         if start_node == end_node &&
             let Some(text) = start_node.downcast::<CharacterData>()
         {
-            if end_offset > start_offset {
-                self.report_change();
-            }
-
             // Step 3.1. Replace data of originalStartNode with originalStartOffset,
             // originalEndOffset − originalStartOffset, and the empty string.
             // Step 3.2. Return.
@@ -1391,12 +1388,12 @@ pub(crate) fn live_range_insert_steps(parent: &Node, child: &Node, count: u32) {
             // Step 5.1: For each live range whose start node is parent and start offset is
             // greater than child’s index: increase its start offset by count.
             if &*range.start_container() == parent && range.start_offset() > *child_index {
-                range.set_start(parent, range.start_offset() + count);
+                range.set_start_without_reporting(parent, range.start_offset() + count);
             }
             // Step 5.2: For each live range whose end node is parent and end offset is
             // greater than child’s index: increase its end offset by count.
             if &*range.end_container() == parent && range.end_offset() > *child_index {
-                range.set_end(parent, range.end_offset() + count);
+                range.set_end_without_reporting(parent, range.end_offset() + count);
             }
         }
     }
@@ -1421,12 +1418,12 @@ pub(crate) fn live_range_pre_remove_steps_for_removed_subtree(
         // Step 4: For each live range whose start node is an inclusive descendant of
         // node, set its start to (parent, index).
         if &*range.start_container() == inclusive_descendant_of_removed_node {
-            range.set_start(parent_of_removed_node, index_of_removed_node());
+            range.set_start_without_reporting(parent_of_removed_node, index_of_removed_node());
         }
         // Step 5: For each live range whose end node is an inclusive descendant of node,
         // set its end to (parent, index).
         if &*range.end_container() == inclusive_descendant_of_removed_node {
-            range.set_end(parent_of_removed_node, index_of_removed_node());
+            range.set_end_without_reporting(parent_of_removed_node, index_of_removed_node());
         }
     }
 }
@@ -1440,12 +1437,12 @@ pub(crate) fn live_range_pre_remove_steps_for_parent(
         // Step 6: For each live range whose start node is parent and start offset is
         // greater than index, decrease its start offset by 1.
         if &*range.start_container() == parent && range.start_offset() > node_index() {
-            range.set_start(parent, range.start_offset() - 1);
+            range.set_start_without_reporting(parent, range.start_offset() - 1);
         }
         // Step 7: For each live range whose end node is parent and end offset is greater than
         // index, decrease its end offset by 1.
         if &*range.end_container() == parent && range.end_offset() > node_index() {
-            range.set_end(parent, range.end_offset() - 1);
+            range.set_end_without_reporting(parent, range.end_offset() - 1);
         }
     }
 }
@@ -1471,12 +1468,12 @@ pub(crate) fn live_range_normalization_steps(
         // Step 6.1: For each live range whose start node is currentNode: add length to
         // its start offset and set its start node to node.
         if &*range.start_container() == current_node {
-            range.set_start(node, range.start_offset() + length);
+            range.set_start_without_reporting(node, range.start_offset() + length);
         }
         // Step 6.2: For each live range whose end node is currentNode: add length to its
         // end offset and set its end node to node.
         if &*range.end_container() == current_node {
-            range.set_end(node, range.end_offset() + length);
+            range.set_end_without_reporting(node, range.end_offset() + length);
         }
     }
 
@@ -1485,13 +1482,13 @@ pub(crate) fn live_range_normalization_steps(
         // start offset is currentNode’s index: set its start node to node and its start
         // offset to length.
         if &*range.start_container() == parent && range.start_offset() == current_node_index() {
-            range.set_start(node, length);
+            range.set_start_without_reporting(node, length);
         }
         // Step 6.4: For each live range whose end node is currentNode’s parent and end
         // offset is currentNode’s index: set its end node to node and its end offset to
         // length.
         if &*range.end_container() == parent && range.end_offset() == current_node_index() {
-            range.set_end(node, length);
+            range.set_end_without_reporting(node, length);
         }
     }
 }
@@ -1501,7 +1498,7 @@ pub(crate) fn live_range_replace_data_steps(
     node: &Node,
     offset: u32,
     removed_code_units: u32,
-    added_code_units: u32,
+    added_code_units: &mut dyn FnMut() -> u32,
 ) {
     for range in node.live_ranges() {
         // Step 8: For each live range whose start node is node and start offset is
@@ -1513,7 +1510,7 @@ pub(crate) fn live_range_replace_data_steps(
             start_offset > offset &&
             start_offset <= offset + removed_code_units
         {
-            range.set_start(node, offset);
+            range.set_start_without_reporting(node, offset);
         }
         // Step 9: For each live range whose end node is node and end offset is
         // greater than offset but less than or equal to offset + count: set its end
@@ -1524,19 +1521,25 @@ pub(crate) fn live_range_replace_data_steps(
             end_offset > offset &&
             end_offset <= offset + removed_code_units
         {
-            range.set_end(node, offset);
+            range.set_end_without_reporting(node, offset);
         }
         // Step 10: For each live range whose start node is node and start offset is
         // greater than offset + count: increase its start offset by data’s length and
         // decrease it by count.
         if &*start_container == node && start_offset > offset + removed_code_units {
-            range.set_start(node, start_offset + added_code_units - removed_code_units);
+            range.set_start_without_reporting(
+                node,
+                start_offset + added_code_units() - removed_code_units,
+            );
         }
         // Step 11: For each live range whose end node is node and end offset is
         // greater than offset + count: increase its end offset by data’s length and
         // decrease it by count.
         if &*end_container == node && end_offset > offset + removed_code_units {
-            range.set_end(node, end_offset + added_code_units - removed_code_units);
+            range.set_end_without_reporting(
+                node,
+                end_offset + added_code_units() - removed_code_units,
+            );
         }
     }
 }
@@ -1553,13 +1556,13 @@ pub(crate) fn live_range_text_split_steps(
         // greater than offset, set its start node to newNode and decrease its start
         // offset by offset.
         if &*range.start_container() == node && range.start_offset() > offset {
-            range.set_start(new_node, range.start_offset() - offset);
+            range.set_start_without_reporting(new_node, range.start_offset() - offset);
         }
         // Step 7.3. For each live range whose end node is node and end offset is
         // greater than offset, set its end node to newNode and decrease its end
         // offset by offset.
         if &*range.end_container() == node && range.end_offset() > offset {
-            range.set_end(new_node, range.end_offset() - offset);
+            range.set_end_without_reporting(new_node, range.end_offset() - offset);
         }
     }
 
@@ -1568,13 +1571,13 @@ pub(crate) fn live_range_text_split_steps(
         // Step 7.4. For each live range whose start node is parent and start offset
         // is equal to the index of node plus 1, increase its start offset by 1.
         if &*range.start_container() == parent && range.start_offset() == *node_index + 1 {
-            range.set_start(parent, range.start_offset() + 1);
+            range.set_start_without_reporting(parent, range.start_offset() + 1);
         }
 
         // Step 7.5. For each live range whose end node is parent and end offset is
         // equal to the index of node plus 1, increase its end offset by 1.
         if &*range.end_container() == parent && range.end_offset() == *node_index + 1 {
-            range.set_end(parent, range.end_offset() + 1);
+            range.set_end_without_reporting(parent, range.end_offset() + 1);
         }
     }
 }
@@ -1596,7 +1599,11 @@ pub(crate) fn live_range_pre_remove_steps(node: &Node, old_parent: &Node) {
     // its end to (parent, index).
     //
     // TODO: Only run this part if there are live ranges in this subtree and/or a selection.
+    let selection = node.owner_document().selection();
     for descendant in node.traverse_preorder(ShadowIncluding::No) {
+        if let Some(selection) = &selection {
+            selection.remove_steps_for_removed_subtree(&descendant, old_parent, &mut lazy_index);
+        }
         live_range_pre_remove_steps_for_removed_subtree(&descendant, old_parent, &mut lazy_index);
     }
 
@@ -1604,5 +1611,8 @@ pub(crate) fn live_range_pre_remove_steps(node: &Node, old_parent: &Node) {
     // than index, decrease its start offset by 1.
     // Step 7. For each live range whose end node is parent and end offset is greater than
     // index, decrease its end offset by 1.
+    if let Some(selection) = &selection {
+        selection.remove_steps_for_parent(old_parent, &mut lazy_index);
+    }
     live_range_pre_remove_steps_for_parent(old_parent, &mut lazy_index);
 }

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -97,10 +97,6 @@ impl Selection {
         live_range: &Range,
         notification: SelectionLiveRangeNotification,
     ) {
-        if notification.is_empty() {
-            return;
-        }
-
         let start_changed;
         let end_changed;
         {
@@ -110,14 +106,14 @@ impl Selection {
                 .expect("A live range implies a selection range");
 
             start_changed = notification.contains(SelectionLiveRangeNotification::Start) &&
-                !range.start.equivalent(live_range.start());
+                range.start != *live_range.start();
             if start_changed {
                 range.start =
                     SelectionBoundary::new(&live_range.start_container(), live_range.start_offset())
             }
 
             end_changed = notification.contains(SelectionLiveRangeNotification::End) &&
-                !range.end.equivalent(live_range.end());
+                range.end != *live_range.end();
             if end_changed {
                 range.end =
                     SelectionBoundary::new(&live_range.end_container(), live_range.end_offset())
@@ -172,8 +168,10 @@ impl Selection {
         // > or the content script, the user agent must schedule a selectionchange event on
         // > document.
         //
-        // This means we should fire the event even if the boundaries themselves did not
-        // change. A change to the range object is enough.
+        // This means we should fire the event even if the boundaries themselves did not change. A
+        // change to the range object is enough. Normally, this happens in `set_range`, but
+        // only when the boundaries changed. In this case the call to `set_range` above did
+        // not queue the task.
         if !boundaries_changed {
             self.queue_selectionchange_task();
         }
@@ -452,6 +450,8 @@ impl Selection {
             return;
         };
 
+        // TODO: For now the live range is equal to the selection range, but one selections
+        // can span shadow root boundaries they will be different.
         let range = self.range.borrow();
         let range = range
             .as_ref()
@@ -1340,7 +1340,8 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // into account `display: none`. The case for textarea and input elements is
         // completely unhandled here.
         self.GetRangeAt(cx, 0)
-            .map_or(Default::default(), |range| range.Stringifier(cx.no_gc()))
+            .map(|range| range.Stringifier(cx.no_gc()))
+            .unwrap_or_default()
     }
 }
 

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -267,7 +267,7 @@ impl Selection {
         let start_offset = range.start.offset as usize;
         let end_offset = range.end.offset as usize;
         let start_container = range.start.container.as_rooted();
-        let end_container = range.start.container.as_rooted();
+        let end_container = range.end.container.as_rooted();
         let start_position =
             position_in_flat_tree_for_selection(no_gc, start_container.clone(), start_offset);
         let end_position =

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -2,12 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::Cell;
+use std::cell::{Cell, LazyCell};
 use std::cmp::Ordering;
 
+use bitflags::bitflags;
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
 use rustc_hash::FxHashSet;
+use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::ShadowRootBinding::ShadowRootMethods;
 use script_bindings::dom::UnrootedDom;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
@@ -21,13 +23,14 @@ use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
-use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, MutNullableDom, ToLayoutOptional};
+use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::iterators::PrePostIteration;
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::range::Range;
+use crate::dom::selection_range::{SelectionBoundary, SelectionRange};
 use crate::dom::types::ShadowRoot;
 use crate::dom::{CharacterData, FlatTreeParent, NodeDamage, NodeFlags};
 
@@ -38,11 +41,18 @@ enum Direction {
     Directionless,
 }
 
+/// <https://w3c.github.io/selection-api/#dfn-selection>
 #[dom_struct]
 pub(crate) struct Selection {
     reflector_: Reflector,
     document: Dom<Document>,
-    range: MutNullableDom<Range>,
+    /// A range that holds the start and end of this selection, which may potentially
+    /// cross shadow roots.
+    range: DomRefCell<Option<SelectionRange>>,
+    /// The live range version of this selection, which will never cross shadow roots.
+    live_range: MutNullableDom<Range>,
+    /// The [`Direction`] of this [`Selection`] which determines which endpoint of
+    /// [`Self::range`] is the anchor and which is the focus.
     direction: Cell<Direction>,
     /// <https://w3c.github.io/selection-api/#dfn-has-scheduled-selectionchange-event>
     has_scheduled_selectionchange_event: Cell<bool>,
@@ -56,7 +66,8 @@ impl Selection {
         Selection {
             reflector_: Reflector::new(),
             document: Dom::from_ref(document),
-            range: MutNullableDom::new(None),
+            range: Default::default(),
+            live_range: MutNullableDom::new(None),
             direction: Cell::new(Direction::Directionless),
             has_scheduled_selectionchange_event: Cell::new(false),
             visible_selection_dirty: Cell::new(false),
@@ -75,27 +86,83 @@ impl Selection {
         self.visible_selection_dirty.get()
     }
 
-    fn set_range(&self, new_range: Option<&Range>) {
-        // If we are setting to literally the same Range object and not just the same
-        // positions, then there's nothing changing and no task to queue.
-        if new_range == self.range.get().as_deref() {
+    fn clear_cached_live_range(&self) {
+        if let Some(old_range) = self.live_range.take() {
+            old_range.disassociate_selection(self);
+        }
+    }
+
+    pub(crate) fn update_from_live_range(
+        &self,
+        live_range: &Range,
+        notification: SelectionLiveRangeNotification,
+    ) {
+        if notification.is_empty() {
             return;
         }
 
-        let old_range = self.range.take();
-        if let Some(old_range) = old_range.as_ref() {
-            old_range.disassociate_selection(self);
+        let start_changed;
+        let end_changed;
+        {
+            let mut range = self.range.borrow_mut();
+            let range = range
+                .as_mut()
+                .expect("A live range implies a selection range");
+
+            start_changed = notification.contains(SelectionLiveRangeNotification::Start) &&
+                !range.start.equivalent(live_range.start());
+            if start_changed {
+                range.start =
+                    SelectionBoundary::new(&live_range.start_container(), live_range.start_offset())
+            }
+
+            end_changed = notification.contains(SelectionLiveRangeNotification::End) &&
+                !range.end.equivalent(live_range.end());
+            if end_changed {
+                range.end =
+                    SelectionBoundary::new(&live_range.end_container(), live_range.end_offset())
+            }
         }
 
-        let boundary_points_changed = match (old_range, new_range) {
-            (Some(old_range), Some(new_range)) => {
-                old_range.start() != new_range.start() || old_range.end() != new_range.end()
-            },
-            _ => true,
-        };
+        if start_changed || end_changed {
+            self.selection_boundaries_changed();
+        }
+    }
 
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
+    fn set_range(&self, new_range: Option<SelectionRange>) -> bool {
+        let changed;
+        {
+            let mut range = self.range.borrow_mut();
+            changed = *range != new_range;
+            *range = new_range;
+        }
+
+        // Any changes must unconditionally install a new live range.
+        self.clear_cached_live_range();
+
+        if changed {
+            self.selection_boundaries_changed();
+            self.assert_valid_selection();
+        }
+
+        changed
+    }
+
+    pub(crate) fn set_live_range(&self, new_range: Option<&Range>) {
+        if new_range == self.live_range.get().as_deref() {
+            return;
+        }
+
+        let boundaries_changed = self.set_range(new_range.map(|new_range| new_range.into()));
+
+        // It's possible that `set_range` was a no-op, but still in that case we need to
+        // replace the live range per-specification.
+        if let Some(old_range) = self.live_range.take() {
+            old_range.disassociate_selection(self);
+        }
         if let Some(new_range) = new_range {
-            self.range.set(Some(new_range));
+            self.live_range.set(Some(new_range));
             new_range.associate_selection(self);
         }
 
@@ -107,14 +174,24 @@ impl Selection {
         //
         // This means we should fire the event even if the boundaries themselves did not
         // change. A change to the range object is enough.
+        if !boundaries_changed {
+            self.queue_selectionchange_task();
+        }
+    }
+
+    fn selection_boundaries_changed(&self) {
+        self.set_visible_selection_dirty();
         self.queue_selectionchange_task();
 
-        // On the other hand, clearing command overrides and marking the visible selection
-        // as dirty should only happen when the selection really changed.
-        if boundary_points_changed {
-            self.set_visible_selection_dirty();
-            self.clear_command_overrides();
-        }
+        // See:
+        //  - <https://w3c.github.io/editing/docs/execCommand/#state-override> and
+        //  - <https://w3c.github.io/editing/docs/execCommand/#value-override>
+        //
+        // > Whenever the number of ranges in the selection changes to something
+        // > different, and whenever a boundary point of the range at a given index in the
+        // > selection changes to something different, the state override and value
+        // > override must be unset for every command.
+        self.document.clear_command_overrides();
     }
 
     fn iter_nodes_with_overlaps_document_selection_flag<'no_gc>(
@@ -174,7 +251,8 @@ impl Selection {
             }
         };
 
-        let Some(range) = self.range.get() else {
+        let range = self.range.borrow();
+        let Some(range) = range.as_ref() else {
             for node in previously_flagged_nodes {
                 remove_selection(&node)
             }
@@ -188,14 +266,15 @@ impl Selection {
         // so we don’t need HashDoS resistance and can use a faster hasher than `std`’s default
         let mut previously_flagged_nodes: FxHashSet<_> = previously_flagged_nodes.collect();
 
-        let start_offset = range.start_offset() as usize;
-        let end_offset = range.end_offset() as usize;
-        let start_container = range.start_container();
-        let end_container = range.end_container();
+        let start_offset = range.start.offset as usize;
+        let end_offset = range.end.offset as usize;
+        let start_container = range.start.container.as_rooted();
+        let end_container = range.start.container.as_rooted();
         let start_position =
             position_in_flat_tree_for_selection(no_gc, start_container.clone(), start_offset);
         let end_position =
             position_in_flat_tree_for_selection(no_gc, end_container.clone(), end_offset);
+
         let start_node = start_position.node();
         let end_node = end_position.node();
 
@@ -289,18 +368,6 @@ impl Selection {
         }
     }
 
-    /// An implementation of:
-    ///  - <https://w3c.github.io/editing/docs/execCommand/#state-override> and
-    ///  - <https://w3c.github.io/editing/docs/execCommand/#value-override>
-    ///
-    /// > Whenever the number of ranges in the selection changes to something
-    /// > different, and whenever a boundary point of the range at a given index in the
-    /// > selection changes to something different, the state override and value
-    /// > override must be unset for every command.
-    pub(crate) fn clear_command_overrides(&self) {
-        self.document.clear_command_overrides();
-    }
-
     /// <https://w3c.github.io/selection-api/#dfn-schedule-a-selectionchange-event>
     pub(crate) fn queue_selectionchange_task(&self) {
         // Step 1. If target's has scheduled selectionchange event is true, abort these steps.
@@ -353,16 +420,89 @@ impl Selection {
         (range.end_container(), range.end_offset())
     }
 
-    /// <https://w3c.github.io/editing/docs/execCommand/#active-range>
-    pub(crate) fn active_range(&self, _cx: &mut JSContext) -> Option<DomRoot<Range>> {
-        // > The active range is the range of the selection given by calling
-        // > getSelection() on the context object. (Thus the active range may be null.)
-        self.range.get()
+    fn assert_valid_selection(&self) {
+        #[cfg(not(debug_assertions))]
+        return;
+
+        let range_borrow = self.range.borrow();
+        let Some(range) = range_borrow.as_ref() else {
+            return;
+        };
+        debug_assert_eq!(
+            range.start.container.GetRootNode(&Default::default()),
+            range.end.container.GetRootNode(&Default::default())
+        );
+        debug_assert!(
+            bp_position(
+                &range.start.container,
+                range.start.offset,
+                &range.end.container,
+                range.end.offset
+            ) != Ordering::Greater
+        );
     }
 
-    pub(crate) fn expect_active_range(&self, _cx: &mut JSContext) -> DomRoot<Range> {
-        self.range
-            .get()
+    fn assert_valid_selection_and_live_range(&self) {
+        #[cfg(not(debug_assertions))]
+        return;
+
+        self.assert_valid_selection();
+
+        let Some(active_range) = self.live_range.get() else {
+            return;
+        };
+
+        let range = self.range.borrow();
+        let range = range
+            .as_ref()
+            .expect("Should always have a range if we have an live range");
+        debug_assert!(*range.start.container == *active_range.start_container());
+        debug_assert_eq!(range.start.offset, active_range.start_offset());
+        debug_assert!(*range.end.container == *active_range.end_container());
+        debug_assert_eq!(range.end.offset, active_range.end_offset());
+        debug_assert!(
+            bp_position(
+                &active_range.start_container(),
+                active_range.start_offset(),
+                &active_range.end_container(),
+                active_range.end_offset()
+            ) != Ordering::Greater
+        );
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#active-range>
+    ///
+    /// > The active range is the range of the selection given by calling
+    /// > getSelection() on the context object. (Thus the active range may be null.)
+    pub(crate) fn active_range(&self, cx: &mut JSContext) -> Option<DomRoot<Range>> {
+        self.assert_valid_selection_and_live_range();
+
+        if let Some(active_range) = self.live_range.get() {
+            return Some(active_range);
+        }
+
+        // TODO: This should eventually be the projection of the composed range stored in
+        // `self.range` into the boundaries of a single DOM tree.
+        let active_range = {
+            let range = self.range.borrow();
+            let range = range.as_ref()?;
+            Range::new(
+                cx,
+                &self.document,
+                &range.start.container,
+                range.start.offset,
+                &range.end.container,
+                range.end.offset,
+            )
+        };
+
+        self.live_range.set(Some(&active_range));
+        active_range.associate_selection(self);
+        Some(active_range)
+    }
+
+    pub(crate) fn expect_active_range(&self, cx: &mut JSContext) -> DomRoot<Range> {
+        self.active_range(cx)
             .expect("Should always have an active range")
     }
 
@@ -370,42 +510,284 @@ impl Selection {
         self.visible_selection_dirty.set(true);
     }
 
-    /// <https://w3c.github.io/selection-api/#dfn-anchor>
-    pub(crate) fn anchor_node(&self) -> Option<DomRoot<Node>> {
-        self.range.get().map(|range| match self.direction.get() {
-            Direction::Forwards => range.start_container(),
-            _ => range.end_container(),
+    fn composed_anchor_position(&self) -> Option<(DomRoot<Node>, u32)> {
+        let range = self.range.borrow();
+        let range = range.as_ref()?;
+        Some(match self.direction.get() {
+            Direction::Forwards => (range.start.container.as_rooted(), range.start.offset),
+            _ => (range.end.container.as_rooted(), range.end.offset),
         })
     }
 
     /// <https://w3c.github.io/selection-api/#dfn-anchor>
-    pub(crate) fn anchor_offset(&self) -> u32 {
-        self.range
-            .get()
+    fn live_anchor_node(&self, cx: &mut JSContext) -> Option<DomRoot<Node>> {
+        self.active_range(cx)
             .map(|range| match self.direction.get() {
+                Direction::Forwards => range.start_container(),
+                _ => range.end_container(),
+            })
+    }
+
+    /// <https://w3c.github.io/selection-api/#dfn-anchor>
+    fn live_anchor_offset(&self, cx: &mut JSContext) -> u32 {
+        self.active_range(cx)
+            .map_or(0, |range| match self.direction.get() {
                 Direction::Forwards => range.start_offset(),
                 _ => range.end_offset(),
             })
-            .unwrap_or(0)
     }
 
     /// <https://w3c.github.io/selection-api/#dfn-focus>
-    pub(crate) fn focus_node(&self) -> Option<DomRoot<Node>> {
-        self.range.get().map(|range| match self.direction.get() {
-            Direction::Forwards => range.end_container(),
-            _ => range.start_container(),
-        })
-    }
-
-    /// <https://w3c.github.io/selection-api/#dfn-focus>
-    pub(crate) fn focus_offset(&self) -> u32 {
-        self.range
-            .get()
+    fn live_focus_node(&self, cx: &mut JSContext) -> Option<DomRoot<Node>> {
+        self.active_range(cx)
             .map(|range| match self.direction.get() {
+                Direction::Forwards => range.end_container(),
+                _ => range.start_container(),
+            })
+    }
+
+    /// <https://w3c.github.io/selection-api/#dfn-focus>
+    fn live_focus_offset(&self, cx: &mut JSContext) -> u32 {
+        self.active_range(cx)
+            .map_or(0, |range| match self.direction.get() {
                 Direction::Forwards => range.end_offset(),
                 _ => range.start_offset(),
             })
-            .unwrap_or(0)
+    }
+
+    /// <https://dom.spec.whatwg.org/#concept-node-insert> steps 5.1-5.2
+    /// and
+    /// <https://dom.spec.whatwg.org/#move> steps 17.1-17.2
+    /// adapted for selections.
+    pub(crate) fn insert_steps(&self, parent: &Node, child: &Node, count: u32) {
+        let mut range_borrow = self.range.borrow_mut();
+        let Some(range) = &mut *range_borrow else {
+            return;
+        };
+        let child_index = LazyCell::new(|| child.index());
+        // Step 5.1: For each live range whose start node is parent and start offset is
+        // greater than child’s index: increase its start offset by count.
+        if range.start.container == parent && range.start.offset > *child_index {
+            range.start.offset += count;
+            self.selection_boundaries_changed();
+        }
+        // Step 5.2: For each live range whose end node is parent and end offset is
+        // greater than child’s index: increase its end offset by count.
+        if range.end.container == parent && range.end.offset > *child_index {
+            range.end.offset += count;
+            self.selection_boundaries_changed();
+        }
+    }
+
+    /// <https://dom.spec.whatwg.org/#live-range-pre-remove-steps> steps 4 and 5
+    /// adapted for selections.
+    ///
+    /// These steps are run on the inclusive descendants of a removed node, but to avoid
+    /// having to iterate through those nodes twice, they are run when the inclusive
+    /// descendants themselves are unbound from the tree.
+    pub(crate) fn remove_steps_for_removed_subtree(
+        &self,
+        inclusive_descendant_of_removed_node: &Node, // "node" in the specification
+        parent_of_removed_node: &Node,               // "parent" in the specification
+        index_of_removed_node: &mut dyn FnMut() -> u32, // "index" in the specification
+    ) {
+        // The steps are only supposed to run on DOM tree inclusive descendants of the removal
+        // root and elements in shadow trees are not, so they shouldn't run for them.
+        //
+        // TODO: This won't be true once selections can span shadow tree roots.
+        if inclusive_descendant_of_removed_node.is_in_a_shadow_tree() {
+            return;
+        }
+
+        let mut range_borrow = self.range.borrow_mut();
+        let Some(range) = &mut *range_borrow else {
+            return;
+        };
+        // Step 4: For each live range whose start node is an inclusive descendant of
+        // node, set its start to (parent, index).
+        if range.start.container == inclusive_descendant_of_removed_node {
+            range.start = SelectionBoundary::new(parent_of_removed_node, index_of_removed_node());
+            self.selection_boundaries_changed();
+        }
+        // Step 5: For each live range whose end node is an inclusive descendant of node,
+        // set its end to (parent, index).
+        if range.end.container == inclusive_descendant_of_removed_node {
+            range.end = SelectionBoundary::new(parent_of_removed_node, index_of_removed_node());
+            self.selection_boundaries_changed();
+        }
+    }
+
+    /// <https://dom.spec.whatwg.org/#live-range-pre-remove-steps> steps 6 and 7
+    /// adapted for selections.
+    pub(crate) fn remove_steps_for_parent(
+        &self,
+        parent: &Node,
+        node_index: &mut dyn FnMut() -> u32,
+    ) {
+        let mut range_borrow = self.range.borrow_mut();
+        let Some(range) = &mut *range_borrow else {
+            return;
+        };
+
+        // Step 6: For each live range whose start node is parent and start offset is
+        // greater than index, decrease its start offset by 1.
+        if range.start.container == parent && range.start.offset > node_index() {
+            range.start.offset -= 1;
+            self.selection_boundaries_changed();
+        }
+        // Step 7: For each live range whose end node is parent and end offset is greater than
+        // index, decrease its end offset by 1.
+        if range.end.container == parent && range.end.offset > node_index() {
+            range.end.offset -= 1;
+            self.selection_boundaries_changed();
+        }
+    }
+
+    /// <https://dom.spec.whatwg.org/#dom-node-normalize> Steps 6.1-6.4 adapted for selections.
+    ///
+    /// - `parent`: The parent of both other node arguments.
+    /// - `node`: The node that text is being merged into.
+    /// - `current_node`: The node which has text being merged into `node` and will be
+    ///   removed from the DOM.
+    /// - `length`: The length of the text content that was merged into `node` from
+    ///   siblings before `current_node`.
+    pub(crate) fn normalization_steps(
+        &self,
+        parent: &Node,
+        node: &Node,
+        current_node: &Node,
+        current_node_index: &dyn Fn() -> u32,
+        length: u32,
+    ) {
+        let mut range_borrow = self.range.borrow_mut();
+        let Some(range) = &mut *range_borrow else {
+            return;
+        };
+        // Step 6.1: For each live range whose start node is currentNode: add length to its start
+        // offset and set its start node to node.
+        if range.start.container == current_node {
+            range.start.offset += length;
+            range.start.container = Dom::from_ref(node);
+            self.selection_boundaries_changed();
+        }
+        // Step 6.2 For each live range whose end node is currentNode: add length to its end offset
+        // and set its end node to node.
+        if range.end.container == current_node {
+            range.end.offset += length;
+            range.end.container = Dom::from_ref(node);
+            self.selection_boundaries_changed();
+        }
+        // Step 6.3: For each live range whose start node is currentNode’s parent and start
+        // offset is currentNode’s index: set its start node to node and its start offset
+        // to length.
+        if range.start.container == parent && range.start.offset == current_node_index() {
+            range.start.container = Dom::from_ref(node);
+            range.start.offset = length;
+            self.selection_boundaries_changed();
+        }
+        // Step 6.4: For each live range whose end node is currentNode’s parent and end offset is
+        // currentNode’s index: set its end node to node and its end offset to length.
+        if range.end.container == parent && range.end.offset == current_node_index() {
+            range.end.container = Dom::from_ref(node);
+            range.end.offset = length;
+            self.selection_boundaries_changed();
+        }
+    }
+
+    /// <https://dom.spec.whatwg.org/#concept-cd-replace> steps 8-11
+    /// adapted for selections.
+    pub(crate) fn replace_data_steps(
+        &self,
+        node: &Node,
+        offset: u32,
+        removed_code_units: u32,
+        added_code_units: &mut dyn FnMut() -> u32,
+    ) {
+        let mut range_borrow = self.range.borrow_mut();
+        let Some(range) = &mut *range_borrow else {
+            return;
+        };
+        // Step 8: For each live range whose start node is node and start offset is
+        // greater than offset but less than or equal to offset + count: set its start
+        // offset to offset.
+        let start_container = &range.start.container;
+        let start_offset = range.start.offset;
+        if &**start_container == node &&
+            start_offset > offset &&
+            start_offset <= offset + removed_code_units
+        {
+            range.start.offset = offset;
+            self.selection_boundaries_changed();
+        }
+        // Step 9: For each live range whose end node is node and end offset is
+        // greater than offset but less than or equal to offset + count: set its end
+        // offset to offset.
+        let end_container = &range.end.container;
+        let end_offset = range.end.offset;
+        if &**end_container == node &&
+            end_offset > offset &&
+            end_offset <= offset + removed_code_units
+        {
+            range.end.offset = offset;
+            self.selection_boundaries_changed();
+        }
+        // Step 10: For each live range whose start node is node and start offset is
+        // greater than offset + count: increase its start offset by data’s length and
+        // decrease it by count.
+        if &**start_container == node && start_offset > offset + removed_code_units {
+            range.start.offset = start_offset + added_code_units() - removed_code_units;
+            self.selection_boundaries_changed();
+        }
+        // Step 11: For each live range whose end node is node and end offset is
+        // greater than offset + count: increase its end offset by data’s length and
+        // decrease it by count.
+        if &**end_container == node && end_offset > offset + removed_code_units {
+            range.end.offset = end_offset + added_code_units() - removed_code_units;
+            self.selection_boundaries_changed();
+        }
+    }
+
+    /// <https://dom.spec.whatwg.org/#concept-text-split> steps 7.2-7.3
+    /// adapted for selections.
+    pub(crate) fn text_split_steps(
+        &self,
+        node: &Node,
+        offset: u32,
+        parent_node: &Node,
+        new_node: &Node,
+    ) {
+        let mut range_borrow = self.range.borrow_mut();
+        let Some(range) = &mut *range_borrow else {
+            return;
+        };
+        // Step 7.2: For each live range whose start node is node and start offset is
+        // greater than offset, set its start node to newNode and decrease its start
+        // offset by offset.
+        if range.start.container == node && range.start.offset > offset {
+            range.start.container = Dom::from_ref(new_node);
+            range.start.offset -= offset;
+            self.selection_boundaries_changed();
+        }
+        // Step 7.3: For each live range whose end node is node and end offset is greater
+        // than offset, set its end node to newNode and decrease its end offset by offset.
+        if range.end.container == node && range.end.offset > offset {
+            range.end.container = Dom::from_ref(new_node);
+            range.end.offset -= offset;
+            self.selection_boundaries_changed();
+        }
+        // Step 7.4: For each live range whose start node is parent and start offset is
+        // equal to the index of node plus 1, increase its start offset by 1.
+        let node_index = LazyCell::new(|| node.index());
+        if range.start.container == parent_node && range.start.offset == *node_index + 1 {
+            range.start.offset += 1;
+            self.selection_boundaries_changed();
+        }
+        // Step 7.5: For each live range whose end node is parent and end offset is equal
+        // to the index of node plus 1, increase its end offset by 1.
+        if range.end.container == parent_node && range.end.offset == *node_index + 1 {
+            range.end.offset += 1;
+            self.selection_boundaries_changed();
+        }
     }
 
     pub(crate) fn collapse_to_dom_position(
@@ -428,11 +810,13 @@ impl Selection {
         offset: Utf32CodeUnitsOrNodeOffset,
     ) {
         let offset = container.to_sibling_or_utf16_offset(offset);
-        let is_anchor = self
-            .anchor_node()
-            .is_some_and(|anchor| &*anchor == container) &&
-            self.anchor_offset() == offset;
-        if self.range.get().is_none() || is_anchor {
+        let is_anchor =
+            self.composed_anchor_position()
+                .is_some_and(|(anchor_node, anchor_offset)| {
+                    &*anchor_node == container && anchor_offset == offset
+                });
+
+        if self.range.borrow().is_none() || is_anchor {
             let _ = self.Collapse(cx, Some(container), offset);
         } else {
             let _ = self.Extend(cx, container, offset);
@@ -442,10 +826,10 @@ impl Selection {
 
 impl SelectionMethods<crate::DomTypeHolder> for Selection {
     /// <https://w3c.github.io/selection-api/#dom-selection-anchornode>
-    fn GetAnchorNode(&self) -> Option<DomRoot<Node>> {
+    fn GetAnchorNode(&self, cx: &mut JSContext) -> Option<DomRoot<Node>> {
         // > The attribute must return the anchor node of this, or null if the anchor is
         // > null or anchor is not in the document tree.
-        let anchor_node = self.anchor_node()?;
+        let anchor_node = self.live_anchor_node(cx)?;
         if !anchor_node.is_in_a_document_tree() {
             return None;
         }
@@ -453,23 +837,23 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-anchoroffset>
-    fn AnchorOffset(&self) -> u32 {
+    fn AnchorOffset(&self, cx: &mut JSContext) -> u32 {
         // > The attribute must return the anchor offset of this, or 0 if the anchor is null
         // > or anchor is not in the document tree.
         if self
-            .anchor_node()
+            .live_anchor_node(cx)
             .is_none_or(|anchor_node| !anchor_node.is_in_a_document_tree())
         {
             return 0;
         }
-        self.anchor_offset()
+        self.live_anchor_offset(cx)
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-focusnode>
-    fn GetFocusNode(&self) -> Option<DomRoot<Node>> {
+    fn GetFocusNode(&self, cx: &mut JSContext) -> Option<DomRoot<Node>> {
         // > The attribute must return the focus node of this, or null if the focus is
         // > null or focus is not in the document tree.
-        let focus_node = self.focus_node()?;
+        let focus_node = self.live_focus_node(cx)?;
         if !focus_node.is_in_a_document_tree() {
             return None;
         }
@@ -477,30 +861,31 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-focusoffset>
-    fn FocusOffset(&self) -> u32 {
+    fn FocusOffset(&self, cx: &mut JSContext) -> u32 {
         // > The attribute must return the focus offset of this, or 0 if the focus is null
         // > or focus is not in the document tree.
         if self
-            .focus_node()
+            .live_focus_node(cx)
             .is_none_or(|focus_node| !focus_node.is_in_a_document_tree())
         {
             return 0;
         }
-        self.focus_offset()
+        self.live_focus_offset(cx)
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-iscollapsed>
-    fn IsCollapsed(&self) -> bool {
+    fn IsCollapsed(&self, cx: &mut JSContext) -> bool {
         // > The attribute must return true if and only if the anchor and focus are the
         // > same (including if both are null). Otherwise it must return false.
-        self.range.get().is_none_or(|range| range.collapsed())
+        self.active_range(cx).is_none_or(|range| range.collapsed())
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-rangecount>
     fn RangeCount(&self) -> u32 {
         // > The attribute must return 0 if this is empty or either focus or anchor is not
         // > in the document tree, and must return 1 otherwise.
-        let Some(range) = self.range.get() else {
+        let range = self.range.borrow();
+        let Some(range) = range.as_ref() else {
             return 0;
         };
         if !range.start_and_end_are_in_document_tree() {
@@ -514,7 +899,8 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // > The attribute must return "None" if this is empty or either focus or anchor
         // > is not in the document tree, "Caret" if this's range is collapsed, and "Range"
         // > otherwise.
-        let Some(range) = self.range.get() else {
+        let range = self.range.borrow();
+        let Some(range) = range.as_ref() else {
             return DOMString::from_static("None");
         };
         if !range.start_and_end_are_in_document_tree() {
@@ -529,23 +915,26 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-getrangeat>
-    fn GetRangeAt(&self, index: u32) -> Fallible<DomRoot<Range>> {
+    fn GetRangeAt(&self, cx: &mut JSContext, index: u32) -> Fallible<DomRoot<Range>> {
         // > The method must throw an IndexSizeError exception if index is not 0, or if this
         // > is empty or either focus or anchor is not in the document tree. Otherwise, it
         // > must return a reference to (not a copy of) this's range.
         if index != 0 {
-            return Err(Error::IndexSize(None));
+            return Err(Error::IndexSize(Some("Index must be zero".into())));
         }
 
-        let Some(range) = self.range.get() else {
-            return Err(Error::IndexSize(None));
+        let range = self.range.borrow();
+        let Some(range) = range.as_ref() else {
+            return Err(Error::IndexSize(Some("Selection is empty".into())));
         };
-
         if !range.start_and_end_are_in_document_tree() {
-            return Err(Error::IndexSize(None));
+            return Err(Error::IndexSize(Some(
+                "Start and end are not in document tree".into(),
+            )));
         }
-
-        Ok(DomRoot::from_ref(&range))
+        self.active_range(cx).ok_or(Error::IndexSize(Some(
+            "Could not create live range for selection".into(),
+        )))
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-addrange>
@@ -562,7 +951,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         }
 
         // Step 3. Set this's range to range by a strong reference (not by making a copy).
-        self.set_range(Some(range));
+        self.set_live_range(Some(range));
 
         // Are we supposed to set Direction here? w3c/selection-api#116
         self.direction.set(Direction::Forwards);
@@ -572,7 +961,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     fn RemoveRange(&self, range: &Range) -> ErrorResult {
         // > The method must make this empty by disassociating its range if this's range
         // > is range. Otherwise, it must throw a NotFoundError.
-        if let Some(own_range) = self.range.get() &&
+        if let Some(own_range) = self.live_range.get() &&
             &*own_range == range
         {
             self.set_range(None);
@@ -591,11 +980,11 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     /// <https://w3c.github.io/selection-api/#dom-selection-empty>
     fn Empty(&self) {
         // > The method must be an alias, and behave identically, to removeAllRanges().
-        self.set_range(None);
+        self.RemoveAllRanges();
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-collapse>
-    fn Collapse(&self, cx: &mut JSContext, node: Option<&Node>, offset: u32) -> ErrorResult {
+    fn Collapse(&self, _cx: &mut JSContext, node: Option<&Node>, offset: u32) -> ErrorResult {
         // Step 1. If node is null, this method must behave identically as
         // removeAllRanges() and abort these steps.
         let Some(node) = node else {
@@ -629,10 +1018,10 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
 
         // Step 5. Otherwise, let newRange be a new range.
         // Step 6. Set the start the start and the end of newRange to (node, offset).
-        let new_range = Range::new(cx, &self.document, node, offset, node, offset);
-
         // Step 7. Set this's range to newRange.
-        self.set_range(Some(&new_range));
+        self.set_range(Some(SelectionRange::collapsed_at(SelectionBoundary::new(
+            node, offset,
+        ))));
 
         // Are we supposed to set Direction here? w3c/selection-api#116
         self.direction.set(Direction::Forwards);
@@ -652,11 +1041,15 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // > Otherwise, it must create a new range, set the start both its start and end to
         // > the start of this's range, and then set this's range to the newly-created
         // > range.
-        if let Some(range) = self.range.get() {
-            self.Collapse(cx, Some(&*range.start_container()), range.start_offset())
-        } else {
-            Err(Error::InvalidState(None))
-        }
+        let Some((start_container, start_offset)) = self
+            .range
+            .borrow()
+            .as_ref()
+            .map(|range| (range.start.container.as_rooted(), range.start.offset))
+        else {
+            return Err(Error::InvalidState(None));
+        };
+        self.Collapse(cx, Some(&*start_container), start_offset)
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-collapsetoend>
@@ -664,15 +1057,19 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // > The method must throw InvalidStateError exception if the this is empty.
         // > Otherwise, it must create a new range, set the start both its start and end to
         // > the end of this's range, and then set this's range to the newly-created range.
-        if let Some(range) = self.range.get() {
-            self.Collapse(cx, Some(&*range.end_container()), range.end_offset())
-        } else {
-            Err(Error::InvalidState(None))
-        }
+        let Some((end_container, end_offset)) = self
+            .range
+            .borrow()
+            .as_ref()
+            .map(|range| (range.end.container.as_rooted(), range.end.offset))
+        else {
+            return Err(Error::InvalidState(None));
+        };
+        self.Collapse(cx, Some(&*end_container), end_offset)
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-extend>
-    fn Extend(&self, cx: &mut JSContext, node: &Node, offset: u32) -> ErrorResult {
+    fn Extend(&self, _cx: &mut JSContext, node: &Node, offset: u32) -> ErrorResult {
         // Step 1. If the document associated with this is not a shadow-including
         // inclusive ancestor of node, abort these steps.
         //
@@ -686,7 +1083,8 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         }
 
         // Step 2. If this is empty, throw an InvalidStateError exception and abort these steps.
-        let Some(range) = self.range.get() else {
+        let range_borrow = self.range.borrow();
+        let Some(range) = range_borrow.as_ref() else {
             return Err(Error::InvalidState(None));
         };
 
@@ -706,54 +1104,50 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // newFocus be the boundary point (node, offset).
         //
         // Note: oldFocus is unused, so we do not set it here.
-        let old_anchor_node = &*self
-            .anchor_node()
+        let (old_anchor_node, old_anchor_offset) = self
+            .composed_anchor_position()
             .expect("has range, therefore has anchor node");
-        let old_anchor_offset = self.anchor_offset();
 
         // Step 4. Let newRange be a new range.
-        let new_range;
+        // Note: Set directly to satisfy crown.
         let direction;
 
         // Step 5. If node's root is not the same as the this's range's root, set the
         // start newRange's start and end to newFocus.
-        if !self.is_in_document_of_range(&range.start_container()) {
-            new_range = Range::new(cx, &self.document, node, offset, node, offset);
+        let is_in_document_of_range = self.is_in_document_of_range(&range.start.container);
+        drop(range_borrow);
+
+        if !is_in_document_of_range {
+            self.set_range(Some(SelectionRange::collapsed_at(SelectionBoundary::new(
+                node, offset,
+            ))));
             direction = Direction::Forwards;
         } else {
             let is_old_anchor_before_or_equal = matches!(
-                bp_position(old_anchor_node, old_anchor_offset, node, offset),
+                bp_position(&old_anchor_node, old_anchor_offset, node, offset),
                 Ordering::Less | Ordering::Equal
             );
             if is_old_anchor_before_or_equal {
                 // Step 6. Otherwise, if oldAnchor is before or equal to newFocus, set the start
                 // newRange's start to oldAnchor, then set its end to newFocus.
-                new_range = Range::new(
-                    cx,
-                    &self.document,
-                    old_anchor_node,
-                    old_anchor_offset,
-                    node,
-                    offset,
-                );
+                self.set_range(Some(SelectionRange::new(
+                    SelectionBoundary::new(&old_anchor_node, old_anchor_offset),
+                    SelectionBoundary::new(node, offset),
+                )));
                 direction = Direction::Forwards;
             } else {
                 // Step 7. Otherwise, set the start newRange's start to newFocus, then set
                 // its end to oldAnchor.
-                new_range = Range::new(
-                    cx,
-                    &self.document,
-                    node,
-                    offset,
-                    old_anchor_node,
-                    old_anchor_offset,
-                );
+                self.set_range(Some(SelectionRange::new(
+                    SelectionBoundary::new(node, offset),
+                    SelectionBoundary::new(&old_anchor_node, old_anchor_offset),
+                )));
                 direction = Direction::Backwards;
             }
         }
 
         // Step 8. Set this's range to newRange.
-        self.set_range(Some(&new_range));
+        // Note: Done above to satisfy crown.
 
         // Step 9. If newFocus is before oldAnchor, set this's direction to backwards.
         // Otherwise, set it to forwards.
@@ -765,7 +1159,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     /// <https://w3c.github.io/selection-api/#dom-selection-setbaseandextent>
     fn SetBaseAndExtent(
         &self,
-        cx: &mut JSContext,
+        _cx: &mut JSContext,
         anchor_node: &Node,
         anchor_offset: u32,
         focus_node: &Node,
@@ -807,38 +1201,29 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // Note: We do not model the boundary point in this way.
 
         // Step 4. Let newRange be a new range.
-        let new_range;
-        let direction;
+        // Note: We set the range directly to satisfy crown.
 
         // Step 5. If anchor is before focus, set the start the newRange's start to anchor
         // and its end to focus. Otherwise, set the start them to focus and anchor
         // respectively.
         let is_anchor_before_focus =
             bp_position(anchor_node, anchor_offset, focus_node, focus_offset) == Ordering::Less;
-        if is_anchor_before_focus {
-            new_range = Range::new(
-                cx,
-                &self.document,
-                anchor_node,
-                anchor_offset,
-                focus_node,
-                focus_offset,
-            );
-            direction = Direction::Forwards;
+        let direction = if is_anchor_before_focus {
+            self.set_range(Some(SelectionRange::new(
+                SelectionBoundary::new(anchor_node, anchor_offset),
+                SelectionBoundary::new(focus_node, focus_offset),
+            )));
+            Direction::Forwards
         } else {
-            new_range = Range::new(
-                cx,
-                &self.document,
-                focus_node,
-                focus_offset,
-                anchor_node,
-                anchor_offset,
-            );
-            direction = Direction::Backwards;
-        }
+            self.set_range(Some(SelectionRange::new(
+                SelectionBoundary::new(focus_node, focus_offset),
+                SelectionBoundary::new(anchor_node, anchor_offset),
+            )));
+            Direction::Backwards
+        };
 
         // Step 6. Set this's range to newRange.
-        self.set_range(Some(&new_range));
+        // Note: Done above to satisfy crown.
 
         // Step 7. If focus is before anchor, set this's direction to backwards.
         // Otherwise, set it to forwards
@@ -848,7 +1233,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-selectallchildren>
-    fn SelectAllChildren(&self, cx: &mut JSContext, node: &Node) -> ErrorResult {
+    fn SelectAllChildren(&self, _cx: &mut JSContext, node: &Node) -> ErrorResult {
         // Step 1. If node is a DocumentType, throw an InvalidNodeTypeError exception and
         // abort these steps.
         if node.is_doctype() {
@@ -866,10 +1251,11 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
 
         // Step 4. Set newRange's start to (node, 0).
         // Step 5. Set newRange's end to (node, childCount).
-        let new_range = Range::new(cx, &self.document, node, 0, node, child_count);
-
         // Step 6. Set this's range to newRange.
-        self.set_range(Some(&new_range));
+        self.set_range(Some(SelectionRange::new(
+            SelectionBoundary::new(node, 0),
+            SelectionBoundary::new(node, child_count),
+        )));
 
         // Step 7. Set this's direction to forwards.
         self.direction.set(Direction::Forwards);
@@ -882,14 +1268,17 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // > The method must invoke deleteContents() on this's range if this is not empty
         // > and both focus and anchor are in the document tree. Otherwise the method must
         // > do nothing.
-        let Some(range) = self.range.get() else {
-            return Ok(());
-        };
-        if !range.start_and_end_are_in_document_tree() {
+        if self
+            .range
+            .borrow()
+            .as_ref()
+            .is_none_or(|range| !range.start_and_end_are_in_document_tree())
+        {
             return Ok(());
         }
 
-        range.DeleteContents(cx)
+        self.active_range(cx)
+            .map_or(Ok(()), |active_range| active_range.DeleteContents(cx))
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-containsnode>
@@ -906,18 +1295,18 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // > its range is before or visually equivalent to the last boundary point in the node *and*
         // > end of its range is after or visually equivalent to the first boundary point in the
         // > node.
-
         if !self.is_in_document_of_range(node) {
             return false;
         }
-        let Some(range) = self.range.get() else {
+        let range = self.range.borrow();
+        let Some(range) = range.as_ref() else {
             return false;
         };
-        let start_node = &*range.start_container();
+        let start_node = &*range.start.container;
         if !self.is_in_document_of_range(start_node) {
             return false;
         }
-        let end_node = &*range.end_container();
+        let end_node = &*range.end.container;
 
         let first_offset = 0;
         let last_offset = node.len();
@@ -931,16 +1320,16 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // https://github.com/w3c/selection-api/issues/6
         // For now it is simplified to "position is equal".
         matches!(
-            bp_position(start_node, range.start_offset(), node, compare_start_to),
+            bp_position(start_node, range.start.offset, node, compare_start_to),
             Ordering::Less | Ordering::Equal
         ) && matches!(
-            bp_position(end_node, range.end_offset(), node, compare_end_to),
+            bp_position(end_node, range.end.offset, node, compare_end_to),
             Ordering::Greater | Ordering::Equal
         )
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-stringifier>
-    fn Stringifier(&self, no_gc: &NoGC) -> DOMString {
+    fn Stringifier(&self, cx: &mut JSContext) -> DOMString {
         // > The stringification must return the string, which is the concatenation of the
         // > rendered text if there is a range associated with this.
         // >
@@ -950,18 +1339,15 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // TODO: This implementation should be examined in depth. Does rendered text take
         // into account `display: none`. The case for textarea and input elements is
         // completely unhandled here.
-        if let Some(range) = self.range.get() {
-            range.Stringifier(no_gc)
-        } else {
-            DOMString::new()
-        }
+        self.GetRangeAt(cx, 0)
+            .map_or(Default::default(), |range| range.Stringifier(cx.no_gc()))
     }
 }
 
 impl<'dom> LayoutDom<'dom, Selection> {
     #[expect(unsafe_code)]
-    pub(crate) fn range_for_layout(&self) -> Option<LayoutDom<'dom, Range>> {
-        unsafe { self.unsafe_get().range.to_layout() }
+    pub(crate) fn range_for_layout(&self) -> &Option<SelectionRange> {
+        unsafe { self.unsafe_get().range.borrow_for_layout() }
     }
 }
 
@@ -1024,5 +1410,13 @@ impl Node {
         } else {
             offset.0 as u32
         }
+    }
+}
+
+bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub(crate) struct SelectionLiveRangeNotification: u8 {
+        const Start = 1 << 0;
+        const End = 1 << 1;
     }
 }

--- a/components/script/dom/selection_range.rs
+++ b/components/script/dom/selection_range.rs
@@ -23,8 +23,10 @@ impl SelectionBoundary {
             offset,
         }
     }
+}
 
-    pub(crate) fn equivalent(&self, boundary_point: &BoundaryPoint) -> bool {
+impl PartialEq<BoundaryPoint> for SelectionBoundary {
+    fn eq(&self, boundary_point: &BoundaryPoint) -> bool {
         *self.container == *boundary_point.node().get() &&
             self.offset as usize == boundary_point.offset().0
     }

--- a/components/script/dom/selection_range.rs
+++ b/components/script/dom/selection_range.rs
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::dom::abstractrange::BoundaryPoint;
+use crate::dom::bindings::root::Dom;
+use crate::dom::node::Node;
+use crate::dom::range::Range;
+
+/// A selection boundary. This is similar to `BoundaryPoint`, but supports
+/// positions in the composed tree.
+#[derive(Clone, JSTraceable, PartialEq, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
+pub(crate) struct SelectionBoundary {
+    pub container: Dom<Node>,
+    pub offset: u32,
+}
+
+impl SelectionBoundary {
+    pub(crate) fn new(container: &Node, offset: u32) -> Self {
+        Self {
+            container: Dom::from_ref(container),
+            offset,
+        }
+    }
+
+    pub(crate) fn equivalent(&self, boundary_point: &BoundaryPoint) -> bool {
+        *self.container == *boundary_point.node().get() &&
+            self.offset as usize == boundary_point.offset().0
+    }
+}
+
+#[derive(JSTraceable, PartialEq, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
+pub(crate) struct SelectionRange {
+    pub start: SelectionBoundary,
+    pub end: SelectionBoundary,
+}
+
+impl SelectionRange {
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
+    pub(crate) fn new(start: SelectionBoundary, end: SelectionBoundary) -> Self {
+        Self { start, end }
+    }
+
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
+    pub(crate) fn collapsed_at(at: SelectionBoundary) -> Self {
+        Self {
+            start: at.clone(),
+            end: at,
+        }
+    }
+
+    pub(crate) fn collapsed(&self) -> bool {
+        self.start == self.end
+    }
+
+    pub(crate) fn start_and_end_are_in_document_tree(&self) -> bool {
+        self.start.container.is_in_a_document_tree() && self.end.container.is_in_a_document_tree()
+    }
+}
+
+impl From<&Range> for SelectionRange {
+    fn from(range: &Range) -> Self {
+        Self::new(
+            SelectionBoundary::new(&range.start_container(), range.start_offset()),
+            SelectionBoundary::new(&range.end_container(), range.end_offset()),
+        )
+    }
+}

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1052,8 +1052,23 @@ DOMInterfaces = {
 },
 
 'Selection': {
-    'cx': ['Collapse', 'CollapseToEnd', 'CollapseToStart', 'DeleteFromDocument', 'Extend', 'SelectAllChildren', 'SetBaseAndExtent', 'SetPosition'],
-    'no_gc': ['Stringifier'],
+    'cx': [
+        'AnchorOffset',
+        'Collapse',
+        'CollapseToEnd',
+        'CollapseToStart',
+        'DeleteFromDocument',
+        'Extend',
+        'FocusOffset',
+        'GetAnchorNode',
+        'GetFocusNode',
+        'GetRangeAt',
+        'IsCollapsed',
+        'SelectAllChildren',
+        'SetBaseAndExtent',
+        'SetPosition',
+        'Stringifier'
+    ],
 },
 
 'ServiceWorker': {

--- a/python/tidy/error_message_exceptions.txt
+++ b/python/tidy/error_message_exceptions.txt
@@ -76,7 +76,7 @@
 ./components/script/dom/node/customelementregistry.rs 7
 ./components/script/dom/performance/performanceobserver.rs 4
 ./components/script/dom/range/range.rs 20
-./components/script/dom/selection.rs 14
+./components/script/dom/selection.rs 11
 ./components/script/dom/serviceworker/extendableevent.rs 1
 ./components/script/dom/serviceworker/serviceworker.rs 1
 ./components/script/dom/serviceworker/serviceworkercontainer.rs 2


### PR DESCRIPTION
Instead of storing the `Selection` as a live range, store it as a new
range type. This is necessary so that, in a followup change, selections
can span multiple shadow trees (necessary according to the
specification). This requires duplicating a good deal of the live range
update machinery, but this duplication mirrors what other browsers do:

1. Gecko keeps a composed range as a member of a selection live range
   and adjusts them separately.
1. Chrome keeps potentially-cross-root boundaries separately, as we do,
   and then keeps a cache of a mirrored live range.

Testing: This should not change observable behavior so is covered by existing tests.
Fixes: This is part of #7492.