### PR TITLE
gstreamer: Filter factories by any matching caps.

### DIFF
--- a/components/media/backends/gstreamer/registry_scanner.rs
+++ b/components/media/backends/gstreamer/registry_scanner.rs
@@ -254,7 +254,7 @@ fn has_element_for_media_type(
     match gstreamer::caps::Caps::from_str(media_type) {
         Ok(caps) => {
             for factory in factories {
-                if factory.can_sink_all_caps(&caps) {
+                if factory.can_sink_any_caps(&caps) {
                     return true;
                 }
             }

--- a/tests/wpt/meta/content-security-policy/media-src/media-src-7_2_2.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/media-src/media-src-7_2_2.sub.html.ini
@@ -1,4 +1,0 @@
-[media-src-7_2_2.sub.html]
-  expected: TIMEOUT
-  [Test that securitypolicyviolation events are fired]
-    expected: TIMEOUT

--- a/tests/wpt/meta/content-security-policy/media-src/media-src-blocked.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/media-src/media-src-blocked.sub.html.ini
@@ -1,4 +1,0 @@
-[media-src-blocked.sub.html]
-  expected: TIMEOUT
-  [Disallowed audio source element]
-    expected: TIMEOUT

--- a/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-video.html.ini
+++ b/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-video.html.ini
@@ -1,2 +1,0 @@
-[mix-blend-mode-video.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-colorSpaceConversion.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-colorSpaceConversion.html.ini
@@ -1,0 +1,3 @@
+[createImageBitmap-colorSpaceConversion.html]
+  [createImageBitmap from a Video, and drawImage on the created ImageBitmap with colorSpaceConversion: none]
+    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-video.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-video.html.ini
@@ -58,39 +58,3 @@
 
   [Rec2020-222000000, Context display-p3, ImageData display-p3, cropSource=true]
     expected: FAIL
-
-  [sRGB-FF0100, Context srgb, ImageData srgb, cropSource=false]
-    expected: FAIL
-
-  [sRGB-FF0100, Context srgb, ImageData srgb, cropSource=true]
-    expected: FAIL
-
-  [sRGB-FF0100, Context display-p3, ImageData srgb, cropSource=false]
-    expected: FAIL
-
-  [sRGB-FF0100, Context display-p3, ImageData srgb, cropSource=true]
-    expected: FAIL
-
-  [sRGB-BB0000, Context srgb, ImageData srgb, cropSource=false]
-    expected: FAIL
-
-  [sRGB-BB0000, Context srgb, ImageData srgb, cropSource=true]
-    expected: FAIL
-
-  [sRGB-BB0000, Context display-p3, ImageData srgb, cropSource=false]
-    expected: FAIL
-
-  [sRGB-BB0000, Context display-p3, ImageData srgb, cropSource=true]
-    expected: FAIL
-
-  [Rec2020-3FF000000, Context srgb, ImageData srgb, cropSource=false]
-    expected: FAIL
-
-  [Rec2020-3FF000000, Context srgb, ImageData srgb, cropSource=true]
-    expected: FAIL
-
-  [Rec2020-3FF000000, Context display-p3, ImageData srgb, cropSource=false]
-    expected: FAIL
-
-  [Rec2020-3FF000000, Context display-p3, ImageData srgb, cropSource=true]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-video.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-video.html.ini
@@ -58,39 +58,3 @@
 
   [Rec2020-222000000, Context display-p3, ImageData display-p3, scaleImage=true]
     expected: FAIL
-
-  [sRGB-FF0100, Context srgb, ImageData srgb, scaleImage=false]
-    expected: FAIL
-
-  [sRGB-FF0100, Context srgb, ImageData srgb, scaleImage=true]
-    expected: FAIL
-
-  [sRGB-FF0100, Context display-p3, ImageData srgb, scaleImage=false]
-    expected: FAIL
-
-  [sRGB-FF0100, Context display-p3, ImageData srgb, scaleImage=true]
-    expected: FAIL
-
-  [sRGB-BB0000, Context srgb, ImageData srgb, scaleImage=false]
-    expected: FAIL
-
-  [sRGB-BB0000, Context srgb, ImageData srgb, scaleImage=true]
-    expected: FAIL
-
-  [sRGB-BB0000, Context display-p3, ImageData srgb, scaleImage=false]
-    expected: FAIL
-
-  [sRGB-BB0000, Context display-p3, ImageData srgb, scaleImage=true]
-    expected: FAIL
-
-  [Rec2020-3FF000000, Context srgb, ImageData srgb, scaleImage=false]
-    expected: FAIL
-
-  [Rec2020-3FF000000, Context srgb, ImageData srgb, scaleImage=true]
-    expected: FAIL
-
-  [Rec2020-3FF000000, Context display-p3, ImageData srgb, scaleImage=false]
-    expected: FAIL
-
-  [Rec2020-3FF000000, Context display-p3, ImageData srgb, scaleImage=true]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/mime-types/canPlayType.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/mime-types/canPlayType.html.ini
@@ -9,7 +9,7 @@
     expected: PRECONDITION_FAILED
 
   [audio/webm (optional)]
-    expected: PRECONDITION_FAILED
+    expected: FAIL
 
   [audio/mp4; codecs="mp4a.40.2" (optional)]
     expected: PRECONDITION_FAILED
@@ -18,10 +18,7 @@
     expected: PRECONDITION_FAILED
 
   [video/mp4 (optional)]
-    expected: PRECONDITION_FAILED
-
-  [audio/ogg; codecs="opus" (optional)]
-    expected: PRECONDITION_FAILED
+    expected: FAIL
 
   [video/webm (optional)]
     expected: FAIL
@@ -45,7 +42,7 @@
     expected: FAIL
 
   [audio/mp4 (optional)]
-    expected: PRECONDITION_FAILED
+    expected: FAIL
 
   [video/3gpp (optional)]
     expected: FAIL
@@ -56,29 +53,11 @@
   [video/mp4; codecs="mp4a.40.2" (optional)]
     expected: PRECONDITION_FAILED
 
-  [video/ogg; codecs="opus" (optional)]
-    expected: PRECONDITION_FAILED
-
   [video/3gpp; codecs="mp4v.20.8" (optional)]
     expected: PRECONDITION_FAILED
 
   [audio/wav with and without codecs]
     expected: FAIL
-
-  [audio/webm; codecs="opus" (optional)]
-    expected: PRECONDITION_FAILED
-
-  [audio/webm; codecs="vorbis" (optional)]
-    expected: PRECONDITION_FAILED
-
-  [video/webm; codecs="opus" (optional)]
-    expected: PRECONDITION_FAILED
-
-  [video/mp4 codecs subset]
-    expected: PRECONDITION_FAILED
-
-  [video/mp4 codecs order]
-    expected: PRECONDITION_FAILED
 
   [audio/ogg with and without codecs]
     expected: FAIL
@@ -88,3 +67,6 @@
 
   [audio/mp4; codecs="iamf.001.001.Opus" (optional)]
     expected: PRECONDITION_FAILED
+
+  [audio/webm with and without codecs]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-video-element/resize-during-playback.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-video-element/resize-during-playback.html.ini
@@ -1,3 +1,0 @@
-[resize-during-playback.html]
-  [mp4 video]
-    expected: PRECONDITION_FAILED

--- a/tests/wpt/meta/html/semantics/embedded-content/the-video-element/video_timeupdate_on_seek.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-video-element/video_timeupdate_on_seek.html.ini
@@ -2,3 +2,6 @@
   expected: TIMEOUT
   [timeupdate is emitted after a seek before the data is received: webm.]
     expected: TIMEOUT
+
+  [timeupdate is emitted after a seek before the data is received: mp4.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/resource-timing/initiator-type/video.html.ini
+++ b/tests/wpt/meta/resource-timing/initiator-type/video.html.ini
@@ -1,3 +1,0 @@
-[video.html]
-  [The initiator type for <source src> with type="video/mp4" must be 'video']
-    expected: FAIL


### PR DESCRIPTION
Ensuring that all caps match is too strict and means that mp4 is never reported as playable. Webkit has similar checks that look for intersection: https://searchfox.org/wubkat/rev/4bf9d2cf94e5a07bdcb977203ddc27f3752ecaf7/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp#322

Testing: Many new passing tests.