### PR TITLE
embedder: Observe resource load lifecycle

### DIFF
--- a/components/net/embedder.rs
+++ b/components/net/embedder.rs
@@ -6,8 +6,8 @@ use std::path::PathBuf;
 
 use cookie::Cookie;
 use embedder_traits::{
-    AuthenticationResponse, EmbedderControlId, FilePickerRequest, WebResourceRequest,
-    WebResourceResponseMsg,
+    AuthenticationResponse, EmbedderControlId, FilePickerRequest, WebResourceLoadCompleted,
+    WebResourceRequest, WebResourceResponseMsg, WebResourceResponseReceived,
 };
 use net_traits::CookieOperationId;
 use servo_base::id::WebViewId;
@@ -28,6 +28,11 @@ pub enum NetToEmbedderMsg {
         WebResourceRequest,
         TokioSender<WebResourceResponseMsg>,
     ),
+    /// Read-only metadata for a response Servo received without requiring the
+    /// embedder to intercept or replace the resource.
+    WebResourceResponseReceived(Option<WebViewId>, Box<WebResourceResponseReceived>),
+    /// Read-only completion or failure metadata for a resource Servo loaded.
+    WebResourceLoadCompleted(Option<WebViewId>, Box<WebResourceLoadCompleted>),
     /// Request authentication for a load or navigation from the embedder.
     RequestAuthentication(
         WebViewId,

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -844,10 +844,20 @@ pub async fn main_fetch(
     if request.synchronous {
         // process_response is not supposed to be used
         // by sync fetch, but we overload it here for simplicity
+        context
+            .request_interceptor
+            .lock()
+            .await
+            .notify_response_received(request, &response);
         target.process_response(request, &response);
         if !response_loaded {
             wait_for_response(request, &mut response, target, done_chan, context).await;
         }
+        context
+            .request_interceptor
+            .lock()
+            .await
+            .notify_load_completed(request, &response);
         // overloaded similarly to process_response
         target.process_response_eof(request, &response);
         return response;
@@ -863,6 +873,11 @@ pub async fn main_fetch(
     }
 
     // Step 22.
+    context
+        .request_interceptor
+        .lock()
+        .await
+        .notify_response_received(request, &response);
     target.process_response(request, &response);
     // Send Response to Devtools
     send_response_to_devtools(request, context, &response, None);
@@ -874,6 +889,11 @@ pub async fn main_fetch(
     }
 
     // Step 24.
+    context
+        .request_interceptor
+        .lock()
+        .await
+        .notify_load_completed(request, &response);
     target.process_response_eof(request, &response);
     // Send Response to Devtools
     // This is done after process_response_eof to ensure that the body is fully

--- a/components/net/request_interceptor.rs
+++ b/components/net/request_interceptor.rs
@@ -3,7 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use content_security_policy::Destination;
-use embedder_traits::{GenericEmbedderProxy, WebResourceRequest, WebResourceResponseMsg};
+use embedder_traits::{
+    GenericEmbedderProxy, WebResourceLoadCompleted, WebResourceLoadError, WebResourceLoadId,
+    WebResourceRequest, WebResourceResponse, WebResourceResponseMsg, WebResourceResponseReceived,
+};
 use log::error;
 use net_traits::NetworkError;
 use net_traits::http_status::HttpStatus;
@@ -30,16 +33,7 @@ impl RequestInterceptor {
         context: &FetchContext,
     ) {
         let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
-        let is_for_main_frame = matches!(request.destination, Destination::Document);
-        let web_resource_request = WebResourceRequest {
-            method: request.method.clone(),
-            url: request.url().into_url(),
-            headers: request.headers.clone(),
-            destination: request.destination,
-            referrer_url: request.referrer.to_url().map(|url| url.as_url().clone()),
-            is_for_main_frame,
-            is_redirect: request.redirect_count > 0,
-        };
+        let web_resource_request = web_resource_request(request);
 
         self.embedder_proxy
             .send(NetToEmbedderMsg::WebResourceRequested(
@@ -85,5 +79,186 @@ impl RequestInterceptor {
                 WebResourceResponseMsg::DoNotIntercept => break,
             }
         }
+    }
+
+    pub fn notify_response_received(&self, request: &Request, response: &Response) {
+        if response.is_network_error() {
+            return;
+        }
+        let actual = response.actual_response();
+        let Some(url) = actual.url().map(|url| url.as_url().clone()) else {
+            return;
+        };
+        let Some(status_code) = actual.status.try_code() else {
+            return;
+        };
+        let observed = WebResourceResponseReceived {
+            load_id: web_resource_load_id(request),
+            request: web_resource_request(request),
+            response: WebResourceResponse::new(url)
+                .headers(actual.headers.clone())
+                .status_code(status_code)
+                .status_message(actual.status.message().to_vec()),
+        };
+        self.embedder_proxy
+            .send(NetToEmbedderMsg::WebResourceResponseReceived(
+                request.target_webview_id,
+                Box::new(observed),
+            ));
+    }
+
+    pub fn notify_load_completed(&self, request: &Request, response: &Response) {
+        let completed = WebResourceLoadCompleted {
+            load_id: web_resource_load_id(request),
+            request: web_resource_request(request),
+            error: response
+                .get_network_error()
+                .map(|error| WebResourceLoadError {
+                    message: format!("{error:?}"),
+                    is_cancelled: matches!(error, NetworkError::LoadCancelled),
+                }),
+        };
+        self.embedder_proxy
+            .send(NetToEmbedderMsg::WebResourceLoadCompleted(
+                request.target_webview_id,
+                Box::new(completed),
+            ));
+    }
+}
+
+fn web_resource_request(request: &Request) -> WebResourceRequest {
+    WebResourceRequest {
+        method: request.method.clone(),
+        url: request.url().into_url(),
+        headers: request.headers.clone(),
+        destination: request.destination,
+        referrer_url: request.referrer.to_url().map(|url| url.as_url().clone()),
+        is_for_main_frame: matches!(request.destination, Destination::Document),
+        is_redirect: request.redirect_count > 0,
+    }
+}
+
+fn web_resource_load_id(request: &Request) -> WebResourceLoadId {
+    WebResourceLoadId {
+        request_id: request.id.0,
+        redirect_index: request.redirect_count,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossbeam_channel::{Receiver, unbounded};
+    use embedder_traits::{EventLoopWaker, GenericEmbedderProxy};
+    use http::{HeaderValue, StatusCode};
+    use net_traits::blob_url_store::UrlWithBlobClaim;
+    use net_traits::request::{Referrer, RequestBuilder};
+    use net_traits::{NetworkError, ResourceFetchTiming, ResourceTimingType};
+    use servo_url::ServoUrl;
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct TestEventLoopWaker;
+
+    impl EventLoopWaker for TestEventLoopWaker {
+        fn wake(&self) {}
+
+        fn clone_box(&self) -> Box<dyn EventLoopWaker> {
+            Box::new(self.clone())
+        }
+    }
+
+    fn interceptor() -> (RequestInterceptor, Receiver<NetToEmbedderMsg>) {
+        let (sender, receiver) = unbounded();
+        let embedder_proxy = GenericEmbedderProxy {
+            sender,
+            event_loop_waker: Box::new(TestEventLoopWaker),
+        };
+        (RequestInterceptor::new(embedder_proxy), receiver)
+    }
+
+    fn request(url: &ServoUrl) -> Request {
+        RequestBuilder::new(
+            None,
+            UrlWithBlobClaim::new(url.clone(), None),
+            Referrer::NoReferrer,
+        )
+        .build()
+    }
+
+    #[test]
+    fn response_notification_preserves_request_identity_and_metadata() {
+        let (interceptor, receiver) = interceptor();
+        let url = ServoUrl::parse("https://example.com/download").unwrap();
+        let mut request = request(&url);
+        request.redirect_count = 2;
+        let mut response = Response::new(
+            url.clone(),
+            ResourceFetchTiming::new(ResourceTimingType::Resource),
+        );
+        response.status = HttpStatus::new(StatusCode::OK, b"OK".to_vec());
+        response.headers.insert(
+            "content-type",
+            HeaderValue::from_static("application/octet-stream"),
+        );
+
+        interceptor.notify_response_received(&request, &response);
+
+        let NetToEmbedderMsg::WebResourceResponseReceived(target_webview_id, observed) =
+            receiver.try_recv().unwrap()
+        else {
+            panic!("expected a web resource response notification");
+        };
+        assert_eq!(target_webview_id, request.target_webview_id);
+        assert_eq!(observed.load_id.request_id, request.id.0);
+        assert_eq!(observed.load_id.redirect_index, 2);
+        assert_eq!(observed.response.url, url.into_url());
+        assert_eq!(observed.response.status_code, StatusCode::OK);
+        assert_eq!(
+            observed.response.headers.get("content-type"),
+            Some(&HeaderValue::from_static("application/octet-stream"))
+        );
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn network_errors_do_not_emit_response_notifications() {
+        let (interceptor, receiver) = interceptor();
+        let url = ServoUrl::parse("https://example.com/failure").unwrap();
+        let request = request(&url);
+        let response = Response::network_error(NetworkError::ResourceLoadError(
+            "expected test failure".to_owned(),
+        ));
+
+        interceptor.notify_response_received(&request, &response);
+
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn completion_notification_reports_success_and_failure() {
+        let (interceptor, receiver) = interceptor();
+        let url = ServoUrl::parse("https://example.com/resource").unwrap();
+        let request = request(&url);
+        let response = Response::new(url, ResourceFetchTiming::new(ResourceTimingType::Resource));
+
+        interceptor.notify_load_completed(&request, &response);
+
+        let NetToEmbedderMsg::WebResourceLoadCompleted(_, completed) = receiver.try_recv().unwrap()
+        else {
+            panic!("expected a web resource completion notification");
+        };
+        assert_eq!(completed.load_id.request_id, request.id.0);
+        assert!(completed.error.is_none());
+
+        let response = Response::network_error(NetworkError::LoadCancelled);
+        interceptor.notify_load_completed(&request, &response);
+        let NetToEmbedderMsg::WebResourceLoadCompleted(_, completed) = receiver.try_recv().unwrap()
+        else {
+            panic!("expected a web resource failure notification");
+        };
+        let error = completed.error.expect("expected a load error");
+        assert!(error.is_cancelled);
+        assert_eq!(error.message, "Load cancelled");
     }
 }

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, SystemTime};
 
 use content_security_policy as csp;
-use crossbeam_channel::{Sender, unbounded};
+use crossbeam_channel::{Receiver, Sender, unbounded};
 use devtools_traits::{HttpRequest as DevtoolsHttpRequest, HttpResponse as DevtoolsHttpResponse};
 use headers::{
     AccessControlAllowCredentials, AccessControlAllowHeaders, AccessControlAllowMethods,
@@ -56,6 +56,118 @@ use crate::{
 };
 
 // TODO write a struct that impls Handler for storing test values
+
+struct ObservedResourceLoad {
+    response: Option<embedder_traits::WebResourceResponseReceived>,
+    completed: embedder_traits::WebResourceLoadCompleted,
+}
+
+fn collect_resource_load(
+    receiver: Receiver<net::embedder::NetToEmbedderMsg>,
+) -> ObservedResourceLoad {
+    let mut response = None;
+    loop {
+        match receiver.recv().unwrap() {
+            net::embedder::NetToEmbedderMsg::WebResourceRequested(_, _, response_sender) => {
+                response_sender
+                    .send(embedder_traits::WebResourceResponseMsg::DoNotIntercept)
+                    .unwrap();
+            },
+            net::embedder::NetToEmbedderMsg::WebResourceResponseReceived(_, received) => {
+                response = Some(*received);
+            },
+            net::embedder::NetToEmbedderMsg::WebResourceLoadCompleted(_, completed) => {
+                return ObservedResourceLoad {
+                    response,
+                    completed: *completed,
+                };
+            },
+            _ => {},
+        }
+    }
+}
+
+fn fetch_with_resource_observer(request: Request) -> (Response, ObservedResourceLoad) {
+    let (embedder_proxy, receiver) = create_generic_embedder_proxy_and_receiver();
+    let observer = std::thread::spawn(move || collect_resource_load(receiver));
+    let mut context = new_fetch_context(None, Some(embedder_proxy));
+    let response = fetch_with_context(request, &mut context);
+    (response, observer.join().unwrap())
+}
+
+fn successful_observed_fetch(destination: Destination) -> ObservedResourceLoad {
+    let handler = |_: HyperRequest<Incoming>,
+                   response: &mut HyperResponse<BoxBody<Bytes, hyper::Error>>| {
+        *response.body_mut() = make_body(b"observed".to_vec());
+    };
+    let (_server, url) = make_server(handler);
+    let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
+        .destination(destination)
+        .origin(url.origin())
+        .policy_container(Default::default())
+        .build();
+
+    let (response, observed) = fetch_with_resource_observer(request);
+    assert!(!response.is_network_error());
+    observed
+}
+
+fn failed_observed_fetch(destination: Destination) -> ObservedResourceLoad {
+    let url = ServoUrl::parse("http://example.org:6667").unwrap();
+    let request = RequestBuilder::new(
+        Some(TEST_WEBVIEW_ID),
+        UrlWithBlobClaim::new(url.clone(), None),
+        Referrer::NoReferrer,
+    )
+    .destination(destination)
+    .origin(url.origin())
+    .policy_container(Default::default())
+    .build();
+
+    let (response, observed) = fetch_with_resource_observer(request);
+    assert!(response.is_network_error());
+    observed
+}
+
+#[test]
+fn observes_successful_top_level_navigation() {
+    let observed = successful_observed_fetch(Destination::Document);
+    let response = observed.response.expect("expected response metadata");
+    assert!(response.request.is_for_main_frame);
+    assert_eq!(response.request.destination, Destination::Document);
+    assert!(observed.completed.error.is_none());
+}
+
+#[test]
+fn observes_successful_nested_navigation() {
+    let observed = successful_observed_fetch(Destination::IFrame);
+    let response = observed.response.expect("expected response metadata");
+    assert!(!response.request.is_for_main_frame);
+    assert_eq!(response.request.destination, Destination::IFrame);
+    assert!(observed.completed.error.is_none());
+}
+
+#[test]
+fn observes_failed_navigation() {
+    let observed = failed_observed_fetch(Destination::Document);
+    assert!(observed.response.is_none());
+    assert!(observed.completed.error.is_some());
+}
+
+#[test]
+fn observes_successful_non_navigation_resource() {
+    let observed = successful_observed_fetch(Destination::Script);
+    let response = observed.response.expect("expected response metadata");
+    assert_eq!(response.request.destination, Destination::Script);
+    assert!(observed.completed.error.is_none());
+}
+
+#[test]
+fn observes_failed_non_navigation_resource() {
+    let observed = failed_observed_fetch(Destination::Script);
+    assert!(observed.response.is_none());
+    assert!(observed.completed.error.is_some());
+}
 
 #[test]
 fn test_fetch_response_is_not_network_error() {

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -1805,7 +1805,9 @@ fn test_dont_prompt_credentials_when_unauthorized_response_contains_no_www_authe
                         "Should not have requested authentication as there's no www-authenticate header"
                     );
                 },
-                net::embedder::NetToEmbedderMsg::WebResourceRequested(..) => {},
+                net::embedder::NetToEmbedderMsg::WebResourceRequested(..) |
+                net::embedder::NetToEmbedderMsg::WebResourceResponseReceived(..) |
+                net::embedder::NetToEmbedderMsg::WebResourceLoadCompleted(..) => {},
                 _ => unreachable!(),
             }
         }

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -436,6 +436,24 @@ impl ServoInner {
                     self.delegate.borrow().load_web_resource(web_resource_load);
                 }
             },
+            NetToEmbedderMsg::WebResourceResponseReceived(webview_id, response) => {
+                if let Some(webview) =
+                    webview_id.and_then(|webview_id| self.get_webview_handle(webview_id))
+                {
+                    webview
+                        .delegate()
+                        .notify_web_resource_response_received(webview, *response);
+                }
+            },
+            NetToEmbedderMsg::WebResourceLoadCompleted(webview_id, completed) => {
+                if let Some(webview) =
+                    webview_id.and_then(|webview_id| self.get_webview_handle(webview_id))
+                {
+                    webview
+                        .delegate()
+                        .notify_web_resource_load_completed(webview, *completed);
+                }
+            },
             NetToEmbedderMsg::RequestAuthentication(
                 webview_id,
                 url,

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -12,7 +12,8 @@ use embedder_traits::{
     FilterPattern, InputEventId, InputEventResult, InputMethodType, LoadStatus, MediaSessionEvent,
     NewWebViewDetails, Notification, PermissionFeature, PromptResponse, RgbColor, ScreenGeometry,
     SelectElementOptionOrOptgroup, SelectElementRequest, SimpleDialogRequest, TraversalId,
-    WebResourceRequest, WebResourceResponse, WebResourceResponseMsg,
+    WebResourceLoadCompleted, WebResourceRequest, WebResourceResponse, WebResourceResponseMsg,
+    WebResourceResponseReceived,
 };
 use paint_api::rendering_context::RenderingContext;
 use servo_base::generic_channel::{GenericCallback, GenericSender, SendError};
@@ -1068,6 +1069,25 @@ pub trait WebViewDelegate {
     /// For loads not associated with a [`WebView`], such as those for service workers, Servo
     /// will call [`crate::ServoDelegate::load_web_resource`].
     fn load_web_resource(&self, _webview: WebView, _load: WebResourceLoad) {}
+
+    /// Notify the embedder of read-only request and response metadata after
+    /// Servo receives an HTTP response. Unlike [`Self::load_web_resource`],
+    /// this callback cannot mutate, cancel, or replace the load.
+    fn notify_web_resource_response_received(
+        &self,
+        _webview: WebView,
+        _response: WebResourceResponseReceived,
+    ) {
+    }
+
+    /// Notify the embedder that a resource completed or failed. This callback
+    /// is observational and cannot mutate or cancel the load.
+    fn notify_web_resource_load_completed(
+        &self,
+        _webview: WebView,
+        _completed: WebResourceLoadCompleted,
+    ) {
+    }
 
     /// Request to display a notification.
     fn show_notification(&self, _webview: WebView, _notification: Notification) {}

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -673,6 +673,14 @@ pub enum GamepadHapticEffectType {
 }
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+pub struct WebResourceLoadId {
+    /// Stable identity for the Fetch request across redirects.
+    pub request_id: Uuid,
+    /// Zero-based redirect generation within the request.
+    pub redirect_index: u32,
+}
+
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct WebResourceRequest {
     #[serde(
         deserialize_with = "::hyper_serde::deserialize",
@@ -689,6 +697,31 @@ pub struct WebResourceRequest {
     pub referrer_url: Option<Url>,
     pub is_for_main_frame: bool,
     pub is_redirect: bool,
+}
+
+/// Read-only request and response metadata observed after Servo receives an
+/// HTTP response. This notification cannot mutate, cancel, or replace a load.
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+pub struct WebResourceResponseReceived {
+    pub load_id: WebResourceLoadId,
+    pub request: WebResourceRequest,
+    pub response: WebResourceResponse,
+}
+
+/// Read-only completion metadata for a resource Servo loaded. A missing error
+/// indicates success; failures and cancellations retain the same load identity
+/// used by [`WebResourceResponseReceived`].
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+pub struct WebResourceLoadCompleted {
+    pub load_id: WebResourceLoadId,
+    pub request: WebResourceRequest,
+    pub error: Option<WebResourceLoadError>,
+}
+
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+pub struct WebResourceLoadError {
+    pub message: String,
+    pub is_cancelled: bool,
 }
 
 #[derive(Clone, Deserialize, Serialize)]


### PR DESCRIPTION
## Summary

Expose read-only per-resource response and completion notifications through `WebViewDelegate`. The notifications cover normal and failed loads without requiring the embedder to intercept or replace them and are correlated across redirects.

## Problem

Servo embedders can intercept web resources but cannot observe the response or completion of loads Servo performs itself. That prevents network inspection, HAR-style capture, and reliable download classification without taking ownership of fetch.

## Root cause

The fetch layer previously delivered response and completion state only to internal fetch targets and DevTools. No non-mutating lifecycle event crossed the network-to-embedder boundary.

## Solution

Add `WebResourceResponseReceived` and `WebResourceLoadCompleted` observer payloads with a stable request UUID plus redirect index. The fetch owner emits response metadata when headers arrive and a correlated completion event after body processing, including failure and cancellation details. Servo routes these boxed payloads to the owning `WebViewDelegate`; handlers cannot mutate or cancel the load.

Response-body access is intentionally deferred, following the scope discussed in #47572.

## Behavior changes

- WebView delegates may observe request/response metadata for successful resource loads.
- WebView delegates receive a correlated success, failure, or cancellation completion event.
- Existing interception and replacement behavior is unchanged.
- Loads without a WebView do not produce a delegate callback.

## Validation

- [x] `cargo test -p servo-net request_interceptor` — 3 passed.
- [x] `cargo test -p servo-net observes_` — 5 passed, covering successful top-level navigation, successful nested navigation, failed navigation, successful non-navigation fetch, and failed non-navigation fetch.
- [x] `cargo check -p servo`.
- [x] `cargo clippy -p servo-net -p servo --lib` — completed with existing unrelated warnings.
- [ ] `cargo test -p servo-net` — 393 passed; `filemanager_thread::test_filemanager` hit the existing process-global runtime initialization failure in aggregate and passed on exact isolated rerun.
- [ ] Full platform CI — pending draft PR CI.

## Risk and rollback

The new events add one boxed network-to-embedder message when response metadata arrives and one at completion. Embedders that do not override the default delegate methods discard them. Reverting this commit restores the prior behavior without persistence or migration work.

## Dependencies

Part of #47572. No prerequisite pull requests.

## Review focus

Please review the request-ID and redirect-index semantics, the response/completion emission points, and whether the committed request metadata should move deeper into `http_loader` to include every network-added request header. Response body transport and authenticated-download decisions are explicitly outside this PR.

## Checklist

- [x] The PR contains one logical change.
- [x] The full diff has been self-reviewed.
- [x] Unrelated formatting and refactoring are excluded.
- [x] New behavior has automated tests where practical.
- [x] Existing tests were updated when behavior changed.
- [x] Failure paths and invalid input are handled.
- [x] Logs do not expose secrets or sensitive information.
- [x] Documentation was updated when contracts changed.
- [x] The branch is ready for review rather than exploratory work.
- [ ] All reviewer conversations are resolved.