### PR TITLE
android: Abstract navigation ability to separate class

### DIFF
--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
@@ -48,14 +48,13 @@ import androidx.preference.PreferenceManager
 import androidx.window.core.layout.WindowSizeClass
 import kotlinx.coroutines.launch
 import org.servo.servoview.Servo
+import org.servo.servoview.ServoNavigator
 import org.servo.servoview.ServoView
 
 class MainActivity : ComponentActivity(), Servo.Client {
     private lateinit var servoView: ServoView
 
     private val urlTextFieldState = TextFieldState()
-    private var canGoBackState = mutableStateOf(false)
-    private var canGoForwardState = mutableStateOf(false)
     private var isRefreshingState = mutableStateOf(false)
     private var mediaSession: MediaSession? = null
     private lateinit var historyManager: HistoryManager
@@ -76,12 +75,14 @@ class MainActivity : ComponentActivity(), Servo.Client {
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(applicationContext)
         settings = Settings(sharedPreferences)
 
+        val navigator = ServoNavigator()
         servoView = ServoView(
             context = this,
             client = this,
             servoArgs = intent.getStringExtra("servoargs"),
             servoLog = intent.getStringExtra("servolog"),
             experimentalMode = settings.experimental,
+            navigator = navigator,
         )
 
         historyManager = HistoryManager(this)
@@ -95,10 +96,10 @@ class MainActivity : ComponentActivity(), Servo.Client {
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         if (isWindowWidthAtLeastMedium) {
-                            IconButton(onClick = ::onHistoryBackMenuItemClicked, enabled = canGoBackState.value) {
+                            IconButton(onClick = ::onHistoryBackMenuItemClicked, enabled = navigator.canGoBackState.value) {
                                 Icon(painterResource(R.drawable.arrow_back), stringResource(R.string.history_back))
                             }
-                            IconButton(onClick = ::onHistoryForwardMenuItemClicked, enabled = canGoForwardState.value) {
+                            IconButton(onClick = ::onHistoryForwardMenuItemClicked, enabled = navigator.canGoForwardState.value) {
                                 Icon(painterResource(R.drawable.arrow_forward), stringResource(R.string.history_forward))
                             }
                             IconButton(onClick = { if (isRefreshingState.value) onCancelMenuItemClicked() else onRefreshMenuItemClicked() }) {
@@ -141,14 +142,14 @@ class MainActivity : ComponentActivity(), Servo.Client {
                         NavigationBar {
                             NavigationBarItem(
                                 selected = false,
-                                enabled = canGoBackState.value,
+                                enabled = navigator.canGoBackState.value,
                                 onClick = ::onHistoryBackMenuItemClicked,
                                 icon = { Icon(painterResource(R.drawable.arrow_back), null) },
                                 label = { Text(stringResource(R.string.history_back)) },
                             )
                             NavigationBarItem(
                                 selected = false,
-                                enabled = canGoForwardState.value,
+                                enabled = navigator.canGoForwardState.value,
                                 onClick = { onHistoryForwardMenuItemClicked() },
                                 icon = { Icon(painterResource(R.drawable.arrow_forward), null) },
                                 label = { Text(stringResource(R.string.history_forward)) },
@@ -188,7 +189,7 @@ class MainActivity : ComponentActivity(), Servo.Client {
                     servoView = servoView,
                     modifier = Modifier.padding(innerPadding),
                 )
-                BackHandler(enabled = canGoBackState.value) {
+                BackHandler(enabled = navigator.canGoBackState.value) {
                     servoView.goBack()
                 }
                 alertMessageState.value?.let { alertMessage ->
@@ -299,12 +300,6 @@ class MainActivity : ComponentActivity(), Servo.Client {
     override fun onUrlChanged(url: String) {
         urlTextFieldState.edit { replace(0, length, url) }
         currentUrl = url
-    }
-
-    override fun onHistoryChanged(canGoBack: Boolean, canGoForward: Boolean) {
-        Log.i(TAG, "onHistoryChanged: $canGoBack<->$canGoForward")
-        canGoBackState.value = canGoBack
-        canGoForwardState.value = canGoForward
     }
 
     public override fun onResume() {

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.kt
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.kt
@@ -10,6 +10,8 @@ import android.util.Size
 import android.view.KeyEvent
 import android.view.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.compose.LifecycleResumeEffect
@@ -31,6 +33,15 @@ fun Servo(
     )
 }
 
+@Stable
+class ServoNavigator {
+    var canGoBackState = mutableStateOf(false)
+        internal set
+
+    var canGoForwardState = mutableStateOf(false)
+        internal set
+}
+
 class Servo(
     args: String?,
     url: String?,
@@ -42,9 +53,10 @@ class Servo(
     client: Client,
     context: Context,
     surface: Surface,
+    navigator: ServoNavigator,
 ) {
     private val jni = JNIServo()
-    private val servoCallbacks = Callbacks(client, jni, runCallback)
+    private val servoCallbacks = Callbacks(client, jni, runCallback, navigator)
 
     init {
         this.runCallback.inGLThread {
@@ -173,8 +185,6 @@ class Servo(
 
         fun onUrlChanged(url: String)
 
-        fun onHistoryChanged(canGoBack: Boolean, canGoForward: Boolean)
-
         fun onImeShow()
 
         fun onImeHide()
@@ -196,6 +206,7 @@ class Servo(
         private var client: Client,
         private val jni: JNIServo,
         private val runCallback: RunCallback,
+        private val navigator: ServoNavigator,
     ) : JNIServo.Callbacks, Client {
         var suspended: Boolean = false
 
@@ -234,7 +245,8 @@ class Servo(
         }
 
         override fun onHistoryChanged(canGoBack: Boolean, canGoForward: Boolean) {
-            runCallback.inUIThread { client.onHistoryChanged(canGoBack, canGoForward) }
+            navigator.canGoBackState.value = canGoBack
+            navigator.canGoForwardState.value = canGoForward
         }
 
         override fun onMediaSessionMetadata(title: String, artist: String, album: String) {

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.kt
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.kt
@@ -24,6 +24,7 @@ class ServoView(
     servoArgs: String?,
     servoLog: String?,
     private val experimentalMode: Boolean,
+    navigator: ServoNavigator,
 ) : SurfaceView(context), Servo.RunCallback, Choreographer.FrameCallback {
     private val glThread: GLThread
     private var servo: Servo? = null
@@ -40,6 +41,7 @@ class ServoView(
             client = client,
             servoArgs = servoArgs,
             servoLog = servoLog,
+            navigator = navigator,
         )
         holder.addCallback(surfaceHolderCallback)
         glThread.start()
@@ -151,6 +153,7 @@ class ServoView(
         private val client: Servo.Client,
         private val servoArgs: String?,
         private val servoLog: String?,
+        private val navigator: ServoNavigator,
     ) : SurfaceHolder.Callback {
         private var paused = false
 
@@ -173,6 +176,7 @@ class ServoView(
                     client,
                     servoView.context,
                     surface,
+                    navigator,
                 )
             } else {
                 paused = false


### PR DESCRIPTION
The start of a class that is loosely modelled on the web's [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API). This initially hoists the two simple states, but in future the class will be able to navigate via functions like `back()`, `forward()`, etc.

Testing: There are no automated tests for Android.
Part of: #33742