### PR TITLE
clippy: Enable linter configuration for most crates

### DIFF
--- a/components/allocator/Cargo.toml
+++ b/components/allocator/Cargo.toml
@@ -21,6 +21,9 @@ backtrace = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
 rustc-hash = { workspace = true, optional = true }
 
+[lints]
+workspace = true
+
 [target.'cfg(not(any(windows, target_env = "ohos")))'.dependencies]
 libc = { workspace = true }
 tikv-jemalloc-sys = { workspace = true, optional = true, features = ["stats"] }

--- a/components/background_hang_monitor/Cargo.toml
+++ b/components/background_hang_monitor/Cargo.toml
@@ -35,5 +35,8 @@ nix = { workspace = true, features = ["signal"], optional = true }
 [target.'cfg(target_os = "android")'.dependencies]
 nix = { workspace = true, features = ["signal"], optional = true }
 
+[lints]
+workspace = true
+
 [features]
 sampler = ["mach2", "nix", "rustc-demangle"]

--- a/components/bluetooth/Cargo.toml
+++ b/components/bluetooth/Cargo.toml
@@ -27,6 +27,9 @@ servo-config = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync", "time"], optional = true }
 uuid = { workspace = true }
 
+[lints]
+workspace = true
+
 [features]
 default = ["bluetooth-test"]
 bluetooth-test = ["blurmock"]

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -41,3 +41,6 @@ tracing = { workspace = true, optional = true }
 vello = { workspace = true, optional = true }
 vello_cpu = { workspace = true }
 webrender_api = { workspace = true }
+
+[lints]
+workspace = true

--- a/components/config/Cargo.toml
+++ b/components/config/Cargo.toml
@@ -20,3 +20,6 @@ serde_json = { workspace = true }
 servo-config-macro = { workspace = true }
 strum = { workspace = true }
 stylo_static_prefs = { workspace = true }
+
+[lints]
+workspace = true

--- a/components/default-resources/Cargo.toml
+++ b/components/default-resources/Cargo.toml
@@ -14,3 +14,6 @@ path = "lib.rs"
 
 [dependencies]
 embedder_traits = { workspace = true }
+
+[lints]
+workspace = true

--- a/components/deny_public_fields/Cargo.toml
+++ b/components/deny_public_fields/Cargo.toml
@@ -17,3 +17,6 @@ proc-macro = true
 proc-macro2 = { workspace = true }
 syn = { workspace = true }
 synstructure = { workspace = true }
+
+[lints]
+workspace = true

--- a/components/dom_struct/Cargo.toml
+++ b/components/dom_struct/Cargo.toml
@@ -18,3 +18,6 @@ syn = { workspace = true, features = ["extra-traits", "full", "parsing", "printi
 [lib]
 path = "lib.rs"
 proc-macro = true
+
+[lints]
+workspace = true

--- a/components/geometry/Cargo.toml
+++ b/components/geometry/Cargo.toml
@@ -20,3 +20,6 @@ malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 webrender = { workspace = true }
 webrender_api = { workspace = true }
+
+[lints]
+workspace = true

--- a/components/hyper_serde/Cargo.toml
+++ b/components/hyper_serde/Cargo.toml
@@ -29,3 +29,6 @@ ipc-channel = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_test = { workspace = true }
+
+[lints]
+workspace = true

--- a/components/jstraceable_derive/Cargo.toml
+++ b/components/jstraceable_derive/Cargo.toml
@@ -17,3 +17,6 @@ proc-macro = true
 proc-macro2 = { workspace = true }
 syn = { workspace = true }
 synstructure = { workspace = true }
+
+[lints]
+workspace = true

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -76,3 +76,6 @@ webrender_api = { workspace = true }
 
 [dev-dependencies]
 quickcheck = { workspace = true }
+
+[lints]
+workspace = true

--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -392,7 +392,7 @@ pub(crate) fn generate_pseudo_element_content(
                         let attr_val =
                             element.attribute(&attr.namespace_url, &LocalName::from(attr_name));
                         vec.push(PseudoElementContentItem::Text(
-                            attr_val.map_or("".to_string(), |s| s.to_string()),
+                            attr_val.map_or(String::new(), |s| s.to_string()),
                         ));
                     },
                     ContentItem::Image(image) => {

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -51,3 +51,6 @@ vello_cpu = { workspace = true }
 webrender = { workspace = true }
 webrender_api = { workspace = true }
 wr_malloc_size_of = { workspace = true }
+
+[lints]
+workspace = true

--- a/components/metrics/Cargo.toml
+++ b/components/metrics/Cargo.toml
@@ -22,3 +22,6 @@ script_traits = { workspace = true }
 servo-base = { workspace = true }
 servo-config = { workspace = true }
 servo-url = { workspace = true }
+
+[lints]
+workspace = true

--- a/components/pixels/Cargo.toml
+++ b/components/pixels/Cargo.toml
@@ -26,6 +26,9 @@ webrender_api = { workspace = true }
 [dev-dependencies]
 criterion = { workspace = true, features = ["html_reports"] }
 
+[lints]
+workspace = true
+
 [[bench]]
 name = "unmultiply_inplace"
 path = "benches/unmultiply_inplace.rs"

--- a/components/profile/Cargo.toml
+++ b/components/profile/Cargo.toml
@@ -31,3 +31,6 @@ regex = { workspace = true }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 libc = { workspace = true }
+
+[lints]
+workspace = true

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -207,6 +207,9 @@ servo = { path = ".", features = ["testbinding", "tracing"] }
 tracing = { workspace = true }
 winit = { workspace = true }
 
+[lints]
+workspace = true
+
 [[test]]
 name = "multiprocess"
 harness = false

--- a/components/servo/tests/largest_contentful_paint.rs
+++ b/components/servo/tests/largest_contentful_paint.rs
@@ -81,7 +81,10 @@ fn test_largest_contentful_paint_js_api() {
         "window.lcpEntries[0].toJSON();",
     );
     if let Ok(JSValue::Object(obj)) = lcp {
-        assert_eq!(obj.get("name"), Some(JSValue::String("".into())).as_ref());
+        assert_eq!(
+            obj.get("name"),
+            Some(JSValue::String(String::new())).as_ref()
+        );
         assert_eq!(obj.get("duration"), Some(JSValue::Number(0.0)).as_ref());
         assert_eq!(
             obj.get("entryType"),

--- a/components/servo/tests/site_data_manager.rs
+++ b/components/servo/tests/site_data_manager.rs
@@ -613,7 +613,7 @@ fn test_clear_cookies() {
     servo_test.servo().site_data_manager().clear_cookies(None);
 
     let result = evaluate_javascript(&servo_test, webview.clone(), "document.cookie");
-    assert_eq!(result, Ok(JSValue::String("".into())));
+    assert_eq!(result, Ok(JSValue::String(String::new())));
 }
 
 #[test]

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -1099,8 +1099,8 @@ fn test_preferences_change() {
         // so when layout.unimplemented feature is disabled, the backdrop-filter style specified
         // in the stylesheet won't parse and the computed value undefined
         Ok(JSValue::Array(vec![
-            JSValue::String("".to_string()),
-            JSValue::String("".to_string())
+            JSValue::String(String::new()),
+            JSValue::String(String::new())
         ])),
         evaluate_javascript(
             &servo_test,

--- a/components/servo_tracing/Cargo.toml
+++ b/components/servo_tracing/Cargo.toml
@@ -21,3 +21,6 @@ doctest = false
 
 [dev-dependencies]
 prettyplease = { workspace = true }
+
+[lints]
+workspace = true

--- a/components/storage/Cargo.toml
+++ b/components/storage/Cargo.toml
@@ -39,6 +39,9 @@ profile = { workspace = true }
 servo-default-resources = { workspace = true }
 url = { workspace = true }
 
+[lints]
+workspace = true
+
 [[test]]
 name = "main"
 path = "tests/main.rs"

--- a/components/storage/indexeddb/engines/sqlite/encoding.rs
+++ b/components/storage/indexeddb/engines/sqlite/encoding.rs
@@ -302,7 +302,7 @@ mod tests {
             IndexedDBKeyType::Date(0.0),
             IndexedDBKeyType::Date(100.0),
             // String sorting
-            IndexedDBKeyType::String("".to_string()),
+            IndexedDBKeyType::String(String::new()),
             IndexedDBKeyType::String("\0".to_string()),
             IndexedDBKeyType::String("a".to_string()),
             IndexedDBKeyType::String("aa".to_string()),

--- a/components/timers/Cargo.toml
+++ b/components/timers/Cargo.toml
@@ -17,3 +17,6 @@ path = "lib.rs"
 crossbeam-channel = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
+
+[lints]
+workspace = true

--- a/components/url/Cargo.toml
+++ b/components/url/Cargo.toml
@@ -23,3 +23,6 @@ serde = { workspace = true, features = ["derive"] }
 servo_arc = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 uuid = { workspace = true, features = ["serde"] }
+
+[lints]
+workspace = true

--- a/components/wakelock/Cargo.toml
+++ b/components/wakelock/Cargo.toml
@@ -16,3 +16,6 @@ path = "lib.rs"
 [dependencies]
 embedder_traits = { workspace = true }
 serde = { workspace = true }
+
+[lints]
+workspace = true

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -39,3 +39,6 @@ url = { workspace = true }
 uuid = { workspace = true }
 warp = { workspace = true, features = ["server"] }
 webdriver = { workspace = true }
+
+[lints]
+workspace = true

--- a/components/webdriver_server/server.rs
+++ b/components/webdriver_server/server.rs
@@ -421,7 +421,7 @@ fn build_route<U: 'static + WebDriverExtensionRoute + Send + Sync>(
                   content_type_header: Option<String>,
                   body: Bytes| {
                 if method == Method::HEAD {
-                    return warp::reply::with_status("".into(), StatusCode::OK);
+                    return warp::reply::with_status(String::new(), StatusCode::OK);
                 }
                 if let Some(host) = host_header {
                     if !is_host_allowed(&server_address, &allow_hosts, &host) {
@@ -500,7 +500,7 @@ fn build_route<U: 'static + WebDriverExtensionRoute + Send + Sync>(
                         Some("text/plain") => {
                             warn!(
                                 "Rejected POST request with disallowed content type {}",
-                                content_type.unwrap_or_else(|| "".into())
+                                content_type.unwrap_or_default()
                             );
                             let err = WebDriverError::new(
                                 ErrorStatus::UnknownError,

--- a/components/webgl/Cargo.toml
+++ b/components/webgl/Cargo.toml
@@ -37,3 +37,6 @@ surfman = { workspace = true }
 webrender_api = { workspace = true }
 webxr = { workspace = true, optional = true }
 webxr-api = { workspace = true, optional = true }
+
+[lints]
+workspace = true

--- a/components/webgpu/Cargo.toml
+++ b/components/webgpu/Cargo.toml
@@ -36,3 +36,6 @@ wgpu-core = { workspace = true, features = ["gles", "vulkan"] }
 
 [target.'cfg(windows)'.dependencies]
 wgpu-core = { workspace = true, features = ["dx12", "vulkan"] }
+
+[lints]
+workspace = true

--- a/components/webvtt/Cargo.toml
+++ b/components/webvtt/Cargo.toml
@@ -19,3 +19,6 @@ regex = { workspace = true }
 
 [dev-dependencies]
 servo-webvtt = { path = ".", features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/components/webvtt/tests/integration_test.rs
+++ b/components/webvtt/tests/integration_test.rs
@@ -299,7 +299,7 @@ Positioning on the top of the viewport, in the middle."
                 ..Default::default()
             },
             WebVttCue {
-                identifier: "".into(),
+                identifier: String::new(),
                 start_time: compute_result_in_seconds(0., 0., 15., 500.),
                 end_time: compute_result_in_seconds(0., 0., 30., 500.),
                 text: "Bear is Coming!!!!!
@@ -322,7 +322,7 @@ Positioning on the center of the video."
                 ..Default::default()
             },
             WebVttCue {
-                identifier: "".into(),
+                identifier: String::new(),
                 start_time: compute_result_in_seconds(0., 0., 46., 0.),
                 end_time: compute_result_in_seconds(0., 1., 0., 500.),
                 text: "I said Bear is coming!!!!
@@ -344,7 +344,7 @@ Positioning on the bottom middle."
                 ..Default::default()
             },
             WebVttCue {
-                identifier: "".into(),
+                identifier: String::new(),
                 start_time: compute_result_in_seconds(0., 1., 31., 0.),
                 end_time: compute_result_in_seconds(0., 2., 0., 500.),
                 text: "I said Bear is coming now!!!!
@@ -356,7 +356,7 @@ Positioning on the bottom middle. Only 1 line shows."
                 ..Default::default()
             },
             WebVttCue {
-                identifier: "".into(),
+                identifier: String::new(),
                 start_time: compute_result_in_seconds(0., 2., 1., 0.),
                 end_time: compute_result_in_seconds(0., 2., 30., 0.),
                 text: "I said Bear is coming now!!!!

--- a/components/webxr/Cargo.toml
+++ b/components/webxr/Cargo.toml
@@ -39,3 +39,6 @@ webxr-api = { workspace = true }
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { workspace = true, features = ["d3d11", "dxgi", "winerror"], optional = true }
 wio = { workspace = true, optional = true }
+
+[lints]
+workspace = true

--- a/components/xpath/Cargo.toml
+++ b/components/xpath/Cargo.toml
@@ -14,3 +14,6 @@ log = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 markup5ever = { workspace = true }
+
+[lints]
+workspace = true


### PR DESCRIPTION
The first commit enables the lint configuration to inherit from the workspace in most crates. The second commit fixes the violations.

Not all crates are covered yet, since some have custom lints configuration that I need to figure out how to work with (currently Cargo doesn't allow overriding with inheritance).

Part of #47512

Testing: it compiles