### PR TITLE
gstreamer: Prefix-match any generic supported codec against the requested codec.

### DIFF
--- a/components/media/backends/gstreamer/registry_scanner.rs
+++ b/components/media/backends/gstreamer/registry_scanner.rs
@@ -32,7 +32,12 @@ impl GStreamerRegistryScanner {
     }
 
     fn is_codec_supported(&self, codec: &str) -> bool {
-        self.supported_codecs.contains(codec)
+        self.supported_codecs
+            .iter()
+            .any(|entry| match entry.strip_suffix('*') {
+                Some(prefix) => codec.starts_with(prefix),
+                None => codec == *entry,
+            })
     }
 
     pub fn are_all_codecs_supported(&self, codecs: &Vec<&str>) -> bool {

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/mime-types/canPlayType.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/mime-types/canPlayType.html.ini
@@ -1,42 +1,6 @@
 [canPlayType.html]
-  [video/mp4; codecs="mp4v.20.8" (optional)]
-    expected: PRECONDITION_FAILED
-
   [video/3gpp; codecs="samr" (optional)]
-    expected: PRECONDITION_FAILED
-
-  [video/mp4; codecs="mp4v.20.240" (optional)]
-    expected: PRECONDITION_FAILED
-
-  [audio/mp4; codecs="mp4a.40.2" (optional)]
-    expected: PRECONDITION_FAILED
-
-  [video/mp4; codecs="avc1.64001E" (optional)]
-    expected: PRECONDITION_FAILED
-
-  [video/mp4; codecs="avc1.4D401E" (optional)]
-    expected: PRECONDITION_FAILED
-
-  [video/mp4; codecs="avc1.42E01E" (optional)]
-    expected: PRECONDITION_FAILED
-
-  [video/mp4; codecs="avc1.58A01E" (optional)]
-    expected: PRECONDITION_FAILED
-
-  [video/mp4; codecs="mp4a.40.2" (optional)]
-    expected: PRECONDITION_FAILED
-
-  [video/3gpp; codecs="mp4v.20.8" (optional)]
     expected: PRECONDITION_FAILED
 
   [audio/mp4; codecs="iamf.001.001.Opus" (optional)]
     expected: PRECONDITION_FAILED
-
-  [audio/mp4 with and without codecs]
-    expected: FAIL
-
-  [video/3gpp with and without codecs]
-    expected: FAIL
-
-  [video/mp4 with and without codecs]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/playing-the-media-resource/fragmented-mp4-end.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/playing-the-media-resource/fragmented-mp4-end.html.ini
@@ -1,3 +1,0 @@
-[fragmented-mp4-end.html]
-  [fragmented-mp4-end]
-    expected: PRECONDITION_FAILED

--- a/tests/wpt/webgl/meta/conformance/textures/misc/texture-corner-case-videos.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/misc/texture-corner-case-videos.html.ini
@@ -1,0 +1,18 @@
+[texture-corner-case-videos.html]
+  [WebGL test #6]
+    expected: FAIL
+
+  [WebGL test #7]
+    expected: FAIL
+
+  [WebGL test #8]
+    expected: FAIL
+
+  [WebGL test #9]
+    expected: FAIL
+
+  [WebGL test #10]
+    expected: FAIL
+
+  [WebGL test #11]
+    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/textures/misc/video-rotation.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/misc/video-rotation.html.ini
@@ -1,3 +1,60 @@
 [video-rotation.html]
-  [WebGL test #0]
+  [WebGL test #8]
+    expected: FAIL
+
+  [WebGL test #10]
+    expected: FAIL
+
+  [WebGL test #11]
+    expected: FAIL
+
+  [WebGL test #12]
+    expected: FAIL
+
+  [WebGL test #14]
+    expected: FAIL
+
+  [WebGL test #15]
+    expected: FAIL
+
+  [WebGL test #16]
+    expected: FAIL
+
+  [WebGL test #17]
+    expected: FAIL
+
+  [WebGL test #18]
+    expected: FAIL
+
+  [WebGL test #19]
+    expected: FAIL
+
+  [WebGL test #20]
+    expected: FAIL
+
+  [WebGL test #21]
+    expected: FAIL
+
+  [WebGL test #22]
+    expected: FAIL
+
+  [WebGL test #23]
+    expected: FAIL
+
+  [WebGL test #24]
+    expected: FAIL
+
+  [WebGL test #25]
+    expected: FAIL
+
+  [WebGL test #27]
+    expected: FAIL
+
+  [WebGL test #28]
+    expected: FAIL
+
+  [WebGL test #29]
+    expected: FAIL
+
+  [WebGL test #31]
     expected: FAIL


### PR DESCRIPTION
We store values like "mp4*" and perform an exact match against it, but the actual codec values are different (`mp4v.20.8`). This change matches the behaviour of WebKit's codec lookup as well: https://searchfox.org/wubkat/rev/4bf9d2cf94e5a07bdcb977203ddc27f3752ecaf7/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp#844

Testing: New passing tests.
Fixes: #46259
