### PR TITLE
layout: Track layout changes which affect accessibility.

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -289,11 +289,6 @@ impl AccessibilityTree {
             update.insert_damage(root_id, AccessibilityDamage::Rebuild);
             update.insert_dom_node(root_id, *root_dom_node);
             self.populate_pending_scroll_updates_from_scroll_tree(context);
-        } else {
-            // TODO(#47161) This hack is necessary because we don't collect accessibility damage
-            // from layout.
-            update.insert_damage(root_id, AccessibilityDamage::Subtree);
-            update.insert_dom_node(root_id, *root_dom_node);
         }
 
         self.root_node = Some(root_node);
@@ -431,7 +426,14 @@ impl AccessibilityTree {
             }
         }
 
-        common_ancestors.pop()
+        let lowest_common_ancestor = common_ancestors.pop();
+
+        for ancestor_id in common_ancestors {
+            let ancestor = self.assert_node_for_id(&ancestor_id);
+            ancestor.borrow_mut().dirty_state -= DirtyState::DescendantHasDamage;
+        }
+
+        lowest_common_ancestor
     }
 
     /// Get the [`AccessibilityNode`] corresponding to the given DOM node.
@@ -755,36 +757,44 @@ impl AccessibilityNode {
     ) -> LocalAccessibilityDamage {
         let mut local_damage = LocalAccessibilityDamage::empty();
 
-        let damage = self.compute_damage(update);
+        let dom_node = update.take_dom_node(&self.id);
+        let damage = self.compute_damage(dom_node, update);
+        let mut children_changed = false;
 
-        if let Some(dom_node) = update.take_dom_node(&self.id) {
+        if let Some(dom_node) = dom_node {
             // TODO(#47162, #47161): Once we handle scrolling properly and have a way of tracking
             // damage from layout, we won't need to update every node.
             local_damage.insert(self.update_properties_and_children_from_dom_node(
                 ref_self, &dom_node, damage, tree, update,
             ));
-            self.update_bounds_from_dom_node(&dom_node, context, update);
+            self.update_node_from_layout(&dom_node, damage, context, update);
 
-            if local_damage.contains(LocalAccessibilityDamage::SubtreeChanged) &&
-                let Some(scroll_offset) = self.scroll_offset
-            {
-                // If children have changed, re-set the scroll transforms on all children.
-                self.set_scroll_offset(scroll_offset, update);
+            if local_damage.contains(LocalAccessibilityDamage::SubtreeChanged) {
+                children_changed = true;
             }
 
             self.dirty_state -= DirtyState::HasDamage;
         }
 
-        for child_node in self.children() {
-            let child_node_ref = child_node.clone();
-            let mut child_node = child_node.borrow_mut();
-            let child_local_damage =
-                child_node.update_subtree(child_node_ref, context, tree, update);
-            if !child_local_damage.is_empty() {
-                local_damage.insert(LocalAccessibilityDamage::SubtreeChanged);
+        if self.dirty_state.descendant_has_damage() ||
+            damage.contains(AccessibilityDamage::DescendantHasDamage)
+        {
+            for child_node in self.children() {
+                let child_node_ref = child_node.clone();
+                let mut child_node = child_node.borrow_mut();
+                let child_local_damage =
+                    child_node.update_subtree(child_node_ref, context, tree, update);
+                if !child_local_damage.is_empty() {
+                    local_damage.insert(LocalAccessibilityDamage::SubtreeChanged);
+                }
             }
         }
         self.dirty_state -= DirtyState::DescendantHasDamage;
+
+        if children_changed && let Some(scroll_offset) = self.scroll_offset {
+            // If this node may have new children, update their scroll offsets.
+            self.set_scroll_offset(scroll_offset, update);
+        }
 
         local_damage.insert(self.update_node_local(local_damage, update));
 
@@ -829,9 +839,13 @@ impl AccessibilityNode {
     ) -> LocalAccessibilityDamage {
         let mut local_damage = LocalAccessibilityDamage::empty();
 
-        // TODO(#47162): We currently need to walk the children each time so that we always find the
-        // DOM node for each accessibility node, since we update bounds on every node.
-        // Once this is no longer true, we can check dom_damage and potentially early return here.
+        if !dom_damage.intersects(
+            AccessibilityDamage::Node |
+                AccessibilityDamage::Children |
+                AccessibilityDamage::DescendantHasDamage,
+        ) {
+            return local_damage;
+        }
 
         update.counters.nodes_updated_from_dom += 1;
 
@@ -849,13 +863,15 @@ impl AccessibilityNode {
         &mut self,
         ref_self: ArcRefCell<AccessibilityNode>,
         dom_node: &ServoLayoutNode<'update>,
-        _dom_damage: AccessibilityDamage,
+        dom_damage: AccessibilityDamage,
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate<'update>,
     ) -> LocalAccessibilityDamage {
-        // TODO(#47162): We currently need to walk the children each time so that we always find the
-        // DOM node for each accessibility node, since we update bounds on every node.
-        // Once this is no longer true, we can check _dom_damage and potentially early return here.
+        if !dom_damage
+            .intersects(AccessibilityDamage::Children | AccessibilityDamage::DescendantHasDamage)
+        {
+            return LocalAccessibilityDamage::empty();
+        }
 
         let mut remaining_dom_children = dom_node.flat_tree_children().peekable();
         let mut old_child_ids = self.child_ids().iter().peekable();
@@ -947,12 +963,17 @@ impl AccessibilityNode {
     }
 
     /// Update this node's bounds from the current layout geometry.
-    fn update_bounds_from_dom_node(
+    fn update_node_from_layout(
         &mut self,
-        dom_node: &ServoLayoutNode,
+        dom_node: &ServoLayoutNode<'_>,
+        dom_damage: AccessibilityDamage,
         context: &AccessibilityContext,
         update: &mut AccessibilityUpdate,
     ) {
+        if !dom_damage.contains(AccessibilityDamage::Layout) {
+            return;
+        }
+
         update.counters.nodes_updated_bounds += 1;
 
         // Border box without transforms. Bounds are in CSS pixels, relative to the document origin;
@@ -984,8 +1005,8 @@ impl AccessibilityNode {
         // its rendered descendants.
         match bounds {
             Some(bounds) => self.set_bounds(bounds),
-            None => self.clear_bounds(),
-        }
+            None => self.clear_bounds(), // display: contents case
+        };
     }
 
     /// Update this node's properties based on changes already made to the accessibility tree.
@@ -1216,13 +1237,26 @@ impl AccessibilityNode {
         );
     }
 
-    fn compute_damage(&self, update: &mut AccessibilityUpdate) -> AccessibilityDamage {
+    fn compute_damage(
+        &self,
+        dom_node: Option<ServoLayoutNode<'_>>,
+        update: &mut AccessibilityUpdate,
+    ) -> AccessibilityDamage {
         let mut damage = AccessibilityDamage::empty();
 
         if self.dirty_state.has_damage() {
             damage |= update.take_damage(&self.id);
         }
 
+        if let Some(dom_node) = dom_node &&
+            let Some(element) = dom_node.as_element() &&
+            let Some(style_data) = element.style_data()
+        {
+            let mut element_data = style_data.element_data.borrow_mut();
+            let restyle_damage = std::mem::take(&mut element_data.damage);
+            let damage_from_layout = AccessibilityDamage::from_bits_retain(restyle_damage.bits());
+            damage |= damage_from_layout;
+        }
         damage
     }
 }

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -27,6 +27,7 @@ use servo_config::opts::{self, DiagnosticsLogging, DiagnosticsLoggingOption};
 use servo_config::pref;
 use style::Atom;
 use style::dom::OpaqueNode;
+use style::selector_parser::RestyleDamage;
 use style_traits::CSSPixel;
 use web_atoms::{LocalName, local_name, ns};
 use webrender_api::ExternalScrollId;
@@ -246,7 +247,7 @@ impl AccessibilityTree {
 
         self.ensure_root_node(root_dom_node, &context, &mut update);
 
-        self.apply_changes_from_dom_tree(&context, &mut update);
+        self.apply_changes_from_dom_tree(root_dom_node, &context, &mut update);
 
         self.handle_pending_scroll_updates(&mut update);
 
@@ -297,8 +298,12 @@ impl AccessibilityTree {
     /// Update all nodes with damage tracked in `update` based on their `AccessibilityDamage`. If
     /// any [`LocalAccessibilityDamage`] results from the update, propagate
     /// [`LocalAccessibilityDamage::SubtreeChanged`] to its ancestors.
-    fn apply_changes_from_dom_tree(
+    ///
+    /// If the [`expensive_accessibility_test_assertions_enabled`] preference is enabled, check the
+    /// DOM tree at the end to ensure there is no leftover damage store in any element.
+    fn apply_changes_from_dom_tree<'update>(
         &mut self,
+        root_dom_node: &ServoLayoutNode<'update>,
         context: &AccessibilityContext,
         update: &mut AccessibilityUpdate,
     ) {
@@ -312,6 +317,10 @@ impl AccessibilityTree {
                 .update_subtree(damage_root.clone(), context, self, update);
 
         damage_root.borrow().update_ancestors(local_damage, update);
+
+        if pref!(expensive_accessibility_test_assertions_enabled) {
+            Self::assert_no_layout_damage(root_dom_node);
+        }
     }
 
     /// Read all scroll offsets directly from the scroll tree, and use them to populate
@@ -648,6 +657,22 @@ impl AccessibilityTree {
         assert_eq!(seen_node_ids, self.nodes.keys().copied().collect());
     }
 
+    /// Walk the flat DOM tree from `root_dom_node` and check that no element in the tree has
+    /// left-over damage in its `element_data.damage`.
+    fn assert_no_layout_damage(root_dom_node: &ServoLayoutNode<'_>) {
+        let mut nodes = vec![(*root_dom_node)];
+        while let Some(node) = nodes.pop() {
+            let Some(element) = node.as_element() else {
+                continue;
+            };
+            if let Some(style_data) = element.style_data() {
+                let element_data = style_data.element_data.borrow();
+                assert_eq!(element_data.damage, RestyleDamage::empty());
+            }
+            nodes.extend(node.flat_tree_children());
+        }
+    }
+
     fn print(&self) {
         let Some(root_node) = self.root_node.clone() else {
             return;
@@ -758,14 +783,14 @@ impl AccessibilityNode {
         let mut local_damage = LocalAccessibilityDamage::empty();
 
         let dom_node = update.take_dom_node(&self.id);
-        let damage = self.compute_damage(dom_node, update);
+        let damage = self.take_damage(dom_node, update);
         let mut children_changed = false;
 
         if let Some(dom_node) = dom_node {
             // TODO(#47162, #47161): Once we handle scrolling properly and have a way of tracking
             // damage from layout, we won't need to update every node.
             local_damage.insert(self.update_properties_and_children_from_dom_node(
-                ref_self, &dom_node, damage, tree, update,
+                &ref_self, &dom_node, damage, tree, update,
             ));
             self.update_node_from_layout(&dom_node, damage, context, update);
 
@@ -777,7 +802,7 @@ impl AccessibilityNode {
         }
 
         if self.dirty_state.descendant_has_damage() ||
-            damage.contains(AccessibilityDamage::DescendantHasDamage)
+            damage.contains(AccessibilityDamage::DescendantHasDamageFromLayout)
         {
             for child_node in self.children() {
                 let child_node_ref = child_node.clone();
@@ -831,7 +856,7 @@ impl AccessibilityNode {
     // Any changed nodes will be added to the given [`AccessibilityUpdate`].
     fn update_properties_and_children_from_dom_node<'update>(
         &mut self,
-        ref_self: ArcRefCell<Self>,
+        ref_self: &ArcRefCell<Self>,
         dom_node: &ServoLayoutNode<'update>,
         dom_damage: AccessibilityDamage,
         tree: &mut AccessibilityTree,
@@ -842,17 +867,25 @@ impl AccessibilityNode {
         if !dom_damage.intersects(
             AccessibilityDamage::Node |
                 AccessibilityDamage::Children |
-                AccessibilityDamage::DescendantHasDamage,
+                AccessibilityDamage::DescendantHasDamageFromLayout,
         ) {
             return local_damage;
         }
 
         update.counters.nodes_updated_from_dom += 1;
 
-        local_damage.insert(self.update_properties_from_dom_node(dom_node, dom_damage));
-        local_damage.insert(
-            self.update_children_from_dom_node(ref_self, dom_node, dom_damage, tree, update),
-        );
+        if dom_damage.contains(AccessibilityDamage::Node) {
+            local_damage.insert(self.update_properties_from_dom_node(dom_node));
+        }
+
+        if dom_damage.intersects(
+            AccessibilityDamage::Children | AccessibilityDamage::DescendantHasDamageFromLayout,
+        ) {
+            // If a descendant has damage from layout, this ensures that all of its children have
+            // their corresponding DOM nodes in `update`.
+            local_damage
+                .insert(self.update_children_from_dom_node(ref_self, dom_node, tree, update));
+        }
 
         local_damage
     }
@@ -861,24 +894,17 @@ impl AccessibilityNode {
     /// If it has new children, those will be created here, but not yet populated.
     fn update_children_from_dom_node<'update>(
         &mut self,
-        ref_self: ArcRefCell<AccessibilityNode>,
+        ref_self: &ArcRefCell<AccessibilityNode>,
         dom_node: &ServoLayoutNode<'update>,
-        dom_damage: AccessibilityDamage,
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate<'update>,
     ) -> LocalAccessibilityDamage {
-        if !dom_damage
-            .intersects(AccessibilityDamage::Children | AccessibilityDamage::DescendantHasDamage)
-        {
-            return LocalAccessibilityDamage::empty();
-        }
-
         let mut remaining_dom_children = dom_node.flat_tree_children().peekable();
         let mut old_child_ids = self.child_ids().iter().peekable();
-        let mut unchanged_count = 0usize;
 
         // Iterate over existing children and DOM children while they match. No action is necessary
         // for these nodes.
+        let mut unchanged_count = 0usize;
         while let Some(&old_id) = old_child_ids.peek() &&
             let Some(dom_child) = remaining_dom_children.peek()
         {
@@ -945,12 +971,8 @@ impl AccessibilityNode {
     fn update_properties_from_dom_node(
         &mut self,
         dom_node: &ServoLayoutNode,
-        dom_damage: AccessibilityDamage,
     ) -> LocalAccessibilityDamage {
         let mut local_damage = LocalAccessibilityDamage::empty();
-        if !dom_damage.contains(AccessibilityDamage::Node) {
-            return local_damage;
-        }
         local_damage.insert(self.set_role(role_from_dom_node(dom_node)));
         if dom_node.type_id() == Some(LayoutNodeType::Text) {
             let text_content = dom_node.text_content();
@@ -1237,7 +1259,9 @@ impl AccessibilityNode {
         );
     }
 
-    fn compute_damage(
+    /// Take the damage from `dom_node` and `update` for this node and combine into a single
+    /// `AccessibilityDamage` value for this node.
+    fn take_damage(
         &self,
         dom_node: Option<ServoLayoutNode<'_>>,
         update: &mut AccessibilityUpdate,

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -787,8 +787,6 @@ impl AccessibilityNode {
         let mut children_changed = false;
 
         if let Some(dom_node) = dom_node {
-            // TODO(#47162, #47161): Once we handle scrolling properly and have a way of tracking
-            // damage from layout, we won't need to update every node.
             local_damage.insert(self.update_properties_and_children_from_dom_node(
                 &ref_self, &dom_node, damage, tree, update,
             ));
@@ -1028,7 +1026,7 @@ impl AccessibilityNode {
         match bounds {
             Some(bounds) => self.set_bounds(bounds),
             None => self.clear_bounds(), // display: contents case
-        };
+        }
     }
 
     /// Update this node's properties based on changes already made to the accessibility tree.
@@ -1278,7 +1276,7 @@ impl AccessibilityNode {
         {
             let mut element_data = style_data.element_data.borrow_mut();
             let restyle_damage = std::mem::take(&mut element_data.damage);
-            let damage_from_layout = AccessibilityDamage::from_bits_retain(restyle_damage.bits());
+            let damage_from_layout = AccessibilityDamage::from(restyle_damage);
             damage |= damage_from_layout;
         }
         damage

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -62,6 +62,9 @@ pub(crate) struct LayoutContext<'a> {
 
     /// The device dimensions on which this layout is running, in device pixels.
     pub device_size: Size2D<f32, DevicePixel>,
+
+    /// Whether accessibility is active.
+    pub accessibility_active: bool,
 }
 
 impl LayoutContext<'_> {

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -63,8 +63,8 @@ pub(crate) struct LayoutContext<'a> {
     /// The device dimensions on which this layout is running, in device pixels.
     pub device_size: Size2D<f32, DevicePixel>,
 
-    /// Whether accessibility is active.
-    pub accessibility_active: bool,
+    /// Whether the accessibility tree will be updated during this reflow.
+    pub will_update_accessibility_tree: bool,
 }
 
 impl LayoutContext<'_> {

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1349,24 +1349,10 @@ impl LayoutThread {
             }
 
             debug_assert!(!layout_roots.is_empty());
-            if let Some(map) = accessibility_damage.as_mut() {
-                for layout_root in layout_roots.iter() {
-                    let node = layout_root.node;
-                    if let Some(element) = node.as_element() {
-                        let accessibility_damage = AccessibilityDamage::from_bits_retain(
-                            element.element_data().damage.bits(),
-                        );
-                        map.insert(
-                            layout_root.node.opaque(),
-                            (layout_root.node, accessibility_damage),
-                        );
-                    }
-                }
-            }
-            if layout_roots
-                .iter()
-                .all(|layout_root| layout_root.try_layout(&layout_context))
-            {
+
+            if layout_roots.iter().all(|layout_root| {
+                layout_root.try_layout(&layout_context, accessibility_damage.as_deref_mut())
+            }) {
                 return (
                     ReflowPhasesRun::RanLayout,
                     std::mem::take(&mut *layout_context.iframe_sizes.lock()),
@@ -1379,8 +1365,12 @@ impl LayoutThread {
             // layout, we need to ensure that none of the partial layout results corrupt
             // the upcoming full layout.
             for layout_root in layout_roots {
-                layout_root.handle_failed_layout_root_layout();
+                layout_root.handle_failed_layout_root_layout(accessibility_damage.as_deref_mut());
             }
+        } else if let Some(map) = accessibility_damage.as_mut() {
+            let accessibility_damage =
+                AccessibilityDamage::from_bits_retain(root_element.element_data().damage.bits());
+            map.insert(root_node.opaque(), (root_node, accessibility_damage));
         }
 
         let box_tree = &*box_tree;
@@ -1412,12 +1402,6 @@ impl LayoutThread {
                 .stylist
                 .rule_tree()
                 .dump_stdout(&layout_context.style_context.guards);
-        }
-
-        if let Some(map) = accessibility_damage.as_mut() {
-            let accessibility_damage =
-                AccessibilityDamage::from_bits_retain(root_element.element_data().damage.bits());
-            map.insert(root_node.opaque(), (root_node, accessibility_damage));
         }
 
         // GC the rule tree if some heuristics are met.

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -20,11 +20,12 @@ use fonts::{FontContext, FontContextWebFontMethods};
 use fonts_traits::{StylesheetWebFontLoadFinishedCallback, WebFontSetDifference};
 use icu_locale_core::subtags::Language;
 use layout_api::{
-    AxesOverflow, BoxAreaType, CSSPixelRectVec, DangerousStyleNode, HitTestFlags, HitTestResult,
-    IFrameSizes, Layout, LayoutConfig, LayoutDamage, LayoutElement, LayoutFactory, LayoutNode,
-    NodeRenderingType, OffsetParentResponse, PhysicalSides, QueryMsg, ReflowGoal, ReflowPhasesRun,
-    ReflowRequest, ReflowRequestRestyle, ReflowResult, ReflowStatistics, ScrollContainerQueryFlags,
-    ScrollContainerResponse, TrustedNodeAddress, with_layout_state,
+    AccessibilityDamage, AxesOverflow, BoxAreaType, CSSPixelRectVec, DangerousStyleNode,
+    HitTestFlags, HitTestResult, IFrameSizes, Layout, LayoutConfig, LayoutDamage, LayoutElement,
+    LayoutFactory, LayoutNode, NodeRenderingType, OffsetParentResponse, PhysicalSides, QueryMsg,
+    ReflowGoal, ReflowPhasesRun, ReflowRequest, ReflowRequestRestyle, ReflowResult,
+    ReflowStatistics, ScrollContainerQueryFlags, ScrollContainerResponse, TrustedNodeAddress,
+    with_layout_state,
 };
 use log::{debug, warn};
 use malloc_size_of::{MallocConditionalSizeOf, MallocSizeOf, MallocSizeOfOps};
@@ -37,7 +38,7 @@ use profile_traits::time::{
     self as profile_time, TimerMetadata, TimerMetadataFrameType, TimerMetadataReflowType,
 };
 use profile_traits::{path, time_profile};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use script::layout_dom::{
     ServoDangerousStyleDocument, ServoDangerousStyleElement, ServoLayoutElement, ServoLayoutNode,
 };
@@ -942,14 +943,14 @@ impl LayoutThread {
     fn handle_accessibility_tree_update(
         &self,
         root_element: &ServoLayoutNode,
-        reflow_request: &mut ReflowRequest,
+        accessibility_damage: Option<AccessibilityDamageMap>,
+        rooted_nodes: Option<FxHashSet<OpaqueNode>>,
         reflow_statistics: &mut ReflowStatistics,
     ) -> bool {
-        let Some(accessibility_damage) = std::mem::take(&mut reflow_request.accessibility_damage)
-        else {
+        let Some(damage) = accessibility_damage else {
             return false;
         };
-        if !self.force_accessibility_update() && accessibility_damage.is_empty() {
+        if !self.force_accessibility_update() && damage.is_empty() {
             return false;
         }
 
@@ -968,17 +969,6 @@ impl LayoutThread {
             return false;
         };
         debug_assert!(!self.need_new_stacking_context_tree.get());
-
-        let rooted_nodes =
-            std::mem::take(&mut reflow_request.rooted_nodes_for_accessibility_integrity_check);
-
-        let damage: AccessibilityDamageMap = accessibility_damage
-            .into_iter()
-            .map(|(address, damage)| {
-                let node = unsafe { ServoLayoutNode::new(&address) };
-                (node.opaque(), (node, damage))
-            })
-            .collect();
 
         let accessibility_context = AccessibilityContext {
             layout_thread: self,
@@ -1055,8 +1045,25 @@ impl LayoutThread {
         });
         let mut reflow_statistics = Default::default();
 
+        let mut accessibility_damage: Option<FxHashMap<_, _>> =
+            std::mem::take(&mut reflow_request.accessibility_damage).map(|vec| {
+                vec.into_iter()
+                    .map(|(address, damage)| {
+                        let node = unsafe { ServoLayoutNode::new(&address) };
+                        (node.opaque(), (node, damage))
+                    })
+                    .collect()
+            });
+
         let (mut reflow_phases_run, iframe_sizes, changed_web_fonts) = self
-            .restyle_and_build_trees(&mut reflow_request, document, root_element, &image_resolver);
+            .restyle_and_build_trees(
+                &mut reflow_request,
+                document,
+                root_element,
+                &image_resolver,
+                accessibility_damage.as_mut(),
+            );
+
         if self.build_stacking_context_tree_for_reflow(&reflow_request) {
             reflow_phases_run.insert(ReflowPhasesRun::BuiltStackingContextTree);
         }
@@ -1068,7 +1075,8 @@ impl LayoutThread {
         }
         if self.handle_accessibility_tree_update(
             &root_element.as_node(),
-            &mut reflow_request,
+            accessibility_damage,
+            reflow_request.rooted_nodes_for_accessibility_integrity_check,
             &mut reflow_statistics,
         ) {
             reflow_phases_run.insert(ReflowPhasesRun::UpdatedAccessibilityTree);
@@ -1174,12 +1182,13 @@ impl LayoutThread {
     }
 
     #[servo_tracing::instrument(skip_all)]
-    fn restyle_and_build_trees(
+    fn restyle_and_build_trees<'dom>(
         &mut self,
         reflow_request: &mut ReflowRequest,
         document: ServoDangerousStyleDocument<'_>,
-        root_element: ServoLayoutElement<'_>,
+        root_element: ServoLayoutElement<'dom>,
         image_resolver: &Arc<ImageResolver>,
+        mut accessibility_damage: Option<&mut AccessibilityDamageMap<'dom>>,
     ) -> (ReflowPhasesRun, IFrameSizes, WebFontSetDifference) {
         let mut snapshot_map = SnapshotMap::new();
         let _snapshot_setter = match reflow_request.restyle.as_mut() {
@@ -1247,6 +1256,7 @@ impl LayoutThread {
             parallelism_job_count_minimum: pref!(layout_parallelism_job_count_minimum) as usize,
             parallelism_job_size_minimum: pref!(layout_parallelism_job_size_minimum) as usize,
             device_size: reflow_request.viewport_details.device_size.cast_unit(),
+            accessibility_active: self.accessibility_active(),
         };
 
         let restyle = reflow_request
@@ -1339,15 +1349,24 @@ impl LayoutThread {
             }
 
             debug_assert!(!layout_roots.is_empty());
+            if let Some(map) = accessibility_damage.as_mut() {
+                for layout_root in layout_roots.iter() {
+                    let node = layout_root.node;
+                    if let Some(element) = node.as_element() {
+                        let accessibility_damage = AccessibilityDamage::from_bits_retain(
+                            element.element_data().damage.bits(),
+                        );
+                        map.insert(
+                            layout_root.node.opaque(),
+                            (layout_root.node, accessibility_damage),
+                        );
+                    }
+                }
+            }
             if layout_roots
                 .iter()
                 .all(|layout_root| layout_root.try_layout(&layout_context))
             {
-                if self.accessibility_active() {
-                    // TODO(#47162) Compute accessibility damage rather than forcing a full update.
-                    self.set_force_accessibility_update();
-                }
-
                 return (
                     ReflowPhasesRun::RanLayout,
                     std::mem::take(&mut *layout_context.iframe_sizes.lock()),
@@ -1395,9 +1414,10 @@ impl LayoutThread {
                 .dump_stdout(&layout_context.style_context.guards);
         }
 
-        if self.accessibility_active() {
-            // TODO(#47162) Compute accessibility damage rather than forcing a full upate.
-            self.set_force_accessibility_update();
+        if let Some(map) = accessibility_damage.as_mut() {
+            let accessibility_damage =
+                AccessibilityDamage::from_bits_retain(root_element.element_data().damage.bits());
+            map.insert(root_node.opaque(), (root_node, accessibility_damage));
         }
 
         // GC the rule tree if some heuristics are met.

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1045,15 +1045,8 @@ impl LayoutThread {
         });
         let mut reflow_statistics = Default::default();
 
-        let mut accessibility_damage: Option<FxHashMap<_, _>> =
-            std::mem::take(&mut reflow_request.accessibility_damage).map(|vec| {
-                vec.into_iter()
-                    .map(|(address, damage)| {
-                        let node = unsafe { ServoLayoutNode::new(&address) };
-                        (node.opaque(), (node, damage))
-                    })
-                    .collect()
-            });
+        let mut accessibility_damage =
+            to_accessibility_damage_map(std::mem::take(&mut reflow_request.accessibility_damage));
 
         let (mut reflow_phases_run, iframe_sizes, changed_web_fonts) = self
             .restyle_and_build_trees(
@@ -1350,9 +1343,17 @@ impl LayoutThread {
 
             debug_assert!(!layout_roots.is_empty());
 
-            if layout_roots.iter().all(|layout_root| {
-                layout_root.try_layout(&layout_context, accessibility_damage.as_deref_mut())
-            }) {
+            if let Some(damage_map) = accessibility_damage.as_mut() {
+                damage_map.extend(layout_roots.iter().map(|layout_root| {
+                    let node = layout_root.node();
+                    (node.opaque(), (node, AccessibilityDamage::empty()))
+                }));
+            }
+
+            if layout_roots
+                .iter()
+                .all(|layout_root| layout_root.try_layout(&layout_context))
+            {
                 return (
                     ReflowPhasesRun::RanLayout,
                     std::mem::take(&mut *layout_context.iframe_sizes.lock()),
@@ -1365,12 +1366,15 @@ impl LayoutThread {
             // layout, we need to ensure that none of the partial layout results corrupt
             // the upcoming full layout.
             for layout_root in layout_roots {
-                layout_root.handle_failed_layout_root_layout(accessibility_damage.as_deref_mut());
+                layout_root.handle_failed_layout_root_layout();
             }
-        } else if let Some(map) = accessibility_damage.as_mut() {
-            let accessibility_damage =
-                AccessibilityDamage::from_bits_retain(root_element.element_data().damage.bits());
-            map.insert(root_node.opaque(), (root_node, accessibility_damage));
+        }
+
+        if let Some(map) = accessibility_damage.as_mut() {
+            map.insert(
+                root_node.opaque(),
+                (root_node, AccessibilityDamage::empty()),
+            );
         }
 
         let box_tree = &*box_tree;
@@ -1678,6 +1682,19 @@ impl LayoutThread {
         );
         self.need_containing_block_calculation.set(false)
     }
+}
+
+fn to_accessibility_damage_map<'dom>(
+    damage_from_dom: Option<Vec<(TrustedNodeAddress, AccessibilityDamage)>>,
+) -> Option<AccessibilityDamageMap<'dom>> {
+    damage_from_dom.map(|vec| {
+        vec.into_iter()
+            .map(|(address, damage)| {
+                let node = unsafe { ServoLayoutNode::new(&address) };
+                (node.opaque(), (node, damage))
+            })
+            .collect()
+    })
 }
 
 fn get_ua_stylesheets(shared_lock: &SharedRwLock) -> Rc<UserAgentStylesheets> {

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1249,7 +1249,7 @@ impl LayoutThread {
             parallelism_job_count_minimum: pref!(layout_parallelism_job_count_minimum) as usize,
             parallelism_job_size_minimum: pref!(layout_parallelism_job_size_minimum) as usize,
             device_size: reflow_request.viewport_details.device_size.cast_unit(),
-            accessibility_active: self.accessibility_active(),
+            will_update_accessibility_tree: accessibility_damage.is_some(),
         };
 
         let restyle = reflow_request

--- a/components/layout/layout_root.rs
+++ b/components/layout/layout_root.rs
@@ -34,7 +34,7 @@ use crate::fragment_tree::Fragment;
 /// has started to escape from the layout root. In that case, a full fragment tree layout
 /// becomes necessary to rebuild the fragment properly.
 pub(crate) struct LayoutRoot<'dom> {
-    node: ServoLayoutNode<'dom>,
+    pub(crate) node: ServoLayoutNode<'dom>,
 }
 
 impl<'dom> TryFrom<ServoLayoutNode<'dom>> for LayoutRoot<'dom> {

--- a/components/layout/layout_root.rs
+++ b/components/layout/layout_root.rs
@@ -2,11 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use layout_api::{AccessibilityDamage, LayoutElement, LayoutNode};
 use script::layout_dom::ServoLayoutNode;
-use style::selector_parser::RestyleDamage;
 
-use crate::accessibility_tree::AccessibilityDamageMap;
 use crate::context::LayoutContext;
 use crate::dom::{LayoutBox, NodeExt};
 use crate::flexbox::FlexLevelBox;
@@ -64,11 +61,7 @@ impl<'dom> TryFrom<ServoLayoutNode<'dom>> for LayoutRoot<'dom> {
 }
 
 impl<'dom> LayoutRoot<'dom> {
-    pub(crate) fn try_layout(
-        &self,
-        layout_context: &LayoutContext,
-        mut accessibility_damage: Option<&mut AccessibilityDamageMap<'dom>>,
-    ) -> bool {
+    pub(crate) fn try_layout(&self, layout_context: &LayoutContext) -> bool {
         let Some(inner_layout_data) = self.node.inner_layout_data_mut() else {
             return false;
         };
@@ -119,77 +112,21 @@ impl<'dom> LayoutRoot<'dom> {
 
         // If an `Err` is returned here, that means that this layout root is no longer
         // a viable layout root and a full fragment tree layout is necessary.
-        let is_ok = layout_inputs
+        layout_inputs
             .layout(
                 layout_context,
                 formatting_context,
                 &layout_root_fragment.fragment,
             )
-            .is_ok();
-
-        if is_ok &&
-            let Some(map) = accessibility_damage.as_mut() &&
-            let Some(element) = self.node.as_element()
-        {
-            // Insert this element into the accessibility damage map with the damage stored on the
-            // element. This allows the accessibility tree to use it as a starting point for damage
-            // resolution for damage from layout. See
-            // AccessibilityTree::apply_changes_from_dom_tree().
-            let accessibility_damage =
-                AccessibilityDamage::from_bits_retain(element.element_data().damage.bits());
-            map.insert(self.node.opaque(), (self.node, accessibility_damage));
-        }
-
-        is_ok
+            .is_ok()
     }
 
-    pub(crate) fn handle_failed_layout_root_layout(
-        &self,
-        accessibility_damage: Option<&mut AccessibilityDamageMap<'dom>>,
-    ) {
+    pub(crate) fn handle_failed_layout_root_layout(&self) {
         self.node
             .clear_fragments_and_dirty_fragment_caches_recursively();
-
-        if let Some(map) = accessibility_damage {
-            self.propagate_accessibility_damage_to_root(map);
-        }
     }
 
-    /// If the accessibility tree can't use this node as a starting point for resolving damage from
-    /// layout, remove it from the accessibility damage map, propagate the accessibility damage up
-    /// to the root, and add the root element to the damage map instead.
-    #[expect(unsafe_code)]
-    fn propagate_accessibility_damage_to_root(&self, map: &mut AccessibilityDamageMap<'dom>) {
-        let Some(element) = self.node.as_element() else {
-            return;
-        };
-        map.remove(&self.node.opaque());
-
-        let damage = RestyleDamage::from_bits_retain(
-            AccessibilityDamage::DescendantHasDamageFromLayout.bits(),
-        );
-        let mut ancestor = unsafe { self.node.dangerous_flat_tree_parent() };
-        let mut root_element = element;
-        while let Some(node) = ancestor {
-            let element = node
-                .as_element()
-                .expect("All ancestors of elements should be elements");
-            let mut element_data = element.element_data_mut();
-            element_data.damage |= damage;
-            ancestor = unsafe { node.dangerous_flat_tree_parent() };
-            if ancestor.is_none() {
-                root_element = element;
-                break;
-            }
-        }
-
-        let root_node = root_element.as_node();
-        map.insert(
-            root_node.opaque(),
-            (
-                root_node,
-                AccessibilityDamage::from_bits_retain(root_element.element_data().damage.bits()),
-            ),
-        );
+    pub(crate) fn node(&self) -> ServoLayoutNode<'dom> {
+        self.node
     }
 }

--- a/components/layout/layout_root.rs
+++ b/components/layout/layout_root.rs
@@ -2,8 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use layout_api::{AccessibilityDamage, LayoutElement, LayoutNode};
 use script::layout_dom::ServoLayoutNode;
+use style::selector_parser::RestyleDamage;
 
+use crate::accessibility_tree::AccessibilityDamageMap;
 use crate::context::LayoutContext;
 use crate::dom::{LayoutBox, NodeExt};
 use crate::flexbox::FlexLevelBox;
@@ -34,7 +37,7 @@ use crate::fragment_tree::Fragment;
 /// has started to escape from the layout root. In that case, a full fragment tree layout
 /// becomes necessary to rebuild the fragment properly.
 pub(crate) struct LayoutRoot<'dom> {
-    pub(crate) node: ServoLayoutNode<'dom>,
+    pub node: ServoLayoutNode<'dom>,
 }
 
 impl<'dom> TryFrom<ServoLayoutNode<'dom>> for LayoutRoot<'dom> {
@@ -60,8 +63,12 @@ impl<'dom> TryFrom<ServoLayoutNode<'dom>> for LayoutRoot<'dom> {
     }
 }
 
-impl LayoutRoot<'_> {
-    pub(crate) fn try_layout(&self, layout_context: &LayoutContext) -> bool {
+impl<'dom> LayoutRoot<'dom> {
+    pub(crate) fn try_layout(
+        &self,
+        layout_context: &LayoutContext,
+        mut accessibility_damage: Option<&mut AccessibilityDamageMap<'dom>>,
+    ) -> bool {
         let Some(inner_layout_data) = self.node.inner_layout_data_mut() else {
             return false;
         };
@@ -112,17 +119,77 @@ impl LayoutRoot<'_> {
 
         // If an `Err` is returned here, that means that this layout root is no longer
         // a viable layout root and a full fragment tree layout is necessary.
-        layout_inputs
+        let is_ok = layout_inputs
             .layout(
                 layout_context,
                 formatting_context,
                 &layout_root_fragment.fragment,
             )
-            .is_ok()
+            .is_ok();
+
+        if is_ok &&
+            let Some(map) = accessibility_damage.as_mut() &&
+            let Some(element) = self.node.as_element()
+        {
+            // Insert this element into the accessibility damage map with the damage stored on the
+            // element. This allows the accessibility tree to use it as a starting point for damage
+            // resolution for damage from layout. See
+            // AccessibilityTree::apply_changes_from_dom_tree().
+            let accessibility_damage =
+                AccessibilityDamage::from_bits_retain(element.element_data().damage.bits());
+            map.insert(self.node.opaque(), (self.node, accessibility_damage));
+        }
+
+        is_ok
     }
 
-    pub(crate) fn handle_failed_layout_root_layout(&self) {
+    pub(crate) fn handle_failed_layout_root_layout(
+        &self,
+        accessibility_damage: Option<&mut AccessibilityDamageMap<'dom>>,
+    ) {
         self.node
             .clear_fragments_and_dirty_fragment_caches_recursively();
+
+        if let Some(map) = accessibility_damage {
+            self.propagate_accessibility_damage_to_root(map);
+        }
+    }
+
+    /// If the accessibility tree can't use this node as a starting point for resolving damage from
+    /// layout, remove it from the accessibility damage map, propagate the accessibility damage up
+    /// to the root, and add the root element to the damage map instead.
+    #[expect(unsafe_code)]
+    fn propagate_accessibility_damage_to_root(&self, map: &mut AccessibilityDamageMap<'dom>) {
+        let Some(element) = self.node.as_element() else {
+            return;
+        };
+        map.remove(&self.node.opaque());
+
+        let damage = RestyleDamage::from_bits_retain(
+            AccessibilityDamage::DescendantHasDamageFromLayout.bits(),
+        );
+        let mut ancestor = unsafe { self.node.dangerous_flat_tree_parent() };
+        let mut root_element = element;
+        while let Some(node) = ancestor {
+            let element = node
+                .as_element()
+                .expect("All ancestors of elements should be elements");
+            let mut element_data = element.element_data_mut();
+            element_data.damage |= damage;
+            ancestor = unsafe { node.dangerous_flat_tree_parent() };
+            if ancestor.is_none() {
+                root_element = element;
+                break;
+            }
+        }
+
+        let root_node = root_element.as_node();
+        map.insert(
+            root_node.opaque(),
+            (
+                root_node,
+                AccessibilityDamage::from_bits_retain(root_element.element_data().damage.bits()),
+            ),
+        );
     }
 }

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -5,7 +5,8 @@
 use std::sync::Arc;
 
 use layout_api::{
-    DangerousStyleElement, DangerousStyleNode, LayoutDamage, LayoutElement, LayoutNode,
+    AccessibilityDamage, DangerousStyleElement, DangerousStyleNode, LayoutDamage, LayoutElement,
+    LayoutNode,
 };
 use script::layout_dom::ServoLayoutNode;
 use style::context::{SharedStyleContext, StyleContext};
@@ -155,6 +156,15 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_above_dirty_root<'dom>(
     let mut damage_for_parent = layout_damage;
     let mut maybe_parent_node = unsafe { dirty_root.dangerous_flat_tree_parent() };
     while let Some(parent_node) = maybe_parent_node {
+        if layout_context.accessibility_active &&
+            damage_for_parent.contains(LayoutDamage::DescendantHasAccessibilityDamage) &&
+            let Some(parent_element) = parent_node.as_element()
+        {
+            let mut element_data = parent_element.element_data_mut();
+            element_data.damage.insert(RestyleDamage::from_bits_retain(
+                AccessibilityDamage::DescendantHasDamage.bits(),
+            ));
+        }
         let damage_set = ElementDamageSet {
             node: parent_node,
             from_parent: LayoutDamage::empty(),
@@ -225,6 +235,17 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_below_dirty_root<'dom>(
         damage_for_children,
         layout_roots,
     );
+
+    if layout_context.accessibility_active &&
+        damage_set
+            .from_children
+            .intersects(LayoutDamage::DescendantHasAccessibilityDamage)
+    {
+        let mut element_data = element.element_data_mut();
+        element_data.damage.insert(RestyleDamage::from_bits_retain(
+            AccessibilityDamage::DescendantHasDamage.bits(),
+        ));
+    }
 
     // Apply the calculated damage to this element (perhaps triggering box tree layout),
     // and propagate resulting damage to ancestors.
@@ -327,9 +348,24 @@ impl<'a> ElementDamageSet<'a> {
         let only_layout_mode_damage =
             (self.from_parent | self.on_element | self.from_children).only_layout_modes();
 
+        let record_accessibility_layout_damage = || {
+            if layout_context.accessibility_active &&
+                let Some(element) = self.node.as_element()
+            {
+                let mut element_data = element.element_data_mut();
+                element_data.damage.insert(RestyleDamage::from_bits_retain(
+                    AccessibilityDamage::Layout.bits(),
+                ));
+                return LayoutDamage::DescendantHasAccessibilityDamage;
+            }
+            LayoutDamage::empty()
+        };
+
         let invalidate_for_rebuild = || {
             self.node.unset_all_boxes();
-            LayoutDamage::DescendantHasBoxDamage | LayoutDamage::Relayout
+            record_accessibility_layout_damage() |
+                LayoutDamage::DescendantHasBoxDamage |
+                LayoutDamage::Relayout
         };
 
         // This removes any dirty layout roots from descendants.
@@ -349,7 +385,9 @@ impl<'a> ElementDamageSet<'a> {
                 {
                     // In this case, we have rebuilt the box tree from this point and we do not
                     // have to propagate rebuild box tree damage up the tree any further.
-                    LayoutDamage::Relayout | LayoutDamage::RecomputeInlineContentSizes
+                    record_accessibility_layout_damage() |
+                        LayoutDamage::Relayout |
+                        LayoutDamage::RecomputeInlineContentSizes
                 } else {
                     // A descendant needs to be rebuilt, but couldn't be rebuilt here,
                     // because this node was an not a rebuild-compatible independent
@@ -416,7 +454,9 @@ impl<'a> ElementDamageSet<'a> {
                     base.invalidate_caches(&self);
                     base.mark_fragments_as_descendants_changed();
                 });
-                LayoutDamage::RecalculateOverflow |
+
+                record_accessibility_layout_damage() |
+                    LayoutDamage::RecalculateOverflow |
                     LayoutDamage::DescendantCollectedAsLayoutRoot |
                     LayoutDamage::RecomputeInlineContentSizes
             },

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -156,17 +156,6 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_above_dirty_root<'dom>(
     let mut damage_for_parent = layout_damage;
     let mut maybe_parent_node = unsafe { dirty_root.dangerous_flat_tree_parent() };
     while let Some(parent_node) = maybe_parent_node {
-        if layout_context.accessibility_active {
-            let propagate =
-                damage_for_parent.contains(LayoutDamage::DescendantHasAccessibilityDamage);
-
-            if propagate && let Some(parent_element) = parent_node.as_element() {
-                let mut element_data = parent_element.element_data_mut();
-                element_data.damage.insert(RestyleDamage::from(
-                    AccessibilityDamage::DescendantHasDamageFromLayout,
-                ));
-            }
-        }
         let damage_set = ElementDamageSet {
             node: parent_node,
             from_parent: LayoutDamage::empty(),
@@ -238,19 +227,6 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_below_dirty_root<'dom>(
         layout_roots,
     );
 
-    if layout_context.accessibility_active {
-        let descendant_has_accessibility_damage = damage_set
-            .from_children
-            .intersects(LayoutDamage::DescendantHasAccessibilityDamage);
-
-        if descendant_has_accessibility_damage {
-            let mut element_data = element.element_data_mut();
-            element_data.damage.insert(RestyleDamage::from(
-                AccessibilityDamage::DescendantHasDamageFromLayout,
-            ));
-        }
-    }
-
     // Apply the calculated damage to this element (perhaps triggering box tree layout),
     // and propagate resulting damage to ancestors.
     damage_set.apply_damage(layout_context, layout_roots)
@@ -269,6 +245,39 @@ enum BoxDamageAction<'a> {
 impl BoxDamageAction<'_> {
     fn rebuilds_box(&self) -> bool {
         matches!(self, Self::RebuildAncestor | Self::TryRebuild)
+    }
+
+    /// Compute the accessibility damage which should be written to this node, and the accessibility
+    /// damage which should be propagated to its parent, respectively.
+    fn accessibility_damage(&self, from_children: LayoutDamage) -> (LayoutDamage, LayoutDamage) {
+        dbg!(&from_children);
+        let accessibility_damage_from_children =
+            from_children.intersection(LayoutDamage::DescendantHasAccessibilityDamage);
+
+        match self {
+            // Box(es) for this node may be recomputed. Bounds will need to be recalculated, and
+            // any layout roots are further up the tree, so we need to propagate damage to the
+            // parent.
+            BoxDamageAction::TryRebuild |
+            BoxDamageAction::RebuildAncestor |
+            BoxDamageAction::InvalidateFragmentTreeBelowLayoutRoot => (
+                accessibility_damage_from_children | LayoutDamage::HasAccessibilityDamage,
+                LayoutDamage::DescendantHasAccessibilityDamage,
+            ),
+            // Box(es) for this node will be recomputed, so bounds will need to be recalculated.
+            // Since this is a layout root, we don't need to propagate damage up the tree, since it
+            // will be added to the accessibility damage map which will be passes to
+            // `update_tree()`.
+            BoxDamageAction::CollectLayoutRoot(_) => (
+                accessibility_damage_from_children | LayoutDamage::HasAccessibilityDamage,
+                LayoutDamage::empty(),
+            ),
+            // Boxes for this node won't be changed.
+            _ => (
+                accessibility_damage_from_children,
+                accessibility_damage_from_children,
+            ),
+        }
     }
 }
 
@@ -354,9 +363,6 @@ impl<'a> ElementDamageSet<'a> {
 
         let action = self.box_damage_action();
 
-        let accessibility_damage_for_parent =
-            self.record_accessibility_damage(layout_context.accessibility_active, &action);
-
         let invalidate_for_rebuild = || {
             self.node.unset_all_boxes();
 
@@ -369,6 +375,8 @@ impl<'a> ElementDamageSet<'a> {
         };
 
         let will_rebuild_box = action.rebuilds_box();
+        let (accessibility_damage_for_node, accessibility_damage_for_parent) =
+            action.accessibility_damage(self.from_children);
         let layout_damage_for_parent = match action {
             BoxDamageAction::TryRebuild => {
                 discard_any_descendant_layout_roots(layout_roots);
@@ -489,6 +497,16 @@ impl<'a> ElementDamageSet<'a> {
             self.node.repair_style(&layout_context.style_context);
         }
 
+        if layout_context.will_update_accessibility_tree &&
+            !accessibility_damage_for_node.is_empty() &&
+            let Some(element) = self.node.as_element()
+        {
+            element
+                .element_data_mut()
+                .damage
+                .insert(RestyleDamage::from(accessibility_damage_for_node));
+        }
+
         accessibility_damage_for_parent | layout_damage_for_parent
     }
 
@@ -552,60 +570,5 @@ impl<'a> ElementDamageSet<'a> {
             LayoutDamage::RecomputeInlineContentSizes,
             !self.on_element.is_empty() || children_need_inline_content_size_recalculation,
         );
-    }
-
-    /// If `accessibility_active` is true, write the appropriate damage for accessibility to this
-    /// element's `element_data.damage`, and return any accessibility-related damage to be
-    /// propagated to the parent, based on the value of `action`.
-    fn record_accessibility_damage(
-        &self,
-        accessibility_active: bool,
-        action: &BoxDamageAction,
-    ) -> LayoutDamage {
-        if !accessibility_active {
-            return LayoutDamage::empty();
-        }
-
-        let Some(element) = self.node.as_element() else {
-            return LayoutDamage::empty();
-        };
-
-        let (damage_for_node, damage_for_parent) = match action {
-            // Box(es) for this node may be recomputed. Bounds will need to be recalculated, and
-            // any layout roots are further up the tree, so we need to propagate damage to the
-            // parent.
-            BoxDamageAction::TryRebuild => (
-                AccessibilityDamage::Layout,
-                LayoutDamage::DescendantHasAccessibilityDamage,
-            ),
-            BoxDamageAction::RebuildAncestor => (
-                AccessibilityDamage::Layout,
-                LayoutDamage::DescendantHasAccessibilityDamage,
-            ),
-            BoxDamageAction::InvalidateFragmentTreeBelowLayoutRoot => (
-                AccessibilityDamage::Layout,
-                LayoutDamage::DescendantHasAccessibilityDamage,
-            ),
-            // Box(es) for this node will be recomputed, so bounds will need to be recalculated.
-            // Since this is a layout root, we don't need to propagate damage up the tree, since it
-            // will be added to the accessibility damage map which will be passes to
-            // `update_tree()`.
-            BoxDamageAction::CollectLayoutRoot(_) => {
-                (AccessibilityDamage::Layout, LayoutDamage::empty())
-            },
-            // Boxes for this node won't be changed.
-            BoxDamageAction::InvalidateFragmentTreeAboveLayoutRoot => {
-                (AccessibilityDamage::empty(), LayoutDamage::empty())
-            },
-            BoxDamageAction::InvalidateScrollableOverflow => {
-                (AccessibilityDamage::empty(), LayoutDamage::empty())
-            },
-            BoxDamageAction::None => (AccessibilityDamage::empty(), LayoutDamage::empty()),
-        };
-
-        let damage_for_node = RestyleDamage::from(damage_for_node);
-        element.element_data_mut().damage.insert(damage_for_node);
-
-        damage_for_parent
     }
 }

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -238,15 +238,17 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_below_dirty_root<'dom>(
         layout_roots,
     );
 
-    if layout_context.accessibility_active &&
-        damage_set
+    if layout_context.accessibility_active {
+        let descendant_has_accessibility_damage = damage_set
             .from_children
-            .intersects(LayoutDamage::DescendantHasAccessibilityDamage)
-    {
-        let mut element_data = element.element_data_mut();
-        element_data.damage.insert(RestyleDamage::from_bits_retain(
-            AccessibilityDamage::DescendantHasDamageFromLayout.bits(),
-        ));
+            .intersects(LayoutDamage::DescendantHasAccessibilityDamage);
+
+        if descendant_has_accessibility_damage {
+            let mut element_data = element.element_data_mut();
+            element_data.damage.insert(RestyleDamage::from_bits_retain(
+                AccessibilityDamage::DescendantHasDamageFromLayout.bits(),
+            ));
+        }
     }
 
     // Apply the calculated damage to this element (perhaps triggering box tree layout),
@@ -340,28 +342,6 @@ impl<'a> ElementDamageSet<'a> {
         }
     }
 
-    fn record_accessibility_damage(
-        &self,
-        accessibility_active: bool,
-        propagate: bool,
-    ) -> LayoutDamage {
-        if !accessibility_active {
-            return LayoutDamage::empty();
-        }
-
-        if let Some(element) = self.node.as_element() {
-            let mut element_data = element.element_data_mut();
-            element_data.damage.insert(RestyleDamage::from_bits_retain(
-                AccessibilityDamage::Layout.bits(),
-            ));
-            if propagate {
-                return LayoutDamage::DescendantHasAccessibilityDamage;
-            }
-        }
-
-        LayoutDamage::empty()
-    }
-
     /// Given the damage from this element, the parent, and children, determine what action to
     /// take for this element's boxes and return the damage that should be propagated to parents.
     fn apply_damage(
@@ -372,13 +352,15 @@ impl<'a> ElementDamageSet<'a> {
         let only_layout_mode_damage =
             (self.from_parent | self.on_element | self.from_children).only_layout_modes();
 
-        let accessibility_active = layout_context.accessibility_active;
+        let action = self.box_damage_action();
+
+        let accessibility_damage_for_parent =
+            self.record_accessibility_damage(layout_context.accessibility_active, &action);
 
         let invalidate_for_rebuild = || {
             self.node.unset_all_boxes();
-            let accessibility_damage = self.record_accessibility_damage(accessibility_active, true);
 
-            accessibility_damage | LayoutDamage::DescendantHasBoxDamage | LayoutDamage::Relayout
+            LayoutDamage::DescendantHasBoxDamage | LayoutDamage::Relayout
         };
 
         // This removes any dirty layout roots from descendants.
@@ -386,9 +368,8 @@ impl<'a> ElementDamageSet<'a> {
             layout_roots.truncate(self.incoming_layout_root_count);
         };
 
-        let action = self.box_damage_action();
         let will_rebuild_box = action.rebuilds_box();
-        let damage_for_parent = match action {
+        let layout_damage_for_parent = match action {
             BoxDamageAction::TryRebuild => {
                 discard_any_descendant_layout_roots(layout_roots);
 
@@ -398,12 +379,7 @@ impl<'a> ElementDamageSet<'a> {
                 {
                     // In this case, we have rebuilt the box tree from this point and we do not
                     // have to propagate rebuild box tree damage up the tree any further.
-                    let accessibility_damage =
-                        self.record_accessibility_damage(accessibility_active, true);
-
-                    accessibility_damage |
-                        LayoutDamage::Relayout |
-                        LayoutDamage::RecomputeInlineContentSizes
+                    LayoutDamage::Relayout | LayoutDamage::RecomputeInlineContentSizes
                 } else {
                     // A descendant needs to be rebuilt, but couldn't be rebuilt here,
                     // because this node was an not a rebuild-compatible independent
@@ -449,10 +425,7 @@ impl<'a> ElementDamageSet<'a> {
                     inline_size_depends_on_content,
                 );
 
-                let accessibility_damage =
-                    self.record_accessibility_damage(accessibility_active, true);
-
-                accessibility_damage | damage_for_parent
+                damage_for_parent
             },
             BoxDamageAction::CollectLayoutRoot(layout_root) => {
                 // A layout root should only be collected if a parent node does not
@@ -474,11 +447,7 @@ impl<'a> ElementDamageSet<'a> {
                     base.mark_fragments_as_descendants_changed();
                 });
 
-                let accessibility_damage =
-                    self.record_accessibility_damage(accessibility_active, false);
-
-                accessibility_damage |
-                    LayoutDamage::RecalculateOverflow |
+                LayoutDamage::RecalculateOverflow |
                     LayoutDamage::DescendantCollectedAsLayoutRoot |
                     LayoutDamage::RecomputeInlineContentSizes
             },
@@ -520,7 +489,7 @@ impl<'a> ElementDamageSet<'a> {
             self.node.repair_style(&layout_context.style_context);
         }
 
-        damage_for_parent
+        accessibility_damage_for_parent | layout_damage_for_parent
     }
 
     fn box_damage_action(&self) -> BoxDamageAction<'a> {
@@ -583,5 +552,60 @@ impl<'a> ElementDamageSet<'a> {
             LayoutDamage::RecomputeInlineContentSizes,
             !self.on_element.is_empty() || children_need_inline_content_size_recalculation,
         );
+    }
+
+    /// If `accessibility_active` is true, write the appropriate damage for accessibility to this
+    /// element's `element_data.damage`, and return any accessibility-related damage to be
+    /// propagated to the parent, based on the value of `action`.
+    fn record_accessibility_damage(
+        &self,
+        accessibility_active: bool,
+        action: &BoxDamageAction,
+    ) -> LayoutDamage {
+        if !accessibility_active {
+            return LayoutDamage::empty();
+        }
+
+        let Some(element) = self.node.as_element() else {
+            return LayoutDamage::empty();
+        };
+
+        let (damage_for_node, damage_for_parent) = match action {
+            // Box(es) for this node may be recomputed. Bounds will need to be recalculated, and
+            // any layout roots are further up the tree, so we need to propagate damage to the
+            // parent.
+            BoxDamageAction::TryRebuild => (
+                AccessibilityDamage::Layout,
+                LayoutDamage::DescendantHasAccessibilityDamage,
+            ),
+            BoxDamageAction::RebuildAncestor => (
+                AccessibilityDamage::Layout,
+                LayoutDamage::DescendantHasAccessibilityDamage,
+            ),
+            BoxDamageAction::InvalidateFragmentTreeBelowLayoutRoot => (
+                AccessibilityDamage::Layout,
+                LayoutDamage::DescendantHasAccessibilityDamage,
+            ),
+            // Box(es) for this node will be recomputed, so bounds will need to be recalculated.
+            // Since this is a layout root, we don't need to propagate damage up the tree, since it
+            // will be added to the accessibility damage map which will be passes to
+            // `update_tree()`.
+            BoxDamageAction::CollectLayoutRoot(_) => {
+                (AccessibilityDamage::Layout, LayoutDamage::empty())
+            },
+            // Boxes for this node won't be changed.
+            BoxDamageAction::InvalidateFragmentTreeAboveLayoutRoot => {
+                (AccessibilityDamage::empty(), LayoutDamage::empty())
+            },
+            BoxDamageAction::InvalidateScrollableOverflow => {
+                (AccessibilityDamage::empty(), LayoutDamage::empty())
+            },
+            BoxDamageAction::None => (AccessibilityDamage::empty(), LayoutDamage::empty()),
+        };
+
+        let damage_for_node = RestyleDamage::from_bits_retain(damage_for_node.bits());
+        element.element_data_mut().damage.insert(damage_for_node);
+
+        damage_for_parent
     }
 }

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -156,14 +156,16 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_above_dirty_root<'dom>(
     let mut damage_for_parent = layout_damage;
     let mut maybe_parent_node = unsafe { dirty_root.dangerous_flat_tree_parent() };
     while let Some(parent_node) = maybe_parent_node {
-        if layout_context.accessibility_active &&
-            damage_for_parent.contains(LayoutDamage::DescendantHasAccessibilityDamage) &&
-            let Some(parent_element) = parent_node.as_element()
-        {
-            let mut element_data = parent_element.element_data_mut();
-            element_data.damage.insert(RestyleDamage::from_bits_retain(
-                AccessibilityDamage::DescendantHasDamage.bits(),
-            ));
+        if layout_context.accessibility_active {
+            let propagate =
+                damage_for_parent.contains(LayoutDamage::DescendantHasAccessibilityDamage);
+
+            if propagate && let Some(parent_element) = parent_node.as_element() {
+                let mut element_data = parent_element.element_data_mut();
+                element_data.damage.insert(RestyleDamage::from_bits_retain(
+                    AccessibilityDamage::DescendantHasDamageFromLayout.bits(),
+                ));
+            }
         }
         let damage_set = ElementDamageSet {
             node: parent_node,
@@ -243,7 +245,7 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_below_dirty_root<'dom>(
     {
         let mut element_data = element.element_data_mut();
         element_data.damage.insert(RestyleDamage::from_bits_retain(
-            AccessibilityDamage::DescendantHasDamage.bits(),
+            AccessibilityDamage::DescendantHasDamageFromLayout.bits(),
         ));
     }
 
@@ -338,6 +340,28 @@ impl<'a> ElementDamageSet<'a> {
         }
     }
 
+    fn record_accessibility_damage(
+        &self,
+        accessibility_active: bool,
+        propagate: bool,
+    ) -> LayoutDamage {
+        if !accessibility_active {
+            return LayoutDamage::empty();
+        }
+
+        if let Some(element) = self.node.as_element() {
+            let mut element_data = element.element_data_mut();
+            element_data.damage.insert(RestyleDamage::from_bits_retain(
+                AccessibilityDamage::Layout.bits(),
+            ));
+            if propagate {
+                return LayoutDamage::DescendantHasAccessibilityDamage;
+            }
+        }
+
+        LayoutDamage::empty()
+    }
+
     /// Given the damage from this element, the parent, and children, determine what action to
     /// take for this element's boxes and return the damage that should be propagated to parents.
     fn apply_damage(
@@ -348,24 +372,13 @@ impl<'a> ElementDamageSet<'a> {
         let only_layout_mode_damage =
             (self.from_parent | self.on_element | self.from_children).only_layout_modes();
 
-        let record_accessibility_layout_damage = || {
-            if layout_context.accessibility_active &&
-                let Some(element) = self.node.as_element()
-            {
-                let mut element_data = element.element_data_mut();
-                element_data.damage.insert(RestyleDamage::from_bits_retain(
-                    AccessibilityDamage::Layout.bits(),
-                ));
-                return LayoutDamage::DescendantHasAccessibilityDamage;
-            }
-            LayoutDamage::empty()
-        };
+        let accessibility_active = layout_context.accessibility_active;
 
         let invalidate_for_rebuild = || {
             self.node.unset_all_boxes();
-            record_accessibility_layout_damage() |
-                LayoutDamage::DescendantHasBoxDamage |
-                LayoutDamage::Relayout
+            let accessibility_damage = self.record_accessibility_damage(accessibility_active, true);
+
+            accessibility_damage | LayoutDamage::DescendantHasBoxDamage | LayoutDamage::Relayout
         };
 
         // This removes any dirty layout roots from descendants.
@@ -385,7 +398,10 @@ impl<'a> ElementDamageSet<'a> {
                 {
                     // In this case, we have rebuilt the box tree from this point and we do not
                     // have to propagate rebuild box tree damage up the tree any further.
-                    record_accessibility_layout_damage() |
+                    let accessibility_damage =
+                        self.record_accessibility_damage(accessibility_active, true);
+
+                    accessibility_damage |
                         LayoutDamage::Relayout |
                         LayoutDamage::RecomputeInlineContentSizes
                 } else {
@@ -433,7 +449,10 @@ impl<'a> ElementDamageSet<'a> {
                     inline_size_depends_on_content,
                 );
 
-                damage_for_parent
+                let accessibility_damage =
+                    self.record_accessibility_damage(accessibility_active, true);
+
+                accessibility_damage | damage_for_parent
             },
             BoxDamageAction::CollectLayoutRoot(layout_root) => {
                 // A layout root should only be collected if a parent node does not
@@ -455,7 +474,10 @@ impl<'a> ElementDamageSet<'a> {
                     base.mark_fragments_as_descendants_changed();
                 });
 
-                record_accessibility_layout_damage() |
+                let accessibility_damage =
+                    self.record_accessibility_damage(accessibility_active, false);
+
+                accessibility_damage |
                     LayoutDamage::RecalculateOverflow |
                     LayoutDamage::DescendantCollectedAsLayoutRoot |
                     LayoutDamage::RecomputeInlineContentSizes

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -162,8 +162,8 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_above_dirty_root<'dom>(
 
             if propagate && let Some(parent_element) = parent_node.as_element() {
                 let mut element_data = parent_element.element_data_mut();
-                element_data.damage.insert(RestyleDamage::from_bits_retain(
-                    AccessibilityDamage::DescendantHasDamageFromLayout.bits(),
+                element_data.damage.insert(RestyleDamage::from(
+                    AccessibilityDamage::DescendantHasDamageFromLayout,
                 ));
             }
         }
@@ -245,8 +245,8 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_below_dirty_root<'dom>(
 
         if descendant_has_accessibility_damage {
             let mut element_data = element.element_data_mut();
-            element_data.damage.insert(RestyleDamage::from_bits_retain(
-                AccessibilityDamage::DescendantHasDamageFromLayout.bits(),
+            element_data.damage.insert(RestyleDamage::from(
+                AccessibilityDamage::DescendantHasDamageFromLayout,
             ));
         }
     }
@@ -603,7 +603,7 @@ impl<'a> ElementDamageSet<'a> {
             BoxDamageAction::None => (AccessibilityDamage::empty(), LayoutDamage::empty()),
         };
 
-        let damage_for_node = RestyleDamage::from_bits_retain(damage_for_node.bits());
+        let damage_for_node = RestyleDamage::from(damage_for_node);
         element.element_data_mut().damage.insert(damage_for_node);
 
         damage_for_parent

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -5,8 +5,7 @@
 use std::sync::Arc;
 
 use layout_api::{
-    AccessibilityDamage, DangerousStyleElement, DangerousStyleNode, LayoutDamage, LayoutElement,
-    LayoutNode,
+    DangerousStyleElement, DangerousStyleNode, LayoutDamage, LayoutElement, LayoutNode,
 };
 use script::layout_dom::ServoLayoutNode;
 use style::context::{SharedStyleContext, StyleContext};

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -1050,10 +1050,10 @@ fn find_node_matching(
     mut pred: impl FnMut(&NodeId, &accesskit::Node) -> bool,
 ) -> &accesskit::Node {
     let mut matches = update.nodes.iter().filter(|(id, node)| pred(id, node));
-    let node = matches.next().unwrap_or_else(|| panic!());
+    let node = matches.next().expect("Exactly one node should match pred");
     assert!(
         matches.next().is_none(),
-        "Exactly one node should match predicate"
+        "Exactly one node should match pred"
     );
     &node.1
 }

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -1028,6 +1028,48 @@ fn test_accessibility_update_failed_layout_from_layout_root() {
     assert_rect_eq(node_b_bounds, Rect::new(20.0, 20.0, 50.0, 40.0));
 }
 
+#[test]
+fn test_accessibility_bounds_changed_by_sibling() {
+    let url = "data:text/html,<!DOCTYPE HTML>\
+               <body style='margin:0;'>\
+               <main id=main style='width:100px;height:100px;'></main>\
+               <footer id=footer style='width:100px;height:100px;'>Hello</footer>\
+               </body>";
+
+    let (servo_test, delegate, webview, tree) = build_webview_and_tree(url);
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let children: Vec<accesskit_consumer::Node> = root.children().collect();
+    assert_eq!(children.len(), 2);
+    let (main, footer) = (children[0], children[1]);
+    assert_rect_eq(
+        main.raw_bounds().expect("main should have bounds"),
+        Rect::new(0.0, 0.0, 100.0, 100.0),
+    );
+    assert_rect_eq(
+        footer.raw_bounds().expect("footer should have bounds"),
+        Rect::new(0.0, 100.0, 100.0, 200.0),
+    );
+    let main_id = main.locate().0;
+    let footer_id = footer.locate().0;
+
+    let _ = evaluate_javascript(&servo_test, webview.clone(), "main.style.height = '200px';");
+
+    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
+    let update = &updates[0];
+    dbg!(update);
+
+    let main = find_node_matching(&update, |&id, _node| id == main_id);
+    let main_bounds = main.bounds().expect("main should have bounds after update");
+    assert_rect_eq(main_bounds, Rect::new(0.0, 0.0, 100.0, 200.0));
+
+    // Fails - footer's bounds are not updated :(
+    // let footer = find_node_matching(&update, |&id, _node| id == footer_id);
+    // let footer_bounds = footer
+    //     .bounds()
+    //     .expect("footer should have bounds after update");
+    // assert_rect_eq(footer_bounds, Rect::new(0.0, 200.0, 100.0, 300.0));
+}
+
 // ************************************************************************************************
 // If you're adding a new test here, consider adding a matching test in
 // tests/wpt/mozilla/tests/accessibility-tree/

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -824,7 +824,7 @@ fn test_accessibility_bounds_updated_after_renderer_scroll() {
     let root = assert_tree_structure_and_get_root_web_area(&tree);
     let main = find_first_matching_node(root, |node| node.role() == Role::Main)
         .expect("Document should contain a main element");
-    let main_id = main.locate().0; // Maps to layout's NodeId
+
     assert_rect_eq(
         main.raw_bounds().expect("main should have bounds"),
         Rect::new(10.0, 100.0, 110.0, 150.0),
@@ -862,7 +862,7 @@ fn test_accessibility_bounds_updated_after_script_scroll() {
     let root = assert_tree_structure_and_get_root_web_area(&tree);
     let main = find_first_matching_node(root, |node| node.role() == Role::Main)
         .expect("Document should contain a main element");
-    let main_id = main.locate().0; // Maps to layout's NodeId
+
     assert_rect_eq(
         main.raw_bounds().expect("main should have bounds"),
         Rect::new(10.0, 100.0, 110.0, 150.0),
@@ -926,9 +926,11 @@ fn test_accessibility_build_initial_tree_after_scroll() {
 fn test_accessibility_unchanged_bounds_are_not_resent() {
     // Absolutely positioned divs; resizing one doesn't affect the other
     let url = "data:text/html,<!DOCTYPE html>\
-               <div id='a' style='position:absolute;left:0;top:0;width:10px;height:10px'></div>\
-               <div id='b' style='position:absolute;left:100px;top:100px;\
-               width:10px;height:10px'></div>";
+               <section id='a' style='position:absolute;left:0;top:0;width:10px;height:10px'>\
+                 <article id='c'></article>\
+               </section>\
+               <footer id='b' style='position:absolute;left:100px;top:100px;\
+               width:10px;height:10px'></footer>";
     let (servo_test, delegate, webview, tree) = build_webview_and_tree(url);
 
     let root = assert_tree_structure_and_get_root_web_area(&tree);
@@ -963,6 +965,69 @@ fn test_accessibility_unchanged_bounds_are_not_resent() {
     );
 }
 
+#[test]
+fn test_accessibility_update_failed_layout_from_layout_root() {
+    // Absolutely positioned elements create layout roots during incremental update.
+    let url = "data:text/html,<!DOCTYPE html>\
+               <section id='a' style='position:absolute;left:0;top:0;width:10px;height:10px'>\
+                 <article id='b' style='position:absolute;top:20px;left:20px;\
+                                        width:20px;height:20px;'></article>\
+               </section>\
+               <footer id='c' style='position:absolute;left:100px;top:100px;\
+                                     width:10px;height:10px'></footer>";
+    let (servo_test, delegate, webview, tree) = build_webview_and_tree(url);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let children: Vec<accesskit_consumer::Node> = root.children().collect();
+    assert_eq!(children.len(), 2);
+    let (node_a, node_c) = (children[0], children[1]);
+    assert_rect_eq(
+        node_a.raw_bounds().expect("a should have bounds"),
+        Rect::new(0.0, 0.0, 10.0, 10.0),
+    );
+    assert_rect_eq(
+        node_c.raw_bounds().expect("b should have bounds"),
+        Rect::new(100.0, 100.0, 110.0, 110.0),
+    );
+    let node_a_id = node_a.locate().0;
+
+    let a_children: Vec<_> = node_a.children().collect();
+    let node_b = a_children[0];
+    assert_rect_eq(
+        node_b.raw_bounds().expect("c should have bounds"),
+        Rect::new(20.0, 20.0, 40.0, 40.0),
+    );
+    let node_b_id = node_b.locate().0;
+
+    // Making `b` position: fixed will cause layout from the layout root at `a` to fail, triggering
+    // relayout from the root.
+    let _ = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "b.style.position = 'fixed'; \
+         b.style.width = '30px'; \
+         a.style.width = '50px';",
+    );
+
+    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
+
+    // This test really passes if:
+    // a) there's no hang because the accessibility tree never updates, and
+    // b) the integrity checks in the accessibility tree pass,
+    // but let's check the new bounds anyway.
+
+    let update = &updates[0];
+    assert_eq!(update.nodes.len(), 2);
+
+    let node_a = find_node_matching(&update, |&id, _node| id == node_a_id);
+    let node_a_bounds = node_a.bounds().expect("a should have bounds after update");
+    assert_rect_eq(node_a_bounds, Rect::new(0.0, 0.0, 50.0, 10.0));
+
+    let node_b = find_node_matching(&update, |&id, _node| id == node_b_id);
+    let node_b_bounds = node_b.bounds().expect("b should have bounds after update");
+    assert_rect_eq(node_b_bounds, Rect::new(20.0, 20.0, 50.0, 40.0));
+}
+
 // ************************************************************************************************
 // If you're adding a new test here, consider adding a matching test in
 // tests/wpt/mozilla/tests/accessibility-tree/
@@ -975,13 +1040,20 @@ const TEST_VIEWPORT_SIZE: f64 = 500.0;
 /// update is unspecified, so tests must not depend on it.
 #[track_caller]
 fn find_node_with_role(update: &TreeUpdate, role: Role) -> &accesskit::Node {
-    let mut matches = update.nodes.iter().filter(|(_, node)| node.role() == role);
-    let node = matches
-        .next()
-        .unwrap_or_else(|| panic!("Update should contain a node with role {role:?}"));
+    find_node_matching(update, |_, node| node.role() == role)
+}
+
+/// Find the single node matching the given predicte in a [`TreeUpdate`].
+#[track_caller]
+fn find_node_matching(
+    update: &TreeUpdate,
+    mut pred: impl FnMut(&NodeId, &accesskit::Node) -> bool,
+) -> &accesskit::Node {
+    let mut matches = update.nodes.iter().filter(|(id, node)| pred(id, node));
+    let node = matches.next().unwrap_or_else(|| panic!());
     assert!(
         matches.next().is_none(),
-        "Update should contain exactly one node with role {role:?}"
+        "Exactly one node should match predicate"
     );
     &node.1
 }

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -1056,7 +1056,6 @@ fn test_accessibility_bounds_changed_by_sibling() {
 
     let updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
     let update = &updates[0];
-    dbg!(update);
 
     let main = find_node_matching(&update, |&id, _node| id == main_id);
     let main_bounds = main.bounds().expect("main should have bounds after update");

--- a/components/shared/layout/layout_damage.rs
+++ b/components/shared/layout/layout_damage.rs
@@ -31,10 +31,16 @@ bitflags! {
         /// Rebuild this box and all of its ancestors. Do not rebuild any children. This
         /// is used when a box's content (such as text content) changes or a descendant
         /// has box damage ([`Self::BOX_DAMAGE`]).
-        const DescendantHasBoxDamage = 0b0011_1111_1111_0000;
+        const DescendantHasBoxDamage = 0b0011_0000_0000_0000;
+
         /// Rebuild this box, all of its ancestors and all of its descendants. This is the
         /// most a box can be damaged.
-        const BoxDamage = 0b1111_1111_1111_0000;
+        const BoxDamage = 0b1111_1111_0000_0000;
+
+        // Accessibility-specific damage
+        /// A descendant of this node has accessibility damage. This node should be marked as having
+        /// `AccessibilityDamage::DescendantHasDamage`.
+        const DescendantHasAccessibilityDamage = 0b0000_0000_1000_0000;
     }
 }
 
@@ -61,8 +67,10 @@ bitflags! {
     pub struct AccessibilityDamage: u16 {
         const Node = 0b0001;
         const Children = 0b0010;
-        const Subtree = 0b0100;
+        const Layout = 0b1000;
         const Rebuild = 0b1111;
+
+        const DescendantHasDamage = 0b1000_0000;
     }
 }
 malloc_size_of::malloc_size_of_is_0!(AccessibilityDamage);

--- a/components/shared/layout/layout_damage.rs
+++ b/components/shared/layout/layout_damage.rs
@@ -86,3 +86,15 @@ bitflags! {
     }
 }
 malloc_size_of::malloc_size_of_is_0!(AccessibilityDamage);
+
+impl From<RestyleDamage> for AccessibilityDamage {
+    fn from(restyle_damage: RestyleDamage) -> Self {
+        AccessibilityDamage::from_bits_retain(restyle_damage.bits())
+    }
+}
+
+impl From<AccessibilityDamage> for RestyleDamage {
+    fn from(accessibility_damage: AccessibilityDamage) -> Self {
+        RestyleDamage::from_bits_retain(accessibility_damage.bits())
+    }
+}

--- a/components/shared/layout/layout_damage.rs
+++ b/components/shared/layout/layout_damage.rs
@@ -92,9 +92,3 @@ impl From<RestyleDamage> for AccessibilityDamage {
         AccessibilityDamage::from_bits_retain(restyle_damage.bits())
     }
 }
-
-impl From<AccessibilityDamage> for RestyleDamage {
-    fn from(accessibility_damage: AccessibilityDamage) -> Self {
-        RestyleDamage::from_bits_retain(accessibility_damage.bits())
-    }
-}

--- a/components/shared/layout/layout_damage.rs
+++ b/components/shared/layout/layout_damage.rs
@@ -38,8 +38,12 @@ bitflags! {
         const BoxDamage = 0b1111_1111_0000_0000;
 
         // Accessibility-specific damage
-        /// A descendant of this node has accessibility damage. This node should be marked as having
-        /// `AccessibilityDamage::DescendantHasDamage`.
+        //
+        // These should be kept in sync with the layout-related values in `AccessibilityDamage`
+
+        /// Corresponds to [`AccessibilityDamage::Layout`].
+        const HasAccessibilityDamage = 0b0000_0000_0001_0000;
+        /// Corresponds to [`AccessibilityDamage::DescendantHasDamageFromLayout`].
         const DescendantHasAccessibilityDamage = 0b0000_0000_1000_0000;
     }
 }
@@ -65,12 +69,20 @@ impl From<LayoutDamage> for RestyleDamage {
 bitflags! {
     #[derive(Clone, Copy, Default, Debug, Eq, PartialEq)]
     pub struct AccessibilityDamage: u16 {
+        /// The properties of this node (other than children) have changed.
         const Node = 0b0001;
+        /// Children have been added to or removed from this node.
         const Children = 0b0010;
-        const Layout = 0b1000;
-        const Rebuild = 0b1111;
 
-        const DescendantHasDamage = 0b1000_0000;
+        // Layout-related values: keep in sync with accessibility-related values in `LayoutDamage`.
+
+        /// This node's box(es) was recomputed during layout.
+        const Layout = 0b0000_0000_0001_0000;
+        /// A descendent of this node has damage from layout.
+        const DescendantHasDamageFromLayout = 0b0000_0000_1000_0000;
+
+        /// All properties of this node need to be recomputed.
+        const Rebuild = 0b0000_0000_0001_0011;
     }
 }
 malloc_size_of::malloc_size_of_is_0!(AccessibilityDamage);

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -11430,7 +11430,7 @@
      ]
     ],
     "accessibility-update-layout-from-layout-root-failed.html": [
-     "359fbc3f76b683b103f687992d225aaf1c0fa64c",
+     "03202d2ef8f9a397a5fd60b89e2ce7f4b2dcf85d",
      [
       null,
       {}

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -11416,14 +11416,35 @@
      ]
     ],
     "accessibility-update-children-of-heading-change.html": [
-     "362d24c4aa572ef951fa60d61e9378f7df00c501",
+     "f03b9ee27982cc8a35671bce31b88f5c2a5c93f5",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-descendants-of-heading-change.html": [
-     "0cafef06b23e2a478cd55918e2bd481ad4649b10",
+     "4e6caabbae5723387f60bbcaf22d46fc5079a9e1",
+     [
+      null,
+      {}
+     ]
+    ],
+    "accessibility-update-layout-from-layout-root-failed.html": [
+     "359fbc3f76b683b103f687992d225aaf1c0fa64c",
+     [
+      null,
+      {}
+     ]
+    ],
+    "accessibility-update-layout-from-layout-root.html": [
+     "6067ea745f55d575b5fef66bee65ed4d6bf07561",
+     [
+      null,
+      {}
+     ]
+    ],
+    "accessibility-update-layout-from-layout-roots.html": [
+     "5f24fff3c00f4975598219847c55769633a28c71",
      [
       null,
       {}

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -11409,42 +11409,42 @@
   "testharness": {
    "accessibility-tree": {
     "accessibility-update-basic-mutation.html": [
-     "29f6c8d5c9c46e1134b9a0bb5ad1636554e1cf44",
+     "abf3f9fe8d658356ed2a863cb945330faa82c639",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-children-of-heading-change.html": [
-     "a5147a6a8f6745f6e30e18afdf5da3bc9ce8f7c2",
+     "362d24c4aa572ef951fa60d61e9378f7df00c501",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-descendants-of-heading-change.html": [
-     "bd8c0e35509d8d32038e1b5df7e06fa19c0c7ff9",
+     "0cafef06b23e2a478cd55918e2bd481ad4649b10",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-mutation-move-nodes.html": [
-     "71e749f898ce0e731986dbdef48bc7f76ce20932",
+     "27bd37752fcebe51c429bd676a3ed1f98c4de138",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-partial-subtree-move-and-delete.html": [
-     "8e61b0b1f2484d387efe2aebbaf81331fae4faf4",
+     "0e2d375bbd4efba12cd7e12072925daa4c793313",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-text-change.html": [
-     "c39136e64d3ced27ef7d04c0e722bc90f3af469a",
+     "1a0071fbbbfa22f0b310044419f589ed7ec94a7c",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-basic-mutation.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-basic-mutation.html
@@ -24,15 +24,17 @@
       let update = ServoTestUtils.forceAccessibilityUpdate();
 
       // Only the <section> is updated from the DOM
-      // But we need to walk all the nodes to make sure we can update bounds.
-      assert_equals(update.nodesUpdatedFromDom, 17, "nodesUpdatedFromDom");
+      // Nodes visited because of subtree layout damage:
+      // - <html>
+      // - <body>
+      assert_equals(update.nodesUpdatedFromDom, 3, "nodesUpdatedFromDom");
 
       // The <section>, its parent <body> and the document are checked for changes as their subtrees
       // changed
       assert_equals(update.nodesUpdatedFromTree, 3, "nodesUpdatedFromTree");
 
-      // Bounds are refreshed for every node still in the tree (the <h2> and its text are gone)
-      assert_equals(update.nodesUpdatedBounds, 17, "nodesUpdatedBounds");
+      // Bounds are updated for the <section> and its ancestors.
+      assert_equals(update.nodesUpdatedBounds, 3, "nodesUpdatedFromLayout");
 
       // The tree update holds the parent <section> of the removed <h2>, plus the <body> and the
       // document, whose heights shrank when the <h2> was removed

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-children-of-heading-change.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-children-of-heading-change.html
@@ -23,14 +23,16 @@
 
       // Updated nodes:
       // - h2 (<code> removed)
-      // But we need to walk all the nodes to make sure we can update bounds.
-      assert_equals(update.nodesUpdatedFromDom, 13, "nodesUpdatedFromDom");
+      // Nodes visited because of subtree layout damage:
+      // - <html>
+      // - <body>
+      assert_equals(update.nodesUpdatedFromDom, 3, "nodesUpdatedFromDom");
 
       // <html>, <body>, <h2>
       assert_equals(update.nodesUpdatedFromTree, 3, "nodesUpdatedFromTree");
 
-      // Bounds are refreshed for every node still in the tree (the <code> and its text are gone)
-      assert_equals(update.nodesUpdatedBounds, 13, "nodesUpdatedBounds");
+      // Bounds are updated for the <h2> and its ancestors.
+      assert_equals(update.nodesUpdatedBounds, 3, "nodesUpdatedBounds");
 
       // Changed nodes:
       // - <h2>, children and label changed (its geometry did not: the text still fits one line)

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-children-of-heading-change.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-children-of-heading-change.html
@@ -23,15 +23,13 @@
 
       // Updated nodes:
       // - h2 (<code> removed)
-      // Nodes visited because of subtree layout damage:
-      // - <html>
-      // - <body>
+      // - <html>, <body> (children walked)
       assert_equals(update.nodesUpdatedFromDom, 3, "nodesUpdatedFromDom");
 
       // <html>, <body>, <h2>
       assert_equals(update.nodesUpdatedFromTree, 3, "nodesUpdatedFromTree");
 
-      // Bounds are updated for the <h2> and its ancestors.
+      // Bounds are updated for the <h2>, and checked for ancestors <html> and <body>.
       assert_equals(update.nodesUpdatedBounds, 3, "nodesUpdatedBounds");
 
       // Changed nodes:

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-descendants-of-heading-change.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-descendants-of-heading-change.html
@@ -25,14 +25,17 @@
 
       // Updated nodes:
       // - em (<strong> removed)
-      // But we need to walk all the nodes to make sure we can update bounds.
-      assert_equals(update.nodesUpdatedFromDom, 16, "nodesUpdatedFromDom");
+      // Nodes visited because of subtree layout damage:
+      // - <html>
+      // - <body>
+      // - <h2>
+      assert_equals(update.nodesUpdatedFromDom, 4, "nodesUpdatedFromDom");
 
       // <html>, <body>, <h2>, <em>
       assert_equals(update.nodesUpdatedFromTree, 4, "nodesUpdatedFromTree");
 
-      // Bounds are refreshed for every node still in the tree (the <strong> and its text are gone)
-      assert_equals(update.nodesUpdatedBounds, 16, "nodesUpdatedBounds");
+      // Bounds are updated for the <em> and its ancestors.
+      assert_equals(update.nodesUpdatedBounds, 4, "nodesUpdatedBounds");
 
       // Changed nodes:
       // - <h2>, label changed

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-descendants-of-heading-change.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-descendants-of-heading-change.html
@@ -24,17 +24,14 @@
       let update = ServoTestUtils.forceAccessibilityUpdate();
 
       // Updated nodes:
-      // - em (<strong> removed)
-      // Nodes visited because of subtree layout damage:
-      // - <html>
-      // - <body>
-      // - <h2>
+      // - <em> (<strong> removed),
+      // - <html>, <body>, <h2> (children walked)
       assert_equals(update.nodesUpdatedFromDom, 4, "nodesUpdatedFromDom");
 
       // <html>, <body>, <h2>, <em>
       assert_equals(update.nodesUpdatedFromTree, 4, "nodesUpdatedFromTree");
 
-      // Bounds are updated for the <em> and its ancestors.
+      // Bounds are checked for the <em> and all its ancestors.
       assert_equals(update.nodesUpdatedBounds, 4, "nodesUpdatedBounds");
 
       // Changed nodes:

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-layout-from-layout-root-failed.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-layout-from-layout-root-failed.html
@@ -51,8 +51,8 @@
 
       let update = ServoTestUtils.forceAccessibilityUpdate();
 
-      // Children walked: <html>, <body>, #a
-      assert_equals(update.nodesUpdatedFromDom, 3, "nodesUpdatedFromDom");
+      // Children walked: #a
+      assert_equals(update.nodesUpdatedFromDom, 1, "nodesUpdatedFromDom");
 
       assert_equals(update.nodesUpdatedFromTree, 0, "nodesUpdatedFromTree");
 

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-layout-from-layout-root-failed.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-layout-from-layout-root-failed.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  section#a {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 10px;
+    height: 10px;
+  }
+
+  article#b {
+    position: absolute;
+    left: 20px;
+    top: 20px;
+    width: 20px;
+    height: 20px;
+  }
+
+  footer#c {
+    position: absolute;
+    left: 100px;
+    top: 100px;
+    width: 10px;
+    height: 10px;
+  }
+</style>
+
+<section id="a">
+  <article id="b"></article>
+</section>
+<footer id="c"></footer>
+
+<script>
+  setup({ explicit_done: true });
+  window.onload = () => {
+    test((t) => {
+      ServoTestUtils.ensureAccessibilityActive();
+      let initial = ServoTestUtils.forceAccessibilityUpdate();
+
+      assert_equals(initial.nodesUpdatedFromDom, 20, "nodesUpdatedFromDom");
+      assert_equals(initial.nodesUpdatedFromTree, 20, "nodesUpdatedFromTree");
+      assert_equals(initial.nodesUpdatedBounds, 20, "nodesUpdatedBounds");
+      assert_equals(initial.nodesInTreeUpdate, 20, "nodesInTreeUpdate");
+
+      a.style.width = "50px";
+      b.style.position = "fixed";
+      b.style.width = "30px";
+
+      let update = ServoTestUtils.forceAccessibilityUpdate();
+
+      // Children walked: <html>, <body>, #a
+      assert_equals(update.nodesUpdatedFromDom, 3, "nodesUpdatedFromDom");
+
+      assert_equals(update.nodesUpdatedFromTree, 0, "nodesUpdatedFromTree");
+
+      // Bounds are updated for #a and #b
+      assert_equals(update.nodesUpdatedBounds, 2, "nodesUpdatedBounds");
+
+      // Changed nodes: #a and #b (bounds changed)
+      assert_equals(update.nodesInTreeUpdate, 2, "nodesInTreeUpdate");
+    }, "");
+
+    done();
+  };
+</script>

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-layout-from-layout-root.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-layout-from-layout-root.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  section#a {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 10px;
+    height: 10px;
+  }
+
+  article#b {
+    width: 20px;
+    height: 20px;
+  }
+
+  aside#c {
+    position: absolute;
+    left: 100px;
+    top: 100px;
+    width: 100px;
+    height: 100px;
+  }
+
+  p#d {
+    width: 30px;
+    height: 20px;
+  }
+</style>
+
+<main>
+  <section id="a">
+    <article id="b"></article>
+  </section>
+  <aside id="c">
+    <p id="d"></p>
+  </aside>
+</main>
+
+<script>
+  setup({ explicit_done: true });
+  window.onload = () => {
+    test((t) => {
+      ServoTestUtils.ensureAccessibilityActive();
+      let initial = ServoTestUtils.forceAccessibilityUpdate();
+
+      assert_equals(initial.nodesUpdatedFromDom, 26, "nodesUpdatedFromDom");
+      assert_equals(initial.nodesUpdatedFromTree, 26, "nodesUpdatedFromTree");
+      assert_equals(initial.nodesUpdatedBounds, 26, "nodesUpdatedBounds");
+      assert_equals(initial.nodesInTreeUpdate, 26, "nodesInTreeUpdate");
+
+      b.style.width = "50px";
+
+      let update = ServoTestUtils.forceAccessibilityUpdate();
+
+      // Children of #a walked
+      assert_equals(update.nodesUpdatedFromDom, 1, "nodesUpdatedFromDom");
+
+      assert_equals(update.nodesUpdatedFromTree, 0, "nodesUpdatedFromTree");
+
+      // Bounds are updated for #b, and checked for #a
+      assert_equals(update.nodesUpdatedBounds, 2, "nodesUpdatedBounds");
+
+      // Changed nodes: #b (bounds changed)
+      assert_equals(update.nodesInTreeUpdate, 1, "nodesInTreeUpdate");
+    }, "");
+
+    done();
+  };
+</script>

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-layout-from-layout-roots.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-layout-from-layout-roots.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  section#a {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 10px;
+    height: 10px;
+  }
+
+  article#b {
+    width: 20px;
+    height: 20px;
+  }
+
+  aside#c {
+    position: absolute;
+    left: 100px;
+    top: 100px;
+    width: 100px;
+    height: 100px;
+  }
+
+  p#d {
+    width: 30px;
+    height: 20px;
+  }
+</style>
+
+<main>
+  <section id="a">
+    <article id="b"></article>
+  </section>
+  <aside id="c">
+    <p id="d"></p>
+  </aside>
+</main>
+
+<script>
+  setup({ explicit_done: true });
+  window.onload = () => {
+    test((t) => {
+      ServoTestUtils.ensureAccessibilityActive();
+      let initial = ServoTestUtils.forceAccessibilityUpdate();
+
+      assert_equals(initial.nodesUpdatedFromDom, 26, "nodesUpdatedFromDom");
+      assert_equals(initial.nodesUpdatedFromTree, 26, "nodesUpdatedFromTree");
+      assert_equals(initial.nodesUpdatedBounds, 26, "nodesUpdatedBounds");
+      assert_equals(initial.nodesInTreeUpdate, 26, "nodesInTreeUpdate");
+
+      b.style.width = "50px";
+      d.style.width = "60px";
+
+      let update = ServoTestUtils.forceAccessibilityUpdate();
+
+      // Children of #a and #c walked
+      assert_equals(update.nodesUpdatedFromDom, 2, "nodesUpdatedFromDom");
+
+      assert_equals(update.nodesUpdatedFromTree, 0, "nodesUpdatedFromTree");
+
+      // Bounds are updated for #b and #d, and checked for #a and #c
+      assert_equals(update.nodesUpdatedBounds, 4, "nodesUpdatedBounds");
+
+      // Changed nodes: #b and #d (bounds changed)
+      assert_equals(update.nodesInTreeUpdate, 2, "nodesInTreeUpdate");
+    }, "");
+
+    done();
+  };
+</script>

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-mutation-move-nodes.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-mutation-move-nodes.html
@@ -30,8 +30,10 @@
       // - div1 (child added)
       // - div2 (child added)
       // - <section> (children removed)
-      // But we need to walk all the nodes to make sure we can update bounds.
-      assert_equals(update.nodesUpdatedFromDom, 23, "nodesUpdatedFromDom");
+      // Nodes visited because of subtree layout damage:
+      // - <html>
+      // - <body>
+      assert_equals(update.nodesUpdatedFromDom, 5, "nodesUpdatedFromDom");
 
       // Nodes checked for changes based on the tree:
       // - the document
@@ -41,8 +43,7 @@
       // - div2
       assert_equals(update.nodesUpdatedFromTree, 5, "nodesUpdatedFromTree");
 
-      // Bounds are refreshed for every node in the tree; moving nodes removes none
-      assert_equals(update.nodesUpdatedBounds, 23, "nodesUpdatedBounds");
+      assert_equals(update.nodesUpdatedBounds, 7, "nodesUpdatedBounds");
 
       //  updated nodes:
       // - <section>, which had 2 children removed

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-partial-subtree-move-and-delete.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-partial-subtree-move-and-delete.html
@@ -36,17 +36,16 @@
       // - <section> (div1 removed)
       // - div2 (<p> and <h1> removed)
       // - div3 (new children)
-      // But we need to walk all the nodes to make sure we can update bounds.
-      assert_equals(update.nodesUpdatedFromDom, 24, "nodesUpdatedFromDom");
+      // Nodes visited because of subtree layout damage:
+      // - <html>
+      // - <body>
+      assert_equals(update.nodesUpdatedFromDom, 5, "nodesUpdatedFromDom");
 
       // <html>, <body>, <section>, div3, div2
       assert_equals(update.nodesUpdatedFromTree, 5, "nodesUpdatedFromTree");
 
-      // Bounds are refreshed for every node still in the tree. Gone are div1, the <p> and its
-      // text, plus the two whitespace-only text nodes that were direct children of div1: one
-      // between div1's start tag and div2 (div2 itself moved out, but not its whitespace
-      // siblings), and one between div2 and div1's end tag.
-      assert_equals(update.nodesUpdatedBounds, 24, "nodesUpdatedBounds");
+      // <html>, <body>, <section>, div3, <h1>, div2
+      assert_equals(update.nodesUpdatedBounds, 6, "nodesUpdatedBounds");
 
       // Changed nodes:
       // - <section>, children changed (and it shrank, changing its bounds)
@@ -54,7 +53,8 @@
       // - div3, children changed (and it now wraps more content, changing its bounds)
       // - <h2>, which moved up when the <p> was removed, changing its bounds
       // - <body> and the document, whose heights shrank, changing their bounds
-      assert_equals(update.nodesInTreeUpdate, 6, "nodesInTreeUpdate");
+      // The <h1>'s bounds do NOT change.
+      assert_equals(update.nodesInTreeUpdate, 5, "nodesInTreeUpdate");
     }, "");
 
     done();

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-text-change.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-text-change.html
@@ -23,14 +23,18 @@
       let update = window.ServoTestUtils.forceAccessibilityUpdate();
 
       // Just the text node has changed
-      // But we need to walk all the nodes to make sure we can update bounds.
-      assert_equals(update.nodesUpdatedFromDom, 16, "nodesUpdatedFromDom");
+      // Nodes visited because of subtree layout damage:
+      // - <html>
+      // - <body>
+      // - <section>
+      // - <h1>
+      assert_equals(update.nodesUpdatedFromDom, 4, "nodesUpdatedFromDom");
 
       // The document, <body>, <section>, <h1> and the text node.
       assert_equals(update.nodesUpdatedFromTree, 5, "nodesUpdatedFromTree");
 
-      // Bounds are refreshed for every node in the tree; no nodes were added or removed
-      assert_equals(update.nodesUpdatedBounds, 16, "nodesUpdatedBounds");
+      // Bounds are checked for the <h1> and its ancestors.
+      assert_equals(update.nodesUpdatedBounds, 4, "nodesUpdatedBounds");
 
       //  updated nodes:
       // - <h1>, computed label changed


### PR DESCRIPTION
Note: This change has been split into two PRs; this one and #47772.

This change introduces accessibility damage tracking into layout.

In order to do this, we now write an `AccessibilityDamage` value into elements' `ElementData::damage` field when necessary, after taking the previously computed `LayoutDamage` value.

This may include one or both of two new values for `AccessibilityDamage`:
- `Layout`, indicating that the box(es) for this node has/have been recomputed and its bounds have likely changed,
- `DescendantHasDamageFromLayout`, indicating that at least one of this node's descendants has some kind of accessibility damage.

`DescendantHasDamageFromLayout` is necessary because unlike how we track accessibility damage from DOM changes, we don't add every node with damage from layout into the accessibility damage map which is passed in to `AccessibilityTree::update_tree`. Instead, we propagate `DescendantHasDamageFromLayout` up the tree, setting it on ancestors of nodes with accessibility damage from layout during the `computed_damage_and_rebuild_box_tree()` traversal. This means that damage is propagated up the tree at least as far as the dirty root, but may not be propagated all the way up to the root node.

In order to ensure the accessibility tree visits the damaged nodes during the tree update, we add the layout root(s) to the accessibility damage map, if it was passed in via `ReflowRequest`. (The map may be empty, but if it was passed in, we know that accssibility is active and that the accessibility tree will be updated in this reflow.)

The accessibility tree then checks the `ElementData::damage` field when computing damage for nodes in the damage map, and traverses into the DOM children of nodes with `DescendantHasDamageFromLayout`.

This change also adds values to the `LayoutDamage` bitflags: 
- `DescendantHasAccessibilityDamage` - This value corresponds to `AccessibilityDamage::DescendantHasDamageFromLayout`, and is used to propagate the `AccessibilityDamage::DescendantHasDamage`: in `ElementDamageSet::apply_damage()`, this value is added to the return value if the node being visited has accessibility damage. It is then propagated back up the call stack via `ElementDamageSet::from_children`, and used to set `AccessibilityDamage::DescendantHasDamage` on each ancestor.
- `HasAccessibilityDamage` - This value is added purely to correspond to `AccessibilityDamage::Layout`, to ensure that any `AccessibilityDamage` bits which may be written to `element_data.damage` during layout don't conflict with any non-accessibility `LayoutDamage` values.

Fixes: part of #47162
Testing: Added tests for handling of layout root layout (successful and failed). Passes existing integration tests; WPT test expectations updated since fewer nodes have their bounds updated.