### PR TITLE
android: Make `ServoView.client` non-null

### DIFF
--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
@@ -72,7 +72,7 @@ class MainActivity : ComponentActivity(), Servo.Client {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        servoView = ServoView(this)
+        servoView = ServoView(this, this)
 
         historyManager = HistoryManager(this)
 
@@ -197,7 +197,6 @@ class MainActivity : ComponentActivity(), Servo.Client {
             }
         }
 
-        servoView.setClient(this)
         servoView.requestFocus()
 
         val sdcard = getExternalFilesDir("")

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.kt
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.kt
@@ -5,6 +5,7 @@
  */
 package org.servo.servoview
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
@@ -16,7 +17,11 @@ import android.view.MotionEvent
 import android.view.SurfaceHolder
 import android.view.SurfaceView
 
-class ServoView(context: Context) : SurfaceView(context), Servo.RunCallback, Choreographer.FrameCallback {
+@SuppressLint("ViewConstructor")
+class ServoView(
+    context: Context,
+    client: Servo.Client,
+) : SurfaceView(context), Servo.RunCallback, Choreographer.FrameCallback {
     private val glThread: GLThread
     private val surfaceHolderCallback: SurfaceHolderCallback
     private var servo: Servo? = null
@@ -31,13 +36,9 @@ class ServoView(context: Context) : SurfaceView(context), Servo.RunCallback, Cho
         isClickable = true
         addTouchables(arrayListOf(this))
         glThread = GLThread()
-        surfaceHolderCallback = SurfaceHolderCallback(this)
+        surfaceHolderCallback = SurfaceHolderCallback(this, client)
         holder.addCallback(surfaceHolderCallback)
         glThread.start()
-    }
-
-    fun setClient(client: Servo.Client) {
-        surfaceHolderCallback.client = client
     }
 
     fun setServoArgs(args: String?, log: String?, experimentalMode: Boolean) {
@@ -147,8 +148,10 @@ class ServoView(context: Context) : SurfaceView(context), Servo.RunCallback, Cho
         }
     }
 
-    private class SurfaceHolderCallback(private val servoView: ServoView) : SurfaceHolder.Callback {
-        var client: Servo.Client? = null
+    private class SurfaceHolderCallback(
+        private val servoView: ServoView,
+        private val client: Servo.Client,
+    ) : SurfaceHolder.Callback {
         var servoLog: String? = null
         private var paused = false
 
@@ -169,7 +172,7 @@ class ServoView(context: Context) : SurfaceView(context), Servo.RunCallback, Cho
                     true,
                     servoView.experimentalMode,
                     servoView,
-                    client!!,
+                    client,
                     servoView.context,
                     surface,
                 )


### PR DESCRIPTION
This suppresses the `ViewConstructor` lint since, as mentioned in 201c46059b2b91439dcf41a731302c9b43a65a89, we no longer want to promote the usage of `ServoView` via the XML Views.

Testing: There are no automated tests for Android.