### PR TITLE
deps: Bump ocb3 to 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,15 +139,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aead-stream"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a901e5bcd15b4a9555a8f17a608d28ef92cf77bc4aa3b4a0c1a3fce1a9cc0bac"
-dependencies = [
- "aead",
-]
-
-[[package]]
 name = "aes"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6013,17 +6004,14 @@ dependencies = [
 
 [[package]]
 name = "ocb3"
-version = "0.2.0-rc.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b07d573bb0b2f2f4158dadc1888df3bb55ae0a2e246c99af4d2870ee3892b17"
+checksum = "912ff80ac25d578d4c9e260650b9e6d65cea9f5b4a49ce9e88a2c5536e2326b2"
 dependencies = [
  "aead",
- "aead-stream",
  "cipher",
- "ctr",
+ "ctutils",
  "dbl",
- "subtle",
- "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,7 +173,7 @@ objc2-core-foundation = "0.3.2"
 objc2-core-graphics = "0.3.2"
 objc2-core-text = "0.3.2"
 objc2-foundation = { version = "0.3.1", default-features = false }
-ocb3 = { version = "=0.2.0-rc.3", features = ["zeroize"] }
+ocb3 = "0.2"
 ohos-abilitykit-sys = "0.1.6"
 ohos-deviceinfo = "0.1.0"
 ohos-deviceinfo-sys = "0.1.7"


### PR DESCRIPTION
Bump ocb3 from 0.2.0-rc.3 to 0.2.0.

The new version ocb3 no longer have the `zeroize` feature. Since the code for handling AES key is shared with other AES algorithms, and the key is already protected by the `zeroize` feature of `hybrid-array` crate. It is safe to remove the `zeroize` feature from the ocb3 crate.

Testing: No code change.
Part-of: #45823