### PR TITLE
net: Fix potential bug in http cache where still transfering requests could get removed from cache

### DIFF
--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -310,6 +310,14 @@ impl MemoryCacheLifecycle {
 impl Lifecycle<CacheKey, CacheEntry> for MemoryCacheLifecycle {
     type RequestState = ();
 
+    // Cached Resources that are not complete could get evicted which means they cannot fill their body.
+    // We allow unfinished resources to stay in the cache.
+    fn is_pinned(&self, _: &CacheKey, val: &CacheEntry) -> bool {
+        val.blocking_read()
+            .iter()
+            .any(|resource| !resource.is_done())
+    }
+
     fn on_evict(&self, _state: &mut Self::RequestState, key: CacheKey, value: CacheEntry) {
         if let Some(disk_cache_data) = &self.disk_cache {
             let disk_cache_data = disk_cache_data.clone();


### PR DESCRIPTION
This fixes a potential bug if the memory cache is small.
Requests that are still ongoing, get inserted into the cache, even when they do not have yet a finished body.
If the cache is small, these elements could get evicted. While the requests are probably being kept alive, it might lead to other logic errors.

Testing: There are no automatic tests for this.
