### PR TITLE
servoshell: Fix non compiling non-gamepad build

### DIFF
--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -231,8 +231,8 @@ impl ApplicationHandler<AppEvent> for App {
                     headed_window.handle_winit_app_event(state.clone(), app_event);
                 }
             },
+            #[cfg(feature = "gamepad")]
             AppEvent::Gamepad(event, gamepad_name, gamepad_index) => {
-                #[cfg(feature = "gamepad")]
                 state.handle_gamepad_events(event, gamepad_name, gamepad_index);
             },
         }

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -232,6 +232,7 @@ impl ApplicationHandler<AppEvent> for App {
                 }
             },
             AppEvent::Gamepad(event, gamepad_name, gamepad_index) => {
+                #[cfg(feature = "gamepad")]
                 state.handle_gamepad_events(event, gamepad_name, gamepad_index);
             },
         }

--- a/ports/servoshell/desktop/event_loop.rs
+++ b/ports/servoshell/desktop/event_loop.rs
@@ -9,7 +9,9 @@ use std::time;
 
 use gilrs::Event;
 use log::warn;
-use servo::{EventLoopWaker, GamepadIndex};
+use servo::EventLoopWaker;
+#[cfg(feature = "gamepad")]
+use servo::GamepadIndex;
 use winit::event_loop::{EventLoop, EventLoop as WinitEventLoop, EventLoopProxy};
 
 use super::app::App;
@@ -19,6 +21,7 @@ pub enum AppEvent {
     /// Another process or thread has kicked the OS event loop with EventLoopWaker.
     Waker,
     Accessibility(egui_winit::accesskit_winit::Event),
+    #[cfg(feature = "gamepad")]
     Gamepad(Event, String, GamepadIndex),
 }
 

--- a/ports/servoshell/desktop/tracing.rs
+++ b/ports/servoshell/desktop/tracing.rs
@@ -53,6 +53,7 @@ mod from_winit {
                 Self::DeviceEvent { .. } => target!("DeviceEvent"),
                 Self::UserEvent(AppEvent::Waker) => target!("UserEvent(Waker)"),
                 Self::UserEvent(AppEvent::Accessibility(..)) => target!("UserEvent(Accessibility)"),
+                #[cfg(feature = "gamepad")]
                 Self::UserEvent(AppEvent::Gamepad(..)) => target!("UserEvent(Gamepad)"),
                 Self::Suspended => target!("Suspended"),
                 Self::Resumed => target!("Resumed"),


### PR DESCRIPTION
Disabling the gamepad feature flag lead to a compilation error. This fixes this error.

Testing: Compilation is the test.
