### PR TITLE
layout: Send scroll updates to the accessibility tree.

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -8,12 +8,17 @@ use std::iter::repeat;
 use std::sync::atomic::AtomicU64;
 use std::sync::{LazyLock, atomic};
 
-use accesskit::{NodeId, Role};
+use accesskit::{Affine, NodeId, Role};
 use app_units::Au;
 use bitflags::bitflags;
 use euclid::Rect;
-use layout_api::{AccessibilityDamage, BoxAreaType, LayoutElement, LayoutNode, LayoutNodeType};
+use layout_api::{
+    AccessibilityDamage, BoxAreaType, LayoutElement, LayoutNode, LayoutNodeType,
+    node_id_from_scroll_id,
+};
 use log::trace;
+use num_traits::ToPrimitive;
+use paint_api::display_list::SpatialTreeNodeInfo;
 use rustc_hash::{FxHashMap, FxHashSet};
 use script::layout_dom::{ServoLayoutElement, ServoLayoutNode};
 use servo_base::Epoch;
@@ -24,6 +29,8 @@ use style::Atom;
 use style::dom::OpaqueNode;
 use style_traits::CSSPixel;
 use web_atoms::{LocalName, local_name, ns};
+use webrender_api::ExternalScrollId;
+use webrender_api::units::LayoutVector2D;
 
 use crate::ArcRefCell;
 use crate::cell::WeakRefCell;
@@ -65,6 +72,13 @@ fn au_rect_to_accesskit_rect(rect: Rect<Au, CSSPixel>) -> accesskit::Rect {
         rect.max_x().to_f64_px(),
         rect.max_y().to_f64_px(),
     )
+}
+
+fn scroll_offset_to_affine(layout_vector: LayoutVector2D) -> Affine {
+    Affine::translate((
+        -layout_vector.x.to_f64().unwrap_or(0.),
+        -layout_vector.y.to_f64().unwrap_or(0.),
+    ))
 }
 
 /// Changes which have occurred during the current update, and data required to process the update.
@@ -126,6 +140,9 @@ struct AccessibilityNode {
     /// An accessibility node may not correspond to a DOM node if it corresponds to a
     /// pseudo-element, or in a test.
     opaque_node: Option<OpaqueNode>,
+    /// This node's scroll offset, if it is a scroll container which has scrolled. This is used to
+    /// translate this node's children.
+    scroll_offset: Option<LayoutVector2D>,
     /// Any dirty state for the current update.
     dirty_state: DirtyState,
 }
@@ -157,6 +174,9 @@ pub struct AccessibilityTree {
     /// Also used for any complete tree walk, such as in [`Self::assert_integrity()`] and
     /// [`Self::print()`].
     root_node: Option<ArcRefCell<AccessibilityNode>>,
+    /// If any nodes were scrolled since the last update, they are tracked here so that the next
+    /// update can update the tree accordingly.
+    pending_scroll_updates: Option<FxHashMap<ExternalScrollId, LayoutVector2D>>,
     /// Sent to the embedder alongside each [`accesskit::TreeUpdate`], so that the embedder can
     /// drop updates from documents which have been navigated away from.
     embedder_epoch: Epoch,
@@ -207,6 +227,7 @@ impl AccessibilityTree {
             id_to_opaque_node: FxHashMap::default(),
             tree_id,
             root_node: None,
+            pending_scroll_updates: None,
             embedder_epoch,
             debug: opts::get().debug.clone(),
         }
@@ -223,11 +244,24 @@ impl AccessibilityTree {
     ) -> (Option<accesskit::TreeUpdate>, UpdateCounters) {
         let mut update = AccessibilityUpdate::new(damage_from_dom, rooted_nodes, self);
 
-        self.ensure_root_node(root_dom_node, &mut update);
+        self.ensure_root_node(root_dom_node, &context, &mut update);
 
         self.apply_changes_from_dom_tree(&context, &mut update);
 
+        self.handle_pending_scroll_updates(&mut update);
+
         update.finalize(self)
+    }
+
+    pub(super) fn add_pending_scroll_updates(
+        &mut self,
+        scroll_states: &FxHashMap<ExternalScrollId, LayoutVector2D>,
+    ) {
+        if let Some(pending_scroll_updates) = self.pending_scroll_updates.as_mut() {
+            pending_scroll_updates.extend(scroll_states);
+        } else {
+            self.pending_scroll_updates = Some(scroll_states.clone());
+        }
     }
 
     /// Get the node corresponding to the root DOM node, and set it as this tree's root. If the root
@@ -236,6 +270,7 @@ impl AccessibilityTree {
     fn ensure_root_node<'update>(
         &mut self,
         root_dom_node: &ServoLayoutNode<'update>,
+        context: &AccessibilityContext<'update>,
         update: &mut AccessibilityUpdate<'update>,
     ) {
         let (root_id, root_node) = self.get_or_create_node(root_dom_node, update);
@@ -244,9 +279,10 @@ impl AccessibilityTree {
             update.clear_damage();
             update.insert_damage(root_id, AccessibilityDamage::Rebuild);
             update.insert_dom_node(root_id, *root_dom_node);
+            self.add_pending_scroll_updates_from_scroll_tree(context);
         } else {
-            // TODO(#47162, #47161) This hack is necessary because we don't collect accessibility damage
-            // from layout, and we don't handle scrolling properly.
+            // TODO(#47161) This hack is necessary because we don't collect accessibility damage
+            // from layout.
             update.insert_damage(root_id, AccessibilityDamage::Subtree);
             update.insert_dom_node(root_id, *root_dom_node);
         }
@@ -272,6 +308,53 @@ impl AccessibilityTree {
                 .update_subtree(damage_root.clone(), context, self, update);
 
         damage_root.borrow().update_ancestors(local_damage, update);
+    }
+
+    fn add_pending_scroll_updates_from_scroll_tree(&mut self, context: &AccessibilityContext) {
+        self.clear_pending_scroll_updates();
+        let scroll_tree = &context.stacking_context_tree.paint_info.scroll_tree;
+        let scroll_updates = scroll_tree
+            .nodes
+            .iter()
+            .filter_map(|n| match n.info {
+                SpatialTreeNodeInfo::Scroll(ref info) => {
+                    let offset = info.offset;
+                    Some((info.external_id, offset))
+                },
+                _ => None,
+            })
+            .collect();
+        self.add_pending_scroll_updates(&scroll_updates);
+    }
+
+    fn handle_pending_scroll_updates(&mut self, update: &mut AccessibilityUpdate) {
+        let Some(pending_scroll_updates) = std::mem::take(&mut self.pending_scroll_updates) else {
+            return;
+        };
+
+        for (opaque, offset) in
+            pending_scroll_updates
+                .into_iter()
+                .filter_map(|(scroll_id, translate)| {
+                    if scroll_id.is_root() {
+                        let root_node_opaque =
+                            self.root_node.as_ref()?.clone().borrow().opaque_node?;
+                        return Some((root_node_opaque, translate));
+                    }
+                    let node_id = node_id_from_scroll_id(scroll_id.0 as usize);
+                    let opaque = OpaqueNode(node_id);
+                    Some((opaque, translate))
+                })
+        {
+            let Some(node) = self.node_for_opaque(opaque) else {
+                continue;
+            };
+            node.borrow_mut().set_scroll_offset(offset, update);
+        }
+    }
+
+    fn clear_pending_scroll_updates(&mut self) {
+        self.pending_scroll_updates = None;
     }
 
     /// Given an iterator of `NodeId`s corresponding to nodes which have received some damage from
@@ -390,6 +473,12 @@ impl AccessibilityTree {
             panic!("{id:?} does not exist in tree");
         };
         node.clone()
+    }
+
+    fn node_for_opaque(&self, opaque: OpaqueNode) -> Option<ArcRefCell<AccessibilityNode>> {
+        self.nodes
+            .get(&self.existing_id_for_opaque(opaque)?)
+            .cloned()
     }
 
     /// Consume the [`AccessibilityUpdate`] by deleting all nodes it detected as being removed from
@@ -630,6 +719,7 @@ impl AccessibilityNode {
             parent_node: None,
             child_nodes: vec![],
             opaque_node: None,
+            scroll_offset: None,
             dirty_state: DirtyState::empty(),
         }
     }
@@ -663,6 +753,14 @@ impl AccessibilityNode {
                 ref_self, &dom_node, damage, tree, update,
             ));
             self.update_bounds_from_dom_node(&dom_node, context, update);
+
+            if local_damage.contains(LocalAccessibilityDamage::SubtreeChanged) &&
+                let Some(scroll_offset) = self.scroll_offset
+            {
+                // If children have changed, re-set the scroll transforms on all children.
+                self.set_scroll_offset(scroll_offset, update);
+            }
+
             self.dirty_state -= DirtyState::HasDamage;
         }
 
@@ -846,16 +944,18 @@ impl AccessibilityNode {
     ) {
         update.counters.nodes_updated_bounds += 1;
 
-        // Border box with transforms, matching getBoundingClientRect(). Bounds are in CSS pixels,
-        // relative to the viewport origin; the embedder's graft node carries the transform that
-        // composes them into AccessKit's coordinate space (see the "Coordinates" section of
+        // Border box without transforms. Bounds are in CSS pixels, relative to the document origin;
+        // scroll containers set translations on their child nodes, and the embedder's graft node
+        // carries the transform that composes them into AccessKit's coordinate space (see the
+        // "Coordinates" section of
         // <https://docs.rs/accesskit/latest/accesskit/struct.Node.html>).
+        // TODO(#47166): This doesn't take any CSS transforms into account.
         let bounds = process_box_area_request(
             context.layout_thread,
             context.stacking_context_tree,
             *dom_node,
             BoxAreaType::Border,
-            false, /* exclude_transform_and_inline */
+            true, /* exclude_transform_and_inline */
         )
         .map(au_rect_to_accesskit_rect);
 
@@ -863,15 +963,14 @@ impl AccessibilityNode {
         // `display: none` content, gets its bounds cleared. That leaves two kinds of nodes
         // without geometry which assistive technology would like to have some:
         //
-        // TODO(accessibility): A text node never has bounds of its own: `LayoutBox::Text` has no
+        // TODO(#47164): A text node never has bounds of its own: `LayoutBox::Text` has no
         // `LayoutBoxBase`, and `Fragment::Text` has no box area, so the query above always returns
         // `None` for one. Text nodes should get the union of the rectangles of their own
-        // `Fragment::Text` fragments, once `cumulative_box_area_rect()` can handle those. See
-        // #47164.
+        // `Fragment::Text` fragments, once `cumulative_box_area_rect()` can handle those.
         //
-        // TODO(accessibility): A `display: contents` element generates no box either. Other
+        // TODO(#47163): A `display: contents` element generates no box either. Other
         // engines (Blink, WebKit, Gecko) compute its bounds as the union of the bounding boxes of
-        // its rendered descendants. See #47163.
+        // its rendered descendants.
         match bounds {
             Some(bounds) => self.set_bounds(bounds),
             None => self.clear_bounds(),
@@ -962,6 +1061,20 @@ impl AccessibilityNode {
         self.accesskit_node.children()
     }
 
+    fn set_scroll_offset(&mut self, offset: LayoutVector2D, update: &mut AccessibilityUpdate) {
+        self.scroll_offset = Some(offset);
+        let transform = scroll_offset_to_affine(offset);
+        for child in self.children() {
+            let mut child = child.borrow_mut();
+            child.set_transform(transform);
+            if child.dirty_state.updated() {
+                update.add(&mut child);
+            }
+        }
+    }
+
+    // TODO: use macros to generate getter/setter methods.
+
     fn role(&self) -> Role {
         self.accesskit_node.role()
     }
@@ -1039,6 +1152,29 @@ impl AccessibilityNode {
             return;
         }
         self.accesskit_node.clear_bounds();
+        self.dirty_state |= DirtyState::Updated;
+    }
+
+    fn set_transform(&mut self, transform: Affine) {
+        // TODO(#47166): Right now a node will only ever have a single transform from a scroll
+        // container, if any. Once we correctly support CSS transforms, a node may have multiple
+        // transforms, which we'll need to be able to combine.
+        if self.accesskit_node.transform() == Some(&transform) {
+            return;
+        }
+        if transform == Affine::IDENTITY {
+            self.clear_transform();
+            return;
+        }
+        self.accesskit_node.set_transform(transform);
+        self.dirty_state |= DirtyState::Updated;
+    }
+
+    fn clear_transform(&mut self) {
+        if self.accesskit_node.transform().is_none() {
+            return;
+        }
+        self.accesskit_node.clear_transform();
         self.dirty_state |= DirtyState::Updated;
     }
 

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -176,7 +176,7 @@ pub struct AccessibilityTree {
     root_node: Option<ArcRefCell<AccessibilityNode>>,
     /// If any nodes were scrolled since the last update, they are tracked here so that the next
     /// update can update the tree accordingly.
-    pending_scroll_updates: Option<FxHashMap<ExternalScrollId, LayoutVector2D>>,
+    pending_scroll_updates: FxHashMap<ExternalScrollId, LayoutVector2D>,
     /// Sent to the embedder alongside each [`accesskit::TreeUpdate`], so that the embedder can
     /// drop updates from documents which have been navigated away from.
     embedder_epoch: Epoch,
@@ -227,7 +227,7 @@ impl AccessibilityTree {
             id_to_opaque_node: FxHashMap::default(),
             tree_id,
             root_node: None,
-            pending_scroll_updates: None,
+            pending_scroll_updates: FxHashMap::default(),
             embedder_epoch,
             debug: opts::get().debug.clone(),
         }
@@ -253,15 +253,24 @@ impl AccessibilityTree {
         update.finalize(self)
     }
 
+    /// Add all given scroll updates to [`Self::pending_scroll_updates`].
+    /// See [`Self::handle_pending_scroll_updates()`].
     pub(super) fn add_pending_scroll_updates(
         &mut self,
-        scroll_states: &FxHashMap<ExternalScrollId, LayoutVector2D>,
+        scroll_states: FxHashMap<ExternalScrollId, LayoutVector2D>,
     ) {
-        if let Some(pending_scroll_updates) = self.pending_scroll_updates.as_mut() {
-            pending_scroll_updates.extend(scroll_states);
-        } else {
-            self.pending_scroll_updates = Some(scroll_states.clone());
-        }
+        self.pending_scroll_updates.extend(scroll_states);
+    }
+
+    /// Add the given scroll update to [`Self::pending_scroll_updates`].
+    /// See [`Self::handle_pending_scroll_updates()`].
+    pub(super) fn add_pending_scroll_update(
+        &mut self,
+        external_scroll_id: ExternalScrollId,
+        offset: LayoutVector2D,
+    ) {
+        self.pending_scroll_updates
+            .insert(external_scroll_id, offset);
     }
 
     /// Get the node corresponding to the root DOM node, and set it as this tree's root. If the root
@@ -279,7 +288,7 @@ impl AccessibilityTree {
             update.clear_damage();
             update.insert_damage(root_id, AccessibilityDamage::Rebuild);
             update.insert_dom_node(root_id, *root_dom_node);
-            self.add_pending_scroll_updates_from_scroll_tree(context);
+            self.populate_pending_scroll_updates_from_scroll_tree(context);
         } else {
             // TODO(#47161) This hack is necessary because we don't collect accessibility damage
             // from layout.
@@ -310,8 +319,11 @@ impl AccessibilityTree {
         damage_root.borrow().update_ancestors(local_damage, update);
     }
 
-    fn add_pending_scroll_updates_from_scroll_tree(&mut self, context: &AccessibilityContext) {
-        self.clear_pending_scroll_updates();
+    /// Read all scroll offsets directly from the scroll tree, and use them to populate
+    /// [`Self::pending_scroll_updates`].
+    /// This will clear any previous pending scroll updates, as the scroll tree contains all scroll
+    /// information.
+    fn populate_pending_scroll_updates_from_scroll_tree(&mut self, context: &AccessibilityContext) {
         let scroll_tree = &context.stacking_context_tree.paint_info.scroll_tree;
         let scroll_updates = scroll_tree
             .nodes
@@ -324,14 +336,17 @@ impl AccessibilityTree {
                 _ => None,
             })
             .collect();
-        self.add_pending_scroll_updates(&scroll_updates);
+        self.pending_scroll_updates = scroll_updates;
     }
 
+    /// For each entry in [`Self::pending_scroll_updates`], set the scroll offset on the
+    /// [`AccessibilityNode`] corresponding to its [`ExternalScrollId`], if any.
+    /// This sets a transformation on every direct child of the scrolled node.
+    ///
+    /// This should be called after the tree has been updated, so that we can be sure not to miss
+    /// any newly-added nodes.
     fn handle_pending_scroll_updates(&mut self, update: &mut AccessibilityUpdate) {
-        let Some(pending_scroll_updates) = std::mem::take(&mut self.pending_scroll_updates) else {
-            return;
-        };
-
+        let pending_scroll_updates = std::mem::take(&mut self.pending_scroll_updates);
         for (opaque, offset) in
             pending_scroll_updates
                 .into_iter()
@@ -351,10 +366,6 @@ impl AccessibilityTree {
             };
             node.borrow_mut().set_scroll_offset(offset, update);
         }
-    }
-
-    fn clear_pending_scroll_updates(&mut self) {
-        self.pending_scroll_updates = None;
     }
 
     /// Given an iterator of `NodeId`s corresponding to nodes which have received some damage from

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -328,7 +328,7 @@ impl AccessibilityTree {
         let scroll_updates = scroll_tree
             .nodes
             .iter()
-            .filter_map(|n| match n.info {
+            .filter_map(|node| match node.info {
                 SpatialTreeNodeInfo::Scroll(ref info) => {
                     let offset = info.offset;
                     Some((info.external_id, offset))
@@ -1057,8 +1057,6 @@ impl AccessibilityNode {
     fn parent(&self) -> Option<ArcRefCell<AccessibilityNode>> {
         self.parent_node.as_ref().and_then(|weak| weak.upgrade())
     }
-
-    // TODO: use macros to generate getter/setter methods.
 
     fn children(&self) -> impl DoubleEndedIterator<Item = &ArcRefCell<AccessibilityNode>> {
         self.child_nodes.iter()

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -716,7 +716,7 @@ impl Layout for LayoutThread {
         if self.accessibility_active() {
             let mut accessibility_tree = self.accessibility_tree.borrow_mut();
             if let Some(accessibility_tree) = accessibility_tree.as_mut() {
-                accessibility_tree.add_pending_scroll_updates(&offsets);
+                accessibility_tree.add_pending_scroll_updates(offsets);
             };
 
             self.set_force_accessibility_update();
@@ -1600,15 +1600,13 @@ impl LayoutThread {
                 external_scroll_id,
             );
 
-            // Accessibility node bounds are relative to the viewport origin, so a script scroll
-            // makes every one of them stale even though no layout ran. Requesting an accessibility
-            // update lets the next "update the rendering" reflow recompute them, mirroring how
-            // `set_scroll_offsets_from_renderer()` handles renderer scrolls.
-            if self.accessibility_active() {
-                if let Some(accessibility_tree) = self.accessibility_tree.borrow_mut().as_mut() {
-                    let pending_updates = FxHashMap::from_iter([(external_scroll_id, offset)]);
-                    accessibility_tree.add_pending_scroll_updates(&pending_updates);
-                }
+            if self.accessibility_active() &&
+                let Some(accessibility_tree) = self.accessibility_tree.borrow_mut().as_mut()
+            {
+                accessibility_tree.add_pending_scroll_update(external_scroll_id, offset);
+
+                // Ensure the scroll updates are applied in the accessibility tree and sent to the
+                // embedder, even if there are no other changes which affect the accessibility tree.
                 self.set_force_accessibility_update();
             }
             true

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -703,7 +703,7 @@ impl Layout for LayoutThread {
             return;
         };
 
-        stacking_context_tree
+        let offsets = stacking_context_tree
             .paint_info
             .scroll_tree
             .set_all_scroll_offsets(scroll_states);
@@ -714,6 +714,11 @@ impl Layout for LayoutThread {
         // allowing the bounds to be recomputed against the new scroll offsets. See #47161 for a
         // transform-based alternative to recomputing every node.
         if self.accessibility_active() {
+            let mut accessibility_tree = self.accessibility_tree.borrow_mut();
+            if let Some(accessibility_tree) = accessibility_tree.as_mut() {
+                accessibility_tree.add_pending_scroll_updates(&offsets);
+            };
+
             self.set_force_accessibility_update();
         }
     }
@@ -1600,6 +1605,10 @@ impl LayoutThread {
             // update lets the next "update the rendering" reflow recompute them, mirroring how
             // `set_scroll_offsets_from_renderer()` handles renderer scrolls.
             if self.accessibility_active() {
+                if let Some(accessibility_tree) = self.accessibility_tree.borrow_mut().as_mut() {
+                    let pending_updates = FxHashMap::from_iter([(external_scroll_id, offset)]);
+                    accessibility_tree.add_pending_scroll_updates(&pending_updates);
+                }
                 self.set_force_accessibility_update();
             }
             true

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -5,6 +5,7 @@
 //! WebView API unit tests.
 mod common;
 
+use std::cell::Cell;
 use std::collections::VecDeque;
 use std::rc::Rc;
 
@@ -12,8 +13,8 @@ use accesskit::{NodeId, Rect, Role, TreeId, TreeUpdate};
 use accesskit_consumer::TreeChangeHandler;
 use euclid::Scale;
 use servo::{
-    DiagnosticsLoggingOption, LoadStatus, Opts, Preferences, Scroll, WebViewBuilder, WebViewPoint,
-    WebViewVector,
+    DiagnosticsLoggingOption, LoadStatus, Opts, Preferences, Scroll, WebView, WebViewBuilder,
+    WebViewPoint, WebViewVector,
 };
 use url::Url;
 use webrender_api::units::{DevicePoint, DeviceVector2D};
@@ -837,24 +838,15 @@ fn test_accessibility_bounds_updated_after_renderer_scroll() {
     );
 
     let updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
-    let expected = Rect::new(-10.0, 60.0, 90.0, 110.0);
-    let updated_bounds = updates
-        .iter()
-        .flat_map(|update| update.nodes.iter())
-        .filter(|(id, _)| *id == main_id)
-        .filter_map(|(_, node)| node.bounds())
-        .next_back()
-        .expect("The main element should have been re-sent with new bounds");
-    assert_rect_eq(updated_bounds, expected);
-
     for update in updates {
         tree.update_and_process_changes(update, &mut NoOpChangeHandler);
     }
     let root = assert_tree_structure_and_get_root_web_area(&tree);
     let main = find_first_matching_node(root, |node| node.role() == Role::Main)
         .expect("Document should contain a main element");
+    let expected = Rect::new(-10.0, 60.0, 90.0, 110.0);
     assert_rect_eq(
-        main.raw_bounds().expect("main should have bounds"),
+        main.bounding_box().expect("main should have bounds"),
         expected,
     );
 }
@@ -881,15 +873,6 @@ fn test_accessibility_bounds_updated_after_script_scroll() {
     let _ = evaluate_javascript(&servo_test, webview.clone(), "window.scrollTo(20, 40);");
 
     let updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
-    let expected = Rect::new(-10.0, 60.0, 90.0, 110.0);
-    let updated_bounds = updates
-        .iter()
-        .flat_map(|update| update.nodes.iter())
-        .filter(|(id, _)| *id == main_id)
-        .filter_map(|(_, node)| node.bounds())
-        .next_back()
-        .expect("The main element should have been re-sent with new bounds");
-    assert_rect_eq(updated_bounds, expected);
 
     for update in updates {
         tree.update_and_process_changes(update, &mut NoOpChangeHandler);
@@ -897,8 +880,44 @@ fn test_accessibility_bounds_updated_after_script_scroll() {
     let root = assert_tree_structure_and_get_root_web_area(&tree);
     let main = find_first_matching_node(root, |node| node.role() == Role::Main)
         .expect("Document should contain a main element");
+    let expected = Rect::new(-10.0, 60.0, 90.0, 110.0);
     assert_rect_eq(
-        main.raw_bounds().expect("main should have bounds"),
+        main.bounding_box().expect("main should have bounds"),
+        expected,
+    );
+}
+
+#[test]
+fn test_accessibility_build_initial_tree_after_scroll() {
+    let servo_test = build_test();
+    let url = "data:text/html,<!DOCTYPE html>\
+               <main style='position:absolute;left:10px;top:100px;\
+               width:100px;height:50px'>Target</main>\
+               <div style='width:2000px;height:2000px'></div>";
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(Url::parse(url).unwrap())
+        .build();
+    let load_webview = webview.clone();
+    servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
+
+    webview.notify_scroll_event(
+        Scroll::Delta(WebViewVector::Device(DeviceVector2D::new(20.0, 40.0))),
+        WebViewPoint::Device(DevicePoint::new(250.0, 250.0)),
+    );
+    wait_for_webview_scene_to_be_up_to_date(&servo_test, &webview);
+
+    webview.set_accessibility_active(true);
+
+    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 2);
+    let tree = build_tree(updates);
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let main = find_first_matching_node(root, |node| node.role() == Role::Main)
+        .expect("Document should contain a main element");
+    let expected = Rect::new(-10.0, 60.0, 90.0, 110.0);
+    assert_rect_eq(
+        main.bounding_box().expect("main should have bounds"),
         expected,
     );
 }
@@ -1124,4 +1143,17 @@ fn find_all_matching_nodes(
         }
     }
     result
+}
+
+/// Wait for the WebRender scene to reflect the current state of the WebView
+/// by triggering a screenshot, waiting for it to be ready, and then throwing
+/// away the results.
+fn wait_for_webview_scene_to_be_up_to_date(servo_test: &ServoTest, webview: &WebView) {
+    let waiting = Rc::new(Cell::new(true));
+    let callback_waiting = waiting.clone();
+    webview.take_screenshot(None, move |result| {
+        assert!(result.is_ok());
+        callback_waiting.set(false);
+    });
+    servo_test.spin(move || waiting.get());
 }

--- a/components/shared/paint/display_list.rs
+++ b/components/shared/paint/display_list.rs
@@ -557,6 +557,8 @@ impl ScrollTree {
 
     /// Given a set of all scroll offsets coming from the Servo renderer, update all of the offsets
     /// for nodes that actually exist in this tree.
+    ///
+    /// Returns a map of all scroll offsets which were actually set.
     pub fn set_all_scroll_offsets(
         &mut self,
         offsets: &FxHashMap<ExternalScrollId, LayoutVector2D>,

--- a/components/shared/paint/display_list.rs
+++ b/components/shared/paint/display_list.rs
@@ -560,16 +560,23 @@ impl ScrollTree {
     pub fn set_all_scroll_offsets(
         &mut self,
         offsets: &FxHashMap<ExternalScrollId, LayoutVector2D>,
-    ) {
+    ) -> FxHashMap<ExternalScrollId, LayoutVector2D> {
+        let mut result = FxHashMap::default();
         for node in self.nodes.iter_mut() {
             if let SpatialTreeNodeInfo::Scroll(ref mut scroll_info) = node.info &&
-                let Some(offset) = offsets.get(&scroll_info.external_id)
+                let Some(offset) = offsets.get(&scroll_info.external_id) &&
+                let Some(result_offset) =
+                    scroll_info.scroll_to_offset(*offset, ScrollType::Script)
             {
-                scroll_info.scroll_to_offset(*offset, ScrollType::Script);
+                result.insert(scroll_info.external_id, result_offset);
             }
         }
 
-        self.invalidate_cached_transforms();
+        if !result.is_empty() {
+            self.invalidate_cached_transforms();
+        }
+
+        result
     }
 
     /// Set the offsets of all scrolling nodes in this tree to 0.


### PR DESCRIPTION
Handle scroll updates from script and renderer by sending the scroll offsets to the accessibility tree, and applying them as transforms on the child nodes of the scroll container during the tree update process.

Testing: This passes the existing tests for bounds computation (with modifications to test the relevant computed properties), which don't test situations where transforms other than scrolling are applied. It also adds one extra test for the case where scrolling occurs before the accessibility tree is built. #47166 tracks the need to handle CSS transforms, but there may be other situations which are also untested and unhandled. Advice from reviewers on these cases would be very helpful. 
Fixes: #47161