### PR TITLE
android: Require `experimentalMode` in constructor

### DIFF
--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
@@ -73,18 +73,18 @@ class MainActivity : ComponentActivity(), Servo.Client {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        sharedPreferences = PreferenceManager.getDefaultSharedPreferences(applicationContext)
+        settings = Settings(sharedPreferences)
+
         servoView = ServoView(
             context = this,
             client = this,
             servoArgs = intent.getStringExtra("servoargs"),
             servoLog = intent.getStringExtra("servolog"),
+            experimentalMode = settings.experimental,
         )
 
         historyManager = HistoryManager(this)
-
-        sharedPreferences = PreferenceManager.getDefaultSharedPreferences(applicationContext)
-        settings = Settings(sharedPreferences)
-        servoView.setExperimentalMode(settings.experimental)
 
         setContent {
             val isWindowWidthAtLeastMedium = currentWindowAdaptiveInfo().windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND)

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.kt
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.kt
@@ -23,12 +23,11 @@ class ServoView(
     client: Servo.Client,
     servoArgs: String?,
     servoLog: String?,
+    private val experimentalMode: Boolean,
 ) : SurfaceView(context), Servo.RunCallback, Choreographer.FrameCallback {
     private val glThread: GLThread
     private var servo: Servo? = null
     private var initialUri: String? = null
-
-    private var experimentalMode = false
 
     init {
         isFocusable = true
@@ -132,7 +131,7 @@ class ServoView(
     }
 
     fun setExperimentalMode(enable: Boolean) {
-        servo?.setExperimentalMode(enable) ?: run { experimentalMode = enable }
+        servo!!.setExperimentalMode(enable)
     }
 
     private class GLThread : Thread() {


### PR DESCRIPTION
Makes it self-evident that passing `experimentalMode` during construction is part of the initialisation phase of the JNI.

`setExperimentalMode` now contains a non-null assertion, but that will be removed as `servo` becomes non-null in a future PR.

Testing: There are no automated tests for Android.