### PR TITLE
script: Move live ranges to the `Document`

### DIFF
--- a/components/script/dom/characterdata/characterdata.rs
+++ b/components/script/dom/characterdata/characterdata.rs
@@ -24,7 +24,6 @@ use crate::dom::cdatasection::CDATASection;
 use crate::dom::comment::Comment;
 use crate::dom::document::Document;
 use crate::dom::element::Element;
-use crate::dom::live_range_replace_data_steps;
 use crate::dom::mutationobserver::{Mutation, MutationObserver};
 use crate::dom::node::virtualmethods::vtable_for;
 use crate::dom::node::{ChildrenMutation, Node, NodeDamage};
@@ -138,10 +137,11 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
         };
 
         let node: &Node = self.upcast();
-        if let Some(selection) = node.owner_doc_unrooted(cx.no_gc()).selection() {
+        let document = node.owner_doc_unrooted(cx.no_gc());
+        if let Some(selection) = document.selection() {
             selection.replace_data_steps(node, 0, old_length, &mut lazy_length);
         }
-        live_range_replace_data_steps(node, 0, old_length, &mut lazy_length);
+        document.live_range_replace_data_steps(cx.no_gc(), node, 0, old_length, &mut lazy_length);
     }
 
     /// <https://dom.spec.whatwg.org/#dom-characterdata-length>
@@ -273,13 +273,11 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
             *utf16_length.get_or_insert_with(|| Utf16CodeUnits::length_of(&arg.str()).0 as u32)
         };
 
-        if let Some(selection) = node.owner_doc_unrooted(cx.no_gc()).selection() {
+        let document = node.owner_doc_unrooted(cx.no_gc());
+        if let Some(selection) = document.selection() {
             selection.replace_data_steps(node, offset, count, &mut lazy_length);
         }
-
-        if node.has_live_ranges() {
-            live_range_replace_data_steps(node, offset, count, &mut lazy_length);
-        }
+        document.live_range_replace_data_steps(cx.no_gc(), node, offset, count, &mut lazy_length);
 
         // Step 12: If node is a ProcessingInstruction node and piAttributesAlreadyUpdated
         // is false, then update attributes from data given node.

--- a/components/script/dom/characterdata/text.rs
+++ b/components/script/dom/characterdata/text.rs
@@ -18,7 +18,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::characterdata::CharacterData;
 use crate::dom::document::Document;
 use crate::dom::html::htmlslotelement::{HTMLSlotElement, Slottable};
-use crate::dom::live_range_text_split_steps;
 use crate::dom::node::Node;
 use crate::dom::window::Window;
 
@@ -86,8 +85,8 @@ impl TextMethods<crate::DomTypeHolder> for Text {
         let new_data = cdata.SubstringData(offset, count).unwrap();
         // Step 5: Let newNode be the result of creating a text node given node’s node document and newData.
         let node = self.upcast::<Node>();
-        let owner_doc = node.owner_doc();
-        let new_text_node = owner_doc.CreateTextNode(cx, new_data);
+        let document = node.owner_doc();
+        let new_text_node = document.CreateTextNode(cx, new_data);
         // Step 6: Let parent be node’s parent.
         let parent = node.GetParentNode();
         // Step 7: If parent is non-null:
@@ -99,10 +98,10 @@ impl TextMethods<crate::DomTypeHolder> for Text {
                 .unwrap();
 
             // Steps 7.2-7.5: The live range update steps.
-            if let Some(selection) = owner_doc.selection() {
+            if let Some(selection) = document.selection() {
                 selection.text_split_steps(node, offset, parent, new_node);
             }
-            live_range_text_split_steps(parent, node, offset, new_node);
+            document.live_range_text_split_steps(cx.no_gc(), parent, node, offset, new_node);
         }
         // Step 8.
         cdata.DeleteData(cx, offset, count).unwrap();

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -86,7 +86,6 @@ use url::{Host, Position};
 
 use crate::css::stylesheet_loader::StylesheetContextId;
 use crate::css::stylesheet_set::StylesheetSetRef;
-use crate::dom::FlatTreeParent;
 use crate::dom::animationtimeline::AnimationTimeline;
 use crate::dom::attr::Attr;
 use crate::dom::beforeunloadevent::BeforeUnloadEvent;
@@ -216,6 +215,7 @@ use crate::dom::window::scrolling_box::{ScrollAxisState, ScrollingBox};
 use crate::dom::windowproxy::WindowProxy;
 use crate::dom::xpathevaluator::XPathEvaluator;
 use crate::dom::xpathexpression::XPathExpression;
+use crate::dom::{FlatTreeParent, WeakRangeVec};
 use crate::event_loop::document_loader::{DocumentLoader, LoadType};
 use crate::event_loop::script_thread::{ScriptThread, SharedRwLocks};
 use crate::event_loop::timers::{OneshotTimerCallback, OneshotTimers};
@@ -735,6 +735,10 @@ pub(crate) struct Document {
     /// <https://html.spec.whatwg.org/multipage/#concept-document-internal-ancestor-origin-objects-list>
     #[no_trace]
     internal_ancestor_origin_objects_list: RefCell<Option<Vec<ImmutableOrigin>>>,
+
+    /// A vector of weak references to Range instances that are live on
+    /// this document.
+    live_ranges: WeakRangeVec,
 }
 
 impl Document {
@@ -3750,6 +3754,11 @@ impl Document {
 
         computed_objects
     }
+
+    /// Get a reference to this [`Document`]'s vector of weak live ranges.
+    pub(crate) fn live_ranges(&self) -> &WeakRangeVec {
+        &self.live_ranges
+    }
 }
 
 /// Holds DOM object memory sizes for fine-grained memory reports.
@@ -4067,6 +4076,7 @@ impl Document {
             history: Default::default(),
             theme: Default::default(),
             window_detached: Default::default(),
+            live_ranges: Default::default(),
         }
     }
 

--- a/components/script/dom/node/context.rs
+++ b/components/script/dom/node/context.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::Cell;
-
 use crate::dom::Node;
 
 /// The context of the binding to tree of a node.
@@ -58,12 +56,9 @@ impl<'a> BindContext<'a> {
 /// The context of the unbinding from a tree of a node when one of its
 /// inclusive ancestors is removed.
 pub(crate) struct UnbindContext<'a> {
-    /// The index of the inclusive ancestor that was removed.
-    index: Cell<Option<u32>>,
     /// The parent of the inclusive ancestor that was removed.
     pub(crate) parent: &'a Node,
-    /// The previous sibling of the inclusive ancestor that was removed.
-    prev_sibling: Option<&'a Node>,
+
     /// The next sibling of the inclusive ancestor that was removed.
     pub(crate) next_sibling: Option<&'a Node>,
 
@@ -83,31 +78,14 @@ pub(crate) struct UnbindContext<'a> {
 
 impl<'a> UnbindContext<'a> {
     /// Create a new `UnbindContext` value.
-    pub(crate) fn new(
-        parent: &'a Node,
-        prev_sibling: Option<&'a Node>,
-        next_sibling: Option<&'a Node>,
-        cached_index: Option<u32>,
-    ) -> Self {
+    pub(crate) fn new(parent: &'a Node, next_sibling: Option<&'a Node>) -> Self {
         UnbindContext {
-            index: Cell::new(cached_index),
             parent,
-            prev_sibling,
             next_sibling,
             tree_connected: parent.is_connected(),
             tree_is_in_a_document_tree: parent.is_in_a_document_tree(),
             tree_is_in_a_shadow_tree: parent.is_in_a_shadow_tree(),
         }
-    }
-
-    /// The index of the inclusive ancestor that was removed from the tree.
-    pub(crate) fn index(&self) -> u32 {
-        if let Some(index) = self.index.get() {
-            return index;
-        }
-        let index = self.prev_sibling.map_or(0, |sibling| sibling.index() + 1);
-        self.index.set(Some(index));
-        index
     }
 }
 

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -57,6 +57,7 @@ use uuid::Uuid;
 use xml5ever::{local_name, serialize as xml_serialize};
 
 use crate::conversions::Convert;
+use crate::dom::ChildrenMutation;
 use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use crate::dom::bindings::codegen::Bindings::CSSStyleDeclarationBinding::CSSStyleDeclarationMethods;
@@ -117,7 +118,6 @@ use crate::dom::node::iterators::{
 use crate::dom::node::nodelist::NodeList;
 use crate::dom::node::virtualmethods::{VirtualMethods, vtable_for};
 use crate::dom::pointerevent::{PointerEvent, PointerId};
-use crate::dom::range::WeakRangeVec;
 use crate::dom::raredata::NodeRareData;
 use crate::dom::servoparser::html::HtmlSerialize;
 use crate::dom::servoparser::serialize_html_fragment;
@@ -126,11 +126,6 @@ use crate::dom::text::Text;
 use crate::dom::traversal::LightDomNoGcTraversal;
 use crate::dom::types::{CDATASection, KeyboardEvent, MouseEvent, ProcessingInstruction};
 use crate::dom::window::Window;
-use crate::dom::{
-    ChildrenMutation, Range, live_range_insert_steps, live_range_normalization_steps,
-    live_range_pre_remove_steps, live_range_pre_remove_steps_for_parent,
-    live_range_pre_remove_steps_for_removed_subtree,
-};
 use crate::drag::document_selection_drag::DocumentSelectionDragHandler;
 use crate::drag::drag_gesture::{DragGesture, DragHandler};
 use crate::event_loop::document_loader::DocumentLoader;
@@ -518,7 +513,7 @@ impl Node {
     /// Removes the given child from this node's list of children.
     ///
     /// Fails unless `child` is a child of this node.
-    fn remove_child(&self, cx: &mut JSContext, child: &Node, cached_index: Option<u32>) {
+    fn remove_child(&self, cx: &mut JSContext, child: &Node) {
         assert!(child.parent_node.get().as_deref() == Some(self));
 
         if let Some(element) = self.downcast::<Element>() {
@@ -549,12 +544,7 @@ impl Node {
             },
         }
 
-        let context = UnbindContext::new(
-            self,
-            prev_sibling.as_deref(),
-            next_sibling.as_deref(),
-            cached_index,
-        );
+        let context = UnbindContext::new(self, next_sibling.as_deref());
 
         child.prev_sibling.set(None);
         child.next_sibling.set(None);
@@ -835,29 +825,6 @@ impl Node {
 
     pub(crate) fn children_count(&self) -> u32 {
         self.children_count.get()
-    }
-
-    pub(crate) fn ensure_weak_ranges(&self) -> RefMut<'_, WeakRangeVec> {
-        RefMut::map(self.ensure_rare_data(), |rare_data| {
-            &mut rare_data.weak_ranges
-        })
-    }
-
-    /// Whether or not this node has any live ranges.
-    pub(crate) fn has_live_ranges(&self) -> bool {
-        self.rare_data
-            .borrow()
-            .as_ref()
-            .is_some_and(|data| !data.weak_ranges.is_empty())
-    }
-
-    /// Return a `SmallVec` of all live ranges registered on this node.
-    pub(crate) fn live_ranges(&self) -> SmallVec<[DomRoot<Range>; 4]> {
-        let rare_data = self.rare_data.borrow();
-        let Some(rare_data) = &*rare_data else {
-            return Default::default();
-        };
-        rare_data.weak_ranges.live_ranges()
     }
 
     #[inline]
@@ -1463,7 +1430,13 @@ impl Node {
             .expect("old_parent should always be initialized");
 
         // Step 9. Run the live range pre-remove steps, given node.
-        live_range_pre_remove_steps(node, &old_parent);
+        let document = node.owner_doc_unrooted(cx.no_gc());
+        let mut cached_index = None;
+        let mut lazy_index = || *cached_index.get_or_insert_with(|| node.index());
+        if let Some(selection) = document.selection() {
+            selection.pre_remove_steps(node, &old_parent, &mut lazy_index);
+        }
+        document.live_range_pre_remove_steps(cx.no_gc(), node, &old_parent, &mut lazy_index);
 
         // TODO Step 10. For each NodeIterator object iterator whose root’s node document is node’s
         // node document: run the NodeIterator pre-remove steps given node and iterator.
@@ -1535,10 +1508,11 @@ impl Node {
         // Step 17. If child is non-null:
         if let Some(child) = child {
             // Steps 17.1-17.2: The live range move steps.
-            if let Some(selection) = new_parent.owner_document().selection() {
+            let document = new_parent.owner_doc_unrooted(cx.no_gc());
+            if let Some(selection) = document.selection() {
                 selection.insert_steps(new_parent, child, 1);
             }
-            live_range_insert_steps(new_parent, child, 1);
+            document.live_range_insert_steps(cx.no_gc(), new_parent, child, 1);
         }
 
         // Step 18. Let newPreviousSibling be child’s previous sibling if child is non-null, and
@@ -2429,6 +2403,13 @@ impl Node {
                 // Step 3.4. Run the adopting steps with inclusiveDescendant and oldDocument.
                 vtable_for(&descendant).adopting_steps(cx, &old_doc);
             }
+
+            // It's possible that in the process of adopting this node a Range has moved from the
+            // old document to the new one. We must iterate a vector here because
+            // `maybe_udpate_document` modifies the list of Ranges we'd like to iterate.
+            for range in old_doc.live_ranges().as_vec() {
+                range.maybe_update_document();
+            }
         }
 
         old_doc.remove_script_and_layout_blocker(cx);
@@ -2688,10 +2669,11 @@ impl Node {
         if let Some(child) = child {
             // Step 5.1. The live range insert steps.
             let count = count.try_into().unwrap();
-            if let Some(selection) = parent.owner_document().selection() {
+            let document = parent.owner_doc_unrooted(cx.no_gc());
+            if let Some(selection) = document.selection() {
                 selection.insert_steps(parent, child, count);
             }
-            live_range_insert_steps(parent, child, count);
+            document.live_range_insert_steps(cx.no_gc(), parent, child, count);
         }
 
         // Step 6. Let previousSibling be child’s previous sibling or parent’s last child if child is null.
@@ -2991,10 +2973,11 @@ impl Node {
         let mut cached_index = None;
         {
             let mut lazy_index = || *cached_index.get_or_insert_with(|| node.index());
-            if let Some(selection) = node.owner_document().selection() {
-                selection.remove_steps_for_parent(parent, &mut lazy_index);
+            let document = parent.owner_doc_unrooted(cx.no_gc());
+            if let Some(selection) = document.selection() {
+                selection.pre_remove_steps(node, parent, &mut lazy_index);
             }
-            live_range_pre_remove_steps_for_parent(parent, &mut lazy_index);
+            document.live_range_pre_remove_steps(cx.no_gc(), node, parent, &mut lazy_index);
         }
 
         // TODO: Step 4. Pre-removing steps for node iterators
@@ -3007,7 +2990,7 @@ impl Node {
 
         // Step 7. Remove node from its parent's children.
         // Step 11-14. Run removing steps and enqueue disconnected custom element reactions for the subtree.
-        parent.remove_child(cx, node, cached_index);
+        parent.remove_child(cx, node);
 
         // Step 8. If node is assigned, then run assign slottables for node’s assigned slot.
         if let Some(slot) = node.assigned_slot() {
@@ -4046,7 +4029,9 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
     /// <https://dom.spec.whatwg.org/#dom-node-normalize>
     fn Normalize(&self, cx: &mut JSContext) {
         let mut children = self.children().peekable();
-        let selection = self.owner_document().selection();
+
+        let document = self.owner_document();
+        let selection = document.selection();
         while let Some(node) = children.next() {
             // The normalize() method steps are to run these steps for each descendant
             // exclusive Text node node of this:
@@ -4115,7 +4100,14 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
                         length,
                     );
                 }
-                live_range_normalization_steps(self, &node, current_node.upcast(), &index, length);
+                document.live_range_normalization_steps(
+                    cx.no_gc(),
+                    self,
+                    &node,
+                    current_node.upcast(),
+                    &index,
+                    length,
+                );
                 // Step 6.5:  Add currentNode’s length to length.
                 length += current_node.Length();
                 // Step 6.6 Set currentNode to its next sibling.
@@ -4516,23 +4508,6 @@ impl VirtualMethods for Node {
 
         self.owner_doc_unrooted(cx.no_gc())
             .content_and_heritage_changed(cx.no_gc(), self);
-    }
-
-    /// <https://dom.spec.whatwg.org/#concept-node-remove>
-    fn unbind_from_tree(&self, cx: &mut JSContext, context: &UnbindContext) {
-        self.super_type().unwrap().unbind_from_tree(cx, context);
-
-        // The steps are only supposed to run on DOM tree inclusive descendants of the removal
-        // root and elements in shadow trees are not, so they shouldn't run for them.
-        let mut cached_index = None;
-        let mut lazy_index = || *cached_index.get_or_insert_with(|| context.index());
-        if let Some(selection) = self.owner_document().selection() {
-            selection.remove_steps_for_removed_subtree(self, context.parent, &mut lazy_index);
-        }
-
-        if !self.is_in_a_shadow_tree() {
-            live_range_pre_remove_steps_for_removed_subtree(self, context.parent, &mut lazy_index);
-        }
     }
 
     fn moving_steps(&self, cx: &mut JSContext, context: &MoveContext) {

--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::{LazyCell, RefCell};
+use std::cell::LazyCell;
 use std::cmp::Ordering;
 use std::iter;
 use std::rc::Rc;
@@ -14,7 +14,7 @@ use js::context::{JSContext, NoGC};
 use js::jsapi::JSTracer;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
-use script_bindings::dom::UnrootedDom;
+use script_bindings::dom::{MutDom, UnrootedDom};
 use script_bindings::reflector::reflect_weak_referenceable_dom_object_with_proto;
 use smallvec::SmallVec;
 use style_traits::CSSPixel;
@@ -51,6 +51,10 @@ use crate::dom::window::Window;
 #[dom_struct]
 pub(crate) struct Range {
     abstract_range: AbstractRange,
+    /// The [`Document`] that this range belongs to i.e. the owner [`Document`]
+    /// of its two nodes. [`Range`] is written to ensure that both ends share
+    /// a root, so this should always be the same for both ends.
+    document: MutDom<Document>,
     // A range that belongs to a Selection needs to know about it
     // so selectionchange can fire when the range changes.
     // A range shouldn't belong to more than one Selection at a time,
@@ -75,16 +79,18 @@ impl Range {
         start_offset: u32,
         end_container: &Node,
         end_offset: u32,
-    ) -> Range {
+        start_container_document: &Document,
+    ) -> Self {
         debug_assert!(start_offset <= start_container.len());
         debug_assert!(end_offset <= end_container.len());
-        Range {
+        Self {
             abstract_range: AbstractRange::new_inherited(
                 start_container,
                 start_offset,
                 end_container,
                 end_offset,
             ),
+            document: MutDom::new(start_container_document),
             associated_selections: DomRefCell::new(vec![]),
         }
     }
@@ -93,9 +99,9 @@ impl Range {
         cx: &mut JSContext,
         document: &Document,
         proto: Option<HandleObject>,
-    ) -> DomRoot<Range> {
+    ) -> DomRoot<Self> {
         let root = document.upcast();
-        Range::new_with_proto(cx, document, proto, root, 0, root, 0)
+        Self::new_with_proto(cx, document, proto, root, 0, root, 0)
     }
 
     pub(crate) fn new(
@@ -119,32 +125,31 @@ impl Range {
 
     fn new_with_proto(
         cx: &mut JSContext,
-        document: &Document,
+        document_to_reflect_into: &Document,
         proto: Option<HandleObject>,
         start_container: &Node,
         start_offset: u32,
         end_container: &Node,
         end_offset: u32,
     ) -> DomRoot<Range> {
+        let start_container_document = start_container.owner_document();
         let range = reflect_weak_referenceable_dom_object_with_proto(
             cx,
-            Rc::new(Range::new_inherited(
+            Rc::new(Self::new_inherited(
                 start_container,
                 start_offset,
                 end_container,
                 end_offset,
+                &start_container_document,
             )),
-            document.window(),
+            document_to_reflect_into.window(),
             proto,
         );
-        start_container
-            .ensure_weak_ranges()
+
+        start_container_document
+            .live_ranges()
             .push(WeakRef::new(&range));
-        if start_container != end_container {
-            end_container
-                .ensure_weak_ranges()
-                .push(WeakRef::new(&range));
-        }
+
         range
     }
 
@@ -243,18 +248,6 @@ impl Range {
         if self.start().node() == node && self.start_offset() == offset {
             return false;
         }
-
-        if self.start().node() != node {
-            if self.start().node() == self.end().node() {
-                node.ensure_weak_ranges().push(WeakRef::new(self));
-            } else if self.end().node() == node {
-                self.start_container().ensure_weak_ranges().remove(self);
-            } else {
-                node.ensure_weak_ranges()
-                    .push(self.start_container().ensure_weak_ranges().remove(self));
-            }
-        }
-
         self.start().set(node, offset);
         true
     }
@@ -270,17 +263,6 @@ impl Range {
         if self.end().node() == node && self.end_offset() == offset {
             return false;
         }
-        if self.end().node() != node {
-            if self.end().node() == self.start().node() {
-                node.ensure_weak_ranges().push(WeakRef::new(self));
-            } else if self.start().node() == node {
-                self.end_container().ensure_weak_ranges().remove(self);
-            } else {
-                node.ensure_weak_ranges()
-                    .push(self.end_container().ensure_weak_ranges().remove(self));
-            }
-        }
-
         self.end().set(node, offset);
         true
     }
@@ -487,8 +469,32 @@ impl Range {
             },
         }
 
+        self.maybe_update_document();
         self.report_change(notification);
         Ok(())
+    }
+
+    /// When:
+    ///
+    /// - The start and end node have changed in a way in which they no longer have the same
+    ///   [`Document`]
+    /// - A node is adopted into a different [`Document`]
+    ///
+    /// this method ensures that the [`Document`] of this [`Range`] remains the same. If it doesn't
+    /// the [`Range`] is moved from the old [`Document`] to the new one.
+    pub(crate) fn maybe_update_document(&self) {
+        // Note: `debug_assert_eq!` requires the arguments to implement `Debug`.
+        debug_assert!(
+            self.start_container().owner_document() == self.end_container().owner_document(),
+        );
+
+        let current_document = self.document.get();
+        let new_document = self.start_container().owner_document();
+        if new_document != current_document {
+            current_document.live_ranges().remove(self);
+            new_document.live_ranges().push(WeakRef::new(self));
+            self.document.set(&new_document);
+        }
     }
 }
 
@@ -969,6 +975,8 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-detach>
+    /// > The detach() method steps are to do nothing. Its functionality (disabling a Range object)
+    /// > was removed, but the method itself is preserved for compatibility.
     fn Detach(&self) {
         // This method intentionally left blank.
     }
@@ -1367,40 +1375,47 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
 
 #[derive(MallocSizeOf)]
 pub(crate) struct WeakRangeVec {
-    cell: RefCell<WeakRefVec<Range>>,
+    cell: DomRefCell<WeakRefVec<Range>>,
 }
 
 impl Default for WeakRangeVec {
     fn default() -> Self {
         WeakRangeVec {
-            cell: RefCell::new(WeakRefVec::new()),
+            cell: DomRefCell::new(WeakRefVec::new()),
         }
     }
 }
 
 impl WeakRangeVec {
-    /// Whether that vector of ranges is empty.
+    /// Get a rooted version of the contents of this [`WeakRangeVec`]
+    pub(crate) fn as_vec(&self) -> SmallVec<[DomRoot<Range>; 4]> {
+        self.cell
+            .borrow()
+            .iter()
+            .filter_map(|range| range.root())
+            .collect()
+    }
+
+    pub(crate) fn for_each(&self, no_gc: &NoGC, mut callback: impl FnMut(&Range)) {
+        for weak_range in self.cell.safe_borrow_mut(no_gc).iter() {
+            if let Some(range) = weak_range.unrooted(no_gc) {
+                callback(&range);
+            }
+        }
+    }
+
     pub(crate) fn is_empty(&self) -> bool {
         self.cell.borrow().is_empty()
     }
 
-    /// Get a rooted version of the contents of this [`WeakRangeVec`]
-    pub(crate) fn live_ranges(&self) -> SmallVec<[DomRoot<Range>; 4]> {
-        let cell = self.cell.borrow();
-        if cell.is_empty() {
-            return Default::default();
-        }
-        cell.iter().filter_map(|range| range.root()).collect()
+    fn push(&self, weak_range: WeakRef<Range>) {
+        self.cell.borrow_mut().push(weak_range);
     }
 
-    pub(crate) fn push(&self, ref_: WeakRef<Range>) {
-        self.cell.borrow_mut().push(ref_);
-    }
-
-    fn remove(&self, range: &Range) -> WeakRef<Range> {
-        let mut ranges = self.cell.borrow_mut();
-        let position = ranges.iter().position(|ref_| ref_ == range).unwrap();
-        ranges.swap_remove(position)
+    fn remove(&self, range_to_remove: &Range) {
+        self.cell
+            .borrow_mut()
+            .retain(|range| range != range_to_remove);
     }
 }
 
@@ -1411,13 +1426,23 @@ unsafe impl JSTraceable for WeakRangeVec {
     }
 }
 
-/// <https://dom.spec.whatwg.org/#concept-node-insert> steps 5.1-5.2
-/// and
-/// <https://dom.spec.whatwg.org/#move> steps 17.1-17.2.
-pub(crate) fn live_range_insert_steps(parent: &Node, child: &Node, count: u32) {
-    if parent.has_live_ranges() {
+impl Document {
+    /// <https://dom.spec.whatwg.org/#concept-node-insert> steps 5.1-5.2
+    /// and
+    /// <https://dom.spec.whatwg.org/#move> steps 17.1-17.2.
+    pub(crate) fn live_range_insert_steps(
+        &self,
+        no_gc: &NoGC,
+        parent: &Node,
+        child: &Node,
+        count: u32,
+    ) {
+        if self.live_ranges().is_empty() {
+            return;
+        }
+
         let child_index = LazyCell::new(|| child.index());
-        for range in parent.live_ranges() {
+        self.live_ranges().for_each(no_gc, |range| {
             // Step 5.1: For each live range whose start node is parent and start offset is
             // greater than child’s index: increase its start offset by count.
             if &*range.start_container() == parent && range.start_offset() > *child_index {
@@ -1428,219 +1453,205 @@ pub(crate) fn live_range_insert_steps(parent: &Node, child: &Node, count: u32) {
             if &*range.end_container() == parent && range.end_offset() > *child_index {
                 range.set_end_without_reporting(parent, range.end_offset() + count);
             }
-        }
-    }
-}
-
-/// <https://dom.spec.whatwg.org/#live-range-pre-remove-steps> steps 4 and 5.
-///
-/// These steps are run on the inclusive descendants of a removed node, but to avoid
-/// having to iterate through those nodes twice, they are run when the inclusive
-/// descendants themselves are unbound from the tree.
-pub(crate) fn live_range_pre_remove_steps_for_removed_subtree(
-    inclusive_descendant_of_removed_node: &Node, // "node" in the specification
-    parent_of_removed_node: &Node,               // "parent" in the specification
-    index_of_removed_node: &mut dyn FnMut() -> u32, // "index" in the specification
-) {
-    for range in inclusive_descendant_of_removed_node.live_ranges() {
-        // Step 4: For each live range whose start node is an inclusive descendant of
-        // node, set its start to (parent, index).
-        if &*range.start_container() == inclusive_descendant_of_removed_node {
-            range.set_start_without_reporting(parent_of_removed_node, index_of_removed_node());
-        }
-        // Step 5: For each live range whose end node is an inclusive descendant of node,
-        // set its end to (parent, index).
-        if &*range.end_container() == inclusive_descendant_of_removed_node {
-            range.set_end_without_reporting(parent_of_removed_node, index_of_removed_node());
-        }
-    }
-}
-
-/// <https://dom.spec.whatwg.org/#live-range-pre-remove-steps> steps 6 and 7.
-pub(crate) fn live_range_pre_remove_steps_for_parent(
-    parent: &Node,
-    node_index: &mut dyn FnMut() -> u32,
-) {
-    for range in parent.live_ranges() {
-        // Step 6: For each live range whose start node is parent and start offset is
-        // greater than index, decrease its start offset by 1.
-        if &*range.start_container() == parent && range.start_offset() > node_index() {
-            range.set_start_without_reporting(parent, range.start_offset() - 1);
-        }
-        // Step 7: For each live range whose end node is parent and end offset is greater than
-        // index, decrease its end offset by 1.
-        if &*range.end_container() == parent && range.end_offset() > node_index() {
-            range.set_end_without_reporting(parent, range.end_offset() - 1);
-        }
-    }
-}
-
-/// <https://dom.spec.whatwg.org/#dom-node-normalize> Steps 6.1-6.4.
-///
-/// - `parent`: The parent of both other node arguments.
-/// - `node`: The node that text is being merged into.
-/// - `current_node`: The node which has text being merged into `node` and will be
-///   removed from the DOM.
-/// - `current_node_index`: The index of `current_node` in `parent`.
-/// - `length`: The length of the text content in `node`, its orginal length plus
-///   the length of all content that has already been merged from siblings before
-///   `current_node`.
-pub(crate) fn live_range_normalization_steps(
-    parent: &Node,
-    node: &Node,
-    current_node: &Node,
-    current_node_index: &dyn Fn() -> u32,
-    length: u32,
-) {
-    for range in current_node.live_ranges() {
-        // Step 6.1: For each live range whose start node is currentNode: add length to
-        // its start offset and set its start node to node.
-        if &*range.start_container() == current_node {
-            range.set_start_without_reporting(node, range.start_offset() + length);
-        }
-        // Step 6.2: For each live range whose end node is currentNode: add length to its
-        // end offset and set its end node to node.
-        if &*range.end_container() == current_node {
-            range.set_end_without_reporting(node, range.end_offset() + length);
-        }
+        });
     }
 
-    for range in parent.live_ranges() {
-        // Step 6.3: For each live range whose start node is currentNode’s parent and
-        // start offset is currentNode’s index: set its start node to node and its start
-        // offset to length.
-        if &*range.start_container() == parent && range.start_offset() == current_node_index() {
-            range.set_start_without_reporting(node, length);
+    /// <https://dom.spec.whatwg.org/#live-range-pre-remove-steps> steps 4-7.
+    pub(crate) fn live_range_pre_remove_steps(
+        &self,
+        no_gc: &NoGC,
+        removed_node: &Node,           // "node" in the specification
+        parent_of_removed_node: &Node, // "parent" in the specification
+        index_of_removed_node: &mut dyn FnMut() -> u32, // "index" in the specification
+    ) {
+        if self.live_ranges().is_empty() {
+            return;
         }
-        // Step 6.4: For each live range whose end node is currentNode’s parent and end
-        // offset is currentNode’s index: set its end node to node and its end offset to
-        // length.
-        if &*range.end_container() == parent && range.end_offset() == current_node_index() {
-            range.set_end_without_reporting(node, length);
-        }
-    }
-}
 
-/// <https://dom.spec.whatwg.org/#concept-cd-replace> steps 8-11.
-pub(crate) fn live_range_replace_data_steps(
-    node: &Node,
-    offset: u32,
-    removed_code_units: u32,
-    added_code_units: &mut dyn FnMut() -> u32,
-) {
-    for range in node.live_ranges() {
-        // Step 8: For each live range whose start node is node and start offset is
-        // greater than offset but less than or equal to offset + count: set its start
-        // offset to offset.
-        let start_container = range.start_container();
-        let start_offset = range.start_offset();
-        if &*start_container == node &&
-            start_offset > offset &&
-            start_offset <= offset + removed_code_units
-        {
-            range.set_start_without_reporting(node, offset);
-        }
-        // Step 9: For each live range whose end node is node and end offset is
-        // greater than offset but less than or equal to offset + count: set its end
-        // offset to offset.
-        let end_container = range.end_container();
-        let end_offset = range.end_offset();
-        if &*end_container == node &&
-            end_offset > offset &&
-            end_offset <= offset + removed_code_units
-        {
-            range.set_end_without_reporting(node, offset);
-        }
-        // Step 10: For each live range whose start node is node and start offset is
-        // greater than offset + count: increase its start offset by data’s length and
-        // decrease it by count.
-        if &*start_container == node && start_offset > offset + removed_code_units {
-            range.set_start_without_reporting(
-                node,
-                start_offset + added_code_units() - removed_code_units,
-            );
-        }
-        // Step 11: For each live range whose end node is node and end offset is
-        // greater than offset + count: increase its end offset by data’s length and
-        // decrease it by count.
-        if &*end_container == node && end_offset > offset + removed_code_units {
-            range.set_end_without_reporting(
-                node,
-                end_offset + added_code_units() - removed_code_units,
-            );
-        }
-    }
-}
+        // Step 1. Let parent be node’s parent.
+        // Note: This is `parent_of_removed_node`.
+        // Step 2. Assert: parent is non-null.
+        // Note: Cannot be null.
 
-/// <https://dom.spec.whatwg.org/#concept-text-split> steps 7.2-7.5.
-pub(crate) fn live_range_text_split_steps(
-    parent: &Node,
-    node: &Node,
-    offset: u32,
-    new_node: &Node,
-) {
-    for range in node.live_ranges() {
-        // Step 7.2. For each live range whose start node is node and start offset is
-        // greater than offset, set its start node to newNode and decrease its start
-        // offset by offset.
-        if &*range.start_container() == node && range.start_offset() > offset {
-            range.set_start_without_reporting(new_node, range.start_offset() - offset);
-        }
-        // Step 7.3. For each live range whose end node is node and end offset is
-        // greater than offset, set its end node to newNode and decrease its end
-        // offset by offset.
-        if &*range.end_container() == node && range.end_offset() > offset {
-            range.set_end_without_reporting(new_node, range.end_offset() - offset);
-        }
+        // Step 3. Let index be node’s index.
+        // Note: This is `index_of_removed_node`.
+
+        self.live_ranges().for_each(no_gc, |range| {
+            // Step 4: For each live range whose start node is an inclusive descendant of
+            // node, set its start to (parent, index).
+            let start_container = range.start_container();
+            if removed_node.is_inclusive_ancestor_of(&start_container) {
+                range.set_start_without_reporting(parent_of_removed_node, index_of_removed_node());
+            }
+            // Step 5: For each live range whose end node is an inclusive descendant of node,
+            // set its end to (parent, index).
+            if removed_node.is_inclusive_ancestor_of(&range.end_container()) {
+                range.set_end_without_reporting(parent_of_removed_node, index_of_removed_node());
+            }
+
+            // Step 6: For each live range whose start node is parent and start offset is
+            // greater than index, decrease its start offset by 1.
+            if &*range.start_container() == parent_of_removed_node &&
+                range.start_offset() > index_of_removed_node()
+            {
+                range.set_start_without_reporting(parent_of_removed_node, range.start_offset() - 1);
+            }
+            // Step 7: For each live range whose end node is parent and end offset is greater than
+            // index, decrease its end offset by 1.
+            if &*range.end_container() == parent_of_removed_node &&
+                range.end_offset() > index_of_removed_node()
+            {
+                range.set_end_without_reporting(parent_of_removed_node, range.end_offset() - 1);
+            }
+        });
     }
 
-    let node_index = LazyCell::new(|| node.index());
-    for range in parent.live_ranges() {
-        // Step 7.4. For each live range whose start node is parent and start offset
-        // is equal to the index of node plus 1, increase its start offset by 1.
-        if &*range.start_container() == parent && range.start_offset() == *node_index + 1 {
-            range.set_start_without_reporting(parent, range.start_offset() + 1);
+    /// <https://dom.spec.whatwg.org/#dom-node-normalize> Steps 6.1-6.4.
+    ///
+    /// - `parent`: The parent of both other node arguments.
+    /// - `node`: The node that text is being merged into.
+    /// - `current_node`: The node which has text being merged into `node` and will be
+    ///   removed from the DOM.
+    /// - `current_node_index`: The index of `current_node` in `parent`.
+    /// - `length`: The length of the text content in `node`, its original length plus
+    ///   the length of all content that has already been merged from siblings before
+    ///   `current_node`.
+    pub(crate) fn live_range_normalization_steps(
+        &self,
+        no_gc: &NoGC,
+        parent: &Node,
+        node: &Node,
+        current_node: &Node,
+        current_node_index: &dyn Fn() -> u32,
+        length: u32,
+    ) {
+        if self.live_ranges().is_empty() {
+            return;
         }
 
-        // Step 7.5. For each live range whose end node is parent and end offset is
-        // equal to the index of node plus 1, increase its end offset by 1.
-        if &*range.end_container() == parent && range.end_offset() == *node_index + 1 {
-            range.set_end_without_reporting(parent, range.end_offset() + 1);
+        self.live_ranges().for_each(no_gc, |range| {
+            // Step 6.1: For each live range whose start node is currentNode: add length to
+            // its start offset and set its start node to node.
+            if &*range.start_container() == current_node {
+                range.set_start_without_reporting(node, range.start_offset() + length);
+            }
+            // Step 6.2: For each live range whose end node is currentNode: add length to its
+            // end offset and set its end node to node.
+            if &*range.end_container() == current_node {
+                range.set_end_without_reporting(node, range.end_offset() + length);
+            }
+
+            // Step 6.3: For each live range whose start node is currentNode’s parent and
+            // start offset is currentNode’s index: set its start node to node and its start
+            // offset to length.
+            if &*range.start_container() == parent && range.start_offset() == current_node_index() {
+                range.set_start_without_reporting(node, length);
+            }
+            // Step 6.4: For each live range whose end node is currentNode’s parent and end
+            // offset is currentNode’s index: set its end node to node and its end offset to
+            // length.
+            if &*range.end_container() == parent && range.end_offset() == current_node_index() {
+                range.set_end_without_reporting(node, length);
+            }
+        });
+    }
+
+    /// <https://dom.spec.whatwg.org/#concept-cd-replace> steps 8-11.
+    pub(crate) fn live_range_replace_data_steps(
+        &self,
+        no_gc: &NoGC,
+        node: &Node,
+        offset: u32,
+        removed_code_units: u32,
+        added_code_units: &mut dyn FnMut() -> u32,
+    ) {
+        if self.live_ranges().is_empty() {
+            return;
         }
+
+        self.live_ranges().for_each(no_gc, |range| {
+            // Step 8: For each live range whose start node is node and start offset is
+            // greater than offset but less than or equal to offset + count: set its start
+            // offset to offset.
+            let start_container = range.start_container();
+            let start_offset = range.start_offset();
+            if &*start_container == node &&
+                start_offset > offset &&
+                start_offset <= offset + removed_code_units
+            {
+                range.set_start_without_reporting(node, offset);
+            }
+            // Step 9: For each live range whose end node is node and end offset is
+            // greater than offset but less than or equal to offset + count: set its end
+            // offset to offset.
+            let end_container = range.end_container();
+            let end_offset = range.end_offset();
+            if &*end_container == node &&
+                end_offset > offset &&
+                end_offset <= offset + removed_code_units
+            {
+                range.set_end_without_reporting(node, offset);
+            }
+            // Step 10: For each live range whose start node is node and start offset is
+            // greater than offset + count: increase its start offset by data’s length and
+            // decrease it by count.
+            if &*start_container == node && start_offset > offset + removed_code_units {
+                range.set_start_without_reporting(
+                    node,
+                    start_offset + added_code_units() - removed_code_units,
+                );
+            }
+            // Step 11: For each live range whose end node is node and end offset is
+            // greater than offset + count: increase its end offset by data’s length and
+            // decrease it by count.
+            if &*end_container == node && end_offset > offset + removed_code_units {
+                range.set_end_without_reporting(
+                    node,
+                    end_offset + added_code_units() - removed_code_units,
+                );
+            }
+        });
     }
-}
 
-/// <https://dom.spec.whatwg.org/#live-range-pre-remove-steps>
-pub(crate) fn live_range_pre_remove_steps(node: &Node, old_parent: &Node) {
-    // Step 1. Let parent be node’s parent.
-    // Note: This is `old_parent`.
-    // Step 2. Assert: parent is non-null.
-    // Note: Cannot be null.
-
-    // Step 3. Let index be node’s index.
-    let mut cached_index = None;
-    let mut lazy_index = || *cached_index.get_or_insert_with(|| node.index());
-
-    // Step 4. For each live range whose start node is an inclusive descendant of node,
-    // set its start to (parent, index).
-    // Step 5. For each live range whose end node is an inclusive descendant of node, set
-    // its end to (parent, index).
-    //
-    // TODO: Only run this part if there are live ranges in this subtree and/or a selection.
-    let selection = node.owner_document().selection();
-    for descendant in node.traverse_preorder(ShadowIncluding::No) {
-        if let Some(selection) = &selection {
-            selection.remove_steps_for_removed_subtree(&descendant, old_parent, &mut lazy_index);
+    /// <https://dom.spec.whatwg.org/#concept-text-split> steps 7.2-7.5.
+    pub(crate) fn live_range_text_split_steps(
+        &self,
+        no_gc: &NoGC,
+        parent: &Node,
+        node: &Node,
+        offset: u32,
+        new_node: &Node,
+    ) {
+        if self.live_ranges().is_empty() {
+            return;
         }
-        live_range_pre_remove_steps_for_removed_subtree(&descendant, old_parent, &mut lazy_index);
-    }
 
-    // Step 6. For each live range whose start node is parent and start offset is greater
-    // than index, decrease its start offset by 1.
-    // Step 7. For each live range whose end node is parent and end offset is greater than
-    // index, decrease its end offset by 1.
-    if let Some(selection) = &selection {
-        selection.remove_steps_for_parent(old_parent, &mut lazy_index);
+        let node_index = LazyCell::new(|| node.index());
+        self.live_ranges().for_each(no_gc, |range| {
+            // Step 7.2. For each live range whose start node is node and start offset is
+            // greater than offset, set its start node to newNode and decrease its start
+            // offset by offset.
+            if &*range.start_container() == node && range.start_offset() > offset {
+                range.set_start_without_reporting(new_node, range.start_offset() - offset);
+            }
+            // Step 7.3. For each live range whose end node is node and end offset is
+            // greater than offset, set its end node to newNode and decrease its end
+            // offset by offset.
+            if &*range.end_container() == node && range.end_offset() > offset {
+                range.set_end_without_reporting(new_node, range.end_offset() - offset);
+            }
+
+            // Step 7.4. For each live range whose start node is parent and start offset
+            // is equal to the index of node plus 1, increase its start offset by 1.
+            if &*range.start_container() == parent && range.start_offset() == *node_index + 1 {
+                range.set_start_without_reporting(parent, range.start_offset() + 1);
+            }
+
+            // Step 7.5. For each live range whose end node is parent and end offset is
+            // equal to the index of node plus 1, increase its end offset by 1.
+            if &*range.end_container() == parent && range.end_offset() == *node_index + 1 {
+                range.set_end_without_reporting(parent, range.end_offset() + 1);
+            }
+        });
     }
-    live_range_pre_remove_steps_for_parent(old_parent, &mut lazy_index);
 }

--- a/components/script/dom/raredata.rs
+++ b/components/script/dom/raredata.rs
@@ -20,7 +20,7 @@ use crate::dom::html::internals::elementinternals::ElementInternals;
 use crate::dom::intersectionobserver::IntersectionObserverRegistration;
 use crate::dom::mutationobserver::RegisteredObserver;
 use crate::dom::nodelist::NodeList;
-use crate::dom::range::{Range, WeakRangeVec};
+use crate::dom::range::Range;
 use crate::dom::shadowroot::ShadowRoot;
 use crate::dom::types::Element;
 use crate::dom::window::LayoutValue;
@@ -41,12 +41,6 @@ pub(crate) struct NodeRareData {
     pub(crate) unique_id: Option<UniqueId>,
 
     pub(crate) slottable_data: SlottableData,
-
-    /// A vector of weak references to Range instances of which the start
-    /// or end containers are this node. No range should ever be found
-    /// twice in this vector, even if both the start and end containers
-    /// are this node.
-    pub(crate) weak_ranges: WeakRangeVec,
 
     /// The live list of children return by .childNodes.
     pub(crate) child_list: MutNullableDom<NodeList>,

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -583,57 +583,44 @@ impl Selection {
         }
     }
 
-    /// <https://dom.spec.whatwg.org/#live-range-pre-remove-steps> steps 4 and 5
+    /// <https://dom.spec.whatwg.org/#live-range-pre-remove-steps> steps 4-7
     /// adapted for selections.
-    ///
-    /// These steps are run on the inclusive descendants of a removed node, but to avoid
-    /// having to iterate through those nodes twice, they are run when the inclusive
-    /// descendants themselves are unbound from the tree.
-    pub(crate) fn remove_steps_for_removed_subtree(
+    pub(crate) fn pre_remove_steps(
         &self,
-        inclusive_descendant_of_removed_node: &Node, // "node" in the specification
-        parent_of_removed_node: &Node,               // "parent" in the specification
+        removed_node: &Node,           // "node" in the specification
+        parent_of_removed_node: &Node, // "parent" in the specification
         index_of_removed_node: &mut dyn FnMut() -> u32, // "index" in the specification
     ) {
         let mut range_borrow = self.range.borrow_mut();
         let Some(range) = &mut *range_borrow else {
             return;
         };
+
         // Step 4: For each live range whose start node is an inclusive descendant of
         // node, set its start to (parent, index).
-        if range.start.container == inclusive_descendant_of_removed_node {
+        if removed_node.is_shadow_including_inclusive_ancestor_of(&range.start.container) {
             range.start = SelectionBoundary::new(parent_of_removed_node, index_of_removed_node());
             self.selection_boundaries_changed();
         }
         // Step 5: For each live range whose end node is an inclusive descendant of node,
         // set its end to (parent, index).
-        if range.end.container == inclusive_descendant_of_removed_node {
+        if removed_node.is_shadow_including_inclusive_ancestor_of(&range.end.container) {
             range.end = SelectionBoundary::new(parent_of_removed_node, index_of_removed_node());
             self.selection_boundaries_changed();
         }
-    }
-
-    /// <https://dom.spec.whatwg.org/#live-range-pre-remove-steps> steps 6 and 7
-    /// adapted for selections.
-    pub(crate) fn remove_steps_for_parent(
-        &self,
-        parent: &Node,
-        node_index: &mut dyn FnMut() -> u32,
-    ) {
-        let mut range_borrow = self.range.borrow_mut();
-        let Some(range) = &mut *range_borrow else {
-            return;
-        };
-
         // Step 6: For each live range whose start node is parent and start offset is
         // greater than index, decrease its start offset by 1.
-        if range.start.container == parent && range.start.offset > node_index() {
+        if range.start.container == parent_of_removed_node &&
+            range.start.offset > index_of_removed_node()
+        {
             range.start.offset -= 1;
             self.selection_boundaries_changed();
         }
         // Step 7: For each live range whose end node is parent and end offset is greater than
         // index, decrease its end offset by 1.
-        if range.end.container == parent && range.end.offset > node_index() {
+        if range.end.container == parent_of_removed_node &&
+            range.end.offset > index_of_removed_node()
+        {
             range.end.offset -= 1;
             self.selection_boundaries_changed();
         }

--- a/components/script_bindings/weakref.rs
+++ b/components/script_bindings/weakref.rs
@@ -15,12 +15,14 @@ use std::hash::{Hash, Hasher};
 use std::rc::{Rc, Weak};
 use std::{mem, ptr};
 
+use js::context::NoGC;
 use js::jsapi::JSTracer;
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 
 use crate::JSTraceable;
+use crate::dom::UnrootedDom;
 use crate::reflector::DomObject;
-use crate::root::DomRoot;
+use crate::root::{Dom, DomRoot};
 
 /// A weak reference to a JS-managed DOM object.
 #[derive(Clone)]
@@ -57,6 +59,14 @@ impl<T: WeakReferenceable> WeakRef<T> {
     /// DomRoot a weak reference. Returns `None` if the object was already collected.
     pub fn root(&self) -> Option<DomRoot<T>> {
         self.0.upgrade().map(|x| DomRoot::from_ref(&*x))
+    }
+
+    /// Return an [`UnrootedDom`] reference to the data contained in this [`WeakRef`],
+    /// if it is still alive.
+    pub fn unrooted<'a>(&self, no_gc: &'a NoGC) -> Option<UnrootedDom<'a, T>> {
+        self.0
+            .upgrade()
+            .map(|x| UnrootedDom::from_dom(Dom::from_ref(&*x), no_gc))
     }
 
     /// Return whether the weakly-referenced object is still alive.


### PR DESCRIPTION
This change moves the live `Range` objects to be stored on the
`Document` itself. In addition to more closely matching the
specification, this allows avoiding another full subtree traversal
during `moveBefore`. In addition, this reduces rooting and
per-node-in-subtree operations during node removal.

Testing: This should not change observable behavior so should be covered by existing tests.
