### PR TITLE
script: Fire events for cues

### DIFF
--- a/components/script/dom/html/embedded_content/htmlmediaelement.rs
+++ b/components/script/dom/html/embedded_content/htmlmediaelement.rs
@@ -61,6 +61,7 @@ use crate::dom::bindings::codegen::Bindings::NodeBinding::Node_Binding::NodeMeth
 use crate::dom::bindings::codegen::Bindings::TextTrackBinding::{
     TextTrackKind, TextTrackMethods, TextTrackMode,
 };
+use crate::dom::bindings::codegen::Bindings::TextTrackCueBinding::TextTrackCueMethods;
 use crate::dom::bindings::codegen::Bindings::URLBinding::URLMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
 use crate::dom::bindings::codegen::UnionTypes::{
@@ -97,6 +98,7 @@ use crate::dom::performance::performanceresourcetiming::InitiatorType;
 use crate::dom::promise::Promise;
 use crate::dom::referrer_policy_for_element;
 use crate::dom::texttrack::TextTrack;
+use crate::dom::texttrackcue::TextTrackCue;
 use crate::dom::texttracklist::TextTrackList;
 use crate::dom::timeranges::{TimeRanges, TimeRangesContainer};
 use crate::dom::trackevent::TrackEvent;
@@ -614,6 +616,19 @@ pub(crate) struct HTMLMediaElement {
     media_controls_id: DomRefCell<Option<String>>,
     /// <https://html.spec.whatwg.org/multipage/#did-perform-automatic-track-selection>
     did_perform_automatic_track_selection: Cell<bool>,
+    /// Used to track the
+    /// <https://html.spec.whatwg.org/multipage/#current-playback-position>
+    /// when
+    /// <https://html.spec.whatwg.org/multipage/#time-marches-on>
+    /// was last invoked (if any)
+    position_when_time_marches_on_ran: Cell<Option<f64>>,
+    /// Used to track whether the only reason
+    /// <https://html.spec.whatwg.org/multipage/#time-marches-on>
+    /// was called, because it was called as a normal monotic increase.
+    #[no_trace]
+    playback_was_moved: Cell<PlaybackPositionWasMoved>,
+    /// <https://html.spec.whatwg.org/multipage/#list-of-newly-introduced-cues>
+    newly_introduced_cues: DomRefCell<Vec<Dom<TextTrackCue>>>,
 }
 
 /// <https://html.spec.whatwg.org/multipage/#dom-media-networkstate>
@@ -643,6 +658,16 @@ pub(crate) enum ReadyState {
 enum PlaybackDirection {
     Forwards,
     Backwards,
+}
+
+/// Used to determine whether the current playback position was changed
+/// during normal playback or not in
+/// <https://html.spec.whatwg.org/multipage/#time-marches-on>
+#[derive(Clone, Copy, Default, MallocSizeOf, PartialEq)]
+enum PlaybackPositionWasMoved {
+    #[default]
+    ExplicitMove,
+    NormalPlayback,
 }
 
 impl HTMLMediaElement {
@@ -698,6 +723,9 @@ impl HTMLMediaElement {
             current_fetch_context: RefCell::new(None),
             media_controls_id: DomRefCell::new(None),
             did_perform_automatic_track_selection: Default::default(),
+            position_when_time_marches_on_ran: Default::default(),
+            playback_was_moved: Default::default(),
+            newly_introduced_cues: Default::default(),
         }
     }
 
@@ -767,17 +795,235 @@ impl HTMLMediaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#time-marches-on>
-    fn time_marches_on(&self) {
+    fn time_marches_on(&self, cx: &mut JSContext, playback_was_moved: PlaybackPositionWasMoved) {
+        let playback_was_moved_monotonic_increase =
+            self.playback_was_moved.get() == PlaybackPositionWasMoved::NormalPlayback;
+        self.playback_was_moved.set(playback_was_moved);
+        // Step 1. Let current cues be a list of cues,
+        // initialized to contain all the cues of all the hidden or
+        // showing text tracks of the media element (not the disabled ones)
+        // whose start times are less than or equal to the current playback position
+        // and whose end times are greater than the current playback position.
+        // Step 2. Let other cues be a list of cues, initialized to contain
+        // all the cues of hidden and showing text tracks of the media element
+        // that are not present in current cues.
+        let current_playback_position = self.current_playback_position.get();
+        let Some(text_tracks_list) = self.text_tracks_list.get() else {
+            return;
+        };
+        type CueVec = Vec<DomRoot<TextTrackCue>>;
+        let (current_cues, other_cues): (CueVec, CueVec) = text_tracks_list
+            .iter()
+            .filter_map(|text_track| {
+                // Implicitly `GetCues` already filters for Disabled and returns
+                // None in that case
+                text_track.GetCues(cx)
+            })
+            .flat_map(|text_track| text_track.cues())
+            .partition(|cue| {
+                cue.start_time() <= current_playback_position &&
+                    cue.end_time() > current_playback_position
+            });
+        // Step 3. Let last time be the current playback position at the time
+        // this algorithm was last run for this media element,
+        // if this is not the first time it has run.
+        let last_time = self.position_when_time_marches_on_ran.get();
+        self.position_when_time_marches_on_ran
+            .set(Some(current_playback_position));
+
+        // Step 4. If the current playback position has,
+        // since the last time this algorithm was run,
+        // only changed through its usual monotonic increase during normal playback,
+        // then let missed cues be the list of cues in other cues whose start times
+        // are greater than or equal to last time and whose end times are less
+        // than or equal to the current playback position.
+        // Otherwise, let missed cues be an empty list.
+        // Step 5. Remove all the cues in missed cues that are also in
+        // the media element's list of newly introduced cues,
+        // and then empty the element's list of newly introduced cues.
+        let missed_cues =
+            if playback_was_moved_monotonic_increase && let Some(last_time) = last_time {
+                let newly_introduced_cues: Vec<DomRoot<TextTrackCue>> =
+                    std::mem::take(&mut *self.newly_introduced_cues.safe_borrow_mut(cx.no_gc()))
+                        .iter()
+                        .map(|cue| cue.as_rooted())
+                        .collect();
+                other_cues
+                    .iter()
+                    .filter(|cue| {
+                        cue.start_time() >= last_time &&
+                            cue.end_time() <= current_playback_position &&
+                            !newly_introduced_cues
+                                .iter()
+                                .any(|newly_cue| **newly_cue == ***cue)
+                    })
+                    .cloned()
+                    .collect()
+            } else {
+                self.newly_introduced_cues
+                    .safe_borrow_mut(cx.no_gc())
+                    .clear();
+                vec![]
+            };
+
         // Step 6. If the time was reached through the usual monotonic increase of the current
         // playback position during normal playback, and if the user agent has not fired a
         // timeupdate event at the element in the past 15 to 250ms and is not still running event
         // handlers for such an event, then the user agent must queue a media element task given the
         // media element to fire an event named timeupdate at the element.
-        if Instant::now() > self.next_timeupdate_event.get() {
+        if playback_was_moved_monotonic_increase &&
+            Instant::now() > self.next_timeupdate_event.get()
+        {
             self.queue_media_element_task_to_fire_event(atom!("timeupdate"));
             self.next_timeupdate_event
                 .set(Instant::now() + Duration::from_millis(250));
         }
+
+        // Step 7. If all of the cues in current cues have their text track cue active flag set,
+        // none of the cues in other cues have their text track cue active flag set,
+        // and missed cues is empty, then return.
+        if current_cues.iter().all(|cue| cue.is_active()) &&
+            !other_cues.iter().any(|cue| cue.is_active()) &&
+            missed_cues.is_empty()
+        {
+            return;
+        }
+
+        // Step 8. If the time was reached through the usual monotonic increase of the
+        // current playback position during normal playback,
+        // and there are cues in other cues that have their text track cue pause-on-exit flag
+        // set and that either have their text track cue active flag set or are also in missed cues,
+        // then immediately pause the media element.
+        if playback_was_moved_monotonic_increase &&
+            other_cues.iter().any(|cue| {
+                cue.PauseOnExit() &&
+                    (cue.is_active() || missed_cues.iter().any(|missed_cue| missed_cue == cue))
+            })
+        {
+            self.Pause(cx);
+        }
+
+        // Step 9. Let events be a list of tasks, initially empty.
+        // Each task in this list will be associated with a text track,
+        // a text track cue, and a time, which are used to sort the list before the tasks are queued.
+        // Let affected tracks be a list of text tracks, initially empty.
+        // When the steps below say to prepare an event named event for
+        // a text track cue target with a time time,
+        // the user agent must run these steps:
+        let mut events: Vec<(f64, (Atom, DomRoot<TextTrackCue>))> = vec![];
+        let mut affected_tracks = vec![];
+        // https://html.spec.whatwg.org/multipage/#prepare-an-event
+        let mut prepare_an_event =
+            |time: f64, event: Atom, text_track_cue: DomRoot<TextTrackCue>| {
+                // Step 1. Let track be the text track with which the text track cue target is associated.
+                let track = text_track_cue
+                    .get_track()
+                    .expect("Must always have a corresponding track element");
+                // Step 2. Create a task to fire an event named event at target.
+                //
+                // We create the task in the for-loops below
+
+                // Step 3. Add the newly created task to events, associated with the time time,
+                // the text track track, and the text track cue target.
+                events.push((time, (event, text_track_cue)));
+                // Step 4. Add track to affected tracks.
+                affected_tracks.push(track);
+            };
+
+        // Step 10. For each text track cue in missed cues,
+        // prepare an event named enter for the TextTrackCue object with the text track cue start time.
+        for text_track_cue in &missed_cues {
+            prepare_an_event(
+                text_track_cue.start_time(),
+                atom!("enter"),
+                text_track_cue.clone(),
+            );
+        }
+
+        // Step 11. For each text track cue in other cues that either
+        // has its text track cue active flag set
+        // or is in missed cues, prepare an event named exit for the TextTrackCue object with
+        // the later of the text track cue end time and the text track cue start time.
+        for text_track_cue in &other_cues {
+            if text_track_cue.is_active() || missed_cues.iter().any(|cue| cue == text_track_cue) {
+                prepare_an_event(
+                    text_track_cue.start_time().max(text_track_cue.end_time()),
+                    atom!("exit"),
+                    text_track_cue.clone(),
+                );
+            }
+        }
+
+        // Step 12. For each text track cue in current cues that does not have
+        // its text track cue active flag set,
+        // prepare an event named enter for the TextTrackCue object with the text track cue start time.
+        for text_track_cue in &current_cues {
+            if !text_track_cue.is_active() {
+                prepare_an_event(
+                    text_track_cue.start_time(),
+                    atom!("enter"),
+                    text_track_cue.clone(),
+                );
+            }
+        }
+
+        // Step 13. Sort the tasks in events in ascending time order (tasks with earlier times first).
+        events.sort_by(|(a_time, _), (b_time, _)| a_time.total_cmp(b_time));
+
+        // Step 14. Queue a media element task given the media element for each task in events,
+        // in list order.
+        for (_, (event, text_track_cue)) in events {
+            let target = Trusted::new(&*text_track_cue);
+
+            self.owner_global()
+                .task_manager()
+                .media_element_task_source()
+                .queue(task!(queue_event: move |cx| {
+                    target.root().upcast::<EventTarget>().fire_event(cx, event);
+                }));
+        }
+
+        // Step 15. Sort affected tracks in the same order as the text tracks appear
+        // in the media element's list of text tracks, and remove duplicates.
+        // TODO
+
+        // Step 16. For each text track in affected tracks, in the list order,
+        // queue a media element task given the media element to fire
+        // an event named cuechange at the TextTrack object,
+        // and, if the text track has a corresponding track element,
+        // to then fire an event named cuechange at the track element as well.
+        for text_track in affected_tracks {
+            let text_track = Trusted::new(&*text_track);
+
+            self.owner_global()
+                .task_manager()
+                .media_element_task_source()
+                .queue(task!(queue_event: move |cx| {
+                    let text_track = text_track.root();
+                    text_track.upcast::<EventTarget>().fire_event(cx, atom!("cuechange"));
+
+                    if let Some(track_element) = text_track.associated_track() {
+                        track_element.upcast::<EventTarget>().fire_event(cx, atom!("cuechange"));
+                    }
+                }));
+        }
+
+        // Step 17. Set the text track cue active flag of all the cues in the current cues,
+        // and unset the text track cue active flag of all the cues in the other cues.
+        for text_track_cue in current_cues {
+            text_track_cue.set_active(true);
+        }
+        for text_track_cue in other_cues {
+            text_track_cue.set_active(false);
+        }
+
+        // Step 18. Run the rules for updating the text track rendering of each
+        // of the text tracks in affected tracks that are showing,
+        // providing the text track's text track language as the fallback language
+        // if it is not the empty string.
+        // For example, for text tracks based on WebVTT,
+        // the rules for updating the display of WebVTT text tracks. [WEBVTT]
+        // TODO
     }
 
     /// <https://html.spec.whatwg.org/multipage/#internal-play-steps>
@@ -813,7 +1059,7 @@ impl HTMLMediaElement {
             // false and run the time marches on steps.
             if self.show_poster.get() {
                 self.show_poster.set(false);
-                self.time_marches_on();
+                self.time_marches_on(cx, PlaybackPositionWasMoved::ExplicitMove);
             }
 
             // Step 3.3. Queue a media element task given the media element to fire an event named
@@ -948,7 +1194,7 @@ impl HTMLMediaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#ready-states>
-    fn change_ready_state(&self, ready_state: ReadyState) {
+    fn change_ready_state(&self, cx: &mut JSContext, ready_state: ReadyState) {
         let old_ready_state = self.ready_state.get();
         self.ready_state.set(ready_state);
 
@@ -1047,7 +1293,7 @@ impl HTMLMediaElement {
                 // time marches on steps.
                 if self.show_poster.get() {
                     self.show_poster.set(false);
-                    self.time_marches_on();
+                    self.time_marches_on(cx, PlaybackPositionWasMoved::ExplicitMove);
                 }
 
                 // Step 3. Queue a media element task given the element to fire an event named play
@@ -1764,7 +2010,7 @@ impl HTMLMediaElement {
 
             // Step 7.5. If readyState is not set to HAVE_NOTHING, then set it to that state.
             if self.ready_state.get() != ReadyState::HaveNothing {
-                self.change_ready_state(ReadyState::HaveNothing);
+                self.change_ready_state(cx, ReadyState::HaveNothing);
             }
 
             // Step 7.6. If the paused attribute is false, then:
@@ -2079,7 +2325,7 @@ impl HTMLMediaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-media-seek>
-    fn seek_end(&self) {
+    fn seek_end(&self, cx: &mut JSContext) {
         // Any time the user agent provides a stable state, the official playback position must be
         // set to the current playback position.
         self.official_playback_position
@@ -2091,7 +2337,7 @@ impl HTMLMediaElement {
         self.current_seek_position.set(f64::NAN);
 
         // Step 15. Run the time marches on steps.
-        self.time_marches_on();
+        self.time_marches_on(cx, PlaybackPositionWasMoved::ExplicitMove);
 
         // Step 16. Queue a media element task given the media element to fire an event named
         // timeupdate at the element.
@@ -2297,7 +2543,7 @@ impl HTMLMediaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#reaches-the-end>
-    fn end_of_playback_in_forwards_direction(&self) {
+    fn end_of_playback_in_forwards_direction(&self, cx: &mut JSContext) {
         // When the current playback position reaches the end of the media resource when the
         // direction of playback is forwards, then the user agent must follow these steps:
 
@@ -2352,7 +2598,7 @@ impl HTMLMediaElement {
             }));
 
         // <https://html.spec.whatwg.org/multipage/#dom-media-have_current_data>
-        self.change_ready_state(ReadyState::HaveCurrentData);
+        self.change_ready_state(cx, ReadyState::HaveCurrentData);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#reaches-the-end>
@@ -2366,14 +2612,14 @@ impl HTMLMediaElement {
         }
     }
 
-    fn playback_end(&self) {
+    fn playback_end(&self, cx: &mut JSContext) {
         // Abort the following steps of the end of playback if seeking is in progress.
         if self.seeking.get() {
             return;
         }
 
         match self.direction_of_playback() {
-            PlaybackDirection::Forwards => self.end_of_playback_in_forwards_direction(),
+            PlaybackDirection::Forwards => self.end_of_playback_in_forwards_direction(cx),
             PlaybackDirection::Backwards => self.end_of_playback_in_backwards_direction(),
         }
     }
@@ -2589,7 +2835,7 @@ impl HTMLMediaElement {
         }
 
         // Step 6. Set the readyState attribute to HAVE_METADATA.
-        self.change_ready_state(ReadyState::HaveMetadata);
+        self.change_ready_state(cx, ReadyState::HaveMetadata);
 
         // Step 7. Let jumped be false.
         let mut jumped = false;
@@ -2761,7 +3007,17 @@ impl HTMLMediaElement {
             .add(self.current_playback_position.get(), position);
         self.current_playback_position.set(position);
         self.official_playback_position.set(position);
-        self.time_marches_on();
+        // https://html.spec.whatwg.org/multipage/#playing-the-media-resource
+        // > When the current playback position of a media element changes (e.g. due to playback or seeking),
+        // > the user agent must run the time marches on steps.
+        // > To support use cases that depend on the timing accuracy of cue event firing,
+        // > such as synchronizing captions with shot changes in a video,
+        // > user agents should fire cue events as close as possible to their position on the media timeline,
+        // > and ideally within 20 milliseconds.
+        // > If the current playback position changes while the steps are running,
+        // > then the user agent must wait for the steps to complete, and then must immediately rerun the steps.
+        // > These steps are thus run as often as possible or needed.
+        self.time_marches_on(cx, PlaybackPositionWasMoved::NormalPlayback);
 
         let media_position_state =
             MediaPositionState::new(self.duration.get(), self.playback_rate.get(), position);
@@ -2799,13 +3055,13 @@ impl HTMLMediaElement {
             PlaybackState::Paused => {
                 media_session_playback_state = MediaSessionPlaybackState::Paused;
                 if self.ready_state.get() == ReadyState::HaveMetadata {
-                    self.change_ready_state(ReadyState::HaveEnoughData);
+                    self.change_ready_state(cx, ReadyState::HaveEnoughData);
                 }
             },
             PlaybackState::Playing => {
                 media_session_playback_state = MediaSessionPlaybackState::Playing;
                 if self.ready_state.get() == ReadyState::HaveMetadata {
-                    self.change_ready_state(ReadyState::HaveEnoughData);
+                    self.change_ready_state(cx, ReadyState::HaveEnoughData);
                 }
             },
             PlaybackState::Buffering => {
@@ -2998,7 +3254,41 @@ impl HTMLMediaElement {
         true
     }
 
-    pub(crate) fn was_added_to_list_of_text_tracks(&self) {
+    /// <https://html.spec.whatwg.org/multipage/#list-of-newly-introduced-cues>
+    pub(crate) fn add_newly_added_cue(&self, cx: &mut JSContext, cue: &TextTrackCue) {
+        // > Whenever a text track cue is added to the list of cues of a text track
+        // > that is in the list of text tracks for a media element,
+        // > that cue must be added to the media element's list of newly introduced cues.
+        self.newly_introduced_cues
+            .borrow_mut()
+            .push(Dom::from_ref(cue));
+        // > When a media element's list of newly introduced cues has new cues added
+        // > while the media element's show poster flag is not set,
+        // > then the user agent must run the time marches on steps.
+        if !self.show_poster.get() {
+            self.time_marches_on(cx, PlaybackPositionWasMoved::ExplicitMove);
+        }
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#list-of-newly-introduced-cues>
+    pub(crate) fn was_added_to_list_of_text_tracks(&self, cx: &mut JSContext, track: &TextTrack) {
+        // > Whenever a text track is added to the list of text tracks for a media element,
+        // all of the cues in that text track's list of cues must be added to
+        // the media element's list of newly introduced cues.
+        let cues = track.get_cues();
+        let has_new_cues = !cues.is_empty();
+        for cue in cues {
+            self.newly_introduced_cues
+                .borrow_mut()
+                .push(cue.as_traced());
+        }
+        // > When a media element's list of newly introduced cues has new cues added
+        // > while the media element's show poster flag is not set,
+        // > then the user agent must run the time marches on steps.
+        if has_new_cues && !self.show_poster.get() {
+            self.time_marches_on(cx, PlaybackPositionWasMoved::ExplicitMove);
+        }
+
         // https://html.spec.whatwg.org/multipage/#sourcing-out-of-band-text-tracks
         // > When a text track corresponding to a track element is added to a media element's list of text tracks,
         // > the user agent must queue a media element task given the media element to
@@ -3422,7 +3712,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
         // > in the same order as in the list of text tracks.
         let window = self.owner_window();
         self.text_tracks_list
-            .or_init(|| TextTrackList::new(cx, &window, &[]))
+            .or_init(|| TextTrackList::new(cx, self, &window, &[]))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-media-addtexttrack>
@@ -3455,7 +3745,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
         // named addtrack at the media element's textTracks attribute's TextTrackList object,
         // using TrackEvent, with the track attribute initialized to
         // the new text track's TextTrack object.
-        self.TextTracks(cx).add(self, &track);
+        self.TextTracks(cx).add(cx, &track);
         // Step 5. Return the new TextTrack object.
         DomRoot::from_ref(&track)
     }
@@ -3648,7 +3938,7 @@ impl MicrotaskRunnable for MediaElementMicrotask {
                 generation_id,
             } => {
                 if generation_id == elem.generation_id.get() {
-                    elem.seek_end();
+                    elem.seek_end(cx);
                 }
             },
             &MediaElementMicrotask::SelectNextSourceChild {
@@ -4169,7 +4459,7 @@ impl HTMLMediaElementEventHandler {
 
         match event {
             PlayerEvent::DurationChanged(duration) => element.playback_duration_changed(duration),
-            PlayerEvent::EndOfStream => element.playback_end(),
+            PlayerEvent::EndOfStream => element.playback_end(cx),
             PlayerEvent::EnoughData => element.playback_enough_data(),
             PlayerEvent::Error(ref error) => element.playback_error(error, cx),
             PlayerEvent::MetadataUpdated(ref metadata) => {

--- a/components/script/dom/html/embedded_content/htmltrackelement.rs
+++ b/components/script/dom/html/embedded_content/htmltrackelement.rs
@@ -175,12 +175,16 @@ impl HTMLTrackElement {
             // > given the media element to fire an event named addtrack at the media element's
             // > textTracks attribute's TextTrackList object, using TrackEvent,
             // > with the track attribute initialized to the text track's TextTrack object.
-            parent.TextTracks(cx).add(&parent, &self.track);
+            parent.TextTracks(cx).add(cx, &self.track);
 
             // https://html.spec.whatwg.org/multipage/#sourcing-out-of-band-text-tracks:start-the-track-processing-model
             // > The track element's parent element changes and the new parent is a media element.
             self.start_the_track_processing_model(cx);
         }
+    }
+
+    pub(crate) fn track(&self) -> DomRoot<TextTrack> {
+        self.track.as_rooted()
     }
 }
 
@@ -434,7 +438,7 @@ impl WebVttParserSink<JSContext> for TextTrackCueSink {
         let text_track = &element.track;
 
         let cue = VTTCue::create_from_vtt(cx, cue, global.as_window(), Some(text_track));
-        text_track.get_cues(cx).add(cue.upcast());
+        text_track.get_text_track_cue_list(cx).add(cx, cue.upcast());
     }
 }
 

--- a/components/script/dom/webvtt/texttrack.rs
+++ b/components/script/dom/webvtt/texttrack.rs
@@ -83,13 +83,27 @@ impl TextTrack {
         )
     }
 
-    pub(crate) fn get_cues(&self, cx: &mut JSContext) -> DomRoot<TextTrackCueList> {
+    pub(crate) fn get_cues(&self) -> Vec<DomRoot<TextTrackCue>> {
         self.cue_list
-            .or_init(|| TextTrackCueList::new(cx, self.global().as_window(), &[]))
+            .get()
+            .map(|list| list.cues())
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn get_text_track_cue_list(&self, cx: &mut JSContext) -> DomRoot<TextTrackCueList> {
+        self.cue_list
+            .or_init(|| TextTrackCueList::new(cx, self, self.global().as_window(), &[]))
     }
 
     pub(crate) fn id(&self) -> &str {
         &self.id
+    }
+
+    pub(crate) fn track_list(&self) -> Option<DomRoot<TextTrackList>> {
+        self.track_list
+            .borrow()
+            .as_ref()
+            .map(|track_list| track_list.as_rooted())
     }
 
     pub(crate) fn add_track_list(&self, track_list: &TextTrackList) {
@@ -165,7 +179,7 @@ impl TextTrackMethods<crate::DomTypeHolder> for TextTrack {
     fn GetCues(&self, cx: &mut JSContext) -> Option<DomRoot<TextTrackCueList>> {
         match self.Mode() {
             TextTrackMode::Disabled => None,
-            _ => Some(self.get_cues(cx)),
+            _ => Some(self.get_text_track_cue_list(cx)),
         }
     }
 
@@ -173,7 +187,12 @@ impl TextTrackMethods<crate::DomTypeHolder> for TextTrack {
     fn GetActiveCues(&self, cx: &mut JSContext) -> Option<DomRoot<TextTrackCueList>> {
         // XXX implement active cues logic
         //      https://github.com/servo/servo/issues/22314
-        Some(TextTrackCueList::new(cx, self.global().as_window(), &[]))
+        Some(TextTrackCueList::new(
+            cx,
+            self,
+            self.global().as_window(),
+            &[],
+        ))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-texttrack-addcue>
@@ -189,14 +208,14 @@ impl TextTrackMethods<crate::DomTypeHolder> for TextTrack {
             }
         }
         // Step 4
-        self.get_cues(cx).add(cue);
+        self.get_text_track_cue_list(cx).add(cx, cue);
         Ok(())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-texttrack-removecue>
     fn RemoveCue(&self, cx: &mut JSContext, cue: &TextTrackCue) -> ErrorResult {
         // Step 1
-        let cues = self.get_cues(cx);
+        let cues = self.get_text_track_cue_list(cx);
         let index = match cues.find(cue) {
             Some(i) => Ok(i),
             None => Err(Error::NotFound(None)),

--- a/components/script/dom/webvtt/texttrackcue.rs
+++ b/components/script/dom/webvtt/texttrackcue.rs
@@ -17,11 +17,17 @@ use crate::dom::texttrack::TextTrack;
 #[dom_struct]
 pub(crate) struct TextTrackCue {
     eventtarget: EventTarget,
+    /// <https://html.spec.whatwg.org/multipage/#text-track-cue-identifier>
     id: DomRefCell<DOMString>,
     track: Option<Dom<TextTrack>>,
+    /// <https://html.spec.whatwg.org/multipage/#text-track-cue-start-time>
     start_time: Cell<f64>,
+    /// <https://html.spec.whatwg.org/multipage/#text-track-cue-end-time>
     end_time: Cell<f64>,
+    /// <https://html.spec.whatwg.org/multipage/#text-track-cue-pause-on-exit-flag>
     pause_on_exit: Cell<bool>,
+    /// <https://html.spec.whatwg.org/multipage/#text-track-cue-active-flag>
+    active: Cell<bool>,
 }
 
 impl TextTrackCue {
@@ -38,6 +44,7 @@ impl TextTrackCue {
             start_time: Cell::new(start_time),
             end_time: Cell::new(end_time),
             pause_on_exit: Cell::new(false),
+            active: Default::default(),
         }
     }
 
@@ -47,6 +54,22 @@ impl TextTrackCue {
 
     pub(crate) fn get_track(&self) -> Option<DomRoot<TextTrack>> {
         self.track.as_ref().map(|t| DomRoot::from_ref(&**t))
+    }
+
+    pub(crate) fn start_time(&self) -> f64 {
+        self.start_time.get()
+    }
+
+    pub(crate) fn end_time(&self) -> f64 {
+        self.end_time.get()
+    }
+
+    pub(crate) fn is_active(&self) -> bool {
+        self.active.get()
+    }
+
+    pub(crate) fn set_active(&self, active: bool) {
+        self.active.set(active)
     }
 }
 

--- a/components/script/dom/webvtt/texttrackcuelist.rs
+++ b/components/script/dom/webvtt/texttrackcuelist.rs
@@ -8,31 +8,42 @@ use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
 use crate::dom::bindings::codegen::Bindings::TextTrackCueListBinding::TextTrackCueListMethods;
-use crate::dom::bindings::root::{Dom, DomRoot};
+use crate::dom::bindings::root::{Dom, DomRoot, MutDom};
 use crate::dom::bindings::str::DOMString;
+use crate::dom::texttrack::TextTrack;
 use crate::dom::texttrackcue::TextTrackCue;
 use crate::dom::window::Window;
 
 #[dom_struct]
 pub(crate) struct TextTrackCueList {
     reflector_: Reflector,
+    text_track: MutDom<TextTrack>,
     dom_cues: DomRefCell<Vec<Dom<TextTrackCue>>>,
 }
 
 impl TextTrackCueList {
-    pub(crate) fn new_inherited(cues: &[&TextTrackCue]) -> TextTrackCueList {
+    pub(crate) fn new_inherited(
+        text_track: &TextTrack,
+        cues: &[&TextTrackCue],
+    ) -> TextTrackCueList {
         TextTrackCueList {
             reflector_: Reflector::new(),
+            text_track: MutDom::new(text_track),
             dom_cues: DomRefCell::new(cues.iter().map(|g| Dom::from_ref(&**g)).collect()),
         }
     }
 
     pub(crate) fn new(
         cx: &mut JSContext,
+        text_track: &TextTrack,
         window: &Window,
         cues: &[&TextTrackCue],
     ) -> DomRoot<TextTrackCueList> {
-        reflect_dom_object_with_cx(Box::new(TextTrackCueList::new_inherited(cues)), window, cx)
+        reflect_dom_object_with_cx(
+            Box::new(TextTrackCueList::new_inherited(text_track, cues)),
+            window,
+            cx,
+        )
     }
 
     pub(crate) fn item(&self, idx: usize) -> Option<DomRoot<TextTrackCue>> {
@@ -51,10 +62,13 @@ impl TextTrackCueList {
             .map(|(i, _)| i)
     }
 
-    pub(crate) fn add(&self, cue: &TextTrackCue) {
+    pub(crate) fn add(&self, cx: &mut JSContext, cue: &TextTrackCue) {
         // Only add a cue if it does not exist in the list
         if self.find(cue).is_none() {
             self.dom_cues.borrow_mut().push(Dom::from_ref(cue));
+            if let Some(track_list) = self.text_track.get().track_list() {
+                track_list.notify_media_element_for_added_cue(cx, cue);
+            }
         }
     }
 
@@ -64,6 +78,15 @@ impl TextTrackCueList {
 
     pub(crate) fn empty(&self) {
         self.dom_cues.borrow_mut().clear();
+    }
+
+    pub(crate) fn cues(&self) -> Vec<DomRoot<TextTrackCue>> {
+        self.dom_cues
+            .borrow()
+            .clone()
+            .into_iter()
+            .map(|track| track.as_rooted())
+            .collect()
     }
 }
 

--- a/components/script/dom/webvtt/texttracklist.rs
+++ b/components/script/dom/webvtt/texttracklist.rs
@@ -18,30 +18,44 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::html::htmlmediaelement::HTMLMediaElement;
+use crate::dom::html::htmltrackelement::HTMLTrackElement;
+use crate::dom::node::node::Node;
 use crate::dom::texttrack::TextTrack;
+use crate::dom::texttrackcue::TextTrackCue;
 use crate::dom::trackevent::TrackEvent;
 use crate::dom::window::Window;
 
 #[dom_struct]
 pub(crate) struct TextTrackList {
     eventtarget: EventTarget,
+    /// <https://html.spec.whatwg.org/multipage/#list-of-text-tracks>
+    media_element: Dom<HTMLMediaElement>,
     dom_tracks: DomRefCell<Vec<Dom<TextTrack>>>,
 }
 
 impl TextTrackList {
-    pub(crate) fn new_inherited(tracks: &[&TextTrack]) -> TextTrackList {
+    pub(crate) fn new_inherited(
+        media_element: &HTMLMediaElement,
+        tracks: &[&TextTrack],
+    ) -> TextTrackList {
         TextTrackList {
             eventtarget: EventTarget::new_inherited(),
+            media_element: Dom::from_ref(media_element),
             dom_tracks: DomRefCell::new(tracks.iter().map(|g| Dom::from_ref(&**g)).collect()),
         }
     }
 
     pub(crate) fn new(
         cx: &mut JSContext,
+        media_element: &HTMLMediaElement,
         window: &Window,
         tracks: &[&TextTrack],
     ) -> DomRoot<TextTrackList> {
-        reflect_dom_object_with_cx(Box::new(TextTrackList::new_inherited(tracks)), window, cx)
+        reflect_dom_object_with_cx(
+            Box::new(TextTrackList::new_inherited(media_element, tracks)),
+            window,
+            cx,
+        )
     }
 
     pub(crate) fn item(&self, idx: usize) -> Option<DomRoot<TextTrack>> {
@@ -72,7 +86,15 @@ impl TextTrackList {
             .collect()
     }
 
-    pub(crate) fn add(&self, media_element: &HTMLMediaElement, track: &TextTrack) {
+    pub(crate) fn notify_media_element_for_added_cue(
+        &self,
+        cx: &mut JSContext,
+        cue: &TextTrackCue,
+    ) {
+        self.media_element.add_newly_added_cue(cx, cue);
+    }
+
+    pub(crate) fn add(&self, cx: &mut JSContext, track: &TextTrack) {
         // Only add a track if it does not exist in the list
         if self.find(track).is_some() {
             return;
@@ -80,7 +102,8 @@ impl TextTrackList {
         self.dom_tracks.borrow_mut().push(Dom::from_ref(track));
 
         track.add_track_list(self);
-        media_element.was_added_to_list_of_text_tracks();
+        self.media_element
+            .was_added_to_list_of_text_tracks(cx, track);
 
         let this = Trusted::new(self);
         let track = Trusted::new(track);
@@ -136,6 +159,18 @@ impl TextTrackList {
                 event.upcast::<Event>().fire(cx, this.upcast::<EventTarget>());
             }));
     }
+
+    pub(crate) fn iter(&self) -> TextTrackListIterator {
+        TextTrackListIterator {
+            track_elements: self
+                .media_element
+                .upcast::<Node>()
+                .children()
+                .filter_map(DomRoot::downcast::<HTMLTrackElement>)
+                .collect(),
+            current_track_element_index: 0,
+        }
+    }
 }
 
 impl TextTrackListMethods<crate::DomTypeHolder> for TextTrackList {
@@ -167,4 +202,31 @@ impl TextTrackListMethods<crate::DomTypeHolder> for TextTrackList {
 
     // https://html.spec.whatwg.org/multipage/#handler-texttracklist-onremovetrack
     event_handler!(removetrack, GetOnremovetrack, SetOnremovetrack);
+}
+
+/// <https://html.spec.whatwg.org/multipage/#list-of-text-tracks>
+pub(crate) struct TextTrackListIterator {
+    track_elements: Vec<DomRoot<HTMLTrackElement>>,
+    current_track_element_index: usize,
+}
+
+impl Iterator for TextTrackListIterator {
+    type Item = DomRoot<TextTrack>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // > The text tracks are sorted as follows:
+        // Step 1. The text tracks corresponding to track element children of the media element, in tree order.
+        if let Some(track_element) = self.track_elements.get(self.current_track_element_index) {
+            self.current_track_element_index += 1;
+            return Some(track_element.track());
+        }
+        // Step 2. Any text tracks added using the addTextTrack() method,
+        // in the order they were added, oldest first.
+        // TODO
+        // Step 3. Any media-resource-specific text tracks
+        // (text tracks corresponding to data in the media resource),
+        // in the order defined by the media resource's format specification.
+        // TODO
+        None
+    }
 }

--- a/components/script/resources/media-controls.js
+++ b/components/script/resources/media-controls.js
@@ -28,7 +28,11 @@
     },
     pause: {
       buffering: PAUSED,
-      playing: PAUSED
+      playing: PAUSED,
+      // https://html.spec.whatwg.org/multipage/#playing-the-media-resource
+      // > It is possible for a media element to have both ended playback
+      // > and paused for user interaction at the same time.
+      ended: ENDED,
     },
     play: {
       buffering: PLAYING,

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-active-cues.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-active-cues.html.ini
@@ -1,5 +1,3 @@
 [track-active-cues.html]
-  expected: TIMEOUT
   [Ensure that no text track cues are active after the video is unloaded]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-cuechange-dynamically-created-track-element.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-cuechange-dynamically-created-track-element.html.ini
@@ -1,5 +1,0 @@
-[track-cues-cuechange-dynamically-created-track-element.html]
-  expected: TIMEOUT
-  ['cuechange' event on dynamically created track element]
-    expected: TIMEOUT
-

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-cuechange.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-cuechange.html.ini
@@ -1,4 +1,3 @@
 [track-cues-cuechange.html]
-  expected: TIMEOUT
   [TextTrack's cues are indexed and updated in order during video playback]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-enter-exit.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-enter-exit.html.ini
@@ -1,4 +1,3 @@
 [track-cues-enter-exit.html]
-  expected: TIMEOUT
   [TextTrack's cues are indexed and updated in order during video playback]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-enter-seeking.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-enter-seeking.html.ini
@@ -1,4 +1,0 @@
-[track-cues-enter-seeking.html]
-  expected: TIMEOUT
-  [TextTrack's cue onenter handler called when seeked onto]
-    expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-missed.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-missed.html.ini
@@ -1,0 +1,3 @@
+[track-cues-missed.html]
+  [Events are triggered for missed (skipped) cues during normal playback]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-pause-on-exit.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-pause-on-exit.html.ini
@@ -1,4 +1,3 @@
 [track-cues-pause-on-exit.html]
-  expected: TIMEOUT
   [Video is paused after cues having pause-on-exit flag are processed]
-    expected: TIMEOUT
+    expected: FAIL


### PR DESCRIPTION
This implements the enter, exit and cuechange events for both text track cues and track elements. It introduces an iterator for the `TextTrackCueList`, which I plan to use in other places as well in follow-up PRs.

Requires servo/stylo#451

Part of #46288

Testing: new WPT tests pass