### PR TITLE
script: Handle WebDriver script execution via a native promise handler

### DIFF
--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -24,9 +24,8 @@ use devtools_traits::{ScriptToDevtoolsControlMsg, TimelineMarker, TimelineMarker
 use dom_struct::dom_struct;
 use embedder_traits::user_contents::UserScript;
 use embedder_traits::{
-    AlertResponse, ConfirmResponse, EmbedderMsg, JavaScriptEvaluationError, PromptResponse,
-    ScriptToEmbedderChan, SimpleDialogRequest, Theme, UntrustedNodeAddress, ViewportDetails,
-    WebDriverJSResult, WebDriverLoadStatus,
+    AlertResponse, ConfirmResponse, EmbedderMsg, PromptResponse, ScriptToEmbedderChan,
+    SimpleDialogRequest, Theme, UntrustedNodeAddress, ViewportDetails, WebDriverLoadStatus,
 };
 use euclid::{Point2D, Rect, Scale, Size2D, Vector2D};
 use fonts::{
@@ -131,9 +130,7 @@ use crate::dom::bindings::codegen::Bindings::WindowBinding::{
 use crate::dom::bindings::codegen::UnionTypes::{
     RequestOrUSVString, TrustedScriptOrString, TrustedScriptOrStringOrFunction,
 };
-use crate::dom::bindings::error::{
-    Error, ErrorInfo, ErrorResult, Fallible, javascript_error_info_from_error_info,
-};
+use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
 use crate::dom::bindings::inheritance::{Castable, ElementTypeId, HTMLElementTypeId, NodeTypeId};
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::refcounted::Trusted;
@@ -201,9 +198,7 @@ use crate::dom::workletglobalscope::WorkletGlobalScopeType;
 use crate::event_loop::script_thread::ScriptThread;
 use crate::event_loop::script_window_proxies::ScriptWindowProxies;
 use crate::event_loop::timers::{IsInterval, OneshotTimers, TimerCallback};
-use crate::event_loop::webdriver_handlers::{
-    find_node_by_unique_id_in_document, jsval_to_webdriver,
-};
+use crate::event_loop::webdriver_handlers::find_node_by_unique_id_in_document;
 use crate::fetch::fetch;
 use crate::fetch::network_listener::{ResourceTimingListener, submit_timing};
 use crate::messaging::{MainThreadScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
@@ -378,10 +373,6 @@ pub(crate) struct Window {
     /// cases.
     #[no_trace]
     layout_blocker: Cell<LayoutBlocker>,
-
-    /// A channel for communicating results of async scripts back to the webdriver server
-    #[no_trace]
-    webdriver_script_chan: DomRefCell<Option<GenericSender<WebDriverJSResult>>>,
 
     /// A channel to notify webdriver if there is a navigation
     #[no_trace]
@@ -1918,27 +1909,6 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     /// <https://html.spec.whatwg.org/multipage/#dom-window-releaseevents>
     fn ReleaseEvents(&self) {
         // This method intentionally does nothing
-    }
-
-    // check-tidy: no specs after this line
-    fn WebdriverCallback(&self, realm: &mut CurrentRealm, value: HandleValue) {
-        let webdriver_script_sender = self.webdriver_script_chan.borrow_mut().take();
-        if let Some(webdriver_script_sender) = webdriver_script_sender {
-            let result = jsval_to_webdriver(realm, &self.globalscope, value);
-            let _ = webdriver_script_sender.send(result);
-        }
-    }
-
-    fn WebdriverException(&self, cx: &mut JSContext, value: HandleValue) {
-        let webdriver_script_sender = self.webdriver_script_chan.borrow_mut().take();
-        if let Some(webdriver_script_sender) = webdriver_script_sender {
-            let error_info = ErrorInfo::from_value(cx, value);
-            let _ = webdriver_script_sender.send(Err(
-                JavaScriptEvaluationError::EvaluationFailure(Some(
-                    javascript_error_info_from_error_info(cx, &error_info, value),
-                )),
-            ));
-        }
     }
 
     fn WebdriverElement(&self, id: DOMString) -> Option<DomRoot<Element>> {
@@ -3544,10 +3514,6 @@ impl Window {
         }
     }
 
-    pub(crate) fn set_webdriver_script_chan(&self, chan: Option<GenericSender<WebDriverJSResult>>) {
-        *self.webdriver_script_chan.borrow_mut() = chan;
-    }
-
     pub(crate) fn set_webdriver_load_status_sender(
         &self,
         sender: Option<GenericSender<WebDriverLoadStatus>>,
@@ -4004,7 +3970,6 @@ impl Window {
             current_state: Cell::new(WindowState::Alive),
             devtools_marker_sender: Default::default(),
             devtools_markers: Default::default(),
-            webdriver_script_chan: Default::default(),
             webdriver_load_status_sender: Default::default(),
             error_reporter,
             media_query_lists: DOMTracker::new(),

--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -2691,7 +2691,7 @@ impl ScriptThread {
             WebDriverScriptCommand::ExecuteScriptWithCallback(script, reply) => {
                 let window = documents.find_window(pipeline_id);
                 drop(documents);
-                webdriver_handlers::handle_execute_async_script(window, script, reply, cx);
+                webdriver_handlers::handle_execute_script(window, script, reply, cx);
             },
             WebDriverScriptCommand::SetProtocolHandlerAutomationMode(mode) => {
                 webdriver_handlers::set_protocol_handler_automation_mode(

--- a/components/script/event_loop/webdriver_handlers.rs
+++ b/components/script/event_loop/webdriver_handlers.rs
@@ -36,6 +36,7 @@ use servo_base::id::{BrowsingContextId, PipelineId};
 use webdriver::error::ErrorStatus;
 
 use crate::DomTypeHolder;
+use crate::dom::Promise;
 use crate::dom::attr::is_boolean_attribute;
 use crate::dom::bindings::codegen::Bindings::CSSStyleDeclarationBinding::CSSStyleDeclarationMethods;
 use crate::dom::bindings::codegen::Bindings::DOMRectBinding::DOMRectMethods;
@@ -62,7 +63,10 @@ use crate::dom::bindings::conversions::{
     ConversionBehavior, ConversionResult, get_property, get_property_jsval, jsid_to_string,
     root_from_object,
 };
-use crate::dom::bindings::error::{Error, report_pending_exception, throw_dom_exception};
+use crate::dom::bindings::error::{
+    Error, ErrorInfo, javascript_error_info_from_error_info, report_pending_exception,
+    throw_dom_exception,
+};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::DomRoot;
@@ -86,7 +90,8 @@ use crate::dom::html::htmltextareaelement::HTMLTextAreaElement;
 use crate::dom::iterators::ShadowIncluding;
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::nodelist::NodeList;
-use crate::dom::types::ShadowRoot;
+use crate::dom::promisenativehandler::Callback;
+use crate::dom::types::{PromiseNativeHandler, ShadowRoot};
 use crate::dom::validitystate::ValidationFlags;
 use crate::dom::window::Window;
 use crate::dom::xmlserializer::XMLSerializer;
@@ -606,41 +611,84 @@ fn clone_an_object(
     return_val
 }
 
-pub(crate) fn handle_execute_async_script(
+#[derive(MallocSizeOf, JSTraceable)]
+struct WebDriverExecuteScriptFulfillmentHandler {
+    #[no_trace]
+    reply_sender: GenericSender<WebDriverJSResult>,
+}
+
+impl Callback for WebDriverExecuteScriptFulfillmentHandler {
+    fn callback(&self, cx: &mut CurrentRealm, return_value: HandleValue) {
+        let global_scope = GlobalScope::from_current_realm(cx);
+        let result = jsval_to_webdriver(cx, &global_scope, return_value);
+        let _ = self.reply_sender.send(result);
+    }
+}
+
+#[derive(MallocSizeOf, JSTraceable)]
+struct WebDriverExecuteScriptRejectionHandler {
+    #[no_trace]
+    reply_sender: GenericSender<WebDriverJSResult>,
+}
+
+impl Callback for WebDriverExecuteScriptRejectionHandler {
+    fn callback(&self, cx: &mut CurrentRealm, return_value: HandleValue) {
+        let error_info = ErrorInfo::from_value(cx, return_value);
+        let _ = self
+            .reply_sender
+            .send(Err(JavaScriptEvaluationError::EvaluationFailure(Some(
+                javascript_error_info_from_error_info(cx, &error_info, return_value),
+            ))));
+    }
+}
+
+pub(crate) fn handle_execute_script(
     window: Option<DomRoot<Window>>,
     eval: String,
-    reply: GenericSender<WebDriverJSResult>,
+    reply_sender: GenericSender<WebDriverJSResult>,
     cx: &mut JSContext,
 ) {
-    match window {
-        Some(window) => {
-            let reply_sender = reply.clone();
-            window.set_webdriver_script_chan(Some(reply));
+    let Some(window) = window else {
+        reply_sender
+            .send(Err(JavaScriptEvaluationError::DocumentNotFound))
+            .unwrap_or_else(|error| {
+                error!("ExecuteAsyncScript Failed to send reply: {error}");
+            });
+        return;
+    };
 
-            let global_scope = window.as_global_scope();
+    let global_scope = window.as_global_scope();
+    let mut realm = enter_auto_realm(cx, global_scope);
+    let mut realm = realm.current_realm();
+    let cx = &mut realm;
 
-            let mut realm = enter_auto_realm(cx, global_scope);
-            let mut realm = realm.current_realm();
-            if let Err(error) = global_scope.evaluate_js_on_global(
-                &mut realm,
-                eval.into(),
-                "",
-                None, // No known `introductionType` for JS code from WebDriver
-                None,
-            ) {
-                reply_sender.send(Err(error)).unwrap_or_else(|error| {
-                    error!("ExecuteAsyncScript Failed to send reply: {error}");
-                });
-            }
-        },
-        None => {
-            reply
-                .send(Err(JavaScriptEvaluationError::DocumentNotFound))
-                .unwrap_or_else(|error| {
-                    error!("ExecuteAsyncScript Failed to send reply: {error}");
-                });
-        },
+    rooted!(&in(cx) let mut return_value = UndefinedValue());
+    if let Err(error) = global_scope.evaluate_js_on_global(
+        cx,
+        eval.into(),
+        "",
+        None, // No known `introductionType` for JS code from WebDriver
+        Some(return_value.handle_mut()),
+    ) {
+        reply_sender.send(Err(error)).unwrap_or_else(|error| {
+            error!("ExecuteAsyncScript Failed to send reply: {error}");
+        });
+        return;
     }
+
+    let promise = Promise::new_resolved(cx, global_scope, return_value.handle());
+    let fulfillment_handler = WebDriverExecuteScriptFulfillmentHandler {
+        reply_sender: reply_sender.clone(),
+    };
+    let rejection_handler = WebDriverExecuteScriptRejectionHandler { reply_sender };
+
+    let handler = PromiseNativeHandler::new(
+        cx,
+        global_scope,
+        Some(Box::new(fulfillment_handler)),
+        Some(Box::new(rejection_handler)),
+    );
+    promise.append_native_handler(cx, &handler);
 }
 
 /// Get BrowsingContextId for <https://w3c.github.io/webdriver/#switch-to-parent-frame>

--- a/components/script_bindings/webidls/Window.webidl
+++ b/components/script_bindings/webidls/Window.webidl
@@ -137,8 +137,6 @@ partial interface Window {
 // WebDriver extensions
 partial interface Window {
   // Shouldn't be public, but just to make things work for now
-  undefined webdriverCallback(optional any result);
-  undefined webdriverException(optional any result);
   Element? webdriverElement(DOMString id);
   WindowProxy? webdriverFrame(DOMString id);
   WindowProxy webdriverWindow(DOMString id);

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2058,31 +2058,16 @@ impl Handler {
     ) -> WebDriverResult<WebDriverResponse> {
         // Step 1. Let body and arguments be the result of trying to extract the script arguments
         // from a request with argument parameters.
-        let (func_body, args_string) = self.extract_script_arguments(parameters)?;
+        let (function_body, arguments_vec) = self.extract_script_arguments(parameters)?;
+        let joined_arguments = arguments_vec.join(", ");
 
-        // This is pretty ugly; we really want something that acts like
-        // new Function() and then takes the resulting function and executes
-        // it with a vec of arguments.
         let script = format!(
-            r#"(async function(__wd_eid) {{
-                try {{
-                    let result = (async function() {{
-                        {func_body}
-                    }})({});
-                    let value = await result;
-                    if (window.__wd_eid === __wd_eid) {{
-                        window.webdriverCallback(value);
-                    }}
-                }} catch (err) {{
-                    if (window.__wd_eid === __wd_eid) {{
-                        window.webdriverException(err);
-                    }}
-                }}
-            }})(window.__wd_eid = (window.__wd_eid || 0) + 1);"#,
-            args_string.join(", ")
+            r#"(async function() {{
+                {function_body}
+               }})({joined_arguments})"#
         );
+        debug!("Executing {script}");
 
-        debug!("{}", script);
         // Step 2. If session's current browsing context is no longer open,
         // return error with error code no such window.
         self.verify_browsing_context_is_open(self.browsing_context_id()?)?;
@@ -2112,31 +2097,21 @@ impl Handler {
     ) -> WebDriverResult<WebDriverResponse> {
         // Step 1. Let body and arguments be the result of trying to extract the script arguments
         // from a request with argument parameters.
-        let (function_body, mut args_string) = self.extract_script_arguments(parameters)?;
-        args_string.push("resolve".to_string());
+        let (function_body, mut arguments_vec) = self.extract_script_arguments(parameters)?;
+        arguments_vec.push("(value) => resolve(value)".into());
+        let joined_arguments = arguments_vec.join(", ");
 
-        let joined_args = args_string.join(", ");
         let script = format!(
-            r#"(async function(__wd_eid) {{
-                try {{
-                    let result = new Promise(function(resolve, reject) {{
-                      (async function() {{
-                        {function_body}
-                      }})({joined_args})
-                        .catch(reject)
-                    }});
-                    let value = await result;
-                    if (window.__wd_eid === __wd_eid) {{
-                        window.webdriverCallback(value);
-                    }}
-                }} catch (err) {{
-                    if (window.__wd_eid === __wd_eid) {{
-                        window.webdriverException(err);
-                    }}
-                }}
-            }})(window.__wd_eid = (window.__wd_eid || 0) + 1);"#,
+            r#"(function() {{
+                return new Promise(function(resolve, reject) {{
+                  (async function() {{
+                    {function_body}
+                  }}({joined_arguments}))
+                    .catch(reject)
+                  }});
+              }})()"#,
         );
-        debug!("{}", script);
+        debug!("Executing {script}");
 
         // Step 2. If session's current browsing context is no longer open,
         // return error with error code no such window.

--- a/tests/wpt/meta/html/browsers/the-windowproxy-exotic-object/windowproxy-prevent-extensions.html.ini
+++ b/tests/wpt/meta/html/browsers/the-windowproxy-exotic-object/windowproxy-prevent-extensions.html.ini
@@ -1,2 +1,6 @@
 [windowproxy-prevent-extensions.html]
-  expected: TIMEOUT
+  [Object.preventExtensions throws a TypeError]
+    expected: FAIL
+
+  [Reflect.preventExtensions returns false]
+    expected: FAIL


### PR DESCRIPTION
Instead of handling WebDriver script execution via `Window` callbacks,
have the script return a `Promise` to which we attach a native handler.
This greatly simplifies the way that script execution happens and
additionally prevents the native callbacks from being visible. Their
visibility was causing intermittent failures in some tests.

Testing: This causes a WPT test that previously timed out to fail properly.
