### PR TITLE
media: disconnect setup error handler from the object it was connected to

### DIFF
--- a/components/media/backends/gstreamer/player.rs
+++ b/components/media/backends/gstreamer/player.rs
@@ -924,7 +924,7 @@ impl GStreamerPlayer {
         };
 
         let result = receiver.recv().unwrap();
-        glib::signal::signal_handler_disconnect(&inner.lock().unwrap().player, error_handler_id);
+        glib::signal::signal_handler_disconnect(&inner.lock().unwrap()._signal_adapter, error_handler_id);
         result
     }
 }


### PR DESCRIPTION
In the GStreamer player setup path, `error_handler_id` is returned by `signal_adapter.connect_error(...)` but is then disconnected from the `Play` object instead of the `PlaySignalAdapter`. GLib refuses the mismatched disconnect, logging a deterministic `GLib-GObject-CRITICAL` on every media element setup, and the temporary setup error handler — whose callback calls `stop()` — is silently left connected for the player's lifetime, so a later error signal can stop playback unexpectedly. Disconnect the handler from the adapter it was connected to.

Testing: Verified manually on Linux arm64 (RK3588, GStreamer 1.24): the per-setup GLib CRITICAL no longer appears (it previously reproduced with the same handler id on every run). Related hardware context in #47701. No automated test; the mismatched disconnect is directly observable as the CRITICAL.