### PR TITLE
font: Replace None spacing in fonts with zero sized App Unit

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -458,9 +458,9 @@ pub struct ShapingOptions {
     ///
     /// Letter spacing is not applied to all characters. Use [Self::letter_spacing_for_character] to
     /// determine the amount of spacing to apply.
-    pub letter_spacing: Option<Au>,
+    pub letter_spacing: Au,
     /// Spacing to add between each word. Corresponds to the CSS 2.1 `word-spacing` property.
-    pub word_spacing: Option<Au>,
+    pub word_spacing: Au,
     /// The Unicode script property of the characters in this run.
     pub script: Script,
     /// The preferred language, obtained from the `lang` attribute.
@@ -482,12 +482,14 @@ pub struct ShapingOptions {
 }
 
 impl ShapingOptions {
-    pub(crate) fn letter_spacing_for_character(&self, character: char) -> Option<Au> {
+    pub(crate) fn letter_spacing_for_character(&self, character: char) -> Au {
         // https://drafts.csswg.org/css-text/#letter-spacing-property
         // Letter spacing ignores invisible zero-width formatting characters (such as those from the Unicode Cf category).
         // Spacing must be added as if those characters did not exist in the document.
+        if GeneralCategory::for_char(character) == GeneralCategory::Format {
+            return Au::zero();
+        }
         self.letter_spacing
-            .filter(|_| GeneralCategory::for_char(character) != GeneralCategory::Format)
     }
 }
 
@@ -495,8 +497,8 @@ impl ShapingOptions {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct ShapeCacheEntry {
     text: String,
-    letter_spacing: Option<Au>,
-    word_spacing: Option<Au>,
+    letter_spacing: Au,
+    word_spacing: Au,
     script: Script,
     language: Language,
     font_features: Box<[(Tag, u32)]>,

--- a/components/fonts/glyph.rs
+++ b/components/fonts/glyph.rs
@@ -416,11 +416,9 @@ impl ShapedText {
         // applied to the last glyph in the cluster. Note that this is unconditionally
         // converting the previous glyph to a detailed one because it's quite likely that
         // the advance will not fit into the simple bitmask due to being negative.
-        if let Some(letter_spacing) = options.letter_spacing &&
-            letter_spacing != Au::zero()
-        {
+        if options.letter_spacing != Au::zero() {
             let last_glyph_index = self.ensure_last_glyph_is_detailed();
-            self.detailed_glyphs[last_glyph_index].advance -= letter_spacing;
+            self.detailed_glyphs[last_glyph_index].advance -= options.letter_spacing;
         }
 
         // Add a detailed glyph entry for this new glyph, but it corresponds to a character
@@ -486,19 +484,15 @@ impl ShapedGlyph {
         character: char,
         shaping_options: &ShapingOptions,
     ) {
-        if let Some(letter_spacing) = shaping_options.letter_spacing_for_character(character) {
-            self.advance += letter_spacing;
-        };
+        self.advance += shaping_options.letter_spacing_for_character(character);
 
         // CSS 2.1 § 16.4 states that "word spacing affects each space (U+0020) and non-breaking
         // space (U+00A0) left in the text after the white space processing rules have been
         // applied. The effect of the property on other word-separator characters is undefined."
         // We elect to only space the two required code points.
-        if let Some(word_spacing) = shaping_options.word_spacing &&
-            (character == ' ' || character == '\u{a0}')
-        {
+        if character == ' ' || character == '\u{a0}' {
             // https://drafts.csswg.org/css-text-3/#word-spacing-property
-            self.advance += word_spacing;
+            self.advance += shaping_options.word_spacing;
         }
     }
 }

--- a/components/fonts/tests/font.rs
+++ b/components/fonts/tests/font.rs
@@ -14,6 +14,7 @@ use fonts::{
 };
 use icu_locale_core::subtags::Language;
 use servo_url::ServoUrl;
+use style::Zero;
 use style::computed_values::font_optical_sizing::T as FontOpticalSizing;
 use style::computed_values::font_variant_position::T as FontVariantPosition;
 use style::properties::longhands::font_variant_caps::computed_value::T as FontVariantCaps;
@@ -79,8 +80,8 @@ fn test_font_can_do_fast_shaping() {
 
     // Fast shaping requires a font with a kern table and no GPOS or GSUB tables.
     let shaping_options = ShapingOptions {
-        letter_spacing: None,
-        word_spacing: None,
+        letter_spacing: Au::zero(),
+        word_spacing: Au::zero(),
         script: Script::Latin,
         language: Language::UNKNOWN,
         flags: ShapingFlags::empty(),
@@ -96,8 +97,8 @@ fn test_font_can_do_fast_shaping() {
 
     // Non-Latin script should never have fast shaping.
     let shaping_options = ShapingOptions {
-        letter_spacing: None,
-        word_spacing: None,
+        letter_spacing: Au::zero(),
+        word_spacing: Au::zero(),
         script: Script::Cherokee,
         language: Language::UNKNOWN,
         flags: ShapingFlags::empty(),
@@ -113,8 +114,8 @@ fn test_font_can_do_fast_shaping() {
 
     // Right-to-left text should never use fast shaping.
     let shaping_options = ShapingOptions {
-        letter_spacing: None,
-        word_spacing: None,
+        letter_spacing: Au::zero(),
+        word_spacing: Au::zero(),
         script: Script::Latin,
         language: Language::UNKNOWN,
         flags: ShapingFlags::RTL_FLAG,

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -149,6 +149,8 @@ impl From<&FontAndScriptInfo> for ShapingOptions {
         if letter_spacing.is_some() {
             ligatures = FontVariantLigatures::NONE;
         };
+        let letter_spacing = letter_spacing.unwrap_or(Au::zero());
+        let word_spacing = info.font_info.word_spacing.unwrap_or(Au::zero());
         if info.font_info.text_rendering == TextRendering::Optimizespeed {
             ligatures = FontVariantLigatures::NONE;
             flags.insert(ShapingFlags::DISABLE_KERNING_SHAPING_FLAG)
@@ -161,7 +163,7 @@ impl From<&FontAndScriptInfo> for ShapingOptions {
 
         Self {
             letter_spacing,
-            word_spacing: info.font_info.word_spacing,
+            word_spacing,
             script: info.script,
             language: info.font_info.language,
             ligatures,

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -32,6 +32,7 @@ use servo_canvas_traits::canvas::{
 };
 use servo_constellation_traits::ScriptToConstellationMessage;
 use servo_url::{ImmutableOrigin, ServoUrl};
+use style::Zero;
 use style::color::{AbsoluteColor, ColorFlags, ColorSpace};
 use style::computed_values::font_variant_position::T as FontVariantPosition;
 use style::properties::longhands::font_variant_caps::computed_value::T as FontVariantCaps;
@@ -2572,8 +2573,8 @@ impl UnshapedTextRun<'_> {
         let font = self.font?;
 
         let options = ShapingOptions {
-            letter_spacing: None,
-            word_spacing: None,
+            letter_spacing: Au::zero(),
+            word_spacing: Au::zero(),
             script: self.script,
             language: self.language,
             flags: ShapingFlags::empty(),


### PR DESCRIPTION
Simplifies the `ShapingOptions` struct and removes a bit of branching from character and word spacing lookup. 

Testing: Type changed in existing tests. No measurable change in behavior expected.
Fixes: #44036 
