### PR TITLE
script: Allow DOMString to convert efficiently from static strings

### DIFF
--- a/components/script/dom/abort/abortsignal.rs
+++ b/components/script/dom/abort/abortsignal.rs
@@ -384,7 +384,7 @@ impl AbortSignalMethods<crate::DomTypeHolder> for AbortSignal {
 
         // Step 3. Run steps after a timeout given global, "AbortSignal-timeout", milliseconds, and the following step:
         global.run_steps_after_a_timeout(
-            DOMString::from("AbortSignal-timeout"),
+            DOMString::from_static("AbortSignal-timeout"),
             ms_i64,
             move |_cx, global| {
                 let task_source = global.task_manager().timer_task_source().to_sendable();

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -490,7 +490,7 @@ pub(crate) fn stringify_handle_value(cx: &mut JSContext, message: HandleValue) -
         rooted!(&in(cx) let mut obj = value.to_object());
         let mut object_class = ESClass::Other;
         if !unsafe { GetBuiltinClass(cx, obj.handle(), &mut object_class as *mut _) } {
-            return DOMString::from("/* invalid */");
+            return DOMString::from_static("/* invalid */");
         }
         let mut ids = IdVector::new(cx);
         if !unsafe {
@@ -501,12 +501,12 @@ pub(crate) fn stringify_handle_value(cx: &mut JSContext, message: HandleValue) -
                 ids.handle_mut(),
             )
         } {
-            return DOMString::from("/* invalid */");
+            return DOMString::from_static("/* invalid */");
         }
         let truncate = ids.len() > MAX_LOG_CHILDREN;
         if object_class != ESClass::Array && object_class != ESClass::Object {
             if truncate {
-                return DOMString::from("…");
+                return DOMString::from_static("…");
             } else {
                 return handle_value_to_string(cx, value);
             }
@@ -528,13 +528,13 @@ pub(crate) fn stringify_handle_value(cx: &mut JSContext, message: HandleValue) -
                     &mut is_none,
                 )
             } {
-                return DOMString::from("/* invalid */");
+                return DOMString::from_static("/* invalid */");
             }
 
             rooted!(&in(cx) let mut property = UndefinedValue());
             if !unsafe { JS_GetPropertyById(cx, obj.handle(), id.handle(), property.handle_mut()) }
             {
-                return DOMString::from("/* invalid */");
+                return DOMString::from_static("/* invalid */");
             }
 
             if !explicit_keys {
@@ -553,11 +553,11 @@ pub(crate) fn stringify_handle_value(cx: &mut JSContext, message: HandleValue) -
                 let key = if id.is_string() || id.is_symbol() || id.is_int() {
                     rooted!(&in(cx) let mut key_value = UndefinedValue());
                     if !unsafe { JS_IdToValue(cx, id.handle().get(), key_value.handle_mut()) } {
-                        return DOMString::from("/* invalid */");
+                        return DOMString::from_static("/* invalid */");
                     }
                     handle_value_to_string(cx, key_value.handle())
                 } else {
-                    return DOMString::from("/* invalid */");
+                    return DOMString::from_static("/* invalid */");
                 };
                 props.push(format!("{}: {}", key, value_string,));
             } else {
@@ -575,15 +575,15 @@ pub(crate) fn stringify_handle_value(cx: &mut JSContext, message: HandleValue) -
     }
     fn stringify_inner(cx: &mut JSContext, value: HandleValue, mut parents: Vec<u64>) -> DOMString {
         if parents.len() >= MAX_LOG_DEPTH {
-            return DOMString::from("...");
+            return DOMString::from_static("...");
         }
         let value_bits = value.asBits_;
         if parents.contains(&value_bits) {
-            return DOMString::from("[circular]");
+            return DOMString::from_static("[circular]");
         }
         if value.is_undefined() {
             // This produces a better value than "(void 0)" from JS_ValueToSource.
-            return DOMString::from("undefined");
+            return DOMString::from_static("undefined");
         } else if !value.is_object() {
             return handle_value_to_string(cx, value);
         }

--- a/components/script/dom/css/cssstyledeclaration.rs
+++ b/components/script/dom/css/cssstyledeclaration.rs
@@ -507,7 +507,7 @@ impl CSSStyleDeclarationMethods<crate::DomTypeHolder> for CSSStyleDeclaration {
 
         self.owner.with_block(|pdb| {
             if pdb.property_priority(&id).important() {
-                DOMString::from("important")
+                DOMString::from_static("important")
             } else {
                 // Step 4
                 DOMString::new()

--- a/components/script/dom/datatransfer/datatransfer.rs
+++ b/components/script/dom/datatransfer/datatransfer.rs
@@ -56,8 +56,8 @@ impl DataTransfer {
     ) -> DataTransfer {
         DataTransfer {
             reflector_: Reflector::new(),
-            drop_effect: DomRefCell::new(DOMString::from("none")),
-            effect_allowed: DomRefCell::new(DOMString::from("none")),
+            drop_effect: DomRefCell::new(DOMString::from_static("none")),
+            effect_allowed: DomRefCell::new(DOMString::from_static("none")),
             items: Dom::from_ref(item_list),
             data_store,
         }
@@ -191,11 +191,11 @@ impl DataTransferMethods<crate::DomTypeHolder> for DataTransfer {
 
         let type_override = match_domstring_ascii!(format,
             // Step 5 If format equals "text", change it to "text/plain".
-            "text" => Some(DOMString::from("text/plain")),
+            "text" => Some(DOMString::from_static("text/plain")),
             // Step 6 If format equals "url", change it to "text/uri-list" and set convert-to-URL to true.
             "url" => {
                 convert_to_url = true;
-                Some(DOMString::from("text/uri-list"))
+                Some(DOMString::from_static("text/uri-list"))
             },
             _ => None,
         );

--- a/components/script/dom/datatransfer/datatransferitem.rs
+++ b/components/script/dom/datatransfer/datatransferitem.rs
@@ -92,8 +92,8 @@ impl DataTransferItemMethods<crate::DomTypeHolder> for DataTransferItem {
     fn Kind(&self) -> DOMString {
         self.item_kind()
             .map_or(DOMString::new(), |item| match *item {
-                Kind::Text { .. } => DOMString::from("string"),
-                Kind::File { .. } => DOMString::from("file"),
+                Kind::Text { .. } => DOMString::from_static("string"),
+                Kind::File { .. } => DOMString::from_static("file"),
             })
     }
 

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -5958,7 +5958,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
 
     /// <https://html.spec.whatwg.org/multipage/#document.title>
     fn Title(&self) -> DOMString {
-        self.title().unwrap_or_else(DOMString::new)
+        self.title().unwrap_or_default()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#document.title>

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -5480,7 +5480,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
 
     /// <https://dom.spec.whatwg.org/#dom-document-characterset>
     fn CharacterSet(&self) -> DOMString {
-        DOMString::from(self.encoding.get().name())
+        DOMString::from_static(self.encoding.get().name())
     }
 
     /// <https://dom.spec.whatwg.org/#dom-document-charset>
@@ -5958,7 +5958,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
 
     /// <https://html.spec.whatwg.org/multipage/#document.title>
     fn Title(&self) -> DOMString {
-        self.title().unwrap_or_else(|| DOMString::from(""))
+        self.title().unwrap_or_else(DOMString::new)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#document.title>

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -1230,22 +1230,22 @@ impl DocumentEventHandler {
             input_event.active_keyboard_modifiers,
             MouseButton::Secondary,
             input_event.pressed_mouse_buttons,
-            None,                     // related_target
-            None,                     // point_in_target
-            PointerId::Mouse as i32,  // pointer_id
-            1,                        // width
-            1,                        // height
-            0.5,                      // pressure
-            0.0,                      // tangential_pressure
-            0,                        // tilt_x
-            0,                        // tilt_y
-            0,                        // twist
-            PI / 2.0,                 // altitude_angle
-            0.0,                      // azimuth_angle
-            DOMString::from("mouse"), // pointer_type
-            true,                     // is_primary
-            vec![],                   // coalesced_events
-            vec![],                   // predicted_events
+            None,                            // related_target
+            None,                            // point_in_target
+            PointerId::Mouse as i32,         // pointer_id
+            1,                               // width
+            1,                               // height
+            0.5,                             // pressure
+            0.0,                             // tangential_pressure
+            0,                               // tilt_x
+            0,                               // tilt_y
+            0,                               // twist
+            PI / 2.0,                        // altitude_angle
+            0.0,                             // azimuth_angle
+            DOMString::from_static("mouse"), // pointer_type
+            true,                            // is_primary
+            vec![],                          // coalesced_events
+            vec![],                          // predicted_events
         );
         menu_event.upcast::<Event>().set_composed(true);
 
@@ -2086,7 +2086,7 @@ impl DocumentEventHandler {
 
                     // Step 7.1.2.1.1 If clipboard-part contains plain text, then
                     let data = DOMString::from(text_contents);
-                    let type_ = DOMString::from("text/plain");
+                    let type_ = DOMString::from_static("text/plain");
                     let _ = drag_data_store.add(Kind::Text { data, type_ });
 
                     // Step 7.1.2.1.2 TODO If clipboard-part represents file references, then for each file reference

--- a/components/script/dom/document/visibilitystateentry.rs
+++ b/components/script/dom/document/visibilitystateentry.rs
@@ -30,8 +30,8 @@ impl VisibilityStateEntry {
         timestamp: CrossProcessInstant,
     ) -> VisibilityStateEntry {
         let name = match state {
-            DocumentVisibilityState::Visible => DOMString::from("visible"),
-            DocumentVisibilityState::Hidden => DOMString::from("hidden"),
+            DocumentVisibilityState::Visible => DOMString::from_static("visible"),
+            DocumentVisibilityState::Hidden => DOMString::from_static("hidden"),
         };
         VisibilityStateEntry {
             entry: PerformanceEntry::new_inherited(

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -197,7 +197,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
         {
             // Step 3. Append a new doctype, with "html" as its name and with its node document set to doc, to doc.
             let doc_node = doc.upcast::<Node>();
-            let doc_type = DocumentType::new(cx, DOMString::from("html"), None, None, &doc);
+            let doc_type = DocumentType::new(cx, DOMString::from_static("html"), None, None, &doc);
             doc_node.AppendChild(cx, doc_type.upcast()).unwrap();
         }
 

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -5379,7 +5379,7 @@ pub(crate) fn reflect_cross_origin_attribute(element: &Element) -> Option<DOMStr
     element
         .get_attribute_string_value(&local_name!("crossorigin"))
         .map(|value| {
-            DOMString::from(
+            DOMString::from_static(
                 ["anonymous", "use-credentials"]
                     .into_iter()
                     .find(|keyword| value.eq_ignore_ascii_case(keyword))

--- a/components/script/dom/encoding/textencoder.rs
+++ b/components/script/dom/encoding/textencoder.rs
@@ -57,7 +57,7 @@ impl TextEncoderMethods<crate::DomTypeHolder> for TextEncoder {
 
     /// <https://encoding.spec.whatwg.org/#dom-textencoder-encoding>
     fn Encoding(&self) -> DOMString {
-        DOMString::from("utf-8")
+        DOMString::from_static("utf-8")
     }
 
     /// <https://encoding.spec.whatwg.org/#dom-textencoder-encode>

--- a/components/script/dom/encoding/textencoderstream.rs
+++ b/components/script/dom/encoding/textencoderstream.rs
@@ -362,7 +362,7 @@ impl TextEncoderStreamMethods<crate::DomTypeHolder> for TextEncoderStream {
     /// <https://encoding.spec.whatwg.org/#dom-textencoder-encoding>
     fn Encoding(&self) -> DOMString {
         // Returns "utf-8".
-        DOMString::from("utf-8")
+        DOMString::from_static("utf-8")
     }
 
     /// <https://streams.spec.whatwg.org/#dom-generictransformstream-readable>

--- a/components/script/dom/event/mouseevent.rs
+++ b/components/script/dom/event/mouseevent.rs
@@ -406,7 +406,7 @@ impl MouseEvent {
             0,        // twist
             PI / 2.0, // altitude_angle (perpendicular to surface)
             0.0,      // azimuth_angle
-            DOMString::from("mouse"),
+            DOMString::from_static("mouse"),
             true,   // is_primary (mouse is always primary)
             vec![], // coalesced_events
             vec![], // predicted_events
@@ -465,7 +465,7 @@ impl MouseEvent {
             0,                       // twist
             PI / 2.0,                // altitude_angle (perpendicular to surface)
             0.0,                     // azimuth_angle
-            DOMString::from("mouse"),
+            DOMString::from_static("mouse"),
             true,   // is_primary (mouse is always primary)
             vec![], // coalesced_events
             vec![], // predicted_events

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -517,7 +517,7 @@ impl EventSource {
             eventtarget: EventTarget::new_inherited(),
             url,
             request: DomRefCell::new(None),
-            last_event_id: DomRefCell::new(DOMString::from("")),
+            last_event_id: DomRefCell::new(DOMString::new()),
             reconnection_time: Cell::new(DEFAULT_RECONNECTION_TIME),
             generation_id: Cell::new(GenerationId(0)),
 

--- a/components/script/dom/execcommand/basecommand.rs
+++ b/components/script/dom/execcommand/basecommand.rs
@@ -70,8 +70,8 @@ impl DefaultSingleLineContainerName {
 impl From<DefaultSingleLineContainerName> for DOMString {
     fn from(default_single_line_container_name: DefaultSingleLineContainerName) -> Self {
         match default_single_line_container_name {
-            DefaultSingleLineContainerName::Div => DOMString::from("div"),
-            DefaultSingleLineContainerName::Paragraph => DOMString::from("p"),
+            DefaultSingleLineContainerName::Div => DOMString::from_static("div"),
+            DefaultSingleLineContainerName::Paragraph => DOMString::from_static("p"),
         }
     }
 }

--- a/components/script/dom/form/formdata.rs
+++ b/components/script/dom/form/formdata.rs
@@ -141,7 +141,7 @@ impl FormDataMethods<crate::DomTypeHolder> for FormData {
         self.data.borrow_mut().push((
             NoTrace(LocalName::from(name.0.clone())),
             FormDatumUnrooted {
-                ty: DOMString::from("string"),
+                ty: DOMString::from_static("string"),
                 name: DOMString::from(name.0),
                 value: FormDatumValueUnrooted::String(DOMString::from(str_value.0)),
             },
@@ -161,7 +161,7 @@ impl FormDataMethods<crate::DomTypeHolder> for FormData {
         self.data.borrow_mut().push((
             NoTrace(LocalName::from(name.0.clone())),
             FormDatumUnrooted {
-                ty: DOMString::from("file"),
+                ty: DOMString::from_static("file"),
                 name: DOMString::from(name.0),
                 value: FormDatumValueUnrooted::File(file.as_traced()),
             },
@@ -227,7 +227,7 @@ impl FormDataMethods<crate::DomTypeHolder> for FormData {
         data.push((
             NoTrace(local_name),
             FormDatumUnrooted {
-                ty: DOMString::from("string"),
+                ty: DOMString::from_static("string"),
                 name: DOMString::from(name.0),
                 value: FormDatumValueUnrooted::String(DOMString::from(str_value.0)),
             },
@@ -246,7 +246,7 @@ impl FormDataMethods<crate::DomTypeHolder> for FormData {
         data.push((
             NoTrace(LocalName::from(name.0.clone())),
             FormDatumUnrooted {
-                ty: DOMString::from("file"),
+                ty: DOMString::from_static("file"),
                 name: DOMString::from(name.0),
                 value: FormDatumValueUnrooted::File(file.as_traced()),
             },
@@ -266,7 +266,7 @@ impl FormData {
         let name = match opt_filename {
             Some(filename) => DOMString::from(filename.0),
             None => match blob.downcast::<File>() {
-                None => DOMString::from("blob"),
+                None => DOMString::from_static("blob"),
                 // If it is already a file and no filename was given,
                 // then neither step 3 nor step 4 happens, so instead of
                 // creating a new File object we use the existing one.

--- a/components/script/dom/form/radionodelist.rs
+++ b/components/script/dom/form/radionodelist.rs
@@ -95,7 +95,7 @@ impl RadioNodeListMethods<crate::DomTypeHolder> for RadioNodeList {
                         // Step 3-4
                         let value = input.Value();
                         Some(if value.is_empty() {
-                            DOMString::from("on")
+                            DOMString::from_static("on")
                         } else {
                             value
                         })

--- a/components/script/dom/gamepad/gamepadhapticactuator.rs
+++ b/components/script/dom/gamepad/gamepadhapticactuator.rs
@@ -201,7 +201,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
             self.global().task_manager().gamepad_task_source().queue(
                 task!(preempt_promise: move |cx| {
                     let promise = trusted_promise.root();
-                    let message = DOMString::from("preempted");
+                    let message = DOMString::from_static("preempted");
                     promise.resolve_native(cx, &message);
                 }),
             );
@@ -265,7 +265,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
             self.global().task_manager().gamepad_task_source().queue(
                 task!(preempt_promise: move |cx| {
                     let promise = trusted_promise.root();
-                    let message = DOMString::from("preempted");
+                    let message = DOMString::from_static("preempted");
                     promise.resolve_native(cx, &message);
                 }),
             );
@@ -307,7 +307,7 @@ impl GamepadHapticActuator {
         }
         let playing_effect_promise = self.playing_effect_promise.borrow_mut().take();
         if let Some(promise) = playing_effect_promise {
-            let message = DOMString::from("complete");
+            let message = DOMString::from_static("complete");
             promise.resolve_native(cx, &message);
         }
     }
@@ -332,7 +332,7 @@ impl GamepadHapticActuator {
                         return;
                     }
                     let promise = trusted_promise.root();
-                    let message = DOMString::from("complete");
+                    let message = DOMString::from_static("complete");
                     promise.resolve_native(cx, &message);
                 })
             );
@@ -352,7 +352,7 @@ impl GamepadHapticActuator {
                 let Some(promise) = actuator.playing_effect_promise.borrow_mut().take() else {
                     return;
                 };
-                let message = DOMString::from("preempted");
+                let message = DOMString::from_static("preempted");
                 promise.resolve_native(cx, &message);
             }),
         );

--- a/components/script/dom/html/embedded_content/htmlmediaelement.rs
+++ b/components/script/dom/html/embedded_content/htmlmediaelement.rs
@@ -2416,7 +2416,7 @@ impl HTMLMediaElement {
 
             // Step 1. Create an AudioTrack object to represent the audio track.
             let kind = match i {
-                0 => DOMString::from("main"),
+                0 => DOMString::from_static("main"),
                 _ => DOMString::new(),
             };
 
@@ -2483,7 +2483,7 @@ impl HTMLMediaElement {
 
             // Step 1. Create a VideoTrack object to represent the video track.
             let kind = match i {
-                0 => DOMString::from("main"),
+                0 => DOMString::from_static("main"),
                 _ => DOMString::new(),
             };
 

--- a/components/script/dom/html/embedded_content/htmltrackelement.rs
+++ b/components/script/dom/html/embedded_content/htmltrackelement.rs
@@ -201,12 +201,12 @@ impl HTMLTrackElementMethods<crate::DomTypeHolder> for HTMLTrackElement {
             _ if kind.is_empty() => {
                 // The default value should be "subtitles". If "kind" has not
                 // been set, the real value for "kind" is "subtitles"
-                DOMString::from("subtitles")
+                DOMString::from_static("subtitles")
             },
             _ => {
                 // If "kind" has been set but it is not one of the valid
                 // values, return the default invalid value of "metadata"
-                DOMString::from("metadata")
+                DOMString::from_static("metadata")
             },
         }
     }

--- a/components/script/dom/html/form_controls/htmlbuttonelement.rs
+++ b/components/script/dom/html/form_controls/htmlbuttonelement.rs
@@ -113,8 +113,8 @@ impl HTMLButtonElementMethods<crate::DomTypeHolder> for HTMLButtonElement {
             // Step 3. If command is in the Unknown state, then return the empty string.
             CommandState::Unknown => DOMString::default(),
             // Step 4. Return the keyword corresponding to the value of command.
-            CommandState::Close => DOMString::from("close"),
-            CommandState::ShowModal => DOMString::from("show-modal"),
+            CommandState::Close => DOMString::from_static("close"),
+            CommandState::ShowModal => DOMString::from_static("show-modal"),
         }
     }
 
@@ -135,9 +135,9 @@ impl HTMLButtonElementMethods<crate::DomTypeHolder> for HTMLButtonElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-button-type>
     fn Type(&self) -> DOMString {
         match self.button_type.get() {
-            ButtonType::Submit => DOMString::from("submit"),
-            ButtonType::Button => DOMString::from("button"),
-            ButtonType::Reset => DOMString::from("reset"),
+            ButtonType::Submit => DOMString::from_static("submit"),
+            ButtonType::Button => DOMString::from_static("button"),
+            ButtonType::Reset => DOMString::from_static("reset"),
         }
     }
 

--- a/components/script/dom/html/form_controls/htmlformelement.rs
+++ b/components/script/dom/html/form_controls/htmlformelement.rs
@@ -1322,7 +1322,7 @@ impl HTMLFormElement {
 
                 // Step: 5.11.3 Create an entry with dirname and dir, and append it to entry list.
                 data_set.push(FormDatum {
-                    ty: DOMString::from("string"),
+                    ty: DOMString::from_static("string"),
                     name: dirname,
                     value: FormDatumValue::String(dir),
                 });

--- a/components/script/dom/html/form_controls/htmlinputelement.rs
+++ b/components/script/dom/html/form_controls/htmlinputelement.rs
@@ -1153,7 +1153,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
                 .map(|value| value.into())
                 .unwrap_or(DOMString::from("on")),
             ValueMode::Filename => {
-                let mut path = DOMString::from("");
+                let mut path = DOMString::new();
                 match self.input_type().as_specific().get_files() {
                     Some(ref fl) => match fl.Item(0) {
                         Some(ref f) => {
@@ -1265,7 +1265,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
             )));
         }
         if value.is_null() {
-            return self.SetValue(cx, DOMString::from(""));
+            return self.SetValue(cx, DOMString::new());
         }
         let mut msecs: f64 = 0.0;
         // We need to go through unsafe code to interrogate jsapi about a Date.
@@ -1283,12 +1283,12 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
                 return Err(Error::JSFailed);
             }
             if !msecs.is_finite() {
-                return self.SetValue(cx, DOMString::from(""));
+                return self.SetValue(cx, DOMString::new());
             }
         }
 
         let Ok(date_time) = OffsetDateTime::from_unix_timestamp_nanos((msecs * 1e6) as i128) else {
-            return self.SetValue(cx, DOMString::from(""));
+            return self.SetValue(cx, DOMString::new());
         };
         self.SetValue(
             cx,
@@ -1313,7 +1313,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
                 "Input element value cannot be treated as a number".into(),
             )))
         } else if value.is_nan() {
-            self.SetValue(cx, DOMString::from(""))
+            self.SetValue(cx, DOMString::new())
         } else if let Some(converted) = self.convert_number_to_string(value) {
             self.SetValue(cx, converted)
         } else {
@@ -1321,7 +1321,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
             // overflow is impossible, but just setting an overflow to the empty string
             // matches Firefox's behavior. For example, try input.valueAsNumber=1e30 on
             // a type="date" input.
-            self.SetValue(cx, DOMString::from(""))
+            self.SetValue(cx, DOMString::new())
         }
     }
 
@@ -1625,7 +1625,7 @@ impl HTMLInputElement {
                 // Step 5.7.1: If the field element has a value attribute specified, then let value be the value of that attribute; otherwise, let value be the string "on".
                 let field_value = self.Value();
                 let value = if field_value.is_empty() {
-                    DOMString::from("on")
+                    DOMString::from_static("on")
                 } else {
                     field_value
                 };
@@ -1674,7 +1674,7 @@ impl HTMLInputElement {
             InputType::Hidden(_) if name.eq_ignore_ascii_case("_charset_") => {
                 // Step 5.9.1: Let charset be the name of encoding.
                 let charset = match encoding {
-                    None => DOMString::from("UTF-8"),
+                    None => DOMString::from_static("UTF-8"),
                     Some(enc) => DOMString::from(enc.name()),
                 };
                 // Step 5.9.2: Create an entry with name and charset, and append it to entry list.
@@ -1763,7 +1763,7 @@ impl HTMLInputElement {
         self.value_dirty.set(false);
         self.checked_changed.set(false);
         // Step 2. Set value to empty string.
-        self.textinput.borrow_mut().set_content(DOMString::from(""));
+        self.textinput.borrow_mut().set_content(DOMString::new());
         // Step 3. Set checkedness based on presence of content attribute.
         self.update_checked_state(cx, self.DefaultChecked(), false);
         // Step 4. Empty selected files
@@ -2121,7 +2121,7 @@ impl VirtualMethods for HTMLInputElement {
                             (_, _, ValueMode::Filename)
                                 if old_value_mode != ValueMode::Filename =>
                             {
-                                self.SetValue(cx, DOMString::from(""))
+                                self.SetValue(cx, DOMString::new())
                                     .expect("Failed to set input value on type change to ValueMode::Filename.");
                             },
                             _ => {},

--- a/components/script/dom/html/form_controls/htmloutputelement.rs
+++ b/components/script/dom/html/form_controls/htmloutputelement.rs
@@ -113,7 +113,7 @@ impl HTMLOutputElementMethods<crate::DomTypeHolder> for HTMLOutputElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-output-type>
     fn Type(&self) -> DOMString {
-        DOMString::from("output")
+        DOMString::from_static("output")
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-fe-name

--- a/components/script/dom/html/form_controls/htmltextareaelement.rs
+++ b/components/script/dom/html/form_controls/htmltextareaelement.rs
@@ -416,7 +416,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea-type>
     fn Type(&self) -> DOMString {
-        DOMString::from("textarea")
+        DOMString::from_static("textarea")
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea-defaultvalue>
@@ -577,7 +577,7 @@ impl HTMLTextAreaElement {
     /// Used by WebDriver to clear the textarea element.
     pub(crate) fn clear(&self) {
         self.value_dirty.set(false);
-        self.textinput.borrow_mut().set_content(DOMString::from(""));
+        self.textinput.borrow_mut().set_content(DOMString::new());
     }
 
     pub(crate) fn reset(&self, cx: &mut JSContext) {

--- a/components/script/dom/html/form_controls/input_type/file_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/file_input_type.rs
@@ -266,7 +266,7 @@ impl FileInputShadowTree {
         selector_button
             .downcast::<HTMLButtonElement>()
             .expect("This should be guaranteed by the element type used above")
-            .SetType(cx, DOMString::from("button"));
+            .SetType(cx, DOMString::from_static("button"));
 
         selector_button
             .downcast::<HTMLElement>()
@@ -303,12 +303,15 @@ impl FileInputShadowTree {
                 .upcast::<Node>()
                 .set_text_content_for_element(
                     cx,
-                    Some(DOMString::from(SELECTOR_BUTTON_MULTIPLE_TEXT)),
+                    Some(DOMString::from_static(SELECTOR_BUTTON_MULTIPLE_TEXT)),
                 );
         } else {
             self.selector_button
                 .upcast::<Node>()
-                .set_text_content_for_element(cx, Some(DOMString::from(SELECTOR_BUTTON_TEXT)));
+                .set_text_content_for_element(
+                    cx,
+                    Some(DOMString::from_static(SELECTOR_BUTTON_TEXT)),
+                );
         }
 
         self.value_container

--- a/components/script/dom/html/form_controls/text_input.rs
+++ b/components/script/dom/html/form_controls/text_input.rs
@@ -96,9 +96,9 @@ impl From<DOMString> for SelectionDirection {
 impl From<SelectionDirection> for DOMString {
     fn from(direction: SelectionDirection) -> DOMString {
         match direction {
-            SelectionDirection::Forward => DOMString::from("forward"),
-            SelectionDirection::Backward => DOMString::from("backward"),
-            SelectionDirection::None => DOMString::from("none"),
+            SelectionDirection::Forward => DOMString::from_static("forward"),
+            SelectionDirection::Backward => DOMString::from_static("backward"),
+            SelectionDirection::None => DOMString::from_static("none"),
         }
     }
 }

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -687,8 +687,8 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
             cx,
             &html5ever::local_name!("translate"),
             match yesno {
-                true => DOMString::from("yes"),
-                false => DOMString::from("no"),
+                true => DOMString::from_static("yes"),
+                false => DOMString::from_static("no"),
             },
         );
     }

--- a/components/script/dom/html/interactive/htmldialogelement.rs
+++ b/components/script/dom/html/interactive/htmldialogelement.rs
@@ -107,8 +107,8 @@ impl HTMLDialogElement {
             atom!("beforetoggle"),
             EventBubbles::DoesNotBubble,
             EventCancelable::Cancelable,
-            DOMString::from("closed"),
-            DOMString::from("open"),
+            DOMString::from_static("closed"),
+            DOMString::from_static("open"),
             source.as_deref(),
         );
         let event = event.upcast::<Event>();
@@ -188,8 +188,8 @@ impl HTMLDialogElement {
             atom!("beforetoggle"),
             EventBubbles::DoesNotBubble,
             EventCancelable::NotCancelable,
-            DOMString::from("open"),
-            DOMString::from("closed"),
+            DOMString::from_static("open"),
+            DOMString::from_static("closed"),
             source.as_deref(),
         );
         let event = event.upcast::<Event>();
@@ -390,8 +390,8 @@ impl HTMLDialogElementMethods<crate::DomTypeHolder> for HTMLDialogElement {
             atom!("beforetoggle"),
             EventBubbles::DoesNotBubble,
             EventCancelable::Cancelable,
-            DOMString::from("closed"),
-            DOMString::from("open"),
+            DOMString::from_static("closed"),
+            DOMString::from_static("open"),
             None,
         );
         let event = event.upcast::<Event>();

--- a/components/script/dom/html/internals/elementinternals.rs
+++ b/components/script/dom/html/internals/elementinternals.rs
@@ -170,14 +170,14 @@ impl ElementInternals {
             SubmissionValue::None => {},
             SubmissionValue::USVString(string) => {
                 entry_list.push(FormDatum {
-                    ty: DOMString::from("string"),
+                    ty: DOMString::from_static("string"),
                     name,
                     value: FormDatumValue::String(DOMString::from(string.to_string())),
                 });
             },
             SubmissionValue::File(file) => {
                 entry_list.push(FormDatum {
-                    ty: DOMString::from("file"),
+                    ty: DOMString::from_static("file"),
                     name,
                     value: FormDatumValue::File(DomRoot::from_ref(file)),
                 });

--- a/components/script/dom/html/scripting/htmlscriptelement.rs
+++ b/components/script/dom/html/scripting/htmlscriptelement.rs
@@ -1384,7 +1384,7 @@ impl HTMLScriptElementMethods<crate::DomTypeHolder> for HTMLScriptElement {
         let value = TrustedScript::get_trusted_type_compliant_string(
             cx,
             &self.owner_global(),
-            value.unwrap_or(TrustedScriptOrString::String(DOMString::from(""))),
+            value.unwrap_or(TrustedScriptOrString::String(DOMString::new())),
             "HTMLScriptElement textContent",
         )?;
         // Step 2: Set this's script text value to value.

--- a/components/script/dom/navigator/navigatorinfo.rs
+++ b/components/script/dom/navigator/navigatorinfo.rs
@@ -6,22 +6,22 @@ use crate::dom::bindings::str::DOMString;
 
 #[expect(non_snake_case)]
 pub(crate) fn Product() -> DOMString {
-    DOMString::from("Gecko")
+    DOMString::from_static("Gecko")
 }
 
 #[expect(non_snake_case)]
 pub(crate) fn ProductSub() -> DOMString {
-    DOMString::from("20100101")
+    DOMString::from_static("20100101")
 }
 
 #[expect(non_snake_case)]
 pub(crate) fn Vendor() -> DOMString {
-    DOMString::from("")
+    DOMString::new()
 }
 
 #[expect(non_snake_case)]
 pub(crate) fn VendorSub() -> DOMString {
-    DOMString::from("")
+    DOMString::new()
 }
 
 #[expect(non_snake_case)]
@@ -31,12 +31,12 @@ pub(crate) fn TaintEnabled() -> bool {
 
 #[expect(non_snake_case)]
 pub(crate) fn AppName() -> DOMString {
-    DOMString::from("Netscape") // Like Gecko/Webkit
+    DOMString::from_static("Netscape") // Like Gecko/Webkit
 }
 
 #[expect(non_snake_case)]
 pub(crate) fn AppCodeName() -> DOMString {
-    DOMString::from("Mozilla")
+    DOMString::from_static("Mozilla")
 }
 
 #[expect(non_snake_case)]
@@ -48,7 +48,7 @@ pub(crate) fn Platform() -> DOMString {
 #[expect(non_snake_case)]
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "freebsd"))]
 pub(crate) fn Platform() -> DOMString {
-    DOMString::from("Linux")
+    DOMString::from_static("Linux")
 }
 
 #[expect(non_snake_case)]
@@ -70,7 +70,7 @@ pub(crate) fn UserAgent(user_agent: &str) -> DOMString {
 
 #[expect(non_snake_case)]
 pub(crate) fn AppVersion() -> DOMString {
-    DOMString::from("4.0")
+    DOMString::from_static("4.0")
 }
 
 #[expect(non_snake_case)]

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -3651,18 +3651,20 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
             NodeTypeId::Attr => self.downcast::<Attr>().unwrap().qualified_name(),
             NodeTypeId::Element(..) => self.downcast::<Element>().unwrap().TagName(),
             NodeTypeId::CharacterData(CharacterDataTypeId::Text(TextTypeId::Text)) => {
-                DOMString::from("#text")
+                DOMString::from_static("#text")
             },
             NodeTypeId::CharacterData(CharacterDataTypeId::Text(TextTypeId::CDATASection)) => {
-                DOMString::from("#cdata-section")
+                DOMString::from_static("#cdata-section")
             },
             NodeTypeId::CharacterData(CharacterDataTypeId::ProcessingInstruction) => {
                 self.downcast::<ProcessingInstruction>().unwrap().Target()
             },
-            NodeTypeId::CharacterData(CharacterDataTypeId::Comment) => DOMString::from("#comment"),
+            NodeTypeId::CharacterData(CharacterDataTypeId::Comment) => {
+                DOMString::from_static("#comment")
+            },
             NodeTypeId::DocumentType => self.downcast::<DocumentType>().unwrap().name().clone(),
-            NodeTypeId::DocumentFragment(_) => DOMString::from("#document-fragment"),
-            NodeTypeId::Document(_) => DOMString::from("#document"),
+            NodeTypeId::DocumentFragment(_) => DOMString::from_static("#document-fragment"),
+            NodeTypeId::Document(_) => DOMString::from_static("#document"),
         }
     }
 

--- a/components/script/dom/performance/largestcontentfulpaint.rs
+++ b/components/script/dom/performance/largestcontentfulpaint.rs
@@ -42,7 +42,7 @@ impl LargestContentfulPaint {
     ) -> LargestContentfulPaint {
         LargestContentfulPaint {
             entry: PerformanceEntry::new_inherited(
-                DOMString::from(""),
+                DOMString::new(),
                 EntryType::LargestContentfulPaint,
                 Some(render_time),
                 Duration::ZERO,

--- a/components/script/dom/performance/performancepainttiming.rs
+++ b/components/script/dom/performance/performancepainttiming.rs
@@ -26,9 +26,9 @@ impl PerformancePaintTiming {
         start_time: CrossProcessInstant,
     ) -> PerformancePaintTiming {
         let name = match metric_type {
-            ProgressiveWebMetricType::FirstPaint => DOMString::from("first-paint"),
+            ProgressiveWebMetricType::FirstPaint => DOMString::from_static("first-paint"),
             ProgressiveWebMetricType::FirstContentfulPaint => {
-                DOMString::from("first-contentful-paint")
+                DOMString::from_static("first-contentful-paint")
             },
             _ => DOMString::from(""),
         };

--- a/components/script/dom/performance/performanceresourcetiming.rs
+++ b/components/script/dom/performance/performanceresourcetiming.rs
@@ -153,14 +153,14 @@ impl PerformanceResourceTimingMethods<crate::DomTypeHolder> for PerformanceResou
     /// <https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-initiatortype>
     fn InitiatorType(&self) -> DOMString {
         match self.initiator_type {
-            InitiatorType::Beacon => DOMString::from("beacon"),
-            InitiatorType::Css => DOMString::from("css"),
+            InitiatorType::Beacon => DOMString::from_static("beacon"),
+            InitiatorType::Css => DOMString::from_static("css"),
             InitiatorType::LocalName(ref n) => DOMString::from(n.clone()),
-            InitiatorType::Navigation => DOMString::from("navigation"),
-            InitiatorType::XMLHttpRequest => DOMString::from("xmlhttprequest"),
-            InitiatorType::Fetch => DOMString::from("fetch"),
-            InitiatorType::Track => DOMString::from("track"),
-            InitiatorType::Other => DOMString::from("other"),
+            InitiatorType::Navigation => DOMString::from_static("navigation"),
+            InitiatorType::XMLHttpRequest => DOMString::from_static("xmlhttprequest"),
+            InitiatorType::Fetch => DOMString::from_static("fetch"),
+            InitiatorType::Track => DOMString::from_static("track"),
+            InitiatorType::Other => DOMString::from_static("other"),
         }
     }
 
@@ -170,7 +170,7 @@ impl PerformanceResourceTimingMethods<crate::DomTypeHolder> for PerformanceResou
     fn NextHopProtocol(&self) -> DOMString {
         match self.next_hop {
             Some(ref protocol) => protocol.clone(),
-            None => DOMString::from(""),
+            None => DOMString::new(),
         }
     }
 

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -404,16 +404,16 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // > is not in the document tree, "Caret" if this's range is collapsed, and "Range"
         // > otherwise.
         let Some(range) = self.range.get() else {
-            return DOMString::from("None");
+            return DOMString::from_static("None");
         };
         if !range.start_and_end_are_in_document_tree() {
-            return DOMString::from("None");
+            return DOMString::from_static("None");
         }
 
         if range.collapsed() {
-            DOMString::from("Caret")
+            DOMString::from_static("Caret")
         } else {
-            DOMString::from("Range")
+            DOMString::from_static("Range")
         }
     }
 
@@ -842,7 +842,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         if let Some(range) = self.range.get() {
             range.Stringifier(no_gc)
         } else {
-            DOMString::from("")
+            DOMString::new()
         }
     }
 }

--- a/components/script/dom/testing/servotestutils.rs
+++ b/components/script/dom/testing/servotestutils.rs
@@ -42,19 +42,19 @@ impl ServoTestUtilsMethods<crate::DomTypeHolder> for ServoTestUtils {
 
         let mut phases = Vec::new();
         if phases_run.contains(ReflowPhasesRun::RanLayout) {
-            phases.push(DOMString::from("RanLayout"))
+            phases.push(DOMString::from_static("RanLayout"))
         }
         if phases_run.contains(ReflowPhasesRun::BuiltStackingContextTree) {
-            phases.push(DOMString::from("BuiltStackingContextTree"))
+            phases.push(DOMString::from_static("BuiltStackingContextTree"))
         }
         if phases_run.contains(ReflowPhasesRun::BuiltDisplayList) {
-            phases.push(DOMString::from("BuiltDisplayList"))
+            phases.push(DOMString::from_static("BuiltDisplayList"))
         }
         if phases_run.contains(ReflowPhasesRun::UpdatedScrollNodeOffset) {
-            phases.push(DOMString::from("UpdatedScrollNodeOffset"))
+            phases.push(DOMString::from_static("UpdatedScrollNodeOffset"))
         }
         if phases_run.contains(ReflowPhasesRun::UpdatedImageData) {
-            phases.push(DOMString::from("UpdatedImageData"))
+            phases.push(DOMString::from_static("UpdatedImageData"))
         }
 
         LayoutResult::new(

--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -627,7 +627,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
             elementSequence: None,
             shortValue: None,
             stringValue: None,
-            type_: Some(DOMString::from("success")),
+            type_: Some(DOMString::from_static("success")),
             unrestrictedDoubleValue: None,
             unrestrictedFloatValue: None,
             unsignedLongLongValue: None,

--- a/components/script/dom/trustedtypes/trustedtypepolicyfactory.rs
+++ b/components/script/dom/trustedtypes/trustedtypepolicyfactory.rs
@@ -450,31 +450,31 @@ impl TrustedTypePolicyFactoryMethods<crate::DomTypeHolder> for TrustedTypePolicy
             interface.local == local_name!("iframe") &&
             property == "srcdoc"
         {
-            expected_type = Some(DOMString::from("TrustedHTML"))
+            expected_type = Some(DOMString::from_static("TrustedHTML"))
         } else if interface.ns == ns!(html) &&
             interface.local == local_name!("script") &&
             property == "innerText"
         {
-            expected_type = Some(DOMString::from("TrustedScript"))
+            expected_type = Some(DOMString::from_static("TrustedScript"))
         } else if interface.ns == ns!(html) &&
             interface.local == local_name!("script") &&
             property == "src"
         {
-            expected_type = Some(DOMString::from("TrustedScriptURL"))
+            expected_type = Some(DOMString::from_static("TrustedScriptURL"))
         } else if interface.ns == ns!(html) &&
             interface.local == local_name!("script") &&
             property == "text"
         {
-            expected_type = Some(DOMString::from("TrustedScript"))
+            expected_type = Some(DOMString::from_static("TrustedScript"))
         } else if interface.ns == ns!(html) &&
             interface.local == local_name!("script") &&
             property == "textContent"
         {
-            expected_type = Some(DOMString::from("TrustedScript"))
+            expected_type = Some(DOMString::from_static("TrustedScript"))
         } else if property == "innerHTML" {
-            expected_type = Some(DOMString::from("TrustedHTML"))
+            expected_type = Some(DOMString::from_static("TrustedHTML"))
         } else if property == "outerHTML" {
-            expected_type = Some(DOMString::from("TrustedHTML"))
+            expected_type = Some(DOMString::from_static("TrustedHTML"))
         }
         // Step 6: Return expectedType.
         expected_type

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -2189,7 +2189,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         // getPublicKey operation.
         let get_public_key_algorithm = match normalize_algorithm::<GetPublicKeyOperation>(
             cx,
-            &AlgorithmIdentifier::String(DOMString::from(algorithm.name().as_str())),
+            &AlgorithmIdentifier::String(DOMString::from_static(algorithm.name().as_str())),
         ) {
             Ok(normalized_algorithm) => normalized_algorithm,
             Err(error) => {
@@ -2435,7 +2435,9 @@ pub(crate) fn check_support_for_algorithm(
         // getPublicKey operation.
         return normalize_algorithm::<GetPublicKeyOperation>(
             cx,
-            &AlgorithmIdentifier::String(DOMString::from(normalized_algorithm.name().as_str())),
+            &AlgorithmIdentifier::String(DOMString::from_static(
+                normalized_algorithm.name().as_str(),
+            )),
         )
         .is_ok();
     }

--- a/components/script/dom/webcrypto/subtlecrypto/aes_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_common.rs
@@ -584,7 +584,7 @@ pub(crate) fn export_key(
             let mut jwk = JsonWebKey::default();
 
             // Step 2.2. Set the kty attribute of jwk to the string "oct".
-            jwk.kty = Some(DOMString::from("oct"));
+            jwk.kty = Some(DOMString::from_static("oct"));
 
             // Step 2.3. Set the k attribute of jwk to be a string containing the raw octets of the
             // key represented by [[handle]] internal slot of key, encoded according to Section 6.4

--- a/components/script/dom/webcrypto/subtlecrypto/chacha20_poly1305_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/chacha20_poly1305_operation.rs
@@ -365,7 +365,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             let mut jwk = JsonWebKey::default();
 
             // Step 2.2. Set the kty attribute of jwk to the string "oct".
-            jwk.kty = Some(DOMString::from("oct"));
+            jwk.kty = Some(DOMString::from_static("oct"));
 
             // Step 2.3. Set the k attribute of jwk to be a string containing the raw octets of the
             // key represented by [[handle]] internal slot of key, encoded according to Section 6.4
@@ -373,7 +373,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             jwk.encode_string_field(JwkStringField::K, chacha20poly1305_key.as_slice());
 
             // Step 2.4. Set the alg attribute of jwk to the string "C20P".
-            jwk.alg = Some(DOMString::from("C20P"));
+            jwk.alg = Some(DOMString::from_static("C20P"));
 
             // Step 2.5. Set the key_ops attribute of jwk to equal the usages attribute of key.
             jwk.set_key_ops(key.usages());

--- a/components/script/dom/webcrypto/subtlecrypto/ec_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ec_common.rs
@@ -1021,7 +1021,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             let mut jwk = JsonWebKey::default();
 
             // Step 3.2. Set the kty attribute of jwk to "EC".
-            jwk.kty = Some(DOMString::from("EC"));
+            jwk.kty = Some(DOMString::from_static("EC"));
 
             // Step 3.3.
             let KeyAlgorithmAndDerivatives::EcKeyAlgorithm(algorithm) = key.algorithm() else {

--- a/components/script/dom/webcrypto/subtlecrypto/ed25519_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ed25519_operation.rs
@@ -539,13 +539,13 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             let mut jwk = JsonWebKey::default();
 
             // Step 3.2. Set the kty attribute of jwk to "OKP".
-            jwk.kty = Some(DOMString::from("OKP"));
+            jwk.kty = Some(DOMString::from_static("OKP"));
 
             // Step 3.3. Set the alg attribute of jwk to "Ed25519".
-            jwk.alg = Some(DOMString::from("Ed25519"));
+            jwk.alg = Some(DOMString::from_static("Ed25519"));
 
             // Step 3.4. Set the crv attribute of jwk to "Ed25519".
-            jwk.crv = Some(DOMString::from("Ed25519"));
+            jwk.crv = Some(DOMString::from_static("Ed25519"));
 
             // Step 3.5. Set the x attribute of jwk according to the definition in Section 2 of
             // [RFC8037].

--- a/components/script/dom/webcrypto/subtlecrypto/ed448_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ed448_operation.rs
@@ -644,13 +644,13 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             let mut jwk = JsonWebKey::default();
 
             // Step 3.2. Set the kty attribute of jwk to "OKP".
-            jwk.kty = Some(DOMString::from("OKP"));
+            jwk.kty = Some(DOMString::from_static("OKP"));
 
             // Step 3.3. Set the alg attribute of jwk to "Ed448".
-            jwk.alg = Some(DOMString::from("Ed448"));
+            jwk.alg = Some(DOMString::from_static("Ed448"));
 
             // Step 3.4. Set the crv attribute of jwk to "Ed448".
-            jwk.crv = Some(DOMString::from("Ed448"));
+            jwk.crv = Some(DOMString::from_static("Ed448"));
 
             // Step 3.5. Set the x attribute of jwk according to the definition in Section 2 of
             // [RFC8037].

--- a/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
@@ -378,7 +378,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             let mut jwk = JsonWebKey::default();
 
             // Step 4.2. Set the kty attribute of jwk to the string "oct".
-            jwk.kty = Some(DOMString::from("oct"));
+            jwk.kty = Some(DOMString::from_static("oct"));
 
             // Step 4.3. Set the k attribute of jwk to be a string containing data, encoded according
             // to Section 6.4 of JSON Web Algorithms [JWA].

--- a/components/script/dom/webcrypto/subtlecrypto/kmac_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/kmac_operation.rs
@@ -425,7 +425,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             let mut jwk = JsonWebKey::default();
 
             // Step 4.2. Set the kty attribute of jwk to the string "oct".
-            jwk.kty = Some(DOMString::from("oct"));
+            jwk.kty = Some(DOMString::from_static("oct"));
 
             // Step 4.3. Set the k attribute of jwk to be a string containing data, encoded
             // according to Section 6.4 of JSON Web Algorithms [JWA].
@@ -443,10 +443,10 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             // If the name member of keyAlgorithm is "KMAC256":
             //     Set the alg attribute of jwk to the string "K256".
             if key_algorithm.name == CryptoAlgorithm::Kmac128 {
-                jwk.alg = Some(DOMString::from("K128"));
+                jwk.alg = Some(DOMString::from_static("K128"));
             }
             if key_algorithm.name == CryptoAlgorithm::Kmac256 {
-                jwk.alg = Some(DOMString::from("K256"));
+                jwk.alg = Some(DOMString::from_static("K256"));
             }
 
             // Step 4.6. Set the key_ops attribute of jwk to equal the usages attribute of key.

--- a/components/script/dom/webcrypto/subtlecrypto/ml_dsa_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ml_dsa_operation.rs
@@ -1075,7 +1075,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             };
 
             // Step 3.3. Set the kty attribute of jwk to "AKP".
-            jwk.kty = Some(DOMString::from("AKP"));
+            jwk.kty = Some(DOMString::from_static("AKP"));
 
             // Step 3.4. Set the alg attribute of jwk to the name member of normalizedAlgorithm.
             jwk.alg = Some(DOMString::from(key_algorithm.name.as_str()));

--- a/components/script/dom/webcrypto/subtlecrypto/ml_kem_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ml_kem_operation.rs
@@ -1187,7 +1187,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             };
 
             // Step 2.3. Set the kty attribute of jwk to "AKP".
-            jwk.kty = Some(DOMString::from("AKP"));
+            jwk.kty = Some(DOMString::from_static("AKP"));
 
             // Step 2.4. Set the alg attribute of jwk to the alg value corresponding to the name
             // member of normalizedAlgorithm indicated in Section 8 of [draft-ietf-jose-pqc-kem-05]

--- a/components/script/dom/webcrypto/subtlecrypto/rsa_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsa_common.rs
@@ -766,7 +766,7 @@ pub(crate) fn export_key(
             let mut jwk = JsonWebKey::default();
 
             // Step 3.2. Set the kty attribute of jwk to the string "RSA".
-            jwk.kty = Some(DOMString::from("RSA"));
+            jwk.kty = Some(DOMString::from_static("RSA"));
 
             // Step 3.3. Let hash be the name attribute of the hash attribute of the [[algorithm]]
             // internal slot of key.

--- a/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
@@ -644,10 +644,10 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             let mut jwk = JsonWebKey::default();
 
             // Step 3.2. Set the kty attribute of jwk to "OKP".
-            jwk.kty = Some(DOMString::from("OKP"));
+            jwk.kty = Some(DOMString::from_static("OKP"));
 
             // Step 3.3. Set the crv attribute of jwk to "X25519".
-            jwk.crv = Some(DOMString::from("X25519"));
+            jwk.crv = Some(DOMString::from_static("X25519"));
 
             // Step 3.4. Set the x attribute of jwk according to the definition in Section 2 of
             // [RFC8037].

--- a/components/script/dom/webcrypto/subtlecrypto/x448_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/x448_operation.rs
@@ -670,10 +670,10 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             let mut jwk = JsonWebKey::default();
 
             // Step 3.2. Set the kty attribute of jwk to "OKP".
-            jwk.kty = Some(DOMString::from("OKP"));
+            jwk.kty = Some(DOMString::from_static("OKP"));
 
             // Step 3.3. Set the crv attribute of jwk to "X448".
-            jwk.crv = Some(DOMString::from("X448"));
+            jwk.crv = Some(DOMString::from_static("X448"));
 
             // Step 3.4. Set the x attribute of jwk according to the definition in Section 2 of
             // [RFC8037].

--- a/components/script/dom/webrtc/rtcdatachannel.rs
+++ b/components/script/dom/webrtc/rtcdatachannel.rs
@@ -114,7 +114,7 @@ impl RTCDataChannel {
             negotiated: options.negotiated,
             id: options.id,
             ready_state: Cell::new(RTCDataChannelState::Connecting),
-            binary_type: DomRefCell::new(DOMString::from("blob")),
+            binary_type: DomRefCell::new(DOMString::from_static("blob")),
             peer_connection: Dom::from_ref(peer_connection),
             droppable: DroppableRTCDataChannel::new(WeakRef::new(peer_connection), servo_media_id),
         }

--- a/components/script/dom/window/windowproxy.rs
+++ b/components/script/dom/window/windowproxy.rs
@@ -535,7 +535,7 @@ impl WindowProxy {
         };
         // Step 5. If target is the empty string, then set target to "_blank".
         let non_empty_target = if target.is_empty() {
-            DOMString::from("_blank")
+            DOMString::from_static("_blank")
         } else {
             target
         };

--- a/components/script/dom/workers/sharedworkerglobalscope.rs
+++ b/components/script/dom/workers/sharedworkerglobalscope.rs
@@ -674,7 +674,7 @@ impl SharedWorkerGlobalScope {
                 let inside_port = inside_port.root();
 
                 rooted!(&in(cx) let mut data = UndefinedValue());
-                DOMString::from("").safe_to_jsval(cx,
+                DOMString::new().safe_to_jsval(cx,
                     data.handle_mut(),
                 );
 
@@ -688,7 +688,7 @@ impl SharedWorkerGlobalScope {
                     false,
                     false,
                     data.handle(),
-                    DOMString::from(""),
+                    DOMString::new(),
                     Some(&source),
                     DOMString::new(),
                     vec![inside_port],

--- a/components/script/drag/drag_data_store.rs
+++ b/components/script/drag/drag_data_store.rs
@@ -153,7 +153,7 @@ impl DragDataStore {
         // Step 2.2 If there are any items in the item list whose kind is File,
         // add an entry to L consisting of the string "Files".
         if has_files {
-            types.push(DOMString::from("Files"));
+            types.push(DOMString::from_static("Files"));
         }
         types
     }
@@ -284,9 +284,9 @@ fn normalize_mime(mut format: DOMString) -> DOMString {
 
     match &*format.str() {
         // If format equals "text", change it to "text/plain".
-        "text" => DOMString::from("text/plain"),
+        "text" => DOMString::from_static("text/plain"),
         // If format equals "url", change it to "text/uri-list".
-        "url" => DOMString::from("text/uri-list"),
+        "url" => DOMString::from_static("text/uri-list"),
         s => DOMString::from(s),
     }
 }

--- a/components/script/event_loop/webdriver_handlers.rs
+++ b/components/script/event_loop/webdriver_handlers.rs
@@ -318,7 +318,7 @@ fn all_matching_links(
     // Step 7.2. If a DOMException, SyntaxError, XPathException, or other error occurs
     // during the execution of the element location strategy, return error invalid selector.
     root_node
-        .query_selector_all(cx, DOMString::from("a"))
+        .query_selector_all(cx, DOMString::from_static("a"))
         .map_err(|_| ErrorStatus::InvalidSelector)
         .map(|nodes| matching_links(cx, &nodes, link_text, partial).collect())
 }

--- a/components/script/fetch/body.rs
+++ b/components/script/fetch/body.rs
@@ -627,7 +627,7 @@ impl Extractable for DOMString {
     ) -> Fallible<ExtractedBody> {
         let bytes = self.as_bytes().to_owned();
         let total_bytes = bytes.len();
-        let content_type = Some(DOMString::from("text/plain;charset=UTF-8"));
+        let content_type = Some(DOMString::from_static("text/plain;charset=UTF-8"));
         let stream = stream_from_body_init_bytes(cx, global, bytes)?;
         Ok(ExtractedBody {
             stream,
@@ -671,7 +671,7 @@ impl Extractable for URLSearchParams {
     ) -> Fallible<ExtractedBody> {
         let bytes = self.serialize_utf8().into_bytes();
         let total_bytes = bytes.len();
-        let content_type = Some(DOMString::from(
+        let content_type = Some(DOMString::from_static(
             "application/x-www-form-urlencoded;charset=UTF-8",
         ));
         let stream = stream_from_body_init_bytes(cx, global, bytes)?;

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -405,7 +405,7 @@ impl DOMString {
                 EncodedBytes::Latin1(Ref::map(inner, |inner| inner.as_raw_bytes()))
             },
             #[cfg(test)]
-            DOMStringType::Latin1Vec(items) => {
+            DOMStringType::Latin1Vec(..) => {
                 EncodedBytes::Latin1(Ref::map(inner, |inner| inner.as_raw_bytes()))
             },
         }
@@ -1153,8 +1153,10 @@ mod tests {
         let s = from_latin1(vec![b'a', b'b', b'c', b'%', b'$']);
         let string = String::from("abc%$");
         let s2 = DOMString::from(string.clone());
+        let s3 = DOMString::from_static("abc%$");
         assert_eq!(s, s2);
         assert_eq!(s, string);
+        assert_eq!(s, s3);
     }
 
     #[test]
@@ -1196,13 +1198,16 @@ mod tests {
         let s_converted = from_latin1(vec![b'a', b'b', b'c', b'%', b'$', 0xB2]);
         s_converted.ensure_rust_string();
         let s2 = DOMString::from("abc%$²");
+        let s3 = DOMString::from_static("abc%$²");
 
         let hash_s = hash_value(&s);
         let hash_s_converted = hash_value(&s_converted);
         let hash_s2 = hash_value(&s2);
+        let hash_s3 = hash_value(&s3);
 
         assert_eq!(hash_s, hash_s2);
         assert_eq!(hash_s, hash_s_converted);
+        assert_eq!(hash_s, hash_s3);
     }
 
     // Testing match_lazydomstring if it executes the statements in the match correctly
@@ -1256,6 +1261,14 @@ mod tests {
             let s = from_latin1(vec![b'a', b'b', b'c']);
             match_domstring_ascii!( s,
                 "abcdd" => assert!(false),
+                "bcd" => assert!(false),
+                _ => (),
+            );
+        }
+        {
+            let s = DOMString::from_static("abc");
+            match_domstring_ascii!( s,
+                "abc" => assert!(true),
                 "bcd" => assert!(false),
                 _ => (),
             );
@@ -1362,6 +1375,13 @@ mod tests {
             s.ensure_rust_string();
             assert_eq!(&*s.str(), "abc%$");
         }
+        {
+            let mut s = DOMString::from_static("   \n  abc%$ ");
+
+            s.strip_leading_and_trailing_ascii_whitespace();
+            s.ensure_rust_string();
+            assert_eq!(&*s.str(), "abc%$");
+        }
     }
 
     // https://infra.spec.whatwg.org/#ascii-whitespace
@@ -1396,6 +1416,11 @@ mod tests {
         assert!(!s.contains_html_space_characters());
         s.ensure_rust_string();
         assert!(!s.contains_html_space_characters());
+
+        let s = DOMString::from_static("aba aaa");
+        assert!(s.contains_html_space_characters());
+        s.ensure_rust_string();
+        assert!(s.contains_html_space_characters());
     }
 
     #[test]
@@ -1408,6 +1433,12 @@ mod tests {
         let s3 = from_latin1(vec![b'a', b'a', b'a', 0xB2, b'a', b'a']);
         let atom3 = Atom::from(s3);
         assert_ne!(atom1, atom3);
+        let s3 = DOMString::from_static("aaa\u{03B1}aa");
+        let atom3 = Atom::from(s3);
+        assert_ne!(atom1, atom3);
+        let s4 = DOMString::from_static("aaa aa");
+        let atom4 = Atom::from(s4);
+        assert_eq!(atom2, atom4);
     }
 
     #[test]
@@ -1420,6 +1451,9 @@ mod tests {
         let s3 = from_latin1(vec![b'a', b'a', b'a', LATIN1_POWER2, b'a', b'a']);
         let atom3 = Namespace::from(s3);
         assert_ne!(atom1, atom3);
+        let s4 = DOMString::from_static("aaa aa");
+        let atom4 = Namespace::from(s4);
+        assert_eq!(atom2, atom4);
     }
 
     #[test]
@@ -1432,6 +1466,9 @@ mod tests {
         let s3 = from_latin1(vec![b'a', b'a', b'a', LATIN1_POWER2, b'a', b'a']);
         let atom3 = LocalName::from(s3);
         assert_ne!(atom1, atom3);
+        let s4 = DOMString::from_static("aaa aa");
+        let atom4 = LocalName::from(s4);
+        assert_eq!(atom2, atom4);
     }
 
     #[test]
@@ -1447,6 +1484,8 @@ mod tests {
         let s = DOMString::from("`aaaz");
         assert!(!s.is_ascii_lowercase());
         let s = DOMString::from("aaaz");
+        assert!(s.is_ascii_lowercase());
+        let s = DOMString::from_static("aaaz");
         assert!(s.is_ascii_lowercase());
     }
 
@@ -1488,6 +1527,8 @@ mod tests {
         assert_eq!(&*s.as_bytes(), str.as_bytes());
         let str = "AbBcC❤&%$#".to_owned();
         let s = DOMString::from(str.clone());
+        assert_eq!(&*s.as_bytes(), str.as_bytes());
+        let s = DOMString::from_static("AbBcC❤&%$#");
         assert_eq!(&*s.as_bytes(), str.as_bytes());
     }
 }

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -105,6 +105,8 @@ enum DOMStringType {
     /// This is used for testing of the bindings to give
     /// a raw u8 Latin1 encoded string without having a js engine.
     Latin1Vec(Vec<u8>),
+    #[zeroize(skip)] // static strings will never have secrets.
+    RustStatic(&'static str),
 }
 
 impl Default for DOMStringType {
@@ -126,6 +128,7 @@ impl DOMStringType {
             },
             #[cfg(test)]
             DOMStringType::Latin1Vec(items) => items,
+            DOMStringType::RustStatic(s) => s.as_bytes(),
         }
     }
 
@@ -148,6 +151,8 @@ impl DOMStringType {
                 // buffer is the size specified in the documentation, so this should be safe.
                 unsafe { String::from_utf8_unchecked(v) }
             },
+            // Currently because we return a `&mut String` we need to own the string.
+            DOMStringType::RustStatic(s) => s.to_owned(),
         };
         *self = DOMStringType::Rust(new_string);
         self.ensure_rust_string()
@@ -224,6 +229,7 @@ unsafe impl Trace for DOMStringType {
                 DOMStringType::JSString(rooted_traceable_box) => rooted_traceable_box.trace(tracer),
                 #[cfg(test)]
                 DOMStringType::Latin1Vec(_s) => {},
+                DOMStringType::RustStatic(_) => {},
             }
         }
     }
@@ -239,6 +245,7 @@ impl malloc_size_of::MallocSizeOf for DOMStringType {
             },
             #[cfg(test)]
             DOMStringType::Latin1Vec(s) => s.size_of(ops),
+            DOMStringType::RustStatic(_s) => 0,
         }
     }
 }
@@ -252,6 +259,10 @@ impl std::fmt::Debug for DOMStringType {
             DOMStringType::Latin1Vec(s) => f
                 .debug_struct("DOMString")
                 .field("latin1_string", s)
+                .finish(),
+            DOMStringType::RustStatic(s) => f
+                .debug_struct("DOMString")
+                .field("static_string", s)
                 .finish(),
         }
     }
@@ -337,6 +348,11 @@ impl DOMString {
         }
     }
 
+    /// Creates a DOMString from a `&'static str` reference. More efficient than allocating the string.
+    pub fn from_static(s: &'static str) -> DOMString {
+        DOMString(RefCell::new(DOMStringType::RustStatic(s)))
+    }
+
     /// Transforms the internal storage of this [`DOMString`] into a Rust string if it is not
     /// yet one. This will make a copy of the underlying string data.
     fn ensure_rust_string(&self) -> RefMut<'_, String> {
@@ -357,6 +373,7 @@ impl DOMString {
             },
             #[cfg(test)]
             DOMStringType::Latin1Vec(ref items) => info!("Latin1 string"),
+            DOMStringType::RustStatic(s) => info!("Static Rust String ({})", s),
         }
     }
 
@@ -799,6 +816,7 @@ impl ToJSValConvertible for DOMString {
                     .expect("Error in constructin test string")
                     .safe_to_jsval(cx, rval);
             },
+            DOMStringType::RustStatic(s) => s.safe_to_jsval(cx, rval),
         };
     }
 }
@@ -885,6 +903,7 @@ impl From<std::string::String> for DOMString {
     }
 }
 
+/// If you have a static str use the provided `DOMString::from_static`.
 impl From<&str> for DOMString {
     fn from(string: &str) -> Self {
         String::from(string).into()
@@ -924,6 +943,7 @@ impl From<DOMString> for String {
             DOMStringType::JSString(_) => unreachable!(),
             #[cfg(test)]
             DOMStringType::Latin1Vec(items) => String::from_utf8(items).expect("Not valid latin1"),
+            DOMStringType::RustStatic(s) => s.to_owned(),
         }
     }
 }
@@ -937,6 +957,7 @@ impl From<DOMString> for Vec<u8> {
             DOMStringType::JSString(_) => unreachable!(),
             #[cfg(test)]
             DOMStringType::Latin1Vec(items) => items,
+            DOMStringType::RustStatic(_) => unreachable!(),
         }
     }
 }

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -398,10 +398,16 @@ impl DOMString {
     pub fn encoded_bytes(&self) -> EncodedBytes<'_> {
         let inner = self.0.borrow();
         match &*inner {
-            DOMStringType::Rust(..) => {
+            DOMStringType::Rust(..) | DOMStringType::RustStatic(..) => {
                 EncodedBytes::Utf8(Ref::map(inner, |inner| inner.as_raw_bytes()))
             },
-            _ => EncodedBytes::Latin1(Ref::map(inner, |inner| inner.as_raw_bytes())),
+            DOMStringType::JSString(..) => {
+                EncodedBytes::Latin1(Ref::map(inner, |inner| inner.as_raw_bytes()))
+            },
+            #[cfg(test)]
+            DOMStringType::Latin1Vec(items) => {
+                EncodedBytes::Latin1(Ref::map(inner, |inner| inner.as_raw_bytes()))
+            },
         }
     }
 


### PR DESCRIPTION
We allow DOMStrings to efficiently convert from static strings by introducing the DOMString::from_static method.
We achieve this by having another entry in our enum that holds the static string. This will safe on memory for DOMStrings that never change.


The rest of the changes are mechanical and the static lifetime guarantees that the string will never go out of scope.

Adapted the original idea from in house fork.

Testing: WPT tests should find anything that breaks.
