### PR TITLE
script: Return list of matching fonts from `FontFaceSet.load`

### DIFF
--- a/components/script/dom/css/fontface.rs
+++ b/components/script/dom/css/fontface.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::{Cell, RefCell};
+use std::cell::{Cell, Ref, RefCell};
 use std::rc::Rc;
 
 use cssparser::{Parser, ParserInput};
@@ -354,18 +354,24 @@ impl FontFace {
 
     /// <https://drafts.csswg.org/css-font-loading/#css-connected>
     pub(crate) fn is_css_connected(&self) -> bool {
-        self.css_font_face_rule.borrow().is_some()
+        self.css_font_face_rule().is_some()
+    }
+
+    pub(crate) fn css_font_face_rule(&self) -> Ref<'_, Option<ServoArc<FontFaceRuleInfo>>> {
+        self.css_font_face_rule.borrow()
     }
 
     /// Return true if the `FontFace` is [css-connected] *and* was created by the provided
     /// `@font-face` rule.
     ///
     /// [css-connected]: https://drafts.csswg.org/css-font-loading/#css-connected
-    pub(crate) fn is_connected_to_font_face_rule(&self, target_rule: &FontFaceRuleInfo) -> bool {
-        self.css_font_face_rule
-            .borrow()
+    pub(crate) fn is_connected_to_font_face_rule(
+        &self,
+        target_rule: &ServoArc<FontFaceRuleInfo>,
+    ) -> bool {
+        self.css_font_face_rule()
             .as_ref()
-            .is_some_and(|connected_rule| ServoArc::ptr_eq(&connected_rule.rule, &target_rule.rule))
+            .is_some_and(|connected_rule| ServoArc::ptr_eq(connected_rule, target_rule))
     }
 
     /// Step 3 of <https://drafts.csswg.org/css-font-loading/#font-face-constructor>

--- a/components/script/dom/css/fontfaceset.rs
+++ b/components/script/dom/css/fontfaceset.rs
@@ -5,6 +5,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use cssparser::{Parser, ParserInput, UnicodeRange};
 use dom_struct::dom_struct;
 use fonts::FontFaceRuleInfo;
 use js::context::JSContext;
@@ -20,7 +21,14 @@ use script_bindings::codegen::GenericBindings::FontFaceBinding::{
 use script_bindings::like::Setlike;
 use script_bindings::reflector::reflect_dom_object_with_proto;
 use servo_arc::Arc as ServoArc;
+use style::font_face::FamilyName;
+use style::properties::shorthands::font;
+use style::stylesheets::CssRuleType;
+use style::values::computed::font::{FontFamilyList, SingleFontFamily};
+use style::values::specified::font as specified_font;
+use style_traits::ParsingMode;
 
+use crate::css::css::parser_context_for_document;
 use crate::dom::bindings::codegen::Bindings::FontFaceSetBinding::FontFaceSetMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::error::{Error, Fallible};
@@ -28,6 +36,7 @@ use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
+use crate::dom::document::Document;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::fontface::FontFace;
 use crate::dom::globalscope::GlobalScope;
@@ -184,6 +193,85 @@ impl FontFaceSet {
             matching_font_face_object.disconnect_from_css();
         }
     }
+
+    /// Uses the font matching rules to select font faces within `self` that can be used to
+    /// render the provided text.
+    ///
+    /// This is used to implement Step 6 of
+    /// <https://drafts.csswg.org/css-font-loading/#find-the-matching-font-faces>.
+    fn query_fonts(&self, target_family: &FamilyName, sample_text: &str) -> Vec<DomRoot<FontFace>> {
+        let mut matching_fonts = Vec::default();
+        for font in self.set_entries.borrow().iter() {
+            let font_face_rule = font.css_font_face_rule();
+            let Some(font_face_rule) = font_face_rule.as_ref() else {
+                // FIXME: Don't ignore font faces that are not css-connected here.
+                continue;
+            };
+
+            if font_face_rule
+                .descriptors
+                .font_family
+                .as_ref()
+                .is_none_or(|family| family != target_family)
+            {
+                continue;
+            }
+
+            if font_face_rule
+                .descriptors
+                .unicode_range
+                .as_ref()
+                .is_some_and(|ranges| !any_character_in_any_unicode_range(sample_text, ranges))
+            {
+                continue;
+            }
+
+            // FIXME: Check other fields (weight, style, ...) here too. We need to investigate what other
+            // browsers are doing, because at this point the font isn't actually loaded yet,
+            // so the full descriptor is not available.
+            matching_fonts.push(font.as_rooted());
+        }
+
+        matching_fonts
+    }
+
+    /// <https://drafts.csswg.org/css-font-loading/#find-the-matching-font-faces>
+    fn find_the_matching_font_faces(
+        &self,
+        document: &Document,
+        font: &str,
+        sample_text: &str,
+    ) -> Result<Vec<DomRoot<FontFace>>, FontQuerySyntaxError> {
+        let parameters = FontQueryParameters::parse(document, font)?;
+
+        // Step 2. If text was not explicitly provided, let it be a string containing a
+        // single space character (U+0020 SPACE).
+        // Note: "text" is not optional in our implementation yet.
+
+        // Step 4. Let available font faces be the available font faces within source.
+        // If the allow system fonts flag is specified, add all system fonts to available font faces.
+
+        // Step 5. Let matched font faces initially be an empty list.
+        let mut matched_faces = vec![];
+
+        // Step 6. For each family in font family list, use the font matching rules to select the font faces
+        // from available font faces that match the font style, and add them to matched font faces.
+        // The use of the unicodeRange attribute means that this may be more than just a single font face.
+        // Step 7. If matched font faces is empty, set the found faces flag to false. Otherwise, set it to true.
+        // Note We don't need this yet.
+        // Step 8. For each font face in matched font faces, if its defined unicode-range does not include the
+        // codepoint of at least one character in text, remove it from the list.
+        for family in parameters.families.list.iter() {
+            let SingleFontFamily::FamilyName(target_family) = family else {
+                continue; // Skip generic font faces
+            };
+
+            matched_faces.extend_from_slice(&self.query_fonts(target_family, sample_text));
+        }
+
+        // Step 9. Return matched font faces and the found faces flag.
+        Ok(matched_faces)
+    }
 }
 
 impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
@@ -254,39 +342,53 @@ impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
     }
 
     /// <https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-load>
-    fn Load(&self, cx: &mut JSContext, _font: DOMString, _text: DOMString) -> Rc<Promise> {
+    fn Load(&self, cx: &mut JSContext, font: DOMString, text: DOMString) -> Rc<Promise> {
         // Step 1. Let font face set be the FontFaceSet object this method was called on. Let
         // promise be a newly-created promise object.
         let load_promise = Promise::new(cx, &self.global());
 
-        // Step 3. Find the matching font faces from font face set using the font and text
-        // arguments passed to the function, and let font face list be the return value (ignoring
-        // the found faces flag). If a syntax error was returned, reject promise with a SyntaxError
-        // exception and terminate these steps.
-        //
-        // TODO: Implement this.
-
+        // Step 2. Return promise. Complete the rest of these steps asynchronously.
         #[derive(MallocSizeOf, JSTraceable)]
         struct LoadPromiseFulfillmentHandler {
+            /// The font faces that this should wait on.
+            ///
+            /// (Our current implementation waits for `document.fonts.ready` instead)
+            font_face_objects: Vec<DomRoot<FontFace>>,
+
             #[conditional_malloc_size_of]
             load_promise: Rc<Promise>,
         }
         impl Callback for LoadPromiseFulfillmentHandler {
             fn callback(&self, cx: &mut CurrentRealm, _: Handle<Value>) {
                 self.load_promise
-                    .resolve_native(cx, &Vec::<&FontFace>::new());
+                    .resolve_native(cx, &self.font_face_objects);
             }
         }
 
         // Step 4. Queue a task to run the following steps synchronously:
         let trusted_this = Trusted::new(self);
         let trusted_load_promise = TrustedPromise::new(load_promise.clone());
+        let font = font.to_string();
+        let text = text.to_string();
         self.global()
             .task_manager()
             .font_loading_task_source()
             .queue(task!(resolve_font_face_set_load_task: move |cx| {
                 let load_promise = trusted_load_promise.root();
                 let this = trusted_this.root();
+
+                // This will need adjustments once FontFaceSet is exposed to workers.
+                let window = DomRoot::downcast::<Window>(this.global()).unwrap();
+                let document = window.Document();
+
+                // Step 3. Find the matching font faces from font face set using the font and text
+                // arguments passed to the function, and let font face list be the return value (ignoring
+                // the found faces flag). If a syntax error was returned, reject promise with a SyntaxError
+                // exception and terminate these steps.
+                let Ok(font_face_objects) = this.find_the_matching_font_faces(&document, &font, &text) else {
+                    load_promise.reject_error(cx, Error::Syntax(Some("Failed to parse font query".into())));
+                    return;
+                };
 
                 // Step 4.1. For all of the font faces in the font face list, call their load()
                 // method.
@@ -304,6 +406,7 @@ impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
                     cx,
                     &global,
                     Some(Box::new(LoadPromiseFulfillmentHandler {
+                        font_face_objects,
                         load_promise,
                     })),
                     None,
@@ -364,4 +467,66 @@ impl Setlike for FontFaceSet {
         self.flush_author_font_set(cx);
         self.delete_face(&to_delete)
     }
+}
+
+/// Represents a parsed query for [`FontFaceSet::load`] and [`FontFaceSet::check`].
+///
+/// [`FontFaceSet::load`]: https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-load
+/// [`FontFaceSet::check`]: https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-check
+struct FontQueryParameters {
+    families: FontFamilyList,
+    // TODO: Store a font descriptor here once we actually use that for matching.
+}
+
+/// Returned from <https://drafts.csswg.org/css-font-loading/#find-the-matching-font-faces> to indicate failure.
+struct FontQuerySyntaxError;
+
+impl FontQueryParameters {
+    /// Implements Steps 1 and 3 of <https://drafts.csswg.org/css-font-loading/#find-the-matching-font-faces>.
+    fn parse(document: &Document, font: &str) -> Result<Self, FontQuerySyntaxError> {
+        // Step 1. Parse font using the CSS value syntax of the font property.
+        // If a syntax error occurs, return a syntax error.
+        // If the parsed value is a CSS-wide keyword, return a syntax error.
+        // Absolutize all relative lengths against the initial values of the corresponding properties.
+        // (For example, a relative font weight like bolder is evaluated against the initial value normal.)
+        // Step 3. Let font family list be the list of font families parsed from font,
+        // and font style be the other font style attributes parsed from font.
+        let font_family;
+
+        let urlextradata = document.url().into_url().into();
+        let parser_context = parser_context_for_document(
+            document,
+            CssRuleType::FontFace,
+            ParsingMode::DEFAULT,
+            &urlextradata,
+        );
+
+        let mut input = ParserInput::new(font);
+        let mut parser = Parser::new(&mut input);
+        let Ok(font_shorthand) =
+            parser.parse_entirely(|parser| font::parse_value(&parser_context, parser))
+        else {
+            return Err(FontQuerySyntaxError);
+        };
+
+        match font_shorthand.font_family {
+            specified_font::FontFamily::Values(family_list) => font_family = family_list,
+            specified_font::FontFamily::System(_) => return Err(FontQuerySyntaxError),
+        }
+
+        Ok(Self {
+            families: font_family,
+        })
+    }
+}
+
+fn any_character_in_any_unicode_range(text: &str, unicode_ranges: &[UnicodeRange]) -> bool {
+    for character in text.chars() {
+        for unicode_range in unicode_ranges {
+            if (unicode_range.start..=unicode_range.end).contains(&(character as u32)) {
+                return true;
+            }
+        }
+    }
+    false
 }

--- a/components/script/dom/css/fontfaceset.rs
+++ b/components/script/dom/css/fontfaceset.rs
@@ -242,6 +242,8 @@ impl FontFaceSet {
         font: &str,
         sample_text: &str,
     ) -> Result<Vec<DomRoot<FontFace>>, FontQuerySyntaxError> {
+        // Step 1. (Parse "font") and Step 2. (Unpack font shorthand) are implemented
+        // in FontQueryParameters::parse.
         let parameters = FontQueryParameters::parse(document, font)?;
 
         // Step 2. If text was not explicitly provided, let it be a string containing a
@@ -378,7 +380,10 @@ impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
                 let this = trusted_this.root();
 
                 // This will need adjustments once FontFaceSet is exposed to workers.
-                let window = DomRoot::downcast::<Window>(this.global()).unwrap();
+                let Some(window) = DomRoot::downcast::<Window>(this.global()) else {
+                    log::error!("FontFaceSet should not be exposed to non-window globals");
+                    return;
+                };
                 let document = window.Document();
 
                 // Step 3. Find the matching font faces from font face set using the font and text

--- a/components/shared/fonts/font_descriptor.rs
+++ b/components/shared/fonts/font_descriptor.rs
@@ -7,7 +7,7 @@ use std::ops::{Deref, RangeInclusive};
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 use style::computed_values::font_optical_sizing::T as FontOpticalSizing;
-use style::computed_values::font_variant_caps;
+use style::computed_values::font_variant_caps::T as FontVariantCaps;
 use style::font_face::{
     ComputedFontStretchRange, ComputedFontStyleRange, ComputedFontWeightRange, Descriptors,
     FontStretchRange, FontStyleRange, FontWeightRange,
@@ -26,7 +26,7 @@ pub struct FontDescriptor {
     pub weight: FontWeight,
     pub stretch: FontStretch,
     pub style: FontStyle,
-    pub variant: font_variant_caps::T,
+    pub variant: FontVariantCaps,
     pub pt_size: Au,
     /// The value of the `@font-variation-settings` property.
     ///

--- a/components/shared/fonts/lib.rs
+++ b/components/shared/fonts/lib.rs
@@ -205,6 +205,9 @@ pub struct FontFaceRuleInfo {
     /// The descriptors on the `@font-face` rule.
     pub descriptors: Descriptors,
     /// The CSS rule that created this `@font-face`.
+    ///
+    /// This does *not* uniquely identify this struct across updates
+    /// to the set of live `@font-face` rules.
     #[conditional_malloc_size_of]
     pub rule: ServoArc<LockedFontFaceRule>,
 }

--- a/tests/wpt/meta/css/css-font-loading/fontfaceset-load-css-wide-keywords.html.ini
+++ b/tests/wpt/meta/css/css-font-loading/fontfaceset-load-css-wide-keywords.html.ini
@@ -1,8 +1,5 @@
 [fontfaceset-load-css-wide-keywords.html]
   expected: ERROR
-  [Loading CSS-wide keyword "initial" causes SyntaxError (document)]
-    expected: FAIL
-
   [Loading CSS-wide keyword "initial" causes SyntaxError (worker)]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/css/css-font-loading/fontfaceset-load-var.html.ini
+++ b/tests/wpt/meta/css/css-font-loading/fontfaceset-load-var.html.ini
@@ -1,11 +1,5 @@
 [fontfaceset-load-var.html]
   expected: ERROR
-  [Loading "var(--x) serif" causes SyntaxError (document)]
-    expected: FAIL
-
-  [Loading "var(--x, 10px) serif" causes SyntaxError (document)]
-    expected: FAIL
-
   [Loading "var(--x) serif" causes SyntaxError (worker)]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/css/css-fonts/font-face-range-order.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-face-range-order.html.ini
@@ -1,4 +1,0 @@
-[font-face-range-order.html]
-  [CSS Fonts Module Level 3: Order of values in @font-face range descriptors]
-    expected: FAIL
-

--- a/tests/wpt/meta/css/css-fonts/font-face-style-normal.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-face-style-normal.html.ini
@@ -1,12 +1,3 @@
 [font-face-style-normal.html]
-  [CSS Fonts: parsing 'normal' in the font-style descriptor]
-    expected: FAIL
-
-  [CSS Fonts: parsing 'normal' in the font-style descriptor 1]
-    expected: FAIL
-
-  [CSS Fonts: parsing 'normal' in the font-style descriptor 2]
-    expected: FAIL
-
   [CSS Fonts: parsing 'normal' in the font-style descriptor 3]
     expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/generic-family-keywords-003.html.ini
+++ b/tests/wpt/meta/css/css-fonts/generic-family-keywords-003.html.ini
@@ -13,3 +13,15 @@
 
   [@font-face matching for quoted and unquoted ui-serif (drawing text in a canvas)]
     expected: FAIL
+
+  [@font-face matching for quoted and unquoted generic(fangsong) (drawing text in a canvas)]
+    expected: FAIL
+
+  [@font-face matching for quoted and unquoted generic(kai) (drawing text in a canvas)]
+    expected: FAIL
+
+  [@font-face matching for quoted and unquoted generic(khmer-mul) (drawing text in a canvas)]
+    expected: FAIL
+
+  [@font-face matching for quoted and unquoted generic(nastaliq) (drawing text in a canvas)]
+    expected: FAIL


### PR DESCRIPTION
`FontFaceSet.load` receives a CSS `font` shorthand and is supposed to query matching faces in the set, wait for all of them to load and then return a list of the corresponding `FontFace` objects. Currently we instead wait for `document.fonts.ready` and return an empty list. This change begins implementing the font query. Font matching is done in a naive manner for now, we simply return all fonts with a matching `font-family`. Its unclear to me how proper matching should be done, as this needs to happen before the font data is available. Still, this is progress.

Testing: New tests start to pass
Part of https://github.com/servo/servo/issues/21565