### PR TITLE
script_webgpu: Use trait_alias crate instead of manual defining trait restrictions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9536,6 +9536,7 @@ dependencies = [
  "servo-malloc-size-of",
  "servo-script-bindings",
  "servo-webgpu-traits",
+ "trait-set",
  "wgpu-core 30.0.1",
  "wgpu-types 30.0.0",
 ]
@@ -11097,6 +11098,17 @@ name = "tracy-rs"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce607aae8ab0ab3abf3a2723a9ab6f09bb8639ed83fdd888d857b8e556c868d8"
+
+[[package]]
+name = "trait-set"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55442dd31337ec4b06189213a6a65cc414e4ae34e4cbc7bc050fae1573d14ed5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
 
 [[package]]
 name = "transpose"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,6 +250,7 @@ syn = { version = "2", default-features = false, features = ["clone-impls", "der
 synstructure = "0.13"
 sys-locale = "0.3"
 taffy = { version = "0.14.0", default-features = false, features = ["calc", "detailed_layout_info", "grid", "std"] }
+trait-set = "0.5"
 tempfile = "3"
 tendril = { version = "0.5", features = ["encoding_rs"] }
 tikv-jemalloc-sys = "0.6.1"

--- a/components/script_webgpu/Cargo.toml
+++ b/components/script_webgpu/Cargo.toml
@@ -30,6 +30,7 @@ malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 num-traits = { workspace = true }
 servo-base = { workspace = true }
+trait-set = { workspace = true }
 webgpu_traits = { workspace = true }
 wgpu-core = { workspace = true }
 wgpu-types = { workspace = true }

--- a/components/script_webgpu/gpu.rs
+++ b/components/script_webgpu/gpu.rs
@@ -24,7 +24,7 @@ use wgpu_types::PowerPreference;
 use super::wgsllanguagefeatures::WGSLLanguageFeatures;
 use crate::dom::bindings::error::Error;
 use crate::gpuadapter::GPUAdapter;
-use crate::traits::{WebGPUGlobalTrait, WebGPUPromiseTrait};
+use crate::traits::{Equivalence, WebGPUGlobalTrait, WebGPUPromiseTrait};
 
 #[dom_struct]
 pub struct GPU<D: DomTypes> {
@@ -35,10 +35,7 @@ pub struct GPU<D: DomTypes> {
     phantom: PhantomData<D>,
 }
 
-impl<D> GPU<D>
-where
-    D: DomTypes<GPU = GPU<D>>,
-{
+impl<D: Equivalence> GPU<D> {
     pub(crate) fn new_inherited() -> GPU<D> {
         GPU {
             reflector_: Reflector::new(),
@@ -61,9 +58,9 @@ where
     }
 }
 
-impl<D: DomTypes> GPUMethods<D> for GPU<D>
+impl<D> GPUMethods<D> for GPU<D>
 where
-    D: DomTypes<GPU = GPU<D>, WGSLLanguageFeatures = WGSLLanguageFeatures<D>>,
+    D: Equivalence,
     D::Promise: PromiseHelpers<D> + WebGPUPromiseTrait<D>,
     D::GPU: DomGlobalGeneric<D>,
     D::GlobalScope: WebGPUGlobalTrait,

--- a/components/script_webgpu/gpuadapter.rs
+++ b/components/script_webgpu/gpuadapter.rs
@@ -26,7 +26,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::gpuadapterinfo::GPUAdapterInfo;
 use crate::gpusupportedfeatures::{GPUSupportedFeatures, gpu_to_wgt_feature};
 use crate::gpusupportedlimits::{GPUSupportedLimits, set_limit};
-use crate::traits::{WebGPUGlobalTrait, WebGPUPromiseTrait};
+use crate::traits::{Equivalence, WebGPUGlobalTrait, WebGPUPromiseTrait};
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUAdapter {
@@ -65,12 +65,7 @@ pub struct GPUAdapter<D: DomTypes> {
 
 impl<D> GPUAdapter<D>
 where
-    D: DomTypes<
-            GPUAdapter = GPUAdapter<D>,
-            GPUAdapterInfo = GPUAdapterInfo<D>,
-            GPUSupportedFeatures = GPUSupportedFeatures<D>,
-            GPUSupportedLimits = GPUSupportedLimits<D>,
-        >,
+    D: Equivalence,
 {
     fn new_inherited(
         channel: WebGPU,
@@ -198,12 +193,7 @@ where
 
 impl<D> GPUAdapterMethods<D> for GPUAdapter<D>
 where
-    D: DomTypes<
-            GPUAdapter = GPUAdapter<D>,
-            GPUAdapterInfo = GPUAdapterInfo<D>,
-            GPUSupportedFeatures = GPUSupportedFeatures<D>,
-            GPUSupportedLimits = GPUSupportedLimits<D>,
-        >,
+    D: Equivalence,
     D::Promise: WebGPUPromiseTrait<D> + PromiseHelpers<D>,
     D::GlobalScope: WebGPUGlobalTrait + GlobalScopeHelpers<D>,
 {

--- a/components/script_webgpu/gpuadapterinfo.rs
+++ b/components/script_webgpu/gpuadapterinfo.rs
@@ -16,6 +16,7 @@ use script_bindings::reflector::{Reflector, reflect_dom_object_with_wrap};
 
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
+use crate::traits::Equivalence;
 
 #[dom_struct]
 pub struct GPUAdapterInfo<D: DomTypes> {
@@ -31,10 +32,7 @@ pub struct GPUAdapterInfo<D: DomTypes> {
     phantom: PhantomData<D>,
 }
 
-impl<D> GPUAdapterInfo<D>
-where
-    D: DomTypes<GPUAdapterInfo = GPUAdapterInfo<D>>,
-{
+impl<D: Equivalence> GPUAdapterInfo<D> {
     fn new_inherited(
         vendor: DOMString,
         architecture: DOMString,

--- a/components/script_webgpu/gpubindgroup.rs
+++ b/components/script_webgpu/gpubindgroup.rs
@@ -22,11 +22,10 @@ use wgpu_core::binding_model::BindGroupDescriptor;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
 use crate::gpubindgrouplayout::GPUBindGroupLayout;
-use crate::gpubuffer::GPUBuffer;
 use crate::gpuconvert::{WebGPUConvert, convert_bind_group_entry};
 use crate::traits::{
-    GPUDeviceTrait, GPUExternalTextureTrait, GPUSamplerTrait, GPUTextureTrait, GPUTextureViewTrait,
-    WebGPUGlobalTrait,
+    Equivalence, GPUDeviceTrait, GPUExternalTextureTrait, GPUSamplerTrait, GPUTextureTrait,
+    GPUTextureViewTrait, WebGPUGlobalTrait,
 };
 
 #[derive(JSTraceable, MallocSizeOf)]
@@ -62,10 +61,7 @@ pub struct GPUBindGroup<D: DomTypes> {
     droppable: DroppableGPUBindGroup,
 }
 
-impl<D> GPUBindGroup<D>
-where
-    D: DomTypes<GPUBindGroup = GPUBindGroup<D>>,
-{
+impl<D: Equivalence> GPUBindGroup<D> {
     fn new_inherited(
         channel: WebGPU,
         bind_group: WebGPUBindGroup,
@@ -107,11 +103,7 @@ where
 
 impl<D> GPUBindGroup<D>
 where
-    D: DomTypes<
-            GPUBuffer = GPUBuffer<D>,
-            GPUBindGroup = GPUBindGroup<D>,
-            GPUBindGroupLayout = GPUBindGroupLayout<D>,
-        >,
+    D: Equivalence,
     D::GPUDevice: DomGlobalGeneric<D> + GPUDeviceTrait<D>,
     D::GlobalScope: WebGPUGlobalTrait,
     D::GPUExternalTexture: GPUExternalTextureTrait,

--- a/components/script_webgpu/gpubindgrouplayout.rs
+++ b/components/script_webgpu/gpubindgrouplayout.rs
@@ -24,7 +24,7 @@ use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::USVString;
 use crate::gpuconvert::{WebGPUConvert, convert_bind_group_layout_entry};
-use crate::traits::{GPUDeviceTrait, WebGPUGlobalTrait};
+use crate::traits::{Equivalence, GPUDeviceTrait, WebGPUGlobalTrait};
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUBindGroupLayout {
@@ -58,10 +58,7 @@ pub struct GPUBindGroupLayout<D: DomTypes> {
     phantom: PhantomData<D>,
 }
 
-impl<D> GPUBindGroupLayout<D>
-where
-    D: DomTypes<GPUBindGroupLayout = GPUBindGroupLayout<D>>,
-{
+impl<D: Equivalence> GPUBindGroupLayout<D> {
     fn new_inherited(
         channel: WebGPU,
         bind_group_layout: WebGPUBindGroupLayout,
@@ -100,7 +97,7 @@ where
 
 impl<D> GPUBindGroupLayout<D>
 where
-    D: DomTypes<GPUBindGroupLayout = GPUBindGroupLayout<D>>,
+    D: Equivalence,
     D::GPUDevice: GPUDeviceTrait<D>,
     D::GlobalScope: WebGPUGlobalTrait + GlobalScopeHelpers<D>,
 {

--- a/components/script_webgpu/gpubuffer.rs
+++ b/components/script_webgpu/gpubuffer.rs
@@ -30,7 +30,7 @@ use crate::datablock::DataBlock;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
 use crate::gpuconvert::WebGPUConvert;
-use crate::traits::{GPUDeviceTrait, WebGPUGlobalTrait, WebGPUPromiseTrait};
+use crate::traits::{Equivalence, GPUDeviceTrait, WebGPUGlobalTrait, WebGPUPromiseTrait};
 
 #[derive(JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
@@ -110,7 +110,7 @@ pub struct GPUBuffer<D: DomTypes> {
 
 impl<D> GPUBuffer<D>
 where
-    D: DomTypes<GPUBuffer = GPUBuffer<D>>,
+    D: Equivalence,
     D::Promise: PromiseHelpers<D>,
 {
     fn new_inherited(
@@ -159,7 +159,7 @@ where
 
 impl<D> GPUBuffer<D>
 where
-    D: DomTypes<GPUBuffer = GPUBuffer<D>>,
+    D: Equivalence,
     D::GPUDevice: DomGlobalGeneric<D> + GPUDeviceTrait<D>,
     D::GlobalScope: WebGPUGlobalTrait,
     D::Promise: PromiseHelpers<D>,
@@ -221,7 +221,7 @@ where
 
 impl<D> GPUBufferMethods<D> for GPUBuffer<D>
 where
-    D: DomTypes<GPUBuffer = GPUBuffer<D>>,
+    D: Equivalence,
     D::Promise: PromiseHelpers<D> + WebGPUPromiseTrait<D> + PartialEq,
     D::GPUDevice: GPUDeviceTrait<D>,
     D::GPUDevice: DomGlobalGeneric<D> + GPUDeviceTrait<D>,

--- a/components/script_webgpu/gpucommandbuffer.rs
+++ b/components/script_webgpu/gpucommandbuffer.rs
@@ -19,6 +19,7 @@ use webgpu_traits::{WebGPU, WebGPUCommandBuffer, WebGPURequest};
 
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::USVString;
+use crate::traits::Equivalence;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUCommandBuffer {
@@ -52,10 +53,7 @@ pub struct GPUCommandBuffer<D: DomTypes> {
     phantom: PhantomData<D>,
 }
 
-impl<D> GPUCommandBuffer<D>
-where
-    D: DomTypes<GPUCommandBuffer = GPUCommandBuffer<D>>,
-{
+impl<D: Equivalence> GPUCommandBuffer<D> {
     fn new_inherited(
         channel: WebGPU,
         command_buffer: WebGPUCommandBuffer,

--- a/components/script_webgpu/gpucompilationinfo.rs
+++ b/components/script_webgpu/gpucompilationinfo.rs
@@ -17,6 +17,7 @@ use webgpu_traits::ShaderCompilationInfo;
 use crate::JSTraceable;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::gpucompilationmessage::GPUCompilationMessage;
+use crate::traits::Equivalence;
 
 #[dom_struct]
 pub struct GPUCompilationInfo<D: DomTypes> {
@@ -25,13 +26,7 @@ pub struct GPUCompilationInfo<D: DomTypes> {
     msg: Vec<Dom<GPUCompilationMessage<D>>>,
 }
 
-impl<D> GPUCompilationInfo<D>
-where
-    D: DomTypes<
-            GPUCompilationInfo = GPUCompilationInfo<D>,
-            GPUCompilationMessage = GPUCompilationMessage<D>,
-        >,
-{
+impl<D: Equivalence> GPUCompilationInfo<D> {
     pub(crate) fn new_inherited(msg: Vec<DomRoot<GPUCompilationMessage<D>>>) -> Self {
         Self {
             reflector_: Reflector::new(),

--- a/components/script_webgpu/gpucompilationmessage.rs
+++ b/components/script_webgpu/gpucompilationmessage.rs
@@ -17,6 +17,7 @@ use webgpu_traits::ShaderCompilationInfo;
 use crate::JSTraceable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
+use crate::traits::Equivalence;
 
 #[dom_struct]
 pub struct GPUCompilationMessage<D: DomTypes> {
@@ -31,10 +32,7 @@ pub struct GPUCompilationMessage<D: DomTypes> {
     phantom: PhantomData<D>,
 }
 
-impl<D> GPUCompilationMessage<D>
-where
-    D: DomTypes<GPUCompilationMessage = GPUCompilationMessage<D>>,
-{
+impl<D: Equivalence> GPUCompilationMessage<D> {
     fn new_inherited(
         message: DOMString,
         mtype: GPUCompilationMessageType,

--- a/components/script_webgpu/gpuconvert.rs
+++ b/components/script_webgpu/gpuconvert.rs
@@ -31,9 +31,8 @@ use wgpu_core::resource::{QuerySetDescriptor, TextureDescriptor};
 use wgpu_types::{self, AstcBlock, AstcChannel, IndexFormat};
 
 use crate::dom::bindings::error::{Error, Fallible};
-use crate::gpubuffer::GPUBuffer;
 use crate::traits::{
-    GPUDeviceTrait, GPUExternalTextureTrait, GPUQuerySetTrait, GPUSamplerTrait,
+    Equivalence, GPUDeviceTrait, GPUExternalTextureTrait, GPUQuerySetTrait, GPUSamplerTrait,
     GPUShaderModuleTrait, GPUTextureTrait, GPUTextureViewTrait, WebGPUGlobalTrait,
 };
 
@@ -521,7 +520,7 @@ impl WebGPUConvert<wgpu_types::StencilOperation> for GPUStencilOperation {
 
 impl<D> WebGPUConvert<wgpu_com::TexelCopyBufferInfo> for &GPUTexelCopyBufferInfo<D>
 where
-    D: DomTypes<GPUBuffer = GPUBuffer<D>>,
+    D: Equivalence,
     D::GPUDevice: DomGlobalGeneric<D> + GPUDeviceTrait<D>,
     D::GlobalScope: WebGPUGlobalTrait,
     D::Promise: PromiseHelpers<D>,
@@ -798,7 +797,7 @@ pub(crate) fn convert_bind_group_entry<'a, D>(
     bind_group: &GPUBindGroupEntry<D>,
 ) -> BindGroupEntry<'a>
 where
-    D: DomTypes<GPUBuffer = GPUBuffer<D>>,
+    D: Equivalence,
     D::GPUTexture: GPUTextureTrait,
     D::GPUTextureView: GPUTextureViewTrait,
     D::GPUSampler: GPUSamplerTrait,

--- a/components/script_webgpu/gpudevicelostinfo.rs
+++ b/components/script_webgpu/gpudevicelostinfo.rs
@@ -16,6 +16,7 @@ use script_bindings::reflector::{Reflector, reflect_dom_object_with_wrap};
 use crate::JSTraceable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
+use crate::traits::Equivalence;
 
 #[dom_struct]
 pub struct GPUDeviceLostInfo<D: DomTypes> {
@@ -26,10 +27,7 @@ pub struct GPUDeviceLostInfo<D: DomTypes> {
     phantom: PhantomData<D>,
 }
 
-impl<D> GPUDeviceLostInfo<D>
-where
-    D: DomTypes<GPUDeviceLostInfo = GPUDeviceLostInfo<D>>,
-{
+impl<D: Equivalence> GPUDeviceLostInfo<D> {
     fn new_inherited(message: DOMString, reason: GPUDeviceLostReason) -> Self {
         Self {
             reflector_: Reflector::new(),

--- a/components/script_webgpu/gpurenderbundle.rs
+++ b/components/script_webgpu/gpurenderbundle.rs
@@ -19,6 +19,7 @@ use webgpu_traits::{WebGPU, WebGPUDevice, WebGPURenderBundle, WebGPURequest};
 
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::USVString;
+use crate::traits::Equivalence;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPURenderBundle {
@@ -54,10 +55,7 @@ pub struct GPURenderBundle<D: DomTypes> {
     phantom: PhantomData<D>,
 }
 
-impl<D> GPURenderBundle<D>
-where
-    D: DomTypes<GPURenderBundle = GPURenderBundle<D>>,
-{
+impl<D: Equivalence> GPURenderBundle<D> {
     fn new_inherited(
         render_bundle: WebGPURenderBundle,
         device: WebGPUDevice,

--- a/components/script_webgpu/gpusupportedfeatures.rs
+++ b/components/script_webgpu/gpusupportedfeatures.rs
@@ -24,6 +24,7 @@ use crate::JSTraceable;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
+use crate::traits::Equivalence;
 
 #[dom_struct]
 pub struct GPUSupportedFeatures<D: DomTypes> {
@@ -38,10 +39,7 @@ pub struct GPUSupportedFeatures<D: DomTypes> {
     phantom: PhantomData<D>,
 }
 
-impl<D> GPUSupportedFeatures<D>
-where
-    D: DomTypes<GPUSupportedFeatures = GPUSupportedFeatures<D>>,
-{
+impl<D: Equivalence> GPUSupportedFeatures<D> {
     fn new(
         cx: &mut JSContext,
         global: &D::GlobalScope,

--- a/components/script_webgpu/gpusupportedlimits.rs
+++ b/components/script_webgpu/gpusupportedlimits.rs
@@ -17,6 +17,7 @@ use wgpu_types::Limits;
 
 use crate::JSTraceable;
 use crate::dom::bindings::root::DomRoot;
+use crate::traits::Equivalence;
 
 /// <https://gpuweb.github.io/gpuweb/#gpusupportedlimits>
 #[dom_struct]
@@ -29,10 +30,7 @@ pub struct GPUSupportedLimits<D: DomTypes> {
     phantom: PhantomData<D>,
 }
 
-impl<D> GPUSupportedLimits<D>
-where
-    D: DomTypes<GPUSupportedLimits = GPUSupportedLimits<D>>,
-{
+impl<D: Equivalence> GPUSupportedLimits<D> {
     fn new_inherited(limits: Limits) -> Self {
         Self {
             reflector_: Reflector::new(),

--- a/components/script_webgpu/traits.rs
+++ b/components/script_webgpu/traits.rs
@@ -20,8 +20,48 @@ use wgpu_types::TextureFormat;
 
 use crate::gpu::GPU;
 use crate::gpuadapter::GPUAdapter;
+use crate::gpuadapterinfo::GPUAdapterInfo;
+use crate::gpubindgroup::GPUBindGroup;
+use crate::gpubindgrouplayout::GPUBindGroupLayout;
 use crate::gpubuffer::GPUBuffer;
+use crate::gpubufferusage::GPUBufferUsage;
+use crate::gpucolorwrite::GPUColorWrite;
+use crate::gpucommandbuffer::GPUCommandBuffer;
+use crate::gpucompilationinfo::GPUCompilationInfo;
+use crate::gpucompilationmessage::GPUCompilationMessage;
+use crate::gpudevicelostinfo::GPUDeviceLostInfo;
+use crate::gpumapmode::GPUMapMode;
+use crate::gpurenderbundle::GPURenderBundle;
+use crate::gpushaderstage::GPUShaderStage;
+use crate::gpusupportedfeatures::GPUSupportedFeatures;
+use crate::gpusupportedlimits::GPUSupportedLimits;
+use crate::gputextureusage::GPUTextureUsage;
 use crate::identityhub::IdentityHub;
+use crate::wgsllanguagefeatures::WGSLLanguageFeatures;
+
+// This trait enforces the equivalence of all local types with the types in DomTypes.
+trait_set::trait_set! {
+pub trait Equivalence =  DomTypes<
+    GPU = GPU<Self>,
+        GPUAdapter = GPUAdapter<Self>,
+        GPUAdapterInfo = GPUAdapterInfo<Self>,
+        GPUBindGroup = GPUBindGroup<Self>,
+        GPUBindGroupLayout = GPUBindGroupLayout<Self>,
+        GPUBuffer = GPUBuffer<Self>,
+        GPUBufferUsage = GPUBufferUsage<Self>,
+        GPUColorWrite = GPUColorWrite<Self>,
+        GPUCommandBuffer = GPUCommandBuffer<Self>,
+        GPUCompilationInfo = GPUCompilationInfo<Self>,
+        GPUCompilationMessage = GPUCompilationMessage<Self>,
+        GPUDeviceLostInfo = GPUDeviceLostInfo<Self>,
+        GPUMapMode = GPUMapMode<Self>,
+        GPURenderBundle = GPURenderBundle<Self>,
+        GPUShaderStage = GPUShaderStage<Self>,
+        GPUSupportedFeatures = GPUSupportedFeatures<Self>,
+        GPUSupportedLimits = GPUSupportedLimits<Self>,
+        GPUTextureUsage = GPUTextureUsage<Self>,
+        WGSLLanguageFeatures = WGSLLanguageFeatures<Self>>;
+}
 
 /// The main trait for creating and using promises in script_webgpu.
 pub trait WebGPUPromiseTrait<D: DomTypes> {

--- a/components/script_webgpu/wgsllanguagefeatures.rs
+++ b/components/script_webgpu/wgsllanguagefeatures.rs
@@ -23,6 +23,7 @@ use wgpu_core::naga::front::wgsl::ImplementedLanguageExtension;
 
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
+use crate::traits::Equivalence;
 
 #[dom_struct]
 pub struct WGSLLanguageFeatures<D: DomTypes> {
@@ -34,10 +35,7 @@ pub struct WGSLLanguageFeatures<D: DomTypes> {
     phantom: PhantomData<D>,
 }
 
-impl<D> WGSLLanguageFeatures<D>
-where
-    D: DomTypes<WGSLLanguageFeatures = WGSLLanguageFeatures<D>>,
-{
+impl<D: Equivalence> WGSLLanguageFeatures<D> {
     pub fn new(
         cx: &mut JSContext,
         global: &D::GlobalScope,


### PR DESCRIPTION
This replaces the trait restriction we currently have (`D: DomTypes<GPU=GPU<D>, ...>`) with a trait alias. As trait aliases are not stable we use the trait-set crate (https://crates.io/crates/trait-set) which seems to be the most popular crate. This simplifies the above construction to `D: Equivalence`.

Testing: As this just changes trait bounds compilation is the test.
