### PR TITLE
config: Disable SpiderMonkey's compacting GC by default.

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -533,7 +533,9 @@ impl Preferences {
             js_disable_jit: false,
             js_ion_enabled: true,
             js_ion_unsafe_eager_compilation_enabled: false,
-            js_mem_gc_compacting_enabled: true,
+            // The layout system currently does not work with compacting GC, so it is disabled by default.
+            // See https://github.com/servo/servo/issues/47577
+            js_mem_gc_compacting_enabled: false,
             js_mem_gc_empty_chunk_count_min: 1,
             js_mem_gc_high_frequency_heap_growth_max: 300,
             js_mem_gc_high_frequency_heap_growth_min: 150,


### PR DESCRIPTION
Based on the issue discovered in #47577, it seem like a compacting GC will break Servo's layout system.

This patch sets the default value of preference that controls if compacting GC is enabled in SM to 'false', as it seems misleading to have it enabled by default when it can't work.

Testing: There are no tests as this shouldn't change existing behaviour - SM doesn't shrink the heap unless we explicitly call the GC API with the relevant option. We don't do that in servo/mozjs, as noted in #47577 .
