### PR TITLE
layout: Advance the containing block walk past boxless ancestors

### DIFF
--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -793,6 +793,8 @@ fn containing_block_for_node<'a>(node: ServoLayoutNode<'a>) -> Option<ServoLayou
 
     #[expect(unsafe_code)]
     while let Some(ancestor) = unsafe { current_ancestor.dangerous_flat_tree_parent() } {
+        current_ancestor = ancestor;
+
         let Some((ancestor_style, ancestor_flags)) = style_and_flags_for_node(&ancestor) else {
             continue;
         };
@@ -803,7 +805,6 @@ fn containing_block_for_node<'a>(node: ServoLayoutNode<'a>) -> Option<ServoLayou
         }
 
         current_position_value = ancestor_style.clone_position();
-        current_ancestor = ancestor;
     }
     None
 }

--- a/tests/wpt/tests/intersection-observer/display-contents.html
+++ b/tests/wpt/tests/intersection-observer/display-contents.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://www.w3.org/TR/intersection-observer/#calculate-intersection-rect-algo">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<style>
+  #wrapper { display: contents; }
+  #target { width: 100px; height: 100px; background: green; }
+</style>
+<div id="wrapper"><div id="target"></div></div>
+<script>
+// An ancestor with display: contents generates no box, so walking from the target
+// to its containing block has to step over it rather than stop or spin.
+let t = async_test("A target is observed through an ancestor with display: contents");
+new IntersectionObserver(t.step_func_done(function(entries) {
+  assert_equals(entries.length, 1);
+  assert_true(entries[0].isIntersecting);
+})).observe(document.querySelector("#target"));
+</script>

--- a/tests/wpt/tests/intersection-observer/slotted-target.html
+++ b/tests/wpt/tests/intersection-observer/slotted-target.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://www.w3.org/TR/intersection-observer/#calculate-intersection-rect-algo">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#flow-content-3">
+<style>
+  #target { width: 100px; height: 100px; background: green; }
+</style>
+<div id="host"><div id="target"></div></div>
+<script>
+// The UA stylesheet gives slot { display: contents }, so the flat tree parent of
+// slotted content generates no box. This needs no author style to reproduce.
+document.querySelector("#host")
+        .attachShadow({ mode: "open" })
+        .innerHTML = "<div><slot></slot></div>";
+
+let t = async_test("A slotted target is observed, though its flat tree parent is a slot");
+new IntersectionObserver(t.step_func_done(function(entries) {
+  assert_equals(entries.length, 1);
+  assert_true(entries[0].isIntersecting);
+})).observe(document.querySelector("#target"));
+</script>


### PR DESCRIPTION
`containing_block_for_node` walks up the flat tree, but assigns `current_ancestor` only at the bottom of the loop body. The early continue for an ancestor with no layout box therefore re-reads the same flat tree parent forever. It is an infinite loop in the script thread.

Testing: Two new tests in intersection-observer. Both timeout without this change.
Fixes: #45915