### PR TITLE
android: Move handling of `ServoView` suspension to library

### DIFF
--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
@@ -304,13 +304,7 @@ class MainActivity : ComponentActivity(), Servo.Client {
         canGoForwardState.value = canGoForward
     }
 
-    public override fun onPause() {
-        servoView.onPause()
-        super.onPause()
-    }
-
     public override fun onResume() {
-        servoView.onResume()
         super.onResume()
         updateSettingsIfNecessary(false)
     }

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.kt
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.kt
@@ -12,12 +12,19 @@ import android.view.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.compose.LifecycleResumeEffect
 
 @Composable
 fun Servo(
     servoView: ServoView,
     modifier: Modifier = Modifier,
 ) {
+    LifecycleResumeEffect(servoView) {
+        servoView.onResume()
+        onPauseOrDispose {
+            servoView.onPause()
+        }
+    }
     AndroidView(
         factory = { _ -> servoView },
         modifier = modifier,

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.kt
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.kt
@@ -95,11 +95,11 @@ class ServoView(
         Choreographer.getInstance().postFrameCallback(this)
     }
 
-    fun onPause() {
+    internal fun onPause() {
         servo?.suspend(true)
     }
 
-    fun onResume() {
+    internal fun onResume() {
         servo?.suspend(false)
     }
 


### PR DESCRIPTION
Previously, if implementing a custom Servo chrome using the Servo library, one would need to remember to implement pausing and resuming the web view when the surrounding Activity pauses and resumes. Instead, we can just move that logic to the library so library consumers don't need to worry about it.

Testing: There are no automated tests for Android.
Part of: https://github.com/servo/servo/issues/33742
