### PR TITLE
Update chacha20 to 0.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cipher",


### PR DESCRIPTION
Update chacha20 to 0.10.2 to unblock CI.

Testing: No tests for dependency update.

Fixes: #47583
