### PR TITLE
github: Decrease frequency of dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,11 @@ updates:
     - "tests/blink_perf/**"
     - "tests/wpt/**"
   schedule:
-    interval: weekly
-    day: "sunday"
+    interval: "cron"
+    cronjob: "0 1 * * 1,4"  # monday and thursday at 1am
     # default timezone is UTC
     # CI is usually busiest during european daytime.
     timezone: Europe/Berlin
-    time: "01:00"
   cooldown:
     default-days: 7
     include: "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,16 @@ updates:
     - "tests/blink_perf/**"
     - "tests/wpt/**"
   schedule:
-    interval: daily
+    interval: weekly
+    day: "sunday"
     # default timezone is UTC
     # CI is usually busiest during european daytime.
-    time: "00:00"
-  open-pull-requests-limit: 7
+    timezone: Europe/Berlin
+    time: "01:00"
+  cooldown:
+    default-days: 7
+    include: "*"
+  open-pull-requests-limit: 10
   allow:
   - dependency-type: direct
   - dependency-type: indirect

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     - "tests/wpt/**"
   schedule:
     interval: "cron"
-    cronjob: "0 1 * * 3,7"  # wednesday and sunday at 1am
+    cronjob: "0 1 * * WED,SUN"  # wednesday and sunday at 1am
     # default timezone is UTC
     # CI is usually busiest during european daytime.
     timezone: Europe/Berlin

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     - "tests/wpt/**"
   schedule:
     interval: "cron"
-    cronjob: "0 1 * * 1,4"  # monday and thursday at 1am
+    cronjob: "0 1 * * 3,7"  # wednesday and sunday at 1am
     # default timezone is UTC
     # CI is usually busiest during european daytime.
     timezone: Europe/Berlin


### PR DESCRIPTION
This changes some dependabot settings.

- Switch to twice a week (Monday and Thursday) updates instead of daily.
- Specify Europe/Berlin Saturday 1am time.
- Have a cooldown of 7 days before any packages is seen as an "update".
- Allows 10 open PRs.

Testing: Dependabot doesn't have any testing.
Fixes: https://github.com/servo/servo/issues/47599
