### PR TITLE
paint: Add tracing for various `cumulative transform` methods

### DIFF
--- a/components/shared/paint/display_list.rs
+++ b/components/shared/paint/display_list.rs
@@ -716,6 +716,7 @@ impl ScrollTree {
             .cumulative_sticky_offsets
     }
 
+    #[servo_tracing::instrument(name = "ScrollTree::cumulative_node_transform", skip_all)]
     fn cumulative_node_transform(
         &self,
         node_id: ScrollTreeNodeId,
@@ -731,6 +732,7 @@ impl ScrollTree {
     }
 
     /// Traverse a scroll node to its root to calculate the transform.
+    #[servo_tracing::instrument(name = "ScrollTree::cumulative_node_transform_inner", skip_all)]
     fn cumulative_node_transform_inner(
         &self,
         node: &ScrollTreeNode,
@@ -805,6 +807,7 @@ impl ScrollTree {
         }
     }
 
+    #[servo_tracing::instrument(name = "ScrollTree::invalidate_cached_transforms", skip_all)]
     fn invalidate_cached_transforms(&self) {
         let Some(root_node) = self.nodes.first() else {
             return;


### PR DESCRIPTION
Add tracing for various cumulative transform methods

Testing: Attached Screenshot for Perfetto UI
<img width="2569" height="1411" alt="image" src="https://github.com/user-attachments/assets/7dc7ed82-3cb1-4206-adf3-3b5e3c69ec59" />
