### PR TITLE
deps: Update to mozangle 0.7.0 (Firefox 153)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5426,9 +5426,9 @@ dependencies = [
 
 [[package]]
 name = "mozangle"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b428c032f0af701a3ca440c92e7b552c25b2a5af2b08a85077ee8e9d2ae699"
+checksum = "154d9b50b65e888bea450db3f12b1e24f8498ff7fe4afb26e9c71347b943f07f"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ mime = "0.3.13"
 mime_guess = "2.0.5"
 ml-dsa = { version = "0.1", features = ["zeroize"] }
 ml-kem = { version = "0.3", features = ["getrandom", "pkcs8", "zeroize"] }
-mozangle = "0.6"
+mozangle = "0.7"
 napi-derive-ohos = "1.2.0"
 napi-ohos = "1.2.0"
 nix = "0.30"


### PR DESCRIPTION
Companion to https://github.com/servo/mozangle/pull/103

draft because it needs mozangle release

Try run: https://github.com/sagudev/servo/actions/runs/33326263523
