### PR TITLE
devtools: Implement eager evaluation

### DIFF
--- a/components/default-resources/resources/debugger.js
+++ b/components/default-resources/resources/debugger.js
@@ -8,7 +8,6 @@ const debuggeesToWorkerIds = new Map;
 const sourceIdsToScripts = new Map;
 const frameActorsToFrames = new Map;
 const objectActorsToObjects = new Map;
-const environmentActorsToEnvironments = new Map;
 const environmentsToEnvironmentActors = new Map;
 const blackboxing = new Map;
 let suspendedFrame = null;
@@ -397,55 +396,140 @@ function getPreview(obj, depth) {
 // Evaluate some javascript code in the global context of the debuggee
 // See executeInGlobal() at <https://firefox-source-docs.mozilla.org/devtools-user/debugger-api/debugger.object/index.html#function-properties-of-the-debugger-object-prototype>
 addEventListener("eval", event => {
-    const {code, pipelineId, workerId, frameActorId} = event;
+    const { code, pipelineId, workerId, frameActorId } = event;
 
-    let completionValue;
+    let frame;
     if (frameActorId) {
-        const frame = frameActorsToFrames.get(frameActorId);
-        // <https://searchfox.org/firefox-main/source/js/src/doc/Debugger/Debugger.Frame.md#223>
-        if (frame?.onStack) {
-            completionValue = frame.eval(code);
+        frame = frameActorsToFrames.get(frameActorId);
+    }
+    let global = workerId !== undefined ?
+        findKeyByValue(debuggeesToWorkerIds, workerId) :
+        findDebuggeeByPipelineId(pipelineId);
+
+    let noSideEffectDebugger;
+    if (event.eager) {
+        noSideEffectDebugger = createSideEffectFreeDebugger(global);
+
+        // We need to eval in the context of the temporary debugger to apply side-effect tracking
+        if (frame) {
+            frame = noSideEffectDebugger.adoptFrame(frame);
         } else {
-            completionValue = { throw: "Frame not available" };
+            global = noSideEffectDebugger.adoptDebuggeeValue(global);
         }
-    } else {
-        const object = workerId !== undefined ?
-            findKeyByValue(debuggeesToWorkerIds, workerId) :
-            findDebuggeeByPipelineId(pipelineId);
-        completionValue = object.executeInGlobal(code);
     }
 
-    // Completion values: <https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#completion-values>
-    let resultValue;
-    if (completionValue === null) {
-        resultValue = {
-            value: createValueGrip(undefined, 0),
-            hasException: false,
-        };
-    } else if ("throw" in completionValue) {
-        // See adoptDebuggeeValue() in <https://firefox-source-docs.mozilla.org/devtools-user/debugger-api/debugger/index.html>
-        // <https://searchfox.org/firefox-main/source/devtools/server/actors/webconsole/eval-with-debugger.js#312>
-        // we probably don't need adoptDebuggeeValue, as we only have one debugger instance for now
-        // let value = dbg.adoptDebuggeeValue(completionValue.throw);
-        let realError = completionValue.throw.unsafeDereference();
-        resultValue = {
-            value: createValueGrip(completionValue.throw, 0),
-            exceptionMessage: realError.message,
-            hasException: true,
-        };
-    } else if ("return" in completionValue) {
-        resultValue = {
-            value: createValueGrip(completionValue.return, 0),
-            hasException: false,
-        };
-    }
+    try {
+        let completionValue;
+        if (frame) {
+            // <https://searchfox.org/firefox-main/source/js/src/doc/Debugger/Debugger.Frame.md#223>
+            if (frame?.onStack) {
+                completionValue = frame.eval(code);
+            } else {
+                completionValue = { throw: "Frame not available" };
+            }
+        } else {
+            completionValue = global.executeInGlobal(code);
+        }
 
-    evalResult(event, {
-        serializedValue: JSON.stringify(resultValue.value),
-        exceptionMessage: resultValue.hasException ? resultValue.exceptionMessage : null,
-        hasException: resultValue.hasException,
-    });
+        // Completion values: <https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#completion-values>
+        let resultValue;
+        if (completionValue === null) {
+            resultValue = {
+                value: createValueGrip(undefined, 0),
+                hasException: false,
+            };
+        } else if ("throw" in completionValue) {
+            let realError = completionValue.throw.unsafeDereference();
+            resultValue = {
+                value: createValueGrip(completionValue.throw, 0),
+                exceptionMessage: realError.message,
+                hasException: true,
+            };
+        } else if ("return" in completionValue) {
+            resultValue = {
+                value: createValueGrip(completionValue.return, 0),
+                hasException: false,
+            };
+        }
+
+        evalResult(event, {
+            serializedValue: JSON.stringify(resultValue.value),
+            exceptionMessage: resultValue.hasException ? resultValue.exceptionMessage : null,
+            hasException: resultValue.hasException,
+        });
+    } finally {
+        if (noSideEffectDebugger) {
+            noSideEffectDebugger.onNativeCall = undefined;
+            noSideEffectDebugger.shouldAvoidSideEffects = false;
+
+            // This must be called last as the cleanup above depends on the list of debuggees
+            noSideEffectDebugger.removeAllDebuggees();
+        }
+    }
 });
+
+// <https://searchfox.org/firefox-main/source/devtools/server/actors/webconsole/eval-with-debugger.js#436>
+function createSideEffectFreeDebugger(debuggee) {
+    const eagerDbg = new Debugger;
+
+    // Special flag in order to ensure that any evaluation or call being
+    // made via this debugger will be ignored by all debuggers except this one.
+    eagerDbg.exclusiveDebuggerOnEval = true;
+
+    // TODO: Add other debuggees that the evaluation might use
+    eagerDbg.addDebuggee(debuggee.unsafeDereference());
+
+    const timeoutDuration = 100;
+    const endTime = Date.now() + timeoutDuration;
+    let count = 0;
+    function shouldCancel() {
+        // To keep the evaled code as quick as possible, we avoid querying the
+        // current time on ever single step and instead check every 100 steps
+        // as an arbitrary count that seemed to be "often enough".
+        return ++count % 100 === 0 && Date.now() > endTime;
+    }
+
+    const executedScripts = new Set();
+    const handler = {
+        hit: () => null,
+    };
+    // null means abort; undefined means continue
+    eagerDbg.onEnterFrame = frame => {
+        if (shouldCancel()) {
+            return null;
+        }
+        frame.onStep = () => {
+            if (shouldCancel()) {
+                return null;
+            }
+            return undefined;
+        };
+
+        const script = frame.script;
+        if (executedScripts.has(script)) {
+            // Skip setting breakpoints in the same script again
+            return undefined;
+        }
+        executedScripts.add(script);
+
+        const offsets = script.getEffectfulOffsets();
+        for (const offset of offsets) {
+            script.setBreakpoint(offset, handler);
+        }
+
+        return undefined;
+    };
+
+    eagerDbg.onNativeCall = (_callee, _reason) => {
+        // TODO: Allow side-effect-free native calls
+        // Aborting on all native calls is naïve but safe
+        return null;
+    };
+
+    eagerDbg.shouldAvoidSideEffects = true;
+
+    return eagerDbg;
+}
 
 addEventListener("getPossibleBreakpoints", event => {
     const {spidermonkeyId} = event;

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -246,16 +246,19 @@ impl ConsoleActor {
         msg: &Map<String, Value>,
     ) -> Result<EvaluateJSReply, ()> {
         let input = msg.get("text").unwrap().as_str().unwrap().to_owned();
+        let eager = msg.get("eager").and_then(|v| v.as_bool()).unwrap_or(false);
         let frame_actor_id = msg
             .get("frameActor")
             .and_then(|v| v.as_str())
             .map(String::from);
+
         let (chan, port) = generic_channel::channel().unwrap();
         self.script_chan(registry)
             .send(DevtoolScriptControlMsg::Eval(
                 input.clone(),
                 self.pipeline_id(registry),
                 frame_actor_id,
+                eager,
                 chan,
             ))
             .unwrap();
@@ -468,12 +471,6 @@ impl Actor for ConsoleActor {
                 // Emit an eager reply so that the client starts listening
                 // for an async event with the resultID
                 let mut stream = request.reply(&early_reply)?;
-
-                if msg.get("eager").and_then(|v| v.as_bool()).unwrap_or(false) {
-                    // We don't support the side-effect free evaluation that eager evaluation
-                    // really needs.
-                    return Ok(());
-                }
 
                 let reply = self.evaluate_js(registry, msg).unwrap();
                 let msg = EvaluateJSEvent {

--- a/components/script/dom/debugger/debuggerevalevent.rs
+++ b/components/script/dom/debugger/debuggerevalevent.rs
@@ -21,6 +21,7 @@ pub(crate) struct DebuggerEvalEvent {
     pipeline_id: Dom<PipelineId>,
     worker_id: Option<DOMString>,
     frame_actor_id: Option<DOMString>,
+    eager: bool,
 }
 
 impl DebuggerEvalEvent {
@@ -31,6 +32,7 @@ impl DebuggerEvalEvent {
         pipeline_id: &PipelineId,
         worker_id: Option<DOMString>,
         frame_actor_id: Option<DOMString>,
+        eager: bool,
     ) -> DomRoot<Self> {
         let result = Box::new(Self {
             event: Event::new_inherited(),
@@ -38,6 +40,7 @@ impl DebuggerEvalEvent {
             pipeline_id: Dom::from_ref(pipeline_id),
             worker_id,
             frame_actor_id,
+            eager,
         });
         let result = reflect_dom_object_with_cx(result, debugger_global, cx);
         result.event.init_event("eval".into(), false, false);
@@ -64,6 +67,10 @@ impl DebuggerEvalEventMethods<crate::DomTypeHolder> for DebuggerEvalEvent {
 
     fn GetFrameActorId(&self) -> Option<DOMString> {
         self.frame_actor_id.clone()
+    }
+
+    fn Eager(&self) -> bool {
+        self.eager
     }
 
     fn IsTrusted(&self) -> bool {

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -184,6 +184,7 @@ impl DebuggerGlobalScope {
         );
     }
 
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn fire_eval(
         &self,
         cx: &mut JSContext,
@@ -191,6 +192,7 @@ impl DebuggerGlobalScope {
         debuggee_pipeline_id: PipelineId,
         debuggee_worker_id: Option<WorkerId>,
         frame_actor_id: Option<String>,
+        eager: bool,
         result_sender: GenericSender<EvaluateJSReply>,
     ) {
         assert!(
@@ -209,6 +211,7 @@ impl DebuggerGlobalScope {
             &debuggee_pipeline_id,
             debuggee_worker_id.map(|id| id.to_string().into()),
             frame_actor_id.map(|id| id.into()),
+            eager,
         ));
         assert!(
             event.fire(cx, self.upcast()),

--- a/components/script/dom/workers/sharedworkerglobalscope.rs
+++ b/components/script/dom/workers/sharedworkerglobalscope.rs
@@ -753,13 +753,14 @@ impl SharedWorkerGlobalScope {
         match msg {
             MixedMessage::Devtools(msg) => match msg {
                 DevtoolScriptControlMsg::WantsLiveNotifications(_pipe_id, _bool_val) => {},
-                DevtoolScriptControlMsg::Eval(code, id, frame_actor_id, reply) => {
+                DevtoolScriptControlMsg::Eval(code, id, frame_actor_id, eager, reply) => {
                     self.debugger_global.fire_eval(
                         cx,
                         code.into(),
                         id,
                         Some(self.upcast::<WorkerGlobalScope>().worker_id()),
                         frame_actor_id,
+                        eager,
                         reply,
                     );
                 },

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -1181,7 +1181,7 @@ impl WorkerGlobalScope {
     pub(crate) fn handle_devtools_message(&self, msg: DevtoolScriptControlMsg, cx: &mut JSContext) {
         match msg {
             DevtoolScriptControlMsg::WantsLiveNotifications(_pipe_id, _wants_updates) => {},
-            DevtoolScriptControlMsg::Eval(code, id, frame_actor_id, reply) => {
+            DevtoolScriptControlMsg::Eval(code, id, frame_actor_id, eager, reply) => {
                 let debugger_global_handle = rooted_heap_handle(self, |this| &this.debugger_global);
                 let debugger_global =
                     root_from_handlevalue::<DebuggerGlobalScope>(cx, debugger_global_handle)
@@ -1193,6 +1193,7 @@ impl WorkerGlobalScope {
                     id,
                     Some(self.worker_id()),
                     frame_actor_id,
+                    eager,
                     reply,
                 );
             },

--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -2233,9 +2233,16 @@ impl ScriptThread {
                     node_id.as_deref(),
                 )
             },
-            DevtoolScriptControlMsg::Eval(code, id, frame_actor_id, reply) => {
-                self.debugger_global
-                    .fire_eval(cx, code.into(), id, None, frame_actor_id, reply);
+            DevtoolScriptControlMsg::Eval(code, id, frame_actor_id, eager, reply) => {
+                self.debugger_global.fire_eval(
+                    cx,
+                    code.into(),
+                    id,
+                    None,
+                    frame_actor_id,
+                    eager,
+                    reply,
+                );
             },
             DevtoolScriptControlMsg::GetPossibleBreakpoints(spidermonkey_id, result_sender) => {
                 self.debugger_global.fire_get_possible_breakpoints(

--- a/components/script_bindings/webidls/DebuggerEvalEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerEvalEvent.webidl
@@ -10,6 +10,7 @@ interface DebuggerEvalEvent : Event {
     readonly attribute PipelineId pipelineId;
     readonly attribute DOMString? workerId;
     readonly attribute DOMString? frameActorId;
+    readonly attribute boolean eager;
 };
 
 partial interface DebuggerGlobalScope {

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -475,6 +475,7 @@ pub enum DevtoolScriptControlMsg {
         String,
         PipelineId,
         Option<String>,
+        bool,
         GenericSender<EvaluateJSReply>,
     ),
     GetPossibleBreakpoints(u32, GenericSender<Vec<RecommendedBreakpointLocation>>),

--- a/python/servo/devtools_tests/test_console_tab.py
+++ b/python/servo/devtools_tests/test_console_tab.py
@@ -8,6 +8,7 @@
 # except according to those terms.
 
 from concurrent.futures import Future
+from queue import Queue
 
 import pytest
 from geckordp.actors.events import Events
@@ -190,6 +191,52 @@ class TestConsoleTab:
             assert not result["result"]
             assert result["exception"]
             assert "Not enough arguments" in result["exceptionMessage"]
+
+    def test_eager_evaluation(self, run_servoshell):
+        run_servoshell(url="data:text/html,")
+
+        with Devtools.connect() as devtools:
+            console = WebConsoleActor(devtools.client, devtools.targets[0]["consoleActor"])
+            evaluation_result = Future()
+
+            def on_evaluation(data):
+                evaluation_result.set_result(data)
+
+            devtools.client.add_event_listener(console.actor_id, Events.WebConsole.EVALUATION_RESULT, on_evaluation)
+
+            console.evaluate_js_async("2 + 2", eager=True)
+            result = evaluation_result.result(1)
+
+            assert result["result"] == 4
+            assert not result["exception"]
+
+    def test_eager_evaluation_aborts_assignment(self, run_servoshell):
+        run_servoshell(url="data:text/html,<head><script>let value = 5;</script></head>")
+
+        with Devtools.connect() as devtools:
+            console = WebConsoleActor(devtools.client, devtools.targets[0]["consoleActor"])
+            queue = Queue()
+
+            def on_evaluation(data):
+                queue.put_nowait(data)
+
+            devtools.client.add_event_listener(console.actor_id, Events.WebConsole.EVALUATION_RESULT, on_evaluation)
+
+            console.evaluate_js_async("value = 4; value", eager=True)
+            result1 = queue.get(timeout=1)
+
+            console.evaluate_js_async("let newValue = 6; newValue", eager=True)
+            result2 = queue.get(timeout=1)
+
+            console.evaluate_js_async("document.head.append('boo!'); document.head.childNodes", eager=True)
+            result3 = queue.get(timeout=1)
+
+            assert result1["result"]["type"] == "undefined"
+            assert not result1["exception"]
+            assert result2["result"]["type"] == "undefined"
+            assert not result2["exception"]
+            assert result3["result"]["type"] == "undefined"
+            assert not result3["exception"]
 
     def test_global_autocomplete(self, run_servoshell):
         script_tag = "<script>console_test_value = 5;</script>"


### PR DESCRIPTION
Adds support for eager evaluation, with the console evaluating code without side-effects as the user is typing. In eager mode, evaluation is aborted upon hitting effectful bytecode or conditionally upon native calls.

Known issues:
- Calls to native code are currently assumed to always have side-effects (and therefore aborted), see the `eagerDbg.onNativeCall` hook
- Firefox eagerly renders `SyntaxError`. Nominally these would be filtered out on the client, but this filter relies upon the `error` preview, which we don't support yet. This means that you get shown syntax errors as you type

Testing: Covered by new python tests
Fixes: Part of #39858
