### PR TITLE
Add "devcontainer-lock.json" to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ support/macos/Brewfile.lock.json
 
 # Justfiles
 justfile
+
+# devcontainer
+devcontainer-lock.json


### PR DESCRIPTION
This lockfile is used by some implementations of the devcontainer spec, including the [reference implementation] . The [file format] is defined in the devcontainers documentation.

[reference implementation]: https://github.com/devcontainers/cli
[file format]: https://github.com/devcontainers/spec/blob/main/docs/specs/devcontainer-lockfile.md
