### PR TITLE
Allow embedders to report online/offline changes

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1468,6 +1468,9 @@ where
             EmbedderToConstellationMessage::SetAccessibilityActive(webview_id, active) => {
                 self.set_accessibility_active(webview_id, active);
             },
+            EmbedderToConstellationMessage::OnlineChanged(online) => {
+                self.handle_online_changed(online);
+            },
         }
     }
 
@@ -6355,5 +6358,12 @@ where
                 })
             })
             .clone()
+    }
+
+    fn handle_online_changed(&self, _online: bool) {
+        for _pipeline in self.pipelines.iter() {
+            // TODO: send message to each pipeline,
+            // The ScriptMessage variant wait for https://github.com/servo/servo/pull/37076 to be merged
+        }
     }
 }

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1468,8 +1468,8 @@ where
             EmbedderToConstellationMessage::SetAccessibilityActive(webview_id, active) => {
                 self.set_accessibility_active(webview_id, active);
             },
-            EmbedderToConstellationMessage::SetOnlineStatus(online) => {
-                self.handle_set_online_status(online);
+            EmbedderToConstellationMessage::SetNetworkOnlineState(online) => {
+                self.handle_set_network_online_state(online);
             },
         }
     }
@@ -6360,12 +6360,12 @@ where
             .clone()
     }
 
-    fn handle_set_online_status(&mut self, online: bool) {
+    fn handle_set_network_online_state(&mut self, online: bool) {
         let pipelines: Vec<_> = self.pipelines.keys().copied().collect();
         for pipeline in pipelines {
             self.send_message_to_pipeline(
                 pipeline,
-                ScriptThreadMessage::SetNetworkOnlineStatus(online),
+                ScriptThreadMessage::SetNetworkOnlineState(online),
                 "Set network online status after closure",
             );
         }

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1468,8 +1468,8 @@ where
             EmbedderToConstellationMessage::SetAccessibilityActive(webview_id, active) => {
                 self.set_accessibility_active(webview_id, active);
             },
-            EmbedderToConstellationMessage::OnlineChanged(online) => {
-                self.handle_online_changed(online);
+            EmbedderToConstellationMessage::SetOnlineStatus(online) => {
+                self.handle_set_online_status(online);
             },
         }
     }
@@ -6360,7 +6360,7 @@ where
             .clone()
     }
 
-    fn handle_online_changed(&self, _online: bool) {
+    fn handle_set_online_status(&self, _online: bool) {
         for _pipeline in self.pipelines.iter() {
             // TODO: send message to each pipeline,
             // The ScriptMessage variant wait for https://github.com/servo/servo/pull/37076 to be merged

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -6360,10 +6360,14 @@ where
             .clone()
     }
 
-    fn handle_set_online_status(&self, _online: bool) {
-        for _pipeline in self.pipelines.iter() {
-            // TODO: send message to each pipeline,
-            // The ScriptMessage variant wait for https://github.com/servo/servo/pull/37076 to be merged
+    fn handle_set_online_status(&mut self, online: bool) {
+        let pipelines: Vec<_> = self.pipelines.keys().copied().collect();
+        for pipeline in pipelines {
+            self.send_message_to_pipeline(
+                pipeline,
+                ScriptThreadMessage::SetNetworkOnlineStatus(online),
+                "Set network online status after closure",
+            );
         }
     }
 }

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -82,7 +82,7 @@ mod from_embedder {
                 Self::UserContentManagerAction(..) => target!("UserContentManagerAction"),
                 Self::UpdatePinchZoomInfos(..) => target!("UpdatePinchZoomInfos"),
                 Self::SetAccessibilityActive(..) => target!("SetAccessibilityActive"),
-                Self::OnlineChanged(..) => target!("OnlineChanged"),
+                Self::SetOnlineStatus(..) => target!("OnlineChanged"),
             }
         }
     }

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -82,6 +82,7 @@ mod from_embedder {
                 Self::UserContentManagerAction(..) => target!("UserContentManagerAction"),
                 Self::UpdatePinchZoomInfos(..) => target!("UpdatePinchZoomInfos"),
                 Self::SetAccessibilityActive(..) => target!("SetAccessibilityActive"),
+                Self::OnlineChanged(..) => target!("OnlineChanged"),
             }
         }
     }

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -82,7 +82,7 @@ mod from_embedder {
                 Self::UserContentManagerAction(..) => target!("UserContentManagerAction"),
                 Self::UpdatePinchZoomInfos(..) => target!("UpdatePinchZoomInfos"),
                 Self::SetAccessibilityActive(..) => target!("SetAccessibilityActive"),
-                Self::SetOnlineStatus(..) => target!("OnlineChanged"),
+                Self::SetNetworkOnlineState(..) => target!("OnlineChanged"),
             }
         }
     }

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
 
 use devtools_traits::{
     BlackboxCoverage, DebuggerValue, DevtoolScriptControlMsg, EvaluateJSReply,
@@ -116,6 +117,7 @@ impl DebuggerGlobalScope {
                 gpu_id_hub,
                 None,
                 false,
+                Rc::new(Cell::new(true)),
             ),
             devtools_to_script_sender,
             get_possible_breakpoints_result_sender: RefCell::new(None),

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -391,6 +391,10 @@ pub(crate) struct GlobalScope {
     /// <https://fetch.spec.whatwg.org/#environment-settings-object-fetch-group>
     #[no_trace]
     fetch_group: RefCell<FetchGroup>,
+
+    /// Switch offline and online events
+    #[conditional_malloc_size_of]
+    is_online: Rc<Cell<bool>>,
 }
 
 /// A wrapper for glue-code between the ipc router and the event-loop.
@@ -781,6 +785,7 @@ impl GlobalScope {
         #[cfg(feature = "webgpu")] gpu_id_hub: Arc<IdentityHub>,
         inherited_secure_context: Option<bool>,
         unminify_js: bool,
+        is_online: Rc<Cell<bool>>,
     ) -> Self {
         let fetch_group = RefCell::new(FetchGroup::new(resource_threads.sender()));
         Self {
@@ -825,6 +830,7 @@ impl GlobalScope {
             import_map: Default::default(),
             resolved_module_set: Default::default(),
             fetch_group,
+            is_online,
         }
     }
 
@@ -3528,6 +3534,10 @@ impl GlobalScope {
 
         // Step 5. Return timerKey.
         timer_key
+    }
+
+    pub(crate) fn is_online(&self) -> Rc<Cell<bool>> {
+        self.is_online.clone()
     }
 }
 

--- a/components/script/dom/navigator/navigator.rs
+++ b/components/script/dom/navigator/navigator.rs
@@ -379,7 +379,7 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-online>
     fn OnLine(&self) -> bool {
-        true
+        self.global().is_online().get()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-plugins>

--- a/components/script/dom/window/dissimilaroriginwindow.rs
+++ b/components/script/dom/window/dissimilaroriginwindow.rs
@@ -79,6 +79,7 @@ impl DissimilarOriginWindow {
                 global_to_clone_from.wgpu_id_hub(),
                 Some(global_to_clone_from.is_secure_context()),
                 false,
+                global_to_clone_from.is_online().clone(),
             ),
             window_proxy: Dom::from_ref(window_proxy),
             location: Default::default(),

--- a/components/script/dom/window/dissimilaroriginwindow.rs
+++ b/components/script/dom/window/dissimilaroriginwindow.rs
@@ -79,7 +79,7 @@ impl DissimilarOriginWindow {
                 global_to_clone_from.wgpu_id_hub(),
                 Some(global_to_clone_from.is_secure_context()),
                 false,
-                global_to_clone_from.is_online().clone(),
+                global_to_clone_from.is_online(),
             ),
             window_proxy: Dom::from_ref(window_proxy),
             location: Default::default(),

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -3915,6 +3915,7 @@ impl Window {
         inherited_secure_context: Option<bool>,
         embedder_theme: Theme,
         weak_script_thread: Weak<ScriptThread>,
+        is_online: Rc<Cell<bool>>,
     ) -> DomRoot<Self> {
         let error_reporter = CSSErrorReporter {
             pipelineid: pipeline_id,
@@ -3937,6 +3938,7 @@ impl Window {
                 gpu_id_hub,
                 inherited_secure_context,
                 unminify_js,
+                is_online,
             ),
             caches: Default::default(),
             ongoing_navigation: Default::default(),

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::{OnceCell, RefCell, RefMut};
+use std::cell::{Cell, OnceCell, RefCell, RefMut};
 use std::collections::HashSet;
 use std::default::Default;
 use std::rc::Rc;
@@ -424,6 +424,7 @@ impl WorkerGlobalScope {
                 gpu_id_hub,
                 init.inherited_secure_context,
                 init.unminify_js,
+                Rc::new(Cell::new(true)),
             ),
             caches: Default::default(),
             microtask_queue: runtime.microtask_queue.clone(),

--- a/components/script/dom/workers/workernavigator.rs
+++ b/components/script/dom/workers/workernavigator.rs
@@ -110,7 +110,7 @@ impl WorkerNavigatorMethods<crate::DomTypeHolder> for WorkerNavigator {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-online>
     fn OnLine(&self) -> bool {
-        true
+        self.global().is_online().get()
     }
 
     /// <https://w3c.github.io/permissions/#navigator-and-workernavigator-extension>

--- a/components/script/dom/worklet/workletglobalscope.rs
+++ b/components/script/dom/worklet/workletglobalscope.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::cell::Cell;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -145,6 +146,7 @@ impl WorkletGlobalScope {
                 init.gpu_id_hub.clone(),
                 inherited_secure_context,
                 false,
+                Rc::new(Cell::new(true)),
             ),
             base_url,
             to_script_thread_sender: init.to_script_thread_sender.clone(),

--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -135,7 +135,7 @@ use crate::dom::html::htmliframeelement::{HTMLIFrameElement, IframeContext, Proc
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::script_execution::{RethrowErrors, ScriptOptions};
 use crate::dom::servoparser::{ParserContext, ServoParser};
-use crate::dom::types::DebuggerGlobalScope;
+use crate::dom::types::{DebuggerGlobalScope, EventTarget};
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::identityhub::IdentityHub;
 use crate::dom::window::Window;
@@ -414,6 +414,9 @@ pub struct ScriptThread {
     privileged_urls: Vec<ServoUrl>,
 
     devtools_state: DevtoolsState,
+
+    /// Switch offline and online events
+    is_online: Rc<Cell<bool>>,
 }
 
 struct BHMExitSignal {
@@ -966,6 +969,7 @@ impl ScriptThread {
                     privileged_urls: state.privileged_urls,
                     this: weak_script_thread.clone(),
                     devtools_state: Default::default(),
+                    is_online: Rc::new(Cell::new(true)),
                 }
             }),
             cx,
@@ -1945,6 +1949,23 @@ impl ScriptThread {
             ScriptThreadMessage::TriggerGarbageCollection => unsafe {
                 JS_GC(cx, GCReason::API);
             },
+            ScriptThreadMessage::SetNetworkOnlineStatus(is_online) => {
+                self.handle_network_status(is_online, cx);
+            },
+        }
+    }
+
+    fn fire_network_events(&self, is_online: bool, cx: &mut JSContext) {
+        let event_name = if is_online {
+            Atom::from("online")
+        } else {
+            Atom::from("offline")
+        };
+
+        for (_, document) in self.documents.borrow().iter() {
+            let window = document.window();
+            let event_target = window.upcast::<EventTarget>();
+            event_target.fire_event(cx, event_name.clone());
         }
     }
 
@@ -3511,6 +3532,7 @@ impl ScriptThread {
                     incomplete.load_data.inherited_secure_context,
                     incomplete.embedder_theme,
                     self.this.clone(),
+                    self.is_online.clone(),
                 )
             },
         };
@@ -4447,6 +4469,13 @@ impl ScriptThread {
         } else {
             warn!("No MediaSession for this pipeline ID");
         };
+    }
+
+    fn handle_network_status(&self, is_online: bool, cx: &mut JSContext) {
+        let previous = self.is_online.replace(is_online);
+        if previous != is_online {
+            self.fire_network_events(is_online, cx);
+        }
     }
 
     pub(crate) fn enqueue_microtask(cx: &js::context::JSContext, job: Box<dyn MicrotaskRunnable>) {

--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -1949,7 +1949,7 @@ impl ScriptThread {
             ScriptThreadMessage::TriggerGarbageCollection => unsafe {
                 JS_GC(cx, GCReason::API);
             },
-            ScriptThreadMessage::SetNetworkOnlineStatus(is_online) => {
+            ScriptThreadMessage::SetNetworkOnlineState(is_online) => {
                 self.handle_network_status(is_online, cx);
             },
         }

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -112,7 +112,7 @@ impl MixedMessage {
                 ScriptThreadMessage::UpdatePinchZoomInfos(id, _) => Some(*id),
                 ScriptThreadMessage::SetAccessibilityActive(..) => None,
                 ScriptThreadMessage::TriggerGarbageCollection => None,
-                ScriptThreadMessage::SetNetworkOnlineStatus(_) => None,
+                ScriptThreadMessage::SetNetworkOnlineState(_) => None,
             },
             MixedMessage::FromScript(inner_msg) => match inner_msg {
                 MainThreadScriptMsg::Common(CommonScriptMsg::Task(_, _, pipeline_id, _)) => {

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -112,6 +112,7 @@ impl MixedMessage {
                 ScriptThreadMessage::UpdatePinchZoomInfos(id, _) => Some(*id),
                 ScriptThreadMessage::SetAccessibilityActive(..) => None,
                 ScriptThreadMessage::TriggerGarbageCollection => None,
+                ScriptThreadMessage::SetNetworkOnlineStatus(_) => None,
             },
             MixedMessage::FromScript(inner_msg) => match inner_msg {
                 MainThreadScriptMsg::Common(CommonScriptMsg::Task(_, _, pipeline_id, _)) => {

--- a/components/servo/network_manager.rs
+++ b/components/servo/network_manager.rs
@@ -84,7 +84,7 @@ impl NetworkManager {
     }
 
     /// Set the network online state.
-    pub fn set_network_online_state(&self, online: bool) {
+    pub fn set_online_state(&self, online: bool) {
         self.constellation_proxy
             .send(EmbedderToConstellationMessage::SetNetworkOnlineState(
                 online,

--- a/components/servo/network_manager.rs
+++ b/components/servo/network_manager.rs
@@ -5,6 +5,9 @@
 use std::collections::HashSet;
 
 use net_traits::ResourceThreads;
+use servo_constellation_traits::EmbedderToConstellationMessage;
+
+use crate::proxies::ConstellationProxy;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct CacheEntry {
@@ -29,16 +32,19 @@ impl CacheEntry {
 pub struct NetworkManager {
     public_resource_threads: ResourceThreads,
     private_resource_threads: ResourceThreads,
+    constellation_proxy: ConstellationProxy,
 }
 
 impl NetworkManager {
     pub(crate) fn new(
         public_resource_threads: ResourceThreads,
         private_resource_threads: ResourceThreads,
+        constellation_proxy: ConstellationProxy,
     ) -> Self {
         Self {
             public_resource_threads,
             private_resource_threads,
+            constellation_proxy,
         }
     }
 
@@ -75,5 +81,13 @@ impl NetworkManager {
     pub fn clear_cache(&self) {
         self.public_resource_threads.clear_cache();
         self.private_resource_threads.clear_cache();
+    }
+
+    /// Set the network online state.
+    pub fn set_network_online_state(&self, online: bool) {
+        self.constellation_proxy
+            .send(EmbedderToConstellationMessage::SetNetworkOnlineState(
+                online,
+            ));
     }
 }

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -1156,7 +1156,9 @@ impl Servo {
     pub fn report_online_changed(&self, online: bool) {
         self.0
             .constellation_proxy
-            .send(EmbedderToConstellationMessage::SetOnlineStatus(online));
+            .send(EmbedderToConstellationMessage::SetNetworkOnlineState(
+                online,
+            ));
     }
 }
 

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -1029,6 +1029,7 @@ impl Servo {
             network_manager: Rc::new(RefCell::new(NetworkManager::new(
                 public_resource_threads.clone(),
                 private_resource_threads.clone(),
+                constellation_proxy.clone(),
             ))),
             site_data_manager: SiteDataManager::new(
                 public_resource_threads,
@@ -1151,14 +1152,6 @@ impl Servo {
     /// Registers a [`WebXrRegistry`]
     pub fn register_webxr_registry(&self, registry: Box<dyn WebXrRegistry>) {
         self.0.paint.borrow().register_webxr_registry(registry);
-    }
-
-    pub fn report_online_changed(&self, online: bool) {
-        self.0
-            .constellation_proxy
-            .send(EmbedderToConstellationMessage::SetNetworkOnlineState(
-                online,
-            ));
     }
 }
 

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -1152,6 +1152,12 @@ impl Servo {
     pub fn register_webxr_registry(&self, registry: Box<dyn WebXrRegistry>) {
         self.0.paint.borrow().register_webxr_registry(registry);
     }
+
+    pub fn report_online_changed(&self, online: bool) {
+        self.0
+            .constellation_proxy
+            .send(EmbedderToConstellationMessage::OnlineChanged(online));
+    }
 }
 
 fn create_embedder_channel(

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -1156,7 +1156,7 @@ impl Servo {
     pub fn report_online_changed(&self, online: bool) {
         self.0
             .constellation_proxy
-            .send(EmbedderToConstellationMessage::OnlineChanged(online));
+            .send(EmbedderToConstellationMessage::SetOnlineStatus(online));
     }
 }
 

--- a/components/servo/tests/network_manager.rs
+++ b/components/servo/tests/network_manager.rs
@@ -13,7 +13,7 @@ use hyper::{Request as HyperRequest, Response as HyperResponse};
 use net::test_util::{make_body, make_server};
 use servo::{CacheEntry, WebViewBuilder};
 
-use crate::common::{ServoTest, WebViewDelegateImpl};
+use crate::common::{ServoTest, WebViewDelegateImpl, evaluate_javascript};
 
 #[test]
 fn test_cache_entries() {
@@ -96,4 +96,45 @@ fn test_clear_cache() {
 
     let cache_entries = network_manager.cache_entries();
     assert_eq!(cache_entries.len(), 0);
+}
+
+#[test]
+fn test_set_online() {
+    let servo_test = ServoTest::new();
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .build();
+
+    evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "addEventListener('online', () => console.log('online'))",
+    )
+    .unwrap();
+    evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "addEventListener('offline', () => console.log('offline'))",
+    )
+    .unwrap();
+
+    let network_manager = servo_test.servo().network_manager();
+    network_manager.set_network_online_state(false);
+    network_manager.set_network_online_state(true);
+
+    servo_test.spin({
+        let delegate = delegate.clone();
+        move || delegate.console_messages.borrow().len() < 2
+    });
+    assert_eq!(
+        delegate
+            .console_messages
+            .borrow()
+            .iter()
+            .map(|p| p.1.clone())
+            .collect::<Vec<_>>(),
+        vec!["offline".to_string(), "online".to_string(),]
+    );
 }

--- a/components/servo/tests/network_manager.rs
+++ b/components/servo/tests/network_manager.rs
@@ -99,7 +99,7 @@ fn test_clear_cache() {
 }
 
 #[test]
-fn test_set_online() {
+fn test_set_network_online() {
     let servo_test = ServoTest::new();
     let delegate = Rc::new(WebViewDelegateImpl::default());
 
@@ -121,8 +121,8 @@ fn test_set_online() {
     .unwrap();
 
     let network_manager = servo_test.servo().network_manager();
-    network_manager.set_network_online_state(false);
-    network_manager.set_network_online_state(true);
+    network_manager.set_online_state(false);
+    network_manager.set_online_state(true);
 
     servo_test.spin({
         let delegate = delegate.clone();

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -115,7 +115,7 @@ pub enum EmbedderToConstellationMessage {
     /// Activate or deactivate accessibility features for the given `WebView`.
     SetAccessibilityActive(WebViewId, bool),
     /// Update the online status
-    OnlineChanged(bool),
+    SetOnlineStatus(bool),
 }
 
 pub enum UserContentManagerAction {

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -115,7 +115,7 @@ pub enum EmbedderToConstellationMessage {
     /// Activate or deactivate accessibility features for the given `WebView`.
     SetAccessibilityActive(WebViewId, bool),
     /// Update the online status
-    SetOnlineStatus(bool),
+    SetNetworkOnlineState(bool),
 }
 
 pub enum UserContentManagerAction {

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -114,6 +114,8 @@ pub enum EmbedderToConstellationMessage {
     UpdatePinchZoomInfos(PipelineId, PinchZoomInfos),
     /// Activate or deactivate accessibility features for the given `WebView`.
     SetAccessibilityActive(WebViewId, bool),
+    /// Update the online status
+    OnlineChanged(bool),
 }
 
 pub enum UserContentManagerAction {

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -343,6 +343,8 @@ pub enum ScriptThreadMessage {
     SetAccessibilityActive(PipelineId, bool, Epoch),
     /// Force a garbage collection in this script thread.
     TriggerGarbageCollection,
+    /// Parameter indicates if online (true) or offline (false)
+    SetNetworkOnlineStatus(bool),
 }
 
 impl fmt::Debug for ScriptThreadMessage {

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -344,7 +344,7 @@ pub enum ScriptThreadMessage {
     /// Force a garbage collection in this script thread.
     TriggerGarbageCollection,
     /// Parameter indicates if online (true) or offline (false)
-    SetNetworkOnlineStatus(bool),
+    SetNetworkOnlineState(bool),
 }
 
 impl fmt::Debug for ScriptThreadMessage {


### PR DESCRIPTION
constellation: allow embedders to report online/offline changes

This PR includes:

1. [x] add a new `EmbedderToConstellationMessage::OnlineChanged` variant to update the online status
2. [ ] in the Constellation code to handle this event, iterate over all pipelines and send the ScriptThreadMessage from Fire online and offline events #36610
   - **wait for #37076 to be merged to define the ScriptThreadMessage message**
3. [x] add a new public method `report_online_changed` to Servo to send the new EmbedderToConstellationMessage value

Testing: Not yet covered, wait for real system integration to detect online status change
Fixes: #36611
