### PR TITLE
net: Fix mime sniff mp4 bug

### DIFF
--- a/components/shared/net/mime_classifier.rs
+++ b/components/shared/net/mime_classifier.rs
@@ -493,12 +493,15 @@ impl Mp4Matcher {
         data[8..].starts_with(&mp4) ||
         // Step 8. Let bytes-read be 16.
         // Step 9. While bytes-read is less than box-size, continuously loop through these steps:
+        {
+            assert!(box_size >= 16);
             data[16..box_size]
-            // Step 11. Increment bytes-read by 4.
+                // Step 11. Increment bytes-read by 4.
                 .chunks(4)
                 // Step 10. If the three bytes from sequence[bytes-read] to sequence[bytes-read + 2]
                 // are equal to 0x6D 0x70 0x34 ("mp4"), return true.
                 .any(|chunk| chunk.starts_with(&mp4))
+        }
         // Step 12. Return false.
     }
 }


### PR DESCRIPTION
This fixes https://github.com/servo/servo/issues/47603 and adds the test case.

Testing: WPT tests seem to have very little mime sniff test, so this was just tested with the testcase.
Fixes: https://github.com/servo/servo/issues/47603
