### PR TITLE
script: Add `getComposedRanges` and `direction` to `Selection`

### DIFF
--- a/components/script/dom/range/staticrange.rs
+++ b/components/script/dom/range/staticrange.rs
@@ -27,6 +27,25 @@ pub(crate) struct StaticRange {
 }
 
 impl StaticRange {
+    pub(crate) fn new(
+        cx: &mut JSContext,
+        document: &Document,
+        start_container: &Node,
+        start_offset: u32,
+        end_container: &Node,
+        end_offset: u32,
+    ) -> DomRoot<StaticRange> {
+        Self::new_with_proto(
+            cx,
+            document,
+            start_container,
+            start_offset,
+            end_container,
+            end_offset,
+            None, /* proto */
+        )
+    }
+
     fn new_inherited(
         start_container: &Node,
         start_offset: u32,
@@ -42,28 +61,23 @@ impl StaticRange {
             ),
         }
     }
-    pub(crate) fn new_with_doc(
-        cx: &mut JSContext,
-        document: &Document,
-        proto: Option<HandleObject>,
-        init: &StaticRangeInit,
-    ) -> DomRoot<StaticRange> {
-        StaticRange::new_with_proto(cx, document, proto, init)
-    }
 
     pub(crate) fn new_with_proto(
         cx: &mut JSContext,
         document: &Document,
+        start_container: &Node,
+        start_offset: u32,
+        end_container: &Node,
+        end_offset: u32,
         proto: Option<HandleObject>,
-        init: &StaticRangeInit,
     ) -> DomRoot<StaticRange> {
         reflect_weak_referenceable_dom_object_with_proto(
             cx,
             Rc::new(StaticRange::new_inherited(
-                &init.startContainer,
-                init.startOffset,
-                &init.endContainer,
-                init.endOffset,
+                start_container,
+                start_offset,
+                end_container,
+                end_offset,
             )),
             document.window(),
             proto,
@@ -96,6 +110,14 @@ impl StaticRangeMethods<crate::DomTypeHolder> for StaticRange {
             _ => (),
         }
         let document = window.Document();
-        Ok(StaticRange::new_with_doc(cx, &document, proto, init))
+        Ok(StaticRange::new_with_proto(
+            cx,
+            &document,
+            &init.startContainer,
+            init.startOffset,
+            &init.endContainer,
+            init.endOffset,
+            proto,
+        ))
     }
 }

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -930,8 +930,8 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // > "backward" if this selection's direction is backwards.
         match self.direction.get() {
             Direction::Directionless => DOMString::from_static("none"),
-            Direction::Forwards => DOMString::from_static("forwards"),
-            Direction::Backwards => DOMString::from_static("backwards"),
+            Direction::Forwards => DOMString::from_static("forward"),
+            Direction::Backwards => DOMString::from_static("backward"),
         }
     }
 
@@ -1021,11 +1021,19 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         let mut start_node = range.start.container.as_rooted();
         let mut start_offset = range.start.offset;
 
+        let is_ancestor_of_provided_shadow_roots = |shadow_root: &ShadowRoot| {
+            let shadow_root_node = shadow_root.upcast::<Node>();
+            options.shadowRoots.iter().any(|option_shadow_root| {
+                shadow_root_node
+                    .is_shadow_including_inclusive_ancestor_of(option_shadow_root.upcast())
+            })
+        };
+
         // Step 3. While startNode is a node, startNode's root is a shadow root, and
         // startNode's root is not a shadow-including inclusive ancestor of any of
         // options["shadowRoots"], repeat these steps:
-        if let Some(containing_shadow_root) = start_node.containing_shadow_root() &&
-            !options.shadowRoots.contains(&containing_shadow_root)
+        while let Some(containing_shadow_root) = start_node.containing_shadow_root() &&
+            !is_ancestor_of_provided_shadow_roots(&containing_shadow_root)
         {
             // Step 3.1. Set startOffset to index of startNode's root's host.
             let host = DomRoot::upcast::<Node>(containing_shadow_root.Host());
@@ -1047,8 +1055,8 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // Step 5. While endNode is a node, endNode's root is a shadow root, and endNode's
         // root is not a shadow-including inclusive ancestor of any of
         // options["shadowRoots"], repeat these steps:
-        if let Some(containing_shadow_root) = end_node.containing_shadow_root() &&
-            !options.shadowRoots.contains(&containing_shadow_root)
+        while let Some(containing_shadow_root) = end_node.containing_shadow_root() &&
+            !is_ancestor_of_provided_shadow_roots(&containing_shadow_root)
         {
             // Step 5.1. Set endOffset to index of endNode's root's host plus 1.
             let host = DomRoot::upcast::<Node>(containing_shadow_root.Host());

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -18,7 +18,9 @@ use servo_base::text::{RangeAny, Utf16CodeUnits, Utf32CodeUnits, Utf32CodeUnitsO
 use crate::dom::abstractrange::bp_position;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::{GetRootNodeOptions, NodeMethods};
 use crate::dom::bindings::codegen::Bindings::RangeBinding::RangeMethods;
-use crate::dom::bindings::codegen::Bindings::SelectionBinding::SelectionMethods;
+use crate::dom::bindings::codegen::Bindings::SelectionBinding::{
+    GetComposedRangesOptions, SelectionMethods,
+};
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
@@ -31,6 +33,7 @@ use crate::dom::iterators::PrePostIteration;
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::range::Range;
 use crate::dom::selection_range::{SelectionBoundary, SelectionRange};
+use crate::dom::staticrange::StaticRange;
 use crate::dom::types::ShadowRoot;
 use crate::dom::{CharacterData, FlatTreeParent, NodeDamage, NodeFlags};
 
@@ -132,6 +135,10 @@ impl Selection {
             let mut range = self.range.borrow_mut();
             changed = *range != new_range;
             *range = new_range;
+
+            if range.is_none() {
+                self.direction.set(Direction::Directionless);
+            }
         }
 
         // Any changes must unconditionally install a new live range.
@@ -916,6 +923,18 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         }
     }
 
+    /// <https://w3c.github.io/selection-api/#dom-selection-direction>
+    fn Direction(&self) -> DOMString {
+        // > The attribute must return "none" if this is empty or this selection is
+        // > directionless. "forward" if this selection's direction is forwards and
+        // > "backward" if this selection's direction is backwards.
+        match self.direction.get() {
+            Direction::Directionless => DOMString::from_static("none"),
+            Direction::Forwards => DOMString::from_static("forwards"),
+            Direction::Backwards => DOMString::from_static("backwards"),
+        }
+    }
+
     /// <https://w3c.github.io/selection-api/#dom-selection-getrangeat>
     fn GetRangeAt(&self, cx: &mut JSContext, index: u32) -> Fallible<DomRoot<Range>> {
         // > The method must throw an IndexSizeError exception if index is not 0, or if this
@@ -983,6 +1002,79 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     fn Empty(&self, no_gc: &NoGC) {
         // > The method must be an alias, and behave identically, to removeAllRanges().
         self.RemoveAllRanges(no_gc);
+    }
+
+    /// <https://w3c.github.io/selection-api/#dom-selection-getcomposedranges>
+    fn GetComposedRanges(
+        &self,
+        cx: &mut JSContext,
+        options: &GetComposedRangesOptions,
+    ) -> Vec<DomRoot<StaticRange>> {
+        // Step 1. If this is empty, return an empty array.
+        let borrowed_range = self.range.borrow();
+        let Some(range) = borrowed_range.as_ref() else {
+            return Vec::new();
+        };
+
+        // Step 2. Otherwise, let startNode be start node of the range associated with
+        // this, and let startOffset be start offset of the range.
+        let mut start_node = range.start.container.as_rooted();
+        let mut start_offset = range.start.offset;
+
+        // Step 3. While startNode is a node, startNode's root is a shadow root, and
+        // startNode's root is not a shadow-including inclusive ancestor of any of
+        // options["shadowRoots"], repeat these steps:
+        if let Some(containing_shadow_root) = start_node.containing_shadow_root() &&
+            !options.shadowRoots.contains(&containing_shadow_root)
+        {
+            // Step 3.1. Set startOffset to index of startNode's root's host.
+            let host = DomRoot::upcast::<Node>(containing_shadow_root.Host());
+            start_offset = host.index();
+
+            // Step 3.2. Set startNode to startNode's root's host's parent.
+            // See <https://github.com/w3c/selection-api/issues/161> for why
+            // we always know that the start_node is a node.
+            start_node = host
+                .GetParentNode()
+                .expect("The host should always have a parent node");
+        }
+
+        // Step 4. Let endNode be end node of the range associated with this, and let
+        // endOffset be end offset of the range.
+        let mut end_node = range.end.container.as_rooted();
+        let mut end_offset = range.end.offset;
+
+        // Step 5. While endNode is a node, endNode's root is a shadow root, and endNode's
+        // root is not a shadow-including inclusive ancestor of any of
+        // options["shadowRoots"], repeat these steps:
+        if let Some(containing_shadow_root) = end_node.containing_shadow_root() &&
+            !options.shadowRoots.contains(&containing_shadow_root)
+        {
+            // Step 5.1. Set endOffset to index of endNode's root's host plus 1.
+            let host = DomRoot::upcast::<Node>(containing_shadow_root.Host());
+            end_offset = host.index() + 1;
+
+            // Step 5.2. Set endNode to endNode's root's host's parent.
+            // See <https://github.com/w3c/selection-api/issues/161> for why
+            // we always know that the end_node is a node.
+            end_node = host
+                .GetParentNode()
+                .expect("The host should always have a parent node.");
+        }
+
+        drop(borrowed_range);
+
+        // Step 6. Return an array consisting of new StaticRange whose start node is
+        // startNode, start offset is startOffset, end node is endNode, and end offset is
+        // endOffset.
+        vec![DomRoot::from_ref(&StaticRange::new(
+            cx,
+            &self.document,
+            &start_node,
+            start_offset,
+            &end_node,
+            end_offset,
+        ))]
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-collapse>

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1074,6 +1074,7 @@ DOMInterfaces = {
         'Extend',
         'FocusOffset',
         'GetAnchorNode',
+        'GetComposedRanges',
         'GetFocusNode',
         'GetRangeAt',
         'IsCollapsed',

--- a/components/script_bindings/webidls/Selection.webidl
+++ b/components/script_bindings/webidls/Selection.webidl
@@ -12,11 +12,13 @@ readonly attribute Node? anchorNode;
   readonly attribute boolean isCollapsed;
   readonly attribute unsigned long rangeCount;
   readonly attribute DOMString type;
+  readonly attribute DOMString direction;
   [Throws] Range getRangeAt(unsigned long index);
   undefined addRange(Range range);
   [Throws] undefined removeRange(Range range);
   undefined removeAllRanges();
   undefined empty();
+  sequence<StaticRange> getComposedRanges(optional GetComposedRangesOptions options = {});
   [Throws] undefined collapse(Node? node, optional unsigned long offset = 0);
   [Throws] undefined setPosition(Node? node, optional unsigned long offset = 0);
   [Throws] undefined collapseToStart();
@@ -29,4 +31,8 @@ readonly attribute Node? anchorNode;
   undefined deleteFromDocument();
   boolean containsNode(Node node, optional boolean allowPartialContainment = false);
   stringifier;
+};
+
+dictionary GetComposedRangesOptions {
+  sequence<ShadowRoot> shadowRoots = [];
 };

--- a/tests/wpt/meta/selection/idlharness.window.js.ini
+++ b/tests/wpt/meta/selection/idlharness.window.js.ini
@@ -7,18 +7,3 @@
 
   [Selection interface: calling modify(optional DOMString, optional DOMString, optional DOMString) on getSelection() with too few arguments must throw TypeError]
     expected: FAIL
-
-  [Selection interface: attribute direction]
-    expected: FAIL
-
-  [Selection interface: getSelection() must inherit property "direction" with the proper type]
-    expected: FAIL
-
-  [Selection interface: operation getComposedRanges(optional GetComposedRangesOptions)]
-    expected: FAIL
-
-  [Selection interface: getSelection() must inherit property "getComposedRanges(optional GetComposedRangesOptions)" with the proper type]
-    expected: FAIL
-
-  [Selection interface: calling getComposedRanges(optional GetComposedRangesOptions) on getSelection() with too few arguments must throw TypeError]
-    expected: FAIL

--- a/tests/wpt/meta/selection/shadow-dom/tentative/Selection-collapse-and-extend.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/tentative/Selection-collapse-and-extend.html.ini
@@ -2,11 +2,5 @@
   [collapse can set selection to a node inside a shadow tree]
     expected: FAIL
 
-  [collapse abort steps when called with a disconnected node inside a shadow tree]
-    expected: FAIL
-
   [extend can set selection to a node inside a shadow tree]
-    expected: FAIL
-
-  [extend abort steps when called with a disconnected node inside a shadow tree]
     expected: FAIL

--- a/tests/wpt/meta/selection/shadow-dom/tentative/Selection-direction.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/tentative/Selection-direction.html.ini
@@ -1,18 +1,6 @@
 [Selection-direction.html]
-  [direction returns "forward" when there is a forward-direction selection in the document tree]
-    expected: FAIL
-
-  [direction returns "backward" when there is a backward-direction selection in the document tree]
-    expected: FAIL
-
   [direction returns "forward" when there is a forward selection in the shadow tree]
     expected: FAIL
 
-  [direction returns "backward" when there is a backward selection in the shadow tree]
-    expected: FAIL
-
   [direction returns "forward" when there is a forward selection that crosses shadow boundaries]
-    expected: FAIL
-
-  [direction returns "backward" when there is a forward selection that crosses shadow boundaries]
     expected: FAIL

--- a/tests/wpt/meta/selection/shadow-dom/tentative/Selection-direction.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/tentative/Selection-direction.html.ini
@@ -1,7 +1,4 @@
 [Selection-direction.html]
-  [direction returns "none" when there is no selection]
-    expected: FAIL
-
   [direction returns "forward" when there is a forward-direction selection in the document tree]
     expected: FAIL
 

--- a/tests/wpt/meta/selection/shadow-dom/tentative/Selection-getComposedRanges-dom-mutations-removal.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/tentative/Selection-getComposedRanges-dom-mutations-removal.html.ini
@@ -5,13 +5,7 @@
   [Range is fully in shadow tree. Removing parent of shadow host collapses composed StaticRange.]
     expected: FAIL
 
-  [Range is in light DOM. Removing startContainer rescopes new composed range to its parent.]
-    expected: FAIL
-
   [Range is across shadow trees. Replacing shadowRoot content rescopes new composed range to the shadowRoot.]
-    expected: FAIL
-
-  [Range is between two light slotted contents. Removing start container rescopes to its parent in light tree.]
     expected: FAIL
 
   [Range is across shadow trees. Removing ancestor shadow host rescopes composed range end to parent.]
@@ -25,13 +19,7 @@
   [Range is fully in shadow tree. Removing parent of shadow host collapses composed StaticRange.]
     expected: FAIL
 
-  [Range is in light DOM. Removing startContainer rescopes new composed range to its parent.]
-    expected: FAIL
-
   [Range is across shadow trees. Replacing shadowRoot content rescopes new composed range to the shadowRoot.]
-    expected: FAIL
-
-  [Range is between two light slotted contents. Removing start container rescopes to its parent in light tree.]
     expected: FAIL
 
   [Range is across shadow trees. Removing ancestor shadow host rescopes composed range end to parent.]

--- a/tests/wpt/meta/selection/shadow-dom/tentative/Selection-getComposedRanges-range-update.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/tentative/Selection-getComposedRanges-range-update.html.ini
@@ -14,9 +14,6 @@
   [modify getRangeAt() range: selectNode() innerHost for all ranges.]
     expected: FAIL
 
-  [modify getRangeAt() range: collapse() collapses all ranges.]
-    expected: FAIL
-
   [modify createRange() range: adding to selection sets the selection]
     expected: FAIL
 

--- a/tests/wpt/meta/selection/shadow-dom/tentative/Selection-getComposedRanges-slot.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/tentative/Selection-getComposedRanges-slot.html.ini
@@ -2,8 +2,5 @@
   [Setting the range to start on slotted content and end in shadow tree, should follow DOM tree order.]
     expected: FAIL
 
-  [Setting the range to start and end on slotted content, should follow DOM tree order.]
-    expected: FAIL
-
   [Setting the range to start on unslotted content and end in shadow tree, should follow DOM tree order.]
     expected: FAIL

--- a/tests/wpt/meta/selection/shadow-dom/tentative/Selection-getComposedRanges.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/tentative/Selection-getComposedRanges.html.ini
@@ -1,13 +1,4 @@
 [Selection-getComposedRanges.html]
-  [getComposedRanges returns an empty sequence when there is no selection]
-    expected: FAIL
-
-  [getComposedRanges returns a sequence with a static range when there is a forward-direction selection in the document tree]
-    expected: FAIL
-
-  [getComposedRanges returns a sequence with a static range when there is a backward-direction selection in the document tree]
-    expected: FAIL
-
   [getComposedRanges returns a sequence with a static range pointing to the shadow host when there is a selection in a shadow tree and the shadow tree is not specified as an argument]
     expected: FAIL
 

--- a/tests/wpt/meta/selection/shadow-dom/tentative/Selection-isCollapsed.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/tentative/Selection-isCollapsed.html.ini
@@ -1,7 +1,4 @@
 [Selection-isCollapsed.html]
-  [Selection in light tree is not collapsed]
-    expected: FAIL
-
   [Selection in shadow tree is not collapsed]
     expected: FAIL
 

--- a/tests/wpt/meta/selection/shadow-dom/tentative/Selection-later-become-slotted-content.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/tentative/Selection-later-become-slotted-content.html.ini
@@ -1,4 +1,0 @@
-[Selection-later-become-slotted-content.html]
-  expected: OK
-  [test to select a light DOM element and it becomes a slotted content after the selection]
-    expected: FAIL


### PR DESCRIPTION
This change implements these newer, missing members of the `Selection`
interface.

Testing: This change gets several WPT subtests to start passing.
Fixes: This is part of #7492.
