### PR TITLE
script: Run "abort_a_document_and_its_descendants" during navigation

### DIFF
--- a/components/script/css/stylesheet_loader.rs
+++ b/components/script/css/stylesheet_loader.rs
@@ -552,7 +552,7 @@ impl ElementStylesheetLoader<'_> {
         .referrer_policy(referrer_policy)
         .integrity_metadata(integrity_metadata);
 
-        document.fetch(LoadType::Stylesheet(url), request, context);
+        document.fetch_blocking(LoadType::Stylesheet(url), request, context);
     }
 
     fn parse(

--- a/components/script/dom/abort/abortsignal.rs
+++ b/components/script/dom/abort/abortsignal.rs
@@ -199,6 +199,7 @@ impl AbortSignal {
             },
             AbortAlgorithm::FetchLater(deferred_fetch_record_id) => {
                 global
+                    .fetch_group()
                     .deferred_fetch_record_for_id(deferred_fetch_record_id)
                     .abort();
             },

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -220,7 +220,7 @@ use crate::event_loop::document_loader::{DocumentLoader, LoadType};
 use crate::event_loop::script_thread::{ScriptThread, SharedRwLocks};
 use crate::event_loop::timers::{OneshotTimerCallback, OneshotTimers};
 use crate::fetch::fetch::{DeferredFetchRecordInvokeState, FetchCanceller};
-use crate::fetch::network_listener::{FetchResponseListener, NetworkListener};
+use crate::fetch::network_listener::FetchResponseListener;
 use crate::mime::{APPLICATION, CHARSET};
 use crate::navigation::navigate;
 use crate::runtime::script_runtime::compute_size;
@@ -1996,18 +1996,14 @@ impl Document {
         request_builder: RequestBuilder,
         listener: Listener,
     ) {
-        let global_scope = self.window().as_global_scope();
-        let listener = NetworkListener::new(
-            listener,
-            self.owner_global()
-                .task_manager()
-                .networking_task_source()
-                .into(),
-            global_scope,
-        );
-        global_scope
-            .fetch_group_mut()
-            .fetch(request_builder, listener);
+        let networking_task_source = self
+            .owner_global()
+            .task_manager()
+            .networking_task_source()
+            .to_sendable();
+        self.window()
+            .as_global_scope()
+            .fetch(request_builder, listener, networking_task_source);
     }
 
     /// <https://fetch.spec.whatwg.org/#deferred-fetch-control-document>

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -10,7 +10,7 @@ use std::default::Default;
 use std::ops::Deref;
 use std::rc::Rc;
 use std::str::FromStr;
-use std::sync::{Arc as StdArc, LazyLock, Mutex};
+use std::sync::{Arc as StdArc, LazyLock};
 use std::time::Duration;
 
 use bitflags::bitflags;
@@ -1981,40 +1981,33 @@ impl Document {
             .insert(key, preload_id);
     }
 
-    pub(crate) fn fetch<Listener: FetchResponseListener>(
+    pub(crate) fn fetch_blocking<Listener: FetchResponseListener>(
         &self,
         load: LoadType,
         request: RequestBuilder,
         listener: Listener,
     ) {
-        let callback = NetworkListener {
-            context: std::sync::Arc::new(Mutex::new(Some(listener))),
-            task_source: self
-                .owner_global()
-                .task_manager()
-                .networking_task_source()
-                .into(),
-        }
-        .into_callback();
-        self.loader_mut()
-            .fetch_async_with_callback(load, request, callback);
+        self.loader_mut().add_blocking_load(load);
+        self.fetch_background(request, listener);
     }
 
     pub(crate) fn fetch_background<Listener: FetchResponseListener>(
         &self,
-        request: RequestBuilder,
+        request_builder: RequestBuilder,
         listener: Listener,
     ) {
-        let callback = NetworkListener {
-            context: std::sync::Arc::new(Mutex::new(Some(listener))),
-            task_source: self
-                .owner_global()
+        let global_scope = self.window().as_global_scope();
+        let listener = NetworkListener::new(
+            listener,
+            self.owner_global()
                 .task_manager()
                 .networking_task_source()
                 .into(),
-        }
-        .into_callback();
-        self.loader_mut().fetch_async_background(request, callback);
+            global_scope,
+        );
+        global_scope
+            .fetch_group_mut()
+            .fetch(request_builder, listener);
     }
 
     /// <https://fetch.spec.whatwg.org/#deferred-fetch-control-document>
@@ -2074,7 +2067,8 @@ impl Document {
         // TODO
         // Step 8.2. For each deferred fetch record deferredRecord of navigable’s active document’s
         // relevant settings object’s fetch group’s deferred fetch records:
-        for deferred_fetch in navigable.as_global_scope().deferred_fetches() {
+        let deferred_fetches = navigable.as_global_scope().fetch_group().deferred_fetches();
+        for deferred_fetch in deferred_fetches {
             // Step 8.2.1. If deferredRecord’s invoke state is not "pending", then continue.
             if deferred_fetch.invoke_state.get() != DeferredFetchRecordInvokeState::Pending {
                 continue;
@@ -2864,24 +2858,6 @@ impl Document {
         // TODO
     }
 
-    /// <https://fetch.spec.whatwg.org/#concept-fetch-group-terminate>
-    fn terminate_fetch_group(&self) -> bool {
-        let mut load_cancellers = self.loader.borrow_mut().cancel_all_loads();
-
-        // Step 1. For each fetch record record of fetchGroup’s fetch records,
-        // if record’s controller is non-null and record’s request’s done flag
-        // is unset and keepalive is false, terminate record’s controller.
-        for canceller in &mut load_cancellers {
-            if !canceller.keep_alive() {
-                canceller.terminate();
-            }
-        }
-        // Step 2. Process deferred fetches for fetchGroup.
-        self.owner_global().process_deferred_fetches();
-
-        !load_cancellers.is_empty()
-    }
-
     /// <https://html.spec.whatwg.org/multipage/#active-parser>
     fn active_parser(&self) -> Option<DomRoot<ServoParser>> {
         // > A Document is said to have an active parser if it is associated with
@@ -2908,8 +2884,11 @@ impl Document {
         *self.asap_scripts_set.borrow_mut() = vec![];
         self.asap_in_order_scripts_list.clear();
         self.deferred_scripts.clear();
-        let loads_cancelled = self.terminate_fetch_group();
-        let event_sources_canceled = self.window.as_global_scope().close_event_sources();
+
+        let global = self.window.as_global_scope();
+        let loads_cancelled = global.fetch_group_mut().terminate(global);
+        let event_sources_canceled = global.close_event_sources();
+
         if loads_cancelled || event_sources_canceled {
             // If any loads were canceled.
             self.salvageable.set(false);

--- a/components/script/dom/fetch/fetchlaterresult.rs
+++ b/components/script/dom/fetch/fetchlaterresult.rs
@@ -48,6 +48,7 @@ impl FetchLaterResultMethods<crate::DomTypeHolder> for FetchLaterResult {
     fn Activated(&self) -> bool {
         // The activated getter steps are to return the result of running this’s activated getter steps.
         self.global()
+            .fetch_group()
             .deferred_fetch_record_for_id(&self.deferred_record_id)
             .activated_getter_steps()
     }

--- a/components/script/dom/fetch/request.rs
+++ b/components/script/dom/fetch/request.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::cell::Ref;
 use std::rc::Rc;
 use std::str::FromStr;
 
@@ -585,8 +586,8 @@ impl Request {
         Ok(r_clone)
     }
 
-    pub(crate) fn get_request(&self) -> NetTraitsRequest {
-        self.request.borrow().clone()
+    pub(crate) fn request(&self) -> Ref<'_, NetTraitsRequest> {
+        self.request.borrow()
     }
 }
 

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -46,9 +46,7 @@ use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{
     InsecureRequestsPolicy, Origin as RequestOrigin, Referrer, RequestBuilder, RequestClient,
 };
-use net_traits::{
-    CoreResourceMsg, CoreResourceThread, ReferrerPolicy, ResourceThreads, fetch_async,
-};
+use net_traits::{CoreResourceMsg, CoreResourceThread, ReferrerPolicy, ResourceThreads};
 use profile_traits::{
     generic_channel as profile_generic_channel, ipc as profile_ipc, mem as profile_mem,
     time as profile_time,
@@ -148,7 +146,7 @@ use crate::event_loop::timers::{
     IsInterval, OneshotTimerCallback, OneshotTimerHandle, OneshotTimers, TimerCallback,
     TimerEventId, TimerSource,
 };
-use crate::fetch::fetch::{DeferredFetchRecordId, FetchGroup, QueuedDeferredFetchRecord};
+use crate::fetch::fetch::FetchGroup;
 use crate::fetch::network_listener::{FetchResponseListener, NetworkListener};
 use crate::messaging::{CommonScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::modules::import_map::ImportMap;
@@ -784,6 +782,7 @@ impl GlobalScope {
         inherited_secure_context: Option<bool>,
         unminify_js: bool,
     ) -> Self {
+        let fetch_group = RefCell::new(FetchGroup::new(resource_threads.sender()));
         Self {
             message_port_state: DomRefCell::new(MessagePortState::UnManaged),
             broadcast_channel_state: DomRefCell::new(BroadcastChannelState::UnManaged),
@@ -825,7 +824,7 @@ impl GlobalScope {
             notification_permission_request_callback_map: Default::default(),
             import_map: Default::default(),
             resolved_module_set: Default::default(),
-            fetch_group: Default::default(),
+            fetch_group,
         }
     }
 
@@ -3397,20 +3396,9 @@ impl GlobalScope {
         context: Listener,
         task_source: SendableTaskSource,
     ) {
-        let network_listener = NetworkListener::new(context, task_source);
-        self.fetch_with_network_listener(request_builder, network_listener);
-    }
-
-    pub(crate) fn fetch_with_network_listener<Listener: FetchResponseListener>(
-        &self,
-        request_builder: RequestBuilder,
-        network_listener: NetworkListener<Listener>,
-    ) {
-        fetch_async(
-            &self.core_resource_thread(),
+        self.fetch_group_mut().fetch(
             request_builder,
-            None,
-            network_listener.into_callback(),
+            NetworkListener::new(context, task_source, self),
         );
     }
 
@@ -3471,46 +3459,12 @@ impl GlobalScope {
             .remove(&callback_id)
     }
 
-    pub(crate) fn append_deferred_fetch(
-        &self,
-        deferred_fetch: QueuedDeferredFetchRecord,
-    ) -> DeferredFetchRecordId {
-        let deferred_record_id = DeferredFetchRecordId::default();
-        self.fetch_group
-            .borrow_mut()
-            .deferred_fetch_records
-            .insert(deferred_record_id, deferred_fetch);
-        deferred_record_id
+    pub(crate) fn fetch_group(&self) -> Ref<'_, FetchGroup> {
+        self.fetch_group.borrow()
     }
 
-    pub(crate) fn deferred_fetches(&self) -> Vec<QueuedDeferredFetchRecord> {
-        self.fetch_group
-            .borrow()
-            .deferred_fetch_records
-            .values()
-            .cloned()
-            .collect()
-    }
-
-    pub(crate) fn deferred_fetch_record_for_id(
-        &self,
-        deferred_fetch_record_id: &DeferredFetchRecordId,
-    ) -> QueuedDeferredFetchRecord {
-        self.fetch_group
-            .borrow()
-            .deferred_fetch_records
-            .get(deferred_fetch_record_id)
-            .expect("Should always use a generated fetch_record_id instead of passing your own")
-            .clone()
-    }
-
-    /// <https://fetch.spec.whatwg.org/#process-deferred-fetches>
-    pub(crate) fn process_deferred_fetches(&self) {
-        // Step 1. For each deferred fetch record deferredRecord of fetchGroup’s
-        // deferred fetch records, process a deferred fetch deferredRecord.
-        for deferred_fetch in self.deferred_fetches() {
-            deferred_fetch.process(self);
-        }
+    pub(crate) fn fetch_group_mut(&self) -> RefMut<'_, FetchGroup> {
+        self.fetch_group.borrow_mut()
     }
 
     pub(crate) fn import_map(&self) -> Ref<'_, ImportMap> {

--- a/components/script/event_loop/document_loader.rs
+++ b/components/script/event_loop/document_loader.rs
@@ -26,9 +26,8 @@ pub(crate) enum LoadType {
     Media,
 }
 
-/// Canary value ensuring that manually added blocking loads (ie. ones that weren't
-/// created via DocumentLoader::fetch_async) are always removed by the time
-/// that the owner is destroyed.
+/// Canary value ensuring that manually added blocking loads are always removed by the
+/// time that the owner is destroyed.
 #[derive(JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct LoadBlocker {

--- a/components/script/event_loop/document_loader.rs
+++ b/components/script/event_loop/document_loader.rs
@@ -8,15 +8,13 @@
 
 use std::collections::HashMap;
 
-use net_traits::request::RequestBuilder;
-use net_traits::{BoxedFetchCallback, ResourceThreads, fetch_async};
+use net_traits::ResourceThreads;
 use script_bindings::cell::DomRefCell;
 use script_bindings::script_runtime::{during_gc_collection, runtime_is_alive};
 use servo_url::ServoUrl;
 
 use crate::dom::bindings::root::Dom;
 use crate::dom::document::Document;
-use crate::fetch::fetch::FetchCanceller;
 
 #[derive(Clone, Debug, Eq, Hash, JSTraceable, MallocSizeOf, PartialEq)]
 pub(crate) enum LoadType {
@@ -99,7 +97,6 @@ pub(crate) struct DocumentLoader {
     /// reaches zero, it is removed from the map and no longer blocks the load.
     blocking_loads: HashMap<LoadType, u32>,
     events_inhibited: bool,
-    cancellers: Vec<FetchCanceller>,
 }
 
 impl DocumentLoader {
@@ -122,17 +119,11 @@ impl DocumentLoader {
             resource_threads,
             blocking_loads: initial_loads,
             events_inhibited: false,
-            cancellers: Vec::new(),
         }
     }
 
-    /// <https://fetch.spec.whatwg.org/#concept-fetch-group-terminate>
-    pub(crate) fn cancel_all_loads(&mut self) -> Vec<FetchCanceller> {
-        self.cancellers.drain(..).collect()
-    }
-
     /// Add a load to the list of blocking loads.
-    fn add_blocking_load(&mut self, load: LoadType) {
+    pub(crate) fn add_blocking_load(&mut self, load: LoadType) {
         debug!(
             "Adding blocking load {:?} ({}).",
             load,
@@ -142,31 +133,6 @@ impl DocumentLoader {
             .entry(load)
             .and_modify(|load_number| *load_number += 1)
             .or_insert(1);
-    }
-
-    /// Initiate a new fetch given a response callback.
-    pub(crate) fn fetch_async_with_callback(
-        &mut self,
-        load: LoadType,
-        request: RequestBuilder,
-        callback: BoxedFetchCallback,
-    ) {
-        self.add_blocking_load(load);
-        self.fetch_async_background(request, callback);
-    }
-
-    /// Initiate a new fetch that does not block the document load event.
-    pub(crate) fn fetch_async_background(
-        &mut self,
-        request: RequestBuilder,
-        callback: BoxedFetchCallback,
-    ) {
-        self.cancellers.push(FetchCanceller::new(
-            request.id,
-            request.keep_alive,
-            self.resource_threads.core_thread.clone(),
-        ));
-        fetch_async(&self.resource_threads.core_thread, request, None, callback);
     }
 
     /// Mark an in-progress network request complete.

--- a/components/script/fetch/fetch.rs
+++ b/components/script/fetch/fetch.rs
@@ -19,7 +19,7 @@ use net_traits::request::{
 };
 use net_traits::{
     CoreResourceMsg, CoreResourceThread, FetchChannels, FetchMetadata, FetchResponseMsg,
-    FilteredMetadata, Metadata, NetworkError, ResourceFetchTiming, cancel_async_fetch,
+    FilteredMetadata, Metadata, NetworkError, ResourceFetchTiming, cancel_async_fetch, fetch_async,
 };
 use rustc_hash::FxHashMap;
 use script_bindings::cformat;
@@ -123,8 +123,8 @@ impl FetchCanceller {
     }
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
 /// An id to differentiate one deferred fetch record from another.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub(crate) struct DeferredFetchRecordId(Uuid);
 
 impl Default for DeferredFetchRecordId {
@@ -135,12 +135,156 @@ impl Default for DeferredFetchRecordId {
 
 pub(crate) type QueuedDeferredFetchRecord = Rc<DeferredFetchRecord>;
 
+/// <https://fetch.spec.whatwg.org/#fetch-record>
+#[derive(MallocSizeOf)]
+pub(crate) struct FetchRecord {
+    /// <https://fetch.spec.whatwg.org/#concept-fetch-record-fetch>
+    ///
+    /// Note: The fetch controller is currently represented in Servo by the [`FetchCanceller`].
+    controller: Option<FetchCanceller>,
+    /// Whether or not the [`Request`] has finished.
+    ///
+    /// TODO: In the specification this is in the [`Request`], so it should be moved there and the
+    /// [`Request`] stored here, which requires making everything traceable.
+    done: bool,
+}
+
 /// <https://fetch.spec.whatwg.org/#concept-fetch-group>
-#[derive(Default, MallocSizeOf)]
+#[derive(MallocSizeOf)]
 pub(crate) struct FetchGroup {
+    /// The [`CoreResourceThread`] for this [`FetchGroup`].
+    core_resource_thread: CoreResourceThread,
     /// <https://fetch.spec.whatwg.org/#fetch-group-deferred-fetch-records>
     #[conditional_malloc_size_of]
     pub(crate) deferred_fetch_records: FxHashMap<DeferredFetchRecordId, QueuedDeferredFetchRecord>,
+    /// <https://fetch.spec.whatwg.org/#concept-fetch-record>
+    pub(crate) fetch_records: FxHashMap<RequestId, FetchRecord>,
+}
+
+impl FetchGroup {
+    pub(crate) fn new(core_resource_thread: CoreResourceThread) -> Self {
+        Self {
+            core_resource_thread,
+            deferred_fetch_records: Default::default(),
+            fetch_records: Default::default(),
+        }
+    }
+
+    pub(crate) fn fetch<Listener: FetchResponseListener>(
+        &mut self,
+        request: RequestBuilder,
+        listener: NetworkListener<Listener>,
+    ) {
+        self.fetch_records.insert(
+            request.id,
+            FetchRecord {
+                controller: Some(FetchCanceller::new(
+                    request.id,
+                    request.keep_alive,
+                    self.core_resource_thread.clone(),
+                )),
+                done: false,
+            },
+        );
+        fetch_async(
+            &self.core_resource_thread,
+            request,
+            None,
+            listener.into_callback(),
+        );
+    }
+
+    pub(crate) fn deferred_fetches(&self) -> Vec<QueuedDeferredFetchRecord> {
+        self.deferred_fetch_records.values().cloned().collect()
+    }
+
+    pub(crate) fn deferred_fetch_record_for_id(
+        &self,
+        deferred_fetch_record_id: &DeferredFetchRecordId,
+    ) -> QueuedDeferredFetchRecord {
+        self.deferred_fetch_records
+            .get(deferred_fetch_record_id)
+            .expect("Should always use a generated fetch_record_id instead of passing your own")
+            .clone()
+    }
+
+    pub(crate) fn fetch_controller(
+        &mut self,
+        request_id: &RequestId,
+    ) -> Option<&mut FetchCanceller> {
+        self.fetch_records.get_mut(request_id)?.controller.as_mut()
+    }
+
+    /// <https://fetch.spec.whatwg.org/#concept-fetch-group-terminate>
+    ///
+    /// Returns `true` if any fetches were cancelled and `false` otherwise.
+    pub(crate) fn terminate(&mut self, global: &GlobalScope) -> bool {
+        // Step 1. For each fetch record record of fetchGroup’s fetch records,
+        // if record’s controller is non-null and record’s request’s done flag
+        // is unset and keepalive is false, terminate record’s controller.
+        let mut cancelled_any = false;
+        self.fetch_records.retain(|_, fetch_record| {
+            let Some(controller) = fetch_record.controller.as_mut() else {
+                return false;
+            };
+            if fetch_record.done {
+                return false;
+            }
+            if !controller.keep_alive() {
+                controller.terminate();
+                cancelled_any = true;
+                return false;
+            }
+            true
+        });
+
+        // Step 2. Process deferred fetches for fetchGroup.
+        self.process_deferred_fetches(global);
+
+        cancelled_any
+    }
+
+    /// <https://fetch.spec.whatwg.org/#process-deferred-fetches>
+    pub(crate) fn process_deferred_fetches(&mut self, global: &GlobalScope) {
+        // Step 1. For each deferred fetch record deferredRecord of fetchGroup’s
+        // deferred fetch records, process a deferred fetch deferredRecord.
+        for deferred_fetch in self.deferred_fetches() {
+            self.process_a_deferred_fetch(global, &deferred_fetch);
+        }
+    }
+
+    /// <https://fetch.spec.whatwg.org/#process-a-deferred-fetch>
+    pub(crate) fn process_a_deferred_fetch(
+        &mut self,
+        global: &GlobalScope,
+        deferred_fetch: &DeferredFetchRecord,
+    ) {
+        // Step 1. If deferredRecord’s invoke state is not "pending", then return.
+        if deferred_fetch.invoke_state.get() != DeferredFetchRecordInvokeState::Pending {
+            return;
+        }
+        // Step 2. Set deferredRecord’s invoke state to "sent".
+        deferred_fetch
+            .invoke_state
+            .set(DeferredFetchRecordInvokeState::Sent);
+        // Step 3. Fetch deferredRecord’s request.
+        let fetch_later_listener = FetchLaterListener {
+            url: deferred_fetch.request.url(),
+            global: Trusted::new(global),
+        };
+        let task_source = global.task_manager().networking_task_source().to_sendable();
+        self.fetch(
+            request_init_from_request(deferred_fetch.request.clone(), global),
+            NetworkListener::new(fetch_later_listener, task_source, global),
+        );
+        // Step 4 is handled by caller
+    }
+
+    pub(crate) fn mark_fetch_request_as_done(&mut self, request_id: &RequestId) {
+        if let Some(fetch_record) = self.fetch_records.get_mut(request_id) {
+            fetch_record.done = true;
+        }
+    }
 }
 
 fn request_init_from_request(request: NetTraitsRequest, global: &GlobalScope) -> RequestBuilder {
@@ -232,8 +376,7 @@ pub(crate) fn Fetch(
         Ok(r) => r,
     };
     // Step 3. Let request be requestObject’s request.
-    let request = request_object.get_request();
-    let request_id = request.id;
+    let request = request_object.request();
 
     // Step 4. If requestObject’s signal is aborted, then:
     let signal = request_object.Signal();
@@ -253,18 +396,17 @@ pub(crate) fn Fetch(
         return promise;
     }
 
-    let keep_alive = request.keep_alive;
     // Step 5. Let globalObject be request’s client’s global object.
     // NOTE:   We already get the global object as an argument
-    let mut request_init = request_init_from_request(request, global);
+    let mut request_builder = request_init_from_request(request.clone(), global);
 
     // Step 6. If globalObject is a ServiceWorkerGlobalScope object, then set request’s
     //         service-workers mode to "none".
     if global.is::<ServiceWorkerGlobalScope>() {
-        request_init.service_workers_mode = ServiceWorkersMode::None;
+        request_builder.service_workers_mode = ServiceWorkersMode::None;
     }
 
-    // Step 8. Let relevantRealm be this’s relevant realm.
+    // Step p8. Let relevantRealm be this’s relevant realm.
     //
     // Is `comp` as argument
 
@@ -276,12 +418,12 @@ pub(crate) fn Fetch(
         request: Trusted::new(&*request_object),
         global: Trusted::new(global),
         locally_aborted: false,
-        canceller: FetchCanceller::new(request_id, keep_alive, global.core_resource_thread()),
-        url: request_init.url.url(),
+        url: request_builder.url.url(),
     };
     let network_listener = NetworkListener::new(
         fetch_context,
         global.task_manager().networking_task_source().to_sendable(),
+        global,
     );
     let fetch_context = network_listener.context.clone();
 
@@ -290,7 +432,9 @@ pub(crate) fn Fetch(
 
     // Step 12. Set controller to the result of calling fetch given request and
     // processResponse given response being these steps:
-    global.fetch_with_network_listener(request_init, network_listener);
+    global
+        .fetch_group_mut()
+        .fetch(request_builder, network_listener);
 
     // Step 13. Return p.
     promise
@@ -317,14 +461,22 @@ fn queue_deferred_fetch(
         invoke_state: Cell::new(DeferredFetchRecordInvokeState::Pending),
         activated: Cell::new(false),
     });
+
     // Step 5. Append deferredRecord to request’s client’s fetch group’s deferred fetch records.
-    let deferred_fetch_record_id = global.append_deferred_fetch(deferred_record);
+    let deferred_fetch_record_id = DeferredFetchRecordId::default();
+    global
+        .fetch_group_mut()
+        .deferred_fetch_records
+        .insert(deferred_fetch_record_id, deferred_record);
+
     // Step 6. If activateAfter is non-null, then run the following steps in parallel:
     global.schedule_timer(TimerEventRequest {
         callback: Box::new(move || {
             // Step 6.2. Process deferredRecord.
             let global = trusted_global.root();
-            global.deferred_fetch_record_for_id(&deferred_fetch_record_id).process(&global);
+            let mut fetch_group = global.fetch_group_mut();
+            let deferred_fetch_record =fetch_group.deferred_fetch_record_for_id(&deferred_fetch_record_id);
+            fetch_group.process_a_deferred_fetch(&global, &deferred_fetch_record);
 
             // Last step of https://fetch.spec.whatwg.org/#process-a-deferred-fetch
             //
@@ -333,7 +485,7 @@ fn queue_deferred_fetch(
             let trusted_global = trusted_global.clone();
             global.task_manager().deferred_fetch_task_source().queue(
                 task!(notify_deferred_record: move || {
-                    trusted_global.root().deferred_fetch_record_for_id(&deferred_fetch_record_id).activate();
+                    trusted_global.root().fetch_group().deferred_fetch_record_for_id(&deferred_fetch_record_id).activate();
                 }),
             );
         }),
@@ -369,7 +521,7 @@ pub(crate) fn FetchLater(
         return Err(Error::JSFailed);
     }
     // Step 3. Let request be requestObject’s request.
-    let request = request_object.get_request();
+    let request = request_object.request();
     // Step 4. Let activateAfter be null.
     let mut activate_after = Finite::wrap(0_f64);
     // Step 5. If init is given and init["activateAfter"] exists, then set
@@ -415,7 +567,7 @@ pub(crate) fn FetchLater(
     // Step 12. Let activated be false.
     // Step 13. Let deferredRecord be the result of calling queue a deferred fetch given request,
     // activateAfter, and the following step: set activated to true.
-    let deferred_record_id = queue_deferred_fetch(request, activate_after, global_scope);
+    let deferred_record_id = queue_deferred_fetch(request.clone(), activate_after, global_scope);
     // Step 14. Add the following abort steps to requestObject’s signal: Set deferredRecord’s invoke state to "aborted".
     signal.add(&AbortAlgorithm::FetchLater(deferred_record_id));
     // Step 15. Return a new FetchLaterResult whose activated getter steps are to return activated.
@@ -457,27 +609,6 @@ impl DeferredFetchRecord {
         // whose activated getter steps are to return activated.
         self.activated.get()
     }
-    /// <https://fetch.spec.whatwg.org/#process-a-deferred-fetch>
-    pub(crate) fn process(&self, global: &GlobalScope) {
-        // Step 1. If deferredRecord’s invoke state is not "pending", then return.
-        if self.invoke_state.get() != DeferredFetchRecordInvokeState::Pending {
-            return;
-        }
-        // Step 2. Set deferredRecord’s invoke state to "sent".
-        self.invoke_state.set(DeferredFetchRecordInvokeState::Sent);
-        // Step 3. Fetch deferredRecord’s request.
-        let fetch_later_listener = FetchLaterListener {
-            url: self.request.url(),
-            global: Trusted::new(global),
-        };
-        let request_init = request_init_from_request(self.request.clone(), global);
-        global.fetch(
-            request_init,
-            fetch_later_listener,
-            global.task_manager().networking_task_source().to_sendable(),
-        );
-        // Step 4 is handled by caller
-    }
 }
 
 #[derive(JSTraceable, MallocSizeOf)]
@@ -488,7 +619,6 @@ pub(crate) struct FetchContext {
     request: Trusted<Request>,
     global: Trusted<GlobalScope>,
     locally_aborted: bool,
-    canceller: FetchCanceller,
     #[no_trace]
     url: ServoUrl,
 }
@@ -498,12 +628,22 @@ impl FetchContext {
     pub(crate) fn abort_fetch(&mut self, abort_reason: HandleValue, cx: &mut JSContext) {
         // Step 11.1. Set locallyAborted to true.
         self.locally_aborted = true;
+
         // Step 11.2. Assert: controller is non-null.
         //
-        // N/a, that's self
+        // Note: We currently prune fetch records that have finished
+        // (behaviorally equivalent to the specification and better for memory
+        // usage), so it might be the case that there is actually no controller
+        // here.
+        let global = self.global.root();
+        let request = self.request.root();
+        let mut fetch_group = global.fetch_group_mut();
+        let Some(controller) = fetch_group.fetch_controller(&request.request().id) else {
+            return;
+        };
 
         // Step 11.3. Abort controller with requestObject’s signal’s abort reason.
-        self.canceller.abort();
+        controller.abort();
 
         // Step 11.4. Abort the fetch() call with p, request, responseObject,
         // and requestObject’s signal’s abort reason.
@@ -514,10 +654,10 @@ impl FetchContext {
             .root();
         abort_fetch_call(
             promise,
-            &self.request.root(),
+            &request,
             Some(&self.response_object.root()),
             abort_reason,
-            &self.global.root(),
+            &global,
             cx,
         );
     }

--- a/components/script/fetch/fetch.rs
+++ b/components/script/fetch/fetch.rs
@@ -198,6 +198,16 @@ impl FetchGroup {
         self.deferred_fetch_records.values().cloned().collect()
     }
 
+    fn append_deferred_fetch(
+        &mut self,
+        deferred_record: DeferredFetchRecord,
+    ) -> DeferredFetchRecordId {
+        let deferred_fetch_record_id = DeferredFetchRecordId::default();
+        self.deferred_fetch_records
+            .insert(deferred_fetch_record_id, Rc::new(deferred_record));
+        deferred_fetch_record_id
+    }
+
     pub(crate) fn deferred_fetch_record_for_id(
         &self,
         deferred_fetch_record_id: &DeferredFetchRecordId,
@@ -274,7 +284,7 @@ impl FetchGroup {
         };
         let task_source = global.task_manager().networking_task_source().to_sendable();
         self.fetch(
-            request_init_from_request(deferred_fetch.request, global),
+            request_init_from_request(deferred_fetch.request.clone(), global),
             NetworkListener::new(fetch_later_listener, task_source, global),
         );
         // Step 4 is handled by caller
@@ -376,7 +386,7 @@ pub(crate) fn Fetch(
         Ok(r) => r,
     };
     // Step 3. Let request be requestObject’s request.
-    let request = request_object.request();
+    let request = request_object.request().clone();
 
     // Step 4. If requestObject’s signal is aborted, then:
     let signal = request_object.Signal();
@@ -398,7 +408,7 @@ pub(crate) fn Fetch(
 
     // Step 5. Let globalObject be request’s client’s global object.
     // NOTE:   We already get the global object as an argument
-    let mut request_builder = request_init_from_request(request.clone(), global);
+    let mut request_builder = request_init_from_request(request, global);
 
     // Step 6. If globalObject is a ServiceWorkerGlobalScope object, then set request’s
     //         service-workers mode to "none".
@@ -456,18 +466,16 @@ fn queue_deferred_fetch(
     // Step 3. Set request’s keepalive to true.
     request.keep_alive = true;
     // Step 4. Let deferredRecord be a new deferred fetch record whose request is request, and whose notify invoked is onActivatedWithoutTermination.
-    let deferred_record = Rc::new(DeferredFetchRecord {
+    let deferred_record = DeferredFetchRecord {
         request,
         invoke_state: Cell::new(DeferredFetchRecordInvokeState::Pending),
         activated: Cell::new(false),
-    });
+    };
 
     // Step 5. Append deferredRecord to request’s client’s fetch group’s deferred fetch records.
-    let deferred_fetch_record_id = DeferredFetchRecordId::default();
-    global
+    let deferred_fetch_record_id = global
         .fetch_group_mut()
-        .deferred_fetch_records
-        .insert(deferred_fetch_record_id, deferred_record);
+        .append_deferred_fetch(deferred_record);
 
     // Step 6. If activateAfter is non-null, then run the following steps in parallel:
     global.schedule_timer(TimerEventRequest {
@@ -632,19 +640,19 @@ impl FetchContext {
 
         // Step 11.2. Assert: controller is non-null.
         //
-        // Note: We currently prune fetch records that have finished
-        // (behaviorally equivalent to the specification and better for memory
-        // usage), so it might be the case that there is actually no controller
-        // here.
-        let global = self.global.root();
-        let request = self.request.root();
-        let mut fetch_group = global.fetch_group_mut();
-        let Some(controller) = fetch_group.fetch_controller(&request.request().id) else {
-            return;
-        };
+        // Note: We currently prune fetch records that have finished (behaviorally
+        // equivalent to the specification and better for memory usage), so it might be
+        // the case that the `FetchRecord` is gone and the controller inaccessible.
 
         // Step 11.3. Abort controller with requestObject’s signal’s abort reason.
-        controller.abort();
+        let global = self.global.root();
+        let request = self.request.root();
+        if let Some(controller) = global
+            .fetch_group_mut()
+            .fetch_controller(&request.request().id)
+        {
+            controller.abort();
+        }
 
         // Step 11.4. Abort the fetch() call with p, request, responseObject,
         // and requestObject’s signal’s abort reason.

--- a/components/script/fetch/fetch.rs
+++ b/components/script/fetch/fetch.rs
@@ -274,7 +274,7 @@ impl FetchGroup {
         };
         let task_source = global.task_manager().networking_task_source().to_sendable();
         self.fetch(
-            request_init_from_request(deferred_fetch.request.clone(), global),
+            request_init_from_request(deferred_fetch.request, global),
             NetworkListener::new(fetch_later_listener, task_source, global),
         );
         // Step 4 is handled by caller
@@ -406,7 +406,7 @@ pub(crate) fn Fetch(
         request_builder.service_workers_mode = ServiceWorkersMode::None;
     }
 
-    // Step p8. Let relevantRealm be this’s relevant realm.
+    // Step 8. Let relevantRealm be this’s relevant realm.
     //
     // Is `comp` as argument
 
@@ -475,7 +475,8 @@ fn queue_deferred_fetch(
             // Step 6.2. Process deferredRecord.
             let global = trusted_global.root();
             let mut fetch_group = global.fetch_group_mut();
-            let deferred_fetch_record =fetch_group.deferred_fetch_record_for_id(&deferred_fetch_record_id);
+            let deferred_fetch_record =
+                fetch_group.deferred_fetch_record_for_id(&deferred_fetch_record_id);
             fetch_group.process_a_deferred_fetch(&global, &deferred_fetch_record);
 
             // Last step of https://fetch.spec.whatwg.org/#process-a-deferred-fetch

--- a/components/script/fetch/network_listener.rs
+++ b/components/script/fetch/network_listener.rs
@@ -14,6 +14,7 @@ use net_traits::{
 use servo_url::ServoUrl;
 
 use crate::dom::bindings::inheritance::Castable;
+use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::performance::performanceentry::PerformanceEntry;
@@ -130,20 +131,35 @@ pub(crate) trait FetchResponseListener: Send + 'static {
 pub(crate) struct NetworkListener<Listener: FetchResponseListener> {
     pub(crate) context: Arc<Mutex<Option<Listener>>>,
     pub(crate) task_source: SendableTaskSource,
+    /// The [`GlobalScope`] this [`NetworkListener`] was created for.
+    pub(crate) global_scope: Trusted<GlobalScope>,
 }
 
 impl<Listener: FetchResponseListener> NetworkListener<Listener> {
-    pub(crate) fn new(context: Listener, task_source: SendableTaskSource) -> Self {
+    pub(crate) fn new(
+        context: Listener,
+        task_source: SendableTaskSource,
+        global_scope: &GlobalScope,
+    ) -> Self {
         Self {
             context: Arc::new(Mutex::new(Some(context))),
             task_source,
+            global_scope: Trusted::new(global_scope),
         }
     }
 
     pub(crate) fn notify(&mut self, message: FetchResponseMsg) {
         let context = self.context.clone();
+        let global_scope = self.global_scope.clone();
         self.task_source
             .queue(task!(network_listener_response: move |cx| {
+                if let FetchResponseMsg::ProcessResponseEOF(request_id, ..) = &message {
+                    global_scope
+                        .root()
+                        .fetch_group_mut()
+                        .mark_fetch_request_as_done(request_id);
+                }
+
                 let mut context = context.lock().unwrap();
                 let Some(fetch_listener) = &mut *context else {
                     return;

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -366,7 +366,7 @@ pub(crate) fn navigate(
     force_reload: bool,
     mut load_data: LoadData,
 ) {
-    let doc = window.Document();
+    let document = window.Document();
 
     // <https://html.spec.whatwg.org/multipage/#process-a-navigate-fetch>
     if force_reload {
@@ -385,7 +385,7 @@ pub(crate) fn navigate(
     let window_proxy = window.window_proxy();
     if let Some(active) = window_proxy.currently_active() &&
         pipeline_id == active &&
-        doc.is_prompting_or_unloading()
+        document.is_prompting_or_unloading()
     {
         return;
     }
@@ -399,7 +399,8 @@ pub(crate) fn navigate(
         // Note: `targetNavigable` is not actually defined in the spec, "active document" is
         // assumed to be the correct reference based on WPT results
         if let LoadOrigin::Script(initiator_origin) = initiator_origin_snapshot {
-            if load_data.url == doc.url() && initiator_origin.same_origin(&*doc.origin()) {
+            if load_data.url == document.url() && initiator_origin.same_origin(&*document.origin())
+            {
                 NavigationHistoryBehavior::Replace
             } else {
                 // Step 12.2. Otherwise, set historyHandling to "push".
@@ -417,12 +418,12 @@ pub(crate) fn navigate(
     // document, then set historyHandling to "replace".
     //
     // Inlines implementation of https://html.spec.whatwg.org/multipage/#the-navigation-must-be-a-replace
-    let history_handling = if load_data.url.scheme() == "javascript" || doc.is_initial_about_blank()
-    {
-        NavigationHistoryBehavior::Replace
-    } else {
-        history_handling
-    };
+    let history_handling =
+        if load_data.url.scheme() == "javascript" || document.is_initial_about_blank() {
+            NavigationHistoryBehavior::Replace
+        } else {
+            history_handling
+        };
 
     // Step 14. If all of the following are true:
     // > documentResource is null;
@@ -430,7 +431,7 @@ pub(crate) fn navigate(
     if !force_reload
         // > url equals navigable's active session history entry's URL with exclude fragments set to true; and
         && load_data.url.as_url()[..Position::AfterQuery] ==
-            doc.url().as_url()[..Position::AfterQuery]
+            document.url().as_url()[..Position::AfterQuery]
         // > url's fragment is non-null,
         && load_data.url.fragment().is_some()
     {
@@ -528,7 +529,7 @@ pub(crate) fn navigate(
 
     // Step 24.1. Let unloadPromptCanceled be the result of checking if unloading
     // is canceled for navigable's active document's inclusive descendant navigables.
-    let unload_prompt_canceled = doc.check_if_unloading_is_cancelled(cx, false);
+    let unload_prompt_canceled = document.check_if_unloading_is_cancelled(cx, false);
     // Step 24.2. If unloadPromptCanceled is not "continue",
     // or navigable's ongoing navigation is no longer navigationId:
     //
@@ -545,7 +546,7 @@ pub(crate) fn navigate(
     // Step 24.4. Queue a global task on the navigation and traversal task source given
     // navigable's active window to abort a document and its descendants given navigable's
     // active document.
-    let trusted_document = Trusted::new(&*window.Document());
+    let trusted_document = Trusted::new(&*document);
     window
         .task_manager()
         .navigation_and_traversal_task_source()

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -518,27 +518,42 @@ pub(crate) fn navigate(
         return;
     }
 
-    // Step 23. In parallel, run these steps:
+    // Step 23. If sourceDocument is navigable's container document, then reserve deferred
+    // fetch quota for navigable's container given url's origin.
+    // TODO: Implement this.
+
+    // Step 24. In parallel, run these steps:
     //
     // TODO: in parallel
 
-    // Step 23.1. Let unloadPromptCanceled be the result of checking if unloading
+    // Step 24.1. Let unloadPromptCanceled be the result of checking if unloading
     // is canceled for navigable's active document's inclusive descendant navigables.
     let unload_prompt_canceled = doc.check_if_unloading_is_cancelled(cx, false);
-    // Step 23.2. If unloadPromptCanceled is not "continue",
+    // Step 24.2. If unloadPromptCanceled is not "continue",
     // or navigable's ongoing navigation is no longer navigationId:
     //
     // TODO: Check for ongoing navigation
     if !unload_prompt_canceled {
-        // Step 23.2.1. Invoke WebDriver BiDi navigation failed with navigable
+        // Step 24.2.1. Invoke WebDriver BiDi navigation failed with navigable
         // and a new WebDriver BiDi navigation status whose id is navigationId,
         // status is "canceled", and url is url.
         // TODO
-        // Step 23.2.2. Abort these steps.
+        // Step 24.2.2. Abort these steps.
         return;
     }
 
-    // Step 23.9. Attempt to populate the history entry's document for historyEntry,
+    // Step 24.4. Queue a global task on the navigation and traversal task source given
+    // navigable's active window to abort a document and its descendants given navigable's
+    // active document.
+    let trusted_document = Trusted::new(&*window.Document());
+    window
+        .task_manager()
+        .navigation_and_traversal_task_source()
+        .queue(task!(abort_a_document_and_its_descendants: move |cx| {
+            trusted_document.root().abort_a_document_and_its_descendants(cx);
+        }));
+
+    // Step 24.9. Attempt to populate the history entry's document for historyEntry,
     // given navigable, "navigate", sourceSnapshotParams, targetSnapshotParams,
     // userInvolvement, navigationId, navigationParams, cspNavigationType,
     // with allowPOST set to true and completionSteps set to the following step:

--- a/tests/wpt/meta/cookies/partitioned-cookies/partitioned-cookies-top-level-redirect.tentative.https.html.ini
+++ b/tests/wpt/meta/cookies/partitioned-cookies/partitioned-cookies-top-level-redirect.tentative.https.html.ini
@@ -1,3 +1,0 @@
-[partitioned-cookies-top-level-redirect.tentative.https.html]
-  [Partitioned Cookies are available in top-level cross-site to same-site redirects]
-    expected: FAIL

--- a/tests/wpt/meta/fetch/fetch-later/send-on-deactivate.https.window.js.ini
+++ b/tests/wpt/meta/fetch/fetch-later/send-on-deactivate.https.window.js.ini
@@ -4,6 +4,3 @@
 
   [fetchLater() does not send aborted request on navigating away a page w/o BFCache.]
     expected: FAIL
-
-  [fetchLater() with activateAfter=1m sends on page entering BFCache if BackgroundSync is off.]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/eligibility/inflight-fetch-1.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/eligibility/inflight-fetch-1.html.ini
@@ -1,0 +1,6 @@
+[inflight-fetch-1.html]
+  [Eligibility (in-flight fetch): Header received before BFCache and body received when in BFCache]
+    expected: PRECONDITION_FAILED
+
+  [Eligibility (in-flight fetch): Header received before BFCache and body received after BFCache]
+    expected: PRECONDITION_FAILED

--- a/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/eligibility/inflight-fetch-2.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/eligibility/inflight-fetch-2.html.ini
@@ -1,0 +1,9 @@
+[inflight-fetch-2.html]
+  [Eligibility (in-flight fetch): Header and body received when in BFCache]
+    expected: PRECONDITION_FAILED
+
+  [Eligibility (in-flight fetch): Header received when in BFCache and body received after BFCache]
+    expected: PRECONDITION_FAILED
+
+  [Eligibility (in-flight fetch): Header and body received after BFCache]
+    expected: PRECONDITION_FAILED

--- a/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/eligibility/inflight-fetch-cors.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/eligibility/inflight-fetch-cors.html.ini
@@ -1,0 +1,6 @@
+[inflight-fetch-cors.html]
+  [Eligibility (in-flight fetch): CORS succeeded when in BFCache]
+    expected: PRECONDITION_FAILED
+
+  [Eligibility (in-flight fetch): CORS failed when in BFCache]
+    expected: PRECONDITION_FAILED

--- a/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/eligibility/inflight-fetch-redirects.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/eligibility/inflight-fetch-redirects.html.ini
@@ -1,0 +1,12 @@
+[inflight-fetch-redirects.html]
+  [Eligibility (in-flight fetch): Redirect header received when in BFCache]
+    expected: PRECONDITION_FAILED
+
+  [Eligibility (in-flight fetch): Redirect header received when in BFCache w/ CSP passing]
+    expected: PRECONDITION_FAILED
+
+  [Eligibility (in-flight fetch): Cross-origin redirect header received when in BFCache]
+    expected: PRECONDITION_FAILED
+
+  [Eligibility (in-flight fetch): Cross-origin redirect header received when in BFCache w/ CSP failing]
+    expected: PRECONDITION_FAILED


### PR DESCRIPTION
The specification says to run this run "abort a document and its
descendants given navigable's active document" during navigation. This
prevents loads that happen quickly from causing flakes.

This requires implementing more of the specification around fetch
records and integrating the `FetchCanceller` concept into it. This has
the effect of letting `DocumentLoader` take care of blocking loads and
the `FetchGroup` take care of fetch records and cancellation, a much
better alignment with the specification.

One issue addressed by this change (by necessity) is that before any
canceller remaining in the `DocumentLoader` made the `Document` be
considered unsalvageable. Now we follow the specification more closely
and only fetch records that are not already marked done and are not for
keep-alive requests move the `Document` to an unsalvageable state.

Testing: This change causes one subtest to start passing and a variety of other
to hit PRECONDITION_FAILED. The previous passing result for those tests was a
false positive, so this is a progression that matches Firefox's behavior. We
also are lacking the special code to ensure that unsalvageable pages can live
in the BFCache.
