### PR TITLE
servo: Rename IpcResponder to AutomaticResponder

### DIFF
--- a/components/servo/responders.rs
+++ b/components/servo/responders.rs
@@ -109,15 +109,15 @@ impl<T> AbstractSender for OneshotSender<T> {
     }
 }
 
-/// Sends a response over an IPC channel, or a default response on [`Drop`] if no response was sent.
-pub(crate) struct IpcResponder<T> {
+/// Sends a response over a Generic channel, or a default response on [`Drop`] if no response was sent.
+pub(crate) struct GenericResponder<T> {
     response_sender: Box<dyn AbstractSender<Message = T>>,
     response_sent: bool,
     /// Always present, except when taken by [`Drop`].
     default_response: Option<T>,
 }
 
-impl<T: Serialize + 'static> IpcResponder<T> {
+impl<T: Serialize + 'static> GenericResponder<T> {
     pub(crate) fn new(response_sender: GenericSender<T>, default_response: T) -> Self {
         Self {
             response_sender: Box::new(response_sender),
@@ -127,7 +127,7 @@ impl<T: Serialize + 'static> IpcResponder<T> {
     }
 }
 
-impl<T: 'static> IpcResponder<T> {
+impl<T: 'static> GenericResponder<T> {
     pub(crate) fn new_same_process(
         response_sender: Box<dyn AbstractSender<Message = T>>,
         default_response: T,
@@ -140,7 +140,7 @@ impl<T: 'static> IpcResponder<T> {
     }
 }
 
-impl<T> IpcResponder<T> {
+impl<T> GenericResponder<T> {
     pub(crate) fn send(&mut self, response: T) -> SendResult {
         let result = self.response_sender.send(response);
         self.response_sent = true;
@@ -148,7 +148,7 @@ impl<T> IpcResponder<T> {
     }
 }
 
-impl<T> Drop for IpcResponder<T> {
+impl<T> Drop for GenericResponder<T> {
     fn drop(&mut self) {
         if !self.response_sent {
             let response = self

--- a/components/servo/responders.rs
+++ b/components/servo/responders.rs
@@ -109,15 +109,15 @@ impl<T> AbstractSender for OneshotSender<T> {
     }
 }
 
-/// Sends a response over a Generic channel, or a default response on [`Drop`] if no response was sent.
-pub(crate) struct GenericResponder<T> {
+/// Sends a response over a channel, or a default response on [`Drop`] if no response was sent.
+pub(crate) struct AutomaticResponder<T> {
     response_sender: Box<dyn AbstractSender<Message = T>>,
     response_sent: bool,
     /// Always present, except when taken by [`Drop`].
     default_response: Option<T>,
 }
 
-impl<T: Serialize + 'static> GenericResponder<T> {
+impl<T: Serialize + 'static> AutomaticResponder<T> {
     pub(crate) fn new(response_sender: GenericSender<T>, default_response: T) -> Self {
         Self {
             response_sender: Box::new(response_sender),
@@ -127,7 +127,7 @@ impl<T: Serialize + 'static> GenericResponder<T> {
     }
 }
 
-impl<T: 'static> GenericResponder<T> {
+impl<T: 'static> AutomaticResponder<T> {
     pub(crate) fn new_same_process(
         response_sender: Box<dyn AbstractSender<Message = T>>,
         default_response: T,
@@ -140,7 +140,7 @@ impl<T: 'static> GenericResponder<T> {
     }
 }
 
-impl<T> GenericResponder<T> {
+impl<T> AutomaticResponder<T> {
     pub(crate) fn send(&mut self, response: T) -> SendResult {
         let result = self.response_sender.send(response);
         self.response_sent = true;
@@ -148,7 +148,7 @@ impl<T> GenericResponder<T> {
     }
 }
 
-impl<T> Drop for GenericResponder<T> {
+impl<T> Drop for AutomaticResponder<T> {
     fn drop(&mut self) {
         if !self.response_sent {
             let response = self

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -39,7 +39,7 @@ use webrender_api::units::{DeviceIntRect, DevicePixel, DevicePoint, DeviceSize};
 use crate::clipboard_delegate::{ClipboardDelegate, DefaultClipboardDelegate};
 #[cfg(feature = "gamepad")]
 use crate::gamepad_delegate::{DefaultGamepadDelegate, GamepadDelegate};
-use crate::responders::GenericResponder;
+use crate::responders::AutomaticResponder;
 use crate::servo::PendingHandledInputEvent;
 use crate::webview_delegate::{CreateNewWebViewRequest, DefaultWebViewDelegate, WebViewDelegate};
 use crate::{
@@ -252,7 +252,7 @@ impl WebView {
     ) {
         let request = CreateNewWebViewRequest {
             servo: self.inner().servo.clone(),
-            responder: GenericResponder::new(response_sender, None),
+            responder: AutomaticResponder::new(response_sender, None),
         };
         self.delegate().request_create_new(self.clone(), request);
     }
@@ -1096,7 +1096,7 @@ pub struct WebViewBuilder {
     delegate: Rc<dyn WebViewDelegate>,
     url: Option<Url>,
     hidpi_scale_factor: Scale<f32, DeviceIndependentPixel, DevicePixel>,
-    create_new_webview_responder: Option<GenericResponder<Option<NewWebViewDetails>>>,
+    create_new_webview_responder: Option<AutomaticResponder<Option<NewWebViewDetails>>>,
     user_content_manager: Option<Rc<UserContentManager>>,
     clipboard_delegate: Option<Rc<dyn ClipboardDelegate>>,
     #[cfg(feature = "gamepad")]
@@ -1126,7 +1126,7 @@ impl WebViewBuilder {
     pub(crate) fn new_for_create_request(
         servo: &Servo,
         rendering_context: Rc<dyn RenderingContext>,
-        responder: GenericResponder<Option<NewWebViewDetails>>,
+        responder: AutomaticResponder<Option<NewWebViewDetails>>,
     ) -> Self {
         let mut builder = Self::new(servo, rendering_context);
         builder.create_new_webview_responder = Some(responder);

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -39,7 +39,7 @@ use webrender_api::units::{DeviceIntRect, DevicePixel, DevicePoint, DeviceSize};
 use crate::clipboard_delegate::{ClipboardDelegate, DefaultClipboardDelegate};
 #[cfg(feature = "gamepad")]
 use crate::gamepad_delegate::{DefaultGamepadDelegate, GamepadDelegate};
-use crate::responders::IpcResponder;
+use crate::responders::GenericResponder;
 use crate::servo::PendingHandledInputEvent;
 use crate::webview_delegate::{CreateNewWebViewRequest, DefaultWebViewDelegate, WebViewDelegate};
 use crate::{
@@ -252,7 +252,7 @@ impl WebView {
     ) {
         let request = CreateNewWebViewRequest {
             servo: self.inner().servo.clone(),
-            responder: IpcResponder::new(response_sender, None),
+            responder: GenericResponder::new(response_sender, None),
         };
         self.delegate().request_create_new(self.clone(), request);
     }
@@ -1096,7 +1096,7 @@ pub struct WebViewBuilder {
     delegate: Rc<dyn WebViewDelegate>,
     url: Option<Url>,
     hidpi_scale_factor: Scale<f32, DeviceIndependentPixel, DevicePixel>,
-    create_new_webview_responder: Option<IpcResponder<Option<NewWebViewDetails>>>,
+    create_new_webview_responder: Option<GenericResponder<Option<NewWebViewDetails>>>,
     user_content_manager: Option<Rc<UserContentManager>>,
     clipboard_delegate: Option<Rc<dyn ClipboardDelegate>>,
     #[cfg(feature = "gamepad")]
@@ -1126,7 +1126,7 @@ impl WebViewBuilder {
     pub(crate) fn new_for_create_request(
         servo: &Servo,
         rendering_context: Rc<dyn RenderingContext>,
-        responder: IpcResponder<Option<NewWebViewDetails>>,
+        responder: GenericResponder<Option<NewWebViewDetails>>,
     ) -> Self {
         let mut builder = Self::new(servo, rendering_context);
         builder.create_new_webview_responder = Some(responder);

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -24,7 +24,7 @@ use url::Url;
 use webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize};
 
 use crate::proxies::ConstellationProxy;
-use crate::responders::{GenericResponder, OneshotSender, ServoErrorSender};
+use crate::responders::{AutomaticResponder, OneshotSender, ServoErrorSender};
 use crate::{RegisterOrUnregister, Servo, WebView, WebViewBuilder};
 
 /// A request to navigate a [`WebView`] or one of its inner frames. This can be handled
@@ -99,7 +99,7 @@ impl PermissionRequest {
 /// to Servo. This is used as a part of requests from Servo to the embedder
 /// to perform certain actions and the request can either be allowed or denied
 /// by the embedder.
-pub struct AllowOrDenyRequest(GenericResponder<AllowOrDeny>, ServoErrorSender);
+pub struct AllowOrDenyRequest(AutomaticResponder<AllowOrDeny>, ServoErrorSender);
 
 impl AllowOrDenyRequest {
     pub(crate) fn new(
@@ -108,7 +108,7 @@ impl AllowOrDenyRequest {
         error_sender: ServoErrorSender,
     ) -> Self {
         Self(
-            GenericResponder::new(response_sender, default_response),
+            AutomaticResponder::new(response_sender, default_response),
             error_sender,
         )
     }
@@ -119,7 +119,7 @@ impl AllowOrDenyRequest {
         error_sender: ServoErrorSender,
     ) -> Self {
         Self(
-            GenericResponder::new_same_process(Box::new(callback), default_response),
+            AutomaticResponder::new_same_process(Box::new(callback), default_response),
             error_sender,
         )
     }
@@ -157,7 +157,7 @@ pub struct ProtocolHandlerRegistration {
 /// A request to let the user chose a Bluetooth device.
 pub struct BluetoothDeviceSelectionRequest {
     devices: Vec<BluetoothDeviceDescription>,
-    responder: GenericResponder<Option<String>>,
+    responder: AutomaticResponder<Option<String>>,
 }
 
 impl BluetoothDeviceSelectionRequest {
@@ -167,7 +167,7 @@ impl BluetoothDeviceSelectionRequest {
     ) -> Self {
         Self {
             devices,
-            responder: GenericResponder::new(responder, None),
+            responder: AutomaticResponder::new(responder, None),
         }
     }
 
@@ -193,7 +193,7 @@ impl BluetoothDeviceSelectionRequest {
 pub struct AuthenticationRequest {
     pub(crate) url: Url,
     pub(crate) for_proxy: bool,
-    pub(crate) responder: GenericResponder<Option<AuthenticationResponse>>,
+    pub(crate) responder: AutomaticResponder<Option<AuthenticationResponse>>,
     pub(crate) error_sender: ServoErrorSender,
 }
 
@@ -207,7 +207,7 @@ impl AuthenticationRequest {
         Self {
             url,
             for_proxy,
-            responder: GenericResponder::new_same_process(
+            responder: AutomaticResponder::new_same_process(
                 Box::new(OneshotSender::from(response_sender)),
                 None,
             ),
@@ -239,7 +239,7 @@ impl AuthenticationRequest {
 /// by calling [`WebResourceLoad::intercept`].
 pub struct WebResourceLoad {
     pub request: WebResourceRequest,
-    pub(crate) responder: GenericResponder<WebResourceResponseMsg>,
+    pub(crate) responder: AutomaticResponder<WebResourceResponseMsg>,
     pub(crate) error_sender: ServoErrorSender,
 }
 
@@ -251,7 +251,7 @@ impl WebResourceLoad {
     ) -> Self {
         Self {
             request: web_resource_request,
-            responder: GenericResponder::new_same_process(
+            responder: AutomaticResponder::new_same_process(
                 Box::new(response_sender),
                 WebResourceResponseMsg::DoNotIntercept,
             ),
@@ -286,7 +286,7 @@ impl WebResourceLoad {
 /// this interception will automatically be finished when dropped.
 pub struct InterceptedWebResourceLoad {
     pub request: WebResourceRequest,
-    pub(crate) response_sender: GenericResponder<WebResourceResponseMsg>,
+    pub(crate) response_sender: AutomaticResponder<WebResourceResponseMsg>,
     pub(crate) finished: bool,
     pub(crate) error_sender: ServoErrorSender,
 }
@@ -901,7 +901,7 @@ impl PromptDialog {
 /// Refer to the documentation of [`WebViewDelegate::request_create_new`] for more information.
 pub struct CreateNewWebViewRequest {
     pub(crate) servo: Servo,
-    pub(crate) responder: GenericResponder<Option<NewWebViewDetails>>,
+    pub(crate) responder: AutomaticResponder<Option<NewWebViewDetails>>,
 }
 
 impl CreateNewWebViewRequest {

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -24,7 +24,7 @@ use url::Url;
 use webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize};
 
 use crate::proxies::ConstellationProxy;
-use crate::responders::{IpcResponder, OneshotSender, ServoErrorSender};
+use crate::responders::{GenericResponder, OneshotSender, ServoErrorSender};
 use crate::{RegisterOrUnregister, Servo, WebView, WebViewBuilder};
 
 /// A request to navigate a [`WebView`] or one of its inner frames. This can be handled
@@ -99,7 +99,7 @@ impl PermissionRequest {
 /// to Servo. This is used as a part of requests from Servo to the embedder
 /// to perform certain actions and the request can either be allowed or denied
 /// by the embedder.
-pub struct AllowOrDenyRequest(IpcResponder<AllowOrDeny>, ServoErrorSender);
+pub struct AllowOrDenyRequest(GenericResponder<AllowOrDeny>, ServoErrorSender);
 
 impl AllowOrDenyRequest {
     pub(crate) fn new(
@@ -108,7 +108,7 @@ impl AllowOrDenyRequest {
         error_sender: ServoErrorSender,
     ) -> Self {
         Self(
-            IpcResponder::new(response_sender, default_response),
+            GenericResponder::new(response_sender, default_response),
             error_sender,
         )
     }
@@ -119,7 +119,7 @@ impl AllowOrDenyRequest {
         error_sender: ServoErrorSender,
     ) -> Self {
         Self(
-            IpcResponder::new_same_process(Box::new(callback), default_response),
+            GenericResponder::new_same_process(Box::new(callback), default_response),
             error_sender,
         )
     }
@@ -157,7 +157,7 @@ pub struct ProtocolHandlerRegistration {
 /// A request to let the user chose a Bluetooth device.
 pub struct BluetoothDeviceSelectionRequest {
     devices: Vec<BluetoothDeviceDescription>,
-    responder: IpcResponder<Option<String>>,
+    responder: GenericResponder<Option<String>>,
 }
 
 impl BluetoothDeviceSelectionRequest {
@@ -167,7 +167,7 @@ impl BluetoothDeviceSelectionRequest {
     ) -> Self {
         Self {
             devices,
-            responder: IpcResponder::new(responder, None),
+            responder: GenericResponder::new(responder, None),
         }
     }
 
@@ -193,7 +193,7 @@ impl BluetoothDeviceSelectionRequest {
 pub struct AuthenticationRequest {
     pub(crate) url: Url,
     pub(crate) for_proxy: bool,
-    pub(crate) responder: IpcResponder<Option<AuthenticationResponse>>,
+    pub(crate) responder: GenericResponder<Option<AuthenticationResponse>>,
     pub(crate) error_sender: ServoErrorSender,
 }
 
@@ -207,7 +207,7 @@ impl AuthenticationRequest {
         Self {
             url,
             for_proxy,
-            responder: IpcResponder::new_same_process(
+            responder: GenericResponder::new_same_process(
                 Box::new(OneshotSender::from(response_sender)),
                 None,
             ),
@@ -239,7 +239,7 @@ impl AuthenticationRequest {
 /// by calling [`WebResourceLoad::intercept`].
 pub struct WebResourceLoad {
     pub request: WebResourceRequest,
-    pub(crate) responder: IpcResponder<WebResourceResponseMsg>,
+    pub(crate) responder: GenericResponder<WebResourceResponseMsg>,
     pub(crate) error_sender: ServoErrorSender,
 }
 
@@ -251,7 +251,7 @@ impl WebResourceLoad {
     ) -> Self {
         Self {
             request: web_resource_request,
-            responder: IpcResponder::new_same_process(
+            responder: GenericResponder::new_same_process(
                 Box::new(response_sender),
                 WebResourceResponseMsg::DoNotIntercept,
             ),
@@ -286,7 +286,7 @@ impl WebResourceLoad {
 /// this interception will automatically be finished when dropped.
 pub struct InterceptedWebResourceLoad {
     pub request: WebResourceRequest,
-    pub(crate) response_sender: IpcResponder<WebResourceResponseMsg>,
+    pub(crate) response_sender: GenericResponder<WebResourceResponseMsg>,
     pub(crate) finished: bool,
     pub(crate) error_sender: ServoErrorSender,
 }
@@ -901,7 +901,7 @@ impl PromptDialog {
 /// Refer to the documentation of [`WebViewDelegate::request_create_new`] for more information.
 pub struct CreateNewWebViewRequest {
     pub(crate) servo: Servo,
-    pub(crate) responder: IpcResponder<Option<NewWebViewDetails>>,
+    pub(crate) responder: GenericResponder<Option<NewWebViewDetails>>,
 }
 
 impl CreateNewWebViewRequest {


### PR DESCRIPTION
This just renames the struct to be GenericResponder instead of IpcResponder, more in line with what it actually uses.

Testing: This is just a rename so compilation is the test.
