### PR TITLE
ci: Minimize try-label permissions to currently required set

### DIFF
--- a/.github/workflows/try-label.yml
+++ b/.github/workflows/try-label.yml
@@ -8,6 +8,9 @@ jobs:
   parse-comment:
     name: Trigger Try
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     concurrency:
       group: try-${{ github.event.number }}
     outputs:
@@ -115,6 +118,13 @@ jobs:
     if: ${{ needs.parse-comment.outputs.try_string }}
     needs: ["parse-comment"]
     name: ${{ matrix.name }}
+    permissions:
+      contents: read
+      attestations: read
+      # TODO: This is used by our runner-selection job to delete temporary artifacts.
+      # We should find a nother way to handle that to avoid needing to hand-out this
+      # permission.
+      actions: write
     strategy:
       fail-fast: ${{ fromJson(needs.parse-comment.outputs.configuration).fail_fast }}
       matrix:
@@ -140,6 +150,8 @@ jobs:
     name: Results
     needs: ["parse-comment", "run-try"]
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     if: ${{ always() && needs.parse-comment.outputs.try_string }}
     steps:
       - name: Post PR Comment with results

--- a/.github/workflows/try-label.yml
+++ b/.github/workflows/try-label.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
+      pull-requests: write
     concurrency:
       group: try-${{ github.event.number }}
     outputs:
@@ -151,7 +151,7 @@ jobs:
     needs: ["parse-comment", "run-try"]
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      pull-requests: write
     if: ${{ always() && needs.parse-comment.outputs.try_string }}
     steps:
       - name: Post PR Comment with results


### PR DESCRIPTION
We should try to get rid of `actions: write` in a follow-up, this PR focuses on encoding the currently required permissions, so everything else is dropped. The `issues: write` permission is apparently not sufficient to remove labels on PRs, despite us using the issues REST API. 

The job overview page shows that cache-writes fail (due to lack of permissions) with a warning, but that seems fine to me and I don't see a need to add more permissions for this.

Testing: Tested by merginng to main on my fork, opening a [dummy PR](https://github.com/jschwe/servo/pull/5) and adding a label which triggered [this try-label run](https://github.com/jschwe/servo/actions/runs/33360630400/job/99394311468). Removing the label and posting the PR comment worked.

