### PR TITLE
script: More faithfully implement "evaluate a JavaScript URL"

### DIFF
--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -119,9 +119,7 @@ use crate::dom::eventsource::EventSource;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::file::File;
 use crate::dom::globalscope::broadcastchannel::BroadcastChannel;
-use crate::dom::globalscope::script_execution::{
-    ErrorReporting, evaluate_script, fill_compile_options,
-};
+use crate::dom::globalscope::script_execution::{evaluate_script, fill_compile_options};
 use crate::dom::idbfactory::IDBFactory;
 use crate::dom::messageport::MessagePort;
 use crate::dom::paintworkletglobalscope::PaintWorkletGlobalScope;
@@ -129,6 +127,7 @@ use crate::dom::performance::performance::Performance;
 use crate::dom::performance::performanceentry::EntryType;
 use crate::dom::promise::Promise;
 use crate::dom::readablestream::{CrossRealmTransformReadable, ReadableStream};
+use crate::dom::script_execution::ScriptOptions;
 use crate::dom::serviceworker::ServiceWorker;
 use crate::dom::serviceworkerglobalscope::ServiceWorkerGlobalScope;
 use crate::dom::serviceworkerregistration::ServiceWorkerRegistration;
@@ -2968,13 +2967,15 @@ impl GlobalScope {
             let url = self.api_base_url();
             let fetch_options = ScriptFetchOptions::default_classic_script();
 
+            let mut script_options = ScriptOptions::empty();
+            script_options.set(ScriptOptions::ReturnsAValue, rval.is_some());
+
             let options = fill_compile_options(
                 cx,
                 filename,
+                script_options,
                 introduction_type,
-                ErrorReporting::Unmuted,
-                rval.is_none(), // noScriptRval
-                1,              // lineno
+                1, // line_number
             );
 
             let mut source = transform_str_to_source_text(&code);

--- a/components/script/dom/globalscope/script_execution.rs
+++ b/components/script/dom/globalscope/script_execution.rs
@@ -48,6 +48,8 @@ pub(crate) struct ClassicScript {
     url: ServoUrl,
     /// <https://html.spec.whatwg.org/multipage/#muted-errors>
     muted_errors: ErrorReporting,
+    /// Whether or not this script was compiled to return a value or not.
+    returns_a_value: bool,
 }
 
 #[derive(Clone, Copy, JSTraceable, MallocSizeOf)]
@@ -85,6 +87,7 @@ impl GlobalScope {
         introduction_type: Option<&'static CStr>,
         line_number: u32,
         external: bool,
+        returns_a_value: bool,
     ) -> ClassicScript {
         let mut source = if let Some(unminified_js_dir) = self.unminified_js_dir() {
             let mut script_source = ScriptSource {
@@ -111,7 +114,7 @@ impl GlobalScope {
             url.as_str(),
             introduction_type,
             muted_errors,
-            true, // noScriptRval
+            !returns_a_value,
             line_number,
         );
 
@@ -140,6 +143,7 @@ impl GlobalScope {
             url,
             fetch_options,
             muted_errors,
+            returns_a_value,
         }
     }
 
@@ -150,10 +154,18 @@ impl GlobalScope {
         cx: &mut JSContext,
         script: ClassicScript,
         rethrow_errors: RethrowErrors,
+        return_value: Option<MutableHandleValue>,
     ) -> ErrorResult {
+        assert_eq!(
+            return_value.is_some(),
+            script.returns_a_value,
+            "Classic script compiled to not return a value, but a return value was requested."
+        );
+
         // TODO Step 1. Let settings be the settings object of script.
 
-        // Step 2. Check if we can run script with settings. If this returns "do not run", then return NormalCompletion(empty).
+        // Step 2. Check if we can run script with settings. If this returns "do not run", then
+        // return NormalCompletion(empty).
         if !self.can_run_script() {
             return Ok(());
         }
@@ -170,7 +182,8 @@ impl GlobalScope {
             let mut result = false;
 
             match script.record {
-                // Step 6. If script's error to rethrow is not null, then set evaluationStatus to ThrowCompletion(script's error to rethrow).
+                // Step 6. If script's error to rethrow is not null, then set evaluationStatus
+                // to ThrowCompletion(script's error to rethrow).
                 Err(error_to_rethrow) => unsafe {
                     JS_SetPendingException(
                         cx,
@@ -180,7 +193,8 @@ impl GlobalScope {
                 },
                 // Step 7. Otherwise, set evaluationStatus to ScriptEvaluation(script's record).
                 Ok(compiled_script) => {
-                    rooted!(&in(cx) let mut rval = UndefinedValue());
+                    rooted!(&in(cx) let mut fallback_value = UndefinedValue());
+                    let return_value = return_value.unwrap_or_else(|| fallback_value.handle_mut());
                     let script_ptr = NonNull::new(compiled_script.get())
                         .expect("Compiled script must not be null");
                     result = evaluate_script(
@@ -188,7 +202,7 @@ impl GlobalScope {
                         script_ptr,
                         script.url,
                         script.fetch_options,
-                        rval.handle_mut(),
+                        return_value,
                     );
                 },
             }

--- a/components/script/dom/globalscope/script_execution.rs
+++ b/components/script/dom/globalscope/script_execution.rs
@@ -7,6 +7,7 @@ use std::ffi::CStr;
 use std::ptr::NonNull;
 use std::rc::Rc;
 
+use bitflags::bitflags;
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use js::context::JSContext;
 use js::jsapi::{ExceptionStackBehavior, Heap, JSScript, SetScriptPrivate};
@@ -34,6 +35,21 @@ use crate::modules::script_module::{ModuleScript, ModuleTree, RethrowError, Scri
 use crate::realms::enter_auto_realm;
 use crate::unminify::{ScriptSource, unminify_js};
 
+/// Options that were used when creating a script.
+#[derive(Clone, Copy, JSTraceable, MallocSizeOf)]
+pub(crate) struct ScriptOptions(u8);
+
+bitflags! {
+    impl ScriptOptions: u8 {
+        /// <https://html.spec.whatwg.org/multipage/#muted-errors>
+        const MutedErrors = 1 << 0;
+        /// Whether or not this script was compiled to return a value.
+        const ReturnsAValue = 1 << 1;
+        /// Whether or not this script was external.
+        const External = 1 << 2;
+    }
+}
+
 /// <https://html.spec.whatwg.org/multipage/#classic-script>
 #[derive(JSTraceable, MallocSizeOf)]
 pub(crate) struct ClassicScript {
@@ -46,26 +62,8 @@ pub(crate) struct ClassicScript {
     /// <https://html.spec.whatwg.org/multipage/#concept-script-base-url>
     #[no_trace]
     url: ServoUrl,
-    /// <https://html.spec.whatwg.org/multipage/#muted-errors>
-    muted_errors: ErrorReporting,
-    /// Whether or not this script was compiled to return a value or not.
-    returns_a_value: bool,
-}
-
-#[derive(Clone, Copy, JSTraceable, MallocSizeOf)]
-pub(crate) enum ErrorReporting {
-    Muted,
-    Unmuted,
-}
-
-impl From<bool> for ErrorReporting {
-    fn from(boolean: bool) -> Self {
-        if boolean {
-            ErrorReporting::Muted
-        } else {
-            ErrorReporting::Unmuted
-        }
-    }
+    /// The options that were used when compiling this script.
+    options: ScriptOptions,
 }
 
 pub(crate) enum RethrowErrors {
@@ -82,17 +80,15 @@ impl GlobalScope {
         cx: &mut JSContext,
         source: Cow<'_, str>,
         url: ServoUrl,
+        options: ScriptOptions,
         fetch_options: ScriptFetchOptions,
-        muted_errors: ErrorReporting,
         introduction_type: Option<&'static CStr>,
         line_number: u32,
-        external: bool,
-        returns_a_value: bool,
     ) -> ClassicScript {
         let mut source = if let Some(unminified_js_dir) = self.unminified_js_dir() {
             let mut script_source = ScriptSource {
                 source,
-                external,
+                external: options.contains(ScriptOptions::External),
                 url: &url,
             };
             unminify_js(&mut script_source, unminified_js_dir);
@@ -109,17 +105,11 @@ impl GlobalScope {
 
         // TODO Step 9. Record classic script creation time given script and sourceURLForWindowScripts.
 
-        let options = fill_compile_options(
-            cx,
-            url.as_str(),
-            introduction_type,
-            muted_errors,
-            !returns_a_value,
-            line_number,
-        );
+        let compilation_options =
+            fill_compile_options(cx, url.as_str(), options, introduction_type, line_number);
 
         // Step 10. Let result be ParseScript(source, settings's realm, script).
-        rooted!(&in(cx) let compiled_script = unsafe { Compile1(cx, options.ptr, &mut source) });
+        rooted!(&in(cx) let compiled_script = unsafe { Compile1(cx, compilation_options.ptr, &mut source) });
 
         // Step 11. If result is a list of errors, then:
         let record = if compiled_script.get().is_null() {
@@ -142,8 +132,7 @@ impl GlobalScope {
             record,
             url,
             fetch_options,
-            muted_errors,
-            returns_a_value,
+            options,
         }
     }
 
@@ -158,8 +147,8 @@ impl GlobalScope {
     ) -> ErrorResult {
         assert_eq!(
             return_value.is_some(),
-            script.returns_a_value,
-            "Classic script compiled to not return a value, but a return value was requested."
+            script.options.contains(ScriptOptions::ReturnsAValue),
+            "Classic script returns a value option does not match `return_value` argument"
         );
 
         // TODO Step 1. Let settings be the settings object of script.
@@ -211,40 +200,38 @@ impl GlobalScope {
             if unsafe { JS_IsExceptionPending(cx) } {
                 warn!("Error evaluating script");
 
-                match rethrow_errors {
-                    RethrowErrors::Yes => {
-                        match script.muted_errors {
-                            // Step 8.1. If rethrow errors is true and script's muted errors is false, then:
-                            // Rethrow evaluationStatus.[[Value]].
-                            ErrorReporting::Unmuted => return Err(Error::JSFailed),
-                            // Step 8.2. If rethrow errors is true and script's muted errors is true, then:
-                            ErrorReporting::Muted => {
-                                unsafe { JS_ClearPendingException(cx) };
-                                // Throw a "NetworkError" DOMException.
-                                return Err(Error::Network(None));
-                            },
-                        }
+                match (
+                    rethrow_errors,
+                    script.options.contains(ScriptOptions::MutedErrors),
+                ) {
+                    (RethrowErrors::Yes, false) => {
+                        // Step 8.1. If rethrow errors is true and script's muted errors is false, then:
+                        // Rethrow evaluationStatus.[[Value]].
+                        return Err(Error::JSFailed);
+                    },
+                    (RethrowErrors::Yes, true) => {
+                        // Step 8.2. If rethrow errors is true and script's muted errors is true, then:
+                        unsafe { JS_ClearPendingException(cx) };
+                        // Throw a "NetworkError" DOMException.
+                        return Err(Error::Network(None));
                     },
                     // Step 8.3. Otherwise, rethrow errors is false. Perform the following steps:
-                    RethrowErrors::No => {
-                        // Report an exception given by evaluationStatus.[[Value]] for script's
-                        // settings object's global object.
-                        match script.muted_errors {
-                            ErrorReporting::Unmuted => {
-                                report_pending_exception(cx);
+                    // Report an exception given by evaluationStatus.[[Value]] for script's
+                    // settings object's global object.
+                    (RethrowErrors::No, false) => {
+                        report_pending_exception(cx);
+                        return Err(Error::JSFailed);
+                    },
+                    (RethrowErrors::No, true) => {
+                        unsafe { JS_ClearPendingException(cx) };
+                        self.report_an_error(
+                            cx,
+                            ErrorInfo {
+                                message: String::from("Script error."),
+                                ..Default::default()
                             },
-                            ErrorReporting::Muted => {
-                                unsafe { JS_ClearPendingException(cx) };
-                                self.report_an_error(
-                                    cx,
-                                    ErrorInfo {
-                                        message: String::from("Script error."),
-                                        ..Default::default()
-                                    },
-                                    HandleValue::null(),
-                                );
-                            },
-                        }
+                            HandleValue::null(),
+                        );
                         return Err(Error::JSFailed);
                     },
                 }
@@ -343,16 +330,10 @@ impl GlobalScope {
 pub(crate) fn fill_compile_options(
     cx: &mut JSContext,
     filename: &str,
+    script_options: ScriptOptions,
     introduction_type: Option<&'static CStr>,
-    muted_errors: ErrorReporting,
-    no_script_rval: bool,
     line_number: u32,
 ) -> CompileOptionsWrapper {
-    let muted_errors = match muted_errors {
-        ErrorReporting::Muted => true,
-        ErrorReporting::Unmuted => false,
-    };
-
     // TODO: pass filename as CString to avoid allocation
     // See https://github.com/servo/servo/issues/42126
     let mut options = CompileOptionsWrapper::new(cx, cformat!("{filename}"), line_number);
@@ -361,11 +342,11 @@ pub(crate) fn fill_compile_options(
     }
 
     // https://searchfox.org/firefox-main/rev/46fa95cd7f10222996ec267947ab94c5107b1475/js/public/CompileOptions.h#284
-    options.set_muted_errors(muted_errors);
+    options.set_muted_errors(script_options.contains(ScriptOptions::MutedErrors));
 
     // https://searchfox.org/firefox-main/rev/46fa95cd7f10222996ec267947ab94c5107b1475/js/public/CompileOptions.h#518
     options.set_is_run_once(true);
-    options.set_no_script_rval(no_script_rval);
+    options.set_no_script_rval(!script_options.contains(ScriptOptions::ReturnsAValue));
 
     options
 }

--- a/components/script/dom/html/scripting/htmlscriptelement.rs
+++ b/components/script/dom/html/scripting/htmlscriptelement.rs
@@ -51,11 +51,12 @@ use crate::dom::element::{
 };
 use crate::dom::event::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::globalscope::script_execution::{ClassicScript, ErrorReporting, RethrowErrors};
+use crate::dom::globalscope::script_execution::{ClassicScript, RethrowErrors};
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::virtualmethods::VirtualMethods;
 use crate::dom::node::{ChildrenMutation, CloneChildrenFlag, Node, NodeTraits, UnbindContext};
 use crate::dom::performance::performanceresourcetiming::InitiatorType;
+use crate::dom::script_execution::ScriptOptions;
 use crate::dom::trustedtypes::trustedscript::TrustedScript;
 use crate::dom::trustedtypes::trustedscripturl::TrustedScriptURL;
 use crate::dom::window::Window;
@@ -394,7 +395,11 @@ impl FetchResponseListener for ClassicContext {
         }
 
         // Step 5.6. Let mutedErrors be true if response was CORS-cross-origin, and false otherwise.
-        let muted_errors = self.response_was_cors_cross_origin;
+        let mut script_options = ScriptOptions::External;
+        script_options.set(
+            ScriptOptions::MutedErrors,
+            self.response_was_cors_cross_origin,
+        );
 
         // Step 5.7. Let script be the result of creating a classic script given
         // sourceText, settingsObject, response's URL, options, mutedErrors, and url.
@@ -402,12 +407,10 @@ impl FetchResponseListener for ClassicContext {
             cx,
             source_text,
             final_url,
+            script_options,
             self.fetch_options.clone(),
-            ErrorReporting::from(muted_errors),
             Some(IntroductionType::SRC_SCRIPT),
             1,
-            true,  /* external */
-            false, /* returns_a_value */
         );
 
         /*
@@ -761,7 +764,7 @@ impl HTMLScriptElement {
         };
 
         // Step 29. Fetch options.
-        let mut options = ScriptFetchOptions {
+        let mut script_fetch_options = ScriptFetchOptions {
             cryptographic_nonce,
             integrity_metadata,
             parser_metadata,
@@ -819,20 +822,27 @@ impl HTMLScriptElement {
 
             // Step 31.9. If el is currently render-blocking, then set options's render-blocking to true.
             if self.marked_as_render_blocking.get() {
-                options.render_blocking = true;
+                script_fetch_options.render_blocking = true;
             }
 
             // Step 31.11. Switch on el's type:
             match script_type {
                 ScriptType::Classic => {
                     // Step 31.11. Fetch a classic script.
-                    fetch_a_classic_script(self, kind, url, cors_setting, options, encoding);
+                    fetch_a_classic_script(
+                        self,
+                        kind,
+                        url,
+                        cors_setting,
+                        script_fetch_options,
+                        encoding,
+                    );
                 },
                 ScriptType::Module => {
                     // If el does not have an integrity attribute, then set options's integrity metadata to
                     // the result of resolving a module integrity metadata with url and settings object.
                     if integrity_val_is_none {
-                        options.integrity_metadata = global
+                        script_fetch_options.integrity_metadata = global
                             .import_map()
                             .resolve_a_module_integrity_metadata(&url.url());
                     }
@@ -844,7 +854,7 @@ impl HTMLScriptElement {
                         cx,
                         url,
                         global,
-                        options,
+                        script_fetch_options,
                         move |cx, module_tree| {
                             let load = module_tree.map(Script::Module).ok_or(());
                             *script.result.borrow_mut() = Some(load);
@@ -869,12 +879,10 @@ impl HTMLScriptElement {
                         cx,
                         text,
                         base_url,
-                        options,
-                        ErrorReporting::Unmuted,
+                        ScriptOptions::empty(),
+                        script_fetch_options,
                         introduction_type,
                         self.line_number as u32,
-                        false, /* external */
-                        false, /* returns_a_value */
                     );
                     let result = Ok(Script::Classic(script));
 
@@ -904,7 +912,7 @@ impl HTMLScriptElement {
                         doc.increment_render_blocking_element_count();
 
                         // Step 32.2.2.2.2 Set options's render-blocking to true.
-                        options.render_blocking = true;
+                        script_fetch_options.render_blocking = true;
                     }
 
                     let script = DomRoot::from_ref(self);
@@ -915,7 +923,7 @@ impl HTMLScriptElement {
                         global,
                         text,
                         base_url,
-                        options,
+                        script_fetch_options,
                         self.line_number as u32,
                         introduction_type,
                         move |_, module_tree| {
@@ -1018,7 +1026,7 @@ impl HTMLScriptElement {
                     cx,
                     script,
                     RethrowErrors::No,
-                    None, /* return_value */
+                    None, // return_value
                 );
 
                 // Step 6."classic".4. Set document's currentScript attribute to oldCurrentScript.

--- a/components/script/dom/html/scripting/htmlscriptelement.rs
+++ b/components/script/dom/html/scripting/htmlscriptelement.rs
@@ -406,7 +406,8 @@ impl FetchResponseListener for ClassicContext {
             ErrorReporting::from(muted_errors),
             Some(IntroductionType::SRC_SCRIPT),
             1,
-            true,
+            true,  /* external */
+            false, /* returns_a_value */
         );
 
         /*
@@ -872,7 +873,8 @@ impl HTMLScriptElement {
                         ErrorReporting::Unmuted,
                         introduction_type,
                         self.line_number as u32,
-                        false,
+                        false, /* external */
+                        false, /* returns_a_value */
                     );
                     let result = Ok(Script::Classic(script));
 
@@ -1012,9 +1014,12 @@ impl HTMLScriptElement {
                 }
 
                 // Step 6."classic".3. Run the classic script given by el's result.
-                _ = self
-                    .owner_global()
-                    .run_a_classic_script(cx, script, RethrowErrors::No);
+                _ = self.owner_global().run_a_classic_script(
+                    cx,
+                    script,
+                    RethrowErrors::No,
+                    None, /* return_value */
+                );
 
                 // Step 6."classic".4. Set document's currentScript attribute to oldCurrentScript.
                 document.set_current_script(old_script.as_deref());

--- a/components/script/dom/serviceworker/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworker/serviceworkerglobalscope.rs
@@ -474,9 +474,15 @@ impl ServiceWorkerGlobalScope {
                         ErrorReporting::Unmuted,
                         Some(IntroductionType::WORKER),
                         1,
-                        true,
+                        true,  /* external */
+                        false, /* returns_a_value */
                     );
-                    _ = global_scope.run_a_classic_script(&mut realm, script, RethrowErrors::No);
+                    _ = global_scope.run_a_classic_script(
+                        &mut realm,
+                        script,
+                        RethrowErrors::No,
+                        None, /* return_value */
+                    );
                     global.dispatch_activate(&mut realm);
                 }
 

--- a/components/script/dom/serviceworker/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworker/serviceworkerglobalscope.rs
@@ -53,7 +53,8 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::extendableevent::ExtendableEvent;
 use crate::dom::extendablemessageevent::ExtendableMessageEvent;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::globalscope::script_execution::{ErrorReporting, RethrowErrors};
+use crate::dom::globalscope::script_execution::RethrowErrors;
+use crate::dom::script_execution::ScriptOptions;
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::identityhub::IdentityHub;
 use crate::dom::worker::TrustedWorkerAddress;
@@ -470,18 +471,16 @@ impl ServiceWorkerGlobalScope {
                         &mut realm,
                         String::from_utf8_lossy(&source),
                         url,
+                        ScriptOptions::External,
                         ScriptFetchOptions::default_classic_script(),
-                        ErrorReporting::Unmuted,
                         Some(IntroductionType::WORKER),
                         1,
-                        true,  /* external */
-                        false, /* returns_a_value */
                     );
                     _ = global_scope.run_a_classic_script(
                         &mut realm,
                         script,
                         RethrowErrors::No,
-                        None, /* return_value */
+                        None, // return_value
                     );
                     global.dispatch_activate(&mut realm);
                 }

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -71,7 +71,7 @@ use crate::dom::csp::{GlobalCspReporting, Violation, parse_csp_list_from_metadat
 use crate::dom::debugger::debuggerglobalscope::DebuggerGlobalScope;
 use crate::dom::dedicatedworkerglobalscope::DedicatedWorkerGlobalScope;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::globalscope::script_execution::{ErrorReporting, RethrowErrors};
+use crate::dom::globalscope::script_execution::RethrowErrors;
 use crate::dom::htmlscriptelement::{SCRIPT_JS_MIMES, Script};
 use crate::dom::idbfactory::IDBFactory;
 use crate::dom::performance::performance::Performance;
@@ -79,6 +79,7 @@ use crate::dom::performance::performanceresourcetiming::InitiatorType;
 use crate::dom::promise::Promise;
 use crate::dom::reporting::reportingendpoint::{ReportingEndpoint, SendReportsToEndpoints};
 use crate::dom::reporting::reportingobserver::ReportingObserver;
+use crate::dom::script_execution::ScriptOptions;
 use crate::dom::serviceworker::cachestorage::CacheStorage;
 use crate::dom::sharedworkerglobalscope::SharedWorkerGlobalScope;
 use crate::dom::trustedtypes::trustedscripturl::TrustedScriptURL;
@@ -248,12 +249,10 @@ impl FetchResponseListener for ScriptFetchContext {
             cx,
             source,
             scope.worker_url.borrow().clone(),
+            ScriptOptions::External,
             ScriptFetchOptions::default_classic_script(),
-            ErrorReporting::Unmuted,
             Some(IntroductionType::WORKER),
             1,
-            true,  /* external */
-            false, /* returns_a_value */
         );
 
         // Step 6 Run onComplete given script.
@@ -692,7 +691,7 @@ impl WorkerGlobalScope {
                         cx,
                         script,
                         RethrowErrors::No,
-                        None, /* return_value */
+                        None, // return_value
                     );
                 },
                 Script::Module(module_tree) => {
@@ -842,16 +841,16 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
 
             // Step 10. Let script be the result of creating a classic script
             // given sourceText, settingsObject, response's URL, the default script fetch options, and mutedErrors.
+            let mut script_options = ScriptOptions::External;
+            script_options.set(ScriptOptions::MutedErrors, muted_errors);
             let script = self.globalscope.create_a_classic_script(
                 cx,
                 source,
                 url,
+                script_options,
                 ScriptFetchOptions::default_classic_script(),
-                ErrorReporting::from(muted_errors),
                 Some(IntroductionType::WORKER),
                 1,
-                true,  /* external */
-                false, /* returns_a_value */
             );
 
             // Run the classic script script, with rethrow errors set to true.
@@ -859,7 +858,7 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
                 cx,
                 script,
                 RethrowErrors::Yes,
-                None, /* return_value */
+                None, // return_value
             );
 
             if let Err(error) = result {

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -252,7 +252,8 @@ impl FetchResponseListener for ScriptFetchContext {
             ErrorReporting::Unmuted,
             Some(IntroductionType::WORKER),
             1,
-            true,
+            true,  /* external */
+            false, /* returns_a_value */
         );
 
         // Step 6 Run onComplete given script.
@@ -687,9 +688,12 @@ impl WorkerGlobalScope {
             self.execution_ready.store(true, Ordering::Relaxed);
             match script {
                 Script::Classic(script) => {
-                    _ = self
-                        .globalscope
-                        .run_a_classic_script(cx, script, RethrowErrors::No);
+                    _ = self.globalscope.run_a_classic_script(
+                        cx,
+                        script,
+                        RethrowErrors::No,
+                        None, /* return_value */
+                    );
                 },
                 Script::Module(module_tree) => {
                     self.globalscope.run_a_module_script(cx, module_tree, false);
@@ -846,13 +850,17 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
                 ErrorReporting::from(muted_errors),
                 Some(IntroductionType::WORKER),
                 1,
-                true,
+                true,  /* external */
+                false, /* returns_a_value */
             );
 
             // Run the classic script script, with rethrow errors set to true.
-            let result = self
-                .globalscope
-                .run_a_classic_script(cx, script, RethrowErrors::Yes);
+            let result = self.globalscope.run_a_classic_script(
+                cx,
+                script,
+                RethrowErrors::Yes,
+                None, /* return_value */
+            );
 
             if let Err(error) = result {
                 if self.is_closing() {

--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -137,7 +137,7 @@ use crate::dom::element::Element;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmliframeelement::{HTMLIFrameElement, IframeContext, ProcessingMode};
 use crate::dom::node::{Node, NodeTraits};
-use crate::dom::script_execution::{ErrorReporting, RethrowErrors};
+use crate::dom::script_execution::{RethrowErrors, ScriptOptions};
 use crate::dom::servoparser::{ParserContext, ServoParser};
 use crate::dom::types::DebuggerGlobalScope;
 #[cfg(feature = "webgpu")]
@@ -3895,7 +3895,7 @@ impl ScriptThread {
     /// <https://html.spec.whatwg.org/multipage/#evaluate-a-javascript:-url>
     ///
     /// This fills the provided [`LoadData`] with the result of evaluating the given
-    /// JavaScript URL. Return `true` if a result is produced and `false` otherwise.
+    /// JavaScript URL. Returns `true` if a result is produced and `false` otherwise.
     fn evaluate_a_javascript_url(
         cx: &mut js::context::JSContext,
         global_scope: &GlobalScope,
@@ -3923,12 +3923,10 @@ impl ScriptThread {
             cx,
             script_source,
             base_url,
+            ScriptOptions::ReturnsAValue,
             ScriptFetchOptions::default_classic_script(),
-            ErrorReporting::Unmuted,
             Some(IntroductionType::JAVASCRIPT_URL),
-            1,     /* line_number */
-            false, /* external */
-            true,  /* returns_a_value */
+            1, // line_number
         );
 
         // Step 7. Let evaluationStatus be the result of running the classic script script.
@@ -3966,24 +3964,19 @@ impl ScriptThread {
         // Step 12. Let policyContainer be targetNavigable's active document's policy
         // container.
         let policy_container = global_scope.policy_container();
-        let sandbox_flags = policy_container
-            .csp_list
-            .as_ref()
-            .and_then(|csp_list| csp_list.get_sandboxing_flag_set_for_document())
-            .unwrap_or_default();
         load_data.policy_container = Some(policy_container);
 
         // Step 13. Let finalSandboxFlags be policyContainer's CSP list's CSP-derived
         // sandboxing flags.
-        load_data.creation_sandboxing_flag_set |= sandbox_flags;
+        // TODO: Implement this.
 
         // Step 14. Let coop be targetNavigable's active document's opener policy.
         // TODO: Implement this.
 
         // Step 15. Let coopEnforcementResult be a new opener policy enforcement result with
-        // -url: url
-        // -origin: newDocumentOrigin
-        // -opener policy: coop
+        // - url: url
+        // - origin: newDocumentOrigin
+        // - opener policy: coop
         // TODO Implement this.
 
         // Step 16. Let navigationParams be a new navigation params, with
@@ -3997,14 +3990,14 @@ impl ScriptThread {
         // - reserved environment: null
         // - origin: newDocumentOrigin
         // - policy container: policyContainer
-        // - final sandboxing flag: set finalSandboxFlags
+        // - final sandboxing flag set: finalSandboxFlags
         // - iframe element referrer policy: targetSnapshotParams's iframe element referrer policy
         // - opener policy: coop
         // - navigation timing type: "navigate"
         // - about base URL: targetNavigable's active document's about base URL
-        // -  user involvement: userInvolvement
+        // - user involvement: userInvolvement
         //
-        // TODO: Implement the rest of these once Servo supports navigations params.
+        // TODO: Implement the rest of these once Servo supports navigation params.
         load_data.about_base_url = global_scope.as_window().Document().about_base_url();
         true
     }

--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -137,6 +137,7 @@ use crate::dom::element::Element;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmliframeelement::{HTMLIFrameElement, IframeContext, ProcessingMode};
 use crate::dom::node::{Node, NodeTraits};
+use crate::dom::script_execution::{ErrorReporting, RethrowErrors};
 use crate::dom::servoparser::{ParserContext, ServoParser};
 use crate::dom::types::DebuggerGlobalScope;
 #[cfg(feature = "webgpu")]
@@ -157,6 +158,7 @@ use crate::messaging::{
     ScriptThreadReceivers, ScriptThreadSenders,
 };
 use crate::mime::{APPLICATION, CHARSET, MimeExt, TEXT, XML};
+use crate::modules::script_module::ScriptFetchOptions;
 use crate::navigation::{InProgressLoad, NavigationListener};
 use crate::realms::enter_auto_realm;
 use crate::runtime::microtask::{MicrotaskQueue, MicrotaskRunnable};
@@ -672,7 +674,8 @@ impl ScriptThread {
         container: Option<&Element>,
         initial_insertion: Option<bool>,
     ) -> bool {
-        // Step 6. If the result of should navigation request of type be blocked by Content Security Policy? given request and cspNavigationType is "Blocked", then return.
+        // Step 6. If the result of should navigation request of type be blocked by Content
+        // Security Policy? given request and cspNavigationType is "Blocked", then return.
         if !Self::can_navigate_to_javascript_url(
             cx,
             initiator_global,
@@ -685,32 +688,24 @@ impl ScriptThread {
 
         // Step 7. Let newDocument be the result of evaluating a javascript: URL given targetNavigable,
         // url, initiatorOrigin, and userInvolvement.
-        let Some(body) = Self::eval_js_url(cx, target_global, &load_data.url) else {
+        if !Self::evaluate_a_javascript_url(cx, target_global, load_data) {
             // Step 8. If newDocument is null:
             let window_proxy = target_global.as_window().window_proxy();
             if let Some(frame_element) = window_proxy
                 .frame_element()
                 .and_then(Castable::downcast::<HTMLIFrameElement>)
             {
-                // Step 8.1 If initialInsertion is true and targetNavigable's active document's is initial about:blank is true, then run the iframe load event steps given targetNavigable's container.
+                // Step 8.1 If initialInsertion is true and targetNavigable's active document's
+                // is initial about:blank is true, then run the iframe load event steps given
+                // targetNavigable's container.
                 if initial_insertion == Some(true) && frame_element.is_initial_blank_document() {
                     frame_element.run_iframe_load_event_steps(cx);
                 }
             }
             // Step 8.2. Return.
             return false;
-        };
+        }
 
-        // Step 11. of <https://html.spec.whatwg.org/multipage/#evaluate-a-javascript:-url>.
-        // Let response be a new response with
-        // URL         targetNavigable's active document's URL
-        // header list « (`Content-Type`, `text/html;charset=utf-8`) »
-        // body        the UTF-8 encoding of result, as a body
-        load_data.js_eval_result = Some(body);
-        load_data.url = target_global.get_url();
-        load_data
-            .headers
-            .typed_insert(headers::ContentType::from(mime::TEXT_HTML_UTF_8));
         true
     }
 
@@ -3897,54 +3892,121 @@ impl ScriptThread {
         }
     }
 
-    /// Turn javascript: URL into JS code to eval, according to the steps in
     /// <https://html.spec.whatwg.org/multipage/#evaluate-a-javascript:-url>
-    /// Returns the evaluated body, if available.
-    fn eval_js_url(
+    ///
+    /// This fills the provided [`LoadData`] with the result of evaluating the given
+    /// JavaScript URL. Return `true` if a result is produced and `false` otherwise.
+    fn evaluate_a_javascript_url(
         cx: &mut js::context::JSContext,
         global_scope: &GlobalScope,
-        url: &ServoUrl,
-    ) -> Option<String> {
+        load_data: &mut LoadData,
+    ) -> bool {
         // Step 1. Let urlString be the result of running the URL serializer on url.
-        // Step 2. Let encodedScriptSource be the result of removing the leading "javascript:" from urlString.
-        let encoded = &url[Position::AfterScheme..][1..];
+        // Step 2. Let encodedScriptSource be the result of removing the leading "javascript:"
+        // from urlString.
+        let encoded = &load_data.url[Position::AfterScheme..][1..];
 
-        // // Step 3. Let scriptSource be the UTF-8 decoding of the percent-decoding of encodedScriptSource.
+        // Step 3. Let scriptSource be the UTF-8 decoding of the percent-decoding of
+        // encodedScriptSource.
         let script_source = percent_decode(encoded.as_bytes()).decode_utf8_lossy();
 
-        // Step 4. Let settings be targetNavigable's active document's relevant settings object.
+        // Step 4. Let settings be targetNavigable's active document's relevant settings
+        // object.
         // Step 5. Let baseURL be settings's API base URL.
-        // Step 6. Let script be the result of creating a classic script given scriptSource, settings, baseURL, and the default script fetch options.
-        // Note: these steps are handled by `evaluate_js_on_global`.
+        let base_url = global_scope.api_base_url();
+
+        // Step 6. Let script be the result of creating a classic script given scriptSource,
+        // settings, baseURL, and the default script fetch options.
         let mut realm = enter_auto_realm(cx, global_scope);
         let cx = &mut realm.current_realm();
-
-        rooted!(&in(cx) let mut jsval = UndefinedValue());
-        // Step 7. Let evaluationStatus be the result of running the classic script script.
-        let evaluation_status = global_scope.evaluate_js_on_global(
+        let classic_script = global_scope.create_a_classic_script(
             cx,
             script_source,
-            "",
+            base_url,
+            ScriptFetchOptions::default_classic_script(),
+            ErrorReporting::Unmuted,
             Some(IntroductionType::JAVASCRIPT_URL),
-            Some(jsval.handle_mut()),
+            1,     /* line_number */
+            false, /* external */
+            true,  /* returns_a_value */
         );
 
-        // Step 9. If evaluationStatus is a normal completion, and evaluationStatus.[[Value]]
-        //   is a String, then set result to evaluationStatus.[[Value]].
-        // Step 10. Otherwise, return null.
-        if evaluation_status.is_err() || !jsval.get().is_string() {
-            return None;
-        }
+        // Step 7. Let evaluationStatus be the result of running the classic script script.
+        rooted!(&in(cx) let mut return_value = UndefinedValue());
+        let evaluation_status = global_scope.run_a_classic_script(
+            cx,
+            classic_script,
+            RethrowErrors::No,
+            Some(return_value.handle_mut()),
+        );
 
-        let strval = DOMString::safe_from_jsval(cx, jsval.handle(), StringificationBehavior::Empty);
-        match strval {
-            Ok(ConversionResult::Success(s)) => {
-                // Step 11. Let response be a new response with
-                // the UTF-8 encoding of result, as a body.
-                Some(String::from(s))
-            },
-            _ => unreachable!("Couldn't get a string from a JS string??"),
+        // Step 8. Let result be null.
+        // Step 9. If evaluationStatus is a normal completion, and evaluationStatus.
+        // is a String, then set result to evaluationStatus.
+        // Step 10. Otherwise, return null.
+        if evaluation_status.is_err() || !return_value.get().is_string() {
+            return false;
         }
+        let Ok(ConversionResult::Success(body)) =
+            DOMString::safe_from_jsval(cx, return_value.handle(), StringificationBehavior::Empty)
+        else {
+            return false;
+        };
+
+        // Step 11. Let response be a new response with
+        // - URL: targetNavigable's active document's URL
+        // - header list: (`Content-Type`, `text/html;charset=utf-8`)
+        // - body the UTF-8 encoding of result, as a body
+        load_data.url = global_scope.get_url();
+        load_data
+            .headers
+            .typed_insert(headers::ContentType::from(mime::TEXT_HTML_UTF_8));
+        load_data.js_eval_result = Some(body.into());
+
+        // Step 12. Let policyContainer be targetNavigable's active document's policy
+        // container.
+        let policy_container = global_scope.policy_container();
+        let sandbox_flags = policy_container
+            .csp_list
+            .as_ref()
+            .and_then(|csp_list| csp_list.get_sandboxing_flag_set_for_document())
+            .unwrap_or_default();
+        load_data.policy_container = Some(policy_container);
+
+        // Step 13. Let finalSandboxFlags be policyContainer's CSP list's CSP-derived
+        // sandboxing flags.
+        load_data.creation_sandboxing_flag_set |= sandbox_flags;
+
+        // Step 14. Let coop be targetNavigable's active document's opener policy.
+        // TODO: Implement this.
+
+        // Step 15. Let coopEnforcementResult be a new opener policy enforcement result with
+        // -url: url
+        // -origin: newDocumentOrigin
+        // -opener policy: coop
+        // TODO Implement this.
+
+        // Step 16. Let navigationParams be a new navigation params, with
+        // - id: navigationId
+        // - navigable: targetNavigable
+        // - request: null
+        // - response: response
+        // - fetch: controller null
+        // - commit early hints: null
+        // - COOP enforcement result: coopEnforcementResult
+        // - reserved environment: null
+        // - origin: newDocumentOrigin
+        // - policy container: policyContainer
+        // - final sandboxing flag: set finalSandboxFlags
+        // - iframe element referrer policy: targetSnapshotParams's iframe element referrer policy
+        // - opener policy: coop
+        // - navigation timing type: "navigate"
+        // - about base URL: targetNavigable's active document's about base URL
+        // -  user involvement: userInvolvement
+        //
+        // TODO: Implement the rest of these once Servo supports navigations params.
+        load_data.about_base_url = global_scope.as_window().Document().about_base_url();
+        true
     }
 
     /// Instructs the constellation to fetch the document that will be loaded. Stores the InProgressLoad

--- a/components/script/event_loop/timers.rs
+++ b/components/script/event_loop/timers.rs
@@ -812,11 +812,17 @@ impl JsTimerTask {
                     ErrorReporting::Unmuted,
                     Some(IntroductionType::DOM_TIMER),
                     1,
-                    false,
+                    false, /* external */
+                    false, /* returns_a_value */
                 );
 
                 // Step 9.6.9. Run the classic script script.
-                _ = global.run_a_classic_script(cx, script, RethrowErrors::No);
+                _ = global.run_a_classic_script(
+                    cx,
+                    script,
+                    RethrowErrors::No,
+                    None, /* return_value */
+                );
             },
             // Step 9.5. If handler is a Function, then invoke handler given arguments and
             // "report", and with callback this value set to thisArg.

--- a/components/script/event_loop/timers.rs
+++ b/components/script/event_loop/timers.rs
@@ -36,7 +36,8 @@ use crate::dom::csp::CspReporting;
 use crate::dom::document::RefreshRedirectDue;
 use crate::dom::eventsource::EventSourceTimeoutCallback;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::globalscope::script_execution::{ErrorReporting, RethrowErrors};
+use crate::dom::globalscope::script_execution::RethrowErrors;
+use crate::dom::script_execution::ScriptOptions;
 #[cfg(feature = "testbinding")]
 use crate::dom::testbinding::TestBindingCallback;
 use crate::dom::trustedtypes::trustedscript::TrustedScript;
@@ -808,12 +809,10 @@ impl JsTimerTask {
                     cx,
                     (*code_str.str()).into(),
                     base_url,
+                    ScriptOptions::empty(),
                     fetch_options,
-                    ErrorReporting::Unmuted,
                     Some(IntroductionType::DOM_TIMER),
                     1,
-                    false, /* external */
-                    false, /* returns_a_value */
                 );
 
                 // Step 9.6.9. Run the classic script script.
@@ -821,7 +820,7 @@ impl JsTimerTask {
                     cx,
                     script,
                     RethrowErrors::No,
-                    None, /* return_value */
+                    None, // return_value
                 );
             },
             // Step 9.5. If handler is a Function, then invoke handler given arguments and

--- a/components/script/modules/script_module.rs
+++ b/components/script/modules/script_module.rs
@@ -65,11 +65,12 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::csp::{GlobalCspReporting, Violation};
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::globalscope::script_execution::{ErrorReporting, fill_compile_options};
+use crate::dom::globalscope::script_execution::fill_compile_options;
 use crate::dom::html::htmlscriptelement::{SCRIPT_JS_MIMES, substitute_with_local_script};
 use crate::dom::performance::performanceresourcetiming::InitiatorType;
 use crate::dom::promise::Promise;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
+use crate::dom::script_execution::ScriptOptions;
 use crate::dom::types::{
     DedicatedWorkerGlobalScope, SharedWorkerGlobalScope, WorkerGlobalScope, WorkletGlobalScope,
 };
@@ -281,9 +282,8 @@ impl ModuleTree {
         let compile_options = fill_compile_options(
             cx,
             url.as_str(),
+            ScriptOptions::empty(),
             introduction_type,
-            ErrorReporting::Unmuted,
-            true, // noScriptRval
             line_number,
         );
 
@@ -367,10 +367,9 @@ impl ModuleTree {
         let compile_options = fill_compile_options(
             cx,
             url.as_str(),
+            ScriptOptions::empty(),
             introduction_type,
-            ErrorReporting::Unmuted,
-            true, // noScriptRval
-            1,    // lineno
+            1, // line_number
         );
 
         rooted!(&in(cx) let mut module_script: *mut JSObject = std::ptr::null_mut());

--- a/tests/wpt/meta/content-security-policy/inheritance/iframe-all-local-schemes.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/inheritance/iframe-all-local-schemes.sub.html.ini
@@ -13,6 +13,3 @@
 
   [window url='blob:...' inherits policy.]
     expected: FAIL
-
-  [window url='javascript:...'>'s inherits policy (static <img> is blocked)]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/inheritance/inheritance-from-initiator.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/inheritance/inheritance-from-initiator.sub.html.ini
@@ -45,25 +45,7 @@
 
 
 [inheritance-from-initiator.sub.html?scheme=javascript]
-  [javascript: Setting src inherits from parent (apart from javascript:, which keeps target policies).]
-    expected: FAIL
-
-  [javascript: Changing contentWindow.location inherits from who changed it (apart from javascript:, which keeps target policies, and blob:, which always inherits from creator).]
-    expected: FAIL
-
-  [javascript: Changing contentWindow.location indirectly inherits from who changed it directly (apart from javascript:, which keeps target policies).]
-    expected: FAIL
-
   [javascript: window.open() inherits from caller (apart from javascript:, which keeps target policies, and blob:, which always inherits from creator).]
-    expected: FAIL
-
-  [javascript: Click on anchor inherits from owner of the anchor (apart from javascript:, which keeps target policies, and blob:, which always inherits from creator).]
-    expected: FAIL
-
-  [javascript: Form submission through submit() inherits  from owner of form (apart from javascript:, which keeps target policies).]
-    expected: FAIL
-
-  [javascript: Form submission through button click inherits from owner of form (apart from javascript:, which keeps target policies).]
     expected: FAIL
 
 

--- a/tests/wpt/meta/content-security-policy/inheritance/javascript-url-open-in-main-window.html.ini
+++ b/tests/wpt/meta/content-security-policy/inheritance/javascript-url-open-in-main-window.html.ini
@@ -1,3 +1,0 @@
-[javascript-url-open-in-main-window.html]
-  [Executing Javascript URL keeps enforcing previous CSPs of the document.]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/inheritance/window.html.ini
+++ b/tests/wpt/meta/content-security-policy/inheritance/window.html.ini
@@ -7,6 +7,3 @@
 
   [window.open('blob:...') inherits policy.]
     expected: FAIL
-
-  [window.open('javascript:...') inherits policy.]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/navigation/javascript-url-navigation-evaluated-to-string-inherits-csp.html.ini
+++ b/tests/wpt/meta/content-security-policy/navigation/javascript-url-navigation-evaluated-to-string-inherits-csp.html.ini
@@ -1,3 +1,0 @@
-[javascript-url-navigation-evaluated-to-string-inherits-csp.html]
-  [Violation report status OK.]
-    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/generic/inheritance/iframe-inheritance-javascript-child.html.ini
+++ b/tests/wpt/meta/referrer-policy/generic/inheritance/iframe-inheritance-javascript-child.html.ini
@@ -1,3 +1,0 @@
-[iframe-inheritance-javascript-child.html]
-  [Referrer Policy: iframes with javascript url reuse referrer policy 3]
-    expected: FAIL

--- a/tests/wpt/meta/trusted-types/navigate-to-javascript-url-007-crash.html.ini
+++ b/tests/wpt/meta/trusted-types/navigate-to-javascript-url-007-crash.html.ini
@@ -1,2 +1,0 @@
-[navigate-to-javascript-url-007-crash.html]
-  expected: CRASH


### PR DESCRIPTION
This change makes it so that the "evaluate a JavaScript URL" procedure
from the specification is more faithfully implemented. In particular, it
builds and executes a classic script, which nows grows the ability to
return a value, as specified. More specification steps are filled out in
general.
    
Testing: This results in a progression on a decent number of WPT subtests.
