### PR TITLE
script: Continue implementation of `WindowProxy` `ProxyTraps`

### DIFF
--- a/components/script/dom/window/windowproxy.rs
+++ b/components/script/dom/window/windowproxy.rs
@@ -1407,6 +1407,9 @@ unsafe extern "C" fn maybe_cross_origin_get_prototype_wrapper_rawcx(
     )
 }
 
+// TODO: These traps should change their behavior depending on
+// `IsPlatformObjectSameOrigin(this.[[Window]])`
+// See <https://github.com/servo/servo/issues/44669>
 static PROXY_TRAPS: ProxyTraps = ProxyTraps {
     enter: None,
     getOwnPropertyDescriptor: Some(get_own_property_descriptor),

--- a/components/script/dom/window/windowproxy.rs
+++ b/components/script/dom/window/windowproxy.rs
@@ -1390,7 +1390,7 @@ unsafe extern "C" fn get_prototype_if_ordinary(
 }
 
 #[expect(unsafe_code)]
-unsafe extern "C" fn maybe_xorigin_get_prototype_wrapper_rawcx(
+unsafe extern "C" fn maybe_cross_origin_get_prototype_wrapper_rawcx(
     cx: *mut RawJSContext,
     proxy: RawHandleObject,
     result: RawMutableHandleObject,
@@ -1415,7 +1415,7 @@ static PROXY_TRAPS: ProxyTraps = ProxyTraps {
     delete_: None,
     enumerate: None,
     getPrototypeIfOrdinary: Some(get_prototype_if_ordinary),
-    getPrototype: Some(maybe_xorigin_get_prototype_wrapper_rawcx),
+    getPrototype: Some(maybe_cross_origin_get_prototype_wrapper_rawcx),
     setPrototype: Some(maybe_cross_origin_set_prototype_rawcx),
     setImmutablePrototype: None,
     preventExtensions: Some(prevent_extensions),
@@ -1476,7 +1476,7 @@ impl WindowProxyHandler {
         /// Sharing a single instance should be fine because all methods on this pointer in C++
         /// are const and don't modify its internal state.
         static SINGLETON: OnceLock<WindowProxyHandler> = OnceLock::new();
-        SINGLETON.get_or_init(|| Self::new(&XORIGIN_PROXY_TRAPS))
+        SINGLETON.get_or_init(|| Self::new(&CROSS_ORIGIN_PROXY_TRAPS))
     }
 
     /// Returns a single, shared WindowProxyHandler that contains normal PROXY_TRAPS.
@@ -1532,7 +1532,7 @@ fn throw_security_error(realm: &mut CurrentRealm) -> bool {
 }
 
 #[expect(unsafe_code)]
-unsafe extern "C" fn has_xorigin(
+unsafe extern "C" fn cross_origin_has(
     cx: *mut RawJSContext,
     proxy: RawHandleObject,
     id: RawHandleId,
@@ -1557,7 +1557,7 @@ unsafe extern "C" fn has_xorigin(
 }
 
 #[expect(unsafe_code)]
-unsafe extern "C" fn get_xorigin(
+unsafe extern "C" fn cross_origin_get(
     cx: *mut RawJSContext,
     proxy: RawHandleObject,
     receiver: RawHandleValue,
@@ -1565,12 +1565,12 @@ unsafe extern "C" fn get_xorigin(
     vp: RawMutableHandleValue,
 ) -> bool {
     let mut found = false;
-    unsafe { has_xorigin(cx, proxy, id, &mut found) };
+    unsafe { cross_origin_has(cx, proxy, id, &mut found) };
     found && unsafe { get(cx, proxy, receiver, id, vp) }
 }
 
 #[expect(unsafe_code)]
-unsafe extern "C" fn set_xorigin(
+unsafe extern "C" fn cross_origin_set(
     cx: *mut RawJSContext,
     _: RawHandleObject,
     _: RawHandleId,
@@ -1602,8 +1602,7 @@ unsafe extern "C" fn delete_xorigin(
 }
 
 #[expect(unsafe_code)]
-#[expect(non_snake_case)]
-unsafe extern "C" fn getOwnPropertyDescriptor_xorigin(
+unsafe extern "C" fn cross_origin_get_own_property_descriptor(
     cx: *mut RawJSContext,
     proxy: RawHandleObject,
     id: RawHandleId,
@@ -1611,13 +1610,12 @@ unsafe extern "C" fn getOwnPropertyDescriptor_xorigin(
     is_none: *mut bool,
 ) -> bool {
     let mut found = false;
-    unsafe { has_xorigin(cx, proxy, id, &mut found) };
+    unsafe { cross_origin_has(cx, proxy, id, &mut found) };
     found && unsafe { get_own_property_descriptor(cx, proxy, id, desc, is_none) }
 }
 
 #[expect(unsafe_code)]
-#[expect(non_snake_case)]
-unsafe extern "C" fn defineProperty_xorigin(
+unsafe extern "C" fn cross_origin_define_property(
     cx: *mut RawJSContext,
     _: RawHandleObject,
     _: RawHandleId,
@@ -1632,27 +1630,30 @@ unsafe extern "C" fn defineProperty_xorigin(
     throw_security_error(&mut realm)
 }
 
-static XORIGIN_PROXY_TRAPS: ProxyTraps = ProxyTraps {
+// TODO: Some of these callbacks need proper support for handling cross-origin
+// properties, notably `set` and `ownPropertyKeys`, but there may also be others.
+//
+// TODO: Implement `getOwnPropertyKeys` for cross-origin `WindowProxy`.
+// https://github.com/servo/servo/issues/47548.
+static CROSS_ORIGIN_PROXY_TRAPS: ProxyTraps = ProxyTraps {
     enter: None,
-    getOwnPropertyDescriptor: Some(getOwnPropertyDescriptor_xorigin),
-    defineProperty: Some(defineProperty_xorigin),
-    // TODO: Implement `getOwnPropertyKeys` for cross-origin `WindowProxy`.
-    // https://github.com/servo/servo/issues/47548.
+    getOwnPropertyDescriptor: Some(cross_origin_get_own_property_descriptor),
+    defineProperty: Some(cross_origin_define_property),
     ownPropertyKeys: None,
     delete_: Some(delete_xorigin),
     enumerate: None,
     getPrototypeIfOrdinary: Some(maybe_cross_origin_get_prototype_if_ordinary_rawcx),
-    getPrototype: Some(maybe_xorigin_get_prototype_wrapper_rawcx),
+    getPrototype: Some(maybe_cross_origin_get_prototype_wrapper_rawcx),
     setPrototype: Some(maybe_cross_origin_set_prototype_rawcx),
     setImmutablePrototype: None,
     preventExtensions: Some(prevent_extensions),
     isExtensible: Some(is_extensible),
-    has: Some(has_xorigin),
-    get: Some(get_xorigin),
-    set: Some(set_xorigin),
+    has: Some(cross_origin_has),
+    get: Some(cross_origin_get),
+    set: Some(cross_origin_set),
     call: None,
     construct: None,
-    hasOwn: Some(has_xorigin),
+    hasOwn: Some(cross_origin_has),
     getOwnEnumerablePropertyKeys: None,
     nativeCall: None,
     objectClassIs: None,

--- a/components/script/dom/window/windowproxy.rs
+++ b/components/script/dom/window/windowproxy.rs
@@ -13,6 +13,7 @@ use indexmap::map::IndexMap;
 use itertools::Either;
 use js::JSCLASS_IS_GLOBAL;
 use js::context::JSContext;
+use js::gc::MutableHandleObject;
 use js::glue::{
     CreateWrapperProxyHandler, DeleteWrapperProxyHandler, GetProxyPrivate, GetProxyReservedSlot,
     ProxyTraps, SetProxyReservedSlot,
@@ -35,8 +36,12 @@ use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use net_traits::ReferrerPolicy;
 use net_traits::request::Referrer;
 use script_bindings::cell::DomRefCell;
-use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
-use script_bindings::proxyhandler::set_property_descriptor;
+use script_bindings::codegen::GenericBindings::WindowBinding::{GetProtoObject, WindowMethods};
+use script_bindings::proxyhandler::{
+    is_extensible, maybe_cross_origin_get_prototype,
+    maybe_cross_origin_get_prototype_if_ordinary_rawcx, maybe_cross_origin_set_prototype_rawcx,
+    prevent_extensions, set_property_descriptor,
+};
 use script_bindings::reflector::{DomObject, MutDomObject, Reflector};
 use script_traits::NewPipelineInfo;
 use serde::{Deserialize, Serialize};
@@ -51,6 +56,7 @@ use servo_url::{ImmutableOrigin, OriginSnapshot, ServoUrl};
 use storage_traits::webstorage_thread::WebStorageThreadMsg;
 use style::attr::parse_integer;
 
+use crate::DomTypeHolder;
 use crate::dom::bindings::conversions::{ToJSValConvertible, root_from_handleobject};
 use crate::dom::bindings::error::{Error, Fallible, throw_dom_exception};
 use crate::dom::bindings::inheritance::Castable;
@@ -1383,9 +1389,25 @@ unsafe extern "C" fn get_prototype_if_ordinary(
     true
 }
 
+#[expect(unsafe_code)]
+unsafe extern "C" fn maybe_xorigin_get_prototype_wrapper_rawcx(
+    cx: *mut RawJSContext,
+    proxy: RawHandleObject,
+    result: RawMutableHandleObject,
+) -> bool {
+    let mut cx = unsafe { JSContext::from_ptr(ptr::NonNull::new(cx).unwrap()) };
+    let mut realm = CurrentRealm::assert(&mut cx);
+    let proxy = unsafe { Handle::from_raw(proxy) };
+    let result = unsafe { MutableHandleObject::from_raw(result) };
+    maybe_cross_origin_get_prototype::<DomTypeHolder>(
+        &mut realm,
+        proxy,
+        GetProtoObject::<DomTypeHolder>,
+        result,
+    )
+}
+
 static PROXY_TRAPS: ProxyTraps = ProxyTraps {
-    // TODO: These traps should change their behavior depending on
-    //       `IsPlatformObjectSameOrigin(this.[[Window]])`
     enter: None,
     getOwnPropertyDescriptor: Some(get_own_property_descriptor),
     defineProperty: Some(define_property),
@@ -1393,11 +1415,11 @@ static PROXY_TRAPS: ProxyTraps = ProxyTraps {
     delete_: None,
     enumerate: None,
     getPrototypeIfOrdinary: Some(get_prototype_if_ordinary),
-    getPrototype: None, // TODO: return `null` if cross origin-domain
-    setPrototype: None,
+    getPrototype: Some(maybe_xorigin_get_prototype_wrapper_rawcx),
+    setPrototype: Some(maybe_cross_origin_set_prototype_rawcx),
     setImmutablePrototype: None,
-    preventExtensions: None,
-    isExtensible: None,
+    preventExtensions: Some(prevent_extensions),
+    isExtensible: Some(is_extensible),
     has: Some(has),
     get: Some(get),
     set: Some(set),
@@ -1610,34 +1632,21 @@ unsafe extern "C" fn defineProperty_xorigin(
     throw_security_error(&mut realm)
 }
 
-#[expect(unsafe_code)]
-#[expect(non_snake_case)]
-unsafe extern "C" fn preventExtensions_xorigin(
-    cx: *mut RawJSContext,
-    _: RawHandleObject,
-    _: *mut ObjectOpResult,
-) -> bool {
-    let mut cx = unsafe {
-        // SAFETY: We are in SM hook
-        JSContext::from_ptr(NonNull::new(cx).expect("JSContext should not be null in SM hook"))
-    };
-    let mut realm = CurrentRealm::assert(&mut cx);
-    throw_security_error(&mut realm)
-}
-
 static XORIGIN_PROXY_TRAPS: ProxyTraps = ProxyTraps {
     enter: None,
     getOwnPropertyDescriptor: Some(getOwnPropertyDescriptor_xorigin),
     defineProperty: Some(defineProperty_xorigin),
+    // TODO: Implement `getOwnPropertyKeys` for cross-origin `WindowProxy`.
+    // https://github.com/servo/servo/issues/47548.
     ownPropertyKeys: None,
     delete_: Some(delete_xorigin),
     enumerate: None,
-    getPrototypeIfOrdinary: None,
-    getPrototype: None,
-    setPrototype: None,
+    getPrototypeIfOrdinary: Some(maybe_cross_origin_get_prototype_if_ordinary_rawcx),
+    getPrototype: Some(maybe_xorigin_get_prototype_wrapper_rawcx),
+    setPrototype: Some(maybe_cross_origin_set_prototype_rawcx),
     setImmutablePrototype: None,
-    preventExtensions: Some(preventExtensions_xorigin),
-    isExtensible: None,
+    preventExtensions: Some(prevent_extensions),
+    isExtensible: Some(is_extensible),
     has: Some(has_xorigin),
     get: Some(get_xorigin),
     set: Some(set_xorigin),

--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -149,9 +149,12 @@ pub(crate) unsafe extern "C" fn delete(
 
 /// Controls whether the Extensible bit can be changed
 ///
+/// [`Location`]: https://html.spec.whatwg.org/multipage/#location-preventextensions
+/// [`WindowProxy`]: <https://html.spec.whatwg.org/multipage/#windowproxy-preventextensions>
+///
 /// # Safety
 /// `result` must point to a valid, non-null ObjectOpResult.
-pub(crate) unsafe extern "C" fn prevent_extensions(
+pub unsafe extern "C" fn prevent_extensions(
     _cx: *mut RawJSContext,
     _proxy: RawHandleObject,
     result: *mut ObjectOpResult,
@@ -162,9 +165,12 @@ pub(crate) unsafe extern "C" fn prevent_extensions(
 
 /// Reports whether the object is Extensible
 ///
+/// [`Location`]: https://html.spec.whatwg.org/multipage/#location-isextensible
+/// [`WindowProxy`]: <https://html.spec.whatwg.org/multipage/#windowproxy-isextensible>
+///
 /// # Safety
 /// `succeeded` must point to a valid, non-null bool.
-pub(crate) unsafe extern "C" fn is_extensible(
+pub unsafe extern "C" fn is_extensible(
     _cx: *mut RawJSContext,
     _proxy: RawHandleObject,
     succeeded: *mut bool,
@@ -312,7 +318,7 @@ fn cross_origin_own_property_keys(
 
 /// # Safety
 /// `is_ordinary` must point to a valid, non-null bool.
-pub(crate) unsafe extern "C" fn maybe_cross_origin_get_prototype_if_ordinary_rawcx(
+pub unsafe extern "C" fn maybe_cross_origin_get_prototype_if_ordinary_rawcx(
     _: *mut RawJSContext,
     _proxy: RawHandleObject,
     is_ordinary: *mut bool,
@@ -330,7 +336,7 @@ pub(crate) unsafe extern "C" fn maybe_cross_origin_get_prototype_if_ordinary_raw
 ///
 /// # Safety
 /// `result` must point to a valid, non-null ObjectOpResult.
-pub(crate) unsafe extern "C" fn maybe_cross_origin_set_prototype_rawcx(
+pub unsafe extern "C" fn maybe_cross_origin_set_prototype_rawcx(
     cx: *mut RawJSContext,
     proxy: RawHandleObject,
     proto: RawHandleObject,
@@ -630,7 +636,8 @@ pub(crate) unsafe extern "C" fn maybe_cross_origin_set_rawcx<D: DomTypes>(
 /// Implementation of `[[GetPrototypeOf]]` for [`Location`].
 ///
 /// [`Location`]: https://html.spec.whatwg.org/multipage/#location-getprototypeof
-pub(crate) fn maybe_cross_origin_get_prototype<D: DomTypes>(
+/// [`WindowProxy`]: https://html.spec.whatwg.org/multipage/#windowproxy-getprototypeof
+pub fn maybe_cross_origin_get_prototype<D: DomTypes>(
     cx: &mut CurrentRealm,
     proxy: HandleObject,
     get_proto_object: fn(cx: &mut JSContext, global: HandleObject, rval: MutableHandleObject),

--- a/tests/wpt/meta/html/browsers/the-windowproxy-exotic-object/windowproxy-prevent-extensions.html.ini
+++ b/tests/wpt/meta/html/browsers/the-windowproxy-exotic-object/windowproxy-prevent-extensions.html.ini
@@ -1,6 +1,0 @@
-[windowproxy-prevent-extensions.html]
-  [Object.preventExtensions throws a TypeError]
-    expected: FAIL
-
-  [Reflect.preventExtensions returns false]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/the-windowproxy-exotic-object/windowproxy-prototype-setting-cross-origin-domain.sub.html.ini
+++ b/tests/wpt/meta/html/browsers/the-windowproxy-exotic-object/windowproxy-prototype-setting-cross-origin-domain.sub.html.ini
@@ -1,18 +1,6 @@
 [windowproxy-prototype-setting-cross-origin-domain.sub.html]
-  [Cross-origin via document.domain: the prototype is null]
-    expected: FAIL
-
   [Cross-origin via document.domain: setting the prototype to an empty object via __proto__ should throw a "SecurityError" DOMException]
     expected: FAIL
 
-  [Cross-origin via document.domain: the prototype must still be null]
-    expected: FAIL
-
-  [Cross-origin via document.domain: setting the prototype to null via Object.setPrototypeOf should not throw]
-    expected: FAIL
-
   [Cross-origin via document.domain: setting the prototype to null via __proto__ should throw a "SecurityError" since it ends up in CrossOriginGetOwnProperty]
-    expected: FAIL
-
-  [Cross-origin via document.domain: setting the prototype to null via Reflect.setPrototypeOf should return true]
     expected: FAIL

--- a/tests/wpt/meta/html/browsers/the-windowproxy-exotic-object/windowproxy-prototype-setting-cross-origin.sub.html.ini
+++ b/tests/wpt/meta/html/browsers/the-windowproxy-exotic-object/windowproxy-prototype-setting-cross-origin.sub.html.ini
@@ -1,18 +1,6 @@
 [windowproxy-prototype-setting-cross-origin.sub.html]
-  [Cross-origin: the prototype is null]
-    expected: FAIL
-
   [Cross-origin: setting the prototype to an empty object via __proto__ should throw a "SecurityError" DOMException]
     expected: FAIL
 
-  [Cross-origin: the prototype must still be null]
-    expected: FAIL
-
-  [Cross-origin: setting the prototype to null via Object.setPrototypeOf should not throw]
-    expected: FAIL
-
   [Cross-origin: setting the prototype to null via __proto__ should throw a "SecurityError" since it ends up in CrossOriginGetOwnProperty]
-    expected: FAIL
-
-  [Cross-origin: setting the prototype to null via Reflect.setPrototypeOf should return true]
     expected: FAIL

--- a/tests/wpt/meta/html/browsers/the-windowproxy-exotic-object/windowproxy-prototype-setting-goes-cross-origin-domain.sub.html.ini
+++ b/tests/wpt/meta/html/browsers/the-windowproxy-exotic-object/windowproxy-prototype-setting-goes-cross-origin-domain.sub.html.ini
@@ -1,27 +1,9 @@
 [windowproxy-prototype-setting-goes-cross-origin-domain.sub.html]
-  [Became cross-origin via document.domain: the prototype is now null]
-    expected: FAIL
-
   [Became cross-origin via document.domain: setting the prototype to an empty object via __proto__ should throw a "SecurityError" DOMException]
-    expected: FAIL
-
-  [Became cross-origin via document.domain: the prototype must still be null]
-    expected: FAIL
-
-  [Became cross-origin via document.domain: setting the prototype to null via Object.setPrototypeOf should not throw]
     expected: FAIL
 
   [Became cross-origin via document.domain: setting the prototype to null via __proto__ should throw a "SecurityError" since it ends up in CrossOriginGetOwnProperty]
     expected: FAIL
 
-  [Became cross-origin via document.domain: setting the prototype to null via Reflect.setPrototypeOf should return true]
-    expected: FAIL
-
-  [Became cross-origin via document.domain: setting the prototype to the original value from before going cross-origin via Object.setPrototypeOf should throw a TypeError]
-    expected: FAIL
-
   [Became cross-origin via document.domain: setting the prototype to the original value from before going cross-origin via __proto__ should throw a "SecurityError" DOMException]
-    expected: FAIL
-
-  [Became cross-origin via document.domain: setting the prototype to the original value from before going cross-origin via Reflect.setPrototypeOf should return false]
     expected: FAIL


### PR DESCRIPTION
The `ProxyTraps` allow implementation of JavaScript object behaviors
such as `getPrototype` on the "exotic" `WindowProxy` object. Several of
these traps were not implemented so this change implements more of them.
Luckly, much of the logic is duplicated with the `Location` object so
this change reuses a good deal of that code from `script_bindings`.
The only remaining traps are for cross origin `ownPropertyKeys` which is
more complex and to finish other behavior for `set`, etc that rely on
the cross-origin property list.

Testing: This causes a number of WPT tests to start passing.