### PR TITLE
base: Hide IpcError behind generic SendError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9217,7 +9217,6 @@ dependencies = [
  "gleam",
  "glow",
  "image",
- "ipc-channel",
  "log",
  "malloc_size_of_derive",
  "parking_lot",

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -116,7 +116,6 @@ use embedder_traits::{
 };
 use euclid::default::Size2D as UntypedSize2D;
 use fonts::SystemFontServiceProxy;
-use ipc_channel::IpcError;
 use ipc_channel::router::ROUTER;
 use keyboard_types::{Key, KeyState, Modifiers, NamedKey};
 use layout_api::{LayoutFactory, ScriptThreadFactory};
@@ -304,7 +303,7 @@ pub struct Constellation<STF, SWF> {
     /// A channel for the constellation to receive messages from script threads.
     /// This is the constellation's view of `script_sender`.
     script_receiver:
-        Receiver<Result<(WebViewId, PipelineId, ScriptToConstellationMessage), IpcError>>,
+        Receiver<Result<(WebViewId, PipelineId, ScriptToConstellationMessage), SendError>>,
 
     /// A handle to register components for hang monitoring.
     /// None when in multiprocess mode.
@@ -961,7 +960,7 @@ where
         parent_pipeline_id: Option<PipelineId>,
         load_data: &LoadData,
         is_private: bool,
-    ) -> Result<Rc<EventLoop>, IpcError> {
+    ) -> Result<Rc<EventLoop>, SendError> {
         let registered_domain_name = if load_data
             .creation_sandboxing_flag_set
             .contains(SandboxingFlagSet::SANDBOXED_ORIGIN_BROWSING_CONTEXT_FLAG)
@@ -1030,7 +1029,7 @@ where
             is_private,
         ) {
             Ok(event_loop) => event_loop,
-            Err(error) => return self.handle_send_error(new_pipeline_id, error.into()),
+            Err(error) => return self.handle_send_error(new_pipeline_id, error),
         };
 
         let user_content_manager_id = self

--- a/components/constellation/event_loop.rs
+++ b/components/constellation/event_loop.rs
@@ -12,7 +12,6 @@ use std::rc::Rc;
 
 use background_hang_monitor_api::{BackgroundHangMonitorControlMsg, HangAlert};
 use embedder_traits::ScriptToEmbedderChan;
-use ipc_channel::IpcError;
 use layout_api::ScriptThreadFactory;
 use log::error;
 use media::WindowGLContext;
@@ -66,7 +65,7 @@ impl EventLoop {
     pub(crate) fn spawn<STF: ScriptThreadFactory, SWF: ServiceWorkerManagerFactory>(
         constellation: &mut Constellation<STF, SWF>,
         is_private: bool,
-    ) -> Result<Rc<Self>, IpcError> {
+    ) -> Result<Rc<Self>, SendError> {
         let (script_chan, script_port) =
             servo_base::generic_channel::channel().expect("Pipeline script chan");
 
@@ -154,7 +153,7 @@ impl EventLoop {
     fn spawn_in_process<STF: ScriptThreadFactory, SWF: ServiceWorkerManagerFactory>(
         constellation: &mut Constellation<STF, SWF>,
         initial_script_state: InitialScriptState,
-    ) -> Result<Self, IpcError> {
+    ) -> Result<Self, SendError> {
         let script_chan = initial_script_state.constellation_to_script_sender.clone();
         let id = initial_script_state.id;
 

--- a/components/constellation/process_manager.rs
+++ b/components/constellation/process_manager.rs
@@ -7,6 +7,7 @@ use std::process::Child;
 use crossbeam_channel::{Receiver, Select};
 use log::{debug, warn};
 use profile_traits::mem::{ProfilerChan, ProfilerMsg};
+use servo_base::generic_channel::SendError;
 
 pub enum Process {
     Unsandboxed(Child),
@@ -34,7 +35,7 @@ impl Process {
     }
 }
 
-type ProcessReceiver = Receiver<Result<(), ipc_channel::IpcError>>;
+type ProcessReceiver = Receiver<Result<(), SendError>>;
 
 pub(crate) struct ProcessManager {
     processes: Vec<(Process, ProcessReceiver)>,

--- a/components/script/dom/indexeddb/idbrequest.rs
+++ b/components/script/dom/indexeddb/idbrequest.rs
@@ -13,7 +13,7 @@ use js::rust::HandleValue;
 use profile_traits::generic_callback::GenericCallback;
 use script_bindings::reflector::{DomObject, reflect_dom_object_with_cx};
 use serde::{Deserialize, Serialize};
-use servo_base::generic_channel::GenericSend;
+use servo_base::generic_channel::{GenericSend, SendError};
 use storage_traits::indexeddb::{
     AsyncOperation, AsyncReadOnlyOperation, BackendError, BackendResult, IndexedDBKeyType,
     IndexedDBRecord, IndexedDBThreadMsg, IndexedDBTxnMode, PutItemResult, SyncOperation,
@@ -508,7 +508,7 @@ impl IDBRequest {
             .database_access_task_source()
             .to_sendable();
 
-        let closure = move |message: Result<BackendResult<T>, ipc_channel::IpcError>| {
+        let closure = move |message: Result<BackendResult<T>, SendError>| {
             let response_listener = response_listener.clone();
             task_source.queue(task!(request_callback: move |cx| {
                 response_listener.handle_async_request_finished(

--- a/components/script/dom/indexeddb/idbtransaction.rs
+++ b/components/script/dom/indexeddb/idbtransaction.rs
@@ -318,7 +318,7 @@ impl IDBTransaction {
         // connection callbacks) instead of creating one per transaction operation.
         let callback = GenericCallback::new(
             global.time_profiler_chan().clone(),
-            move |message: Result<TxnCompleteMsg, ipc_channel::IpcError>| {
+            move |message: Result<TxnCompleteMsg, SendError>| {
                 let this = this.clone();
                 let task_source = task_source.clone();
                 task_source.queue(task!(handle_commit_result: move |cx| {
@@ -522,7 +522,7 @@ impl IDBTransaction {
             .to_sendable();
         let callback = GenericCallback::new(
             global.time_profiler_chan().clone(),
-            move |message: Result<TxnCompleteMsg, ipc_channel::IpcError>| {
+            move |message: Result<TxnCompleteMsg, SendError>| {
                 let this = this.clone();
                 let task_source = task_source.clone();
                 task_source.queue(task!(handle_abort_result: move || {
@@ -733,7 +733,7 @@ impl IDBTransaction {
             .to_sendable();
         GenericCallback::new(
             self.global().time_profiler_chan().clone(),
-            move |error: Result<BackendError, ipc_channel::IpcError>| {
+            move |error: Result<BackendError, SendError>| {
                 let Ok(error) = error else {
                     return;
                 };

--- a/components/script/dom/indexeddb/idbtransaction.rs
+++ b/components/script/dom/indexeddb/idbtransaction.rs
@@ -12,7 +12,7 @@ use profile_traits::generic_channel::channel;
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericUnionTypes::StringOrStringSequence;
 use script_bindings::reflector::reflect_dom_object;
-use servo_base::generic_channel::{GenericSend, GenericSender};
+use servo_base::generic_channel::{GenericSend, GenericSender, SendError};
 use servo_base::id::ScriptEventLoopId;
 use storage_traits::indexeddb::{
     BackendError, IndexedDBIndex, IndexedDBThreadMsg, IndexedDBTxnMode, KeyPath, SyncOperation,

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -42,7 +42,7 @@ use profile_traits::{mem, time};
 use rustc_hash::FxHashMap;
 use script::{JSEngineSetup, ServiceWorkerManager};
 use servo_background_hang_monitor::HangMonitorRegister;
-use servo_base::generic_channel::{GenericCallback, GenericSender, RoutedReceiver};
+use servo_base::generic_channel::{GenericCallback, GenericSender, RoutedReceiver, SendError};
 pub use servo_base::id::WebViewId;
 use servo_base::id::{EMBEDDER_PIPELINE_NAMESPACE_ID, PipelineNamespace};
 #[cfg(feature = "bluetooth")]
@@ -1187,7 +1187,7 @@ fn create_paint_channel(
     let sender_clone = sender.clone();
     let event_loop_waker_clone = event_loop_waker.clone();
     // This callback is equivalent to `PaintProxy::send`
-    let result_callback = move |msg: Result<PaintMessage, ipc_channel::IpcError>| {
+    let result_callback = move |msg: Result<PaintMessage, SendError>| {
         if let Err(err) = sender_clone.send(msg) {
             warn!("Failed to send response ({:?}).", err);
         }

--- a/components/shared/base/generic_channel/callback.rs
+++ b/components/shared/base/generic_channel/callback.rs
@@ -80,7 +80,7 @@ use crate::generic_channel::{
 /// except that this type is not wrapped in a Box.
 /// The callback will be wrapped in either a Box or an Arc, depending on if it is run on
 /// the router, or passed to the recipient.
-pub type MsgCallback<T> = dyn FnMut(Result<T, ipc_channel::IpcError>) + Send;
+pub type MsgCallback<T> = dyn FnMut(Result<T, SendError>) + Send;
 
 /// A mechanism to run a callback in the process this callback was constructed in.
 ///
@@ -132,11 +132,12 @@ where
     /// Creates a new GenericCallback.
     ///
     /// The callback should not do any heavy work and not block.
-    pub fn new<F: FnMut(Result<T, ipc_channel::IpcError>) + Send + 'static>(
+    pub fn new<F: FnMut(Result<T, SendError>) + Send + 'static>(
         mut callback: F,
-    ) -> Result<Self, ipc_channel::IpcError> {
+    ) -> Result<Self, SendError> {
         let generic_callback = if use_ipc() {
-            let (ipc_sender, ipc_receiver) = ipc_channel::ipc::channel()?;
+            let (ipc_sender, ipc_receiver) =
+                ipc_channel::ipc::channel().map_err(SendError::from)?;
             let new_callback = move |msg: Result<T, ipc_channel::SerDeError>| {
                 callback(msg.map_err(|error| error.into()))
             };
@@ -150,9 +151,9 @@ where
     }
 
     /// Produces a GenericCallback and a channel. You can block on this channel for the result.
-    pub fn new_blocking() -> Result<(Self, GenericReceiver<T>), ipc_channel::IpcError> {
+    pub fn new_blocking() -> Result<(Self, GenericReceiver<T>), SendError> {
         if use_ipc() {
-            let (sender, receiver) = ipc_channel::ipc::channel()?;
+            let (sender, receiver) = ipc_channel::ipc::channel().map_err(SendError::from)?;
             let generic_callback = GenericCallback(GenericCallbackVariants::CrossProcess(sender));
             let receiver = GenericReceiver(GenericReceiverVariants::Ipc(receiver));
             Ok((generic_callback, receiver))
@@ -312,15 +313,14 @@ mod single_process_callback_test {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    use crate::generic_channel::GenericCallback;
+    use crate::generic_channel::{GenericCallback, SendError};
 
     #[test]
     fn generic_callback() {
         let number = Arc::new(AtomicUsize::new(0));
         let number_clone = number.clone();
-        let callback = move |msg: Result<usize, ipc_channel::IpcError>| {
-            number_clone.store(msg.unwrap(), Ordering::SeqCst)
-        };
+        let callback =
+            move |msg: Result<usize, SendError>| number_clone.store(msg.unwrap(), Ordering::SeqCst);
         let generic_callback = GenericCallback::new(callback).unwrap();
         std::thread::scope(|s| {
             s.spawn(move || generic_callback.send(42));
@@ -332,9 +332,8 @@ mod single_process_callback_test {
     fn generic_callback_via_generic_sender() {
         let number = Arc::new(AtomicUsize::new(0));
         let number_clone = number.clone();
-        let callback = move |msg: Result<usize, ipc_channel::IpcError>| {
-            number_clone.store(msg.unwrap(), Ordering::SeqCst)
-        };
+        let callback =
+            move |msg: Result<usize, SendError>| number_clone.store(msg.unwrap(), Ordering::SeqCst);
         let generic_callback = GenericCallback::new(callback).unwrap();
         let (tx, rx) = crate::generic_channel::channel().unwrap();
 
@@ -352,9 +351,8 @@ mod single_process_callback_test {
     fn generic_callback_via_ipc_sender() {
         let number = Arc::new(AtomicUsize::new(0));
         let number_clone = number.clone();
-        let callback = move |msg: Result<usize, ipc_channel::IpcError>| {
-            number_clone.store(msg.unwrap(), Ordering::SeqCst)
-        };
+        let callback =
+            move |msg: Result<usize, SendError>| number_clone.store(msg.unwrap(), Ordering::SeqCst);
         let generic_callback = GenericCallback::new(callback).unwrap();
         let (tx, rx) = ipc_channel::ipc::channel().unwrap();
 

--- a/components/shared/base/generic_channel/generic_channelset.rs
+++ b/components/shared/base/generic_channel/generic_channelset.rs
@@ -5,7 +5,7 @@ use ipc_channel::ipc::{IpcReceiverSet, IpcSelectionResult};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
-use crate::generic_channel::{GenericReceiver, GenericReceiverVariants, use_ipc};
+use crate::generic_channel::{GenericReceiver, GenericReceiverVariants, SendError, use_ipc};
 
 /// A GenericReceiverSet. Allows you to wait on multiple GenericReceivers.
 /// Automatically selects either Ipc or crossbeam depending on multiprocess mode.
@@ -37,7 +37,7 @@ impl<T: Serialize + for<'de> Deserialize<'de>> Default for GenericReceiverSet<T>
 }
 enum GenericReceiverSetVariants<T: for<'de> Deserialize<'de>> {
     Ipc(ipc_channel::ipc::IpcReceiverSet),
-    Crossbeam(Vec<crossbeam_channel::Receiver<Result<T, ipc_channel::IpcError>>>),
+    Crossbeam(Vec<crossbeam_channel::Receiver<Result<T, SendError>>>),
 }
 
 #[cfg(test)]
@@ -178,7 +178,7 @@ pub struct Selector<'a, T: Serialize + for<'de> Deserialize<'de>> {
 enum SelectorInner<'a, T: for<'de> Deserialize<'de>> {
     Ipc(&'a mut IpcReceiverSet),
     Crossbeam {
-        receivers: &'a [crossbeam_channel::Receiver<Result<T, ipc_channel::IpcError>>],
+        receivers: &'a [crossbeam_channel::Receiver<Result<T, SendError>>],
         sel: crossbeam_channel::Select<'a>,
     },
 }

--- a/components/shared/base/generic_channel/lazy_callback.rs
+++ b/components/shared/base/generic_channel/lazy_callback.rs
@@ -219,10 +219,7 @@ where
     T: Serialize + for<'de> Deserialize<'de> + Send + 'static,
 {
     /// This sets the callback.
-    pub fn set_callback<F: FnMut(Result<T, ipc_channel::IpcError>) + Send + 'static>(
-        self,
-        mut callback: F,
-    ) {
+    pub fn set_callback<F: FnMut(Result<T, SendError>) + Send + 'static>(self, mut callback: F) {
         match self.0 {
             CallbackSetterVariants::InProcess(sender) => {
                 let callback = GenericCallback::new(callback).expect("Could not create callback");

--- a/components/shared/base/generic_channel/mod.rs
+++ b/components/shared/base/generic_channel/mod.rs
@@ -4,16 +4,16 @@
 
 //! Enum wrappers to be able to select different channel implementations at runtime.
 
-use std::fmt;
 use std::fmt::Display;
 use std::marker::PhantomData;
 use std::panic::Location;
 use std::sync::OnceLock;
 use std::time::Duration;
+use std::{fmt, io};
 
 use crossbeam_channel::RecvTimeoutError;
-use ipc_channel::IpcError;
 use ipc_channel::router::ROUTER;
+use ipc_channel::{IpcError, SerDeError};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use malloc_size_of_derive::MallocSizeOf;
 use serde::de::VariantAccess;
@@ -95,7 +95,7 @@ enum GenericSenderVariants<T: Serialize> {
     /// The crossbeam channel does not involve serializing, so we can't have this error,
     /// but replicating the API allows us to have one channel type as the receiver
     /// after routing the receiver .
-    Crossbeam(crossbeam_channel::Sender<Result<T, ipc_channel::IpcError>>),
+    Crossbeam(crossbeam_channel::Sender<Result<T, SendError>>),
 }
 
 fn serialize_generic_sender_variants<T: Serialize, S: Serializer>(
@@ -169,7 +169,7 @@ impl<'de, T: Serialize + Deserialize<'de>> serde::de::Visitor<'de> for GenericSe
                     ));
                 }
                 let addr = variant_data.newtype_variant::<usize>()?;
-                let ptr = addr as *mut crossbeam_channel::Sender<Result<T, ipc_channel::IpcError>>;
+                let ptr = addr as *mut crossbeam_channel::Sender<Result<T, SendError>>;
                 // SAFETY: We know we are in the same address space as the sender, so we can safely
                 // reconstruct the Box.
                 #[expect(unsafe_code)]
@@ -284,6 +284,19 @@ impl From<IpcError> for SendError {
     }
 }
 
+impl From<SerDeError> for SendError {
+    fn from(value: SerDeError) -> Self {
+        SendError::SerializationError(value.to_string())
+    }
+}
+
+impl From<io::Error> for SendError {
+    fn from(value: io::Error) -> Self {
+        log::error!("IO Error in IPC {:?}", value);
+        SendError::Disconnected
+    }
+}
+
 impl Display for SendError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{self:?}")
@@ -374,11 +387,11 @@ impl From<crossbeam_channel::TryRecvError> for TryReceiveError {
     }
 }
 
-pub type RoutedReceiver<T> = crossbeam_channel::Receiver<Result<T, ipc_channel::IpcError>>;
+pub type RoutedReceiver<T> = crossbeam_channel::Receiver<Result<T, SendError>>;
 pub type ReceiveResult<T> = Result<T, ReceiveError>;
 pub type TryReceiveResult<T> = Result<T, TryReceiveError>;
 pub type RoutedReceiverReceiveResult<T> =
-    Result<Result<T, ipc_channel::IpcError>, crossbeam_channel::RecvError>;
+    Result<Result<T, SendError>, crossbeam_channel::RecvError>;
 
 pub fn to_receive_result<T>(receive_result: RoutedReceiverReceiveResult<T>) -> ReceiveResult<T> {
     match receive_result {
@@ -474,8 +487,7 @@ where
                 ROUTER.add_typed_route(
                     ipc_receiver,
                     Box::new(move |message| {
-                        let _ = crossbeam_sender_clone
-                            .send(message.map_err(IpcError::SerializationError));
+                        let _ = crossbeam_sender_clone.send(message.map_err(|e| e.into()));
                     }),
                 );
                 crossbeam_receiver

--- a/components/shared/base/lib.rs
+++ b/components/shared/base/lib.rs
@@ -23,8 +23,6 @@ use std::fs::File;
 use std::io::{BufWriter, Read};
 use std::path::Path;
 
-use ipc_channel::IpcError;
-use ipc_channel::ipc::IpcSender;
 use log::{trace, warn};
 use malloc_size_of_derive::MallocSizeOf;
 pub use rope::{Rope, RopeChars, RopeIndex, RopeMovement, RopeSlice};
@@ -114,19 +112,4 @@ impl WebRenderEpochToU16 for WebRenderEpoch {
     fn as_u16(&self) -> u16 {
         (self.0 % u16::MAX as u32) as u16
     }
-}
-
-pub type IpcSendResult = Result<(), IpcError>;
-
-/// Abstraction of the ability to send a particular type of message,
-/// used by net_traits::ResourceThreads to ease the use its IpcSender sub-fields
-/// XXX: If this trait will be used more in future, some auto derive might be appealing
-pub trait IpcSend<T>
-where
-    T: serde::Serialize + for<'de> serde::Deserialize<'de>,
-{
-    /// send message T
-    fn send(&self, _: T) -> IpcSendResult;
-    /// get underlying sender
-    fn sender(&self) -> IpcSender<T>;
 }

--- a/components/shared/paint/Cargo.toml
+++ b/components/shared/paint/Cargo.toml
@@ -26,7 +26,6 @@ euclid = { workspace = true }
 gleam = { workspace = true }
 glow = { workspace = true }
 image = { workspace = true }
-ipc-channel = { workspace = true }
 log = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }

--- a/components/shared/paint/lib.rs
+++ b/components/shared/paint/lib.rs
@@ -36,7 +36,7 @@ use euclid::default::Size2D as UntypedSize2D;
 use profile_traits::mem::{OpaqueSender, ReportsChan};
 use serde::{Deserialize, Serialize};
 use servo_base::generic_channel::{
-    self, GenericCallback, GenericReceiver, GenericSender, GenericSharedMemory,
+    self, GenericCallback, GenericReceiver, GenericSender, GenericSharedMemory, SendError,
 };
 pub use webrender_api::ExternalImageSource;
 use webrender_api::units::{DevicePixel, LayoutVector2D, TexelRect};
@@ -53,7 +53,7 @@ use crate::viewport_description::ViewportDescription;
 /// Sends messages to `Paint`.
 #[derive(Clone)]
 pub struct PaintProxy {
-    pub sender: Sender<Result<PaintMessage, ipc_channel::IpcError>>,
+    pub sender: Sender<Result<PaintMessage, SendError>>,
     /// Access to [`Self::sender`] that is possible to send across an IPC
     /// channel. These messages are routed via the router thread to
     /// [`Self::sender`].
@@ -76,7 +76,7 @@ impl PaintProxy {
     ///
     /// This method is a temporary solution, and will be removed when migrating
     /// to `GenericChannel`.
-    pub fn route_msg(&self, msg: Result<PaintMessage, ipc_channel::IpcError>) {
+    pub fn route_msg(&self, msg: Result<PaintMessage, SendError>) {
         if let Err(err) = self.sender.send(msg) {
             warn!("Failed to send response ({:?}).", err);
         }

--- a/components/shared/profile/generic_callback.rs
+++ b/components/shared/profile/generic_callback.rs
@@ -4,7 +4,7 @@
 
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
-use servo_base::generic_channel::SendResult;
+use servo_base::generic_channel::{SendError, SendResult};
 
 use crate::time::{ProfilerCategory, ProfilerChan};
 use crate::time_profile;
@@ -22,10 +22,10 @@ impl<T> GenericCallback<T>
 where
     T: for<'de> Deserialize<'de> + Serialize + Send + 'static,
 {
-    pub fn new<F: FnMut(Result<T, ipc_channel::IpcError>) + Send + 'static>(
+    pub fn new<F: FnMut(Result<T, SendError>) + Send + 'static>(
         time_profiler_chan: ProfilerChan,
         callback: F,
-    ) -> Result<Self, ipc_channel::IpcError> {
+    ) -> Result<Self, SendError> {
         Ok(GenericCallback {
             callback: servo_base::generic_channel::GenericCallback::new(callback)?,
             time_profiler_chan,


### PR DESCRIPTION
This switches all remaining uses of IpcError to SendError in the codebase. This allows us to remove the dependency of ipc-channel for some crates and making any changes to GenericChannel easier.

Testing: This changes some error types around, so compilation is the test.
