### PR TITLE
script: Preallocate message queue and Box large message

### DIFF
--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -1405,7 +1405,7 @@ impl ScriptThread {
 
         // Process the gathered events.
         debug!("Processing events.");
-        for msg in sequential.drain(0..) {
+        for msg in sequential.drain(..) {
             debug!("Processing event {:?}.", msg);
             let category = self.categorize_msg(&msg);
             let pipeline_id = msg.pipeline_id();

--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -99,6 +99,7 @@ use servo_constellation_traits::{
     TargetSnapshotParams, TraversalDirection, WindowSizeType,
 };
 use servo_url::{ImmutableOrigin, MutableOrigin, OriginSnapshot, ServoUrl};
+use smallvec::SmallVec;
 use storage_traits::StorageThreads;
 use storage_traits::webstorage_thread::WebStorageType;
 use style::context::QuirksMode;
@@ -1348,7 +1349,7 @@ impl ScriptThread {
     /// Handle incoming messages from other tasks and the task queue.
     fn handle_msgs(&self, cx: &mut js::context::JSContext) -> bool {
         // Proritize rendering tasks and others, and gather all other events as `sequential`.
-        let mut sequential = vec![];
+        let mut sequential: SmallVec<[MixedMessage; 10]> = SmallVec::new();
 
         // Notify the background-hang-monitor we are waiting for an event.
         self.background_hang_monitor.notify_wait();
@@ -1404,7 +1405,7 @@ impl ScriptThread {
 
         // Process the gathered events.
         debug!("Processing events.");
-        for msg in sequential {
+        for msg in sequential.drain(0..) {
             debug!("Processing event {:?}.", msg);
             let category = self.categorize_msg(&msg);
             let pipeline_id = msg.pipeline_id();
@@ -1451,7 +1452,7 @@ impl ScriptThread {
                                 self.handle_msg_from_script(inner_msg, $cx)
                             },
                             MixedMessage::FromDevtools(inner_msg) => {
-                                self.handle_msg_from_devtools(inner_msg, $cx)
+                                self.handle_msg_from_devtools(*inner_msg, $cx)
                             },
                             MixedMessage::FromImageCache(inner_msg) => {
                                 self.handle_msg_from_image_cache(inner_msg, $cx)

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -42,10 +42,11 @@ use crate::tasks::task_source::TaskSourceName;
 
 #[expect(clippy::large_enum_variant)]
 #[derive(Debug)]
+// We box only the devtools message because it is the largest and least used message.
 pub(crate) enum MixedMessage {
     FromConstellation(ScriptThreadMessage),
     FromScript(MainThreadScriptMsg),
-    FromDevtools(DevtoolScriptControlMsg),
+    FromDevtools(Box<DevtoolScriptControlMsg>),
     FromImageCache(ImageCacheResponseMessage),
     #[cfg(feature = "webgpu")]
     FromWebGPUServer(WebGPUMsg),
@@ -481,12 +482,12 @@ impl ScriptThreadReceivers {
                         .unwrap(),
                 )
             } else if index == devtools_index {
-                MixedMessage::FromDevtools(
+                MixedMessage::FromDevtools(Box::new(
                     operation
                         .recv(&self.devtools_server_receiver)
                         .unwrap()
                         .unwrap(),
-                )
+                ))
             } else if index == image_cache_index {
                 MixedMessage::FromImageCache(operation.recv(&self.image_cache_receiver).unwrap())
             } else {
@@ -534,7 +535,7 @@ impl ScriptThreadReceivers {
             return MixedMessage::FromScript(message).into();
         }
         if let Ok(message) = self.devtools_server_receiver.try_recv() {
-            return MixedMessage::FromDevtools(message.unwrap()).into();
+            return MixedMessage::FromDevtools(Box::new(message.unwrap())).into();
         }
         if let Ok(message) = self.image_cache_receiver.try_recv() {
             return MixedMessage::FromImageCache(message).into();


### PR DESCRIPTION
We preallocate the vector for messages. Looking at the length of the output we have it mostly at <=10 with higher and lower parts.
To improve memory usage we also box the devtools message. This will make devtools message creation fractionally slower but saves us memory if we do not have devtools messages.

Testing: This should not change observable behavior.
