### PR TITLE
devtools: Evaluate primitive throw arguments

### DIFF
--- a/components/default-resources/resources/debugger.js
+++ b/components/default-resources/resources/debugger.js
@@ -439,10 +439,23 @@ addEventListener("eval", event => {
                 hasException: false,
             };
         } else if ("throw" in completionValue) {
-            let realError = completionValue.throw.unsafeDereference();
+            // See adoptDebuggeeValue() in <https://firefox-source-docs.mozilla.org/devtools-user/debugger-api/debugger/index.html>
+            // <https://searchfox.org/firefox-main/source/devtools/server/actors/webconsole/eval-with-debugger.js#312>
+            // we probably don't need adoptDebuggeeValue, as we only have one debugger instance for now
+            // let value = dbg.adoptDebuggeeValue(completionValue.throw);
+            let exceptionMessage= null;
+            if(typeof completionValue.throw.unsafeDereference === "function") {
+                const deref = completionValue.throw.unsafeDereference();
+                if(typeof deref.message === "string") {
+                    exceptionMessage = deref.message;
+                }
+            }
+            if(!exceptionMessage) {
+                exceptionMessage = `Uncaught ${completionValue.throw}`;
+            }
             resultValue = {
                 value: createValueGrip(completionValue.throw, 0),
-                exceptionMessage: realError.message,
+                exceptionMessage,
                 hasException: true,
             };
         } else if ("return" in completionValue) {

--- a/components/default-resources/resources/debugger.js
+++ b/components/default-resources/resources/debugger.js
@@ -439,10 +439,6 @@ addEventListener("eval", event => {
                 hasException: false,
             };
         } else if ("throw" in completionValue) {
-            // See adoptDebuggeeValue() in <https://firefox-source-docs.mozilla.org/devtools-user/debugger-api/debugger/index.html>
-            // <https://searchfox.org/firefox-main/source/devtools/server/actors/webconsole/eval-with-debugger.js#312>
-            // we probably don't need adoptDebuggeeValue, as we only have one debugger instance for now
-            // let value = dbg.adoptDebuggeeValue(completionValue.throw);
             let exceptionMessage= null;
             if(typeof completionValue.throw.unsafeDereference === "function") {
                 const deref = completionValue.throw.unsafeDereference();

--- a/components/default-resources/resources/debugger.js
+++ b/components/default-resources/resources/debugger.js
@@ -439,14 +439,14 @@ addEventListener("eval", event => {
                 hasException: false,
             };
         } else if ("throw" in completionValue) {
-            let exceptionMessage= null;
-            if(typeof completionValue.throw.unsafeDereference === "function") {
+            let exceptionMessage = null;
+            if (typeof completionValue.throw.unsafeDereference === "function") {
                 const deref = completionValue.throw.unsafeDereference();
-                if(typeof deref.message === "string") {
+                if (typeof deref.message === "string") {
                     exceptionMessage = deref.message;
                 }
             }
-            if(!exceptionMessage) {
+            if (!exceptionMessage) {
                 exceptionMessage = `Uncaught ${completionValue.throw}`;
             }
             resultValue = {

--- a/python/servo/devtools_tests/test_console_tab.py
+++ b/python/servo/devtools_tests/test_console_tab.py
@@ -249,21 +249,21 @@ class TestConsoleTab:
             {"input": "throw NaN;", "exceptionMessage": "Uncaught NaN"},
             {"input": "throw Infinity;", "exceptionMessage": "Uncaught Infinity"},
         ]
+        queue = Queue()
 
         with Devtools.connect() as devtools:
             console = WebConsoleActor(devtools.client, devtools.targets[0]["consoleActor"])
+
+            def on_evaluation(data):
+                queue.put_nowait(data)
+
+            devtools.client.add_event_listener(console.actor_id, Events.WebConsole.EVALUATION_RESULT, on_evaluation)
             for testCase in testCases:
-                evaluation_result = Future()
-
-                def on_evaluation(data):
-                    assert not data["result"]
-                    assert data["hasException"]
-                    assert testCase["exceptionMessage"] in data["exceptionMessage"]
-                    evaluation_result.set_result(data)
-
-                devtools.client.add_event_listener(console.actor_id, Events.WebConsole.EVALUATION_RESULT, on_evaluation)
                 console.evaluate_js_async(testCase["input"])
-                evaluation_result.result(1)
+                data = queue.get(timeout=1)
+                assert not data["result"]
+                assert data["hasException"]
+                assert testCase["exceptionMessage"] in data["exceptionMessage"]
 
     def test_global_autocomplete(self, run_servoshell):
         script_tag = "<script>console_test_value = 5;</script>"

--- a/python/servo/devtools_tests/test_console_tab.py
+++ b/python/servo/devtools_tests/test_console_tab.py
@@ -242,7 +242,7 @@ class TestConsoleTab:
         run_servoshell(url="data:text/html,")
         testCases = [
             {"input": "throw 0;", "exceptionMessage": "Uncaught 0"},
-            {"input": "throw \"\";", "exceptionMessage": "Uncaught "},
+            {"input": 'throw "";', "exceptionMessage": "Uncaught "},
             {"input": "throw {};", "exceptionMessage": "Uncaught [object Object]"},
             {"input": "throw true;", "exceptionMessage": "Uncaught true"},
             {"input": "const fn=()=>{};throw fn;", "exceptionMessage": "Uncaught [object Object]"},

--- a/python/servo/devtools_tests/test_console_tab.py
+++ b/python/servo/devtools_tests/test_console_tab.py
@@ -238,6 +238,33 @@ class TestConsoleTab:
             assert result3["result"]["type"] == "undefined"
             assert not result3["exception"]
 
+    def test_console_throw_primitives(self, run_servoshell):
+        run_servoshell(url="data:text/html,")
+        testCases = [
+            {"input": "throw 0;", "exceptionMessage": "Uncaught 0"},
+            {"input": "throw \"\";", "exceptionMessage": "Uncaught "},
+            {"input": "throw {};", "exceptionMessage": "Uncaught [object Object]"},
+            {"input": "throw true;", "exceptionMessage": "Uncaught true"},
+            {"input": "const fn=()=>{};throw fn;", "exceptionMessage": "Uncaught [object Object]"},
+            {"input": "throw NaN;", "exceptionMessage": "Uncaught NaN"},
+            {"input": "throw Infinity;", "exceptionMessage": "Uncaught Infinity"},
+        ]
+
+        with Devtools.connect() as devtools:
+            console = WebConsoleActor(devtools.client, devtools.targets[0]["consoleActor"])
+            for testCase in testCases:
+                evaluation_result = Future()
+
+                def on_evaluation(data):
+                    assert not data["result"]
+                    assert data["hasException"]
+                    assert testCase["exceptionMessage"] in data["exceptionMessage"]
+                    evaluation_result.set_result(data)
+
+                devtools.client.add_event_listener(console.actor_id, Events.WebConsole.EVALUATION_RESULT, on_evaluation)
+                console.evaluate_js_async(testCase["input"])
+                evaluation_result.result(1)
+
     def test_global_autocomplete(self, run_servoshell):
         script_tag = "<script>console_test_value = 5;</script>"
         run_servoshell(url=f"data:text/html,{script_tag}")


### PR DESCRIPTION
The debugger would stop responding if it evaluated a `throw` on a primitive value.

The implemented fix is to check for the presence of both the `unsafeDereference` function and the `message` property before trying to access them. Should this fail, the throw value is simply returned in an `Uncaught` string.

Testing: A new test has been added in `test_console_tab.py` which throws a variety of different error values.
Fixes: #47517
