### PR TITLE
android: Stop double-trimming URI before loading

### DIFF
--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
@@ -104,7 +104,7 @@ class MainActivity : ComponentActivity(), Servo.Client {
                         Omnibox(
                             urlTextFieldState,
                             onSearch = { search ->
-                                loadUrl(search)
+                                servoView.loadUri(search)
                                 servoView.requestFocus()
                             },
                             modifier = Modifier
@@ -259,10 +259,6 @@ class MainActivity : ComponentActivity(), Servo.Client {
         startActivityForResult(Intent(this, HistoryActivity::class.java), HISTORY_REQUEST_CODE)
     }
 
-    private fun loadUrl(search: String) {
-        servoView.loadUri(search.trim { it <= ' ' })
-    }
-
     override fun onImeShow() {
         getSystemService<InputMethodManager>()?.showSoftInput(servoView, InputMethodManager.SHOW_IMPLICIT)
     }
@@ -327,7 +323,7 @@ class MainActivity : ComponentActivity(), Servo.Client {
             val url = data.getStringExtra("url")
             if (!url.isNullOrEmpty()) {
                 urlTextFieldState.edit { replace(0, length, url) }
-                loadUrl(urlTextFieldState.text.toString())
+                servoView.loadUri(urlTextFieldState.text.toString())
             }
         }
     }


### PR DESCRIPTION
We already trim the URI before loading in Rust, so there's no need to pre-do it in Kotlin.

https://github.com/servo/servo/blob/c3bc20759d19b9c6a951a3cf4c906eaf4d9d400f/ports/servoshell/parser.rs#L73

With this, the `loadUrl` function has been inlined as it is now just a simple proxy to `servoView`.

Testing: There are no automated tests for Android.
