### PR TITLE
base: Reduce allocation for generic channel select

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8241,6 +8241,7 @@ dependencies = [
  "serde_json",
  "servo-config",
  "servo-malloc-size-of",
+ "smallvec",
  "time",
  "unicode-segmentation",
  "webrender_api",

--- a/components/shared/base/Cargo.toml
+++ b/components/shared/base/Cargo.toml
@@ -27,6 +27,7 @@ rayon = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+smallvec = { workspace = true }
 servo-config = { workspace = true }
 time = { workspace = true }
 unicode-segmentation = { workspace = true }

--- a/components/shared/base/generic_channel/generic_channelset.rs
+++ b/components/shared/base/generic_channel/generic_channelset.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use ipc_channel::ipc::{IpcReceiverSet, IpcSelectionResult};
 use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 
 use crate::generic_channel::{GenericReceiver, GenericReceiverVariants, use_ipc};
 
@@ -162,7 +163,7 @@ impl<T: Serialize + for<'de> Deserialize<'de>> GenericReceiverSet<T> {
     ///
     /// For usage in loops consider using [`GenericReceiverSet::selector()`] to build the selector
     /// once upfront.
-    pub fn select(&mut self) -> Vec<GenericSelectionResult<T>> {
+    pub fn select(&mut self) -> SmallVec<[GenericSelectionResult<T>; 2]> {
         self.selector().select()
     }
 }
@@ -187,7 +188,7 @@ impl<'a, T: Serialize + for<'de> Deserialize<'de>> Selector<'a, T> {
     ///
     /// Note: The IPC variant can return multiple results in one call.
     /// The crossbeam variant always returns exactly one.
-    pub fn select(&mut self) -> Vec<GenericSelectionResult<T>> {
+    pub fn select(&mut self) -> SmallVec<[GenericSelectionResult<T>; 2]> {
         match &mut self.inner {
             SelectorInner::Ipc(ipc_receiver_set) => ipc_receiver_set
                 .select()
@@ -197,7 +198,9 @@ impl<'a, T: Serialize + for<'de> Deserialize<'de>> Selector<'a, T> {
                         .map(|selection_result| selection_result.into())
                         .collect()
                 })
-                .unwrap_or_else(|e| vec![GenericSelectionResult::Error(e.to_string())]),
+                .unwrap_or_else(|e| {
+                    smallvec::smallvec![GenericSelectionResult::Error(e.to_string())]
+                }),
             SelectorInner::Crossbeam { receivers, sel } => {
                 let selected = sel.select();
                 let index = selected.index();
@@ -211,7 +214,7 @@ impl<'a, T: Serialize + for<'de> Deserialize<'de>> Selector<'a, T> {
                         Err(_) => GenericSelectionResult::ChannelClosed(index as u64),
                     },
                 };
-                vec![selection_result]
+                smallvec::smallvec![selection_result]
             },
         }
     }


### PR DESCRIPTION
We reduce the allocations for GenericChannel::select by using SmallVec<[T;2]> instead of allocating a vector.

This reduces the allocator churn when the browser is idle. The methodology was analyzing with heaptrack and see where the memory consumption is constant, to see where these allocation occur.

Testing: This does not have an automatic test.
