### PR TITLE
script/net: Use Bytes/BytesMut instead of Vec<u8> to avoid copying

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,6 +1130,9 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "calendrical_calculations"
@@ -8111,6 +8114,7 @@ dependencies = [
 name = "servo-devtools-traits"
 version = "0.5.0"
 dependencies = [
+ "bytes",
  "http 1.5.0",
  "malloc_size_of_derive",
  "serde",
@@ -8387,6 +8391,7 @@ version = "0.5.0"
 dependencies = [
  "app_units",
  "atomic_refcell",
+ "bytes",
  "content-security-policy",
  "cookie 0.18.2",
  "crossbeam-channel",
@@ -8746,6 +8751,7 @@ dependencies = [
 name = "servo-net-traits"
 version = "0.5.0"
 dependencies = [
+ "bytes",
  "content-security-policy",
  "cookie 0.18.2",
  "crossbeam-channel",
@@ -8924,6 +8930,7 @@ dependencies = [
  "bitflags 2.13.1",
  "brotli",
  "buf-read-ext",
+ "bytes",
  "cbc",
  "chacha20poly1305",
  "chardetng",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ buf-read-ext = "0.4"
 byte-slice-cast = "1.2.3"
 bytemuck = "1"
 byteorder = "1.5"
-bytes = "1.0"
+bytes = { version = "1.0", features = ["serde"] }
 cbc = { version = "0.2", features = ["alloc", "zeroize"] }
 cc = "1.2"
 cfg-if = "1.0.4"

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -402,7 +402,7 @@ impl Actor for NetworkEventActor {
 
                 let msg = GetRequestPostDataReply {
                     from: self.name().into(),
-                    post_data: request.request.body.as_ref().map(|b| b.0.clone()),
+                    post_data: request.request.body.as_ref().map(|b| b.to_vec()),
                     post_data_discarded: request.request.body.is_none(),
                 };
                 client_request.reply_final(&msg)?
@@ -472,7 +472,7 @@ impl Actor for NetworkEventActor {
                         let value = long_string_actor.long_string_obj();
                         (None, serde_json::to_value(value).unwrap())
                     } else {
-                        let b64 = STANDARD.encode(&body.0);
+                        let b64 = STANDARD.encode(body);
                         (Some("base64".into()), serde_json::to_value(b64).unwrap())
                     };
                     let is_content_encoded = encoding.is_some();

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -1393,7 +1393,7 @@ impl RemoteWebFontDownloader {
                     self.web_font_family_name, new_bytes
                 );
                 if self.response_valid {
-                    self.response_data.extend(new_bytes.0)
+                    self.response_data.extend(new_bytes)
                 }
                 DownloaderResponseResult::InProcess
             },

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -15,6 +15,7 @@ path = "lib.rs"
 [dependencies]
 app_units = { workspace = true }
 atomic_refcell = { workspace = true }
+bytes = { workspace = true }
 cookie = { workspace = true }
 content-security-policy = { workspace = true }
 crossbeam-channel = { workspace = true }

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -730,6 +730,20 @@ impl<T: MallocSizeOf> MallocSizeOf for std::sync::Weak<T> {
     }
 }
 
+impl MallocSizeOf for bytes::Bytes {
+    fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize {
+        // This is an underapproximation but because it is efficiently stored, we might not have the correct data.
+        if self.is_unique() { self.len() } else { 0 }
+    }
+}
+
+impl MallocSizeOf for bytes::BytesMut {
+    fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize {
+        // This is an underapproximation but because it is efficiently stored, we might not have the correct data.
+        self.len()
+    }
+}
+
 /// If a mutex is stored directly as a member of a data type that is being measured,
 /// it is the unique owner of its contents and deserves to be measured.
 ///

--- a/components/net/devtools.rs
+++ b/components/net/devtools.rs
@@ -4,6 +4,7 @@
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use bytes::Bytes;
 use crossbeam_channel::Sender;
 use devtools_traits::{
     ChromeToDevtoolsControlMsg, DevtoolsControlMsg, HttpRequest as DevtoolsHttpRequest,
@@ -12,10 +13,10 @@ use devtools_traits::{
 use http::{HeaderMap, Method};
 use hyper_serde::Serde;
 use log::error;
+use net_traits::FetchMetadata;
 use net_traits::http_status::HttpStatus;
 use net_traits::request::{Destination, Request};
 use net_traits::response::{CacheState, Response};
-use net_traits::{DebugVec, FetchMetadata};
 use servo_base::id::{BrowsingContextId, PipelineId};
 use servo_url::ServoUrl;
 
@@ -40,7 +41,7 @@ pub(crate) fn prepare_devtools_request(
         url,
         method,
         headers,
-        body: body.map(DebugVec::from),
+        body: body.map(Bytes::from),
         pipeline_id,
         started_date_time,
         time_stamp: started_date_time
@@ -115,7 +116,7 @@ pub(crate) fn send_response_values_to_devtools(
         let devtoolsresponse = DevtoolsHttpResponse {
             headers,
             status,
-            body: body.map(DebugVec::from),
+            body: body.map(Bytes::from),
             from_cache,
             pipeline_id,
             browsing_context_id,

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -8,6 +8,7 @@ use std::{io, mem, str};
 
 use base64::Engine as _;
 use base64::engine::general_purpose;
+use bytes::Bytes;
 use content_security_policy as csp;
 use crossbeam_channel::Sender;
 use devtools_traits::DevtoolsControlMsg;
@@ -63,7 +64,7 @@ pub type Target<'a> = &'a mut (dyn FetchTaskTarget + Send);
 
 #[derive(Clone, Deserialize, Serialize)]
 pub enum Data {
-    Payload(Vec<u8>),
+    Payload(bytes::Bytes),
     ContentLength(usize),
     Done,
     Cancelled,
@@ -904,11 +905,11 @@ async fn wait_for_response(
                 Some(Data::ContentLength(length)) => {
                     target.process_response_length_hint(request, length);
                 },
-                Some(Data::Payload(vec)) => {
+                Some(Data::Payload(bytes)) => {
                     if let Some(body) = devtools_body.as_mut() {
-                        body.extend(&vec);
+                        body.extend(&bytes);
                     }
-                    target.process_response_chunk(request, vec);
+                    target.process_response_chunk(request, bytes);
                 },
                 Some(Data::Error(network_error)) => {
                     if network_error == NetworkError::DecompressionError {
@@ -938,7 +939,7 @@ async fn wait_for_response(
                 // in case there was no channel to wait for, the body was
                 // obtained synchronously via scheme_fetch for data/file/about/etc
                 // We should still send the body across as a chunk
-                target.process_response_chunk(request, vec.clone());
+                target.process_response_chunk(request, Bytes::copy_from_slice(vec));
                 if context.devtools_chan.is_some() {
                     // Now that we've replayed the entire cached body,
                     // notify the DevTools server with the full Response.

--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{self, AtomicBool, AtomicUsize, Ordering};
 
+use bytes::Bytes;
 use embedder_traits::{
     EmbedderControlId, EmbedderControlResponse, FilePickerRequest, GenericEmbedderProxy,
     SelectedFile,
@@ -248,7 +249,7 @@ impl FileManager {
                         );
                         let chunk = &buffer[0..offset];
                         body.extend_from_slice(chunk);
-                        let _ = done_sender.send(Data::Payload(chunk.to_vec()));
+                        let _ = done_sender.send(Data::Payload(Bytes::copy_from_slice(chunk)));
                     }
                     buffer_len
                 };
@@ -317,7 +318,7 @@ impl FileManager {
                 let mut bytes = vec![];
                 bytes.extend_from_slice(buf.bytes.index(range));
 
-                let _ = done_sender.send(Data::Payload(bytes));
+                let _ = done_sender.send(Data::Payload(Bytes::copy_from_slice(&bytes)));
                 let _ = done_sender.send(Data::Done);
 
                 Ok(())

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -2357,7 +2357,7 @@ async fn http_network_fetch(
                 }
                 if let ResponseBody::Receiving(ref mut body) = *response_body_accumulator.lock() {
                     body.extend_from_slice(&chunk);
-                    let _ = done_sender.send(Data::Payload(chunk.to_vec()));
+                    let _ = done_sender.send(Data::Payload(chunk));
                 }
                 future::ready(Ok(response_body_accumulator))
             })

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -165,8 +165,8 @@ fn test_fetch_blob() {
     impl FetchTaskTarget for FetchResponseCollector {
         fn process_request_body(&mut self, _: &Request) {}
         fn process_response(&mut self, _: &Request, _: &Response) {}
-        fn process_response_chunk(&mut self, _: &Request, chunk: Vec<u8>) {
-            self.buffer.extend_from_slice(chunk.as_slice());
+        fn process_response_chunk(&mut self, _: &Request, chunk: bytes::Bytes) {
+            self.buffer.extend_from_slice(&chunk);
         }
         /// Fired when the response is fully fetched
         fn process_response_eof(&mut self, _: &Request, response: &Response) {

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -1606,7 +1606,7 @@ fn test_fetch_compressed_response_update_count() {
     impl FetchTaskTarget for FetchResponseCollector {
         fn process_request_body(&mut self, _: &Request) {}
         fn process_response(&mut self, _: &Request, _: &Response) {}
-        fn process_response_chunk(&mut self, _: &Request, _: Vec<u8>) {
+        fn process_response_chunk(&mut self, _: &Request, _: bytes::Bytes) {
             self.update_count += 1;
         }
         /// Fired when the response is fully fetched

--- a/components/net/tests/image_cache.rs
+++ b/components/net/tests/image_cache.rs
@@ -14,8 +14,8 @@ use net_traits::image_cache::{
 };
 use net_traits::request::RequestId;
 use net_traits::{
-    DebugVec, FetchMetadata, FetchResponseMsg, FilteredMetadata, Metadata, NetworkError,
-    ResourceFetchTiming, ResourceTimingType,
+    FetchMetadata, FetchResponseMsg, FilteredMetadata, Metadata, NetworkError, ResourceFetchTiming,
+    ResourceTimingType,
 };
 use paint_api::{CrossProcessPaintApi, PaintMessage};
 // For dummy Font Resolver
@@ -195,7 +195,7 @@ fn test_notify_pending_response_with_partial_chunk() {
     let small_chunk = vec![0u8; 10];
     cache.notify_pending_response(
         id,
-        FetchResponseMsg::ProcessResponseChunk(create_request_id(), DebugVec(small_chunk)),
+        FetchResponseMsg::ProcessResponseChunk(create_request_id(), small_chunk.into()),
     );
 
     let result = cache.get_cached_image_status(url, origin, None);
@@ -228,7 +228,7 @@ fn test_notify_pending_response_with_metadata_chunk() {
     let metadata_chunk = jpeg_bytes[..200.min(jpeg_bytes.len())].to_vec();
     cache.notify_pending_response(
         id,
-        FetchResponseMsg::ProcessResponseChunk(create_request_id(), DebugVec(metadata_chunk)),
+        FetchResponseMsg::ProcessResponseChunk(create_request_id(), metadata_chunk.into()),
     );
 
     let result = cache.get_cached_image_status(url, origin, None);
@@ -262,7 +262,7 @@ fn test_notify_pending_response_complete() {
     let jpeg_bytes = jpeg_image_bytes();
     cache.notify_pending_response(
         id,
-        FetchResponseMsg::ProcessResponseChunk(create_request_id(), DebugVec(jpeg_bytes)),
+        FetchResponseMsg::ProcessResponseChunk(create_request_id(), jpeg_bytes.into()),
     );
 
     cache.notify_pending_response(
@@ -340,7 +340,7 @@ fn test_image_listener_on_complete_response() {
     let jpeg_bytes = jpeg_image_bytes();
     cache.notify_pending_response(
         id,
-        FetchResponseMsg::ProcessResponseChunk(create_request_id(), DebugVec(jpeg_bytes)),
+        FetchResponseMsg::ProcessResponseChunk(create_request_id(), jpeg_bytes.into()),
     );
 
     cache.notify_pending_response(
@@ -422,7 +422,7 @@ fn test_image_listener_on_metadata_available() {
     let metadata_chunk = jpeg_bytes[..200.min(jpeg_bytes.len())].to_vec();
     cache.notify_pending_response(
         id,
-        FetchResponseMsg::ProcessResponseChunk(create_request_id(), DebugVec(metadata_chunk)),
+        FetchResponseMsg::ProcessResponseChunk(create_request_id(), metadata_chunk.into()),
     );
 
     match receiver.recv_timeout(std::time::Duration::from_millis(100)) {
@@ -473,7 +473,7 @@ fn test_multiple_listeners_same_image() {
     let jpeg_bytes = jpeg_image_bytes();
     cache.notify_pending_response(
         id,
-        FetchResponseMsg::ProcessResponseChunk(create_request_id(), DebugVec(jpeg_bytes)),
+        FetchResponseMsg::ProcessResponseChunk(create_request_id(), jpeg_bytes.into()),
     );
 
     cache.notify_pending_response(
@@ -519,7 +519,7 @@ fn test_cached_image_reuse() {
     let jpeg_bytes = jpeg_image_bytes();
     cache.notify_pending_response(
         id,
-        FetchResponseMsg::ProcessResponseChunk(create_request_id(), DebugVec(jpeg_bytes)),
+        FetchResponseMsg::ProcessResponseChunk(create_request_id(), jpeg_bytes.into()),
     );
 
     cache.notify_pending_response(
@@ -559,7 +559,7 @@ fn test_svg_rasterization() {
     let svg_bytes = svg_image_bytes();
     cache.notify_pending_response(
         id,
-        FetchResponseMsg::ProcessResponseChunk(create_request_id(), DebugVec(svg_bytes)),
+        FetchResponseMsg::ProcessResponseChunk(create_request_id(), svg_bytes.into()),
     );
 
     cache.notify_pending_response(
@@ -611,7 +611,7 @@ fn test_rasterization_listener() {
     let svg_bytes = svg_image_bytes();
     cache.notify_pending_response(
         id,
-        FetchResponseMsg::ProcessResponseChunk(create_request_id(), DebugVec(svg_bytes)),
+        FetchResponseMsg::ProcessResponseChunk(create_request_id(), svg_bytes.into()),
     );
 
     cache.notify_pending_response(
@@ -681,7 +681,7 @@ fn test_svg_rasterization_do_not_double_rasterize() {
     let svg_bytes = svg_image_bytes();
     cache.notify_pending_response(
         id,
-        FetchResponseMsg::ProcessResponseChunk(create_request_id(), DebugVec(svg_bytes)),
+        FetchResponseMsg::ProcessResponseChunk(create_request_id(), svg_bytes.into()),
     );
 
     cache.notify_pending_response(
@@ -741,7 +741,7 @@ fn test_svg_not_rasterize_zero_size() {
     let svg_bytes = svg_image_bytes();
     cache.notify_pending_response(
         id,
-        FetchResponseMsg::ProcessResponseChunk(create_request_id(), DebugVec(svg_bytes)),
+        FetchResponseMsg::ProcessResponseChunk(create_request_id(), svg_bytes.into()),
     );
 
     cache.notify_pending_response(

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -152,7 +152,7 @@ fn new_fetch_context(
 impl FetchTaskTarget for FetchResponseCollector {
     fn process_request_body(&mut self, _: &Request) {}
     fn process_response(&mut self, _: &Request, _: &Response) {}
-    fn process_response_chunk(&mut self, _: &Request, _: Vec<u8>) {}
+    fn process_response_chunk(&mut self, _: &Request, _: bytes::Bytes) {}
     /// Fired when the response is fully fetched
     fn process_response_eof(&mut self, _: &Request, response: &Response) {
         let _ = self.sender.take().unwrap().send(response.clone());

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -96,6 +96,7 @@ base64ct = { workspace = true }
 bitflags = { workspace = true }
 brotli = { workspace = true, optional = true }
 buf-read-ext = { workspace = true }
+bytes = { workspace = true }
 cbc = { workspace = true, optional = true }
 chacha20poly1305 = { workspace = true, optional = true }
 chardetng = { workspace = true }

--- a/components/script/css/stylesheet_loader.rs
+++ b/components/script/css/stylesheet_loader.rs
@@ -5,6 +5,7 @@
 use std::io::{Read, Seek, Write};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use bytes::{Bytes, BytesMut};
 use crossbeam_channel::Sender;
 use cssparser::SourceLocation;
 use encoding_rs::UTF_8;
@@ -105,7 +106,7 @@ struct StylesheetContext {
     url: ServoUrl,
     metadata: Option<Metadata>,
     /// The response body received to date.
-    data: Vec<u8>,
+    data: BytesMut,
     /// The node document for elem when the load was initiated.
     document: Trusted<Document>,
     shadow_root: Option<Trusted<ShadowRoot>>,
@@ -125,7 +126,7 @@ impl StylesheetContext {
             return;
         };
 
-        let mut style_content = std::mem::take(&mut self.data);
+        let mut style_content = std::mem::take(&mut self.data).to_vec();
         if let Some((input, mut output)) = create_temp_files() &&
             execute_js_beautify(
                 input.path(),
@@ -145,7 +146,9 @@ impl StylesheetContext {
             },
         }
 
-        self.data = style_content;
+        self.data = Bytes::copy_from_slice(&style_content)
+            .try_into_mut()
+            .unwrap();
     }
 
     fn empty_stylesheet(&self, document: &Document) -> Arc<Stylesheet> {
@@ -366,9 +369,9 @@ impl FetchResponseListener for StylesheetContext {
         &mut self,
         _: &mut js::context::JSContext,
         _: RequestId,
-        mut payload: Vec<u8>,
+        payload: Bytes,
     ) {
-        self.data.append(&mut payload);
+        self.data.extend_from_slice(&payload);
     }
 
     fn process_response_eof(
@@ -503,7 +506,7 @@ impl ElementStylesheetLoader<'_> {
             media,
             url: url.clone(),
             metadata: None,
-            data: vec![],
+            data: BytesMut::new(),
             document: Trusted::new(&*document),
             shadow_root,
             origin_clean: true,

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -8,6 +8,7 @@ use std::rc::Rc;
 use std::str::{Chars, FromStr};
 use std::time::Duration;
 
+use bytes::Bytes;
 use dom_struct::dom_struct;
 use encoding_rs::{Decoder, UTF_8};
 use headers::ContentType;
@@ -435,7 +436,7 @@ impl FetchResponseListener for EventSourceContext {
         }
     }
 
-    fn process_response_chunk(&mut self, cx: &mut JSContext, _: RequestId, chunk: Vec<u8>) {
+    fn process_response_chunk(&mut self, cx: &mut JSContext, _: RequestId, chunk: Bytes) {
         let mut output = String::with_capacity(chunk.len());
         let mut input = &chunk[..];
 

--- a/components/script/dom/fetch/response.rs
+++ b/components/script/dom/fetch/response.rs
@@ -6,6 +6,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 use std::str::FromStr;
 
+use bytes::Bytes;
 use dom_struct::dom_struct;
 use http::header::HeaderMap as HyperHeaders;
 use hyper_serde::Serde;
@@ -534,12 +535,12 @@ impl Response {
         *self.stream_consumer.borrow_mut() = sc;
     }
 
-    pub(crate) fn stream_chunk(&self, cx: &mut js::context::JSContext, chunk: Vec<u8>) {
+    pub(crate) fn stream_chunk(&self, cx: &mut js::context::JSContext, chunk: Bytes) {
         // Note, are these two actually mutually exclusive?
         if let Some(stream_consumer) = self.stream_consumer.borrow().as_ref() {
-            stream_consumer.consume_chunk(chunk.as_slice());
+            stream_consumer.consume_chunk(&chunk);
         } else if let Some(body) = self.fetch_body_stream.get() {
-            body.enqueue_native(cx, chunk);
+            body.enqueue_native(cx, chunk.to_vec());
         }
     }
 

--- a/components/script/dom/html/document_metadata/htmllinkelement.rs
+++ b/components/script/dom/html/document_metadata/htmllinkelement.rs
@@ -7,6 +7,7 @@ use std::cell::Cell;
 use std::default::Default;
 use std::str::FromStr;
 
+use bytes::{Bytes, BytesMut};
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name};
 use js::context::{JSContext, NoGC};
@@ -674,7 +675,7 @@ impl HTMLLinkElement {
             link: Some(Trusted::new(self)),
             global: Trusted::new(&document.global()),
             type_: LinkFetchContextType::Prefetch,
-            response_body: vec![],
+            response_body: BytesMut::new(),
         };
 
         document.fetch_background(request, fetch_context);
@@ -1313,11 +1314,11 @@ impl FetchResponseListener for FaviconFetchContext {
         &mut self,
         _: &mut js::context::JSContext,
         request_id: RequestId,
-        chunk: Vec<u8>,
+        chunk: Bytes,
     ) {
         self.image_cache.notify_pending_response(
             self.id,
-            FetchResponseMsg::ProcessResponseChunk(request_id, chunk.into()),
+            FetchResponseMsg::ProcessResponseChunk(request_id, chunk),
         );
     }
 

--- a/components/script/dom/html/document_metadata/processingoptions.rs
+++ b/components/script/dom/html/document_metadata/processingoptions.rs
@@ -4,6 +4,7 @@
 
 use std::str::FromStr;
 
+use bytes::{Bytes, BytesMut};
 use cssparser::match_ignore_ascii_case;
 use http::header::HeaderMap;
 use hyper_serde::Serde;
@@ -316,7 +317,7 @@ impl LinkProcessingOptions {
             link,
             global: Trusted::new(&document.global()),
             type_: LinkFetchContextType::Preload,
-            response_body: vec![],
+            response_body: BytesMut::new(),
         };
         document.insert_preloaded_resource(key, preload_id);
         // Step 11. Set controller to the result of fetching request, with processResponseConsumeBody
@@ -467,7 +468,7 @@ pub(crate) struct LinkFetchContext {
     /// The type of fetching we perform, used when report timings.
     pub(crate) type_: LinkFetchContextType,
 
-    pub(crate) response_body: Vec<u8>,
+    pub(crate) response_body: BytesMut,
 }
 
 impl FetchResponseListener for LinkFetchContext {
@@ -486,10 +487,10 @@ impl FetchResponseListener for LinkFetchContext {
         &mut self,
         _: &mut js::context::JSContext,
         _: RequestId,
-        mut chunk: Vec<u8>,
+        chunk: Bytes,
     ) {
         if matches!(self.type_, LinkFetchContextType::Preload) {
-            self.response_body.append(&mut chunk);
+            self.response_body.extend_from_slice(&chunk);
         }
     }
 

--- a/components/script/dom/html/embedded_content/htmlimageelement.rs
+++ b/components/script/dom/html/embedded_content/htmlimageelement.rs
@@ -7,6 +7,7 @@ use std::mem;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use bytes::Bytes;
 use dom_struct::dom_struct;
 use euclid::default::Point2D;
 use html5ever::{LocalName, Prefix, QualName, local_name, ns};
@@ -225,12 +226,12 @@ impl FetchResponseListener for ImageContext {
         &mut self,
         _: &mut js::context::JSContext,
         request_id: RequestId,
-        payload: Vec<u8>,
+        payload: Bytes,
     ) {
         if self.status.is_ok() {
             self.image_cache.notify_pending_response(
                 self.id,
-                FetchResponseMsg::ProcessResponseChunk(request_id, payload.into()),
+                FetchResponseMsg::ProcessResponseChunk(request_id, payload),
             );
         }
     }

--- a/components/script/dom/html/embedded_content/htmlmediaelement.rs
+++ b/components/script/dom/html/embedded_content/htmlmediaelement.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Mutex, OnceLock, RwLock, Weak};
 use std::time::{Duration, Instant};
 use std::{f64, mem};
 
+use bytes::Bytes;
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use dom_struct::dom_struct;
 use embedder_traits::{MediaPositionState, MediaSessionEvent, MediaSessionPlaybackState};
@@ -3947,7 +3948,7 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
         }
     }
 
-    fn process_response_chunk(&mut self, _: &mut JSContext, _: RequestId, chunk: Vec<u8>) {
+    fn process_response_chunk(&mut self, _: &mut JSContext, _: RequestId, chunk: Bytes) {
         let element = self.element.root();
 
         self.fetched_content_length += chunk.len() as u64;
@@ -3959,25 +3960,24 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
             }
 
             // Discard chunk of the response body if fetch context doesn't support range requests.
-            let payload = if !current_fetch_context.is_seekable() &&
-                self.content_length_to_discard != 0
-            {
-                if chunk.len() as u64 > self.content_length_to_discard {
-                    let shrink_chunk = chunk[self.content_length_to_discard as usize..].to_vec();
-                    self.content_length_to_discard = 0;
-                    shrink_chunk
+            let payload =
+                if !current_fetch_context.is_seekable() && self.content_length_to_discard != 0 {
+                    if chunk.len() as u64 > self.content_length_to_discard {
+                        let shrink_chunk = chunk.slice(self.content_length_to_discard as usize..);
+                        self.content_length_to_discard = 0;
+                        shrink_chunk
+                    } else {
+                        // Completely discard this response chunk.
+                        self.content_length_to_discard -= chunk.len() as u64;
+                        return;
+                    }
                 } else {
-                    // Completely discard this response chunk.
-                    self.content_length_to_discard -= chunk.len() as u64;
-                    return;
-                }
-            } else {
-                chunk
-            };
+                    chunk
+                };
 
             if let Err(e) = {
                 let mut data_source = current_fetch_context.data_source().borrow_mut();
-                data_source.add_buffer_to_queue(DataBuffer::Payload(payload));
+                data_source.add_buffer_to_queue(DataBuffer::Payload(payload.to_vec()));
                 data_source
                     .process_into_player_from_queue(element.player.borrow().as_ref().unwrap())
             } {

--- a/components/script/dom/html/embedded_content/htmltrackelement.rs
+++ b/components/script/dom/html/embedded_content/htmltrackelement.rs
@@ -4,6 +4,7 @@
 
 use std::cell::Cell;
 
+use bytes::Bytes;
 use content_security_policy::Destination;
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name};
@@ -457,7 +458,7 @@ impl FetchResponseListener for HTMLTrackElementFetchListener {
     ) {
     }
 
-    fn process_response_chunk(&mut self, _: &mut JSContext, _: RequestId, payload: Vec<u8>) {
+    fn process_response_chunk(&mut self, _: &mut JSContext, _: RequestId, payload: Bytes) {
         self.payload.extend_from_slice(&payload);
     }
 

--- a/components/script/dom/html/embedded_content/htmlvideoelement.rs
+++ b/components/script/dom/html/embedded_content/htmlvideoelement.rs
@@ -6,6 +6,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use bytes::Bytes;
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
 use html5ever::{LocalName, Prefix, local_name, ns};
@@ -516,12 +517,7 @@ impl FetchResponseListener for PosterFrameFetchContext {
         }
     }
 
-    fn process_response_chunk(
-        &mut self,
-        _: &mut JSContext,
-        request_id: RequestId,
-        payload: Vec<u8>,
-    ) {
+    fn process_response_chunk(&mut self, _: &mut JSContext, request_id: RequestId, payload: Bytes) {
         if self.cancelled {
             // An error was received previously, skip processing the payload.
             return;
@@ -529,7 +525,7 @@ impl FetchResponseListener for PosterFrameFetchContext {
 
         self.image_cache.notify_pending_response(
             self.id,
-            FetchResponseMsg::ProcessResponseChunk(request_id, payload.into()),
+            FetchResponseMsg::ProcessResponseChunk(request_id, payload),
         );
     }
 

--- a/components/script/dom/html/scripting/htmlscriptelement.rs
+++ b/components/script/dom/html/scripting/htmlscriptelement.rs
@@ -9,6 +9,7 @@ use std::fs::read_to_string;
 use std::path::PathBuf;
 use std::rc::Rc;
 
+use bytes::{Bytes, BytesMut};
 use dom_struct::dom_struct;
 use encoding_rs::Encoding;
 use html5ever::{LocalName, Prefix, local_name};
@@ -281,7 +282,7 @@ struct ClassicContext {
     /// script" algorithm.
     character_encoding: &'static Encoding,
     /// The response body received to date.
-    data: Vec<u8>,
+    data: BytesMut,
     /// The response metadata received to date.
     metadata: Option<Metadata>,
     /// The initial URL requested.
@@ -338,10 +339,10 @@ impl FetchResponseListener for ClassicContext {
         &mut self,
         _: &mut js::context::JSContext,
         _: RequestId,
-        mut chunk: Vec<u8>,
+        chunk: Bytes,
     ) {
         if self.status.is_ok() {
-            self.data.append(&mut chunk);
+            self.data.extend_from_slice(&chunk);
         }
     }
 
@@ -535,7 +536,7 @@ fn fetch_a_classic_script(
         elem: Trusted::new(script),
         kind,
         character_encoding,
-        data: vec![],
+        data: BytesMut::new(),
         metadata: None,
         url,
         status: Ok(()),

--- a/components/script/dom/navigator/navigator.rs
+++ b/components/script/dom/navigator/navigator.rs
@@ -8,6 +8,7 @@ use std::convert::TryInto;
 use std::ops::Deref;
 use std::sync::LazyLock;
 
+use bytes::Bytes;
 use dom_struct::dom_struct;
 use embedder_traits::{EmbedderMsg, ProtocolHandlerUpdateRegistration, RegisterOrUnregister};
 use headers::HeaderMap;
@@ -692,7 +693,7 @@ impl FetchResponseListener for BeaconFetchListener {
         &mut self,
         _: &mut js::context::JSContext,
         _: RequestId,
-        chunk: Vec<u8>,
+        chunk: Bytes,
     ) {
         _ = chunk;
     }

--- a/components/script/dom/reporting/reportingendpoint.rs
+++ b/components/script/dom/reporting/reportingendpoint.rs
@@ -4,6 +4,7 @@
 
 use std::collections::HashMap;
 
+use bytes::Bytes;
 use headers::{ContentType, HeaderMapExt};
 use http::HeaderMap;
 use hyper_serde::Serde;
@@ -328,7 +329,7 @@ impl FetchResponseListener for CSPReportEndpointFetchListener {
         &mut self,
         _: &mut js::context::JSContext,
         _: RequestId,
-        chunk: Vec<u8>,
+        chunk: Bytes,
     ) {
         _ = chunk;
     }

--- a/components/script/dom/security/cspviolationreporttask.rs
+++ b/components/script/dom/security/cspviolationreporttask.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use bytes::Bytes;
 use content_security_policy as csp;
 use headers::{ContentType, HeaderMap, HeaderMapExt};
 use js::context::JSContext;
@@ -192,7 +193,7 @@ impl FetchResponseListener for CSPReportUriFetchListener {
         _ = fetch_metadata;
     }
 
-    fn process_response_chunk(&mut self, _: &mut JSContext, _: RequestId, chunk: Vec<u8>) {
+    fn process_response_chunk(&mut self, _: &mut JSContext, _: RequestId, chunk: Bytes) {
         _ = chunk;
     }
 

--- a/components/script/dom/serviceworker/notification.rs
+++ b/components/script/dom/serviceworker/notification.rs
@@ -6,6 +6,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use bytes::Bytes;
 use dom_struct::dom_struct;
 use embedder_traits::{
     EmbedderMsg, Notification as EmbedderNotification,
@@ -785,12 +786,12 @@ impl FetchResponseListener for ResourceFetchListener {
         &mut self,
         _: &mut js::context::JSContext,
         request_id: RequestId,
-        payload: Vec<u8>,
+        payload: Bytes,
     ) {
         if self.status.is_ok() {
             self.image_cache.notify_pending_response(
                 self.pending_image_id,
-                FetchResponseMsg::ProcessResponseChunk(request_id, payload.into()),
+                FetchResponseMsg::ProcessResponseChunk(request_id, payload),
             );
         }
     }

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -9,6 +9,7 @@ use std::rc::Rc;
 
 use base64::Engine as _;
 use base64::engine::general_purpose;
+use bytes::Bytes;
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use devtools_traits::ScriptToDevtoolsControlMsg;
 use dom_struct::dom_struct;
@@ -585,12 +586,12 @@ impl ServoParser {
         self.network_input.push_back(chunk);
     }
 
-    fn push_bytes_input_chunk(&self, chunk: Vec<u8>) {
+    fn push_bytes_input_chunk(&self, chunk: impl AsRef<[u8]>) {
         // For byte input, we convert it to text using the network decoder.
         if let Some(decoded_chunk) = self
             .network_decoder
             .borrow_mut()
-            .push(&chunk, &self.document)
+            .push(chunk.as_ref(), &self.document)
         {
             self.push_tendril_input_chunk(decoded_chunk);
         }
@@ -602,7 +603,7 @@ impl ServoParser {
             // to overwrite the network input, this prefetching may
             // have been wasted, but in most cases it won't.
             let mut prefetch_decoder = self.prefetch_decoder.borrow_mut();
-            prefetch_decoder.process(ByteTendril::from(&*chunk));
+            prefetch_decoder.process(ByteTendril::from(chunk.as_ref()));
 
             self.prefetch_input
                 .push_back(mem::take(&mut prefetch_decoder.inner_sink_mut().output));
@@ -685,7 +686,7 @@ impl ServoParser {
         }
     }
 
-    fn parse_bytes_chunk(&self, cx: &mut JSContext, input: Vec<u8>) {
+    fn parse_bytes_chunk(&self, cx: &mut JSContext, input: impl AsRef<[u8]>) {
         let mut realm = enter_auto_realm(cx, &*self.document);
         let cx = &mut realm.current_realm();
         self.document.set_current_parser(Some(self));
@@ -1555,7 +1556,7 @@ impl FetchResponseListener for ParserContext {
         }
     }
 
-    fn process_response_chunk(&mut self, cx: &mut JSContext, _: RequestId, payload: Vec<u8>) {
+    fn process_response_chunk(&mut self, cx: &mut JSContext, _: RequestId, payload: Bytes) {
         if self.is_synthesized_document {
             return;
         }
@@ -1572,7 +1573,7 @@ impl FetchResponseListener for ParserContext {
             // https://mimesniff.spec.whatwg.org/#read-the-resource-header
             self.navigation_params
                 .resource_header
-                .extend_from_slice(&payload);
+                .extend_from_slice(payload.as_ref());
             // the number of bytes in buffer is greater than or equal to 1445.
             if self.navigation_params.resource_header.len() >= 1445 {
                 self.load_document(cx, Some(&parser), &document);

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -586,12 +586,12 @@ impl ServoParser {
         self.network_input.push_back(chunk);
     }
 
-    fn push_bytes_input_chunk(&self, chunk: impl AsRef<[u8]>) {
+    fn push_bytes_input_chunk(&self, chunk: &[u8]) {
         // For byte input, we convert it to text using the network decoder.
         if let Some(decoded_chunk) = self
             .network_decoder
             .borrow_mut()
-            .push(chunk.as_ref(), &self.document)
+            .push(chunk, &self.document)
         {
             self.push_tendril_input_chunk(decoded_chunk);
         }
@@ -603,7 +603,7 @@ impl ServoParser {
             // to overwrite the network input, this prefetching may
             // have been wasted, but in most cases it won't.
             let mut prefetch_decoder = self.prefetch_decoder.borrow_mut();
-            prefetch_decoder.process(ByteTendril::from(chunk.as_ref()));
+            prefetch_decoder.process(ByteTendril::from(chunk));
 
             self.prefetch_input
                 .push_back(mem::take(&mut prefetch_decoder.inner_sink_mut().output));
@@ -686,11 +686,11 @@ impl ServoParser {
         }
     }
 
-    fn parse_bytes_chunk(&self, cx: &mut JSContext, input: impl AsRef<[u8]>) {
+    fn parse_bytes_chunk(&self, cx: &mut JSContext, input: &[u8]) {
         let mut realm = enter_auto_realm(cx, &*self.document);
         let cx = &mut realm.current_realm();
         self.document.set_current_parser(Some(self));
-        self.push_bytes_input_chunk(input);
+        self.push_bytes_input_chunk(input.as_ref());
         if !self.suspended.get() {
             self.parse_sync(cx);
         }
@@ -1135,7 +1135,7 @@ impl ParserContext {
         if let Some(parser) = parser {
             parser.parse_bytes_chunk(
                 cx,
-                std::mem::take(&mut self.navigation_params.resource_header),
+                std::mem::take(&mut self.navigation_params.resource_header).as_ref(),
             );
         }
     }
@@ -1579,7 +1579,7 @@ impl FetchResponseListener for ParserContext {
                 self.load_document(cx, Some(&parser), &document);
             }
         } else {
-            parser.parse_bytes_chunk(cx, payload);
+            parser.parse_bytes_chunk(cx, payload.as_ref());
         }
     }
 

--- a/components/script/dom/window/layout_image.rs
+++ b/components/script/dom/window/layout_image.rs
@@ -8,6 +8,7 @@
 
 use std::sync::Arc;
 
+use bytes::Bytes;
 use net_traits::blob_url_store::UrlWithBlobClaim;
 use net_traits::image_cache::{ImageCache, PendingImageId};
 use net_traits::request::{Destination, InternalRequest, RequestBuilder, RequestId};
@@ -50,11 +51,11 @@ impl FetchResponseListener for LayoutImageContext {
         &mut self,
         _: &mut js::context::JSContext,
         request_id: RequestId,
-        payload: Vec<u8>,
+        payload: Bytes,
     ) {
         self.cache.notify_pending_response(
             self.id,
-            FetchResponseMsg::ProcessResponseChunk(request_id, payload.into()),
+            FetchResponseMsg::ProcessResponseChunk(request_id, payload),
         );
     }
 

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
+use bytes::{Bytes, BytesMut};
 use content_security_policy::CspList;
 use devtools_traits::{DevtoolScriptControlMsg, WorkerId};
 use dom_struct::dom_struct;
@@ -148,7 +149,7 @@ pub(crate) fn prepare_workerscope_init(
 pub(crate) struct ScriptFetchContext {
     scope: Trusted<WorkerGlobalScope>,
     response: Option<Metadata>,
-    body_bytes: Vec<u8>,
+    body_bytes: BytesMut,
     url: ServoUrl,
     policy_container: PolicyContainer,
 }
@@ -162,7 +163,7 @@ impl ScriptFetchContext {
         ScriptFetchContext {
             scope,
             response: None,
-            body_bytes: Vec::new(),
+            body_bytes: BytesMut::new(),
             url,
             policy_container,
         }
@@ -184,8 +185,8 @@ impl FetchResponseListener for ScriptFetchContext {
         });
     }
 
-    fn process_response_chunk(&mut self, _: &mut JSContext, _: RequestId, mut chunk: Vec<u8>) {
-        self.body_bytes.append(&mut chunk);
+    fn process_response_chunk(&mut self, _: &mut JSContext, _: RequestId, chunk: Bytes) {
+        self.body_bytes.extend_from_slice(&chunk);
     }
 
     fn process_response_eof(

--- a/components/script/dom/xmlhttprequest/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest/xmlhttprequest.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use atomic_refcell::AtomicRefCell;
+use bytes::{Bytes, BytesMut};
 use data_url::mime::Mime;
 use dom_struct::dom_struct;
 use encoding_rs::{Encoding, UTF_8};
@@ -125,7 +126,7 @@ impl FetchResponseListener for XHRContext {
         }
     }
 
-    fn process_response_chunk(&mut self, cx: &mut JSContext, _: RequestId, chunk: Vec<u8>) {
+    fn process_response_chunk(&mut self, cx: &mut JSContext, _: RequestId, chunk: Bytes) {
         self.xhr
             .root()
             .process_data_available(cx, self.gen_id, chunk);
@@ -177,7 +178,7 @@ pub(crate) enum XHRProgress {
     /// Notify that headers have been received
     HeadersReceived(GenerationId, Option<HeaderMap>, HttpStatus),
     /// Partial progress (after receiving headers), containing portion of the response
-    Loading(GenerationId, Vec<u8>),
+    Loading(GenerationId, Bytes),
     /// Loading is done
     Done(GenerationId),
     /// There was an error (only Error::Abort(None), Error::Timeout(None) or Error::Network(None) is used)
@@ -205,7 +206,8 @@ pub(crate) struct XMLHttpRequest {
     response_url: DomRefCell<String>,
     #[no_trace]
     status: DomRefCell<HttpStatus>,
-    response: DomRefCell<Vec<u8>>,
+    #[no_trace]
+    response: DomRefCell<BytesMut>,
     response_type: Cell<XMLHttpRequestResponseType>,
     response_xml: MutNullableDom<Document>,
     response_blob: MutNullableDom<Blob>,
@@ -252,7 +254,7 @@ impl XMLHttpRequest {
             upload: Dom::from_ref(upload),
             response_url: DomRefCell::new(String::new()),
             status: DomRefCell::new(HttpStatus::new_error()),
-            response: DomRefCell::new(vec![]),
+            response: DomRefCell::new(BytesMut::new()),
             response_type: Cell::new(XMLHttpRequestResponseType::_empty),
             response_xml: Default::default(),
             response_blob: Default::default(),
@@ -1079,7 +1081,7 @@ impl XMLHttpRequest {
         Ok(())
     }
 
-    fn process_data_available(&self, cx: &mut JSContext, gen_id: GenerationId, payload: Vec<u8>) {
+    fn process_data_available(&self, cx: &mut JSContext, gen_id: GenerationId, payload: Bytes) {
         self.process_partial_response(cx, XHRProgress::Loading(gen_id, payload));
     }
 
@@ -1174,14 +1176,14 @@ impl XMLHttpRequest {
                     self.change_ready_state(cx, XMLHttpRequestState::HeadersReceived);
                 }
             },
-            XHRProgress::Loading(_, mut partial_response) => {
+            XHRProgress::Loading(_, partial_response) => {
                 // For synchronous requests, this should not fire any events, and just store data
                 // Part of step 11, send() (processing response body)
                 // XXXManishearth handle errors, if any (substep 2)
 
                 self.response
                     .safe_borrow_mut(cx.no_gc())
-                    .append(&mut partial_response);
+                    .extend_from_slice(&partial_response);
                 if !self.sync.get() {
                     if self.ready_state.get() == XMLHttpRequestState::HeadersReceived {
                         self.ready_state.set(XMLHttpRequestState::Loading);

--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -32,6 +32,7 @@ use background_hang_monitor_api::{
     BackgroundHangMonitor, BackgroundHangMonitorExitSignal, BackgroundHangMonitorRegister,
     HangAnnotation, MonitoredComponentId, MonitoredComponentType,
 };
+use bytes::Bytes;
 use chrono::{DateTime, Local};
 use crossbeam_channel::unbounded;
 use data_url::mime::Mime;
@@ -4122,7 +4123,7 @@ impl ScriptThread {
                 self.handle_fetch_metadata(cx, pipeline_id, request_id, metadata)
             },
             FetchResponseMsg::ProcessResponseChunk(request_id, chunk) => {
-                self.handle_fetch_chunk(cx, pipeline_id, request_id, chunk.0)
+                self.handle_fetch_chunk(cx, pipeline_id, request_id, chunk)
             },
             FetchResponseMsg::ProcessResponseEOF(request_id, eof, timing) => {
                 self.handle_fetch_eof(cx, pipeline_id, request_id, eof, timing)
@@ -4164,7 +4165,7 @@ impl ScriptThread {
         cx: &mut js::context::JSContext,
         pipeline_id: PipelineId,
         request_id: RequestId,
-        chunk: Vec<u8>,
+        chunk: Bytes,
     ) {
         let mut incomplete_parser_contexts = self.incomplete_parser_contexts.0.borrow_mut();
         let parser = incomplete_parser_contexts
@@ -4380,7 +4381,7 @@ impl ScriptThread {
         context.process_response(cx, dummy_request_id, Ok(FetchMetadata::Unfiltered(meta)));
         context.set_policy_container(policy_container.as_ref());
         context.set_about_base_url(about_base_url);
-        context.process_response_chunk(cx, dummy_request_id, chunk);
+        context.process_response_chunk(cx, dummy_request_id, Bytes::copy_from_slice(&chunk));
         context.process_response_eof(
             cx,
             dummy_request_id,

--- a/components/script/fetch/fetch.rs
+++ b/components/script/fetch/fetch.rs
@@ -6,6 +6,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 use std::time::Duration;
 
+use bytes::Bytes;
 use js::context::JSContext;
 use js::jsapi::ExceptionStackBehavior;
 use js::jsval::UndefinedValue;
@@ -596,7 +597,7 @@ impl FetchResponseListener for FetchContext {
         self.fetch_promise = Some(TrustedPromise::new(promise));
     }
 
-    fn process_response_chunk(&mut self, cx: &mut JSContext, _: RequestId, chunk: Vec<u8>) {
+    fn process_response_chunk(&mut self, cx: &mut JSContext, _: RequestId, chunk: Bytes) {
         let response = self.response_object.root();
         response.stream_chunk(cx, chunk);
     }
@@ -664,7 +665,7 @@ impl FetchResponseListener for FetchLaterListener {
         _ = fetch_metadata;
     }
 
-    fn process_response_chunk(&mut self, _: &mut JSContext, _: RequestId, chunk: Vec<u8>) {
+    fn process_response_chunk(&mut self, _: &mut JSContext, _: RequestId, chunk: Bytes) {
         _ = chunk;
     }
 

--- a/components/script/fetch/network_listener.rs
+++ b/components/script/fetch/network_listener.rs
@@ -4,6 +4,7 @@
 
 use std::sync::{Arc, Mutex};
 
+use bytes::Bytes;
 use content_security_policy::Violation;
 use js::context::JSContext;
 use net_traits::request::RequestId;
@@ -107,7 +108,7 @@ pub(crate) trait FetchResponseListener: Send + 'static {
         request_id: RequestId,
         metadata: Result<FetchMetadata, NetworkError>,
     );
-    fn process_response_chunk(&mut self, cx: &mut JSContext, request_id: RequestId, chunk: Vec<u8>);
+    fn process_response_chunk(&mut self, cx: &mut JSContext, request_id: RequestId, chunk: Bytes);
     fn process_response_eof(
         self,
         cx: &mut JSContext,
@@ -161,7 +162,7 @@ impl<Listener: FetchResponseListener> NetworkListener<Listener> {
                         fetch_listener.process_response(cx, request_id, meta)
                     },
                     FetchResponseMsg::ProcessResponseChunk(request_id, data) => {
-                        fetch_listener.process_response_chunk(cx, request_id, data.0)
+                        fetch_listener.process_response_chunk(cx, request_id, data)
                     },
                     FetchResponseMsg::ProcessResponseEOF(request_id, result, timing) => {
                         if let Some(fetch_listener) = context.take() {

--- a/components/script/modules/script_module.rs
+++ b/components/script/modules/script_module.rs
@@ -14,6 +14,7 @@ use std::ptr::NonNull;
 use std::rc::Rc;
 use std::{mem, ptr};
 
+use bytes::{Bytes, BytesMut};
 use encoding_rs::UTF_8;
 use headers::{HeaderMapExt, ReferrerPolicy as ReferrerPolicyHeader};
 use hyper_serde::Serde;
@@ -584,7 +585,7 @@ struct ModuleContext {
     /// The owner of the module that initiated the request.
     owner: Trusted<GlobalScope>,
     /// The response body received to date.
-    data: Vec<u8>,
+    data: BytesMut,
     /// The response metadata received to date.
     metadata: Option<Metadata>,
     /// Url and type of the requested module.
@@ -640,10 +641,10 @@ impl FetchResponseListener for ModuleContext {
         &mut self,
         _: &mut js::context::JSContext,
         _: RequestId,
-        mut chunk: Vec<u8>,
+        chunk: Bytes,
     ) {
         if self.status.is_ok() {
-            self.data.append(&mut chunk);
+            self.data.extend_from_slice(&chunk);
         }
     }
 
@@ -1506,7 +1507,7 @@ pub(crate) fn fetch_a_single_module_script(
 
     let context = ModuleContext {
         owner: Trusted::new(global),
-        data: vec![],
+        data: BytesMut::new(),
         metadata: None,
         module_request,
         options,

--- a/components/shared/devtools/Cargo.toml
+++ b/components/shared/devtools/Cargo.toml
@@ -14,6 +14,7 @@ name = "devtools_traits"
 path = "lib.rs"
 
 [dependencies]
+bytes = { workspace = true }
 embedder_traits = { workspace = true }
 http = { workspace = true }
 malloc_size_of = { workspace = true }

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -27,9 +27,9 @@ pub use embedder_traits::ConsoleLogLevel;
 use embedder_traits::Theme;
 use http::{HeaderMap, Method};
 use malloc_size_of_derive::MallocSizeOf;
+use net_traits::TlsSecurityInfo;
 use net_traits::http_status::HttpStatus;
 use net_traits::request::Destination;
-use net_traits::{DebugVec, TlsSecurityInfo};
 use profile_traits::mem::ReportsChan;
 use serde::de::{Error, Visitor};
 use serde::{Deserialize, Serialize};
@@ -568,7 +568,7 @@ pub struct HttpRequest {
     pub url: ServoUrl,
     pub method: Method,
     pub headers: HeaderMap,
-    pub body: Option<DebugVec>,
+    pub body: Option<bytes::Bytes>,
     pub pipeline_id: PipelineId,
     pub started_date_time: SystemTime,
     pub time_stamp: i64,
@@ -584,7 +584,7 @@ pub struct HttpResponse {
     #[ignore_malloc_size_of = "Http type"]
     pub headers: Option<HeaderMap>,
     pub status: HttpStatus,
-    pub body: Option<DebugVec>,
+    pub body: Option<bytes::Bytes>,
     pub from_cache: bool,
     pub pipeline_id: PipelineId,
     pub browsing_context_id: BrowsingContextId,

--- a/components/shared/net/Cargo.toml
+++ b/components/shared/net/Cargo.toml
@@ -19,6 +19,7 @@ doctest = false
 test-util = []
 
 [dependencies]
+bytes = { workspace = true }
 content-security-policy = { workspace = true }
 cookie = { workspace = true }
 crossbeam-channel = { workspace = true }

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -8,6 +8,7 @@ use std::fmt::{self, Debug, Display};
 use std::sync::{LazyLock, OnceLock};
 use std::thread::{self, JoinHandle};
 
+use bytes::Bytes;
 use content_security_policy::{self as csp};
 use cookie::Cookie;
 use crossbeam_channel::{Receiver, Sender, unbounded};
@@ -266,32 +267,10 @@ pub enum FetchResponseMsg {
     ProcessRequestBody(RequestId),
     // todo: send more info about the response (or perhaps the entire Response)
     ProcessResponse(RequestId, Result<FetchMetadata, NetworkError>),
-    ProcessResponseChunk(RequestId, DebugVec),
+    ProcessResponseChunk(RequestId, Bytes),
     ProcessResponseEOF(RequestId, Result<(), NetworkError>, ResourceFetchTiming),
     ProcessCspViolations(RequestId, Vec<csp::Violation>),
     ProcessContentLength(RequestId, usize),
-}
-
-#[derive(Deserialize, PartialEq, Serialize, MallocSizeOf)]
-pub struct DebugVec(pub Vec<u8>);
-
-impl From<Vec<u8>> for DebugVec {
-    fn from(v: Vec<u8>) -> Self {
-        Self(v)
-    }
-}
-
-impl std::ops::Deref for DebugVec {
-    type Target = Vec<u8>;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl std::fmt::Debug for DebugVec {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("[...; {}]", self.0.len()))
-    }
 }
 
 impl FetchResponseMsg {
@@ -319,7 +298,7 @@ pub trait FetchTaskTarget {
     fn process_response(&mut self, request: &Request, response: &Response);
 
     /// Fired when a chunk of response content is received
-    fn process_response_chunk(&mut self, request: &Request, chunk: Vec<u8>);
+    fn process_response_chunk(&mut self, request: &Request, chunk: bytes::Bytes);
 
     /// <https://fetch.spec.whatwg.org/#process-response-end-of-file>
     ///
@@ -384,11 +363,8 @@ impl FetchTaskTarget for GenericCallback<FetchResponseMsg> {
         ));
     }
 
-    fn process_response_chunk(&mut self, request: &Request, chunk: Vec<u8>) {
-        let _ = self.send(FetchResponseMsg::ProcessResponseChunk(
-            request.id,
-            chunk.into(),
-        ));
+    fn process_response_chunk(&mut self, request: &Request, chunk: bytes::Bytes) {
+        let _ = self.send(FetchResponseMsg::ProcessResponseChunk(request.id, chunk));
     }
 
     fn process_response_eof(&mut self, request: &Request, response: &Response) {
@@ -481,7 +457,7 @@ impl FetchTaskTarget for IpcSender<WebSocketNetworkEvent> {
             let _ = self.send(WebSocketNetworkEvent::Fail);
         }
     }
-    fn process_response_chunk(&mut self, _: &Request, _: Vec<u8>) {}
+    fn process_response_chunk(&mut self, _: &Request, _: bytes::Bytes) {}
     fn process_response_eof(&mut self, _: &Request, _: &Response) {}
     fn process_csp_violations(&mut self, _: &Request, violations: Vec<csp::Violation>) {
         let _ = self.send(WebSocketNetworkEvent::ReportCSPViolations(violations));
@@ -497,7 +473,7 @@ pub struct DiscardFetch;
 impl FetchTaskTarget for DiscardFetch {
     fn process_request_body(&mut self, _: &Request) {}
     fn process_response(&mut self, _: &Request, _: &Response) {}
-    fn process_response_chunk(&mut self, _: &Request, _: Vec<u8>) {}
+    fn process_response_chunk(&mut self, _: &Request, _: bytes::Bytes) {}
     fn process_response_eof(&mut self, _: &Request, _: &Response) {}
     fn process_csp_violations(&mut self, _: &Request, _: Vec<csp::Violation>) {}
     fn process_response_length_hint(&mut self, _: &Request, _: usize) {}


### PR DESCRIPTION
This switches our usage of Vec<u8> to bytes::Bytes (which we already use partially in the net code).
The main change is that ProcessResponseChunk now gives a Bytes instead of Vec<u8>.

- This reduces at least one copy for every chunk in http_loader.
- We probably also save a copy from process_response_chunk (as the FetchResponseMsg was already a bytes::Bytes.
- We use generic in some part of servoparser (impl AsRef<[u8]>).
- We remove DebugVec.
- Some implementations of "process_response_chunk" now use "extend_from_slice" which should for u8 be the same as the previous append.
- We use a new feature flag for bytes to allow serialization/deserialization.
- Because BytesMut has trouble freeing its space, we only use it in short lived structs.

Testing: This should just be a refactor as bytes dereferences to [u8]. WPT test should cover anything that is missed.
