### PR TITLE
layout: preserve intrinsic width for text inputs

### DIFF
--- a/components/layout/fragment_tree/base_fragment.rs
+++ b/components/layout/fragment_tree/base_fragment.rs
@@ -124,6 +124,9 @@ pub(crate) struct BaseFragmentInfo {
 
     /// The flags to use for the new BaseFragment.
     pub flags: FragmentFlags,
+
+    /// The HTML `size` value for a text-like input, used for its automatic preferred width.
+    pub input_size: Option<u32>,
 }
 
 impl BaseFragmentInfo {
@@ -131,6 +134,7 @@ impl BaseFragmentInfo {
         Self {
             tag: None,
             flags: FragmentFlags::empty(),
+            input_size: None,
         }
     }
 
@@ -141,6 +145,7 @@ impl BaseFragmentInfo {
                 pseudo_element_chain: Default::default(),
             }),
             flags: FragmentFlags::empty(),
+            input_size: None,
         }
     }
 
@@ -159,6 +164,7 @@ impl From<ServoLayoutNode<'_>> for BaseFragmentInfo {
     fn from(node: ServoLayoutNode) -> Self {
         let pseudo_element_chain = node.pseudo_element_chain();
         let mut flags = FragmentFlags::empty();
+        let mut input_size = None;
 
         if let Some(innermost_pseudo) = pseudo_element_chain.innermost() {
             match innermost_pseudo {
@@ -185,6 +191,7 @@ impl From<ServoLayoutNode<'_>> for BaseFragmentInfo {
             return Self {
                 tag: Some(node.into()),
                 flags,
+                input_size: None,
             };
         }
 
@@ -205,16 +212,38 @@ impl From<ServoLayoutNode<'_>> for BaseFragmentInfo {
                 },
                 &local_name!("input") => {
                     flags.insert(FragmentFlags::IS_INPUT_ELEMENT);
-                    if element
+                    let input_type = element
                         .attribute(&ns!(), &local_name!("type"))
-                        .is_some_and(|attr| {
-                            matches!(
-                                attr.as_atom().to_ascii_lowercase(),
-                                atom!("button") | atom!("color") | atom!("reset") | atom!("submit")
-                            )
-                        })
-                    {
+                        .map(|attr| attr.as_atom().to_ascii_lowercase());
+                    if input_type.as_ref().is_some_and(|input_type| {
+                        matches!(
+                            *input_type,
+                            atom!("button") | atom!("color") | atom!("reset") | atom!("submit")
+                        )
+                    }) {
                         flags.insert(FragmentFlags::IS_BUTTON);
+                    }
+                    if !input_type.as_ref().is_some_and(|input_type| {
+                        matches!(
+                            *input_type,
+                            atom!("hidden") |
+                                atom!("range") |
+                                atom!("color") |
+                                atom!("checkbox") |
+                                atom!("radio") |
+                                atom!("file") |
+                                atom!("submit") |
+                                atom!("image") |
+                                atom!("reset") |
+                                atom!("button")
+                        )
+                    }) {
+                        flags.insert(FragmentFlags::IS_TEXT_INPUT_ELEMENT);
+                        input_size = Some(
+                            element
+                                .attribute(&ns!(), &local_name!("size"))
+                                .map_or(20, |attribute| attribute.as_uint()),
+                        );
                     }
                 },
                 &local_name!("button") => {
@@ -227,6 +256,7 @@ impl From<ServoLayoutNode<'_>> for BaseFragmentInfo {
         Self {
             tag: Some(node.into()),
             flags,
+            input_size,
         }
     }
 }
@@ -276,6 +306,9 @@ bitflags! {
         const IS_INPUT_ELEMENT = 1 << 12;
         /// Whether this is a <button> element, or an <input> that uses button layout.
         const IS_BUTTON = 1 << 13;
+        /// Whether this input uses the default preferred size defined for text-entry and
+        /// domain-specific controls in the HTML rendering rules.
+        const IS_TEXT_INPUT_ELEMENT = 1 << 14;
     }
 }
 

--- a/components/layout/layout_box_base.rs
+++ b/components/layout/layout_box_base.rs
@@ -29,6 +29,7 @@ use crate::fragment_tree::{
 use crate::geom::LogicalSides1D;
 use crate::positioned::{PositioningContext, relative_adjustement};
 use crate::sizing::{ComputeInlineContentSizes, InlineContentSizesResult, SizeConstraint};
+use crate::style_ext::ComputedValuesExt;
 use crate::traversal::ElementDamageSet;
 use crate::{ConstraintSpace, ContainingBlock, ContainingBlockSize};
 
@@ -111,8 +112,26 @@ impl LayoutBoxBase {
             // TODO: Should we keep multiple caches for various block sizes?
         }
 
-        let result =
+        let mut result =
             layout_box.compute_inline_content_sizes_with_fixup(layout_context, constraint_space);
+        // Text-entry controls have a default preferred width based on 20 average characters when
+        // their computed inline size is auto. Their internal shadow text can be empty, so using
+        // only descendant content sizes incorrectly collapses the widget to its padding.
+        //
+        // <https://html.spec.whatwg.org/multipage/#the-input-element-as-a-text-entry-widget>
+        if self
+            .base_fragment_info
+            .flags
+            .contains(crate::fragment_tree::FragmentFlags::IS_TEXT_INPUT_ELEMENT) &&
+            self.style.box_size(self.style.writing_mode).inline.is_initial()
+        {
+            let character_count = self.base_fragment_info.input_size.unwrap_or(20);
+            let font_size: Au = self.style.get_font().font_size.computed_size().into();
+            let default_preferred_inline_size =
+                font_size.scale_by(character_count as f32 * 0.5);
+            result.sizes.min_content.max_assign(default_preferred_inline_size);
+            result.sizes.max_content.max_assign(default_preferred_inline_size);
+        }
         *cache = Some(Box::new((constraint_space.block_size, result)));
         result
     }

--- a/tests/wpt/tests/html/rendering/widgets/input-auto-width-size.html
+++ b/tests/wpt/tests/html/rendering/widgets/input-auto-width-size.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Text input automatic width honours the size attribute</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#the-input-element-as-a-text-entry-widget">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<input id="default-size" type="text" style="width: auto">
+<input id="small-size" type="search" size="1" style="width: auto">
+<input id="email-size" type="email" style="width: auto">
+<input id="url-size" type="url" style="width: auto">
+<input id="explicit-width" type="search" style="width: 3px">
+<input id="button" type="button" value="button" style="width: auto">
+<input id="checkbox" type="checkbox" style="width: auto">
+
+<script>
+test(() => {
+  const defaultWidth = document.querySelector('#default-size').getBoundingClientRect().width;
+  const smallWidth = document.querySelector('#small-size').getBoundingClientRect().width;
+  assert_greater_than(defaultWidth, smallWidth);
+}, 'An author width of auto preserves the text control default preferred size');
+
+test(() => {
+  const defaultWidth = document.querySelector('#default-size').getBoundingClientRect().width;
+  for (const id of ['email-size', 'url-size']) {
+    assert_greater_than_equal(
+      document.querySelector(`#${id}`).getBoundingClientRect().width,
+      defaultWidth,
+      `${id} uses the text-entry preferred size`,
+    );
+  }
+}, 'Domain-specific text controls receive the default preferred size');
+
+test(() => {
+  assert_equals(document.querySelector('#explicit-width').getBoundingClientRect().width, 3);
+}, 'An explicit CSS width remains authoritative');
+
+test(() => {
+  const textWidth = document.querySelector('#default-size').getBoundingClientRect().width;
+  assert_less_than(document.querySelector('#button').getBoundingClientRect().width, textWidth);
+  assert_less_than(document.querySelector('#checkbox').getBoundingClientRect().width, textWidth);
+}, 'Non-text controls do not receive the text-entry preferred size');
+</script>


### PR DESCRIPTION
## Summary

Text-entry inputs with an automatic inline size can collapse to their padding when their internal shadow content contributes no measurable width. This is visible with text and search controls that should remain usable without an author-specified width.

I maintain Solipsism Browser, an open-source Android browser that embeds Servo for experimental testing. While integrating Servo, I reduced this to a generic layout case and implemented the fix here without any host-, product-, or site-specific logic.

## Expected behaviour

- Text-entry and domain-specific input controls retain the HTML default preferred width of approximately 20 characters.
- The HTML `size` attribute changes that preferred width.
- An explicit CSS width remains authoritative.
- Non-text controls do not receive the text-entry default.

## Implementation

- Carry text-entry classification and the parsed `size` value into fragment metadata.
- During intrinsic inline-size calculation, contribute the standards-defined character-based preferred width only when the computed inline size is automatic.
- Add a WPT regression test covering text, search, email, URL, explicit-width, and non-text controls.

## Standards

This follows the WHATWG HTML rendering requirements for text-entry and domain-specific widgets, CSS Sizing Level 3 intrinsic sizing, CSS Basic User Interface widget behaviour, and Servo WPT conventions. The implementation uses font metrics, so exact pixels remain font-dependent as they are in other browser engines.

## Validation

- WPT manifest regenerated with `./mach update-manifest`.
- `git diff --check` passes.
- Targeted layout code was built successfully in the downstream integration tree.
- Full local Servo WPT execution requires a locally built Servo binary; CI can provide the complete upstream run.

Closes no site-specific issue; this is a general standards compliance fix.