### PR TITLE
script: Do not panic when a memory report outlives its event loop

### DIFF
--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -370,7 +370,9 @@ impl QueuedTaskConversion for MainThreadScriptMsg {
 
 impl OpaqueSender<CommonScriptMsg> for ScriptEventLoopSender {
     fn send(&self, message: CommonScriptMsg) {
-        self.send(message).unwrap()
+        if self.send(message).is_err() {
+            log::warn!("Error communicating with the target thread from the profiler");
+        }
     }
 }
 


### PR DESCRIPTION
`ScriptEventLoopSender` panics if a memory profiler callback tries to send to an event loop that has already shut down:

```
thread 'MemoryProfiler' panicked at
components/script/messaging.rs:372:28:
called `Result::unwrap()` on an `Err` value: "SendError(..)"
```

The other `OpaqueSender` implementations already handle send failures by logging a warning. This makes `ScriptEventLoopSender` consistent with them and avoids taking down the process-wide profiler.

**Testing:** No automated test. The issue does reproduce in an embedder that requests a memory report once a second, against a page that spawns a worker every 15 ms and terminates it 30 ms later.
