### PR TITLE
clippy: Enable `manual_string_new` linter for some components

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -372,6 +372,9 @@ webxr-api = { package = "servo-webxr-api", version = "=0.5.0", path = "component
 xpath = { package = "servo-xpath", version = "=0.5.0", path = "components/xpath" }
 # End workspace-version dependencies - Don't change this comment, we grep for it in scripts!
 
+[workspace.lints.clippy]
+manual_string_new = "deny"
+
 # RSA key generation could be very slow without compilation
 # optimizations, in development mode. Without optimizations, WPT might
 # consider RSA key generation tests fail due to timeout.

--- a/components/devtools/Cargo.toml
+++ b/components/devtools/Cargo.toml
@@ -40,3 +40,6 @@ uuid = { workspace = true }
 
 [build-dependencies]
 chrono = { workspace = true }
+
+[lints]
+workspace = true

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -440,7 +440,7 @@ impl Actor for ConsoleActor {
                     AutocompleteReply {
                         from: self.name().into(),
                         matches: vec![],
-                        match_prop: "".to_owned(),
+                        match_prop: String::new(),
                         is_element_access: false,
                     }
                 } else {

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -392,7 +392,7 @@ impl From<EventListenerInfo> for DevtoolsEventListenerInfo {
             handler: "todo".to_owned(),
             capturing: event_listener_info.capturing,
             origin: "todo".to_owned(),
-            tags: "".to_owned(),
+            tags: String::new(),
             hide: Value::Object(Default::default()),
             native: false,
             source_actor: "todo".to_owned(),

--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -182,7 +182,7 @@ impl PageStyleActor {
             // get all of the rules associated with it.
 
             let style_attribute_rule = MatchedRule {
-                selector: "".into(),
+                selector: String::new(),
                 stylesheet_index: usize::MAX,
                 block_id: 0,
                 ancestor_data: vec![],
@@ -244,7 +244,7 @@ impl PageStyleActor {
             .ok_or(ActorError::BadParameterType)?;
         let node_actor = registry.find::<NodeActor>(node_name);
         let style_attribute_rule = devtools_traits::MatchedRule {
-            selector: "".into(),
+            selector: String::new(),
             stylesheet_index: usize::MAX,
             block_id: 0,
             ancestor_data: vec![],

--- a/components/devtools/actors/inspector/style_rule.rs
+++ b/components/devtools/actors/inspector/style_rule.rs
@@ -199,8 +199,8 @@ impl StyleRuleActor {
                 .as_ref()
                 .map(|r| r.ancestor_data.clone())
                 .unwrap_or_default(),
-            authored_text: "".into(),
-            css_text: "".into(), // TODO: Specify the css text
+            authored_text: String::new(),
+            css_text: String::new(), // TODO: Specify the css text
             declarations: style
                 .into_iter()
                 .map(|decl| {
@@ -212,7 +212,7 @@ impl StyleRuleActor {
                         name: decl.name,
                         offsets: vec![], // TODO: Get the source of the declaration
                         priority: decl.priority,
-                        terminator: "".into(),
+                        terminator: String::new(),
                         value: decl.value,
                     }
                 })

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -479,7 +479,7 @@ impl Actor for NetworkEventActor {
 
                     ResponseContent {
                         body_size: body.len(),
-                        content_charset: "".into(),
+                        content_charset: String::new(),
                         decoded_body_size: body.len(),
                         encoding,
                         headers_size: raw_headers.len(),
@@ -701,7 +701,7 @@ impl ActorEncode<NetworkEventMsg> for NetworkEventActor {
                 .unwrap_or_default()
                 .as_millis() as i64,
         ) {
-            LocalResult::None => "".to_owned(),
+            LocalResult::None => String::new(),
             LocalResult::Single(date_time) => date_time.to_rfc3339(),
             LocalResult::Ambiguous(date_time, _) => date_time.to_rfc3339(),
         };

--- a/components/devtools/actors/preference.rs
+++ b/components/devtools/actors/preference.rs
@@ -63,7 +63,7 @@ impl PreferenceActor {
     ) -> Result<(), ActorError> {
         match msg_type {
             "getBoolPref" => self.write_bool(request, false),
-            "getCharPref" => self.write_char(request, "".into()),
+            "getCharPref" => self.write_char(request, String::new()),
             "getIntPref" => self.write_int(request, 0),
             "getFloatPref" => self.write_float(request, 0.),
             _ => Err(ActorError::UnrecognizedPacketType),

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -258,7 +258,7 @@ impl Actor for RootActor {
                             actor: worker_actor.name().into(),
                             scope,
                             url: url.clone(),
-                            registration_state: "".to_string(),
+                            registration_state: String::new(),
                             last_update_time: 0,
                             traits: HashMap::new(),
                             evaluating_worker: None,

--- a/components/devtools/actors/stylesheets.rs
+++ b/components/devtools/actors/stylesheets.rs
@@ -176,7 +176,7 @@ impl StyleSheetsActor {
                 system: info.system,
                 is_new: false,
                 file_name: None,
-                source_map_url: Some("".to_string()),
+                source_map_url: Some(String::new()),
                 source_map_base_url: Some(info.href.unwrap_or_else(|| url.clone())),
                 style_sheet_index: info.style_sheet_index,
                 constructed: false,

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -105,6 +105,9 @@ net = { package = "servo-net", path = ".", features = ["test-util"] }
 rustls = { workspace = true, features = ["aws-lc-rs"] }
 servo-default-resources = { workspace = true }
 
+[lints]
+workspace = true
+
 [[test]]
 name = "main"
 path = "tests/main.rs"

--- a/components/net/cookie_storage.rs
+++ b/components/net/cookie_storage.rs
@@ -238,7 +238,7 @@ impl CookieStorage {
         };
 
         // Serialize the cookie-list into a cookie-string by processing each cookie in the cookie-list in order
-        let result = cookie_list.fold("".to_owned(), reducer);
+        let result = cookie_list.fold(String::new(), reducer);
 
         info!(" === COOKIES SENT: {}", result);
         match result.len() {

--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -646,7 +646,7 @@ impl FileManagerStore {
         let filename_path = Path::new(file_name);
         let type_string = match mime_guess::from_path(filename_path).first() {
             Some(x) => format!("{}", x),
-            None => "".to_string(),
+            None => String::new(),
         };
 
         Ok(SelectedFile {
@@ -709,7 +709,7 @@ impl FileManagerStore {
                 if seeked_start == (range.start as u64) {
                     let type_string = match mime {
                         Some(x) => format!("{}", x),
-                        None => "".to_string(),
+                        None => String::new(),
                     };
 
                     read_file_in_chunks(sender, file, range.len(), opt_filename, type_string).await;

--- a/components/net/tests/cookie.rs
+++ b/components/net/tests/cookie.rs
@@ -410,7 +410,7 @@ fn add_retrieve_cookies(
     let url = ServoUrl::parse(final_location).unwrap();
     storage
         .cookies_for_url(&url, source)
-        .unwrap_or("".to_string())
+        .unwrap_or(String::new())
 }
 
 #[test]

--- a/components/net/tests/cookie_http_state.rs
+++ b/components/net/tests/cookie_http_state.rs
@@ -23,7 +23,7 @@ fn run(set_location: &str, set_cookies: &[&str], final_location: &str) -> String
     let url = ServoUrl::parse(final_location).unwrap();
     storage
         .cookies_for_url(&url, source)
-        .unwrap_or("".to_string())
+        .unwrap_or(String::new())
 }
 
 // Following are all tests extracted from https://github.com/abarth/http-state.git

--- a/components/shared/embedder/Cargo.toml
+++ b/components/shared/embedder/Cargo.toml
@@ -44,3 +44,6 @@ url = { workspace = true }
 uuid = { workspace = true }
 webdriver = { workspace = true }
 webrender_api = { workspace = true }
+
+[lints]
+workspace = true

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -570,8 +570,8 @@ impl MediaMetadata {
     pub fn new(title: String) -> Self {
         Self {
             title,
-            artist: "".to_owned(),
-            album: "".to_owned(),
+            artist: String::new(),
+            album: String::new(),
         }
     }
 }

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -134,9 +134,17 @@ class MachCommands(CommandBase):
         env = self.build_env()
         env["RUSTC"] = "rustc"
 
-        # arguments to be passed through to clippy (as opposed to the cargo clippy wrapper)
-        # These should mainly be `--allow`, `--warn`, `--deny`, `--forbid`
-        # Note that some lints can additionally be configured by `.clippy.toml` at the repository root.
+        # Arguments to be passed through to clippy (as opposed to the cargo clippy wrapper)
+        # Prefer to specify these in the `lints.clippy` section in `/Cargo.toml`. Note that
+        # to enable linter warnings in a specific package, the `[lints]` section must inherit
+        # from the workspace. Example `components/X/Cargo.toml`:
+        #
+        # ```
+        # [lints]
+        # workspace = true
+        # ```
+        #
+        # TODO(47512): Move these to `workspace.lints.clippy` once all `Cargo.toml` specify lints
         clippy_args = ["--deny=clippy::disallowed_types", "--warn=clippy::redundant-clone"]
 
         if self.target.is_cross_build():


### PR DESCRIPTION
To prepare for a DOMString-specific variant of this Clippy lint, enable it in a couple of components. Unfortunately specifying the `workspace.lints.clippy` in `/Cargo.toml` isn't sufficient, as all relevant Cargo.toml in each component also need to specify the `[lints]` section to inherit from the workspace. Therefore, to allow for a gradual rollout, enable these in a couple of places.

This removes the overall need to specify all clippy rules as arguments on the command line.

Part of #47512

Testing: it compiles with Clippy