### PR TITLE
ci: Reduce permissions and exposure in wpt-export workflow

### DIFF
--- a/.github/workflows/pull-request-wpt-export.yml
+++ b/.github/workflows/pull-request-wpt-export.yml
@@ -8,6 +8,10 @@ concurrency:
   group: ${{ github.head_ref }}
   cancel-in-progress: false
 
+permissions:
+  # Required by actions/checkout
+  contents: read
+
 jobs:
   upstream:
     # Run job only on servo/servo
@@ -45,5 +49,5 @@ jobs:
          source .venv/bin/activate
          servo/python/wpt/export.py
         env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
+          GITHUB_EVENT: ${{ toJson(github.event) }}
           WPT_SYNC_TOKEN: ${{ secrets.WPT_SYNC_TOKEN }}

--- a/python/wpt/export.py
+++ b/python/wpt/export.py
@@ -21,7 +21,7 @@ from exporter import WPTSync
 
 
 def main() -> int:
-    context = json.loads(os.environ["GITHUB_CONTEXT"])
+    github_event = json.loads(os.environ["GITHUB_EVENT"])
     logging.getLogger().level = logging.INFO
 
     success = WPTSync(
@@ -35,7 +35,7 @@ def main() -> int:
         github_username="servo-wpt-sync",
         github_email="ghbot+wpt-sync@servo.org",
         github_name="Servo WPT Sync",
-    ).run(context["event"])
+    ).run(github_event)
     return 0 if success else 1
 
 


### PR DESCRIPTION
Reduce the github token permissions to the minimum required (we use a secret for the actual operations).
By default the token has all permissions, by specifying permissions explicitly, everything unspecified becomes `None`. Additionally also only pass the required github event to the export.py script, since it doesn't need access to other information (specifically `github.token`).

This reduces the impact of a supply-chain attack of our python dependencies to only being able to leak our wpt sync key, but not being able to do arbitrary things with the privileged github token.

Testing: Not tested, but the changes are minimal

