### PR TITLE
paint: drop retired pipelines' scene state from WebRender on final exit

### DIFF
--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -843,8 +843,21 @@ impl Painter {
         pipeline_exit_source: PipelineExitSource,
     ) {
         debug!("Paint got pipeline exited: {webview_id:?} {pipeline_id:?}",);
-        if let Some(webview_renderer) = self.webview_renderers.get_mut(&webview_id) {
-            webview_renderer.pipeline_exited(pipeline_id, pipeline_exit_source);
+        let fully_exited =
+            self.webview_renderers
+                .get_mut(&webview_id)
+                .is_some_and(|webview_renderer| {
+                    webview_renderer.pipeline_exited(pipeline_id, pipeline_exit_source)
+                });
+
+        // Once every part of Servo has finished with this `Pipeline`, drop its
+        // retained scene state (built display list, spatial/clip data) from
+        // WebRender as well. Without this, `Scene.pipelines` accumulates one
+        // entry per navigation for the lifetime of the process.
+        if fully_exited {
+            let mut transaction = Transaction::new();
+            transaction.remove_pipeline(pipeline_id.into());
+            self.send_transaction(transaction);
         }
     }
 

--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -207,10 +207,17 @@ impl WebViewRenderer {
             .or_insert_with(PipelineDetails::new)
     }
 
-    pub(crate) fn pipeline_exited(&mut self, pipeline_id: PipelineId, source: PipelineExitSource) {
+    /// Record that `source` has reported `pipeline_id` as exited. Returns `true`
+    /// once every source has done so and the pipeline details have been discarded,
+    /// so that the caller can also drop the pipeline's scene state in WebRender.
+    pub(crate) fn pipeline_exited(
+        &mut self,
+        pipeline_id: PipelineId,
+        source: PipelineExitSource,
+    ) -> bool {
         let pipeline = self.pipelines.entry(pipeline_id);
         let Entry::Occupied(mut pipeline) = pipeline else {
-            return;
+            return false;
         };
 
         pipeline.get_mut().exited.insert(source);
@@ -219,13 +226,14 @@ impl WebViewRenderer {
         // finished processing the pipeline shutdown. This prevents any followup messges
         // from re-adding the pipeline details and creating a zombie.
         if !pipeline.get().exited.is_all() {
-            return;
+            return false;
         }
 
         // Flush the LCP candidates when exiting pipeline.
         pipeline.get_mut().lcp_candidates.clear();
 
         pipeline.remove_entry();
+        true
     }
 
     pub(crate) fn set_frame_tree(&mut self, frame_tree: &SendableFrameTree) {


### PR DESCRIPTION
Remove retired pipelines from WebRender once all pipeline exit sources have
completed. Servo already removes its local PipelineDetails at this point, but
the corresponding WebRender ScenePipeline was left in Scene.pipelines, causing
display-list memory to accumulate across navigations.

WebViewRenderer::pipeline_exited now reports when the final exit has completed,
and Painter sends a remove_pipeline transaction for that PipelineId.

Testing: No new automated test was added. I validated the change with repeated
top-level and iframe navigation, and with 10,000 about:blank reloads. Before
the change, webrender/display-list grew by about 576 bytes per navigation;
after the change it remained around 1.7 KiB throughout the run.
