### PR TITLE
script: Use `Selection` and `Range` JavaScript API in editing code

### DIFF
--- a/components/script/dom/execcommand/commands/delete.rs
+++ b/components/script/dom/execcommand/commands/delete.rs
@@ -128,9 +128,9 @@ pub(crate) fn execute_delete_command(
                 }))
     {
         // Step 5.1. Call collapse(node, offset) on the context object's selection.
-        selection.collapse_active_range(&node, offset);
+        let _ = selection.Collapse(cx, Some(&node), offset);
         // Step 5.2. Call extend(node, offset − 1) on the context object's selection.
-        selection.extend_active_range(&node, offset - 1);
+        let _ = selection.Extend(cx, &node, offset - 1);
         // Step 5.3. Delete the selection.
         selection.delete_the_selection(
             cx,
@@ -272,9 +272,9 @@ pub(crate) fn execute_delete_command(
                 }))
     {
         // Step 13.1. Call collapse(start node, start offset − 1) on the context object's selection.
-        selection.collapse_active_range(&start_node, start_offset - 1);
+        let _ = selection.Collapse(cx, Some(&start_node), start_offset - 1);
         // Step 13.2. Call extend(start node, start offset) on the context object's selection.
-        selection.extend_active_range(&start_node, start_offset);
+        let _ = selection.Extend(cx, &start_node, start_offset);
         // Step 13.3. Delete the selection.
         selection.delete_the_selection(
             cx,
@@ -284,7 +284,7 @@ pub(crate) fn execute_delete_command(
             Default::default(),
         );
         // Step 13.4. Call collapse(node, offset) on the selection.
-        selection.collapse_active_range(&node, offset);
+        let _ = selection.Collapse(cx, Some(&node), offset);
         // Step 13.5. Return true.
         return true;
     }
@@ -323,10 +323,10 @@ pub(crate) fn execute_delete_command(
     }
 
     // Step 17. Call collapse(start node, start offset) on the context object's selection.
-    selection.collapse_active_range(&start_node, start_offset);
+    let _ = selection.Collapse(cx, Some(&start_node), start_offset);
 
     // Step 18. Call extend(node, offset) on the context object's selection.
-    selection.extend_active_range(&node, offset);
+    let _ = selection.Extend(cx, &node, offset);
 
     // Step 19. Delete the selection, with direction "backward".
     selection.delete_the_selection(

--- a/components/script/dom/execcommand/commands/insertparagraph.rs
+++ b/components/script/dom/execcommand/commands/insertparagraph.rs
@@ -4,6 +4,7 @@
 
 use html5ever::local_name;
 use js::context::JSContext;
+use script_bindings::codegen::GenericBindings::SelectionBinding::SelectionMethods;
 use script_bindings::inheritance::Castable;
 
 use crate::dom::Node;
@@ -38,11 +39,7 @@ pub(crate) fn execute_insert_paragraph_command(
         Default::default(),
     );
     // Step 3. Let node and offset be the active range's start node and offset.
-    let active_range = selection
-        .active_range(cx)
-        .expect("Must always have an active range");
-    let mut node = active_range.start_container();
-    let mut offset = active_range.start_offset();
+    let (mut node, mut offset) = selection.start_boundary(cx);
     // Step 2. If the active range's start node is neither editable
     // nor an editing host, return true.
     if !node.is_editable_or_editing_host() {
@@ -70,7 +67,7 @@ pub(crate) fn execute_insert_paragraph_command(
         node = node.GetParentNode().expect("Must always have a parent");
     }
     // Step 7. Call collapse(node, offset) on the context object's selection.
-    selection.collapse_active_range(&node, offset);
+    let _ = selection.Collapse(cx, Some(&node), offset);
     // Step 8. Let container equal node.
     let mut container = node.clone();
     // Step 9. While container is not a single-line container,
@@ -118,7 +115,7 @@ pub(crate) fn execute_insert_paragraph_command(
         // Step 11.1. Let tag be the default single-line container name.
         let tag = document.default_single_line_container_name();
         // Step 11.2. Block-extend the active range, and let new range be the result.
-        let new_range = active_range.block_extend(cx, document);
+        let new_range = selection.expect_active_range(cx).block_extend(cx, document);
         // Step 11.4. Append to node list the first node in tree order that is contained in new range and is an allowed child of "p", if any.
         let mut node_list = if let Some(eligible_node) = new_range
             .contained_children()
@@ -141,7 +138,10 @@ pub(crate) fn execute_insert_paragraph_command(
             // Step 11.5.1. If tag is not an allowed child of the active range's start node, return true.
             if !is_allowed_child(
                 NodeOrString::String(tag.str().to_owned()),
-                NodeOrString::from_node(&active_range.start_container(), cx.no_gc()),
+                NodeOrString::from_node(
+                    &selection.expect_active_range(cx).start_container(),
+                    cx.no_gc(),
+                ),
             ) {
                 return true;
             }
@@ -149,7 +149,11 @@ pub(crate) fn execute_insert_paragraph_command(
             let container = document.create_element(cx, tag.str());
             let container = container.upcast::<Node>();
             // Step 11.5.3. Call insertNode(container) on the active range.
-            if active_range.InsertNode(cx, container).is_err() {
+            if selection
+                .expect_active_range(cx)
+                .InsertNode(cx, container)
+                .is_err()
+            {
                 unreachable!("Must always be able to insert");
             }
             // Step 11.5.4. Call createElement("br") on the context object,
@@ -159,7 +163,7 @@ pub(crate) fn execute_insert_paragraph_command(
                 unreachable!("Must always be able to append");
             }
             // Step 11.5.5. Call collapse(container, 0) on the context object's selection.
-            selection.collapse_active_range(container, 0);
+            let _ = selection.Collapse(cx, Some(container), 0);
             // Step 11.5.6. Return true.
             return true;
         };
@@ -197,11 +201,15 @@ pub(crate) fn execute_insert_paragraph_command(
         // Step 12.1. Let br be the result of calling createElement("br") on the context object.
         let br = document.create_element(cx, "br");
         // Step 12.2. Call insertNode(br) on the active range.
-        if active_range.InsertNode(cx, br.upcast()).is_err() {
+        if selection
+            .expect_active_range(cx)
+            .InsertNode(cx, br.upcast())
+            .is_err()
+        {
             unreachable!("Must always be able to insert");
         }
         // Step 12.3. Call collapse(node, offset + 1) on the context object's selection.
-        selection.collapse_active_range(&node, offset + 1);
+        let _ = selection.Collapse(cx, Some(&node), offset + 1);
         // Step 12.4. If br is the last descendant of container,
         // let br be the result of calling createElement("br") on the context object,
         // then call insertNode(br) on the active range.
@@ -211,7 +219,11 @@ pub(crate) fn execute_insert_paragraph_command(
             .is_some_and(|child| *child == *br.upcast())
         {
             let br = document.create_element(cx, "br");
-            if active_range.InsertNode(cx, br.upcast()).is_err() {
+            if selection
+                .expect_active_range(cx)
+                .InsertNode(cx, br.upcast())
+                .is_err()
+            {
                 unreachable!("Must always be able to insert");
             }
         }
@@ -260,8 +272,9 @@ pub(crate) fn execute_insert_paragraph_command(
     // Step 14. Let new line range be a new range whose start is the same as the active range's,
     // and whose end is (container, length of container).
     let new_line_range = document.CreateRange(cx);
-    new_line_range.set_start(&active_range.start_container(), active_range.start_offset());
-    new_line_range.set_end(&container, container.len());
+    let (start_container, start_offset) = selection.start_boundary(cx);
+    let _ = new_line_range.SetStart(&start_container, start_offset);
+    let _ = new_line_range.SetEnd(&container, container.len());
     // Step 15. While new line range's start offset is zero and its start node
     // is not a prohibited paragraph child,
     // set its start to (parent of start node, index of start node).
@@ -271,7 +284,7 @@ pub(crate) fn execute_insert_paragraph_command(
             .is_prohibited_paragraph_child()
     {
         let start = new_line_range.start_container();
-        new_line_range.set_start(
+        let _ = new_line_range.SetStart(
             &start.GetParentNode().expect("Must always have a parent"),
             start.index(),
         );
@@ -285,7 +298,7 @@ pub(crate) fn execute_insert_paragraph_command(
             .is_prohibited_paragraph_child()
     {
         let start = new_line_range.start_container();
-        new_line_range.set_start(
+        let _ = new_line_range.SetStart(
             &start.GetParentNode().expect("Must always have a parent"),
             1 + start.index(),
         );
@@ -421,7 +434,7 @@ pub(crate) fn execute_insert_paragraph_command(
         }
     }
     // Step 34. Call collapse(new container, 0) on the context object's selection.
-    selection.collapse_active_range(&new_container_node, 0);
+    let _ = selection.Collapse(cx, Some(&new_container_node), 0);
     // Step 35. Return true.
     true
 }

--- a/components/script/dom/execcommand/contenteditable/htmlelement.rs
+++ b/components/script/dom/execcommand/contenteditable/htmlelement.rs
@@ -4,6 +4,7 @@
 
 use html5ever::local_name;
 use js::context::JSContext;
+use script_bindings::codegen::GenericBindings::RangeBinding::RangeMethods;
 use script_bindings::inheritance::Castable;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::properties::{LonghandId, PropertyDeclarationId, ShorthandId};
@@ -261,8 +262,8 @@ impl HTMLElement {
             }
             previous_node = child;
         }
-        range.set_start(&selected_node, selected_offset);
-        range.set_end(&selected_node, selected_offset);
+        let _ = range.SetStart(&selected_node, selected_offset);
+        let _ = range.SetEnd(&selected_node, selected_offset);
         selection.AddRange(&range);
     }
 }

--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -674,14 +674,14 @@ where
             let start_offset = range.start_offset();
 
             if start_container == parent_of_new_parent && start_offset == new_parent.index() {
-                range.set_start(&start_container, start_offset + 1);
+                let _ = range.SetStart(&start_container, start_offset + 1);
             }
 
             let end_container = range.end_container();
             let end_offset = range.end_offset();
 
             if end_container == parent_of_new_parent && end_offset == new_parent.index() {
-                range.set_end(&end_container, end_offset + 1);
+                let _ = range.SetEnd(&end_container, end_offset + 1);
             }
         }
     }

--- a/components/script/dom/execcommand/contenteditable/range.rs
+++ b/components/script/dom/execcommand/contenteditable/range.rs
@@ -196,8 +196,8 @@ impl Range {
         // Step 8. Let new range be a new range whose start and end nodes and offsets are start node,
         // start offset, end node, and end offset.
         let new_range = document.CreateRange(cx);
-        new_range.set_start(&start_node, start_offset);
-        new_range.set_end(&end_node, end_offset);
+        let _ = new_range.SetStart(&start_node, start_offset);
+        let _ = new_range.SetEnd(&end_node, end_offset);
         // Step 9. Return new range.
         new_range
     }

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -336,30 +336,6 @@ impl Selection {
             .expect("Should always have an active range")
     }
 
-    pub(crate) fn collapse_active_range(&self, node: &Node, offset: u32) {
-        let range = self.range.get().expect("Must always have a range");
-        range.set_start(node, offset);
-        range.set_end(node, offset);
-
-        self.set_visible_selection_dirty();
-    }
-
-    pub(crate) fn extend_active_range(&self, node: &Node, offset: u32) {
-        let range = self.range.get().expect("Must always have a range");
-        assert!(range.collapsed(), "Must only extend after collapsing");
-
-        let anchor_node = range.start_container();
-        if (*anchor_node == *node && range.start_offset() < offset) || anchor_node.is_before(node) {
-            range.set_end(node, offset);
-            self.direction.set(Direction::Forwards);
-        } else {
-            range.set_start(node, offset);
-            self.direction.set(Direction::Backwards);
-        }
-
-        self.set_visible_selection_dirty();
-    }
-
     pub(crate) fn set_visible_selection_dirty(&self) {
         self.visible_selection_dirty.set(true);
     }

--- a/tests/wpt/meta/editing/run/delete.html.ini
+++ b/tests/wpt/meta/editing/run/delete.html.ini
@@ -196,18 +196,6 @@
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p><u>foo</u><p>[\]bar" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["delete",""\]\] "<p style=color:blue>foo</p>[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["delete",""\]\] "<p style=color:blue>foo</p>[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["delete",""\]\] "<div style=color:blue><p style=color:green>foo</div>[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["delete",""\]\] "<div style=color:blue><p style=color:green>foo</div>[\]bar" compare innerHTML]
-    expected: FAIL
-
   [[["delete",""\]\] "<p>foo</p><p>{bar</p>}<p>baz</p>" compare innerHTML]
     expected: FAIL
 
@@ -284,32 +272,11 @@
   [[["delete",""\]\] "foo<br><span></span>[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\]\] "<div><div><p>foo</div></div>[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<div><div><p>foo</div></div><!--abc-->[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<div><div><p>foo</div><!--abc--></div>[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<div><div><p>foo</p><!--abc--></div></div>[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<div><div><p>foo<!--abc--></div></div>[\]bar" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["delete",""\]\] "<p style=color:blue>foo<p>[\]bar" queryCommandState("stylewithcss") before]
     expected: FAIL
 
 
 [delete.html?1-1000]
-  [[["delete",""\]\] "<p>foo</p>[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<p>foo<br></p>[\]bar" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo<br><br></p><p>[\]bar</p>" compare innerHTML]
     expected: FAIL
 
@@ -320,12 +287,6 @@
     expected: FAIL
 
   [[["delete",""\]\] "foo<br><br><p>[\]bar</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<div><p>foo</p></div>[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<pre>foo</pre>[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["delete",""\]\] "foo<br>[\]bar" compare innerHTML]
@@ -408,9 +369,6 @@
   [[["delete",""\]\] "<ol><li>foo<br>bar<li>[\]baz</ol>" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\]\] "<ol><li><p>foo</p>{}bar</ol>" compare innerHTML]
-    expected: FAIL
-
   [[["delete",""\]\] "<ol><li><p>foo<li>[\]bar</ol>" compare innerHTML]
     expected: FAIL
 
@@ -429,19 +387,7 @@
   [[["delete",""\]\] "<dl><dt>foo<dd>bar<dd>[\]baz</dl>" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\]\] "<ol><li>foo</ol>[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<ol><li>foo<br></ol>[\]bar" compare innerHTML]
-    expected: FAIL
-
   [[["delete",""\]\] "<ol><li>foo<br><br></ol>[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<ol><li><br></ol>[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<ol><li>foo<li><br></ol>[\]bar" compare innerHTML]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<ol><li>foo<br><br></ol><p>[\]bar" compare innerHTML]
@@ -590,15 +536,6 @@
   [[["styleWithCSS","false"\],["delete",""\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo<br></span></p><p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span></p>" queryCommandValue("foreColor") after]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["delete",""\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo</span></p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["delete",""\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo</span><br></p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["delete",""\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo<br></span></p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span>" compare innerHTML]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["delete",""\]\] "<span style=\\"color:rgb(0, 0, 255)\\">foo</span><br><p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span></p>" queryCommandValue("foreColor") after]
     expected: FAIL
 
@@ -647,16 +584,10 @@
   [[["delete",""\]\] "<table><tr><th>a<th><b>[b</b><th><b>c</b><th><b>d\]</b><th>e</table>" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\]\] "<div style=display:flex><span>abc</span><span>def</span></div>[\]ghi" compare innerHTML]
-    expected: FAIL
-
   [[["delete",""\]\] "<div style=display:inline-flex><span>abc</span><span>def</span></div>[\]ghi" compare innerHTML]
     expected: FAIL
 
   [[["delete",""\]\] "012<div style=display:inline-flex><span>[\]abc</span><span>def</span></div>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<div style=display:grid><span>abc</span><span>def</span></div>[\]ghi" compare innerHTML]
     expected: FAIL
 
   [[["delete",""\]\] "<div style=display:inline-grid><span>abc</span><span>def</span></div>[\]ghi" compare innerHTML]
@@ -768,6 +699,15 @@
     expected: FAIL
 
   [[["delete",""\]\] "<div style=display:inline-grid><span>{}<br></span></div><div>abc</div>": execCommand("delete", false, "") return value]
+    expected: FAIL
+
+  [[["styleWithCSS","false"\],["delete",""\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo</span></p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span>" queryCommandValue("foreColor") after]
+    expected: FAIL
+
+  [[["styleWithCSS","false"\],["delete",""\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo</span><br></p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span>" queryCommandValue("foreColor") after]
+    expected: FAIL
+
+  [[["styleWithCSS","false"\],["delete",""\]\] "<p><span style=\\"color:rgb(0, 0, 255)\\">foo<br></span></p><span style=\\"color:rgb(255, 0, 0)\\">[\]bar</span>" queryCommandValue("foreColor") after]
     expected: FAIL
 
 


### PR DESCRIPTION
Instead of using internal setters for `Selection` and `Range`, which do
not adhere to the specification, use the JavaScript API methods. This
prevents `Selection`s and `Range`s from going into invalid states.

Testing: This gets a good number of editing subtests passing.
Three start failing, but I believe they were falsely passing
before.
