### PR TITLE
webdriver: Add adhoc `SetPermission` implmentation

### DIFF
--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -2641,6 +2641,9 @@ impl ScriptThread {
                     mode,
                 )
             },
+            WebDriverScriptCommand::SetPermission(name, state, reply) => {
+                webdriver_handlers::set_permission(&documents, pipeline_id, name, state, reply)
+            },
         }
     }
 

--- a/components/script/event_loop/webdriver_handlers.rs
+++ b/components/script/event_loop/webdriver_handlers.rs
@@ -26,6 +26,9 @@ use js::rust::wrappers2::{
 use js::rust::{HandleObject, HandleValue, IdVector};
 use net_traits::CookieSource::{HTTP, NonHTTP};
 use net_traits::CoreResourceMsg::{DeleteCookie, DeleteCookies, GetCookiesForUrl, SetCookieForUrl};
+use script_bindings::codegen::GenericBindings::PermissionStatusBinding::{
+    PermissionName, PermissionState,
+};
 use script_bindings::codegen::GenericBindings::ShadowRootBinding::ShadowRootMethods;
 use script_bindings::conversions::is_array_like;
 use script_bindings::num::Finite;
@@ -33,6 +36,7 @@ use script_bindings::reflector::DomObject;
 use script_bindings::settings_stack::run_a_script;
 use servo_base::generic_channel::{self, GenericOneshotSender, GenericSend, GenericSender};
 use servo_base::id::{BrowsingContextId, PipelineId};
+use webdriver::command::SetPermissionState;
 use webdriver::error::ErrorStatus;
 
 use crate::DomTypeHolder;
@@ -2230,5 +2234,44 @@ pub(crate) fn set_protocol_handler_automation_mode(
 ) {
     if let Some(document) = documents.find_document(pipeline) {
         document.set_protocol_handler_automation_mode(mode);
+    }
+}
+
+pub(crate) fn set_permission(
+    documents: &DocumentCollection,
+    pipeline: PipelineId,
+    name: String,
+    state: SetPermissionState,
+    reply: GenericOneshotSender<bool>,
+) {
+    let Ok(name) = name.parse::<PermissionName>() else {
+        if let Err(err) = reply.send(false) {
+            error!("SetPermission Failed to send reply: {err}");
+        }
+        return;
+    };
+    let state = match state {
+        SetPermissionState::Denied => PermissionState::Denied,
+        SetPermissionState::Granted => PermissionState::Granted,
+        SetPermissionState::Prompt => PermissionState::Prompt,
+    };
+
+    let Some(global) = documents.find_global(pipeline) else {
+        if let Err(err) = reply.send(false) {
+            error!("SetPermission Failed to send reply: {err}");
+        }
+        return;
+    };
+
+    global
+        .permission_state_invocation_results()
+        .borrow_mut()
+        .insert(name, state);
+
+    // TODO: dispatch "change" event.
+    // This is currently impossible because eventtarget is not registered.
+
+    if let Err(err) = reply.send(true) {
+        error!("SetPermission Failed to send reply: {err}");
     }
 }

--- a/components/script/event_loop/webdriver_handlers.rs
+++ b/components/script/event_loop/webdriver_handlers.rs
@@ -2237,6 +2237,7 @@ pub(crate) fn set_protocol_handler_automation_mode(
     }
 }
 
+/// <https://www.w3.org/TR/permissions/#webdriver-command-set-permission>
 pub(crate) fn set_permission(
     documents: &DocumentCollection,
     pipeline: PipelineId,
@@ -2263,6 +2264,7 @@ pub(crate) fn set_permission(
         return;
     };
 
+    // TODO: Make this per-origin instead of per-document/globalscope according to spec.
     global
         .permission_state_invocation_results()
         .borrow_mut()

--- a/components/script/event_loop/webdriver_handlers.rs
+++ b/components/script/event_loop/webdriver_handlers.rs
@@ -2243,10 +2243,10 @@ pub(crate) fn set_permission(
     pipeline: PipelineId,
     name: String,
     state: SetPermissionState,
-    reply: GenericOneshotSender<bool>,
+    reply: GenericOneshotSender<Result<(), ErrorStatus>>,
 ) {
     let Ok(name) = name.parse::<PermissionName>() else {
-        if let Err(err) = reply.send(false) {
+        if let Err(err) = reply.send(Err(ErrorStatus::InvalidArgument)) {
             error!("SetPermission Failed to send reply: {err}");
         }
         return;
@@ -2258,7 +2258,7 @@ pub(crate) fn set_permission(
     };
 
     let Some(global) = documents.find_global(pipeline) else {
-        if let Err(err) = reply.send(false) {
+        if let Err(err) = reply.send(Err(ErrorStatus::NoSuchWindow)) {
             error!("SetPermission Failed to send reply: {err}");
         }
         return;
@@ -2273,7 +2273,7 @@ pub(crate) fn set_permission(
     // TODO: dispatch "change" event.
     // This is currently impossible because eventtarget is not registered.
 
-    if let Err(err) = reply.send(true) {
+    if let Err(err) = reply.send(Ok(())) {
         error!("SetPermission Failed to send reply: {err}");
     }
 }

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -20,6 +20,7 @@ use servo_base::id::{BrowsingContextId, WebViewId};
 use servo_geometry::{DeviceIndependentIntRect, DeviceIndependentPixel};
 use style_traits::CSSPixel;
 use url::Url;
+use webdriver::command::SetPermissionState;
 use webdriver::error::ErrorStatus;
 
 use crate::{InputEvent, JSValue, JavaScriptEvaluationError, ScreenshotCaptureError, TraversalId};
@@ -268,6 +269,7 @@ pub enum WebDriverScriptCommand {
     AddLoadStatusSender(WebViewId, GenericSender<WebDriverLoadStatus>),
     RemoveLoadStatusSender(WebViewId),
     SetProtocolHandlerAutomationMode(CustomHandlersAutomationMode),
+    SetPermission(String, SetPermissionState, GenericOneshotSender<bool>),
 }
 
 pub type WebDriverJSResult = Result<JSValue, JavaScriptEvaluationError>;

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -269,7 +269,11 @@ pub enum WebDriverScriptCommand {
     AddLoadStatusSender(WebViewId, GenericSender<WebDriverLoadStatus>),
     RemoveLoadStatusSender(WebViewId),
     SetProtocolHandlerAutomationMode(CustomHandlersAutomationMode),
-    SetPermission(String, SetPermissionState, GenericOneshotSender<bool>),
+    SetPermission(
+        String,
+        SetPermissionState,
+        GenericOneshotSender<Result<(), ErrorStatus>>,
+    ),
 }
 
 pub type WebDriverJSResult = Result<JSValue, JavaScriptEvaluationError>;

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -59,8 +59,8 @@ use webdriver::capabilities::CapabilitiesMatching;
 use webdriver::command::{
     ActionsParameters, AddCookieParameters, GetParameters, JavascriptCommandParameters,
     LocatorParameters, NewSessionParameters, NewWindowParameters, SendKeysParameters,
-    SwitchToFrameParameters, SwitchToWindowParameters, TimeoutsParameters, WebDriverCommand,
-    WebDriverExtensionCommand, WebDriverMessage, WindowRectParameters,
+    SetPermissionParameters, SwitchToFrameParameters, SwitchToWindowParameters, TimeoutsParameters,
+    WebDriverCommand, WebDriverExtensionCommand, WebDriverMessage, WindowRectParameters,
 };
 use webdriver::common::{
     Cookie, Date, LocatorStrategy, Parameters, ShadowRoot, WebElement, WebFrame, WebWindow,
@@ -2662,6 +2662,30 @@ impl Handler {
             browsing_cotext_id,
         ))
     }
+
+    fn handle_set_permission(
+        &self,
+        parameters: SetPermissionParameters,
+    ) -> WebDriverResult<WebDriverResponse> {
+        let (sender, receiver) = generic_channel::oneshot().unwrap();
+
+        self.send_message_to_embedder(WebDriverCommandMsg::ScriptCommand(
+            self.browsing_context_id()?,
+            WebDriverScriptCommand::SetPermission(
+                parameters.descriptor.name,
+                parameters.state,
+                sender,
+            ),
+        ))?;
+
+        match wait_for_oneshot_response(receiver)? {
+            true => Ok(WebDriverResponse::Void),
+            false => Err(WebDriverError::new(
+                ErrorStatus::InvalidArgument,
+                "invalid name or state".to_string(),
+            )),
+        }
+    }
 }
 
 impl WebDriverHandler<ServoExtensionRoute> for Handler {
@@ -2774,6 +2798,7 @@ impl WebDriverHandler<ServoExtensionRoute> for Handler {
             WebDriverCommand::TakeElementScreenshot(ref x) => {
                 self.handle_take_element_screenshot(x)
             },
+            WebDriverCommand::SetPermission(params) => self.handle_set_permission(params),
             WebDriverCommand::Extension(extension) => match extension {
                 ServoExtensionCommand::GetPrefs(ref x) => self.handle_get_prefs(x),
                 ServoExtensionCommand::SetPrefs(ref x) => self.handle_set_prefs(x),

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2680,11 +2680,8 @@ impl Handler {
         ))?;
 
         match wait_for_oneshot_response(receiver)? {
-            true => Ok(WebDriverResponse::Void),
-            false => Err(WebDriverError::new(
-                ErrorStatus::InvalidArgument,
-                "invalid name or state".to_string(),
-            )),
+            Ok(()) => Ok(WebDriverResponse::Void),
+            Err(status) => Err(WebDriverError::new(status, "failed to set permission")),
         }
     }
 }

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2663,6 +2663,7 @@ impl Handler {
         ))
     }
 
+    /// <https://www.w3.org/TR/permissions/#webdriver-command-set-permission>
     fn handle_set_permission(
         &self,
         parameters: SetPermissionParameters,

--- a/tests/wpt/meta/fetch/fetch-later/send-on-deactivate-with-background-sync.https.window.js.ini
+++ b/tests/wpt/meta/fetch/fetch-later/send-on-deactivate-with-background-sync.https.window.js.ini
@@ -1,9 +1,0 @@
-[send-on-deactivate-with-background-sync.https.window.html]
-  [fetchLater() does send on page entering BFCache even if BackgroundSync is on.]
-    expected: FAIL
-
-  [fetchLater() with activateAfter=0 sends on page entering BFCache if BackgroundSync is on.]
-    expected: FAIL
-
-  [fetchLater() with activateAfter=1m does send on page entering BFCache even if BackgroundSync is on.]
-    expected: FAIL

--- a/tests/wpt/meta/geolocation/PositionOptions.https.html.ini
+++ b/tests/wpt/meta/geolocation/PositionOptions.https.html.ini
@@ -1,7 +1,7 @@
 [PositionOptions.https.html]
-  expected: ERROR
+  expected: TIMEOUT
   [Set timeout and maximumAge to 0, check that timeout error raised (getCurrentPosition)]
-    expected: NOTRUN
+    expected: TIMEOUT
 
   [Set timeout and maximumAge to 0, check that timeout error raised (watchPosition)]
     expected: NOTRUN

--- a/tests/wpt/meta/geolocation/disabled-by-permissions-policy.https.sub.html.ini
+++ b/tests/wpt/meta/geolocation/disabled-by-permissions-policy.https.sub.html.ini
@@ -1,7 +1,7 @@
 [disabled-by-permissions-policy.https.sub.html]
-  expected: ERROR
+  expected: TIMEOUT
   [Permissions-Policy header geolocation=() disallows the top-level document.]
-    expected: NOTRUN
+    expected: TIMEOUT
 
   [Permissions-Policy header geolocation=() disallows same-origin iframes.]
     expected: NOTRUN

--- a/tests/wpt/meta/geolocation/enabled-by-permission-policy-attribute.https.sub.html.ini
+++ b/tests/wpt/meta/geolocation/enabled-by-permission-policy-attribute.https.sub.html.ini
@@ -1,7 +1,6 @@
 [enabled-by-permission-policy-attribute.https.sub.html]
-  expected: ERROR
   [Permissions policy "geolocation" can be enabled in same-origin iframe using allow="geolocation" attribute]
-    expected: NOTRUN
+    expected: FAIL
 
   [Permissions policy "geolocation" can be enabled in cross-origin iframe using allow="geolocation" attribute]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/geolocation/getCurrentPosition_permission_deny.https.html.ini
+++ b/tests/wpt/meta/geolocation/getCurrentPosition_permission_deny.https.html.ini
@@ -1,4 +1,4 @@
 [getCurrentPosition_permission_deny.https.html]
-  expected: ERROR
+  expected: TIMEOUT
   [User denies access, check that error callback is called with correct code]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/geolocation/heading-stationary.https.html.ini
+++ b/tests/wpt/meta/geolocation/heading-stationary.https.html.ini
@@ -1,7 +1,7 @@
 [heading-stationary.https.html]
   expected: ERROR
   [heading is null when stationary (speed is 0)]
-    expected: NOTRUN
+    expected: FAIL
 
   [heading has a value when moving (speed > 0)]
     expected: NOTRUN

--- a/tests/wpt/meta/geolocation/watchPosition_permission_deny.https.html.ini
+++ b/tests/wpt/meta/geolocation/watchPosition_permission_deny.https.html.ini
@@ -1,7 +1,7 @@
 [watchPosition_permission_deny.https.html]
-  expected: ERROR
+  expected: TIMEOUT
   [Check that watchPosition returns synchronously before any callbacks are invoked.]
-    expected: FAIL
+    expected: TIMEOUT
 
   [User denies access, check that error callback is called.]
     expected: NOTRUN

--- a/tests/wpt/meta/geolocation/watchposition-timeout.https.window.js.ini
+++ b/tests/wpt/meta/geolocation/watchposition-timeout.https.window.js.ini
@@ -1,4 +1,0 @@
-[watchposition-timeout.https.window.html]
-  expected: ERROR
-  [Passing timeout=1 should not cause multiple timeout errors]
-    expected: NOTRUN

--- a/tests/wpt/meta/infrastructure/testdriver/set_permission.https.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/set_permission.https.html.ini
@@ -1,6 +1,0 @@
-[set_permission.https.html]
-  [Grant Permission]
-    expected: FAIL
-
-  [Deny Permission]
-    expected: FAIL

--- a/tests/wpt/meta/notifications/cross-origin-nested.tentative.https.sub.html.ini
+++ b/tests/wpt/meta/notifications/cross-origin-nested.tentative.https.sub.html.ini
@@ -1,7 +1,7 @@
 [cross-origin-nested.tentative.https.sub.html]
-  expected: ERROR
+  expected: TIMEOUT
   [third party iframe]
-    expected: NOTRUN
+    expected: TIMEOUT
 
   [nested first party iframe]
     expected: NOTRUN

--- a/tests/wpt/meta/notifications/cross-origin-same-site-request.tentative.https.sub.html.ini
+++ b/tests/wpt/meta/notifications/cross-origin-same-site-request.tentative.https.sub.html.ini
@@ -1,4 +1,0 @@
-[cross-origin-same-site-request.tentative.https.sub.html]
-  expected: ERROR
-  [same-site cross-origin iframe]
-    expected: NOTRUN

--- a/tests/wpt/meta/notifications/cross-origin-serviceworker.tentative.https.sub.html.ini
+++ b/tests/wpt/meta/notifications/cross-origin-serviceworker.tentative.https.sub.html.ini
@@ -1,4 +1,4 @@
 [cross-origin-serviceworker.tentative.https.sub.html]
-  expected: ERROR
+  expected: TIMEOUT
   [third party serviceworker]
-    expected: NOTRUN
+    expected: TIMEOUT

--- a/tests/wpt/meta/notifications/event-onclose.https.html.ini
+++ b/tests/wpt/meta/notifications/event-onclose.https.html.ini
@@ -1,7 +1,7 @@
 [event-onclose.https.html]
-  expected: ERROR
+  expected: TIMEOUT
   [Invoked the onclose event handler.]
-    expected: NOTRUN
+    expected: TIMEOUT
 
   [Invoked the onclose event handler on immediate close.]
     expected: NOTRUN

--- a/tests/wpt/meta/notifications/event-onshow.https.html.ini
+++ b/tests/wpt/meta/notifications/event-onshow.https.html.ini
@@ -1,4 +1,4 @@
 [event-onshow.https.html]
-  expected: ERROR
+  expected: TIMEOUT
   [Invoked the onshow event handler.]
-    expected: NOTRUN
+    expected: TIMEOUT

--- a/tests/wpt/meta/notifications/instance.https.window.js.ini
+++ b/tests/wpt/meta/notifications/instance.https.window.js.ini
@@ -1,37 +1,36 @@
 [instance.https.window.html]
-  expected: ERROR
   [new Notification(): Setup]
-    expected: NOTRUN
+    expected: FAIL
 
   [new Notification(): Attribute exists with expected value: title]
-    expected: NOTRUN
+    expected: FAIL
 
   [new Notification(): Attribute exists with expected value: dir]
-    expected: NOTRUN
+    expected: FAIL
 
   [new Notification(): Attribute exists with expected value: lang]
-    expected: NOTRUN
+    expected: FAIL
 
   [new Notification(): Attribute exists with expected value: body]
-    expected: NOTRUN
+    expected: FAIL
 
   [new Notification(): Attribute exists with expected value: tag]
-    expected: NOTRUN
+    expected: FAIL
 
   [new Notification(): Attribute exists with expected value: icon]
-    expected: NOTRUN
+    expected: FAIL
 
   [new Notification(): Attribute exists with expected value: data]
-    expected: NOTRUN
+    expected: FAIL
 
   [Service worker test setup]
-    expected: NOTRUN
+    expected: FAIL
 
   [new Notification(): Attribute exists with expected value: requireInteraction]
-    expected: NOTRUN
+    expected: FAIL
 
   [new Notification(): Attribute exists with expected value: silent]
-    expected: NOTRUN
+    expected: FAIL
 
   [new Notification(): Attribute exists with expected value: actions]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/notifications/tag.https.html.ini
+++ b/tests/wpt/meta/notifications/tag.https.html.ini
@@ -1,7 +1,7 @@
 [tag.https.html]
-  expected: ERROR
+  expected: TIMEOUT
   [Opening two notifications with the same tag should close the first one]
-    expected: NOTRUN
+    expected: TIMEOUT
 
   [Opening two notifications with the same tag should fire close event before show event]
     expected: NOTRUN

--- a/tests/wpt/meta/notifications/worker-gc.https.window.js.ini
+++ b/tests/wpt/meta/notifications/worker-gc.https.window.js.ini
@@ -1,4 +1,0 @@
-[worker-gc.https.window.html]
-  expected: ERROR
-  [An active notification should prevent worker cycle collection]
-    expected: NOTRUN

--- a/tests/wpt/meta/permissions/event-model.https.html.ini
+++ b/tests/wpt/meta/permissions/event-model.https.html.ini
@@ -1,12 +1,13 @@
 [event-model.https.html]
+  expected: TIMEOUT
   [Multiple listeners on a single PermissionStatus should all fire on change]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Multiple transitions generate multiple "change" events]
-    expected: FAIL
+    expected: NOTRUN
 
   [Multiple PermissionStatus objects observe the same transition]
-    expected: FAIL
+    expected: NOTRUN
 
   [PermissionStatus out of scope should still fire "change" event]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/permissions/non-fully-active.https.html.ini
+++ b/tests/wpt/meta/permissions/non-fully-active.https.html.ini
@@ -1,5 +1,5 @@
 [non-fully-active.https.html]
-  expected: ERROR
+  expected: TIMEOUT
   [Trying to query() a non-fully active document rejects with a InvalidStateError]
     expected: FAIL
 

--- a/tests/wpt/meta/permissions/permissions-cg.https.html.ini
+++ b/tests/wpt/meta/permissions/permissions-cg.https.html.ini
@@ -1,4 +1,4 @@
 [permissions-cg.https.html]
-  expected: ERROR
+  expected: TIMEOUT
   [status is not garbage collected when it goes out of scope]
     expected: TIMEOUT

--- a/tests/wpt/meta/permissions/permissions-garbage-collect.https.html.ini
+++ b/tests/wpt/meta/permissions/permissions-garbage-collect.https.html.ini
@@ -1,4 +1,4 @@
 [permissions-garbage-collect.https.html]
-  expected: ERROR
+  expected: TIMEOUT
   [Events fire even if the status object is garbage collected]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/permissions/revocation.https.html.ini
+++ b/tests/wpt/meta/permissions/revocation.https.html.ini
@@ -1,6 +1,7 @@
 [revocation.https.html]
+  expected: TIMEOUT
   [Transition "granted" -> "prompt" fires a "change" event]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Transition "granted" -> "denied" fires a "change" event]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/screen-wake-lock/wakelock-enabled-by-permissions-policy.https.html.ini
+++ b/tests/wpt/meta/screen-wake-lock/wakelock-enabled-by-permissions-policy.https.html.ini
@@ -1,10 +1,9 @@
 [wakelock-enabled-by-permissions-policy.https.html]
-  expected: TIMEOUT
   [Permissions-Policy header "screen-wake-lock=*" allows the top-level document.]
     expected: FAIL
 
   [Permissions-Policy header "screen-wake-lock=*" allows same-origin iframes.]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Permissions-Policy header "screen-wake-lock=*" allows cross-origin iframes.]
     expected: FAIL

--- a/tests/wpt/meta/screen-wake-lock/wakelock-enabled-on-self-origin-by-permissions-policy.https.html.ini
+++ b/tests/wpt/meta/screen-wake-lock/wakelock-enabled-on-self-origin-by-permissions-policy.https.html.ini
@@ -1,10 +1,9 @@
 [wakelock-enabled-on-self-origin-by-permissions-policy.https.html]
-  expected: TIMEOUT
   [Permissions-Policy header "screen-wake-lock=self" allows the top-level document.]
     expected: FAIL
 
   [Permissions-Policy header "screen-wake-lock=self" allows same-origin iframes.]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Permissions-Policy header "screen-wake-lock=self" disallows cross-origin iframes.]
     expected: FAIL

--- a/tests/wpt/meta/screen-wake-lock/wakelock-request-denied.https.html.ini
+++ b/tests/wpt/meta/screen-wake-lock/wakelock-request-denied.https.html.ini
@@ -1,3 +1,0 @@
-[wakelock-request-denied.https.html]
-  [Denied requests should abort with NotAllowedError]
-    expected: FAIL

--- a/tests/wpt/meta/screen-wake-lock/wakelockpermissiondescriptor.https.html.ini
+++ b/tests/wpt/meta/screen-wake-lock/wakelockpermissiondescriptor.https.html.ini
@@ -1,3 +1,0 @@
-[wakelockpermissiondescriptor.https.html]
-  [PermissionDescriptor with name='screen-wake-lock' works]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/external/permissions/set.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/external/permissions/set.py.ini
@@ -1,9 +1,0 @@
-[set.py]
-  [test_set_to_state[granted\]]
-    expected: FAIL
-
-  [test_set_to_state[denied\]]
-    expected: FAIL
-
-  [test_set_to_state[prompt\]]
-    expected: FAIL


### PR DESCRIPTION
Add an adhoc `SetPermission` implementation. Since in current architecture, permissions is only stored on each `globalscope`, it's impossible to strictly follows the spec [steps](https://www.w3.org/TR/permissions/#webdriver-command-set-permission). This PR is only intended to pass other wpt tests such as https://github.com/servo/servo/issues/44130

Testing: Passing `tests/wpt/tests/webdriver/tests/classic/external/permissions/` and passing/enabling many other testdriver tests that require permissions.
Fixes: https://github.com/servo/servo/issues/44130
