### PR TITLE
gstreamer: Use more lenient MIME type parser for canPlayType.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8865,6 +8865,7 @@ name = "servo-media-gstreamer"
 version = "0.5.0"
 dependencies = [
  "byte-slice-cast",
+ "data-url",
  "glib",
  "glib-sys",
  "gstreamer",
@@ -8877,7 +8878,6 @@ dependencies = [
  "gstreamer-video",
  "gstreamer-webrtc",
  "log",
- "mime",
  "servo-base",
  "servo-media",
  "servo-media-audio",

--- a/components/media/backends/gstreamer/Cargo.toml
+++ b/components/media/backends/gstreamer/Cargo.toml
@@ -20,6 +20,7 @@ v1_28 = ["gstreamer/v1_28"]
 
 [dependencies]
 byte-slice-cast = { workspace = true }
+data-url = { workspace = true }
 glib = { workspace = true }
 glib-sys = { workspace = true }
 gstreamer = { workspace = true }
@@ -32,7 +33,6 @@ gstreamer-sys = { workspace = true }
 gstreamer-video = { workspace = true }
 gstreamer-webrtc = { workspace = true }
 log = { workspace = true }
-mime = { workspace = true }
 servo-base = { workspace = true }
 servo-media = { workspace = true }
 servo-media-audio = { workspace = true }

--- a/components/media/backends/gstreamer/lib.rs
+++ b/components/media/backends/gstreamer/lib.rs
@@ -24,11 +24,11 @@ use std::sync::{Arc, LazyLock, Mutex, OnceLock, Weak};
 use std::thread;
 use std::vec::Vec;
 
+use data_url::mime::Mime;
 use device_monitor::GStreamerDeviceMonitor;
 use gstreamer::prelude::*;
 use log::warn;
 use media_stream::GStreamerMediaStream;
-use mime::Mime;
 use registry_scanner::GSTREAMER_REGISTRY_SCANNER;
 use servo_base::generic_channel::GenericCallback;
 use servo_media::{Backend, BackendDeInit, BackendInit, MediaInstanceError, SupportsMediaType};
@@ -285,13 +285,9 @@ impl Backend for GStreamerBackend {
 
     fn can_play_type(&self, media_type: &str) -> SupportsMediaType {
         if let Ok(mime) = media_type.parse::<Mime>() {
-            let mime_type = mime.type_().as_str().to_owned() + "/" + mime.subtype().as_str();
-            let codecs = match mime.get_param("codecs") {
-                Some(codecs) => codecs
-                    .as_str()
-                    .split(',')
-                    .map(|codec| codec.trim())
-                    .collect(),
+            let mime_type = format!("{}/{}", mime.type_, mime.subtype);
+            let codecs = match mime.get_parameter("codecs") {
+                Some(codecs) => codecs.split(',').map(|codec| codec.trim()).collect(),
                 None => vec![],
             };
 

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/mime-types/canPlayType.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/mime-types/canPlayType.html.ini
@@ -8,29 +8,14 @@
   [video/mp4; codecs="mp4v.20.240" (optional)]
     expected: PRECONDITION_FAILED
 
-  [audio/webm (optional)]
-    expected: FAIL
-
   [audio/mp4; codecs="mp4a.40.2" (optional)]
     expected: PRECONDITION_FAILED
 
   [video/mp4; codecs="avc1.64001E" (optional)]
     expected: PRECONDITION_FAILED
 
-  [video/mp4 (optional)]
-    expected: FAIL
-
-  [video/webm (optional)]
-    expected: FAIL
-
-  [video/webm with and without codecs]
-    expected: FAIL
-
   [video/mp4; codecs="avc1.4D401E" (optional)]
     expected: PRECONDITION_FAILED
-
-  [audio/wav (optional)]
-    expected: FAIL
 
   [video/mp4; codecs="avc1.42E01E" (optional)]
     expected: PRECONDITION_FAILED
@@ -38,35 +23,20 @@
   [video/mp4; codecs="avc1.58A01E" (optional)]
     expected: PRECONDITION_FAILED
 
-  [video/ogg (optional)]
-    expected: FAIL
-
-  [audio/mp4 (optional)]
-    expected: FAIL
-
-  [video/3gpp (optional)]
-    expected: FAIL
-
-  [audio/ogg (optional)]
-    expected: FAIL
-
   [video/mp4; codecs="mp4a.40.2" (optional)]
     expected: PRECONDITION_FAILED
 
   [video/3gpp; codecs="mp4v.20.8" (optional)]
     expected: PRECONDITION_FAILED
 
-  [audio/wav with and without codecs]
-    expected: FAIL
-
-  [audio/ogg with and without codecs]
-    expected: FAIL
-
-  [video/ogg with and without codecs]
-    expected: FAIL
-
   [audio/mp4; codecs="iamf.001.001.Opus" (optional)]
     expected: PRECONDITION_FAILED
 
-  [audio/webm with and without codecs]
+  [audio/mp4 with and without codecs]
+    expected: FAIL
+
+  [video/3gpp with and without codecs]
+    expected: FAIL
+
+  [video/mp4 with and without codecs]
     expected: FAIL


### PR DESCRIPTION
The tests that now pass were using a MIME type like "audio/mp4;codecs", for which the mime crate returns an error because it expects a = following each MIME type parameter name. The data-url crate's MIME type parser handles this the same way as other browsers; there's a parameter named `codecs` with an empty value.

Testing: New passing tests.