### PR TITLE
script: Remove simple IpcChannel occurence in htmliframeelement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8404,7 +8404,6 @@ dependencies = [
  "encoding_rs",
  "euclid",
  "http 1.5.0",
- "ipc-channel",
  "log",
  "malloc_size_of_derive",
  "rustc-hash 2.1.3",

--- a/components/script/dom/html/embedded_content/htmliframeelement.rs
+++ b/components/script/dom/html/embedded_content/htmliframeelement.rs
@@ -15,7 +15,7 @@ use js::context::JSContext;
 use js::rust::HandleObject;
 use net_traits::ReferrerPolicy;
 use net_traits::request::Destination;
-use profile_traits::ipc as ProfiledIpc;
+use profile_traits::generic_channel::channel;
 use script_bindings::cell::DomRefCell;
 use script_traits::{NewPipelineInfo, UpdatePipelineIdReason};
 use servo_base::id::{BrowsingContextId, PipelineId, WebViewId};
@@ -883,8 +883,7 @@ impl HTMLIFrameElement {
         // TODO
 
         // Step 5. Destroy a document and its descendants given navigable's active document.
-        let (sender, receiver) =
-            ProfiledIpc::channel(self.global().time_profiler_chan().clone()).unwrap();
+        let (sender, receiver) = channel(self.global().time_profiler_chan().clone()).unwrap();
         let msg = ScriptToConstellationMessage::RemoveIFrame(browsing_context_id, sender);
         self.owner_window()
             .as_global_scope()

--- a/components/shared/constellation/Cargo.toml
+++ b/components/shared/constellation/Cargo.toml
@@ -29,7 +29,6 @@ euclid = { workspace = true }
 fonts_traits = { workspace = true }
 http = { workspace = true }
 hyper_serde = { workspace = true }
-ipc-channel = { workspace = true }
 log = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -18,7 +18,6 @@ use encoding_rs::Encoding;
 use euclid::default::Size2D as UntypedSize2D;
 use fonts_traits::SystemFontServiceProxySender;
 use http::{HeaderMap, Method};
-use ipc_channel::ipc::IpcSender;
 use malloc_size_of_derive::MallocSizeOf;
 use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{Destination, InsecureRequestsPolicy, Referrer, RequestBody};
@@ -763,7 +762,7 @@ pub enum ScriptToConstellationMessage {
     JointSessionHistoryLength(GenericSender<u32>),
     /// Notification that this iframe should be removed.
     /// Returns a list of pipelines which were closed.
-    RemoveIFrame(BrowsingContextId, IpcSender<Vec<PipelineId>>),
+    RemoveIFrame(BrowsingContextId, GenericSender<Vec<PipelineId>>),
     /// Successful response to [crate::ConstellationControlMsg::SetThrottled].
     SetThrottledComplete(bool),
     /// A load has been requested in an IFrame.


### PR DESCRIPTION
This seems to have been missed. Change from IpcChannel to GenericChannel.

Testing: GenericChannel is well tested so this is just a refactor.
