### PR TITLE
release: Bump version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5266,7 +5266,7 @@ dependencies = [
 
 [[package]]
 name = "malloc_size_of_tests"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "servo-malloc-size-of",
  "servo_arc",
@@ -7146,7 +7146,7 @@ dependencies = [
 
 [[package]]
 name = "profile_tests"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "ipc-channel",
  "servo-base",
@@ -7862,7 +7862,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script_tests"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "encoding_rs",
  "euclid",
@@ -8107,7 +8107,7 @@ dependencies = [
 
 [[package]]
 name = "servo"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -8187,7 +8187,7 @@ dependencies = [
 
 [[package]]
 name = "servo-allocator"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "backtrace",
  "libc",
@@ -8200,7 +8200,7 @@ dependencies = [
 
 [[package]]
 name = "servo-background-hang-monitor"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "backtrace",
  "crossbeam-channel",
@@ -8217,7 +8217,7 @@ dependencies = [
 
 [[package]]
 name = "servo-background-hang-monitor-api"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "servo-base",
@@ -8225,7 +8225,7 @@ dependencies = [
 
 [[package]]
 name = "servo-base"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "accesskit",
  "crossbeam-channel",
@@ -8249,7 +8249,7 @@ dependencies = [
 
 [[package]]
 name = "servo-bluetooth"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitflags 2.13.1",
  "blurmock",
@@ -8267,7 +8267,7 @@ dependencies = [
 
 [[package]]
 name = "servo-bluetooth-traits"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "regex",
  "serde",
@@ -8277,7 +8277,7 @@ dependencies = [
 
 [[package]]
 name = "servo-canvas"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bytemuck",
  "crossbeam-channel",
@@ -8306,7 +8306,7 @@ dependencies = [
 
 [[package]]
 name = "servo-canvas-traits"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -8328,7 +8328,7 @@ dependencies = [
 
 [[package]]
 name = "servo-capi"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "dpi",
  "libc",
@@ -8339,14 +8339,14 @@ dependencies = [
 
 [[package]]
 name = "servo-capi-tests"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "servo-config"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "num_enum",
  "serde",
@@ -8358,7 +8358,7 @@ dependencies = [
 
 [[package]]
 name = "servo-config-macro"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8368,7 +8368,7 @@ dependencies = [
 
 [[package]]
 name = "servo-constellation"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "accesskit",
  "backtrace",
@@ -8415,7 +8415,7 @@ dependencies = [
 
 [[package]]
 name = "servo-constellation-traits"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base64 0.23.1",
  "content-security-policy",
@@ -8451,14 +8451,14 @@ dependencies = [
 
 [[package]]
 name = "servo-default-resources"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "servo-embedder-traits",
 ]
 
 [[package]]
 name = "servo-deny-public-fields"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "syn 2.0.119",
@@ -8467,7 +8467,7 @@ dependencies = [
 
 [[package]]
 name = "servo-devtools"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "atomic_refcell",
  "base64 0.23.1",
@@ -8496,7 +8496,7 @@ dependencies = [
 
 [[package]]
 name = "servo-devtools-traits"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "http 1.5.0",
@@ -8513,7 +8513,7 @@ dependencies = [
 
 [[package]]
 name = "servo-dom-struct"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -8523,7 +8523,7 @@ dependencies = [
 
 [[package]]
 name = "servo-embedder-traits"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "accesskit",
  "bitflags 2.13.1",
@@ -8556,7 +8556,7 @@ dependencies = [
 
 [[package]]
 name = "servo-fonts"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -8615,7 +8615,7 @@ dependencies = [
 
 [[package]]
 name = "servo-fonts-traits"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "atomic_refcell",
  "dwrote",
@@ -8639,7 +8639,7 @@ dependencies = [
 
 [[package]]
 name = "servo-geometry"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "app_units",
  "euclid",
@@ -8651,7 +8651,7 @@ dependencies = [
 
 [[package]]
 name = "servo-hyper-serde"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "cookie 0.18.2",
  "headers",
@@ -8668,7 +8668,7 @@ dependencies = [
 
 [[package]]
 name = "servo-jstraceable-derive"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "syn 2.0.119",
@@ -8677,7 +8677,7 @@ dependencies = [
 
 [[package]]
 name = "servo-layout"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "accesskit",
  "app_units",
@@ -8738,7 +8738,7 @@ dependencies = [
 
 [[package]]
 name = "servo-layout-api"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -8771,7 +8771,7 @@ dependencies = [
 
 [[package]]
 name = "servo-malloc-size-of"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -8816,7 +8816,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "servo-base",
  "servo-media-audio",
@@ -8828,7 +8828,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-audio"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "byte-slice-cast",
  "euclid",
@@ -8852,7 +8852,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-auto"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "servo-media-dummy",
  "servo-media-gstreamer",
@@ -8860,7 +8860,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-derive"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8869,7 +8869,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-dummy"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "servo-base",
  "servo-media",
@@ -8882,7 +8882,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-examples"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "euclid",
  "freetype-sys",
@@ -8895,7 +8895,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "byte-slice-cast",
  "data-url",
@@ -8926,7 +8926,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "gstreamer",
  "servo-media-player",
@@ -8934,7 +8934,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render-android"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8947,7 +8947,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render-unix"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8962,7 +8962,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-ohos"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "crossbeam-channel",
  "libc",
@@ -8984,7 +8984,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-player"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "malloc_size_of_derive",
  "serde",
@@ -8996,7 +8996,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-streams"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "malloc_size_of_derive",
  "servo-malloc-size-of",
@@ -9005,7 +9005,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-thread"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "euclid",
  "ipc-channel",
@@ -9023,7 +9023,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-traits"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "malloc_size_of_derive",
  "servo-malloc-size-of",
@@ -9031,7 +9031,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-webrtc"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "log",
  "servo-media-streams",
@@ -9040,7 +9040,7 @@ dependencies = [
 
 [[package]]
 name = "servo-metrics"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "malloc_size_of_derive",
  "servo-base",
@@ -9054,7 +9054,7 @@ dependencies = [
 
 [[package]]
 name = "servo-net"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-compression",
  "async-recursion",
@@ -9134,7 +9134,7 @@ dependencies = [
 
 [[package]]
 name = "servo-net-traits"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "content-security-policy",
@@ -9177,7 +9177,7 @@ dependencies = [
 
 [[package]]
 name = "servo-paint"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitflags 2.13.1",
  "crossbeam-channel",
@@ -9216,7 +9216,7 @@ dependencies = [
 
 [[package]]
 name = "servo-paint-api"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitflags 2.13.1",
  "crossbeam-channel",
@@ -9251,7 +9251,7 @@ dependencies = [
 
 [[package]]
 name = "servo-pixels"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "euclid",
@@ -9266,7 +9266,7 @@ dependencies = [
 
 [[package]]
 name = "servo-profile"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "libc",
  "log",
@@ -9283,7 +9283,7 @@ dependencies = [
 
 [[package]]
 name = "servo-profile-traits"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "crossbeam-channel",
  "ipc-channel",
@@ -9299,7 +9299,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -9449,7 +9449,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script-bindings"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "atomic_refcell",
  "bitflags 2.13.1",
@@ -9493,7 +9493,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script-traits"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "accesskit",
  "bitflags 2.13.1",
@@ -9529,7 +9529,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script-webgpu"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "indexmap",
  "log",
@@ -9550,7 +9550,7 @@ dependencies = [
 
 [[package]]
 name = "servo-storage"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "libc",
  "log",
@@ -9577,7 +9577,7 @@ dependencies = [
 
 [[package]]
 name = "servo-storage-traits"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "malloc_size_of_derive",
  "serde",
@@ -9590,7 +9590,7 @@ dependencies = [
 
 [[package]]
 name = "servo-timers"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "crossbeam-channel",
  "malloc_size_of_derive",
@@ -9599,7 +9599,7 @@ dependencies = [
 
 [[package]]
 name = "servo-tracing"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -9609,7 +9609,7 @@ dependencies = [
 
 [[package]]
 name = "servo-url"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "encoding_rs",
  "malloc_size_of_derive",
@@ -9622,7 +9622,7 @@ dependencies = [
 
 [[package]]
 name = "servo-wakelock"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "servo-embedder-traits",
@@ -9630,7 +9630,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webdriver-server"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -9661,7 +9661,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgl"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitflags 2.13.1",
  "byteorder",
@@ -9686,7 +9686,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgpu"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arrayvec",
  "euclid",
@@ -9704,7 +9704,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgpu-traits"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arrayvec",
  "malloc_size_of_derive",
@@ -9719,7 +9719,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webvtt"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "html5ever",
  "markup5ever",
@@ -9729,7 +9729,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webxr"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -9747,7 +9747,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webxr-api"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "euclid",
  "ipc-channel",
@@ -9762,7 +9762,7 @@ dependencies = [
 
 [[package]]
 name = "servo-xpath"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "log",
  "malloc_size_of_derive",
@@ -9781,7 +9781,7 @@ dependencies = [
 
 [[package]]
 name = "servoshell"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "accesskit",
  "android_logger",
@@ -10250,7 +10250,7 @@ dependencies = [
 
 [[package]]
 name = "style_tests"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "app_units",
  "cssparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default-members = ["ports/servoshell"]
 exclude = [".cargo", "support/crown"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 authors = ["The Servo Project Developers"]
 repository = "https://github.com/servo/servo"
 # A generic description for packages that don't have a meaningful description yet.
@@ -303,74 +303,74 @@ zeroize = "1.8"
 # be listed here, between the `Begin` and `End` comments, so that we can easily find and
 # update the version requirements when bumping the workspace version.
 # Begin workspace-version dependencies - Don't change this comment, we grep for it in scripts!
-deny_public_fields = { package = "servo-deny-public-fields", version = "=0.5.0", path = "components/deny_public_fields" }
-devtools = { package = "servo-devtools", version = "=0.5.0", path = "components/devtools" }
-devtools_traits = { package = "servo-devtools-traits", version = "=0.5.0", path = "components/shared/devtools" }
-dom_struct = { package = "servo-dom-struct", version = "=0.5.0", path = "components/dom_struct" }
-embedder_traits = { package = "servo-embedder-traits", version = "=0.5.0", path = "components/shared/embedder" }
-fonts = { package = "servo-fonts", version = "=0.5.0", path = "components/fonts" }
-fonts_traits = { package = "servo-fonts-traits", version = "=0.5.0", path = "components/shared/fonts" }
-hyper_serde = { package = "servo-hyper-serde", version = "=0.5.0", path = "components/hyper_serde" }
-jstraceable_derive = { package = "servo-jstraceable-derive", version = "=0.5.0", path = "components/jstraceable_derive" }
-layout = { package = "servo-layout", version = "=0.5.0", path = "components/layout" }
-layout_api = { package = "servo-layout-api", version = "=0.5.0", path = "components/shared/layout" }
-malloc_size_of = { package = "servo-malloc-size-of", version = "=0.5.0", path = "components/malloc_size_of" }
-media = { package = "servo-media-thread", version = "=0.5.0", path = "components/media/media-thread" }
-metrics = { package = "servo-metrics", version = "=0.5.0", path = "components/metrics" }
-net = { package = "servo-net", version = "=0.5.0", path = "components/net" }
-net_traits = { package = "servo-net-traits", version = "=0.5.0", path = "components/shared/net" }
-paint = { package = "servo-paint", version = "=0.5.0", path = "components/paint" }
-paint_api = { package = "servo-paint-api", version = "=0.5.0", path = "components/shared/paint" }
-pixels = { package = "servo-pixels", version = "=0.5.0", path = "components/pixels" }
-profile = { package = "servo-profile", version = "=0.5.0", path = "components/profile" }
-profile_traits = { package = "servo-profile-traits", version = "=0.5.0", path = "components/shared/profile" }
-script = { package = "servo-script", version = "=0.5.0", path = "components/script" }
-script_bindings = { package = "servo-script-bindings", version = "=0.5.0", path = "components/script_bindings" }
-script_webgpu = { package = "servo-script-webgpu", version = "=0.5.0", path = "components/script_webgpu" }
-script_traits = { package = "servo-script-traits", version = "=0.5.0", path = "components/shared/script" }
-servo = { version = "=0.5.0", path = "components/servo", default-features = false }
-servo-allocator = { version = "=0.5.0", path = "components/allocator" }
-servo-background-hang-monitor = { version = "=0.5.0", path = "components/background_hang_monitor" }
-servo-background-hang-monitor-api = { version = "=0.5.0", path = "components/shared/background_hang_monitor" }
-servo-base = { version = "=0.5.0", path = "components/shared/base" }
-servo-bluetooth = { version = "=0.5.0", path = "components/bluetooth" }
-servo-bluetooth-traits = { version = "=0.5.0", path = "components/shared/bluetooth" }
-servo-canvas = { version = "=0.5.0", path = "components/canvas" }
-servo-canvas-traits = { version = "=0.5.0", path = "components/shared/canvas" }
-servo-config = { version = "=0.5.0", path = "components/config" }
-servo-config-macro = { version = "=0.5.0", path = "components/config/macro" }
-servo-constellation = { version = "=0.5.0", path = "components/constellation" }
-servo-constellation-traits = { version = "=0.5.0", path = "components/shared/constellation" }
-servo-default-resources = { version = "=0.5.0", path = "components/default-resources" }
-servo-geometry = { version = "=0.5.0", path = "components/geometry" }
-servo-media = { version = "=0.5.0", path = "components/media/servo-media" }
-servo-media-audio = { version = "=0.5.0", path = "components/media/audio" }
-servo-media-auto = { version = "=0.5.0", path = "components/media/backends/auto" }
-servo-media-derive = { version = "=0.5.0", path = "components/media/servo-media-derive" }
-servo-media-dummy = { version = "=0.5.0", path = "components/media/backends/dummy" }
-servo-media-gstreamer = { version = "=0.5.0", path = "components/media/backends/gstreamer" }
-servo-media-gstreamer-render = { version = "=0.5.0", path = "components/media/backends/gstreamer/render" }
-servo-media-gstreamer-render-android = { version = "=0.5.0", path = "components/media/backends/gstreamer/render-android" }
-servo-media-gstreamer-render-unix = { version = "=0.5.0", path = "components/media/backends/gstreamer/render-unix" }
-servo-media-ohos = { version = "=0.5.0", path = "components/media/backends/ohos" }
-servo-media-player = { version = "=0.5.0", path = "components/media/player" }
-servo-media-streams = { version = "=0.5.0", path = "components/media/streams" }
-servo-media-traits = { version = "=0.5.0", path = "components/media/traits" }
-servo-media-webrtc = { version = "=0.5.0", path = "components/media/webrtc" }
-servo-tracing = { version = "=0.5.0", path = "components/servo_tracing" }
-servo-url = { version = "=0.5.0", path = "components/url" }
-servo-wakelock = { version = "=0.5.0", path = "components/wakelock" }
-servo-webvtt = { version = "=0.5.0", path = "components/webvtt" }
-storage = { package = "servo-storage", version = "=0.5.0", path = "components/storage" }
-storage_traits = { package = "servo-storage-traits", version = "=0.5.0", path = "components/shared/storage" }
-timers = { package = "servo-timers", version = "=0.5.0", path = "components/timers" }
-webdriver_server = { package = "servo-webdriver-server", version = "=0.5.0", path = "components/webdriver_server" }
-webgl = { package = "servo-webgl", version = "=0.5.0", path = "components/webgl", default-features = false }
-webgpu = { package = "servo-webgpu", version = "=0.5.0", path = "components/webgpu" }
-webgpu_traits = { package = "servo-webgpu-traits", version = "=0.5.0", path = "components/shared/webgpu" }
-webxr = { package = "servo-webxr", version = "=0.5.0", path = "components/webxr" }
-webxr-api = { package = "servo-webxr-api", version = "=0.5.0", path = "components/shared/webxr" }
-xpath = { package = "servo-xpath", version = "=0.5.0", path = "components/xpath" }
+deny_public_fields = { package = "servo-deny-public-fields", version = "=0.6.0", path = "components/deny_public_fields" }
+devtools = { package = "servo-devtools", version = "=0.6.0", path = "components/devtools" }
+devtools_traits = { package = "servo-devtools-traits", version = "=0.6.0", path = "components/shared/devtools" }
+dom_struct = { package = "servo-dom-struct", version = "=0.6.0", path = "components/dom_struct" }
+embedder_traits = { package = "servo-embedder-traits", version = "=0.6.0", path = "components/shared/embedder" }
+fonts = { package = "servo-fonts", version = "=0.6.0", path = "components/fonts" }
+fonts_traits = { package = "servo-fonts-traits", version = "=0.6.0", path = "components/shared/fonts" }
+hyper_serde = { package = "servo-hyper-serde", version = "=0.6.0", path = "components/hyper_serde" }
+jstraceable_derive = { package = "servo-jstraceable-derive", version = "=0.6.0", path = "components/jstraceable_derive" }
+layout = { package = "servo-layout", version = "=0.6.0", path = "components/layout" }
+layout_api = { package = "servo-layout-api", version = "=0.6.0", path = "components/shared/layout" }
+malloc_size_of = { package = "servo-malloc-size-of", version = "=0.6.0", path = "components/malloc_size_of" }
+media = { package = "servo-media-thread", version = "=0.6.0", path = "components/media/media-thread" }
+metrics = { package = "servo-metrics", version = "=0.6.0", path = "components/metrics" }
+net = { package = "servo-net", version = "=0.6.0", path = "components/net" }
+net_traits = { package = "servo-net-traits", version = "=0.6.0", path = "components/shared/net" }
+paint = { package = "servo-paint", version = "=0.6.0", path = "components/paint" }
+paint_api = { package = "servo-paint-api", version = "=0.6.0", path = "components/shared/paint" }
+pixels = { package = "servo-pixels", version = "=0.6.0", path = "components/pixels" }
+profile = { package = "servo-profile", version = "=0.6.0", path = "components/profile" }
+profile_traits = { package = "servo-profile-traits", version = "=0.6.0", path = "components/shared/profile" }
+script = { package = "servo-script", version = "=0.6.0", path = "components/script" }
+script_bindings = { package = "servo-script-bindings", version = "=0.6.0", path = "components/script_bindings" }
+script_webgpu = { package = "servo-script-webgpu", version = "=0.6.0", path = "components/script_webgpu" }
+script_traits = { package = "servo-script-traits", version = "=0.6.0", path = "components/shared/script" }
+servo = { version = "=0.6.0", path = "components/servo", default-features = false }
+servo-allocator = { version = "=0.6.0", path = "components/allocator" }
+servo-background-hang-monitor = { version = "=0.6.0", path = "components/background_hang_monitor" }
+servo-background-hang-monitor-api = { version = "=0.6.0", path = "components/shared/background_hang_monitor" }
+servo-base = { version = "=0.6.0", path = "components/shared/base" }
+servo-bluetooth = { version = "=0.6.0", path = "components/bluetooth" }
+servo-bluetooth-traits = { version = "=0.6.0", path = "components/shared/bluetooth" }
+servo-canvas = { version = "=0.6.0", path = "components/canvas" }
+servo-canvas-traits = { version = "=0.6.0", path = "components/shared/canvas" }
+servo-config = { version = "=0.6.0", path = "components/config" }
+servo-config-macro = { version = "=0.6.0", path = "components/config/macro" }
+servo-constellation = { version = "=0.6.0", path = "components/constellation" }
+servo-constellation-traits = { version = "=0.6.0", path = "components/shared/constellation" }
+servo-default-resources = { version = "=0.6.0", path = "components/default-resources" }
+servo-geometry = { version = "=0.6.0", path = "components/geometry" }
+servo-media = { version = "=0.6.0", path = "components/media/servo-media" }
+servo-media-audio = { version = "=0.6.0", path = "components/media/audio" }
+servo-media-auto = { version = "=0.6.0", path = "components/media/backends/auto" }
+servo-media-derive = { version = "=0.6.0", path = "components/media/servo-media-derive" }
+servo-media-dummy = { version = "=0.6.0", path = "components/media/backends/dummy" }
+servo-media-gstreamer = { version = "=0.6.0", path = "components/media/backends/gstreamer" }
+servo-media-gstreamer-render = { version = "=0.6.0", path = "components/media/backends/gstreamer/render" }
+servo-media-gstreamer-render-android = { version = "=0.6.0", path = "components/media/backends/gstreamer/render-android" }
+servo-media-gstreamer-render-unix = { version = "=0.6.0", path = "components/media/backends/gstreamer/render-unix" }
+servo-media-ohos = { version = "=0.6.0", path = "components/media/backends/ohos" }
+servo-media-player = { version = "=0.6.0", path = "components/media/player" }
+servo-media-streams = { version = "=0.6.0", path = "components/media/streams" }
+servo-media-traits = { version = "=0.6.0", path = "components/media/traits" }
+servo-media-webrtc = { version = "=0.6.0", path = "components/media/webrtc" }
+servo-tracing = { version = "=0.6.0", path = "components/servo_tracing" }
+servo-url = { version = "=0.6.0", path = "components/url" }
+servo-wakelock = { version = "=0.6.0", path = "components/wakelock" }
+servo-webvtt = { version = "=0.6.0", path = "components/webvtt" }
+storage = { package = "servo-storage", version = "=0.6.0", path = "components/storage" }
+storage_traits = { package = "servo-storage-traits", version = "=0.6.0", path = "components/shared/storage" }
+timers = { package = "servo-timers", version = "=0.6.0", path = "components/timers" }
+webdriver_server = { package = "servo-webdriver-server", version = "=0.6.0", path = "components/webdriver_server" }
+webgl = { package = "servo-webgl", version = "=0.6.0", path = "components/webgl", default-features = false }
+webgpu = { package = "servo-webgpu", version = "=0.6.0", path = "components/webgpu" }
+webgpu_traits = { package = "servo-webgpu-traits", version = "=0.6.0", path = "components/shared/webgpu" }
+webxr = { package = "servo-webxr", version = "=0.6.0", path = "components/webxr" }
+webxr-api = { package = "servo-webxr-api", version = "=0.6.0", path = "components/shared/webxr" }
+xpath = { package = "servo-xpath", version = "=0.6.0", path = "components/xpath" }
 # End workspace-version dependencies - Don't change this comment, we grep for it in scripts!
 
 [workspace.lints.clippy]

--- a/ports/servoshell/platform/macos/Info.plist
+++ b/ports/servoshell/platform/macos/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.0</string>
+	<string>0.6.0</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSPrincipalClass</key>

--- a/ports/servoshell/platform/windows/servoshell.exe.manifest
+++ b/ports/servoshell/platform/windows/servoshell.exe.manifest
@@ -4,7 +4,7 @@
           xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <assemblyIdentity type="win32"
                     name="servo.ServoShell"
-                    version="0.5.0.0"/>
+                    version="0.6.0.0"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>

--- a/resources/resource_protocol/license.html
+++ b/resources/resource_protocol/license.html
@@ -1119,7 +1119,7 @@
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/psychon/as-raw-xcb-connection ">as-raw-xcb-connection 1.0.1</a></li>
-                        <li><a href=" https://github.com/hsivonen/chardetng ">chardetng 0.1.17</a></li>
+                        <li><a href=" https://github.com/hsivonen/chardetng ">chardetng 1.0.0</a></li>
                         <li><a href=" https://github.com/KyleMayes/clang-sys ">clang-sys 1.9.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">cmov 0.5.4</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">ctutils 0.4.2</a></li>
@@ -1127,6 +1127,8 @@
                         <li><a href=" https://github.com/hsivonen/encoding_c_mem ">encoding_c_mem 0.2.6</a></li>
                         <li><a href=" https://github.com/hsivonen/encoding_rs ">encoding_rs 0.8.35</a></li>
                         <li><a href=" https://github.com/linebender/kurbo ">kurbo 0.13.1</a></li>
+                        <li><a href=" https://github.com/servo/mozjs ">mozjs_utf16_iter 153.0.0</a></li>
+                        <li><a href=" https://github.com/servo/mozjs ">mozjs_utf8_iter 153.0.0</a></li>
                         <li><a href=" https://github.com/paritytech/nohash-hasher ">nohash-hasher 0.2.0</a></li>
                         <li><a href=" https://github.com/Ralith/openxrs ">openxr-sys 0.13.1</a></li>
                         <li><a href=" https://github.com/linebender/kurbo ">polycool 0.4.0</a></li>
@@ -2446,8 +2448,8 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.55</a></li>
-                        <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.55</a></li>
+                        <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.56</a></li>
+                        <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.56</a></li>
                     </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -2657,7 +2659,7 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/unicode-org/icu4x ">calendrical_calculations 0.1.3</a>
+                            <a href=" https://github.com/unicode-org/icu4x ">calendrical_calculations 0.2.4</a>
                     </p>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3076,7 +3078,7 @@ Software.
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/awxkee/moxcms.git ">moxcms 0.8.1</a></li>
                         <li><a href=" https://github.com/awxkee/pxfm ">pxfm 0.1.30</a></li>
-                        <li><a href=" https://github.com/awxkee/yuvutils-rs ">yuv 0.8.16</a></li>
+                        <li><a href=" https://github.com/awxkee/yuvutils-rs ">yuv 0.8.17</a></li>
                     </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3291,10 +3293,11 @@ Software.
                         <li><a href=" https://github.com/enarx/ciborium ">ciborium 0.2.2</a></li>
                         <li><a href=" https://github.com/brendanzab/codespan ">codespan-reporting 0.13.1</a></li>
                         <li><a href=" https://github.com/entropyxyz/crypto-primes ">crypto-primes 0.7.2</a></li>
+                        <li><a href=" https://github.com/openharmony-rs/ohos-pasteboard ">ohos-pasteboard 0.1.0</a></li>
                         <li><a href=" https://github.com/rustls/rustls-platform-verifier ">rustls-platform-verifier 0.7.0</a></li>
                         <li><a href=" https://github.com/Voultapher/self_cell ">self_cell 1.3.0</a></li>
                         <li><a href=" https://github.com/1Password/sys-locale ">sys-locale 0.3.2</a></li>
-                        <li><a href=" https://github.com/etemesi254/zune-image ">zune-core 0.5.1</a></li>
+                        <li><a href=" https://github.com/etemesi254/zune-image ">zune-core 0.5.3</a></li>
                         <li><a href=" https://github.com/etemesi254/zune-image/tree/dev/crates/zune-jpeg ">zune-jpeg 0.5.15</a></li>
                     </ul>
                 <pre class="license-text">                                 Apache License
@@ -3504,7 +3507,7 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/krisprice/ipnet ">ipnet 2.12.0</a>
+                            <a href=" https://github.com/krisprice/ipnet ">ipnet 2.12.1</a>
                     </p>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3925,17 +3928,19 @@ Software.
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstream 0.6.21</a></li>
+                        <li><a href=" https://github.com/rust-cli/anstyle.git ">anstream 1.0.0</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-parse 0.2.7</a></li>
+                        <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-parse 1.0.0</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-query 1.1.5</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-wincon 3.0.11</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.14</a></li>
-                        <li><a href=" https://github.com/clap-rs/clap ">clap 4.6.4</a></li>
-                        <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.6.2</a></li>
+                        <li><a href=" https://github.com/clap-rs/clap ">clap 4.6.6</a></li>
+                        <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.6.6</a></li>
                         <li><a href=" https://github.com/clap-rs/clap ">clap_lex 1.1.0</a></li>
                         <li><a href=" https://github.com/jamesmunns/cobs.rs ">cobs 0.3.0</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">colorchoice 1.0.5</a></li>
-                        <li><a href=" https://github.com/rust-ammonia/rust-content-security-policy ">content-security-policy 0.8.1</a></li>
-                        <li><a href=" https://github.com/srijs/rust-crc32fast ">crc32fast 1.5.0</a></li>
+                        <li><a href=" https://github.com/rust-ammonia/rust-content-security-policy ">content-security-policy 0.8.2</a></li>
+                        <li><a href=" https://github.com/srijs/rust-crc32fast ">crc32fast 1.5.1</a></li>
                         <li><a href=" https://github.com/rust-cli/env_logger ">env_filter 0.1.4</a></li>
                         <li><a href=" https://github.com/rust-cli/env_logger ">env_logger 0.11.8</a></li>
                         <li><a href=" https://github.com/sfackler/rust-fallible-iterator ">fallible-iterator 0.3.0</a></li>
@@ -3952,10 +3957,12 @@ Software.
                         <li><a href=" https://github.com/polyfill-rs/once_cell_polyfill ">once_cell_polyfill 1.70.2</a></li>
                         <li><a href=" http://github.com/tailhook/quick-error ">quick-error 2.0.1</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">serde_spanned 1.1.1</a></li>
-                        <li><a href=" https://github.com/toml-rs/toml ">toml 1.1.3+spec-1.1.0</a></li>
+                        <li><a href=" https://github.com/toml-rs/toml ">toml 0.9.12+spec-1.1.0</a></li>
+                        <li><a href=" https://github.com/toml-rs/toml ">toml 1.1.4+spec-1.1.0</a></li>
+                        <li><a href=" https://github.com/toml-rs/toml ">toml_datetime 0.7.5+spec-1.1.0</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">toml_datetime 1.1.1+spec-1.1.0</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">toml_edit 0.25.13+spec-1.1.0</a></li>
-                        <li><a href=" https://github.com/toml-rs/toml ">toml_parser 1.1.2+spec-1.1.0</a></li>
+                        <li><a href=" https://github.com/toml-rs/toml ">toml_parser 1.1.3+spec-1.1.0</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">toml_writer 1.1.2+spec-1.1.0</a></li>
                         <li><a href=" https://github.com/gifnksm/topological-sort-rs ">topological-sort 0.1.0</a></li>
                         <li><a href=" https://github.com/swgillespie/unicode-categories ">unicode_categories 0.1.1</a></li>
@@ -4366,15 +4373,226 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-channel 0.3.33</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-core 0.3.33</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-executor 0.3.33</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-io 0.3.33</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-macro 0.3.33</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-sink 0.3.33</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-task 0.3.33</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-util 0.3.33</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures 0.3.33</a></li>
+                        <li><a href=" https://github.com/ejmahler/RustFFT ">rustfft 6.4.1</a></li>
+                        <li><a href=" http://github.com/ejmahler/strength_reduce ">strength_reduce 0.2.4</a></li>
+                    </ul>
+                <pre class="license-text">                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      &quot;control&quot; means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      &quot;Source&quot; form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      &quot;Object&quot; form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      &quot;Work&quot; shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      &quot;Contribution&quot; shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets &quot;{}&quot;
+      replaced with your own identifying information. (Don&#x27;t include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same &quot;printed page&quot; as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                    <h4>Used by:</h4>
+                    <ul class="license-used-by">
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-channel 0.3.34</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-core 0.3.34</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-executor 0.3.34</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-io 0.3.34</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-macro 0.3.34</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-sink 0.3.34</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-task 0.3.34</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-util 0.3.34</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures 0.3.34</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -4793,7 +5011,7 @@ limitations under the License.</pre>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/SergioBenitez/cookie-rs ">cookie 0.16.2</a></li>
-                        <li><a href=" https://github.com/SergioBenitez/cookie-rs ">cookie 0.18.1</a></li>
+                        <li><a href=" https://github.com/SergioBenitez/cookie-rs ">cookie 0.18.2</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -6262,9 +6480,9 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/rust-diplomat/diplomat ">diplomat-runtime 0.8.3</a></li>
-                        <li><a href=" https://github.com/rust-diplomat/diplomat ">diplomat 0.8.0</a></li>
-                        <li><a href=" https://github.com/rust-diplomat/diplomat ">diplomat_core 0.8.1</a></li>
+                        <li><a href=" https://github.com/rust-diplomat/diplomat ">diplomat-runtime 0.14.0</a></li>
+                        <li><a href=" https://github.com/rust-diplomat/diplomat ">diplomat 0.14.0</a></li>
+                        <li><a href=" https://github.com/rust-diplomat/diplomat ">diplomat_core 0.14.0</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -7314,14 +7532,14 @@ limitations under the License.</pre>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/servo/stylo ">servo_arc 0.4.3</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_malloc_size_of 0.19.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-malloc-size-of 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_malloc_size_of 0.20.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-malloc-size-of 0.6.0</a></li>
                         <li><a href=" https://github.com/gimli-rs/addr2line ">addr2line 0.25.1</a></li>
                         <li><a href=" https://github.com/tkaitchuck/ahash ">ahash 0.8.12</a></li>
                         <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.9.2</a></li>
                         <li><a href=" https://github.com/bluss/arrayvec ">arrayvec 0.7.8</a></li>
                         <li><a href=" https://github.com/smol-rs/async-channel ">async-channel 2.5.0</a></li>
-                        <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.42</a></li>
+                        <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.43</a></li>
                         <li><a href=" https://github.com/smol-rs/async-executor ">async-executor 1.14.0</a></li>
                         <li><a href=" https://github.com/smol-rs/async-io ">async-io 2.6.0</a></li>
                         <li><a href=" https://github.com/smol-rs/async-lock ">async-lock 3.4.2</a></li>
@@ -7332,16 +7550,16 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/cuviper/autocfg ">autocfg 1.5.1</a></li>
                         <li><a href=" https://github.com/rust-lang/backtrace-rs ">backtrace 0.3.76</a></li>
                         <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.22.1</a></li>
-                        <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.23.0</a></li>
+                        <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.23.1</a></li>
                         <li><a href=" https://github.com/bitflags/bitflags ">bitflags 1.3.2</a></li>
                         <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.13.1</a></li>
-                        <li><a href=" https://github.com/smol-rs/blocking ">blocking 1.6.2</a></li>
+                        <li><a href=" https://github.com/smol-rs/blocking ">blocking 1.7.0</a></li>
                         <li><a href=" https://github.com/pacak/bpaf ">bpaf 0.9.27</a></li>
                         <li><a href=" https://github.com/pacak/bpaf ">bpaf_derive 0.5.26</a></li>
                         <li><a href=" https://github.com/mikedilger/buf-read-ext ">buf-read-ext 0.4.0</a></li>
                         <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.20.3</a></li>
                         <li><a href=" https://github.com/japaric/cast.rs ">cast 0.3.0</a></li>
-                        <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.67</a></li>
+                        <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.4.4</a></li>
                         <li><a href=" https://github.com/jethrogb/rust-cexpr ">cexpr 0.6.0</a></li>
                         <li><a href=" https://github.com/rust-lang/cfg-if ">cfg-if 1.0.4</a></li>
                         <li><a href=" https://github.com/servo/cgl-rs ">cgl 0.3.2</a></li>
@@ -7364,7 +7582,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/dalek-cryptography/curve25519-dalek ">curve25519-dalek-derive 0.1.1</a></li>
                         <li><a href=" https://github.com/servo/rust-url ">data-url 0.3.2</a></li>
                         <li><a href=" https://github.com/yaahc/displaydoc ">displaydoc 0.2.6</a></li>
-                        <li><a href=" https://github.com/rayon-rs/either ">either 1.17.0</a></li>
+                        <li><a href=" https://github.com/rayon-rs/either ">either 1.18.0</a></li>
                         <li><a href=" https://github.com/indexmap-rs/equivalent ">equivalent 1.0.2</a></li>
                         <li><a href=" https://github.com/lambda-fairy/rust-errno ">errno 0.3.14</a></li>
                         <li><a href=" https://github.com/servo/euclid ">euclid 0.22.14</a></li>
@@ -7372,7 +7590,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/smol-rs/event-listener ">event-listener 5.4.2</a></li>
                         <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.5.0</a></li>
                         <li><a href=" https://github.com/alexcrichton/filetime ">filetime 0.2.29</a></li>
-                        <li><a href=" https://github.com/rust-lang/cc-rs ">find-msvc-tools 0.1.9</a></li>
+                        <li><a href=" https://github.com/rust-lang/cc-rs ">find-msvc-tools 0.1.11</a></li>
                         <li><a href=" https://github.com/petgraph/fixedbitset ">fixedbitset 0.5.7</a></li>
                         <li><a href=" https://github.com/rust-lang/flate2-rs ">flate2 1.1.9</a></li>
                         <li><a href=" https://github.com/servo/rust-fnv ">fnv 1.0.7</a></li>
@@ -7394,7 +7612,7 @@ limitations under the License.</pre>
                         <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-video 0.25.3</a></li>
                         <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-webrtc 0.25.2</a></li>
                         <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer 0.25.3</a></li>
-                        <li><a href=" https://github.com/servo/rust-harfbuzz ">harfbuzz-sys 0.7.0</a></li>
+                        <li><a href=" https://github.com/servo/rust-harfbuzz ">harfbuzz-sys 0.8.0</a></li>
                         <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.15.5</a></li>
                         <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.16.1</a></li>
                         <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.17.1</a></li>
@@ -7425,7 +7643,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/hyperium/mime ">mime 0.3.17</a></li>
                         <li><a href=" https://github.com/rust-num/num-complex ">num-complex 0.4.6</a></li>
                         <li><a href=" https://github.com/rust-num/num-derive ">num-derive 0.4.2</a></li>
-                        <li><a href=" https://github.com/rust-num/num-integer ">num-integer 0.1.46</a></li>
+                        <li><a href=" https://github.com/rust-num/num-integer ">num-integer 0.1.47</a></li>
                         <li><a href=" https://github.com/rust-num/num-rational ">num-rational 0.4.2</a></li>
                         <li><a href=" https://github.com/rust-num/num-traits ">num-traits 0.2.19</a></li>
                         <li><a href=" https://github.com/seanmonstar/num_cpus ">num_cpus 1.17.0</a></li>
@@ -7442,17 +7660,17 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/servo/rust-url/ ">percent-encoding 2.3.2</a></li>
                         <li><a href=" https://github.com/petgraph/petgraph ">petgraph 0.8.3</a></li>
                         <li><a href=" https://github.com/smol-rs/piper ">piper 0.2.5</a></li>
-                        <li><a href=" https://github.com/rust-lang/pkg-config-rs ">pkg-config 0.3.33</a></li>
+                        <li><a href=" https://github.com/rust-lang/pkg-config-rs ">pkg-config 0.3.34</a></li>
                         <li><a href=" https://github.com/randomites/plain ">plain 0.2.3</a></li>
                         <li><a href=" https://github.com/image-rs/image-png ">png 0.18.1</a></li>
                         <li><a href=" https://github.com/smol-rs/polling ">polling 3.11.0</a></li>
                         <li><a href=" https://github.com/jamesmunns/postcard ">postcard 1.1.3</a></li>
+                        <li><a href=" https://github.com/huonw/primal ">primal-check 0.3.4</a></li>
                         <li><a href=" https://github.com/rayon-rs/rayon ">rayon-core 1.13.0</a></li>
                         <li><a href=" https://github.com/rayon-rs/rayon ">rayon 1.12.0</a></li>
-                        <li><a href=" https://github.com/rust-lang/regex ">regex-automata 0.4.16</a></li>
+                        <li><a href=" https://github.com/rust-lang/regex ">regex-automata 0.4.18</a></li>
                         <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.8.11</a></li>
                         <li><a href=" https://github.com/rust-lang/regex ">regex 1.13.1</a></li>
-                        <li><a href=" https://github.com/ron-rs/ron ">ron 0.12.2</a></li>
                         <li><a href=" https://github.com/RazrFalcon/roxmltree ">roxmltree 0.20.0</a></li>
                         <li><a href=" https://github.com/RazrFalcon/roxmltree ">roxmltree 0.21.1</a></li>
                         <li><a href=" https://github.com/rust-lang/rustc-demangle ">rustc-demangle 0.1.28</a></li>
@@ -7461,7 +7679,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 0.38.44</a></li>
                         <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 1.1.4</a></li>
                         <li><a href=" https://github.com/rustls/rustls-native-certs ">rustls-native-certs 0.8.4</a></li>
-                        <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.42</a></li>
+                        <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.43</a></li>
                         <li><a href=" https://github.com/alexcrichton/scoped-tls ">scoped-tls 1.0.1</a></li>
                         <li><a href=" https://github.com/bluss/scopeguard ">scopeguard 1.2.0</a></li>
                         <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys 2.17.0</a></li>
@@ -7495,7 +7713,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/RazrFalcon/unicode-vo ">unicode-vo 0.1.0</a></li>
                         <li><a href=" https://github.com/unicode-rs/unicode-width ">unicode-width 0.2.2</a></li>
                         <li><a href=" https://github.com/servo/rust-url ">url 2.5.8</a></li>
-                        <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.24.0</a></li>
+                        <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.26.0</a></li>
                         <li><a href=" https://github.com/SergioBenitez/version_check ">version_check 0.9.5</a></li>
                         <li><a href=" https://github.com/bytecodealliance/wasi ">wasi 0.11.1+wasi-snapshot-preview1</a></li>
                         <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures ">wasm-bindgen-futures 0.4.67</a></li>
@@ -7504,8 +7722,9 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared 0.2.117</a></li>
                         <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen ">wasm-bindgen 0.2.117</a></li>
                         <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys ">web-sys 0.3.94</a></li>
-                        <li><a href=" https://github.com/servo/html5ever ">web_atoms 0.2.5</a></li>
+                        <li><a href=" https://github.com/servo/html5ever ">web_atoms 0.2.6</a></li>
                         <li><a href=" https://github.com/bytecodealliance/wit-bindgen ">wit-bindgen 0.51.0</a></li>
+                        <li><a href=" https://github.com/YaLTeR/wl-clipboard-rs ">wl-clipboard-rs 0.9.3</a></li>
                         <li><a href=" https://crates.io/crates/wr_malloc_size_of ">wr_malloc_size_of 0.2.2</a></li>
                         <li><a href=" https://github.com/Stebalien/xattr ">xattr 1.6.1</a></li>
                         <li><a href=" https://github.com/servo/html5ever ">xml5ever 0.39.0</a></li>
@@ -8559,17 +8778,17 @@ limitations under the License.</pre>
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/RustCrypto/AEADs ">aes-gcm 0.11.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/AEADs ">aes-gcm 0.11.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/block-ciphers ">aes 0.9.2</a></li>
-                        <li><a href=" https://github.com/RustCrypto/password-hashes ">argon2 0.6.0-rc.8</a></li>
+                        <li><a href=" https://github.com/RustCrypto/password-hashes ">argon2 0.6.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats ">base16ct 1.0.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats ">base64ct 1.8.3</a></li>
-                        <li><a href=" https://github.com/RustCrypto/hashes ">blake2 0.11.0-rc.6</a></li>
+                        <li><a href=" https://github.com/RustCrypto/hashes ">blake2 0.11.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.10.4</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.12.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">block-padding 0.4.2</a></li>
                         <li><a href=" https://github.com/RustCrypto/block-modes ">cbc 0.2.1</a></li>
-                        <li><a href=" https://github.com/RustCrypto/stream-ciphers ">chacha20 0.10.1</a></li>
+                        <li><a href=" https://github.com/RustCrypto/stream-ciphers ">chacha20 0.10.2</a></li>
                         <li><a href=" https://github.com/RustCrypto/AEADs ">chacha20poly1305 0.11.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/traits ">cipher 0.5.2</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats ">const-oid 0.10.2</a></li>
@@ -8590,13 +8809,13 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/RustCrypto/universal-hashes ">ghash 0.6.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/elliptic-curves ">hash2curve 0.14.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/MACs ">hmac 0.13.0</a></li>
-                        <li><a href=" https://github.com/RustCrypto/hybrid-array ">hybrid-array 0.4.13</a></li>
+                        <li><a href=" https://github.com/RustCrypto/hybrid-array ">hybrid-array 0.4.14</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">inout 0.2.2</a></li>
                         <li><a href=" https://github.com/RustCrypto/XOFs ">k12 0.5.1</a></li>
-                        <li><a href=" https://github.com/RustCrypto/sponges ">keccak 0.2.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/sponges ">keccak 0.2.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/KEMs ">ml-kem 0.3.2</a></li>
                         <li><a href=" https://github.com/RustCrypto/KEMs ">module-lattice 0.2.3</a></li>
-                        <li><a href=" https://github.com/RustCrypto/AEADs ">ocb3 0.2.0-rc.3</a></li>
+                        <li><a href=" https://github.com/RustCrypto/AEADs ">ocb3 0.2.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/elliptic-curves ">p256 0.14.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/elliptic-curves ">p384 0.14.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/elliptic-curves ">p521 0.14.0</a></li>
@@ -8620,7 +8839,6 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/RustCrypto/traits ">signature 3.0.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats ">spki 0.8.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">sponge-cursor 0.1.0</a></li>
-                        <li><a href=" https://github.com/RustCrypto/XOFs ">turboshake 0.7.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/traits ">universal-hash 0.6.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/elliptic-curves ">wnaf 0.14.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/elliptic-curves/tree/master/x448 ">x448 0.14.0-pre.12</a></li>
@@ -9868,6 +10086,215 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
+                            <a href=" https://github.com/ejmahler/transpose ">transpose 0.2.3</a>
+                    </p>
+                <pre class="license-text">                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   &quot;control&quot; means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   &quot;Source&quot; form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   &quot;Object&quot; form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   &quot;Work&quot; shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   &quot;Contribution&quot; shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
+   replaced with your own identifying information. (Don&#x27;t include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same &quot;printed page&quot; as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2022 The transpose developers
+
+Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                    <p>
+                        Used by
                             <a href=" https://github.com/grovesNL/glow ">glow 0.17.0</a>
                     </p>
                 <pre class="license-text">                              Apache License
@@ -10286,7 +10713,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/googlefonts/fontations ">font-types 0.12.1</a></li>
+                        <li><a href=" https://github.com/googlefonts/fontations ">font-types 0.12.4</a></li>
                         <li><a href=" https://github.com/googlefonts/fontations ">read-fonts 0.41.0</a></li>
                         <li><a href=" https://github.com/googlefonts/fontations ">skrifa 0.44.0</a></li>
                     </ul>
@@ -10592,9 +11019,7 @@ limitations under the License.
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/googlefonts/fontations ">font-types 0.11.3</a></li>
                         <li><a href=" https://github.com/googlefonts/fontations ">read-fonts 0.37.0</a></li>
-                        <li><a href=" https://github.com/googlefonts/fontations ">read-fonts 0.39.2</a></li>
                         <li><a href=" https://github.com/googlefonts/fontations ">skrifa 0.40.0</a></li>
-                        <li><a href=" https://github.com/googlefonts/fontations ">skrifa 0.42.1</a></li>
                     </ul>
                 <pre class="license-text">Apache License
 
@@ -11298,7 +11723,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/mmastrac/linktime ">ctor 1.0.12</a>
+                            <a href=" https://github.com/mmastrac/linktime ">ctor 1.0.13</a>
                     </p>
                 <pre class="license-text">Apache License
                            Version 2.0, January 2004
@@ -11507,7 +11932,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/Lokathor/bytemuck ">bytemuck 1.25.1</a></li>
+                        <li><a href=" https://github.com/Lokathor/bytemuck ">bytemuck 1.25.2</a></li>
                         <li><a href=" https://github.com/Lokathor/bytemuck ">bytemuck_derive 1.11.0</a></li>
                     </ul>
                 <pre class="license-text">Apache License
@@ -12204,7 +12629,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/servo/servo ">servo-hyper-serde 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-hyper-serde 0.6.0</a></li>
                         <li><a href=" https://github.com/alexheretic/ab-glyph ">ab_glyph 0.2.32</a></li>
                         <li><a href=" https://github.com/alexheretic/ab-glyph ">ab_glyph_rasterizer 0.1.10</a></li>
                         <li><a href=" https://github.com/AccessKit/accesskit ">accesskit 0.24.0</a></li>
@@ -12216,11 +12641,12 @@ limitations under the License.
                         <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_winit 0.32.2</a></li>
                         <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
                         <li><a href=" https://github.com/rust-mobile/android-activity ">android-activity 0.6.1</a></li>
-                        <li><a href=" https://github.com/nical/android_system_properties ">android_system_properties 0.1.5</a></li>
+                        <li><a href=" https://github.com/nical/android_system_properties ">android_system_properties 0.1.6</a></li>
                         <li><a href=" https://github.com/zrzka/anes-rs ">anes 0.1.6</a></li>
                         <li><a href=" https://github.com/1Password/arboard ">arboard 3.6.1</a></li>
+                        <li><a href=" https://github.com/paulocsanz/arraystring ">arraystring 0.3.0</a></li>
                         <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.89</a></li>
-                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.43.0</a></li>
+                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.44.0</a></li>
                         <li><a href=" https://github.com/jrmuizel/build-parallel ">build-parallel 0.1.2</a></li>
                         <li><a href=" https://github.com/linebender/color ">color 0.3.3</a></li>
                         <li><a href=" https://github.com/soc/directories-rs ">directories 6.0.0</a></li>
@@ -12246,7 +12672,7 @@ limitations under the License.
                         <li><a href=" https://gitlab.com/gilrs-project/gilrs ">gilrs-core 0.6.7</a></li>
                         <li><a href=" https://gitlab.com/gilrs-project/gilrs ">gilrs 0.11.1</a></li>
                         <li><a href=" https://github.com/brendanzab/gl-rs/ ">gl_generator 0.14.0</a></li>
-                        <li><a href=" https://github.com/linebender/vello ">glifo 0.1.1</a></li>
+                        <li><a href=" https://github.com/linebender/vello ">glifo 0.3.0</a></li>
                         <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-play 0.25.0</a></li>
                         <li><a href=" https://github.com/nical/guillotiere ">guillotiere 0.7.0</a></li>
                         <li><a href=" https://github.com/VoidStarKat/half-rs ">half 2.7.1</a></li>
@@ -12266,8 +12692,8 @@ limitations under the License.
                         <li><a href=" https://github.com/LukasKalbertodt/litrs ">litrs 1.0.0</a></li>
                         <li><a href=" https://github.com/JohnTitor/mach2 ">mach2 0.6.0</a></li>
                         <li><a href=" https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide ">miniz_oxide 0.8.9</a></li>
-                        <li><a href=" https://github.com/gfx-rs/wgpu ">naga-types 30.0.0</a></li>
-                        <li><a href=" https://github.com/gfx-rs/wgpu ">naga 30.0.0</a></li>
+                        <li><a href=" https://github.com/gfx-rs/wgpu ">naga-types 30.0.1</a></li>
+                        <li><a href=" https://github.com/gfx-rs/wgpu ">naga 30.0.1</a></li>
                         <li><a href=" https://github.com/rust-windowing/android-ndk-rs ">ndk-context 0.1.1</a></li>
                         <li><a href=" https://github.com/rust-mobile/ndk ">ndk-sys 0.6.0+11769913</a></li>
                         <li><a href=" https://github.com/rust-mobile/ndk ">ndk 0.9.0</a></li>
@@ -12291,7 +12717,8 @@ limitations under the License.
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-ime-sys 0.2.4</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-ime ">ohos-ime 0.4.2</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-media-sys 0.1.1</a></li>
-                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-sys-opaque-types 0.1.10</a></li>
+                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-pasteboard-sys 0.1.5</a></li>
+                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-sys-opaque-types 0.1.11</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-vsync-sys 0.1.6</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-vsync ">ohos-vsync 0.1.3</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-window-manager-sys 0.1.4</a></li>
@@ -12305,7 +12732,7 @@ limitations under the License.
                         <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.17</a></li>
                         <li><a href=" https://github.com/taiki-e/pin-project ">pin-project 1.1.13</a></li>
                         <li><a href=" https://github.com/taiki-e/portable-atomic-util ">portable-atomic-util 0.2.7</a></li>
-                        <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic 1.14.0</a></li>
+                        <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic 1.15.0</a></li>
                         <li><a href=" https://github.com/dtolnay/prettyplease ">prettyplease 0.2.37</a></li>
                         <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.107</a></li>
                         <li><a href=" https://github.com/aclysma/profiling ">profiling 1.0.18</a></li>
@@ -12324,11 +12751,10 @@ limitations under the License.
                         <li><a href=" https://github.com/SeaQL/sea-query ">sea-query-derive 1.0.0</a></li>
                         <li><a href=" https://github.com/SeaQL/sea-query ">sea-query-rusqlite 0.8.0</a></li>
                         <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.28</a></li>
-                        <li><a href=" https://github.com/dtolnay/seq-macro ">seq-macro 0.3.6</a></li>
-                        <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.228</a></li>
+                        <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.229</a></li>
                         <li><a href=" https://github.com/serde-rs/bytes ">serde_bytes 0.11.19</a></li>
-                        <li><a href=" https://github.com/serde-rs/serde ">serde_core 1.0.228</a></li>
-                        <li><a href=" https://github.com/serde-rs/serde ">serde_derive 1.0.228</a></li>
+                        <li><a href=" https://github.com/serde-rs/serde ">serde_core 1.0.229</a></li>
+                        <li><a href=" https://github.com/serde-rs/serde ">serde_derive 1.0.229</a></li>
                         <li><a href=" https://github.com/serde-rs/json ">serde_json 1.0.151</a></li>
                         <li><a href=" https://github.com/dtolnay/serde-repr ">serde_repr 0.1.20</a></li>
                         <li><a href=" https://github.com/serde-rs/test ">serde_test 1.0.177</a></li>
@@ -12340,6 +12766,7 @@ limitations under the License.
                         <li><a href=" https://github.com/gfx-rs/rspirv ">spirv 0.4.0+sdk-1.4.341.0</a></li>
                         <li><a href=" https://github.com/nical/rust_debug ">svg_fmt 0.4.5</a></li>
                         <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.119</a></li>
+                        <li><a href=" https://github.com/dtolnay/syn ">syn 3.0.4</a></li>
                         <li><a href=" https://github.com/Actyx/sync_wrapper ">sync_wrapper 1.0.2</a></li>
                         <li><a href=" https://github.com/mozilla/thin-vec ">thin-vec 0.2.19</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 1.0.69</a></li>
@@ -12349,7 +12776,8 @@ limitations under the License.
                         <li><a href=" https://github.com/time-rs/time ">time-core 0.1.9</a></li>
                         <li><a href=" https://github.com/time-rs/time ">time-macros 0.2.32</a></li>
                         <li><a href=" https://github.com/time-rs/time ">time 0.3.55</a></li>
-                        <li><a href=" https://github.com/dtolnay/typeid ">typeid 1.0.3</a></li>
+                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">udmf-sys 0.1.4</a></li>
+                        <li><a href=" https://github.com/openharmony-rs/udmf ">udmf 0.1.1</a></li>
                         <li><a href=" https://github.com/open-i18n/rust-unic/ ">unic-char-property 0.9.0</a></li>
                         <li><a href=" https://github.com/open-i18n/rust-unic/ ">unic-char-range 0.9.0</a></li>
                         <li><a href=" https://github.com/open-i18n/rust-unic/ ">unic-common 0.9.0</a></li>
@@ -12359,21 +12787,21 @@ limitations under the License.
                         <li><a href=" https://github.com/linebender/resvg ">usvg 0.48.1</a></li>
                         <li><a href=" https://github.com/alacritty/vte ">utf8parse 0.2.2</a></li>
                         <li><a href=" https://github.com/linebender/vello ">vello_common 0.0.6</a></li>
-                        <li><a href=" https://github.com/linebender/vello ">vello_common 0.0.9</a></li>
+                        <li><a href=" https://github.com/linebender/vello ">vello_common 0.2.0</a></li>
                         <li><a href=" https://github.com/linebender/vello ">vello_cpu 0.0.6</a></li>
-                        <li><a href=" https://github.com/linebender/vello ">vello_cpu 0.0.9</a></li>
+                        <li><a href=" https://github.com/linebender/vello ">vello_cpu 0.2.0</a></li>
                         <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip2 1.0.2+wasi-0.2.9</a></li>
                         <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip3 0.4.0+wasi-0.3.0-rc-2026-01-06</a></li>
                         <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core-deps-apple 30.0.0</a></li>
                         <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core-deps-emscripten 30.0.0</a></li>
                         <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core-deps-windows-linux-android 30.0.0</a></li>
-                        <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core 30.0.0</a></li>
+                        <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core 30.0.1</a></li>
                         <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-hal 30.0.0</a></li>
                         <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-naga-bridge 30.0.0</a></li>
                         <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-types 30.0.0</a></li>
                         <li><a href=" https://github.com/retep998/winapi-rs ">winapi-i686-pc-windows-gnu 0.4.0</a></li>
                         <li><a href=" https://github.com/retep998/winapi-rs ">winapi-x86_64-pc-windows-gnu 0.4.0</a></li>
-                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">xcomponent-sys 0.3.6</a></li>
+                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">xcomponent-sys 0.4.0</a></li>
                         <li><a href=" https://github.com/gyscos/zstd-rs ">zstd-safe 7.2.4</a></li>
                         <li><a href=" https://github.com/gyscos/zstd-rs ">zstd-sys 2.0.16+zstd.1.5.7</a></li>
                     </ul>
@@ -13094,9 +13522,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/servo/servo ">servo-script-bindings 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script-bindings 0.6.0</a></li>
                         <li><a href=" https://github.com/dropbox/rust-alloc-no-stdlib ">alloc-stdlib 0.2.4</a></li>
-                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.43.0</a></li>
+                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.44.0</a></li>
                         <li><a href=" https://github.com/mitsuhiko/sha1-smol ">sha1_smol 1.0.1</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) &lt;year&gt; &lt;owner&gt;. 
@@ -13193,7 +13621,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSL-1.0">Boost Software License 1.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/DoumanAsh/error-code ">error-code 3.3.2</a>
+                            <a href=" https://github.com/DoumanAsh/error-code ">error-code 3.4.0</a>
                     </p>
                 <pre class="license-text">Boost Software License - Version 1.0 - August 17th, 2003
 
@@ -13350,7 +13778,7 @@ THIS SOFTWARE.</pre>
                 <h3 id="ISC">ISC License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/hannobraun/inotify-rs ">inotify 0.11.4</a>
+                            <a href=" https://github.com/hannobraun/inotify-rs ">inotify 0.11.5</a>
                     </p>
                 <pre class="license-text">Copyright (c) Hanno Braun and contributors
 
@@ -13392,7 +13820,7 @@ THIS SOFTWARE.
                 <h3 id="ISC">ISC License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.13</a>
+                            <a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.15</a>
                     </p>
                 <pre class="license-text">Except as otherwise noted, this project is licensed under the following
 (ISC-style) terms:
@@ -13419,8 +13847,8 @@ third-party/chromium/LICENSE.
                 <h3 id="ISC">ISC License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.17.3</a></li>
-                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.43.0</a></li>
+                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.18.0</a></li>
+                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.44.0</a></li>
                     </ul>
                 <pre class="license-text">ISC License:
 
@@ -13714,7 +14142,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-backend 0.3.16</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-backend 0.3.17</a></li>
                         <li><a href=" https://github.com/smithay/wayland-rs ">wayland-client 0.31.15</a></li>
                         <li><a href=" https://github.com/smithay/wayland-rs ">wayland-cursor 0.31.14</a></li>
                         <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols-plasma 0.3.12</a></li>
@@ -13749,7 +14177,7 @@ THE SOFTWARE.
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/mbrubeck/rust-debug-unreachable ">new_debug_unreachable 1.0.6</a></li>
-                        <li><a href=" https://github.com/reem/rust-ordered-float ">ordered-float 5.3.0</a></li>
+                        <li><a href=" https://github.com/reem/rust-ordered-float ">ordered-float 5.5.0</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) 2015 Jonathan Reem
 
@@ -13880,7 +14308,6 @@ SOFTWARE.</pre>
                     <ul class="license-used-by">
                         <li><a href=" https://gitlab.redox-os.org/redox-os/syscall ">redox_syscall 0.4.1</a></li>
                         <li><a href=" https://gitlab.redox-os.org/redox-os/syscall ">redox_syscall 0.5.18</a></li>
-                        <li><a href=" https://gitlab.redox-os.org/redox-os/syscall ">redox_syscall 0.9.1</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) 2017 Redox OS Developers
 
@@ -13938,7 +14365,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/hyperium/h2 ">h2 0.4.15</a>
+                            <a href=" https://github.com/hyperium/h2 ">h2 0.4.19</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2017 h2 authors
 
@@ -14300,7 +14727,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/hyperium/http-body ">http-body-util 0.1.4</a></li>
+                        <li><a href=" https://github.com/hyperium/http-body ">http-body-util 0.1.5</a></li>
                         <li><a href=" https://github.com/hyperium/http-body ">http-body 1.1.0</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) 2019-2026 Sean McArthur &amp; Hyper Contributors
@@ -14442,13 +14869,46 @@ THE SOFTWARE.
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus 5.18.0</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_macros 5.18.0</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_macros 5.19.0</a></li>
                         <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_names 4.3.4</a></li>
                         <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_xml 5.2.1</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant 5.13.1</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant_derive 5.13.1</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant 5.15.0</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant_derive 5.15.0</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) 2024 Zeeshan Ali Khan &amp; zbus contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the &quot;Software&quot;), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                    <p>
+                        Used by
+                            <a href=" https://github.com/z-galaxy/zcheapstr/ ">zcheapstr 1.1.0</a>
+                    </p>
+                <pre class="license-text">Copyright (c) 2026 Zeeshan Ali Khan &amp; zcheapstr contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -14525,11 +14985,10 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
-                    <h4>Used by:</h4>
-                    <ul class="license-used-by">
-                        <li><a href=" https://github.com/QnnOkabayashi/strck ">strck 0.1.2</a></li>
-                        <li><a href=" https://github.com/QnnOkabayashi/strck ">strck_ident 0.1.2</a></li>
-                    </ul>
+                    <p>
+                        Used by
+                            <a href=" https://github.com/QnnOkabayashi/strck ">strck 1.0.0</a>
+                    </p>
                 <pre class="license-text">Copyright 2022 Quinn Okabayashi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -14597,6 +15056,35 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
 BRIAN PAUL BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
 AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                    <p>
+                        Used by
+                            <a href=" https://github.com/mbrubeck/tree_magic/ ">tree_magic_mini 3.2.2</a>
+                    </p>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2017 Aaron Hancock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 </pre>
             </li>
             <li class="license">
@@ -14915,7 +15403,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/esposm03/xcursor-rs ">xcursor 0.3.10</a>
+                            <a href=" https://github.com/esposm03/xcursor-rs ">xcursor 0.3.11</a>
                     </p>
                 <pre class="license-text">MIT License
 
@@ -15002,7 +15490,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/arthurprs/quick-cache ">quick_cache 0.6.24</a>
+                            <a href=" https://github.com/arthurprs/quick-cache ">quick_cache 0.7.0</a>
                     </p>
                 <pre class="license-text">MIT License
 
@@ -15060,7 +15548,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://gitlab.redox-os.org/redox-os/libredox.git ">libredox 0.1.18</a>
+                            <a href=" https://gitlab.redox-os.org/redox-os/libredox.git ">libredox 0.1.21</a>
                     </p>
                 <pre class="license-text">MIT License
 
@@ -15198,11 +15686,12 @@ SOFTWARE.</pre>
                         <li><a href=" https://github.com/plotters-rs/plotters ">plotters-backend 0.3.7</a></li>
                         <li><a href=" https://github.com/plotters-rs/plotters.git ">plotters-svg 0.3.7</a></li>
                         <li><a href=" https://github.com/plotters-rs/plotters ">plotters 0.3.7</a></li>
+                        <li><a href=" https://github.com/HEnquist/realfft ">realfft 3.5.0</a></li>
                         <li><a href=" https://crates.io/crates/rsqlite-vfs ">rsqlite-vfs 0.1.1</a></li>
-                        <li><a href=" https://github.com/DioxusLabs/taffy ">taffy 0.12.2</a></li>
+                        <li><a href=" https://github.com/DioxusLabs/taffy ">taffy 0.14.0</a></li>
                         <li><a href=" https://github.com/reem/rust-void.git ">void 1.0.2</a></li>
                         <li><a href=" https://github.com/nicoburns/wuff ">wuff-capi 0.2.0</a></li>
-                        <li><a href=" https://github.com/nicoburns/wuff ">wuff 0.2.7</a></li>
+                        <li><a href=" https://github.com/nicoburns/wuff ">wuff 0.2.8</a></li>
                     </ul>
                 <pre class="license-text">MIT License
 
@@ -15344,35 +15833,6 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/becheran/grid ">grid 1.0.1</a>
-                    </p>
-                <pre class="license-text">MIT License
-
-Copyright (c) 2020 Armin Becher
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
                             <a href=" https://github.com/Riey/fontconfig-parser ">fontconfig-parser 0.5.8</a>
                     </p>
                 <pre class="license-text">MIT License
@@ -15416,7 +15876,7 @@ SOFTWARE.
                         <li><a href=" https://github.com/luukvanderduim/zbus-lockstep ">zbus-lockstep-macros 0.5.2</a></li>
                         <li><a href=" https://github.com/luukvanderduim/zbus-lockstep ">zbus-lockstep 0.5.2</a></li>
                         <li><a href=" https://github.com/dtolnay/zmij ">zmij 1.0.23</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant_utils 3.5.0</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant_utils 4.2.0</a></li>
                     </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -15445,10 +15905,11 @@ DEALINGS IN THE SOFTWARE.
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/winnow-rs/winnow ">winnow 1.0.4</a>
-                    </p>
+                    <h4>Used by:</h4>
+                    <ul class="license-used-by">
+                        <li><a href=" https://github.com/winnow-rs/winnow ">winnow 0.7.15</a></li>
+                        <li><a href=" https://github.com/winnow-rs/winnow ">winnow 1.0.4</a></li>
+                    </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
 &quot;Software&quot;), to deal in the Software without restriction, including
@@ -15503,8 +15964,8 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/kornelski/xml-rs ">xml-rs 0.8.28</a></li>
-                        <li><a href=" https://github.com/kornelski/xml-rs ">xml 1.3.0</a></li>
+                        <li><a href=" https://github.com/kornelski/xml-rs ">xml-rs 0.8.29</a></li>
+                        <li><a href=" https://github.com/kornelski/xml-rs ">xml 1.4.0</a></li>
                     </ul>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -15565,7 +16026,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/BurntSushi/aho-corasick ">aho-corasick 1.1.4</a></li>
+                        <li><a href=" https://github.com/BurntSushi/aho-corasick ">aho-corasick 1.1.5</a></li>
                         <li><a href=" https://github.com/image-rs/byteorder-lite ">byteorder-lite 0.1.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/byteorder ">byteorder 1.5.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/fst ">fst 0.4.7</a></li>
@@ -15625,6 +16086,37 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                    <p>
+                        Used by
+                            <a href=" https://github.com/rapidfuzz/strsim-rs ">strsim 0.11.1</a>
+                    </p>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2015 Danny Guo
+Copyright (c) 2016 Titus Wormer &lt;tituswormer@gmail.com&gt;
+Copyright (c) 2018 Akash Kurdekar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 </pre>
             </li>
             <li class="license">
@@ -15720,7 +16212,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/ia0/data-encoding ">data-encoding 2.11.0</a>
+                            <a href=" https://github.com/ia0/data-encoding ">data-encoding 2.11.1</a>
                     </p>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -15750,7 +16242,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.43.0</a>
+                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.44.0</a>
                     </p>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -16132,6 +16624,33 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                    <p>
+                        Used by
+                            <a href=" https://github.com/oconnor663/os_pipe.rs ">os_pipe 1.2.3</a>
+                    </p>
+                <pre class="license-text">The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 </pre>
             </li>
             <li class="license">
@@ -17418,6 +17937,7 @@ defined by the Mozilla Public License, v. 2.0.
                 <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
+                        <li><a href=" https://github.com/mozilla/cbindgen ">cbindgen 0.29.4</a></li>
                         <li><a href=" https://github.com/upsuper/dtoa-short ">dtoa-short 0.3.5</a></li>
                         <li><a href=" https://github.com/asajeffrey/swapper ">swapper 0.1.0</a></li>
                         <li><a href=" https://github.com/badboy/zeitstempel ">zeitstempel 0.2.2</a></li>
@@ -17803,7 +18323,6 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/servo/rust-cssparser ">cssparser-macros 0.7.0</a></li>
                         <li><a href=" https://github.com/servo/rust-cssparser ">cssparser 0.37.0</a></li>
-                        <li><a href=" https://github.com/servo/mozjs/ ">mozjs_sys 140.13.0-0</a></li>
                     </ul>
                 <pre class="license-text">Mozilla Public License Version 2.0
 &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
@@ -18184,91 +18703,97 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/servo/stylo ">stylo 0.19.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">selectors 0.39.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_atoms 0.19.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_derive 0.19.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_dom 0.19.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_static_prefs 0.19.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_traits 0.19.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo 0.20.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">selectors 0.40.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_atoms 0.20.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_derive 0.20.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_dom 0.20.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_static_prefs 0.20.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_traits 0.20.0</a></li>
                         <li><a href=" https://github.com/servo/stylo ">to_shmem 0.5.0</a></li>
                         <li><a href=" https://github.com/servo/stylo ">to_shmem_derive 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-allocator 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-background-hang-monitor 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-bluetooth 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-canvas 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-config 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-config-macro 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-constellation 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-default-resources 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-deny-public-fields 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-devtools 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-dom-struct 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-fonts 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-geometry 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-jstraceable-derive 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-layout 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-audio 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-auto 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-dummy 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render-android 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render-unix 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-ohos 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-examples 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-thread 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-player 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-derive 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-streams 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-traits 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-webrtc 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-metrics 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-net 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-paint 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-pixels 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-profile 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-script 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-script-bindings 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-script-webgpu 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-tracing 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-background-hang-monitor-api 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-base 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-bluetooth-traits 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-canvas-traits 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-constellation-traits 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-devtools-traits 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-embedder-traits 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-fonts-traits 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-layout-api 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-net-traits 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-paint-api 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-profile-traits 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-script-traits 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-storage-traits 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webgpu-traits 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webxr-api 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-storage 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-timers 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-url 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-wakelock 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webdriver-server 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webgl 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webgpu 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webvtt 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webxr 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-xpath 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-capi 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servoshell 0.5.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-capi-tests 0.5.0</a></li>
-                        <li><a href=" https://crates.io/crates/malloc_size_of_tests ">malloc_size_of_tests 0.5.0</a></li>
-                        <li><a href=" https://crates.io/crates/profile_tests ">profile_tests 0.5.0</a></li>
-                        <li><a href=" https://crates.io/crates/script_tests ">script_tests 0.5.0</a></li>
-                        <li><a href=" https://crates.io/crates/style_tests ">style_tests 0.5.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-allocator 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-background-hang-monitor 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-bluetooth 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-canvas 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-config 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-config-macro 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-constellation 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-default-resources 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-deny-public-fields 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-devtools 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-dom-struct 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-fonts 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-geometry 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-jstraceable-derive 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-layout 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-audio 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-auto 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-dummy 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render-android 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render-unix 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-ohos 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-examples 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-thread 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-player 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-derive 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-streams 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-traits 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-webrtc 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-metrics 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-net 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-paint 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-pixels 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-profile 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script-bindings 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script-webgpu 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-tracing 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-background-hang-monitor-api 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-base 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-bluetooth-traits 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-canvas-traits 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-constellation-traits 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-devtools-traits 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-embedder-traits 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-fonts-traits 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-layout-api 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-net-traits 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-paint-api 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-profile-traits 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script-traits 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-storage-traits 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webgpu-traits 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webxr-api 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-storage 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-timers 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-url 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-wakelock 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webdriver-server 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webgl 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webgpu 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webvtt 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webxr 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-xpath 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-capi 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servoshell 0.6.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-capi-tests 0.6.0</a></li>
+                        <li><a href=" https://crates.io/crates/malloc_size_of_tests ">malloc_size_of_tests 0.6.0</a></li>
+                        <li><a href=" https://crates.io/crates/profile_tests ">profile_tests 0.6.0</a></li>
+                        <li><a href=" https://crates.io/crates/script_tests ">script_tests 0.6.0</a></li>
+                        <li><a href=" https://crates.io/crates/style_tests ">style_tests 0.6.0</a></li>
                         <li><a href=" https://github.com/servo/app_units ">app_units 0.7.8</a></li>
                         <li><a href=" https://github.com/servo/dwrote-rs ">dwrote 0.11.5</a></li>
+                        <li><a href=" https://github.com/servo/mozjs ">mozjs_collator_glue 153.0.0</a></li>
+                        <li><a href=" https://github.com/servo/mozjs ">mozjs_locale_glue 153.0.0</a></li>
+                        <li><a href=" https://github.com/servo/mozjs ">mozjs_normalizer_glue 153.0.0</a></li>
+                        <li><a href=" https://github.com/servo/mozjs ">mozjs_properties_glue 153.0.0</a></li>
+                        <li><a href=" https://github.com/servo/mozjs/ ">mozjs_sys 153.0.0-0</a></li>
+                        <li><a href=" https://github.com/servo/mozjs ">mozjs_unicode_bidi_ffi 153.0.0</a></li>
                         <li><a href=" https://github.com/soc/option-ext.git ">option-ext 0.2.0</a></li>
                         <li><a href=" https://hg.mozilla.org/mozilla-central/file/tip/testing/webdriver ">webdriver 0.53.0</a></li>
                         <li><a href=" https://github.com/servo/webrender ">webrender 0.70.0</a></li>
@@ -18655,7 +19180,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/servo/mozjs/ ">mozjs 0.21.0</a>
+                            <a href=" https://github.com/servo/mozjs/ ">mozjs 0.25.0</a>
                     </p>
                 <pre class="license-text">Mozilla Public License Version 2.0
 &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
@@ -19239,10 +19764,11 @@ DEALINGS IN THE FONT SOFTWARE.
             </li>
             <li class="license">
                 <h3 id="Unicode-3.0">Unicode License v3</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.24</a>
-                    </p>
+                    <h4>Used by:</h4>
+                    <ul class="license-used-by">
+                        <li><a href=" https://github.com/servo/mozjs ">mozjs_icu_normalizer_data 153.0.0</a></li>
+                        <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.24</a></li>
+                    </ul>
                 <pre class="license-text">UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
@@ -19288,31 +19814,58 @@ authorization of the copyright holder.
                 <h3 id="Unicode-3.0">Unicode License v3</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/unicode-org/icu4x ">icu_calendar 1.5.2</a></li>
-                        <li><a href=" https://github.com/unicode-org/icu4x ">icu_calendar_data 1.5.1</a></li>
-                        <li><a href=" https://github.com/unicode-org/icu4x ">icu_capi 1.5.0</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">icu_calendar 2.1.1</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">icu_calendar_data 2.1.1</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">icu_capi 2.1.2</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">icu_casemap 2.1.1</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">icu_casemap_data 2.1.1</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">icu_collections 1.5.0</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">icu_collections 2.1.1</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">icu_locale 2.1.1</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">icu_locale_core 2.3.0</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">icu_locale_data 2.1.2</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">icu_locid 1.5.0</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">icu_locid_transform 1.5.0</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">icu_locid_transform_data 1.5.1</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer 1.5.0</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer_data 1.5.1</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties 1.5.1</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties 2.1.2</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties_data 1.5.1</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties_data 2.1.2</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">icu_provider 1.5.0</a></li>
-                        <li><a href=" https://github.com/unicode-org/icu4x ">icu_provider_adapters 1.5.0</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">icu_provider 2.3.1</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">icu_provider_adapters 2.1.1</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">icu_provider_macros 1.5.0</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">icu_segmenter 1.5.0</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">icu_segmenter 2.1.2</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">icu_segmenter_data 1.5.1</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">icu_segmenter_data 2.1.1</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">icu_time 2.1.1</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">icu_time_data 2.1.1</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">ixdtf 0.6.6</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">litemap 0.7.5</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">litemap 0.8.3</a></li>
+                        <li><a href=" https://github.com/servo/mozjs ">mozjs_icu_collator 153.0.0</a></li>
+                        <li><a href=" https://github.com/servo/mozjs ">mozjs_icu_collator_data 153.0.0</a></li>
+                        <li><a href=" https://github.com/servo/mozjs ">mozjs_icu_collections 153.0.0</a></li>
+                        <li><a href=" https://github.com/servo/mozjs ">mozjs_icu_normalizer 153.0.0</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">potential_utf 0.1.6</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">tinystr 0.7.6</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">tinystr 0.8.4</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">writeable 0.5.5</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">writeable 0.6.4</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">yoke-derive 0.7.5</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">yoke-derive 0.8.2</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">yoke 0.7.5</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">yoke 0.8.3</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom-derive 0.1.7</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom 0.1.8</a></li>
-                        <li><a href=" https://github.com/unicode-org/icu4x ">zerovec-derive 0.10.3</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">zerotrie 0.2.5</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">zerovec-derive 0.10.4</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">zerovec-derive 0.11.6</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">zerovec 0.10.4</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">zerovec 0.11.8</a></li>
                     </ul>
                 <pre class="license-text">UNICODE LICENSE V3
 

--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -16,7 +16,7 @@ android {
         minSdk = libs.versions.android.sdk.min.get().toInt()
         targetSdk = 34
         versionCode = generatedVersionCode
-        versionName = "0.5.0"
+        versionName = "0.6.0"
     }
 
     compileOptions {

--- a/support/openharmony/entry/oh-package.json5
+++ b/support/openharmony/entry/oh-package.json5
@@ -5,7 +5,7 @@
   "name": "servoshell",
   "description": "Please describe the basic information.",
   "main": "",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "dependencies": {
     "libservoshell.so": "file:./src/main/cpp/types/libentry"
   }

--- a/support/openharmony/oh-package.json5
+++ b/support/openharmony/oh-package.json5
@@ -8,6 +8,6 @@
   "name": "servoshell",
   "description": "Servo browser shell",
   "main": "",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "dependencies": {}
 }

--- a/support/windows/servoshell.wxs.mako
+++ b/support/windows/servoshell.wxs.mako
@@ -4,7 +4,7 @@
            UpgradeCode="060cd15d-eab1-4614-b438-3988e3efdcf1"
            Language="1033"
            Codepage="1252"
-           Version="0.5.0"
+           Version="0.6.0"
            InstallerVersion="200">
     <SummaryInformation Keywords="Installer"
                         Description="Servo Tech Demo Installer"


### PR DESCRIPTION
Generated by running `./mach release 0.6.0`.
Normal monthly bump.

Testing: Not required, covered by existing tests.

