### PR TITLE
script: Allow `Selection` to live in shadow roots

### DIFF
--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -4522,12 +4522,17 @@ impl VirtualMethods for Node {
     fn unbind_from_tree(&self, cx: &mut JSContext, context: &UnbindContext) {
         self.super_type().unwrap().unbind_from_tree(cx, context);
 
+        // The steps are only supposed to run on DOM tree inclusive descendants of the removal
+        // root and elements in shadow trees are not, so they shouldn't run for them.
         let mut cached_index = None;
         let mut lazy_index = || *cached_index.get_or_insert_with(|| context.index());
         if let Some(selection) = self.owner_document().selection() {
             selection.remove_steps_for_removed_subtree(self, context.parent, &mut lazy_index);
         }
-        live_range_pre_remove_steps_for_removed_subtree(self, context.parent, &mut lazy_index);
+
+        if !self.is_in_a_shadow_tree() {
+            live_range_pre_remove_steps_for_removed_subtree(self, context.parent, &mut lazy_index);
+        }
     }
 
     fn moving_steps(&self, cx: &mut JSContext, context: &MoveContext) {

--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -1442,11 +1442,6 @@ pub(crate) fn live_range_pre_remove_steps_for_removed_subtree(
     parent_of_removed_node: &Node,               // "parent" in the specification
     index_of_removed_node: &mut dyn FnMut() -> u32, // "index" in the specification
 ) {
-    // The steps are only supposed to run on DOM tree inclusive descendants of the removal
-    // root and elements in shadow trees are not, so they shouldn't run for them.
-    if inclusive_descendant_of_removed_node.is_in_a_shadow_tree() {
-        return;
-    }
     for range in inclusive_descendant_of_removed_node.live_ranges() {
         // Step 4: For each live range whose start node is an inclusive descendant of
         // node, set its start to (parent, index).

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -408,12 +408,9 @@ impl Selection {
             );
     }
 
-    fn is_in_document_of_range(&self, node: &Node) -> bool {
-        // TODO(mrobinson): This should eventually allow nodes in the same composed tree (and
-        // not just the same tree), but this requires more work to allow `Selection` to cross
-        // shadow tree boundaries.
-        &*node.GetRootNode(&GetRootNodeOptions { composed: false }) ==
-            self.document.upcast::<Node>()
+    fn is_in_composed_tree_of_document_and_is_not_ua_widget(&self, node: &Node) -> bool {
+        &*node.GetRootNode(&GetRootNodeOptions { composed: true }) == self.document.upcast::<Node>() &&
+            !node.is_in_ua_widget()
     }
 
     pub(crate) fn start_boundary(&self, cx: &mut JSContext) -> (DomRoot<Node>, u32) {
@@ -598,14 +595,6 @@ impl Selection {
         parent_of_removed_node: &Node,               // "parent" in the specification
         index_of_removed_node: &mut dyn FnMut() -> u32, // "index" in the specification
     ) {
-        // The steps are only supposed to run on DOM tree inclusive descendants of the removal
-        // root and elements in shadow trees are not, so they shouldn't run for them.
-        //
-        // TODO: This won't be true once selections can span shadow tree roots.
-        if inclusive_descendant_of_removed_node.is_in_a_shadow_tree() {
-            return;
-        }
-
         let mut range_borrow = self.range.borrow_mut();
         let Some(range) = &mut *range_borrow else {
             return;
@@ -960,7 +949,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     fn AddRange(&self, no_gc: &NoGC, range: &Range) {
         // Step 1. If the root of the range's boundary points are not the document
         // associated with this, abort these steps.
-        if !self.is_in_document_of_range(&range.start_container()) {
+        if &*range.root() != self.document.upcast() {
             return;
         }
 
@@ -1040,9 +1029,10 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
             // Step 3.2. Set startNode to startNode's root's host's parent.
             // See <https://github.com/w3c/selection-api/issues/161> for why
             // we always know that the start_node is a node.
-            start_node = host
-                .GetParentNode()
-                .expect("The host should always have a parent node");
+            let Some(new_start_node) = host.GetParentNode() else {
+                return Vec::new();
+            };
+            start_node = new_start_node;
         }
 
         // Step 4. Let endNode be end node of the range associated with this, and let
@@ -1063,9 +1053,10 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
             // Step 5.2. Set endNode to endNode's root's host's parent.
             // See <https://github.com/w3c/selection-api/issues/161> for why
             // we always know that the end_node is a node.
-            end_node = host
-                .GetParentNode()
-                .expect("The host should always have a parent node.");
+            let Some(new_end_node) = host.GetParentNode() else {
+                return Vec::new();
+            };
+            end_node = new_end_node;
         }
 
         drop(borrowed_range);
@@ -1106,13 +1097,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
 
         // Step 4. If document associated with this is not a shadow-including inclusive
         // ancestor of node, abort these steps.
-        //
-        // TODO(mrobinson): This should eventually allow nodes in the same composed tree (and
-        // not just the same tree), but this requires more work to allow `Selection` to cross
-        // shadow tree boundaries.
-        if &*node.GetRootNode(&GetRootNodeOptions { composed: false }) !=
-            self.document.upcast::<Node>()
-        {
+        if !self.is_in_composed_tree_of_document_and_is_not_ua_widget(node) {
             return Ok(());
         }
 
@@ -1175,13 +1160,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     fn Extend(&self, cx: &mut JSContext, node: &Node, offset: u32) -> ErrorResult {
         // Step 1. If the document associated with this is not a shadow-including
         // inclusive ancestor of node, abort these steps.
-        //
-        // TODO(mrobinson): This should eventually allow nodes in the same composed tree (and
-        // not just the same tree), but this requires more work to allow `Selection` to cross
-        // shadow tree boundaries.
-        if &*node.GetRootNode(&GetRootNodeOptions { composed: false }) !=
-            self.document.upcast::<Node>()
-        {
+        if !self.is_in_composed_tree_of_document_and_is_not_ua_widget(node) {
             return Ok(());
         }
 
@@ -1217,10 +1196,10 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
 
         // Step 5. If node's root is not the same as the this's range's root, set the
         // start newRange's start and end to newFocus.
-        let is_in_document_of_range = self.is_in_document_of_range(&range.start.container);
+        let in_different_roots = !nodes_have_same_shadow_root(&range.start.container, node);
         drop(range_borrow);
 
-        if !is_in_document_of_range {
+        if in_different_roots {
             self.set_range(
                 cx.no_gc(),
                 Some(SelectionRange::collapsed_at(SelectionBoundary::new(
@@ -1298,17 +1277,8 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
 
         // Step 2. If document associated with this is not a shadow-including inclusive
         // ancestor of anchorNode or focusNode, abort these steps.
-        //
-        // TODO(mrobinson): This should eventually allow nodes in the same composed tree (and
-        // not just the same tree), but this requires more work to allow `Selection` to cross
-        // shadow tree boundaries.
-        if &*anchor_node.GetRootNode(&GetRootNodeOptions { composed: false }) !=
-            self.document.upcast::<Node>()
-        {
-            return Ok(());
-        }
-        if &*focus_node.GetRootNode(&GetRootNodeOptions { composed: false }) !=
-            self.document.upcast::<Node>()
+        if !self.is_in_composed_tree_of_document_and_is_not_ua_widget(anchor_node) ||
+            !self.is_in_composed_tree_of_document_and_is_not_ua_widget(focus_node)
         {
             return Ok(());
         }
@@ -1321,17 +1291,23 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // Step 4. Let newRange be a new range.
         // Note: We set the range directly to satisfy crown.
 
+        // TODO(mrobinson): Eventually we should allow nodes in different roots, but for
+        // now they must be contained within the same one.
+        if !nodes_have_same_shadow_root(anchor_node, focus_node) {
+            return Ok(());
+        }
+
         // Step 5. If anchor is before focus, set the start the newRange's start to anchor
         // and its end to focus. Otherwise, set the start them to focus and anchor
         // respectively.
-        let is_anchor_before_focus = bp_position(
+        let ordering = bp_position(
             cx.no_gc(),
             anchor_node,
             anchor_offset,
             focus_node,
             focus_offset,
-        ) == Ordering::Less;
-        let direction = if is_anchor_before_focus {
+        );
+        if ordering == Ordering::Less {
             self.set_range(
                 cx.no_gc(),
                 Some(SelectionRange::new(
@@ -1339,7 +1315,6 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
                     SelectionBoundary::new(focus_node, focus_offset),
                 )),
             );
-            Direction::Forwards
         } else {
             self.set_range(
                 cx.no_gc(),
@@ -1348,7 +1323,6 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
                     SelectionBoundary::new(anchor_node, anchor_offset),
                 )),
             );
-            Direction::Backwards
         };
 
         // Step 6. Set this's range to newRange.
@@ -1356,7 +1330,11 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
 
         // Step 7. If focus is before anchor, set this's direction to backwards.
         // Otherwise, set it to forwards
-        self.direction.set(direction);
+        if ordering == Ordering::Greater {
+            self.direction.set(Direction::Backwards);
+        } else {
+            self.direction.set(Direction::Forwards);
+        }
 
         Ok(())
     }
@@ -1371,7 +1349,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
 
         // Step 2. If node's root is not the document associated with this, abort these
         // steps.
-        if !self.is_in_document_of_range(node) {
+        if !self.is_in_composed_tree_of_document_and_is_not_ua_widget(node) {
             return Ok(());
         }
 
@@ -1427,7 +1405,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // > its range is before or visually equivalent to the last boundary point in the node *and*
         // > end of its range is after or visually equivalent to the first boundary point in the
         // > node.
-        if !self.is_in_document_of_range(node) {
+        if !self.is_in_composed_tree_of_document_and_is_not_ua_widget(node) {
             return false;
         }
         let range = self.range.borrow();
@@ -1435,10 +1413,15 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
             return false;
         };
         let start_node = &*range.start.container;
-        if !self.is_in_document_of_range(start_node) {
+        if !self.is_in_composed_tree_of_document_and_is_not_ua_widget(start_node) {
             return false;
         }
         let end_node = &*range.end.container;
+
+        // TODO: Eventually this should support comparing nodes from different shadow roots.
+        if !nodes_have_same_shadow_root(start_node, node) {
+            return false;
+        }
 
         let first_offset = 0;
         let last_offset = node.len();
@@ -1558,4 +1541,8 @@ bitflags! {
         const Start = 1 << 0;
         const End = 1 << 1;
     }
+}
+
+fn nodes_have_same_shadow_root(a: &Node, b: &Node) -> bool {
+    a.is_connected() && b.is_connected() && a.containing_shadow_root() == b.containing_shadow_root()
 }

--- a/tests/wpt/meta/editing/other/editable-state-and-focus-in-shadow-dom-in-designMode.tentative.html.ini
+++ b/tests/wpt/meta/editing/other/editable-state-and-focus-in-shadow-dom-in-designMode.tentative.html.ini
@@ -10,9 +10,3 @@
 
   [SelectAll in the <div contenteditable> in the closed shadow DOM]
     expected: FAIL
-
-  [Typing "A" after Collapse selection into text in <div contenteditable> in the open shadow DOM]
-    expected: FAIL
-
-  [Typing "A" after Collapse selection into text in <div contenteditable> in the closed shadow DOM]
-    expected: FAIL

--- a/tests/wpt/meta/selection/shadow-dom/selection-at-nodes-not-part-of-flattened-tree.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/selection-at-nodes-not-part-of-flattened-tree.html.ini
@@ -31,3 +31,6 @@
 
   [getRangeAt(0).comparePoint of the start of the default span child should return 0 (when all children of the default span is selected)]
     expected: FAIL
+
+  [containsNode of the default span child should return false (when all children of the default span is selected)]
+    expected: FAIL

--- a/tests/wpt/meta/selection/shadow-dom/tentative/Selection-collapse-and-extend.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/tentative/Selection-collapse-and-extend.html.ini
@@ -1,6 +1,0 @@
-[Selection-collapse-and-extend.html]
-  [collapse can set selection to a node inside a shadow tree]
-    expected: FAIL
-
-  [extend can set selection to a node inside a shadow tree]
-    expected: FAIL

--- a/tests/wpt/meta/selection/shadow-dom/tentative/Selection-direction.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/tentative/Selection-direction.html.ini
@@ -1,6 +1,3 @@
 [Selection-direction.html]
-  [direction returns "forward" when there is a forward selection in the shadow tree]
-    expected: FAIL
-
   [direction returns "forward" when there is a forward selection that crosses shadow boundaries]
     expected: FAIL

--- a/tests/wpt/meta/selection/shadow-dom/tentative/Selection-getComposedRanges-dom-mutations-removal.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/tentative/Selection-getComposedRanges-dom-mutations-removal.html.ini
@@ -2,9 +2,6 @@
   [Range is fully in shadow tree. Removing shadow host collapses composed StaticRange. Note it does not update previously returned composed StaticRange.]
     expected: FAIL
 
-  [Range is fully in shadow tree. Removing parent of shadow host collapses composed StaticRange.]
-    expected: FAIL
-
   [Range is across shadow trees. Replacing shadowRoot content rescopes new composed range to the shadowRoot.]
     expected: FAIL
 
@@ -14,9 +11,6 @@
 
 [Selection-getComposedRanges-dom-mutations-removal.html?mode=closed]
   [Range is fully in shadow tree. Removing shadow host collapses composed StaticRange. Note it does not update previously returned composed StaticRange.]
-    expected: FAIL
-
-  [Range is fully in shadow tree. Removing parent of shadow host collapses composed StaticRange.]
     expected: FAIL
 
   [Range is across shadow trees. Replacing shadowRoot content rescopes new composed range to the shadowRoot.]

--- a/tests/wpt/meta/selection/shadow-dom/tentative/Selection-getComposedRanges.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/tentative/Selection-getComposedRanges.html.ini
@@ -1,24 +1,9 @@
 [Selection-getComposedRanges.html]
-  [getComposedRanges returns a sequence with a static range pointing to the shadow host when there is a selection in a shadow tree and the shadow tree is not specified as an argument]
-    expected: FAIL
-
   [getComposedRanges a sequence with a static range pointing to the shadow host when there is a forward selection that crosses shadow boundaries and the shadow tree is not specified as an argument]
     expected: FAIL
 
   [getComposedRanges a sequence with a static range that crosses shadow boundaries when there is a forward selection that crosses shadow boundaries and the shadow tree is specified as an argument]
     expected: FAIL
 
-  [getComposedRanges returns a sequence with a static range pointing to the outer shadow host when there is a selection in an inner shadow tree and no shadow tree is specified as an argument]
-    expected: FAIL
-
-  [getComposedRanges returns a sequence with a static range pointing to the inner shadow tree when there is a selection in an inner shadow tree and the inner shadow tree is specified as an argument]
-    expected: FAIL
-
-  [getComposedRanges returns a sequence with a static range pointing to the outer shadow tree when there is a selection in an inner shadow tree and the outer shadow tree is specified as an argument]
-    expected: FAIL
-
   [getComposedRanges returns a sequence with a static range without rescoping when there is a selection in an outer shadow tree and the inner shadow tree is specified as an argument]
-    expected: FAIL
-
-  [getComposedRanges returns a sequence with a static range pointing to a shadow tree when there is a selection in the shadow tree and the shadow tree is specified as an argument]
     expected: FAIL


### PR DESCRIPTION
This change makes `Selection` capable of living inside shadow roots, but
only when those selections do not span shadow root boundaries. A
followup change will allow shadow-spanning `Selection`, but this is a
transitionary step.

Testing: This causes a few subtests to start passing and one to start failing (this was a false pass previously).
Fixes: #47118.
Fixes: #47119.