### PR TITLE
build: bump cargo-ohos from 0.3.2 to 0.3.3

### DIFF
--- a/python/servo/platform/build_target.py
+++ b/python/servo/platform/build_target.py
@@ -291,7 +291,7 @@ class OpenHarmonyTarget(CrossBuildTarget):
     # will bump the schema version in cargo-ohos.
     CARGO_OHOS_EXPECTED_SCHEMA_VERSION = 1
     # Pin a cargo-ohos semver version for bootstrap
-    REQUESTED_CARGO_OHOS_VERSION = "0.3.2"
+    REQUESTED_CARGO_OHOS_VERSION = "0.3.3"
 
     cargo_ohos_info: Optional[dict[str, Any]] = None
 


### PR DESCRIPTION
Use cargo-ohos's --download-sdk flag, so that `mach build --ohos` fetches the SDK automatically when neither $OHOS_SDK_NATIVE nor `.servobuild`'s [ohos] ndk is configured.

Together-with: https://github.com/openharmony-rs/cargo-ohos/pull/10

Testing: Tested Locally