### PR TITLE
android: Merge `setExperimentalMode` methods

### DIFF
--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
@@ -212,8 +212,6 @@ class MainActivity : ComponentActivity(), Servo.Client {
             e.printStackTrace()
         }
 
-        servoView.setExperimentalModeInit(settings.experimental)
-
         if (Intent.ACTION_VIEW == intent.action) {
             servoView.loadUri(intent.data.toString())
         }

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.kt
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.kt
@@ -46,10 +46,6 @@ class ServoView(
         glThread.start()
     }
 
-    fun setExperimentalModeInit(experimentalMode: Boolean) {
-        this.experimentalMode = experimentalMode
-    }
-
     override fun inGLThread(r: Runnable) {
         glThread.glLooperHandler!!.post(r)
     }
@@ -136,7 +132,7 @@ class ServoView(
     }
 
     fun setExperimentalMode(enable: Boolean) {
-        servo?.setExperimentalMode(enable)
+        servo?.setExperimentalMode(enable) ?: run { experimentalMode = enable }
     }
 
     private class GLThread : Thread() {


### PR DESCRIPTION
Currently, calling `setExperimentalModeInit` only works if `ServoView` **has not** initialised `Servo` yet, and calling `setExperimentalMode` only works if `ServoView` **has** already initialised `Servo`.  Calling these functions outside their allowed lifecycles just produces no-ops.

As a library consumer, this requires knowledge of the  `ServoView` class internals, and can be confusing when no-ops occur. The need for this knowledge can be removed by just having a single `setExperimentalMode` that internally knows how to set the experimental mode given whichever state the class is in.

Since `MainActivity#onCreate` has always been erroneously calling both `setExperimentalModeInit` _and_ `setExperimentalMode` (via `updateSettingsIfNecessary(true)`, the deletion of the `setExperimentalModeInit` invocation is enough for this to work.

Testing: There are no automated tests for Android.
