### PR TITLE
script: Inherit initiator origin when loading `about:blank` and `about:srcdoc`

### DIFF
--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -38,7 +38,7 @@ use script_bindings::script_runtime::temp_cx;
 use script_traits::DocumentActivity;
 use servo_base::id::{PipelineId, WebViewId};
 use servo_config::pref;
-use servo_constellation_traits::{LoadOrigin, TargetSnapshotParams};
+use servo_constellation_traits::TargetSnapshotParams;
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use style::context::QuirksMode as ServoQuirksMode;
 use tendril::stream::LossyDecoder;
@@ -936,7 +936,12 @@ pub(crate) struct ParserContext {
     /// To report CSP violations to the global that initiated the navigation
     parent_info: Option<PipelineId>,
     target_snapshot_params: TargetSnapshotParams,
-    load_origin: LoadOrigin,
+    /// The source origin this load if this navigation was initiated by script.
+    /// This is used to ensure that `about:blank` and `about:srcdoc` pages are
+    /// able to inherit the aliased [`MutableOrigin`] of their initiating pages
+    /// properly. In the case that the initiator is in another event loop, this
+    /// will be a non-aliased copy of the origin.
+    source_origin: Option<MutableOrigin>,
     document: Option<Trusted<Document>>,
 }
 
@@ -948,7 +953,7 @@ impl ParserContext {
         creation_sandboxing_flag_set: SandboxingFlagSet,
         parent_info: Option<PipelineId>,
         target_snapshot_params: TargetSnapshotParams,
-        load_origin: LoadOrigin,
+        source_origin: Option<MutableOrigin>,
     ) -> ParserContext {
         ParserContext {
             parser: None,
@@ -969,7 +974,7 @@ impl ParserContext {
                 iframe_element_referrer_policy: Default::default(),
             },
             target_snapshot_params,
-            load_origin,
+            source_origin,
             document: None,
         }
     }
@@ -1390,16 +1395,10 @@ impl ParserContext {
         // Step 21.11. Set responseOrigin to the result of determining the origin
         // given response's URL, finalSandboxFlags, and entry's document state's
         // initiator origin.
-        let source_origin = match self.load_origin {
-            LoadOrigin::Script(ref snapshot) => {
-                Some(MutableOrigin::from_snapshot(snapshot.clone()))
-            },
-            _ => None,
-        };
         let origin = determine_the_origin(
             metadata.as_ref().map(|metadata| &metadata.final_url),
             final_sandboxing_flag_set,
-            source_origin,
+            self.source_origin.clone(),
         );
 
         let Some(document) = script_thread.handle_page_headers_available(

--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -4002,16 +4002,42 @@ impl ScriptThread {
     /// argument until a notification is received that the fetch is complete.
     #[servo_tracing::instrument(skip_all)]
     fn pre_page_load(&self, cx: &mut js::context::JSContext, mut incomplete: InProgressLoad) {
-        let url_str = incomplete.load_data.url.as_str();
-        if url_str == "about:blank" || incomplete.load_data.js_eval_result.is_some() {
-            self.start_synchronous_page_load(cx, incomplete);
+        let preserved_origin = || -> Option<MutableOrigin> {
+            // When loading `about:blank`, `about:srcdoc` and `javascript:`
+            // URLs, the specification says that the origin should be aliased
+            // from the creator origin. This means that changes to the creator
+            // origin via things like `document.domain` are reflected in the
+            // child Document. This code attempts to look up the creator
+            // Document and alias the origin for these type of pages.
+            //
+            // TODO: This should be eliminated by not having these types of pages
+            // use the parser at at all.
+            let creator_pipeline_id = incomplete.load_data.creator_pipeline_id?;
+            Some(
+                ScriptThread::find_document(creator_pipeline_id)?
+                    .origin()
+                    .clone(),
+            )
+        };
+
+        if incomplete.load_data.is_for_about_blank() || incomplete.load_data.is_for_javascript_url()
+        {
+            let source_origin = preserved_origin();
+            self.start_synchronous_page_load(cx, incomplete, source_origin);
             return;
         }
-        if url_str == "about:srcdoc" {
-            self.page_load_about_srcdoc(cx, incomplete);
+        if incomplete.load_data.is_for_about_srcdoc() {
+            let source_origin = preserved_origin();
+            self.page_load_about_srcdoc(cx, incomplete, source_origin);
             return;
         }
 
+        let source_origin = match incomplete.load_data.load_origin {
+            LoadOrigin::Script(ref snapshot) => {
+                Some(MutableOrigin::from_snapshot(snapshot.clone()))
+            },
+            _ => None,
+        };
         let context = ParserContext::new(
             incomplete.webview_id,
             incomplete.pipeline_id,
@@ -4019,7 +4045,7 @@ impl ScriptThread {
             incomplete.load_data.creation_sandboxing_flag_set,
             incomplete.parent_info,
             incomplete.target_snapshot_params,
-            incomplete.load_data.load_origin.clone(),
+            source_origin,
         );
         self.incomplete_parser_contexts
             .0
@@ -4230,6 +4256,7 @@ impl ScriptThread {
         &self,
         cx: &mut js::context::JSContext,
         mut incomplete: InProgressLoad,
+        source_origin: Option<MutableOrigin>,
     ) {
         let mut context = ParserContext::new(
             incomplete.webview_id,
@@ -4238,7 +4265,7 @@ impl ScriptThread {
             incomplete.load_data.creation_sandboxing_flag_set,
             incomplete.parent_info,
             incomplete.target_snapshot_params,
-            incomplete.load_data.load_origin.clone(),
+            source_origin,
         );
 
         let mut meta = Metadata::default(incomplete.load_data.url.clone());
@@ -4272,6 +4299,7 @@ impl ScriptThread {
         &self,
         cx: &mut js::context::JSContext,
         mut incomplete: InProgressLoad,
+        source_origin: Option<MutableOrigin>,
     ) {
         let url = ServoUrl::parse("about:srcdoc").unwrap();
         let mut meta = Metadata::default(url.clone());
@@ -4289,7 +4317,6 @@ impl ScriptThread {
         let parent_info = incomplete.parent_info;
         let about_base_url = incomplete.load_data.about_base_url.clone();
         let target_snapshot_params = incomplete.target_snapshot_params;
-        let load_origin = incomplete.load_data.load_origin.clone();
         self.incomplete_loads.borrow_mut().push(incomplete);
 
         let mut context = ParserContext::new(
@@ -4299,7 +4326,7 @@ impl ScriptThread {
             creation_sandboxing_flag_set,
             parent_info,
             target_snapshot_params,
-            load_origin,
+            source_origin,
         );
         context.process_response(self, cx, Ok(FetchMetadata::Unfiltered(meta)));
         context.set_policy_container(policy_container.as_ref());

--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -4002,6 +4002,15 @@ impl ScriptThread {
     /// argument until a notification is received that the fetch is complete.
     #[servo_tracing::instrument(skip_all)]
     fn pre_page_load(&self, cx: &mut js::context::JSContext, mut incomplete: InProgressLoad) {
+        let origin_from_snapshot = || -> Option<MutableOrigin> {
+            match incomplete.load_data.load_origin {
+                LoadOrigin::Script(ref snapshot) => {
+                    Some(MutableOrigin::from_snapshot(snapshot.clone()))
+                },
+                _ => None,
+            }
+        };
+
         let preserved_origin = || -> Option<MutableOrigin> {
             // When loading `about:blank`, `about:srcdoc` and `javascript:`
             // URLs, the specification says that the origin should be aliased
@@ -4020,24 +4029,19 @@ impl ScriptThread {
             )
         };
 
-        if incomplete.load_data.is_for_about_blank() || incomplete.load_data.is_for_javascript_url()
-        {
-            let source_origin = preserved_origin();
+        let url_str = incomplete.load_data.url.as_str();
+        if url_str == "about:blank" || incomplete.load_data.js_eval_result.is_some() {
+            let source_origin = preserved_origin().or(origin_from_snapshot());
             self.start_synchronous_page_load(cx, incomplete, source_origin);
             return;
         }
-        if incomplete.load_data.is_for_about_srcdoc() {
-            let source_origin = preserved_origin();
+        if url_str == "about:srcdoc" {
+            let source_origin = preserved_origin().or(origin_from_snapshot());
             self.page_load_about_srcdoc(cx, incomplete, source_origin);
             return;
         }
 
-        let source_origin = match incomplete.load_data.load_origin {
-            LoadOrigin::Script(ref snapshot) => {
-                Some(MutableOrigin::from_snapshot(snapshot.clone()))
-            },
-            _ => None,
-        };
+        let source_origin = origin_from_snapshot();
         let context = ParserContext::new(
             incomplete.webview_id,
             incomplete.pipeline_id,

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -192,6 +192,7 @@ impl InProgressLoad {
     /// Create a new InProgressLoad object.
     pub(crate) fn new(new_pipeline_info: NewPipelineInfo) -> InProgressLoad {
         let url = new_pipeline_info.load_data.url.clone();
+
         InProgressLoad {
             pipeline_id: new_pipeline_info.new_pipeline_id,
             browsing_context_id: new_pipeline_info.browsing_context_id,

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -204,6 +204,18 @@ impl LoadData {
             SandboxingFlagSet::empty(),
         )
     }
+
+    pub fn is_for_about_blank(&self) -> bool {
+        self.url.matches_about_blank()
+    }
+
+    pub fn is_for_about_srcdoc(&self) -> bool {
+        self.url.as_str() == "about:srcdoc"
+    }
+
+    pub fn is_for_javascript_url(&self) -> bool {
+        self.js_eval_result.is_some()
+    }
 }
 
 /// <https://html.spec.whatwg.org/multipage/#navigation-supporting-concepts:navigationhistorybehavior>

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -204,18 +204,6 @@ impl LoadData {
             SandboxingFlagSet::empty(),
         )
     }
-
-    pub fn is_for_about_blank(&self) -> bool {
-        self.url.matches_about_blank()
-    }
-
-    pub fn is_for_about_srcdoc(&self) -> bool {
-        self.url.as_str() == "about:srcdoc"
-    }
-
-    pub fn is_for_javascript_url(&self) -> bool {
-        self.js_eval_result.is_some()
-    }
 }
 
 /// <https://html.spec.whatwg.org/multipage/#navigation-supporting-concepts:navigationhistorybehavior>

--- a/tests/wpt/meta/html/browsers/origin/inheritance/about-blank-iframe.html.ini
+++ b/tests/wpt/meta/html/browsers/origin/inheritance/about-blank-iframe.html.ini
@@ -1,3 +1,0 @@
-[about-blank-iframe.html]
-  [about:blank in child browsing context aliases security origin]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/origin/inheritance/about-blank-window.html.ini
+++ b/tests/wpt/meta/html/browsers/origin/inheritance/about-blank-window.html.ini
@@ -1,3 +1,0 @@
-[about-blank-window.html]
-  [about:blank in auxiliary browsing context aliases security origin]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/origin/inheritance/about-srcdoc.html.ini
+++ b/tests/wpt/meta/html/browsers/origin/inheritance/about-srcdoc.html.ini
@@ -1,3 +1,0 @@
-[about-srcdoc.html]
-  [about:srcdoc aliases security origin]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/origin/inheritance/javascript-url.html.ini
+++ b/tests/wpt/meta/html/browsers/origin/inheritance/javascript-url.html.ini
@@ -1,3 +1,0 @@
-[javascript-url.html]
-  [javascript: aliases security origin]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/origin/relaxing-the-same-origin-restriction/document_domain_setter_srcdoc.html.ini
+++ b/tests/wpt/meta/html/browsers/origin/relaxing-the-same-origin-restriction/document_domain_setter_srcdoc.html.ini
@@ -1,6 +1,0 @@
-[document_domain_setter_srcdoc.html]
-  [srcdoc can access with valid 'document.domain'.]
-    expected: FAIL
-
-  [srcdoc can access when parent modifies 'document.domain'.]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/windows/document-domain-nested-set.window.js.ini
+++ b/tests/wpt/meta/html/browsers/windows/document-domain-nested-set.window.js.ini
@@ -1,3 +1,0 @@
-[document-domain-nested-set.window.html]
-  [Initial about:blank frame and document.domain in the frame]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/windows/document-domain-nested.window.js.ini
+++ b/tests/wpt/meta/html/browsers/windows/document-domain-nested.window.js.ini
@@ -1,3 +1,0 @@
-[document-domain-nested.window.html]
-  [Initial about:blank frame and document.domain]
-    expected: FAIL


### PR DESCRIPTION
The [specification] says that `about:blank` and `about:srcdoc` should
inherit their source origin. This means that instead of always creating
a new opaque origin in the parser for these kind of pages, we should try
harder to preserve the source origin.

[specification]: https://html.spec.whatwg.org/multipage/#determining-the-origin

Testing: This will cause more tests to pass once #47632 lands.
