### PR TITLE
cargo-deny: Allow yanked crates.

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,11 @@ feature-depth = 1
 # More documentation for the advisories section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
+# Our `mach` integration currently errors on warnings. We should add support
+# for warnings without failing tidy to mach and then change this to `warn`.
+# We don't want to deny yanked crates, since it creates incentives to update
+# quickly, which could be abused by supply-chain attacks that yank old versions.
+yanked = "allow"
 ignore = [
     # The crate `paste` is no longer maintained.
     "RUSTSEC-2024-0436",


### PR DESCRIPTION
It's unfortunate that we can't `warn` instead,
but that would require more changes in mach which I currently don't have
 the time for.

Testing: Works if CI passes
Fixes: #45890
