### PR TITLE
script: Move more webgpu to script_webgpu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9523,6 +9523,8 @@ dependencies = [
 name = "servo-script-webgpu"
 version = "0.6.0"
 dependencies = [
+ "arrayvec",
+ "euclid",
  "indexmap",
  "log",
  "malloc_size_of_derive",
@@ -9534,8 +9536,10 @@ dependencies = [
  "servo-dom-struct",
  "servo-jstraceable-derive",
  "servo-malloc-size-of",
+ "servo-pixels",
  "servo-script-bindings",
  "servo-webgpu-traits",
+ "stylo_atoms",
  "trait-set",
  "wgpu-core 30.0.1",
  "wgpu-types 30.0.0",

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -14,6 +14,7 @@ use script_bindings::cell::DomRefCell;
 use script_bindings::cformat;
 use script_bindings::codegen::GenericBindings::WebGPUBinding::GPUAdapterMethods;
 use script_bindings::reflector::reflect_weak_referenceable_dom_object;
+use script_webgpu::PipelineLayout;
 use script_webgpu::gpuconvert::WebGPUConvert;
 use script_webgpu::traits::GPUDeviceTrait;
 use webgpu_traits::{
@@ -21,7 +22,6 @@ use webgpu_traits::{
     WebGPUPoppedErrorScopeResponse, WebGPUQueue, WebGPURenderPipeline,
     WebGPURenderPipelineResponse, WebGPURequest,
 };
-use wgpu_core::id::PipelineLayoutId;
 use wgpu_core::pipeline as wgpu_pipe;
 use wgpu_core::pipeline::RenderPipelineDescriptor;
 use wgpu_types::{self, TextureFormat};
@@ -107,20 +107,6 @@ pub(crate) struct GPUDevice {
     lost_promise: DomRefCell<Rc<Promise>>,
     valid: Cell<bool>,
     droppable: DroppableGPUDevice,
-}
-
-pub(crate) enum PipelineLayout {
-    Implicit,
-    Explicit(PipelineLayoutId),
-}
-
-impl PipelineLayout {
-    pub(crate) fn explicit(&self) -> Option<PipelineLayoutId> {
-        match self {
-            PipelineLayout::Explicit(layout_id) => Some(*layout_id),
-            PipelineLayout::Implicit => None,
-        }
-    }
 }
 
 impl GPUDevice {
@@ -798,5 +784,18 @@ impl GPUDeviceTrait<crate::DomTypeHolder> for GPUDevice {
         gpu_texture_format: &GPUTextureFormat,
     ) -> Fallible<TextureFormat> {
         self.validate_texture_format_required_features(gpu_texture_format)
+    }
+
+    fn get_pipeline_layout_data(
+        &self,
+        layout: &script_bindings::codegen::GenericUnionTypes::GPUPipelineLayoutOrGPUAutoLayoutMode<
+            crate::DomTypeHolder,
+        >,
+    ) -> PipelineLayout {
+        self.get_pipeline_layout_data(layout)
+    }
+
+    fn queue_id(&self) -> WebGPUQueue {
+        self.queue_id()
     }
 }

--- a/components/script/dom/webgpu/gpuexternaltexture.rs
+++ b/components/script/dom/webgpu/gpuexternaltexture.rs
@@ -286,7 +286,7 @@ impl GPUExternalTextureMethods<crate::DomTypeHolder> for GPUExternalTexture {
     }
 }
 
-impl GPUExternalTextureTrait for GPUExternalTexture {
+impl GPUExternalTextureTrait<crate::DomTypeHolder> for GPUExternalTexture {
     fn id(&self) -> WebGPUExternalTexture {
         self.id()
     }

--- a/components/script/dom/webgpu/gpushadermodule_promise_listener.rs
+++ b/components/script/dom/webgpu/gpushadermodule_promise_listener.rs
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::rc::Rc;
+
+use webgpu_traits::ShaderCompilationInfo;
+
+use crate::dom::bindings::reflector::DomGlobal;
+use crate::dom::promise::Promise;
+use crate::dom::types::{GPUCompilationInfo, GPUShaderModule};
+use crate::routed_promise::RoutedPromiseListener;
+
+impl RoutedPromiseListener<Option<ShaderCompilationInfo>> for GPUShaderModule {
+    fn handle_response(
+        &self,
+        cx: &mut js::context::JSContext,
+        response: Option<ShaderCompilationInfo>,
+        promise: &Rc<Promise>,
+    ) {
+        let info = GPUCompilationInfo::from(cx, &self.global(), response);
+        promise.resolve_native(cx, &info);
+    }
+}

--- a/components/script/dom/webgpu/mod.rs
+++ b/components/script/dom/webgpu/mod.rs
@@ -11,7 +11,7 @@ use wgpu_core::resource::BufferAccessError;
 
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::gpu::GPU;
-use crate::dom::types::{GPUAdapter, GPUBuffer};
+use crate::dom::types::{GPUAdapter, GPUBuffer, GPUShaderModule};
 use crate::dom::{GlobalScope, Promise};
 use crate::routed_promise::callback_promise;
 
@@ -52,7 +52,10 @@ pub(crate) mod gpucommandbuffer {
     pub(crate) type GPUCommandBuffer =
         script_webgpu::gpucommandbuffer::GPUCommandBuffer<crate::DomTypeHolder>;
 }
-pub(crate) mod gpucommandencoder;
+pub(crate) mod gpucommandencoder {
+    pub(crate) type GPUCommandEncoder =
+        script_webgpu::gpucommandencoder::GPUCommandEncoder<crate::DomTypeHolder>;
+}
 pub(crate) mod gpucompilationinfo {
     pub(crate) type GPUCompilationInfo =
         script_webgpu::gpucompilationinfo::GPUCompilationInfo<crate::DomTypeHolder>;
@@ -61,8 +64,14 @@ pub(crate) mod gpucompilationmessage {
     pub(crate) type GPUCompilationMessage =
         script_webgpu::gpucompilationmessage::GPUCompilationMessage<crate::DomTypeHolder>;
 }
-pub(crate) mod gpucomputepassencoder;
-pub(crate) mod gpucomputepipeline;
+pub(crate) mod gpucomputepassencoder {
+    pub(crate) type GPUComputePassEncoder =
+        script_webgpu::gpucomputepassencoder::GPUComputePassEncoder<crate::DomTypeHolder>;
+}
+pub(crate) mod gpucomputepipeline {
+    pub(crate) type GPUComputePipeline =
+        script_webgpu::gpucomputepipeline::GPUComputePipeline<crate::DomTypeHolder>;
+}
 pub(crate) mod gpudevice;
 pub(crate) mod gpudevicelostinfo {
     pub(crate) type GPUDeviceLostInfo =
@@ -76,19 +85,38 @@ pub(crate) mod gpumapmode {
 }
 pub(crate) mod gpuoutofmemoryerror;
 pub(crate) mod gpupipelineerror;
-#[expect(dead_code)]
-pub(crate) mod gpupipelinelayout;
-pub(crate) mod gpuqueryset;
+pub(crate) mod gpupipelinelayout {
+    pub(crate) type GPUPipelineLayout =
+        script_webgpu::gpupipelinelayout::GPUPipelineLayout<crate::DomTypeHolder>;
+}
+pub(crate) mod gpuqueryset {
+    pub(crate) type GPUQuerySet = script_webgpu::gpuqueryset::GPUQuerySet<crate::DomTypeHolder>;
+}
 pub(crate) mod gpuqueue;
 pub(crate) mod gpurenderbundle {
     pub(crate) type GPURenderBundle =
         script_webgpu::gpurenderbundle::GPURenderBundle<crate::DomTypeHolder>;
 }
-pub(crate) mod gpurenderbundleencoder;
-pub(crate) mod gpurenderpassencoder;
-pub(crate) mod gpurenderpipeline;
-pub(crate) mod gpusampler;
-pub(crate) mod gpushadermodule;
+pub(crate) mod gpurenderbundleencoder {
+    pub(crate) type GPURenderBundleEncoder =
+        script_webgpu::gpurenderbundleencoder::GPURenderBundleEncoder<crate::DomTypeHolder>;
+}
+pub(crate) mod gpurenderpassencoder {
+    pub(crate) type GPURenderPassEncoder =
+        script_webgpu::gpurenderpassencoder::GPURenderPassEncoder<crate::DomTypeHolder>;
+}
+pub(crate) mod gpurenderpipeline {
+    pub(crate) type GPURenderPipeline =
+        script_webgpu::gpurenderpipeline::GPURenderPipeline<crate::DomTypeHolder>;
+}
+pub(crate) mod gpusampler {
+    pub(crate) type GPUSampler = script_webgpu::gpusampler::GPUSampler<crate::DomTypeHolder>;
+}
+pub(crate) mod gpushadermodule_promise_listener;
+pub(crate) mod gpushadermodule {
+    pub(crate) type GPUShaderModule =
+        script_webgpu::gpushadermodule::GPUShaderModule<crate::DomTypeHolder>;
+}
 pub(crate) mod gpushaderstage {
     pub(crate) type GPUShaderStage =
         script_webgpu::gpushaderstage::GPUShaderStage<crate::DomTypeHolder>;
@@ -101,12 +129,17 @@ pub(crate) mod gpusupportedlimits {
     pub(crate) type GPUSupportedLimits =
         script_webgpu::gpusupportedlimits::GPUSupportedLimits<crate::DomTypeHolder>;
 }
-pub(crate) mod gputexture;
+pub(crate) mod gputexture {
+    pub(crate) type GPUTexture = script_webgpu::gputexture::GPUTexture<crate::DomTypeHolder>;
+}
 pub(crate) mod gputextureusage {
     pub(crate) type GPUTextureUsage =
         script_webgpu::gputextureusage::GPUTextureUsage<crate::DomTypeHolder>;
 }
-pub(crate) mod gputextureview;
+pub(crate) mod gputextureview {
+    pub(crate) type GPUTextureView =
+        script_webgpu::gputextureview::GPUTextureView<crate::DomTypeHolder>;
+}
 pub(crate) mod gpuuncapturederrorevent;
 pub(crate) mod gpuvalidationerror;
 pub(crate) mod identityhub {
@@ -139,6 +172,15 @@ impl WebGPUPromiseTrait<crate::DomTypeHolder> for Promise {
         d: &GPU,
     ) -> servo_base::generic_channel::GenericCallback<webgpu_traits::WebGPUAdapterResponse> {
         let task_manager = <GPU as DomGlobal>::global(d).task_manager();
+        callback_promise(self, d, task_manager.dom_manipulation_task_source())
+    }
+
+    fn callback_promise_gpushadermodule(
+        self: &Rc<Self>,
+        d: &script_webgpu::gpushadermodule::GPUShaderModule<crate::DomTypeHolder>,
+    ) -> servo_base::generic_channel::GenericCallback<Option<webgpu_traits::ShaderCompilationInfo>>
+    {
+        let task_manager = <GPUShaderModule as DomGlobal>::global(d).task_manager();
         callback_promise(self, d, task_manager.dom_manipulation_task_source())
     }
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1766,7 +1766,9 @@ Unions = {
 
 SubCrates = {
     'script_webgpu': ['GPU', 'GPUAdapter', 'GPUAdapterInfo', 'GPUBindGroup', 'GPUBindGroupLayout',
-    'GPUBuffer', 'GPUBufferUsage', 'GPUCommandBuffer', 'GPUColorWrite',
-    'GPUCompilationInfo', 'GPUCompilationMessage', 'GPUDeviceLostInfo', 'GPUMapMode', 'GPURenderBundle', 'GPUShaderStage',
-    'GPUSupportedLimits', 'GPUSupportedFeatures', 'GPUTextureUsage', 'WGSLLanguageFeatures'],
+    'GPUBuffer', 'GPUBufferUsage', 'GPUCommandBuffer', 'GPUCommandEncoder', 'GPUColorWrite',
+    'GPUCompilationInfo', 'GPUCompilationMessage', 'GPUComputePipeline', 'GPUComputePassEncoder', 'GPUPipelineLayout', 'GPUDeviceLostInfo',
+    'GPUMapMode', 'GPURenderPipeline', 'GPURenderPassEncoder', 'GPUQuerySet', 'GPURenderBundleEncoder', 'GPUSampler',
+    'GPURenderBundle', 'GPUShaderStage', 'GPUShaderModule', 'GPUSupportedLimits', 'GPUSupportedFeatures', 'GPUTexture', 'GPUTextureView',
+    'GPUTextureUsage', 'WGSLLanguageFeatures'],
 }

--- a/components/script_webgpu/Cargo.toml
+++ b/components/script_webgpu/Cargo.toml
@@ -18,6 +18,9 @@ path = "lib.rs"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(crown)'] }
 
 [dependencies]
+stylo_atoms = { workspace = true }
+arrayvec = { workspace = true }
+euclid = { workspace = true }
 servo-constellation-traits = { workspace = true }
 deny_public_fields = { workspace = true }
 dom_struct = { workspace = true }
@@ -29,6 +32,7 @@ script_bindings = { workspace = true, features = ["webgpu"] }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 num-traits = { workspace = true }
+pixels = { workspace = true }
 servo-base = { workspace = true }
 trait-set = { workspace = true }
 webgpu_traits = { workspace = true }

--- a/components/script_webgpu/gpu.rs
+++ b/components/script_webgpu/gpu.rs
@@ -52,10 +52,6 @@ impl<D: Equivalence> GPU<D> {
             GPUWrap::<D>,
         )
     }
-
-    fn global(&self) -> DomRoot<D::GlobalScope> {
-        <D::GPU as DomGlobalGeneric<D>>::global_from_reflector(self)
-    }
 }
 
 impl<D> GPUMethods<D> for GPU<D>
@@ -64,6 +60,7 @@ where
     D::Promise: PromiseHelpers<D> + WebGPUPromiseTrait<D>,
     D::GPU: DomGlobalGeneric<D>,
     D::GlobalScope: WebGPUGlobalTrait,
+    Self: DomGlobalGeneric<D>,
 {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpu-requestadapter>
     fn RequestAdapter(
@@ -71,7 +68,7 @@ where
         cx: &mut CurrentRealm,
         options: &GPURequestAdapterOptions,
     ) -> Rc<D::Promise> {
-        let global = &self.global();
+        let global = self.global_from_reflector();
         // 1. Let promise be a new promise.
         let promise = D::Promise::new_in_realm(cx);
         let callback = D::Promise::callback_promise_gpu(&promise, self);
@@ -145,6 +142,6 @@ where
         cx: &mut js::context::JSContext,
     ) -> DomRoot<WGSLLanguageFeatures<D>> {
         self.wgsl_language_features
-            .or_init(|| WGSLLanguageFeatures::new(cx, &*self.global(), None))
+            .or_init(|| WGSLLanguageFeatures::new(cx, &*self.global_from_reflector(), None))
     }
 }

--- a/components/script_webgpu/gpuadapter.rs
+++ b/components/script_webgpu/gpuadapter.rs
@@ -185,17 +185,14 @@ where
     pub fn channel(&self) -> WebGPU {
         self.droppable.channel.clone()
     }
-
-    fn global(&self) -> DomRoot<D::GlobalScope> {
-        <Self as DomGlobalGeneric<D>>::global_from_reflector(self)
-    }
 }
 
 impl<D> GPUAdapterMethods<D> for GPUAdapter<D>
 where
     D: Equivalence,
     D::Promise: WebGPUPromiseTrait<D> + PromiseHelpers<D>,
-    D::GlobalScope: WebGPUGlobalTrait + GlobalScopeHelpers<D>,
+    D::GlobalScope: WebGPUGlobalTrait,
+    Self: DomGlobalGeneric<D>,
 {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapter-requestdevice>
     fn RequestDevice(
@@ -242,9 +239,15 @@ where
             trace: wgpu_types::Trace::Off,
             experimental_features: ExperimentalFeatures::disabled(),
         };
-        let device_id = self.global().global_wgpu_id_hub().create_device_id();
-        let queue_id = self.global().global_wgpu_id_hub().create_queue_id();
-        let pipeline_id = self.global().pipeline_id();
+        let device_id = self
+            .global_from_reflector()
+            .global_wgpu_id_hub()
+            .create_device_id();
+        let queue_id = self
+            .global_from_reflector()
+            .global_wgpu_id_hub()
+            .create_queue_id();
+        let pipeline_id = self.global_from_reflector().pipeline_id();
         if self
             .droppable
             .channel

--- a/components/script_webgpu/gpubindgroup.rs
+++ b/components/script_webgpu/gpubindgroup.rs
@@ -23,10 +23,7 @@ use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
 use crate::gpubindgrouplayout::GPUBindGroupLayout;
 use crate::gpuconvert::{WebGPUConvert, convert_bind_group_entry};
-use crate::traits::{
-    Equivalence, GPUDeviceTrait, GPUExternalTextureTrait, GPUSamplerTrait, GPUTextureTrait,
-    GPUTextureViewTrait, WebGPUGlobalTrait,
-};
+use crate::traits::{Equivalence, GPUDeviceTrait, GPUExternalTextureTrait, WebGPUGlobalTrait};
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUBindGroup {
@@ -104,12 +101,9 @@ impl<D: Equivalence> GPUBindGroup<D> {
 impl<D> GPUBindGroup<D>
 where
     D: Equivalence,
-    D::GPUDevice: DomGlobalGeneric<D> + GPUDeviceTrait<D>,
+    D::GPUDevice: GPUDeviceTrait<D>,
+    D::GPUExternalTexture: GPUExternalTextureTrait<D>,
     D::GlobalScope: WebGPUGlobalTrait,
-    D::GPUExternalTexture: GPUExternalTextureTrait,
-    D::GPUSampler: GPUSamplerTrait,
-    D::GPUTexture: GPUTextureTrait,
-    D::GPUTextureView: GPUTextureViewTrait,
     D::Promise: PromiseHelpers<D>,
 {
     pub fn id(&self) -> &WebGPUBindGroup {

--- a/components/script_webgpu/gpubindgrouplayout.rs
+++ b/components/script_webgpu/gpubindgrouplayout.rs
@@ -15,7 +15,6 @@ use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::WebGPUBinding::{
     GPUBindGroupLayoutDescriptor, GPUBindGroupLayoutMethods, GPUBindGroupLayoutWrap,
 };
-use script_bindings::interfaces::GlobalScopeHelpers;
 use script_bindings::reflector::{DomGlobalGeneric, Reflector, reflect_dom_object_with_wrap};
 use webgpu_traits::{WebGPU, WebGPUBindGroupLayout, WebGPURequest};
 use wgpu_core::binding_model::BindGroupLayoutDescriptor;
@@ -99,7 +98,7 @@ impl<D> GPUBindGroupLayout<D>
 where
     D: Equivalence,
     D::GPUDevice: GPUDeviceTrait<D>,
-    D::GlobalScope: WebGPUGlobalTrait + GlobalScopeHelpers<D>,
+    D::GlobalScope: WebGPUGlobalTrait,
 {
     pub fn id(&self) -> WebGPUBindGroupLayout {
         self.droppable.bind_group_layout

--- a/components/script_webgpu/gpucommandencoder.rs
+++ b/components/script_webgpu/gpucommandencoder.rs
@@ -4,33 +4,38 @@
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
+use log::warn;
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
-use script_webgpu::gpuconvert::{
-    WebGPUConvert, WebGPUTryConvert, convert_load_op, convert_texture_for_wgpu_with_cx,
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{
+    GPUCommandBufferDescriptor, GPUCommandEncoderDescriptor, GPUCommandEncoderMethods,
+    GPUCommandEncoderWrap, GPUComputePassDescriptor, GPURenderPassDescriptor, GPUSize64,
+    GPUTexelCopyBufferInfo, GPUTexelCopyTextureInfo,
 };
+use script_bindings::codegen::GenericUnionTypes::RangeEnforcedUnsignedLongSequenceOrGPUExtent3DDict as GPUExtent3D;
+use script_bindings::interfaces::PromiseHelpers;
+use script_bindings::reflector::{DomGlobalGeneric, Reflector, reflect_dom_object_with_wrap};
 use webgpu_traits::{
     WebGPU, WebGPUCommandBuffer, WebGPUCommandEncoder, WebGPUComputePass, WebGPUDevice,
     WebGPURenderPass, WebGPURequest,
 };
 use wgpu_core::command as wgpu_com;
 
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
-    GPUCommandBufferDescriptor, GPUCommandEncoderDescriptor, GPUCommandEncoderMethods,
-    GPUComputePassDescriptor, GPUExtent3D, GPURenderPassDescriptor, GPUSize64,
-    GPUTexelCopyBufferInfo, GPUTexelCopyTextureInfo,
-};
+use crate::JSTraceable;
 use crate::dom::bindings::error::Fallible;
-use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
-use crate::dom::globalscope::GlobalScope;
-use crate::dom::types::GPUQuerySet;
-use crate::dom::webgpu::gpubuffer::GPUBuffer;
-use crate::dom::webgpu::gpucommandbuffer::GPUCommandBuffer;
-use crate::dom::webgpu::gpucomputepassencoder::GPUComputePassEncoder;
-use crate::dom::webgpu::gpudevice::GPUDevice;
-use crate::dom::webgpu::gpurenderpassencoder::GPURenderPassEncoder;
+use crate::gpubuffer::GPUBuffer;
+use crate::gpucommandbuffer::GPUCommandBuffer;
+use crate::gpucomputepassencoder::GPUComputePassEncoder;
+use crate::gpuconvert::{
+    WebGPUConvert, WebGPUTryConvert, convert_load_op, convert_texture_for_wgpu_with_cx,
+};
+use crate::gpuqueryset::GPUQuerySet;
+use crate::gpurenderpassencoder::GPURenderPassEncoder;
+use crate::traits::{Equivalence, GPUDeviceTrait, WebGPUGlobalTrait};
+
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUCommandEncoder {
     #[no_trace]
@@ -40,11 +45,11 @@ struct DroppableGPUCommandEncoder {
 }
 
 #[dom_struct]
-pub(crate) struct GPUCommandEncoder {
+pub struct GPUCommandEncoder<D: DomTypes> {
     reflector_: Reflector,
     droppable: DroppableGPUCommandEncoder,
     label: DomRefCell<USVString>,
-    device: Dom<GPUDevice>,
+    device: Dom<D::GPUDevice>,
 }
 
 impl Drop for DroppableGPUCommandEncoder {
@@ -59,10 +64,10 @@ impl Drop for DroppableGPUCommandEncoder {
     }
 }
 
-impl GPUCommandEncoder {
+impl<D: Equivalence> GPUCommandEncoder<D> {
     pub(crate) fn new_inherited(
         channel: WebGPU,
-        device: &GPUDevice,
+        device: &D::GPUDevice,
         encoder: WebGPUCommandEncoder,
         label: USVString,
     ) -> Self {
@@ -76,23 +81,30 @@ impl GPUCommandEncoder {
 
     pub(crate) fn new(
         cx: &mut JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         channel: WebGPU,
-        device: &GPUDevice,
+        device: &D::GPUDevice,
         encoder: WebGPUCommandEncoder,
         label: USVString,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
-            cx,
+        reflect_dom_object_with_wrap::<D, _, _>(
             Box::new(GPUCommandEncoder::new_inherited(
                 channel, device, encoder, label,
             )),
             global,
+            cx,
+            GPUCommandEncoderWrap::<D>,
         )
     }
 }
 
-impl GPUCommandEncoder {
+impl<D> GPUCommandEncoder<D>
+where
+    D: Equivalence,
+    D::GPUDevice: GPUDeviceTrait<D> + DomGlobalGeneric<D>,
+    D::GlobalScope: WebGPUGlobalTrait,
+    Self: DomGlobalGeneric<D>,
+{
     pub(crate) fn id(&self) -> WebGPUCommandEncoder {
         self.droppable.encoder
     }
@@ -102,12 +114,15 @@ impl GPUCommandEncoder {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createcommandencoder>
-    pub(crate) fn create(
+    pub fn create(
         cx: &mut JSContext,
-        device: &GPUDevice,
+        device: &D::GPUDevice,
         descriptor: &GPUCommandEncoderDescriptor,
-    ) -> DomRoot<GPUCommandEncoder> {
-        let command_encoder_id = device.global().wgpu_id_hub().create_command_encoder_id();
+    ) -> DomRoot<GPUCommandEncoder<D>> {
+        let command_encoder_id = device
+            .global_from_reflector()
+            .global_wgpu_id_hub()
+            .create_command_encoder_id();
         device
             .channel()
             .0
@@ -124,7 +139,7 @@ impl GPUCommandEncoder {
 
         GPUCommandEncoder::new(
             cx,
-            &device.global(),
+            &*device.global_from_reflector(),
             device.channel(),
             device,
             encoder,
@@ -133,7 +148,14 @@ impl GPUCommandEncoder {
     }
 }
 
-impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
+impl<D> GPUCommandEncoderMethods<D> for GPUCommandEncoder<D>
+where
+    D: Equivalence,
+    D::GPUDevice: GPUDeviceTrait<D>,
+    D::GlobalScope: WebGPUGlobalTrait,
+    D::Promise: PromiseHelpers<D>,
+    Self: DomGlobalGeneric<D>,
+{
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
@@ -148,9 +170,12 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
     fn BeginComputePass(
         &self,
         cx: &mut JSContext,
-        descriptor: &GPUComputePassDescriptor,
-    ) -> DomRoot<GPUComputePassEncoder> {
-        let compute_pass_id = self.global().wgpu_id_hub().create_compute_pass_id();
+        descriptor: &GPUComputePassDescriptor<D>,
+    ) -> DomRoot<GPUComputePassEncoder<D>> {
+        let compute_pass_id = self
+            .global_from_reflector()
+            .global_wgpu_id_hub()
+            .create_compute_pass_id();
 
         if let Err(error) = self
             .droppable
@@ -172,7 +197,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
 
         GPUComputePassEncoder::new(
             cx,
-            &self.global(),
+            &*self.global_from_reflector(),
             self.droppable.channel.clone(),
             self,
             WebGPUComputePass(compute_pass_id),
@@ -184,8 +209,8 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
     fn BeginRenderPass(
         &self,
         cx: &mut JSContext,
-        descriptor: &GPURenderPassDescriptor,
-    ) -> Fallible<DomRoot<GPURenderPassEncoder>> {
+        descriptor: &GPURenderPassDescriptor<D>,
+    ) -> Fallible<DomRoot<GPURenderPassEncoder<D>>> {
         let depth_stencil_attachment = descriptor.depthStencilAttachment.as_ref().map(|ds| {
             wgpu_com::RenderPassDepthStencilAttachment {
                 depth: wgpu_com::PassChannel {
@@ -232,7 +257,10 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
                 }))
             })
             .collect::<Fallible<Vec<_>>>()?;
-        let render_pass_id = self.global().wgpu_id_hub().create_render_pass_id();
+        let render_pass_id = self
+            .global_from_reflector()
+            .global_wgpu_id_hub()
+            .create_render_pass_id();
 
         if let Err(error) = self
             .droppable
@@ -256,7 +284,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
 
         Ok(GPURenderPassEncoder::new(
             cx,
-            &self.global(),
+            &*self.global_from_reflector(),
             self.droppable.channel.clone(),
             WebGPURenderPass(render_pass_id),
             self,
@@ -267,9 +295,9 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-copybuffertobuffer>
     fn CopyBufferToBuffer(
         &self,
-        source: &GPUBuffer,
+        source: &GPUBuffer<D>,
         source_offset: GPUSize64,
-        destination: &GPUBuffer,
+        destination: &GPUBuffer<D>,
         destination_offset: GPUSize64,
         size: GPUSize64,
     ) {
@@ -291,8 +319,8 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-copybuffertotexture>
     fn CopyBufferToTexture(
         &self,
-        source: &GPUTexelCopyBufferInfo,
-        destination: &GPUTexelCopyTextureInfo,
+        source: &GPUTexelCopyBufferInfo<D>,
+        destination: &GPUTexelCopyTextureInfo<D>,
         copy_size: GPUExtent3D,
     ) -> Fallible<()> {
         self.droppable
@@ -313,8 +341,8 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-copybuffertotexture>
     fn CopyTextureToBuffer(
         &self,
-        source: &GPUTexelCopyTextureInfo,
-        destination: &GPUTexelCopyBufferInfo,
+        source: &GPUTexelCopyTextureInfo<D>,
+        destination: &GPUTexelCopyBufferInfo<D>,
         copy_size: GPUExtent3D,
     ) -> Fallible<()> {
         self.droppable
@@ -335,8 +363,8 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
     /// <https://gpuweb.github.io/gpuweb/#GPUCommandEncoder-copyTextureToTexture>
     fn CopyTextureToTexture(
         &self,
-        source: &GPUTexelCopyTextureInfo,
-        destination: &GPUTexelCopyTextureInfo,
+        source: &GPUTexelCopyTextureInfo<D>,
+        destination: &GPUTexelCopyTextureInfo<D>,
         copy_size: GPUExtent3D,
     ) -> Fallible<()> {
         self.droppable
@@ -359,8 +387,11 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
         &self,
         cx: &mut JSContext,
         descriptor: &GPUCommandBufferDescriptor,
-    ) -> DomRoot<GPUCommandBuffer> {
-        let command_buffer_id = self.global().wgpu_id_hub().create_command_buffer_id();
+    ) -> DomRoot<GPUCommandBuffer<D>> {
+        let command_buffer_id = self
+            .global_from_reflector()
+            .global_wgpu_id_hub()
+            .create_command_buffer_id();
         self.droppable
             .channel
             .0
@@ -377,7 +408,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
         let buffer = WebGPUCommandBuffer(command_buffer_id);
         GPUCommandBuffer::new(
             cx,
-            &self.global(),
+            &*self.global_from_reflector(),
             self.droppable.channel.clone(),
             buffer,
             descriptor.parent.label.clone(),
@@ -433,10 +464,10 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
 
     fn ResolveQuerySet(
         &self,
-        query_set: &GPUQuerySet,
+        query_set: &GPUQuerySet<D>,
         first_query: u32,
         query_count: u32,
-        destination: &GPUBuffer,
+        destination: &GPUBuffer<D>,
         destination_offset: u64,
     ) {
         if let Err(error) = self

--- a/components/script_webgpu/gpucomputepassencoder.rs
+++ b/components/script_webgpu/gpucomputepassencoder.rs
@@ -4,24 +4,31 @@
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
+use log::warn;
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{
+    GPUComputePassEncoderMethods, GPUComputePassEncoderWrap,
+};
+use script_bindings::interfaces::PromiseHelpers;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_wrap};
 use webgpu_traits::{WebGPU, WebGPUComputePass, WebGPURequest};
 
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUComputePassEncoderMethods;
+use crate::JSTraceable;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
-use crate::dom::globalscope::GlobalScope;
-use crate::dom::webgpu::gpubindgroup::GPUBindGroup;
-use crate::dom::webgpu::gpubuffer::GPUBuffer;
-use crate::dom::webgpu::gpucommandencoder::GPUCommandEncoder;
-use crate::dom::webgpu::gpucomputepipeline::GPUComputePipeline;
+use crate::gpubindgroup::GPUBindGroup;
+use crate::gpubuffer::GPUBuffer;
+use crate::gpucommandencoder::GPUCommandEncoder;
+use crate::gpucomputepipeline::GPUComputePipeline;
+use crate::traits::{
+    Equivalence, GPUDeviceTrait, GPUExternalTextureTrait, WebGPUGlobalTrait, WebGPUPromiseTrait,
+};
 
-#[derive(JSTraceable, MallocSizeOf)]
+#[derive(MallocSizeOf)]
 struct DroppableGPUComputePassEncoder {
-    #[no_trace]
     channel: WebGPU,
-    #[no_trace]
     compute_pass: WebGPUComputePass,
 }
 
@@ -38,17 +45,22 @@ impl Drop for DroppableGPUComputePassEncoder {
 }
 
 #[dom_struct]
-pub(crate) struct GPUComputePassEncoder {
+pub struct GPUComputePassEncoder<D: DomTypes> {
     reflector_: Reflector,
     label: DomRefCell<USVString>,
-    command_encoder: Dom<GPUCommandEncoder>,
+    command_encoder: Dom<GPUCommandEncoder<D>>,
+    #[no_trace]
     droppable: DroppableGPUComputePassEncoder,
 }
 
-impl GPUComputePassEncoder {
+impl<D> GPUComputePassEncoder<D>
+where
+    D: Equivalence,
+    D::GPUDevice: GPUDeviceTrait<D>,
+{
     fn new_inherited(
         channel: WebGPU,
-        parent: &GPUCommandEncoder,
+        parent: &GPUCommandEncoder<D>,
         compute_pass: WebGPUComputePass,
         label: USVString,
     ) -> Self {
@@ -65,14 +77,13 @@ impl GPUComputePassEncoder {
 
     pub(crate) fn new(
         cx: &mut JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         channel: WebGPU,
-        parent: &GPUCommandEncoder,
+        parent: &GPUCommandEncoder<D>,
         compute_pass: WebGPUComputePass,
         label: USVString,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
-            cx,
+        reflect_dom_object_with_wrap::<D, _, _>(
             Box::new(GPUComputePassEncoder::new_inherited(
                 channel,
                 parent,
@@ -80,11 +91,20 @@ impl GPUComputePassEncoder {
                 label,
             )),
             global,
+            cx,
+            GPUComputePassEncoderWrap::<D>,
         )
     }
 }
 
-impl GPUComputePassEncoderMethods<crate::DomTypeHolder> for GPUComputePassEncoder {
+impl<D> GPUComputePassEncoderMethods<D> for GPUComputePassEncoder<D>
+where
+    D: Equivalence,
+    D::GlobalScope: WebGPUGlobalTrait,
+    D::GPUDevice: GPUDeviceTrait<D>,
+    D::GPUExternalTexture: GPUExternalTextureTrait<D>,
+    D::Promise: WebGPUPromiseTrait<D> + PromiseHelpers<D>,
+{
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
@@ -114,7 +134,7 @@ impl GPUComputePassEncoderMethods<crate::DomTypeHolder> for GPUComputePassEncode
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucomputepassencoder-dispatchworkgroupsindirect>
-    fn DispatchWorkgroupsIndirect(&self, buffer: &GPUBuffer, offset: u64) {
+    fn DispatchWorkgroupsIndirect(&self, buffer: &GPUBuffer<D>, offset: u64) {
         if let Err(e) =
             self.droppable
                 .channel
@@ -146,7 +166,7 @@ impl GPUComputePassEncoderMethods<crate::DomTypeHolder> for GPUComputePassEncode
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuprogrammablepassencoder-setbindgroup>
-    fn SetBindGroup(&self, index: u32, bind_group: &GPUBindGroup, offsets: Vec<u32>) {
+    fn SetBindGroup(&self, index: u32, bind_group: &GPUBindGroup<D>, offsets: Vec<u32>) {
         if let Err(e) = self
             .droppable
             .channel
@@ -164,7 +184,7 @@ impl GPUComputePassEncoderMethods<crate::DomTypeHolder> for GPUComputePassEncode
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucomputepassencoder-setpipeline>
-    fn SetPipeline(&self, pipeline: &GPUComputePipeline) {
+    fn SetPipeline(&self, pipeline: &GPUComputePipeline<D>) {
         if let Err(e) = self
             .droppable
             .channel

--- a/components/script_webgpu/gpucomputepipeline.rs
+++ b/components/script_webgpu/gpucomputepipeline.rs
@@ -4,9 +4,15 @@
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
+use log::warn;
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
-use script_webgpu::gpuconvert::WebGPUConvert;
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{
+    GPUComputePipelineDescriptor, GPUComputePipelineMethods, GPUComputePipelineWrap,
+};
+use script_bindings::interfaces::{GlobalScopeHelpers, PromiseHelpers};
+use script_bindings::reflector::{DomGlobalGeneric, Reflector, reflect_dom_object_with_wrap};
 use servo_base::generic_channel::GenericCallback;
 use webgpu_traits::{
     WebGPU, WebGPUBindGroupLayout, WebGPUComputePipeline, WebGPUComputePipelineResponse,
@@ -14,16 +20,13 @@ use webgpu_traits::{
 };
 use wgpu_core::pipeline::ComputePipelineDescriptor;
 
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
-    GPUComputePipelineDescriptor, GPUComputePipelineMethods,
-};
+use crate::JSTraceable;
 use crate::dom::bindings::error::Fallible;
-use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
-use crate::dom::globalscope::GlobalScope;
-use crate::dom::webgpu::gpubindgrouplayout::GPUBindGroupLayout;
-use crate::dom::webgpu::gpudevice::GPUDevice;
+use crate::gpubindgrouplayout::GPUBindGroupLayout;
+use crate::gpuconvert::WebGPUConvert;
+use crate::traits::{Equivalence, GPUDeviceTrait, WebGPUGlobalTrait, WebGPUPromiseTrait};
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUComputePipeline {
@@ -49,18 +52,22 @@ impl Drop for DroppableGPUComputePipeline {
 }
 
 #[dom_struct]
-pub(crate) struct GPUComputePipeline {
+pub struct GPUComputePipeline<D: DomTypes> {
     reflector_: Reflector,
     label: DomRefCell<USVString>,
-    device: Dom<GPUDevice>,
+    device: Dom<D::GPUDevice>,
     droppable: DroppableGPUComputePipeline,
 }
 
-impl GPUComputePipeline {
+impl<D> GPUComputePipeline<D>
+where
+    D: Equivalence,
+    D::GPUDevice: GPUDeviceTrait<D>,
+{
     fn new_inherited(
         compute_pipeline: WebGPUComputePipeline,
         label: USVString,
-        device: &GPUDevice,
+        device: &D::GPUDevice,
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
@@ -73,37 +80,47 @@ impl GPUComputePipeline {
         }
     }
 
-    pub(crate) fn new(
+    pub fn new(
         cx: &mut JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         compute_pipeline: WebGPUComputePipeline,
         label: USVString,
-        device: &GPUDevice,
+        device: &D::GPUDevice,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
-            cx,
+        reflect_dom_object_with_wrap::<D, _, _>(
             Box::new(GPUComputePipeline::new_inherited(
                 compute_pipeline,
                 label,
                 device,
             )),
             global,
+            cx,
+            GPUComputePipelineWrap::<D>,
         )
     }
 }
 
-impl GPUComputePipeline {
+impl<D> GPUComputePipeline<D>
+where
+    D: Equivalence,
+    D::Promise: WebGPUPromiseTrait<D> + PromiseHelpers<D>,
+    D::GlobalScope: WebGPUGlobalTrait + GlobalScopeHelpers<D>,
+    D::GPUDevice: GPUDeviceTrait<D>,
+{
     pub(crate) fn id(&self) -> &WebGPUComputePipeline {
         &self.droppable.compute_pipeline
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createcomputepipeline>
-    pub(crate) fn create(
-        device: &GPUDevice,
-        descriptor: &GPUComputePipelineDescriptor,
+    pub fn create(
+        device: &D::GPUDevice,
+        descriptor: &GPUComputePipelineDescriptor<D>,
         async_sender: Option<GenericCallback<WebGPUComputePipelineResponse>>,
     ) -> WebGPUComputePipeline {
-        let compute_pipeline_id = device.global().wgpu_id_hub().create_compute_pipeline_id();
+        let compute_pipeline_id = device
+            .global_from_reflector()
+            .global_wgpu_id_hub()
+            .create_compute_pipeline_id();
 
         let pipeline_layout = device.get_pipeline_layout_data(&descriptor.parent.layout);
 
@@ -129,7 +146,14 @@ impl GPUComputePipeline {
     }
 }
 
-impl GPUComputePipelineMethods<crate::DomTypeHolder> for GPUComputePipeline {
+impl<D> GPUComputePipelineMethods<D> for GPUComputePipeline<D>
+where
+    D: Equivalence,
+    D::GlobalScope: WebGPUGlobalTrait,
+    D::GPUDevice: GPUDeviceTrait<D>,
+    Self: DomGlobalGeneric<D>,
+    D::Promise: PromiseHelpers<D> + WebGPUPromiseTrait<D>,
+{
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
@@ -145,8 +169,11 @@ impl GPUComputePipelineMethods<crate::DomTypeHolder> for GPUComputePipeline {
         &self,
         cx: &mut JSContext,
         index: u32,
-    ) -> Fallible<DomRoot<GPUBindGroupLayout>> {
-        let id = self.global().wgpu_id_hub().create_bind_group_layout_id();
+    ) -> Fallible<DomRoot<GPUBindGroupLayout<D>>> {
+        let id = self
+            .global_from_reflector()
+            .global_wgpu_id_hub()
+            .create_bind_group_layout_id();
 
         if let Err(e) = self
             .droppable
@@ -164,7 +191,7 @@ impl GPUComputePipelineMethods<crate::DomTypeHolder> for GPUComputePipeline {
 
         Ok(GPUBindGroupLayout::new(
             cx,
-            &self.global(),
+            &*self.global_from_reflector(),
             self.droppable.channel.clone(),
             WebGPUBindGroupLayout(id),
             USVString::default(),

--- a/components/script_webgpu/gpuconvert.rs
+++ b/components/script_webgpu/gpuconvert.rs
@@ -21,7 +21,7 @@ use script_bindings::codegen::GenericBindings::WebGPUBinding::{
     GPUTextureViewDimension, GPUVertexFormat,
 };
 use script_bindings::codegen::GenericUnionTypes::GPUTextureOrGPUTextureView;
-use script_bindings::interfaces::PromiseHelpers;
+use script_bindings::interfaces::{GlobalScopeHelpers, PromiseHelpers};
 use script_bindings::reflector::DomGlobalGeneric;
 use webgpu_traits::WebGPUTextureView;
 use wgpu_core::binding_model::{BindGroupEntry, BindingResource, BufferBinding};
@@ -32,8 +32,7 @@ use wgpu_types::{self, AstcBlock, AstcChannel, IndexFormat};
 
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::traits::{
-    Equivalence, GPUDeviceTrait, GPUExternalTextureTrait, GPUQuerySetTrait, GPUSamplerTrait,
-    GPUShaderModuleTrait, GPUTextureTrait, GPUTextureViewTrait, WebGPUGlobalTrait,
+    Equivalence, GPUDeviceTrait, GPUExternalTextureTrait, WebGPUGlobalTrait, WebGPUPromiseTrait,
 };
 
 /// A version of the `Into<T>` trait from the standard library that can be used
@@ -586,8 +585,9 @@ impl WebGPUTryConvert<wgpu_types::Origin2d> for &GPUOrigin2D {
 
 impl<D> WebGPUTryConvert<wgpu_com::TexelCopyTextureInfo> for &GPUTexelCopyTextureInfo<D>
 where
-    D: DomTypes,
-    D::GPUTexture: GPUTextureTrait,
+    D: Equivalence,
+    D::GPUDevice: GPUDeviceTrait<D>,
+    D::GlobalScope: WebGPUGlobalTrait,
 {
     type Error = Error;
 
@@ -757,8 +757,10 @@ impl WebGPUTryConvert<wgpu_types::Color> for &GPUColor {
 
 impl<'a, D> WebGPUConvert<ProgrammableStageDescriptor<'a>> for &GPUProgrammableStage<D>
 where
-    D: DomTypes,
-    D::GPUShaderModule: GPUShaderModuleTrait,
+    D: Equivalence,
+    D::GlobalScope: WebGPUGlobalTrait + GlobalScopeHelpers<D>,
+    D::GPUDevice: GPUDeviceTrait<D>,
+    D::Promise: PromiseHelpers<D> + WebGPUPromiseTrait<D>,
 {
     fn convert(self) -> ProgrammableStageDescriptor<'a> {
         ProgrammableStageDescriptor {
@@ -782,9 +784,9 @@ pub fn convert_texture_for_wgpu_with_cx<D>(
     texture_view: &GPUTextureOrGPUTextureView<D>,
 ) -> WebGPUTextureView
 where
-    D: DomTypes,
-    D::GPUTexture: GPUTextureTrait,
-    D::GPUTextureView: GPUTextureViewTrait,
+    D: Equivalence,
+    D::GPUDevice: DomGlobalGeneric<D> + GPUDeviceTrait<D>,
+    D::GlobalScope: WebGPUGlobalTrait,
 {
     match texture_view {
         GPUTextureOrGPUTextureView::GPUTextureView(view) => view.id(),
@@ -798,11 +800,8 @@ pub(crate) fn convert_bind_group_entry<'a, D>(
 ) -> BindGroupEntry<'a>
 where
     D: Equivalence,
-    D::GPUTexture: GPUTextureTrait,
-    D::GPUTextureView: GPUTextureViewTrait,
-    D::GPUSampler: GPUSamplerTrait,
-    D::GPUExternalTexture: GPUExternalTextureTrait,
     D::GPUDevice: DomGlobalGeneric<D> + GPUDeviceTrait<D>,
+    D::GPUExternalTexture: GPUExternalTextureTrait<D>,
     D::GlobalScope: WebGPUGlobalTrait,
     D::Promise: PromiseHelpers<D>,
 {
@@ -864,8 +863,9 @@ impl WebGPUConvert<QuerySetDescriptor<'static>> for &GPUQuerySetDescriptor {
 
 impl<D> WebGPUConvert<PassTimestampWrites> for &GPUComputePassTimestampWrites<D>
 where
-    D: DomTypes,
-    D::GPUQuerySet: GPUQuerySetTrait,
+    D: Equivalence,
+    D::GPUDevice: GPUDeviceTrait<D>,
+    D::GlobalScope: WebGPUGlobalTrait,
 {
     fn convert(self) -> PassTimestampWrites {
         PassTimestampWrites {
@@ -878,8 +878,9 @@ where
 
 impl<D> WebGPUConvert<PassTimestampWrites> for &GPURenderPassTimestampWrites<D>
 where
-    D: DomTypes,
-    D::GPUQuerySet: GPUQuerySetTrait,
+    D: Equivalence,
+    D::GPUDevice: GPUDeviceTrait<D>,
+    D::GlobalScope: WebGPUGlobalTrait,
 {
     fn convert(self) -> PassTimestampWrites {
         PassTimestampWrites {
@@ -892,8 +893,9 @@ where
 
 impl<D> WebGPUConvert<ComputePassDescriptor<'static>> for &GPUComputePassDescriptor<D>
 where
-    D: DomTypes,
-    D::GPUQuerySet: GPUQuerySetTrait,
+    D: Equivalence,
+    D::GPUDevice: GPUDeviceTrait<D>,
+    D::GlobalScope: WebGPUGlobalTrait,
 {
     fn convert(self) -> ComputePassDescriptor<'static> {
         ComputePassDescriptor {

--- a/components/script_webgpu/gpupipelinelayout.rs
+++ b/components/script_webgpu/gpupipelinelayout.rs
@@ -3,29 +3,30 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::borrow::Cow;
+use std::marker::PhantomData;
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
+use log::warn;
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
-use script_webgpu::gpuconvert::WebGPUConvert;
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{
+    GPUPipelineLayoutDescriptor, GPUPipelineLayoutMethods, GPUPipelineLayoutWrap,
+};
+use script_bindings::reflector::{DomGlobalGeneric, Reflector, reflect_dom_object_with_wrap};
 use webgpu_traits::{WebGPU, WebGPUBindGroupLayout, WebGPUPipelineLayout, WebGPURequest};
 use wgpu_core::binding_model::PipelineLayoutDescriptor;
 
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
-    GPUPipelineLayoutDescriptor, GPUPipelineLayoutMethods,
-};
-use crate::dom::bindings::reflector::DomGlobal;
+use crate::JSTraceable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::USVString;
-use crate::dom::globalscope::GlobalScope;
-use crate::dom::webgpu::gpudevice::GPUDevice;
+use crate::gpuconvert::WebGPUConvert;
+use crate::traits::{Equivalence, GPUDeviceTrait, WebGPUGlobalTrait};
 
-#[derive(JSTraceable, MallocSizeOf)]
+#[derive(MallocSizeOf)]
 struct DroppableGPUPipelineLayout {
-    #[no_trace]
     channel: WebGPU,
-    #[no_trace]
     pipeline_layout: WebGPUPipelineLayout,
 }
 
@@ -45,15 +46,21 @@ impl Drop for DroppableGPUPipelineLayout {
 }
 
 #[dom_struct]
-pub(crate) struct GPUPipelineLayout {
+pub struct GPUPipelineLayout<D: DomTypes> {
     reflector_: Reflector,
     label: DomRefCell<USVString>,
     #[no_trace]
     bind_group_layouts: Vec<WebGPUBindGroupLayout>,
+    #[no_trace]
     droppable: DroppableGPUPipelineLayout,
+    #[no_trace = "PhantomData does not exist"]
+    phantom: PhantomData<D>,
 }
 
-impl GPUPipelineLayout {
+impl<D> GPUPipelineLayout<D>
+where
+    D: Equivalence,
+{
     fn new_inherited(
         channel: WebGPU,
         pipeline_layout: WebGPUPipelineLayout,
@@ -68,19 +75,19 @@ impl GPUPipelineLayout {
                 channel,
                 pipeline_layout,
             },
+            phantom: PhantomData,
         }
     }
 
     pub(crate) fn new(
         cx: &mut JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         channel: WebGPU,
         pipeline_layout: WebGPUPipelineLayout,
         label: USVString,
         bgls: Vec<WebGPUBindGroupLayout>,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
-            cx,
+        reflect_dom_object_with_wrap::<D, _, _>(
             Box::new(GPUPipelineLayout::new_inherited(
                 channel,
                 pipeline_layout,
@@ -88,25 +95,33 @@ impl GPUPipelineLayout {
                 bgls,
             )),
             global,
+            cx,
+            GPUPipelineLayoutWrap::<D>,
         )
     }
 }
 
-impl GPUPipelineLayout {
-    pub(crate) fn id(&self) -> WebGPUPipelineLayout {
+impl<D> GPUPipelineLayout<D>
+where
+    D: Equivalence,
+    D::GPUDevice: GPUDeviceTrait<D>,
+    D::GlobalScope: WebGPUGlobalTrait,
+{
+    pub fn id(&self) -> WebGPUPipelineLayout {
         self.droppable.pipeline_layout
     }
 
-    pub(crate) fn bind_group_layouts(&self) -> Vec<WebGPUBindGroupLayout> {
+    #[expect(unused)]
+    fn bind_group_layouts(&self) -> Vec<WebGPUBindGroupLayout> {
         self.bind_group_layouts.clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createpipelinelayout>
-    pub(crate) fn create(
+    pub fn create(
         cx: &mut JSContext,
-        device: &GPUDevice,
-        descriptor: &GPUPipelineLayoutDescriptor,
-    ) -> DomRoot<GPUPipelineLayout> {
+        device: &D::GPUDevice,
+        descriptor: &GPUPipelineLayoutDescriptor<D>,
+    ) -> DomRoot<GPUPipelineLayout<D>> {
         let bgls = descriptor
             .bindGroupLayouts
             .iter()
@@ -120,7 +135,10 @@ impl GPUPipelineLayout {
             immediate_size: 0,
         };
 
-        let pipeline_layout_id = device.global().wgpu_id_hub().create_pipeline_layout_id();
+        let pipeline_layout_id = device
+            .global_from_reflector()
+            .global_wgpu_id_hub()
+            .create_pipeline_layout_id();
         device
             .channel()
             .0
@@ -134,7 +152,7 @@ impl GPUPipelineLayout {
         let pipeline_layout = WebGPUPipelineLayout(pipeline_layout_id);
         GPUPipelineLayout::new(
             cx,
-            &device.global(),
+            &*device.global_from_reflector(),
             device.channel(),
             pipeline_layout,
             descriptor.parent.label.clone(),
@@ -143,7 +161,7 @@ impl GPUPipelineLayout {
     }
 }
 
-impl GPUPipelineLayoutMethods<crate::DomTypeHolder> for GPUPipelineLayout {
+impl<D: DomTypes> GPUPipelineLayoutMethods<D> for GPUPipelineLayout<D> {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()

--- a/components/script_webgpu/gpuqueryset.rs
+++ b/components/script_webgpu/gpuqueryset.rs
@@ -1,30 +1,30 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+use std::marker::PhantomData;
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
+use log::warn;
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
 use script_bindings::cell::DomRefCell;
-use script_bindings::codegen::GenericBindings::WebGPUBinding::{GPUDeviceMethods, GPUQueryType};
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{
+    GPUDeviceMethods, GPUQuerySetDescriptor, GPUQuerySetMethods, GPUQuerySetWrap, GPUQueryType,
+};
 use script_bindings::error::{Error, Fallible};
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{DomGlobalGeneric, Reflector, reflect_dom_object_with_wrap};
 use script_bindings::root::DomRoot;
-use script_webgpu::gpuconvert::WebGPUConvert;
-use script_webgpu::traits::GPUQuerySetTrait;
 use webgpu_traits::{WebGPU, WebGPUQuerySet, WebGPURequest};
 
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
-    GPUQuerySetDescriptor, GPUQuerySetMethods,
-};
-use crate::dom::bindings::reflector::DomGlobal as _;
+use crate::JSTraceable;
 use crate::dom::bindings::str::USVString;
-use crate::dom::types::{GPUDevice, GlobalScope};
+use crate::gpuconvert::WebGPUConvert;
+use crate::traits::{Equivalence, GPUDeviceTrait, WebGPUGlobalTrait};
 
-#[derive(JSTraceable, MallocSizeOf)]
+#[derive(MallocSizeOf)]
 struct DroppableGPUQuerySet {
-    #[no_trace]
     channel: WebGPU,
-    #[no_trace]
     query_set: WebGPUQuerySet,
 }
 
@@ -44,15 +44,23 @@ impl Drop for DroppableGPUQuerySet {
 }
 
 #[dom_struct]
-pub(crate) struct GPUQuerySet {
+pub struct GPUQuerySet<D: DomTypes> {
     reflector_: Reflector,
+    #[no_trace]
     droppable: DroppableGPUQuerySet,
     label: DomRefCell<USVString>,
     r#type: GPUQueryType,
     count: u32,
+    #[no_trace = "PhantomData does not exist"]
+    phantom: PhantomData<D>,
 }
 
-impl GPUQuerySet {
+impl<D> GPUQuerySet<D>
+where
+    D: Equivalence,
+    D::GPUDevice: GPUDeviceTrait<D>,
+    D::GlobalScope: WebGPUGlobalTrait,
+{
     pub(crate) fn new_inherited(
         label: USVString,
         channel: WebGPU,
@@ -66,31 +74,33 @@ impl GPUQuerySet {
             droppable: DroppableGPUQuerySet { channel, query_set },
             r#type,
             count,
+            phantom: PhantomData,
         }
     }
 
     pub(crate) fn new(
         cx: &mut JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         label: USVString,
         channel: WebGPU,
         query_set: WebGPUQuerySet,
         r#type: GPUQueryType,
         count: u32,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
-            cx,
+        reflect_dom_object_with_wrap::<D, _, _>(
             Box::new(GPUQuerySet::new_inherited(
                 label, channel, query_set, r#type, count,
             )),
             global,
+            cx,
+            GPUQuerySetWrap::<D>,
         )
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createqueryset>
-    pub(crate) fn create(
+    pub fn create(
         cx: &mut JSContext,
-        device: &GPUDevice,
+        device: &D::GPUDevice,
         descriptor: &GPUQuerySetDescriptor,
     ) -> Fallible<DomRoot<Self>> {
         // 1. If descriptor.type is "timestamp", but "timestamp-query" is not enabled for this:
@@ -106,7 +116,10 @@ impl GPUQuerySet {
             ));
         }
         // 2. Let q be ! create a new WebGPU object(this, GPUQuerySet, descriptor).
-        let query_set_id = device.global().wgpu_id_hub().create_query_set_id();
+        let query_set_id = device
+            .global_from_reflector()
+            .global_wgpu_id_hub()
+            .create_query_set_id();
         // 5. Issue the initialization steps on the Device timeline of this.
         let channel = device.channel();
         if let Err(error) = channel.0.send(WebGPURequest::CreateQuerySet {
@@ -119,7 +132,7 @@ impl GPUQuerySet {
         // 6. Return q
         Ok(Self::new(
             cx,
-            &device.global(),
+            &device.global_from_reflector(),
             descriptor.parent.label.clone(),
             channel,
             WebGPUQuerySet(query_set_id),
@@ -135,7 +148,12 @@ impl GPUQuerySet {
     }
 }
 
-impl GPUQuerySetMethods<crate::DomTypeHolder> for GPUQuerySet {
+impl<D> GPUQuerySetMethods<D> for GPUQuerySet<D>
+where
+    D: Equivalence,
+    D::GPUDevice: GPUDeviceTrait<D>,
+    D::GlobalScope: WebGPUGlobalTrait,
+{
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueryset-destroy>
     fn Destroy(&self) {
         // 1. Issue the subsequent steps on the device timeline.
@@ -170,11 +188,5 @@ impl GPUQuerySetMethods<crate::DomTypeHolder> for GPUQuerySet {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueryset-count>
     fn Count(&self) -> u32 {
         self.count
-    }
-}
-
-impl GPUQuerySetTrait for GPUQuerySet {
-    fn id(&self) -> WebGPUQuerySet {
-        self.id()
     }
 }

--- a/components/script_webgpu/gpurenderbundleencoder.rs
+++ b/components/script_webgpu/gpurenderbundleencoder.rs
@@ -6,28 +6,31 @@ use std::borrow::Cow;
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
+use log::warn;
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
-use script_webgpu::gpuconvert::WebGPUConvert;
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{
+    GPUIndexFormat, GPURenderBundleDescriptor, GPURenderBundleEncoderDescriptor,
+    GPURenderBundleEncoderMethods, GPURenderBundleEncoderWrap,
+};
+use script_bindings::interfaces::{GlobalScopeHelpers, PromiseHelpers};
+use script_bindings::reflector::{DomGlobalGeneric, Reflector, reflect_dom_object_with_wrap};
 use webgpu_traits::{
     RenderBundleCommand, WebGPU, WebGPURenderBundle, WebGPURenderBundleEncoder, WebGPURequest,
 };
 use wgpu_core::command::RenderBundleEncoderDescriptor;
 
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
-    GPUIndexFormat, GPURenderBundleDescriptor, GPURenderBundleEncoderDescriptor,
-    GPURenderBundleEncoderMethods,
-};
+use crate::JSTraceable;
 use crate::dom::bindings::error::Fallible;
-use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
-use crate::dom::globalscope::GlobalScope;
-use crate::dom::webgpu::gpubindgroup::GPUBindGroup;
-use crate::dom::webgpu::gpubuffer::GPUBuffer;
-use crate::dom::webgpu::gpudevice::GPUDevice;
-use crate::dom::webgpu::gpurenderbundle::GPURenderBundle;
-use crate::dom::webgpu::gpurenderpipeline::GPURenderPipeline;
+use crate::gpubindgroup::GPUBindGroup;
+use crate::gpubuffer::GPUBuffer;
+use crate::gpuconvert::WebGPUConvert;
+use crate::gpurenderbundle::GPURenderBundle;
+use crate::gpurenderpipeline::GPURenderPipeline;
+use crate::traits::{Equivalence, GPUDeviceTrait, GPUExternalTextureTrait, WebGPUGlobalTrait};
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPURenderBundleEncoder {
@@ -51,16 +54,19 @@ impl Drop for DroppableGPURenderBundleEncoder {
 }
 
 #[dom_struct]
-pub(crate) struct GPURenderBundleEncoder {
+pub struct GPURenderBundleEncoder<D: DomTypes> {
     reflector_: Reflector,
-    device: Dom<GPUDevice>,
+    device: Dom<D::GPUDevice>,
     label: DomRefCell<USVString>,
     droppable: DroppableGPURenderBundleEncoder,
 }
 
-impl GPURenderBundleEncoder {
+impl<D> GPURenderBundleEncoder<D>
+where
+    D: Equivalence,
+{
     fn new_inherited(
-        device: &GPUDevice,
+        device: &D::GPUDevice,
         channel: WebGPU,
         label: USVString,
         render_bundle_encoder: WebGPURenderBundleEncoder,
@@ -78,14 +84,13 @@ impl GPURenderBundleEncoder {
 
     pub(crate) fn new(
         cx: &mut JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         render_bundle_encoder: WebGPURenderBundleEncoder,
-        device: &GPUDevice,
+        device: &D::GPUDevice,
         channel: WebGPU,
         label: USVString,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
-            cx,
+        reflect_dom_object_with_wrap::<D, _, _>(
             Box::new(GPURenderBundleEncoder::new_inherited(
                 device,
                 channel,
@@ -93,17 +98,25 @@ impl GPURenderBundleEncoder {
                 render_bundle_encoder,
             )),
             global,
+            cx,
+            GPURenderBundleEncoderWrap::<D>,
         )
     }
 }
 
-impl GPURenderBundleEncoder {
+impl<D> GPURenderBundleEncoder<D>
+where
+    D: Equivalence,
+    D::GPUDevice: GPUDeviceTrait<D>,
+    D::GlobalScope: WebGPUGlobalTrait,
+    Self: DomGlobalGeneric<D>,
+{
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createrenderbundleencoder>
-    pub(crate) fn create(
+    pub fn create(
         cx: &mut JSContext,
-        device: &GPUDevice,
+        device: &D::GPUDevice,
         descriptor: &GPURenderBundleEncoderDescriptor,
-    ) -> Fallible<DomRoot<GPURenderBundleEncoder>> {
+    ) -> Fallible<DomRoot<GPURenderBundleEncoder<D>>> {
         let desc = RenderBundleEncoderDescriptor {
             label: (&descriptor.parent.parent).convert(),
             color_formats: Cow::Owned(
@@ -136,8 +149,8 @@ impl GPURenderBundleEncoder {
         };
 
         let id = device
-            .global()
-            .wgpu_id_hub()
+            .global_from_reflector()
+            .global_wgpu_id_hub()
             .create_render_bundle_encoder_id();
         let render_bundle_encoder = WebGPURenderBundleEncoder(id);
 
@@ -156,7 +169,7 @@ impl GPURenderBundleEncoder {
 
         Ok(GPURenderBundleEncoder::new(
             cx,
-            &device.global(),
+            &*device.global_from_reflector(),
             render_bundle_encoder,
             device,
             device.channel(),
@@ -169,7 +182,15 @@ impl GPURenderBundleEncoder {
     }
 }
 
-impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEncoder {
+impl<D> GPURenderBundleEncoderMethods<D> for GPURenderBundleEncoder<D>
+where
+    D: Equivalence,
+    D::GPUDevice: DomGlobalGeneric<D> + GPUDeviceTrait<D>,
+    D::GPUExternalTexture: GPUExternalTextureTrait<D>,
+    D::GlobalScope: WebGPUGlobalTrait + GlobalScopeHelpers<D>,
+    D::Promise: PromiseHelpers<D>,
+    Self: DomGlobalGeneric<D>,
+{
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
@@ -181,7 +202,7 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuprogrammablepassencoder-setbindgroup>
-    fn SetBindGroup(&self, index: u32, bind_group: &GPUBindGroup, dynamic_offsets: Vec<u32>) {
+    fn SetBindGroup(&self, index: u32, bind_group: &GPUBindGroup<D>, dynamic_offsets: Vec<u32>) {
         if let Err(error) =
             self.droppable
                 .channel
@@ -204,7 +225,7 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-setpipeline>
-    fn SetPipeline(&self, pipeline: &GPURenderPipeline) {
+    fn SetPipeline(&self, pipeline: &GPURenderPipeline<D>) {
         if let Err(error) =
             self.droppable
                 .channel
@@ -225,7 +246,7 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
     /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-setindexbuffer>
     fn SetIndexBuffer(
         &self,
-        buffer: &GPUBuffer,
+        buffer: &D::GPUBuffer,
         index_format: GPUIndexFormat,
         offset: u64,
         size: u64,
@@ -253,7 +274,7 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-setvertexbuffer>
-    fn SetVertexBuffer(&self, slot: u32, buffer: Option<&GPUBuffer>, offset: u64, size: u64) {
+    fn SetVertexBuffer(&self, slot: u32, buffer: Option<&GPUBuffer<D>>, offset: u64, size: u64) {
         if let Err(error) =
             self.droppable
                 .channel
@@ -333,7 +354,7 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-drawindirect>
-    fn DrawIndirect(&self, indirect_buffer: &GPUBuffer, indirect_offset: u64) {
+    fn DrawIndirect(&self, indirect_buffer: &GPUBuffer<D>, indirect_offset: u64) {
         if let Err(error) =
             self.droppable
                 .channel
@@ -355,7 +376,7 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-drawindexedindirect>
-    fn DrawIndexedIndirect(&self, indirect_buffer: &GPUBuffer, indirect_offset: u64) {
+    fn DrawIndexedIndirect(&self, indirect_buffer: &GPUBuffer<D>, indirect_offset: u64) {
         if let Err(error) =
             self.droppable
                 .channel
@@ -440,11 +461,14 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
         &self,
         cx: &mut JSContext,
         descriptor: &GPURenderBundleDescriptor,
-    ) -> DomRoot<GPURenderBundle> {
+    ) -> DomRoot<D::GPURenderBundle> {
         let desc = wgpu_types::RenderBundleDescriptor {
             label: (&descriptor.parent).convert(),
         };
-        let render_bundle_id = self.global().wgpu_id_hub().create_render_bundle_id();
+        let render_bundle_id = self
+            .global_from_reflector()
+            .global_wgpu_id_hub()
+            .create_render_bundle_id();
 
         if let Err(error) =
             self.droppable
@@ -466,7 +490,7 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
         let render_bundle = WebGPURenderBundle(render_bundle_id);
         GPURenderBundle::new(
             cx,
-            &self.global(),
+            &*self.global_from_reflector(),
             render_bundle,
             self.device.id(),
             self.droppable.channel.clone(),

--- a/components/script_webgpu/gpurenderpassencoder.rs
+++ b/components/script_webgpu/gpurenderpassencoder.rs
@@ -4,30 +4,35 @@
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
+use log::warn;
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
-use script_webgpu::gpuconvert::WebGPUTryConvert;
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{
+    GPUIndexFormat, GPURenderPassEncoderMethods, GPURenderPassEncoderWrap,
+};
+use script_bindings::codegen::GenericUnionTypes::DoubleSequenceOrGPUColorDict as GPUColor;
+use script_bindings::error::Fallible;
+use script_bindings::interfaces::PromiseHelpers;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_wrap};
+use script_bindings::root::DomRoot;
 use webgpu_traits::{RenderCommand, WebGPU, WebGPURenderPass, WebGPURequest};
 
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
-    GPUColor, GPUIndexFormat, GPURenderPassEncoderMethods,
-};
-use crate::dom::bindings::error::Fallible;
+use crate::JSTraceable;
 use crate::dom::bindings::num::Finite;
-use crate::dom::bindings::root::{Dom, DomRoot};
+use crate::dom::bindings::root::Dom;
 use crate::dom::bindings::str::USVString;
-use crate::dom::globalscope::GlobalScope;
-use crate::dom::webgpu::gpubindgroup::GPUBindGroup;
-use crate::dom::webgpu::gpubuffer::GPUBuffer;
-use crate::dom::webgpu::gpucommandencoder::GPUCommandEncoder;
-use crate::dom::webgpu::gpurenderbundle::GPURenderBundle;
-use crate::dom::webgpu::gpurenderpipeline::GPURenderPipeline;
+use crate::gpubindgroup::GPUBindGroup;
+use crate::gpubuffer::GPUBuffer;
+use crate::gpucommandencoder::GPUCommandEncoder;
+use crate::gpuconvert::WebGPUTryConvert;
+use crate::gpurenderbundle::GPURenderBundle;
+use crate::gpurenderpipeline::GPURenderPipeline;
+use crate::traits::{Equivalence, GPUDeviceTrait, GPUExternalTextureTrait, WebGPUGlobalTrait};
 
-#[derive(JSTraceable, MallocSizeOf)]
+#[derive(MallocSizeOf)]
 struct DroppableGPURenderPassEncoder {
-    #[no_trace]
     channel: WebGPU,
-    #[no_trace]
     render_pass: WebGPURenderPass,
 }
 
@@ -43,18 +48,24 @@ impl Drop for DroppableGPURenderPassEncoder {
     }
 }
 #[dom_struct]
-pub(crate) struct GPURenderPassEncoder {
+pub struct GPURenderPassEncoder<D: DomTypes> {
     reflector_: Reflector,
     label: DomRefCell<USVString>,
-    command_encoder: Dom<GPUCommandEncoder>,
+    command_encoder: Dom<GPUCommandEncoder<D>>,
+    #[no_trace]
     droppable: DroppableGPURenderPassEncoder,
 }
 
-impl GPURenderPassEncoder {
+impl<D> GPURenderPassEncoder<D>
+where
+    D: Equivalence,
+    D::GPUDevice: GPUDeviceTrait<D>,
+    D::GlobalScope: WebGPUGlobalTrait,
+{
     fn new_inherited(
         channel: WebGPU,
         render_pass: WebGPURenderPass,
-        parent: &GPUCommandEncoder,
+        parent: &GPUCommandEncoder<D>,
         label: USVString,
     ) -> Self {
         Self {
@@ -70,14 +81,13 @@ impl GPURenderPassEncoder {
 
     pub(crate) fn new(
         cx: &mut JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         channel: WebGPU,
         render_pass: WebGPURenderPass,
-        parent: &GPUCommandEncoder,
+        parent: &GPUCommandEncoder<D>,
         label: USVString,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
-            cx,
+        reflect_dom_object_with_wrap::<D, _, _>(
             Box::new(GPURenderPassEncoder::new_inherited(
                 channel,
                 render_pass,
@@ -85,6 +95,8 @@ impl GPURenderPassEncoder {
                 label,
             )),
             global,
+            cx,
+            GPURenderPassEncoderWrap::<D>,
         )
     }
 
@@ -104,13 +116,20 @@ impl GPURenderPassEncoder {
     }
 }
 
-impl GPURenderPassEncoder {
+impl<D: DomTypes> GPURenderPassEncoder<D> {
     pub(crate) fn id(&self) -> WebGPURenderPass {
         self.droppable.render_pass
     }
 }
 
-impl GPURenderPassEncoderMethods<crate::DomTypeHolder> for GPURenderPassEncoder {
+impl<D> GPURenderPassEncoderMethods<D> for GPURenderPassEncoder<D>
+where
+    D: Equivalence,
+    D::Promise: PromiseHelpers<D>,
+    D::GPUDevice: GPUDeviceTrait<D>,
+    D::GPUExternalTexture: GPUExternalTextureTrait<D>,
+    D::GlobalScope: WebGPUGlobalTrait,
+{
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
@@ -122,7 +141,7 @@ impl GPURenderPassEncoderMethods<crate::DomTypeHolder> for GPURenderPassEncoder 
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuprogrammablepassencoder-setbindgroup>
-    fn SetBindGroup(&self, index: u32, bind_group: &GPUBindGroup, offsets: Vec<u32>) {
+    fn SetBindGroup(&self, index: u32, bind_group: &GPUBindGroup<D>, offsets: Vec<u32>) {
         self.send_render_command(RenderCommand::SetBindGroup {
             index,
             bind_group_id: bind_group.id().0,
@@ -182,14 +201,14 @@ impl GPURenderPassEncoderMethods<crate::DomTypeHolder> for GPURenderPassEncoder 
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-setpipeline>
-    fn SetPipeline(&self, pipeline: &GPURenderPipeline) {
+    fn SetPipeline(&self, pipeline: &GPURenderPipeline<D>) {
         self.send_render_command(RenderCommand::SetPipeline(pipeline.id().0))
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-setindexbuffer>
     fn SetIndexBuffer(
         &self,
-        buffer: &GPUBuffer,
+        buffer: &GPUBuffer<D>,
         index_format: GPUIndexFormat,
         offset: u64,
         size: u64,
@@ -206,7 +225,7 @@ impl GPURenderPassEncoderMethods<crate::DomTypeHolder> for GPURenderPassEncoder 
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-setvertexbuffer>
-    fn SetVertexBuffer(&self, slot: u32, buffer: Option<&GPUBuffer>, offset: u64, size: u64) {
+    fn SetVertexBuffer(&self, slot: u32, buffer: Option<&GPUBuffer<D>>, offset: u64, size: u64) {
         self.send_render_command(RenderCommand::SetVertexBuffer {
             slot,
             buffer_id: buffer.map(|b| b.id().0),
@@ -244,7 +263,7 @@ impl GPURenderPassEncoderMethods<crate::DomTypeHolder> for GPURenderPassEncoder 
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-drawindirect>
-    fn DrawIndirect(&self, buffer: &GPUBuffer, offset: u64) {
+    fn DrawIndirect(&self, buffer: &GPUBuffer<D>, offset: u64) {
         self.send_render_command(RenderCommand::DrawIndirect {
             buffer_id: buffer.id().0,
             offset,
@@ -252,7 +271,7 @@ impl GPURenderPassEncoderMethods<crate::DomTypeHolder> for GPURenderPassEncoder 
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-drawindexedindirect>
-    fn DrawIndexedIndirect(&self, buffer: &GPUBuffer, offset: u64) {
+    fn DrawIndexedIndirect(&self, buffer: &GPUBuffer<D>, offset: u64) {
         self.send_render_command(RenderCommand::DrawIndexedIndirect {
             buffer_id: buffer.id().0,
             offset,
@@ -260,7 +279,7 @@ impl GPURenderPassEncoderMethods<crate::DomTypeHolder> for GPURenderPassEncoder 
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-executebundles>
-    fn ExecuteBundles(&self, bundles: Vec<DomRoot<GPURenderBundle>>) {
+    fn ExecuteBundles(&self, bundles: Vec<DomRoot<GPURenderBundle<D>>>) {
         let bundle_ids: Vec<_> = bundles.iter().map(|b| b.id().0).collect();
         self.send_render_command(RenderCommand::ExecuteBundles(bundle_ids))
     }

--- a/components/script_webgpu/gpurenderpipeline.rs
+++ b/components/script_webgpu/gpurenderpipeline.rs
@@ -4,8 +4,15 @@
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
+use jstraceable_derive::JSTraceable;
+use log::warn;
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{
+    GPURenderPipelineMethods, GPURenderPipelineWrap,
+};
+use script_bindings::reflector::{DomGlobalGeneric, Reflector, reflect_dom_object_with_wrap};
 use servo_base::generic_channel::GenericCallback;
 use webgpu_traits::{
     WebGPU, WebGPUBindGroupLayout, WebGPURenderPipeline, WebGPURenderPipelineResponse,
@@ -13,14 +20,11 @@ use webgpu_traits::{
 };
 use wgpu_core::pipeline::RenderPipelineDescriptor;
 
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPURenderPipelineMethods;
 use crate::dom::bindings::error::Fallible;
-use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
-use crate::dom::globalscope::GlobalScope;
-use crate::dom::webgpu::gpubindgrouplayout::GPUBindGroupLayout;
-use crate::dom::webgpu::gpudevice::GPUDevice;
+use crate::gpubindgrouplayout::GPUBindGroupLayout;
+use crate::traits::{Equivalence, GPUDeviceTrait, WebGPUGlobalTrait};
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPURenderPipeline {
@@ -46,18 +50,22 @@ impl Drop for DroppableGPURenderPipeline {
 }
 
 #[dom_struct]
-pub(crate) struct GPURenderPipeline {
+pub struct GPURenderPipeline<D: DomTypes> {
     reflector_: Reflector,
     label: DomRefCell<USVString>,
-    device: Dom<GPUDevice>,
+    device: Dom<D::GPUDevice>,
     droppable: DroppableGPURenderPipeline,
 }
 
-impl GPURenderPipeline {
+impl<D> GPURenderPipeline<D>
+where
+    D: Equivalence,
+    D::GPUDevice: GPUDeviceTrait<D>,
+{
     fn new_inherited(
         render_pipeline: WebGPURenderPipeline,
         label: USVString,
-        device: &GPUDevice,
+        device: &D::GPUDevice,
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
@@ -70,37 +78,47 @@ impl GPURenderPipeline {
         }
     }
 
-    pub(crate) fn new(
+    pub fn new(
         cx: &mut JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         render_pipeline: WebGPURenderPipeline,
         label: USVString,
-        device: &GPUDevice,
+        device: &D::GPUDevice,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
-            cx,
+        reflect_dom_object_with_wrap::<D, _, _>(
             Box::new(GPURenderPipeline::new_inherited(
                 render_pipeline,
                 label,
                 device,
             )),
             global,
+            cx,
+            GPURenderPipelineWrap::<D>,
         )
     }
 }
 
-impl GPURenderPipeline {
+impl<D> GPURenderPipeline<D>
+where
+    D: Equivalence,
+    D::GPUDevice: GPUDeviceTrait<D>,
+    D::GlobalScope: WebGPUGlobalTrait,
+    Self: DomGlobalGeneric<D>,
+{
     pub(crate) fn id(&self) -> WebGPURenderPipeline {
         self.droppable.render_pipeline
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createrenderpipeline>
-    pub(crate) fn create(
-        device: &GPUDevice,
+    pub fn create(
+        device: &D::GPUDevice,
         descriptor: RenderPipelineDescriptor<'static>,
         async_sender: Option<GenericCallback<WebGPURenderPipelineResponse>>,
     ) -> Fallible<WebGPURenderPipeline> {
-        let render_pipeline_id = device.global().wgpu_id_hub().create_render_pipeline_id();
+        let render_pipeline_id = device
+            .global_from_reflector()
+            .global_wgpu_id_hub()
+            .create_render_pipeline_id();
 
         device
             .channel()
@@ -117,7 +135,13 @@ impl GPURenderPipeline {
     }
 }
 
-impl GPURenderPipelineMethods<crate::DomTypeHolder> for GPURenderPipeline {
+impl<D> GPURenderPipelineMethods<D> for GPURenderPipeline<D>
+where
+    D: Equivalence,
+    D::GlobalScope: DomGlobalGeneric<D> + WebGPUGlobalTrait,
+    D::GPUDevice: GPUDeviceTrait<D>,
+    Self: DomGlobalGeneric<D>,
+{
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
@@ -133,8 +157,11 @@ impl GPURenderPipelineMethods<crate::DomTypeHolder> for GPURenderPipeline {
         &self,
         cx: &mut JSContext,
         index: u32,
-    ) -> Fallible<DomRoot<GPUBindGroupLayout>> {
-        let id = self.global().wgpu_id_hub().create_bind_group_layout_id();
+    ) -> Fallible<DomRoot<GPUBindGroupLayout<D>>> {
+        let id = self
+            .global_from_reflector()
+            .global_wgpu_id_hub()
+            .create_bind_group_layout_id();
 
         if let Err(e) = self
             .droppable
@@ -152,7 +179,7 @@ impl GPURenderPipelineMethods<crate::DomTypeHolder> for GPURenderPipeline {
 
         Ok(GPUBindGroupLayout::new(
             cx,
-            &self.global(),
+            &*self.global_from_reflector(),
             self.droppable.channel.clone(),
             WebGPUBindGroupLayout(id),
             USVString::default(),

--- a/components/script_webgpu/gpusampler.rs
+++ b/components/script_webgpu/gpusampler.rs
@@ -2,23 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::marker::PhantomData;
+
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
+use log::warn;
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
-use script_webgpu::gpuconvert::WebGPUConvert;
-use script_webgpu::traits::GPUSamplerTrait;
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{
+    GPUSamplerDescriptor, GPUSamplerMethods, GPUSamplerWrap,
+};
+use script_bindings::reflector::{DomGlobalGeneric, Reflector, reflect_dom_object_with_wrap};
 use webgpu_traits::{WebGPU, WebGPUDevice, WebGPURequest, WebGPUSampler};
 use wgpu_core::resource::SamplerDescriptor;
 
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
-    GPUSamplerDescriptor, GPUSamplerMethods,
-};
-use crate::dom::bindings::reflector::DomGlobal;
+use crate::JSTraceable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::USVString;
-use crate::dom::globalscope::GlobalScope;
-use crate::dom::webgpu::gpudevice::GPUDevice;
+use crate::gpuconvert::WebGPUConvert;
+use crate::traits::{Equivalence, GPUDeviceTrait, WebGPUGlobalTrait};
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUSampler {
@@ -41,16 +44,18 @@ impl Drop for DroppableGPUSampler {
 }
 
 #[dom_struct]
-pub(crate) struct GPUSampler {
+pub struct GPUSampler<D: DomTypes> {
     reflector_: Reflector,
     label: DomRefCell<USVString>,
     #[no_trace]
     device: WebGPUDevice,
     compare_enable: bool,
     dropppable: DroppableGPUSampler,
+    #[no_trace = "PhantomData does not exist"]
+    phantom: PhantomData<D>,
 }
 
-impl GPUSampler {
+impl<D: Equivalence> GPUSampler<D> {
     fn new_inherited(
         channel: WebGPU,
         device: WebGPUDevice,
@@ -64,20 +69,20 @@ impl GPUSampler {
             device,
             compare_enable,
             dropppable: DroppableGPUSampler { channel, sampler },
+            phantom: PhantomData,
         }
     }
 
     pub(crate) fn new(
         cx: &mut JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         channel: WebGPU,
         device: WebGPUDevice,
         compare_enable: bool,
         sampler: WebGPUSampler,
         label: USVString,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
-            cx,
+        reflect_dom_object_with_wrap::<D, _, _>(
             Box::new(GPUSampler::new_inherited(
                 channel,
                 device,
@@ -86,22 +91,32 @@ impl GPUSampler {
                 label,
             )),
             global,
+            cx,
+            GPUSamplerWrap::<D>,
         )
     }
 }
 
-impl GPUSampler {
+impl<D> GPUSampler<D>
+where
+    D: Equivalence,
+    D::GlobalScope: WebGPUGlobalTrait,
+    D::GPUDevice: GPUDeviceTrait<D>,
+{
     pub(crate) fn id(&self) -> WebGPUSampler {
         self.dropppable.sampler
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createsampler>
-    pub(crate) fn create(
+    pub fn create(
         cx: &mut JSContext,
-        device: &GPUDevice,
+        device: &D::GPUDevice,
         descriptor: &GPUSamplerDescriptor,
-    ) -> DomRoot<GPUSampler> {
-        let sampler_id = device.global().wgpu_id_hub().create_sampler_id();
+    ) -> DomRoot<GPUSampler<D>> {
+        let sampler_id = device
+            .global_from_reflector()
+            .global_wgpu_id_hub()
+            .create_sampler_id();
         let compare_enable = descriptor.compare.is_some();
         let desc = SamplerDescriptor {
             label: (&descriptor.parent).convert(),
@@ -134,7 +149,7 @@ impl GPUSampler {
 
         GPUSampler::new(
             cx,
-            &device.global(),
+            &*device.global_from_reflector(),
             device.channel(),
             device.id(),
             compare_enable,
@@ -144,7 +159,7 @@ impl GPUSampler {
     }
 }
 
-impl GPUSamplerMethods<crate::DomTypeHolder> for GPUSampler {
+impl<D: DomTypes> GPUSamplerMethods<D> for GPUSampler<D> {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
@@ -153,11 +168,5 @@ impl GPUSamplerMethods<crate::DomTypeHolder> for GPUSampler {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
         *self.label.safe_borrow_mut(no_gc) = value;
-    }
-}
-
-impl GPUSamplerTrait for GPUSampler {
-    fn id(&self) -> WebGPUSampler {
-        self.id()
     }
 }

--- a/components/script_webgpu/gpushadermodule.rs
+++ b/components/script_webgpu/gpushadermodule.rs
@@ -7,23 +7,22 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
 use js::realm::CurrentRealm;
+use log::warn;
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
-use script_webgpu::traits::GPUShaderModuleTrait;
-use webgpu_traits::{ShaderCompilationInfo, WebGPU, WebGPURequest, WebGPUShaderModule};
-
-use super::gpucompilationinfo::GPUCompilationInfo;
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
-    GPUShaderModuleDescriptor, GPUShaderModuleMethods,
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{
+    GPUShaderModuleDescriptor, GPUShaderModuleMethods, GPUShaderModuleWrap,
 };
-use crate::dom::bindings::reflector::DomGlobal;
+use script_bindings::interfaces::PromiseHelpers;
+use script_bindings::reflector::{DomGlobalGeneric, Reflector, reflect_dom_object_with_wrap};
+use webgpu_traits::{WebGPU, WebGPURequest, WebGPUShaderModule};
+
+use crate::JSTraceable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::USVString;
 use crate::dom::bindings::trace::RootedTraceableBox;
-use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
-use crate::dom::types::GPUDevice;
-use crate::routed_promise::{RoutedPromiseListener, callback_promise};
+use crate::traits::{Equivalence, GPUDeviceTrait, WebGPUGlobalTrait, WebGPUPromiseTrait};
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUShaderModule {
@@ -49,20 +48,20 @@ impl Drop for DroppableGPUShaderModule {
 }
 
 #[dom_struct]
-pub(crate) struct GPUShaderModule {
+pub struct GPUShaderModule<D: DomTypes> {
     reflector_: Reflector,
     label: DomRefCell<USVString>,
     #[ignore_malloc_size_of = "promise"]
-    compilation_info_promise: Rc<Promise>,
+    compilation_info_promise: Rc<D::Promise>,
     droppable: DroppableGPUShaderModule,
 }
 
-impl GPUShaderModule {
+impl<D: Equivalence> GPUShaderModule<D> {
     fn new_inherited(
         channel: WebGPU,
         shader_module: WebGPUShaderModule,
         label: USVString,
-        promise: Rc<Promise>,
+        promise: Rc<D::Promise>,
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
@@ -77,14 +76,13 @@ impl GPUShaderModule {
 
     pub(crate) fn new(
         cx: &mut JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         channel: WebGPU,
         shader_module: WebGPUShaderModule,
         label: USVString,
-        promise: Rc<Promise>,
+        promise: Rc<D::Promise>,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
-            cx,
+        reflect_dom_object_with_wrap::<D, _, _>(
             Box::new(GPUShaderModule::new_inherited(
                 channel,
                 shader_module,
@@ -92,39 +90,44 @@ impl GPUShaderModule {
                 promise,
             )),
             global,
+            cx,
+            GPUShaderModuleWrap::<D>,
         )
     }
 }
 
-impl GPUShaderModule {
+impl<D> GPUShaderModule<D>
+where
+    D: Equivalence,
+    D::Promise: WebGPUPromiseTrait<D> + PromiseHelpers<D>,
+    D::GlobalScope: WebGPUGlobalTrait,
+    D::GPUDevice: GPUDeviceTrait<D>,
+{
     pub(crate) fn id(&self) -> WebGPUShaderModule {
         self.droppable.shader_module
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createshadermodule>
-    pub(crate) fn create(
+    pub fn create(
         cx: &mut CurrentRealm<'_>,
-        device: &GPUDevice,
+        device: &D::GPUDevice,
         descriptor: RootedTraceableBox<GPUShaderModuleDescriptor>,
-    ) -> DomRoot<GPUShaderModule> {
-        let program_id = device.global().wgpu_id_hub().create_shader_module_id();
-        let promise = Promise::new_in_realm(cx);
+    ) -> DomRoot<GPUShaderModule<D>> {
+        let program_id = device
+            .global_from_reflector()
+            .global_wgpu_id_hub()
+            .create_shader_module_id();
+        let promise = D::Promise::new_in_realm(cx);
         let shader_module = GPUShaderModule::new(
             cx,
-            &device.global(),
+            &*device.global_from_reflector(),
             device.channel(),
             WebGPUShaderModule(program_id),
             descriptor.parent.label.clone(),
             promise.clone(),
         );
-        let callback = callback_promise(
-            &promise,
-            &*shader_module,
-            device
-                .global()
-                .task_manager()
-                .dom_manipulation_task_source(),
-        );
+        let callback =
+            WebGPUPromiseTrait::<D>::callback_promise_gpushadermodule(&promise, &*shader_module);
         device
             .channel()
             .0
@@ -140,7 +143,7 @@ impl GPUShaderModule {
     }
 }
 
-impl GPUShaderModuleMethods<crate::DomTypeHolder> for GPUShaderModule {
+impl<D: DomTypes> GPUShaderModuleMethods<D> for GPUShaderModule<D> {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
@@ -152,25 +155,7 @@ impl GPUShaderModuleMethods<crate::DomTypeHolder> for GPUShaderModule {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpushadermodule-getcompilationinfo>
-    fn GetCompilationInfo(&self) -> Rc<Promise> {
+    fn GetCompilationInfo(&self) -> Rc<D::Promise> {
         self.compilation_info_promise.clone()
-    }
-}
-
-impl RoutedPromiseListener<Option<ShaderCompilationInfo>> for GPUShaderModule {
-    fn handle_response(
-        &self,
-        cx: &mut js::context::JSContext,
-        response: Option<ShaderCompilationInfo>,
-        promise: &Rc<Promise>,
-    ) {
-        let info = GPUCompilationInfo::from(cx, &self.global(), response);
-        promise.resolve_native(cx, &info);
-    }
-}
-
-impl GPUShaderModuleTrait for GPUShaderModule {
-    fn id(&self) -> WebGPUShaderModule {
-        self.id()
     }
 }

--- a/components/script_webgpu/gputexture.rs
+++ b/components/script_webgpu/gputexture.rs
@@ -6,24 +6,26 @@ use std::string::String;
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
+use log::warn;
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
-use script_webgpu::gpuconvert::{WebGPUConvert, convert_texture_descriptor};
-use script_webgpu::traits::GPUTextureTrait;
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{
+    GPUTextureAspect, GPUTextureDescriptor, GPUTextureDimension, GPUTextureFormat,
+    GPUTextureMethods, GPUTextureViewDescriptor, GPUTextureWrap,
+};
+use script_bindings::dom::MutNullableDom;
+use script_bindings::reflector::{DomGlobalGeneric, Reflector, reflect_dom_object_with_wrap};
 use webgpu_traits::{WebGPU, WebGPURequest, WebGPUTexture, WebGPUTextureView};
 use wgpu_core::resource::{self, TextureDescriptor};
 
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
-    GPUTextureAspect, GPUTextureDescriptor, GPUTextureDimension, GPUTextureFormat,
-    GPUTextureMethods, GPUTextureViewDescriptor,
-};
+use crate::JSTraceable;
 use crate::dom::bindings::error::Fallible;
-use crate::dom::bindings::reflector::DomGlobal;
-use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
-use crate::dom::globalscope::GlobalScope;
-use crate::dom::webgpu::gpudevice::GPUDevice;
-use crate::dom::webgpu::gputextureview::GPUTextureView;
+use crate::gpuconvert::{WebGPUConvert, convert_texture_descriptor};
+use crate::gputextureview::GPUTextureView;
+use crate::traits::{Equivalence, GPUDeviceTrait, WebGPUGlobalTrait};
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUTexture {
@@ -49,10 +51,10 @@ impl Drop for DroppableGPUTexture {
 }
 
 #[dom_struct]
-pub(crate) struct GPUTexture {
+pub struct GPUTexture<D: DomTypes> {
     reflector_: Reflector,
     label: DomRefCell<USVString>,
-    device: Dom<GPUDevice>,
+    device: Dom<D::GPUDevice>,
     #[no_trace]
     #[ignore_malloc_size_of = "External type"]
     texture_size: wgpu_types::Extent3d,
@@ -62,14 +64,14 @@ pub(crate) struct GPUTexture {
     format: GPUTextureFormat,
     texture_usage: u32,
     droppable: DroppableGPUTexture,
-    default_view: MutNullableDom<GPUTextureView>,
+    default_view: MutNullableDom<GPUTextureView<D>>,
 }
 
-impl GPUTexture {
+impl<D: Equivalence> GPUTexture<D> {
     #[expect(clippy::too_many_arguments)]
     fn new_inherited(
         texture: WebGPUTexture,
-        device: &GPUDevice,
+        device: &D::GPUDevice,
         channel: WebGPU,
         texture_size: wgpu_types::Extent3d,
         mip_level_count: u32,
@@ -97,9 +99,9 @@ impl GPUTexture {
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         cx: &mut JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         texture: WebGPUTexture,
-        device: &GPUDevice,
+        device: &D::GPUDevice,
         channel: WebGPU,
         texture_size: wgpu_types::Extent3d,
         mip_level_count: u32,
@@ -109,8 +111,7 @@ impl GPUTexture {
         texture_usage: u32,
         label: USVString,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
-            cx,
+        reflect_dom_object_with_wrap::<D, _, _>(
             Box::new(GPUTexture::new_inherited(
                 texture,
                 device,
@@ -124,16 +125,23 @@ impl GPUTexture {
                 label,
             )),
             global,
+            cx,
+            GPUTextureWrap::<D>,
         )
     }
 }
 
-impl GPUTexture {
-    pub(crate) fn id(&self) -> WebGPUTexture {
+impl<D> GPUTexture<D>
+where
+    D: Equivalence,
+    D::GPUDevice: GPUDeviceTrait<D>,
+    D::GlobalScope: WebGPUGlobalTrait,
+{
+    pub fn id(&self) -> WebGPUTexture {
         self.droppable.texture
     }
 
-    pub(crate) fn wgpu_texture_descriptor(&self) -> TextureDescriptor<'static> {
+    pub fn wgpu_texture_descriptor(&self) -> TextureDescriptor<'static> {
         TextureDescriptor {
             label: Some(self.label.borrow().to_string().into()),
             size: self.texture_size,
@@ -147,14 +155,17 @@ impl GPUTexture {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createtexture>
-    pub(crate) fn create(
+    pub fn create(
         cx: &mut JSContext,
-        device: &GPUDevice,
+        device: &D::GPUDevice,
         descriptor: &GPUTextureDescriptor,
-    ) -> Fallible<DomRoot<GPUTexture>> {
-        let (desc, size) = convert_texture_descriptor::<crate::DomTypeHolder>(descriptor, device)?;
+    ) -> Fallible<DomRoot<GPUTexture<D>>> {
+        let (desc, size) = convert_texture_descriptor::<D>(descriptor, device)?;
 
-        let texture_id = device.global().wgpu_id_hub().create_texture_id();
+        let texture_id = device
+            .global_from_reflector()
+            .global_wgpu_id_hub()
+            .create_texture_id();
 
         device
             .channel()
@@ -170,7 +181,7 @@ impl GPUTexture {
 
         Ok(GPUTexture::new(
             cx,
-            &device.global(),
+            &*device.global_from_reflector(),
             texture,
             device,
             device.channel(),
@@ -194,7 +205,13 @@ impl GPUTexture {
     }
 }
 
-impl GPUTextureMethods<crate::DomTypeHolder> for GPUTexture {
+impl<D> GPUTextureMethods<D> for GPUTexture<D>
+where
+    D: Equivalence,
+    D::GPUDevice: GPUDeviceTrait<D>,
+    D::GlobalScope: WebGPUGlobalTrait,
+    Self: DomGlobalGeneric<D>,
+{
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
@@ -210,7 +227,7 @@ impl GPUTextureMethods<crate::DomTypeHolder> for GPUTexture {
         &self,
         cx: &mut JSContext,
         descriptor: &GPUTextureViewDescriptor,
-    ) -> Fallible<DomRoot<GPUTextureView>> {
+    ) -> Fallible<DomRoot<GPUTextureView<D>>> {
         let desc = if !matches!(descriptor.mipLevelCount, Some(0)) &&
             !matches!(descriptor.arrayLayerCount, Some(0))
         {
@@ -244,7 +261,10 @@ impl GPUTextureMethods<crate::DomTypeHolder> for GPUTexture {
             None
         };
 
-        let texture_view_id = self.global().wgpu_id_hub().create_texture_view_id();
+        let texture_view_id = self
+            .global_from_reflector()
+            .global_wgpu_id_hub()
+            .create_texture_view_id();
 
         self.droppable
             .channel
@@ -261,7 +281,7 @@ impl GPUTextureMethods<crate::DomTypeHolder> for GPUTexture {
 
         Ok(GPUTextureView::new(
             cx,
-            &self.global(),
+            &*self.global_from_reflector(),
             self.droppable.channel.clone(),
             texture_view,
             self,
@@ -323,15 +343,5 @@ impl GPUTextureMethods<crate::DomTypeHolder> for GPUTexture {
     /// <https://gpuweb.github.io/gpuweb/#dom-gputexture-usage>
     fn Usage(&self) -> u32 {
         self.texture_usage
-    }
-}
-
-impl GPUTextureTrait for GPUTexture {
-    fn id(&self) -> WebGPUTexture {
-        self.id()
-    }
-
-    fn get_default_view(&self, cx: &mut JSContext) -> WebGPUTextureView {
-        self.get_default_view(cx)
     }
 }

--- a/components/script_webgpu/gputextureview.rs
+++ b/components/script_webgpu/gputextureview.rs
@@ -4,16 +4,21 @@
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
+use log::warn;
+use malloc_size_of_derive::MallocSizeOf;
+use script_bindings::DomTypes;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
-use script_webgpu::traits::GPUTextureViewTrait;
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{
+    GPUTextureViewMethods, GPUTextureViewWrap,
+};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_wrap};
 use webgpu_traits::{WebGPU, WebGPURequest, WebGPUTextureView};
 
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUTextureViewMethods;
+use crate::JSTraceable;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
-use crate::dom::globalscope::GlobalScope;
-use crate::dom::webgpu::gputexture::GPUTexture;
+use crate::gputexture::GPUTexture;
+use crate::traits::Equivalence;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUTextureView {
@@ -40,20 +45,20 @@ impl Drop for DroppableGPUTextureView {
 }
 
 #[dom_struct]
-pub(crate) struct GPUTextureView {
+pub struct GPUTextureView<D: DomTypes> {
     reflector_: Reflector,
     label: DomRefCell<USVString>,
-    texture: Dom<GPUTexture>,
+    texture: Dom<GPUTexture<D>>,
     droppable: DroppableGPUTextureView,
 }
 
-impl GPUTextureView {
+impl<D: Equivalence> GPUTextureView<D> {
     fn new_inherited(
         channel: WebGPU,
         texture_view: WebGPUTextureView,
-        texture: &GPUTexture,
+        texture: &GPUTexture<D>,
         label: USVString,
-    ) -> GPUTextureView {
+    ) -> GPUTextureView<D> {
         Self {
             reflector_: Reflector::new(),
             texture: Dom::from_ref(texture),
@@ -67,14 +72,13 @@ impl GPUTextureView {
 
     pub(crate) fn new(
         cx: &mut JSContext,
-        global: &GlobalScope,
+        global: &D::GlobalScope,
         channel: WebGPU,
         texture_view: WebGPUTextureView,
-        texture: &GPUTexture,
+        texture: &GPUTexture<D>,
         label: USVString,
-    ) -> DomRoot<GPUTextureView> {
-        reflect_dom_object(
-            cx,
+    ) -> DomRoot<GPUTextureView<D>> {
+        reflect_dom_object_with_wrap::<D, _, _>(
             Box::new(GPUTextureView::new_inherited(
                 channel,
                 texture_view,
@@ -82,17 +86,19 @@ impl GPUTextureView {
                 label,
             )),
             global,
+            cx,
+            GPUTextureViewWrap::<D>,
         )
     }
 }
 
-impl GPUTextureView {
+impl<D: DomTypes> GPUTextureView<D> {
     pub(crate) fn id(&self) -> WebGPUTextureView {
         self.droppable.texture_view
     }
 }
 
-impl GPUTextureViewMethods<crate::DomTypeHolder> for GPUTextureView {
+impl<D: DomTypes> GPUTextureViewMethods<D> for GPUTextureView<D> {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
@@ -101,11 +107,5 @@ impl GPUTextureViewMethods<crate::DomTypeHolder> for GPUTextureView {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
         *self.label.safe_borrow_mut(no_gc) = value;
-    }
-}
-
-impl GPUTextureViewTrait for GPUTextureView {
-    fn id(&self) -> WebGPUTextureView {
-        self.id()
     }
 }

--- a/components/script_webgpu/lib.rs
+++ b/components/script_webgpu/lib.rs
@@ -16,16 +16,28 @@ pub mod gpubuffer;
 pub mod gpubufferusage;
 pub mod gpucolorwrite;
 pub mod gpucommandbuffer;
+pub mod gpucommandencoder;
 pub mod gpucompilationinfo;
 pub mod gpucompilationmessage;
+pub mod gpucomputepassencoder;
+pub mod gpucomputepipeline;
 pub mod gpuconvert;
 pub mod gpudevicelostinfo;
 pub mod gpumapmode;
+pub mod gpupipelinelayout;
+pub mod gpuqueryset;
 pub mod gpurenderbundle;
+pub mod gpurenderbundleencoder;
+pub mod gpurenderpassencoder;
+pub mod gpurenderpipeline;
+pub mod gpusampler;
+pub mod gpushadermodule;
 pub mod gpushaderstage;
 pub mod gpusupportedfeatures;
 pub mod gpusupportedlimits;
+pub mod gputexture;
 pub mod gputextureusage;
+pub mod gputextureview;
 pub mod identityhub;
 pub mod traits;
 pub mod wgsllanguagefeatures;
@@ -34,8 +46,23 @@ pub(crate) use js::gc::Traceable as JSTraceable;
 pub(crate) use jstraceable_derive::JSTraceable;
 pub(crate) use script_bindings::reflector::{DomObject, MutDomObject, Reflector};
 pub(crate) use script_bindings::trace::CustomTraceable;
+use wgpu_core::id::PipelineLayoutId;
 
 pub(crate) use crate::dom::bindings::inheritance::HasParent;
+
+pub enum PipelineLayout {
+    Implicit,
+    Explicit(PipelineLayoutId),
+}
+
+impl PipelineLayout {
+    pub fn explicit(&self) -> Option<PipelineLayoutId> {
+        match self {
+            PipelineLayout::Explicit(layout_id) => Some(*layout_id),
+            PipelineLayout::Implicit => None,
+        }
+    }
+}
 
 // Reexports
 pub(crate) mod dom {
@@ -70,15 +97,27 @@ pub(crate) mod codegen {
         use crate::gpubufferusage::GPUBufferUsage;
         use crate::gpucolorwrite::GPUColorWrite;
         use crate::gpucommandbuffer::GPUCommandBuffer;
+        use crate::gpucommandencoder::GPUCommandEncoder;
         use crate::gpucompilationinfo::GPUCompilationInfo;
         use crate::gpucompilationmessage::GPUCompilationMessage;
+        use crate::gpucomputepassencoder::GPUComputePassEncoder;
+        use crate::gpucomputepipeline::GPUComputePipeline;
         use crate::gpudevicelostinfo::GPUDeviceLostInfo;
         use crate::gpumapmode::GPUMapMode;
+        use crate::gpupipelinelayout::GPUPipelineLayout;
+        use crate::gpuqueryset::GPUQuerySet;
         use crate::gpurenderbundle::GPURenderBundle;
+        use crate::gpurenderbundleencoder::GPURenderBundleEncoder;
+        use crate::gpurenderpassencoder::GPURenderPassEncoder;
+        use crate::gpurenderpipeline::GPURenderPipeline;
+        use crate::gpusampler::GPUSampler;
+        use crate::gpushadermodule::GPUShaderModule;
         use crate::gpushaderstage::GPUShaderStage;
         use crate::gpusupportedfeatures::GPUSupportedFeatures;
         use crate::gpusupportedlimits::GPUSupportedLimits;
+        use crate::gputexture::GPUTexture;
         use crate::gputextureusage::GPUTextureUsage;
+        use crate::gputextureview::GPUTextureView;
         use crate::wgsllanguagefeatures::WGSLLanguageFeatures;
         include!(concat!(
             env!("OUT_DIR"),

--- a/components/script_webgpu/traits.rs
+++ b/components/script_webgpu/traits.rs
@@ -5,19 +5,20 @@
 use std::rc::Rc;
 use std::sync::Arc;
 
-use js::context::JSContext;
 use script_bindings::DomTypes;
 use script_bindings::codegen::GenericBindings::WebGPUBinding::GPUTextureFormat;
+use script_bindings::codegen::GenericUnionTypes::GPUPipelineLayoutOrGPUAutoLayoutMode;
 use script_bindings::error::Fallible;
+use script_bindings::reflector::DomGlobalGeneric;
 use servo_base::generic_channel::GenericCallback;
 use webgpu_traits::{
-    Mapping, WebGPU, WebGPUAdapterResponse, WebGPUDevice, WebGPUDeviceResponse,
-    WebGPUExternalTexture, WebGPUQuerySet, WebGPUSampler, WebGPUShaderModule, WebGPUTexture,
-    WebGPUTextureView,
+    Mapping, ShaderCompilationInfo, WebGPU, WebGPUAdapterResponse, WebGPUDevice,
+    WebGPUDeviceResponse, WebGPUExternalTexture, WebGPUQueue,
 };
 use wgpu_core::resource::BufferAccessError;
 use wgpu_types::TextureFormat;
 
+use crate::PipelineLayout;
 use crate::gpu::GPU;
 use crate::gpuadapter::GPUAdapter;
 use crate::gpuadapterinfo::GPUAdapterInfo;
@@ -27,15 +28,27 @@ use crate::gpubuffer::GPUBuffer;
 use crate::gpubufferusage::GPUBufferUsage;
 use crate::gpucolorwrite::GPUColorWrite;
 use crate::gpucommandbuffer::GPUCommandBuffer;
+use crate::gpucommandencoder::GPUCommandEncoder;
 use crate::gpucompilationinfo::GPUCompilationInfo;
 use crate::gpucompilationmessage::GPUCompilationMessage;
+use crate::gpucomputepassencoder::GPUComputePassEncoder;
+use crate::gpucomputepipeline::GPUComputePipeline;
 use crate::gpudevicelostinfo::GPUDeviceLostInfo;
 use crate::gpumapmode::GPUMapMode;
+use crate::gpupipelinelayout::GPUPipelineLayout;
+use crate::gpuqueryset::GPUQuerySet;
 use crate::gpurenderbundle::GPURenderBundle;
+use crate::gpurenderbundleencoder::GPURenderBundleEncoder;
+use crate::gpurenderpassencoder::GPURenderPassEncoder;
+use crate::gpurenderpipeline::GPURenderPipeline;
+use crate::gpusampler::GPUSampler;
+use crate::gpushadermodule::GPUShaderModule;
 use crate::gpushaderstage::GPUShaderStage;
 use crate::gpusupportedfeatures::GPUSupportedFeatures;
 use crate::gpusupportedlimits::GPUSupportedLimits;
+use crate::gputexture::GPUTexture;
 use crate::gputextureusage::GPUTextureUsage;
+use crate::gputextureview::GPUTextureView;
 use crate::identityhub::IdentityHub;
 use crate::wgsllanguagefeatures::WGSLLanguageFeatures;
 
@@ -51,15 +64,27 @@ pub trait Equivalence =  DomTypes<
         GPUBufferUsage = GPUBufferUsage<Self>,
         GPUColorWrite = GPUColorWrite<Self>,
         GPUCommandBuffer = GPUCommandBuffer<Self>,
+        GPUCommandEncoder = GPUCommandEncoder<Self>,
         GPUCompilationInfo = GPUCompilationInfo<Self>,
         GPUCompilationMessage = GPUCompilationMessage<Self>,
+        GPUComputePassEncoder = GPUComputePassEncoder<Self>,
+        GPUComputePipeline = GPUComputePipeline<Self>,
         GPUDeviceLostInfo = GPUDeviceLostInfo<Self>,
         GPUMapMode = GPUMapMode<Self>,
+        GPUPipelineLayout = GPUPipelineLayout<Self>,
+        GPUQuerySet = GPUQuerySet<Self>,
         GPURenderBundle = GPURenderBundle<Self>,
+        GPURenderBundleEncoder = GPURenderBundleEncoder<Self>,
+        GPURenderPassEncoder = GPURenderPassEncoder<Self>,
+        GPURenderPipeline = GPURenderPipeline<Self>,
+        GPUSampler = GPUSampler<Self>,
+        GPUShaderModule = GPUShaderModule<Self>,
         GPUShaderStage = GPUShaderStage<Self>,
         GPUSupportedFeatures = GPUSupportedFeatures<Self>,
         GPUSupportedLimits = GPUSupportedLimits<Self>,
+        GPUTexture = GPUTexture<Self>,
         GPUTextureUsage = GPUTextureUsage<Self>,
+        GPUTextureView = GPUTextureView<Self>,
         WGSLLanguageFeatures = WGSLLanguageFeatures<Self>>;
 }
 
@@ -76,13 +101,18 @@ pub trait WebGPUPromiseTrait<D: DomTypes> {
     ) -> GenericCallback<Result<Mapping, BufferAccessError>>;
 
     fn callback_promise_gpu(self: &Rc<Self>, d: &GPU<D>) -> GenericCallback<WebGPUAdapterResponse>;
+
+    fn callback_promise_gpushadermodule(
+        self: &Rc<Self>,
+        d: &GPUShaderModule<D>,
+    ) -> GenericCallback<Option<ShaderCompilationInfo>>;
 }
 
 pub trait WebGPUGlobalTrait {
     fn global_wgpu_id_hub(&self) -> Arc<IdentityHub>;
 }
 
-pub trait GPUDeviceTrait<D: DomTypes> {
+pub trait GPUDeviceTrait<D: DomTypes>: DomGlobalGeneric<D> {
     fn is_lost(&self) -> bool;
     fn id(&self) -> WebGPUDevice;
     fn channel(&self) -> WebGPU;
@@ -91,29 +121,13 @@ pub trait GPUDeviceTrait<D: DomTypes> {
         &self,
         gpu_texture_format: &GPUTextureFormat,
     ) -> Fallible<TextureFormat>;
+    fn get_pipeline_layout_data(
+        &self,
+        layout: &GPUPipelineLayoutOrGPUAutoLayoutMode<D>,
+    ) -> PipelineLayout;
+    fn queue_id(&self) -> WebGPUQueue;
 }
 
-pub trait GPUTextureTrait {
-    fn id(&self) -> WebGPUTexture;
-    fn get_default_view(&self, cx: &mut JSContext) -> WebGPUTextureView;
-}
-
-pub trait GPUTextureViewTrait {
-    fn id(&self) -> WebGPUTextureView;
-}
-
-pub trait GPUSamplerTrait {
-    fn id(&self) -> WebGPUSampler;
-}
-
-pub trait GPUExternalTextureTrait {
+pub trait GPUExternalTextureTrait<D: DomTypes> {
     fn id(&self) -> WebGPUExternalTexture;
-}
-
-pub trait GPUQuerySetTrait {
-    fn id(&self) -> WebGPUQuerySet;
-}
-
-pub trait GPUShaderModuleTrait {
-    fn id(&self) -> WebGPUShaderModule;
 }


### PR DESCRIPTION
This moves more WebGPU types to script_webgpu. Including GPUCommandEncoder, GPUComputePassEncoder, GPUComputePipeline, GPUPipelineLayout, GPUQuerySet, GPURenderBundleEncoder, GPURenderPassEncoder, GPURenderPipeline, GPUSampler, GPUShaderModule, GPUTexture and GPUTextureView.
This removes some traits that were introduced in the last PR because they now live in the same crate.
Of note:
- Moving of GPUDevice::PipelineLayout to script_webgpu/lib.rs (this is a small helper enum).
- GPUDevice now has in GPUDeviceTrait global() which sadly means that all calls to global need to be disambiguate with DomGlobal::global() calls.
- GPUExternalTextureTrait got introduced and GPUDeviceTrait extended.
- script_webgpu has more workspace dependencies that are needed.
- Some more usage of script_webgpu::Equivalence in gpuconvert.rs.

Otherwise these are mostly mechanical changes.

Testing: This is a refactor so compilation is the test.
Part of https://github.com/servo/servo/issues/46658
