### PR TITLE
net: Allow * in Access-Control-Allow-Headers to cover authorization

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -2591,9 +2591,14 @@ async fn cors_preflight_fetch(
 
         // Step 7.6 If one of request’s header list’s names is a CORS non-wildcard request-header name
         // and is not a byte-case-insensitive match for an item in headerNames, then return a network error.
+        //
+        // Note: This check deviates from the spec. Other browsers (Chrome, Firefox, Safari) all treat a
+        // `*` in headerNames as covering CORS non-wildcard request-header names.
+        let header_names_set: HashSet<&HeaderName> = HashSet::from_iter(header_names.iter());
         if request.headers.iter().any(|(name, _)| {
             is_cors_non_wildcard_request_header_name(name) &&
-                header_names.iter().all(|header_name| header_name != name)
+                !header_names_set.contains(name) &&
+                !header_names_set.contains(&HeaderName::from_static("*"))
         }) {
             return Response::network_error(NetworkError::CorsAuthorization);
         }
@@ -2602,14 +2607,10 @@ async fn cors_preflight_fetch(
         // if unsafeName is not a byte-case-insensitive match for an item in headerNames and request’s credentials
         // mode is "include" or headerNames does not contain `*`, return a network error.
         let unsafe_names = get_cors_unsafe_header_names(&request.headers);
-        let header_names_set: HashSet<&HeaderName> = HashSet::from_iter(header_names.iter());
-        let header_names_contains_star = header_names
-            .iter()
-            .any(|header_name| header_name.as_str() == "*");
         for unsafe_name in unsafe_names.iter() {
             if !header_names_set.contains(unsafe_name) &&
                 (request.credentials_mode == CredentialsMode::Include ||
-                    !header_names_contains_star)
+                    !header_names_set.contains(&HeaderName::from_static("*")))
             {
                 return Response::network_error(NetworkError::CorsHeaders);
             }

--- a/tests/wpt/meta/fetch/api/cors/cors-preflight-cache.any.js.ini
+++ b/tests/wpt/meta/fetch/api/cors/cors-preflight-cache.any.js.ini
@@ -2,7 +2,13 @@
   [CORS preflight cache reuses explicit header entries]
     expected: FAIL
 
+  [CORS preflight cache does not reuse wildcard header entries for Authorization]
+    expected: FAIL
+
 
 [cors-preflight-cache.any.html]
   [CORS preflight cache reuses explicit header entries]
+    expected: FAIL
+
+  [CORS preflight cache does not reuse wildcard header entries for Authorization]
     expected: FAIL

--- a/tests/wpt/meta/fetch/api/cors/cors-preflight-star.any.js.ini
+++ b/tests/wpt/meta/fetch/api/cors/cors-preflight-star.any.js.ini
@@ -1,0 +1,8 @@
+[cors-preflight-star.any.worker.html]
+  [CORS that fails with credentials: false; method: POST (allowed: *); header: Authorization,123 (allowed: *)]
+    expected: FAIL
+
+
+[cors-preflight-star.any.html]
+  [CORS that fails with credentials: false; method: POST (allowed: *); header: Authorization,123 (allowed: *)]
+    expected: FAIL

--- a/tests/wpt/meta/fetch/api/cors/cors-preflight.any.js.ini
+++ b/tests/wpt/meta/fetch/api/cors/cors-preflight.any.js.ini
@@ -1,0 +1,8 @@
+[cors-preflight.any.html]
+  ["authorization" should not be covered by the wildcard symbol]
+    expected: FAIL
+
+
+[cors-preflight.any.worker.html]
+  ["authorization" should not be covered by the wildcard symbol]
+    expected: FAIL


### PR DESCRIPTION
[Zulip chat](https://servo.zulipchat.com/#narrow/channel/263398-general/topic/.22authorization.22.20should.20not.20be.20covered.20by.20the.20wildcard.20symbol/with/619720785).

According to MDN/Spec/WPT tests, this should not be allowed. 
However, all browsers allow it, and fail these WPT tests.
This is discovered when visiting some websites but failed with "CORS Authorization check".

Testing: Updated WPT. All other browsers fail these specific tests.
[Test1](https://wpt.fyi/results/fetch/api/cors/cors-preflight.any.html?q=%2Ffetch%2Fapi%2Fcors%2Fcors-preflight.any.html&run_id=5120815879421952&run_id=6266127830482944&run_id=4925178911129600&run_id=6310660769316864)
[Test2](https://wpt.fyi/results/fetch/api/cors/cors-preflight-star.any.html?q=%2Ffetch%2Fapi%2Fcors%2Fcors-preflight-star.any.html&run_id=5120815879421952&run_id=6266127830482944&run_id=4925178911129600&run_id=6310660769316864)
[Test3](https://wpt.fyi/results/fetch/api/cors/cors-preflight-cache.any.html?q=%2Ffetch%2Fapi%2Fcors%2Fcors-preflight-cache.any.html&run_id=5120815879421952&run_id=6266127830482944&run_id=4925178911129600&run_id=6310660769316864)

---

Spec issue: https://github.com/whatwg/fetch/issues/1919