### PR TITLE
script: Only measure memory for Attr nodes once.

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -3782,6 +3782,7 @@ impl Document {
                                 &computed_objects,
                             );
                             sizes.attribute_nodes_size += size;
+                            computed_objects.insert(attr.upcast::<Node>().jsobject());
                         }
                     }
                 },


### PR DESCRIPTION
Any Attr node measured while traversing the DOM tree should be ignored later when we are scanning the full GC graph.

Testing: No automated tests for about:memory.