### PR TITLE
net: Store encoded stream in the disk cache instead of decoded one

### DIFF
--- a/components/net/decoder.rs
+++ b/components/net/decoder.rs
@@ -20,9 +20,10 @@ use std::error::Error;
 use std::fmt;
 use std::io::{self};
 use std::pin::Pin;
+use std::sync::{Arc, Mutex};
 
 use async_compression::tokio::bufread::{BrotliDecoder, GzipDecoder, ZlibDecoder, ZstdDecoder};
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use futures::stream::Peekable;
 use futures::task::{Context, Poll};
 use futures::{Future, Stream};
@@ -32,6 +33,9 @@ use http_body_util::BodyExt;
 use hyper::Response;
 use hyper::body::Body;
 use hyper::header::{CONTENT_ENCODING, HeaderValue, TRANSFER_ENCODING};
+use log::warn;
+use net_traits::DecoderType;
+use servo_config::pref;
 use tokio_util::codec::{BytesCodec, FramedRead};
 use tokio_util::io::StreamReader;
 
@@ -81,14 +85,7 @@ pub fn map_decode_error(err: io::Error) -> io::Error {
 /// The inner decoder may be constructed asynchronously.
 pub struct Decoder {
     inner: Inner,
-}
-
-#[derive(PartialEq)]
-enum DecoderType {
-    Gzip,
-    Brotli,
-    Deflate,
-    Zstd,
+    encoded_data: Arc<Mutex<Option<(BytesMut, DecoderType)>>>,
 }
 
 enum Inner {
@@ -119,17 +116,27 @@ impl fmt::Debug for Decoder {
 }
 
 impl Decoder {
+    /// Returns the buffer the encoded bytes will be stored in.
+    /// Originally this will be `None`. After the decoder is polled to completion (via the Stream impl), this can contain two values.
+    /// Either `None`, meaning the decoded bytes and encoded bytes are equal. Or the encoded bytes.
+    pub fn encoded_bytes(&self) -> Arc<Mutex<Option<(BytesMut, DecoderType)>>> {
+        self.encoded_data.clone()
+    }
+
     /// A plain text decoder.
     ///
     /// This decoder will emit the underlying bytes as-is.
     #[inline]
-    fn plain_text(
+    pub fn plain_text(
         body: BoxedBody,
         is_secure_scheme: bool,
         content_length: Option<ContentLength>,
     ) -> Decoder {
+        let body = BodyStream::new(body, is_secure_scheme, content_length);
+        let encoded_data = body.data.clone();
         Decoder {
-            inner: Inner::PlainText(BodyStream::new(body, is_secure_scheme, content_length)),
+            inner: Inner::PlainText(body),
+            encoded_data,
         }
     }
 
@@ -137,17 +144,20 @@ impl Decoder {
     ///
     /// This decoder will buffer and decompress bytes that are encoded in the expected format.
     #[inline]
-    fn pending(
+    pub fn pending(
         body: BoxedBody,
         type_: DecoderType,
         is_secure_scheme: bool,
         content_length: Option<ContentLength>,
     ) -> Decoder {
+        let body = BodyStream::new(body, is_secure_scheme, content_length);
+        let encoded_data = body.data.clone();
         Decoder {
             inner: Inner::Pending(Pending {
-                body: BodyStream::new(body, is_secure_scheme, content_length).peekable(),
+                body: body.peekable(),
                 type_,
             }),
+            encoded_data,
         }
     }
 
@@ -239,6 +249,14 @@ impl Future for Pending {
     type Output = Result<Inner, io::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // In the event that we have a compressed stream, we want our first poll to be already written to the data. The first poll will be executed by poll_peek, so we have to do this first.
+        // If we are in plaintext mode, we will disarm the body.
+        // This method gets only called a couple of times.
+
+        if !pref!(network_http_disk_cache).is_empty() || cfg!(feature = "test-util") {
+            self.body.get_ref().arm_copy_mechanism(self.type_.clone());
+        }
+
         match futures_core::ready!(Pin::new(&mut self.body).poll_peek(cx)) {
             Some(Ok(_)) => {
                 // fallthrough
@@ -251,45 +269,56 @@ impl Future for Pending {
                 .expect("just peeked Some")
                 .unwrap_err()));
             },
-            None => return Poll::Ready(Ok(Inner::PlainText(BodyStream::empty()))),
+            None => {
+                self.body.get_ref().disarm_copy_mechanism();
+                return Poll::Ready(Ok(Inner::PlainText(BodyStream::empty(
+                    self.body.get_ref().data.clone(),
+                ))));
+            },
         };
 
-        let body = std::mem::replace(&mut self.body, BodyStream::empty().peekable());
+        let data = self.body.get_ref().data.clone();
+        let body = std::mem::replace(&mut self.body, BodyStream::empty(data).peekable());
 
-        match self.type_ {
-            DecoderType::Brotli => Poll::Ready(Ok(Inner::Brotli(FramedRead::with_capacity(
+        let value = match self.type_ {
+            DecoderType::Brotli => Inner::Brotli(FramedRead::with_capacity(
                 BrotliDecoder::new(StreamReader::new(body)),
                 BytesCodec::new(),
                 DECODER_BUFFER_SIZE,
-            )))),
-            DecoderType::Gzip => Poll::Ready(Ok(Inner::Gzip(FramedRead::with_capacity(
+            )),
+            DecoderType::Gzip => Inner::Gzip(FramedRead::with_capacity(
                 GzipDecoder::new(StreamReader::new(body)),
                 BytesCodec::new(),
                 DECODER_BUFFER_SIZE,
-            )))),
-            DecoderType::Deflate => Poll::Ready(Ok(Inner::Deflate(FramedRead::with_capacity(
+            )),
+            DecoderType::Deflate => Inner::Deflate(FramedRead::with_capacity(
                 ZlibDecoder::new(StreamReader::new(body)),
                 BytesCodec::new(),
                 DECODER_BUFFER_SIZE,
-            )))),
-            DecoderType::Zstd => Poll::Ready(Ok(Inner::Zstd(FramedRead::with_capacity(
+            )),
+            DecoderType::Zstd => Inner::Zstd(FramedRead::with_capacity(
                 ZstdDecoder::new(StreamReader::new(body)),
                 BytesCodec::new(),
                 DECODER_BUFFER_SIZE,
-            )))),
-        }
+            )),
+        };
+
+        Poll::Ready(Ok(value))
     }
 }
 
+/// This takes the BoxedBody and reads the bytes from it. We record the length because of rustls (see impl of Stream).
+/// If the data field contains not None, we copy all (remaining) undecoded bytes into the data field.
 struct BodyStream {
     body: BoxedBody,
     is_secure_scheme: bool,
     content_length: Option<ContentLength>,
     total_read: u64,
+    data: Arc<Mutex<Option<(BytesMut, DecoderType)>>>,
 }
 
 impl BodyStream {
-    fn empty() -> Self {
+    fn empty(data: Arc<Mutex<Option<(BytesMut, DecoderType)>>>) -> Self {
         BodyStream {
             body: http_body_util::Empty::new()
                 .map_err(|_| unreachable!())
@@ -297,6 +326,7 @@ impl BodyStream {
             is_secure_scheme: false,
             content_length: None,
             total_read: 0,
+            data,
         }
     }
 
@@ -306,7 +336,23 @@ impl BodyStream {
             is_secure_scheme,
             content_length,
             total_read: 0,
+            data: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// Arms the copy mechanism. All bytes that get received by the body stream will be also written to `self.data`
+    fn arm_copy_mechanism(&self, decoder_type: DecoderType) {
+        let mut data = self.data.lock().unwrap();
+        if data.is_none() {
+            *data = Some((BytesMut::new(), decoder_type));
+        } else {
+            warn!("You are arming the copy mechanism a second time")
+        }
+    }
+
+    /// Disarms the copy mechanism and destroys all bytes that were already copied.
+    fn disarm_copy_mechanism(&self) {
+        *self.data.lock().unwrap() = None;
     }
 }
 
@@ -320,6 +366,11 @@ impl Stream for BodyStream {
                     return Poll::Ready(None);
                 };
                 self.total_read += bytes.len() as u64;
+
+                let mut data_lock = self.data.lock().unwrap();
+                if let Some(data) = data_lock.as_mut() {
+                    data.0.extend_from_slice(&bytes);
+                }
                 Poll::Ready(Some(Ok(bytes)))
             },
             Some(Err(err)) => {

--- a/components/net/disk_cache.rs
+++ b/components/net/disk_cache.rs
@@ -247,12 +247,15 @@ impl DiskCache {
             }
             bytes
         };
-        let _span = profile_traits::trace_span!("deserialize cache request").entered();
-        let Ok(value) = postcard::from_bytes::<Vec<DiskCachedResource>>(&bytes) else {
-            error!("Could not deserialize cached resource");
-            return None;
+
+        let value = {
+            let _span = profile_traits::trace_span!("deserialize cache request").entered();
+            let Ok(value) = postcard::from_bytes::<Vec<DiskCachedResource>>(&bytes) else {
+                error!("Could not deserialize cached resource");
+                return None;
+            };
+            value
         };
-        drop(_span);
 
         let resources = join_all(value.into_iter().map(
             |disk_cached_resource: DiskCachedResource| disk_cached_resource.make_cached_reource(),

--- a/components/net/disk_cache.rs
+++ b/components/net/disk_cache.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use futures::future::join_all;
 use log::error;
 use malloc_size_of_derive::MallocSizeOf;
 use rusqlite::Row;
@@ -17,7 +18,8 @@ use servo_url::ServoUrl;
 use tokio::sync::{Mutex as TokioMutex, RwLock as TokioRwLock};
 
 use crate::http_cache::{
-    CacheEntry, CacheKey, CachedResource, HttpCacheAssignment, MemoryCacheLifecycle,
+    CacheEntry, CacheKey, CachedResource, DiskCachedResource, HttpCacheAssignment,
+    MemoryCacheLifecycle,
 };
 
 #[derive(MallocSizeOf)]
@@ -246,11 +248,19 @@ impl DiskCache {
             bytes
         };
         let _span = profile_traits::trace_span!("deserialize cache request").entered();
-        let Ok(value) = postcard::from_bytes(&bytes) else {
+        let Ok(value) = postcard::from_bytes::<Vec<DiskCachedResource>>(&bytes) else {
             error!("Could not deserialize cached resource");
             return None;
         };
-        let deserialized_vec_cached_response = std::sync::Arc::new(TokioRwLock::new(value));
+        drop(_span);
+
+        let resources = join_all(value.into_iter().map(
+            |disk_cached_resource: DiskCachedResource| disk_cached_resource.make_cached_reource(),
+        ))
+        .await
+        .into_iter()
+        .collect::<Option<Vec<_>>>()?;
+        let deserialized_vec_cached_response = std::sync::Arc::new(TokioRwLock::new(resources));
 
         Some(deserialized_vec_cached_response)
     }
@@ -259,10 +269,13 @@ impl DiskCache {
     #[servo_tracing::instrument(skip(self))]
     pub(crate) async fn store(&self, key: CacheKey, entry: CacheEntry) {
         let entry = entry.read().await;
-        let data_to_serialize: Vec<&CachedResource> = entry
+        let data_to_serialize = entry
             .iter()
             .filter(|cached_resource| cached_resource.is_done())
-            .collect();
+            .cloned()
+            .map(|cached_resource| cached_resource.into())
+            .collect::<Vec<DiskCachedResource>>();
+
         let Ok(data) = postcard::to_stdvec(&*data_to_serialize) else {
             error!("Could not deserialize value");
             return;

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -30,7 +30,9 @@ use net_traits::request::{
     Request, RequestBody, RequestId, RequestMode, ResponseTainting, is_cors_safelisted_method,
     is_cors_safelisted_request_header,
 };
-use net_traits::response::{Response, ResponseBody, ResponseType, TerminationReason};
+use net_traits::response::{
+    DoneResponseBody, Response, ResponseBody, ResponseType, TerminationReason,
+};
 use net_traits::{
     FetchTaskTarget, NetworkError, ReferrerPolicy, ResourceAttribute, ResourceFetchTiming,
     ResourceFetchTimingContainer, ResourceTimeValue, ResourceTimingType, WebSocketDomAction,
@@ -935,15 +937,23 @@ async fn wait_for_response(
         }
     } else {
         match *response.actual_response().body.lock() {
-            ResponseBody::Done(ref vec) if !vec.is_empty() => {
+            ResponseBody::Done(ref done_response) if !done_response.decoded_body.is_empty() => {
                 // in case there was no channel to wait for, the body was
                 // obtained synchronously via scheme_fetch for data/file/about/etc
                 // We should still send the body across as a chunk
-                target.process_response_chunk(request, Bytes::copy_from_slice(vec));
+                target.process_response_chunk(
+                    request,
+                    Bytes::copy_from_slice(&done_response.decoded_body),
+                );
                 if context.devtools_chan.is_some() {
                     // Now that we've replayed the entire cached body,
                     // notify the DevTools server with the full Response.
-                    send_response_to_devtools(request, context, response, Some(vec.clone()));
+                    send_response_to_devtools(
+                        request,
+                        context,
+                        response,
+                        Some(done_response.decoded_body.clone()),
+                    );
                 }
             },
             ResponseBody::Done(_) | ResponseBody::Empty => {},
@@ -989,7 +999,10 @@ fn create_blank_reply(url: ServoUrl, timing_type: ResourceTimingType) -> Respons
     response
         .headers
         .typed_insert(ContentType::from(mime::TEXT_HTML_UTF_8));
-    *response.body.lock() = ResponseBody::Done(vec![]);
+    *response.body.lock() = ResponseBody::Done(DoneResponseBody {
+        decoded_body: vec![],
+        encoded_body: None,
+    });
     response.status = HttpStatus::default();
     response
 }
@@ -999,7 +1012,10 @@ fn create_about_memory(url: ServoUrl, timing_type: ResourceTimingType) -> Respon
     response
         .headers
         .typed_insert(ContentType::from(mime::TEXT_HTML_UTF_8));
-    *response.body.lock() = ResponseBody::Done(resources::read_bytes(Resource::AboutMemoryHTML));
+    *response.body.lock() = ResponseBody::Done(DoneResponseBody {
+        decoded_body: resources::read_bytes(Resource::AboutMemoryHTML),
+        encoded_body: None,
+    });
     response.status = HttpStatus::default();
     response
 }

--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -23,7 +23,7 @@ use net_traits::filemanager_thread::{
     FileManagerResult, FileManagerThreadError, FileManagerThreadMsg, FileTokenCheck,
     GetTokenForFileReply, ReadFileProgress, RelativePos,
 };
-use net_traits::response::{Response, ResponseBody};
+use net_traits::response::{DoneResponseBody, Response, ResponseBody};
 use parking_lot::{Mutex, RwLock};
 use rustc_hash::{FxHashMap, FxHashSet};
 use servo_arc::Arc as ServoArc;
@@ -217,7 +217,10 @@ impl FileManager {
         spawn_task(async move {
             loop {
                 if cancellation_listener.cancelled() {
-                    *res_body.lock() = ResponseBody::Done(vec![]);
+                    *res_body.lock() = ResponseBody::Done(DoneResponseBody {
+                        decoded_body: vec![],
+                        encoded_body: None,
+                    });
                     let _ = done_sender.send(Data::Cancelled);
                     return;
                 }
@@ -259,7 +262,10 @@ impl FileManager {
                         ResponseBody::Receiving(ref mut body) => std::mem::take(body),
                         _ => vec![],
                     };
-                    *body = ResponseBody::Done(completed_body);
+                    *body = ResponseBody::Done(DoneResponseBody {
+                        decoded_body: completed_body,
+                        encoded_body: None,
+                    });
                     let _ = done_sender.send(Data::Done);
                     break;
                 }

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -7,11 +7,13 @@
 //! A memory cache implementing the logic specified in <http://tools.ietf.org/html/rfc7234>
 //! and <http://tools.ietf.org/html/rfc7232>.
 
+use std::io::Cursor;
 use std::ops::Bound;
 use std::sync::Arc as StdArc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime};
 
+use async_compression::tokio::bufread::{BrotliDecoder, GzipDecoder, ZlibDecoder, ZstdDecoder};
 use headers::{
     CacheControl, ContentRange, Expires, HeaderMapExt, LastModified, Pragma, Range, Vary,
 };
@@ -21,8 +23,8 @@ use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use malloc_size_of_derive::MallocSizeOf;
 use net_traits::http_status::HttpStatus;
 use net_traits::request::{CacheMode, Request};
-use net_traits::response::{Response, ResponseBody};
-use net_traits::{CacheEntryDescriptor, FetchMetadata, Metadata, ResourceFetchTiming};
+use net_traits::response::{DoneResponseBody, Response, ResponseBody};
+use net_traits::{CacheEntryDescriptor, DecoderType, FetchMetadata, Metadata, ResourceFetchTiming};
 use parking_lot::Mutex as ParkingLotMutex;
 use quick_cache::sync::{Cache, PlaceholderGuard};
 use quick_cache::{DefaultHashBuilder, Lifecycle, UnitWeighter};
@@ -30,6 +32,7 @@ use serde::{Deserialize, Serialize};
 use servo_arc::Arc;
 use servo_config::pref;
 use servo_url::ServoUrl;
+use tokio::io::AsyncReadExt;
 use tokio::sync::mpsc::{UnboundedSender as TokioSender, unbounded_channel as unbounded};
 use tokio::sync::{OwnedRwLockWriteGuard, RwLock as TokioRwLock};
 
@@ -129,7 +132,7 @@ impl CacheKey {
 }
 
 /// A complete cached resource.
-#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+#[derive(Clone, Debug, MallocSizeOf)]
 pub struct CachedResource {
     #[conditional_malloc_size_of]
     request_headers: Arc<ParkingLotMutex<SerializeableHeaderMap>>,
@@ -138,7 +141,6 @@ pub struct CachedResource {
     #[conditional_malloc_size_of]
     aborted: Arc<AtomicBool>,
     #[conditional_malloc_size_of]
-    #[serde(skip)]
     awaiting_body: Arc<ParkingLotMutex<Vec<TokioSender<Data>>>>,
     metadata: CachedMetadata,
     location_url: Option<Result<ServoUrl, String>>,
@@ -147,9 +149,118 @@ pub struct CachedResource {
     expires: ApproxDuration,
     stale_while_revalidate: ApproxDuration,
     #[conditional_malloc_size_of]
-    #[serde(skip)]
     revalidating: StdArc<AtomicBool>,
     last_validated: SystemTime,
+}
+
+#[derive(Debug, Deserialize, MallocSizeOf, Serialize)]
+/// This is the type of body we cached on the disk.
+pub enum DiskResponseBody {
+    /// The encoded type
+    Encoded(Vec<u8>, DecoderType),
+    /// The decoded type
+    Decoded(Vec<u8>),
+}
+
+#[derive(Debug, Deserialize, MallocSizeOf, Serialize)]
+/// This is CachedResource specified for the disk cache.
+pub struct DiskCachedResource {
+    request_headers: SerializeableHeaderMap,
+    body: DiskResponseBody,
+    aborted: bool,
+    metadata: CachedMetadata,
+    location_url: Option<Result<ServoUrl, String>>,
+    status: HttpStatus,
+    url_list: Vec<ServoUrl>,
+    expires: ApproxDuration,
+    stale_while_revalidate: ApproxDuration,
+    last_validated: SystemTime,
+}
+
+impl From<CachedResource> for DiskCachedResource {
+    fn from(value: CachedResource) -> Self {
+        let body = match &*value.body.lock() {
+            ResponseBody::Empty => unreachable!("Should never happen"),
+            ResponseBody::Receiving(_) => unreachable!("Should never happen"),
+            ResponseBody::Done(DoneResponseBody {
+                decoded_body,
+                encoded_body,
+            }) => {
+                if let Some(encoded_body) = encoded_body {
+                    DiskResponseBody::Encoded(encoded_body.0.to_owned(), encoded_body.1.clone())
+                } else {
+                    DiskResponseBody::Decoded(decoded_body.to_owned())
+                }
+            },
+        };
+        DiskCachedResource {
+            request_headers: value.request_headers.lock().clone().into(),
+            body,
+            aborted: value.aborted.load(std::sync::atomic::Ordering::Relaxed),
+            metadata: value.metadata,
+            location_url: value.location_url,
+            status: value.status,
+            url_list: value.url_list,
+            expires: value.expires,
+            stale_while_revalidate: value.stale_while_revalidate,
+            last_validated: value.last_validated,
+        }
+    }
+}
+
+impl DiskCachedResource {
+    /// Returns from a [`CachedResource`] from a `DiskCachedResource`. Returns None if there was a problem decoding the resource.
+    pub(crate) async fn make_cached_reource(self) -> Option<CachedResource> {
+        let done_body = match self.body {
+            DiskResponseBody::Encoded(items, decoder_type) => {
+                let cursor = Cursor::new(items.clone());
+
+                let mut output = vec![];
+                match decoder_type {
+                    DecoderType::Gzip => GzipDecoder::new(cursor)
+                        .read_to_end(&mut output)
+                        .await
+                        .ok()?,
+                    DecoderType::Brotli => BrotliDecoder::new(cursor)
+                        .read_to_end(&mut output)
+                        .await
+                        .ok()?,
+                    DecoderType::Deflate => ZlibDecoder::new(cursor)
+                        .read_to_end(&mut output)
+                        .await
+                        .ok()?,
+                    DecoderType::Zstd => ZstdDecoder::new(cursor)
+                        .read_to_end(&mut output)
+                        .await
+                        .ok()?,
+                };
+                DoneResponseBody {
+                    decoded_body: output,
+                    encoded_body: Some((items, decoder_type)),
+                }
+            },
+            DiskResponseBody::Decoded(items) => DoneResponseBody {
+                decoded_body: items,
+                encoded_body: None,
+            },
+        };
+
+        let body = ResponseBody::Done(done_body);
+        Some(CachedResource {
+            request_headers: Arc::new(ParkingLotMutex::new(self.request_headers)),
+            body: Arc::new(ParkingLotMutex::new(body)),
+            aborted: Arc::new(AtomicBool::new(self.aborted)),
+            awaiting_body: Arc::new(ParkingLotMutex::new(vec![])),
+            metadata: self.metadata,
+            location_url: self.location_url,
+            status: self.status,
+            url_list: self.url_list,
+            expires: self.expires,
+            stale_while_revalidate: self.stale_while_revalidate,
+            revalidating: std::sync::Arc::new(AtomicBool::new(false)),
+            last_validated: self.last_validated,
+        })
+    }
 }
 
 impl CachedResource {
@@ -611,7 +722,10 @@ fn create_resource_with_bytes_from_resource(
 ) -> CachedResource {
     CachedResource {
         request_headers: resource.request_headers.clone(),
-        body: Arc::new(ParkingLotMutex::new(ResponseBody::Done(bytes.to_owned()))),
+        body: Arc::new(ParkingLotMutex::new(ResponseBody::Done(DoneResponseBody {
+            decoded_body: bytes.to_owned(),
+            encoded_body: None,
+        }))),
         aborted: Arc::new(AtomicBool::new(false)),
         awaiting_body: Arc::new(ParkingLotMutex::new(vec![])),
         metadata: resource.metadata.clone(),
@@ -648,7 +762,7 @@ fn handle_range_request(
         // TODO: add support for complete and partial resources,
         // whose body is in the ResponseBody::Receiving state.
         let body_len = match *complete_resource.body.lock() {
-            ResponseBody::Done(ref body) => body.len(),
+            ResponseBody::Done(ref body) => body.decoded_body.len(),
             _ => 0,
         };
         let bound = range_spec
@@ -664,7 +778,7 @@ fn handle_range_request(
                     }
                     let b = beginning as usize;
                     let e = end as usize + 1;
-                    let requested = body.get(b..e);
+                    let requested = body.decoded_body.get(b..e);
                     if let Some(bytes) = requested {
                         let new_resource =
                             create_resource_with_bytes_from_resource(bytes, complete_resource);
@@ -684,7 +798,7 @@ fn handle_range_request(
             (Bound::Included(beginning), Bound::Unbounded) => {
                 if let ResponseBody::Done(ref body) = *complete_resource.body.lock() {
                     let b = beginning as usize;
-                    let requested = body.get(b..);
+                    let requested = body.decoded_body.get(b..);
                     if let Some(bytes) = requested {
                         let new_resource =
                             create_resource_with_bytes_from_resource(bytes, complete_resource);
@@ -729,7 +843,7 @@ fn handle_range_request(
                             ResponseBody::Done(body) => {
                                 let b = beginning as usize - res_beginning as usize;
                                 let e = end as usize - res_beginning as usize + 1;
-                                body.get(b..e)
+                                body.decoded_body.get(b..e)
                             },
                             _ => continue,
                         };
@@ -765,7 +879,7 @@ fn handle_range_request(
                         let requested = match resource_body {
                             ResponseBody::Done(body) => {
                                 let from_byte = beginning as usize - res_beginning as usize;
-                                body.get(from_byte..)
+                                body.decoded_body.get(from_byte..)
                             },
                             _ => continue,
                         };

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -50,7 +50,9 @@ use net_traits::request::{
     is_cors_non_wildcard_request_header_name, is_cors_safelisted_method,
     is_cors_safelisted_request_header,
 };
-use net_traits::response::{CacheState, RedirectTaint, Response, ResponseBody, ResponseType};
+use net_traits::response::{
+    CacheState, DoneResponseBody, RedirectTaint, Response, ResponseBody, ResponseType,
+};
 use net_traits::{
     CookieSource, DOCUMENT_ACCEPT_HEADER_VALUE, DiscardFetch, NetworkError, RedirectEndValue,
     RedirectStartValue, ReferrerPolicy, ResourceAttribute, ResourceFetchTimingContainer,
@@ -2343,12 +2345,17 @@ async fn http_network_fetch(
         let _ = done_sender.send(Data::ContentLength(possible_length));
     }
 
+    let response_body_stream = response_stream.into_body();
+    let encoded_data = response_body_stream.encoded_bytes();
+    let encoded_data2 = response_body_stream.encoded_bytes();
     spawn_task(
-        response_stream
-            .into_body()
+        response_body_stream
             .try_fold(response_body, move |response_body_accumulator, chunk| {
                 if cancellation_listener.cancelled() {
-                    *response_body_accumulator.lock() = ResponseBody::Done(vec![]);
+                    *response_body_accumulator.lock() = ResponseBody::Done(DoneResponseBody {
+                        decoded_body: vec![],
+                        encoded_body: None,
+                    });
                     let _ = done_sender.send(Data::Cancelled);
                     return future::ready(Err(std::io::Error::new(
                         std::io::ErrorKind::Interrupted,
@@ -2362,7 +2369,6 @@ async fn http_network_fetch(
                 future::ready(Ok(response_body_accumulator))
             })
             .and_then(move |complete_response_body| {
-                debug!("successfully finished response for {:?}", url1);
                 let mut body = complete_response_body.lock();
                 let mut completed_body = match *body {
                     ResponseBody::Receiving(ref mut body) => std::mem::take(body),
@@ -2374,7 +2380,13 @@ async fn http_network_fetch(
                 // be unused anyway.
                 let devtools_response_body =
                     devtools_chan.is_some().then(|| completed_body.clone());
-                *body = ResponseBody::Done(completed_body);
+                let encoded_data = encoded_data.lock().unwrap().clone();
+                *body = ResponseBody::Done(DoneResponseBody {
+                    decoded_body: completed_body,
+                    // Sadly this arc is still owned by response_body_stream so we have to clone it like this.
+                    encoded_body: encoded_data
+                        .map(|encoded_data| (encoded_data.0.to_vec(), encoded_data.1)),
+                });
                 send_response_values_to_devtools(
                     Some(headers),
                     status,
@@ -2389,11 +2401,14 @@ async fn http_network_fetch(
             })
             .map_err(move |error| {
                 if let std::io::ErrorKind::InvalidData = error.kind() {
-                    debug!("Content decompression error for {:?}", url2);
+                    debug!("Content decompression error for {:?}", url1);
                     let _ = done_sender3.send(Data::Error(NetworkError::DecompressionError));
                     let mut body = response_body2.lock();
 
-                    *body = ResponseBody::Done(vec![]);
+                    *body = ResponseBody::Done(DoneResponseBody {
+                        decoded_body: vec![],
+                        encoded_body: None,
+                    });
                 }
                 debug!("finished response for {:?}", url2);
                 let mut body = response_body2.lock();
@@ -2401,7 +2416,14 @@ async fn http_network_fetch(
                     ResponseBody::Receiving(ref mut body) => std::mem::take(body),
                     _ => vec![],
                 };
-                *body = ResponseBody::Done(completed_body);
+                *body = ResponseBody::Done(DoneResponseBody {
+                    decoded_body: completed_body,
+                    encoded_body: std::sync::Arc::into_inner(encoded_data2)
+                        .unwrap()
+                        .into_inner()
+                        .unwrap()
+                        .map(|value| (value.0.to_vec(), value.1)),
+                });
                 timing_ptr3.set_attribute(ResourceAttribute::ResponseEnd);
                 let _ = done_sender3.send(Data::Done);
             }),

--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -8,7 +8,7 @@ pub mod async_runtime;
 pub mod connector;
 pub mod cookie;
 pub mod cookie_storage;
-mod decoder;
+pub mod decoder;
 mod devtools;
 mod disk_cache;
 pub mod embedder;

--- a/components/net/local_directory_listing.rs
+++ b/components/net/local_directory_listing.rs
@@ -9,7 +9,7 @@ use chrono::{DateTime, Local};
 use embedder_traits::resources::{Resource, read_string};
 use headers::{ContentType, HeaderMapExt};
 use net_traits::request::Request;
-use net_traits::response::{Response, ResponseBody};
+use net_traits::response::{DoneResponseBody, Response, ResponseBody};
 use net_traits::{NetworkError, ResourceFetchTiming};
 use servo_config::pref;
 use servo_url::ServoUrl;
@@ -42,7 +42,10 @@ pub(crate) async fn fetch(request: &mut Request, url: ServoUrl, path_buf: PathBu
 
     let mut response = Response::new(url, ResourceFetchTiming::new(request.timing_type()));
     response.headers.typed_insert(ContentType::html());
-    *response.body.lock() = ResponseBody::Done(output.into_bytes());
+    *response.body.lock() = ResponseBody::Done(DoneResponseBody {
+        decoded_body: output.into_bytes(),
+        encoded_body: None,
+    });
 
     response
 }

--- a/components/net/protocols/data.rs
+++ b/components/net/protocols/data.rs
@@ -34,7 +34,11 @@ impl ProtocolHandler for DataProtocolHander {
                 Ok((bytes, _fragment_id)) => {
                     let mut response =
                         Response::new(url, ResourceFetchTiming::new(request.timing_type()));
-                    *response.body.lock() = ResponseBody::Done(bytes);
+                    *response.body.lock() =
+                        ResponseBody::Done(net_traits::response::DoneResponseBody {
+                            decoded_body: bytes,
+                            encoded_body: None,
+                        });
 
                     if let Ok(content_type_header_value) =
                         HeaderValue::from_str(&data_url.mime_type().to_string())

--- a/components/net/request_interceptor.rs
+++ b/components/net/request_interceptor.rs
@@ -8,7 +8,7 @@ use log::error;
 use net_traits::NetworkError;
 use net_traits::http_status::HttpStatus;
 use net_traits::request::Request;
-use net_traits::response::{Response, ResponseBody};
+use net_traits::response::{DoneResponseBody, Response, ResponseBody};
 
 use crate::embedder::NetToEmbedderMsg;
 use crate::fetch::methods::FetchContext;
@@ -74,8 +74,10 @@ impl RequestInterceptor {
                         error!("Received unexpected FinishLoad message");
                         break;
                     };
-                    *response.body.lock() =
-                        ResponseBody::Done(accumulated_body.into_iter().flatten().collect());
+                    *response.body.lock() = ResponseBody::Done(DoneResponseBody {
+                        decoded_body: accumulated_body.into_iter().flatten().collect(),
+                        encoded_body: None,
+                    });
                     break;
                 },
                 WebResourceResponseMsg::CancelLoad => {

--- a/components/net/subresource_integrity.rs
+++ b/components/net/subresource_integrity.rs
@@ -144,8 +144,8 @@ fn apply_algorithm_to_response(
     body: MutexGuard<ResponseBody>,
     algorithm: &'static digest::Algorithm,
 ) -> String {
-    if let ResponseBody::Done(ref vec) = *body {
-        let response_digest = digest::digest(algorithm, vec);
+    if let ResponseBody::Done(ref done_body) = *body {
+        let response_digest = digest::digest(algorithm, &done_body.decoded_body);
         base64::engine::general_purpose::STANDARD.encode(response_digest)
     } else {
         unreachable!("Tried to calculate digest of incomplete response body")

--- a/components/net/tests/data_loader.rs
+++ b/components/net/tests/data_loader.rs
@@ -55,7 +55,7 @@ fn assert_parse(
             let resp_body = response.body.lock();
             match *resp_body {
                 ResponseBody::Done(ref val) => {
-                    assert_eq!(val, &data);
+                    assert_eq!(&val.decoded_body, &data);
                 },
                 _ => panic!(),
             }

--- a/components/net/tests/decoder.rs
+++ b/components/net/tests/decoder.rs
@@ -2,9 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::io;
+use std::io::{self, Read};
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
+use bytes::{Bytes, BytesMut};
+use flate2::Compression;
+use flate2::read::GzEncoder;
+use http_body_util::BodyExt;
+use hyper::body::{Body, Frame};
+use net::decoder::Decoder;
 use net::test::{BodyStreamError, map_decode_error};
+use net_traits::DecoderType;
+use tokio_stream::StreamExt;
 
 #[test]
 fn test_map_decode_error_wraps_decoder_errors_as_invalid_data() {
@@ -38,4 +48,115 @@ fn test_map_decode_error_passes_nested_network_errors_through() {
     let wrapped = io::Error::new(io::ErrorKind::BrokenPipe, network_error);
     let mapped = map_decode_error(wrapped);
     assert_eq!(mapped.kind(), io::ErrorKind::BrokenPipe);
+}
+
+#[tokio::test]
+/// Test if the bodystream gzip decoding preserves the encoded bytes if setup.
+async fn test_bodystream_gzip_decoding() {
+    struct MyBody {
+        bytes: Bytes,
+        done: bool,
+    }
+
+    impl Body for MyBody {
+        type Data = Bytes;
+        type Error = hyper::Error;
+
+        // Required method
+        fn poll_frame(
+            mut self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+        ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+            if self.done {
+                Poll::Ready(None)
+            } else if self.bytes.len() < 4 {
+                self.done = true;
+                Poll::Ready(Some(Ok(Frame::data(self.bytes.clone()))))
+            } else {
+                let old_data = self.bytes.split_off(4);
+                let new_data = self.bytes.clone();
+                self.bytes = old_data;
+
+                Poll::Ready(Some(Ok(Frame::data(new_data))))
+            }
+        }
+    }
+
+    let teststring = "This is a big test string that we are going to compress. \nI am making this a bit longer than normal to test hopefully not just the first frame";
+
+    let mut compressed_bytes = Vec::new();
+    let mut gz = GzEncoder::new(teststring.as_bytes(), Compression::fast());
+    gz.read_to_end(&mut compressed_bytes).unwrap();
+
+    let bytes = Bytes::copy_from_slice(&compressed_bytes);
+    let body = MyBody { bytes, done: false };
+
+    let decoder = Decoder::pending(body.boxed(), DecoderType::Gzip, false, None);
+    let encoded_bytes = decoder.encoded_bytes();
+    let output = decoder
+        .fold(BytesMut::new(), |mut acc, data| {
+            if let Ok(data) = data {
+                acc.extend_from_slice(&data);
+            }
+            acc
+        })
+        .await;
+    assert_eq!(Bytes::copy_from_slice(teststring.as_bytes()), output);
+
+    let encoded_bytes = encoded_bytes.lock().unwrap();
+    assert!(encoded_bytes.is_some());
+    assert_eq!(compressed_bytes, encoded_bytes.as_ref().unwrap().0);
+}
+
+#[tokio::test]
+/// Test if the bodystream plain decoding does not preserve the encoded bytes
+async fn test_bodystream_plain_decoding() {
+    struct MyBody {
+        bytes: Bytes,
+        done: bool,
+    }
+
+    impl Body for MyBody {
+        type Data = Bytes;
+        type Error = hyper::Error;
+
+        // Required method
+        fn poll_frame(
+            mut self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+        ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+            if self.done {
+                Poll::Ready(None)
+            } else if self.bytes.len() < 4 {
+                self.done = true;
+                Poll::Ready(Some(Ok(Frame::data(self.bytes.clone()))))
+            } else {
+                let old_data = self.bytes.split_off(4);
+                let new_data = self.bytes.clone();
+                self.bytes = old_data;
+
+                Poll::Ready(Some(Ok(Frame::data(new_data))))
+            }
+        }
+    }
+
+    let teststring = "This is a big test string that we are going to compress. \nI am making this a bit longer than normal to test hopefully not just the first frame";
+
+    let bytes = Bytes::copy_from_slice(&teststring.as_bytes());
+    let body = MyBody { bytes, done: false };
+
+    let decoder = Decoder::plain_text(body.boxed(), false, None);
+    let encoded_bytes = decoder.encoded_bytes();
+    let output = decoder
+        .fold(BytesMut::new(), |mut acc, data| {
+            if let Ok(data) = data {
+                acc.extend_from_slice(&data);
+            }
+            acc
+        })
+        .await;
+    assert_eq!(Bytes::copy_from_slice(teststring.as_bytes()), output);
+
+    let encoded_bytes = encoded_bytes.lock().unwrap();
+    assert!(encoded_bytes.is_none());
 }

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -38,7 +38,7 @@ use net_traits::http_status::HttpStatus;
 use net_traits::request::{
     Destination, RedirectMode, Referrer, Request, RequestBuilder, RequestMode,
 };
-use net_traits::response::{CacheState, Response, ResponseBody, ResponseType};
+use net_traits::response::{CacheState, DoneResponseBody, Response, ResponseBody, ResponseType};
 use net_traits::{
     FetchTaskTarget, IncludeSubdomains, NetworkError, ReferrerPolicy, ResourceFetchTiming,
     ResourceTimingType, get_current_locale,
@@ -118,7 +118,7 @@ fn test_fetch_response_body_matches_const_message() {
 
     match *fetch_response.body.lock() {
         ResponseBody::Done(ref body) => {
-            assert_eq!(&**body, MESSAGE);
+            assert_eq!(&*body.decoded_body, MESSAGE);
         },
         _ => panic!(),
     };
@@ -149,7 +149,10 @@ fn test_fetch_aboutblank() {
     let actual_response = fetch_response.actual_response();
     assert!(!actual_response.is_network_error());
     let resp_body = actual_response.body.lock();
-    assert_eq!(*resp_body, ResponseBody::Done(vec![]));
+    assert_eq!(
+        *resp_body,
+        ResponseBody::Done(DoneResponseBody::new(vec![]))
+    );
 }
 
 #[test]
@@ -285,7 +288,7 @@ fn test_file() {
 
     match *resp_body {
         ResponseBody::Done(ref val) => {
-            assert_eq!(val, &file);
+            assert_eq!(&val.decoded_body, &file);
         },
         _ => panic!(),
     }
@@ -386,7 +389,7 @@ fn test_cors_preflight_fetch() {
 
     assert!(!fetch_response.is_network_error());
     match *fetch_response.body.lock() {
-        ResponseBody::Done(ref body) => assert_eq!(&**body, ACK),
+        ResponseBody::Done(ref body) => assert_eq!(&*body.decoded_body, ACK),
         _ => panic!(),
     };
 }
@@ -459,11 +462,11 @@ fn test_cors_preflight_cache_fetch() {
     assert_eq!(true, cache.match_method(&wrapped_request3, Method::GET));
 
     match *fetch_response0.body.lock() {
-        ResponseBody::Done(ref body) => assert_eq!(&**body, ACK),
+        ResponseBody::Done(ref body) => assert_eq!(&*body.decoded_body, ACK),
         _ => panic!(),
     };
     match *fetch_response1.body.lock() {
-        ResponseBody::Done(ref body) => assert_eq!(&**body, ACK),
+        ResponseBody::Done(ref body) => assert_eq!(&*body.decoded_body, ACK),
         _ => panic!(),
     };
 }
@@ -1115,7 +1118,7 @@ fn test_fetch_redirect_count_ceiling() {
 
     match *fetch_response.body.lock() {
         ResponseBody::Done(ref body) => {
-            assert_eq!(&**body, MESSAGE);
+            assert_eq!(&*body.decoded_body, MESSAGE);
         },
         _ => panic!(),
     };
@@ -1596,7 +1599,10 @@ fn test_fetch_request_intercepted() {
     let body = response.body.lock();
     match &*body {
         ResponseBody::Done(data) => {
-            assert_eq!(data, &EXPECTED_BODY, "Body content does not match");
+            assert_eq!(
+                &data.decoded_body, &EXPECTED_BODY,
+                "Body content does not match"
+            );
         },
         _ => panic!("Expected ResponseBody::Done, but got {:?}", *body),
     }

--- a/components/net/tests/http_cache.rs
+++ b/components/net/tests/http_cache.rs
@@ -7,7 +7,7 @@ use http::{HeaderMap, StatusCode};
 use net::http_cache::{CacheKey, HttpCache, HttpCacheAssignment, ValidationStatus, refresh};
 use net_traits::blob_url_store::UrlWithBlobClaim;
 use net_traits::request::{Referrer, RequestBuilder};
-use net_traits::response::{Response, ResponseBody};
+use net_traits::response::{DoneResponseBody, Response, ResponseBody};
 use net_traits::{ResourceFetchTiming, ResourceTimingType};
 use servo_base::id::TEST_PIPELINE_ID;
 use servo_url::ServoUrl;
@@ -18,7 +18,7 @@ async fn test_refreshing_resource_sets_done_chan_the_appropriate_value() {
     let response_bodies = vec![
         ResponseBody::Receiving(vec![]),
         ResponseBody::Empty,
-        ResponseBody::Done(vec![]),
+        ResponseBody::Done(DoneResponseBody::new(vec![])),
     ];
     let url = ServoUrl::parse("https://servo.org").unwrap();
     let request = RequestBuilder::new(
@@ -90,7 +90,7 @@ async fn test_skip_incomplete_cache_for_range_request_with_no_end_bound() {
     let timing = ResourceFetchTiming::new(ResourceTimingType::Navigation);
     let mut initial_incomplete_response = Response::new(url.clone(), timing);
     *initial_incomplete_response.body.lock() =
-        ResponseBody::Done(incomplete_response_body.to_vec());
+        ResponseBody::Done(DoneResponseBody::new(incomplete_response_body.to_vec()));
     initial_incomplete_response.headers.insert(
         CONTENT_RANGE,
         HeaderValue::from_str(&format!(
@@ -141,7 +141,7 @@ async fn stale_while_revalidate_freshness_for_cache_control(
 
     let timing = ResourceFetchTiming::new(ResourceTimingType::Navigation);
     let mut response = Response::new(url, timing);
-    *response.body.lock() = ResponseBody::Done(vec![1, 2, 3]);
+    *response.body.lock() = ResponseBody::Done(DoneResponseBody::new(vec![1, 2, 3]));
     response
         .headers
         .insert(CACHE_CONTROL, HeaderValue::from_str(cache_control).unwrap());
@@ -190,7 +190,7 @@ async fn test_stale_while_revalidate_not_used_when_request_demands_revalidation(
 
     let timing = ResourceFetchTiming::new(ResourceTimingType::Navigation);
     let mut response = Response::new(url.clone(), timing);
-    *response.body.lock() = ResponseBody::Done(vec![1, 2, 3]);
+    *response.body.lock() = ResponseBody::Done(DoneResponseBody::new(vec![1, 2, 3]));
     response.headers.insert(
         CACHE_CONTROL,
         HeaderValue::from_str("max-age=0, stale-while-revalidate=30").unwrap(),

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -40,7 +40,7 @@ use net_traits::request::{
     CredentialsMode, Destination, Referrer, Request, RequestBuilder, RequestMode,
     TraversableForUserPrompts, create_request_body_with_content,
 };
-use net_traits::response::{Response, ResponseBody};
+use net_traits::response::{DoneResponseBody, Response, ResponseBody};
 use net_traits::{CookieSource, FetchTaskTarget, NetworkError, ReferrerPolicy, get_current_locale};
 use parking_lot::{Mutex, RwLock};
 use servo_base::id::{TEST_PIPELINE_ID, TEST_WEBVIEW_ID};
@@ -592,10 +592,14 @@ fn test_load_should_decode_the_response_as_deflate_when_response_headers_have_co
 
     let internal_response = response.internal_response.unwrap();
     assert!(internal_response.status.clone().code().is_success());
-    assert_eq!(
-        *internal_response.body.lock(),
-        ResponseBody::Done(b"Yay!".to_vec())
-    );
+
+    let response = internal_response.body.lock();
+    match &*response {
+        ResponseBody::Empty | ResponseBody::Receiving(_) => assert!(false),
+        ResponseBody::Done(done_response_body) => {
+            assert_eq!(done_response_body.decoded_body, b"Yay!".to_vec())
+        },
+    };
 }
 
 #[test]
@@ -628,10 +632,13 @@ fn test_load_should_decode_the_response_as_gzip_when_response_headers_have_conte
 
     let internal_response = response.internal_response.unwrap();
     assert!(internal_response.status.clone().code().is_success());
-    assert_eq!(
-        *internal_response.body.lock(),
-        ResponseBody::Done(b"Yay!".to_vec())
-    );
+    let response = internal_response.body.lock();
+    match &*response {
+        ResponseBody::Empty | ResponseBody::Receiving(_) => assert!(false),
+        ResponseBody::Done(done_response_body) => {
+            assert_eq!(done_response_body.decoded_body, b"Yay!".to_vec())
+        },
+    };
 }
 
 #[test]
@@ -1268,7 +1275,7 @@ fn test_load_succeeds_with_a_redirect_loop() {
     assert_eq!(response.url_list, [url_a.url(), url_b.url(), url_a.url()]);
     assert_eq!(
         *response.body.lock(),
-        ResponseBody::Done(b"Success".to_vec())
+        ResponseBody::Done(DoneResponseBody::new(b"Success".to_vec()))
     );
 }
 
@@ -1312,7 +1319,7 @@ fn test_load_follows_a_redirect() {
     assert!(internal_response.status.clone().code().is_success());
     assert_eq!(
         *internal_response.body.lock(),
-        ResponseBody::Done(b"Yay!".to_vec())
+        ResponseBody::Done(DoneResponseBody::new(b"Yay!".to_vec()))
     );
 }
 
@@ -1402,7 +1409,7 @@ fn test_redirect_from_x_to_y_provides_y_cookies_from_y() {
     assert!(internal_response.status.clone().code().is_success());
     assert_eq!(
         *internal_response.body.lock(),
-        ResponseBody::Done(b"Yay!".to_vec())
+        ResponseBody::Done(DoneResponseBody::new(b"Yay!".to_vec()))
     );
 }
 
@@ -1458,7 +1465,7 @@ fn test_redirect_from_x_to_x_provides_x_with_cookie_from_first_response() {
     assert!(internal_response.status.clone().code().is_success());
     assert_eq!(
         *internal_response.body.lock(),
-        ResponseBody::Done(b"Yay!".to_vec())
+        ResponseBody::Done(DoneResponseBody::new(b"Yay!".to_vec()))
     );
 }
 

--- a/components/net/tests/subresource_integrity.rs
+++ b/components/net/tests/subresource_integrity.rs
@@ -5,7 +5,7 @@
 use net::subresource_integrity::{
     Algorithm, SriEntry, get_strongest_metadata, is_response_integrity_valid, parsed_metadata,
 };
-use net_traits::response::{Response, ResponseBody};
+use net_traits::response::{DoneResponseBody, Response, ResponseBody};
 use net_traits::{ResourceFetchTiming, ResourceTimingType};
 use servo_url::ServoUrl;
 
@@ -69,7 +69,7 @@ fn test_response_integrity_valid() {
         "sha384-H8BRh8j48O9oYatfu5AZzq6A9RINhZO5H16dQZngK7T62em8MUt1FLm52t+eX6xO";
     let response_body = "alert('Hello, world.');".to_owned().into_bytes();
 
-    *response.body.lock() = ResponseBody::Done(response_body);
+    *response.body.lock() = ResponseBody::Done(DoneResponseBody::new(response_body));
     assert!(is_response_integrity_valid(integrity_metadata, &response));
 }
 
@@ -85,6 +85,6 @@ fn test_response_integrity_invalid() {
         "sha256-H8BRh8j48O9oYatfu5AZzq6A9RINhZO5H16dQZngK7T62em8MUt1FLm52t+eX6xO";
     let response_body = "alert('Hello, world.');".to_owned().into_bytes();
 
-    *response.body.lock() = ResponseBody::Done(response_body);
+    *response.body.lock() = ResponseBody::Done(DoneResponseBody::new(response_body));
     assert!(!is_response_integrity_valid(integrity_metadata, &response));
 }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -139,7 +139,7 @@ pub mod protocol_handler {
     pub use net_traits::filemanager_thread::RelativePos;
     pub use net_traits::http_status::HttpStatus;
     pub use net_traits::request::Request;
-    pub use net_traits::response::{Response, ResponseBody};
+    pub use net_traits::response::{DoneResponseBody, Response, ResponseBody};
     pub use net_traits::{NetworkError, ResourceFetchTiming};
 
     pub use crate::webview_delegate::ProtocolHandlerRegistration;

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -71,6 +71,14 @@ pub mod fetch {
     pub mod headers;
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, MallocSizeOf)]
+pub enum DecoderType {
+    Gzip,
+    Brotli,
+    Deflate,
+    Zstd,
+}
+
 /// A loading context, for context-specific sniffing, as defined in
 /// <https://mimesniff.spec.whatwg.org/#context-specific-sniffing>
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]

--- a/components/shared/net/response.rs
+++ b/components/shared/net/response.rs
@@ -18,8 +18,8 @@ use crate::fetch::headers::extract_mime_type_as_mime;
 use crate::http_status::HttpStatus;
 use crate::resource_fetch_timing::{ResourceFetchTimingContainer, ResourceTimingType};
 use crate::{
-    FetchMetadata, FilteredMetadata, Metadata, NetworkError, ReferrerPolicy, ResourceFetchTiming,
-    TlsSecurityInfo,
+    DecoderType, FetchMetadata, FilteredMetadata, Metadata, NetworkError, ReferrerPolicy,
+    ResourceFetchTiming, TlsSecurityInfo,
 };
 
 /// [Response type](https://fetch.spec.whatwg.org/#concept-response-type)
@@ -41,6 +41,25 @@ pub enum TerminationReason {
     Timeout,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, MallocSizeOf)]
+/// The Response is completely received. Optionally contains the encoded body.
+pub struct DoneResponseBody {
+    #[serde(with = "serde_bytes")]
+    pub decoded_body: Vec<u8>,
+    /// None means that the decoded_body is the same as the encoded body
+    pub encoded_body: Option<(Vec<u8>, DecoderType)>,
+}
+
+#[cfg(feature = "test-util")]
+impl DoneResponseBody {
+    pub fn new(encoded_bytes: Vec<u8>) -> Self {
+        DoneResponseBody {
+            decoded_body: encoded_bytes,
+            encoded_body: None,
+        }
+    }
+}
+
 /// The response body can still be pushed to after fetch
 /// This provides a way to store unfinished response bodies
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
@@ -48,8 +67,7 @@ pub enum ResponseBody {
     Empty, // XXXManishearth is this necessary, or is Done(vec![]) enough?
     #[serde(with = "serde_bytes")]
     Receiving(Vec<u8>),
-    #[serde(with = "serde_bytes")]
-    Done(Vec<u8>),
+    Done(DoneResponseBody),
 }
 
 impl ResponseBody {

--- a/ports/servoshell/desktop/protocols/servo.rs
+++ b/ports/servoshell/desktop/protocols/servo.rs
@@ -16,8 +16,8 @@ use std::pin::Pin;
 use headers::{ContentType, HeaderMapExt};
 use servo::UserAgentPlatform;
 use servo::protocol_handler::{
-    DoneChannel, FetchContext, NetworkError, ProtocolHandler, Request, ResourceFetchTiming,
-    Response, ResponseBody,
+    DoneChannel, DoneResponseBody, FetchContext, NetworkError, ProtocolHandler, Request,
+    ResourceFetchTiming, Response, ResponseBody,
 };
 
 use crate::desktop::protocols::resource::ResourceProtocolHandler;
@@ -101,6 +101,9 @@ fn json_response(
         ResourceFetchTiming::new(request.timing_type()),
     );
     response.headers.typed_insert(ContentType::json());
-    *response.body.lock() = ResponseBody::Done(body.into_bytes());
+    *response.body.lock() = ResponseBody::Done(DoneResponseBody {
+        decoded_body: body.into_bytes(),
+        encoded_body: None,
+    });
     Box::pin(std::future::ready(response))
 }

--- a/ports/servoshell/desktop/protocols/urlinfo.rs
+++ b/ports/servoshell/desktop/protocols/urlinfo.rs
@@ -7,8 +7,8 @@ use std::pin::Pin;
 
 use headers::{ContentType, HeaderMapExt};
 use servo::protocol_handler::{
-    DoneChannel, FetchContext, HttpStatus, ProtocolHandler, Request, ResourceFetchTiming, Response,
-    ResponseBody,
+    DoneChannel, DoneResponseBody, FetchContext, HttpStatus, ProtocolHandler, Request,
+    ResourceFetchTiming, Response, ResponseBody,
 };
 
 #[derive(Default)]
@@ -34,7 +34,12 @@ impl ProtocolHandler for UrlInfoProtocolHander {
             url.query()
         );
         let mut response = Response::new(url, ResourceFetchTiming::new(request.timing_type()));
-        *response.body.lock() = ResponseBody::Done(content.as_bytes().to_vec());
+
+        *response.body.lock() = ResponseBody::Done(DoneResponseBody {
+            decoded_body: content.as_bytes().to_vec(),
+            encoded_body: None,
+        });
+
         response.headers.typed_insert(ContentType::text());
         response.status = HttpStatus::default();
 


### PR DESCRIPTION
This now stores the encoded stream (gzip/deflate etc.) in the disk cache instead of the encoded/plain text one.
This has the following changes:

- BodyStream (the sink the decoder reads from) now stores the encoded stream with it (if not plaintext).
- These encoded bytes are then stored in ResponseBody which has a new substruct DoneResponseBody (ResponseBody::Done(DoneResponseBody) with the encoded and decoded stream.
- The http cache now stores both of the streams.
- The disk cache now stores DiskCachedResources instead of CachedResources to better encapsulate which data gets stored in the disk cache.
- Decoding on fetch from the disk cache is async.


Multiple tests had to be adjusted and the new DoneResponseBody occurs in the servo api (used for protocol handlers).

Testing: We do not have automatic tests for the disk cache but it was manually tested. Storing of encoded and decoded bytes got new integration tests.
Fixes: https://github.com/servo/servo/issues/47456
