### PR TITLE
script_bindings: Support incremental migration to rooted promise type for WebIDL interfaces.

### DIFF
--- a/components/script/dom/audio/audiocontext.rs
+++ b/components/script/dom/audio/audiocontext.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::rc::Rc;
-
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::realm::CurrentRealm;
@@ -34,7 +32,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::html::htmlmediaelement::HTMLMediaElement;
 use crate::dom::mediastream::MediaStream;
 use crate::dom::mediastreamtrack::MediaStreamTrack;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise};
 use crate::dom::window::Window;
 
 #[dom_struct]
@@ -141,9 +139,9 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-suspend>
-    fn Suspend(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
+    fn Suspend(&self, cx: &mut CurrentRealm) -> RootedPromise {
         // Step 1.
-        let promise = Promise::new_in_realm(cx);
+        let promise = Promise::new_in_realm_rooted(cx);
 
         // Step 2.
         if self.context.control_thread_state() == ProcessingState::Closed {
@@ -158,7 +156,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
         }
 
         // Steps 4 and 5.
-        let trusted_promise = TrustedPromise::new(promise.clone());
+        let trusted_promise = TrustedPromise::from(promise.clone());
         match self.context.audio_context_impl().lock().unwrap().suspend() {
             Some(_) => {
                 let base_context = Trusted::new(&self.context);
@@ -197,9 +195,9 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-close>
-    fn Close(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
+    fn Close(&self, cx: &mut CurrentRealm) -> RootedPromise {
         // Step 1.
-        let promise = Promise::new_in_realm(cx);
+        let promise = Promise::new_in_realm_rooted(cx);
 
         // Step 2.
         if self.context.control_thread_state() == ProcessingState::Closed {
@@ -214,7 +212,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
         }
 
         // Steps 4 and 5.
-        let trusted_promise = TrustedPromise::new(promise.clone());
+        let trusted_promise = TrustedPromise::from(promise.clone());
         match self.context.audio_context_impl().lock().unwrap().close() {
             Some(_) => {
                 let base_context = Trusted::new(&self.context);

--- a/components/script/dom/bindings/refcounted.rs
+++ b/components/script/dom/bindings/refcounted.rs
@@ -18,7 +18,7 @@ pub(crate) use script_bindings::refcounted::Trusted;
 use script_bindings::reflector::DomObject;
 use script_bindings::trace::trace_reflector;
 
-use crate::dom::promise::{Promise, RootedPromise};
+use crate::dom::promise::Promise;
 use crate::tasks::task::TaskOnce;
 
 thread_local!(pub(super) static LIVE_REFERENCES: Rc<RefCell<LivePromiseReferences>> =
@@ -59,12 +59,6 @@ pub struct TrustedPromise {
 }
 
 unsafe impl Send for TrustedPromise {}
-
-impl From<RootedPromise> for TrustedPromise {
-    fn from(promise: RootedPromise) -> Self {
-        TrustedPromise::new((*promise).clone())
-    }
-}
 
 impl TrustedPromise {
     /// Create a new `TrustedPromise` instance from an existing DOM object. The object will

--- a/components/script/dom/promise/promise.rs
+++ b/components/script/dom/promise/promise.rs
@@ -189,7 +189,6 @@ impl Promise {
         Promise::new_with_js_promise(cx, obj.handle())
     }
 
-    #[expect(dead_code)]
     pub(crate) fn new_in_realm_rooted(current_realm: &mut CurrentRealm) -> RootedPromise {
         RootedPromise(Self::new_in_realm(current_realm))
     }

--- a/components/script/dom/promise/promise.rs
+++ b/components/script/dom/promise/promise.rs
@@ -34,12 +34,14 @@ use js::rust::wrappers2::{
     SetAnyPromiseIsHandled, SetPromiseUserInputEventHandlingState,
 };
 use js::rust::{HandleObject, HandleValue, MutableHandleObject, Runtime};
+use script_bindings::interfaces::PromiseHelpers;
 use script_bindings::reflector::{DomObject, MutDomObject, Reflector};
 use script_bindings::settings_stack::run_a_script;
 
 use crate::DomTypeHolder;
 use crate::dom::bindings::conversions::root_from_object;
 use crate::dom::bindings::error::{Error, ErrorToJsval};
+use crate::dom::bindings::refcounted::TrustedPromise;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{AsHandleValue, Dom};
 use crate::dom::globalscope::GlobalScope;
@@ -48,10 +50,11 @@ use crate::event_loop::script_thread::ScriptThread;
 use crate::realms::enter_auto_realm;
 use crate::runtime::microtask::MicrotaskRunnable;
 
+#[derive(Clone)]
 pub(crate) struct RootedPromise(Rc<Promise>);
 
 impl Deref for RootedPromise {
-    type Target = Rc<Promise>;
+    type Target = Promise;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -66,6 +69,32 @@ impl From<RootedPromise> for Rc<Promise> {
 impl RootedPromise {
     pub(crate) fn to_traced(&self) -> TracedPromise {
         TracedPromise(self.0.clone())
+    }
+}
+
+impl From<RootedPromise> for TrustedPromise {
+    fn from(promise: RootedPromise) -> Self {
+        TrustedPromise::new(promise.0)
+    }
+}
+
+impl js::conversions::FromJSValConvertible for RootedPromise {
+    type Config = ();
+
+    fn from_jsval(
+        cx: &mut JSContext,
+        value: HandleValue,
+        _option: Self::Config,
+    ) -> Result<ConversionResult<Self>, ()> {
+        if value.get().is_null() {
+            return Ok(ConversionResult::Failure(c"null not allowed".into()));
+        }
+
+        let mut realm = CurrentRealm::assert(cx);
+        let global_scope = GlobalScope::from_current_realm(&mut realm);
+
+        let promise = Promise::new_resolved_rooted(cx, &global_scope, value);
+        Ok(ConversionResult::Success(promise))
     }
 }
 
@@ -699,7 +728,9 @@ pub(crate) fn wait_for_all_promise(
     promise
 }
 
-impl script_bindings::interfaces::PromiseHelpers<crate::DomTypeHolder> for Promise {
+impl PromiseHelpers<crate::DomTypeHolder> for Promise {
+    type StackRoot = RootedPromise;
+
     fn new_in_realm(
         cx: &mut CurrentRealm,
     ) -> Rc<<crate::DomTypeHolder as script_bindings::DomTypes>::Promise> {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -50,7 +50,6 @@ DOMInterfaces = {
 'AudioContext': {
     'realm': ['Close', 'Suspend'],
     'cx':['CreateMediaElementSource', 'CreateMediaStreamDestination', 'CreateMediaStreamSource', 'CreateMediaStreamTrackSource'],
-    'useRcPromise': True,
 },
 
 'BaseAudioContext': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -50,14 +50,17 @@ DOMInterfaces = {
 'AudioContext': {
     'realm': ['Close', 'Suspend'],
     'cx':['CreateMediaElementSource', 'CreateMediaStreamDestination', 'CreateMediaStreamSource', 'CreateMediaStreamTrackSource'],
+    'useRcPromise': True,
 },
 
 'BaseAudioContext': {
     'cx': ['CreateBuffer', 'CreateGain', 'CreateOscillator', 'CreatePanner', 'CreatePeriodicWave', 'CreateStereoPanner', 'CreateBiquadFilter', 'CreateIIRFilter', 'CreateAnalyser', 'CreateConstantSource', 'CreateChannelMerger', 'CreateChannelSplitter', 'CreateBufferSource', 'Destination', 'Listener'],
     'realm': ['DecodeAudioData', 'Resume'],
+    'useRcPromise': True,
 },
 
 'Blob': {
+    'useRcPromise': True,
     'weakReferenceable': True,
     'realm': ['ArrayBuffer', 'Bytes', 'Text'],
     'cx': ['Stream', 'Slice', 'TextStream']
@@ -65,28 +68,34 @@ DOMInterfaces = {
 
 'Bluetooth': {
     'realm': ['GetAvailability', 'RequestDevice'],
+    'useRcPromise': True,
 },
 
 'BluetoothDevice': {
     'realm': ['WatchAdvertisements'],
     'cx': ['GetGatt'],
+    'useRcPromise': True,
 },
 
 'BluetoothRemoteGATTCharacteristic': {
     'realm': ['ReadValue', 'StartNotifications', 'StopNotifications', 'WriteValue', 'GetDescriptor', 'GetDescriptors'],
+    'useRcPromise': True,
 },
 
 'BluetoothRemoteGATTDescriptor': {
     'realm': ['ReadValue', 'WriteValue'],
+    'useRcPromise': True,
 },
 
 'BluetoothRemoteGATTServer': {
     'realm': ['Connect', 'GetPrimaryService', 'GetPrimaryServices'],
     'cx': ['Disconnect'],
+    'useRcPromise': True,
 },
 
 'BluetoothRemoteGATTService': {
-    'realm': ['GetCharacteristic', 'GetCharacteristics', 'GetIncludedService', 'GetIncludedServices']
+    'realm': ['GetCharacteristic', 'GetCharacteristics', 'GetIncludedService', 'GetIncludedServices'],
+    'useRcPromise': True,
 },
 
 'BroadcastChannel': {
@@ -99,10 +108,12 @@ DOMInterfaces = {
 
 'CacheStorage': {
     'cx': ['Has', 'Open', 'Delete'],
+    'useRcPromise': True,
 },
 
 'Cache': {
     'cx': ['Keys'],
+    'useRcPromise': True,
 },
 
 'CanvasRenderingContext2D': {
@@ -119,12 +130,14 @@ DOMInterfaces = {
 },
 
 'Clipboard': {
-    'realm': ['ReadText', 'WriteText']
+    'realm': ['ReadText', 'WriteText'],
+    'useRcPromise': True,
 },
 
 'ClipboardItem': {
     'cx': ['Types'],
-    'realm': ['GetType']
+    'realm': ['GetType'],
+    'useRcPromise': True,
 },
 
 'console': {
@@ -133,10 +146,12 @@ DOMInterfaces = {
 
 'CookieStore': {
     'cx': ['Set', 'Set_', 'Get', 'Get_', 'GetAll', 'GetAll_', 'Delete', 'Delete_'],
+    'useRcPromise': True,
 },
 
 'CookieStoreManager': {
     'cx': ['Subscribe', 'GetSubscriptions', 'Unsubscribe'],
+    'useRcPromise': True,
 },
 
 'CountQueuingStrategy': {
@@ -145,6 +160,11 @@ DOMInterfaces = {
 
 'Credential': {
     'realm': ['IsConditionalMediationAvailable', 'WillRequestConditionalCreation'],
+    'useRcPromise': True,
+},
+
+'CredentialsContainer': {
+    'useRcPromise': True,
 },
 
 'CSS': {
@@ -208,6 +228,7 @@ DOMInterfaces = {
         'RemoveRule'
     ],
     'no_gc': ['ReplaceSync'],
+    'useRcPromise': True,
 },
 
 'Crypto': {
@@ -223,7 +244,8 @@ DOMInterfaces = {
 'CustomElementRegistry': {
     'cx': ['Define', 'Get'],
     'realm': ['WhenDefined'],
-    'cx_no_gc': ['Initialize', 'Upgrade']
+    'cx_no_gc': ['Initialize', 'Upgrade'],
+    'useRcPromise': True,
 },
 
 'DataTransfer': {
@@ -249,6 +271,7 @@ DOMInterfaces = {
 },
 
 'Document': {
+    'useRcPromise': True,
     'additionalTraits': ["crate::interfaces::DocumentHelpers"],
     'cx': [
         'AdoptedStyleSheets',
@@ -382,6 +405,7 @@ DOMInterfaces = {
 },
 
 'Element': {
+    'useRcPromise': True,
     'cx': [
         'After',
         'Animate',
@@ -460,6 +484,7 @@ DOMInterfaces = {
 },
 
 'FakeXRDevice': {
+    'useRcPromise': True,
     'cx': ['SimulateInputSourceConnection'],
     'realm': ['Disconnect'],
 },
@@ -482,10 +507,12 @@ DOMInterfaces = {
 
 'FontFace': {
     'cx': ['Load'],
+    'useRcPromise': True,
 },
 
 'FontFaceSet': {
     'cx': ['Add', 'Load', 'Ready', 'Clear', 'Size'],
+    'useRcPromise': True,
 },
 
 'FormData': {
@@ -499,6 +526,7 @@ DOMInterfaces = {
 'GamepadHapticActuator': {
     'cx': ['Effects'],
     'realm': ['PlayEffect', 'Reset'],
+    'useRcPromise': True,
 },
 
 'Geolocation': {
@@ -512,10 +540,12 @@ DOMInterfaces = {
 'GPU': {
     'realm': ['RequestAdapter'],
     'cx': ['WgslLanguageFeatures'],
+    'useRcPromise': True,
 },
 
 'GPUAdapter': {
     'realm': ['RequestDevice'],
+    'useRcPromise': True,
 },
 
 'GPUBindGroup': {
@@ -530,6 +560,7 @@ DOMInterfaces = {
     'realm': ['MapAsync'],
     'cx': ['Destroy', 'GetMappedRange',  'Unmap', 'PopErrorScope'],
     'no_gc': ['SetLabel'],
+    'useRcPromise': True,
 },
 
 'GPUCanvasContext': {
@@ -560,6 +591,7 @@ DOMInterfaces = {
 },
 
 'GPUDevice': {
+    'useRcPromise': True,
     'realm': ['CreateComputePipelineAsync', 'CreateRenderPipelineAsync',
         'CreateShaderModule', # create promise for compilation info
         'PopErrorScope',
@@ -579,6 +611,7 @@ DOMInterfaces = {
 },
 
 'GPUQueue': {
+    'useRcPromise': True,
     'cx': ['CopyExternalImageToTexture', 'OnSubmittedWorkDone', 'WriteBuffer', 'WriteTexture'],
     'no_gc': ['SetLabel'],
 },
@@ -616,6 +649,7 @@ DOMInterfaces = {
 },
 
 'GPUShaderModule': {
+    'useRcPromise': True,
     'no_gc': ['SetLabel'],
 },
 
@@ -708,6 +742,7 @@ DOMInterfaces = {
 
 'HTMLImageElement': {
     'cx': ['Decode', 'Image', 'ReportValidity'],
+    'useRcPromise': True,
 },
 
 'HTMLInputElement': {
@@ -734,6 +769,7 @@ DOMInterfaces = {
 
 'HTMLMediaElement': {
     'realm': ['Play'],
+    'useRcPromise': True,
     'weakReferenceable': True,
     'cx': ['AddTextTrack', 'AudioTracks', 'Buffered', 'Played', 'Seekable', 'TextTracks', 'Load', 'Pause', 'VideoTracks'],
 },
@@ -831,6 +867,7 @@ DOMInterfaces = {
 
 'IDBFactory': {
     'cx': ['Cmp', 'Databases', 'DeleteDatabase', 'Open'],
+    'useRcPromise': True,
 },
 
 'IDBIndex': {
@@ -878,6 +915,7 @@ DOMInterfaces = {
 'MediaDevices': {
     'realm': ['GetUserMedia'],
     'cx': ['EnumerateDevices'],
+    'useRcPromise': True,
 },
 
 'MediaList': {
@@ -930,6 +968,7 @@ DOMInterfaces = {
 
 'NavigationPreloadManager': {
     'realm': ['Disable', 'Enable', 'GetState', 'SetHeaderValue'],
+    'useRcPromise': True,
 },
 
 'Navigator': {
@@ -939,10 +978,12 @@ DOMInterfaces = {
 
 'CredentialsContainer': {
     'realm': ['Get', 'Store', 'Create', 'PreventSilentAccess'],
+    'useRcPromise': True,
 },
 
 'WakeLock': {
     'realm': ['Request'],
+    'useRcPromise': True,
 },
 
 'Node': {
@@ -959,7 +1000,8 @@ DOMInterfaces = {
 },
 
 'Notification': {
-    'cx': ['Actions', 'RequestPermission', 'Vibrate']
+    'cx': ['Actions', 'RequestPermission', 'Vibrate'],
+    'useRcPromise': True,
 },
 
 'OESVertexArrayObject': {
@@ -968,10 +1010,12 @@ DOMInterfaces = {
 
 'OfflineAudioContext': {
     'realm': ['StartRendering'],
+    'useRcPromise': True,
 },
 
 'OffscreenCanvas': {
     'cx': ['ConvertToBlob', 'GetContext', 'SetHeight', 'SetWidth', 'TransferToImageBitmap'],
+    'useRcPromise': True,
 },
 
 'OffscreenCanvasRenderingContext2D': {
@@ -1010,11 +1054,12 @@ DOMInterfaces = {
 
 'Permissions': {
     'realm': ['Query', 'Request', 'Revoke'],
+    'useRcPromise': True,
 },
 
 'Promise': {
     'spiderMonkeyInterface': True,
-    'additionalTraits': ["js::conversions::FromJSValConvertibleRc"],
+    'additionalTraits': ["js::conversions::FromJSValConvertibleRc", "crate::interfaces::PromiseHelpers<Self>"],
     'allowDropImpl': True,
 },
 
@@ -1044,20 +1089,24 @@ DOMInterfaces = {
 
 'Request': {
     'cx': ['Headers', 'Clone', 'Text', 'Blob', 'FormData', 'Json', 'ArrayBuffer', 'Bytes', 'TextStream'],
+    'useRcPromise': True,
 },
 
 'Response': {
     'cx': ['CreateFromJson', 'Clone', 'Error', 'Redirect', 'Text', 'Blob', 'FormData', 'Json', 'ArrayBuffer', 'Bytes', 'Headers', 'TextStream'],
+    'useRcPromise': True,
 },
 
 'RTCPeerConnection': {
     'realm': ['AddIceCandidate', 'CreateAnswer', 'CreateOffer', 'SetLocalDescription', 'SetRemoteDescription'],
     'cx': ['AddTransceiver', 'Close', 'CreateDataChannel',],
     'weakReferenceable': True,
+    'useRcPromise': True,
 },
 
 'RTCRtpSender': {
     'cx': ['SetParameters'],
+    'useRcPromise': True,
 },
 
 'Sanitizer': {
@@ -1097,6 +1146,7 @@ DOMInterfaces = {
 
 'ServiceWorkerContainer': {
     'realm': ['GetRegistration', 'Register'],
+    'useRcPromise': True,
 },
 
 'ServiceWorkerGlobalScope': {
@@ -1105,12 +1155,14 @@ DOMInterfaces = {
 
 'ServiceWorkerRegistration': {
     'cx': ['Cookies', 'NavigationPreload', 'Unregister'],
+    'useRcPromise': True,
 },
 
 'ServoInternals': {
     'cx': ['DefaultPreferenceValue', 'GetPreference'],
     'realm': ['ReportMemory'],
     'additionalTraits': ['crate::interfaces::ServoInternalsHelpers'],
+    'useRcPromise': True,
 },
 
 'ServoTestUtils': {
@@ -1137,6 +1189,7 @@ DOMInterfaces = {
 
 'StorageManager': {
     'realm': ['Persisted', 'Persist', 'Estimate'],
+    'useRcPromise': True,
 },
 
 'StyleSheet': {
@@ -1149,6 +1202,7 @@ DOMInterfaces = {
 },
 
 'SubtleCrypto': {
+    'useRcPromise': True,
     'realm': ['Encrypt', 'Decrypt', 'Sign', 'Verify', 'GenerateKey', 'DeriveKey', 'DeriveBits', 'Digest', 'ImportKey', 'ExportKey', 'WrapKey', 'UnwrapKey', 'EncapsulateKey', 'EncapsulateBits', 'DecapsulateKey', 'DecapsulateBits', 'GetPublicKey'],
     'cx': ['Supports', 'Supports_'],
 },
@@ -1160,6 +1214,7 @@ DOMInterfaces = {
 #FIXME(jdm): This should be 'register': False, but then we don't generate enum types
 'TestBinding': {
     'additionalTraits': ['crate::interfaces::TestBindingHelpers'],
+    'useRcPromise': True,
     'cx': [
         'ArrayAttribute',
         'GetDictionaryWithTypedArray',
@@ -1195,10 +1250,12 @@ DOMInterfaces = {
 
 'TestUtils': {
     'cx': ['Gc'],
+    'useRcPromise': True,
 },
 
 'TestWorklet': {
     'realm': ['AddModule'],
+    'useRcPromise': True,
 },
 
 'TestWorkletGlobalScope': {
@@ -1249,6 +1306,7 @@ DOMInterfaces = {
 },
 
 'WebGLRenderingContext': {
+    'useRcPromise': True,
     'no_gc': [
         'CompressedTexImage2D',
         'CompressedTexSubImage2D',
@@ -1304,6 +1362,7 @@ DOMInterfaces = {
 },
 
 'WebGL2RenderingContext': {
+    'useRcPromise': True,
     'no_gc': [
         'CompressedTexImage2D',
         'CompressedTexSubImage2D',
@@ -1399,9 +1458,11 @@ DOMInterfaces = {
 
 'WindowClient': {
     'cx': ['Focus', 'Navigate'],
+    'useRcPromise': True,
 },
 
 'Window': {
+    'useRcPromise': True,
     'additionalTraits': ['crate::interfaces::WindowHelpers', 'crate::interfaces::HasOrigin'],
     'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'WebdriverCallback', 'GetOpener', 'Fetch'],
     'cx': [
@@ -1463,6 +1524,7 @@ DOMInterfaces = {
 },
 
 'WorkerGlobalScope': {
+    'useRcPromise': True,
     'cx': ['Caches', 'Crypto', 'ImportScripts', 'ReportError', 'SetInterval', 'SetTimeout', 'TrustedTypes', 'StructuredClone', 'IndexedDB', 'QueueMicrotask', 'Location', 'Navigator', 'Performance'],
     'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'Fetch'],
 },
@@ -1473,6 +1535,7 @@ DOMInterfaces = {
 
 'Worklet': {
     'realm': ['AddModule'],
+    'useRcPromise': True,
 },
 
 'XMLDocument': {
@@ -1532,16 +1595,19 @@ DOMInterfaces = {
     'cx': ['EnabledFeatures', 'GetSupportedFrameRates', 'UpdateRenderState'],
     'realm': ['End', 'RequestHitTestSource', 'RequestReferenceSpace', 'UpdateTargetFrameRate'],
     'weakReferenceable': True,
+    'useRcPromise': True,
 },
 
 'XRSystem': {
     'cx': ['Test'],
     'realm': ['IsSessionSupported', 'RequestSession'],
+    'useRcPromise': True,
 },
 
 'XRTest': {
     'realm': ['SimulateDeviceConnection', 'DisconnectAllDevices'],
-    'cx': ['SimulateUserActivation']
+    'cx': ['SimulateUserActivation'],
+    'useRcPromise': True,
 },
 
 'XRView': {
@@ -1554,7 +1620,8 @@ DOMInterfaces = {
 
 'ReadableStream': {
     'realm': ['PipeTo', 'PipeThrough'],
-    'cx': ['Cancel', 'GetReader', 'Tee']
+    'cx': ['Cancel', 'GetReader', 'Tee'],
+    'useRcPromise': True,
 },
 
 "ReadableStreamDefaultController": {
@@ -1570,11 +1637,13 @@ DOMInterfaces = {
 },
 
 "ReadableStreamBYOBReader": {
-    "cx": ["Cancel", "Read", "ReleaseLock"]
+    "cx": ["Cancel", "Read", "ReleaseLock"],
+    'useRcPromise': True,
 },
 
 "ReadableStreamDefaultReader": {
-    "cx": ["Cancel", "Read", "ReleaseLock"]
+    "cx": ["Cancel", "Read", "ReleaseLock"],
+    'useRcPromise': True,
 },
 
 'ResizeObserver': {
@@ -1583,6 +1652,18 @@ DOMInterfaces = {
 
 'ResizeObserverEntry': {
     'cx': ['BorderBoxSize', 'ContentBoxSize', 'DevicePixelContentBoxSize'],
+},
+
+'Transformer': {
+    'useRcPromise': True,
+},
+
+'UnderlyingSink': {
+    'useRcPromise': True,
+},
+
+'UnderlyingSource': {
+    'useRcPromise': True,
 },
 
 'VisibilityStateEntry': {
@@ -1594,7 +1675,8 @@ DOMInterfaces = {
 },
 
 'WritableStream': {
-    'realm': ['Abort', 'Close', 'GetWriter']
+    'realm': ['Abort', 'Close', 'GetWriter'],
+    'useRcPromise': True,
 },
 
 'WritableStreamDefaultController': {
@@ -1604,6 +1686,7 @@ DOMInterfaces = {
 'WritableStreamDefaultWriter': {
     'cx': ['ReleaseLock'],
     'realm': ['Abort', 'Close', 'Constructor', 'Write'],
+    'useRcPromise': True,
 },
 
 'TransformStreamDefaultController': {

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -762,7 +762,8 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
                                 defaultValue: IDLValue | None = None,
                                 exceptionCode: str | None = None,
                                 allowTreatNonObjectAsNull: bool = False,
-                                sourceDescription: str = "value") -> JSToNativeConversionInfo:
+                                sourceDescription: str = "value",
+                                useRcPromise: bool = True) -> JSToNativeConversionInfo:
     """
     Get a template for converting a JS value to a native object based on the
     given type and descriptor.  If failureCode is given, then we're actually
@@ -991,7 +992,7 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
         if isArgument:
             declType = CGGeneric("&D::Promise")
         else:
-            declType = CGGeneric("Rc<D::Promise>")
+            declType = CGGeneric("Rc<D::Promise>") if useRcPromise else CGGeneric("<D::Promise as PromiseHelpers<D>>::StackRoot")
         return handleOptional(templateBody, declType, handleDefault("None"))
 
     if type.isGeckoInterface():
@@ -1616,7 +1617,7 @@ def builtin_return_type(returnType: IDLType) -> CGThing:
 
 
 # Returns a CGThing containing the type of the return value.
-def getRetvalDeclarationForType(returnType: IDLType | None, descriptorProvider: DescriptorProvider, isInnerType: bool =False) -> CGThing:
+def getRetvalDeclarationForType(returnType: IDLType | None, descriptorProvider: DescriptorProvider, isInnerType: bool = False, useRcPromise: bool = True) -> CGThing:
     if returnType is None or returnType.isUndefined():
         # Nothing to declare
         return CGGeneric("()")
@@ -1651,7 +1652,7 @@ def getRetvalDeclarationForType(returnType: IDLType | None, descriptorProvider: 
         return result
     if returnType.isPromise():
         assert not returnType.nullable()
-        return CGGeneric("Rc<D::Promise>")
+        return CGGeneric("Rc<D::Promise>") if useRcPromise else CGGeneric("<D::Promise as PromiseHelpers<D>>::StackRoot")
     if returnType.isGeckoInterface():
         descriptor = descriptorProvider.getDescriptor(
             # pyrefly: ignore  # missing-attribute
@@ -1685,7 +1686,7 @@ def getRetvalDeclarationForType(returnType: IDLType | None, descriptorProvider: 
         else:
             return objectType
     if returnType.isSequence():
-        result = getRetvalDeclarationForType(innerContainerType(returnType), descriptorProvider, isInnerType=True)
+        result = getRetvalDeclarationForType(innerContainerType(returnType), descriptorProvider, isInnerType=True, useRcPromise=useRcPromise)
         result = wrapInNativeContainerType(returnType, result)
         if returnType.nullable():
             result = CGWrapper(result, pre="Option<", post=">")
@@ -1693,7 +1694,7 @@ def getRetvalDeclarationForType(returnType: IDLType | None, descriptorProvider: 
     # FIXME: The branches for isSequence() and isRecord() should be the same, but we don't use out-parameters for
     # records containing unrooted JS types yet.
     if returnType.isRecord():
-        result = getRetvalDeclarationForType(innerContainerType(returnType), descriptorProvider)
+        result = getRetvalDeclarationForType(innerContainerType(returnType), descriptorProvider, useRcPromise=useRcPromise)
         result = wrapInNativeContainerType(returnType, result)
         if returnType.nullable():
             result = CGWrapper(result, pre="Option<", post=">")
@@ -3004,15 +3005,15 @@ def DomTypes(descriptors: list[Descriptor],
         if iterableDecl:
             if iterableDecl.isMaplike():
                 keytype = fixupInterfaceTypeReferences(
-                    getRetvalDeclarationForType(iterableDecl.keyType, descriptor).define()
+                    getRetvalDeclarationForType(iterableDecl.keyType, descriptor, useRcPromise=descriptor.useRcPromise).define()
                 )
                 valuetype = fixupInterfaceTypeReferences(
-                    getRetvalDeclarationForType(iterableDecl.valueType, descriptor).define()
+                    getRetvalDeclarationForType(iterableDecl.valueType, descriptor, useRcPromise=descriptor.useRcPromise).define()
                 )
                 traits += [f"crate::like::Maplike<Key={keytype}, Value={valuetype}>"]
             if iterableDecl.isSetlike():
                 keytype = fixupInterfaceTypeReferences(
-                    getRetvalDeclarationForType(iterableDecl.keyType, descriptor).define()
+                    getRetvalDeclarationForType(iterableDecl.keyType, descriptor, useRcPromise=descriptor.useRcPromise).define()
                 )
                 traits += [f"crate::like::Setlike<Key={keytype}>"]
             if iterableDecl.hasKeyType():
@@ -4255,7 +4256,7 @@ class CGCallGenerator(CGThing):
 
         isFallible = errorResult is not None
 
-        result = getRetvalDeclarationForType(returnType, descriptor)
+        result = getRetvalDeclarationForType(returnType, descriptor, useRcPromise=descriptor.useRcPromise)
         if returnType and returnTypeNeedsOutparam(returnType):
             outparamRootType = result
             result = CGGeneric("()")
@@ -7056,7 +7057,8 @@ class CGInterfaceTrait(CGThing):
                                 cx_no_gc: bool = False,
                                 cx: bool = False,
                                 realm: bool = False,
-                                retval: bool = False
+                                retval: bool = False,
+                                useRcPromise: bool = True,
                                 ) -> Iterable[tuple[str, str]]:
             if realm:
                 yield "realm", "&mut CurrentRealm"
@@ -7068,7 +7070,7 @@ class CGInterfaceTrait(CGThing):
                 yield "cx", "&NoGC"
 
             if argument:
-                yield "value", argument_type(descriptor, argument)
+                yield "value", argument_type(descriptor, argument, useRcPromise=useRcPromise)
 
             if retval and returnTypeNeedsOutparam(attribute_type):
                 yield "retval", outparamTypeFromReturnType(attribute_type)
@@ -7094,8 +7096,9 @@ class CGInterfaceTrait(CGThing):
                                                      no_gc=name in descriptor.no_gcMethods,
                                                      cx_no_gc=name in descriptor.cx_no_gcMethods,
                                                      cx=name in descriptor.cxMethods or descriptor.interface.isIteratorInterface(),
-                                                     realm=name in descriptor.realmMethods)
-                        rettype = return_type(descriptor, rettype, infallible)
+                                                     realm=name in descriptor.realmMethods,
+                                                     useRcPromise=descriptor.useRcPromise)
+                        rettype = return_type(descriptor, rettype, infallible, descriptor.useRcPromise)
                         yield f"{name}{'_' * idx}", arguments, rettype, m.isStatic()
                 elif m.isAttr():
                     name = CGSpecializedGetter.makeNativeName(descriptor, m)
@@ -7114,9 +7117,10 @@ class CGInterfaceTrait(CGThing):
                                cx_no_gc=name in descriptor.cx_no_gcMethods,
                                cx=name in descriptor.cxMethods or isEventHandlerCallback(m),
                                realm=name in descriptor.realmMethods,
-                               retval=True
+                               retval=True,
+                               useRcPromise=descriptor.useRcPromise,
                            ),
-                           return_type(descriptor, m.type, infallible),
+                           return_type(descriptor, m.type, infallible, descriptor.useRcPromise),
                            m.isStatic())
 
                     if not m.readonly:
@@ -7135,6 +7139,7 @@ class CGInterfaceTrait(CGThing):
                                    cx=name in descriptor.cxMethods or descriptor.implicitCxSetters or isEventHandlerCallback(m),
                                    realm=name in descriptor.realmMethods,
                                    retval=False,
+                                   useRcPromise=descriptor.useRcPromise,
                                ),
                                rettype,
                                m.isStatic())
@@ -7155,7 +7160,8 @@ class CGInterfaceTrait(CGThing):
                                                      no_gc=name in descriptor.no_gcMethods,
                                                      cx_no_gc=name in descriptor.cx_no_gcMethods,
                                                      cx=name in descriptor.cxMethods,
-                                                     realm=name in descriptor.realmMethods)
+                                                     realm=name in descriptor.realmMethods,
+                                                     useRcPromise=descriptor.useRcPromise)
 
                         # If this interface 'supports named properties', then we
                         # should be able to access 'supported property names'
@@ -7169,8 +7175,9 @@ class CGInterfaceTrait(CGThing):
                                                      no_gc=name in descriptor.no_gcMethods,
                                                      cx_no_gc=name in descriptor.cx_no_gcMethods,
                                                      cx=name in descriptor.cxMethods,
-                                                     realm=name in descriptor.realmMethods)
-                    rettype = return_type(descriptor, rettype, infallible)
+                                                     realm=name in descriptor.realmMethods,
+                                                     useRcPromise=descriptor.useRcPromise)
+                    rettype = return_type(descriptor, rettype, infallible, descriptor.useRcPromise)
                     yield name, arguments, rettype, False
 
         def fmt(arguments: list[tuple[str, str]], leadingComma: bool = True) -> str:
@@ -7211,7 +7218,7 @@ class CGInterfaceTrait(CGThing):
             for (i, (rettype, arguments)) in enumerate(ctor.signatures()):
                 name = (baseName or ctor.identifier.name) + ('_' * i)
                 realm = name in descriptor.realmMethods
-                args = list(method_arguments(descriptor, rettype, arguments, cx=True, realm=realm))
+                args = list(method_arguments(descriptor, rettype, arguments, cx=True, realm=realm, useRcPromise=descriptor.useRcPromise))
                 extra = [
                     ("global", f"&D::{exposedGlobal}"),
                     ("proto", "Option<HandleObject>"),
@@ -7219,7 +7226,7 @@ class CGInterfaceTrait(CGThing):
                 args = [args[0]] + extra + args[1:]
                 yield CGGeneric(
                     f"fn {name}({fmt(args, leadingComma=False)}) -> "
-                    f"{return_type(descriptorProvider, rettype, infallible)};\n"
+                    f"{return_type(descriptorProvider, rettype, infallible, descriptor.useRcPromise)};\n"
                 )
 
         ctor = descriptor.interface.ctor()
@@ -8386,11 +8393,13 @@ def argument_type(descriptorProvider: DescriptorProvider,
                   ty: IDLType,
                   optional: bool = False,
                   defaultValue: DefaultValueType | None = None,
-                  variadic: bool = False
+                  variadic: bool = False,
+                  useRcPromise: bool = True,
                   ) -> str:
     info = getJSToNativeConversionInfo(
         ty, descriptorProvider, isArgument=True,
-        isAutoRooted=type_needs_auto_root(ty))
+        isAutoRooted=type_needs_auto_root(ty),
+        useRcPromise=useRcPromise)
     declType = info.declType
     assert declType is not None
     if variadic:
@@ -8419,7 +8428,8 @@ def method_arguments(descriptorProvider: DescriptorProvider,
                      no_gc: bool = False,
                      cx_no_gc: bool = False,
                      cx: bool = False,
-                     realm: bool = False
+                     realm: bool = False,
+                     useRcPromise: bool = True,
                      ) -> Iterator[tuple[str, str]]:
 
     match needCx(returnType, arguments, passJSBits):
@@ -8441,7 +8451,7 @@ def method_arguments(descriptorProvider: DescriptorProvider,
 
     for argument in arguments:
         ty = argument_type(descriptorProvider, argument.type, argument.optional,
-                           argument.defaultValue, argument.variadic)
+                           argument.defaultValue, argument.variadic, useRcPromise)
         yield CGDictionary.makeMemberName(argument.identifier.name), ty
 
     if trailing:
@@ -8451,8 +8461,8 @@ def method_arguments(descriptorProvider: DescriptorProvider,
         yield "rval", outparamTypeFromReturnType(returnType),
 
 
-def return_type(descriptorProvider: DescriptorProvider, rettype: IDLType, infallible: bool) -> str:
-    result = getRetvalDeclarationForType(rettype, descriptorProvider)
+def return_type(descriptorProvider: DescriptorProvider, rettype: IDLType, infallible: bool, useRcPromise: bool) -> str:
+    result = getRetvalDeclarationForType(rettype, descriptorProvider, useRcPromise=useRcPromise)
     if rettype and returnTypeNeedsOutparam(rettype):
         result = CGGeneric("()")
     if not infallible:
@@ -8470,7 +8480,8 @@ class CGNativeMember(ClassMethod):
                  breakAfter: bool = True,
                  passJSBitsAsNeeded: bool = True,
                  visibility: str = "public",
-                 unsafe: bool = False) -> None:
+                 unsafe: bool = False,
+                 useRcPromise: bool = True) -> None:
         """
         If passJSBitsAsNeeded is false, we don't automatically pass in a
         JSContext* or a JSObject* based on the return and argument types.
@@ -8479,6 +8490,7 @@ class CGNativeMember(ClassMethod):
         self.member = member
         self.extendedAttrs = extendedAttrs
         self.passJSBitsAsNeeded = passJSBitsAsNeeded
+        self.useRcPromise = useRcPromise
         breakAfterSelf = "\n" if breakAfter else ""
         ClassMethod.__init__(self, name,
                              self.getReturnType(signature[0]),
@@ -8494,14 +8506,15 @@ class CGNativeMember(ClassMethod):
 
     def getReturnType(self, type: IDLType) -> str:
         infallible = 'infallible' in self.extendedAttrs
-        typeDecl = return_type(self.descriptorProvider, type, infallible)
+        typeDecl = return_type(self.descriptorProvider, type, infallible, self.useRcPromise)
         return typeDecl
 
     def getArgs(self, returnType: IDLType, argList: list[IDLArgument | FakeArgument]) -> list[Argument]:
         return [Argument(arg[1], arg[0]) for arg in method_arguments(self.descriptorProvider,
                                                                      returnType,
                                                                      argList,
-                                                                     self.passJSBitsAsNeeded)]
+                                                                     self.passJSBitsAsNeeded,
+                                                                     useRcPromise=self.useRcPromise)]
 
 
 class CGCallback(CGClass):
@@ -8615,7 +8628,7 @@ class CGCallbackFunction(CGCallback):
     def __init__(self, callback: IDLCallback, descriptorProvider: DescriptorProvider) -> None:
         CGCallback.__init__(self, callback, descriptorProvider,
                             "CallbackFunction<D>",
-                            methods=[CallCallback(callback, descriptorProvider)])
+                            methods=[CallCallback(callback, descriptorProvider, useRcPromise=True)])
 
     def getConstructors(self) -> list[ClassConstructor]:
         return CGCallback.getConstructors(self)
@@ -8675,7 +8688,7 @@ class FakeMember():
 
 
 class CallbackMember(CGNativeMember):
-    def __init__(self, sig: tuple[IDLType, list[IDLArgument | FakeArgument]], name: str, descriptorProvider: DescriptorProvider, needThisHandling: bool) -> None:
+    def __init__(self, sig: tuple[IDLType, list[IDLArgument | FakeArgument]], name: str, descriptorProvider: DescriptorProvider, needThisHandling: bool, useRcPromise: bool) -> None:
         """
         needThisHandling is True if we need to be able to accept a specified
         thisObj, False otherwise.
@@ -8860,9 +8873,9 @@ class CallbackMember(CGNativeMember):
 
 
 class CallbackMethod(CallbackMember):
-    def __init__(self, sig: tuple[IDLType, list[IDLArgument | FakeArgument]], name: str, descriptorProvider: DescriptorProvider, needThisHandling: bool) -> None:
+    def __init__(self, sig: tuple[IDLType, list[IDLArgument | FakeArgument]], name: str, descriptorProvider: DescriptorProvider, needThisHandling: bool, useRcPromise: bool) -> None:
         CallbackMember.__init__(self, sig, name, descriptorProvider,
-                                needThisHandling)
+                                needThisHandling, useRcPromise)
 
     def getRvalDecl(self) -> str:
         if self.usingOutparam:
@@ -8905,10 +8918,10 @@ class CallbackMethod(CallbackMember):
 
 
 class CallCallback(CallbackMethod):
-    def __init__(self, callback: IDLCallback, descriptorProvider: DescriptorProvider) -> None:
+    def __init__(self, callback: IDLCallback, descriptorProvider: DescriptorProvider, useRcPromise: bool) -> None:
         self.callback = callback
         CallbackMethod.__init__(self, callback.signatures()[0], "Call",
-                                descriptorProvider, needThisHandling=True)
+                                descriptorProvider, needThisHandling=True, useRcPromise=useRcPromise)
 
     def getThisObj(self) -> str:
         return "aThisObj.get()"
@@ -8929,7 +8942,7 @@ class CallbackOperationBase(CallbackMethod):
     def __init__(self, signature: tuple[IDLType, list[IDLArgument | FakeArgument]], jsName: str, nativeName: str, descriptor: Descriptor, singleOperation: bool) -> None:
         self.singleOperation = singleOperation
         self.methodName = jsName
-        CallbackMethod.__init__(self, signature, nativeName, descriptor, singleOperation)
+        CallbackMethod.__init__(self, signature, nativeName, descriptor, singleOperation, useRcPromise=descriptor.useRcPromise)
 
     def getThisObj(self) -> str:
         if not self.singleOperation:

--- a/components/script_bindings/codegen/configuration.py
+++ b/components/script_bindings/codegen/configuration.py
@@ -315,6 +315,7 @@ class Descriptor(DescriptorProvider):
         self.weakReferenceable = desc.get('weakReferenceable', False)
         self.useSystemCompartment = desc.get('useSystemCompartment', False)
         self.allowDropImpl = desc.get('allowDropImpl', False)
+        self.useRcPromise = desc.get('useRcPromise', False)
 
         # If we're concrete, we need to crawl our ancestor interfaces and mark
         # them as having a concrete descendant.

--- a/components/script_bindings/interfaces.rs
+++ b/components/script_bindings/interfaces.rs
@@ -91,6 +91,9 @@ pub trait GlobalScopeHelpers<D: DomTypes> {
 }
 
 pub trait PromiseHelpers<D: DomTypes> {
+    type StackRoot: js::conversions::FromJSValConvertible<Config = ()>
+        + js::conversions::ToJSValConvertible
+        + std::ops::Deref<Target = D::Promise>;
     fn new_in_realm(cx: &mut CurrentRealm) -> Rc<D::Promise>;
     fn reject_error(&self, cx: &mut JSContext, error: Error);
     fn is_rejected(&self) -> bool;


### PR DESCRIPTION
To avoid big boil-the-ocean changes, we can now migrate one interface at a time to return `PromiseRoot` instead of `Rc<Promise>` by removing the new `useRcPromise` entries in Bindings.conf.

Testing: Existing tests suffice.
Part of #45262
