### PR TITLE
script: Drop `safe` naming from mozjs APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -2586,7 +2586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3154,7 +3154,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5439,9 +5439,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658234c314802392f00175e96376c6219fef8e0dd5bded79f93d28e68b77c164"
+checksum = "c666e4b78b1ab5cbfa68cca37fe4de68a12cb40fb48b2807a0d14fe84890ca81"
 dependencies = [
  "bindgen",
  "cc",
@@ -6591,7 +6591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7708,7 +7708,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7765,7 +7765,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10241,7 +10241,7 @@ dependencies = [
  "derive_more",
  "encoding_rs",
  "euclid",
- "icu_segmenter 1.5.0",
+ "icu_segmenter 2.1.2",
  "indexmap",
  "itertools 0.14.0",
  "itoa",
@@ -10529,7 +10529,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12243,7 +12243,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ inventory = "0.3.24"
 ipc-channel = "0.22"
 itertools = "0.15"
 jni = "0.22"
-js = { package = "mozjs", version = "=0.24.0", default-features = false, features = ["intl", "libz-sys"] }
+js = { package = "mozjs", version = "=0.25.0", default-features = false, features = ["intl", "libz-sys"] }
 k12 = "0.5"
 keccak = "0.2"
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }

--- a/components/dom_struct/domobject.rs
+++ b/components/dom_struct/domobject.rs
@@ -38,9 +38,9 @@ pub(crate) fn expand_dom_object(
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     let items = quote! {
         impl #impl_generics ::js::conversions::ToJSValConvertible for #name #ty_generics #where_clause {
-            fn safe_to_jsval(&self, cx: &mut js::context::JSContext, rval: js::rust::MutableHandleValue) {
+            fn to_jsval(&self, cx: &mut js::context::JSContext, rval: js::rust::MutableHandleValue) {
                 let object = crate::DomObject::reflector(self).get_jsobject();
-                object.safe_to_jsval(cx, rval);
+                object.to_jsval(cx, rval);
             }
         }
 

--- a/components/dom_struct/lib.rs
+++ b/components/dom_struct/lib.rs
@@ -122,13 +122,13 @@ fn test_valid_dom_struct_generation() {
             {}
         };
         impl ::js::conversions::ToJSValConvertible for DomElement {
-            fn safe_to_jsval(
+            fn to_jsval(
                 &self,
                 cx: &mut js::context::JSContext,
                 rval: js::rust::MutableHandleValue,
             ) {
                 let object = crate::DomObject::reflector(self).get_jsobject();
-                object.safe_to_jsval(cx, rval);
+                object.to_jsval(cx, rval);
             }
         }
         impl crate::DomObject for DomElement {

--- a/components/script/dom/animations/keyframeeffect.rs
+++ b/components/script/dom/animations/keyframeeffect.rs
@@ -202,7 +202,7 @@ impl KeyframeEffectMethods<crate::DomTypeHolder> for KeyframeEffect {
 
                 // Step 3.3.3 Let value be the result of converting IDL value to an ECMAScript String value.
                 rooted!(&in(cx) let mut value = UndefinedValue());
-                value_string.safe_to_jsval(cx, value.handle_mut());
+                value_string.to_jsval(cx, value.handle_mut());
 
                 // Step 3.3.4 Call the [[DefineOwnProperty]] internal method on output keyframe with property
                 // name property name, Property Descriptor { [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]:
@@ -368,7 +368,7 @@ fn process_a_keyframe_like_object(
     //
     // Note: 'allow lists' is currently never true.
     // Use the following dictionary type:
-    let Ok(keyframe_output) = BaseKeyframe::safe_from_jsval(cx, value, ()) else {
+    let Ok(keyframe_output) = BaseKeyframe::from_jsval(cx, value, ()) else {
         return Err(Error::JSFailed);
     };
     let ConversionResult::Success(keyframe_output) = keyframe_output else {
@@ -461,7 +461,7 @@ fn get_property_declarations(
         // Otherwise,
         // Let property values be the result of converting raw value to a DOMString using the procedure
         // for converting an ECMAScript value to a DOMString [WEBIDL].
-        let property_value = match DOMString::safe_from_jsval(
+        let property_value = match DOMString::from_jsval(
             cx,
             property_value.handle(),
             StringificationBehavior::Default,

--- a/components/script/dom/bindings/constructor.rs
+++ b/components/script/dom/bindings/constructor.rs
@@ -231,7 +231,7 @@ fn html_constructor(
             return Err(());
         }
 
-        result.safe_to_jsval(cx, MutableHandleValue::from_raw(call_args.rval()));
+        result.to_jsval(cx, MutableHandleValue::from_raw(call_args.rval()));
     }
     Ok(())
 }

--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -103,7 +103,7 @@ where
         return Ok(None);
     }
 
-    let value = T::safe_from_jsval(cx, result.handle(), option);
+    let value = T::from_jsval(cx, result.handle(), option);
     match value {
         Ok(ConversionResult::Success(value)) => Ok(Some(value)),
         Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -13,7 +13,7 @@ use backtrace::Backtrace;
 use embedder_traits::JavaScriptErrorInfo;
 use js::context::JSContext;
 use js::conversions::{ToJSValConvertible, jsstr_to_string};
-use js::error::{throw_range_error_safe, throw_type_error_safe};
+use js::error::{throw_range_error, throw_type_error};
 use js::gc::{HandleObject, HandleValue, MutableHandleValue};
 use js::jsapi::ExceptionStackBehavior;
 #[cfg(feature = "js_backtrace")]
@@ -24,7 +24,7 @@ use js::rust::wrappers2::{
     JS_ClearPendingException, JS_ErrorFromException, JS_GetPendingException, JS_GetProperty,
     JS_IsExceptionPending, JS_SetPendingException,
 };
-use js::rust::{describe_scripted_caller_safe, error_info_from_exception_stack_safe};
+use js::rust::{describe_scripted_caller, error_info_from_exception_stack};
 use libc::c_uint;
 #[cfg(feature = "js_backtrace")]
 use script_bindings::cell::DomRefCell;
@@ -73,18 +73,18 @@ pub(crate) fn throw_dom_exception(cx: &mut JSContext, global: &GlobalScope, resu
         Ok(exception) => unsafe {
             assert!(!JS_IsExceptionPending(cx));
             rooted!(&in(cx) let mut thrown = UndefinedValue());
-            exception.safe_to_jsval(cx, thrown.handle_mut());
+            exception.to_jsval(cx, thrown.handle_mut());
             JS_SetPendingException(cx, thrown.handle(), ExceptionStackBehavior::Capture);
         },
 
         Err(JsEngineError::Type(message)) => unsafe {
             assert!(!JS_IsExceptionPending(cx));
-            throw_type_error_safe(cx, &message);
+            throw_type_error(cx, &message);
         },
 
         Err(JsEngineError::Range(message)) => unsafe {
             assert!(!JS_IsExceptionPending(cx));
-            throw_range_error_safe(cx, &message);
+            throw_range_error(cx, &message);
         },
 
         Err(JsEngineError::JSFailed) => unsafe {
@@ -297,7 +297,7 @@ impl ErrorInfo {
 
     fn from_dom_exception(cx: &mut JSContext, object: HandleObject) -> Option<ErrorInfo> {
         let exception = root_from_handleobject::<DOMException>(cx, object).ok()?;
-        let scripted_caller = describe_scripted_caller_safe(cx).unwrap_or_default();
+        let scripted_caller = describe_scripted_caller(cx).unwrap_or_default();
         Some(ErrorInfo {
             message: exception.stringifier().into(),
             filename: scripted_caller.filename,
@@ -325,9 +325,9 @@ impl ErrorInfo {
             }
         }
 
-        match USVString::safe_from_jsval(cx, value, ()) {
+        match USVString::from_jsval(cx, value, ()) {
             Ok(ConversionResult::Success(USVString(string))) => {
-                let scripted_caller = describe_scripted_caller_safe(cx).unwrap_or_default();
+                let scripted_caller = describe_scripted_caller(cx).unwrap_or_default();
                 ErrorInfo {
                     message: format!("uncaught exception: {}", string),
                     filename: scripted_caller.filename,
@@ -358,7 +358,7 @@ fn error_info_from_pending_exception(
         return None;
     }
 
-    let error_info = error_info_from_exception_stack_safe(cx, value)?;
+    let error_info = error_info_from_exception_stack(cx, value)?;
 
     Some(ErrorInfo {
         message: error_info.message,

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -744,7 +744,7 @@ pub(crate) fn write(
     unsafe {
         rooted!(&in(cx) let mut val = UndefinedValue());
         if let Some(transfer) = transfer {
-            transfer.safe_to_jsval(cx, val.handle_mut());
+            transfer.to_jsval(cx, val.handle_mut());
         }
         let mut sc_writer = StructuredDataWriter::default();
         let sc_writer_ptr = &mut sc_writer as *mut _;

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
 #[cfg(feature = "webgl")]
-use js::error::throw_type_error_safe;
+use js::error::throw_type_error;
 use js::realm::CurrentRealm;
 use js::rust::{HandleObject, HandleValue};
 use pixels::{EncodedImageType, Snapshot};
@@ -119,7 +119,7 @@ impl OffscreenCanvas {
         match WebGLContextAttributes::new(cx, options) {
             Ok(ConversionResult::Success(attrs)) => Some(attrs.convert()),
             Ok(ConversionResult::Failure(error)) => {
-                throw_type_error_safe(cx, &error);
+                throw_type_error(cx, &error);
                 None
             },
             _ => {

--- a/components/script/dom/clipboard/clipboarditem.rs
+++ b/components/script/dom/clipboard/clipboarditem.rs
@@ -47,11 +47,11 @@ impl Callback for RepresentationDataPromiseFulfillmentHandler {
         // 1. If v is a DOMString, then follow the below steps:
         if v.get().is_string() {
             // 1.1 Let dataAsBytes be the result of UTF-8 encoding v.
-            let data_as_bytes =
-                match DOMString::safe_from_jsval(cx, v, StringificationBehavior::Default) {
-                    Ok(ConversionResult::Success(s)) => s.as_bytes().to_owned(),
-                    _ => return,
-                };
+            let data_as_bytes = match DOMString::from_jsval(cx, v, StringificationBehavior::Default)
+            {
+                Ok(ConversionResult::Success(s)) => s.as_bytes().to_owned(),
+                _ => return,
+            };
 
             // 1.2 Let blobData be a Blob created using dataAsBytes with its type set to mimeType, serialized.
             let blob_data = Blob::new(
@@ -64,7 +64,7 @@ impl Callback for RepresentationDataPromiseFulfillmentHandler {
             self.promise.resolve_native(cx, &blob_data);
         }
         // 2. If v is a Blob, then follow the below steps:
-        else if DomRoot::<Blob>::safe_from_jsval(cx, v, ())
+        else if DomRoot::<Blob>::from_jsval(cx, v, ())
             .is_ok_and(|result| result.get_success_value().is_some())
         {
             // 2.1 Resolve p with v.

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -26,7 +26,7 @@ use js::rust::wrappers2::{
 };
 use js::rust::{
     CapturedJSStack, HandleObject, HandleValue, IdVector, ToNumber, ToString,
-    describe_scripted_caller_safe, for_of,
+    describe_scripted_caller, for_of,
 };
 use script_bindings::conversions::get_dom_class;
 
@@ -53,7 +53,7 @@ impl Console {
         arguments: Vec<DebuggerValue>,
         stacktrace: Option<Vec<StackFrame>>,
     ) -> ConsoleMessage {
-        let caller = describe_scripted_caller_safe(cx).unwrap_or_default();
+        let caller = describe_scripted_caller(cx).unwrap_or_default();
 
         ConsoleMessage {
             fields: ConsoleMessageFields {

--- a/components/script/dom/debugger/debuggeradddebuggeeevent.rs
+++ b/components/script/dom/debugger/debuggeradddebuggeeevent.rs
@@ -46,9 +46,7 @@ impl DebuggerAddDebuggeeEvent {
         // Convert the debuggee global’s reflector to a Value, wrapping it from its originating realm (debuggee realm)
         // into the active realm (debugger realm) so that it can be passed across compartments.
         rooted!(&in(cx) let mut wrapped_global: Value);
-        global
-            .reflector()
-            .safe_to_jsval(cx, wrapped_global.handle_mut());
+        global.reflector().to_jsval(cx, wrapped_global.handle_mut());
         result.global.set(wrapped_global.to_object());
 
         result

--- a/components/script/dom/document/documentorshadowroot.rs
+++ b/components/script/dom/document/documentorshadowroot.rs
@@ -451,9 +451,8 @@ impl DocumentOrShadowRoot {
         incoming_value: HandleValue,
         owner: &StyleSheetListOwner,
     ) -> ErrorResult {
-        let maybe_stylesheets =
-            Vec::<DomRoot<CSSStyleSheet>>::safe_from_jsval(cx, incoming_value, ())
-                .map_err(|_| Error::JSFailed)?;
+        let maybe_stylesheets = Vec::<DomRoot<CSSStyleSheet>>::from_jsval(cx, incoming_value, ())
+            .map_err(|_| Error::JSFailed)?;
 
         match maybe_stylesheets {
             ConversionResult::Success(stylesheets) => {

--- a/components/script/dom/document/websocket.rs
+++ b/components/script/dom/document/websocket.rs
@@ -619,12 +619,12 @@ impl TaskOnce for MessageReceivedTask {
         let cx = &mut *realm;
         rooted!(&in(cx) let mut message = UndefinedValue());
         match self.message {
-            MessageData::Text(text) => text.safe_to_jsval(cx, message.handle_mut()),
+            MessageData::Text(text) => text.to_jsval(cx, message.handle_mut()),
             MessageData::Binary(data) => match ws.binary_type.get() {
                 BinaryType::Blob => {
                     let blob =
                         Blob::new(cx, &global, BlobImpl::new_from_bytes(data, "".to_owned()));
-                    blob.safe_to_jsval(cx, message.handle_mut());
+                    blob.to_jsval(cx, message.handle_mut());
                 },
                 BinaryType::Arraybuffer => {
                     rooted!(&in(cx) let mut array_buffer = ptr::null_mut::<JSObject>());
@@ -639,7 +639,7 @@ impl TaskOnce for MessageReceivedTask {
                         )
                     };
 
-                    (*array_buffer).safe_to_jsval(cx, message.handle_mut());
+                    (*array_buffer).to_jsval(cx, message.handle_mut());
                 },
             },
         }

--- a/components/script/dom/encoding/textdecoderstream.rs
+++ b/components/script/dom/encoding/textdecoderstream.rs
@@ -33,7 +33,7 @@ pub(crate) fn decode_and_enqueue_a_chunk(
 ) -> Fallible<()> {
     // Step 1. Let bufferSource be the result of converting chunk to an AllowSharedBufferSource.
     let conversion_result =
-        ArrayBufferViewOrArrayBuffer::safe_from_jsval(cx, chunk, ()).map_err(|_| {
+        ArrayBufferViewOrArrayBuffer::from_jsval(cx, chunk, ()).map_err(|_| {
             Error::Type(c"Unable to convert chunk into ArrayBuffer or ArrayBufferView".to_owned())
         })?;
     let buffer_source = conversion_result.get_success_value().ok_or_else(|| {
@@ -58,7 +58,7 @@ pub(crate) fn decode_and_enqueue_a_chunk(
         return Ok(());
     }
     rooted!(&in(cx) let mut rval = UndefinedValue());
-    output_chunk.safe_to_jsval(cx, rval.handle_mut());
+    output_chunk.to_jsval(cx, rval.handle_mut());
     controller.enqueue(cx, global, rval.handle())
 }
 
@@ -87,7 +87,7 @@ pub(crate) fn flush_and_enqueue(
         return Ok(());
     }
     rooted!(&in(cx) let mut rval = UndefinedValue());
-    output_chunk.safe_to_jsval(cx, rval.handle_mut());
+    output_chunk.to_jsval(cx, rval.handle_mut());
     controller.enqueue(cx, global, rval.handle())
 }
 

--- a/components/script/dom/encoding/textencoderstream.rs
+++ b/components/script/dom/encoding/textencoderstream.rs
@@ -270,7 +270,7 @@ pub(crate) fn encode_and_enqueue_a_chunk(
     let chunk = create_buffer_source::<Uint8>(cx, output, js_object.handle_mut())
         .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
     rooted!(&in(cx) let mut rval = UndefinedValue());
-    chunk.safe_to_jsval(cx, rval.handle_mut());
+    chunk.to_jsval(cx, rval.handle_mut());
     // Step 4.2.2.2 Enqueue chunk into encoder’s transform.
     controller.enqueue(cx, global, rval.handle())?;
     Ok(())
@@ -294,7 +294,7 @@ pub(crate) fn encode_and_flush(
                     Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned())
                 })?;
         rooted!(&in(cx) let mut rval = UndefinedValue());
-        chunk.safe_to_jsval(cx, rval.handle_mut());
+        chunk.to_jsval(cx, rval.handle_mut());
         // Step 1.2 Enqueue chunk into encoder’s transform.
         return controller.enqueue(cx, global, rval.handle());
     }

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -283,7 +283,7 @@ impl EventSourceContext {
             let mut realm = enter_auto_realm(cx, &*event_source);
             let cx = &mut realm.current_realm();
             rooted!(&in(cx) let mut data = UndefinedValue());
-            self.data.safe_to_jsval(cx, data.handle_mut());
+            self.data.to_jsval(cx, data.handle_mut());
             MessageEvent::new(
                 cx,
                 &event_source.global(),

--- a/components/script/dom/globalscope/messageport.rs
+++ b/components/script/dom/globalscope/messageport.rs
@@ -217,7 +217,7 @@ impl MessagePort {
         // Let message be OrdinaryObjectCreate(null).
         rooted!(&in(cx) let mut message = unsafe { JS_NewObject(cx, ptr::null()) });
         rooted!(&in(cx) let mut type_string = UndefinedValue());
-        type_.safe_to_jsval(cx, type_string.handle_mut());
+        type_.to_jsval(cx, type_string.handle_mut());
 
         // Perform ! CreateDataProperty(message, "type", type).
         set_dictionary_property(cx, message.handle(), c"type", type_string.handle())
@@ -236,7 +236,7 @@ impl MessagePort {
 
         // Run the message port post message steps providing targetPort, message, and options.
         rooted!(&in(cx) let mut message_val = UndefinedValue());
-        message.safe_to_jsval(cx, message_val.handle_mut());
+        message.to_jsval(cx, message_val.handle_mut());
         self.post_message_impl(cx, message_val.handle(), transfer)
     }
 }

--- a/components/script/dom/globalscope/origin.rs
+++ b/components/script/dom/globalscope/origin.rs
@@ -122,7 +122,7 @@ impl OriginMethods<crate::DomTypeHolder> for Origin {
 
         // Step 2. If value is a string:
         if value.get().is_string() {
-            let s = match DOMString::safe_from_jsval(cx, value, StringificationBehavior::Default) {
+            let s = match DOMString::from_jsval(cx, value, StringificationBehavior::Default) {
                 Ok(ConversionResult::Success(s)) => s,
                 _ => return Err(Error::Type(c"Failed to convert value to string".to_owned())),
             };

--- a/components/script/dom/html/embedded_content/htmlcanvaselement.rs
+++ b/components/script/dom/html/embedded_content/htmlcanvaselement.rs
@@ -10,7 +10,7 @@ use euclid::default::Size2D;
 use html5ever::{LocalName, Prefix, local_name, ns};
 use js::context::NoGC;
 #[cfg(feature = "webgl")]
-use js::error::throw_type_error_safe;
+use js::error::throw_type_error;
 use js::rust::{HandleObject, HandleValue};
 use layout_api::HTMLCanvasData;
 use pixels::{EncodedImageType, Snapshot};
@@ -373,7 +373,7 @@ impl HTMLCanvasElement {
         match WebGLContextAttributes::new(cx, options) {
             Ok(ConversionResult::Success(attrs)) => Some(attrs.convert()),
             Ok(ConversionResult::Failure(error)) => {
-                throw_type_error_safe(cx, &error);
+                throw_type_error(cx, &error);
                 None
             },
             _ => {

--- a/components/script/dom/indexeddb/idbindex.rs
+++ b/components/script/dom/indexeddb/idbindex.rs
@@ -148,10 +148,10 @@ impl IDBIndexMethods<crate::DomTypeHolder> for IDBIndex {
     fn KeyPath(&self, cx: &mut JSContext, retval: MutableHandleValue) {
         match &self.key_path {
             KeyPath::String(string) => {
-                string.safe_to_jsval(cx, retval);
+                string.to_jsval(cx, retval);
             },
             KeyPath::StringSequence(sequence) => {
-                sequence.safe_to_jsval(cx, retval);
+                sequence.to_jsval(cx, retval);
             },
         }
     }

--- a/components/script/dom/indexeddb/idbobjectstore.rs
+++ b/components/script/dom/indexeddb/idbobjectstore.rs
@@ -958,8 +958,8 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
     /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-keypath>
     fn KeyPath(&self, cx: &mut JSContext, mut ret_val: MutableHandleValue) {
         match &self.key_path {
-            Some(KeyPath::String(path)) => path.safe_to_jsval(cx, ret_val),
-            Some(KeyPath::StringSequence(paths)) => paths.safe_to_jsval(cx, ret_val),
+            Some(KeyPath::String(path)) => path.to_jsval(cx, ret_val),
+            Some(KeyPath::StringSequence(paths)) => paths.to_jsval(cx, ret_val),
             None => ret_val.set(NullValue()),
         }
     }

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -185,7 +185,7 @@ impl IDBOpenDBRequest {
         transaction.set_active_flag(false);
 
         rooted!(&in(cx) let mut connection_val = UndefinedValue());
-        connection.safe_to_jsval(cx, connection_val.handle_mut());
+        connection.to_jsval(cx, connection_val.handle_mut());
 
         // Step 10.1: Set request’s result to connection.
         self.idbrequest.set_result(connection_val.handle());
@@ -301,7 +301,7 @@ impl IDBOpenDBRequest {
         let mut realm = enter_auto_realm(cx, result);
         let cx = &mut realm.current_realm();
         rooted!(&in(cx) let mut result_val = UndefinedValue());
-        result.safe_to_jsval(cx, result_val.handle_mut());
+        result.to_jsval(cx, result_val.handle_mut());
         self.set_result(result_val.handle());
 
         let event = Event::new(

--- a/components/script/dom/indexeddb/idbrequest.rs
+++ b/components/script/dom/indexeddb/idbrequest.rs
@@ -172,7 +172,7 @@ impl RequestListener {
                     for (i, key) in keys.into_iter().enumerate() {
                         key_type_to_jsval(cx, &key, array.handle_mut_at(i));
                     }
-                    array.safe_to_jsval(cx, answer.handle_mut());
+                    array.to_jsval(cx, answer.handle_mut());
                 },
                 IdbResult::Value(serialized_data) => {
                     let result = postcard::from_bytes(&serialized_data)
@@ -206,7 +206,7 @@ impl RequestListener {
                             return;
                         };
                     }
-                    values.safe_to_jsval(cx, answer.handle_mut());
+                    values.to_jsval(cx, answer.handle_mut());
                 },
                 IdbResult::Count(count) => {
                     answer.handle_mut().set(DoubleValue(count as f64));

--- a/components/script/dom/indexeddb/key.rs
+++ b/components/script/dom/indexeddb/key.rs
@@ -50,7 +50,7 @@ pub fn key_type_to_jsval(
         IndexedDBKeyType::Number(n) => result.set(DoubleValue(*n)),
 
         // Step 3. If type is string, return an ECMAScript String value equal to value.
-        IndexedDBKeyType::String(s) => s.safe_to_jsval(cx, result),
+        IndexedDBKeyType::String(s) => s.to_jsval(cx, result),
 
         IndexedDBKeyType::Date(d) => unsafe {
             // Step 3.1. Let date be the result of executing the ECMAScript Date
@@ -64,7 +64,7 @@ pub fn key_type_to_jsval(
             );
 
             // Step 3.3. Return date.
-            date.safe_to_jsval(cx, result);
+            date.to_jsval(cx, result);
         },
 
         IndexedDBKeyType::Binary(b) => unsafe {
@@ -157,7 +157,7 @@ pub(crate) fn is_valid_key_path(
     #[expect(unsafe_code)]
     let is_identifier_name = |cx: &mut JSContext, name: &str| -> Result<bool, Error> {
         rooted!(&in(cx) let mut value = UndefinedValue());
-        name.safe_to_jsval(cx, value.handle_mut());
+        name.to_jsval(cx, value.handle_mut());
         rooted!(&in(cx) let string = value.to_string());
 
         unsafe {
@@ -498,7 +498,7 @@ pub(crate) fn evaluate_key_path_on_value(
             }
 
             // Step 1.4. Return result.
-            result.safe_to_jsval(cx, return_val);
+            result.to_jsval(cx, return_val);
         },
         KeyPath::String(key_path) => {
             // Step 2. If keyPath is the empty string, return value and skip the remaining steps.
@@ -520,7 +520,7 @@ pub(crate) fn evaluate_key_path_on_value(
                     rooted!(&in(cx) let string_value = current_value.to_string());
                     unsafe {
                         let string_length = JS_GetStringLength(*string_value) as u64;
-                        string_length.safe_to_jsval(cx, current_value.handle_mut());
+                        string_length.to_jsval(cx, current_value.handle_mut());
                     }
                     continue;
                 }
@@ -550,7 +550,7 @@ pub(crate) fn evaluate_key_path_on_value(
                     let Ok(blob) = root_from_handlevalue::<Blob>(cx, current_value.handle())
                 {
                     // Let value be a Number equal to value’s size.
-                    blob.Size().safe_to_jsval(cx, current_value.handle_mut());
+                    blob.Size().to_jsval(cx, current_value.handle_mut());
 
                     continue;
                 }
@@ -560,7 +560,7 @@ pub(crate) fn evaluate_key_path_on_value(
                     let Ok(blob) = root_from_handlevalue::<Blob>(cx, current_value.handle())
                 {
                     // Let value be a String equal to value’s type.
-                    blob.Type().safe_to_jsval(cx, current_value.handle_mut());
+                    blob.Type().to_jsval(cx, current_value.handle_mut());
 
                     continue;
                 }
@@ -570,7 +570,7 @@ pub(crate) fn evaluate_key_path_on_value(
                     let Ok(file) = root_from_handlevalue::<File>(cx, current_value.handle())
                 {
                     // Let value be a String equal to value’s name.
-                    file.name().safe_to_jsval(cx, current_value.handle_mut());
+                    file.name().to_jsval(cx, current_value.handle_mut());
 
                     continue;
                 }
@@ -580,8 +580,7 @@ pub(crate) fn evaluate_key_path_on_value(
                     let Ok(file) = root_from_handlevalue::<File>(cx, current_value.handle())
                 {
                     // Let value be a Number equal to value’s lastModified.
-                    file.LastModified()
-                        .safe_to_jsval(cx, current_value.handle_mut());
+                    file.LastModified().to_jsval(cx, current_value.handle_mut());
 
                     continue;
                 }
@@ -595,7 +594,7 @@ pub(crate) fn evaluate_key_path_on_value(
                         t: file.LastModified() as f64,
                     };
                     unsafe {
-                        NewDateObject(cx, time).safe_to_jsval(cx, current_value.handle_mut());
+                        NewDateObject(cx, time).to_jsval(cx, current_value.handle_mut());
                     }
 
                     continue;
@@ -748,7 +747,7 @@ pub(crate) fn inject_key_into_value(
             // Step 4.3.1 Let o be a new Object created as if by the expression ({}).
             rooted!(&in(cx) let o = unsafe { JS_NewObject(cx, ptr::null()) });
             rooted!(&in(cx) let mut o_value = UndefinedValue());
-            o.safe_to_jsval(cx, o_value.handle_mut());
+            o.to_jsval(cx, o_value.handle_mut());
 
             // Step 4.3.2 Let status be CreateDataProperty(value, identifier, o).
             define_dictionary_property(

--- a/components/script/dom/node/customelementregistry.rs
+++ b/components/script/dom/node/customelementregistry.rs
@@ -633,7 +633,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
             rooted!(&in(cx) let mut constructor = UndefinedValue());
             definition
                 .constructor
-                .safe_to_jsval(cx, constructor.handle_mut());
+                .to_jsval(cx, constructor.handle_mut());
             // Step 19.1: Resolve this's when-defined promise map[name] with constructor.
             promise.resolve_native(cx, &constructor.get());
         }
@@ -643,7 +643,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
     /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-get>
     fn Get(&self, cx: &mut JSContext, name: DOMString, mut retval: MutableHandleValue) {
         match self.definitions.borrow().get(&LocalName::from(name)) {
-            Some(definition) => definition.constructor.safe_to_jsval(cx, retval),
+            Some(definition) => definition.constructor.to_jsval(cx, retval),
             None => retval.set(UndefinedValue()),
         }
     }
@@ -679,7 +679,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
             rooted!(&in(*realm) let mut constructor = UndefinedValue());
             definition
                 .constructor
-                .safe_to_jsval(realm, constructor.handle_mut());
+                .to_jsval(realm, constructor.handle_mut());
             let promise = Promise::new_in_realm(realm);
             promise.resolve_native(realm, &constructor.get());
             return promise;
@@ -925,7 +925,7 @@ impl CustomElementDefinition {
 
         rooted!(&in(cx) let element_val = ObjectValue(element.get()));
         let element: DomRoot<Element> =
-            match FromJSValConvertible::safe_from_jsval(cx, element_val.handle(), ()) {
+            match FromJSValConvertible::from_jsval(cx, element_val.handle(), ()) {
                 Ok(ConversionResult::Success(element)) => element,
                 Ok(ConversionResult::Failure(..)) => {
                     return Err(Error::Type(
@@ -1105,7 +1105,7 @@ fn run_upgrade_constructor(
     let window = element.owner_window();
     rooted!(&in(cx) let constructor_val = ObjectValue(constructor.callback()));
     rooted!(&in(cx) let mut element_val = UndefinedValue());
-    element.safe_to_jsval(cx, element_val.handle_mut());
+    element.to_jsval(cx, element_val.handle_mut());
     rooted!(&in(cx) let mut construct_result = ptr::null_mut::<JSObject>());
     {
         // Step 9.1. If definition's disable shadow is true and element's shadow root is non-null,
@@ -1373,22 +1373,22 @@ impl CustomElementReactionStack {
 
                 let local_name = DOMString::from(&*local_name);
                 rooted!(&in(cx) let mut name_value = UndefinedValue());
-                local_name.safe_to_jsval(cx, name_value.handle_mut());
+                local_name.to_jsval(cx, name_value.handle_mut());
 
                 rooted!(&in(cx) let mut old_value = NullValue());
                 if let Some(old_val) = old_val {
-                    old_val.safe_to_jsval(cx, old_value.handle_mut());
+                    old_val.to_jsval(cx, old_value.handle_mut());
                 }
 
                 rooted!(&in(cx) let mut value = NullValue());
                 if let Some(val) = val {
-                    val.safe_to_jsval(cx, value.handle_mut());
+                    val.to_jsval(cx, value.handle_mut());
                 }
 
                 rooted!(&in(cx) let mut namespace_value = NullValue());
                 if namespace != ns!() {
                     let namespace = DOMString::from(&*namespace);
-                    namespace.safe_to_jsval(cx, namespace_value.handle_mut());
+                    namespace.to_jsval(cx, namespace_value.handle_mut());
                 }
 
                 let args = vec![

--- a/components/script/dom/promise/promise.rs
+++ b/components/script/dom/promise/promise.rs
@@ -164,7 +164,7 @@ impl Promise {
         let mut realm = enter_auto_realm(cx, global);
         let cx = &mut realm.current_realm();
         rooted!(&in(cx) let mut rval = UndefinedValue());
-        value.safe_to_jsval(cx, rval.handle_mut());
+        value.to_jsval(cx, rval.handle_mut());
         rooted!(&in(cx) let p = unsafe { CallOriginalPromiseResolve(cx, rval.handle()) });
         assert!(!p.handle().is_null());
         Promise::new_with_js_promise(cx, p.handle())
@@ -179,7 +179,7 @@ impl Promise {
         let mut realm = enter_auto_realm(cx, global);
         let cx = &mut realm.current_realm();
         rooted!(&in(cx) let mut rval = UndefinedValue());
-        value.safe_to_jsval(cx, rval.handle_mut());
+        value.to_jsval(cx, rval.handle_mut());
         rooted!(&in(cx) let p = unsafe { CallOriginalPromiseReject(cx, rval.handle()) });
         assert!(!p.handle().is_null());
         Promise::new_with_js_promise(cx, p.handle())
@@ -192,7 +192,7 @@ impl Promise {
         let mut realm = enter_auto_realm(cx, self);
         let cx = &mut realm.current_realm();
         rooted!(&in(cx) let mut v = UndefinedValue());
-        val.safe_to_jsval(cx, v.handle_mut());
+        val.to_jsval(cx, v.handle_mut());
         self.resolve(cx, v.handle());
     }
 
@@ -212,7 +212,7 @@ impl Promise {
         let mut realm = enter_auto_realm(cx, self);
         let cx = &mut realm.current_realm();
         rooted!(&in(cx) let mut v = UndefinedValue());
-        val.safe_to_jsval(cx, v.handle_mut());
+        val.to_jsval(cx, v.handle_mut());
         self.reject(cx, v.handle());
     }
 
@@ -381,7 +381,7 @@ fn create_native_handler_function(
 }
 
 impl FromJSValConvertibleRc for Promise {
-    fn safe_from_jsval(
+    fn from_jsval(
         cx: &mut JSContext,
         value: HandleValue,
     ) -> Result<ConversionResult<Rc<Promise>>, ()> {

--- a/components/script/dom/security/csp.rs
+++ b/components/script/dom/security/csp.rs
@@ -17,7 +17,7 @@ use http::header::{HeaderMap, HeaderValue, ValueIter};
 use hyper_serde::Serde;
 use js::context::JSContext;
 use js::realm::CurrentRealm;
-use js::rust::describe_scripted_caller_safe;
+use js::rust::describe_scripted_caller;
 use log::warn;
 use servo_constellation_traits::{LoadData, LoadOrigin};
 use url::Url;
@@ -382,7 +382,7 @@ pub(crate) trait GlobalCspReporting {
 }
 
 fn compute_scripted_caller_source_position(cx: &mut JSContext) -> SourcePosition {
-    match describe_scripted_caller_safe(cx) {
+    match describe_scripted_caller(cx) {
         Ok(scripted_caller) => SourcePosition {
             source_file: scripted_caller.filename,
             line_number: scripted_caller.line,

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -30,11 +30,11 @@ use crate::routed_promise::{RoutedPromiseListener, callback_promise};
 
 fn pref_to_jsval(cx: &mut js::context::JSContext, pref: &PrefValue, rval: MutableHandleValue) {
     match pref {
-        PrefValue::Bool(b) => b.safe_to_jsval(cx, rval),
-        PrefValue::Int(i) => i.safe_to_jsval(cx, rval),
-        PrefValue::UInt(u) => u.safe_to_jsval(cx, rval),
-        PrefValue::Str(s) => s.safe_to_jsval(cx, rval),
-        PrefValue::Float(f) => f.safe_to_jsval(cx, rval),
+        PrefValue::Bool(b) => b.to_jsval(cx, rval),
+        PrefValue::Int(i) => i.to_jsval(cx, rval),
+        PrefValue::UInt(u) => u.to_jsval(cx, rval),
+        PrefValue::Str(s) => s.to_jsval(cx, rval),
+        PrefValue::Float(f) => f.to_jsval(cx, rval),
         PrefValue::Array(arr) => {
             rooted_vec!(let mut js_arr);
             for item in arr {
@@ -42,7 +42,7 @@ fn pref_to_jsval(cx: &mut js::context::JSContext, pref: &PrefValue, rval: Mutabl
                 pref_to_jsval(cx, item, js_val.handle_mut());
                 js_arr.push(Heap::boxed(js_val.get()));
             }
-            js_arr.safe_to_jsval(cx, rval);
+            js_arr.to_jsval(cx, rval);
         },
     }
 }

--- a/components/script/dom/stream/bytelengthqueuingstrategy.rs
+++ b/components/script/dom/stream/bytelengthqueuingstrategy.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use js::error::throw_type_error_safe;
+use js::error::throw_type_error;
 use js::gc::{HandleValue, MutableHandleValue};
 use js::jsapi::CallArgs;
 use js::jsval::{JSVal, UndefinedValue};
@@ -96,7 +96,7 @@ fn byte_length_queuing_strategy_size(cx: &mut js::context::JSContext, args: Call
     // https://tc39.es/ecma262/#sec-getv
     // Let O be ? ToObject(V).
     if chunk.is_undefined() || chunk.is_null() {
-        throw_type_error_safe(
+        throw_type_error(
             cx,
             c"ByteLengthQueuingStrategy size called with undefined or nulll",
         );

--- a/components/script/dom/stream/compressionstream.rs
+++ b/components/script/dom/stream/compressionstream.rs
@@ -166,7 +166,7 @@ pub(crate) fn compress_and_enqueue_a_chunk(
     let buffer_source = create_buffer_source::<Uint8>(cx, &buffer, js_object.handle_mut())
         .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
     rooted!(&in(cx) let mut rval = UndefinedValue());
-    buffer_source.safe_to_jsval(cx, rval.handle_mut());
+    buffer_source.to_jsval(cx, rval.handle_mut());
     controller.enqueue(cx, global, rval.handle())?;
 
     Ok(())
@@ -203,7 +203,7 @@ pub(crate) fn compress_flush_and_enqueue(
     let buffer_source = create_buffer_source::<Uint8>(cx, &buffer, js_object.handle_mut())
         .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
     rooted!(&in(cx) let mut rval = UndefinedValue());
-    buffer_source.safe_to_jsval(cx, rval.handle_mut());
+    buffer_source.to_jsval(cx, rval.handle_mut());
     controller.enqueue(cx, global, rval.handle())?;
 
     Ok(())
@@ -335,7 +335,7 @@ pub(crate) fn convert_chunk_to_vec(
     chunk: SafeHandleValue,
 ) -> Result<Vec<u8>, Error> {
     let conversion_result =
-        ArrayBufferViewOrArrayBuffer::safe_from_jsval(cx, chunk, ()).map_err(|_| {
+        ArrayBufferViewOrArrayBuffer::from_jsval(cx, chunk, ()).map_err(|_| {
             Error::Type(c"Unable to convert chunk into ArrayBuffer or ArrayBufferView".to_owned())
         })?;
     let buffer_source = conversion_result.get_success_value().ok_or_else(|| {

--- a/components/script/dom/stream/decompressionstream.rs
+++ b/components/script/dom/stream/decompressionstream.rs
@@ -157,7 +157,7 @@ pub(crate) fn decompress_and_enqueue_a_chunk(
     let array = create_buffer_source::<Uint8>(cx, &buffer, js_object.handle_mut())
         .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
     rooted!(&in(cx) let mut rval = UndefinedValue());
-    array.safe_to_jsval(cx, rval.handle_mut());
+    array.to_jsval(cx, rval.handle_mut());
     controller.enqueue(cx, global, rval.handle())?;
 
     // Step 6. If the end of the compressed input has been reached, and ds’s context has not fully
@@ -197,7 +197,7 @@ pub(crate) fn decompress_flush_and_enqueue(
         let array = create_buffer_source::<Uint8>(cx, &buffer, js_object.handle_mut())
             .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
         rooted!(&in(cx) let mut rval = UndefinedValue());
-        array.safe_to_jsval(cx, rval.handle_mut());
+        array.to_jsval(cx, rval.handle_mut());
         controller.enqueue(cx, global, rval.handle())?;
     }
 

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -1616,7 +1616,7 @@ impl ReadableStream {
         if self.is_errored() {
             let promise = Promise::new(cx, global);
             rooted!(&in(cx) let mut rval = UndefinedValue());
-            self.stored_error.safe_to_jsval(cx, rval.handle_mut());
+            self.stored_error.to_jsval(cx, rval.handle_mut());
             promise.reject_native(cx, &rval.handle());
             return promise;
         }
@@ -2399,7 +2399,7 @@ impl CrossRealmTransformReadable {
         // Let error be a new "DataCloneError" DOMException.
         let error = DOMException::new(cx, global, DOMErrorName::DataCloneError);
         rooted!(&in(cx) let mut rooted_error = UndefinedValue());
-        error.safe_to_jsval(cx, rooted_error.handle_mut());
+        error.to_jsval(cx, rooted_error.handle_mut());
 
         // Perform ! CrossRealmTransformSendError(port, error).
         port.cross_realm_transform_send_error(cx, rooted_error.handle());
@@ -2454,7 +2454,7 @@ pub(crate) fn bytes_from_chunk_jsval(
     cx: &mut JSContext,
     chunk: &RootedTraceableBox<Heap<JSVal>>,
 ) -> Result<Vec<u8>, Error> {
-    match Vec::<u8>::safe_from_jsval(cx, chunk.handle(), ConversionBehavior::EnforceRange) {
+    match Vec::<u8>::from_jsval(cx, chunk.handle(), ConversionBehavior::EnforceRange) {
         Ok(ConversionResult::Success(vec)) => Ok(vec),
         Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
         _ => Err(Error::Type(c"Unknown format for bytes read.".to_owned())),

--- a/components/script/dom/stream/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/readablestreamdefaultcontroller.rs
@@ -157,9 +157,9 @@ impl EnqueuedValue {
                 rooted!(&in(cx) let mut array_buffer_ptr = ptr::null_mut::<JSObject>());
                 create_buffer_source::<Uint8>(cx, chunk, array_buffer_ptr.handle_mut())
                     .expect("failed to create buffer source for native chunk.");
-                array_buffer_ptr.safe_to_jsval(cx, rval);
+                array_buffer_ptr.to_jsval(cx, rval);
             },
-            EnqueuedValue::Js(value_with_size) => value_with_size.value.safe_to_jsval(cx, rval),
+            EnqueuedValue::Js(value_with_size) => value_with_size.value.to_jsval(cx, rval),
             EnqueuedValue::CloseSentinel => {
                 unreachable!("The close sentinel is never made available as a js val.")
             },

--- a/components/script/dom/stream/writablestream.rs
+++ b/components/script/dom/stream/writablestream.rs
@@ -1172,7 +1172,7 @@ impl CrossRealmTransformWritable {
         // Let error be a new "DataCloneError" DOMException.
         let error = DOMException::new(cx, global, DOMErrorName::DataCloneError);
         rooted!(&in(cx) let mut rooted_error = UndefinedValue());
-        error.safe_to_jsval(cx, rooted_error.handle_mut());
+        error.to_jsval(cx, rooted_error.handle_mut());
 
         // Perform ! CrossRealmTransformSendError(port, error).
         port.cross_realm_transform_send_error(cx, rooted_error.handle());

--- a/components/script/dom/trustedtypes/trustedtypepolicyfactory.rs
+++ b/components/script/dom/trustedtypes/trustedtypepolicyfactory.rs
@@ -260,10 +260,10 @@ impl TrustedTypePolicyFactory {
         rooted!(&in(cx) let mut trusted_type_name_value = NullValue());
         expected_type
             .as_ref()
-            .safe_to_jsval(cx, trusted_type_name_value.handle_mut());
+            .to_jsval(cx, trusted_type_name_value.handle_mut());
 
         rooted!(&in(cx) let mut sink_value = NullValue());
-        sink.safe_to_jsval(cx, sink_value.handle_mut());
+        sink.to_jsval(cx, sink_value.handle_mut());
 
         let arguments = vec![trusted_type_name_value.handle(), sink_value.handle()];
         let policy_value = default_policy.get_trusted_type_policy_value(

--- a/components/script/dom/webcrypto/cryptokey.rs
+++ b/components/script/dom/webcrypto/cryptokey.rs
@@ -155,14 +155,14 @@ impl CryptoKey {
 
         // Create and store a cached object of algorithm
         rooted!(&in(cx) let mut algorithm_object_value: Value);
-        algorithm.safe_to_jsval(cx, algorithm_object_value.handle_mut());
+        algorithm.to_jsval(cx, algorithm_object_value.handle_mut());
         crypto_key
             .algorithm_cached
             .set(algorithm_object_value.to_object());
 
         // Create and store a cached object of usages
         rooted!(&in(cx) let mut usages_object_value: Value);
-        usages.safe_to_jsval(cx, usages_object_value.handle_mut());
+        usages.to_jsval(cx, usages_object_value.handle_mut());
         crypto_key
             .usages_cached
             .set(usages_object_value.to_object());

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -268,7 +268,7 @@ impl SubtleCrypto {
                 match JsonWebKey::parse(cx, stringified_jwk.as_bytes()) {
                     Ok(jwk) => {
                         rooted!(&in(cx) let mut rval = UndefinedValue());
-                        jwk.safe_to_jsval(cx, rval.handle_mut());
+                        jwk.to_jsval(cx, rval.handle_mut());
                         rooted!(&in(cx) let mut object = rval.to_object());
                         promise.resolve_native(cx, &*object);
                     },
@@ -2904,11 +2904,11 @@ pub(crate) struct KeyAlgorithm {
 
 impl ToJSValConvertible for KeyAlgorithm {
     #[expect(unsafe_code)]
-    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
+    fn to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
         rooted!(&in(cx) let mut object = unsafe { JS_NewObject(cx, ptr::null()) });
 
         rooted!(&in(cx) let mut name_js = UndefinedValue());
-        self.name.as_str().safe_to_jsval(cx, name_js.handle_mut());
+        self.name.as_str().to_jsval(cx, name_js.handle_mut());
         set_dictionary_property(cx, object.handle(), c"name", name_js.handle())
             .expect("Failed to set name property of KeyAlgorithm");
 
@@ -2999,17 +2999,17 @@ pub(crate) struct RsaHashedKeyAlgorithm {
 
 impl ToJSValConvertible for RsaHashedKeyAlgorithm {
     #[expect(unsafe_code)]
-    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
+    fn to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
         rooted!(&in(cx) let mut object = unsafe { JS_NewObject(cx, ptr::null()) });
 
         rooted!(&in(cx) let mut name_js = UndefinedValue());
-        self.name.as_str().safe_to_jsval(cx, name_js.handle_mut());
+        self.name.as_str().to_jsval(cx, name_js.handle_mut());
         set_dictionary_property(cx, object.handle(), c"name", name_js.handle())
             .expect("Failed to set name property of RsaHashedKeyAlgorithm");
 
         rooted!(&in(cx) let mut modulus_length_js = UndefinedValue());
         self.modulus_length
-            .safe_to_jsval(cx, modulus_length_js.handle_mut());
+            .to_jsval(cx, modulus_length_js.handle_mut());
         set_dictionary_property(
             cx,
             object.handle(),
@@ -3026,7 +3026,7 @@ impl ToJSValConvertible for RsaHashedKeyAlgorithm {
             public_exponent_js_object.handle_mut(),
         )
         .expect("Failed to convert publicExponent to Uint8Array");
-        public_exponent.safe_to_jsval(cx, public_exponent_js.handle_mut());
+        public_exponent.to_jsval(cx, public_exponent_js.handle_mut());
         set_dictionary_property(
             cx,
             object.handle(),
@@ -3039,7 +3039,7 @@ impl ToJSValConvertible for RsaHashedKeyAlgorithm {
         let hash = KeyAlgorithm {
             name: self.hash.name(),
         };
-        hash.safe_to_jsval(cx, hash_js.handle_mut());
+        hash.to_jsval(cx, hash_js.handle_mut());
         set_dictionary_property(cx, object.handle(), c"hash", hash_js.handle())
             .expect("Failed to set hash property of RsaHashedKeyAlgorithm");
 
@@ -3222,17 +3222,16 @@ pub(crate) struct EcKeyAlgorithm {
 
 impl ToJSValConvertible for EcKeyAlgorithm {
     #[expect(unsafe_code)]
-    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
+    fn to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
         rooted!(&in(cx) let mut object = unsafe { JS_NewObject(cx, ptr::null()) });
 
         rooted!(&in(cx) let mut name_js = UndefinedValue());
-        self.name.as_str().safe_to_jsval(cx, name_js.handle_mut());
+        self.name.as_str().to_jsval(cx, name_js.handle_mut());
         set_dictionary_property(cx, object.handle(), c"name", name_js.handle())
             .expect("Failed to set name property of EcKeyAlgorithm");
 
         rooted!(&in(cx) let mut named_curve_js = UndefinedValue());
-        self.named_curve
-            .safe_to_jsval(cx, named_curve_js.handle_mut());
+        self.named_curve.to_jsval(cx, named_curve_js.handle_mut());
         set_dictionary_property(cx, object.handle(), c"namedCurve", named_curve_js.handle())
             .expect("Failed to set namedCurve property of EcKeyAlgorithm");
 
@@ -3363,16 +3362,16 @@ pub(crate) struct AesKeyAlgorithm {
 
 impl ToJSValConvertible for AesKeyAlgorithm {
     #[expect(unsafe_code)]
-    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
+    fn to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
         rooted!(&in(cx) let mut object = unsafe { JS_NewObject(cx, ptr::null()) });
 
         rooted!(&in(cx) let mut name_js = UndefinedValue());
-        self.name.as_str().safe_to_jsval(cx, name_js.handle_mut());
+        self.name.as_str().to_jsval(cx, name_js.handle_mut());
         set_dictionary_property(cx, object.handle(), c"name", name_js.handle())
             .expect("Failed to set name property of AesKeyAlgorithm");
 
         rooted!(&in(cx) let mut length_js = UndefinedValue());
-        self.length.safe_to_jsval(cx, length_js.handle_mut());
+        self.length.to_jsval(cx, length_js.handle_mut());
         set_dictionary_property(cx, object.handle(), c"length", length_js.handle())
             .expect("Failed to set length property of AesKeyAlgorithm");
 
@@ -3564,11 +3563,11 @@ pub(crate) struct HmacKeyAlgorithm {
 
 impl ToJSValConvertible for HmacKeyAlgorithm {
     #[expect(unsafe_code)]
-    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
+    fn to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
         rooted!(&in(cx) let mut object = unsafe { JS_NewObject(cx, ptr::null()) });
 
         rooted!(&in(cx) let mut name_js = UndefinedValue());
-        self.name.as_str().safe_to_jsval(cx, name_js.handle_mut());
+        self.name.as_str().to_jsval(cx, name_js.handle_mut());
         set_dictionary_property(cx, object.handle(), c"name", name_js.handle())
             .expect("Failed to set name property of HmacKeyAlgorithm");
 
@@ -3576,12 +3575,12 @@ impl ToJSValConvertible for HmacKeyAlgorithm {
         let hash = KeyAlgorithm {
             name: self.hash.name(),
         };
-        hash.safe_to_jsval(cx, hash_js.handle_mut());
+        hash.to_jsval(cx, hash_js.handle_mut());
         set_dictionary_property(cx, object.handle(), c"hash", hash_js.handle())
             .expect("Failed to set hash property of HmacKeyAlgorithm");
 
         rooted!(&in(cx) let mut length_js = UndefinedValue());
-        self.length.safe_to_jsval(cx, length_js.handle_mut());
+        self.length.to_jsval(cx, length_js.handle_mut());
         set_dictionary_property(cx, object.handle(), c"length", length_js.handle())
             .expect("Failed to set length property of HmacKeyAlgorithm");
 
@@ -4016,16 +4015,16 @@ pub(crate) struct KmacKeyAlgorithm {
 
 impl ToJSValConvertible for KmacKeyAlgorithm {
     #[expect(unsafe_code)]
-    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
+    fn to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
         rooted!(&in(cx) let mut object = unsafe { JS_NewObject(cx, ptr::null()) });
 
         rooted!(&in(cx) let mut name_js = UndefinedValue());
-        self.name.as_str().safe_to_jsval(cx, name_js.handle_mut());
+        self.name.as_str().to_jsval(cx, name_js.handle_mut());
         set_dictionary_property(cx, object.handle(), c"name", name_js.handle())
             .expect("Failed to set name property of KmacKeyAlgorithm");
 
         rooted!(&in(cx) let mut length_js = UndefinedValue());
-        self.length.safe_to_jsval(cx, length_js.handle_mut());
+        self.length.to_jsval(cx, length_js.handle_mut());
         set_dictionary_property(cx, object.handle(), c"length", length_js.handle())
             .expect("Failed to set length property of KmacKeyAlgorithm");
 
@@ -4161,14 +4160,14 @@ struct EncapsulatedKey {
 
 impl ToJSValConvertible for EncapsulatedKey {
     #[expect(unsafe_code)]
-    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
+    fn to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
         rooted!(&in(cx) let mut object = unsafe { JS_NewObject(cx, ptr::null()) });
 
         rooted!(&in(cx) let mut shared_key_js = UndefinedValue());
         self.shared_key
             .as_ref()
             .map(|shared_key| shared_key.root())
-            .safe_to_jsval(cx, shared_key_js.handle_mut());
+            .to_jsval(cx, shared_key_js.handle_mut());
         set_dictionary_property(cx, object.handle(), c"sharedKey", shared_key_js.handle())
             .expect("Failed to set sharedKey property of EncapsulatedKey");
 
@@ -4184,7 +4183,7 @@ impl ToJSValConvertible for EncapsulatedKey {
                 )
                 .expect("Failed to convert ciphertext to ArrayBufferU8")
             })
-            .safe_to_jsval(cx, ciphertext_js.handle_mut());
+            .to_jsval(cx, ciphertext_js.handle_mut());
         set_dictionary_property(cx, object.handle(), c"ciphertext", ciphertext_js.handle())
             .expect("Failed to set ciphertext property of EncapsulatedKey");
 
@@ -4203,7 +4202,7 @@ struct EncapsulatedBits {
 
 impl ToJSValConvertible for EncapsulatedBits {
     #[expect(unsafe_code)]
-    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
+    fn to_jsval(&self, cx: &mut js::context::JSContext, mut rval: MutableHandleValue) {
         rooted!(&in(cx) let mut object = unsafe { JS_NewObject(cx, ptr::null()) });
 
         rooted!(&in(cx) let mut shared_key_js = UndefinedValue());
@@ -4218,7 +4217,7 @@ impl ToJSValConvertible for EncapsulatedBits {
                 )
                 .expect("Failed to convert shared_key to ArrayBufferU8")
             })
-            .safe_to_jsval(cx, shared_key_js.handle_mut());
+            .to_jsval(cx, shared_key_js.handle_mut());
         set_dictionary_property(cx, object.handle(), c"sharedKey", shared_key_js.handle())
             .expect("Failed to set sharedKey property of EncapsulatedBits");
 
@@ -4234,7 +4233,7 @@ impl ToJSValConvertible for EncapsulatedBits {
                 )
                 .expect("Failed to convert ciphertext to ArrayBufferU8")
             })
-            .safe_to_jsval(cx, ciphertext_js.handle_mut());
+            .to_jsval(cx, ciphertext_js.handle_mut());
         set_dictionary_property(cx, object.handle(), c"ciphertext", ciphertext_js.handle())
             .expect("Failed to set ciphertext property of EncapsulatedBits");
 
@@ -4362,14 +4361,14 @@ impl KeyAlgorithmAndDerivatives {
 }
 
 impl ToJSValConvertible for KeyAlgorithmAndDerivatives {
-    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, rval: MutableHandleValue) {
+    fn to_jsval(&self, cx: &mut js::context::JSContext, rval: MutableHandleValue) {
         match self {
-            KeyAlgorithmAndDerivatives::KeyAlgorithm(algo) => algo.safe_to_jsval(cx, rval),
-            KeyAlgorithmAndDerivatives::RsaHashedKeyAlgorithm(algo) => algo.safe_to_jsval(cx, rval),
-            KeyAlgorithmAndDerivatives::EcKeyAlgorithm(algo) => algo.safe_to_jsval(cx, rval),
-            KeyAlgorithmAndDerivatives::AesKeyAlgorithm(algo) => algo.safe_to_jsval(cx, rval),
-            KeyAlgorithmAndDerivatives::HmacKeyAlgorithm(algo) => algo.safe_to_jsval(cx, rval),
-            KeyAlgorithmAndDerivatives::KmacKeyAlgorithm(algo) => algo.safe_to_jsval(cx, rval),
+            KeyAlgorithmAndDerivatives::KeyAlgorithm(algo) => algo.to_jsval(cx, rval),
+            KeyAlgorithmAndDerivatives::RsaHashedKeyAlgorithm(algo) => algo.to_jsval(cx, rval),
+            KeyAlgorithmAndDerivatives::EcKeyAlgorithm(algo) => algo.to_jsval(cx, rval),
+            KeyAlgorithmAndDerivatives::AesKeyAlgorithm(algo) => algo.to_jsval(cx, rval),
+            KeyAlgorithmAndDerivatives::HmacKeyAlgorithm(algo) => algo.to_jsval(cx, rval),
+            KeyAlgorithmAndDerivatives::KmacKeyAlgorithm(algo) => algo.to_jsval(cx, rval),
         }
     }
 }
@@ -4537,7 +4536,7 @@ impl JsonWebKeyExt for JsonWebKey {
     /// bytes.
     fn stringify(&self, cx: &mut js::context::JSContext) -> Result<Zeroizing<DOMString>, Error> {
         rooted!(&in(cx) let mut data = UndefinedValue());
-        self.safe_to_jsval(cx, data.handle_mut());
+        self.to_jsval(cx, data.handle_mut());
         serialize_jsval_to_json_utf8(cx, data.handle()).map(Zeroizing::new)
     }
 
@@ -4769,7 +4768,7 @@ fn normalize_algorithm<Op: Operation>(
                 name: name.to_owned(),
             };
             rooted!(&in(cx) let mut algorithm_value = UndefinedValue());
-            algorithm.safe_to_jsval(cx, algorithm_value.handle_mut());
+            algorithm.to_jsval(cx, algorithm_value.handle_mut());
             let algorithm_object = RootedTraceableBox::new(Heap::default());
             algorithm_object.set(algorithm_value.to_object());
             normalize_algorithm::<Op>(cx, &AlgorithmIdentifier::Object(algorithm_object))

--- a/components/script/dom/webgl/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl/webgl2renderingcontext.rs
@@ -707,10 +707,10 @@ impl WebGL2RenderingContext {
         if pname == constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME {
             match fb.attachment(attachment) {
                 Some(Renderbuffer(rb)) => {
-                    rb.safe_to_jsval(cx, rval);
+                    rb.to_jsval(cx, rval);
                 },
                 Some(Texture(texture)) => {
-                    texture.safe_to_jsval(cx, rval);
+                    texture.to_jsval(cx, rval);
                 },
                 _ => rval.set(NullValue()),
             }
@@ -1051,11 +1051,11 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     fn GetParameter(&self, cx: &mut JSContext, parameter: u32, mut rval: MutableHandleValue) {
         match parameter {
             constants::VERSION => {
-                "WebGL 2.0".safe_to_jsval(cx, rval);
+                "WebGL 2.0".to_jsval(cx, rval);
                 return;
             },
             constants::SHADING_LANGUAGE_VERSION => {
-                "WebGL GLSL ES 3.00".safe_to_jsval(cx, rval);
+                "WebGL GLSL ES 3.00".to_jsval(cx, rval);
                 return;
             },
             constants::MAX_CLIENT_WAIT_TIMEOUT_WEBGL => {
@@ -1074,50 +1074,48 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
                 let idx = (self.base.textures().active_unit_enum() - constants::TEXTURE0) as usize;
                 assert!(idx < self.samplers.len());
                 let sampler = self.samplers[idx].get();
-                sampler.safe_to_jsval(cx, rval);
+                sampler.to_jsval(cx, rval);
                 return;
             },
             constants::COPY_READ_BUFFER_BINDING => {
-                self.bound_copy_read_buffer.get().safe_to_jsval(cx, rval);
+                self.bound_copy_read_buffer.get().to_jsval(cx, rval);
                 return;
             },
             constants::COPY_WRITE_BUFFER_BINDING => {
-                self.bound_copy_write_buffer.get().safe_to_jsval(cx, rval);
+                self.bound_copy_write_buffer.get().to_jsval(cx, rval);
                 return;
             },
             constants::PIXEL_PACK_BUFFER_BINDING => {
-                self.bound_pixel_pack_buffer.get().safe_to_jsval(cx, rval);
+                self.bound_pixel_pack_buffer.get().to_jsval(cx, rval);
                 return;
             },
             constants::PIXEL_UNPACK_BUFFER_BINDING => {
-                self.bound_pixel_unpack_buffer.get().safe_to_jsval(cx, rval);
+                self.bound_pixel_unpack_buffer.get().to_jsval(cx, rval);
                 return;
             },
             constants::TRANSFORM_FEEDBACK_BUFFER_BINDING => {
                 self.bound_transform_feedback_buffer
                     .get()
-                    .safe_to_jsval(cx, rval);
+                    .to_jsval(cx, rval);
                 return;
             },
             constants::UNIFORM_BUFFER_BINDING => {
-                self.bound_uniform_buffer.get().safe_to_jsval(cx, rval);
+                self.bound_uniform_buffer.get().to_jsval(cx, rval);
                 return;
             },
             constants::TRANSFORM_FEEDBACK_BINDING => {
-                self.current_transform_feedback
-                    .get()
-                    .safe_to_jsval(cx, rval);
+                self.current_transform_feedback.get().to_jsval(cx, rval);
                 return;
             },
             constants::ELEMENT_ARRAY_BUFFER_BINDING => {
                 let buffer = self.current_vao(cx).element_array_buffer().get();
-                buffer.safe_to_jsval(cx, rval);
+                buffer.to_jsval(cx, rval);
                 return;
             },
             constants::VERTEX_ARRAY_BINDING => {
                 let vao = self.current_vao(cx);
                 let vao = vao.id().map(|_| &*vao);
-                vao.safe_to_jsval(cx, rval);
+                vao.to_jsval(cx, rval);
                 return;
             },
             // NOTE: DRAW_FRAMEBUFFER_BINDING is the same as FRAMEBUFFER_BINDING, handled on the WebGL1 side
@@ -1125,7 +1123,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
                 self.base
                     .get_read_framebuffer_slot()
                     .get()
-                    .safe_to_jsval(cx, rval);
+                    .to_jsval(cx, rval);
                 return;
             },
             constants::READ_BUFFER => {
@@ -2111,7 +2109,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
 
         match target {
             constants::TRANSFORM_FEEDBACK_BUFFER_BINDING | constants::UNIFORM_BUFFER_BINDING => {
-                binding.buffer.get().safe_to_jsval(cx, retval)
+                binding.buffer.get().to_jsval(cx, retval)
             },
             constants::TRANSFORM_FEEDBACK_BUFFER_START | constants::UNIFORM_BUFFER_START => {
                 retval.set(Int32Value(binding.start.get() as _))
@@ -4676,11 +4674,11 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
             constants::UNIFORM_OFFSET |
             constants::UNIFORM_ARRAY_STRIDE |
             constants::UNIFORM_MATRIX_STRIDE => {
-                values.safe_to_jsval(cx, rval);
+                values.to_jsval(cx, rval);
             },
             constants::UNIFORM_IS_ROW_MAJOR => {
                 let values = values.iter().map(|&v| v != 0).collect::<Vec<_>>();
-                values.safe_to_jsval(cx, rval);
+                values.to_jsval(cx, rval);
             },
             _ => unreachable!(),
         }

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -2192,24 +2192,24 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
 
         match parameter {
             constants::ARRAY_BUFFER_BINDING => {
-                self.bound_buffer_array.get().safe_to_jsval(cx, retval);
+                self.bound_buffer_array.get().to_jsval(cx, retval);
                 return;
             },
             constants::CURRENT_PROGRAM => {
-                self.current_program.get().safe_to_jsval(cx, retval);
+                self.current_program.get().to_jsval(cx, retval);
                 return;
             },
             constants::ELEMENT_ARRAY_BUFFER_BINDING => {
                 let buffer = self.current_vao(cx).element_array_buffer().get();
-                buffer.safe_to_jsval(cx, retval);
+                buffer.to_jsval(cx, retval);
                 return;
             },
             constants::FRAMEBUFFER_BINDING => {
-                self.bound_draw_framebuffer.get().safe_to_jsval(cx, retval);
+                self.bound_draw_framebuffer.get().to_jsval(cx, retval);
                 return;
             },
             constants::RENDERBUFFER_BINDING => {
-                self.bound_renderbuffer.get().safe_to_jsval(cx, retval);
+                self.bound_renderbuffer.get().to_jsval(cx, retval);
                 return;
             },
             constants::TEXTURE_BINDING_2D => {
@@ -2218,7 +2218,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                     .active_texture_slot(constants::TEXTURE_2D, self.webgl_version())
                     .unwrap()
                     .get();
-                texture.safe_to_jsval(cx, retval);
+                texture.to_jsval(cx, retval);
                 return;
             },
             WebGL2RenderingContextConstants::TEXTURE_BINDING_2D_ARRAY => {
@@ -2230,7 +2230,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                     )
                     .unwrap()
                     .get();
-                texture.safe_to_jsval(cx, retval);
+                texture.to_jsval(cx, retval);
                 return;
             },
             WebGL2RenderingContextConstants::TEXTURE_BINDING_3D => {
@@ -2242,7 +2242,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                     )
                     .unwrap()
                     .get();
-                texture.safe_to_jsval(cx, retval);
+                texture.to_jsval(cx, retval);
                 return;
             },
             constants::TEXTURE_BINDING_CUBE_MAP => {
@@ -2251,12 +2251,12 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                     .active_texture_slot(constants::TEXTURE_CUBE_MAP, self.webgl_version())
                     .unwrap()
                     .get();
-                texture.safe_to_jsval(cx, retval);
+                texture.to_jsval(cx, retval);
                 return;
             },
             OESVertexArrayObjectConstants::VERTEX_ARRAY_BINDING_OES => {
                 let vao = self.current_vao.get().filter(|vao| vao.id().is_some());
-                vao.safe_to_jsval(cx, retval);
+                vao.to_jsval(cx, retval);
                 return;
             },
             // In readPixels we currently support RGBA/UBYTE only.  If
@@ -2286,15 +2286,15 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                 return retval.set(ObjectValue(rval.get()));
             },
             constants::VERSION => {
-                "WebGL 1.0".safe_to_jsval(cx, retval);
+                "WebGL 1.0".to_jsval(cx, retval);
                 return;
             },
             constants::RENDERER | constants::VENDOR => {
-                "Mozilla/Servo".safe_to_jsval(cx, retval);
+                "Mozilla/Servo".to_jsval(cx, retval);
                 return;
             },
             constants::SHADING_LANGUAGE_VERSION => {
-                "WebGL GLSL ES 1.0".safe_to_jsval(cx, retval);
+                "WebGL GLSL ES 1.0".to_jsval(cx, retval);
                 return;
             },
             constants::UNPACK_FLIP_Y_WEBGL => {
@@ -2375,7 +2375,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             Parameter::Bool4(param) => {
                 let (sender, receiver) = webgl_channel().unwrap();
                 self.send_command(WebGLCommand::GetParameterBool4(param, sender));
-                receiver.recv().unwrap().safe_to_jsval(cx, retval);
+                receiver.recv().unwrap().to_jsval(cx, retval);
             },
             Parameter::Int(param) => {
                 let (sender, receiver) = webgl_channel().unwrap();
@@ -3441,11 +3441,11 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             if let Some(webgl_attachment) = fb.attachment(attachment) {
                 match webgl_attachment {
                     WebGLFramebufferAttachmentRoot::Renderbuffer(rb) => {
-                        rb.safe_to_jsval(cx, retval);
+                        rb.to_jsval(cx, retval);
                         return;
                     },
                     WebGLFramebufferAttachmentRoot::Texture(texture) => {
-                        texture.safe_to_jsval(cx, retval);
+                        texture.to_jsval(cx, retval);
                         return;
                     },
                 }
@@ -3724,7 +3724,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                 constants::VERTEX_ATTRIB_ARRAY_STRIDE => retval.set(Int32Value(data.stride as i32)),
                 constants::VERTEX_ATTRIB_ARRAY_BUFFER_BINDING => {
                     if let Some(buffer) = data.buffer() {
-                        buffer.safe_to_jsval(cx, retval.reborrow());
+                        buffer.to_jsval(cx, retval.reborrow());
                     } else {
                         retval.set(NullValue());
                     }
@@ -4348,13 +4348,13 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                 WebGLCommand::GetUniformBool,
             ))),
             constants::BOOL_VEC2 => {
-                uniform_get(triple, WebGLCommand::GetUniformBool2).safe_to_jsval(cx, rval)
+                uniform_get(triple, WebGLCommand::GetUniformBool2).to_jsval(cx, rval)
             },
             constants::BOOL_VEC3 => {
-                uniform_get(triple, WebGLCommand::GetUniformBool3).safe_to_jsval(cx, rval)
+                uniform_get(triple, WebGLCommand::GetUniformBool3).to_jsval(cx, rval)
             },
             constants::BOOL_VEC4 => {
-                uniform_get(triple, WebGLCommand::GetUniformBool4).safe_to_jsval(cx, rval)
+                uniform_get(triple, WebGLCommand::GetUniformBool4).to_jsval(cx, rval)
             },
             constants::INT |
             constants::SAMPLER_2D |

--- a/components/script/dom/webrtc/rtcdatachannel.rs
+++ b/components/script/dom/webrtc/rtcdatachannel.rs
@@ -200,7 +200,7 @@ impl RTCDataChannel {
 
         match channel_message {
             DataChannelMessage::Text(text) => {
-                text.safe_to_jsval(cx, message.handle_mut());
+                text.to_jsval(cx, message.handle_mut());
             },
             DataChannelMessage::Binary(data) => {
                 let binary_type = self.binary_type.borrow();
@@ -211,7 +211,7 @@ impl RTCDataChannel {
                             &global,
                             BlobImpl::new_from_bytes(data, "".to_owned()),
                         );
-                        blob.safe_to_jsval(cx, message.handle_mut());
+                        blob.to_jsval(cx, message.handle_mut());
                     },
                     "arraybuffer" => {
                         rooted!(&in(cx) let mut array_buffer = ptr::null_mut::<JSObject>());
@@ -225,7 +225,7 @@ impl RTCDataChannel {
                                 .is_ok()
                             )
                         };
-                        (*array_buffer).safe_to_jsval(cx, message.handle_mut());
+                        (*array_buffer).to_jsval(cx, message.handle_mut());
                     },
                     _ => unreachable!(),
                 )

--- a/components/script/dom/webxr/xrinputsource.rs
+++ b/components/script/dom/webxr/xrinputsource.rs
@@ -83,10 +83,7 @@ impl XRInputSource {
         let mut realm = enter_auto_realm(cx, window);
         let cx = &mut realm.current_realm();
         rooted!(&in(cx) let mut profiles = UndefinedValue());
-        source
-            .info
-            .profiles
-            .safe_to_jsval(cx, profiles.handle_mut());
+        source.info.profiles.to_jsval(cx, profiles.handle_mut());
         source.profiles.set(profiles.get());
         source
     }

--- a/components/script/dom/webxr/xrsystem.rs
+++ b/components/script/dom/webxr/xrsystem.rs
@@ -191,7 +191,7 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
         if let Some(ref r) = init.requiredFeatures {
             for feature in r {
                 if let Ok(ConversionResult::Success(s)) =
-                    String::safe_from_jsval(realm, feature.handle(), ())
+                    String::from_jsval(realm, feature.handle(), ())
                 {
                     required_features.push(s)
                 } else {
@@ -208,7 +208,7 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
         if let Some(ref o) = init.optionalFeatures {
             for feature in o {
                 if let Ok(ConversionResult::Success(s)) =
-                    String::safe_from_jsval(realm, feature.handle(), ())
+                    String::from_jsval(realm, feature.handle(), ())
                 {
                     optional_features.push(s)
                 } else {

--- a/components/script/dom/webxr/xrviewerpose.rs
+++ b/components/script/dom/webxr/xrviewerpose.rs
@@ -182,7 +182,7 @@ impl XRViewerPose {
         );
 
         rooted!(&in(cx) let mut jsval = UndefinedValue());
-        views.safe_to_jsval(cx, jsval.handle_mut());
+        views.to_jsval(cx, jsval.handle_mut());
         pose.views.set(jsval.get());
 
         pose

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -2290,7 +2290,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     /// <https://dom.spec.whatwg.org/#dom-window-event>
     fn Event(&self, cx: &mut JSContext, rval: MutableHandleValue) {
         if let Some(ref event) = *self.current_event.borrow() {
-            event.reflector().get_jsobject().safe_to_jsval(cx, rval);
+            event.reflector().get_jsobject().to_jsval(cx, rval);
         }
     }
 

--- a/components/script/dom/window/windowproxy.rs
+++ b/components/script/dom/window/windowproxy.rs
@@ -488,7 +488,7 @@ impl WindowProxy {
         if opener_proxy.is_browsing_context_discarded() {
             return retval.set(NullValue());
         }
-        opener_proxy.safe_to_jsval(cx, retval);
+        opener_proxy.to_jsval(cx, retval);
     }
 
     // https://html.spec.whatwg.org/multipage/#window-open-steps
@@ -1236,7 +1236,7 @@ unsafe extern "C" fn get_own_property_descriptor(
     let desc = unsafe { MutableHandle::from_raw(desc) };
     if let Some((window, attrs)) = window {
         rooted!(&in(cx) let mut val = UndefinedValue());
-        window.safe_to_jsval(cx, val.handle_mut());
+        window.to_jsval(cx, val.handle_mut());
         set_property_descriptor(desc, val.handle(), attrs, unsafe { &mut *is_none });
         return true;
     }
@@ -1320,7 +1320,7 @@ unsafe extern "C" fn get(
     let window = unsafe { GetSubframeWindowProxy(cx, proxy, id) };
     let vp = unsafe { MutableHandle::from_raw(vp) };
     if let Some((window, _attrs)) = window {
-        window.safe_to_jsval(cx, vp);
+        window.to_jsval(cx, vp);
         return true;
     }
 

--- a/components/script/dom/workers/sharedworkerglobalscope.rs
+++ b/components/script/dom/workers/sharedworkerglobalscope.rs
@@ -674,9 +674,7 @@ impl SharedWorkerGlobalScope {
                 let inside_port = inside_port.root();
 
                 rooted!(&in(cx) let mut data = UndefinedValue());
-                DOMString::new().safe_to_jsval(cx,
-                    data.handle_mut(),
-                );
+                DOMString::new().to_jsval(cx, data.handle_mut());
 
                 let source = WindowProxyOrMessagePortOrServiceWorker::MessagePort(
                     inside_port.clone(),

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -1174,7 +1174,7 @@ impl WorkerGlobalScope {
         rooted!(&in(cx) let mut wrapped_global: Value);
         debugger_global
             .reflector()
-            .safe_to_jsval(cx, wrapped_global.handle_mut());
+            .to_jsval(cx, wrapped_global.handle_mut());
         self.debugger_global.set(*wrapped_global);
     }
 

--- a/components/script/dom/xmlhttprequest/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest/xmlhttprequest.rs
@@ -966,10 +966,10 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
                 if ready_state == XMLHttpRequestState::Done ||
                     ready_state == XMLHttpRequestState::Loading
                 {
-                    self.text_response().safe_to_jsval(cx, rval);
+                    self.text_response().to_jsval(cx, rval);
                 } else {
                     // Step 1
-                    "".safe_to_jsval(cx, rval);
+                    "".to_jsval(cx, rval);
                 }
             },
             // Step 1
@@ -977,13 +977,11 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
                 rval.set(NullValue());
             },
             // Step 2
-            XMLHttpRequestResponseType::Document => {
-                self.document_response(cx).safe_to_jsval(cx, rval)
-            },
+            XMLHttpRequestResponseType::Document => self.document_response(cx).to_jsval(cx, rval),
             XMLHttpRequestResponseType::Json => self.json_response(cx, rval),
-            XMLHttpRequestResponseType::Blob => self.blob_response(cx).safe_to_jsval(cx, rval),
+            XMLHttpRequestResponseType::Blob => self.blob_response(cx).to_jsval(cx, rval),
             XMLHttpRequestResponseType::Arraybuffer => match self.arraybuffer_response(cx) {
-                Some(array_buffer) => array_buffer.safe_to_jsval(cx, rval),
+                Some(array_buffer) => array_buffer.to_jsval(cx, rval),
                 None => rval.set(NullValue()),
             },
         }

--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -3953,7 +3953,7 @@ impl ScriptThread {
             return false;
         }
         let Ok(ConversionResult::Success(body)) =
-            DOMString::safe_from_jsval(cx, return_value.handle(), StringificationBehavior::Empty)
+            DOMString::from_jsval(cx, return_value.handle(), StringificationBehavior::Empty)
         else {
             return false;
         };

--- a/components/script/event_loop/webdriver_handlers.rs
+++ b/components/script/event_loop/webdriver_handlers.rs
@@ -406,7 +406,7 @@ fn jsval_to_webdriver_inner(
         let string = unsafe { jsstr_to_string(cx, string) };
         Ok(JSValue::String(string))
     } else if val.get().is_object() {
-        rooted!(&in(cx) let object = match FromJSValConvertible::safe_from_jsval(cx, val, ()).unwrap() {
+        rooted!(&in(cx) let object = match FromJSValConvertible::from_jsval(cx, val, ()).unwrap() {
             ConversionResult::Success(object) => object,
             _ => unreachable!(),
         });

--- a/components/script/modules/script_module.rs
+++ b/components/script/modules/script_module.rs
@@ -1008,7 +1008,7 @@ unsafe extern "C" fn import_meta_resolve(cx: *mut RawJSContext, argc: u32, vp: *
         Ok(url) => {
             // Step 4.3. Return the serialization of url.
             url.as_str()
-                .safe_to_jsval(cx, unsafe { MutableHandleValue::from_raw(args.rval()) });
+                .to_jsval(cx, unsafe { MutableHandleValue::from_raw(args.rval()) });
             true
         },
         Err(error) => {

--- a/components/script/window_named_properties.rs
+++ b/components/script/window_named_properties.rs
@@ -93,7 +93,7 @@ unsafe extern "C" fn get_own_property_descriptor(
             SymbolId(unsafe { GetWellKnownSymbol(&cx, SymbolCode::toStringTag) }).asBits_
         {
             rooted!(&in(cx) let mut rval = UndefinedValue());
-            "WindowProperties".safe_to_jsval(&mut cx, rval.handle_mut());
+            "WindowProperties".to_jsval(&mut cx, rval.handle_mut());
             set_property_descriptor(
                 unsafe { RustMutableHandle::from_raw(desc) },
                 rval.handle(),
@@ -139,7 +139,7 @@ unsafe extern "C" fn get_own_property_descriptor(
         .expect("global is not a window");
     if let Some(obj) = window.NamedGetter(&mut cx, s.into()) {
         rooted!(&in(cx) let mut rval = UndefinedValue());
-        obj.safe_to_jsval(&mut cx, rval.handle_mut());
+        obj.to_jsval(&mut cx, rval.handle_mut());
         set_property_descriptor(
             unsafe { RustMutableHandle::from_raw(desc) },
             rval.handle(),

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -484,7 +484,7 @@ class CGMethodCall(CGThing):
             if requiredArgs > 0:
                 code = (
                     f"if argc < {requiredArgs} {{\n"
-                    f"    throw_type_error_safe(cx, c\"Not enough arguments to {methodName}.\");\n"
+                    f"    throw_type_error(cx, c\"Not enough arguments to {methodName}.\");\n"
                     "    return false;\n"
                     "}")
                 self.cgRoot.prepend(
@@ -663,7 +663,7 @@ class CGMethodCall(CGThing):
             else:
                 # Just throw; we have no idea what we're supposed to
                 # do with this.
-                caseBody.append(CGGeneric("throw_type_error_safe(cx, c\"Could not convert JavaScript argument\");\n"
+                caseBody.append(CGGeneric("throw_type_error(cx, c\"Could not convert JavaScript argument\");\n"
                                           "return false;"))
 
             argCountCases.append(CGCase(str(argCount),
@@ -675,7 +675,7 @@ class CGMethodCall(CGThing):
         overloadCGThings.append(
             CGSwitch("argcount",
                      argCountCases,
-                     CGGeneric(f"throw_type_error_safe(cx, c\"Not enough arguments to {methodName}.\");\n"
+                     CGGeneric(f"throw_type_error(cx, c\"Not enough arguments to {methodName}.\");\n"
                                "return false;")))
         # XXXjdm Avoid unreachable statement warnings
         # overloadCGThings.append(
@@ -823,7 +823,7 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
         exceptionCode = "return false;\n"
 
     if failureCode is None:
-        failOrPropagate = f"throw_type_error_safe(cx, error.as_ref());\n{exceptionCode}"
+        failOrPropagate = f"throw_type_error(cx, error.as_ref());\n{exceptionCode}"
     else:
         failOrPropagate = failureCode
 
@@ -837,14 +837,14 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
         return CGWrapper(
             CGGeneric(
                 failureCode
-                or (f'throw_type_error_safe(cx, c"{firstCap(sourceDescription)} is not an object.");\n'
+                or (f'throw_type_error(cx, c"{firstCap(sourceDescription)} is not an object.");\n'
                     f'{exceptionCode}')),
             post="\n")
 
     def onFailureNotCallable(failureCode: str | None) -> CGGeneric:
         return CGGeneric(
             failureCode
-            or (f'throw_type_error_safe(cx, c"{firstCap(sourceDescription)} is not callable.");\n'
+            or (f'throw_type_error(cx, c"{firstCap(sourceDescription)} is not callable.");\n'
                 f'{exceptionCode}'))
 
     # A helper function for handling default values.
@@ -886,7 +886,7 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
 
     # A helper function for types that implement FromJSValConvertible trait
     def fromJSValTemplate(config: str, errorHandler: str, exceptionCode: str) -> str:
-        return f"""match FromJSValConvertible::safe_from_jsval(cx, ${{val}}, {config}) {{
+        return f"""match FromJSValConvertible::from_jsval(cx, ${{val}}, {config}) {{
     Ok(ConversionResult::Success(value)) => value,
     Ok(ConversionResult::Failure(error)) => {{
         {errorHandler}
@@ -1025,7 +1025,7 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
 
         if failureCode is None:
             unwrapFailureCode = (
-                f'throw_type_error_safe(cx, c"{sourceDescription} does not '
+                f'throw_type_error(cx, c"{sourceDescription} does not '
                 f'implement interface {descriptor.interface.identifier.name}.");\n'
                 f'{exceptionCode}')
         else:
@@ -1058,7 +1058,7 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
     if is_typed_array(type):
         if failureCode is None:
             unwrapFailureCode = (
-                f'throw_type_error_safe(cx, c"{sourceDescription} is not a typed array.");\n'
+                f'throw_type_error(cx, c"{sourceDescription} is not a typed array.");\n'
                 f'{exceptionCode}'
             )
         else:
@@ -1185,7 +1185,7 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
         # pyrefly: ignore  # missing-attribute
         enum = type.inner.identifier.name
         if invalidEnumValueFatal:
-            handleInvalidEnumValueCode = failureCode or f"throw_type_error_safe(cx, error.as_ref()); {exceptionCode}"
+            handleInvalidEnumValueCode = failureCode or f"throw_type_error(cx, error.as_ref()); {exceptionCode}"
         else:
             handleInvalidEnumValueCode = "return true;"
 
@@ -1516,7 +1516,7 @@ def wrapForType(jsvalRef: str, result: str = 'result', successCode: str = 'true'
       * 'successCode': the code to run once we have done the conversion.
       * 'pre': code to run before the conversion if rooting is necessary
     """
-    wrap = f"{pre}\n({result}).safe_to_jsval(cx, {jsvalRef});"
+    wrap = f"{pre}\n({result}).to_jsval(cx, {jsvalRef});"
     if successCode:
         wrap += f"\n{successCode}"
     return wrap
@@ -4880,7 +4880,7 @@ class CGStaticSetter(CGAbstractStaticBindingMethod):
         checkForArg = CGGeneric(
             "let args = CallArgs::from_vp(vp, argc);\n"
             "if argc == 0 {\n"
-            f'    throw_type_error_safe(cx, c"Not enough arguments to {self.attr.identifier.name} setter.");\n'
+            f'    throw_type_error(cx, c"Not enough arguments to {self.attr.identifier.name} setter.");\n'
             "    return false;\n"
             "}")
         call = CGSetterCall(["&global"], self.attr.type, nativeName, self.descriptor,
@@ -4911,7 +4911,7 @@ if !JS_GetProperty(cx, HandleObject::from_raw(obj), {str_to_cstr_ptr(attrName)},
     return false;
 }}
 if !v.is_object() {{
-    throw_type_error_safe(cx, c"Value.{attrName} is not an object.");
+    throw_type_error(cx, c"Value.{attrName} is not an object.");
     return false;
 }}
 rooted!(&in(cx) let target_obj = v.to_object());
@@ -5431,15 +5431,15 @@ impl std::str::FromStr for super::{ident} {{
 }}
 
 impl ToJSValConvertible for super::{ident} {{
-    fn safe_to_jsval(&self, cx: &mut JSContext, rval: MutableHandleValue) {{
-        pairs[*self as usize].0.safe_to_jsval(cx, rval);
+    fn to_jsval(&self, cx: &mut JSContext, rval: MutableHandleValue) {{
+        pairs[*self as usize].0.to_jsval(cx, rval);
     }}
 }}
 
 impl FromJSValConvertible for super::{ident} {{
     type Config = ();
 
-    fn safe_from_jsval(cx: &mut JSContext, value: HandleValue, _option: ())
+    fn from_jsval(cx: &mut JSContext, value: HandleValue, _option: ())
                          -> Result<ConversionResult<super::{ident}>, ()> {{
         match find_enum_value(cx, value, pairs) {{
             Err(_) => Err(()),
@@ -5630,7 +5630,7 @@ impl{self.generic} Clone for {self.type}{self.genericSuffix} {{
             for (v, wrapper) in templateVars
         ]
         enumConversions = [
-            f"            {self.type}::{v['name']}(ref inner) => inner.safe_to_jsval(cx, rval),"
+            f"            {self.type}::{v['name']}(ref inner) => inner.to_jsval(cx, rval),"
             for (v, _) in templateVars
         ]
         joinedEnumValues = "\n".join(enumValues)
@@ -5644,7 +5644,7 @@ pub enum {self.type}{self.generic} {{
 }}
 
 impl{self.generic} ToJSValConvertible for {self.type}{self.genericSuffix} {{
-    fn safe_to_jsval(&self, cx: &mut JSContext, rval: MutableHandleValue) {{
+    fn to_jsval(&self, cx: &mut JSContext, rval: MutableHandleValue) {{
         match *self {{
 {joinedEnumConversions}
         }}
@@ -5817,7 +5817,7 @@ class CGUnionConversionStruct(CGThing):
         generic, genericSuffix = genericsForType(self.type)
         method = CGWrapper(
             CGIndenter(CGList(conversions, "\n\n")),
-            pre="fn safe_from_jsval(cx: &mut JSContext, value: HandleValue, _option: ())\n"
+            pre="fn from_jsval(cx: &mut JSContext, value: HandleValue, _option: ())\n"
                 f"                     -> Result<ConversionResult<{self.type}{genericSuffix}>, ()> {{\n",
             post="\n}")
         return CGWrapper(
@@ -6342,7 +6342,7 @@ class CGProxyNamedDeleter(CGProxyNamedOperation):
                 f'    let {argName} = match jsid_to_string(cx, id) {{\n'
                 "        Some(val) => val,\n"
                 "        None => {\n"
-                "            throw_type_error_safe(cx, c\"Not a string-convertible JSID\");\n"
+                "            throw_type_error(cx, c\"Not a string-convertible JSID\");\n"
                 "            return false;\n"
                 "        }\n"
                 "    };\n"
@@ -7734,7 +7734,7 @@ impl{self.generic} Clone for {self.makeClassName(self.dictionary)}{self.genericS
                 f"    match {self.makeModuleName(d.parent)}::{self.makeClassName(d.parent)}::new(cx, val)? {{\n"
                 "        ConversionResult::Success(v) => v,\n"
                 "        ConversionResult::Failure(error) => {\n"
-                "            throw_type_error_safe(cx, error.as_ref());\n"
+                "            throw_type_error(cx, error.as_ref());\n"
                 "            return Err(());\n"
                 "        }\n"
                 "    }\n"
@@ -7752,7 +7752,7 @@ impl{self.generic} Clone for {self.makeClassName(self.dictionary)}{self.genericS
         def varInsert(varName: str, dictionaryName: str) -> CGThing:
             insertion = (
                 f"rooted!(&in(cx) let mut {varName}_js = UndefinedValue());\n"
-                f"{varName}.safe_to_jsval(cx, {varName}_js.handle_mut());\n"
+                f"{varName}.to_jsval(cx, {varName}_js.handle_mut());\n"
                 f'set_dictionary_property(cx, obj.handle(), c"{dictionaryName}", {varName}_js.handle()).unwrap();')
             return CGGeneric(insertion)
 
@@ -7807,7 +7807,7 @@ impl{self.generic} Clone for {self.makeClassName(self.dictionary)}{self.genericS
             "\n"
             f"impl{self.generic} FromJSValConvertible for {actualType} {{\n"
             "    type Config = ();\n"
-            "    fn safe_from_jsval(cx: &mut JSContext, value: HandleValue, _option: ())\n"
+            "    fn from_jsval(cx: &mut JSContext, value: HandleValue, _option: ())\n"
             f"                         -> Result<ConversionResult<{actualType}>, ()> {{\n"
             f"        {selfName}::new(cx, value)\n"
             "    }\n"
@@ -7820,7 +7820,7 @@ impl{self.generic} Clone for {self.makeClassName(self.dictionary)}{self.genericS
             "}\n"
             "\n"
             f"impl{self.generic} ToJSValConvertible for {selfName}{self.genericSuffix} {{\n"
-            "    fn safe_to_jsval(&self, cx: &mut JSContext, mut rval: MutableHandleValue) {\n"
+            "    fn to_jsval(&self, cx: &mut JSContext, mut rval: MutableHandleValue) {\n"
             "        rooted!(&in(cx) let mut obj = unsafe { JS_NewObject(cx, ptr::null()) });\n"
             "        self.to_jsobject(cx, obj.handle_mut());\n"
             "        rval.set(ObjectOrNullValue(obj.get()))\n"
@@ -7867,7 +7867,7 @@ impl{self.generic} Clone for {self.makeClassName(self.dictionary)}{self.genericS
         assert (member.defaultValue is None) == (default is None)
         if not member.optional:
             assert default is None
-            default = (f'throw_type_error_safe(cx, c"Missing required member \\"{member.identifier.name}\\".");\n'
+            default = (f'throw_type_error(cx, c"Missing required member \\"{member.identifier.name}\\".");\n'
                        "return Err(());")
         elif not default:
             default = "None"
@@ -8635,8 +8635,8 @@ impl<D: DomTypes> CallbackContainer<D> for {type} {{
 }}
 
 impl<D: DomTypes> ToJSValConvertible for {type} {{
-    fn safe_to_jsval(&self, cx: &mut JSContext, rval: MutableHandleValue) {{
-        self.callback().safe_to_jsval(cx, rval);
+    fn to_jsval(&self, cx: &mut JSContext, rval: MutableHandleValue) {{
+        self.callback().to_jsval(cx, rval);
     }}
 }}
 """)
@@ -9051,7 +9051,7 @@ class CGIterableMethodGenerator(CGGeneric):
             CGGeneric.__init__(self, fill(
                 """
                 if !IsCallable(arg0) {
-                  throw_type_error_safe(cx, c"Argument 1 of ${ifaceName}.forEach is not callable.");
+                  throw_type_error(cx, c"Argument 1 of ${ifaceName}.forEach is not callable.");
                   return false;
                 }
                 rooted!(&in(cx) let arg0 = ObjectValue(arg0));
@@ -9072,8 +9072,8 @@ class CGIterableMethodGenerator(CGGeneric):
                 // https://heycam.github.io/webidl/#es-forEach
                 let mut i = 0;
                 while i < (*this).get_iterable_length(cx) {
-                  (*this).get_value_at_index(cx, i).safe_to_jsval(cx, call_arg1.handle_mut());
-                  (*this).get_key_at_index(cx, i).safe_to_jsval(cx, call_arg2.handle_mut());
+                  (*this).get_value_at_index(cx, i).to_jsval(cx, call_arg1.handle_mut());
+                  (*this).get_key_at_index(cx, i).to_jsval(cx, call_arg2.handle_mut());
                   call_args.set_index(0, call_arg1.handle().get());
                   call_args.set_index(1, call_arg2.handle().get());
                   let call_args_handle = HandleValueArray::from(&call_args);

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -8,7 +8,7 @@ use js::context::JSContext;
 use js::conversions::{
     ConversionResult, FromJSValConvertible, ToJSValConvertible, jsstr_to_string,
 };
-use js::error::throw_type_error_safe;
+use js::error::throw_type_error;
 use js::glue::{
     GetProxyHandlerExtra, GetProxyReservedSlot, IsProxyHandlerFamily, IsWrapper, JS_GetReservedSlot,
 };
@@ -51,8 +51,8 @@ pub trait DerivedFrom<T: Castable>: Castable {}
 
 // http://heycam.github.io/webidl/#es-USVString
 impl ToJSValConvertible for USVString {
-    fn safe_to_jsval(&self, cx: &mut JSContext, rval: MutableHandleValue) {
-        self.0.safe_to_jsval(cx, rval);
+    fn to_jsval(&self, cx: &mut JSContext, rval: MutableHandleValue) {
+        self.0.to_jsval(cx, rval);
     }
 }
 
@@ -69,7 +69,7 @@ pub enum StringificationBehavior {
 impl FromJSValConvertible for DOMString {
     type Config = StringificationBehavior;
 
-    fn safe_from_jsval(
+    fn from_jsval(
         cx: &mut JSContext,
         value: HandleValue,
         null_behavior: StringificationBehavior,
@@ -89,7 +89,7 @@ impl FromJSValConvertible for DOMString {
 impl FromJSValConvertible for USVString {
     type Config = ();
 
-    fn safe_from_jsval(
+    fn from_jsval(
         cx: &mut JSContext,
         value: HandleValue,
         _: (),
@@ -108,7 +108,7 @@ impl FromJSValConvertible for USVString {
 
 // http://heycam.github.io/webidl/#es-ByteString
 impl ToJSValConvertible for ByteString {
-    fn safe_to_jsval(&self, cx: &mut JSContext, mut rval: MutableHandleValue) {
+    fn to_jsval(&self, cx: &mut JSContext, mut rval: MutableHandleValue) {
         let jsstr = unsafe {
             JS_NewStringCopyN(
                 cx,
@@ -127,7 +127,7 @@ impl ToJSValConvertible for ByteString {
 impl FromJSValConvertible for ByteString {
     type Config = ();
 
-    fn safe_from_jsval(
+    fn from_jsval(
         cx: &mut JSContext,
         value: HandleValue,
         _option: (),
@@ -156,7 +156,7 @@ impl FromJSValConvertible for ByteString {
             let char_vec = slice::from_raw_parts(chars, length);
 
             if char_vec.iter().any(|&c| c > 0xFF) {
-                throw_type_error_safe(cx, c"Invalid ByteString");
+                throw_type_error(cx, c"Invalid ByteString");
                 Err(())
             } else {
                 Ok(ConversionResult::Success(ByteString::new(
@@ -168,7 +168,7 @@ impl FromJSValConvertible for ByteString {
 }
 
 impl<T> ToJSValConvertible for Reflector<T> {
-    fn safe_to_jsval(&self, cx: &mut JSContext, mut rval: MutableHandleValue) {
+    fn to_jsval(&self, cx: &mut JSContext, mut rval: MutableHandleValue) {
         let obj = self.get_jsobject().get();
         assert!(!obj.is_null());
         rval.set(ObjectValue(obj));
@@ -179,7 +179,7 @@ impl<T> ToJSValConvertible for Reflector<T> {
 impl<T: DomObject + IDLInterface> FromJSValConvertible for DomRoot<T> {
     type Config = ();
 
-    fn safe_from_jsval(
+    fn from_jsval(
         cx: &mut JSContext,
         value: HandleValue,
         _config: Self::Config,
@@ -192,8 +192,8 @@ impl<T: DomObject + IDLInterface> FromJSValConvertible for DomRoot<T> {
 }
 
 impl<T: DomObject> ToJSValConvertible for DomRoot<T> {
-    fn safe_to_jsval(&self, cx: &mut JSContext, rval: MutableHandleValue) {
-        self.reflector().safe_to_jsval(cx, rval);
+    fn to_jsval(&self, cx: &mut JSContext, rval: MutableHandleValue) {
+        self.reflector().to_jsval(cx, rval);
     }
 }
 
@@ -386,32 +386,32 @@ pub fn jsid_to_string(cx: &js::context::JSContext, id: HandleId) -> Option<DOMSt
 
 impl<T: Float + ToJSValConvertible> ToJSValConvertible for Finite<T> {
     #[inline]
-    fn safe_to_jsval(&self, cx: &mut JSContext, rval: MutableHandleValue) {
+    fn to_jsval(&self, cx: &mut JSContext, rval: MutableHandleValue) {
         let value = **self;
-        value.safe_to_jsval(cx, rval);
+        value.to_jsval(cx, rval);
     }
 }
 
 impl<T: Float + FromJSValConvertible<Config = ()>> FromJSValConvertible for Finite<T> {
     type Config = ();
 
-    fn safe_from_jsval(
+    fn from_jsval(
         cx: &mut JSContext,
         value: HandleValue,
         option: (),
     ) -> Result<ConversionResult<Finite<T>>, ()> {
-        let result = match FromJSValConvertible::safe_from_jsval(cx, value, option)? {
+        let result = match FromJSValConvertible::from_jsval(cx, value, option)? {
             ConversionResult::Success(v) => v,
             ConversionResult::Failure(error) => {
                 // FIXME(emilio): Why throwing instead of propagating the error?
-                throw_type_error_safe(cx, &error);
+                throw_type_error(cx, &error);
                 return Err(());
             },
         };
         match Finite::new(result) {
             Some(v) => Ok(ConversionResult::Success(v)),
             None => {
-                throw_type_error_safe(cx, c"this argument is not a finite floating-point value");
+                throw_type_error(cx, c"this argument is not a finite floating-point value");
                 Err(())
             },
         }
@@ -474,9 +474,9 @@ where
 
 impl<T: ToJSValConvertible + JSTraceable> ToJSValConvertible for RootedTraceableBox<T> {
     #[inline]
-    fn safe_to_jsval(&self, cx: &mut JSContext, rval: MutableHandleValue) {
+    fn to_jsval(&self, cx: &mut JSContext, rval: MutableHandleValue) {
         let value = &**self;
-        value.safe_to_jsval(cx, rval);
+        value.to_jsval(cx, rval);
     }
 }
 
@@ -487,12 +487,12 @@ where
 {
     type Config = T::Config;
 
-    fn safe_from_jsval(
+    fn from_jsval(
         cx: &mut JSContext,
         value: HandleValue,
         config: Self::Config,
     ) -> Result<ConversionResult<Self>, ()> {
-        T::safe_from_jsval(cx, value, config).map(|result| match result {
+        T::from_jsval(cx, value, config).map(|result| match result {
             ConversionResult::Success(inner) => {
                 ConversionResult::Success(RootedTraceableBox::from_box(Heap::boxed(inner)))
             },
@@ -511,8 +511,7 @@ pub fn is_array_like<D: crate::DomTypes>(cx: &mut JSContext, value: HandleValue)
         return true;
     }
 
-    let object: *mut JSObject = match FromJSValConvertible::safe_from_jsval(cx, value, ()).unwrap()
-    {
+    let object: *mut JSObject = match FromJSValConvertible::from_jsval(cx, value, ()).unwrap() {
         ConversionResult::Success(object) => object,
         _ => return false,
     };

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -806,10 +806,10 @@ impl Extend<char> for DOMString {
 }
 
 impl ToJSValConvertible for DOMString {
-    fn safe_to_jsval(&self, cx: &mut JSContext, mut rval: MutableHandleValue) {
+    fn to_jsval(&self, cx: &mut JSContext, mut rval: MutableHandleValue) {
         let val = self.0.borrow();
         match *val {
-            DOMStringType::Rust(ref s) => s.safe_to_jsval(cx, rval),
+            DOMStringType::Rust(ref s) => s.to_jsval(cx, rval),
             DOMStringType::JSString(ref rooted_traceable_box) => unsafe {
                 rval.set(StringValue(&*rooted_traceable_box.get()));
             },
@@ -822,9 +822,9 @@ impl ToJSValConvertible for DOMString {
 
                 String::from_utf8(v)
                     .expect("Error in constructin test string")
-                    .safe_to_jsval(cx, rval);
+                    .to_jsval(cx, rval);
             },
-            DOMStringType::RustStatic(s) => s.safe_to_jsval(cx, rval),
+            DOMStringType::RustStatic(s) => s.to_jsval(cx, rval),
         };
     }
 }

--- a/components/script_bindings/error.rs
+++ b/components/script_bindings/error.rs
@@ -5,7 +5,7 @@
 use std::ffi::CString;
 
 use js::context::JSContext;
-use js::error::throw_type_error_safe;
+use js::error::throw_type_error;
 use js::rust::wrappers2::JS_IsExceptionPending;
 
 use crate::codegen::PrototypeList::proto_id_to_name;
@@ -104,7 +104,7 @@ pub fn throw_invalid_this(cx: &mut JSContext, proto_id: u16) {
         .to_vec();
     vec.extend_from_slice(proto_id_to_name(proto_id).as_bytes());
     let error = CString::new(vec).expect("WebIDL name should not contain nul byte");
-    throw_type_error_safe(cx, &error);
+    throw_type_error(cx, &error);
 }
 
 pub fn throw_constructor_without_new(cx: &mut JSContext, name: &str) {
@@ -112,7 +112,7 @@ pub fn throw_constructor_without_new(cx: &mut JSContext, name: &str) {
     let mut error = name.as_bytes().to_vec();
     error.extend_from_slice(b" constructor: 'new' is required");
     let error = CString::new(error).expect("WebIDL name should not contain nul byte");
-    throw_type_error_safe(cx, &error);
+    throw_type_error(cx, &error);
 }
 
 #[macro_export]

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -11,7 +11,7 @@ pub(crate) mod base {
     pub(crate) use js::conversions::{
         ConversionBehavior, ConversionResult, FromJSValConvertible, ToJSValConvertible,
     };
-    pub(crate) use js::error::throw_type_error_safe;
+    pub(crate) use js::error::throw_type_error;
     pub(crate) use js::gc::RootedVec;
     pub(crate) use js::jsapi::{
         HandleValue as RawHandleValue, HandleValueArray, Heap, IsCallable, JSObject, Value,

--- a/components/script_bindings/interface.rs
+++ b/components/script_bindings/interface.rs
@@ -8,7 +8,7 @@ use std::convert::TryFrom;
 use std::ffi::CStr;
 use std::ptr::{self, NonNull};
 
-use js::error::throw_type_error_safe;
+use js::error::throw_type_error;
 use js::glue::UncheckedUnwrapObject;
 use js::jsapi::JS::CompartmentIterResult;
 use js::jsapi::{
@@ -546,7 +546,7 @@ unsafe extern "C" fn invalid_constructor(
 ) -> bool {
     // SAFETY: it is safe to construct a JSContext from engine hook.
     let mut cx = unsafe { js::context::JSContext::from_ptr(NonNull::new(cx).unwrap()) };
-    throw_type_error_safe(&mut cx, c"Illegal constructor.");
+    throw_type_error(&mut cx, c"Illegal constructor.");
     false
 }
 
@@ -557,7 +557,7 @@ unsafe extern "C" fn non_new_constructor(
 ) -> bool {
     // SAFETY: it is safe to construct a JSContext from engine hook.
     let mut cx = unsafe { js::context::JSContext::from_ptr(NonNull::new(cx).unwrap()) };
-    throw_type_error_safe(&mut cx, c"This constructor needs to be called with `new`.");
+    throw_type_error(&mut cx, c"This constructor needs to be called with `new`.");
     false
 }
 

--- a/components/script_bindings/iterable.rs
+++ b/components/script_bindings/iterable.rs
@@ -123,23 +123,23 @@ impl<D: DomTypes, T: DomObjectIteratorWrap<D> + JSTraceable + Iterable + DomGlob
                 IteratorType::Keys => {
                     self.iterable
                         .get_key_at_index(cx, index)
-                        .safe_to_jsval(cx, value.handle_mut());
+                        .to_jsval(cx, value.handle_mut());
                     dict_return(cx, return_value, false, value.handle())
                 },
                 IteratorType::Values => {
                     self.iterable
                         .get_value_at_index(cx, index)
-                        .safe_to_jsval(cx, value.handle_mut());
+                        .to_jsval(cx, value.handle_mut());
                     dict_return(cx, return_value, false, value.handle())
                 },
                 IteratorType::Entries => {
                     rooted!(&in(cx) let mut key = UndefinedValue());
                     self.iterable
                         .get_key_at_index(cx, index)
-                        .safe_to_jsval(cx, key.handle_mut());
+                        .to_jsval(cx, key.handle_mut());
                     self.iterable
                         .get_value_at_index(cx, index)
-                        .safe_to_jsval(cx, value.handle_mut());
+                        .to_jsval(cx, value.handle_mut());
                     key_and_value_return(cx, return_value, key.handle(), value.handle())
                 },
             }

--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -726,7 +726,7 @@ pub(crate) fn cross_origin_get<D: DomTypes>(
     }
 
     rooted!(&in(cx) let mut getter_jsval = UndefinedValue());
-    getter.get().safe_to_jsval(cx, getter_jsval.handle_mut());
+    getter.get().to_jsval(cx, getter_jsval.handle_mut());
 
     // > 7. Return `? Call(getter, Receiver)`.
     unsafe {
@@ -787,7 +787,7 @@ unsafe fn cross_origin_set<D: DomTypes>(
     }
 
     rooted!(&in(cx) let mut setter_jsval = UndefinedValue());
-    setter.get().safe_to_jsval(cx, setter_jsval.handle_mut());
+    setter.get().to_jsval(cx, setter_jsval.handle_mut());
 
     // > 3.1. Perform ? Call(setter, Receiver, «V»).
     // >

--- a/components/script_bindings/record.rs
+++ b/components/script_bindings/record.rs
@@ -55,7 +55,7 @@ impl RecordKey for USVString {
         rooted!(&in(cx) let mut jsid_value = UndefinedValue());
         unsafe { JS_IdToValue(cx, *id.as_ref(cx), jsid_value.handle_mut()) };
 
-        USVString::safe_from_jsval(cx, jsid_value.handle(), ())
+        USVString::from_jsval(cx, jsid_value.handle(), ())
     }
 }
 
@@ -68,7 +68,7 @@ impl RecordKey for ByteString {
         rooted!(&in(cx) let mut jsid_value = UndefinedValue());
         unsafe { JS_IdToValue(cx, *id.as_ref(cx), jsid_value.handle_mut()) };
 
-        ByteString::safe_from_jsval(cx, jsid_value.handle(), ())
+        ByteString::from_jsval(cx, jsid_value.handle(), ())
     }
 }
 
@@ -110,7 +110,7 @@ where
 {
     type Config = C;
 
-    fn safe_from_jsval(
+    fn from_jsval(
         cx: &mut JSContext,
         value: HandleValue,
         config: C,
@@ -170,7 +170,7 @@ where
                 return Err(());
             }
 
-            let property = match V::safe_from_jsval(cx, property.handle(), config.clone())? {
+            let property = match V::from_jsval(cx, property.handle(), config.clone())? {
                 ConversionResult::Success(property) => property,
                 ConversionResult::Failure(message) => {
                     return Ok(ConversionResult::Failure(message));
@@ -189,14 +189,14 @@ where
     V: ToJSValConvertible,
 {
     #[inline]
-    fn safe_to_jsval(&self, cx: &mut JSContext, mut rval: MutableHandleValue) {
+    fn to_jsval(&self, cx: &mut JSContext, mut rval: MutableHandleValue) {
         rooted!(&in(cx) let js_object = unsafe { JS_NewPlainObject(cx) });
         assert!(!js_object.handle().is_null());
 
         rooted!(&in(cx) let mut js_value = UndefinedValue());
         for (key, value) in &self.map {
             let key = key.to_utf16_vec();
-            value.safe_to_jsval(cx, js_value.handle_mut());
+            value.to_jsval(cx, js_value.handle_mut());
 
             assert!(unsafe {
                 JS_DefineUCProperty2(

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -704,7 +704,7 @@ pub(crate) fn exception_to_promise(cx: &mut JSContext, rval: RawMutableHandleVal
         }
         JS_ClearPendingException(cx);
         if let Some(promise) = NonNull::new(CallOriginalPromiseReject(cx, exception.handle())) {
-            promise.safe_to_jsval(cx, MutableHandleValue::from_raw(rval));
+            promise.to_jsval(cx, MutableHandleValue::from_raw(rval));
             true
         } else {
             // We just give up. Put the exception back.
@@ -875,7 +875,7 @@ pub fn to_frozen_array<T: ToJSValConvertible>(
     convertibles: &[T],
     mut rval: MutableHandleValue,
 ) {
-    convertibles.safe_to_jsval(cx, rval.reborrow());
+    convertibles.to_jsval(cx, rval.reborrow());
 
     rooted!(&in(cx) let obj = rval.to_object());
     unsafe { JS_FreezeObject(cx, obj.handle()) };


### PR DESCRIPTION
Companion PR of https://github.com/servo/mozjs/pull/802, which drops deprecated code and the legacy wrappers.
Now that the `safe` variants are the only ones left, some methods have been renamed back to the original names.

Testing: It compiles
