### PR TITLE
script: Run live range update steps on complete move subtree

### DIFF
--- a/components/script/dom/node/context.rs
+++ b/components/script/dom/node/context.rs
@@ -114,35 +114,13 @@ impl<'a> UnbindContext<'a> {
 /// The context of the moving from a tree of a node when one of its
 /// inclusive ancestors is moved.
 pub(crate) struct MoveContext<'a> {
-    /// The index of the inclusive ancestor that was moved.
-    index: Cell<Option<u32>>,
     /// The old parent, if any, of the inclusive ancestor that was moved.
     pub(crate) old_parent: Option<&'a Node>,
-    /// The previous sibling of the inclusive ancestor that was moved.
-    prev_sibling: Option<&'a Node>,
 }
 
 impl<'a> MoveContext<'a> {
     /// Create a new `MoveContext` value.
-    pub(crate) fn new(
-        old_parent: Option<&'a Node>,
-        prev_sibling: Option<&'a Node>,
-        cached_index: Option<u32>,
-    ) -> Self {
-        MoveContext {
-            index: Cell::new(cached_index),
-            old_parent,
-            prev_sibling,
-        }
-    }
-
-    /// The index of the inclusive ancestor that was moved from the tree.
-    pub(crate) fn index(&self) -> u32 {
-        if let Some(index) = self.index.get() {
-            return index;
-        }
-        let index = self.prev_sibling.map_or(0, |sibling| sibling.index() + 1);
-        self.index.set(Some(index));
-        index
+    pub(crate) fn new(old_parent: Option<&'a Node>) -> Self {
+        MoveContext { old_parent }
     }
 }

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -126,7 +126,8 @@ use crate::dom::types::{CDATASection, KeyboardEvent, MouseEvent, ProcessingInstr
 use crate::dom::window::Window;
 use crate::dom::{
     ChildrenMutation, Range, live_range_insert_steps, live_range_normalization_steps,
-    live_range_pre_remove_steps_for_parent, live_range_pre_remove_steps_for_removed_subtree,
+    live_range_pre_remove_steps, live_range_pre_remove_steps_for_parent,
+    live_range_pre_remove_steps_for_removed_subtree,
 };
 use crate::drag::document_selection_drag::DocumentSelectionDragHandler;
 use crate::drag::drag_gesture::{DragGesture, DragHandler};
@@ -1460,8 +1461,7 @@ impl Node {
             .expect("old_parent should always be initialized");
 
         // Step 9. Run the live range pre-remove steps, given node.
-        let mut cached_index = None;
-        live_range_pre_remove_steps_for_parent(node, &old_parent, &mut cached_index);
+        live_range_pre_remove_steps(node, &old_parent);
 
         // TODO Step 10. For each NodeIterator object iterator whose root’s node document is node’s
         // node document: run the NodeIterator pre-remove steps given node and iterator.
@@ -1498,9 +1498,6 @@ impl Node {
                     .set(node.prev_sibling.get().as_deref());
             },
         }
-
-        let mut context =
-            MoveContext::new(Some(&old_parent), prev_sibling.as_deref(), cached_index);
 
         // Step 13. Remove node from oldParent’s children.
         old_parent.move_child(cx, node);
@@ -1582,10 +1579,9 @@ impl Node {
             // inclusiveDescendant and oldParent.
             // Otherwise, run the moving steps with inclusiveDescendant and null.
             if descendant.deref() == node {
-                vtable_for(&descendant).moving_steps(cx, &context);
+                vtable_for(&descendant).moving_steps(cx, &MoveContext::new(Some(&old_parent)));
             } else {
-                context.old_parent = None;
-                vtable_for(&descendant).moving_steps(cx, &context);
+                vtable_for(&descendant).moving_steps(cx, &MoveContext::new(None));
             }
 
             // Step 24.2. If inclusiveDescendant is custom and newParent is connected,
@@ -2984,7 +2980,10 @@ impl Node {
 
         // Step 3. Run the live range pre-remove steps.
         let mut cached_index = None;
-        live_range_pre_remove_steps_for_parent(node, parent, &mut cached_index);
+        {
+            let mut lazy_index = || *cached_index.get_or_insert_with(|| node.index());
+            live_range_pre_remove_steps_for_parent(parent, &mut lazy_index);
+        }
 
         // TODO: Step 4. Pre-removing steps for node iterators
 
@@ -4526,16 +4525,15 @@ impl VirtualMethods for Node {
     /// <https://dom.spec.whatwg.org/#concept-node-remove>
     fn unbind_from_tree(&self, cx: &mut JSContext, context: &UnbindContext) {
         self.super_type().unwrap().unbind_from_tree(cx, context);
-        live_range_pre_remove_steps_for_removed_subtree(self, context.parent, &|| context.index());
+
+        let mut cached_index = None;
+        let mut lazy_index = || *cached_index.get_or_insert_with(|| context.index());
+        live_range_pre_remove_steps_for_removed_subtree(self, context.parent, &mut lazy_index);
     }
 
     fn moving_steps(&self, cx: &mut JSContext, context: &MoveContext) {
         if let Some(super_type) = self.super_type() {
             super_type.moving_steps(cx, context);
-        }
-
-        if let Some(parent) = context.old_parent {
-            live_range_pre_remove_steps_for_removed_subtree(self, parent, &|| context.index());
         }
 
         self.owner_doc_unrooted(cx.no_gc())

--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -1410,7 +1410,7 @@ pub(crate) fn live_range_insert_steps(parent: &Node, child: &Node, count: u32) {
 pub(crate) fn live_range_pre_remove_steps_for_removed_subtree(
     inclusive_descendant_of_removed_node: &Node, // "node" in the specification
     parent_of_removed_node: &Node,               // "parent" in the specification
-    index_of_removed_node: &dyn Fn() -> u32,     // "index" in the specification
+    index_of_removed_node: &mut dyn FnMut() -> u32, // "index" in the specification
 ) {
     // The steps are only supposed to run on DOM tree inclusive descendants of the removal
     // root and elements in shadow trees are not, so they shouldn't run for them.
@@ -1418,36 +1418,33 @@ pub(crate) fn live_range_pre_remove_steps_for_removed_subtree(
         return;
     }
     for range in inclusive_descendant_of_removed_node.live_ranges() {
-        let index = index_of_removed_node();
         // Step 4: For each live range whose start node is an inclusive descendant of
         // node, set its start to (parent, index).
         if &*range.start_container() == inclusive_descendant_of_removed_node {
-            range.set_start(parent_of_removed_node, index);
+            range.set_start(parent_of_removed_node, index_of_removed_node());
         }
         // Step 5: For each live range whose end node is an inclusive descendant of node,
         // set its end to (parent, index).
         if &*range.end_container() == inclusive_descendant_of_removed_node {
-            range.set_end(parent_of_removed_node, index);
+            range.set_end(parent_of_removed_node, index_of_removed_node());
         }
     }
 }
 
 /// <https://dom.spec.whatwg.org/#live-range-pre-remove-steps> steps 6 and 7.
 pub(crate) fn live_range_pre_remove_steps_for_parent(
-    node: &Node,
     parent: &Node,
-    cached_node_index: &mut Option<u32>,
+    node_index: &mut dyn FnMut() -> u32,
 ) {
     for range in parent.live_ranges() {
-        let node_index = *cached_node_index.get_or_insert_with(|| node.index());
         // Step 6: For each live range whose start node is parent and start offset is
         // greater than index, decrease its start offset by 1.
-        if &*range.start_container() == parent && range.start_offset() > node_index {
+        if &*range.start_container() == parent && range.start_offset() > node_index() {
             range.set_start(parent, range.start_offset() - 1);
         }
         // Step 7: For each live range whose end node is parent and end offset is greater than
         // index, decrease its end offset by 1.
-        if &*range.end_container() == parent && range.end_offset() > node_index {
+        if &*range.end_container() == parent && range.end_offset() > node_index() {
             range.set_end(parent, range.end_offset() - 1);
         }
     }
@@ -1580,4 +1577,32 @@ pub(crate) fn live_range_text_split_steps(
             range.set_end(parent, range.end_offset() + 1);
         }
     }
+}
+
+/// <https://dom.spec.whatwg.org/#live-range-pre-remove-steps>
+pub(crate) fn live_range_pre_remove_steps(node: &Node, old_parent: &Node) {
+    // Step 1. Let parent be node’s parent.
+    // Note: This is `old_parent`.
+    // Step 2. Assert: parent is non-null.
+    // Note: Cannot be null.
+
+    // Step 3. Let index be node’s index.
+    let mut cached_index = None;
+    let mut lazy_index = || *cached_index.get_or_insert_with(|| node.index());
+
+    // Step 4. For each live range whose start node is an inclusive descendant of node,
+    // set its start to (parent, index).
+    // Step 5. For each live range whose end node is an inclusive descendant of node, set
+    // its end to (parent, index).
+    //
+    // TODO: Only run this part if there are live ranges in this subtree and/or a selection.
+    for descendant in node.traverse_preorder(ShadowIncluding::No) {
+        live_range_pre_remove_steps_for_removed_subtree(&descendant, old_parent, &mut lazy_index);
+    }
+
+    // Step 6. For each live range whose start node is parent and start offset is greater
+    // than index, decrease its start offset by 1.
+    // Step 7. For each live range whose end node is parent and end offset is greater than
+    // index, decrease its end offset by 1.
+    live_range_pre_remove_steps_for_parent(old_parent, &mut lazy_index);
 }

--- a/tests/wpt/meta/dom/nodes/moveBefore/live-range-updates.html.ini
+++ b/tests/wpt/meta/dom/nodes/moveBefore/live-range-updates.html.ini
@@ -1,6 +1,0 @@
-[live-range-updates.html]
-  [moveBefore still causes range startContainer to snap up to parent, when startContainer ancestor is moved]
-    expected: FAIL
-
-  [moveBefore still causes range endContainer to snap up to parent, when endContainer ancestor is moved]
-    expected: FAIL


### PR DESCRIPTION
The specification says that live range updates steps need to run on the
entirely (shadow-exclusive) subtree of a moved node.  Because the moving
steps are only run on the moved node itself (not the subtree), this wasn't
happening properly.

This makes move more expensive, but is essential for correctness. The real
fix for the performance regression is to move live ranges to be stored globally
on the `Document` and only run the subtree steps if there is a relevant live
range or a relevant `Selection`.

Testing: This causes a WPT test to pass.
