### PR TITLE
mach: fix always-true dpkg installed-check in Linux bootstrap

### DIFF
--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -154,7 +154,7 @@ class Linux(Base):
                         missing_pkgs,
                     )
 
-            if subprocess.call(["dpkg", "-s"] + pkgs, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE) != 0:
+            if subprocess.call(["dpkg", "-s"] + pkgs, stdout=subprocess.PIPE, stderr=subprocess.PIPE) != 0:
                 install = True
         elif self.distro in ["CentOS", "CentOS Linux", "Fedora", "Fedora Linux", "Fedora Linux Asahi Remix"]:
             command = ["dnf", "install"]


### PR DESCRIPTION
`subprocess.call(["dpkg", "-s"] + pkgs, shell=True, ...)` with a list argument executes bare `dpkg` with no arguments (the list items after the first become shell positional parameters), which always exits non-zero. The installed-package check therefore always reports packages as missing, so `./mach bootstrap` re-runs package installation (and its sudo prompt) on every invocation even when every dependency is already installed, and fails outright where sudo has no TTY. Drop `shell=True` so `dpkg -s` actually receives the package list and the check works as intended.

Testing: Verified manually on Ubuntu 24.04 arm64 (RK3588): with all dependencies installed, `./mach bootstrap` previously always invoked apt via sudo; with this change it correctly skips installation and completes without sudo. Tooling-only change; no automated tests.