### PR TITLE
script: Avoid manual lowercasing in `XMLHttpRequest::GetResponseHeader`

### DIFF
--- a/components/script/dom/fetch/headers.rs
+++ b/components/script/dom/fetch/headers.rs
@@ -143,6 +143,7 @@ impl HeadersMethods<crate::DomTypeHolder> for Headers {
             return Ok(());
         };
 
+        // Validated tokens are always ASCII.
         valid_name.make_ascii_lowercase();
 
         // Step 2 If this’s guard is "request-no-cors", name is not a no-CORS-safelisted request-header name,
@@ -209,6 +210,7 @@ impl HeadersMethods<crate::DomTypeHolder> for Headers {
         else {
             return Ok(());
         };
+        // Validated tokens are always ASCII.
         valid_name.make_ascii_lowercase();
 
         // 3. If this’s guard is "request-no-cors" and (name, value) is not a

--- a/components/script/dom/xmlhttprequest/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest/xmlhttprequest.rs
@@ -853,7 +853,9 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
     /// <https://xhr.spec.whatwg.org/#the-getresponseheader()-method>
     fn GetResponseHeader(&self, name: ByteString) -> Option<ByteString> {
         let headers = self.filter_response_headers();
-        let headers = headers.get_all(HeaderName::from_str(&name.as_str()?.to_lowercase()).ok()?);
+        // > All custom header names are lower cased upon conversion to a HeaderName value.
+        // https://docs.rs/http/latest/http/header/struct.HeaderName.html#representation
+        let headers = headers.get_all(HeaderName::from_str(name.as_str()?).ok()?);
         let mut first = true;
         let s = headers.iter().fold(Vec::new(), |mut vec, value| {
             if !first {


### PR DESCRIPTION
This is done manually in [from_str](https://docs.rs/http/latest/http/header/struct.HeaderName.html#method.from_str).
What's more, we are allocating a new string here.

> All custom header names are lower cased upon conversion to a HeaderName value. This avoids the overhead of dynamically doing lower case conversion during the hash code computation and the comparison operation.

Testing: No behaviour change. Covered by existing tests.