### PR TITLE
shell.nix: Update nixpkgs to unstable 2026-08-31

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -8,7 +8,7 @@ with import (builtins.fetchTarball {
   # NixOS users: if servoshell crashes with an assertion failure in surfman’s x11/connection.rs,
   # eglInitialize() may be failing, or you may be building with an incompatible version of glibc.
   # Use your system nixpkgs here, change `llvmPackages` below if necessary, then do a clean build.
-  url = "https://github.com/NixOS/nixpkgs/archive/d233902339c02a9c334e7e593de68855ad26c4cb.tar.gz";
+  url = "https://github.com/NixOS/nixpkgs/archive/34ab99075ac4f7e40cf037eef32cb1c360bb85e9.tar.gz";
 }) {
   overlays = [
     (import (builtins.fetchTarball {


### PR DESCRIPTION
The old nixpkgs version ran into a build issue where crates.io would
reject nixpkgs' user-agent with status 403 when downloading crates,
causing a failure when running `nix-shell`.

Heads up: I needed to manually delete `.venv` otherwise `./mach` would
fail to run.

Testing: N/A

