### PR TITLE
paint: Remove interior mutability from `PipelineDetails`

### DIFF
--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -467,8 +467,10 @@ impl Painter {
     /// the list.
     fn send_pending_paint_metrics_messages_after_composite(&mut self) {
         let paint_time = CrossProcessInstant::now();
-        for webview_renderer in self.webview_renderers.values() {
-            for (pipeline_id, pipeline) in webview_renderer.pipelines.iter() {
+        let mut events = Vec::<(PipelineId, PaintMetricEvent)>::new();
+
+        for webview_renderer in self.webview_renderers.values_mut() {
+            for (pipeline_id, pipeline) in webview_renderer.pipelines.iter_mut() {
                 let Some(current_epoch) = self
                     .webrender_renderer
                     .as_ref()
@@ -477,7 +479,7 @@ impl Painter {
                     continue;
                 };
 
-                match pipeline.first_paint_metric.get() {
+                match pipeline.first_paint_metric {
                     // We need to check whether the current epoch is later, because
                     // CrossProcessPaintMessage::SendInitialTransaction sends an
                     // empty display list to WebRender which can happen before we receive
@@ -493,17 +495,17 @@ impl Painter {
                             pipeline_id = ?pipeline_id,
                         );
 
-                        self.send_to_constellation(EmbedderToConstellationMessage::PaintMetric(
+                        events.push((
                             *pipeline_id,
                             PaintMetricEvent::FirstPaint(paint_time, first_reflow),
                         ));
 
-                        pipeline.first_paint_metric.set(PaintMetricState::Sent);
+                        pipeline.first_paint_metric = PaintMetricState::Sent;
                     },
                     _ => {},
                 }
 
-                match pipeline.first_contentful_paint_metric.get() {
+                match pipeline.first_contentful_paint_metric {
                     PaintMetricState::Seen(epoch, first_reflow) if epoch <= current_epoch => {
                         #[cfg(feature = "tracing")]
                         tracing::info!(
@@ -513,18 +515,16 @@ impl Painter {
                             paint_time = ?paint_time,
                             pipeline_id = ?pipeline_id,
                         );
-                        self.send_to_constellation(EmbedderToConstellationMessage::PaintMetric(
+                        events.push((
                             *pipeline_id,
                             PaintMetricEvent::FirstContentfulPaint(paint_time, first_reflow),
                         ));
-                        pipeline
-                            .first_contentful_paint_metric
-                            .set(PaintMetricState::Sent);
+                        pipeline.first_contentful_paint_metric = PaintMetricState::Sent;
                     },
                     _ => {},
                 }
 
-                let mut pending_lcp_candidates = pipeline.lcp_candidates.borrow_mut();
+                let pending_lcp_candidates = &mut pipeline.lcp_candidates;
                 while let Some((epoch, candidate)) = pending_lcp_candidates.pop_front() {
                     if epoch > current_epoch {
                         pending_lcp_candidates.push_front((epoch, candidate));
@@ -538,7 +538,7 @@ impl Painter {
                         area = ?candidate.area,
                         pipeline_id = ?pipeline_id,
                     );
-                    self.send_to_constellation(EmbedderToConstellationMessage::PaintMetric(
+                    events.push((
                         *pipeline_id,
                         PaintMetricEvent::LargestContentfulPaint(
                             paint_time,
@@ -549,6 +549,13 @@ impl Painter {
                     ));
                 }
             }
+        }
+
+        for (pipeline_id, event) in events {
+            self.send_to_constellation(EmbedderToConstellationMessage::PaintMetric(
+                pipeline_id,
+                event,
+            ));
         }
     }
 
@@ -972,21 +979,16 @@ impl Painter {
 
         let epoch = display_list_info.epoch.into();
         let first_reflow = display_list_info.first_reflow;
-        if details.first_paint_metric.get() == PaintMetricState::Waiting &&
-            display_list_info.is_paintable
+        if details.first_paint_metric == PaintMetricState::Waiting && display_list_info.is_paintable
         {
-            details
-                .first_paint_metric
-                .set(PaintMetricState::Seen(epoch, first_reflow));
+            details.first_paint_metric = PaintMetricState::Seen(epoch, first_reflow);
         }
 
-        if details.first_contentful_paint_metric.get() == PaintMetricState::Waiting &&
+        if details.first_contentful_paint_metric == PaintMetricState::Waiting &&
             display_list_info.is_paintable &&
             display_list_info.is_contentful
         {
-            details
-                .first_contentful_paint_metric
-                .set(PaintMetricState::Seen(epoch, first_reflow));
+            details.first_contentful_paint_metric = PaintMetricState::Seen(epoch, first_reflow);
         }
 
         details.animations.handle_new_display_list(
@@ -1487,7 +1489,6 @@ impl Painter {
             webview_renderer
                 .ensure_pipeline_details(pipeline_id)
                 .lcp_candidates
-                .borrow_mut()
                 .push_back((epoch.into(), lcp_candidate));
         }
     }

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -467,7 +467,7 @@ impl Painter {
     /// the list.
     fn send_pending_paint_metrics_messages_after_composite(&mut self) {
         let paint_time = CrossProcessInstant::now();
-        let mut events = Vec::<(PipelineId, PaintMetricEvent)>::new();
+        let mut events = Vec::new();
 
         for webview_renderer in self.webview_renderers.values_mut() {
             for (pipeline_id, pipeline) in webview_renderer.pipelines.iter_mut() {

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -467,7 +467,7 @@ impl Painter {
     /// the list.
     fn send_pending_paint_metrics_messages_after_composite(&mut self) {
         let paint_time = CrossProcessInstant::now();
-        let mut events = Vec::new();
+        let mut paint_metric_events = Vec::new();
 
         for webview_renderer in self.webview_renderers.values_mut() {
             for (pipeline_id, pipeline) in webview_renderer.pipelines.iter_mut() {
@@ -495,7 +495,7 @@ impl Painter {
                             pipeline_id = ?pipeline_id,
                         );
 
-                        events.push((
+                        paint_metric_events.push((
                             *pipeline_id,
                             PaintMetricEvent::FirstPaint(paint_time, first_reflow),
                         ));
@@ -515,7 +515,7 @@ impl Painter {
                             paint_time = ?paint_time,
                             pipeline_id = ?pipeline_id,
                         );
-                        events.push((
+                        paint_metric_events.push((
                             *pipeline_id,
                             PaintMetricEvent::FirstContentfulPaint(paint_time, first_reflow),
                         ));
@@ -538,7 +538,7 @@ impl Painter {
                         area = ?candidate.area,
                         pipeline_id = ?pipeline_id,
                     );
-                    events.push((
+                    paint_metric_events.push((
                         *pipeline_id,
                         PaintMetricEvent::LargestContentfulPaint(
                             paint_time,
@@ -551,7 +551,7 @@ impl Painter {
             }
         }
 
-        for (pipeline_id, event) in events {
+        for (pipeline_id, event) in paint_metric_events {
             self.send_to_constellation(EmbedderToConstellationMessage::PaintMetric(
                 pipeline_id,
                 event,

--- a/components/paint/pipeline_details.rs
+++ b/components/paint/pipeline_details.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
 
 use euclid::Scale;
@@ -42,13 +41,13 @@ pub(crate) struct PipelineDetails {
     pub scroll_tree: ScrollTree,
 
     /// The paint metric status of the first paint.
-    pub first_paint_metric: Cell<PaintMetricState>,
+    pub first_paint_metric: PaintMetricState,
 
     /// The paint metric status of the first contentful paint.
-    pub first_contentful_paint_metric: Cell<PaintMetricState>,
+    pub first_contentful_paint_metric: PaintMetricState,
 
     /// LCP candidates waiting to be presented, in order by [WebRenderEpoch].
-    pub lcp_candidates: RefCell<VecDeque<(WebRenderEpoch, LCPCandidate)>>,
+    pub lcp_candidates: VecDeque<(WebRenderEpoch, LCPCandidate)>,
 
     /// The CSS pixel to device pixel scale of the viewport of this pipeline, including
     /// page zoom, but not including any pinch zoom amount. This is used to detect
@@ -92,9 +91,9 @@ impl PipelineDetails {
             animation_callbacks_running: false,
             throttled: false,
             scroll_tree: ScrollTree::default(),
-            first_paint_metric: Cell::new(PaintMetricState::Waiting),
-            first_contentful_paint_metric: Cell::new(PaintMetricState::Waiting),
-            lcp_candidates: RefCell::new(VecDeque::new()),
+            first_paint_metric: PaintMetricState::Waiting,
+            first_contentful_paint_metric: PaintMetricState::Waiting,
+            lcp_candidates: VecDeque::new(),
             exited: PipelineExitSource::empty(),
             display_list_epoch: None,
             animations: Default::default(),

--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -223,7 +223,7 @@ impl WebViewRenderer {
         }
 
         // Flush the LCP candidates when exiting pipeline.
-        pipeline.get_mut().lcp_candidates.borrow_mut().clear();
+        pipeline.get_mut().lcp_candidates.clear();
 
         pipeline.remove_entry();
     }


### PR DESCRIPTION
Remove Cells and RefCells in `PipelineDetails`.

Testing: `tests/wpt/tests/paint-timing`. The test passed but is flaky both before and after this PR.
Fixes: #47550 

