### PR TITLE
layout: Fold accessibility bounds update into regular tree update.

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -225,9 +225,7 @@ impl AccessibilityTree {
 
         self.ensure_root_node(root_dom_node, &mut update);
 
-        self.apply_changes_from_dom_tree(&mut update);
-
-        self.refresh_bounds(root_dom_node, context, &mut update);
+        self.apply_changes_from_dom_tree(&context, &mut update);
 
         update.finalize(self)
     }
@@ -246,14 +244,24 @@ impl AccessibilityTree {
             update.clear_damage();
             update.insert_damage(root_id, AccessibilityDamage::Rebuild);
             update.insert_dom_node(root_id, *root_dom_node);
+        } else {
+            // TODO(#47162, #47161) This hack is necessary because we don't collect accessibility damage
+            // from layout, and we don't handle scrolling properly.
+            update.insert_damage(root_id, AccessibilityDamage::Subtree);
+            update.insert_dom_node(root_id, *root_dom_node);
         }
+
         self.root_node = Some(root_node);
     }
 
-    /// For each DOM node in `damage_from_dom`, update the corresponding accessibility node based on
-    /// its `AccessibilityDamage`. If any [`LocalAccessibilityDamage`] results from the update,
-    /// propagate [`LocalAccessibilityDamage::SubtreeChanged`] to its ancestors.
-    fn apply_changes_from_dom_tree(&mut self, update: &mut AccessibilityUpdate) {
+    /// Update all nodes with damage tracked in `update` based on their `AccessibilityDamage`. If
+    /// any [`LocalAccessibilityDamage`] results from the update, propagate
+    /// [`LocalAccessibilityDamage::SubtreeChanged`] to its ancestors.
+    fn apply_changes_from_dom_tree(
+        &mut self,
+        context: &AccessibilityContext,
+        update: &mut AccessibilityUpdate,
+    ) {
         let Some(damage_root_id) = self.mark_nodes_and_ancestors_dirty(update) else {
             return;
         };
@@ -261,34 +269,9 @@ impl AccessibilityTree {
         let local_damage =
             damage_root
                 .borrow_mut()
-                .update_subtree(damage_root.clone(), self, update);
+                .update_subtree(damage_root.clone(), context, self, update);
 
         damage_root.borrow().update_ancestors(local_damage, update);
-    }
-
-    /// Recompute bounds for every node in the tree from current layout geometry, independent of
-    /// [`AccessibilityDamage`] from the DOM. Nodes whose bounds actually changed are added to
-    /// `update`. See [`AccessibilityNode::refresh_bounds_for_subtree()`].
-    ///
-    /// TODO(accessibility): We might not always need to start from the document root. However,
-    /// since viewport-relative coordinates are used, any ancestor movement/scroll/zoom shifts all
-    /// descendants, and layout does not currently provide fine-grained bounds damage
-    /// notifications. See #47162.
-    fn refresh_bounds<'dom>(
-        &self,
-        root_dom_node: &ServoLayoutNode<'dom>,
-        context: AccessibilityContext<'_>,
-        update: &mut AccessibilityUpdate,
-    ) {
-        // Bounds aren't tracked as `AccessibilityDamage` from the DOM: they can go stale from
-        // scrolling, resizing, or zooming without any DOM change. Refresh them for the whole tree
-        // independently of damage from the DOM.
-        let Some(root_node) = self.root_node.clone() else {
-            return;
-        };
-        root_node
-            .borrow_mut()
-            .refresh_bounds_for_subtree(root_dom_node, &context, self, update);
     }
 
     /// Given an iterator of `NodeId`s corresponding to nodes which have received some damage from
@@ -357,6 +340,9 @@ impl AccessibilityTree {
         common_ancestors.pop()
     }
 
+    /// Get the [`AccessibilityNode`] corresponding to the given DOM node.
+    /// If there is no existing [`AccessibilityNode`] for this DOM node, it will be created and
+    /// marked as having [`AccessibilityDamage::Rebuild`] in `update`.
     fn get_or_create_node(
         &mut self,
         dom_node: &ServoLayoutNode<'_>,
@@ -372,6 +358,8 @@ impl AccessibilityTree {
                 let local_name = dom_element.local_name().to_ascii_lowercase();
                 node.set_html_tag(&local_name);
             }
+            update.insert_damage(id, AccessibilityDamage::Rebuild);
+            node.dirty_state |= DirtyState::HasDamage;
         }
 
         (id, node_ref)
@@ -657,39 +645,37 @@ impl AccessibilityNode {
     ///
     /// At the end of this method, both `has_dirty_descendants` and `is_dirty` should be false for
     /// this node and all its descendants.
-    fn update_subtree(
+    fn update_subtree<'update>(
         &mut self,
         ref_self: ArcRefCell<Self>,
+        context: &AccessibilityContext,
         tree: &mut AccessibilityTree,
-        update: &mut AccessibilityUpdate,
+        update: &mut AccessibilityUpdate<'update>,
     ) -> LocalAccessibilityDamage {
         let mut local_damage = LocalAccessibilityDamage::empty();
 
-        if let Some(dom_damage) = update.take_damage(&self.id) &&
-            let Some(dom_node) = update.take_dom_node(&self.id)
-        {
-            local_damage.insert(self.update_node_and_populate_new_descendants_from_dom_node(
-                ref_self, &dom_node, dom_damage, tree, update,
-            ));
+        let damage = self.compute_damage(update);
 
+        if let Some(dom_node) = update.take_dom_node(&self.id) {
+            // TODO(#47162, #47161): Once we handle scrolling properly and have a way of tracking
+            // damage from layout, we won't need to update every node.
+            local_damage.insert(self.update_properties_and_children_from_dom_node(
+                ref_self, &dom_node, damage, tree, update,
+            ));
+            self.update_bounds_from_dom_node(&dom_node, context, update);
             self.dirty_state -= DirtyState::HasDamage;
         }
 
-        if self.dirty_state.descendant_has_damage() {
-            for child_node in self.children() {
-                let strong_child_node = child_node.clone();
-                let mut child_node = child_node.borrow_mut();
-                if !child_node.dirty_state.self_or_descendant_has_damage() {
-                    continue;
-                }
-                let child_damage = child_node.update_subtree(strong_child_node, tree, update);
-                if !child_damage.is_empty() {
-                    local_damage.insert(LocalAccessibilityDamage::SubtreeChanged);
-                }
+        for child_node in self.children() {
+            let child_node_ref = child_node.clone();
+            let mut child_node = child_node.borrow_mut();
+            let child_local_damage =
+                child_node.update_subtree(child_node_ref, context, tree, update);
+            if !child_local_damage.is_empty() {
+                local_damage.insert(LocalAccessibilityDamage::SubtreeChanged);
             }
-
-            self.dirty_state -= DirtyState::DescendantHasDamage;
         }
+        self.dirty_state -= DirtyState::DescendantHasDamage;
 
         local_damage.insert(self.update_node_local(local_damage, update));
 
@@ -722,46 +708,45 @@ impl AccessibilityNode {
 
     /// Update the given [`AccessibilityNode`] from its corresponding DOM node and
     /// [`AccessibilityDamage`].
-    /// If it has new children, those will be recursively populated here.
+    /// If it has new children, those will be created here, but not yet populated.
     // Any changed nodes will be added to the given [`AccessibilityUpdate`].
-    fn update_node_and_populate_new_descendants_from_dom_node(
+    fn update_properties_and_children_from_dom_node<'update>(
         &mut self,
         ref_self: ArcRefCell<Self>,
-        dom_node: &ServoLayoutNode,
+        dom_node: &ServoLayoutNode<'update>,
         dom_damage: AccessibilityDamage,
         tree: &mut AccessibilityTree,
-        update: &mut AccessibilityUpdate,
+        update: &mut AccessibilityUpdate<'update>,
     ) -> LocalAccessibilityDamage {
         let mut local_damage = LocalAccessibilityDamage::empty();
-        if !dom_damage.intersects(AccessibilityDamage::Node | AccessibilityDamage::Children) {
-            return local_damage;
-        }
+
+        // TODO(#47162): We currently need to walk the children each time so that we always find the
+        // DOM node for each accessibility node, since we update bounds on every node.
+        // Once this is no longer true, we can check dom_damage and potentially early return here.
 
         update.counters.nodes_updated_from_dom += 1;
 
         local_damage.insert(self.update_properties_from_dom_node(dom_node, dom_damage));
         local_damage.insert(
-            self.update_children_and_populate_new_descendants_from_dom_node(
-                ref_self, dom_node, dom_damage, tree, update,
-            ),
+            self.update_children_from_dom_node(ref_self, dom_node, dom_damage, tree, update),
         );
 
         local_damage
     }
 
-    /// Update this node's [`Self::children`] from its corresponding DOM node. If any children are
-    /// newly added to the tree, populate them and recursively populate their children.
-    fn update_children_and_populate_new_descendants_from_dom_node(
+    /// Update this node's [`Self::children`] from its corresponding DOM node.
+    /// If it has new children, those will be created here, but not yet populated.
+    fn update_children_from_dom_node<'update>(
         &mut self,
         ref_self: ArcRefCell<AccessibilityNode>,
-        dom_node: &ServoLayoutNode,
-        dom_damage: AccessibilityDamage,
+        dom_node: &ServoLayoutNode<'update>,
+        _dom_damage: AccessibilityDamage,
         tree: &mut AccessibilityTree,
-        update: &mut AccessibilityUpdate,
+        update: &mut AccessibilityUpdate<'update>,
     ) -> LocalAccessibilityDamage {
-        if !dom_damage.contains(AccessibilityDamage::Children) {
-            return LocalAccessibilityDamage::empty();
-        }
+        // TODO(#47162): We currently need to walk the children each time so that we always find the
+        // DOM node for each accessibility node, since we update bounds on every node.
+        // Once this is no longer true, we can check _dom_damage and potentially early return here.
 
         let mut remaining_dom_children = dom_node.flat_tree_children().peekable();
         let mut old_child_ids = self.child_ids().iter().peekable();
@@ -773,6 +758,7 @@ impl AccessibilityNode {
             let Some(dom_child) = remaining_dom_children.peek()
         {
             if tree.existing_id_for_opaque(dom_child.opaque()) == Some(*old_id) {
+                update.insert_dom_node(*old_id, *dom_child);
                 unchanged_count += 1;
                 old_child_ids.next();
                 remaining_dom_children.next();
@@ -799,6 +785,11 @@ impl AccessibilityNode {
         let weak_self = ref_self.downgrade();
         for dom_child in remaining_dom_children {
             let (child_id, child_ref) = tree.get_or_create_node(&dom_child, update);
+            // TODO(#47162): Since we need to update bounds for all nodes, we need to ensure every
+            // AccessibilityNode has a corresponding DOM node available to be retrieved from the
+            // AccessibilityUpdate. Once we no longer update bounds on all nodes, we won't need to
+            // add all nodes like this.
+            update.insert_dom_node(child_id, dom_child);
 
             // Update self.child_nodes in place.
             self.child_nodes.push(child_ref.clone());
@@ -808,15 +799,7 @@ impl AccessibilityNode {
             child.parent_node = Some(weak_self.clone());
 
             if update.is_new(&child_id) {
-                let child_damage = child.update_node_and_populate_new_descendants_from_dom_node(
-                    child_ref.clone(),
-                    &dom_child,
-                    AccessibilityDamage::Rebuild,
-                    tree,
-                    update,
-                );
-                child.update_node_local(child_damage, update);
-                update.add(&mut child);
+                self.dirty_state |= DirtyState::DescendantHasDamage;
             } else {
                 update.set_tree_state_change(child_id, TreeChange::PendingMove);
             }
@@ -892,30 +875,6 @@ impl AccessibilityNode {
         match bounds {
             Some(bounds) => self.set_bounds(bounds),
             None => self.clear_bounds(),
-        }
-    }
-
-    /// Recompute this node's bounds and its descendants', from current layout geometry.
-    fn refresh_bounds_for_subtree(
-        &mut self,
-        dom_node: &ServoLayoutNode,
-        context: &AccessibilityContext,
-        tree: &AccessibilityTree,
-        update: &mut AccessibilityUpdate,
-    ) {
-        self.update_bounds_from_dom_node(dom_node, context, update);
-
-        if self.dirty_state.updated() {
-            update.add(self);
-        }
-
-        for dom_child in dom_node.flat_tree_children() {
-            let Some(child_id) = tree.existing_id_for_opaque(dom_child.opaque()) else {
-                continue;
-            };
-            tree.assert_node_for_id(&child_id)
-                .borrow_mut()
-                .refresh_bounds_for_subtree(&dom_child, context, tree, update);
         }
     }
 
@@ -1111,6 +1070,16 @@ impl AccessibilityNode {
             "children() IDs didn't match child_ids() for {self:?}"
         );
     }
+
+    fn compute_damage(&self, update: &mut AccessibilityUpdate) -> AccessibilityDamage {
+        let mut damage = AccessibilityDamage::empty();
+
+        if self.dirty_state.has_damage() {
+            damage |= update.take_damage(&self.id);
+        }
+
+        damage
+    }
 }
 
 impl Debug for AccessibilityNode {
@@ -1248,8 +1217,10 @@ impl<'update> AccessibilityUpdate<'update> {
         self.dom_node_map.borrow_mut().insert(node_id, dom_node);
     }
 
-    fn take_damage(&mut self, node_id: &NodeId) -> Option<AccessibilityDamage> {
-        self.damage_map.remove(node_id)
+    fn take_damage(&mut self, node_id: &NodeId) -> AccessibilityDamage {
+        self.damage_map
+            .remove(node_id)
+            .unwrap_or(AccessibilityDamage::empty())
     }
 
     fn take_dom_node(&mut self, node_id: &NodeId) -> Option<ServoLayoutNode<'update>> {
@@ -1275,6 +1246,10 @@ impl<'update> AccessibilityUpdate<'update> {
 impl DirtyState {
     fn updated(&self) -> bool {
         self.contains(DirtyState::Updated)
+    }
+
+    fn has_damage(&self) -> bool {
+        self.contains(DirtyState::HasDamage)
     }
 
     fn descendant_has_damage(&self) -> bool {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -11388,42 +11388,42 @@
   "testharness": {
    "accessibility-tree": {
     "accessibility-update-basic-mutation.html": [
-     "67ef9b7e69a56c5b50920b4a1bc987cab81d6114",
+     "29f6c8d5c9c46e1134b9a0bb5ad1636554e1cf44",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-children-of-heading-change.html": [
-     "f3fcc102de641f065058123fee7305bce52ab7c5",
+     "a5147a6a8f6745f6e30e18afdf5da3bc9ce8f7c2",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-descendants-of-heading-change.html": [
-     "7cd9409f391adfff42f97623beafb6604c9fa3da",
+     "bd8c0e35509d8d32038e1b5df7e06fa19c0c7ff9",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-mutation-move-nodes.html": [
-     "b6fc6ef97291bdd67957e202c3a9b14e0e74f013",
+     "71e749f898ce0e731986dbdef48bc7f76ce20932",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-partial-subtree-move-and-delete.html": [
-     "81a6dcf0f7e5d7eb6fa5938d04696b783e02526f",
+     "8e61b0b1f2484d387efe2aebbaf81331fae4faf4",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-text-change.html": [
-     "12db168a263d741f5ef4404012eea670a20c0681",
+     "c39136e64d3ced27ef7d04c0e722bc90f3af469a",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-basic-mutation.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-basic-mutation.html
@@ -24,7 +24,8 @@
       let update = ServoTestUtils.forceAccessibilityUpdate();
 
       // Only the <section> is updated from the DOM
-      assert_equals(update.nodesUpdatedFromDom, 1, "nodesUpdatedFromDom");
+      // But we need to walk all the nodes to make sure we can update bounds.
+      assert_equals(update.nodesUpdatedFromDom, 17, "nodesUpdatedFromDom");
 
       // The <section>, its parent <body> and the document are checked for changes as their subtrees
       // changed

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-children-of-heading-change.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-children-of-heading-change.html
@@ -23,7 +23,8 @@
 
       // Updated nodes:
       // - h2 (<code> removed)
-      assert_equals(update.nodesUpdatedFromDom, 1, "nodesUpdatedFromDom");
+      // But we need to walk all the nodes to make sure we can update bounds.
+      assert_equals(update.nodesUpdatedFromDom, 13, "nodesUpdatedFromDom");
 
       // <html>, <body>, <h2>
       assert_equals(update.nodesUpdatedFromTree, 3, "nodesUpdatedFromTree");

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-descendants-of-heading-change.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-descendants-of-heading-change.html
@@ -25,7 +25,8 @@
 
       // Updated nodes:
       // - em (<strong> removed)
-      assert_equals(update.nodesUpdatedFromDom, 1, "nodesUpdatedFromDom");
+      // But we need to walk all the nodes to make sure we can update bounds.
+      assert_equals(update.nodesUpdatedFromDom, 16, "nodesUpdatedFromDom");
 
       // <html>, <body>, <h2>, <em>
       assert_equals(update.nodesUpdatedFromTree, 4, "nodesUpdatedFromTree");

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-mutation-move-nodes.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-mutation-move-nodes.html
@@ -30,7 +30,8 @@
       // - div1 (child added)
       // - div2 (child added)
       // - <section> (children removed)
-      assert_equals(update.nodesUpdatedFromDom, 3, "nodesUpdatedFromDom");
+      // But we need to walk all the nodes to make sure we can update bounds.
+      assert_equals(update.nodesUpdatedFromDom, 23, "nodesUpdatedFromDom");
 
       // Nodes checked for changes based on the tree:
       // - the document

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-partial-subtree-move-and-delete.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-partial-subtree-move-and-delete.html
@@ -36,7 +36,8 @@
       // - <section> (div1 removed)
       // - div2 (<p> and <h1> removed)
       // - div3 (new children)
-      assert_equals(update.nodesUpdatedFromDom, 3, "nodesUpdatedFromDom");
+      // But we need to walk all the nodes to make sure we can update bounds.
+      assert_equals(update.nodesUpdatedFromDom, 24, "nodesUpdatedFromDom");
 
       // <html>, <body>, <section>, div3, div2
       assert_equals(update.nodesUpdatedFromTree, 5, "nodesUpdatedFromTree");

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-text-change.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-text-change.html
@@ -23,7 +23,8 @@
       let update = window.ServoTestUtils.forceAccessibilityUpdate();
 
       // Just the text node has changed
-      assert_equals(update.nodesUpdatedFromDom, 1, "nodesUpdatedFromDom");
+      // But we need to walk all the nodes to make sure we can update bounds.
+      assert_equals(update.nodesUpdatedFromDom, 16, "nodesUpdatedFromDom");
 
       // The document, <body>, <section>, <h1> and the text node.
       assert_equals(update.nodesUpdatedFromTree, 5, "nodesUpdatedFromTree");


### PR DESCRIPTION
- Ensure we always walk from the document root by inserting "damage" for the root node.
- When walking the tree in `update_subtree()`,  always call into `update_children_from_dom_node()`, which now adds the DOM nodes for all child nodes into the `AccessibilityUpdate`'s `dom_node_map`.
- Also always call into `update_bounds_from_dom_node()`, of course.
- In `update_children_from_dom_node()`, don't immediately walk into the subtree for new nodes. Instead, for newly created nodes, set the damage to `Rebuild` in `get_or_create_node`.

Testing: Refactor, covered by existing tests.
Fixes: Part of #47159.