### PR TITLE
script: Add error messages for `webgpu` and `script_webgpu`

### DIFF
--- a/components/script/dom/webgpu/gpucanvascontext.rs
+++ b/components/script/dom/webgpu/gpucanvascontext.rs
@@ -409,7 +409,7 @@ impl GPUCanvasContextMethods<crate::DomTypeHolder> for GPUCanvasContext {
         let configuration = self.configuration.borrow();
         let Some(configuration) = configuration.as_ref() else {
             return Err(Error::InvalidState(Some(
-                "GPU canvas context's configuration is null".into(),
+                "GPUCanvasContext is not configured".into(),
             )));
         };
         // 2. Assert this.[[textureDescriptor]] is not null.

--- a/components/script/dom/webgpu/gpucanvascontext.rs
+++ b/components/script/dom/webgpu/gpucanvascontext.rs
@@ -408,7 +408,9 @@ impl GPUCanvasContextMethods<crate::DomTypeHolder> for GPUCanvasContext {
         // 1. If this.[[configuration]] is null, throw an InvalidStateError and return.
         let configuration = self.configuration.borrow();
         let Some(configuration) = configuration.as_ref() else {
-            return Err(Error::InvalidState(None));
+            return Err(Error::InvalidState(Some(
+                "GPU canvas context's configuration is null".into(),
+            )));
         };
         // 2. Assert this.[[textureDescriptor]] is not null.
         let texture_descriptor = self.texture_descriptor.borrow();

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -685,7 +685,7 @@ impl RoutedPromiseListener<WebGPUPoppedErrorScopeResponse> for GPUDevice {
             Ok(None) | Err(PopError::Lost) => promise.resolve_native(cx, &None::<Option<GPUError>>),
             Err(PopError::Empty) => promise.reject_error(
                 cx,
-                Error::Operation(Some("No error returned from error scope stack".into())),
+                Error::Operation(Some("Error scope stack is empty".into())),
             ),
             Ok(Some(error)) => {
                 let error = GPUError::from_error(cx, &self.global(), error);

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -683,7 +683,10 @@ impl RoutedPromiseListener<WebGPUPoppedErrorScopeResponse> for GPUDevice {
     ) {
         match response {
             Ok(None) | Err(PopError::Lost) => promise.resolve_native(cx, &None::<Option<GPUError>>),
-            Err(PopError::Empty) => promise.reject_error(cx, Error::Operation(None)),
+            Err(PopError::Empty) => promise.reject_error(
+                cx,
+                Error::Operation(Some("No error returned from error scope stack".into())),
+            ),
             Ok(Some(error)) => {
                 let error = GPUError::from_error(cx, &self.global(), error);
                 promise.resolve_native(cx, &error);

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -136,15 +136,24 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
         } else {
             (data_size as GPUSize64)
                 .checked_sub(data_offset)
-                .ok_or(Error::Operation(None))?
+                .ok_or(Error::Operation(Some(
+                    "Overflow occured when calculating `contentsSize`".into(),
+                )))?
         };
 
         // Step 4
-        let valid = data_offset + content_size <= data_size as u64 &&
-            (content_size * sizeof_element as u64)
-                .is_multiple_of(wgpu_types::COPY_BUFFER_ALIGNMENT);
-        if !valid {
-            return Err(Error::Operation(None));
+        if !(data_offset + content_size <= data_size as u64) {
+            return Err(Error::Operation(Some(
+                "`dataOffset` + `contentsSize` is greater than `dataSize`".into(),
+            )));
+        }
+
+        if !((content_size * sizeof_element as u64)
+            .is_multiple_of(wgpu_types::COPY_BUFFER_ALIGNMENT))
+        {
+            return Err(Error::Operation(Some(
+                "`contentSize` as bytes is not a multiple of 4 bytes".into(),
+            )));
         }
 
         // Step 5&6
@@ -161,7 +170,9 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
             data: contents,
         }) {
             warn!("Failed to send WriteBuffer({:?}) ({})", buffer.id(), e);
-            return Err(Error::Operation(None));
+            return Err(Error::Operation(Some(
+                "Failed to write buffer to GPU".into(),
+            )));
         }
 
         Ok(())
@@ -178,10 +189,11 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
     ) -> Fallible<()> {
         let bytes = get_buffer_source_slice(&data, cx.no_gc());
         let len = bytes.len() as u64;
-        let valid = data_layout.offset <= len;
 
-        if !valid {
-            return Err(Error::Operation(None));
+        if !(data_layout.offset <= len) {
+            return Err(Error::Operation(Some(
+                "`dataLayout`'s offset is greater than texture buffer length".into(),
+            )));
         }
 
         let texture_cv = destination.try_convert()?;
@@ -202,7 +214,9 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
                 destination.texture.id().0,
                 e
             );
-            return Err(Error::Operation(None));
+            return Err(Error::Operation(Some(
+                "Failed to write texture buffer to GPU".into(),
+            )));
         }
 
         Ok(())
@@ -369,7 +383,9 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
                 "Failed to send CopyExternalImageToTexture({:?}) ({e})",
                 destination.parent.texture.id().0
             );
-            return Err(Error::Operation(None));
+            return Err(Error::Operation(Some(
+                "Failed to copy external image to texture".into(),
+            )));
         }
         Ok(())
     }

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -215,7 +215,7 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
                 e
             );
             return Err(Error::Operation(Some(
-                "Failed to write texture buffer to GPU".into(),
+                "Failed to write to GPUTexture".into(),
             )));
         }
 

--- a/components/script_webgpu/gpu.rs
+++ b/components/script_webgpu/gpu.rs
@@ -123,7 +123,9 @@ where
         {
             promise.reject_error(
                 cx,
-                Error::Operation(Some("Could not request adapter".into())),
+                Error::Operation(Some(
+                    "Could not send `requestAdapter` request from script thread to constellation thread".into(),
+                )),
             );
         }
         // 4. Return promise

--- a/components/script_webgpu/gpubuffer.rs
+++ b/components/script_webgpu/gpubuffer.rs
@@ -361,16 +361,43 @@ where
             .map(RootedTraceableBox::new)
             .ok_or(Error::Operation(Some("No active buffer map".into())))?;
 
-        let valid = offset.is_multiple_of(wgpu_types::MAP_ALIGNMENT) &&
-            range_size % wgpu_types::COPY_BUFFER_ALIGNMENT == 0 &&
-            offset >= mapping.range.start &&
-            offset + range_size <= mapping.range.end;
-        if !valid {
+        if !(offset.is_multiple_of(wgpu_types::MAP_ALIGNMENT)) {
             self.mapping
                 .safe_borrow_mut(cx)
                 .replace(*mapping.into_box());
+
             return Err(Error::Operation(Some(
-                "Buffer Mapping is not active".into(),
+                "`offset` is not a multiple of 8".into(),
+            )));
+        }
+
+        if !(range_size % wgpu_types::COPY_BUFFER_ALIGNMENT == 0) {
+            self.mapping
+                .safe_borrow_mut(cx)
+                .replace(*mapping.into_box());
+
+            return Err(Error::Operation(Some(
+                "`rangeSize` is not a multiple of 4".into(),
+            )));
+        }
+
+        if !(offset >= mapping.range.start) {
+            self.mapping
+                .safe_borrow_mut(cx)
+                .replace(*mapping.into_box());
+
+            return Err(Error::Operation(Some(
+                "`offset` is greater than `[[mapping]].range[0]`".into(),
+            )));
+        }
+
+        if !(offset + range_size <= mapping.range.end) {
+            self.mapping
+                .safe_borrow_mut(cx)
+                .replace(*mapping.into_box());
+
+            return Err(Error::Operation(Some(
+                "`offset` + `rangeSize` is less than or equal to `[[mapping]].range[1]`".into(),
             )));
         }
 
@@ -446,9 +473,12 @@ where
         // Step 4
         let is_lost = self.device.is_lost();
         if is_lost {
-            p.reject_error(cx, Error::Abort(Some("GPUDevice is lost".into())));
+            p.reject_error(cx, Error::Abort(Some("GPU device is lost".into())));
         } else {
-            p.reject_error(cx, Error::Operation(Some("Mapping failure".into())));
+            p.reject_error(
+                cx,
+                Error::Operation(Some("Could not map GPU buffer".into())),
+            );
         }
     }
 

--- a/components/script_webgpu/gpubuffer.rs
+++ b/components/script_webgpu/gpubuffer.rs
@@ -473,12 +473,9 @@ where
         // Step 4
         let is_lost = self.device.is_lost();
         if is_lost {
-            p.reject_error(cx, Error::Abort(Some("GPU device is lost".into())));
+            p.reject_error(cx, Error::Abort(Some("GPUDevice is lost".into())));
         } else {
-            p.reject_error(
-                cx,
-                Error::Operation(Some("Could not map GPU buffer".into())),
-            );
+            p.reject_error(cx, Error::Operation(Some("Failed to map GPUBuffer".into())));
         }
     }
 

--- a/python/tidy/error_message_exceptions.txt
+++ b/python/tidy/error_message_exceptions.txt
@@ -88,9 +88,6 @@
 ./components/script/dom/timeranges.rs 2
 ./components/script/dom/webcrypto/crypto.rs 1
 ./components/script/dom/webgl/webglrenderingcontext.rs 4
-./components/script/dom/webgpu/gpucanvascontext.rs 1
-./components/script/dom/webgpu/gpudevice.rs 1
-./components/script/dom/webgpu/gpuqueue.rs 6
 ./components/script/dom/webrtc/rtcdatachannel.rs 2
 ./components/script/dom/webrtc/rtcpeerconnection.rs 2
 ./components/script/dom/webvtt/texttrack.rs 1


### PR DESCRIPTION
This covers all remaining `None`s in `webgpu` and `script_webgpu`.

Testing: Not necessary
Fixes: Part of #40756
