### PR TITLE
profile_traits: Remove unused IPC bytes channel

### DIFF
--- a/components/shared/profile/ipc.rs
+++ b/components/shared/profile/ipc.rs
@@ -53,30 +53,3 @@ where
     };
     Ok((ipc_sender, profiled_ipc_receiver))
 }
-
-pub struct IpcBytesReceiver {
-    ipc_bytes_receiver: ipc::IpcBytesReceiver,
-    time_profile_chan: ProfilerChan,
-}
-
-impl IpcBytesReceiver {
-    pub fn recv(&self) -> Result<Vec<u8>, IpcError> {
-        time_profile!(
-            ProfilerCategory::IpcBytesReceiver,
-            None,
-            self.time_profile_chan.clone(),
-            move || self.ipc_bytes_receiver.recv(),
-        )
-    }
-}
-
-pub fn bytes_channel(
-    time_profile_chan: ProfilerChan,
-) -> Result<(ipc::IpcBytesSender, IpcBytesReceiver), Error> {
-    let (ipc_bytes_sender, ipc_bytes_receiver) = ipc::bytes_channel()?;
-    let profiled_ipc_bytes_receiver = IpcBytesReceiver {
-        ipc_bytes_receiver,
-        time_profile_chan,
-    };
-    Ok((ipc_bytes_sender, profiled_ipc_bytes_receiver))
-}

--- a/tests/unit/profile/time.rs
+++ b/tests/unit/profile/time.rs
@@ -86,31 +86,6 @@ fn channel_profiler_test() {
     };
 }
 
-#[test]
-fn bytes_channel_profiler_test() {
-    let chan = time::Profiler::create(&Some(OutputOptions::Stdout(5.0)), None);
-    let (profiled_sender, profiled_receiver) = ProfiledIpc::bytes_channel(chan.clone()).unwrap();
-    thread::spawn(move || {
-        thread::sleep(std::time::Duration::from_secs(2));
-        profiled_sender.send(&[1, 2, 3]).unwrap();
-    });
-
-    let val_profile_receiver = profiled_receiver.recv().unwrap();
-    assert_eq!(val_profile_receiver, [1, 2, 3]);
-
-    let (sender, receiver) = generic_channel::channel().unwrap();
-    chan.send(ProfilerMsg::Get(
-        (ProfilerCategory::IpcBytesReceiver, None),
-        sender.clone(),
-    ));
-
-    match receiver.recv().unwrap() {
-        // asserts that the time spent in the sleeping thread is more than 1500 milliseconds
-        ProfilerData::Record(time_data) => assert!(time_data[0] > Duration::milliseconds(1500)),
-        ProfilerData::NoRecords => assert!(false),
-    };
-}
-
 #[cfg(debug_assertions)]
 #[test]
 #[should_panic]


### PR DESCRIPTION
Remove unused IPC bytes channel from `profile_traits`. It is dead code only used by tests.

Testing: No tests required - only removing code
Fixes: #47673 
