### PR TITLE
script: Do not consider `Document`s without browsing contexts to be active

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -995,12 +995,25 @@ impl Document {
         self.content_type.matches(APPLICATION, "xhtml+xml")
     }
 
+    /// <https://html.spec.whatwg.org/multipage/#fully-active>
     pub(crate) fn is_fully_active(&self) -> bool {
-        !self.window_detached() && self.activity.get() == DocumentActivity::FullyActive
+        // > A Document d is said to be fully active when d is the active document of a
+        // > navigable navigable, and either navigable is a top-level traversable or
+        // > navigable's container document is fully active.
+        self.is_active() &&
+            (self.window.is_top_level() || self.activity.get() == DocumentActivity::FullyActive)
     }
 
+    /// <https://html.spec.whatwg.org/multipage/#nav-document>
     pub(crate) fn is_active(&self) -> bool {
-        !self.window_detached() && self.activity.get() != DocumentActivity::Inactive
+        // > A navigable's active document is its active session history entry's document.
+        //
+        // The first two checks stand in for when the document is not the active session history
+        // entry's document, as when that happens they will be false. The session history entry
+        // is not really implemented in script in the same way the specification says.
+        self.browsing_context().is_some() &&
+            !self.window_detached() &&
+            self.activity.get() != DocumentActivity::Inactive
     }
 
     #[inline]

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -5225,16 +5225,13 @@ impl Element {
         self.upcast::<Node>().is_connected()
     }
 
-    // https://html.spec.whatwg.org/multipage/#cannot-navigate
+    /// <https://html.spec.whatwg.org/multipage/#cannot-navigate>
     pub(crate) fn cannot_navigate(&self) -> bool {
+        // > An element element cannot navigate if any of the following are true:
+        // >  - element's node document is not fully active; or
+        // >  - element is not an a element and is not connected.
         let document = self.owner_document();
-
-        // Step 1.
-        !document.is_fully_active() ||
-            (
-                // Step 2.
-                !self.is::<HTMLAnchorElement>() && !self.is_connected()
-            )
+        !document.is_fully_active() || (!self.is::<HTMLAnchorElement>() && !self.is_connected())
     }
 }
 

--- a/components/script/dom/geolocation/geolocation.rs
+++ b/components/script/dom/geolocation/geolocation.rs
@@ -134,7 +134,7 @@ impl GeolocationMethods<DomTypeHolder> for Geolocation {
     ) -> Fallible<()> {
         let error_callback = cast_error_callback(cx, error_callback)?;
         // Step 1. If this's relevant global object's associated Document is not fully active:
-        if !self.global().as_window().Document().is_active() {
+        if !self.global().as_window().Document().is_fully_active() {
             // Step 1.1 Call back with error errorCallback and POSITION_UNAVAILABLE.
             if let Some(error_callback) = error_callback {
                 let position_error = GeolocationPositionError::position_unavailable(
@@ -161,7 +161,7 @@ impl GeolocationMethods<DomTypeHolder> for Geolocation {
     ) -> Fallible<i32> {
         let error_callback = cast_error_callback(cx, error_callback)?;
         // Step 1. If this's relevant global object's associated Document is not fully active:
-        if !self.global().as_window().Document().is_active() {
+        if !self.global().as_window().Document().is_fully_active() {
             // Step 1.1 Call back with error errorCallback and POSITION_UNAVAILABLE.
             if let Some(error_callback) = error_callback {
                 let position_error = GeolocationPositionError::position_unavailable(

--- a/components/script/dom/html/embedded_content/htmlimageelement.rs
+++ b/components/script/dom/html/embedded_content/htmlimageelement.rs
@@ -775,7 +775,7 @@ impl HTMLImageElement {
         self.generation.set(self.generation.get() + 1);
 
         // Step 1. If the element's node document is not fully active, then:
-        if !self.owner_document().is_active() {
+        if !self.owner_document().is_fully_active() {
             // TODO Step 1.1. Continue running this algorithm in parallel.
             // TODO Step 1.2. Wait until the element's node document is fully active.
             // TODO Step 1.3. If another instance of this algorithm for this img element was started after
@@ -925,7 +925,7 @@ impl HTMLImageElement {
         // Step 2. If the img element does not use srcset or picture, its node document is not fully
         // active, it has image data whose resource type is multipart/x-mixed-replace, or its
         // pending request is not null, then return.
-        if !document.is_active() || !self.uses_srcset_or_picture() || has_pending_request {
+        if !document.is_fully_active() || !self.uses_srcset_or_picture() || has_pending_request {
             return;
         }
 

--- a/components/script/dom/html/form_controls/htmlformelement.rs
+++ b/components/script/dom/html/form_controls/htmlformelement.rs
@@ -849,32 +849,34 @@ impl HTMLFormElement {
             // Step 18. Let formTarget be null.
             None
         };
-        // Step 20. Let target be the result of getting an element's target given submitter's form owner and formTarget.
+        // Step 20. Let target be the result of getting an element's target given
+        // submitter's form owner and formTarget.
         let form_owner = submitter.form_owner();
         let form = form_owner.as_deref().unwrap_or(self);
         let target = get_element_target(form.upcast::<Element>(), form_target);
 
-        // Step 21. Let noopener be the result of getting an element's noopener with form, parsed action, and target.
+        // Step 21. Let noopener be the result of getting an element's noopener with form,
+        // parsed action, and target.
         let noopener = self.relations.get().get_element_noopener(target.as_ref());
 
-        // Step 22. Let targetNavigable be the first return value of applying the rules for choosing a navigable given target,
-        // form's node navigable, and noopener.
-        let source = doc.browsing_context().unwrap();
-        let (maybe_chosen, _new) =
-            source.choose_browsing_context(cx, target.unwrap_or_default(), noopener);
-
-        let Some(chosen) = maybe_chosen else {
+        // Step 22. Let targetNavigable be the first return value of applying the rules
+        // for choosing a navigable given target, form's node navigable, and noopener.
+        let Some(chosen) = doc.browsing_context().and_then(|source| {
+            source
+                .choose_browsing_context(cx, target.unwrap_or_default(), noopener)
+                .0
+        }) else {
             // Step 23. If targetNavigable is null, then return.
             return;
         };
-        let target_document = match chosen.document() {
-            Some(doc) => doc,
-            None => return,
+
+        let Some(target_document) = chosen.document() else {
+            return;
         };
 
         // Step 24. Let historyHandling be "auto".
-        // Step 25. If form document equals targetNavigable's active document, and form document has not yet completely loaded,
-        // then set historyHandling to "replace".
+        // Step 25. If form document equals targetNavigable's active document, and form
+        // document has not yet completely loaded, then set historyHandling to "replace".
         let history_handling = if doc == target_document && !doc.completely_loaded() {
             NavigationHistoryBehavior::Replace
         } else {

--- a/components/script/dom/html/links/relations.rs
+++ b/components/script/dom/html/links/relations.rs
@@ -432,7 +432,10 @@ pub(crate) fn follow_hyperlink(
     //         choosing a navigable given targetAttributeValue, subject's node navigable, and
     //         noopener.
     let window = document.window();
-    let source = document.browsing_context().unwrap();
+
+    let Some(source) = document.browsing_context() else {
+        return;
+    };
     let (maybe_chosen, history_handling) = match target_attribute_value {
         Some(name) => {
             let (maybe_chosen, new) = source.choose_browsing_context(cx, name, noopener);
@@ -443,7 +446,7 @@ pub(crate) fn follow_hyperlink(
             };
             (maybe_chosen, history_handling)
         },
-        None => (Some(window.window_proxy()), NavigationHistoryBehavior::Push),
+        None => (Some(source), NavigationHistoryBehavior::Push),
     };
 
     // Step 8: If targetNavigable is null, then return.

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -1362,10 +1362,9 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
         // Step 2. If current is null, then return.
         //
-        // Note: This is equivalent to there being an active `Document` and the WindowProxy
-        // not being discarded due to the parent <iframe> being removed from its `Document`.
+        // Note: This is equivalent to there being an active `Document`.
         let document = self.Document();
-        if !document.is_active() || self.undiscarded_window_proxy().is_none() {
+        if !document.is_active() {
             return;
         }
 

--- a/components/script/dom/window/windowproxy.rs
+++ b/components/script/dom/window/windowproxy.rs
@@ -642,7 +642,7 @@ impl WindowProxy {
         Ok(target_document.browsing_context())
     }
 
-    // https://html.spec.whatwg.org/multipage/#the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name
+    /// <https://html.spec.whatwg.org/multipage/#the-rules-for-choosing-a-navigable>
     pub(crate) fn choose_browsing_context(
         &self,
         cx: &mut JSContext,

--- a/tests/wpt/meta/html/browsers/history/the-history-interface/history_pushstate_too_many_calls_ordering.optional.html.ini
+++ b/tests/wpt/meta/html/browsers/history/the-history-interface/history_pushstate_too_many_calls_ordering.optional.html.ini
@@ -7,6 +7,3 @@
 
   [pushState checks whether the URL can be rewritten before checking the rate limit]
     expected: FAIL
-
-  [pushState checks fully active before checking the rate limit]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/history/the-history-interface/history_replacestate_too_many_calls_ordering.optional.html.ini
+++ b/tests/wpt/meta/html/browsers/history/the-history-interface/history_replacestate_too_many_calls_ordering.optional.html.ini
@@ -7,6 +7,3 @@
 
   [replaceState checks whether the URL can be rewritten before checking the rate limit]
     expected: FAIL
-
-  [replaceState checks fully active before checking the rate limit]
-    expected: FAIL

--- a/tests/wpt/meta/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/url.window.js.ini
+++ b/tests/wpt/meta/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/url.window.js.ini
@@ -1,6 +1,3 @@
 [url.window.html]
   [document.open() does not change document's URL (active but not fully active document)]
     expected: FAIL
-
-  [document.open() does not change document's URL (non-active document with an associated Window object; frame is removed)]
-    expected: FAIL

--- a/tests/wpt/meta/trusted-types/navigate-to-javascript-url-007-crash.html.ini
+++ b/tests/wpt/meta/trusted-types/navigate-to-javascript-url-007-crash.html.ini
@@ -1,0 +1,2 @@
+[navigate-to-javascript-url-007-crash.html]
+  expected: CRASH

--- a/tests/wpt/meta/xhr/open-url-multi-window-2.htm.ini
+++ b/tests/wpt/meta/xhr/open-url-multi-window-2.htm.ini
@@ -1,3 +1,0 @@
-[open-url-multi-window-2.htm]
-  [XMLHttpRequest: open() resolving URLs (multi-Window; 2; evil)]
-    expected: FAIL


### PR DESCRIPTION
Through the active session history entry, the specification indicates
that when a `Document` does not have a `BrowsingContext` it cannot be
considered active or fully active. This change adds that check and
increases specification compliance around active and fully active
browsing contexts in general.

Testing: Several new WPT subtest passes and a new crash due to #47331.
Fixes: Potentially #37920.
