### PR TITLE
android: Move `servo[Args][Log]` to constructor

### DIFF
--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
@@ -72,7 +72,12 @@ class MainActivity : ComponentActivity(), Servo.Client {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        servoView = ServoView(this, this)
+        servoView = ServoView(
+            context = this,
+            client = this,
+            servoArgs = intent.getStringExtra("servoargs"),
+            servoLog = intent.getStringExtra("servolog"),
+        )
 
         historyManager = HistoryManager(this)
 
@@ -207,10 +212,7 @@ class MainActivity : ComponentActivity(), Servo.Client {
             e.printStackTrace()
         }
 
-        val intent = getIntent()
-        val args = intent.getStringExtra("servoargs")
-        val log = intent.getStringExtra("servolog")
-        servoView.setServoArgs(args, log, settings.experimental)
+        servoView.setExperimentalModeInit(settings.experimental)
 
         if (Intent.ACTION_VIEW == intent.action) {
             servoView.loadUri(intent.data.toString())

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.kt
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.kt
@@ -21,11 +21,11 @@ import android.view.SurfaceView
 class ServoView(
     context: Context,
     client: Servo.Client,
+    servoArgs: String?,
+    servoLog: String?,
 ) : SurfaceView(context), Servo.RunCallback, Choreographer.FrameCallback {
     private val glThread: GLThread
-    private val surfaceHolderCallback: SurfaceHolderCallback
     private var servo: Servo? = null
-    private var servoArgs: String? = null
     private var initialUri: String? = null
 
     private var experimentalMode = false
@@ -36,14 +36,17 @@ class ServoView(
         isClickable = true
         addTouchables(arrayListOf(this))
         glThread = GLThread()
-        surfaceHolderCallback = SurfaceHolderCallback(this, client)
+        val surfaceHolderCallback = SurfaceHolderCallback(
+            servoView = this,
+            client = client,
+            servoArgs = servoArgs,
+            servoLog = servoLog,
+        )
         holder.addCallback(surfaceHolderCallback)
         glThread.start()
     }
 
-    fun setServoArgs(args: String?, log: String?, experimentalMode: Boolean) {
-        servoArgs = args
-        surfaceHolderCallback.servoLog = log
+    fun setExperimentalModeInit(experimentalMode: Boolean) {
         this.experimentalMode = experimentalMode
     }
 
@@ -151,8 +154,9 @@ class ServoView(
     private class SurfaceHolderCallback(
         private val servoView: ServoView,
         private val client: Servo.Client,
+        private val servoArgs: String?,
+        private val servoLog: String?,
     ) : SurfaceHolder.Callback {
-        var servoLog: String? = null
         private var paused = false
 
         override fun surfaceCreated(holder: SurfaceHolder) {
@@ -164,7 +168,7 @@ class ServoView(
 
             if (servoView.servo == null && !paused) {
                 servoView.servo = Servo(
-                    servoView.servoArgs,
+                    servoArgs,
                     servoView.initialUri,
                     size,
                     servoView.resources.displayMetrics.density,


### PR DESCRIPTION
`setServoArgs` currently gives the false impression that it can be invoked after the surface has been created and update the engine with it's arguments. This isn't the case though, since calling `setServoArgs` is a no-op after the surface has been created.

It's not possible yet to move `experimentalMode` to the constructor yet, since the argument is calculated assuming an instance of `ServoView` is present, getting us into the chicken and the egg problem.

The method has been renamed to `setExperimentalModeInit` for now to make clear that this is only useful to set during the initialisation phase of the surface. Moving `experimentalMode` to the constructor will be addressed in a follow-up PR though, so this clarity is in the type system instead of a function name.

Testing: There are no automated tests for Android.
