### PR TITLE
script: Update selection paint ranges without relayout

### DIFF
--- a/components/layout/construct_modern.rs
+++ b/components/layout/construct_modern.rs
@@ -83,7 +83,7 @@ impl<'dom> ModernContainerJob<'dom> {
                     inline_formatting_context_builder.push_text(
                         flex_text_run.text,
                         &flex_text_run.info,
-                        flex_text_run.info.node.selection_for_text_node(),
+                        flex_text_run.info.node.text_node_selection(),
                     );
                 }
 

--- a/components/layout/construct_modern.rs
+++ b/components/layout/construct_modern.rs
@@ -83,7 +83,7 @@ impl<'dom> ModernContainerJob<'dom> {
                     inline_formatting_context_builder.push_text(
                         flex_text_run.text,
                         &flex_text_run.info,
-                        flex_text_run.info.node.document_selection_in_text_node(),
+                        flex_text_run.info.node.selection_for_text_node(),
                     );
                 }
 

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1324,7 +1324,7 @@ impl Fragment {
         // OffsetMap contained within `run_data` to convert it to post-transformed character
         // offsets. This allows updating this selection directly from the DOM (skipping layout).
         let selection_character_range =
-            run_data.map_dom_range_to_transformed_range(shared_selection.character_range.clone());
+            run_data.map_dom_range_to_transformed_range(shared_selection.character_range);
 
         if fragment.character_range_in_dom_node.start > selection_character_range.end ||
             fragment.character_range_in_dom_node.end < selection_character_range.start

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1400,6 +1400,10 @@ impl Fragment {
             return;
         }
 
+        if !fragment.run_data.paint_caret {
+            return;
+        }
+
         let insertion_point_rect = Rect::new(
             containing_block_rect.origin + Vector2D::new(start_x + fragment_x_offset, Au::zero()),
             Size2D::new(

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1323,10 +1323,8 @@ impl Fragment {
         // The selection character range is in pre-transformed character offsets, so use the
         // OffsetMap contained within `run_data` to convert it to post-transformed character
         // offsets. This allows updating this selection directly from the DOM (skipping layout).
-        let dom_selection_range = &shared_selection.character_range;
-        let selection_character_range = run_data.map_dom_range_to_transformed_range(
-            Utf32CodeUnits(dom_selection_range.start)..Utf32CodeUnits(dom_selection_range.end),
-        );
+        let selection_character_range =
+            run_data.map_dom_range_to_transformed_range(shared_selection.character_range.clone());
 
         if fragment.character_range_in_dom_node.start > selection_character_range.end ||
             fragment.character_range_in_dom_node.end < selection_character_range.start

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1046,7 +1046,7 @@ impl Fragment {
         let mut baseline_origin = rect.origin;
         baseline_origin.y += fragment.font_metrics.ascent;
 
-        let include_whitespace = fragment.run_data.selection.is_some() ||
+        let include_whitespace = fragment.run_data.selection.borrow().is_some() ||
             state
                 .text_decorations
                 .iter()
@@ -1311,20 +1311,14 @@ impl Fragment {
         justification_adjustment: Au,
     ) {
         let run_data = &fragment.run_data;
-        let Some(shared_selection) = &run_data.selection else {
+        let Some(selection) = *run_data.selection.borrow() else {
             return;
         };
-
-        let shared_selection = shared_selection.borrow();
-        if !shared_selection.enabled {
-            return;
-        }
 
         // The selection character range is in pre-transformed character offsets, so use the
         // OffsetMap contained within `run_data` to convert it to post-transformed character
         // offsets. This allows updating this selection directly from the DOM (skipping layout).
-        let selection_character_range =
-            run_data.map_dom_range_to_transformed_range(shared_selection.character_range);
+        let selection_character_range = run_data.map_dom_range_to_transformed_range(selection);
 
         if fragment.character_range_in_dom_node.start > selection_character_range.end ||
             fragment.character_range_in_dom_node.end < selection_character_range.start

--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -12,6 +12,7 @@ use layout_api::{
 use malloc_size_of_derive::MallocSizeOf;
 use script::layout_dom::ServoLayoutNode;
 use servo_arc::Arc as ServoArc;
+use servo_base::text::{RangeAny, Utf32CodeUnits};
 use smallvec::SmallVec;
 use style::context::SharedStyleContext;
 use style::properties::ComputedValues;
@@ -281,6 +282,15 @@ impl LayoutDataTrait for DOMLayoutData {}
 impl GenericLayoutDataTrait for DOMLayoutData {
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn set_text_run_selection(&self, new_range: Option<RangeAny<Utf32CodeUnits>>) -> bool {
+        if let Some(LayoutBox::Text(text_run)) = &*self.0.borrow().self_box.borrow() {
+            *text_run.borrow().run_data.selection.borrow_mut() = new_range;
+            true
+        } else {
+            false
+        }
     }
 }
 

--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -286,12 +286,14 @@ impl GenericLayoutDataTrait for DOMLayoutData {
 
     fn set_text_run_selection(&self, new_range: Option<RangeAny<Utf32CodeUnits>>) -> bool {
         let inner = self.0.borrow();
-        for pseudo_box in &inner.pseudo_boxes {
-            if let PseudoElement::FirstLetter = pseudo_box.pseudo {
-                // When `::first-letter` is used, one DOM text node can generate multiple text runs
-                // so there isn’t a single place to set the new range
-                return false;
-            }
+        // When `::first-letter` is used, one DOM text node can generate multiple text runs
+        // so there isn’t a single place to set the new range
+        if inner
+            .pseudo_boxes
+            .iter()
+            .any(|pseudo_box| matches!(pseudo_box.pseudo, PseudoElement::FirstLetter))
+        {
+            return false;
         }
         if let Some(LayoutBox::Text(text_run)) = &*inner.self_box.borrow() {
             *text_run.borrow().run_data.selection.borrow_mut() = new_range;

--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -285,7 +285,15 @@ impl GenericLayoutDataTrait for DOMLayoutData {
     }
 
     fn set_text_run_selection(&self, new_range: Option<RangeAny<Utf32CodeUnits>>) -> bool {
-        if let Some(LayoutBox::Text(text_run)) = &*self.0.borrow().self_box.borrow() {
+        let inner = self.0.borrow();
+        for pseudo_box in &inner.pseudo_boxes {
+            if let PseudoElement::FirstLetter = pseudo_box.pseudo {
+                // When `::first-letter` is used, one DOM text node can generate multiple text runs
+                // so there isn’t a single place to set the new range
+                return false;
+            }
+        }
+        if let Some(LayoutBox::Text(text_run)) = &*inner.self_box.borrow() {
             *text_run.borrow().run_data.selection.borrow_mut() = new_range;
             true
         } else {

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -316,7 +316,7 @@ impl InlineFormattingContextBuilder {
         container_info: &NodeAndStyleInfo<'dom>,
         layout_context: &LayoutContext,
     ) -> bool {
-        let selection = info.node.selection_for_text_node();
+        let selection = info.node.text_node_selection();
         if self.has_processed_first_letter || !container_info.pseudo_element_chain().is_empty() {
             self.push_text(text, info, selection);
             return false;
@@ -474,6 +474,7 @@ impl InlineFormattingContextBuilder {
                 character_range_in_ifc_text: new_character_range,
                 original_offset: original_size_before,
                 selection: AtomicRefCell::new(selection),
+                paint_caret: info.node.text_node_paints_caret(),
                 offset_map: self.offset_map.clone(),
             }
             .into(),

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -453,21 +453,18 @@ impl InlineFormattingContextBuilder {
         }
 
         let selection = info.node.form_control_selection_in_text_node().or_else(|| {
-            let document_selection = document_selection?;
-            // Range unbounded at the start: the concrete start is offset zero.
-            let start = document_selection.start.unwrap_or(Utf32CodeUnits(0));
-            // Range unbounded at the end: the concrete end is the full length.
-            let end = document_selection
-                .end
-                .unwrap_or(offset_map.total_original_size() - original_size_before);
-
-            if start == end {
-                return None;
+            let character_range = document_selection?;
+            if let Some(start) = character_range.start &&
+                let Some(end) = character_range.end
+            {
+                if start == end {
+                    return None;
+                }
+                debug_assert!(end > start);
             }
-            debug_assert!(end > start);
 
             Some(Arc::new(AtomicRefCell::new(ScriptSelection {
-                character_range: start..end,
+                character_range,
                 enabled: true,
             })))
         });

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -8,7 +8,6 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
-use fonts::TextByteRange;
 use icu_properties::BidiClass;
 use layout_api::{LayoutNode, ScriptSelection};
 use servo_base::text::{RangeAny, Utf32CodeUnits};
@@ -468,7 +467,6 @@ impl InlineFormattingContextBuilder {
             debug_assert!(end > start);
 
             Some(Arc::new(AtomicRefCell::new(ScriptSelection {
-                range: TextByteRange::default(),
                 character_range: start.0..end.0,
                 enabled: true,
             })))

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -467,7 +467,7 @@ impl InlineFormattingContextBuilder {
             debug_assert!(end > start);
 
             Some(Arc::new(AtomicRefCell::new(ScriptSelection {
-                character_range: start.0..end.0,
+                character_range: start..end,
                 enabled: true,
             })))
         });

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -5,11 +5,10 @@
 use std::borrow::Cow;
 use std::cell::LazyCell;
 use std::ops::Range;
-use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
 use icu_properties::BidiClass;
-use layout_api::{LayoutNode, ScriptSelection};
+use layout_api::LayoutNode;
 use servo_base::text::{RangeAny, Utf32CodeUnits};
 use style::computed_values::direction::T as Direction;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
@@ -317,16 +316,16 @@ impl InlineFormattingContextBuilder {
         container_info: &NodeAndStyleInfo<'dom>,
         layout_context: &LayoutContext,
     ) -> bool {
-        let document_selection = info.node.document_selection_in_text_node();
+        let selection = info.node.selection_for_text_node();
         if self.has_processed_first_letter || !container_info.pseudo_element_chain().is_empty() {
-            self.push_text(text, info, document_selection);
+            self.push_text(text, info, selection);
             return false;
         }
 
         let Some(first_letter_info) =
             container_info.with_pseudo_element(layout_context, PseudoElement::FirstLetter)
         else {
-            self.push_text(text, info, document_selection);
+            self.push_text(text, info, selection);
             return false;
         };
 
@@ -342,14 +341,13 @@ impl InlineFormattingContextBuilder {
         });
         if first_letter_range.start != 0 {
             let leading_whitespace_range = 0..first_letter_range.start;
-            let leading_whitespace_selection_range =
-                document_selection.and_then(|document_selection| {
-                    let leading_whitespace_range_u32 = RangeAny {
-                        start: None,
-                        end: Some(first_letter_range_u32.start),
-                    };
-                    document_selection.intersect(leading_whitespace_range_u32)
-                });
+            let leading_whitespace_selection_range = selection.and_then(|range| {
+                let leading_whitespace_range_u32 = RangeAny {
+                    start: None,
+                    end: Some(first_letter_range_u32.start),
+                };
+                range.intersect(leading_whitespace_range_u32)
+            });
 
             self.push_text(
                 Cow::Borrowed(&text[leading_whitespace_range]).into(),
@@ -367,8 +365,8 @@ impl InlineFormattingContextBuilder {
         box_slot.set(LayoutBox::InlineLevel(inline_item));
 
         let first_letter_text = Cow::Borrowed(&text[first_letter_range.clone()]);
-        let first_letter_selection_range = document_selection.and_then(|document_selection| {
-            document_selection
+        let first_letter_selection_range = selection.and_then(|range| {
+            range
                 .intersect((*first_letter_range_u32).clone().into())
                 .map(|range| range.map(|offset| offset - first_letter_range_u32.start))
         });
@@ -381,12 +379,12 @@ impl InlineFormattingContextBuilder {
         self.has_processed_first_letter = true;
 
         // Now push the non-first-letter text.
-        let remaining_selection_range = document_selection.and_then(|document_selection| {
+        let remaining_selection_range = selection.and_then(|range| {
             let remaining_text_range_u32 = RangeAny {
                 start: Some(first_letter_range_u32.end),
-                end: document_selection.end,
+                end: range.end,
             };
-            document_selection
+            range
                 .intersect(remaining_text_range_u32)
                 .map(|range| range.map(|offset| offset - first_letter_range_u32.end))
         });
@@ -403,7 +401,7 @@ impl InlineFormattingContextBuilder {
         &mut self,
         text: BoxTreeString<'dom>,
         info: &NodeAndStyleInfo<'dom>,
-        document_selection: Option<RangeAny<Utf32CodeUnits>>,
+        selection: Option<RangeAny<Utf32CodeUnits>>,
     ) {
         let mut offset_map = self.offset_map.borrow_mut();
         let original_size_before = offset_map.total_original_size();
@@ -452,23 +450,6 @@ impl InlineFormattingContextBuilder {
             return;
         }
 
-        let selection = info.node.form_control_selection_in_text_node().or_else(|| {
-            let character_range = document_selection?;
-            if let Some(start) = character_range.start &&
-                let Some(end) = character_range.end
-            {
-                if start == end {
-                    return None;
-                }
-                debug_assert!(end > start);
-            }
-
-            Some(Arc::new(AtomicRefCell::new(ScriptSelection {
-                character_range,
-                enabled: true,
-            })))
-        });
-
         if let Some(last_character) = new_text.chars().next_back() {
             self.on_word_boundary = last_character.is_whitespace();
             self.last_inline_box_ended_with_collapsible_white_space =
@@ -492,7 +473,7 @@ impl InlineFormattingContextBuilder {
                 inline_styles: current_inline_styles,
                 character_range_in_ifc_text: new_character_range,
                 original_offset: original_size_before,
-                selection,
+                selection: AtomicRefCell::new(selection),
                 offset_map: self.offset_map.clone(),
             }
             .into(),

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -335,6 +335,8 @@ pub(crate) struct SharedTextRunData {
     /// selection.
     // TODO: make this more compact with a pair of `AtomicUsize`?
     pub selection: AtomicRefCell<Option<RangeAny<Utf32CodeUnits>>>,
+    /// Whether a caret should be painted when the selection is an empty range (start == end)
+    pub paint_caret: bool,
     /// The [`OffsetMap`] used when creating this `TextRun`'s `InlineFormattingContext`. This
     /// is used for mapping between DOM text offsets and layout text offsets (and vice-versa).
     pub offset_map: ArcRefCell<OffsetMap>,
@@ -536,8 +538,8 @@ impl TextRun {
 
             if character == '\n' {
                 finish_current_segment(&mut current, &mut results);
-                let has_selection = self.run_data.selection.borrow().is_some();
-                results.push(TextRunItem::LineBreak(has_selection.then(|| {
+                let paint_caret = self.run_data.paint_caret;
+                results.push(TextRunItem::LineBreak(paint_caret.then(|| {
                     CaretPlaceholder {
                         run_data: self.run_data.clone(),
                         base_fragment_info: self.base_fragment_info,

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -7,11 +7,11 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use app_units::Au;
+use atomic_refcell::AtomicRefCell;
 use fonts::font_feature_values::ResolvedFontVariantAlternates;
 use fonts::{FontContext, FontRef, ShapedText, ShapedTextSlice, ShapingFlags, ShapingOptions};
 use icu_locid::subtags::Language;
 use icu_properties::{self, LineBreak};
-use layout_api::SharedSelection;
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use servo_arc::Arc as ServoArc;
@@ -333,8 +333,8 @@ pub(crate) struct SharedTextRunData {
     pub original_offset: Utf32CodeUnits,
     /// The selected text in this `TextRun`. This may either be document selection or form control
     /// selection.
-    #[conditional_malloc_size_of]
-    pub selection: Option<SharedSelection>,
+    // TODO: make this more compact with a pair of `AtomicUsize`?
+    pub selection: AtomicRefCell<Option<RangeAny<Utf32CodeUnits>>>,
     /// The [`OffsetMap`] used when creating this `TextRun`'s `InlineFormattingContext`. This
     /// is used for mapping between DOM text offsets and layout text offsets (and vice-versa).
     pub offset_map: ArcRefCell<OffsetMap>,
@@ -536,15 +536,16 @@ impl TextRun {
 
             if character == '\n' {
                 finish_current_segment(&mut current, &mut results);
-                results.push(TextRunItem::LineBreak(
-                    self.run_data.selection.is_some().then(|| CaretPlaceholder {
+                let has_selection = self.run_data.selection.borrow().is_some();
+                results.push(TextRunItem::LineBreak(has_selection.then(|| {
+                    CaretPlaceholder {
                         run_data: self.run_data.clone(),
                         base_fragment_info: self.base_fragment_info,
                         // The placeholder that is placed after a newline is for the index after that newline.
                         // The newline itself is at the end of the previous line.
                         character_index: relative_character_index + 1,
-                    }),
-                ));
+                    }
+                })));
                 continue;
             }
 

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -15,7 +15,7 @@ use layout_api::SharedSelection;
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use servo_arc::Arc as ServoArc;
-use servo_base::text::{Utf32CodeUnits, is_bidi_control};
+use servo_base::text::{RangeAny, Utf32CodeUnits, is_bidi_control};
 use smallvec::SmallVec;
 use style::Zero;
 use style::computed_values::font_kerning::T as FontKerning;
@@ -346,12 +346,21 @@ impl SharedTextRunData {
     /// text.
     pub(crate) fn map_dom_range_to_transformed_range(
         &self,
-        range: Range<Utf32CodeUnits>,
+        dom_range: RangeAny<Utf32CodeUnits>,
     ) -> Range<Utf32CodeUnits> {
         let offset_map = self.offset_map.borrow();
         let offset_in_ifc_text = Utf32CodeUnits(self.character_range_in_ifc_text.start);
-        offset_map.map(range.start + self.original_offset) - offset_in_ifc_text..
-            offset_map.map(range.end + self.original_offset) - offset_in_ifc_text
+        let start = if let Some(dom_start) = dom_range.start {
+            offset_map.map(dom_start + self.original_offset) - offset_in_ifc_text
+        } else {
+            Utf32CodeUnits(0)
+        };
+        let end = if let Some(dom_end) = dom_range.end {
+            offset_map.map(dom_end + self.original_offset) - offset_in_ifc_text
+        } else {
+            Utf32CodeUnits(self.character_range_in_ifc_text.len())
+        };
+        start..end
     }
 
     /// Map an offset in the originating `TextRun`s DOM node's transformed text (by white

--- a/components/script/dom/characterdata/characterdata.rs
+++ b/components/script/dom/characterdata/characterdata.rs
@@ -111,11 +111,11 @@ impl CharacterData {
         &self,
         new_range: Option<RangeAny<Utf32CodeUnits>>,
     ) -> bool {
-        if let Some(layout_data) = &*self.upcast::<Node>().layout_data().borrow() {
-            layout_data.set_text_run_selection(new_range)
-        } else {
-            false
-        }
+        self.upcast::<Node>()
+            .layout_data()
+            .borrow()
+            .as_ref()
+            .is_some_and(|layout_data| layout_data.set_text_run_selection(new_range))
     }
 }
 

--- a/components/script/dom/characterdata/characterdata.rs
+++ b/components/script/dom/characterdata/characterdata.rs
@@ -9,7 +9,7 @@ use atomic_refcell::{AtomicRef, AtomicRefCell};
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::codegen::InheritTypes::{CharacterDataTypeId, NodeTypeId, TextTypeId};
-use servo_base::text::Utf16CodeUnits;
+use servo_base::text::{RangeAny, Utf16CodeUnits, Utf32CodeUnits};
 
 use crate::dom::bindings::cell::AtomicSafeBorrowMut;
 use crate::dom::bindings::codegen::Bindings::CharacterDataBinding::CharacterDataMethods;
@@ -104,6 +104,18 @@ impl CharacterData {
             old_value: self.data.borrow().clone(),
         });
         MutationObserver::queue_a_mutation_record(cx, self.upcast::<Node>(), mutation);
+    }
+
+    /// Returns whether `new_range` was successfully set on an existing text run
+    pub(crate) fn set_text_run_selection(
+        &self,
+        new_range: Option<RangeAny<Utf32CodeUnits>>,
+    ) -> bool {
+        if let Some(layout_data) = &*self.upcast::<Node>().layout_data().borrow() {
+            layout_data.set_text_run_selection(new_range)
+        } else {
+            false
+        }
     }
 }
 

--- a/components/script/dom/html/form_controls/htmlinputelement.rs
+++ b/components/script/dom/html/form_controls/htmlinputelement.rs
@@ -1008,7 +1008,7 @@ impl TextControlElement for HTMLInputElement {
         text_input.previous_selection_range = selection_range;
         text_input.selection_for_layout = selection;
 
-        if let Some(text_input_widget) = self.input_type.borrow().text_input_widget() {
+        if let Some(text_input_widget) = self.input_type.borrow().as_specific().text_input_widget() {
             if text_input_widget.borrow().set_text_run_selection(selection) {
                 // Found an already laid out text run to update, so we only need to repaint:
                 self.owner_window().layout().set_needs_new_display_list();

--- a/components/script/dom/html/form_controls/htmlinputelement.rs
+++ b/components/script/dom/html/form_controls/htmlinputelement.rs
@@ -17,12 +17,11 @@ use js::rust::wrappers2::{
     NewDateObject, NewUCRegExpObject, ObjectIsDate, ObjectIsRegExp,
 };
 use js::rust::{HandleObject, MutableHandleObject};
-use layout_api::{ScriptSelection, SharedSelection};
 use num_traits::ToPrimitive;
 use script_bindings::cell::{DomRefCell, Ref};
 use script_bindings::domstring::parse_floating_point_number;
 use servo_base::generic_channel::GenericSender;
-use servo_base::text::Utf16CodeUnits;
+use servo_base::text::{RangeAny, Utf16CodeUnits, Utf32CodeUnits};
 use style::attr::AttrValue;
 use style::str::split_commas;
 use stylo_atoms::Atom;
@@ -120,12 +119,6 @@ pub(crate) struct HTMLInputElement {
     textinput: DomRefCell<TextInput<EmbedderClipboardProvider>>,
     /// <https://html.spec.whatwg.org/multipage/#concept-input-value-dirty-flag>
     value_dirty: Cell<bool>,
-    /// A [`SharedSelection`] that is shared with layout. This can be updated dyanmnically
-    /// and layout should reflect the new value after a display list update.
-    #[no_trace]
-    #[conditional_malloc_size_of]
-    shared_selection: SharedSelection,
-
     form_owner: MutNullableDom<HTMLFormElement>,
     labels_node_list: MutNullableDom<NodeList>,
     validity_state: MutNullableDom<ValidityState>,
@@ -185,7 +178,6 @@ impl HTMLInputElement {
                 },
             )),
             value_dirty: Cell::new(false),
-            shared_selection: Default::default(),
             form_owner: Default::default(),
             labels_node_list: MutNullableDom::new(None),
             validity_state: Default::default(),
@@ -946,11 +938,14 @@ impl<'dom> LayoutDom<'dom, HTMLInputElement> {
         self.unsafe_get().size.get()
     }
 
-    pub(crate) fn selection_for_layout(self) -> Option<SharedSelection> {
-        if !self.unsafe_get().is_textual_or_password.get() {
+    pub(crate) fn selection_for_layout(self) -> Option<RangeAny<Utf32CodeUnits>> {
+        let element = self.unsafe_get();
+        if !element.is_textual_or_password.get() {
             return None;
         }
-        Some(self.unsafe_get().shared_selection.clone())
+        #[expect(unsafe_code)]
+        let textinput = unsafe { element.textinput.borrow_for_layout() };
+        textinput.selection_for_layout
     }
 }
 
@@ -993,17 +988,15 @@ impl TextControlElement for HTMLInputElement {
 
     fn maybe_update_shared_selection(&self) {
         let mut text_input = self.textinput.borrow_mut();
-        let selection_range = text_input.sorted_selection_offsets_range();
+        let selection_range = text_input.selection_start()..text_input.selection_end();
         let enabled = self.is_textual_or_password() && self.upcast::<Element>().focus_state();
 
-        let mut shared_selection = self.shared_selection.borrow_mut();
         let range_remained_equal = selection_range == text_input.previous_selection_range;
-        if range_remained_equal && enabled == shared_selection.enabled {
+        if range_remained_equal && enabled == text_input.selection_for_layout.is_some() {
             return;
         }
 
         if !range_remained_equal {
-            text_input.previous_selection_range = selection_range;
             // https://w3c.github.io/selection-api/#selectionchange-event
             // > When an input or textarea element provide a text selection and its selection changes
             // > (in either extent or direction),
@@ -1011,11 +1004,20 @@ impl TextControlElement for HTMLInputElement {
             self.schedule_a_selection_change_event();
         }
 
-        *shared_selection = ScriptSelection {
-            character_range: text_input.sorted_selection_character_offsets_range(),
-            enabled,
-        };
-        self.owner_window().layout().set_needs_new_display_list();
+        let selection = enabled.then(|| text_input.sorted_selection_character_offsets_range());
+        text_input.previous_selection_range = selection_range;
+        text_input.selection_for_layout = selection;
+
+        if let Some(text_input_widget) = self.input_type.borrow().text_input_widget() {
+            if text_input_widget.borrow().set_text_run_selection(selection) {
+                // Found an already laid out text run to update, so we only need to repaint:
+                self.owner_window().layout().set_needs_new_display_list();
+            } else {
+                // If there isn’t a text run, layout is pending to create it anyway
+            }
+        } else {
+            // Non-text input type. Would this be even called?
+        }
     }
 
     fn is_password_field(&self) -> bool {

--- a/components/script/dom/html/form_controls/htmlinputelement.rs
+++ b/components/script/dom/html/form_controls/htmlinputelement.rs
@@ -1008,7 +1008,8 @@ impl TextControlElement for HTMLInputElement {
         text_input.previous_selection_range = selection_range;
         text_input.selection_for_layout = selection;
 
-        if let Some(text_input_widget) = self.input_type.borrow().as_specific().text_input_widget() {
+        if let Some(text_input_widget) = self.input_type.borrow().as_specific().text_input_widget()
+        {
             if text_input_widget.borrow().set_text_run_selection(selection) {
                 // Found an already laid out text run to update, so we only need to repaint:
                 self.owner_window().layout().set_needs_new_display_list();

--- a/components/script/dom/html/form_controls/htmlinputelement.rs
+++ b/components/script/dom/html/form_controls/htmlinputelement.rs
@@ -8,7 +8,6 @@ use std::{f64, ptr};
 use dom_struct::dom_struct;
 use embedder_traits::{EmbedderControlRequest, InputMethodRequest, RgbColor, SelectedFile};
 use encoding_rs::Encoding;
-use fonts::{ByteIndex, TextByteRange};
 use html5ever::{LocalName, Prefix, local_name};
 use js::context::JSContext;
 use js::jsapi::{ClippedTime, JSObject, RegExpFlag_UnicodeSets, RegExpFlags};
@@ -993,18 +992,18 @@ impl TextControlElement for HTMLInputElement {
     }
 
     fn maybe_update_shared_selection(&self) {
-        let offsets = self.textinput.borrow().sorted_selection_offsets_range();
-        let (start, end) = (offsets.start.0, offsets.end.0);
-        let range = TextByteRange::new(ByteIndex(start), ByteIndex(end));
+        let mut text_input = self.textinput.borrow_mut();
+        let selection_range = text_input.sorted_selection_offsets_range();
         let enabled = self.is_textual_or_password() && self.upcast::<Element>().focus_state();
 
         let mut shared_selection = self.shared_selection.borrow_mut();
-        let range_remained_equal = range == shared_selection.range;
+        let range_remained_equal = selection_range == text_input.previous_selection_range;
         if range_remained_equal && enabled == shared_selection.enabled {
             return;
         }
 
         if !range_remained_equal {
+            text_input.previous_selection_range = selection_range;
             // https://w3c.github.io/selection-api/#selectionchange-event
             // > When an input or textarea element provide a text selection and its selection changes
             // > (in either extent or direction),
@@ -1013,11 +1012,7 @@ impl TextControlElement for HTMLInputElement {
         }
 
         *shared_selection = ScriptSelection {
-            range,
-            character_range: self
-                .textinput
-                .borrow()
-                .sorted_selection_character_offsets_range(),
+            character_range: text_input.sorted_selection_character_offsets_range(),
             enabled,
         };
         self.owner_window().layout().set_needs_new_display_list();

--- a/components/script/dom/html/form_controls/htmltextareaelement.rs
+++ b/components/script/dom/html/form_controls/htmltextareaelement.rs
@@ -7,7 +7,6 @@ use std::default::Default;
 
 use dom_struct::dom_struct;
 use embedder_traits::{EmbedderControlRequest, InputMethodRequest, InputMethodType};
-use fonts::{ByteIndex, TextByteRange};
 use html5ever::{LocalName, Prefix, local_name, ns};
 use js::context::JSContext;
 use js::rust::HandleObject;
@@ -277,18 +276,18 @@ impl TextControlElement for HTMLTextAreaElement {
     }
 
     fn maybe_update_shared_selection(&self) {
-        let offsets = self.textinput.borrow().sorted_selection_offsets_range();
-        let (start, end) = (offsets.start.0, offsets.end.0);
-        let range = TextByteRange::new(ByteIndex(start), ByteIndex(end));
+        let mut text_input = self.textinput.borrow_mut();
+        let selection_range = text_input.sorted_selection_offsets_range();
         let enabled = self.upcast::<Element>().focus_state();
 
         let mut shared_selection = self.shared_selection.borrow_mut();
-        let range_remained_equal = range == shared_selection.range;
+        let range_remained_equal = selection_range == text_input.previous_selection_range;
         if range_remained_equal && enabled == shared_selection.enabled {
             return;
         }
 
         if !range_remained_equal {
+            text_input.previous_selection_range = selection_range;
             // https://w3c.github.io/selection-api/#selectionchange-event
             // > When an input or textarea element provide a text selection and its selection changes
             // > (in either extent or direction),
@@ -297,11 +296,7 @@ impl TextControlElement for HTMLTextAreaElement {
         }
 
         *shared_selection = ScriptSelection {
-            range,
-            character_range: self
-                .textinput
-                .borrow()
-                .sorted_selection_character_offsets_range(),
+            character_range: text_input.sorted_selection_character_offsets_range(),
             enabled,
         };
         self.owner_window().layout().set_needs_new_display_list();

--- a/components/script/dom/html/form_controls/htmltextareaelement.rs
+++ b/components/script/dom/html/form_controls/htmltextareaelement.rs
@@ -10,9 +10,8 @@ use embedder_traits::{EmbedderControlRequest, InputMethodRequest, InputMethodTyp
 use html5ever::{LocalName, Prefix, local_name, ns};
 use js::context::JSContext;
 use js::rust::HandleObject;
-use layout_api::{ScriptSelection, SharedSelection};
 use script_bindings::cell::DomRefCell;
-use servo_base::text::Utf16CodeUnits;
+use servo_base::text::{RangeAny, Utf16CodeUnits, Utf32CodeUnits};
 use style::attr::AttrValue;
 use stylo_dom::ElementState;
 
@@ -67,19 +66,17 @@ pub(crate) struct HTMLTextAreaElement {
     validity_state: MutNullableDom<ValidityState>,
     /// A [`TextInputWidget`] that manages the shadow DOM for this `<textarea>`.
     text_input_widget: DomRefCell<TextInputWidget>,
-    /// A [`SharedSelection`] that is shared with layout. This can be updated dyanmnically
-    /// and layout should reflect the new value after a display list update.
-    #[no_trace]
-    #[conditional_malloc_size_of]
-    shared_selection: SharedSelection,
 
     /// <https://w3c.github.io/selection-api/#dfn-has-scheduled-selectionchange-event>
     has_scheduled_selectionchange_event: Cell<bool>,
 }
 
 impl LayoutDom<'_, HTMLTextAreaElement> {
-    pub(crate) fn selection_for_layout(self) -> SharedSelection {
-        self.unsafe_get().shared_selection.clone()
+    pub(crate) fn selection_for_layout(self) -> Option<RangeAny<Utf32CodeUnits>> {
+        let element = self.unsafe_get();
+        #[expect(unsafe_code)]
+        let textinput = unsafe { element.textinput.borrow_for_layout() };
+        textinput.selection_for_layout
     }
 
     pub(crate) fn get_cols(self) -> u32 {
@@ -136,7 +133,6 @@ impl HTMLTextAreaElement {
             labels_node_list: Default::default(),
             validity_state: Default::default(),
             text_input_widget: Default::default(),
-            shared_selection: Default::default(),
             has_scheduled_selectionchange_event: Default::default(),
         }
     }
@@ -277,17 +273,15 @@ impl TextControlElement for HTMLTextAreaElement {
 
     fn maybe_update_shared_selection(&self) {
         let mut text_input = self.textinput.borrow_mut();
-        let selection_range = text_input.sorted_selection_offsets_range();
+        let selection_range = text_input.selection_start()..text_input.selection_end();
         let enabled = self.upcast::<Element>().focus_state();
 
-        let mut shared_selection = self.shared_selection.borrow_mut();
         let range_remained_equal = selection_range == text_input.previous_selection_range;
-        if range_remained_equal && enabled == shared_selection.enabled {
+        if range_remained_equal && enabled == text_input.selection_for_layout.is_some() {
             return;
         }
 
         if !range_remained_equal {
-            text_input.previous_selection_range = selection_range;
             // https://w3c.github.io/selection-api/#selectionchange-event
             // > When an input or textarea element provide a text selection and its selection changes
             // > (in either extent or direction),
@@ -295,11 +289,20 @@ impl TextControlElement for HTMLTextAreaElement {
             self.schedule_a_selection_change_event();
         }
 
-        *shared_selection = ScriptSelection {
-            character_range: text_input.sorted_selection_character_offsets_range(),
-            enabled,
-        };
-        self.owner_window().layout().set_needs_new_display_list();
+        let selection = enabled.then(|| text_input.sorted_selection_character_offsets_range());
+        text_input.previous_selection_range = selection_range;
+        text_input.selection_for_layout = selection;
+
+        if self
+            .text_input_widget
+            .borrow()
+            .set_text_run_selection(selection)
+        {
+            // Found an already laid out text run to update, so we only need to repaint:
+            self.owner_window().layout().set_needs_new_display_list();
+        } else {
+            // If there isn’t a text run, layout is pending to create it anyway
+        }
     }
 
     fn placeholder_text<'a>(&'a self) -> Ref<'a, DOMString> {

--- a/components/script/dom/html/form_controls/input_type/button_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/button_input_type.rs
@@ -8,6 +8,7 @@ use script_bindings::cell::DomRefCell;
 use crate::dom::html::form_controls::htmlinputelement::HTMLInputElement;
 use crate::dom::html::form_controls::input_type::text_value_widget::TextValueWidget;
 use crate::dom::html::form_controls::input_type::{SpecificInputActivationType, SpecificInputType};
+use crate::dom::input_type::text_input_widget::TextInputWidget;
 
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
@@ -21,6 +22,10 @@ pub(crate) struct ButtonInputActivation;
 impl SpecificInputActivationType for ButtonInputActivation {}
 
 impl SpecificInputType for ButtonInputType {
+    fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
+        None
+    }
+
     fn update_shadow_tree(&self, cx: &mut JSContext, input: &HTMLInputElement) {
         self.text_value_widget
             .borrow()

--- a/components/script/dom/html/form_controls/input_type/checkbox_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/checkbox_input_type.rs
@@ -12,6 +12,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::html::form_controls::htmlinputelement::{HTMLInputElement, InputActivationState};
 use crate::dom::html::form_controls::input_type::text_value_widget::TextValueWidget;
 use crate::dom::html::form_controls::input_type::{SpecificInputActivationType, SpecificInputType};
+use crate::dom::input_type::text_input_widget::TextInputWidget;
 use crate::dom::node::Node;
 
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
@@ -24,6 +25,10 @@ pub(crate) struct CheckboxInputType {
 pub(crate) struct CheckboxInputActivation;
 
 impl SpecificInputType for CheckboxInputType {
+    fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
+        None
+    }
+
     /// <https://html.spec.whatwg.org/multipage/#checkbox-state-(type=checkbox):suffering-from-being-missing>
     fn suffers_from_being_missing(&self, input: &HTMLInputElement, _value: &DOMString) -> bool {
         input.Required() && !input.Checked()

--- a/components/script/dom/html/form_controls/input_type/color_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/color_input_type.rs
@@ -28,6 +28,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::html::form_controls::htmlinputelement::HTMLInputElement;
 use crate::dom::html::form_controls::input_type::{SpecificInputActivationType, SpecificInputType};
 use crate::dom::htmlformelement::HTMLFormElement;
+use crate::dom::input_type::text_input_widget::TextInputWidget;
 use crate::dom::node::{Node, NodeTraits, UnbindContext};
 
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
@@ -181,6 +182,10 @@ impl ColorInputType {
 }
 
 impl SpecificInputType for ColorInputType {
+    fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
+        None
+    }
+
     fn sanitize_value(&self, input: &HTMLInputElement, value: &mut DOMString) {
         // > The value sanitization algorithm is as follows:
         // > Run update a color well control color for the element.

--- a/components/script/dom/html/form_controls/input_type/date_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/date_input_type.rs
@@ -14,10 +14,14 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct DateInputType {
-    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
+    text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for DateInputType {
+    fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
+        Some(&self.text_input_widget)
+    }
+
     fn sanitize_value(&self, _input: &HTMLInputElement, value: &mut DOMString) {
         if !value.str().is_valid_date_string() {
             value.clear();

--- a/components/script/dom/html/form_controls/input_type/date_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/date_input_type.rs
@@ -14,7 +14,7 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct DateInputType {
-    text_input_widget: DomRefCell<TextInputWidget>,
+    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for DateInputType {

--- a/components/script/dom/html/form_controls/input_type/datetime_local_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/datetime_local_input_type.rs
@@ -13,7 +13,7 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct DatetimeLocalInputType {
-    text_input_widget: DomRefCell<TextInputWidget>,
+    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for DatetimeLocalInputType {

--- a/components/script/dom/html/form_controls/input_type/datetime_local_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/datetime_local_input_type.rs
@@ -13,10 +13,14 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct DatetimeLocalInputType {
-    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
+    text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for DatetimeLocalInputType {
+    fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
+        Some(&self.text_input_widget)
+    }
+
     fn sanitize_value(&self, _input: &HTMLInputElement, value: &mut DOMString) {
         let time = value
             .str()

--- a/components/script/dom/html/form_controls/input_type/email_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/email_input_type.rs
@@ -16,7 +16,7 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct EmailInputType {
-    text_input_widget: DomRefCell<TextInputWidget>,
+    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for EmailInputType {

--- a/components/script/dom/html/form_controls/input_type/email_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/email_input_type.rs
@@ -16,10 +16,14 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct EmailInputType {
-    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
+    text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for EmailInputType {
+    fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
+        Some(&self.text_input_widget)
+    }
+
     fn sanitize_value(&self, input: &HTMLInputElement, value: &mut DOMString) {
         if !input.Multiple() {
             value.strip_newlines();

--- a/components/script/dom/html/form_controls/input_type/file_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/file_input_type.rs
@@ -32,6 +32,7 @@ use crate::dom::html::form_controls::htmlinputelement::HTMLInputElement;
 use crate::dom::html::form_controls::input_type::{SpecificInputActivationType, SpecificInputType};
 use crate::dom::htmlbuttonelement::HTMLButtonElement;
 use crate::dom::htmlelement::HTMLElement;
+use crate::dom::input_type::text_input_widget::TextInputWidget;
 use crate::dom::node::{Node, NodeTraits};
 
 const DEFAULT_FILE_INPUT_VALUE: &str = "No file chosen";
@@ -133,6 +134,10 @@ impl FileInputType {
 }
 
 impl SpecificInputType for FileInputType {
+    fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
+        None
+    }
+
     /// <https://html.spec.whatwg.org/multipage/#file-upload-state-(type=file):suffering-from-being-missing>
     fn suffers_from_being_missing(&self, input: &HTMLInputElement, _value: &DOMString) -> bool {
         input.Required() && self.filelist.get().is_none_or(|files| files.Length() == 0)

--- a/components/script/dom/html/form_controls/input_type/hidden_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/hidden_input_type.rs
@@ -2,9 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use script_bindings::cell::DomRefCell;
+
 use crate::dom::html::form_controls::input_type::SpecificInputType;
+use crate::dom::input_type::text_input_widget::TextInputWidget;
 
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 pub(crate) struct HiddenInputType();
 
-impl SpecificInputType for HiddenInputType {}
+impl SpecificInputType for HiddenInputType {
+    fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
+        None
+    }
+}

--- a/components/script/dom/html/form_controls/input_type/image_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/image_input_type.rs
@@ -10,6 +10,7 @@ use crate::dom::html::form_controls::htmlinputelement::HTMLInputElement;
 use crate::dom::html::form_controls::input_type::text_value_widget::TextValueWidget;
 use crate::dom::html::form_controls::input_type::{SpecificInputActivationType, SpecificInputType};
 use crate::dom::htmlformelement::{FormControl, FormSubmitterElement, SubmittedFrom};
+use crate::dom::input_type::text_input_widget::TextInputWidget;
 use crate::dom::node::NodeTraits;
 
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
@@ -22,6 +23,10 @@ pub(crate) struct ImageInputType {
 pub(crate) struct ImageInputActivation;
 
 impl SpecificInputType for ImageInputType {
+    fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
+        None
+    }
+
     fn update_shadow_tree(&self, cx: &mut JSContext, input: &HTMLInputElement) {
         self.text_value_widget
             .borrow()

--- a/components/script/dom/html/form_controls/input_type/mod.rs
+++ b/components/script/dom/html/form_controls/input_type/mod.rs
@@ -156,35 +156,6 @@ pub(crate) enum InputType {
     Week(WeekInputType),
 }
 
-impl InputType {
-    pub(crate) fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
-        match self {
-            InputType::Button(_) => None,
-            InputType::Checkbox(_) => None,
-            InputType::Color(_) => None,
-            InputType::Date(input_type) => Some(&input_type.text_input_widget),
-            InputType::DatetimeLocal(input_type) => Some(&input_type.text_input_widget),
-            InputType::Email(input_type) => Some(&input_type.text_input_widget),
-            InputType::File(_) => None,
-            InputType::Hidden(_) => None,
-            InputType::Image(_) => None,
-            InputType::Month(input_type) => Some(&input_type.text_input_widget),
-            InputType::Number(input_type) => Some(&input_type.text_input_widget),
-            InputType::Password(input_type) => Some(&input_type.text_input_widget),
-            InputType::Radio(_) => None,
-            InputType::Range(_) => None,
-            InputType::Reset(_) => None,
-            InputType::Search(input_type) => Some(&input_type.text_input_widget),
-            InputType::Submit(_) => None,
-            InputType::Tel(input_type) => Some(&input_type.text_input_widget),
-            InputType::Text(input_type) => Some(&input_type.text_input_widget),
-            InputType::Time(input_type) => Some(&input_type.text_input_widget),
-            InputType::Url(input_type) => Some(&input_type.text_input_widget),
-            InputType::Week(input_type) => Some(&input_type.text_input_widget),
-        }
-    }
-}
-
 #[derive(Clone, Copy)]
 pub(crate) enum InputActivationType {
     Button(ButtonInputActivation),
@@ -393,6 +364,8 @@ impl TryFrom<&InputType> for InputMethodType {
 
 pub(crate) trait SpecificInputType {
     fn sanitize_value(&self, _input: &HTMLInputElement, _value: &mut DOMString) {}
+
+    fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>>;
 
     fn convert_string_to_number(&self, _value: &str) -> Option<f64> {
         None

--- a/components/script/dom/html/form_controls/input_type/mod.rs
+++ b/components/script/dom/html/form_controls/input_type/mod.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use embedder_traits::InputMethodType;
 use js::context::JSContext;
+use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::HTMLInputElementBinding::HTMLInputElementMethods;
 use script_bindings::domstring::DOMString;
 use script_bindings::root::DomRoot;
@@ -56,6 +57,7 @@ use crate::dom::html::form_controls::input_type::time_input_type::TimeInputType;
 use crate::dom::html::form_controls::input_type::url_input_type::UrlInputType;
 use crate::dom::html::form_controls::input_type::week_input_type::WeekInputType;
 use crate::dom::htmlformelement::HTMLFormElement;
+use crate::dom::input_type::text_input_widget::TextInputWidget;
 use crate::dom::node::{BindContext, UnbindContext};
 
 pub(crate) mod button_input_type;
@@ -152,6 +154,35 @@ pub(crate) enum InputType {
 
     /// <https://html.spec.whatwg.org/multipage/#week-state-(type=week)>
     Week(WeekInputType),
+}
+
+impl InputType {
+    pub(crate) fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
+        match self {
+            InputType::Button(_) => None,
+            InputType::Checkbox(_) => None,
+            InputType::Color(_) => None,
+            InputType::Date(input_type) => Some(&input_type.text_input_widget),
+            InputType::DatetimeLocal(input_type) => Some(&input_type.text_input_widget),
+            InputType::Email(input_type) => Some(&input_type.text_input_widget),
+            InputType::File(_) => None,
+            InputType::Hidden(_) => None,
+            InputType::Image(_) => None,
+            InputType::Month(input_type) => Some(&input_type.text_input_widget),
+            InputType::Number(input_type) => Some(&input_type.text_input_widget),
+            InputType::Password(input_type) => Some(&input_type.text_input_widget),
+            InputType::Radio(_) => None,
+            InputType::Range(_) => None,
+            InputType::Reset(_) => None,
+            InputType::Search(input_type) => Some(&input_type.text_input_widget),
+            InputType::Submit(_) => None,
+            InputType::Tel(input_type) => Some(&input_type.text_input_widget),
+            InputType::Text(input_type) => Some(&input_type.text_input_widget),
+            InputType::Time(input_type) => Some(&input_type.text_input_widget),
+            InputType::Url(input_type) => Some(&input_type.text_input_widget),
+            InputType::Week(input_type) => Some(&input_type.text_input_widget),
+        }
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/components/script/dom/html/form_controls/input_type/month_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/month_input_type.rs
@@ -15,7 +15,7 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct MonthInputType {
-    text_input_widget: DomRefCell<TextInputWidget>,
+    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for MonthInputType {

--- a/components/script/dom/html/form_controls/input_type/month_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/month_input_type.rs
@@ -15,10 +15,14 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct MonthInputType {
-    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
+    text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for MonthInputType {
+    fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
+        Some(&self.text_input_widget)
+    }
+
     fn sanitize_value(&self, _input: &HTMLInputElement, value: &mut DOMString) {
         if !value.str().is_valid_month_string() {
             value.clear();

--- a/components/script/dom/html/form_controls/input_type/number_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/number_input_type.rs
@@ -13,10 +13,14 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct NumberInputType {
-    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
+    text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for NumberInputType {
+    fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
+        Some(&self.text_input_widget)
+    }
+
     fn sanitize_value(&self, _input: &HTMLInputElement, value: &mut DOMString) {
         if !value.is_valid_floating_point_number_string() {
             value.clear();

--- a/components/script/dom/html/form_controls/input_type/number_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/number_input_type.rs
@@ -13,7 +13,7 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct NumberInputType {
-    text_input_widget: DomRefCell<TextInputWidget>,
+    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for NumberInputType {

--- a/components/script/dom/html/form_controls/input_type/password_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/password_input_type.rs
@@ -12,7 +12,7 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct PasswordInputType {
-    text_input_widget: DomRefCell<TextInputWidget>,
+    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for PasswordInputType {

--- a/components/script/dom/html/form_controls/input_type/password_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/password_input_type.rs
@@ -12,10 +12,14 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct PasswordInputType {
-    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
+    text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for PasswordInputType {
+    fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
+        Some(&self.text_input_widget)
+    }
+
     fn sanitize_value(&self, _input: &HTMLInputElement, value: &mut DOMString) {
         value.strip_newlines();
     }

--- a/components/script/dom/html/form_controls/input_type/radio_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/radio_input_type.rs
@@ -22,6 +22,7 @@ use crate::dom::html::form_controls::input_type::{
     InputType, SpecificInputActivationType, SpecificInputType,
 };
 use crate::dom::htmlformelement::{FormControl, HTMLFormElement};
+use crate::dom::input_type::text_input_widget::TextInputWidget;
 use crate::dom::iterators::ShadowIncluding;
 use crate::dom::node::{BindContext, Node, UnbindContext};
 use crate::dom::validation::Validatable;
@@ -37,6 +38,10 @@ pub(crate) struct RadioInputType {
 pub(crate) struct RadioInputActivation;
 
 impl SpecificInputType for RadioInputType {
+    fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
+        None
+    }
+
     /// <https://html.spec.whatwg.org/multipage/#radio-button-state-(type=radio):suffering-from-being-missing>
     fn suffers_from_being_missing(&self, input: &HTMLInputElement, _value: &DOMString) -> bool {
         if input.radio_group_name().is_none() {

--- a/components/script/dom/html/form_controls/input_type/range_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/range_input_type.rs
@@ -18,6 +18,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::element::{CustomElementCreationMode, Element, ElementCreator};
 use crate::dom::html::form_controls::htmlinputelement::HTMLInputElement;
 use crate::dom::html::form_controls::input_type::SpecificInputType;
+use crate::dom::input_type::text_input_widget::TextInputWidget;
 use crate::dom::node::{Node, NodeTraits};
 
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
@@ -53,6 +54,10 @@ impl RangeInputType {
 }
 
 impl SpecificInputType for RangeInputType {
+    fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
+        None
+    }
+
     /// <https://html.spec.whatwg.org/multipage/#range-state-(type=range):value-sanitization-algorithm>
     fn sanitize_value(&self, input: &HTMLInputElement, value: &mut DOMString) {
         if !value.is_valid_floating_point_number_string() {

--- a/components/script/dom/html/form_controls/input_type/reset_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/reset_input_type.rs
@@ -11,6 +11,7 @@ use crate::dom::html::form_controls::htmlinputelement::HTMLInputElement;
 use crate::dom::html::form_controls::input_type::text_value_widget::TextValueWidget;
 use crate::dom::html::form_controls::input_type::{SpecificInputActivationType, SpecificInputType};
 use crate::dom::htmlformelement::{FormControl, ResetFrom};
+use crate::dom::input_type::text_input_widget::TextInputWidget;
 use crate::dom::node::NodeTraits;
 
 const DEFAULT_RESET_VALUE: &str = "Reset";
@@ -25,6 +26,10 @@ pub(crate) struct ResetInputType {
 pub(crate) struct ResetInputActivation;
 
 impl SpecificInputType for ResetInputType {
+    fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
+        None
+    }
+
     fn value_for_shadow_dom(&self, _input: &HTMLInputElement) -> DOMString {
         DEFAULT_RESET_VALUE.into()
     }

--- a/components/script/dom/html/form_controls/input_type/search_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/search_input_type.rs
@@ -12,10 +12,14 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct SearchInputType {
-    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
+    text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for SearchInputType {
+    fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
+        Some(&self.text_input_widget)
+    }
+
     fn sanitize_value(&self, _input: &HTMLInputElement, value: &mut DOMString) {
         value.strip_newlines();
     }

--- a/components/script/dom/html/form_controls/input_type/search_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/search_input_type.rs
@@ -12,7 +12,7 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct SearchInputType {
-    text_input_widget: DomRefCell<TextInputWidget>,
+    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for SearchInputType {

--- a/components/script/dom/html/form_controls/input_type/submit_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/submit_input_type.rs
@@ -11,6 +11,7 @@ use crate::dom::html::form_controls::htmlinputelement::HTMLInputElement;
 use crate::dom::html::form_controls::input_type::text_value_widget::TextValueWidget;
 use crate::dom::html::form_controls::input_type::{SpecificInputActivationType, SpecificInputType};
 use crate::dom::htmlformelement::{FormControl, FormSubmitterElement, SubmittedFrom};
+use crate::dom::input_type::text_input_widget::TextInputWidget;
 use crate::dom::node::NodeTraits;
 
 const DEFAULT_SUBMIT_VALUE: &str = "Submit";
@@ -25,6 +26,10 @@ pub(crate) struct SubmitInputType {
 pub(crate) struct SubmitInputActivation;
 
 impl SpecificInputType for SubmitInputType {
+    fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
+        None
+    }
+
     fn value_for_shadow_dom(&self, _input: &HTMLInputElement) -> DOMString {
         DEFAULT_SUBMIT_VALUE.into()
     }

--- a/components/script/dom/html/form_controls/input_type/tel_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/tel_input_type.rs
@@ -12,7 +12,7 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct TelInputType {
-    text_input_widget: DomRefCell<TextInputWidget>,
+    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for TelInputType {

--- a/components/script/dom/html/form_controls/input_type/tel_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/tel_input_type.rs
@@ -12,10 +12,14 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct TelInputType {
-    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
+    text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for TelInputType {
+    fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
+        Some(&self.text_input_widget)
+    }
+
     fn sanitize_value(&self, _input: &HTMLInputElement, value: &mut DOMString) {
         value.strip_newlines();
     }

--- a/components/script/dom/html/form_controls/input_type/text_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/text_input_type.rs
@@ -12,7 +12,7 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct TextInputType {
-    text_input_widget: DomRefCell<TextInputWidget>,
+    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for TextInputType {

--- a/components/script/dom/html/form_controls/input_type/text_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/text_input_type.rs
@@ -12,10 +12,14 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct TextInputType {
-    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
+    text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for TextInputType {
+    fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
+        Some(&self.text_input_widget)
+    }
+
     fn sanitize_value(&self, _input: &HTMLInputElement, value: &mut DOMString) {
         value.strip_newlines();
     }

--- a/components/script/dom/html/form_controls/input_type/text_input_widget.rs
+++ b/components/script/dom/html/form_controls/input_type/text_input_widget.rs
@@ -12,6 +12,7 @@ use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
 use script_bindings::codegen::GenericBindings::NodeBinding::NodeMethods;
 use script_bindings::inheritance::Castable;
 use script_bindings::root::{Dom, DomRoot};
+use servo_base::text::{RangeAny, Utf32CodeUnits};
 use style::selector_parser::PseudoElement;
 
 use crate::dom::characterdata::CharacterData;
@@ -65,6 +66,20 @@ impl TextInputWidget {
     ) {
         self.get_or_create_shadow_tree(cx, element)
             .update_placeholder(cx, element);
+    }
+
+    /// Returns whether `new_range` was successfully set on an existing text run
+    pub(crate) fn set_text_run_selection(
+        &self,
+        new_range: Option<RangeAny<Utf32CodeUnits>>,
+    ) -> bool {
+        if let Some(shadow_tree) = &*self.shadow_tree.borrow() &&
+            let Some(character_data) = shadow_tree.value_character_data()
+        {
+            character_data.set_text_run_selection(new_range)
+        } else {
+            false
+        }
     }
 }
 

--- a/components/script/dom/html/form_controls/input_type/text_input_widget.rs
+++ b/components/script/dom/html/form_controls/input_type/text_input_widget.rs
@@ -212,6 +212,9 @@ impl TextInputWidgetShadowTree {
         // This is also used to ensure that the caret will still be rendered when the input is empty.
         // TODO: Could append `<br>` element to prevent collapses and avoid this hack, but we would
         //       need to fix the rendering of caret beforehand.
+        // TODO: maybe not `<br>`, but either way when this hack is removed, allow
+        // `TextInput::sorted_selection_character_offsets_range` to rely on `Rope::last_index()`
+        // to use an unbounded end.
         let value = element.value_text();
         let value_text = match (value.is_empty(), element.is_password_field()) {
             // For a password input, we replace all of the character with its replacement char.

--- a/components/script/dom/html/form_controls/input_type/text_input_widget.rs
+++ b/components/script/dom/html/form_controls/input_type/text_input_widget.rs
@@ -210,11 +210,8 @@ impl TextInputWidgetShadowTree {
         // <https://drafts.csswg.org/css-ui/#element-with-default-preferred-size>.
         //
         // This is also used to ensure that the caret will still be rendered when the input is empty.
-        // TODO: Could append `<br>` element to prevent collapses and avoid this hack, but we would
-        //       need to fix the rendering of caret beforehand.
-        // TODO: maybe not `<br>`, but either way when this hack is removed, allow
-        // `TextInput::sorted_selection_character_offsets_range` to rely on `Rope::last_index()`
-        // to use an unbounded end.
+        // TODO: when this hack is removed, let `TextInput::sorted_selection_character_offsets_range`
+        // rely on `Rope::last_index()` to use an unbounded end in the `RangeAny` it returns.
         let value = element.value_text();
         let value_text = match (value.is_empty(), element.is_password_field()) {
             // For a password input, we replace all of the character with its replacement char.

--- a/components/script/dom/html/form_controls/input_type/time_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/time_input_type.rs
@@ -13,10 +13,14 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct TimeInputType {
-    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
+    text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for TimeInputType {
+    fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
+        Some(&self.text_input_widget)
+    }
+
     fn sanitize_value(&self, _input: &HTMLInputElement, value: &mut DOMString) {
         if !value.str().is_valid_time_string() {
             value.clear();

--- a/components/script/dom/html/form_controls/input_type/time_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/time_input_type.rs
@@ -13,7 +13,7 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct TimeInputType {
-    text_input_widget: DomRefCell<TextInputWidget>,
+    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for TimeInputType {

--- a/components/script/dom/html/form_controls/input_type/url_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/url_input_type.rs
@@ -13,10 +13,14 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct UrlInputType {
-    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
+    text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for UrlInputType {
+    fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
+        Some(&self.text_input_widget)
+    }
+
     fn sanitize_value(&self, _input: &HTMLInputElement, value: &mut DOMString) {
         value.strip_newlines();
         value.strip_leading_and_trailing_ascii_whitespace();

--- a/components/script/dom/html/form_controls/input_type/url_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/url_input_type.rs
@@ -13,7 +13,7 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct UrlInputType {
-    text_input_widget: DomRefCell<TextInputWidget>,
+    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for UrlInputType {

--- a/components/script/dom/html/form_controls/input_type/week_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/week_input_type.rs
@@ -13,10 +13,14 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct WeekInputType {
-    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
+    text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for WeekInputType {
+    fn text_input_widget(&self) -> Option<&DomRefCell<TextInputWidget>> {
+        Some(&self.text_input_widget)
+    }
+
     fn sanitize_value(&self, _input: &HTMLInputElement, value: &mut DOMString) {
         if !value.str().is_valid_week_string() {
             value.clear();

--- a/components/script/dom/html/form_controls/input_type/week_input_type.rs
+++ b/components/script/dom/html/form_controls/input_type/week_input_type.rs
@@ -13,7 +13,7 @@ use crate::dom::html::form_controls::input_type::text_input_widget::TextInputWid
 #[derive(Default, JSTraceable, MallocSizeOf, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct WeekInputType {
-    text_input_widget: DomRefCell<TextInputWidget>,
+    pub(super) text_input_widget: DomRefCell<TextInputWidget>,
 }
 
 impl SpecificInputType for WeekInputType {

--- a/components/script/dom/html/form_controls/text_input.rs
+++ b/components/script/dom/html/form_controls/text_input.rs
@@ -163,6 +163,9 @@ pub struct TextInput<T: ClipboardProvider> {
 
     /// Was last change made by set_content?
     was_last_change_by_set_content: bool,
+
+    #[no_trace]
+    pub(crate) previous_selection_range: Range<Utf8CodeUnits>,
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -298,6 +301,7 @@ impl<T: ClipboardProvider> TextInput<T> {
             min_length: Default::default(),
             selection_direction: SelectionDirection::None,
             was_last_change_by_set_content: true,
+            previous_selection_range: Default::default(),
         }
     }
 

--- a/components/script/dom/html/form_controls/text_input.rs
+++ b/components/script/dom/html/form_controls/text_input.rs
@@ -425,7 +425,11 @@ impl<T: ClipboardProvider> TextInput<T> {
         let start = self.selection_start();
         let end = self.selection_end();
         let start = (start != rope.first_index()).then(|| rope.index_to_character_offset(start));
-        let end = (end != rope.last_index()).then(|| rope.index_to_character_offset(end));
+        // TODO: `TextInputWidgetShadowTree::update` has a hack with a "\u{200B}" to force
+        // the text to be non-empty, so `rope.last_index()` is untrustworthy.
+        // For now, use a bounded end unconditionally instead.
+        // let end = (end != rope.last_index()).then(|| rope.index_to_character_offset(end));
+        let end = Some(rope.index_to_character_offset(end));
         RangeAny { start, end }
     }
 

--- a/components/script/dom/html/form_controls/text_input.rs
+++ b/components/script/dom/html/form_controls/text_input.rs
@@ -165,7 +165,9 @@ pub struct TextInput<T: ClipboardProvider> {
     was_last_change_by_set_content: bool,
 
     #[no_trace]
-    pub(crate) previous_selection_range: Range<Utf8CodeUnits>,
+    pub(crate) previous_selection_range: Range<RopeIndex>,
+    #[no_trace]
+    pub(crate) selection_for_layout: Option<RangeAny<Utf32CodeUnits>>,
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -302,6 +304,7 @@ impl<T: ClipboardProvider> TextInput<T> {
             selection_direction: SelectionDirection::None,
             was_last_change_by_set_content: true,
             previous_selection_range: Default::default(),
+            selection_for_layout: None,
         }
     }
 
@@ -403,24 +406,12 @@ impl<T: ClipboardProvider> TextInput<T> {
         self.rope.index_to_utf16_offset(self.selection_end())
     }
 
-    /// The byte offset of the selection_end()
-    pub fn selection_end_offset(&self) -> Utf8CodeUnits {
-        self.rope.index_to_utf8_offset(self.selection_end())
-    }
-
     /// Whether or not there is an active uncollapsed selection. This means that the
     /// selection origin is set and it differs from the edit point.
     #[inline]
     pub(crate) fn has_uncollapsed_selection(&self) -> bool {
         self.selection_origin
             .is_some_and(|selection_origin| selection_origin != self.edit_point)
-    }
-
-    /// Return the selection range as byte offsets from the start of the content.
-    ///
-    /// If there is no selection, returns an empty range at the edit point.
-    pub(crate) fn sorted_selection_offsets_range(&self) -> Range<Utf8CodeUnits> {
-        self.selection_start_offset()..self.selection_end_offset()
     }
 
     /// Return the selection range as character offsets from the start of the content.

--- a/components/script/dom/html/form_controls/text_input.rs
+++ b/components/script/dom/html/form_controls/text_input.rs
@@ -414,9 +414,12 @@ impl<T: ClipboardProvider> TextInput<T> {
             .is_some_and(|selection_origin| selection_origin != self.edit_point)
     }
 
-    /// Return the selection range as character offsets from the start of the content.
+    /// Return the selection range as UTF-32 offsets from the start of the content.
     ///
     /// If there is no selection, returns an empty range at the edit point.
+    ///
+    /// If the start or/and end of the range is at the start/end of the text,
+    /// return a `RangeAny` unbounded on that side.
     pub(crate) fn sorted_selection_character_offsets_range(&self) -> RangeAny<Utf32CodeUnits> {
         let rope = &self.rope;
         let start = self.selection_start();

--- a/components/script/dom/html/form_controls/text_input.rs
+++ b/components/script/dom/html/form_controls/text_input.rs
@@ -18,7 +18,7 @@ use script_bindings::trace::CustomTraceable;
 use script_traits::MouseButtons;
 use servo_base::generic_channel::GenericCallback;
 use servo_base::id::WebViewId;
-use servo_base::text::{Utf8CodeUnits, Utf16CodeUnits, Utf32CodeUnits};
+use servo_base::text::{RangeAny, Utf8CodeUnits, Utf16CodeUnits, Utf32CodeUnits};
 use servo_base::{Rope, RopeIndex, RopeMovement, RopeSlice};
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
@@ -426,9 +426,13 @@ impl<T: ClipboardProvider> TextInput<T> {
     /// Return the selection range as character offsets from the start of the content.
     ///
     /// If there is no selection, returns an empty range at the edit point.
-    pub(crate) fn sorted_selection_character_offsets_range(&self) -> Range<Utf32CodeUnits> {
-        self.rope.index_to_character_offset(self.selection_start())..
-            self.rope.index_to_character_offset(self.selection_end())
+    pub(crate) fn sorted_selection_character_offsets_range(&self) -> RangeAny<Utf32CodeUnits> {
+        let rope = &self.rope;
+        let start = self.selection_start();
+        let end = self.selection_end();
+        let start = (start != rope.first_index()).then(|| rope.index_to_character_offset(start));
+        let end = (end != rope.last_index()).then(|| rope.index_to_character_offset(end));
+        RangeAny { start, end }
     }
 
     /// The state of the current selection. Can be used to compare whether selection state has changed.

--- a/components/script/dom/html/form_controls/text_input.rs
+++ b/components/script/dom/html/form_controls/text_input.rs
@@ -18,7 +18,7 @@ use script_bindings::trace::CustomTraceable;
 use script_traits::MouseButtons;
 use servo_base::generic_channel::GenericCallback;
 use servo_base::id::WebViewId;
-use servo_base::text::{Utf8CodeUnits, Utf16CodeUnits};
+use servo_base::text::{Utf8CodeUnits, Utf16CodeUnits, Utf32CodeUnits};
 use servo_base::{Rope, RopeIndex, RopeMovement, RopeSlice};
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
@@ -426,7 +426,7 @@ impl<T: ClipboardProvider> TextInput<T> {
     /// Return the selection range as character offsets from the start of the content.
     ///
     /// If there is no selection, returns an empty range at the edit point.
-    pub(crate) fn sorted_selection_character_offsets_range(&self) -> Range<usize> {
+    pub(crate) fn sorted_selection_character_offsets_range(&self) -> Range<Utf32CodeUnits> {
         self.rope.index_to_character_offset(self.selection_start())..
             self.rope.index_to_character_offset(self.selection_end())
     }

--- a/components/script/dom/node/layout_dom.rs
+++ b/components/script/dom/node/layout_dom.rs
@@ -7,7 +7,7 @@
 use atomic_refcell::AtomicRef;
 use layout_api::{
     GenericLayoutData, HTMLCanvasData, HTMLMediaData, LayoutElementType, LayoutNodeType,
-    SVGElementData, SharedSelection,
+    SVGElementData,
 };
 use net_traits::image_cache::Image;
 use pixels::ImageMetadata;
@@ -247,7 +247,17 @@ impl<'dom> LayoutDom<'dom, Node> {
     }
 
     #[expect(unsafe_code)]
-    pub(crate) fn document_selection_in_text_node(&self) -> Option<RangeAny<Utf32CodeUnits>> {
+    pub(crate) fn selection_for_text_node(&self) -> Option<RangeAny<Utf32CodeUnits>> {
+        if let Some(shadow_root) = self.containing_shadow_root_for_layout() {
+            let host = shadow_root.get_host_for_layout();
+            if let Some(input) = host.downcast::<HTMLInputElement>() {
+                return input.selection_for_layout();
+            }
+            if let Some(textarea) = host.downcast::<HTMLTextAreaElement>() {
+                return textarea.selection_for_layout();
+            }
+        }
+
         let unsafe_self = self.unsafe_get();
         if !unsafe_self.get_flag(NodeFlags::OVERLAPS_DOCUMENT_SELECTION) {
             return None;
@@ -272,24 +282,6 @@ impl<'dom> LayoutDom<'dom, Node> {
         let start = is_start_node.then(|| range_start.offset().to_utf32_code_units_in(&text));
         let end = is_end_node.then(|| range_end.offset().to_utf32_code_units_in(&text));
         Some(RangeAny { start, end })
-    }
-
-    /// Get the selection for the given node. This only works for text nodes that are in
-    /// the shadow DOM of user agent widgets for form controls, specifically for `<input>`
-    /// and `<textarea>`.
-    ///
-    /// As we want to expose the selection on the inner text node of the widget's shadow
-    /// DOM, we must find the shadow root and then access the containing element itself.
-    pub(crate) fn form_control_selection_in_text_node(self) -> Option<SharedSelection> {
-        let shadow_root = self
-            .containing_shadow_root_for_layout()?
-            .get_host_for_layout();
-        if let Some(input) = shadow_root.downcast::<HTMLInputElement>() {
-            return input.selection_for_layout();
-        }
-        shadow_root
-            .downcast::<HTMLTextAreaElement>()
-            .map(|textarea| textarea.selection_for_layout())
     }
 
     pub(crate) fn image_url(self) -> Option<ServoUrl> {

--- a/components/script/dom/node/layout_dom.rs
+++ b/components/script/dom/node/layout_dom.rs
@@ -284,6 +284,22 @@ impl<'dom> LayoutDom<'dom, Node> {
         Some(RangeAny { start, end })
     }
 
+    pub(crate) fn text_node_paints_caret(&self) -> bool {
+        if let Some(shadow_root) = self.containing_shadow_root_for_layout() {
+            let host = shadow_root.get_host_for_layout();
+            if host.is::<HTMLInputElement>() || host.is::<HTMLTextAreaElement>() {
+                // This is the cases where, if `selection_for_text_node` returns a selection
+                // it is a `TextInput` selection
+                return true;
+            }
+        }
+        // This is the cases where, if `selection_for_text_node` returns a selection
+        // it is a document selection.
+        // For now, never paint a caret for document selection.
+        // This will change as we improve `contenteditable` support.
+        false
+    }
+
     pub(crate) fn image_url(self) -> Option<ServoUrl> {
         self.downcast::<HTMLImageElement>()
             .expect("not an image!")

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -302,7 +302,7 @@ impl Node {
         &self.flags
     }
 
-    pub(super) fn layout_data(&self) -> &DomRefCell<Option<Box<GenericLayoutData>>> {
+    pub(crate) fn layout_data(&self) -> &DomRefCell<Option<Box<GenericLayoutData>>> {
         &self.layout_data
     }
 

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -168,10 +168,12 @@ impl Selection {
 
         let start_offset = range.start_offset() as usize;
         let end_offset = range.end_offset() as usize;
+        let start_container = range.start_container();
+        let end_container = range.end_container();
         let start_position =
-            position_in_flat_tree_for_selection(no_gc, range.start_container(), start_offset);
+            position_in_flat_tree_for_selection(no_gc, start_container.clone(), start_offset);
         let end_position =
-            position_in_flat_tree_for_selection(no_gc, range.end_container(), end_offset);
+            position_in_flat_tree_for_selection(no_gc, end_container.clone(), end_offset);
         let start_node = start_position.node();
         let end_node = end_position.node();
 
@@ -179,7 +181,7 @@ impl Selection {
         // have changed, always dirty the start and end nodes, if they paint selection.
         // TODO(mrobinson): We should handle changes only to the offsets within a single
         // boundary node explicitly and not traversing the whole range.
-        if let Some(character_data) = start_node.downcast::<CharacterData>() {
+        if let Some(character_data) = start_container.downcast::<CharacterData>() {
             let text = character_data.data();
             let range = RangeAny {
                 start: Some(Utf16CodeUnits(start_offset).to_utf32_code_units_in(&text)),
@@ -188,8 +190,8 @@ impl Selection {
             };
             set_text_run_selection(character_data, Some(range))
         }
-        if end_node != start_node &&
-            let Some(character_data) = end_node.downcast::<CharacterData>()
+        if end_container != start_container &&
+            let Some(character_data) = end_container.downcast::<CharacterData>()
         {
             let text = character_data.data();
             let range = RangeAny {

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -177,10 +177,12 @@ impl Selection {
         let start_node = start_position.node();
         let end_node = end_position.node();
 
-        // In case the range hasn't changed, but the offsets within the start/end end node
-        // have changed, always dirty the start and end nodes, if they paint selection.
+        // In case the range hasn't changed, but the offsets within the start/end end node have
+        // changed, always update the selection on the start and end nodes, if they paint selection.
+
         // TODO(mrobinson): We should handle changes only to the offsets within a single
         // boundary node explicitly and not traversing the whole range.
+        // But that requires keeping track of the previous range, to compare.
         if let Some(character_data) = start_container.downcast::<CharacterData>() {
             let text = character_data.data();
             let range = RangeAny {

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -11,7 +11,7 @@ use rustc_hash::FxHashSet;
 use script_bindings::codegen::GenericBindings::ShadowRootBinding::ShadowRootMethods;
 use script_bindings::dom::UnrootedDom;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
-use servo_base::text::Utf32CodeUnitsOrNodeOffset;
+use servo_base::text::{RangeAny, Utf16CodeUnits, Utf32CodeUnits, Utf32CodeUnitsOrNodeOffset};
 
 use crate::dom::abstractrange::bp_position;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::{GetRootNodeOptions, NodeMethods};
@@ -133,17 +133,31 @@ impl Selection {
 
         let previously_flagged_nodes = self.iter_nodes_with_overlaps_document_selection_flag(no_gc);
 
-        let remove_selection_flag = |node: &Node| {
+        let needs_new_display_list = Cell::new(false);
+        let set_text_run_selection =
+            |character_data: &CharacterData, range: Option<RangeAny<Utf32CodeUnits>>| {
+                if character_data.set_text_run_selection(range) {
+                    needs_new_display_list.set(true)
+                } else {
+                    character_data
+                        .upcast::<Node>()
+                        .dirty(no_gc, NodeDamage::ContentOrHeritage);
+                }
+            };
+        let remove_selection = |node: &Node| {
             node.set_flag(NodeFlags::OVERLAPS_DOCUMENT_SELECTION, false);
             // Currently only `CharacterData` nodes show visible selection.
-            if node.is::<CharacterData>() {
-                node.dirty(no_gc, NodeDamage::ContentOrHeritage);
+            if let Some(character_data) = node.downcast::<CharacterData>() {
+                set_text_run_selection(character_data, None)
             }
         };
 
         let Some(range) = self.range.get() else {
             for node in previously_flagged_nodes {
-                remove_selection_flag(&node)
+                remove_selection(&node)
+            }
+            if needs_new_display_list.get() {
+                self.document.window().layout().set_needs_new_display_list();
             }
             return;
         };
@@ -152,39 +166,42 @@ impl Selection {
         // so we don’t need HashDoS resistance and can use a faster hasher than `std`’s default
         let mut previously_flagged_nodes: FxHashSet<_> = previously_flagged_nodes.collect();
 
-        let start_position = position_in_flat_tree_for_selection(
-            no_gc,
-            range.start_container(),
-            range.start_offset() as usize,
-        );
-        let end_position = position_in_flat_tree_for_selection(
-            no_gc,
-            range.end_container(),
-            range.end_offset() as usize,
-        );
+        let start_offset = range.start_offset() as usize;
+        let end_offset = range.end_offset() as usize;
+        let start_position =
+            position_in_flat_tree_for_selection(no_gc, range.start_container(), start_offset);
+        let end_position =
+            position_in_flat_tree_for_selection(no_gc, range.end_container(), end_offset);
         let start_node = start_position.node();
         let end_node = end_position.node();
 
         // In case the range hasn't changed, but the offsets within the start/end end node
         // have changed, always dirty the start and end nodes, if they paint selection.
         // TODO(mrobinson): We should handle changes only to the offsets within a single
-        // boundary node explicitly and not be unsetting and setting flags on the whole
-        // range.
-        if start_node.is::<CharacterData>() {
-            start_node.dirty(no_gc, NodeDamage::ContentOrHeritage);
+        // boundary node explicitly and not traversing the whole range.
+        if let Some(character_data) = start_node.downcast::<CharacterData>() {
+            let text = character_data.data();
+            let range = RangeAny {
+                start: Some(Utf16CodeUnits(start_offset).to_utf32_code_units_in(&text)),
+                end: (start_node == end_node)
+                    .then_some(Utf16CodeUnits(end_offset).to_utf32_code_units_in(&text)),
+            };
+            set_text_run_selection(character_data, Some(range))
         }
-        if end_node.is::<CharacterData>() {
-            end_node.dirty(no_gc, NodeDamage::ContentOrHeritage);
+        if end_node != start_node &&
+            let Some(character_data) = end_node.downcast::<CharacterData>()
+        {
+            let text = character_data.data();
+            let range = RangeAny {
+                start: None,
+                end: Some(Utf16CodeUnits(end_offset).to_utf32_code_units_in(&text)),
+            };
+            set_text_run_selection(character_data, Some(range))
         }
 
-        let mut add_selection_flag = |node: &UnrootedDom<'no_gc, Node>| {
+        let mut set_selection_flag = |node: &UnrootedDom<'no_gc, Node>| {
             if !node.get_flag(NodeFlags::OVERLAPS_DOCUMENT_SELECTION) {
                 node.set_flag(NodeFlags::OVERLAPS_DOCUMENT_SELECTION, true);
-
-                // Currently only `CharacterData` nodes show visible selection.
-                if node.is::<CharacterData>() {
-                    node.dirty(no_gc, NodeDamage::ContentOrHeritage);
-                }
                 debug_assert!(!previously_flagged_nodes.contains(node));
             } else {
                 previously_flagged_nodes.remove(node);
@@ -198,7 +215,7 @@ impl Selection {
         //   leaves (the only nodes that show visible selection).
         let mut maybe_parent = start_node.parent_in_flat_tree(no_gc);
         while let FlatTreeParent::Parent(parent) = maybe_parent {
-            add_selection_flag(&parent);
+            set_selection_flag(&parent);
             maybe_parent = parent.parent_in_flat_tree(no_gc);
         }
 
@@ -219,10 +236,15 @@ impl Selection {
                     if node == end_node && matches!(end_position, FlatTreeNodePosition::Before(_)) {
                         break;
                     }
-                    add_selection_flag(node);
+                    if node == start_node {
+                        continue;
+                    }
+                    set_selection_flag(node);
+                    if let Some(character_data) = node.downcast::<CharacterData>() {
+                        set_text_run_selection(character_data, Some(RangeAny::full()))
+                    }
                 },
                 PrePostIteration::Leave(node) => {
-                    add_selection_flag(node);
                     if node == end_node {
                         break;
                     }
@@ -233,7 +255,10 @@ impl Selection {
         // Nodes that haven’t been removed from the `HashSet` by `add_selection_flag`
         // should no longer have the flag:
         for node in &previously_flagged_nodes {
-            remove_selection_flag(node)
+            remove_selection(node)
+        }
+        if needs_new_display_list.get() {
+            self.document.window().layout().set_needs_new_display_list();
         }
     }
 

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -239,12 +239,13 @@ impl Selection {
                     if node == start_node {
                         continue;
                     }
-                    set_selection_flag(node);
                     if let Some(character_data) = node.downcast::<CharacterData>() {
                         set_text_run_selection(character_data, Some(RangeAny::full()))
                     }
+                    set_selection_flag(node);
                 },
                 PrePostIteration::Leave(node) => {
+                    set_selection_flag(node);
                     if node == end_node {
                         break;
                     }

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -241,15 +241,15 @@ impl Selection {
                     if node == start_node {
                         continue;
                     }
-                    if let Some(character_data) = node.downcast::<CharacterData>() {
-                        set_text_run_selection(character_data, Some(RangeAny::full()))
-                    }
                     set_selection_flag(node);
                 },
                 PrePostIteration::Leave(node) => {
                     set_selection_flag(node);
                     if node == end_node {
                         break;
+                    }
+                    if let Some(character_data) = node.downcast::<CharacterData>() {
+                        set_text_run_selection(character_data, Some(RangeAny::full()))
                     }
                 },
             }

--- a/components/script/layout_dom/servo_layout_node.rs
+++ b/components/script/layout_dom/servo_layout_node.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use atomic_refcell::AtomicRef;
 use layout_api::{
     GenericLayoutData, HTMLCanvasData, HTMLMediaData, LayoutDataTrait, LayoutElement, LayoutNode,
-    LayoutNodeType, PseudoElementChain, SVGElementData, SharedSelection, TrustedNodeAddress,
+    LayoutNodeType, PseudoElementChain, SVGElementData, TrustedNodeAddress,
 };
 use net_traits::image_cache::Image;
 use pixels::ImageMetadata;
@@ -247,17 +247,13 @@ impl<'dom> LayoutNode<'dom> for ServoLayoutNode<'dom> {
         self.node.text_content()
     }
 
-    fn document_selection_in_text_node(&self) -> Option<RangeAny<Utf32CodeUnits>> {
+    fn selection_for_text_node(&self) -> Option<RangeAny<Utf32CodeUnits>> {
         // Pseudo-elements do not ever have document selection.
         if !self.pseudo_element_chain.is_empty() {
             return None;
         }
 
-        self.node.document_selection_in_text_node()
-    }
-
-    fn form_control_selection_in_text_node(&self) -> Option<SharedSelection> {
-        self.node.form_control_selection_in_text_node()
+        self.node.selection_for_text_node()
     }
 
     fn image_url(&self) -> Option<ServoUrl> {

--- a/components/script/layout_dom/servo_layout_node.rs
+++ b/components/script/layout_dom/servo_layout_node.rs
@@ -247,13 +247,17 @@ impl<'dom> LayoutNode<'dom> for ServoLayoutNode<'dom> {
         self.node.text_content()
     }
 
-    fn selection_for_text_node(&self) -> Option<RangeAny<Utf32CodeUnits>> {
+    fn text_node_selection(&self) -> Option<RangeAny<Utf32CodeUnits>> {
         // Pseudo-elements do not ever have a selection.
         if !self.pseudo_element_chain.is_empty() {
             return None;
         }
 
         self.node.selection_for_text_node()
+    }
+
+    fn text_node_paints_caret(&self) -> bool {
+        self.node.text_node_paints_caret()
     }
 
     fn image_url(&self) -> Option<ServoUrl> {

--- a/components/script/layout_dom/servo_layout_node.rs
+++ b/components/script/layout_dom/servo_layout_node.rs
@@ -248,7 +248,7 @@ impl<'dom> LayoutNode<'dom> for ServoLayoutNode<'dom> {
     }
 
     fn selection_for_text_node(&self) -> Option<RangeAny<Utf32CodeUnits>> {
-        // Pseudo-elements do not ever have document selection.
+        // Pseudo-elements do not ever have a selection.
         if !self.pseudo_element_chain.is_empty() {
             return None;
         }

--- a/components/shared/base/rope.rs
+++ b/components/shared/base/rope.rs
@@ -9,7 +9,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use rayon::iter::Either;
 use unicode_segmentation::UnicodeSegmentation;
 
-use crate::text::{Utf8CodeUnits, Utf16CodeUnits};
+use crate::text::{Utf8CodeUnits, Utf16CodeUnits, Utf32CodeUnits};
 
 fn contents_vec(contents: impl Into<String>) -> Vec<String> {
     let mut contents: Vec<_> = contents
@@ -348,17 +348,17 @@ impl Rope {
     }
 
     /// Convert a [`RopeIndex`] into a character offset from the start of the content.
-    pub fn index_to_character_offset(&self, rope_index: RopeIndex) -> usize {
+    pub fn index_to_character_offset(&self, rope_index: RopeIndex) -> Utf32CodeUnits {
         let rope_index = self.normalize_index(rope_index);
 
         // The offset might be past the end of the line due to being an exclusive offset.
         let final_line = self.line(rope_index.line);
-        let final_line_offset = final_line[0..rope_index.code_point].chars().count();
+        let final_line_offset = Utf32CodeUnits::length_of(&final_line[..rope_index.code_point]);
         self.lines
             .iter()
             .take(rope_index.line)
-            .map(|line| line.chars().count())
-            .sum::<usize>() +
+            .map(|line| Utf32CodeUnits::length_of(line))
+            .sum::<Utf32CodeUnits>() +
             final_line_offset
     }
 

--- a/components/shared/base/rope.rs
+++ b/components/shared/base/rope.rs
@@ -56,6 +56,10 @@ impl Rope {
         self.lines.join("")
     }
 
+    pub fn first_index(&self) -> RopeIndex {
+        RopeIndex::new(0, 0)
+    }
+
     pub fn last_index(&self) -> RopeIndex {
         let line_index = self.lines.len() - 1;
         RopeIndex::new(line_index, self.line(line_index).len())

--- a/components/shared/base/text.rs
+++ b/components/shared/base/text.rs
@@ -71,6 +71,14 @@ impl<T: fmt::Debug> fmt::Debug for RangeAny<T> {
 }
 
 impl<T> RangeAny<T> {
+    /// Returns a `RangeAny` that represents the full range: both bounds unset
+    pub fn full() -> Self {
+        Self {
+            start: None,
+            end: None,
+        }
+    }
+
     /// Apply `Option::map` to each bound of this range
     pub fn map<U>(self, f: impl Fn(T) -> U + Copy) -> RangeAny<U> {
         let Self { start, end } = self;

--- a/components/shared/base/text.rs
+++ b/components/shared/base/text.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::fmt;
 use std::iter::Sum;
 use std::ops::{Add, AddAssign, Range, Sub, SubAssign};
 
@@ -50,12 +51,23 @@ pub fn is_cjk(codepoint: char) -> bool {
 }
 
 /// Equivalent to either `Range`, `RangeTo`, `RangeFrom`, or `RangeFull`
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Eq, PartialEq, MallocSizeOf)]
 pub struct RangeAny<T> {
     /// `None` means zero
     pub start: Option<T>,
     /// `None` means the full available length
     pub end: Option<T>,
+}
+
+impl<T: fmt::Debug> fmt::Debug for RangeAny<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (&self.start, &self.end) {
+            (Some(start), Some(end)) => write!(f, "{start:?}..{end:?}"),
+            (Some(start), None) => write!(f, "{start:?}.."),
+            (None, Some(end)) => write!(f, "..{end:?}"),
+            (None, None) => write!(f, ".."),
+        }
+    }
 }
 
 impl<T> RangeAny<T> {
@@ -112,7 +124,7 @@ impl<T> From<Range<T>> for RangeAny<T> {
 macro_rules! unicode_length_type {
     ($( #[$doc:meta] )+ $type_name:ident) => {
         $( #[$doc] )+
-        #[derive(Clone, Copy, Debug, Default, Eq, MallocSizeOf, Ord, PartialEq, PartialOrd)]
+        #[derive(Clone, Copy, Default, Eq, MallocSizeOf, Ord, PartialEq, PartialOrd)]
         pub struct $type_name(pub usize);
 
         impl $type_name {
@@ -170,6 +182,13 @@ macro_rules! unicode_length_type {
         impl Sum for $type_name {
             fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
                 iter.fold(Self::zero(), |a, b| Self(a.0 + b.0))
+            }
+        }
+
+        /// Use compact formatting regardless of `Formatter::alternate`
+        impl fmt::Debug for $type_name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, concat!(stringify!($type_name), "({:?})"), self.0)
             }
         }
     };

--- a/components/shared/fonts/lib.rs
+++ b/components/shared/fonts/lib.rs
@@ -9,7 +9,6 @@ mod font_identifier;
 mod font_template;
 mod system_font_service_proxy;
 
-use std::ops::{Deref, Range};
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 
@@ -17,117 +16,12 @@ pub use font_descriptor::*;
 pub use font_identifier::*;
 pub use font_template::*;
 use malloc_size_of_derive::MallocSizeOf;
-use num_derive::{NumOps, One, Zero};
 use serde::{Deserialize, Serialize};
 use servo_arc::Arc as ServoArc;
 use servo_base::generic_channel::GenericSharedMemory;
 use style::font_face::Descriptors;
 use style::stylesheets::LockedFontFaceRule;
 pub use system_font_service_proxy::*;
-use webrender_api::euclid::num::One;
-
-/// An index that refers to a byte offset in a text run. This could
-/// the middle of a glyph.
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    Default,
-    Deserialize,
-    Eq,
-    MallocSizeOf,
-    NumOps,
-    Ord,
-    One,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-    Zero,
-)]
-pub struct ByteIndex(pub usize);
-
-impl ByteIndex {
-    pub fn get(&self) -> usize {
-        self.0
-    }
-}
-
-/// A range of UTF-8 bytes in a text run. This is used to identify glyphs in a `GlyphRun`
-/// by their original character byte offsets in the text.
-#[derive(Clone, Debug, Default, Deserialize, MallocSizeOf, PartialEq, Serialize)]
-pub struct TextByteRange(Range<ByteIndex>);
-
-impl TextByteRange {
-    pub fn len(&self) -> ByteIndex {
-        self.0.end - self.0.start
-    }
-
-    #[inline]
-    pub fn intersect(&self, other: &Self) -> Self {
-        let begin = self.start.max(other.start);
-        let end = self.end.min(other.end);
-
-        if end < begin {
-            Self::default()
-        } else {
-            Self::new(begin, end)
-        }
-    }
-
-    #[inline]
-    pub fn contains_inclusive(&self, index: ByteIndex) -> bool {
-        index >= self.start && index <= self.end
-    }
-}
-
-impl Deref for TextByteRange {
-    type Target = Range<ByteIndex>;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl Iterator for TextByteRange {
-    type Item = ByteIndex;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.0.start == self.0.end {
-            None
-        } else {
-            let next = self.0.start;
-            self.0.start = self.0.start + ByteIndex::one();
-            Some(next)
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (
-            self.0.end.0 - self.0.start.0,
-            Some(self.0.end.0 - self.0.start.0),
-        )
-    }
-}
-
-impl DoubleEndedIterator for TextByteRange {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        if self.0.start == self.0.end {
-            None
-        } else {
-            self.0.end = self.0.end - ByteIndex::one();
-            Some(self.0.end)
-        }
-    }
-}
-
-impl TextByteRange {
-    pub fn new(start: ByteIndex, end: ByteIndex) -> Self {
-        Self(start..end)
-    }
-
-    pub fn iter(&self) -> Range<ByteIndex> {
-        self.0.clone()
-    }
-}
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum WebFontLoadEvent {

--- a/components/shared/layout/layout_node.rs
+++ b/components/shared/layout/layout_node.rs
@@ -173,7 +173,11 @@ pub trait LayoutNode<'dom>: Copy + Debug + NodeInfo + Send + Sync {
     /// For a text node, returns which range of this text is part of the document selection
     ///
     /// Returned offsets are counted in `char`s in the `self.text_content()` string.
-    fn selection_for_text_node(&self) -> Option<RangeAny<Utf32CodeUnits>>;
+    fn text_node_selection(&self) -> Option<RangeAny<Utf32CodeUnits>>;
+
+    /// For a text node, whether a caret should be painted when the selection is an empty range
+    /// (start == end)
+    fn text_node_paints_caret(&self) -> bool;
 
     /// If this is an image element, returns its URL. If this is not an image element, fails.
     fn image_url(&self) -> Option<ServoUrl>;

--- a/components/shared/layout/layout_node.rs
+++ b/components/shared/layout/layout_node.rs
@@ -23,7 +23,7 @@ use crate::layout_dom::{DangerousStyleNodeOf, LayoutElementOf, LayoutNodeOf};
 use crate::pseudo_element_chain::PseudoElementChain;
 use crate::{
     GenericLayoutData, HTMLCanvasData, HTMLMediaData, LayoutDataTrait, LayoutDomTypeBundle,
-    LayoutNodeType, SVGElementData, SharedSelection,
+    LayoutNodeType, SVGElementData,
 };
 
 /// A trait that exposes a DOM nodes to layout. Implementors of this trait must abide by certain
@@ -173,10 +173,7 @@ pub trait LayoutNode<'dom>: Copy + Debug + NodeInfo + Send + Sync {
     /// For a text node, returns which range of this text is part of the document selection
     ///
     /// Returned offsets are counted in `char`s in the `self.text_content()` string.
-    fn document_selection_in_text_node(&self) -> Option<RangeAny<Utf32CodeUnits>>;
-
-    /// For a text node, returns which range of this text is part of a form control selection.
-    fn form_control_selection_in_text_node(&self) -> Option<SharedSelection>;
+    fn selection_for_text_node(&self) -> Option<RangeAny<Utf32CodeUnits>>;
 
     /// If this is an image element, returns its URL. If this is not an image element, fails.
     fn image_url(&self) -> Option<ServoUrl>;

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -28,7 +28,7 @@ use background_hang_monitor_api::BackgroundHangMonitorRegister;
 use bitflags::bitflags;
 use embedder_traits::{Cursor, ScriptToEmbedderChan, Theme, UntrustedNodeAddress, ViewportDetails};
 use euclid::{Point2D, Rect};
-use fonts::{FontContext, TextByteRange, WebFontDocumentContext, WebFontSetDifference};
+use fonts::{FontContext, WebFontDocumentContext, WebFontSetDifference};
 pub use layout_damage::{AccessibilityDamage, LayoutDamage};
 pub use layout_dom::{
     DangerousStyleElementOf, DangerousStyleNodeOf, LayoutDomTypeBundle, LayoutElementOf,
@@ -144,8 +144,6 @@ pub enum LayoutElementType {
 /// expected to reflect the new selection visual on the next display list update.
 #[derive(Clone, Debug, Default, MallocSizeOf, PartialEq)]
 pub struct ScriptSelection {
-    /// The range of this selection in the DOM node that manages it.
-    pub range: TextByteRange,
     /// The character range of this selection in the DOM node that manages it.
     pub character_range: Range<usize>,
     /// Whether or not this selection is enabled. Selections may be disabled

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -22,7 +22,6 @@ use std::thread::JoinHandle;
 use std::time::Duration;
 
 use app_units::Au;
-use atomic_refcell::AtomicRefCell;
 use background_hang_monitor_api::BackgroundHangMonitorRegister;
 use bitflags::bitflags;
 use embedder_traits::{Cursor, ScriptToEmbedderChan, Theme, UntrustedNodeAddress, ViewportDetails};
@@ -80,6 +79,9 @@ use webrender_api::{ExternalScrollId, ImageKey};
 
 pub trait GenericLayoutDataTrait: Any + MallocSizeOfTrait + Send + Sync + 'static {
     fn as_any(&self) -> &dyn Any;
+
+    /// Returns whether `new_range` was successfully set on an existing text run
+    fn set_text_run_selection(&self, new_range: Option<RangeAny<Utf32CodeUnits>>) -> bool;
 }
 
 pub trait LayoutDataTrait: GenericLayoutDataTrait + Default {}
@@ -138,33 +140,6 @@ pub enum LayoutElementType {
     SVGSVGElement,
 }
 
-/// A selection shared between script and layout. This selection is managed by the DOM
-/// node that maintains it, and can be modified from script. Once modified, layout is
-/// expected to reflect the new selection visual on the next display list update.
-#[derive(Clone, Debug, MallocSizeOf, PartialEq)]
-pub struct ScriptSelection {
-    /// The character range of this selection in the DOM node that manages it.
-    pub character_range: RangeAny<Utf32CodeUnits>,
-    /// Whether or not this selection is enabled. Selections may be disabled
-    /// when their node loses focus.
-    pub enabled: bool,
-}
-
-impl Default for ScriptSelection {
-    fn default() -> Self {
-        Self {
-            // Default to an empty range.
-            // Note that `start: None, end: None` would mean the full range
-            character_range: RangeAny {
-                start: None,
-                end: Some(Utf32CodeUnits(0)),
-            },
-            enabled: false,
-        }
-    }
-}
-
-pub type SharedSelection = Arc<AtomicRefCell<ScriptSelection>>;
 pub struct HTMLCanvasData {
     pub image_key: Option<ImageKey>,
     pub width: u32,

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -15,7 +15,6 @@ mod layout_node;
 mod pseudo_element_chain;
 
 use std::any::Any;
-use std::ops::Range;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::AtomicIsize;
@@ -55,7 +54,7 @@ use servo_arc::Arc as ServoArc;
 use servo_base::Epoch;
 use servo_base::generic_channel::GenericSender;
 use servo_base::id::{BrowsingContextId, PipelineId, WebViewId};
-use servo_base::text::{Utf32CodeUnits, Utf32CodeUnitsOrNodeOffset};
+use servo_base::text::{RangeAny, Utf32CodeUnits, Utf32CodeUnitsOrNodeOffset};
 use servo_url::{ImmutableOrigin, ServoUrl};
 use style::Atom;
 use style::animation::DocumentAnimationSet;
@@ -142,13 +141,27 @@ pub enum LayoutElementType {
 /// A selection shared between script and layout. This selection is managed by the DOM
 /// node that maintains it, and can be modified from script. Once modified, layout is
 /// expected to reflect the new selection visual on the next display list update.
-#[derive(Clone, Debug, Default, MallocSizeOf, PartialEq)]
+#[derive(Clone, Debug, MallocSizeOf, PartialEq)]
 pub struct ScriptSelection {
     /// The character range of this selection in the DOM node that manages it.
-    pub character_range: Range<Utf32CodeUnits>,
+    pub character_range: RangeAny<Utf32CodeUnits>,
     /// Whether or not this selection is enabled. Selections may be disabled
     /// when their node loses focus.
     pub enabled: bool,
+}
+
+impl Default for ScriptSelection {
+    fn default() -> Self {
+        Self {
+            // Default to an empty range.
+            // Note that `start: None, end: None` would mean the full range
+            character_range: RangeAny {
+                start: None,
+                end: Some(Utf32CodeUnits(0)),
+            },
+            enabled: false,
+        }
+    }
 }
 
 pub type SharedSelection = Arc<AtomicRefCell<ScriptSelection>>;

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -145,7 +145,7 @@ pub enum LayoutElementType {
 #[derive(Clone, Debug, Default, MallocSizeOf, PartialEq)]
 pub struct ScriptSelection {
     /// The character range of this selection in the DOM node that manages it.
-    pub character_range: Range<usize>,
+    pub character_range: Range<Utf32CodeUnits>,
     /// Whether or not this selection is enabled. Selections may be disabled
     /// when their node loses focus.
     pub enabled: bool,

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/inert-node-is-not-highlighted.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/inert-node-is-not-highlighted.html.ini
@@ -1,2 +1,0 @@
-[inert-node-is-not-highlighted.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/inert-node-is-not-highlighted.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/inert-node-is-not-highlighted.html.ini
@@ -1,0 +1,2 @@
+[inert-node-is-not-highlighted.html]
+  expected: FAIL

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-text-input.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-text-input.html.ini
@@ -1,3 +1,0 @@
-[fcp-text-input.html]
-  [Text input should become contentful when its value is non-empty]
-    expected: FAIL


### PR DESCRIPTION
This unifies document selection and `<textarea>`/`<input>` selection in how they are represented between script and layout crates. There is no longer an `Arc`-based `SharedSelection` accessible to both. Instead, script goes through `Node::layout_data` a.k.a. `BoxSlot` to update the selection range in existing text runs when possible.

Testing: WPT should cover most observable behavior, but we may want some more verification that layout is indeed skipped
Fixes: https://github.com/servo/servo/issues/47392
