### PR TITLE
paint/script: Combine largest contentful paint candidate messaging into display list messaging

### DIFF
--- a/components/layout/display_list/paint_timing_handler.rs
+++ b/components/layout/display_list/paint_timing_handler.rs
@@ -499,6 +499,12 @@ impl PaintTimingHandler {
         // TODO Step 8. Let frameTimingInfo be document’s current frame timing info.
         // TODO Step 9. Set document’s current frame timing info to null.
 
+        // Step 7. Let reportedPaints be the document’s set of previously
+        // reported paints. (Directly accessing)
+
+        // TODO Step 8. Let frameTimingInfo be document’s current frame timing info.
+        // TODO Step 9. Set document’s current frame timing info to null.
+
         // Step 10. Let flushPaintTimings be the following steps:
 
         // Note: A new PaintTimingReport to accumulate the paints.

--- a/components/layout/display_list/paint_timing_handler.rs
+++ b/components/layout/display_list/paint_timing_handler.rs
@@ -499,12 +499,6 @@ impl PaintTimingHandler {
         // TODO Step 8. Let frameTimingInfo be document’s current frame timing info.
         // TODO Step 9. Set document’s current frame timing info to null.
 
-        // Step 7. Let reportedPaints be the document’s set of previously
-        // reported paints. (Directly accessing)
-
-        // TODO Step 8. Let frameTimingInfo be document’s current frame timing info.
-        // TODO Step 9. Set document’s current frame timing info to null.
-
         // Step 10. Let flushPaintTimings be the following steps:
 
         // Note: A new PaintTimingReport to accumulate the paints.

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1535,21 +1535,19 @@ impl LayoutThread {
         );
         stacking_context_tree.paint_info.paint_timing_report =
             paint_timing_handler.mark_paint_timing(reflow_request.halt_lcp);
+
+        if let Some(lcp_candidate) = paint_timing_handler.largest_contentful_paint_candidate() {
+            stacking_context_tree.paint_info.lcp_candidate =
+                Some((lcp_candidate.id, lcp_candidate.area));
+        } else {
+            stacking_context_tree.paint_info.lcp_candidate = None;
+        }
+
         self.paint_api.send_display_list(
             self.webview_id,
             &stacking_context_tree.paint_info,
             built_display_list,
         );
-
-        if let Some(lcp_candidate) = paint_timing_handler.largest_contentful_paint_candidate() {
-            self.paint_api.send_lcp_candidate(
-                lcp_candidate.id,
-                lcp_candidate.area,
-                self.webview_id,
-                self.id,
-                stacking_context_tree.paint_info.epoch,
-            );
-        }
 
         let (keys, instance_keys) = self
             .font_context

--- a/components/paint/paint.rs
+++ b/components/paint/paint.rs
@@ -587,11 +587,6 @@ impl Paint {
                     painter.handle_screenshot_readiness_reply(webview_id, pipelines_and_epochs);
                 }
             },
-            PaintMessage::SendLCPCandidate(id, area, webview_id, pipeline_id, epoch) => {
-                if let Some(mut painter) = self.maybe_painter_mut(webview_id.into()) {
-                    painter.append_lcp_candidate(id, area, webview_id, pipeline_id, epoch);
-                }
-            },
         }
     }
 

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -31,7 +31,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use servo_base::Epoch;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_base::generic_channel::{GenericReceiver, GenericSharedMemory};
-use servo_base::id::{LCPCandidateID, PainterId, PipelineId, WebViewId};
+use servo_base::id::{PainterId, PipelineId, WebViewId};
 use servo_base::threadboost::{BoostAffinity, ThreadPriority};
 use servo_config::{opts, pref};
 use servo_constellation_traits::{EmbedderToConstellationMessage, PaintMetricEvent};
@@ -1002,6 +1002,10 @@ impl Painter {
             details.first_contentful_paint_metric = PaintMetricState::Seen(epoch, first_reflow);
         }
 
+        if let Some(lcp_candidate) = display_list_info.lcp_candidate {
+            details.lcp_candidates.push_back((epoch, lcp_candidate));
+        }
+
         details.animations.handle_new_display_list(
             display_list_info.caret_property_binding,
             &self.web_content_animator,
@@ -1487,22 +1491,6 @@ impl Painter {
             .values()
             .map(|renderer| renderer.scroll_trees_memory_usage(ops))
             .sum::<usize>()
-    }
-
-    pub(crate) fn append_lcp_candidate(
-        &mut self,
-        id: LCPCandidateID,
-        area: usize,
-        webview_id: WebViewId,
-        pipeline_id: PipelineId,
-        epoch: Epoch,
-    ) {
-        if let Some(webview_renderer) = self.webview_renderers.get_mut(&webview_id) {
-            webview_renderer
-                .ensure_pipeline_details(pipeline_id)
-                .lcp_candidates
-                .push_back((epoch.into(), (id, area)));
-        }
     }
 }
 

--- a/components/paint/tracing.rs
+++ b/components/paint/tracing.rs
@@ -53,7 +53,6 @@ mod from_constellation {
                 Self::GenerateImageKeysForPipeline(..) => target!("GenerateImageKeysForPipeline"),
                 Self::DelayNewFrameForCanvas(..) => target!("DelayFramesForCanvas"),
                 Self::ScreenshotReadinessReponse(..) => target!("ScreenshotReadinessResponse"),
-                Self::SendLCPCandidate(..) => target!("SendLCPCandidate"),
             }
         }
     }

--- a/components/shared/paint/display_list.rs
+++ b/components/shared/paint/display_list.rs
@@ -14,7 +14,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use servo_base::Epoch;
-use servo_base::id::ScrollTreeNodeId;
+use servo_base::id::{LCPCandidateID, ScrollTreeNodeId};
 use servo_base::print_tree::PrintTree;
 use servo_geometry::FastLayoutTransform;
 use style::values::specified::Overflow;
@@ -951,6 +951,10 @@ pub struct PaintDisplayListInfo {
     /// The paint-timing report for this display list.
     pub paint_timing_report: PaintTimingReport,
 
+    /// New largest-contentful-paint candidate in this display list, if any.
+    /// The pair is the candidate's id and its reported area.
+    pub lcp_candidate: Option<(LCPCandidateID, usize)>,
+
     /// If this display list contains a blinking caret, this value will be filled with its animation
     /// key and original color value so that the painter can animate the caret.
     pub caret_property_binding: Option<(PropertyBindingKey<ColorF>, ColorF)>,
@@ -1003,6 +1007,7 @@ impl PaintDisplayListInfo {
             root_reference_frame_id,
             root_scroll_node_id,
             first_reflow,
+            lcp_candidate: None,
             paint_timing_report: PaintTimingReport::default(),
             caret_property_binding: Default::default(),
         }

--- a/components/shared/paint/lib.rs
+++ b/components/shared/paint/lib.rs
@@ -37,7 +37,6 @@ use serde::{Deserialize, Serialize};
 use servo_base::generic_channel::{
     self, GenericCallback, GenericReceiver, GenericSender, GenericSharedMemory, SendError,
 };
-use servo_base::id::LCPCandidateID;
 pub use webrender_api::ExternalImageSource;
 use webrender_api::units::{DevicePixel, LayoutVector2D, TexelRect};
 use webrender_api::{
@@ -184,8 +183,6 @@ pub enum PaintMessage {
     /// Let `Paint` know that the given WebView is ready to have a screenshot taken
     /// after the given pipeline's epochs have been rendered.
     ScreenshotReadinessReponse(WebViewId, FxHashMap<PipelineId, Epoch>),
-    /// The candidate of largest-contentful-paint, as a pair of its id and area.
-    SendLCPCandidate(LCPCandidateID, usize, WebViewId, PipelineId, Epoch),
 }
 
 impl Debug for PaintMessage {
@@ -360,26 +357,6 @@ impl CrossProcessPaintApi {
 
         if let Err(error) = display_list_data_sender.send(display_list_data) {
             warn!("Error sending display list: {error}");
-        }
-    }
-
-    /// Send the largest contentful paint candidate to `Paint`.
-    pub fn send_lcp_candidate(
-        &self,
-        id: LCPCandidateID,
-        area: usize,
-        webview_id: WebViewId,
-        pipeline_id: PipelineId,
-        epoch: Epoch,
-    ) {
-        if let Err(error) = self.0.send(PaintMessage::SendLCPCandidate(
-            id,
-            area,
-            webview_id,
-            pipeline_id,
-            epoch,
-        )) {
-            warn!("Error sending LCPCandidate: {error}");
         }
     }
 


### PR DESCRIPTION
Extending existing IPC `SendDisplayList` (which sends `PaintTimingReport`) to send `LCPCandidateID`.

Testing: Existing WPT Status Unchanged
Fixes: Part of #42000