### PR TITLE
script: Do not cache the active range during editing

### DIFF
--- a/components/script/dom/execcommand/commands/delete.rs
+++ b/components/script/dom/execcommand/commands/delete.rs
@@ -128,9 +128,9 @@ pub(crate) fn execute_delete_command(
                 }))
     {
         // Step 5.1. Call collapse(node, offset) on the context object's selection.
-        selection.collapse_current_range(&node, offset);
+        selection.collapse_active_range(&node, offset);
         // Step 5.2. Call extend(node, offset − 1) on the context object's selection.
-        selection.extend_current_range(&node, offset - 1);
+        selection.extend_active_range(&node, offset - 1);
         // Step 5.3. Delete the selection.
         selection.delete_the_selection(
             cx,
@@ -272,9 +272,9 @@ pub(crate) fn execute_delete_command(
                 }))
     {
         // Step 13.1. Call collapse(start node, start offset − 1) on the context object's selection.
-        selection.collapse_current_range(&start_node, start_offset - 1);
+        selection.collapse_active_range(&start_node, start_offset - 1);
         // Step 13.2. Call extend(start node, start offset) on the context object's selection.
-        selection.extend_current_range(&start_node, start_offset);
+        selection.extend_active_range(&start_node, start_offset);
         // Step 13.3. Delete the selection.
         selection.delete_the_selection(
             cx,
@@ -284,7 +284,7 @@ pub(crate) fn execute_delete_command(
             Default::default(),
         );
         // Step 13.4. Call collapse(node, offset) on the selection.
-        selection.collapse_current_range(&node, offset);
+        selection.collapse_active_range(&node, offset);
         // Step 13.5. Return true.
         return true;
     }
@@ -323,10 +323,10 @@ pub(crate) fn execute_delete_command(
     }
 
     // Step 17. Call collapse(start node, start offset) on the context object's selection.
-    selection.collapse_current_range(&start_node, start_offset);
+    selection.collapse_active_range(&start_node, start_offset);
 
     // Step 18. Call extend(node, offset) on the context object's selection.
-    selection.extend_current_range(&node, offset);
+    selection.extend_active_range(&node, offset);
 
     // Step 19. Delete the selection, with direction "backward".
     selection.delete_the_selection(

--- a/components/script/dom/execcommand/commands/insertparagraph.rs
+++ b/components/script/dom/execcommand/commands/insertparagraph.rs
@@ -70,7 +70,7 @@ pub(crate) fn execute_insert_paragraph_command(
         node = node.GetParentNode().expect("Must always have a parent");
     }
     // Step 7. Call collapse(node, offset) on the context object's selection.
-    selection.collapse_current_range(&node, offset);
+    selection.collapse_active_range(&node, offset);
     // Step 8. Let container equal node.
     let mut container = node.clone();
     // Step 9. While container is not a single-line container,
@@ -159,7 +159,7 @@ pub(crate) fn execute_insert_paragraph_command(
                 unreachable!("Must always be able to append");
             }
             // Step 11.5.5. Call collapse(container, 0) on the context object's selection.
-            selection.collapse_current_range(container, 0);
+            selection.collapse_active_range(container, 0);
             // Step 11.5.6. Return true.
             return true;
         };
@@ -201,7 +201,7 @@ pub(crate) fn execute_insert_paragraph_command(
             unreachable!("Must always be able to insert");
         }
         // Step 12.3. Call collapse(node, offset + 1) on the context object's selection.
-        selection.collapse_current_range(&node, offset + 1);
+        selection.collapse_active_range(&node, offset + 1);
         // Step 12.4. If br is the last descendant of container,
         // let br be the result of calling createElement("br") on the context object,
         // then call insertNode(br) on the active range.
@@ -421,7 +421,7 @@ pub(crate) fn execute_insert_paragraph_command(
         }
     }
     // Step 34. Call collapse(new container, 0) on the context object's selection.
-    selection.collapse_current_range(&new_container_node, 0);
+    selection.collapse_active_range(&new_container_node, 0);
     // Step 35. Return true.
     true
 }

--- a/components/script/dom/execcommand/commands/removeformat.rs
+++ b/components/script/dom/execcommand/commands/removeformat.rs
@@ -4,6 +4,7 @@
 
 use html5ever::local_name;
 use js::context::JSContext;
+use script_bindings::codegen::GenericBindings::RangeBinding::RangeMethods;
 use script_bindings::inheritance::Castable;
 
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
@@ -103,7 +104,7 @@ pub(crate) fn execute_removeformat_command(
         let Ok(start_text) = start_text.SplitText(cx, start_offset) else {
             unreachable!("Must always be able to split");
         };
-        active_range.set_start(start_text.upcast(), 0);
+        let _ = active_range.SetStart(start_text.upcast(), 0);
     }
     // Step 4. If the active range's end node is an editable Text node,
     // and its end offset is neither zero nor its end node's length,

--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -8,6 +8,7 @@ use std::ops::Deref;
 use cssparser::color::OPAQUE;
 use html5ever::local_name;
 use js::context::{JSContext, NoGC};
+use script_bindings::codegen::GenericBindings::RangeBinding::RangeMethods;
 use script_bindings::inheritance::Castable;
 use style::attr::parse_legacy_color;
 use style::values::specified::box_::DisplayOutside;
@@ -231,8 +232,8 @@ where
     let (new_end_container, new_end_offset) =
         adjust_boundary_point(end_container, end_offset, should_adjust_end);
 
-    active_range.set_start(&new_start_container, new_start_offset);
-    active_range.set_end(&new_end_container, new_end_offset);
+    let _ = active_range.SetStart(&new_start_container, new_start_offset);
+    let _ = active_range.SetEnd(&new_end_container, new_end_offset);
 }
 
 /// <https://w3c.github.io/editing/docs/execCommand/#allowed-child>

--- a/components/script/dom/execcommand/contenteditable/selection.rs
+++ b/components/script/dom/execcommand/contenteditable/selection.rs
@@ -5,6 +5,8 @@
 use std::cmp::Ordering;
 
 use js::context::JSContext;
+use script_bindings::codegen::GenericBindings::RangeBinding::RangeMethods;
+use script_bindings::codegen::GenericBindings::SelectionBinding::SelectionMethods;
 use script_bindings::inheritance::Castable;
 
 use crate::dom::abstractrange::bp_position;
@@ -172,44 +174,32 @@ impl Selection {
         direction: SelectionDeleteDirection,
     ) {
         // Step 1. If the active range is null, abort these steps and do nothing.
-        let Some(active_range) = self.active_range(cx) else {
+        if self.active_range(cx).is_none() {
             return;
         };
 
         // Step 2. Canonicalize whitespace at the active range's start.
-        active_range.start_container().canonicalize_whitespace(
-            cx,
-            active_range.start_offset(),
-            true,
-        );
+        let (start_container, start_offset) = self.start_boundary(cx);
+        start_container.canonicalize_whitespace(cx, start_offset, true);
 
         // Step 3. Canonicalize whitespace at the active range's end.
-        active_range
-            .end_container()
-            .canonicalize_whitespace(cx, active_range.end_offset(), true);
+        let (end_container, end_offset) = self.end_boundary(cx);
+        end_container.canonicalize_whitespace(cx, end_offset, true);
 
         // Step 4. Let (start node, start offset) be the last equivalent point for the active range's start.
-        let (mut start_node, mut start_offset) =
-            (active_range.start_container(), active_range.start_offset()).last_equivalent_point();
+        let (mut start_node, mut start_offset) = self.start_boundary(cx).last_equivalent_point();
 
         // Step 5. Let (end node, end offset) be the first equivalent point for the active range's end.
-        let (mut end_node, mut end_offset) =
-            (active_range.end_container(), active_range.end_offset()).first_equivalent_point();
+        let (mut end_node, mut end_offset) = self.end_boundary(cx).first_equivalent_point();
 
         // Step 6. If (end node, end offset) is not after (start node, start offset):
         if bp_position(&end_node, end_offset, &start_node, start_offset) != Ordering::Greater {
             // Step 6.1. If direction is "forward", call collapseToStart() on the context object's selection.
             if direction == SelectionDeleteDirection::Forward {
-                self.collapse_current_range(
-                    &active_range.start_container(),
-                    active_range.start_offset(),
-                );
+                let _ = self.CollapseToStart(cx);
             } else {
                 // Step 6.2. Otherwise, call collapseToEnd() on the context object's selection.
-                self.collapse_current_range(
-                    &active_range.end_container(),
-                    active_range.end_offset(),
-                );
+                let _ = self.CollapseToEnd(cx);
             }
             // Step 6.3. Abort these steps.
             return;
@@ -232,17 +222,17 @@ impl Selection {
         }
 
         // Step 9. Call collapse(start node, start offset) on the context object's selection.
-        self.collapse_current_range(&start_node, start_offset);
+        let _ = self.Collapse(cx, Some(&start_node), start_offset);
 
         // Step 10. Call extend(end node, end offset) on the context object's selection.
-        self.extend_current_range(&end_node, end_offset);
+        let _ = self.Extend(cx, &end_node, end_offset);
 
         // Step 11.
         //
         // This step does not exist in the spec
 
         // Step 12. Let start block be the active range's start node.
-        let mut start_block = active_range.start_container();
+        let mut start_block = self.start_boundary(cx).0;
 
         // Step 13. While start block's parent is in the same editing host and start block is an inline node,
         // set start block to its parent.
@@ -273,7 +263,7 @@ impl Selection {
         };
 
         // Step 15. Let end block be the active range's end node.
-        let mut end_block = active_range.end_container();
+        let mut end_block = self.end_boundary(cx).0;
 
         // Step 16. While end block's parent is in the same editing host and end block is an inline node, set end block to its parent.
         loop {
@@ -306,7 +296,9 @@ impl Selection {
         // This step does not exist in the spec
 
         // Step 19. Record current states and values, and let overrides be the result.
-        let overrides = active_range.record_current_states_and_values(cx);
+        let overrides = self
+            .expect_active_range(cx)
+            .record_current_states_and_values(cx);
 
         // Step 20.
         //
@@ -329,19 +321,18 @@ impl Selection {
             start_node.canonicalize_whitespace(cx, start_offset, false);
             // Step 21.3. If direction is "forward", call collapseToStart() on the context object's selection.
             if direction == SelectionDeleteDirection::Forward {
-                self.collapse_current_range(
-                    &active_range.start_container(),
-                    active_range.start_offset(),
-                );
+                let _ = self.CollapseToStart(cx);
             } else {
                 // Step 21.4. Otherwise, call collapseToEnd() on the context object's selection.
-                self.collapse_current_range(
-                    &active_range.end_container(),
-                    active_range.end_offset(),
-                );
+                let _ = self.CollapseToEnd(cx);
             }
             // Step 21.5. Restore states and values from overrides.
-            active_range.restore_states_and_values(cx, self, context_object, overrides);
+            self.expect_active_range(cx).restore_states_and_values(
+                cx,
+                self,
+                context_object,
+                overrides,
+            );
 
             // Step 21.6. Abort these steps.
             return;
@@ -365,7 +356,7 @@ impl Selection {
         // Step 24. For each node contained in the active range, append node to node list if the
         // last member of node list (if any) is not an ancestor of node; node is editable;
         // and node is not a thead, tbody, tfoot, tr, th, or td.
-        for node in active_range.contained_nodes(cx.no_gc()) {
+        for node in self.expect_active_range(cx).contained_nodes(cx.no_gc()) {
             // This type is only used to tell the compiler how to handle the type of `node_list.last()`.
             // It is not allowed to add a `& DomRoot<Node>` annotation, as test-tidy disallows that.
             // However, if we omit the type, the compiler doesn't know what it is, since we also
@@ -440,18 +431,14 @@ impl Selection {
         }
 
         // Step 27. Canonicalize whitespace at the active range's start, with fix collapsed space false.
-        active_range.start_container().canonicalize_whitespace(
-            cx,
-            active_range.start_offset(),
-            false,
-        );
+        let (start_container, start_offset) = self.start_boundary(cx);
+        start_container.canonicalize_whitespace(cx, start_offset, false);
 
         // Step 28. Canonicalize whitespace at the active range's end, with fix collapsed space false.
-        active_range
-            .end_container()
-            .canonicalize_whitespace(cx, active_range.end_offset(), false);
+        let (end_container, end_offset) = self.end_boundary(cx);
+        end_container.canonicalize_whitespace(cx, end_offset, false);
 
-        // Step 29.
+        // Step 29
         //
         // This step does not exist in the spec
 
@@ -466,19 +453,18 @@ impl Selection {
         {
             // Step 30.1. If direction is "forward", call collapseToStart() on the context object's selection.
             if direction == SelectionDeleteDirection::Forward {
-                self.collapse_current_range(
-                    &active_range.start_container(),
-                    active_range.start_offset(),
-                );
+                let _ = self.CollapseToStart(cx);
             } else {
                 // Step 30.2. Otherwise, call collapseToEnd() on the context object's selection.
-                self.collapse_current_range(
-                    &active_range.end_container(),
-                    active_range.end_offset(),
-                );
+                let _ = self.CollapseToEnd(cx);
             }
             // Step 30.3. Restore states and values from overrides.
-            active_range.restore_states_and_values(cx, self, context_object, overrides);
+            self.expect_active_range(cx).restore_states_and_values(
+                cx,
+                self,
+                context_object,
+                overrides,
+            );
 
             // Step 30.4. Abort these steps.
             return;
@@ -516,7 +502,7 @@ impl Selection {
             }
             // Step 32.3. Call collapse() on the context object's selection,
             // with first argument start block and second argument the index of reference node.
-            self.collapse_current_range(&start_block, reference_node.index());
+            let _ = self.Collapse(cx, Some(&start_block), reference_node.index());
             // Step 32.4. If end block has no children:
             if end_block.children_count() == 0 {
                 let mut end_block = end_block;
@@ -563,7 +549,12 @@ impl Selection {
                     end_block.remove_self(cx);
                 }
                 // Step 32.4.4. Restore states and values from overrides.
-                active_range.restore_states_and_values(cx, self, context_object, overrides);
+                self.expect_active_range(cx).restore_states_and_values(
+                    cx,
+                    self,
+                    context_object,
+                    overrides,
+                );
 
                 // Step 32.4.5. Abort these steps.
                 return;
@@ -575,7 +566,12 @@ impl Selection {
             // Step 32.5. If end block's firstChild is not an inline node,
             // restore states and values from record, then abort these steps.
             if !first_child.is_inline_node() {
-                active_range.restore_states_and_values(cx, self, context_object, overrides);
+                self.expect_active_range(cx).restore_states_and_values(
+                    cx,
+                    self,
+                    context_object,
+                    overrides,
+                );
                 return;
             }
             // Step 32.6. Let children be a list of nodes, initially empty.
@@ -630,7 +626,7 @@ impl Selection {
         } else if end_block.is_ancestor_of(&start_block) {
             // Step 33.1. Call collapse() on the context object's selection,
             // with first argument start block and second argument start block's length.
-            self.collapse_current_range(&start_block, start_block.len());
+            let _ = self.Collapse(cx, Some(&start_block), start_block.len());
             // Step 33.2. Let reference node be start block.
             let mut reference_node = start_block.clone();
             // Step 33.3. While reference node is not a child of end block, set reference node to its parent.
@@ -691,7 +687,7 @@ impl Selection {
         } else {
             // Step 34.1. Call collapse() on the context object's selection,
             // with first argument start block and second argument start block's length.
-            self.collapse_current_range(&start_block, start_block.len());
+            let _ = self.Collapse(cx, Some(&start_block), start_block.len());
             // Step 34.2. If end block's firstChild is an inline node and start block's lastChild is a br,
             // remove start block's lastChild from it.
             if end_block
@@ -765,7 +761,8 @@ impl Selection {
         start_block.remove_extraneous_line_breaks_at_the_end_of(cx);
 
         // Step 41. Restore states and values from overrides.
-        active_range.restore_states_and_values(cx, self, context_object, overrides);
+        self.expect_active_range(cx)
+            .restore_states_and_values(cx, self, context_object, overrides);
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#set-the-selection%27s-value>
@@ -776,16 +773,13 @@ impl Selection {
         command: CommandName,
         context_object: &Document,
     ) {
-        let active_range = self
-            .active_range(cx)
-            .expect("Must always have an active range");
-
         // Step 1. Let command be the current command.
         //
         // Passed as argument
 
         // Step 2. If there is no formattable node effectively contained in the active range:
-        if active_range
+        if self
+            .expect_active_range(cx)
             .first_formattable_contained_node(cx.no_gc())
             .is_none()
         {
@@ -818,8 +812,7 @@ impl Selection {
         // call splitText() on the active range's start node,
         // with argument equal to the active range's start offset.
         // Then set the active range's start node to the result, and its start offset to zero.
-        let start_node = active_range.start_container();
-        let start_offset = active_range.start_offset();
+        let (start_node, start_offset) = self.start_boundary(cx);
         if start_node.is_editable() &&
             start_offset != 0 &&
             start_offset != start_node.len() &&
@@ -828,14 +821,15 @@ impl Selection {
             let Ok(start_text) = start_text.SplitText(cx, start_offset) else {
                 unreachable!("Must always be able to split");
             };
-            active_range.set_start(start_text.upcast(), 0);
+            let _ = self
+                .expect_active_range(cx)
+                .SetStart(start_text.upcast(), 0);
         }
         // Step 4. If the active range's end node is an editable Text node,
         // and its end offset is neither zero nor its end node's length,
         // call splitText() on the active range's end node,
         // with argument equal to the active range's end offset.
-        let end_node = active_range.end_container();
-        let end_offset = active_range.end_offset();
+        let (end_node, end_offset) = self.end_boundary(cx);
         if end_node.is_editable() &&
             end_offset != 0 &&
             end_offset != end_node.len() &&
@@ -846,27 +840,29 @@ impl Selection {
         };
         // Step 5. Let element list be all editable Elements effectively contained in the active range.
         // Step 6. For each element in element list, clear the value of element.
-        active_range.for_each_effectively_contained_child(|child| {
-            if child.is_editable() &&
-                let Some(element_child) = child.downcast::<HTMLElement>()
-            {
-                element_child.clear_the_value(cx, &command);
-            }
-        });
+        self.expect_active_range(cx)
+            .for_each_effectively_contained_child(|child| {
+                if child.is_editable() &&
+                    let Some(element_child) = child.downcast::<HTMLElement>()
+                {
+                    element_child.clear_the_value(cx, &command);
+                }
+            });
         // Step 7. Let node list be all editable nodes effectively contained in the active range.
         // Step 8. For each node in node list:
-        active_range.for_each_effectively_contained_child(|child| {
-            if child.is_editable() {
-                // Step 8.1. Push down values on node.
-                child.push_down_values(cx, &command, new_value.clone());
-                // Step 8.2. If node is an allowed child of "span", force the value of node.
-                if is_allowed_child(
-                    NodeOrString::from_node(child, cx.no_gc()),
-                    NodeOrString::String("span".to_owned()),
-                ) {
-                    child.force_the_value(cx, &command, new_value.as_ref());
+        self.expect_active_range(cx)
+            .for_each_effectively_contained_child(|child| {
+                if child.is_editable() {
+                    // Step 8.1. Push down values on node.
+                    child.push_down_values(cx, &command, new_value.clone());
+                    // Step 8.2. If node is an allowed child of "span", force the value of node.
+                    if is_allowed_child(
+                        NodeOrString::from_node(child, cx.no_gc()),
+                        NodeOrString::String("span".to_owned()),
+                    ) {
+                        child.force_the_value(cx, &command, new_value.as_ref());
+                    }
                 }
-            }
-        });
+            });
     }
 }

--- a/components/script/dom/execcommand/execcommands.rs
+++ b/components/script/dom/execcommand/execcommands.rs
@@ -51,7 +51,7 @@ fn bump_selection_out_of_invalid_node(cx: &mut JSContext, selection: &Selection)
         let Some(parent) = start_container.GetParentNode() else {
             return Err(());
         };
-        active_range.set_start(&parent, start_container.index());
+        let _ = active_range.SetStart(&parent, start_container.index());
     }
     if let end_container = active_range.end_container() &&
         (end_container.is::<Comment>() || end_container.is::<ProcessingInstruction>())
@@ -59,7 +59,7 @@ fn bump_selection_out_of_invalid_node(cx: &mut JSContext, selection: &Selection)
         let Some(parent) = end_container.GetParentNode() else {
             return Err(());
         };
-        active_range.set_end(&parent, end_container.index());
+        let _ = active_range.SetEnd(&parent, end_container.index());
     }
     Ok(())
 }

--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -332,6 +332,7 @@ impl Range {
             .for_each(|selection| {
                 selection.queue_selectionchange_task();
                 selection.set_visible_selection_dirty();
+                selection.clear_command_overrides();
             });
     }
 

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -82,17 +82,26 @@ impl Selection {
             return;
         }
 
-        if let Some(old_range) = self.range.take() {
+        let old_range = self.range.take();
+        if let Some(old_range) = old_range.as_ref() {
             old_range.disassociate_selection(self);
         }
+
+        let boundary_points_changed = matches!(
+            (old_range, new_range),
+            (Some(old_range), Some(new_range)) if
+                old_range.start() != new_range.start() ||
+                old_range.end() != new_range.end());
 
         if let Some(new_range) = new_range {
             self.range.set(Some(new_range));
             new_range.associate_selection(self);
         }
 
-        self.set_visible_selection_dirty();
-        self.queue_selectionchange_task();
+        if boundary_points_changed {
+            self.set_visible_selection_dirty();
+            self.queue_selectionchange_task();
+        }
     }
 
     fn iter_nodes_with_overlaps_document_selection_flag<'no_gc>(
@@ -287,6 +296,16 @@ impl Selection {
             self.document.upcast::<Node>()
     }
 
+    pub(crate) fn start_boundary(&self, cx: &mut JSContext) -> (DomRoot<Node>, u32) {
+        let range = self.expect_active_range(cx);
+        (range.start_container(), range.start_offset())
+    }
+
+    pub(crate) fn end_boundary(&self, cx: &mut JSContext) -> (DomRoot<Node>, u32) {
+        let range = self.expect_active_range(cx);
+        (range.end_container(), range.end_offset())
+    }
+
     /// <https://w3c.github.io/editing/docs/execCommand/#active-range>
     pub(crate) fn active_range(&self, _cx: &mut JSContext) -> Option<DomRoot<Range>> {
         // > The active range is the range of the selection given by calling
@@ -294,7 +313,13 @@ impl Selection {
         self.range.get()
     }
 
-    pub(crate) fn collapse_current_range(&self, node: &Node, offset: u32) {
+    pub(crate) fn expect_active_range(&self, _cx: &mut JSContext) -> DomRoot<Range> {
+        self.range
+            .get()
+            .expect("Should always have an active range")
+    }
+
+    pub(crate) fn collapse_active_range(&self, node: &Node, offset: u32) {
         let range = self.range.get().expect("Must always have a range");
         range.set_start(node, offset);
         range.set_end(node, offset);
@@ -302,7 +327,7 @@ impl Selection {
         self.set_visible_selection_dirty();
     }
 
-    pub(crate) fn extend_current_range(&self, node: &Node, offset: u32) {
+    pub(crate) fn extend_active_range(&self, node: &Node, offset: u32) {
         let range = self.range.get().expect("Must always have a range");
         assert!(range.collapsed(), "Must only extend after collapsing");
 

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -87,20 +87,33 @@ impl Selection {
             old_range.disassociate_selection(self);
         }
 
-        let boundary_points_changed = matches!(
-            (old_range, new_range),
-            (Some(old_range), Some(new_range)) if
-                old_range.start() != new_range.start() ||
-                old_range.end() != new_range.end());
+        let boundary_points_changed = match (old_range, new_range) {
+            (Some(old_range), Some(new_range)) => {
+                old_range.start() != new_range.start() || old_range.end() != new_range.end()
+            },
+            _ => true,
+        };
 
         if let Some(new_range) = new_range {
             self.range.set(Some(new_range));
             new_range.associate_selection(self);
         }
 
+        // From <https://w3c.github.io/selection-api/#selectionchange-event>:
+        // > When the selection is dissociated with its range, associated with a new
+        // > range, or the associated range's boundary point is mutated either by the user
+        // > or the content script, the user agent must schedule a selectionchange event on
+        // > document.
+        //
+        // This means we should fire the event even if the boundaries themselves did not
+        // change. A change to the range object is enough.
+        self.queue_selectionchange_task();
+
+        // On the other hand, clearing command overrides and marking the visible selection
+        // as dirty should only happen when the selection really changed.
         if boundary_points_changed {
             self.set_visible_selection_dirty();
-            self.queue_selectionchange_task();
+            self.clear_command_overrides();
         }
     }
 
@@ -246,16 +259,20 @@ impl Selection {
         }
     }
 
+    /// An implementation of:
+    ///  - <https://w3c.github.io/editing/docs/execCommand/#state-override> and
+    ///  - <https://w3c.github.io/editing/docs/execCommand/#value-override>
+    ///
+    /// > Whenever the number of ranges in the selection changes to something
+    /// > different, and whenever a boundary point of the range at a given index in the
+    /// > selection changes to something different, the state override and value
+    /// > override must be unset for every command.
+    pub(crate) fn clear_command_overrides(&self) {
+        self.document.clear_command_overrides();
+    }
+
     /// <https://w3c.github.io/selection-api/#dfn-schedule-a-selectionchange-event>
     pub(crate) fn queue_selectionchange_task(&self) {
-        // https://w3c.github.io/editing/docs/execCommand/#state-override
-        // https://w3c.github.io/editing/docs/execCommand/#value-override
-        // > Whenever the number of ranges in the selection changes to something
-        // > different, and whenever a boundary point of the range at a given index in the
-        // > selection changes to something different, the state override and value
-        // > override must be unset for every command.
-        self.document.clear_command_overrides();
-
         // Step 1. If target's has scheduled selectionchange event is true, abort these steps.
         if self.has_scheduled_selectionchange_event.get() {
             return;

--- a/tests/wpt/meta/editing/run/delete.html.ini
+++ b/tests/wpt/meta/editing/run/delete.html.ini
@@ -1,7 +1,4 @@
 [delete.html?6001-7000]
-  [[["delete",""\]\] "<b>foo [&nbsp;</b>bar\]" compare innerHTML]
-    expected: FAIL
-
   [[["delete",""\]\] "<ol><li>foo</ol>{}<br><ol><li>bar</ol>" compare innerHTML]
     expected: FAIL
 
@@ -211,18 +208,6 @@
   [[["stylewithcss","false"\],["delete",""\]\] "<div style=color:blue><p style=color:green>foo</div>[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>{bar</span>baz}" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>{bar</span>baz}" compare innerHTML]
-    expected: FAIL
-
   [[["delete",""\]\] "<p>foo</p><p>{bar</p>}<p>baz</p>" compare innerHTML]
     expected: FAIL
 
@@ -243,40 +228,10 @@
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<div><p>foo<p>[bar<p>baz\]</div>" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\]\] "foo<p>{bar</p>}baz" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo{<p>bar}</p>baz" compare innerHTML]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo{<p>bar}</p>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<p>foo[</p>\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<p>foo{</p>}bar" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<p>foo[</p>\]bar<br>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<p>foo[</p>\]bar<p>baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<div><p>foo[</p></div>\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<div><p>foo</p>bar[</div>\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<div>foo<p>bar[</p></div>\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<p>foo<br>{</p>\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<p>foo<br><br>{</p>\]bar" compare innerHTML]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo<br><br>{<p>\]bar</p>" compare innerHTML]

--- a/tests/wpt/meta/editing/run/forwarddelete.html.ini
+++ b/tests/wpt/meta/editing/run/forwarddelete.html.ini
@@ -5,21 +5,6 @@
   [[["forwarddelete",""\]\] "foo[\]<span></span><br>bar" compare innerHTML]
     expected: FAIL
 
-  [[["forwarddelete",""\]\] "<div><div><p>foo[\]</div></div>bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<div><div><p>foo[\]</div></div><!--abc-->bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<div><div><p>foo[\]</div><!--abc--></div>bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<div><div><p>foo[\]</p><!--abc--></div></div>bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<div><div><p>foo[\]<!--abc--></div></div>bar" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["forwarddelete",""\]\] "foo[\]<blockquote style=\\"color: blue\\">bar</blockquote>" queryCommandState("stylewithcss") before]
     expected: FAIL
 
@@ -41,24 +26,6 @@
     expected: FAIL
 
   [[["forwarddelete",""\]\] "&#x5e9;&#x5c1;&#x5b8;&#x5dc;[\]&#x5d5;&#x5b9;&#x5dd;" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<p>foo[\]</p>bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<p>foo[\]<br></p>bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<p>{}<br></p>foo" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<p>{}<span><br></span></p>foo" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<div><p>foo[\]</p></div>bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<pre>foo[\]</pre>bar" compare innerHTML]
     expected: FAIL
 
   [[["forwarddelete",""\]\] "foo[\]<br>bar" compare innerHTML]
@@ -88,15 +55,6 @@
     expected: FAIL
 
   [[["styleWithCSS","false"\],["defaultparagraphseparator","p"\],["forwarddelete",""\]\] "<p><font color=blue>foo[\]</font><p><font size=5>bar</font>" queryCommandValue("fontSize") before]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["forwarddelete",""\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo[\]</span></p><span style=\\"color:rgb(255, 0, 0)\\">bar</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["forwarddelete",""\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo[\]</span><br></p><span style=\\"color:rgb(255, 0, 0)\\">bar</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["forwarddelete",""\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo[\]<br></span></p><span style=\\"color:rgb(255, 0, 0)\\">bar</span>" compare innerHTML]
     expected: FAIL
 
   [[["forwarddelete",""\]\] "<ul><li><span>[abc</span></li><li>def\]</li></ul>" compare innerHTML]
@@ -147,12 +105,6 @@
   [[["forwarddelete",""\]\] "<table><tr><th>a<th><b>[b</b><th><b>c</b><th><b>d\]</b><th>e</table>" compare innerHTML]
     expected: FAIL
 
-  [[["forwarddelete",""\]\] "<div style=display:flex><span>abc</span><span>def[\]</span></div>ghi" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<div style=display:inline-flex><span>abc</span><span>def[\]</span></div>ghi" compare innerHTML]
-    expected: FAIL
-
   [[["forwarddelete",""\]\] "012[\]<div style=display:inline-flex><span>abc</span><span>def</span></div>" compare innerHTML]
     expected: FAIL
 
@@ -160,12 +112,6 @@
     expected: FAIL
 
   [[["forwarddelete",""\]\] "<div style=display:inline-flex><span>{}<br></span></div><div>abc</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<div style=display:grid><span>abc</span><span>def[\]</span></div>ghi" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<div style=display:inline-grid><span>abc</span><span>def[\]</span></div>ghi" compare innerHTML]
     expected: FAIL
 
   [[["forwarddelete",""\]\] "012[\]<div style=display:inline-grid><span>abc</span><span>def</span></div>" compare innerHTML]
@@ -226,9 +172,6 @@
     expected: FAIL
 
   [[["forwarddelete",""\]\] "<p>abc{}<br> </p> <p><br></p>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<div style=white-space:pre><p>abc{}</p> <p><br></p></div>" compare innerHTML]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["defaultparagraphseparator","div"\],["forwarddelete",""\]\] "<p><font color=blue>foo[\]</font><p><font size=5>bar</font>" queryCommandValue("foreColor") before]
@@ -314,47 +257,11 @@
   [[["defaultparagraphseparator","div"\],["forwarddelete",""\]\] "<ol><li>foo[\]<li><p>bar</ol>" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
-  [[["forwarddelete",""\]\] "<ol><li>foo[\]</ol>bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<ol><li>foo[\]<br></ol>bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<ol><li>{}<br></ol>bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<ol><li>foo<li>{}<br></ol>bar" compare innerHTML]
-    expected: FAIL
-
   [[["forwarddelete",""\]\] "foo<table><tr><td>bar[\]</table><br>baz" compare innerHTML]
     expected: FAIL
 
 
 [forwarddelete.html?4001-5000]
-  [[["stylewithcss","true"\],["forwarddelete",""\]\] "<p style=color:blue>foo[\]</p>bar" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["forwarddelete",""\]\] "<p style=color:blue>foo[\]</p>bar" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["forwarddelete",""\]\] "<div style=color:blue><p style=color:green>foo[\]</div>bar" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["forwarddelete",""\]\] "<div style=color:blue><p style=color:green>foo[\]</div>bar" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["forwarddelete",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["forwarddelete",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["forwarddelete",""\]\] "<p>foo<span style=color:#aBcDeF>{bar</span>baz}" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["forwarddelete",""\]\] "<p>foo<span style=color:#aBcDeF>{bar</span>baz}" compare innerHTML]
-    expected: FAIL
-
   [[["forwarddelete",""\]\] "<p>foo</p><p>{bar</p>}<p>baz</p>" compare innerHTML]
     expected: FAIL
 
@@ -607,40 +514,10 @@
   [[["defaultparagraphseparator","p"\],["forwarddelete",""\]\] "<div><p>foo<p>[bar<p>baz\]</div>" compare innerHTML]
     expected: FAIL
 
-  [[["forwarddelete",""\]\] "foo<p>{bar</p>}baz" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["forwarddelete",""\]\] "foo{<p>bar}</p>baz" compare innerHTML]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["forwarddelete",""\]\] "foo{<p>bar}</p>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<p>foo[</p>\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<p>foo{</p>}bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<p>foo[</p>\]bar<br>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<p>foo[</p>\]bar<p>baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<div><p>foo[</p></div>\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<div><p>foo</p>bar[</div>\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<div>foo<p>bar[</p></div>\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<p>foo<br>{</p>\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["forwarddelete",""\]\] "<p>foo<br><br>{</p>\]bar" compare innerHTML]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["forwarddelete",""\]\] "foo<br><br>{<p>\]bar</p>" compare innerHTML]

--- a/tests/wpt/meta/editing/run/inserthorizontalrule.html.ini
+++ b/tests/wpt/meta/editing/run/inserthorizontalrule.html.ini
@@ -1,9 +1,3 @@
 [inserthorizontalrule.html]
-  [[["defaultparagraphseparator","div"\],["inserthorizontalrule",""\]\] "<p>foo{<p>bar</p>}<p>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["inserthorizontalrule",""\]\] "<p>foo{<p>bar</p>}<p>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["inserthorizontalrule",""\]\] "<div><b>foo</b>{<b>bar</b>}<b>baz</b></div>" queryCommandState("stylewithcss") before]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/insertimage.html.ini
+++ b/tests/wpt/meta/editing/run/insertimage.html.ini
@@ -44,24 +44,6 @@
   [[["insertimage","/img/lion.svg"\]\] "<b>foo[bar</b><i>baz\]quz</i>" compare innerHTML]
     expected: FAIL
 
-  [[["insertimage","/img/lion.svg"\]\] "<p>foo[</p>\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "<p>foo[</p>\]bar<br>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "<p>foo[</p>\]bar<p>baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "<div><p>foo[</p></div>\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "<div><p>foo</p>bar[</div>\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["insertimage","/img/lion.svg"\]\] "<div>foo<p>bar[</p></div>\]baz" compare innerHTML]
-    expected: FAIL
-
   [[["insertimage","/img/lion.svg"\]\] "<div><b>{}<br></b></div>" compare innerHTML]
     expected: FAIL
 

--- a/tests/wpt/meta/editing/run/insertparagraph.html.ini
+++ b/tests/wpt/meta/editing/run/insertparagraph.html.ini
@@ -133,30 +133,6 @@
   [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<p>foo<span style=color:#aBcDeF>{bar}</span>baz" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "<p>foo<span style=color:#aBcDeF>[bar</span>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<p>foo<span style=color:#aBcDeF>{bar</span>baz}" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<p>foo<span style=color:#aBcDeF>{bar</span>baz}" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "<p>foo<span style=color:#aBcDeF>{bar</span>baz}" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "<p>foo<span style=color:#aBcDeF>{bar</span>baz}" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "<p>foo<span style=color:#aBcDeF>[bar\]</span>baz" queryCommandState("stylewithcss") after]
     expected: FAIL
 

--- a/tests/wpt/meta/editing/run/multitest.html.ini
+++ b/tests/wpt/meta/editing/run/multitest.html.ini
@@ -2656,9 +2656,6 @@
   [[["forwarddelete",""\],["inserttext","d"\]\] "<p>abc[\]<br> </p> <p><br></p>" compare innerHTML]
     expected: FAIL
 
-  [[["forwarddelete",""\],["inserttext","d"\]\] "<div style=white-space:pre><p>abc[\]</p> <p><br></p></div>" compare innerHTML]
-    expected: FAIL
-
   [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc{<b><i>def</i></b>}ghi</div>" compare innerHTML]
     expected: FAIL
 

--- a/tests/wpt/meta/editing/whitespaces/chrome-compat/delete.tentative.html.ini
+++ b/tests/wpt/meta/editing/whitespaces/chrome-compat/delete.tentative.html.ini
@@ -1,29 +1,14 @@
 [delete.tentative.html]
-  [execCommand("delete", false, ""): "a&nbsp;[\]" (length of whiteSpace sequence: 1)]
-    expected: FAIL
-
-  [execCommand("delete", false, ""): "a&nbsp;&nbsp;[\]" (length of whiteSpace sequence: 2)]
-    expected: FAIL
-
-  [execCommand("delete", false, ""): "a &nbsp;[\]" (length of whiteSpace sequence: 2)]
-    expected: FAIL
-
   [execCommand("delete", false, ""): "a&nbsp;[\]&nbsp;&nbsp;" (length of whiteSpace sequence: 3)]
     expected: FAIL
 
   [execCommand("delete", false, ""): "a&nbsp;&nbsp;[\]&nbsp;" (length of whiteSpace sequence: 3)]
     expected: FAIL
 
-  [execCommand("delete", false, ""): "a&nbsp;&nbsp;&nbsp;[\]" (length of whiteSpace sequence: 3)]
-    expected: FAIL
-
   [execCommand("delete", false, ""): "a&nbsp;[\] &nbsp;" (length of whiteSpace sequence: 3)]
     expected: FAIL
 
   [execCommand("delete", false, ""): "a&nbsp; [\]&nbsp;" (length of whiteSpace sequence: 3)]
-    expected: FAIL
-
-  [execCommand("delete", false, ""): "a&nbsp; &nbsp;[\]" (length of whiteSpace sequence: 3)]
     expected: FAIL
 
   [execCommand("delete", false, ""): "a [\]&nbsp;&nbsp;" (length of whiteSpace sequence: 3)]
@@ -59,9 +44,6 @@
   [execCommand("delete", false, ""): "a&nbsp; [\]&nbsp;&nbsp;" (length of whiteSpace sequence: 4)]
     expected: FAIL
 
-  [execCommand("delete", false, ""): "a&nbsp; &nbsp;&nbsp;[\]" (length of whiteSpace sequence: 4)]
-    expected: FAIL
-
   [execCommand("delete", false, ""): "a [\]&nbsp; &nbsp;" (length of whiteSpace sequence: 4)]
     expected: FAIL
 
@@ -95,9 +77,6 @@
   [execCommand("delete", false, ""): "a&nbsp; &nbsp; [\]&nbsp;" (length of whiteSpace sequence: 5)]
     expected: FAIL
 
-  [execCommand("delete", false, ""): "a&nbsp; &nbsp; &nbsp;[\]" (length of whiteSpace sequence: 5)]
-    expected: FAIL
-
   [execCommand("delete", false, ""): "a&nbsp;[\]&nbsp;&nbsp; &nbsp;" (length of whiteSpace sequence: 5)]
     expected: FAIL
 
@@ -129,9 +108,6 @@
     expected: FAIL
 
   [execCommand("delete", false, ""): "a&nbsp; &nbsp;&nbsp;[\]&nbsp;" (length of whiteSpace sequence: 5)]
-    expected: FAIL
-
-  [execCommand("delete", false, ""): "a&nbsp; &nbsp;&nbsp;&nbsp;[\]" (length of whiteSpace sequence: 5)]
     expected: FAIL
 
   [execCommand("delete", false, ""): "a&nbsp;[\]&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" (length of whiteSpace sequence: 10)]
@@ -174,9 +150,6 @@
     expected: FAIL
 
   [execCommand("delete", false, ""): "a&nbsp; &nbsp; &nbsp; &nbsp; [\]&nbsp;&nbsp;" (length of whiteSpace sequence: 10)]
-    expected: FAIL
-
-  [execCommand("delete", false, ""): "a&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;[\]" (length of whiteSpace sequence: 10)]
     expected: FAIL
 
   [execCommand("delete", false, ""): "a [\]&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;" (length of whiteSpace sequence: 10)]
@@ -255,9 +228,6 @@
     expected: FAIL
 
   [execCommand("delete", false, ""): "a&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; [\]&nbsp;" (length of whiteSpace sequence: 11)]
-    expected: FAIL
-
-  [execCommand("delete", false, ""): "a&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;[\]" (length of whiteSpace sequence: 11)]
     expected: FAIL
 
   [execCommand("delete", false, ""): "a &nbsp; [\]b" (length of whiteSpace sequence: 3)]
@@ -854,19 +824,10 @@
   [execCommand("delete", false, ""): "&nbsp;[\]&nbsp;" (length of whiteSpace sequence: 2)]
     expected: FAIL
 
-  [execCommand("delete", false, ""): "&nbsp;&nbsp;[\]" (length of whiteSpace sequence: 2)]
-    expected: FAIL
-
   [execCommand("delete", false, ""): "&nbsp;[\]&nbsp;&nbsp;" (length of whiteSpace sequence: 3)]
     expected: FAIL
 
-  [execCommand("delete", false, ""): "&nbsp;&nbsp;&nbsp;[\]" (length of whiteSpace sequence: 3)]
-    expected: FAIL
-
   [execCommand("delete", false, ""): "&nbsp;[\] &nbsp;" (length of whiteSpace sequence: 3)]
-    expected: FAIL
-
-  [execCommand("delete", false, ""): "&nbsp; &nbsp;[\]" (length of whiteSpace sequence: 3)]
     expected: FAIL
 
   [execCommand("delete", false, ""): "&nbsp;[\]&nbsp;&nbsp;&nbsp;" (length of whiteSpace sequence: 4)]
@@ -884,9 +845,6 @@
   [execCommand("delete", false, ""): "&nbsp;[\] &nbsp;&nbsp;" (length of whiteSpace sequence: 4)]
     expected: FAIL
 
-  [execCommand("delete", false, ""): "&nbsp; &nbsp;&nbsp;[\]" (length of whiteSpace sequence: 4)]
-    expected: FAIL
-
   [execCommand("delete", false, ""): "&nbsp;[\]&nbsp;&nbsp;&nbsp;&nbsp;" (length of whiteSpace sequence: 5)]
     expected: FAIL
 
@@ -900,9 +858,6 @@
     expected: FAIL
 
   [execCommand("delete", false, ""): "&nbsp; &nbsp; [\]&nbsp;" (length of whiteSpace sequence: 5)]
-    expected: FAIL
-
-  [execCommand("delete", false, ""): "&nbsp; &nbsp; &nbsp;[\]" (length of whiteSpace sequence: 5)]
     expected: FAIL
 
   [execCommand("delete", false, ""): "&nbsp;[\]&nbsp;&nbsp; &nbsp;" (length of whiteSpace sequence: 5)]
@@ -927,9 +882,6 @@
     expected: FAIL
 
   [execCommand("delete", false, ""): "&nbsp; &nbsp;&nbsp;[\]&nbsp;" (length of whiteSpace sequence: 5)]
-    expected: FAIL
-
-  [execCommand("delete", false, ""): "&nbsp; &nbsp;&nbsp;&nbsp;[\]" (length of whiteSpace sequence: 5)]
     expected: FAIL
 
   [execCommand("delete", false, ""): "&nbsp;[\]&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" (length of whiteSpace sequence: 10)]
@@ -966,9 +918,6 @@
     expected: FAIL
 
   [execCommand("delete", false, ""): "&nbsp; &nbsp; &nbsp; &nbsp; [\]&nbsp;&nbsp;" (length of whiteSpace sequence: 10)]
-    expected: FAIL
-
-  [execCommand("delete", false, ""): "&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;[\]" (length of whiteSpace sequence: 10)]
     expected: FAIL
 
   [execCommand("delete", false, ""): "&nbsp;[\]&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;" (length of whiteSpace sequence: 10)]
@@ -1035,9 +984,6 @@
     expected: FAIL
 
   [execCommand("delete", false, ""): "&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; [\]&nbsp;" (length of whiteSpace sequence: 11)]
-    expected: FAIL
-
-  [execCommand("delete", false, ""): "&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;[\]" (length of whiteSpace sequence: 11)]
     expected: FAIL
 
   [execCommand("delete", false, ""): "&nbsp;[\]&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;" (length of whiteSpace sequence: 11)]

--- a/tests/wpt/meta/editing/whitespaces/chrome-compat/forwarddelete-to-join-blocks.tentative.html.ini
+++ b/tests/wpt/meta/editing/whitespaces/chrome-compat/forwarddelete-to-join-blocks.tentative.html.ini
@@ -46,3 +46,6 @@
 
   [document.execCommand("forwarddelete") when "<div><div>a&nbsp;&nbsp;&nbsp;[\]</div>&nbsp;&nbsp;&nbsp;b</div>"]
     expected: FAIL
+
+  [document.execCommand("forwarddelete") when "<div><div>{}<br></div>&nbsp;&nbsp;&nbsp;</div>"]
+    expected: FAIL

--- a/tests/wpt/meta/editing/whitespaces/chrome-compat/forwarddelete.tentative.html.ini
+++ b/tests/wpt/meta/editing/whitespaces/chrome-compat/forwarddelete.tentative.html.ini
@@ -1,29 +1,14 @@
 [forwarddelete.tentative.html]
-  [execCommand("forwarddelete", false, ""): "a[\]&nbsp;" (length of whitespace sequence: 1)]
-    expected: FAIL
-
-  [execCommand("forwarddelete", false, ""): "a&nbsp;[\]&nbsp;" (length of whitespace sequence: 2)]
-    expected: FAIL
-
-  [execCommand("forwarddelete", false, ""): "a [\]&nbsp;" (length of whitespace sequence: 2)]
-    expected: FAIL
-
   [execCommand("forwarddelete", false, ""): "a[\]&nbsp;&nbsp;&nbsp;" (length of whitespace sequence: 3)]
     expected: FAIL
 
   [execCommand("forwarddelete", false, ""): "a&nbsp;[\]&nbsp;&nbsp;" (length of whitespace sequence: 3)]
     expected: FAIL
 
-  [execCommand("forwarddelete", false, ""): "a&nbsp;&nbsp;[\]&nbsp;" (length of whitespace sequence: 3)]
-    expected: FAIL
-
   [execCommand("forwarddelete", false, ""): "a[\]&nbsp; &nbsp;" (length of whitespace sequence: 3)]
     expected: FAIL
 
   [execCommand("forwarddelete", false, ""): "a&nbsp;[\] &nbsp;" (length of whitespace sequence: 3)]
-    expected: FAIL
-
-  [execCommand("forwarddelete", false, ""): "a&nbsp; [\]&nbsp;" (length of whitespace sequence: 3)]
     expected: FAIL
 
   [execCommand("forwarddelete", false, ""): "a[\] &nbsp;&nbsp;" (length of whitespace sequence: 3)]
@@ -59,9 +44,6 @@
   [execCommand("forwarddelete", false, ""): "a&nbsp;[\] &nbsp;&nbsp;" (length of whitespace sequence: 4)]
     expected: FAIL
 
-  [execCommand("forwarddelete", false, ""): "a&nbsp; &nbsp;[\]&nbsp;" (length of whitespace sequence: 4)]
-    expected: FAIL
-
   [execCommand("forwarddelete", false, ""): "a[\] &nbsp; &nbsp;" (length of whitespace sequence: 4)]
     expected: FAIL
 
@@ -95,9 +77,6 @@
   [execCommand("forwarddelete", false, ""): "a&nbsp; &nbsp;[\] &nbsp;" (length of whitespace sequence: 5)]
     expected: FAIL
 
-  [execCommand("forwarddelete", false, ""): "a&nbsp; &nbsp; [\]&nbsp;" (length of whitespace sequence: 5)]
-    expected: FAIL
-
   [execCommand("forwarddelete", false, ""): "a[\]&nbsp;&nbsp;&nbsp; &nbsp;" (length of whitespace sequence: 5)]
     expected: FAIL
 
@@ -129,9 +108,6 @@
     expected: FAIL
 
   [execCommand("forwarddelete", false, ""): "a&nbsp; &nbsp;[\]&nbsp;&nbsp;" (length of whitespace sequence: 5)]
-    expected: FAIL
-
-  [execCommand("forwarddelete", false, ""): "a&nbsp; &nbsp;&nbsp;[\]&nbsp;" (length of whitespace sequence: 5)]
     expected: FAIL
 
   [execCommand("forwarddelete", false, ""): "a[\]&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" (length of whitespace sequence: 10)]
@@ -174,9 +150,6 @@
     expected: FAIL
 
   [execCommand("forwarddelete", false, ""): "a&nbsp; &nbsp; &nbsp; &nbsp;[\] &nbsp;&nbsp;" (length of whitespace sequence: 10)]
-    expected: FAIL
-
-  [execCommand("forwarddelete", false, ""): "a&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;[\]&nbsp;" (length of whitespace sequence: 10)]
     expected: FAIL
 
   [execCommand("forwarddelete", false, ""): "a[\] &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;" (length of whitespace sequence: 10)]
@@ -255,9 +228,6 @@
     expected: FAIL
 
   [execCommand("forwarddelete", false, ""): "a&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;[\] &nbsp;" (length of whitespace sequence: 11)]
-    expected: FAIL
-
-  [execCommand("forwarddelete", false, ""): "a&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; [\]&nbsp;" (length of whitespace sequence: 11)]
     expected: FAIL
 
   [execCommand("forwarddelete", false, ""): "a &nbsp;[\] b" (length of whitespace sequence: 3)]
@@ -854,19 +824,10 @@
   [execCommand("forwarddelete", false, ""): "[\]&nbsp;&nbsp;" (length of whitespace sequence: 2)]
     expected: FAIL
 
-  [execCommand("forwarddelete", false, ""): "&nbsp;[\]&nbsp;" (length of whitespace sequence: 2)]
-    expected: FAIL
-
   [execCommand("forwarddelete", false, ""): "[\]&nbsp;&nbsp;&nbsp;" (length of whitespace sequence: 3)]
     expected: FAIL
 
-  [execCommand("forwarddelete", false, ""): "&nbsp;&nbsp;[\]&nbsp;" (length of whitespace sequence: 3)]
-    expected: FAIL
-
   [execCommand("forwarddelete", false, ""): "[\]&nbsp; &nbsp;" (length of whitespace sequence: 3)]
-    expected: FAIL
-
-  [execCommand("forwarddelete", false, ""): "&nbsp; [\]&nbsp;" (length of whitespace sequence: 3)]
     expected: FAIL
 
   [execCommand("forwarddelete", false, ""): "[\]&nbsp;&nbsp;&nbsp;&nbsp;" (length of whitespace sequence: 4)]
@@ -884,9 +845,6 @@
   [execCommand("forwarddelete", false, ""): "[\]&nbsp; &nbsp;&nbsp;" (length of whitespace sequence: 4)]
     expected: FAIL
 
-  [execCommand("forwarddelete", false, ""): "&nbsp; &nbsp;[\]&nbsp;" (length of whitespace sequence: 4)]
-    expected: FAIL
-
   [execCommand("forwarddelete", false, ""): "[\]&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" (length of whitespace sequence: 5)]
     expected: FAIL
 
@@ -900,9 +858,6 @@
     expected: FAIL
 
   [execCommand("forwarddelete", false, ""): "&nbsp; &nbsp;[\] &nbsp;" (length of whitespace sequence: 5)]
-    expected: FAIL
-
-  [execCommand("forwarddelete", false, ""): "&nbsp; &nbsp; [\]&nbsp;" (length of whitespace sequence: 5)]
     expected: FAIL
 
   [execCommand("forwarddelete", false, ""): "[\]&nbsp;&nbsp;&nbsp; &nbsp;" (length of whitespace sequence: 5)]
@@ -927,9 +882,6 @@
     expected: FAIL
 
   [execCommand("forwarddelete", false, ""): "&nbsp; &nbsp;[\]&nbsp;&nbsp;" (length of whitespace sequence: 5)]
-    expected: FAIL
-
-  [execCommand("forwarddelete", false, ""): "&nbsp; &nbsp;&nbsp;[\]&nbsp;" (length of whitespace sequence: 5)]
     expected: FAIL
 
   [execCommand("forwarddelete", false, ""): "[\]&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" (length of whitespace sequence: 10)]
@@ -966,9 +918,6 @@
     expected: FAIL
 
   [execCommand("forwarddelete", false, ""): "&nbsp; &nbsp; &nbsp; &nbsp;[\] &nbsp;&nbsp;" (length of whitespace sequence: 10)]
-    expected: FAIL
-
-  [execCommand("forwarddelete", false, ""): "&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;[\]&nbsp;" (length of whitespace sequence: 10)]
     expected: FAIL
 
   [execCommand("forwarddelete", false, ""): "[\]&nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;" (length of whitespace sequence: 10)]
@@ -1035,9 +984,6 @@
     expected: FAIL
 
   [execCommand("forwarddelete", false, ""): "&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;[\] &nbsp;" (length of whitespace sequence: 11)]
-    expected: FAIL
-
-  [execCommand("forwarddelete", false, ""): "&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; [\]&nbsp;" (length of whitespace sequence: 11)]
     expected: FAIL
 
   [execCommand("forwarddelete", false, ""): "[\]&nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;" (length of whitespace sequence: 11)]


### PR DESCRIPTION
`Selection`'s have an attached live range. The specification (and other
browsers) suggests that modifications to the `Selection` should
disconnect any existing live ranges from it. The editing code was
previously assuming that this didn't happen, which is a just a
side-effect of how `Selection` is implemented in Servo and will change
in the near future.

In addition, this avoids clearing command overrides event when the
actual boundary points of a the `Selection` do not change.

Testing: This changes causes a decent number of editing subtests to
start passing and a single subtest to start failing.
