### PR TITLE
android: Remove needless tint from drawables

### DIFF
--- a/support/android/apk/servoapp/src/main/res/drawable/arrow_back.xml
+++ b/support/android/apk/servoapp/src/main/res/drawable/arrow_back.xml
@@ -2,7 +2,6 @@
     android:width="24dp"
     android:height="24dp"
     android:autoMirrored="true"
-    android:tint="?attr/colorControlNormal"
     android:viewportWidth="960"
     android:viewportHeight="960">
     <path

--- a/support/android/apk/servoapp/src/main/res/drawable/arrow_forward.xml
+++ b/support/android/apk/servoapp/src/main/res/drawable/arrow_forward.xml
@@ -2,7 +2,6 @@
     android:width="24dp"
     android:height="24dp"
     android:autoMirrored="true"
-    android:tint="?attr/colorControlNormal"
     android:viewportWidth="960"
     android:viewportHeight="960">
     <path

--- a/support/android/apk/servoapp/src/main/res/drawable/cancel.xml
+++ b/support/android/apk/servoapp/src/main/res/drawable/cancel.xml
@@ -1,7 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:tint="?attr/colorControlNormal"
     android:viewportWidth="960"
     android:viewportHeight="960">
     <path

--- a/support/android/apk/servoapp/src/main/res/drawable/delete.xml
+++ b/support/android/apk/servoapp/src/main/res/drawable/delete.xml
@@ -1,7 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:tint="?attr/colorControlNormal"
     android:viewportWidth="960"
     android:viewportHeight="960">
     <path

--- a/support/android/apk/servoapp/src/main/res/drawable/history.xml
+++ b/support/android/apk/servoapp/src/main/res/drawable/history.xml
@@ -1,7 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:tint="?attr/colorControlNormal"
     android:viewportWidth="960"
     android:viewportHeight="960">
     <path

--- a/support/android/apk/servoapp/src/main/res/drawable/media_session_icon.xml
+++ b/support/android/apk/servoapp/src/main/res/drawable/media_session_icon.xml
@@ -2,7 +2,6 @@
     android:width="24dp"
     android:height="24dp"
     android:autoMirrored="true"
-    android:tint="?attr/colorControlNormal"
     android:viewportWidth="960"
     android:viewportHeight="960">
     <path

--- a/support/android/apk/servoapp/src/main/res/drawable/media_session_pause.xml
+++ b/support/android/apk/servoapp/src/main/res/drawable/media_session_pause.xml
@@ -1,7 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:tint="?attr/colorControlNormal"
     android:viewportWidth="960"
     android:viewportHeight="960">
     <path

--- a/support/android/apk/servoapp/src/main/res/drawable/media_session_play.xml
+++ b/support/android/apk/servoapp/src/main/res/drawable/media_session_play.xml
@@ -1,7 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:tint="?attr/colorControlNormal"
     android:viewportWidth="960"
     android:viewportHeight="960">
     <path

--- a/support/android/apk/servoapp/src/main/res/drawable/refresh.xml
+++ b/support/android/apk/servoapp/src/main/res/drawable/refresh.xml
@@ -1,7 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:tint="?attr/colorControlNormal"
     android:viewportWidth="960"
     android:viewportHeight="960">
     <path

--- a/support/android/apk/servoapp/src/main/res/drawable/settings.xml
+++ b/support/android/apk/servoapp/src/main/res/drawable/settings.xml
@@ -1,7 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:tint="?attr/colorControlNormal"
     android:viewportWidth="960"
     android:viewportHeight="960">
     <path


### PR DESCRIPTION
These tints don't seemingly do anything, as setting them to a value like red (`#ff0000`) doesn't change the colour of the drawables at all.

The motivation for removing these is that it's part of the legacy (non-Compose UI) layout system. This only currently works because the codebase depends on AndroidX Preferences (to also be replaced) which transitively pulls in parts of the legacy layout still.

Testing: There are no automated tests for Android.