### PR TITLE
script: Move Trusted type into script bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9461,6 +9461,7 @@ dependencies = [
  "phf_codegen",
  "phf_shared",
  "regex",
+ "rustc-hash 2.1.3",
  "serde_json",
  "servo-base",
  "servo-config",

--- a/components/script/dom/bindings/refcounted.rs
+++ b/components/script/dom/bindings/refcounted.rs
@@ -2,75 +2,50 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-//! A generic, safe mechanism by which DOM objects can be pinned and transferred
-//! between threads (or intra-thread for asynchronous events). Akin to Gecko's
-//! nsMainThreadPtrHandle, this uses thread-safe reference counting and ensures
-//! that the actual SpiderMonkey GC integration occurs on the script thread via
-//! weak refcounts. Ownership of a `Trusted<T>` object means the DOM object of
-//! type T to which it points remains alive. Any other behaviour is undefined.
-//! To guarantee the lifetime of a DOM object when performing asynchronous operations,
-//! obtain a `Trusted<T>` from that object and pass it along with each operation.
-//! A usable pointer to the original DOM object can be obtained on the script thread
-//! from a `Trusted<T>` via the `root` method.
-//!
-//! The implementation of `Trusted<T>` is as follows:
-//! The `Trusted<T>` object contains an atomic reference counted pointer to the Rust DOM object.
-//! A hashtable resides in the script thread, keyed on the pointer.
-//! The values in this hashtable are weak reference counts. When a `Trusted<T>` object is
-//! created or cloned, the reference count is increased. When a `Trusted<T>` is dropped, the count
-//! decreases. If the count hits zero, the weak reference is emptied, and is removed from
-//! its hash table during the next GC. During GC, the entries of the hash table are counted
-//! as JS roots.
+//! A generic, safe mechanism by which Promise objects can be pinned and transferred
+//! between threads (or intra-thread for asynchronous events). See more information in
+//! script_bindings::refcounted
 
 use std::cell::RefCell;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
-use std::hash::Hash;
-use std::marker::PhantomData;
 use std::rc::Rc;
-use std::sync::{Arc, Weak};
 
+use js::conversions::ToJSValConvertible;
 use js::jsapi::JSTracer;
 use rustc_hash::FxHashMap;
-use script_bindings::reflector::{DomObject, Reflector};
+use script_bindings::error::Error;
+pub(crate) use script_bindings::refcounted::Trusted;
+use script_bindings::reflector::DomObject;
+use script_bindings::trace::trace_reflector;
 
-use crate::dom::bindings::conversions::ToJSValConvertible;
-use crate::dom::bindings::error::Error;
-use crate::dom::bindings::root::DomRoot;
-use crate::dom::bindings::trace::trace_reflector;
 use crate::dom::promise::{Promise, RootedPromise};
 use crate::tasks::task::TaskOnce;
 
-mod dummy {
-    // Attributes don’t apply through the macro.
-    use std::cell::RefCell;
-    use std::rc::Rc;
+thread_local!(pub(super) static LIVE_REFERENCES: Rc<RefCell<LivePromiseReferences>> =
+    Rc::new(RefCell::new(
+    LivePromiseReferences {
+        promise_table: RefCell::new(FxHashMap::default()),
+    }
+)));
 
-    use rustc_hash::FxHashMap;
-
-    use super::LiveDOMReferences;
-    thread_local!(pub(crate) static LIVE_REFERENCES: Rc<RefCell<LiveDOMReferences>> =
-        Rc::new(RefCell::new(
-        LiveDOMReferences {
-            reflectable_table: RefCell::new(FxHashMap::default()),
-            promise_table: RefCell::new(FxHashMap::default()),
-        }
-    )));
+/// The set of live, pinned DOM objects that are currently prevented
+/// from being garbage collected due to outstanding references.
+pub(crate) struct LivePromiseReferences {
+    // keyed on pointer to Rust DOM object
+    promise_table: RefCell<FxHashMap<*const Promise, Vec<Rc<Promise>>>>,
 }
-pub(crate) use self::dummy::LIVE_REFERENCES;
 
-/// A pointer to a Rust DOM object that needs to be destroyed.
-#[derive(MallocSizeOf)]
-struct TrustedReference(
-    #[ignore_malloc_size_of = "This is a shared reference."] *const libc::c_void,
-);
-unsafe impl Send for TrustedReference {}
+impl LivePromiseReferences {
+    pub(crate) fn destruct() {
+        LIVE_REFERENCES.with(|r| {
+            let live_references = r.borrow_mut();
+            let _ = live_references.promise_table.take();
+        });
+    }
 
-impl TrustedReference {
-    /// Creates a new TrustedReference from a pointer to a value that impements DOMObject.
-    /// This is not enforced by the type system to reduce duplicated generic code,
-    /// which is acceptable since this method is internal to this module.
-    unsafe fn new(ptr: *const libc::c_void) -> TrustedReference {
-        TrustedReference(ptr)
+    fn addref_promise(&self, promise: Rc<Promise>) {
+        let mut table = self.promise_table.borrow_mut();
+        table.entry(&*promise).or_default().push(promise)
     }
 }
 
@@ -161,160 +136,11 @@ impl TrustedPromise {
     }
 }
 
-/// A safe wrapper around a raw pointer to a DOM object that can be
-/// shared among threads for use in asynchronous operations. The underlying
-/// DOM object is guaranteed to live at least as long as the last outstanding
-/// `Trusted<T>` instance.
-#[cfg_attr(crown, crown::unrooted_must_root_lint::allow_unrooted_interior)]
-#[derive(MallocSizeOf)]
-pub(crate) struct Trusted<T: DomObject> {
-    /// A pointer to the Rust DOM object of type T, but void to allow
-    /// sending `Trusted<T>` between threads, regardless of T's sendability.
-    #[conditional_malloc_size_of]
-    refcount: Arc<TrustedReference>,
-    #[ignore_malloc_size_of = "These are shared by all `Trusted` types."]
-    owner_thread: *const LiveDOMReferences,
-    phantom: PhantomData<T>,
-}
-
-impl<T: DomObject> std::fmt::Debug for Trusted<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        f.write_str("...")
-    }
-}
-
-unsafe impl<T: DomObject> Send for Trusted<T> {}
-
-impl<T: DomObject> Trusted<T> {
-    /// Create a new `Trusted<T>` instance from an existing DOM pointer. The DOM object will
-    /// be prevented from being GCed for the duration of the resulting `Trusted<T>` object's
-    /// lifetime.
-    pub(crate) fn new(ptr: &T) -> Trusted<T> {
-        fn add_live_reference(
-            ptr: *const libc::c_void,
-        ) -> (Arc<TrustedReference>, *const LiveDOMReferences) {
-            LIVE_REFERENCES.with(|r| {
-                let live_references = &*r.borrow();
-                let refcount = unsafe { live_references.addref(ptr) };
-                (refcount, live_references as *const _)
-            })
-        }
-
-        let (refcount, owner_thread) = add_live_reference(ptr as *const T as *const _);
-        Trusted {
-            refcount,
-            owner_thread,
-            phantom: PhantomData,
-        }
-    }
-
-    /// Obtain a usable DOM pointer from a pinned `Trusted<T>` value. Fails if used on
-    /// a different thread than the original value from which this `Trusted<T>` was
-    /// obtained.
-    pub(crate) fn root(&self) -> DomRoot<T> {
-        fn validate(owner_thread: *const LiveDOMReferences) {
-            assert!(LIVE_REFERENCES.with(|r| {
-                let r = r.borrow();
-                let live_references = &*r;
-                owner_thread == live_references
-            }));
-        }
-        validate(self.owner_thread);
-        unsafe { DomRoot::from_ref(&*(self.refcount.0 as *const T)) }
-    }
-}
-
-impl<T: DomObject> Clone for Trusted<T> {
-    fn clone(&self) -> Trusted<T> {
-        Trusted {
-            refcount: self.refcount.clone(),
-            owner_thread: self.owner_thread,
-            phantom: PhantomData,
-        }
-    }
-}
-
-/// The set of live, pinned DOM objects that are currently prevented
-/// from being garbage collected due to outstanding references.
-pub(crate) struct LiveDOMReferences {
-    // keyed on pointer to Rust DOM object
-    reflectable_table: RefCell<FxHashMap<*const libc::c_void, Weak<TrustedReference>>>,
-    promise_table: RefCell<FxHashMap<*const Promise, Vec<Rc<Promise>>>>,
-}
-
-impl LiveDOMReferences {
-    pub(crate) fn destruct() {
-        LIVE_REFERENCES.with(|r| {
-            let live_references = r.borrow_mut();
-            let _ = live_references.promise_table.take();
-            let _ = live_references.reflectable_table.take();
-        });
-    }
-
-    fn addref_promise(&self, promise: Rc<Promise>) {
-        let mut table = self.promise_table.borrow_mut();
-        table.entry(&*promise).or_default().push(promise)
-    }
-
-    /// ptr must be a pointer to a type that implements DOMObject.
-    /// This is not enforced by the type system to reduce duplicated generic code,
-    /// which is acceptable since this method is internal to this module.
-    #[expect(clippy::arc_with_non_send_sync)]
-    unsafe fn addref(&self, ptr: *const libc::c_void) -> Arc<TrustedReference> {
-        let mut table = self.reflectable_table.borrow_mut();
-        let capacity = table.capacity();
-        let len = table.len();
-        if (0 < capacity) && (capacity <= len) {
-            trace!("growing refcounted references by {}", len);
-            remove_nulls(&mut table);
-            table.reserve(len);
-        }
-        match table.entry(ptr) {
-            Occupied(mut entry) => match entry.get().upgrade() {
-                Some(refcount) => refcount,
-                None => {
-                    let refcount = Arc::new(unsafe { TrustedReference::new(ptr) });
-                    entry.insert(Arc::downgrade(&refcount));
-                    refcount
-                },
-            },
-            Vacant(entry) => {
-                let refcount = Arc::new(unsafe { TrustedReference::new(ptr) });
-                entry.insert(Arc::downgrade(&refcount));
-                refcount
-            },
-        }
-    }
-}
-
-/// Remove null entries from the live references table
-fn remove_nulls<K: Eq + Hash + Clone, V>(table: &mut FxHashMap<K, Weak<V>>) {
-    let to_remove: Vec<K> = table
-        .iter()
-        .filter(|&(_, value)| Weak::upgrade(value).is_none())
-        .map(|(key, _)| key.clone())
-        .collect();
-    trace!("removing {} refcounted references", to_remove.len());
-    for key in to_remove {
-        table.remove(&key);
-    }
-}
-
 /// A JSTraceDataOp for tracing reflectors held in LIVE_REFERENCES
 pub(crate) unsafe fn trace_refcounted_objects(tracer: *mut JSTracer) {
     trace!("tracing live refcounted references");
     LIVE_REFERENCES.with(|r| {
         let live_references = &*r.borrow();
-        {
-            let mut table = live_references.reflectable_table.borrow_mut();
-            remove_nulls(&mut table);
-            for obj in table.keys() {
-                unsafe {
-                    trace_reflector(tracer, "refcounted", &*(*obj as *const Reflector));
-                }
-            }
-        }
-
         {
             let table = live_references.promise_table.borrow_mut();
             for promise in table.keys() {

--- a/components/script/dom/bindings/refcounted.rs
+++ b/components/script/dom/bindings/refcounted.rs
@@ -150,4 +150,7 @@ pub(crate) unsafe fn trace_refcounted_objects(tracer: *mut JSTracer) {
             }
         }
     });
+    unsafe {
+        script_bindings::refcounted::trace_live_domreferences(tracer);
+    }
 }

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -41,10 +41,9 @@ use js::jsapi::{GCTraceKindToAscii, Heap, JSScript, JSString, JSTracer, TraceKin
 use js::jsval::JSVal;
 use malloc_size_of::{MallocConditionalSizeOf, MallocSizeOf, MallocSizeOfOps};
 use rustc_hash::FxBuildHasher;
-use script_bindings::reflector::DomObject;
 pub(crate) use script_bindings::trace::*;
 
-use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
+use crate::dom::bindings::refcounted::TrustedPromise;
 use crate::dom::html::htmlmediaelement::HTMLMediaElementFetchContext;
 use crate::dom::srcset::SourceSet;
 use crate::dom::windowproxy::WindowProxyHandler;
@@ -277,10 +276,3 @@ unsafe_no_jsmanaged_fields!(WindowProxyHandler);
 unsafe_no_jsmanaged_fields!(SourceSet);
 unsafe_no_jsmanaged_fields!(HTMLMediaElementFetchContext);
 unsafe_no_jsmanaged_fields!(StreamConsumer);
-
-unsafe impl<T: DomObject> JSTraceable for Trusted<T> {
-    #[inline]
-    unsafe fn trace(&self, _: *mut JSTracer) {
-        // Do nothing
-    }
-}

--- a/components/script/runtime/script_runtime.rs
+++ b/components/script/runtime/script_runtime.rs
@@ -75,7 +75,7 @@ use crate::dom::bindings::conversions::{
 use crate::dom::bindings::error::{Error, report_pending_exception, throw_dom_exception};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::{
-    LiveDOMReferences, Trusted, TrustedPromise, trace_refcounted_objects,
+    LivePromiseReferences, Trusted, TrustedPromise, trace_refcounted_objects,
 };
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::trace_roots;
@@ -978,7 +978,8 @@ impl Drop for Runtime {
         unsafe {
             DeleteJobQueue(self.job_queue);
         }
-        LiveDOMReferences::destruct();
+        LivePromiseReferences::destruct();
+        script_bindings::refcounted::LiveDOMReferences::destruct();
         mark_runtime_dead();
     }
 }

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -40,6 +40,7 @@ parking_lot = { workspace = true }
 phf = { workspace = true }
 profile_traits = { workspace = true }
 regex = { workspace = true }
+rustc-hash = { workspace = true }
 servo-base = { workspace = true }
 servo-config = { workspace = true }
 servo-constellation-traits = { workspace = true }

--- a/components/script_bindings/lib.rs
+++ b/components/script_bindings/lib.rs
@@ -41,6 +41,7 @@ pub mod principals;
 pub mod proxyhandler;
 pub mod realms;
 pub mod record;
+pub mod refcounted;
 pub mod reflector;
 pub mod root;
 pub mod script_runtime;

--- a/components/script_bindings/refcounted.rs
+++ b/components/script_bindings/refcounted.rs
@@ -1,0 +1,198 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! A generic, safe mechanism by which DOM objects can be pinned and transferred
+//! between threads (or intra-thread for asynchronous events). Akin to Gecko's
+//! nsMainThreadPtrHandle, this uses thread-safe reference counting and ensures
+//! that the actual SpiderMonkey GC integration occurs on the script thread via
+//! weak refcounts. Ownership of a `Trusted<T>` object means the DOM object of
+//! type T to which it points remains alive. Any other behaviour is undefined.
+//! To guarantee the lifetime of a DOM object when performing asynchronous operations,
+//! obtain a `Trusted<T>` from that object and pass it along with each operation.
+//! A usable pointer to the original DOM object can be obtained on the script thread
+//! from a `Trusted<T>` via the `root` method.
+//!
+//! The implementation of `Trusted<T>` is as follows:
+//! The `Trusted<T>` object contains an atomic reference counted pointer to the Rust DOM object.
+//! A hashtable resides in the script thread, keyed on the pointer.
+//! The values in this hashtable are weak reference counts. When a `Trusted<T>` object is
+//! created or cloned, the reference count is increased. When a `Trusted<T>` is dropped, the count
+//! decreases. If the count hits zero, the weak reference is emptied, and is removed from
+//! its hash table during the next GC. During GC, the entries of the hash table are counted
+//! as JS roots.
+
+use std::cell::RefCell;
+use std::collections::hash_map::Entry::{Occupied, Vacant};
+use std::hash::Hash;
+use std::marker::PhantomData;
+use std::rc::Rc;
+use std::sync::{Arc, Weak};
+
+use js::jsapi::JSTracer;
+use rustc_hash::FxHashMap;
+
+thread_local!(pub(super) static LIVE_REFERENCES: Rc<RefCell<LiveDOMReferences>> =
+    Rc::new(RefCell::new(
+    LiveDOMReferences {
+        reflectable_table: RefCell::new(FxHashMap::default()),
+    }
+)));
+
+use crate::DomObject;
+use crate::root::DomRoot;
+
+/// A pointer to a Rust DOM object that needs to be destroyed.
+#[derive(MallocSizeOf)]
+struct TrustedReference(
+    #[ignore_malloc_size_of = "This is a shared reference."] *const libc::c_void,
+);
+unsafe impl Send for TrustedReference {}
+
+impl TrustedReference {
+    /// Creates a new TrustedReference from a pointer to a value that impements DOMObject.
+    /// This is not enforced by the type system to reduce duplicated generic code,
+    /// which is acceptable since this method is internal to this module.
+    unsafe fn new(ptr: *const libc::c_void) -> TrustedReference {
+        TrustedReference(ptr)
+    }
+}
+
+/// A safe wrapper around a raw pointer to a DOM object that can be
+/// shared among threads for use in asynchronous operations. The underlying
+/// DOM object is guaranteed to live at least as long as the last outstanding
+/// `Trusted<T>` instance.
+#[cfg_attr(crown, crown::unrooted_must_root_lint::allow_unrooted_interior)]
+#[derive(MallocSizeOf)]
+pub struct Trusted<T: DomObject> {
+    /// A pointer to the Rust DOM object of type T, but void to allow
+    /// sending `Trusted<T>` between threads, regardless of T's sendability.
+    #[conditional_malloc_size_of]
+    refcount: Arc<TrustedReference>,
+    #[ignore_malloc_size_of = "These are shared by all `Trusted` types."]
+    owner_thread: *const LiveDOMReferences,
+    phantom: PhantomData<T>,
+}
+
+impl<T: DomObject> std::fmt::Debug for Trusted<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        f.write_str("...")
+    }
+}
+
+unsafe impl<T: DomObject> Send for Trusted<T> {}
+
+impl<T: DomObject> Trusted<T> {
+    /// Create a new `Trusted<T>` instance from an existing DOM pointer. The DOM object will
+    /// be prevented from being GCed for the duration of the resulting `Trusted<T>` object's
+    /// lifetime.
+    pub fn new(ptr: &T) -> Trusted<T> {
+        fn add_live_reference(
+            ptr: *const libc::c_void,
+        ) -> (Arc<TrustedReference>, *const LiveDOMReferences) {
+            LIVE_REFERENCES.with(|r| {
+                let live_references = &*r.borrow();
+                let refcount = unsafe { live_references.addref(ptr) };
+                (refcount, live_references as *const _)
+            })
+        }
+
+        let (refcount, owner_thread) = add_live_reference(ptr as *const T as *const _);
+        Trusted {
+            refcount,
+            owner_thread,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Obtain a usable DOM pointer from a pinned `Trusted<T>` value. Fails if used on
+    /// a different thread than the original value from which this `Trusted<T>` was
+    /// obtained.
+    pub fn root(&self) -> DomRoot<T> {
+        fn validate(owner_thread: *const LiveDOMReferences) {
+            assert!(LIVE_REFERENCES.with(|r| {
+                let r = r.borrow();
+                let live_references = &*r;
+                owner_thread == live_references
+            }));
+        }
+        validate(self.owner_thread);
+        unsafe { DomRoot::from_ref(&*(self.refcount.0 as *const T)) }
+    }
+}
+
+impl<T: DomObject> Clone for Trusted<T> {
+    fn clone(&self) -> Trusted<T> {
+        Trusted {
+            refcount: self.refcount.clone(),
+            owner_thread: self.owner_thread,
+            phantom: PhantomData,
+        }
+    }
+}
+
+/// The set of live, pinned DOM objects that are currently prevented
+/// from being garbage collected due to outstanding references.
+pub struct LiveDOMReferences {
+    // keyed on pointer to Rust DOM object
+    reflectable_table: RefCell<FxHashMap<*const libc::c_void, Weak<TrustedReference>>>,
+}
+
+impl LiveDOMReferences {
+    pub fn destruct() {
+        LIVE_REFERENCES.with(|r| {
+            let live_references = r.borrow_mut();
+            let _ = live_references.reflectable_table.take();
+        });
+    }
+
+    /// ptr must be a pointer to a type that implements DOMObject.
+    /// This is not enforced by the type system to reduce duplicated generic code,
+    /// which is acceptable since this method is internal to this module.
+    #[expect(clippy::arc_with_non_send_sync)]
+    unsafe fn addref(&self, ptr: *const libc::c_void) -> Arc<TrustedReference> {
+        let mut table = self.reflectable_table.borrow_mut();
+        let capacity = table.capacity();
+        let len = table.len();
+        if (0 < capacity) && (capacity <= len) {
+            trace!("growing refcounted references by {}", len);
+            remove_nulls(&mut table);
+            table.reserve(len);
+        }
+        match table.entry(ptr) {
+            Occupied(mut entry) => match entry.get().upgrade() {
+                Some(refcount) => refcount,
+                None => {
+                    let refcount = Arc::new(unsafe { TrustedReference::new(ptr) });
+                    entry.insert(Arc::downgrade(&refcount));
+                    refcount
+                },
+            },
+            Vacant(entry) => {
+                let refcount = Arc::new(unsafe { TrustedReference::new(ptr) });
+                entry.insert(Arc::downgrade(&refcount));
+                refcount
+            },
+        }
+    }
+}
+
+/// Remove null entries from the live references table
+fn remove_nulls<K: Eq + Hash + Clone, V>(table: &mut FxHashMap<K, Weak<V>>) {
+    let to_remove: Vec<K> = table
+        .iter()
+        .filter(|&(_, value)| Weak::upgrade(value).is_none())
+        .map(|(key, _)| key.clone())
+        .collect();
+    trace!("removing {} refcounted references", to_remove.len());
+    for key in to_remove {
+        table.remove(&key);
+    }
+}
+
+unsafe impl<T: DomObject> crate::JSTraceable for Trusted<T> {
+    #[inline]
+    unsafe fn trace(&self, _: *mut JSTracer) {
+        // Do nothing
+    }
+}

--- a/components/script_bindings/refcounted.rs
+++ b/components/script_bindings/refcounted.rs
@@ -39,8 +39,9 @@ thread_local!(pub(super) static LIVE_REFERENCES: Rc<RefCell<LiveDOMReferences>> 
     }
 )));
 
-use crate::DomObject;
 use crate::root::DomRoot;
+use crate::trace::trace_reflector;
+use crate::{DomObject, Reflector};
 
 /// A pointer to a Rust DOM object that needs to be destroyed.
 #[derive(MallocSizeOf)]
@@ -136,6 +137,22 @@ impl<T: DomObject> Clone for Trusted<T> {
 pub struct LiveDOMReferences {
     // keyed on pointer to Rust DOM object
     reflectable_table: RefCell<FxHashMap<*const libc::c_void, Weak<TrustedReference>>>,
+}
+
+/// Trace all the references that are in Trusted and liive.
+/// # Safety
+/// tracer must point to a valid, non-null JS tracer.
+pub unsafe fn trace_live_domreferences(tracer: *mut JSTracer) {
+    LIVE_REFERENCES.with(|r| {
+        let live_references = r.borrow();
+        let mut table = live_references.reflectable_table.borrow_mut();
+        remove_nulls(&mut table);
+        for obj in table.keys() {
+            unsafe {
+                trace_reflector(tracer, "refcounted", &*(*obj as *const Reflector));
+            }
+        }
+    })
 }
 
 impl LiveDOMReferences {


### PR DESCRIPTION
This moves Trusted<T> into script_bindings. For this we split LiveReferences into the normal type and the Promise type. The promise type still lives in script.


Testing: Trusted and TrustedPromise should be tested by WPT as it is a fundamental type. https://github.com/Narfinger/servo/actions/runs/33770806995
