### PR TITLE
script_bindings: Put unsafe code in `proxyhandler.rs` into `unsafe` blocks

### DIFF
--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -4,6 +4,9 @@
 
 //! Utilities for the implementation of JSAPI proxy handlers.
 
+// This is allowed on the crate level, but we are gradually fixing it over time.
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use std::ffi::{CStr, CString};
 use std::ops::{Deref, DerefMut};
 use std::os::raw::c_char;
@@ -58,17 +61,17 @@ pub(crate) unsafe extern "C" fn shadow_check_callback(
     // TODO: support OverrideBuiltins when #12978 is fixed.
 
     // SAFETY: it is safe to construct a JSContext from engine hook.
-    let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
+    let mut cx = unsafe { JSContext::from_ptr(NonNull::new(cx).unwrap()) };
     let cx = &mut cx;
 
-    let object = HandleObject::from_raw(object);
+    let object = unsafe { HandleObject::from_raw(object) };
     rooted!(&in(cx) let mut expando = ptr::null_mut::<JSObject>());
     get_expando_object(object, expando.handle_mut());
     if !expando.get().is_null() {
         let mut has_own = false;
-        let raw_id = Handle::from_raw(id);
+        let raw_id = unsafe { Handle::from_raw(id) };
 
-        if !JS_AlreadyHasOwnPropertyById(cx, expando.handle(), raw_id, &mut has_own) {
+        if !unsafe { JS_AlreadyHasOwnPropertyById(cx, expando.handle(), raw_id, &mut has_own) } {
             return DOMProxyShadowsResult::ShadowCheckFailed;
         }
 
@@ -105,17 +108,17 @@ pub(crate) unsafe extern "C" fn define_property(
     result: *mut ObjectOpResult,
 ) -> bool {
     // SAFETY: it is safe to construct a JSContext from engine hook.
-    let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
+    let mut cx = unsafe { JSContext::from_ptr(NonNull::new(cx).unwrap()) };
     let cx = &mut cx;
 
-    let proxy = Handle::from_raw(proxy);
-    let id = Handle::from_raw(id);
-    let desc = Handle::from_raw(desc);
+    let proxy = unsafe { Handle::from_raw(proxy) };
+    let id = unsafe { Handle::from_raw(id) };
+    let desc = unsafe { Handle::from_raw(desc) };
 
     rooted!(&in(cx) let mut expando = ptr::null_mut::<JSObject>());
     ensure_expando_object(cx, proxy, expando.handle_mut());
 
-    JS_DefinePropertyById(cx, expando.handle(), id, desc, result)
+    unsafe { JS_DefinePropertyById(cx, expando.handle(), id, desc, result) }
 }
 
 /// Deletes an expando off the given `proxy`.
@@ -130,21 +133,23 @@ pub(crate) unsafe extern "C" fn delete(
     bp: *mut ObjectOpResult,
 ) -> bool {
     // SAFETY: it is safe to construct a JSContext from engine hook.
-    let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
+    let mut cx = unsafe { JSContext::from_ptr(NonNull::new(cx).unwrap()) };
     let cx = &mut cx;
 
-    let proxy = Handle::from_raw(proxy);
-    let id = Handle::from_raw(id);
+    let proxy = unsafe { Handle::from_raw(proxy) };
+    let id = unsafe { Handle::from_raw(id) };
 
     rooted!(&in(cx) let mut expando = ptr::null_mut::<JSObject>());
     get_expando_object(proxy, expando.handle_mut());
 
     if expando.is_null() {
-        (*bp).code_ = 0 /* OkCode */;
+        unsafe {
+            (*bp).code_ = 0 /* OkCode */
+        };
         return true;
     }
 
-    JS_DeletePropertyById(cx, expando.handle(), id, bp)
+    unsafe { JS_DeletePropertyById(cx, expando.handle(), id, bp) }
 }
 
 /// Controls whether the Extensible bit can be changed
@@ -159,7 +164,7 @@ pub unsafe extern "C" fn prevent_extensions(
     _proxy: RawHandleObject,
     result: *mut ObjectOpResult,
 ) -> bool {
-    (*result).code_ = JSErrNum::JSMSG_CANT_PREVENT_EXTENSIONS as ::libc::uintptr_t;
+    (unsafe { *result }).code_ = JSErrNum::JSMSG_CANT_PREVENT_EXTENSIONS as ::libc::uintptr_t;
     true
 }
 
@@ -175,7 +180,7 @@ pub unsafe extern "C" fn is_extensible(
     _proxy: RawHandleObject,
     succeeded: *mut bool,
 ) -> bool {
-    *succeeded = true;
+    unsafe { *succeeded = true };
     true
 }
 
@@ -197,8 +202,8 @@ pub(crate) unsafe extern "C" fn get_prototype_if_ordinary(
     is_ordinary: *mut bool,
     proto: RawMutableHandleObject,
 ) -> bool {
-    *is_ordinary = true;
-    proto.set(GetStaticPrototype(proxy.get()));
+    unsafe { *is_ordinary = true };
+    proto.set(unsafe { GetStaticPrototype(proxy.get()) });
     true
 }
 
@@ -325,7 +330,7 @@ pub unsafe extern "C" fn maybe_cross_origin_get_prototype_if_ordinary_rawcx(
     _proto: RawMutableHandleObject,
 ) -> bool {
     // We have a custom `[[GetPrototypeOf]]`, so return `false`
-    *is_ordinary = false;
+    unsafe { *is_ordinary = false };
     true
 }
 
@@ -343,7 +348,7 @@ pub unsafe extern "C" fn maybe_cross_origin_set_prototype_rawcx(
     result: *mut ObjectOpResult,
 ) -> bool {
     // SAFETY: it is safe to construct a JSContext from engine hook.
-    let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
+    let mut cx = unsafe { JSContext::from_ptr(NonNull::new(cx).unwrap()) };
     let cx = &mut cx;
     // > 1. Return `! SetImmutablePrototype(this, V)`.
     //
@@ -353,18 +358,18 @@ pub unsafe extern "C" fn maybe_cross_origin_set_prototype_rawcx(
     //
     // > 2. Let current be `? O.[[GetPrototypeOf]]()`.
     rooted!(&in(cx) let mut current = ptr::null_mut::<JSObject>());
-    if !GetObjectProto(cx, Handle::from_raw(proxy), current.handle_mut()) {
+    if !unsafe { GetObjectProto(cx, Handle::from_raw(proxy), current.handle_mut()) } {
         return false;
     }
 
     // > 3. If `SameValue(V, current)` is true, return true.
     if proto.get() == current.get() {
-        (*result).code_ = 0 /* OkCode */;
+        (unsafe { *result }).code_ = 0 /* OkCode */;
         return true;
     }
 
     // > 4. Return false.
-    (*result).code_ = JSErrNum::JSMSG_CANT_SET_PROTO as usize;
+    (unsafe { *result }).code_ = JSErrNum::JSMSG_CANT_SET_PROTO as usize;
     true
 }
 
@@ -408,12 +413,14 @@ pub(crate) unsafe fn cross_origin_has_own(
     // TODO: Once we have the slot for the holder, it'd be more efficient to
     //       use `ensure_cross_origin_property_holder`. We'll need `_proxy` to
     //       do that.
-    *bp = jsid_to_string(cx, id).is_some_and(|key| {
-        cross_origin_properties.keys().any(|defined_key| {
-            let defined_key = CStr::from_ptr(defined_key);
-            defined_key.to_bytes() == key.str().as_bytes()
+    unsafe {
+        *bp = jsid_to_string(cx, id).is_some_and(|key| {
+            cross_origin_properties.keys().any(|defined_key| {
+                let defined_key = CStr::from_ptr(defined_key);
+                defined_key.to_bytes() == key.str().as_bytes()
+            })
         })
-    });
+    };
 
     true
 }
@@ -748,14 +755,16 @@ unsafe fn cross_origin_set<D: DomTypes>(
     // > 1. Let desc be ? O.[[GetOwnProperty]](P).
     rooted!(&in(cx) let mut descriptor = PropertyDescriptor::default());
     let mut is_none = false;
-    if !InvokeGetOwnPropertyDescriptor(
-        GetProxyHandler(*proxy),
-        cx,
-        proxy,
-        id,
-        descriptor.handle_mut(),
-        &mut is_none,
-    ) {
+    if !unsafe {
+        InvokeGetOwnPropertyDescriptor(
+            GetProxyHandler(*proxy),
+            cx,
+            proxy,
+            id,
+            descriptor.handle_mut(),
+            &mut is_none,
+        )
+    } {
         return false;
     }
 
@@ -782,22 +791,24 @@ unsafe fn cross_origin_set<D: DomTypes>(
     // >
     // > 3.2. Return true.
     rooted!(&in(cx) let mut ignored = UndefinedValue());
-    if !Call(
-        cx,
-        receiver,
-        setter_jsval.handle(),
-        // FIXME: Our binding lacks `HandleValueArray(Handle<Value>)`
-        // <https://searchfox.org/mozilla-central/rev/072710086ddfe25aa2962c8399fefb2304e8193b/js/public/ValueArray.h#54-55>
-        &HandleValueArray {
-            length_: 1,
-            elements_: v.ptr,
-        },
-        ignored.handle_mut(),
-    ) {
+    if !unsafe {
+        Call(
+            cx,
+            receiver,
+            setter_jsval.handle(),
+            // FIXME: Our binding lacks `HandleValueArray(Handle<Value>)`
+            // <https://searchfox.org/mozilla-central/rev/072710086ddfe25aa2962c8399fefb2304e8193b/js/public/ValueArray.h#54-55>
+            &HandleValueArray {
+                length_: 1,
+                elements_: v.ptr,
+            },
+            ignored.handle_mut(),
+        )
+    } {
         return false;
     }
 
-    (*result).code_ = 0 /* OkCode */;
+    (unsafe { *result }).code_ = 0 /* OkCode */;
     true
 }
 

--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -164,7 +164,7 @@ pub unsafe extern "C" fn prevent_extensions(
     _proxy: RawHandleObject,
     result: *mut ObjectOpResult,
 ) -> bool {
-    (unsafe { *result }).code_ = JSErrNum::JSMSG_CANT_PREVENT_EXTENSIONS as ::libc::uintptr_t;
+    unsafe { (*result).code_ = JSErrNum::JSMSG_CANT_PREVENT_EXTENSIONS as ::libc::uintptr_t };
     true
 }
 
@@ -364,12 +364,14 @@ pub unsafe extern "C" fn maybe_cross_origin_set_prototype_rawcx(
 
     // > 3. If `SameValue(V, current)` is true, return true.
     if proto.get() == current.get() {
-        (unsafe { *result }).code_ = 0 /* OkCode */;
+        unsafe {
+            (*result).code_ = 0 /* OkCode */
+        };
         return true;
     }
 
     // > 4. Return false.
-    (unsafe { *result }).code_ = JSErrNum::JSMSG_CANT_SET_PROTO as usize;
+    unsafe { (*result).code_ = JSErrNum::JSMSG_CANT_SET_PROTO as usize };
     true
 }
 
@@ -808,7 +810,9 @@ unsafe fn cross_origin_set<D: DomTypes>(
         return false;
     }
 
-    (unsafe { *result }).code_ = 0 /* OkCode */;
+    unsafe {
+        (*result).code_ = 0 /* OkCode */
+    };
     true
 }
 


### PR DESCRIPTION
This incremental work on making all of Servo pass this compiler lint.

Testing: Compilation is enough to test this change.
Fixes: This is part of #35955.
