### PR TITLE
layout: Remove useless Box in BoxFragment

### DIFF
--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -1994,9 +1994,9 @@ impl<'container> PlacementState<'container> {
                 let BlockLevelLayoutInfo {
                     clearance,
                     block_margins_collapsed_with_children: fragment_block_margins,
-                } = *fragment
+                } = fragment
                     .block_level_layout_info
-                    .clone()
+                    .as_ref()
                     .expect("A block-level fragment should have a BlockLevelLayoutInfo.");
                 let mut fragment_block_size = fragment
                     .border_rect()
@@ -2010,7 +2010,7 @@ impl<'container> PlacementState<'container> {
                 // > its margins collapse with the adjoining margins of following siblings but that
                 // > resulting margin does not collapse with the bottom margin of the parent block.
                 if let Some(clearance) = clearance {
-                    fragment_block_size += clearance;
+                    fragment_block_size += *clearance;
                     // Margins can't be adjoining if they are separated by clearance.
                     // Setting `next_in_flow_margin_collapses_with_parent_start_margin` to false
                     // prevents collapsing with the start margin of the parent, and will set

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -147,7 +147,7 @@ pub(crate) struct BoxFragment {
     pub rare_data: OnceBox<AtomicRefCell<BoxFragmentRareData>>,
 
     /// Additional information for block-level boxes.
-    pub block_level_layout_info: Option<Box<BlockLevelLayoutInfo>>,
+    pub block_level_layout_info: Option<BlockLevelLayoutInfo>,
 
     /// The containing spatial tree node of this [`BoxFragment`]. This is assigned during
     /// `StackingContextTree` construction, so isn't available before that time. This is
@@ -306,10 +306,10 @@ impl BoxFragment {
         block_margins_collapsed_with_children: CollapsedBlockMargins,
         clearance: Option<Au>,
     ) -> Self {
-        self.block_level_layout_info = Some(Box::new(BlockLevelLayoutInfo {
+        self.block_level_layout_info = Some(BlockLevelLayoutInfo {
             block_margins_collapsed_with_children,
             clearance,
-        }));
+        });
         self
     }
 


### PR DESCRIPTION
This seems to not be used. There are no occurences of BoxFragment in preallocated vectors or naked in enums. Most of the BoxFragments are in Arc and some functions return them directly.
I doubt this has any performance implications but feels cleaner than having a useless redirection (and a useless clone).

Testing: This should not change observable behavior.
