### PR TITLE
servo: Add a `WebView::clear_session_history` API

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1468,7 +1468,7 @@ where
             EmbedderToConstellationMessage::SetAccessibilityActive(webview_id, active) => {
                 self.set_accessibility_active(webview_id, active);
             },
-            EmbedderToConstellationMessage::ClearHistory(webview_id) => {
+            EmbedderToConstellationMessage::ClearSessionHistory(webview_id) => {
                 self.clear_history(webview_id);
             },
         }

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1468,6 +1468,9 @@ where
             EmbedderToConstellationMessage::SetAccessibilityActive(webview_id, active) => {
                 self.set_accessibility_active(webview_id, active);
             },
+            EmbedderToConstellationMessage::ClearHistory(webview_id) => {
+                self.clear_history(webview_id);
+            },
         }
     }
 
@@ -3200,6 +3203,15 @@ where
             ScriptThreadMessage::SetAccessibilityActive(pipeline_id, active, epoch),
             "Set accessibility active after closure",
         );
+    }
+
+    fn clear_history(&mut self, webview_id: WebViewId) {
+        let Some(webview) = self.webviews.get_mut(&webview_id) else {
+            return;
+        };
+        webview.session_history.future.clear();
+        webview.session_history.past.clear();
+        self.notify_history_changed(webview_id);
     }
 
     fn forward_input_event(

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1469,7 +1469,7 @@ where
                 self.set_accessibility_active(webview_id, active);
             },
             EmbedderToConstellationMessage::ClearSessionHistory(webview_id) => {
-                self.clear_history(webview_id);
+                self.handle_clear_session_history(webview_id);
             },
         }
     }
@@ -3205,7 +3205,7 @@ where
         );
     }
 
-    fn clear_history(&mut self, webview_id: WebViewId) {
+    fn handle_clear_session_history(&mut self, webview_id: WebViewId) {
         let Some(webview) = self.webviews.get_mut(&webview_id) else {
             return;
         };

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -82,6 +82,7 @@ mod from_embedder {
                 Self::UserContentManagerAction(..) => target!("UserContentManagerAction"),
                 Self::UpdatePinchZoomInfos(..) => target!("UpdatePinchZoomInfos"),
                 Self::SetAccessibilityActive(..) => target!("SetAccessibilityActive"),
+                Self::ClearHistory(..) => target!("ClearHistory"),
             }
         }
     }

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -82,7 +82,7 @@ mod from_embedder {
                 Self::UserContentManagerAction(..) => target!("UserContentManagerAction"),
                 Self::UpdatePinchZoomInfos(..) => target!("UpdatePinchZoomInfos"),
                 Self::SetAccessibilityActive(..) => target!("SetAccessibilityActive"),
-                Self::ClearHistory(..) => target!("ClearHistory"),
+                Self::ClearSessionHistory(..) => target!("ClearHistory"),
             }
         }
     }

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -1222,7 +1222,6 @@ fn test_webview_title_updates_when_title_element_is_created_from_javascript() {
 }
 
 #[test]
-// It seems that currently `WebView::load` does not keep the history, so we have to do javascript evaluation.
 fn test_webview_clear_history() {
     let session_history_changed = Arc::new(AtomicBool::new(false));
     struct MyDelegate(Arc<AtomicBool>);
@@ -1244,19 +1243,13 @@ fn test_webview_clear_history() {
         let webview = webview.clone();
         servo_test.spin(move || webview.page_title() != Some("Success".into()));
     }
-    webview.evaluate_javascript(
-        "window.location.assign(\"data:text/html,<script>document.title='Success2';</script>\");",
-        |_| {},
-    );
+    webview.load(Url::parse("data:text/html,<script>document.title='Success2';</script>").unwrap());
     {
         let webview = webview.clone();
         servo_test.spin(move || webview.page_title() != Some("Success2".into()));
     }
 
-    webview.evaluate_javascript(
-        "window.location.assign(\"data:text/html,<script>document.title='Success3';</script>\");",
-        |_| {},
-    );
+    webview.load(Url::parse("data:text/html,<script>document.title='Success3';</script>").unwrap());
     {
         let webview = webview.clone();
         servo_test.spin(move || webview.page_title() != Some("Success3".into()));

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -9,7 +9,7 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicBool, AtomicUsize};
 
 use dpi::PhysicalSize;
 use embedder_traits::UrlRequest;
@@ -1224,10 +1224,17 @@ fn test_webview_title_updates_when_title_element_is_created_from_javascript() {
 #[test]
 // It seems that currently `WebView::load` does not keep the history, so we have to do javascript evaluation.
 fn test_webview_clear_history() {
-    let servo_test = ServoTest::new();
-    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let session_history_changed = Arc::new(AtomicBool::new(false));
+    struct MyDelegate(Arc<AtomicBool>);
+    impl WebViewDelegate for MyDelegate {
+        fn notify_history_changed(&self, _webview: WebView, _entries: Vec<Url>, _current: usize) {
+            self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
 
-    // First load
+    let servo_test = ServoTest::new();
+    let delegate = Rc::new(MyDelegate(session_history_changed.clone()));
+
     let url_1 = Url::parse("data:text/html,<body><title>Success</title></body>").unwrap();
     let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
         .delegate(delegate.clone())
@@ -1237,7 +1244,6 @@ fn test_webview_clear_history() {
         let webview = webview.clone();
         servo_test.spin(move || webview.page_title() != Some("Success".into()));
     }
-    // Second Load
     webview.evaluate_javascript(
         "window.location.assign(\"data:text/html,<script>document.title='Success2';</script>\");",
         |_| {},
@@ -1247,7 +1253,6 @@ fn test_webview_clear_history() {
         servo_test.spin(move || webview.page_title() != Some("Success2".into()));
     }
 
-    // Third Load
     webview.evaluate_javascript(
         "window.location.assign(\"data:text/html,<script>document.title='Success3';</script>\");",
         |_| {},
@@ -1265,12 +1270,10 @@ fn test_webview_clear_history() {
         servo_test.spin(move || webview.page_title() != Some("Success2".into()));
     }
 
-    webview.clear_history();
-    {
-        let webview = webview.clone();
-        // We currently cannot test when the `clear_history` call succeeded, so we have to wait till we do not see the history again
-        servo_test.spin(move || webview.can_go_back());
-    }
+    session_history_changed.store(false, std::sync::atomic::Ordering::SeqCst);
+    webview.clear_session_history();
+
+    servo_test.spin(move || !session_history_changed.load(std::sync::atomic::Ordering::SeqCst));
 
     assert!(!webview.can_go_back());
     assert!(!webview.can_go_forward());

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -1220,3 +1220,71 @@ fn test_webview_title_updates_when_title_element_is_created_from_javascript() {
 
     assert_eq!(webview.page_title().as_deref(), Some("Success"));
 }
+
+#[test]
+// It seems that currently `WebView::load` does not keep the history, so we have to do javascript evaluation.
+fn test_webview_clear_history() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let page_title_changed = Arc::new(AtomicBool::new(false));
+    struct MyDelegate {
+        page_tiitle_changed: Arc<AtomicBool>,
+    }
+    impl WebViewDelegate for MyDelegate {
+        fn notify_page_title_changed(&self, _webview: WebView, _title: Option<String>) {
+            self.page_tiitle_changed.store(true, Ordering::SeqCst);
+        }
+    }
+
+    let servo_test = ServoTest::new();
+    let delegate = Rc::new(MyDelegate {
+        page_tiitle_changed: page_title_changed.clone(),
+    });
+
+    // First load
+    let url_1 = Url::parse(
+        "data:text/html,\
+        <script>document.title='Success';</script>",
+    )
+    .unwrap();
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(url_1)
+        .build();
+
+    // Second Load
+    page_title_changed.store(false, Ordering::SeqCst);
+    let page_title_changed_c = page_title_changed.clone();
+    webview.evaluate_javascript(
+        "window.location.href = \"data:text/html,\
+    <script>document.title='Success2';</script>\";",
+        |_| {},
+    );
+    servo_test.spin(move || page_title_changed_c.load(Ordering::SeqCst));
+
+    // Third Load
+    page_title_changed.store(false, std::sync::atomic::Ordering::SeqCst);
+    let page_title_changed_c = page_title_changed.clone();
+    webview.evaluate_javascript(
+        "window.location.href = \"data:text/html,\
+    <script>document.title='Success3';</script>\";",
+        |_| {},
+    );
+    servo_test.spin(move || page_title_changed_c.load(Ordering::SeqCst));
+
+    assert!(webview.can_go_back());
+
+    // Going one back in the history
+    webview.go_back(1);
+    page_title_changed.store(false, std::sync::atomic::Ordering::SeqCst);
+    let page_title_changed_c = page_title_changed.clone();
+    servo_test.spin(move || page_title_changed_c.load(Ordering::SeqCst));
+    assert!(webview.can_go_back());
+    assert!(webview.can_go_forward());
+
+    webview.clear_history();
+    let load_webview = webview.clone();
+    servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
+    assert!(!webview.can_go_back());
+    assert!(!webview.can_go_forward());
+}

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -1224,67 +1224,54 @@ fn test_webview_title_updates_when_title_element_is_created_from_javascript() {
 #[test]
 // It seems that currently `WebView::load` does not keep the history, so we have to do javascript evaluation.
 fn test_webview_clear_history() {
-    use std::sync::atomic::{AtomicBool, Ordering};
-
-    let page_title_changed = Arc::new(AtomicBool::new(false));
-    struct MyDelegate {
-        page_tiitle_changed: Arc<AtomicBool>,
-    }
-    impl WebViewDelegate for MyDelegate {
-        fn notify_page_title_changed(&self, _webview: WebView, _title: Option<String>) {
-            self.page_tiitle_changed.store(true, Ordering::SeqCst);
-        }
-    }
-
     let servo_test = ServoTest::new();
-    let delegate = Rc::new(MyDelegate {
-        page_tiitle_changed: page_title_changed.clone(),
-    });
+    let delegate = Rc::new(WebViewDelegateImpl::default());
 
     // First load
-    let url_1 = Url::parse(
-        "data:text/html,\
-        <script>document.title='Success';</script>",
-    )
-    .unwrap();
+    let url_1 = Url::parse("data:text/html,<body><title>Success</title></body>").unwrap();
     let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
         .delegate(delegate.clone())
         .url(url_1)
         .build();
-
+    {
+        let webview = webview.clone();
+        servo_test.spin(move || webview.page_title() != Some("Success".into()));
+    }
     // Second Load
-    page_title_changed.store(false, Ordering::SeqCst);
-    let page_title_changed_c = page_title_changed.clone();
     webview.evaluate_javascript(
-        "window.location.href = \"data:text/html,\
-    <script>document.title='Success2';</script>\";",
+        "window.location.assign(\"data:text/html,<script>document.title='Success2';</script>\");",
         |_| {},
     );
-    servo_test.spin(move || page_title_changed_c.load(Ordering::SeqCst));
+    {
+        let webview = webview.clone();
+        servo_test.spin(move || webview.page_title() != Some("Success2".into()));
+    }
 
     // Third Load
-    page_title_changed.store(false, std::sync::atomic::Ordering::SeqCst);
-    let page_title_changed_c = page_title_changed.clone();
     webview.evaluate_javascript(
-        "window.location.href = \"data:text/html,\
-    <script>document.title='Success3';</script>\";",
+        "window.location.assign(\"data:text/html,<script>document.title='Success3';</script>\");",
         |_| {},
     );
-    servo_test.spin(move || page_title_changed_c.load(Ordering::SeqCst));
+    {
+        let webview = webview.clone();
+        servo_test.spin(move || webview.page_title() != Some("Success3".into()));
+    }
 
     assert!(webview.can_go_back());
 
-    // Going one back in the history
     webview.go_back(1);
-    page_title_changed.store(false, std::sync::atomic::Ordering::SeqCst);
-    let page_title_changed_c = page_title_changed.clone();
-    servo_test.spin(move || page_title_changed_c.load(Ordering::SeqCst));
-    assert!(webview.can_go_back());
-    assert!(webview.can_go_forward());
+    {
+        let webview = webview.clone();
+        servo_test.spin(move || webview.page_title() != Some("Success2".into()));
+    }
 
     webview.clear_history();
-    let load_webview = webview.clone();
-    servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
+    {
+        let webview = webview.clone();
+        // We currently cannot test when the `clear_history` call succeeded, so we have to wait till we do not see the history again
+        servo_test.spin(move || webview.can_go_back());
+    }
+
     assert!(!webview.can_go_back());
     assert!(!webview.can_go_forward());
 }

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -9,7 +9,7 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize};
+use std::sync::atomic::AtomicUsize;
 
 use dpi::PhysicalSize;
 use embedder_traits::UrlRequest;
@@ -1223,16 +1223,24 @@ fn test_webview_title_updates_when_title_element_is_created_from_javascript() {
 
 #[test]
 fn test_webview_clear_history() {
-    let session_history_changed = Arc::new(AtomicBool::new(false));
-    struct MyDelegate(Arc<AtomicBool>);
+    let session_history_changed = Rc::new(Cell::new(false));
+    let entries = Rc::new(RefCell::new(vec![]));
+    struct MyDelegate {
+        session_history_changed: Rc<Cell<bool>>,
+        entries: Rc<RefCell<Vec<Url>>>,
+    }
     impl WebViewDelegate for MyDelegate {
-        fn notify_history_changed(&self, _webview: WebView, _entries: Vec<Url>, _current: usize) {
-            self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+        fn notify_history_changed(&self, _webview: WebView, entries: Vec<Url>, _current: usize) {
+            self.session_history_changed.set(true);
+            *self.entries.borrow_mut() = entries;
         }
     }
 
     let servo_test = ServoTest::new();
-    let delegate = Rc::new(MyDelegate(session_history_changed.clone()));
+    let delegate = Rc::new(MyDelegate {
+        session_history_changed: session_history_changed.clone(),
+        entries: entries.clone(),
+    });
 
     let url_1 = Url::parse("data:text/html,<body><title>Success</title></body>").unwrap();
     let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
@@ -1243,7 +1251,9 @@ fn test_webview_clear_history() {
         let webview = webview.clone();
         servo_test.spin(move || webview.page_title() != Some("Success".into()));
     }
-    webview.load(Url::parse("data:text/html,<script>document.title='Success2';</script>").unwrap());
+    let second_url =
+        Url::parse("data:text/html,<script>document.title='Success2';</script>").unwrap();
+    webview.load(second_url.clone());
     {
         let webview = webview.clone();
         servo_test.spin(move || webview.page_title() != Some("Success2".into()));
@@ -1263,11 +1273,13 @@ fn test_webview_clear_history() {
         servo_test.spin(move || webview.page_title() != Some("Success2".into()));
     }
 
-    session_history_changed.store(false, std::sync::atomic::Ordering::SeqCst);
+    session_history_changed.set(false);
+    entries.borrow_mut().clear();
     webview.clear_session_history();
 
-    servo_test.spin(move || !session_history_changed.load(std::sync::atomic::Ordering::SeqCst));
+    servo_test.spin(move || !session_history_changed.get());
 
     assert!(!webview.can_go_back());
     assert!(!webview.can_go_forward());
+    assert_eq!(&*entries.borrow(), &vec![second_url]);
 }

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -1057,6 +1057,13 @@ impl WebView {
         self.delegate()
             .notify_accessibility_tree_update(self.clone(), tree_update);
     }
+
+    pub fn clear_history(&self) {
+        self.inner()
+            .servo
+            .constellation_proxy()
+            .send(EmbedderToConstellationMessage::ClearHistory(self.id()));
+    }
 }
 
 /// A structure used to expose a view of the [`WebView`] to the Servo

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -1058,6 +1058,7 @@ impl WebView {
             .notify_accessibility_tree_update(self.clone(), tree_update);
     }
 
+    /// Clears the history of the current webview, making the current url the only one ever navigated by this webview.
     pub fn clear_history(&self) {
         self.inner()
             .servo

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -1058,12 +1058,14 @@ impl WebView {
             .notify_accessibility_tree_update(self.clone(), tree_update);
     }
 
-    /// Clears the history of the current webview, making the current url the only one ever navigated by this webview.
-    pub fn clear_history(&self) {
-        self.inner()
-            .servo
-            .constellation_proxy()
-            .send(EmbedderToConstellationMessage::ClearHistory(self.id()));
+    /// Clear the session history of this [`WebView`]. The session history is also known
+    /// as the back-forward cache. Once cleared, [`WebViewDelegate::notify_history`]
+    /// will be called asynchronously and the resulting session history will contain only
+    /// a single item with the current URL.
+    pub fn clear_session_history(&self) {
+        self.inner().servo.constellation_proxy().send(
+            EmbedderToConstellationMessage::ClearSessionHistory(self.id()),
+        );
     }
 }
 

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -114,6 +114,8 @@ pub enum EmbedderToConstellationMessage {
     UpdatePinchZoomInfos(PipelineId, PinchZoomInfos),
     /// Activate or deactivate accessibility features for the given `WebView`.
     SetAccessibilityActive(WebViewId, bool),
+    /// Clears the Session History for this WebView with the current url being the only url left
+    ClearHistory(WebViewId),
 }
 
 pub enum UserContentManagerAction {

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -114,8 +114,9 @@ pub enum EmbedderToConstellationMessage {
     UpdatePinchZoomInfos(PipelineId, PinchZoomInfos),
     /// Activate or deactivate accessibility features for the given `WebView`.
     SetAccessibilityActive(WebViewId, bool),
-    /// Clears the Session History for this WebView with the current url being the only url left
-    ClearHistory(WebViewId),
+    /// Clears the session history for the `WebView` with the given `WebViewId`, leaving
+    /// the `WebView` with only the current URL in its session history.
+    ClearSessionHistory(WebViewId),
 }
 
 pub enum UserContentManagerAction {


### PR DESCRIPTION
Embedders might want to clear the SessionHistory. We implement this with a simple message to the constellation.

Testing: This change adds a new `WebView` unit test.
