### PR TITLE
script: Make "choose a navigable" more specification compliant

### DIFF
--- a/components/script/dom/document/document_embedder_controls.rs
+++ b/components/script/dom/document/document_embedder_controls.rs
@@ -438,11 +438,8 @@ impl ContextMenuNodes {
             let Some(browsing_context) = document.browsing_context() else {
                 return;
             };
-            let (browsing_context, new) = browsing_context.choose_browsing_context(
-                cx,
-                "_blank".into(),
-                true, /* nooopener */
-            );
+            let (browsing_context, new) =
+                browsing_context.choose_a_navigable(cx, "_blank".into(), true /* noopener */);
             let Some(browsing_context) = browsing_context else {
                 return;
             };

--- a/components/script/dom/html/form_controls/htmlformelement.rs
+++ b/components/script/dom/html/form_controls/htmlformelement.rs
@@ -862,7 +862,7 @@ impl HTMLFormElement {
         // for choosing a navigable given target, form's node navigable, and noopener.
         let Some(chosen) = doc.browsing_context().and_then(|source| {
             source
-                .choose_browsing_context(cx, target.unwrap_or_default(), noopener)
+                .choose_a_navigable(cx, target.unwrap_or_default(), noopener)
                 .0
         }) else {
             // Step 23. If targetNavigable is null, then return.

--- a/components/script/dom/html/links/relations.rs
+++ b/components/script/dom/html/links/relations.rs
@@ -438,7 +438,7 @@ pub(crate) fn follow_hyperlink(
     };
     let (maybe_chosen, history_handling) = match target_attribute_value {
         Some(name) => {
-            let (maybe_chosen, new) = source.choose_browsing_context(cx, name, noopener);
+            let (maybe_chosen, new) = source.choose_a_navigable(cx, name, noopener);
             let history_handling = if new {
                 NavigationHistoryBehavior::Replace
             } else {

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -572,11 +572,12 @@ impl Window {
     /// A convenience method for
     /// <https://html.spec.whatwg.org/multipage/#a-browsing-context-is-discarded>
     pub(crate) fn discard_browsing_context(&self) {
-        let proxy = match self.window_proxy.get() {
-            Some(proxy) => proxy,
-            None => panic!("Discarding a BC from a window that has none"),
-        };
+        let proxy = self
+            .window_proxy
+            .get()
+            .expect("Discarding a BC from a window that has none");
         proxy.discard_browsing_context();
+
         // Step 4 of https://html.spec.whatwg.org/multipage/#discard-a-document
         // Other steps performed when the `PipelineExit` message
         // is handled by the ScriptThread.

--- a/components/script/dom/window/windowproxy.rs
+++ b/components/script/dom/window/windowproxy.rs
@@ -10,6 +10,7 @@ use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use dom_struct::dom_struct;
 use html5ever::local_name;
 use indexmap::map::IndexMap;
+use itertools::Either;
 use js::JSCLASS_IS_GLOBAL;
 use js::context::JSContext;
 use js::glue::{
@@ -563,7 +564,7 @@ impl WindowProxy {
         // Let targetNavigable and windowType be the result of applying the rules for
         // choosing a navigable given target, sourceDocument's node navigable, and noopener.
         // If targetNavigable is null, then return null.
-        let (chosen, new) = match self.choose_browsing_context(cx, non_empty_target, noopener) {
+        let (chosen, new) = match self.choose_a_navigable(cx, non_empty_target, noopener) {
             (Some(chosen), new) => (chosen, new),
             (None, _) => return Ok(None),
         };
@@ -644,42 +645,183 @@ impl WindowProxy {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-rules-for-choosing-a-navigable>
-    pub(crate) fn choose_browsing_context(
+    pub(crate) fn choose_a_navigable(
         &self,
         cx: &mut JSContext,
         name: DOMString,
         noopener: bool,
     ) -> (Option<DomRoot<WindowProxy>>, bool) {
-        if name.is_empty() || name.eq_ignore_ascii_case("_self") {
-            // Step 3.
-            (Some(DomRoot::from_ref(self)), false)
+        // Step 1. Let chosen be null.
+        // Step 2. Let windowType be "existing or none".
+        // Step 3. Let sandboxingFlagSet be currentNavigable's active document's active
+        // sandboxing flag set.
+        // TODO: Implement this.
+
+        let chosen = if name.is_empty() || name.eq_ignore_ascii_case("_self") {
+            // Step 4. If name is the empty string or an ASCII case-insensitive match for
+            // "_self", then set chosen to currentNavigable.
+            Some((Some(DomRoot::from_ref(self)), false))
         } else if name.eq_ignore_ascii_case("_parent") {
-            // Step 4
-            if let Some(parent) = self.parent() {
-                return (Some(DomRoot::from_ref(parent)), false);
-            }
-            (None, false)
-        } else if name.eq_ignore_ascii_case("_top") {
-            // Step 5
-            (Some(DomRoot::from_ref(self.top())), false)
-        } else if name.eq_ignore_ascii_case("_blank") {
-            (
-                self.create_auxiliary_browsing_context(cx, name, noopener),
-                true,
+            // Step 5. Otherwise, if name is an ASCII case-insensitive match for
+            // "_parent", set chosen to currentNavigable's parent, if any, and
+            // currentNavigable otherwise.
+            Some(
+                self.parent()
+                    .map(|parent| (Some(DomRoot::from_ref(parent)), false))
+                    .unwrap_or_else(|| (Some(DomRoot::from_ref(self)), false)),
             )
+        } else if name.eq_ignore_ascii_case("_top") {
+            // Step 6. Otherwise, if name is an ASCII case-insensitive match for "_top",
+            // set chosen to currentNavigable's traversable navigable.
+            Some((Some(DomRoot::from_ref(self.top())), false))
+        } else if !name.eq_ignore_ascii_case("_blank") {
+            // Step 7. Otherwise, if name is not an ASCII case-insensitive match for
+            // "_blank" and noopener is false, then set chosen to the result of finding a
+            // navigable by target name given name and currentNavigable.
+            //
+            // Note: The noopener==false condition here seems to break WPT tests and
+            // is likely a specification bug.
+            // See <https://github.com/whatwg/html/issues/12839>
+            self.find_navigable_by_target_name(&name)
+                .map(|proxy| (Some(proxy), false))
         } else {
-            // Step 6.
-            // TODO: expand the search to all 'familiar' bc,
-            // including auxiliaries familiar by way of their opener.
-            // See https://html.spec.whatwg.org/multipage/#familiar-with
-            match ScriptThread::find_window_proxy_by_name(&name) {
-                Some(proxy) => (Some(proxy), false),
-                None => (
-                    self.create_auxiliary_browsing_context(cx, name, noopener),
-                    true,
-                ),
+            None
+        };
+
+        if let Some(chosen) = chosen {
+            return chosen;
+        }
+
+        // Step 8. If chosen is null, then a new top-level traversable is being requested,
+        // and what happens depends on the user agent's configuration and abilities — it
+        // is determined by the rules given for the first applicable option from the
+        // following list:
+        (
+            self.create_auxiliary_browsing_context(cx, name, noopener),
+            true,
+        )
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#find-a-navigable-by-target-name>
+    fn find_navigable_by_target_name(&self, name: &DOMString) -> Option<DomRoot<WindowProxy>> {
+        // Step 1. Let currentDocument be currentNavigable's active document.
+        //
+        // Step 2. Let sourceSnapshotParams be the result of snapshotting source snapshot
+        // params given currentDocument.
+        // TODO: This is unimplemented.
+        //
+        // Step 3. Let subtreesToSearch be an implementation-defined choice of one of the
+        // following:
+        //     - « currentNavigable's traversable navigable, currentNavigable »
+        //     - the inclusive ancestor navigables of currentDocument
+        //
+        // From <https://github.com/whatwg/html/issues/10848>:
+        // > WebKit and Chromium search the requesting window's subtree then search from
+        // > the top. Firefox iterates and searches from each ancestor. If there's a way to
+        // > express in the spec that the implementation-defined behavior is fixed for the
+        // > instance of the user agent, then that'd be appropriate here.
+        //
+        // We use the Webkit and Chrome approach here and the reversal is done here
+        // rather than below.
+        let top = self.top();
+        let subtrees_to_search = if top != self {
+            Either::Left([self, top])
+        } else {
+            Either::Right([self])
+        };
+
+        // Step 4. For each subtreeToSearch of subtreesToSearch, in reverse order:
+        for subtree_to_search in subtrees_to_search.into_iter() {
+            // Step 4.1. Let documentToSearch be subtreeToSearch's active document.
+            // Step 4.2. For each navigable of the inclusive descendant navigables of
+            // documentToSearch:
+            if let Some(result) =
+                subtree_to_search.find_navigable_by_target_name_in_descendants(name)
+            {
+                return Some(result);
             }
         }
+
+        // Step 5. Let currentTopLevelBrowsingContext be currentNavigable's active
+        // browsing context's top-level browsing context.
+        // Step 6. Let group be currentTopLevelBrowsingContext's group.
+        //
+        // TODO: Servo doesn't have a concept of the browsing context group in script, so
+        // we just look through all top-level WindowProxy instances.
+        let mut top_level_window_proxies = self.script_window_proxies.top_level_window_proxies();
+
+        // Step 7. For each topLevelBrowsingContext of group's browsing context set, in an
+        // implementation-defined order (the user agent should pick a consistent ordering,
+        // such as the most recently opened, most recently focused, or more closely
+        // related):
+        //
+        // Sorting by `BrowsingContextId` is an attempt to make the order consistent.
+        // This also ensures that newer `BrowsingContextId`s are sorted first.
+        top_level_window_proxies
+            .sort_by_key(|proxy| std::cmp::Reverse(proxy.browsing_context_id()));
+
+        for window_proxy in top_level_window_proxies {
+            // Step 7.1. If currentTopLevelBrowsingContext is topLevelBrowsingContext, then
+            // continue.
+            if &*window_proxy == top {
+                continue;
+            }
+            // Step 7.2. Let documentToSearch be topLevelBrowsingContext's active document.
+            // Step 7.3. For each navigable of the inclusive descendant navigables of
+            // documentToSearch:
+            //
+            // Step 7.3.1 If currentNavigable's active browsing context is not familiar
+            // with navigable's active browsing context, then continue.
+            //
+            // TODO: Servo does not implement the concept of "familiar with".
+            // See: <https://html.spec.whatwg.org/multipage/#familiar-with>
+            // TODO: Properly support navigables in other script threads and with
+            // dissimilar origins, which requires that they be accessible here and
+            // WindowProxy::get_name() returns something useful.
+            //
+            // Step 7.3.2. If currentNavigable is not allowed by sandboxing to navigate
+            // navigable given sourceSnapshotParams, then optionally continue.
+            // Step 7.3.3 If navigable's target name is name, then return navigable.
+            // These steps are handled by `find_navigable_by_target_name_in_descendants`.
+            if let Some(result) = window_proxy.find_navigable_by_target_name_in_descendants(name) {
+                return Some(result);
+            }
+        }
+
+        // Step 8. Return null.
+        None
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#find-a-navigable-by-target-name> step 4 and 7 substeps.
+    fn find_navigable_by_target_name_in_descendants(
+        &self,
+        name: &DOMString,
+    ) -> Option<DomRoot<WindowProxy>> {
+        // Never traverse or return a `WindowProxy` with a discarded browsing context.
+        if self.is_browsing_context_discarded() {
+            return None;
+        }
+
+        // Step 4.2.1 If currentNavigable is not allowed by sandboxing to navigate
+        // navigable given sourceSnapshotParams, then optionally continue.
+        // TODO: This is unimplemented.
+
+        // Step 4.2.2. If navigable's target name is name, then return navigable.
+        if self.get_name() == *name {
+            return Some(DomRoot::from_ref(self));
+        }
+
+        let document = self.document()?;
+        let iframes: Vec<_> = document.iframes().iter().collect();
+        iframes.iter().find_map(|iframe| {
+            iframe
+                .browsing_context_id()
+                .and_then(|browsing_context_id| {
+                    self.script_window_proxies
+                        .find_window_proxy(browsing_context_id)?
+                        .find_navigable_by_target_name_in_descendants(name)
+                })
+        })
     }
 
     pub(crate) fn is_auxiliary(&self) -> bool {

--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -765,12 +765,6 @@ impl ScriptThread {
         with_script_thread(|script_thread| script_thread.window_proxies.clone())
     }
 
-    pub(crate) fn find_window_proxy_by_name(name: &DOMString) -> Option<DomRoot<WindowProxy>> {
-        with_script_thread(|script_thread| {
-            script_thread.window_proxies.find_window_proxy_by_name(name)
-        })
-    }
-
     fn handle_register_paint_worklet(
         &self,
         pipeline_id: PipelineId,
@@ -3219,7 +3213,7 @@ impl ScriptThread {
         &self,
         webview_id: WebViewId,
         pipeline_id: PipelineId,
-        discard_bc: DiscardBrowsingContext,
+        discard_browsing_context: DiscardBrowsingContext,
         cx: &mut js::context::JSContext,
     ) {
         debug!("{pipeline_id}: Starting pipeline exit.");
@@ -3254,8 +3248,10 @@ impl ScriptThread {
                 // We discard the browsing context after requesting layout shut down,
                 // to avoid running layout on detached iframes.
                 let window = document.window();
-                if discard_bc == DiscardBrowsingContext::Yes {
+                if discard_browsing_context == DiscardBrowsingContext::Yes {
+                    let browsing_context_id = window.window_proxy().browsing_context_id();
                     window.discard_browsing_context();
+                    self.window_proxies.remove(browsing_context_id);
                 }
 
                 // Clear the image cache now, instead of waiting for the Window to be

--- a/components/script/event_loop/script_window_proxies.rs
+++ b/components/script/event_loop/script_window_proxies.rs
@@ -6,7 +6,6 @@ use rustc_hash::FxBuildHasher;
 use script_bindings::cell::DomRefCell;
 use script_bindings::inheritance::Castable;
 use script_bindings::root::{Dom, DomRoot};
-use script_bindings::str::DOMString;
 use servo_base::generic_channel;
 use servo_base::id::{BrowsingContextId, PipelineId, WebViewId};
 use servo_constellation_traits::ScriptToConstellationMessage;
@@ -33,16 +32,13 @@ impl ScriptWindowProxies {
             .map(|context| DomRoot::from_ref(&**context))
     }
 
-    pub(crate) fn find_window_proxy_by_name(
-        &self,
-        name: &DOMString,
-    ) -> Option<DomRoot<WindowProxy>> {
-        for proxy in self.map.borrow().values() {
-            if proxy.get_name() == *name {
-                return Some(DomRoot::from_ref(&**proxy));
-            }
-        }
-        None
+    pub(crate) fn top_level_window_proxies(&self) -> Vec<DomRoot<WindowProxy>> {
+        self.map
+            .borrow()
+            .values()
+            .filter(|proxy| proxy.parent().is_none())
+            .map(|proxy| proxy.as_rooted())
+            .collect()
     }
 
     pub(crate) fn insert(&self, id: BrowsingContextId, proxy: &WindowProxy) {

--- a/tests/wpt/meta/shadow-dom/untriaged/html-elements-in-shadow-trees/inert-html-elements/test-001.html.ini
+++ b/tests/wpt/meta/shadow-dom/untriaged/html-elements-in-shadow-trees/inert-html-elements/test-001.html.ini
@@ -1,3 +1,0 @@
-[test-001.html]
-  [A_08_01_01_T01]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_click/navigate.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_click/navigate.py.ini
@@ -5,9 +5,6 @@
   [test_link_from_nested_context_with_target[_top\]]
     expected: FAIL
 
-  [test_link_from_toplevel_context_with_target[_parent\]]
-    expected: FAIL
-
   [test_link_closes_window]
     expected: FAIL
 


### PR DESCRIPTION
This aligns the pre-existing "choose_browsing_context" and
"find_window_proxy_by_name" with the current specification and
implements as well as we can with our current architecture. Notable
changes:

1. Priority now follows the order specified in "find navigable by target
   name".
2. If a `WindowProxy` has a discarded browsing context, it is never
   chosen. These `WindowProxy`s are not meant to be considered by the
   algorithm as they are not really in the tree.
3. A minor spec issue with "_parent" when there is no parent is
   corrected.

This still does allow selecting navigables that are in different
`ScriptThread`s. That requires a lot more work.

Finally, a small, related issue where `WindowProxy`s were leaking is
fixed as well.

Testing: This change causes two new subtests to pass. In addition, I think it should help with trusted-types flakiness.
Closes: #44580.
Fixes: #42343.
