### PR TITLE
script/base/canvas/fonts: Remove more ignore_malloc_size_of

### DIFF
--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -217,7 +217,6 @@ pub(super) struct CanvasState {
     #[no_trace]
     current_default_path: DomRefCell<Path>,
     /// Buffered sender for batching canvas commands.
-    #[ignore_malloc_size_of = "GenericBufferedSender"]
     #[no_trace]
     pub(super) buffered_sender: GenericBufferedSender<CanvasMsg, CanvasCommand>,
 }

--- a/components/script/dom/html/embedded_content/htmlobjectelement.rs
+++ b/components/script/dom/html/embedded_content/htmlobjectelement.rs
@@ -29,8 +29,8 @@ use crate::dom::validitystate::ValidityState;
 #[dom_struct]
 pub(crate) struct HTMLObjectElement {
     htmlelement: HTMLElement,
-    #[ignore_malloc_size_of = "RasterImage"]
     #[no_trace]
+    #[conditional_malloc_size_of]
     image: DomRefCell<Option<Arc<RasterImage>>>,
     form_owner: MutNullableDom<HTMLFormElement>,
     validity_state: MutNullableDom<ValidityState>,

--- a/components/script/dom/indexeddb/idbdatabase.rs
+++ b/components/script/dom/indexeddb/idbdatabase.rs
@@ -44,7 +44,6 @@ pub struct IDBDatabase {
     upgrade_transaction: MutNullableDom<IDBTransaction>,
 
     #[no_trace]
-    #[ignore_malloc_size_of = "Uuid"]
     id: Uuid,
 
     // Flags

--- a/components/script/dom/media/mediasession.rs
+++ b/components/script/dom/media/mediasession.rs
@@ -39,7 +39,6 @@ use crate::realms::enter_auto_realm;
 pub(crate) struct MediaSession {
     reflector_: Reflector,
     /// <https://w3c.github.io/mediasession/#dom-mediasession-metadata>
-    #[ignore_malloc_size_of = "defined in embedder_traits"]
     #[no_trace]
     metadata: DomRefCell<Option<EmbedderMediaMetadata>>,
     /// <https://w3c.github.io/mediasession/#dom-mediasession-playbackstate>

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -446,7 +446,6 @@ pub(crate) struct Window {
     user_scripts: Rc<Vec<UserScript>>,
 
     /// Window's GL context from application
-    #[ignore_malloc_size_of = "defined in script_thread"]
     #[no_trace]
     player_context: WindowGLContext,
 

--- a/components/shared/base/generic_channel/buffered.rs
+++ b/components/shared/base/generic_channel/buffered.rs
@@ -6,6 +6,7 @@ use std::cell::RefCell;
 use std::mem;
 use std::panic::Location;
 
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 
 use super::{GenericSender, SendResult};
@@ -18,12 +19,14 @@ use super::{GenericSender, SendResult};
 /// [`send_immediate`](GenericBufferedSender::send_immediate)
 /// combines the current buffer contents with the new message into a single
 /// packed message, ensuring ordering without an extra flush step.
+#[derive(MallocSizeOf)]
 pub struct GenericBufferedSender<T, U>
 where
     T: Serialize,
 {
     sender: GenericSender<T>,
     buffer: RefCell<Vec<U>>,
+    #[ignore_malloc_size_of = "dyn are difficult to measure"]
     buffering: Box<dyn Fn(Vec<U>) -> T>,
     max_buffer: usize,
 }

--- a/components/shared/canvas/canvas.rs
+++ b/components/shared/canvas/canvas.rs
@@ -392,7 +392,7 @@ impl Path {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 pub enum FillRule {
     Nonzero,
     Evenodd,
@@ -439,7 +439,7 @@ pub struct LineOptions {
 
 pub type CanvasMsg = (CanvasId, CanvasCommand);
 
-#[derive(Debug, Deserialize, Serialize, Display)]
+#[derive(Debug, Deserialize, Serialize, Display, MallocSizeOf)]
 pub enum CanvasCommand {
     /// This is used for resizing (when size is provided) or just clearing the canvas (when size is `None`).
     Recreate(Option<Size2D<u64>>),
@@ -595,7 +595,7 @@ impl RadialGradientStyle {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 pub struct SurfaceStyle {
     pub surface_data: SharedSnapshot,
     pub surface_size: Size2D<u32>,
@@ -622,7 +622,7 @@ impl SurfaceStyle {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 pub enum FillOrStrokeStyle {
     Color(AbsoluteColor),
     LinearGradient(LinearGradientStyle),
@@ -773,13 +773,13 @@ impl FromStr for CompositionOrBlending {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, MallocSizeOf)]
 pub struct GlyphAndPosition {
     pub id: u32,
     pub point: Point2D<f32>,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, MallocSizeOf)]
 pub struct CanvasFont {
     /// A [`FontIdentifier`] for this [`CanvasFont`], maybe either `Local` or `Web`.
     pub identifier: FontIdentifier,
@@ -799,7 +799,7 @@ impl CanvasFont {
     }
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, MallocSizeOf)]
 pub struct TextRun {
     pub font: CanvasFont,
     pub pt_size: f32,

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -556,7 +556,7 @@ impl Debug for EmbedderMsg {
 }
 
 /// <https://w3c.github.io/mediasession/#mediametadata>
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 pub struct MediaMetadata {
     /// Title
     pub title: String,

--- a/components/shared/fonts/font_template.rs
+++ b/components/shared/fonts/font_template.rs
@@ -43,7 +43,6 @@ pub struct FontTemplateDescriptor {
     pub weight: ComputedFontWeightRange,
     pub stretch: ComputedFontStretchRange,
     pub style: ComputedFontStyleRange,
-    #[ignore_malloc_size_of = "MallocSizeOf does not yet support RangeInclusive"]
     pub unicode_range: Option<Vec<RangeInclusive<u32>>>,
 }
 

--- a/components/shared/fonts/lib.rs
+++ b/components/shared/fonts/lib.rs
@@ -164,7 +164,7 @@ impl AsRef<[u8]> for FontData {
 ///
 /// If the font data is of a TTC (TrueType collection) file, then the index of a specific font within
 /// the collection. If the font data is for is single font then the index will always be 0.
-#[derive(Deserialize, Clone, Serialize)]
+#[derive(Deserialize, Clone, Serialize, MallocSizeOf)]
 pub struct FontDataAndIndex {
     /// The raw font file data (.ttf, .otf, .ttc, etc)
     pub data: FontData,


### PR DESCRIPTION
This removes a couple more ignore_malloc_size_of calls for more accurate reporting. This required adding a couple more derives.

Testing: Memory reporting does not have tests but these are trivial changes.
