### PR TITLE
shared: Compact `Utf8CodeUnits` and friends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8063,6 +8063,7 @@ name = "servo-base"
 version = "0.6.0"
 dependencies = [
  "accesskit",
+ "cfg-if",
  "crossbeam-channel",
  "ipc-channel",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8063,7 +8063,6 @@ name = "servo-base"
 version = "0.6.0"
 dependencies = [
  "accesskit",
- "cfg-if",
  "crossbeam-channel",
  "ipc-channel",
  "libc",

--- a/components/fonts/glyph.rs
+++ b/components/fonts/glyph.rs
@@ -13,7 +13,7 @@ use euclid::num::Zero;
 use itertools::Either;
 use log::{debug, error};
 use malloc_size_of_derive::MallocSizeOf;
-use serde::{Deserialize, Serialize};
+use servo_base::text::Utf32CodeUnits;
 
 use crate::{GlyphShapingResult, ShapedGlyph, ShapingOptions};
 
@@ -24,7 +24,7 @@ use crate::{GlyphShapingResult, ShapedGlyph, ShapingOptions};
 ///
 /// In the uncommon case (multiple glyphs per unicode character, large glyph index/advance, or glyph
 /// offsets), we create a DetailedGlyphEntry for the glyph and pack its index into the GlyphEntry.
-#[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, MallocSizeOf, PartialEq)]
 pub struct GlyphEntry {
     value: u32,
 }
@@ -125,7 +125,7 @@ impl GlyphEntry {
     }
 }
 
-#[derive(Clone, Deserialize, MallocSizeOf, Serialize)]
+#[derive(Clone, MallocSizeOf)]
 pub struct DetailedGlyphEntry {
     /// The id of the this glyph within the font.
     id: u32,
@@ -136,7 +136,7 @@ pub struct DetailedGlyphEntry {
     offset: Option<Point2D<Au>>,
     /// The number of character this glyph corresponds to in the original string.
     /// This might be zero and this might be more than one.
-    character_count: usize,
+    character_count: Utf32CodeUnits,
     /// Whether or not the originating character for this glyph was a word separator
     is_word_separator: bool,
 }
@@ -185,9 +185,9 @@ impl GlyphInfo<'_> {
     /// than one when a single glyph is produced for multiple characters. This may
     /// be zero when multiple glyphs are produced for a single character.
     #[inline]
-    pub fn character_count(self) -> usize {
+    pub fn character_count(self) -> Utf32CodeUnits {
         match self {
-            GlyphInfo::Simple(..) => 1,
+            GlyphInfo::Simple(..) => Utf32CodeUnits(1),
             GlyphInfo::Detail(entry) => entry.character_count,
         }
     }
@@ -211,7 +211,7 @@ impl GlyphInfo<'_> {
 /// |               +---+---+                     |
 /// +---------------------------------------------+
 /// ~~~
-#[derive(Clone, Deserialize, MallocSizeOf, Serialize)]
+#[derive(Clone, MallocSizeOf)]
 pub struct ShapedText {
     // TODO(pcwalton): Allocation of this buffer is expensive. Consider a small-vector
     // optimization.
@@ -228,7 +228,7 @@ pub struct ShapedText {
     total_advance: Au,
 
     /// The number of characters that correspond to the glyphs in this [`ShapedText`]
-    character_count: usize,
+    character_count: Utf32CodeUnits,
 
     /// A cache of the number of word separators in the entire glyph store.
     /// See <https://drafts.csswg.org/css-text/#word-separator>.
@@ -248,7 +248,7 @@ impl ShapedText {
             glyphs: Vec::with_capacity(length),
             detailed_glyphs: Default::default(),
             total_advance: Au::zero(),
-            character_count: 0,
+            character_count: Utf32CodeUnits(0),
             total_word_separators: 0,
             is_rtl,
         }
@@ -349,7 +349,7 @@ impl ShapedText {
     }
 
     /// Get the number of characters that were shaped to produce this [`ShapedText`].
-    pub fn character_count(&self) -> usize {
+    pub fn character_count(&self) -> Utf32CodeUnits {
         self.character_count
     }
 
@@ -357,7 +357,7 @@ impl ShapedText {
     #[inline]
     pub(crate) fn add_glyph(&mut self, character: char, glyph: &ShapedGlyph) {
         if !glyph.can_be_simple_glyph() {
-            self.add_detailed_glyph(glyph, Some(character), 1);
+            self.add_detailed_glyph(glyph, Some(character), Utf32CodeUnits(1));
             return;
         }
 
@@ -367,7 +367,7 @@ impl ShapedText {
             simple_glyph_entry.set_char_is_word_separator();
         }
 
-        self.character_count += 1;
+        self.character_count += Utf32CodeUnits(1);
         self.total_advance += glyph.advance;
         self.glyphs.push(simple_glyph_entry)
     }
@@ -376,7 +376,7 @@ impl ShapedText {
         &mut self,
         shaped_glyph: &ShapedGlyph,
         character: Option<char>,
-        character_count: usize,
+        character_count: Utf32CodeUnits,
     ) {
         let is_word_separator = character.is_some_and(character_is_word_separator);
         if is_word_separator {
@@ -402,8 +402,8 @@ impl ShapedText {
             .detailed_glyphs
             .get_mut(detailed_glyph_index)
             .expect("GlyphEntry should have valid index to detailed glyph");
-        detailed_glyph.character_count += 1;
-        self.character_count += 1;
+        detailed_glyph.character_count += Utf32CodeUnits(1);
+        self.character_count += Utf32CodeUnits(1);
     }
 
     fn add_glyph_for_current_character(
@@ -425,7 +425,7 @@ impl ShapedText {
 
         // Add a detailed glyph entry for this new glyph, but it corresponds to a character
         // we have already started processing. It should not contribute any character count.
-        self.add_detailed_glyph(shaped_glyph, None, 0);
+        self.add_detailed_glyph(shaped_glyph, None, Utf32CodeUnits(0));
     }
 
     /// If the last glyph added to this [`ShapedText`] was a simple glyph, convert it to a
@@ -444,7 +444,7 @@ impl ShapedText {
             id: last_glyph.id(),
             advance: last_glyph.advance(),
             offset: Default::default(),
-            character_count: 1,
+            character_count: Utf32CodeUnits(1),
             is_word_separator: last_glyph.char_is_word_separator(),
         });
 
@@ -545,7 +545,7 @@ impl fmt::Debug for ShapedText {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+#[derive(Clone, Debug, MallocSizeOf)]
 pub enum ShapedTextSliceType {
     /// A [`ShapedTextSlice`] that is a word that is not followed by white space.
     Word,
@@ -560,7 +560,7 @@ pub enum ShapedTextSliceType {
 /// A slice of a [`ShapedText`] which allows having different views into a shaped
 /// text run. This is used for splitting up shaped text during layout, without
 /// duplicating the entire run.
-#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+#[derive(Clone, Debug, MallocSizeOf)]
 pub struct ShapedTextSlice {
     /// The [`ShapedText`] that this [`ShapedTextSlice`] refers to.
     #[conditional_malloc_size_of]
@@ -573,7 +573,7 @@ pub struct ShapedTextSlice {
     total_advance: Au,
 
     /// The number of characters that correspond to the glyphs in this [`ShapedTextSlice`]
-    character_count: usize,
+    character_count: Utf32CodeUnits,
 
     /// A precomputed count of the number of word separators in the entire [`ShapedTextSlice`]. See
     /// <https://drafts.csswg.org/css-text/#word-separator>.
@@ -594,7 +594,7 @@ impl ShapedTextSlice {
     /// characters correspond to more than one glyph and some glyphs correspond to more than
     /// one character.
     #[inline]
-    pub fn character_count(&self) -> usize {
+    pub fn character_count(&self) -> Utf32CodeUnits {
         self.character_count
     }
 
@@ -634,7 +634,7 @@ impl ShapedTextSlice {
 /// A data structure used to efficiently slice up a [`ShapedText`] into [`ShapedTextSlice`]s.
 pub struct ShapedTextSlicer {
     current_glyph_offset: usize,
-    current_character_offset: usize,
+    current_character_offset: Utf32CodeUnits,
     shaped_text: Arc<ShapedText>,
 }
 
@@ -648,7 +648,7 @@ impl ShapedTextSlicer {
 
         Self {
             current_glyph_offset,
-            current_character_offset: 0,
+            current_character_offset: Utf32CodeUnits(0),
             shaped_text,
         }
     }
@@ -659,7 +659,7 @@ impl ShapedTextSlicer {
     /// properties. Returns `None` if the resulting slice would not hold any glyphs.
     pub fn slice_until_character_offset(
         &mut self,
-        desired_character_offset: usize,
+        desired_character_offset: Utf32CodeUnits,
         slice_type: ShapedTextSliceType,
     ) -> Option<Arc<ShapedTextSlice>> {
         let mut glyph_count = 0;
@@ -692,7 +692,7 @@ impl ShapedTextSlicer {
             // When glyphs span two character slices, prioritize the first slice and also
             // ensure that glyphs that span zero characters are also included there.
             if self.current_character_offset >= desired_character_offset &&
-                glyph.character_count() > 0
+                glyph.character_count().0 > 0
             {
                 break;
             }

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -16,7 +16,6 @@ use net_traits::image_cache::Image as CachedImage;
 use paint_api::display_list::{PaintDisplayListInfo, SpatialTreeNodeInfo};
 use servo_arc::Arc as ServoArc;
 use servo_base::id::{PipelineId, ScrollTreeNodeId};
-use servo_base::text::Utf32CodeUnits;
 use servo_config::opts::{DiagnosticsLogging, DiagnosticsLoggingOption};
 use servo_config::{pref, prefs};
 use servo_url::ServoUrl;
@@ -1343,7 +1342,7 @@ impl Fragment {
         let mut start_advance = None;
         let mut end_advance = None;
         for glyph_store in fragment.glyphs.iter() {
-            let glyph_store_character_count = Utf32CodeUnits(glyph_store.character_count());
+            let glyph_store_character_count = glyph_store.character_count();
             if current_character_index + glyph_store_character_count <
                 selection_character_range.start
             {
@@ -1362,7 +1361,7 @@ impl Fragment {
                     start_advance = start_advance.or(Some(current_advance));
                 }
 
-                current_character_index += Utf32CodeUnits(glyph.character_count());
+                current_character_index += glyph.character_count();
                 current_advance += glyph.advance();
                 if glyph.char_is_word_separator() {
                     current_advance += justification_adjustment;

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -343,10 +343,8 @@ impl InlineFormattingContextBuilder {
         if first_letter_range.start != 0 {
             let leading_whitespace_range = 0..first_letter_range.start;
             let leading_whitespace_selection_range = selection.and_then(|range| {
-                let leading_whitespace_range_u32 = RangeAny {
-                    start: None,
-                    end: Some(first_letter_range_u32.start),
-                };
+                let leading_whitespace_range_u32 =
+                    RangeAny::new(None, Some(first_letter_range_u32.start));
                 range.intersect(leading_whitespace_range_u32)
             });
 
@@ -381,10 +379,8 @@ impl InlineFormattingContextBuilder {
 
         // Now push the non-first-letter text.
         let remaining_selection_range = selection.and_then(|range| {
-            let remaining_text_range_u32 = RangeAny {
-                start: Some(first_letter_range_u32.end),
-                end: range.end,
-            };
+            let remaining_text_range_u32 =
+                RangeAny::new(Some(first_letter_range_u32.end), range.end());
             range
                 .intersect(remaining_text_range_u32)
                 .map(|range| range.map(|offset| offset - first_letter_range_u32.end))

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -10,7 +10,7 @@ use atomic_refcell::AtomicRefCell;
 use icu_properties::CodePointMapData;
 use icu_properties::props::BidiClass;
 use layout_api::LayoutNode;
-use servo_base::text::{RangeAny, Utf32CodeUnits};
+use servo_base::text::{RangeAny, Utf8CodeUnits, Utf32CodeUnits};
 use style::computed_values::direction::T as Direction;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::dom::NodeInfo;
@@ -49,12 +49,12 @@ pub(crate) struct InlineFormattingContextBuilder {
 
     /// The current offset in the final text string of this [`InlineFormattingContext`],
     /// used to properly set the text range of new [`InlineItem::TextRun`]s.
-    current_text_offset: usize,
+    current_text_offset: Utf8CodeUnits,
 
     /// The current character offset in the final text string of this [`InlineFormattingContext`],
     /// used to properly set the text range of new [`InlineItem::TextRun`]s. Note that this is
     /// different from the UTF-8 code point offset.
-    current_character_offset: usize,
+    current_character_offset: Utf32CodeUnits,
 
     /// Whether the last processed node ended with whitespace. This is used to
     /// implement rule 4 of <https://www.w3.org/TR/css-text-3/#collapse>:
@@ -146,10 +146,10 @@ impl InlineFormattingContextBuilder {
 
     fn push_control_character_string(&mut self, string_to_push: &str) {
         self.text_segments.push(string_to_push.to_owned());
-        self.current_text_offset += string_to_push.len();
+        self.current_text_offset += Utf8CodeUnits::length_of(string_to_push);
 
         let new_characters = Utf32CodeUnits::length_of(string_to_push);
-        self.current_character_offset += new_characters.0;
+        self.current_character_offset += new_characters;
         self.offset_map
             .borrow_mut()
             .push_range(new_characters, new_characters);
@@ -405,7 +405,7 @@ impl InlineFormattingContextBuilder {
 
         let bidi_class_map = CodePointMapData::<BidiClass>::new();
         let white_space_collapse = info.style.clone_white_space_collapse();
-        let mut character_count = 0;
+        let mut character_count = Utf32CodeUnits(0);
         let mut new_text = String::with_capacity(text.len());
         for iteration in TextTransformationIterator::new(
             &text,
@@ -415,7 +415,7 @@ impl InlineFormattingContextBuilder {
         ) {
             offset_map.push_iteration(&iteration);
             for &character in iteration.characters() {
-                character_count += 1;
+                character_count.0 += 1;
 
                 // If this character has a strong right-to-left class the new inline formatting context will
                 // need to be BiDi-aware. This match is derived from the list of strong right-to-left classes
@@ -453,7 +453,8 @@ impl InlineFormattingContextBuilder {
                 self.on_word_boundary && white_space_collapse != WhiteSpaceCollapse::Preserve;
         }
 
-        let new_utf8_range = self.current_text_offset..self.current_text_offset + new_text.len();
+        let new_utf8_range = self.current_text_offset..
+            self.current_text_offset + Utf8CodeUnits::length_of(&new_text);
         self.current_text_offset = new_utf8_range.end;
 
         let new_character_range =
@@ -510,7 +511,7 @@ impl InlineFormattingContextBuilder {
 
         assert!(self.inline_box_stack.is_empty());
         debug_assert_eq!(
-            self.offset_map.borrow().total_final_size().0,
+            self.offset_map.borrow().total_final_size(),
             self.current_character_offset
         );
 

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -10,7 +10,7 @@ use atomic_refcell::AtomicRefCell;
 use icu_properties::CodePointMapData;
 use icu_properties::props::BidiClass;
 use layout_api::LayoutNode;
-use servo_base::text::{RangeAny, Utf8CodeUnits, Utf32CodeUnits};
+use servo_base::text::{RangeAny, Str32, Utf8CodeUnits, Utf32CodeUnits};
 use style::computed_values::direction::T as Direction;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::dom::NodeInfo;
@@ -146,6 +146,7 @@ impl InlineFormattingContextBuilder {
 
     fn push_control_character_string(&mut self, string_to_push: &str) {
         self.text_segments.push(string_to_push.to_owned());
+        let string_to_push = Str32(string_to_push); // string_to_push is always small
         self.current_text_offset += Utf8CodeUnits::length_of(string_to_push);
 
         let new_characters = Utf32CodeUnits::length_of(string_to_push);
@@ -337,8 +338,9 @@ impl InlineFormattingContextBuilder {
 
         // Push any leading white space first.
         let first_letter_range_u32 = LazyCell::new(|| {
-            Utf32CodeUnits::length_of(&text[..first_letter_range.start])..
-                Utf32CodeUnits::length_of(&text[..first_letter_range.end])
+            // TODO: ensure layout doesn’t handle more than 4 GiB at a time?
+            Utf32CodeUnits::length_of(Str32(&text[..first_letter_range.start]))..
+                Utf32CodeUnits::length_of(Str32(&text[..first_letter_range.end]))
         });
         if first_letter_range.start != 0 {
             let leading_whitespace_range = 0..first_letter_range.start;
@@ -453,8 +455,9 @@ impl InlineFormattingContextBuilder {
                 self.on_word_boundary && white_space_collapse != WhiteSpaceCollapse::Preserve;
         }
 
-        let new_utf8_range = self.current_text_offset..
-            self.current_text_offset + Utf8CodeUnits::length_of(&new_text);
+        // TODO: ensure layout doesn’t handle more than 4 GiB at a time?
+        let new_text_len = Utf8CodeUnits::length_of(Str32(&new_text));
+        let new_utf8_range = self.current_text_offset..self.current_text_offset + new_text_len;
         self.current_text_offset = new_utf8_range.end;
 
         let new_character_range =

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -346,7 +346,7 @@ impl InlineFormattingContextBuilder {
             let leading_whitespace_range = 0..first_letter_range.start;
             let leading_whitespace_selection_range = selection.and_then(|range| {
                 let leading_whitespace_range_u32 =
-                    RangeAny::new(None, Some(first_letter_range_u32.start));
+                    RangeAny::from_start_to(first_letter_range_u32.start);
                 range.intersect(leading_whitespace_range_u32)
             });
 

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -10,7 +10,7 @@ use atomic_refcell::AtomicRefCell;
 use icu_properties::CodePointMapData;
 use icu_properties::props::BidiClass;
 use layout_api::LayoutNode;
-use servo_base::text::{RangeAny, Str32, Utf8CodeUnits, Utf32CodeUnits};
+use servo_base::text::{AssumeUnder4GB, RangeAny, Utf8CodeUnits, Utf32CodeUnits};
 use style::computed_values::direction::T as Direction;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::dom::NodeInfo;
@@ -146,10 +146,10 @@ impl InlineFormattingContextBuilder {
 
     fn push_control_character_string(&mut self, string_to_push: &str) {
         self.text_segments.push(string_to_push.to_owned());
-        let string_to_push = Str32(string_to_push); // string_to_push is always small
-        self.current_text_offset += Utf8CodeUnits::length_of(string_to_push);
+        // string_to_push is always small
+        self.current_text_offset += Utf8CodeUnits::length_of(AssumeUnder4GB, string_to_push);
 
-        let new_characters = Utf32CodeUnits::length_of(string_to_push);
+        let new_characters = Utf32CodeUnits::length_of(AssumeUnder4GB, string_to_push);
         self.current_character_offset += new_characters;
         self.offset_map
             .borrow_mut()
@@ -339,8 +339,8 @@ impl InlineFormattingContextBuilder {
         // Push any leading white space first.
         let first_letter_range_u32 = LazyCell::new(|| {
             // TODO: ensure layout doesn’t handle more than 4 GiB at a time?
-            Utf32CodeUnits::length_of(Str32(&text[..first_letter_range.start]))..
-                Utf32CodeUnits::length_of(Str32(&text[..first_letter_range.end]))
+            Utf32CodeUnits::length_of(AssumeUnder4GB, &text[..first_letter_range.start])..
+                Utf32CodeUnits::length_of(AssumeUnder4GB, &text[..first_letter_range.end])
         });
         if first_letter_range.start != 0 {
             let leading_whitespace_range = 0..first_letter_range.start;
@@ -456,7 +456,7 @@ impl InlineFormattingContextBuilder {
         }
 
         // TODO: ensure layout doesn’t handle more than 4 GiB at a time?
-        let new_text_len = Utf8CodeUnits::length_of(Str32(&new_text));
+        let new_text_len = Utf8CodeUnits::length_of(AssumeUnder4GB, &new_text);
         let new_utf8_range = self.current_text_offset..self.current_text_offset + new_text_len;
         self.current_text_offset = new_utf8_range.end;
 

--- a/components/layout/flow/inline/line_breaker.rs
+++ b/components/layout/flow/inline/line_breaker.rs
@@ -6,10 +6,11 @@ use std::ops::Range;
 
 use icu_segmenter::LineSegmenter;
 use icu_segmenter::options::LineBreakOptions;
+use servo_base::text::Utf8CodeUnits;
 
 pub(crate) struct LineBreaker {
-    linebreaks: Vec<usize>,
-    current_offset: usize,
+    linebreaks: Vec<Utf8CodeUnits>,
+    current_linebreak_offset: usize,
 }
 
 impl LineBreaker {
@@ -22,21 +23,31 @@ impl LineBreaker {
             // > opportunity.
             //
             // Skip this first line break opportunity, as it isn't interesting to us.
-            linebreaks: line_segmenter.segment_str(string).skip(1).collect(),
-            current_offset: 0,
+            linebreaks: line_segmenter
+                .segment_str(string)
+                .skip(1)
+                .map(|offset| Utf8CodeUnits(offset as u32))
+                .collect(),
+            current_linebreak_offset: 0,
         }
     }
 
-    pub(crate) fn advance_to_linebreaks_in_range(&mut self, text_range: Range<usize>) -> &[usize] {
+    pub(crate) fn advance_to_linebreaks_in_range(
+        &mut self,
+        text_range: Range<Utf8CodeUnits>,
+    ) -> &[Utf8CodeUnits] {
         let linebreaks_in_range = self.linebreaks_in_range_after_current_offset(text_range);
-        self.current_offset = linebreaks_in_range.end;
+        self.current_linebreak_offset = linebreaks_in_range.end;
         &self.linebreaks[linebreaks_in_range]
     }
 
-    fn linebreaks_in_range_after_current_offset(&self, text_range: Range<usize>) -> Range<usize> {
+    fn linebreaks_in_range_after_current_offset(
+        &self,
+        text_range: Range<Utf8CodeUnits>,
+    ) -> Range<usize> {
         assert!(text_range.start <= text_range.end);
 
-        let mut linebreaks_range = self.current_offset..self.linebreaks.len();
+        let mut linebreaks_range = self.current_linebreak_offset..self.linebreaks.len();
 
         while self.linebreaks[linebreaks_range.start] < text_range.start &&
             linebreaks_range.len() > 1
@@ -59,67 +70,84 @@ impl LineBreaker {
 mod test {
     use super::*;
 
+    fn linebreaks_in_range_after_current_offset(
+        linebreaker: &LineBreaker,
+        range: Range<u32>,
+    ) -> Range<usize> {
+        linebreaker.linebreaks_in_range_after_current_offset(
+            Utf8CodeUnits(range.start)..Utf8CodeUnits(range.end),
+        )
+    }
+
     #[test]
     fn test_linebreaker_ranges() {
         let linebreaker = LineBreaker::new("abc def", LineBreakOptions::default());
         assert_eq!(linebreaker.linebreaks, [4, 7]);
         assert_eq!(
-            linebreaker.linebreaks_in_range_after_current_offset(0..5),
+            linebreaks_in_range_after_current_offset(&linebreaker, 0..5),
             0..1
         );
         // The last linebreak should not be included for the text range we are interested in.
         assert_eq!(
-            linebreaker.linebreaks_in_range_after_current_offset(0..7),
+            linebreaks_in_range_after_current_offset(&linebreaker, 0..7),
             0..1
         );
 
         let linebreaker = LineBreaker::new("abc d def", LineBreakOptions::default());
         assert_eq!(linebreaker.linebreaks, [4, 6, 9]);
         assert_eq!(
-            linebreaker.linebreaks_in_range_after_current_offset(0..5),
+            linebreaks_in_range_after_current_offset(&linebreaker, 0..5),
             0..1
         );
         assert_eq!(
-            linebreaker.linebreaks_in_range_after_current_offset(0..7),
+            linebreaks_in_range_after_current_offset(&linebreaker, 0..7),
             0..2
         );
         assert_eq!(
-            linebreaker.linebreaks_in_range_after_current_offset(0..9),
+            linebreaks_in_range_after_current_offset(&linebreaker, 0..9),
             0..2
         );
 
         assert_eq!(
-            linebreaker.linebreaks_in_range_after_current_offset(4..9),
+            linebreaks_in_range_after_current_offset(&linebreaker, 4..9),
             0..2
         );
 
         std::panic::catch_unwind(|| {
             let linebreaker = LineBreaker::new("abc def", LineBreakOptions::default());
-            linebreaker.linebreaks_in_range_after_current_offset(5..2);
+            linebreaks_in_range_after_current_offset(&linebreaker, 5..2);
         })
         .expect_err("Reversed range should cause an assertion failure.");
+    }
+
+    fn advance_to_linebreaks_in_range(
+        linebreaker: &mut LineBreaker,
+        range: Range<u32>,
+    ) -> &[Utf8CodeUnits] {
+        linebreaker
+            .advance_to_linebreaks_in_range(Utf8CodeUnits(range.start)..Utf8CodeUnits(range.end))
     }
 
     #[test]
     fn test_linebreaker_stateful_advance() {
         let mut linebreaker = LineBreaker::new("abc d def", LineBreakOptions::default());
         assert_eq!(linebreaker.linebreaks, [4, 6, 9]);
-        assert!(linebreaker.advance_to_linebreaks_in_range(0..7) == &[4, 6]);
-        assert!(linebreaker.advance_to_linebreaks_in_range(8..9).is_empty());
+        assert!(advance_to_linebreaks_in_range(&mut linebreaker, 0..7) == &[4, 6]);
+        assert!(advance_to_linebreaks_in_range(&mut linebreaker, 8..9).is_empty());
 
         // We've already advanced, so a range from the beginning shouldn't affect things.
-        assert!(linebreaker.advance_to_linebreaks_in_range(0..9).is_empty());
+        assert!(advance_to_linebreaks_in_range(&mut linebreaker, 0..9).is_empty());
 
-        linebreaker.current_offset = 0;
+        linebreaker.current_linebreak_offset = 0;
 
         // Sending a value out of range shouldn't break things.
-        assert!(linebreaker.advance_to_linebreaks_in_range(0..999) == &[4, 6]);
+        assert!(advance_to_linebreaks_in_range(&mut linebreaker, 0..999) == &[4, 6]);
 
-        linebreaker.current_offset = 0;
+        linebreaker.current_linebreak_offset = 0;
 
         std::panic::catch_unwind(|| {
             let mut linebreaker = LineBreaker::new("abc d def", LineBreakOptions::default());
-            linebreaker.advance_to_linebreaks_in_range(2..0);
+            advance_to_linebreaks_in_range(&mut linebreaker, 2..0);
         })
         .expect_err("Reversed range should cause an assertion failure.");
     }

--- a/components/layout/flow/inline/line_breaker.rs
+++ b/components/layout/flow/inline/line_breaker.rs
@@ -82,7 +82,7 @@ mod test {
     #[test]
     fn test_linebreaker_ranges() {
         let linebreaker = LineBreaker::new("abc def", LineBreakOptions::default());
-        assert_eq!(linebreaker.linebreaks, [4, 7]);
+        assert_eq!(linebreaker.linebreaks, [Utf8CodeUnits(4), Utf8CodeUnits(7)]);
         assert_eq!(
             linebreaks_in_range_after_current_offset(&linebreaker, 0..5),
             0..1
@@ -94,7 +94,10 @@ mod test {
         );
 
         let linebreaker = LineBreaker::new("abc d def", LineBreakOptions::default());
-        assert_eq!(linebreaker.linebreaks, [4, 6, 9]);
+        assert_eq!(
+            linebreaker.linebreaks,
+            [Utf8CodeUnits(4), Utf8CodeUnits(6), Utf8CodeUnits(9)]
+        );
         assert_eq!(
             linebreaks_in_range_after_current_offset(&linebreaker, 0..5),
             0..1
@@ -131,8 +134,14 @@ mod test {
     #[test]
     fn test_linebreaker_stateful_advance() {
         let mut linebreaker = LineBreaker::new("abc d def", LineBreakOptions::default());
-        assert_eq!(linebreaker.linebreaks, [4, 6, 9]);
-        assert!(advance_to_linebreaks_in_range(&mut linebreaker, 0..7) == &[4, 6]);
+        assert_eq!(
+            linebreaker.linebreaks,
+            [Utf8CodeUnits(4), Utf8CodeUnits(6), Utf8CodeUnits(9)]
+        );
+        assert!(
+            advance_to_linebreaks_in_range(&mut linebreaker, 0..7) ==
+                &[Utf8CodeUnits(4), Utf8CodeUnits(6)]
+        );
         assert!(advance_to_linebreaks_in_range(&mut linebreaker, 8..9).is_empty());
 
         // We've already advanced, so a range from the beginning shouldn't affect things.
@@ -141,7 +150,10 @@ mod test {
         linebreaker.current_linebreak_offset = 0;
 
         // Sending a value out of range shouldn't break things.
-        assert!(advance_to_linebreaks_in_range(&mut linebreaker, 0..999) == &[4, 6]);
+        assert!(
+            advance_to_linebreaks_in_range(&mut linebreaker, 0..999) ==
+                &[Utf8CodeUnits(4), Utf8CodeUnits(6)]
+        );
 
         linebreaker.current_linebreak_offset = 0;
 

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -102,7 +102,7 @@ use line::{
 use malloc_size_of_derive::MallocSizeOf;
 use script::layout_dom::ServoLayoutNode;
 use servo_arc::Arc as ServoArc;
-use servo_base::text::Utf32CodeUnits;
+use servo_base::text::{Utf8CodeUnits, Utf32CodeUnits};
 use style::Zero;
 use style::computed_values::line_break::T as LineBreak;
 use style::computed_values::text_wrap_mode::T as TextWrapMode;
@@ -266,13 +266,13 @@ pub(crate) enum InlineItem {
     TextRun(ArcRefCell<TextRun>),
     OutOfFlowAbsolutelyPositionedBox(
         ArcRefCell<AbsolutelyPositionedBox>,
-        usize, /* offset_in_text */
+        Utf8CodeUnits, /* offset_in_text */
     ),
     OutOfFlowFloatBox(ArcRefCell<FloatBox>),
     Atomic(
         ArcRefCell<IndependentFormattingContext>,
-        usize, /* offset_in_text */
-        Level, /* bidi_level */
+        Utf8CodeUnits, /* offset_in_text */
+        Level,         /* bidi_level */
     ),
     BlockLevel(ArcRefCell<BlockLevelBox>),
 }
@@ -398,13 +398,13 @@ pub(crate) enum WeakInlineItem {
     TextRun(WeakRefCell<TextRun>),
     OutOfFlowAbsolutelyPositionedBox(
         WeakRefCell<AbsolutelyPositionedBox>,
-        usize, /* offset_in_text */
+        Utf8CodeUnits, /* offset_in_text */
     ),
     OutOfFlowFloatBox(WeakRefCell<FloatBox>),
     Atomic(
         WeakRefCell<IndependentFormattingContext>,
-        usize, /* offset_in_text */
-        Level, /* bidi_level */
+        Utf8CodeUnits, /* offset_in_text */
+        Level,         /* bidi_level */
     ),
     BlockLevel(WeakRefCell<BlockLevelBox>),
 }
@@ -1727,8 +1727,8 @@ impl InlineFormattingContextLayout<'_> {
                 text_fragment_run_data: caret_placeholder.run_data,
                 base_fragment_info: caret_placeholder.base_fragment_info,
                 info: FontAndScriptInfo::simple_for_font(font),
-                character_range_in_dom_node: Utf32CodeUnits(caret_placeholder.character_index)..
-                    Utf32CodeUnits(caret_placeholder.character_index + 1),
+                character_range_in_dom_node: caret_placeholder.character_index..
+                    caret_placeholder.character_index + Utf32CodeUnits(1),
                 is_empty_for_text_cursor: true,
             },
         ));
@@ -1996,7 +1996,7 @@ impl InlineFormattingContext {
                 },
                 InlineItem::Atomic(_, index_in_text, bidi_level) => {
                     shaping_queue.flush();
-                    *bidi_level = bidi_levels.level(*index_in_text);
+                    *bidi_level = bidi_levels.level(usize::from(*index_in_text));
                 },
                 InlineItem::EndInlineBox(inline_box) => {
                     if inline_box.borrow().breaks_shaping_at_end {
@@ -2188,15 +2188,16 @@ impl InlineFormattingContext {
             .sum()
     }
 
-    fn next_character_prevents_soft_wrap_opportunity(&self, index: usize) -> bool {
-        let Some(character) = self.text_content[index..].chars().nth(1) else {
+    fn next_character_prevents_soft_wrap_opportunity(&self, index: Utf8CodeUnits) -> bool {
+        // FIXME: `iterator.nth(1)` returns the **second** item. Do we want `.next()` instead?
+        let Some(character) = self.text_content[usize::from(index)..].chars().nth(1) else {
             return false;
         };
         char_prevents_soft_wrap_opportunity_when_before_or_after_atomic(character)
     }
 
-    fn previous_character_prevents_soft_wrap_opportunity(&self, index: usize) -> bool {
-        let Some(character) = self.text_content[0..index].chars().next_back() else {
+    fn previous_character_prevents_soft_wrap_opportunity(&self, index: Utf8CodeUnits) -> bool {
+        let Some(character) = self.text_content[..usize::from(index)].chars().next_back() else {
             return false;
         };
         char_prevents_soft_wrap_opportunity_when_before_or_after_atomic(character)
@@ -2545,7 +2546,7 @@ impl IndependentFormattingContext {
     fn layout_into_line_items(
         &self,
         layout: &mut InlineFormattingContextLayout,
-        offset_in_text: usize,
+        offset_in_text: Utf8CodeUnits,
         bidi_level: Level,
     ) {
         // We need to know the inline size of the atomic before deciding whether to do the line break.

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -2189,11 +2189,10 @@ impl InlineFormattingContext {
     }
 
     fn next_character_prevents_soft_wrap_opportunity(&self, index: Utf8CodeUnits) -> bool {
-        // FIXME: `iterator.nth(1)` returns the **second** item. Do we want `.next()` instead?
-        let Some(character) = self.text_content[usize::from(index)..].chars().nth(1) else {
+        let Some(second_character) = self.text_content[usize::from(index)..].chars().nth(1) else {
             return false;
         };
-        char_prevents_soft_wrap_opportunity_when_before_or_after_atomic(character)
+        char_prevents_soft_wrap_opportunity_when_before_or_after_atomic(second_character)
     }
 
     fn previous_character_prevents_soft_wrap_opportunity(&self, index: Utf8CodeUnits) -> bool {

--- a/components/layout/flow/inline/shaping_queue.rs
+++ b/components/layout/flow/inline/shaping_queue.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use fonts::{ShapedText, ShapedTextSlice, ShapedTextSliceType, ShapedTextSlicer, ShapingOptions};
 use icu_segmenter::options::LineBreakOptions;
+use servo_base::text::{Utf8CodeUnits, Utf32CodeUnits};
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::computed_values::word_break::T as WordBreak;
 use style::properties::ComputedValues;
@@ -23,8 +24,8 @@ use crate::flow::inline::text_run::{FontAndScriptInfo, TextRun, TextRunItem, scr
 /// it can outlive a mutable borrow on the owning `TextRun`.
 pub(crate) struct ShapingQueueText {
     info: FontAndScriptInfo,
-    byte_range: Range<usize>,
-    character_range: Range<usize>,
+    byte_range: Range<Utf8CodeUnits>,
+    character_range: Range<Utf32CodeUnits>,
     text_run: ArcRefCell<TextRun>,
     index_in_text_run: usize,
     old_shaped_text: Option<Arc<ShapedText>>,
@@ -75,7 +76,7 @@ struct BatchSlicer<'a> {
     slicer: ShapedTextSlicer,
     text: &'a str,
     line_breaker: &'a mut LineBreaker,
-    character_offset_origin: usize,
+    character_offset_origin: Utf32CodeUnits,
 }
 
 impl BatchSlicer<'_> {
@@ -119,7 +120,7 @@ impl BatchSlicer<'_> {
 
             // Extend the slice to the next UAX#14 line break opportunity.
             let mut slice = last_slice.end..*break_index;
-            let word = &self.text[slice.clone()];
+            let word = &self.text[usize::from(slice.start)..usize::from(slice.end)];
 
             // Split off any trailing whitespace into a separate glyph run.
             let mut whitespace = slice.end..slice.end;
@@ -132,7 +133,7 @@ impl BatchSlicer<'_> {
                 .last()
             {
                 ends_with_whitespace = true;
-                whitespace.start = slice.start + first_white_space_index;
+                whitespace.start = slice.start + Utf8CodeUnits(first_white_space_index as u32);
 
                 // If line breaking for a piece of text that has `white-space-collapse:
                 // break-spaces` there is a line break opportunity *after* every preserved space,
@@ -142,7 +143,7 @@ impl BatchSlicer<'_> {
                 if text_style.white_space_collapse == WhiteSpaceCollapse::BreakSpaces &&
                     !can_break_anywhere
                 {
-                    whitespace.start += first_white_space_character.len_utf8();
+                    whitespace.start += Utf8CodeUnits::length_of_char(first_white_space_character);
                     slice_type = ShapedTextSliceType::WordAndWhiteSpace;
                 }
 
@@ -164,7 +165,8 @@ impl BatchSlicer<'_> {
 
             // Push the non-whitespace part of the range.
             if !slice.is_empty() {
-                current_character_offset += self.text[slice].chars().count();
+                let slice = usize::from(slice.start)..usize::from(slice.end);
+                current_character_offset += Utf32CodeUnits::length_of(&self.text[slice]);
                 maybe_push_run(
                     self.slicer
                         .slice_until_character_offset(current_character_offset, slice_type),
@@ -174,12 +176,13 @@ impl BatchSlicer<'_> {
             if whitespace.is_empty() {
                 continue;
             }
+            let whitespace = usize::from(whitespace.start)..usize::from(whitespace.end);
 
             // If `white-space-collapse: break-spaces` is active, insert a line breaking opportunity
             // between each white space character in the white space that we trimmed off.
             if text_style.white_space_collapse == WhiteSpaceCollapse::BreakSpaces {
                 for _ in self.text[whitespace].chars() {
-                    current_character_offset += 1;
+                    current_character_offset += Utf32CodeUnits(1);
                     maybe_push_run(self.slicer.slice_until_character_offset(
                         current_character_offset,
                         ShapedTextSliceType::WhiteSpace,
@@ -188,7 +191,7 @@ impl BatchSlicer<'_> {
                 continue;
             }
 
-            current_character_offset += self.text[whitespace].chars().count();
+            current_character_offset += Utf32CodeUnits::length_of(&self.text[whitespace]);
             maybe_push_run(self.slicer.slice_until_character_offset(
                 current_character_offset,
                 ShapedTextSliceType::WhiteSpace,
@@ -222,10 +225,10 @@ pub(crate) struct ShapingQueue<'a> {
     line_breaker: LineBreaker,
     /// The byte range of the text to shape in [`Self::text`] for the current batch.
     /// Only contiguous ranges can be shaped together.
-    byte_range: Range<usize>,
+    byte_range: Range<Utf8CodeUnits>,
     /// The character range of the text to shape in [`Self::text`] for the current batch.
     /// Only contiguous ranges can be shaped together.
-    character_range: Range<usize>,
+    character_range: Range<Utf32CodeUnits>,
     /// The resolved script for the current batch. This is used to gradually turn non-specific
     /// scripts into a resolved value for shaping.
     resolved_script: Option<Script>,
@@ -243,7 +246,10 @@ impl<'a> ShapingQueue<'a> {
         }
     }
 
-    fn compatible_old_shaping_result(&self, character_count: usize) -> Option<Arc<ShapedText>> {
+    fn compatible_old_shaping_result(
+        &self,
+        character_count: Utf32CodeUnits,
+    ) -> Option<Arc<ShapedText>> {
         let old_shaped_text = self.queue.first()?.old_shaped_text.as_ref()?;
         if old_shaped_text.character_count() != character_count {
             return None;
@@ -274,7 +280,8 @@ impl<'a> ShapingQueue<'a> {
         options.script = self.resolved_script.unwrap_or(first.info.script);
 
         let font = &first.info.font_info.font;
-        Some(font.shape_text(&self.text[self.byte_range.clone()], &options))
+        let byte_range = usize::from(self.byte_range.start)..usize::from(self.byte_range.end);
+        Some(font.shape_text(&self.text[byte_range], &options))
     }
 
     /// Flush this [`ShapingQueue`]. If any content had been collected up to this point,

--- a/components/layout/flow/inline/shaping_queue.rs
+++ b/components/layout/flow/inline/shaping_queue.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use fonts::{ShapedText, ShapedTextSlice, ShapedTextSliceType, ShapedTextSlicer, ShapingOptions};
 use icu_segmenter::options::LineBreakOptions;
-use servo_base::text::{Utf8CodeUnits, Utf32CodeUnits};
+use servo_base::text::{Str32, Utf8CodeUnits, Utf32CodeUnits};
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::computed_values::word_break::T as WordBreak;
 use style::properties::ComputedValues;
@@ -166,7 +166,8 @@ impl BatchSlicer<'_> {
             // Push the non-whitespace part of the range.
             if !slice.is_empty() {
                 let slice = usize::from(slice.start)..usize::from(slice.end);
-                current_character_offset += Utf32CodeUnits::length_of(&self.text[slice]);
+                // TODO: ensure layout doesn’t handle more than 4 GiB at a time?
+                current_character_offset += Utf32CodeUnits::length_of(Str32(&self.text[slice]));
                 maybe_push_run(
                     self.slicer
                         .slice_until_character_offset(current_character_offset, slice_type),
@@ -191,7 +192,8 @@ impl BatchSlicer<'_> {
                 continue;
             }
 
-            current_character_offset += Utf32CodeUnits::length_of(&self.text[whitespace]);
+            // TODO: ensure layout doesn’t handle more than 4 GiB at a time?
+            current_character_offset += Utf32CodeUnits::length_of(Str32(&self.text[whitespace]));
             maybe_push_run(self.slicer.slice_until_character_offset(
                 current_character_offset,
                 ShapedTextSliceType::WhiteSpace,

--- a/components/layout/flow/inline/shaping_queue.rs
+++ b/components/layout/flow/inline/shaping_queue.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use fonts::{ShapedText, ShapedTextSlice, ShapedTextSliceType, ShapedTextSlicer, ShapingOptions};
 use icu_segmenter::options::LineBreakOptions;
-use servo_base::text::{Str32, Utf8CodeUnits, Utf32CodeUnits};
+use servo_base::text::{AssumeUnder4GB, Utf8CodeUnits, Utf32CodeUnits};
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::computed_values::word_break::T as WordBreak;
 use style::properties::ComputedValues;
@@ -167,7 +167,8 @@ impl BatchSlicer<'_> {
             if !slice.is_empty() {
                 let slice = usize::from(slice.start)..usize::from(slice.end);
                 // TODO: ensure layout doesn’t handle more than 4 GiB at a time?
-                current_character_offset += Utf32CodeUnits::length_of(Str32(&self.text[slice]));
+                current_character_offset +=
+                    Utf32CodeUnits::length_of(AssumeUnder4GB, &self.text[slice]);
                 maybe_push_run(
                     self.slicer
                         .slice_until_character_offset(current_character_offset, slice_type),
@@ -193,7 +194,8 @@ impl BatchSlicer<'_> {
             }
 
             // TODO: ensure layout doesn’t handle more than 4 GiB at a time?
-            current_character_offset += Utf32CodeUnits::length_of(Str32(&self.text[whitespace]));
+            current_character_offset +=
+                Utf32CodeUnits::length_of(AssumeUnder4GB, &self.text[whitespace]);
             maybe_push_run(self.slicer.slice_until_character_offset(
                 current_character_offset,
                 ShapedTextSliceType::WhiteSpace,

--- a/components/layout/flow/inline/shaping_queue.rs
+++ b/components/layout/flow/inline/shaping_queue.rs
@@ -120,7 +120,7 @@ impl BatchSlicer<'_> {
 
             // Extend the slice to the next UAX#14 line break opportunity.
             let mut slice = last_slice.end..*break_index;
-            let word = &self.text[usize::from(slice.start)..usize::from(slice.end)];
+            let word = &self.text[Utf8CodeUnits::to_usize_range(&slice)];
 
             // Split off any trailing whitespace into a separate glyph run.
             let mut whitespace = slice.end..slice.end;
@@ -165,20 +165,21 @@ impl BatchSlicer<'_> {
 
             // Push the non-whitespace part of the range.
             if !slice.is_empty() {
-                let slice = usize::from(slice.start)..usize::from(slice.end);
                 // TODO: ensure layout doesn’t handle more than 4 GiB at a time?
-                current_character_offset +=
-                    Utf32CodeUnits::length_of(AssumeUnder4GB, &self.text[slice]);
+                current_character_offset += Utf32CodeUnits::length_of(
+                    AssumeUnder4GB,
+                    &self.text[Utf8CodeUnits::to_usize_range(&slice)],
+                );
                 maybe_push_run(
                     self.slicer
                         .slice_until_character_offset(current_character_offset, slice_type),
                 );
             }
 
+            let whitespace = Utf8CodeUnits::to_usize_range(&whitespace);
             if whitespace.is_empty() {
                 continue;
             }
-            let whitespace = usize::from(whitespace.start)..usize::from(whitespace.end);
 
             // If `white-space-collapse: break-spaces` is active, insert a line breaking opportunity
             // between each white space character in the white space that we trimmed off.
@@ -284,8 +285,10 @@ impl<'a> ShapingQueue<'a> {
         options.script = self.resolved_script.unwrap_or(first.info.script);
 
         let font = &first.info.font_info.font;
-        let byte_range = usize::from(self.byte_range.start)..usize::from(self.byte_range.end);
-        Some(font.shape_text(&self.text[byte_range], &options))
+        Some(font.shape_text(
+            &self.text[Utf8CodeUnits::to_usize_range(&self.byte_range)],
+            &options,
+        ))
     }
 
     /// Flush this [`ShapingQueue`]. If any content had been collected up to this point,

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -352,12 +352,12 @@ impl SharedTextRunData {
     ) -> Range<Utf32CodeUnits> {
         let offset_map = self.offset_map.borrow();
         let offset_in_ifc_text = Utf32CodeUnits(self.character_range_in_ifc_text.start);
-        let start = if let Some(dom_start) = dom_range.start {
+        let start = if let Some(dom_start) = dom_range.start() {
             offset_map.map(dom_start + self.original_offset) - offset_in_ifc_text
         } else {
             Utf32CodeUnits(0)
         };
-        let end = if let Some(dom_end) = dom_range.end {
+        let end = if let Some(dom_end) = dom_range.end() {
             offset_map.map(dom_end + self.original_offset) - offset_in_ifc_text
         } else {
             Utf32CodeUnits(self.character_range_in_ifc_text.len())

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -15,7 +15,7 @@ use icu_properties::props::{EnumeratedProperty, LineBreak};
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use servo_arc::Arc as ServoArc;
-use servo_base::text::{RangeAny, Utf32CodeUnits, is_bidi_control};
+use servo_base::text::{RangeAny, Utf8CodeUnits, Utf32CodeUnits, is_bidi_control};
 use smallvec::SmallVec;
 use style::Zero;
 use style::computed_values::font_kerning::T as FontKerning;
@@ -182,10 +182,10 @@ pub(crate) struct TextRunSegment {
     pub info: FontAndScriptInfo,
 
     /// The range of bytes in the parent [`super::InlineFormattingContext`]'s text content.
-    pub byte_range: Range<usize>,
+    pub byte_range: Range<Utf8CodeUnits>,
 
     /// The range of characters in the parent [`super::InlineFormattingContext`]'s text content.
-    pub character_range: Range<usize>,
+    pub character_range: Range<Utf32CodeUnits>,
 
     /// Whether or not the linebreaker said that we should allow a line break at the start of this
     /// segment.
@@ -204,8 +204,8 @@ pub(crate) struct TextRunSegment {
 impl TextRunSegment {
     fn new(
         info: FontAndScriptInfo,
-        byte_range: Range<usize>,
-        character_range: Range<usize>,
+        byte_range: Range<Utf8CodeUnits>,
+        character_range: Range<Utf32CodeUnits>,
     ) -> Self {
         Self {
             info,
@@ -242,7 +242,12 @@ impl TextRunSegment {
 
     /// Update this segment to end at the given byte and character index. The update will only ever
     /// make the Script specific and will not change it otherwise.
-    fn update(&mut self, next_byte_index: usize, next_character_index: usize, new_script: Script) {
+    fn update(
+        &mut self,
+        next_byte_index: Utf8CodeUnits,
+        next_character_index: Utf32CodeUnits,
+        new_script: Script,
+    ) {
         if !script_is_specific(self.info.script) && script_is_specific(new_script) {
             self.info = FontAndScriptInfo {
                 script: new_script,
@@ -279,8 +284,7 @@ impl TextRunSegment {
                 run.clone(),
                 text_run,
                 &self.info,
-                Utf32CodeUnits(character_range_start - run_start)..
-                    Utf32CodeUnits(new_character_range_end - run_start),
+                character_range_start - run_start..new_character_range_end - run_start,
             );
 
             character_range_start = new_character_range_end;
@@ -301,7 +305,7 @@ pub(crate) struct CaretPlaceholder {
     pub base_fragment_info: BaseFragmentInfo,
     /// Character index of the preserved newline in the IFC's transformed text, relative
     /// to the start of the DOM node.
-    pub character_index: usize,
+    pub character_index: Utf32CodeUnits,
 }
 
 /// A single item in a [`TextRun`].
@@ -327,7 +331,7 @@ pub(crate) struct SharedTextRunData {
     /// The range of characters in this text in `InlineFormattingContext::text_content`
     /// of the `InlineFormattingContext` that owns this `TextRun`. These are counting
     /// `char`s, *not* UTF-8 offsets.
-    pub character_range_in_ifc_text: Range<usize>,
+    pub character_range_in_ifc_text: Range<Utf32CodeUnits>,
     /// The original offset of this `TextRun` in the `InlineFormattingContext`'s input
     /// text (untransformed by white space collapse and `text-transform`).
     pub original_offset: Utf32CodeUnits,
@@ -351,7 +355,7 @@ impl SharedTextRunData {
         dom_range: RangeAny<Utf32CodeUnits>,
     ) -> Range<Utf32CodeUnits> {
         let offset_map = self.offset_map.borrow();
-        let offset_in_ifc_text = Utf32CodeUnits(self.character_range_in_ifc_text.start);
+        let offset_in_ifc_text = self.character_range_in_ifc_text.start;
         let start = if let Some(dom_start) = dom_range.start() {
             offset_map.map(dom_start + self.original_offset) - offset_in_ifc_text
         } else {
@@ -360,7 +364,7 @@ impl SharedTextRunData {
         let end = if let Some(dom_end) = dom_range.end() {
             offset_map.map(dom_end + self.original_offset) - offset_in_ifc_text
         } else {
-            Utf32CodeUnits(self.character_range_in_ifc_text.len())
+            self.character_range_in_ifc_text.end - self.character_range_in_ifc_text.start
         };
         start..end
     }
@@ -372,7 +376,7 @@ impl SharedTextRunData {
         offset: Utf32CodeUnits,
     ) -> Utf32CodeUnits {
         let offset_map = self.offset_map.borrow();
-        let offset_in_ifc_text = Utf32CodeUnits(self.character_range_in_ifc_text.start);
+        let offset_in_ifc_text = self.character_range_in_ifc_text.start;
         offset_map.reverse_map(offset + offset_in_ifc_text) - self.original_offset
     }
 }
@@ -400,7 +404,7 @@ pub(crate) struct TextRun {
 
     /// The range of text in [`super::InlineFormattingContext::text_content`] of the
     /// [`super::InlineFormattingContext`] that owns this [`TextRun`]. These are UTF-8 offsets.
-    pub text_range: Range<usize>,
+    pub text_range: Range<Utf8CodeUnits>,
 
     /// The [`TextRunItem`]s of this text run. This is produced by segmenting the incoming text
     /// by things such as font and script as well as separating out hard line breaks.
@@ -412,7 +416,7 @@ impl TextRun {
     pub(crate) fn new(
         base_fragment_info: BaseFragmentInfo,
         run_data: Arc<SharedTextRunData>,
-        text_range: Range<usize>,
+        text_range: Range<Utf8CodeUnits>,
         old_text_run: Option<ArcRefCell<TextRun>>,
     ) -> Self {
         // If there was a previous box tree layout of this text run, try to preserve the old shaped text.
@@ -524,17 +528,18 @@ impl TextRun {
                 }
             };
 
-        let text_run_text = &formatting_context_text[self.text_range.clone()];
+        let text_range = usize::from(self.text_range.start)..usize::from(self.text_range.end);
+        let text_run_text = &formatting_context_text[text_range];
         let char_iterator = TwoCharsAtATimeIterator::new(text_run_text.chars());
         // The next bytes index of the character within the entire inline formatting context's text.
         let mut next_byte_index = self.text_range.start;
         for (relative_character_index, (character, next_character)) in char_iterator.enumerate() {
             // The current character index within the entire inline formatting context's text.
-            let current_character_index =
-                self.run_data.character_range_in_ifc_text.start + relative_character_index;
+            let current_character_index = self.run_data.character_range_in_ifc_text.start +
+                Utf32CodeUnits(relative_character_index as u32);
 
             let current_byte_index = next_byte_index;
-            next_byte_index += character.len_utf8();
+            next_byte_index += Utf8CodeUnits::length_of_char(character);
 
             if character == '\n' {
                 finish_current_segment(&mut current, &mut results);
@@ -545,7 +550,7 @@ impl TextRun {
                         base_fragment_info: self.base_fragment_info,
                         // The placeholder that is placed after a newline is for the index after that newline.
                         // The newline itself is at the end of the previous line.
-                        character_index: relative_character_index + 1,
+                        character_index: Utf32CodeUnits((relative_character_index + 1) as u32),
                     }
                 })));
                 continue;
@@ -554,13 +559,17 @@ impl TextRun {
             if character == '\t' {
                 finish_current_segment(&mut current, &mut results);
                 results.push(TextRunItem::Tab {
-                    bidi_level: bidi_levels.level(current_byte_index),
+                    bidi_level: bidi_levels.level(current_byte_index.into()),
                 });
                 continue;
             }
 
             let (font, script, bidi_level) = if character_cannot_change_font(character) {
-                (None, Script::Common, bidi_levels.level(current_byte_index))
+                (
+                    None,
+                    Script::Common,
+                    bidi_levels.level(current_byte_index.into()),
+                )
             } else {
                 (
                     font_group.find_by_codepoint(
@@ -570,7 +579,7 @@ impl TextRun {
                         language,
                     ),
                     Script::from(character),
-                    bidi_levels.level(current_byte_index),
+                    bidi_levels.level(current_byte_index.into()),
                 )
             };
 
@@ -578,7 +587,11 @@ impl TextRun {
             if let Some(current) = current.as_mut() &&
                 current.is_compatible(&font, script, bidi_level)
             {
-                current.update(next_byte_index, current_character_index + 1, script);
+                current.update(
+                    next_byte_index,
+                    current_character_index + Utf32CodeUnits(1),
+                    script,
+                );
                 continue;
             }
 
@@ -618,7 +631,7 @@ impl TextRun {
             current = Some(TextRunSegment::new(
                 info,
                 current_byte_index..next_byte_index,
-                current_character_index..current_character_index + 1,
+                current_character_index..current_character_index + Utf32CodeUnits(1),
             ));
         }
 

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -528,8 +528,8 @@ impl TextRun {
                 }
             };
 
-        let text_range = usize::from(self.text_range.start)..usize::from(self.text_range.end);
-        let text_run_text = &formatting_context_text[text_range];
+        let text_run_text =
+            &formatting_context_text[Utf8CodeUnits::to_usize_range(&self.text_range)];
         let char_iterator = TwoCharsAtATimeIterator::new(text_run_text.chars());
         // The next bytes index of the character within the entire inline formatting context's text.
         let mut next_byte_index = self.text_range.start;

--- a/components/layout/flow/inline/text_transform.rs
+++ b/components/layout/flow/inline/text_transform.rs
@@ -60,9 +60,9 @@ impl CharacterTransformIteration {
         }
     }
 
-    fn collapse(amount_collapsed: usize, character: Option<char>) -> Self {
+    fn collapse(amount_collapsed: Utf32CodeUnits, character: Option<char>) -> Self {
         Self {
-            consumed: Utf32CodeUnits(amount_collapsed),
+            consumed: amount_collapsed,
             characters: character.into_iter().collect(),
         }
     }
@@ -116,7 +116,7 @@ impl<InputIterator: Iterator<Item = char>> WhitespaceCollapse<InputIterator> {
     /// other cases, the white space is simply removed. This method handles that.
     fn iteration_for_collapsed_whitespace(
         &self,
-        collapsed_whitespace: usize,
+        collapsed_whitespace: Utf32CodeUnits,
     ) -> CharacterTransformIteration {
         if !self.following_newline && !self.trimming_leading_white_space {
             CharacterTransformIteration::collapse(collapsed_whitespace, Some(' '))
@@ -127,9 +127,9 @@ impl<InputIterator: Iterator<Item = char>> WhitespaceCollapse<InputIterator> {
 
     fn iteration_for_collected_white_space(
         &self,
-        collected_whitespace: usize,
+        collected_whitespace: Utf32CodeUnits,
     ) -> Option<CharacterTransformIteration> {
-        (collected_whitespace != 0)
+        (collected_whitespace.0 != 0)
             .then(|| self.iteration_for_collapsed_whitespace(collected_whitespace))
     }
 }
@@ -167,7 +167,7 @@ impl<InputIterator: Iterator<Item = char>> Iterator for WhitespaceCollapse<Input
         // a single white space character as soon as we encounter a non-white space
         // character. When that happens we queue up the non-white space character for the
         // next iterator call.
-        let mut collected_whitespace = 0;
+        let mut collected_whitespace = Utf32CodeUnits(0);
 
         while let Some(character) = self.input_iterator.next() {
             // Don't push non-newline whitespace immediately. Instead wait to push it until we
@@ -176,7 +176,7 @@ impl<InputIterator: Iterator<Item = char>> Iterator for WhitespaceCollapse<Input
             if InlineFormattingContextBuilder::is_document_white_space(character) &&
                 character != '\n'
             {
-                collected_whitespace += 1;
+                collected_whitespace += Utf32CodeUnits(1);
                 continue;
             }
 
@@ -195,9 +195,14 @@ impl<InputIterator: Iterator<Item = char>> Iterator for WhitespaceCollapse<Input
                 // > 2. Then any remaining segment break is either transformed into a space (U+0020)
                 // >    or removed depending on the context before and after the break.
                 let iteration = if self.white_space_collapse != WhiteSpaceCollapse::Collapse {
-                    CharacterTransformIteration::collapse(collected_whitespace + 1, Some('\n'))
+                    CharacterTransformIteration::collapse(
+                        collected_whitespace + Utf32CodeUnits(1),
+                        Some('\n'),
+                    )
                 } else {
-                    self.iteration_for_collapsed_whitespace(collected_whitespace + 1)
+                    self.iteration_for_collapsed_whitespace(
+                        collected_whitespace + Utf32CodeUnits(1),
+                    )
                 };
 
                 self.following_newline = true;
@@ -531,7 +536,7 @@ impl OffsetMap {
     pub(crate) fn push_iteration(&mut self, iteration: &CharacterTransformIteration) {
         self.push_range(
             iteration.consumed,
-            Utf32CodeUnits(iteration.characters.len()),
+            Utf32CodeUnits(iteration.characters.len() as u32),
         );
     }
 
@@ -624,7 +629,7 @@ fn test_offsetmap_basic_expansion() {
     assert_eq!(offset_map.map(Utf32CodeUnits(5)).0, 7);
     assert_eq!(offset_map.map(Utf32CodeUnits(100)).0, 7);
 
-    let map_substring = |offset: usize, length: usize| {
+    let map_substring = |offset: u32, length: u32| {
         let start = offset_map
             .map(Utf32CodeUnits(offset))
             .to_utf8_code_units_in(final_string);
@@ -646,7 +651,10 @@ fn test_offsetmap_basic_collapse() {
     let final_string = "aaa b\nc";
 
     let mut offset_map = OffsetMap::default();
-    offset_map.push_iteration(&CharacterTransformIteration::collapse(2, None));
+    offset_map.push_iteration(&CharacterTransformIteration::collapse(
+        Utf32CodeUnits(2),
+        None,
+    ));
     offset_map.push_iteration(&CharacterTransformIteration::one_to_one('a'));
     offset_map.push_iteration(&CharacterTransformIteration::one_to_one('a'));
     offset_map.push_iteration(&CharacterTransformIteration::one_to_one('a'));
@@ -656,9 +664,15 @@ fn test_offsetmap_basic_collapse() {
         "Consecutive one-to-one mappings are merged"
     );
 
-    offset_map.push_iteration(&CharacterTransformIteration::collapse(2, Some(' ')));
+    offset_map.push_iteration(&CharacterTransformIteration::collapse(
+        Utf32CodeUnits(2),
+        Some(' '),
+    ));
     offset_map.push_iteration(&CharacterTransformIteration::one_to_one('b'));
-    offset_map.push_iteration(&CharacterTransformIteration::collapse(2, Some('\n')));
+    offset_map.push_iteration(&CharacterTransformIteration::collapse(
+        Utf32CodeUnits(2),
+        Some('\n'),
+    ));
     offset_map.push_iteration(&CharacterTransformIteration::one_to_one('c'));
 
     assert_eq!(offset_map.map(Utf32CodeUnits(0)).0, 0);
@@ -681,7 +695,7 @@ fn test_offsetmap_basic_collapse() {
     assert_eq!(offset_map.map(Utf32CodeUnits(12)).0, 7);
     assert_eq!(offset_map.map(Utf32CodeUnits(100)).0, 7);
 
-    let map_substring = |offset: usize, length: usize| {
+    let map_substring = |offset: u32, length: u32| {
         let start = offset_map.map(Utf32CodeUnits(offset)).0;
         let end = offset_map.map(Utf32CodeUnits(offset + length)).0;
         &final_string[start..end]

--- a/components/layout/flow/inline/text_transform.rs
+++ b/components/layout/flow/inline/text_transform.rs
@@ -15,6 +15,8 @@ use icu_properties::props::{EnumeratedProperty, GeneralCategory, GeneralCategory
 use icu_segmenter::WordSegmenter;
 use icu_segmenter::options::WordBreakInvariantOptions;
 use malloc_size_of_derive::MallocSizeOf;
+#[cfg(test)]
+use servo_base::text::Str32;
 use servo_base::text::Utf32CodeUnits;
 use style::computed_values::_webkit_text_security::T as WebKitTextSecurity;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
@@ -630,13 +632,17 @@ fn test_offsetmap_basic_expansion() {
     assert_eq!(offset_map.map(Utf32CodeUnits(100)).0, 7);
 
     let map_substring = |offset: u32, length: u32| {
-        let start = offset_map
-            .map(Utf32CodeUnits(offset))
-            .to_utf8_code_units_in(final_string);
-        let end = offset_map
-            .map(Utf32CodeUnits(offset + length))
-            .to_utf8_code_units_in(final_string);
-        &final_string[start.0..end.0]
+        let start = usize::from(
+            offset_map
+                .map(Utf32CodeUnits(offset))
+                .to_utf8_code_units_in(Str32(final_string)),
+        );
+        let end = usize::from(
+            offset_map
+                .map(Utf32CodeUnits(offset + length))
+                .to_utf8_code_units_in(Str32(final_string)),
+        );
+        &final_string[start..end]
     };
     assert_eq!(map_substring(0, 1), "A");
     assert_eq!(map_substring(0, 2), "ASS");
@@ -696,8 +702,8 @@ fn test_offsetmap_basic_collapse() {
     assert_eq!(offset_map.map(Utf32CodeUnits(100)).0, 7);
 
     let map_substring = |offset: u32, length: u32| {
-        let start = offset_map.map(Utf32CodeUnits(offset)).0;
-        let end = offset_map.map(Utf32CodeUnits(offset + length)).0;
+        let start = usize::from(offset_map.map(Utf32CodeUnits(offset)));
+        let end = usize::from(offset_map.map(Utf32CodeUnits(offset + length)));
         &final_string[start..end]
     };
     assert_eq!(map_substring(0, 1), "");

--- a/components/layout/flow/inline/text_transform.rs
+++ b/components/layout/flow/inline/text_transform.rs
@@ -16,7 +16,7 @@ use icu_segmenter::WordSegmenter;
 use icu_segmenter::options::WordBreakInvariantOptions;
 use malloc_size_of_derive::MallocSizeOf;
 #[cfg(test)]
-use servo_base::text::Str32;
+use servo_base::text::AssumeUnder4GB;
 use servo_base::text::Utf32CodeUnits;
 use style::computed_values::_webkit_text_security::T as WebKitTextSecurity;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
@@ -635,12 +635,12 @@ fn test_offsetmap_basic_expansion() {
         let start = usize::from(
             offset_map
                 .map(Utf32CodeUnits(offset))
-                .to_utf8_code_units_in(Str32(final_string)),
+                .to_utf8_code_units_in(AssumeUnder4GB, final_string),
         );
         let end = usize::from(
             offset_map
                 .map(Utf32CodeUnits(offset + length))
-                .to_utf8_code_units_in(Str32(final_string)),
+                .to_utf8_code_units_in(AssumeUnder4GB, final_string),
         );
         &final_string[start..end]
     };

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -542,7 +542,7 @@ impl TextFragment {
                     return Some(current_character);
                 }
                 current_offset += advance;
-                current_character += Utf32CodeUnits(glyph.character_count());
+                current_character += glyph.character_count();
             }
         }
 

--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -5,6 +5,7 @@
 use js::gc::HandleValue;
 use script_bindings::reflector::{DomObject, reflect_dom_object_with_cx};
 use servo_base::generic_channel::{GenericCallback, GenericSender};
+use servo_base::text::Utf8CodeUnits;
 use servo_bluetooth_traits::{BluetoothError, BluetoothRequest, GATTType};
 use servo_bluetooth_traits::{BluetoothResponse, BluetoothResponseResult};
 use servo_bluetooth_traits::blocklist::{Blocklist, uuid_is_blocklisted};
@@ -55,7 +56,7 @@ const MANUFACTURER_DATA_ERROR: &CStr =
     c"'manufacturerData', if present, must be non-empty to filter devices.";
 const MASK_LENGTH_ERROR: &CStr = c"`mask`, if present, must have the same length as `dataPrefix`.";
 // 248 is the maximum number of UTF-8 code units in a Bluetooth Device Name.
-const MAX_DEVICE_NAME_LENGTH: usize = 248;
+const MAX_DEVICE_NAME_LENGTH: Utf8CodeUnits = Utf8CodeUnits(248);
 const NAME_PREFIX_ERROR: &CStr = c"'namePrefix', if present, must be nonempty.";
 const NAME_TOO_LONG_ERROR: &CStr = c"A device name can't be longer than 248 bytes.";
 const SERVICE_DATA_ERROR: &CStr =
@@ -387,8 +388,7 @@ fn canonicalize_filter(filter: &BluetoothLEScanFilterInit) -> Fallible<Bluetooth
     let name = match filter.name {
         Some(ref name) => {
             // Step 4.1.
-            // Note: DOMString::len() gives back the size in bytes.
-            if name.len() > MAX_DEVICE_NAME_LENGTH {
+            if name.len_utf8() > MAX_DEVICE_NAME_LENGTH {
                 return Err(Type(NAME_TOO_LONG_ERROR.to_owned()));
             }
 
@@ -405,7 +405,7 @@ fn canonicalize_filter(filter: &BluetoothLEScanFilterInit) -> Fallible<Bluetooth
             if name_prefix.is_empty() {
                 return Err(Type(NAME_PREFIX_ERROR.to_owned()));
             }
-            if name_prefix.len() > MAX_DEVICE_NAME_LENGTH {
+            if name_prefix.len_utf8() > MAX_DEVICE_NAME_LENGTH {
                 return Err(Type(NAME_TOO_LONG_ERROR.to_owned()));
             }
 

--- a/components/script/dom/characterdata/characterdata.rs
+++ b/components/script/dom/characterdata/characterdata.rs
@@ -9,7 +9,7 @@ use atomic_refcell::{AtomicRef, AtomicRefCell};
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::codegen::InheritTypes::{CharacterDataTypeId, NodeTypeId, TextTypeId};
-use servo_base::text::{RangeAny, Utf16CodeUnits, Utf32CodeUnits};
+use servo_base::text::{RangeAny, Str32, Utf16CodeUnits, Utf32CodeUnits};
 
 use crate::dom::bindings::cell::AtomicSafeBorrowMut;
 use crate::dom::bindings::codegen::Bindings::CharacterDataBinding::CharacterDataMethods;
@@ -133,8 +133,10 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
         self.content_changed(cx);
 
         let mut utf16_length = None;
-        let mut lazy_length =
-            move || *utf16_length.get_or_insert_with(|| Utf16CodeUnits::length_of(&data.str()).0);
+        // TODO: ensure that DOMString’s are under 4 GiB?
+        let mut lazy_length = move || {
+            *utf16_length.get_or_insert_with(|| Utf16CodeUnits::length_of(Str32(&data.str())).0)
+        };
 
         let node: &Node = self.upcast();
         if let Some(selection) = node.owner_doc_unrooted(cx.no_gc()).selection() {
@@ -145,7 +147,8 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
 
     /// <https://dom.spec.whatwg.org/#dom-characterdata-length>
     fn Length(&self) -> u32 {
-        Utf16CodeUnits::length_of(&self.data.borrow()).0
+        // TODO: ensure that DOMString’s are under 4 GiB?
+        Utf16CodeUnits::length_of(Str32(&self.data.borrow())).0
     }
 
     /// <https://dom.spec.whatwg.org/#dom-characterdata-substringdata>
@@ -268,8 +271,10 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
         let node = self.upcast::<Node>();
 
         let mut utf16_length = None;
-        let mut lazy_length =
-            move || *utf16_length.get_or_insert_with(|| Utf16CodeUnits::length_of(&arg.str()).0);
+        // TODO: ensure that DOMString’s are under 4 GiB?
+        let mut lazy_length = move || {
+            *utf16_length.get_or_insert_with(|| Utf16CodeUnits::length_of(Str32(&arg.str())).0)
+        };
 
         if let Some(selection) = node.owner_doc_unrooted(cx.no_gc()).selection() {
             selection.replace_data_steps(node, offset, count, &mut lazy_length);

--- a/components/script/dom/characterdata/characterdata.rs
+++ b/components/script/dom/characterdata/characterdata.rs
@@ -133,9 +133,8 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
         self.content_changed(cx);
 
         let mut utf16_length = None;
-        let mut lazy_length = move || {
-            *utf16_length.get_or_insert_with(|| Utf16CodeUnits::length_of(&data.str()).0 as u32)
-        };
+        let mut lazy_length =
+            move || *utf16_length.get_or_insert_with(|| Utf16CodeUnits::length_of(&data.str()).0);
 
         let node: &Node = self.upcast();
         if let Some(selection) = node.owner_doc_unrooted(cx.no_gc()).selection() {
@@ -146,7 +145,7 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
 
     /// <https://dom.spec.whatwg.org/#dom-characterdata-length>
     fn Length(&self) -> u32 {
-        Utf16CodeUnits::length_of(&self.data.borrow()).0 as u32
+        Utf16CodeUnits::length_of(&self.data.borrow()).0
     }
 
     /// <https://dom.spec.whatwg.org/#dom-characterdata-substringdata>
@@ -253,7 +252,7 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
             new_data = String::with_capacity(
                 prefix.len() +
                     replacement_before.len() +
-                    arg.len() +
+                    usize::from(arg.len_utf8()) +
                     replacement_after.len() +
                     suffix.len(),
             );
@@ -269,9 +268,8 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
         let node = self.upcast::<Node>();
 
         let mut utf16_length = None;
-        let mut lazy_length = move || {
-            *utf16_length.get_or_insert_with(|| Utf16CodeUnits::length_of(&arg.str()).0 as u32)
-        };
+        let mut lazy_length =
+            move || *utf16_length.get_or_insert_with(|| Utf16CodeUnits::length_of(&arg.str()).0);
 
         if let Some(selection) = node.owner_doc_unrooted(cx.no_gc()).selection() {
             selection.replace_data_steps(node, offset, count, &mut lazy_length);

--- a/components/script/dom/characterdata/characterdata.rs
+++ b/components/script/dom/characterdata/characterdata.rs
@@ -9,7 +9,7 @@ use atomic_refcell::{AtomicRef, AtomicRefCell};
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::codegen::InheritTypes::{CharacterDataTypeId, NodeTypeId, TextTypeId};
-use servo_base::text::{RangeAny, Str32, Utf16CodeUnits, Utf32CodeUnits};
+use servo_base::text::{AssumeUnder4GB, RangeAny, Utf16CodeUnits, Utf32CodeUnits};
 
 use crate::dom::bindings::cell::AtomicSafeBorrowMut;
 use crate::dom::bindings::codegen::Bindings::CharacterDataBinding::CharacterDataMethods;
@@ -135,7 +135,8 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
         let mut utf16_length = None;
         // TODO: ensure that DOMString’s are under 4 GiB?
         let mut lazy_length = move || {
-            *utf16_length.get_or_insert_with(|| Utf16CodeUnits::length_of(Str32(&data.str())).0)
+            *utf16_length
+                .get_or_insert_with(|| Utf16CodeUnits::length_of(AssumeUnder4GB, &data.str()).0)
         };
 
         let node: &Node = self.upcast();
@@ -148,7 +149,7 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
     /// <https://dom.spec.whatwg.org/#dom-characterdata-length>
     fn Length(&self) -> u32 {
         // TODO: ensure that DOMString’s are under 4 GiB?
-        Utf16CodeUnits::length_of(Str32(&self.data.borrow())).0
+        Utf16CodeUnits::length_of(AssumeUnder4GB, &self.data.borrow()).0
     }
 
     /// <https://dom.spec.whatwg.org/#dom-characterdata-substringdata>
@@ -273,7 +274,8 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
         let mut utf16_length = None;
         // TODO: ensure that DOMString’s are under 4 GiB?
         let mut lazy_length = move || {
-            *utf16_length.get_or_insert_with(|| Utf16CodeUnits::length_of(Str32(&arg.str())).0)
+            *utf16_length
+                .get_or_insert_with(|| Utf16CodeUnits::length_of(AssumeUnder4GB, &arg.str()).0)
         };
 
         if let Some(selection) = node.owner_doc_unrooted(cx.no_gc()).selection() {

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -3735,7 +3735,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         // Fast path for when the value is small, doesn't contain any markup and doesn't require
         // extra work to set innerHTML.
         if !self.node.has_weird_parser_insertion_mode() &&
-            value.len() < 100 &&
+            value.len_utf8_or_latin1() < 100 &&
             !value
                 .as_bytes()
                 .iter()

--- a/components/script/dom/execcommand/commands/fontsize.rs
+++ b/components/script/dom/execcommand/commands/fontsize.rs
@@ -147,7 +147,7 @@ pub(crate) fn maybe_normalize_pixels(
     document: &Document,
 ) -> Option<DOMString> {
     if command_value.ends_with_str("px") {
-        command_value.str()[0..command_value.len() - 2]
+        command_value.str()[..usize::from(command_value.len_utf8()) - 2]
             .parse::<f32>()
             .ok()
             .map(|value| legacy_font_size_for(value, document))

--- a/components/script/dom/execcommand/commands/fontsize.rs
+++ b/components/script/dom/execcommand/commands/fontsize.rs
@@ -146,8 +146,8 @@ pub(crate) fn maybe_normalize_pixels(
     command_value: &DOMString,
     document: &Document,
 ) -> Option<DOMString> {
-    if command_value.ends_with_str("px") {
-        command_value.str()[..usize::from(command_value.len_utf8()) - 2]
+    if let Some(px_value) = command_value.str().strip_suffix("px") {
+        px_value
             .parse::<f32>()
             .ok()
             .map(|value| legacy_font_size_for(value, document))

--- a/components/script/dom/execcommand/commands/inserttext.rs
+++ b/components/script/dom/execcommand/commands/inserttext.rs
@@ -128,7 +128,7 @@ pub(crate) fn execute_insert_text_command(
         // Step 13.3. Call extend(node, offset + 1) on the context object's selection.
         // Note: We're doing this per UTF-8 character instead of per UTF-16 code unit.
         if selection
-            .Extend(cx, &node, offset + (value.len_utf16().0 as u32))
+            .Extend(cx, &node, offset + value.len_utf16().0)
             .is_err()
         {
             unreachable!("Must always be able to extend the selection");
@@ -159,10 +159,7 @@ pub(crate) fn execute_insert_text_command(
 
         // Step 14.5. Call extend(text, 1) on the context object's selection.
         // Note: We're doing this per UTF-8 character instead of per UTF-16 code unit.
-        if selection
-            .Extend(cx, text, value.len_utf16().0 as u32)
-            .is_err()
-        {
+        if selection.Extend(cx, text, value.len_utf16().0).is_err() {
             unreachable!("Must always be able to extend the selection");
         }
 

--- a/components/script/dom/html/form_controls/htmlinputelement.rs
+++ b/components/script/dom/html/form_controls/htmlinputelement.rs
@@ -757,11 +757,11 @@ impl HTMLInputElement {
         let min_length = self.MinLength();
         let max_length = self.MaxLength();
 
-        if min_length != DEFAULT_MIN_LENGTH && value_len < (min_length as usize) {
+        if min_length != DEFAULT_MIN_LENGTH && value_len < (min_length as u32) {
             failed_flags.insert(ValidationFlags::TOO_SHORT);
         }
 
-        if max_length != DEFAULT_MAX_LENGTH && value_len > (max_length as usize) {
+        if max_length != DEFAULT_MAX_LENGTH && value_len > (max_length as u32) {
             failed_flags.insert(ValidationFlags::TOO_LONG);
         }
 
@@ -1467,7 +1467,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionstart>
     fn GetSelectionStart(&self) -> Option<u32> {
-        self.selection().dom_start().map(|start| start.0 as u32)
+        self.selection().dom_start().map(|start| start.0)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionstart>
@@ -1478,7 +1478,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionend>
     fn GetSelectionEnd(&self) -> Option<u32> {
-        self.selection().dom_end().map(|end| end.0 as u32)
+        self.selection().dom_end().map(|end| end.0)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionend>
@@ -2114,10 +2114,8 @@ impl VirtualMethods for HTMLInputElement {
 
                         // Set or remove the length restrictions depending on whether they apply
                         if self.does_minmaxlength_apply() {
-                            textinput
-                                .set_min_length(self.MinLength().to_usize().map(Utf16CodeUnits));
-                            textinput
-                                .set_max_length(self.MaxLength().to_usize().map(Utf16CodeUnits));
+                            textinput.set_min_length(self.MinLength().to_u32().map(Utf16CodeUnits));
+                            textinput.set_max_length(self.MaxLength().to_u32().map(Utf16CodeUnits));
                         } else {
                             textinput.set_min_length(None);
                             textinput.set_max_length(None);
@@ -2163,7 +2161,7 @@ impl VirtualMethods for HTMLInputElement {
                     if value < 0 {
                         textinput.set_max_length(None);
                     } else {
-                        textinput.set_max_length(Some(Utf16CodeUnits(value as usize)))
+                        textinput.set_max_length(Some(Utf16CodeUnits(value as u32)))
                     }
                 },
                 _ => panic!("Expected an AttrValue::Int"),
@@ -2175,7 +2173,7 @@ impl VirtualMethods for HTMLInputElement {
                     if value < 0 {
                         textinput.set_min_length(None);
                     } else {
-                        textinput.set_min_length(Some(Utf16CodeUnits(value as usize)))
+                        textinput.set_min_length(Some(Utf16CodeUnits(value as u32)))
                     }
                 },
                 _ => panic!("Expected an AttrValue::Int"),

--- a/components/script/dom/html/form_controls/htmltextareaelement.rs
+++ b/components/script/dom/html/form_controls/htmltextareaelement.rs
@@ -439,7 +439,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea-textlength>
     fn TextLength(&self) -> u32 {
-        self.textinput.borrow().len_utf16().0 as u32
+        self.textinput.borrow().len_utf16().0
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-lfe-labels
@@ -452,7 +452,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionstart>
     fn GetSelectionStart(&self) -> Option<u32> {
-        self.selection().dom_start().map(|start| start.0 as u32)
+        self.selection().dom_start().map(|start| start.0)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionstart>
@@ -463,7 +463,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionend>
     fn GetSelectionEnd(&self) -> Option<u32> {
-        self.selection().dom_end().map(|end| end.0 as u32)
+        self.selection().dom_end().map(|end| end.0)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionend>
@@ -633,7 +633,7 @@ impl VirtualMethods for HTMLTextAreaElement {
                     if value < 0 {
                         textinput.set_max_length(None);
                     } else {
-                        textinput.set_max_length(Some(Utf16CodeUnits(value as usize)))
+                        textinput.set_max_length(Some(Utf16CodeUnits(value as u32)))
                     }
                 },
                 _ => panic!("Expected an AttrValue::Int"),
@@ -645,7 +645,7 @@ impl VirtualMethods for HTMLTextAreaElement {
                     if value < 0 {
                         textinput.set_min_length(None);
                     } else {
-                        textinput.set_min_length(Some(Utf16CodeUnits(value as usize)))
+                        textinput.set_min_length(Some(Utf16CodeUnits(value as u32)))
                     }
                 },
                 _ => panic!("Expected an AttrValue::Int"),
@@ -930,7 +930,7 @@ impl Validatable for HTMLTextAreaElement {
             // https://html.spec.whatwg.org/multipage/#limiting-user-input-length%3A-the-maxlength-attribute%3Asuffering-from-being-too-long
             if validate_flags.contains(ValidationFlags::TOO_LONG) {
                 let max_length = self.MaxLength();
-                if max_length != DEFAULT_MAX_LENGTH && value_len > (max_length as usize) {
+                if max_length != DEFAULT_MAX_LENGTH && value_len > (max_length as u32) {
                     failed_flags.insert(ValidationFlags::TOO_LONG);
                 }
             }
@@ -939,7 +939,7 @@ impl Validatable for HTMLTextAreaElement {
             // https://html.spec.whatwg.org/multipage/#setting-minimum-input-length-requirements%3A-the-minlength-attribute%3Asuffering-from-being-too-short
             if validate_flags.contains(ValidationFlags::TOO_SHORT) {
                 let min_length = self.MinLength();
-                if min_length != DEFAULT_MIN_LENGTH && value_len < (min_length as usize) {
+                if min_length != DEFAULT_MIN_LENGTH && value_len < (min_length as u32) {
                     failed_flags.insert(ValidationFlags::TOO_SHORT);
                 }
             }

--- a/components/script/dom/html/form_controls/text_control.rs
+++ b/components/script/dom/html/form_controls/text_control.rs
@@ -63,8 +63,8 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
 
         // Step 2 : Set the selection range with 0 and infinity.
         self.set_range(
-            Some(Utf16CodeUnits::zero()),
-            Some(Utf16CodeUnits(usize::MAX)),
+            Some(Utf16CodeUnits(0)),
+            Some(Utf16CodeUnits(u32::MAX)),
             None,
             None,
         );
@@ -305,7 +305,7 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
                 let old_length = end.saturating_sub(start);
 
                 // Sub-step 2: Let delta be new length minus old length.
-                let delta = (new_length.0 as isize) - (old_length.0 as isize);
+                let delta = (new_length.0 as i32) - (old_length.0 as i32);
 
                 // Sub-step 3: If selection start is greater than end, then increment it
                 // by delta. (If delta is negative, i.e. the new text is shorter than the
@@ -315,7 +315,7 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
                 // start. (This snaps the start of the selection to the start of the new
                 // text if it was in the middle of the text that it replaced.)
                 if selection_start > end {
-                    selection_start = Utf16CodeUnits::from((selection_start.0 as isize) + delta);
+                    selection_start = Utf16CodeUnits(((selection_start.0 as i32) + delta) as u32);
                 } else if selection_start > start {
                     selection_start = start;
                 }
@@ -327,7 +327,7 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
                 // end. (This snaps the end of the selection to the end of the new text if
                 // it was in the middle of the text that it replaced.)
                 if selection_end > end {
-                    selection_end = Utf16CodeUnits::from((selection_end.0 as isize) + delta);
+                    selection_end = Utf16CodeUnits(((selection_end.0 as i32) + delta) as u32);
                 } else if selection_end > start {
                     selection_end = new_end;
                 }

--- a/components/script/dom/html/form_controls/text_control.rs
+++ b/components/script/dom/html/form_controls/text_control.rs
@@ -305,8 +305,6 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
                 let old_length = end.saturating_sub(start);
 
                 // Sub-step 2: Let delta be new length minus old length.
-                let delta = (new_length.0 as i32) - (old_length.0 as i32);
-
                 // Sub-step 3: If selection start is greater than end, then increment it
                 // by delta. (If delta is negative, i.e. the new text is shorter than the
                 // old text, then this will decrease the value of selection start.)
@@ -315,7 +313,7 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
                 // start. (This snaps the start of the selection to the start of the new
                 // text if it was in the middle of the text that it replaced.)
                 if selection_start > end {
-                    selection_start = Utf16CodeUnits(((selection_start.0 as i32) + delta) as u32);
+                    selection_start = selection_start + new_length - old_length;
                 } else if selection_start > start {
                     selection_start = start;
                 }
@@ -327,7 +325,7 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
                 // end. (This snaps the end of the selection to the end of the new text if
                 // it was in the middle of the text that it replaced.)
                 if selection_end > end {
-                    selection_end = Utf16CodeUnits(((selection_end.0 as i32) + delta) as u32);
+                    selection_end = selection_end + new_length - old_length;
                 } else if selection_end > start {
                     selection_end = new_end;
                 }

--- a/components/script/dom/html/form_controls/text_input.rs
+++ b/components/script/dom/html/form_controls/text_input.rs
@@ -18,7 +18,7 @@ use script_bindings::trace::CustomTraceable;
 use script_traits::MouseButtons;
 use servo_base::generic_channel::GenericCallback;
 use servo_base::id::WebViewId;
-use servo_base::text::{RangeAny, Utf8CodeUnits, Utf16CodeUnits, Utf32CodeUnits};
+use servo_base::text::{RangeAny, Str32, Utf8CodeUnits, Utf16CodeUnits, Utf32CodeUnits};
 use servo_base::{Rope, RopeIndex, RopeMovement, RopeSlice};
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
@@ -475,8 +475,10 @@ impl<T: ClipboardProvider> TextInput<T> {
                 self.len_utf16().saturating_sub(self.selection_utf16_len());
             let utf16_length_that_can_be_inserted =
                 max_length.saturating_sub(utf16_length_without_selection);
-            let last_char_index =
-                usize::from(utf16_length_that_can_be_inserted.to_utf8_code_units_in(&insert.str()));
+            // TODO: ensure that DOMString’s are under 4 GiB?
+            let last_char_index = usize::from(
+                utf16_length_that_can_be_inserted.to_utf8_code_units_in(Str32(&insert.str())),
+            );
             &insert.str()[..last_char_index]
         } else {
             &insert.str()

--- a/components/script/dom/html/form_controls/text_input.rs
+++ b/components/script/dom/html/form_controls/text_input.rs
@@ -274,22 +274,6 @@ pub(crate) const CMD_OR_CONTROL: Modifiers = Modifiers::META;
 #[cfg(not(target_os = "macos"))]
 pub(crate) const CMD_OR_CONTROL: Modifiers = Modifiers::CONTROL;
 
-/// The length in bytes of the first n code units in a string when encoded in UTF-16.
-///
-/// If the string is fewer than n code units, returns the length of the whole string.
-fn len_of_first_n_code_units(text: &DOMString, n: Utf16CodeUnits) -> Utf8CodeUnits {
-    let mut utf8_len = Utf8CodeUnits::zero();
-    let mut utf16_len = Utf16CodeUnits::zero();
-    for c in text.str().chars() {
-        utf16_len += Utf16CodeUnits(c.len_utf16());
-        if utf16_len > n {
-            break;
-        }
-        utf8_len += Utf8CodeUnits(c.len_utf8());
-    }
-    utf8_len
-}
-
 impl<T: ClipboardProvider> TextInput<T> {
     /// Instantiate a new text input control
     pub fn new(lines: Lines, initial: DOMString, clipboard_provider: T) -> TextInput<T> {
@@ -479,12 +463,7 @@ impl<T: ClipboardProvider> TextInput<T> {
 
     /// The length of the selected text in UTF-16 code units.
     fn selection_utf16_len(&self) -> Utf16CodeUnits {
-        Utf16CodeUnits(
-            self.selection_slice()
-                .chars()
-                .map(char::len_utf16)
-                .sum::<usize>(),
-        )
+        self.selection_slice().len_utf16()
     }
 
     /// Replace the current selection with the given [`DOMString`]. If the [`Rope`] is in
@@ -496,8 +475,8 @@ impl<T: ClipboardProvider> TextInput<T> {
                 self.len_utf16().saturating_sub(self.selection_utf16_len());
             let utf16_length_that_can_be_inserted =
                 max_length.saturating_sub(utf16_length_without_selection);
-            let Utf8CodeUnits(last_char_index) =
-                len_of_first_n_code_units(insert, utf16_length_that_can_be_inserted);
+            let last_char_index =
+                usize::from(utf16_length_that_can_be_inserted.to_utf8_code_units_in(&insert.str()));
             &insert.str()[..last_char_index]
         } else {
             &insert.str()

--- a/components/script/dom/html/form_controls/text_input.rs
+++ b/components/script/dom/html/form_controls/text_input.rs
@@ -430,7 +430,7 @@ impl<T: ClipboardProvider> TextInput<T> {
         // For now, use a bounded end unconditionally instead.
         // let end = (end != rope.last_index()).then(|| rope.index_to_character_offset(end));
         let end = Some(rope.index_to_character_offset(end));
-        RangeAny { start, end }
+        RangeAny::new(start, end)
     }
 
     /// The state of the current selection. Can be used to compare whether selection state has changed.

--- a/components/script/dom/html/form_controls/text_input.rs
+++ b/components/script/dom/html/form_controls/text_input.rs
@@ -18,7 +18,7 @@ use script_bindings::trace::CustomTraceable;
 use script_traits::MouseButtons;
 use servo_base::generic_channel::GenericCallback;
 use servo_base::id::WebViewId;
-use servo_base::text::{RangeAny, Str32, Utf8CodeUnits, Utf16CodeUnits, Utf32CodeUnits};
+use servo_base::text::{AssumeUnder4GB, RangeAny, Utf8CodeUnits, Utf16CodeUnits, Utf32CodeUnits};
 use servo_base::{Rope, RopeIndex, RopeMovement, RopeSlice};
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
@@ -477,7 +477,8 @@ impl<T: ClipboardProvider> TextInput<T> {
                 max_length.saturating_sub(utf16_length_without_selection);
             // TODO: ensure that DOMString’s are under 4 GiB?
             let last_char_index = usize::from(
-                utf16_length_that_can_be_inserted.to_utf8_code_units_in(Str32(&insert.str())),
+                utf16_length_that_can_be_inserted
+                    .to_utf8_code_units_in(AssumeUnder4GB, &insert.str()),
             );
             &insert.str()[..last_char_index]
         } else {

--- a/components/script/dom/node/layout_dom.rs
+++ b/components/script/dom/node/layout_dom.rs
@@ -278,7 +278,7 @@ impl<'dom> LayoutDom<'dom, Node> {
             .then(|| Utf16CodeUnits(range.start.offset as usize).to_utf32_code_units_in(&text));
         let end = is_end_node
             .then(|| Utf16CodeUnits(range.end.offset as usize).to_utf32_code_units_in(&text));
-        Some(RangeAny { start, end })
+        Some(RangeAny::new(start, end))
     }
 
     pub(crate) fn text_node_paints_caret(&self) -> bool {

--- a/components/script/dom/node/layout_dom.rs
+++ b/components/script/dom/node/layout_dom.rs
@@ -274,10 +274,10 @@ impl<'dom> LayoutDom<'dom, Node> {
         let is_start_node = unsafe { range.start.container.to_layout() } == *self;
         let is_end_node = unsafe { range.end.container.to_layout() } == *self;
 
-        let start = is_start_node
-            .then(|| Utf16CodeUnits(range.start.offset as usize).to_utf32_code_units_in(&text));
-        let end = is_end_node
-            .then(|| Utf16CodeUnits(range.end.offset as usize).to_utf32_code_units_in(&text));
+        let start =
+            is_start_node.then(|| Utf16CodeUnits(range.start.offset).to_utf32_code_units_in(&text));
+        let end =
+            is_end_node.then(|| Utf16CodeUnits(range.end.offset).to_utf32_code_units_in(&text));
         Some(RangeAny::new(start, end))
     }
 

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -284,21 +284,21 @@ impl Selection {
         // But that requires keeping track of the previous range, to compare.
         if let Some(character_data) = start_container.downcast::<CharacterData>() {
             let text = character_data.data();
-            let range = RangeAny {
-                start: Some(Utf16CodeUnits(start_offset).to_utf32_code_units_in(&text)),
-                end: (start_node == end_node)
+            let range = RangeAny::new(
+                Some(Utf16CodeUnits(start_offset).to_utf32_code_units_in(&text)),
+                (start_node == end_node)
                     .then_some(Utf16CodeUnits(end_offset).to_utf32_code_units_in(&text)),
-            };
+            );
             set_text_run_selection(character_data, Some(range))
         }
         if end_container != start_container &&
             let Some(character_data) = end_container.downcast::<CharacterData>()
         {
             let text = character_data.data();
-            let range = RangeAny {
-                start: None,
-                end: Some(Utf16CodeUnits(end_offset).to_utf32_code_units_in(&text)),
-            };
+            let range = RangeAny::new(
+                None,
+                Some(Utf16CodeUnits(end_offset).to_utf32_code_units_in(&text)),
+            );
             set_text_run_selection(character_data, Some(range))
         }
 

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -264,8 +264,8 @@ impl Selection {
         // so we don’t need HashDoS resistance and can use a faster hasher than `std`’s default
         let mut previously_flagged_nodes: FxHashSet<_> = previously_flagged_nodes.collect();
 
-        let start_offset = range.start.offset as usize;
-        let end_offset = range.end.offset as usize;
+        let start_offset = range.start.offset;
+        let end_offset = range.end.offset;
         let start_container = range.start.container.as_rooted();
         let end_container = range.end.container.as_rooted();
         let start_position =
@@ -1414,7 +1414,7 @@ impl FlatTreeNodePosition {
 fn position_in_flat_tree_for_selection(
     no_gc: &NoGC,
     container: DomRoot<Node>,
-    offset: usize,
+    offset: u32,
 ) -> FlatTreeNodePosition {
     if container.is::<CharacterData>() {
         return FlatTreeNodePosition::Inside(container);
@@ -1427,7 +1427,7 @@ fn position_in_flat_tree_for_selection(
             .unwrap_or(DomRoot::from_ref(node))
     };
 
-    if let Some(child) = container.children().nth(offset) {
+    if let Some(child) = container.children().nth(offset as usize) {
         if let FlatTreeParent::Parent(_) = child.parent_in_flat_tree(no_gc) {
             return FlatTreeNodePosition::Before(child);
         }
@@ -1447,9 +1447,9 @@ impl Node {
     /// `CharacterData` or else return the offset in the child list.
     fn to_sibling_or_utf16_offset(&self, offset: Utf32CodeUnitsOrNodeOffset) -> u32 {
         if let Some(character_data) = self.downcast::<CharacterData>() {
-            offset.to_utf16_code_units_in(&character_data.data()).0 as u32
+            offset.to_utf16_code_units_in(&character_data.data()).0
         } else {
-            offset.0 as u32
+            offset.0
         }
     }
 }

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -13,7 +13,9 @@ use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::ShadowRootBinding::ShadowRootMethods;
 use script_bindings::dom::UnrootedDom;
 use script_bindings::reflector::{Reflector, reflect_dom_object};
-use servo_base::text::{RangeAny, Utf16CodeUnits, Utf32CodeUnits, Utf32CodeUnitsOrNodeOffset};
+use servo_base::text::{
+    RangeAny, Str32, Utf16CodeUnits, Utf32CodeUnits, Utf32CodeUnitsOrNodeOffset,
+};
 
 use crate::dom::abstractrange::bp_position;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::{GetRootNodeOptions, NodeMethods};
@@ -1447,7 +1449,10 @@ impl Node {
     /// `CharacterData` or else return the offset in the child list.
     fn to_sibling_or_utf16_offset(&self, offset: Utf32CodeUnitsOrNodeOffset) -> u32 {
         if let Some(character_data) = self.downcast::<CharacterData>() {
-            offset.to_utf16_code_units_in(&character_data.data()).0
+            // TODO: ensure that each `CharacterData` holds no more than 4 GiB?
+            offset
+                .to_utf16_code_units_in(Str32(&character_data.data()))
+                .0
         } else {
             offset.0
         }

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -297,10 +297,8 @@ impl Selection {
             let Some(character_data) = end_container.downcast::<CharacterData>()
         {
             let text = character_data.data();
-            let range = RangeAny::new(
-                None,
-                Some(Utf16CodeUnits(end_offset).to_utf32_code_units_in(&text)),
-            );
+            let range =
+                RangeAny::from_start_to(Utf16CodeUnits(end_offset).to_utf32_code_units_in(&text));
             set_text_run_selection(character_data, Some(range))
         }
 

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -14,7 +14,7 @@ use script_bindings::codegen::GenericBindings::ShadowRootBinding::ShadowRootMeth
 use script_bindings::dom::UnrootedDom;
 use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_base::text::{
-    RangeAny, Str32, Utf16CodeUnits, Utf32CodeUnits, Utf32CodeUnitsOrNodeOffset,
+    AssumeUnder4GB, RangeAny, Utf16CodeUnits, Utf32CodeUnits, Utf32CodeUnitsOrNodeOffset,
 };
 
 use crate::dom::abstractrange::bp_position;
@@ -1451,7 +1451,7 @@ impl Node {
         if let Some(character_data) = self.downcast::<CharacterData>() {
             // TODO: ensure that each `CharacterData` holds no more than 4 GiB?
             offset
-                .to_utf16_code_units_in(Str32(&character_data.data()))
+                .to_utf16_code_units_in(AssumeUnder4GB, &character_data.data())
                 .0
         } else {
             offset.0

--- a/components/script/dom/selection_range.rs
+++ b/components/script/dom/selection_range.rs
@@ -27,8 +27,7 @@ impl SelectionBoundary {
 
 impl PartialEq<BoundaryPoint> for SelectionBoundary {
     fn eq(&self, boundary_point: &BoundaryPoint) -> bool {
-        *self.container == *boundary_point.node().get() &&
-            self.offset as usize == boundary_point.offset().0
+        *self.container == *boundary_point.node().get() && self.offset == boundary_point.offset().0
     }
 }
 

--- a/components/script/dom/webgl/webglprogram.rs
+++ b/components/script/dom/webgl/webglprogram.rs
@@ -11,6 +11,7 @@ use js::context::JSContext;
 use script_bindings::cell::{DomRefCell, Ref};
 use script_bindings::reflector::reflect_dom_object;
 use script_bindings::weakref::WeakRef;
+use servo_base::text::Utf8CodeUnits;
 use servo_canvas_traits::webgl::{
     ActiveAttribInfo, ActiveUniformBlockInfo, ActiveUniformInfo, WebGLCommand, WebGLError,
     WebGLProgramId, WebGLResult, webgl_channel,
@@ -800,7 +801,7 @@ fn validate_glsl_name(name: &DOMString) -> WebGLResult<bool> {
     if name.is_empty() {
         return Ok(false);
     }
-    if name.len() > MAX_UNIFORM_AND_ATTRIBUTE_LEN {
+    if name.len_utf8() > MAX_UNIFORM_AND_ATTRIBUTE_LEN {
         return Err(WebGLError::InvalidValue);
     }
     for c in name.str().chars() {
@@ -864,4 +865,9 @@ fn parse_uniform_name(name: &DOMString) -> Option<(String, Option<i32>)> {
     Some((String::from(&name[..bracket_pos]), Some(index)))
 }
 
-pub(crate) const MAX_UNIFORM_AND_ATTRIBUTE_LEN: usize = 256;
+/// <https://registry.khronos.org/webgl/specs/latest/1.0/#6.20>
+/// > WebGL requires support of tokens up to 256 characters in length.
+/// > Shaders containing tokens longer than 256 characters must fail to compile.
+///
+/// FIXME: how is "character" defined here? Should this be `Utf32CodeUnits` instead?
+pub(crate) const MAX_UNIFORM_AND_ATTRIBUTE_LEN: Utf8CodeUnits = Utf8CodeUnits(256);

--- a/components/script/event_loop/webdriver_handlers.rs
+++ b/components/script/event_loop/webdriver_handlers.rs
@@ -1360,10 +1360,10 @@ pub(crate) fn handle_will_send_keys(
     // using current text length for both the start and end parameters.
     if !element_has_focus {
         if let Some(input_element) = input_element {
-            let length = input_element.Value().len() as u32;
+            let length = input_element.Value().len_utf16().0;
             let _ = input_element.SetSelectionRange(length, length, None);
         } else if let Some(textarea_element) = element.downcast::<HTMLTextAreaElement>() {
-            let length = textarea_element.Value().len() as u32;
+            let length = textarea_element.Value().len_utf16().0;
             let _ = textarea_element.SetSelectionRange(length, length, None);
         }
     }

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -425,21 +425,30 @@ impl DOMString {
     }
 
     /// The length of this string in UTF-8 code units, each one being one byte in size.
-    ///
-    /// Note: This is different than the number of Unicode characters (or code points). A
-    /// character may require multiple UTF-8 code units.
-    pub fn len(&self) -> usize {
-        self.encoded_bytes().len()
-    }
-
-    /// The length of this string in UTF-8 code units, each one being one byte in size.
     /// This method is the same as [`DOMString::len`], but the result is wrapped in a
     /// `Utf8CodeUnits` to be used in code that mixes different kinds of offsets.
     ///
     /// Note: This is different than the number of Unicode characters (or code points). A
     /// character may require multiple UTF-8 code units.
     pub fn len_utf8(&self) -> Utf8CodeUnits {
-        Utf8CodeUnits(self.len())
+        // TODO: add a check that DOMString values never exceed 2 GiB?
+        Utf8CodeUnits(match self.encoded_bytes() {
+            EncodedBytes::Utf8(bytes) => bytes.len() as u32,
+            EncodedBytes::Latin1(bytes) => bytes
+                .iter()
+                // Latin-1 bytes 0x00 to 0x7F are ASCII-compatible and UTF-8-compatible
+                // Latin-1 bytes 0x80 to 0xFF convert to two-bytes UTF-8 sequences
+                .map(|&byte| if byte < 128 { 1 } else { 2 })
+                .sum::<u32>(),
+        })
+    }
+
+    /// Returns a length for “is small” heuristics, whose precise definition does not matter
+    pub fn len_utf8_or_latin1(&self) -> usize {
+        match self.encoded_bytes() {
+            EncodedBytes::Utf8(bytes) => bytes.len(),
+            EncodedBytes::Latin1(bytes) => bytes.len(),
+        }
     }
 
     /// The length of this string in UTF-16 code units, each one being one two bytes in size.
@@ -447,7 +456,22 @@ impl DOMString {
     /// Note: This is different than the number of Unicode characters (or code points). A
     /// character may require multiple UTF-16 code units.
     pub fn len_utf16(&self) -> Utf16CodeUnits {
-        Utf16CodeUnits(self.str().chars().map(char::len_utf16).sum())
+        let inner = self.0.borrow();
+        let as_str = match &*inner {
+            DOMStringType::Rust(string) => Ok(string.as_str()),
+            DOMStringType::RustStatic(string) => Ok(*string),
+            DOMStringType::JSString(rooted_traceable_box) => {
+                Err(unsafe { get_latin1_string_bytes(rooted_traceable_box) })
+            },
+            #[cfg(test)]
+            DOMStringType::Latin1Vec(vec) => Err(vec.as_slice()),
+        };
+        match as_str {
+            // TODO: add a check that DOMString values never exceed 2 GiB?
+            Ok(string) => Utf16CodeUnits::length_of(string),
+            // All Latin-1 bytes characters encode to a single UTF-16 code unit
+            Err(latin1_bytes) => Utf16CodeUnits(latin1_bytes.len() as u32),
+        }
     }
 
     /// This works the same as `make_ascii_lowercase` on std::string. This means that any character in [A-Z]

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -22,7 +22,7 @@ use js::rust::{Runtime, Trace};
 use malloc_size_of::MallocSizeOfOps;
 use num_traits::{ToPrimitive, Zero};
 use regex::Regex;
-use servo_base::text::{Utf8CodeUnits, Utf16CodeUnits};
+use servo_base::text::{Str32, Utf8CodeUnits, Utf16CodeUnits};
 use style::Atom;
 use style::str::HTML_SPACE_CHARACTERS;
 use zeroize::Zeroize;
@@ -468,7 +468,7 @@ impl DOMString {
         };
         match as_str {
             // TODO: add a check that DOMString values never exceed 2 GiB?
-            Ok(string) => Utf16CodeUnits::length_of(string),
+            Ok(string) => Utf16CodeUnits::length_of(Str32(string)),
             // All Latin-1 bytes characters encode to a single UTF-16 code unit
             Err(latin1_bytes) => Utf16CodeUnits(latin1_bytes.len() as u32),
         }
@@ -1080,8 +1080,8 @@ mod tests {
         let s_copy = s.clone();
         assert_eq!(s.to_ascii_lowercase(), "abbcc❤&%$#");
         assert_eq!(s, s_copy);
-        assert_eq!(s.len(), 12);
-        assert_eq!(s_copy.len(), 12);
+        assert_eq!(s.len_utf8().0, 12);
+        assert_eq!(s_copy.len_utf8().0, 12);
         assert!(s.starts_with('A'));
         let s2 = DOMString::from("");
         assert!(s2.is_empty());
@@ -1103,7 +1103,7 @@ mod tests {
             let s = from_latin1(vec![
                 b'A', b'b', b'B', b'c', b'C', b'&', b'%', b'$', b'#', 0xB2,
             ]);
-            assert_eq!(s.len(), 11);
+            assert_eq!(s.len_utf8().0, 11);
             assert!(s.starts_with('A'));
         }
         {
@@ -1146,12 +1146,12 @@ mod tests {
         let s5_utf8 = String::from("àáâãäåæçèéêëìíîï");
         let s6_utf8 = String::from("ðñòóôõö÷øùúûüýþÿ");
 
-        assert_eq!(s1.len(), s1_utf8.len());
-        assert_eq!(s2.len(), s2_utf8.len());
-        assert_eq!(s3.len(), s3_utf8.len());
-        assert_eq!(s4.len(), s4_utf8.len());
-        assert_eq!(s5.len(), s5_utf8.len());
-        assert_eq!(s6.len(), s6_utf8.len());
+        assert_eq!(usize::from(s1.len_utf8()), s1_utf8.len());
+        assert_eq!(usize::from(s2.len_utf8()), s2_utf8.len());
+        assert_eq!(usize::from(s3.len_utf8()), s3_utf8.len());
+        assert_eq!(usize::from(s4.len_utf8()), s4_utf8.len());
+        assert_eq!(usize::from(s5.len_utf8()), s5_utf8.len());
+        assert_eq!(usize::from(s6.len_utf8()), s6_utf8.len());
 
         s1.ensure_rust_string();
         s2.ensure_rust_string();
@@ -1159,12 +1159,12 @@ mod tests {
         s4.ensure_rust_string();
         s5.ensure_rust_string();
         s6.ensure_rust_string();
-        assert_eq!(s1.len(), s1_utf8.len());
-        assert_eq!(s2.len(), s2_utf8.len());
-        assert_eq!(s3.len(), s3_utf8.len());
-        assert_eq!(s4.len(), s4_utf8.len());
-        assert_eq!(s5.len(), s5_utf8.len());
-        assert_eq!(s6.len(), s6_utf8.len());
+        assert_eq!(usize::from(s1.len_utf8()), s1_utf8.len());
+        assert_eq!(usize::from(s2.len_utf8()), s2_utf8.len());
+        assert_eq!(usize::from(s3.len_utf8()), s3_utf8.len());
+        assert_eq!(usize::from(s4.len_utf8()), s4_utf8.len());
+        assert_eq!(usize::from(s5.len_utf8()), s5_utf8.len());
+        assert_eq!(usize::from(s6.len_utf8()), s6_utf8.len());
     }
 
     #[test]

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -78,16 +78,6 @@ impl EncodedBytes<'_> {
         }
     }
 
-    pub fn len(&self) -> usize {
-        match self {
-            Self::Latin1(bytes) => bytes
-                .iter()
-                .map(|b| if *b <= ASCII_END { 1 } else { 2 })
-                .sum(),
-            Self::Utf8(bytes) => bytes.len(),
-        }
-    }
-
     /// Return whether or not there is any data in this collection of bytes.
     pub fn is_empty(&self) -> bool {
         self.bytes().is_empty()
@@ -437,7 +427,7 @@ impl DOMString {
             EncodedBytes::Latin1(bytes) => bytes
                 .iter()
                 // Latin-1 bytes 0x00 to 0x7F are ASCII-compatible and UTF-8-compatible
-                // Latin-1 bytes 0x80 to 0xFF convert to two-bytes UTF-8 sequences
+                // Latin-1 bytes 0x80 to 0xFF convert to two-byte UTF-8 sequences
                 .map(|&byte| if byte < 128 { 1 } else { 2 })
                 .sum::<u32>(),
         })
@@ -456,21 +446,14 @@ impl DOMString {
     /// Note: This is different than the number of Unicode characters (or code points). A
     /// character may require multiple UTF-16 code units.
     pub fn len_utf16(&self) -> Utf16CodeUnits {
-        let inner = self.0.borrow();
-        let as_str = match &*inner {
-            DOMStringType::Rust(string) => Ok(string.as_str()),
-            DOMStringType::RustStatic(string) => Ok(*string),
-            DOMStringType::JSString(rooted_traceable_box) => {
-                Err(unsafe { get_latin1_string_bytes(rooted_traceable_box) })
-            },
-            #[cfg(test)]
-            DOMStringType::Latin1Vec(vec) => Err(vec.as_slice()),
-        };
-        match as_str {
+        match self.encoded_bytes() {
+            // All Latin-1 characters encode to a single UTF-16 code unit.
+            EncodedBytes::Latin1(bytes) => Utf16CodeUnits(bytes.len() as u32),
             // TODO: add a check that DOMString values never exceed 2 GiB?
-            Ok(string) => Utf16CodeUnits::length_of(AssumeUnder4GB, string),
-            // All Latin-1 bytes characters encode to a single UTF-16 code unit
-            Err(latin1_bytes) => Utf16CodeUnits(latin1_bytes.len() as u32),
+            // SAFETY: These are the bytes of a UTF-8 string, so they can be interpreted as UTF-8.
+            EncodedBytes::Utf8(bytes) => Utf16CodeUnits::length_of(AssumeUnder4GB, unsafe {
+                str::from_utf8_unchecked(&bytes)
+            }),
         }
     }
 

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -22,7 +22,7 @@ use js::rust::{Runtime, Trace};
 use malloc_size_of::MallocSizeOfOps;
 use num_traits::{ToPrimitive, Zero};
 use regex::Regex;
-use servo_base::text::{Str32, Utf8CodeUnits, Utf16CodeUnits};
+use servo_base::text::{AssumeUnder4GB, Utf8CodeUnits, Utf16CodeUnits};
 use style::Atom;
 use style::str::HTML_SPACE_CHARACTERS;
 use zeroize::Zeroize;
@@ -468,7 +468,7 @@ impl DOMString {
         };
         match as_str {
             // TODO: add a check that DOMString values never exceed 2 GiB?
-            Ok(string) => Utf16CodeUnits::length_of(Str32(string)),
+            Ok(string) => Utf16CodeUnits::length_of(AssumeUnder4GB, string),
             // All Latin-1 bytes characters encode to a single UTF-16 code unit
             Err(latin1_bytes) => Utf16CodeUnits(latin1_bytes.len() as u32),
         }

--- a/components/shared/base/Cargo.toml
+++ b/components/shared/base/Cargo.toml
@@ -17,6 +17,7 @@ doctest = false
 
 [dependencies]
 accesskit = { workspace = true }
+cfg-if = { workspace = true }
 crossbeam-channel = { workspace = true }
 ipc-channel = { workspace = true }
 log = { workspace = true }

--- a/components/shared/base/Cargo.toml
+++ b/components/shared/base/Cargo.toml
@@ -17,7 +17,6 @@ doctest = false
 
 [dependencies]
 accesskit = { workspace = true }
-cfg-if = { workspace = true }
 crossbeam-channel = { workspace = true }
 ipc-channel = { workspace = true }
 log = { workspace = true }

--- a/components/shared/base/lib.rs
+++ b/components/shared/base/lib.rs
@@ -11,6 +11,7 @@
 
 pub mod cross_process_instant;
 pub mod generic_channel;
+#[macro_use]
 pub mod id;
 pub mod print_tree;
 mod rope;

--- a/components/shared/base/rope.rs
+++ b/components/shared/base/rope.rs
@@ -9,7 +9,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use rayon::iter::Either;
 use unicode_segmentation::UnicodeSegmentation;
 
-use crate::text::{Utf8CodeUnits, Utf16CodeUnits, Utf32CodeUnits};
+use crate::text::{Str32, Utf8CodeUnits, Utf16CodeUnits, Utf32CodeUnits};
 
 fn contents_vec(contents: impl Into<String>) -> Vec<String> {
     let mut contents: Vec<_> = contents
@@ -161,7 +161,7 @@ impl Rope {
         // TODO: add some check that ropes stay under 4 GiB total?
         self.lines
             .iter()
-            .map(|line| Utf16CodeUnits::length_of(line))
+            .map(|line| Utf16CodeUnits::length_of(Str32(line)))
             .sum()
     }
 
@@ -341,12 +341,13 @@ impl Rope {
         let final_line = self.line(rope_index.line);
 
         // The offset might be past the end of the line due to being an exclusive offset.
-        let final_line_offset = Utf16CodeUnits::length_of(&final_line[0..rope_index.code_point]);
+        let final_line_offset =
+            Utf16CodeUnits::length_of(Str32(&final_line[..rope_index.code_point]));
 
         // TODO: add some check that ropes stay under 4 GiB total?
         self.lines[..rope_index.line]
             .iter()
-            .map(|line| Utf16CodeUnits::length_of(line))
+            .map(|line| Utf16CodeUnits::length_of(Str32(line)))
             .sum::<Utf16CodeUnits>() +
             final_line_offset
     }
@@ -358,11 +359,12 @@ impl Rope {
         // The offset might be past the end of the line due to being an exclusive offset.
         let final_line = self.line(rope_index.line);
         // TODO: add some check that ropes stay under 4 GiB total?
-        let final_line_offset = Utf32CodeUnits::length_of(&final_line[..rope_index.code_point]);
+        let final_line_offset =
+            Utf32CodeUnits::length_of(Str32(&final_line[..rope_index.code_point]));
         self.lines
             .iter()
             .take(rope_index.line)
-            .map(|line| Utf32CodeUnits::length_of(line))
+            .map(|line| Utf32CodeUnits::length_of(Str32(line)))
             .sum::<Utf32CodeUnits>() +
             final_line_offset
     }
@@ -381,7 +383,7 @@ impl Rope {
 
     pub fn utf16_offset_to_utf8_offset(&self, utf16_offset: Utf16CodeUnits) -> Utf8CodeUnits {
         // TODO: add some check that ropes stay under 4 GiB total?
-        utf16_offset.to_utf8_code_units_in_iter(&self.lines)
+        utf16_offset.to_utf8_code_units_in_iter(self.lines.iter().map(|line| Str32(line)))
     }
 
     /// Find the boundaries of the word most relevant to the given [`RopeIndex`]. Word

--- a/components/shared/base/rope.rs
+++ b/components/shared/base/rope.rs
@@ -158,7 +158,11 @@ impl Rope {
 
     /// The total number of code units required to encode the content in utf16.
     pub fn len_utf16(&self) -> Utf16CodeUnits {
-        Utf16CodeUnits(self.chars().map(char::len_utf16).sum())
+        // TODO: add some check that ropes stay under 4 GiB total?
+        self.lines
+            .iter()
+            .map(|line| Utf16CodeUnits::length_of(line))
+            .sum()
     }
 
     fn line(&self, index: usize) -> &str {
@@ -321,14 +325,15 @@ impl Rope {
     /// Convert a [`RopeIndex`] into a byte offset from the start of the content.
     pub fn index_to_utf8_offset(&self, rope_index: RopeIndex) -> Utf8CodeUnits {
         let rope_index = self.normalize_index(rope_index);
-        Utf8CodeUnits(
-            self.lines
-                .iter()
-                .take(rope_index.line)
-                .map(String::len)
-                .sum::<usize>() +
-                rope_index.code_point,
-        )
+        let sum = self
+            .lines
+            .iter()
+            .take(rope_index.line)
+            .map(String::len)
+            .sum::<usize>() +
+            rope_index.code_point;
+        // TODO: add some check that ropes stay under 4 GiB total?
+        Utf8CodeUnits(sum as u32)
     }
 
     pub fn index_to_utf16_offset(&self, rope_index: RopeIndex) -> Utf16CodeUnits {
@@ -336,17 +341,12 @@ impl Rope {
         let final_line = self.line(rope_index.line);
 
         // The offset might be past the end of the line due to being an exclusive offset.
-        let final_line_offset = Utf16CodeUnits(
-            final_line[0..rope_index.code_point]
-                .chars()
-                .map(char::len_utf16)
-                .sum(),
-        );
+        let final_line_offset = Utf16CodeUnits::length_of(&final_line[0..rope_index.code_point]);
 
-        self.lines
+        // TODO: add some check that ropes stay under 4 GiB total?
+        self.lines[..rope_index.line]
             .iter()
-            .take(rope_index.line)
-            .map(|line| Utf16CodeUnits(line.chars().map(char::len_utf16).sum()))
+            .map(|line| Utf16CodeUnits::length_of(line))
             .sum::<Utf16CodeUnits>() +
             final_line_offset
     }
@@ -357,6 +357,7 @@ impl Rope {
 
         // The offset might be past the end of the line due to being an exclusive offset.
         let final_line = self.line(rope_index.line);
+        // TODO: add some check that ropes stay under 4 GiB total?
         let final_line_offset = Utf32CodeUnits::length_of(&final_line[..rope_index.code_point]);
         self.lines
             .iter()
@@ -368,7 +369,7 @@ impl Rope {
 
     /// Convert a byte offset from the start of the content into a [`RopeIndex`].
     pub fn utf8_offset_to_rope_index(&self, utf8_offset: Utf8CodeUnits) -> RopeIndex {
-        let mut current_utf8_offset = utf8_offset.0;
+        let mut current_utf8_offset = usize::from(utf8_offset);
         for (line_index, line) in self.lines.iter().enumerate() {
             if current_utf8_offset == 0 || current_utf8_offset < line.len() {
                 return RopeIndex::new(line_index, current_utf8_offset);
@@ -379,18 +380,8 @@ impl Rope {
     }
 
     pub fn utf16_offset_to_utf8_offset(&self, utf16_offset: Utf16CodeUnits) -> Utf8CodeUnits {
-        let mut current_utf16_offset = Utf16CodeUnits::zero();
-        let mut current_utf8_offset = Utf8CodeUnits::zero();
-
-        for character in self.chars() {
-            let utf16_length = character.len_utf16();
-            if current_utf16_offset + Utf16CodeUnits(utf16_length) > utf16_offset {
-                return current_utf8_offset;
-            }
-            current_utf8_offset += Utf8CodeUnits(character.len_utf8());
-            current_utf16_offset += Utf16CodeUnits(utf16_length);
-        }
-        current_utf8_offset
+        // TODO: add some check that ropes stay under 4 GiB total?
+        utf16_offset.to_utf8_code_units_in_iter(&self.lines)
     }
 
     /// Find the boundaries of the word most relevant to the given [`RopeIndex`]. Word
@@ -547,6 +538,12 @@ impl<'a> RopeSlice<'a> {
                 Some(string.unicode_word_indices().next_back()?.0)
             },
         }
+    }
+
+    pub fn len_utf16(self) -> Utf16CodeUnits {
+        // TODO: add some check that ropes stay under 4 GiB total?
+        // TODO: iterate `&str` slices instead and use `Utf16CodeUnits::length_of`
+        self.chars().map(Utf16CodeUnits::length_of_char).sum()
     }
 }
 

--- a/components/shared/base/rope.rs
+++ b/components/shared/base/rope.rs
@@ -9,7 +9,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use rayon::iter::Either;
 use unicode_segmentation::UnicodeSegmentation;
 
-use crate::text::{Str32, Utf8CodeUnits, Utf16CodeUnits, Utf32CodeUnits};
+use crate::text::{AssumeUnder4GB, Utf8CodeUnits, Utf16CodeUnits, Utf32CodeUnits};
 
 fn contents_vec(contents: impl Into<String>) -> Vec<String> {
     let mut contents: Vec<_> = contents
@@ -161,7 +161,7 @@ impl Rope {
         // TODO: add some check that ropes stay under 4 GiB total?
         self.lines
             .iter()
-            .map(|line| Utf16CodeUnits::length_of(Str32(line)))
+            .map(|line| Utf16CodeUnits::length_of(AssumeUnder4GB, line))
             .sum()
     }
 
@@ -342,12 +342,12 @@ impl Rope {
 
         // The offset might be past the end of the line due to being an exclusive offset.
         let final_line_offset =
-            Utf16CodeUnits::length_of(Str32(&final_line[..rope_index.code_point]));
+            Utf16CodeUnits::length_of(AssumeUnder4GB, &final_line[..rope_index.code_point]);
 
         // TODO: add some check that ropes stay under 4 GiB total?
         self.lines[..rope_index.line]
             .iter()
-            .map(|line| Utf16CodeUnits::length_of(Str32(line)))
+            .map(|line| Utf16CodeUnits::length_of(AssumeUnder4GB, line))
             .sum::<Utf16CodeUnits>() +
             final_line_offset
     }
@@ -360,11 +360,11 @@ impl Rope {
         let final_line = self.line(rope_index.line);
         // TODO: add some check that ropes stay under 4 GiB total?
         let final_line_offset =
-            Utf32CodeUnits::length_of(Str32(&final_line[..rope_index.code_point]));
+            Utf32CodeUnits::length_of(AssumeUnder4GB, &final_line[..rope_index.code_point]);
         self.lines
             .iter()
             .take(rope_index.line)
-            .map(|line| Utf32CodeUnits::length_of(Str32(line)))
+            .map(|line| Utf32CodeUnits::length_of(AssumeUnder4GB, line))
             .sum::<Utf32CodeUnits>() +
             final_line_offset
     }
@@ -383,7 +383,7 @@ impl Rope {
 
     pub fn utf16_offset_to_utf8_offset(&self, utf16_offset: Utf16CodeUnits) -> Utf8CodeUnits {
         // TODO: add some check that ropes stay under 4 GiB total?
-        utf16_offset.to_utf8_code_units_in_iter(self.lines.iter().map(|line| Str32(line)))
+        utf16_offset.to_utf8_code_units_in_iter(AssumeUnder4GB, &self.lines)
     }
 
     /// Find the boundaries of the word most relevant to the given [`RopeIndex`]. Word

--- a/components/shared/base/text.rs
+++ b/components/shared/base/text.rs
@@ -217,46 +217,65 @@ impl<T> From<Range<T>> for RangeAny<T> {
     }
 }
 
+#[expect(unexpected_cfgs)] // for `target_pointer_width = "128"`
+fn infalliable_u32_to_usize(value: u32) -> usize {
+    cfg_if::cfg_if! {
+        if #[cfg(any(
+            target_pointer_width = "32",
+            target_pointer_width = "64",
+            // Rust 1.98 supports no 128-bit target but maybe some future version will
+            // Some folks bother to write down RV128I after all
+            target_pointer_width = "128",
+        ))] {
+            value as usize
+        } else if #[cfg(target_pointer_width = "16")] {
+            const _: () = panic!("16-bit targets are not supported");
+        } else {
+            const _: () = panic!("This target exceeds the author’s wildest expectations");
+        }
+    }
+}
+
 macro_rules! unicode_length_type {
     ($( #[$doc:meta] )+ $type_name:ident) => {
         $( #[$doc] )+
         #[derive(Clone, Copy, Default, Eq, MallocSizeOf, Ord, PartialEq, PartialOrd)]
-        pub struct $type_name(pub usize);
+        pub struct $type_name(pub u32);
 
         impl $type_name {
-            pub fn zero() -> Self {
-                Self(0)
-            }
+            const ZERO: Self = Self(0);
 
-            pub fn one() -> Self {
-                Self(1)
-            }
-
+            #[inline]
             pub fn saturating_sub(self, value: Self) -> Self {
                 Self(self.0.saturating_sub(value.0))
             }
         }
 
         impl From<u32> for $type_name {
+            #[inline]
             fn from(value: u32) -> Self {
-                Self(value as usize)
+                Self(value)
             }
         }
 
-        impl From<isize> for $type_name {
-            fn from(value: isize) -> Self {
-                Self(value as usize)
+        impl From<$type_name> for usize {
+            #[inline]
+            fn from(value: $type_name) -> usize {
+                infalliable_u32_to_usize(value.0)
             }
         }
 
         impl Add for $type_name {
             type Output = Self;
+
+            #[inline]
             fn add(self, other: Self) -> Self {
                 Self(self.0 + other.0)
             }
         }
 
         impl AddAssign for $type_name {
+            #[inline]
             fn add_assign(&mut self, other: Self) {
                 *self = Self(self.0 + other.0)
             }
@@ -264,20 +283,24 @@ macro_rules! unicode_length_type {
 
         impl Sub for $type_name {
             type Output = Self;
+
+            #[inline]
             fn sub(self, value: Self) -> Self {
                 Self(self.0 - value.0)
             }
         }
 
         impl SubAssign for $type_name {
+            #[inline]
             fn sub_assign(&mut self, other: Self) {
                 *self = Self(self.0 - other.0)
             }
         }
 
         impl Sum for $type_name {
+            #[inline]
             fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-                iter.fold(Self::zero(), |a, b| Self(a.0 + b.0))
+                iter.fold(Self::ZERO, |a, b| Self(a.0 + b.0))
             }
         }
 
@@ -315,7 +338,26 @@ unicode_length_type! {
     Utf32CodeUnitsOrNodeOffset
 }
 
+impl Utf8CodeUnits {
+    /// Returns the length of `string` in UTF-8 code units (bytes)
+    ///
+    /// Note: this silently wraps and returns an incorrect value for strings larger than
+    /// `u32::MAX` bytes (4 GiB)
+    pub fn length_of(string: &str) -> Self {
+        Self(string.len() as u32)
+    }
+
+    pub fn length_of_char(char: char) -> Self {
+        // Never overflows, the value is always in 1..=4
+        Self(char.len_utf8() as u32)
+    }
+}
+
 impl Utf16CodeUnits {
+    /// Returns the length of `string` in UTF-16 code units
+    ///
+    /// Note: this silently wraps and returns an incorrect value for strings larger than
+    /// `u32::MAX` (~4 billion) code units
     pub fn length_of(string: &str) -> Self {
         Self(string.bytes().map(len_utf16_for_utf8_byte).sum())
 
@@ -326,6 +368,45 @@ impl Utf16CodeUnits {
         // Self(string.encode_utf16().count())
     }
 
+    pub fn length_of_char(char: char) -> Self {
+        // Never overflows, the value is always in 1 or 2
+        Self(char.len_utf16() as u32)
+    }
+
+    /// Convert this UTF-16 offset in `string` to an UTF-8 (byte) offset
+    ///
+    /// Note: this silently wraps and returns an incorrect value for offsets larger than
+    /// `u32::MAX` bytes (4 GiB)
+    pub fn to_utf8_code_units_in(self, string: &str) -> Utf8CodeUnits {
+        self.to_utf8_code_units_in_iter(Some(string))
+    }
+
+    /// Convert this UTF-16 offset in an iterator of strings, to an UTF-8 (byte) offset
+    ///
+    /// Note: this silently wraps and returns an incorrect value for offsets larger than
+    /// `u32::MAX` bytes (4 GiB)
+    pub fn to_utf8_code_units_in_iter<S: AsRef<str>>(
+        self,
+        iter: impl IntoIterator<Item = S>,
+    ) -> Utf8CodeUnits {
+        let mut current_utf16_offset = Utf16CodeUnits(0);
+        let mut current_utf8_offset = Utf8CodeUnits(0);
+        for string in iter {
+            for utf8_byte in string.as_ref().bytes() {
+                if current_utf16_offset >= self {
+                    break;
+                }
+                current_utf16_offset.0 += len_utf16_for_utf8_byte(utf8_byte);
+                current_utf8_offset.0 += len_utf8_for_utf8_byte(utf8_byte);
+            }
+        }
+        current_utf8_offset
+    }
+
+    /// Convert this UTF-16 offset in `string` to an UTF-32 offset
+    ///
+    /// Note: this never overflows since the return value is always less or equal
+    /// since one UTF-32 code unit corresponds to one or two UTF-16 code units.
     pub fn to_utf32_code_units_in(self, string: &str) -> Utf32CodeUnits {
         let mut current_utf16_offset = Utf16CodeUnits(0);
         let mut current_utf32_offset = Utf32CodeUnits(0);
@@ -343,7 +424,7 @@ impl Utf16CodeUnits {
     }
 }
 
-fn len_utf16_for_utf8_byte(byte: u8) -> usize {
+fn len_utf16_for_utf8_byte(byte: u8) -> u32 {
     if byte < 0b1000_0000 {
         // 0b0xxx_xxxx: ASCII-compatible U+0000 to U+007F
         1
@@ -363,6 +444,25 @@ fn len_utf16_for_utf8_byte(byte: u8) -> usize {
     }
 }
 
+fn len_utf8_for_utf8_byte(byte: u8) -> u32 {
+    if byte < 0b1000_0000 {
+        // 0b0xxx_xxxx: ASCII-compatible U+0000 to U+007F
+        1
+    } else if byte < 0b1100_0000 {
+        // 0b10xx_xxxx: UTF-8 continuation byte, already accounted for by its non-continuation byte
+        0
+    } else if byte < 0b1110_0000 {
+        // 0b110x_xxxx: start of a 2-byte UTF-8 sequence for U+0080 to U+07FF
+        2
+    } else if byte < 0b1111_0000 {
+        // 0b1110_xxxx: start of a 3-byte UTF-8 sequence for U+0800 to U+FFFF
+        3
+    } else {
+        // 0b1111_0xxx: start of a 4-byte UTF-8 sequence for U+010000 to U+10FFFF
+        4
+    }
+}
+
 fn increment_offsets_for_utf8_byte(
     utf8_byte: u8,
     utf16_offset: &mut Utf16CodeUnits,
@@ -372,16 +472,24 @@ fn increment_offsets_for_utf8_byte(
     utf16_offset.0 += len_utf16;
     // `len_utf16 != 0` means this byte is the first byte of the UTF-8 byte sequence
     // for one `char` /  UTF-32 code unit
-    utf32_offset.0 += (len_utf16 != 0) as usize;
+    utf32_offset.0 += (len_utf16 != 0) as u32;
 }
 
 impl Utf32CodeUnits {
+    /// Returns the length of `string` in UTF-32 code units (`char` count)
+    ///
+    /// Note: this silently wraps and returns an incorrect value for strings larger than
+    /// `u32::MAX` (~4 billion) code units / `char`s
     pub fn length_of(string: &str) -> Self {
         // `std::str::Chars::count` is optimized in:
         // https://github.com/rust-lang/rust/blob/main/library/core/src/str/count.rs
-        Self(string.chars().count())
+        Self(string.chars().count() as u32)
     }
 
+    /// Convert this UTF-32 (`char`) offset in `string` to an UTF-8 (byte) offset
+    ///
+    /// Note: this silently wraps and returns an incorrect value for offsets larger than
+    /// `u32::MAX` bytes (4 GiB)
     pub fn to_utf8_code_units_in(self, string: &str) -> Utf8CodeUnits {
         let mut current_utf32_offset = Utf32CodeUnits(0);
         for (current_utf8_offset, utf8_byte) in string.bytes().enumerate() {
@@ -390,13 +498,17 @@ impl Utf32CodeUnits {
                 continue;
             }
             if current_utf32_offset >= self {
-                return Utf8CodeUnits(current_utf8_offset);
+                return Utf8CodeUnits(current_utf8_offset as u32);
             }
             current_utf32_offset.0 += 1;
         }
-        Utf8CodeUnits(string.len())
+        Utf8CodeUnits(string.len() as u32)
     }
 
+    /// Convert this UTF-32 (`char`) offset in `string` to an UTF-16 offset
+    ///
+    /// Note: this silently wraps and returns an incorrect value for offsets larger than
+    /// `u32::MAX` (~4 billion) code units
     pub fn to_utf16_code_units_in(self, string: &str) -> Utf16CodeUnits {
         let mut current_utf32_offset = Utf32CodeUnits(0);
         let mut current_utf16_offset = Utf16CodeUnits(0);
@@ -415,6 +527,10 @@ impl Utf32CodeUnits {
 }
 
 impl Utf32CodeUnitsOrNodeOffset {
+    /// Convert this UTF-32 (`char`) offset in `string` to an UTF-16 offset
+    ///
+    /// Note: this silently wraps and returns an incorrect value for offsets larger than
+    /// `u32::MAX` (~4 billion) code units
     pub fn to_utf16_code_units_in(self, string: &str) -> Utf16CodeUnits {
         Utf32CodeUnits(self.0).to_utf16_code_units_in(string)
     }

--- a/components/shared/base/text.rs
+++ b/components/shared/base/text.rs
@@ -391,10 +391,10 @@ impl Utf16CodeUnits {
         let mut current_utf8_offset = Utf8CodeUnits(0);
         for string in iter {
             for utf8_byte in string.0.bytes() {
-                if current_utf16_offset >= self {
+                current_utf16_offset.0 += len_utf16_for_utf8_byte(utf8_byte);
+                if current_utf16_offset > self {
                     break;
                 }
-                current_utf16_offset.0 += len_utf16_for_utf8_byte(utf8_byte);
                 current_utf8_offset.0 += len_utf8_for_utf8_byte(utf8_byte);
             }
         }
@@ -409,14 +409,12 @@ impl Utf16CodeUnits {
         let mut current_utf16_offset = Utf16CodeUnits(0);
         let mut current_utf32_offset = Utf32CodeUnits(0);
         for utf8_byte in string.bytes() {
-            if current_utf16_offset >= self {
+            let len_utf16 = len_utf16_for_utf8_byte(utf8_byte);
+            current_utf16_offset.0 += len_utf16;
+            if current_utf16_offset > self {
                 break;
             }
-            increment_offsets_for_utf8_byte(
-                utf8_byte,
-                &mut current_utf16_offset,
-                &mut current_utf32_offset,
-            );
+            current_utf32_offset.0 += len_utf16_to_len_utf32_for_utf8_byte(len_utf16);
         }
         current_utf32_offset
     }
@@ -461,16 +459,14 @@ fn len_utf8_for_utf8_byte(byte: u8) -> u32 {
     }
 }
 
-fn increment_offsets_for_utf8_byte(
-    utf8_byte: u8,
-    utf16_offset: &mut Utf16CodeUnits,
-    utf32_offset: &mut Utf32CodeUnits,
-) {
-    let len_utf16 = len_utf16_for_utf8_byte(utf8_byte);
-    utf16_offset.0 += len_utf16;
-    // `len_utf16 != 0` means this byte is the first byte of the UTF-8 byte sequence
-    // for one `char` /  UTF-32 code unit
-    utf32_offset.0 += (len_utf16 != 0) as u32;
+fn len_utf16_to_len_utf32_for_utf8_byte(len_utf16: u32) -> u32 {
+    if len_utf16 != 0 {
+        // First byte of the UTF-8 byte sequence for one code point / UTF-32 code unit
+        1
+    } else {
+        // UTF-8 continuation byte
+        0
+    }
 }
 
 impl Utf32CodeUnits {
@@ -505,11 +501,9 @@ impl Utf32CodeUnits {
             if current_utf32_offset >= self {
                 break;
             }
-            increment_offsets_for_utf8_byte(
-                utf8_byte,
-                &mut current_utf16_offset,
-                &mut current_utf32_offset,
-            );
+            let len_utf16 = len_utf16_for_utf8_byte(utf8_byte);
+            current_utf16_offset.0 += len_utf16;
+            current_utf32_offset.0 += len_utf16_to_len_utf32_for_utf8_byte(len_utf16);
         }
         current_utf16_offset
     }
@@ -585,10 +579,10 @@ mod test {
         );
 
         // This 16-bit offset splits the would-be surrogate pair. We return the 32-bit position
-        // after the whole pair. Should this be an error instead?
+        // before the whole pair. Should this be an error instead?
         assert_eq!(
             Utf16CodeUnits(4).to_utf32_code_units_in(s),
-            Utf32CodeUnits(4)
+            Utf32CodeUnits(3)
         );
 
         assert_eq!(

--- a/components/shared/base/text.rs
+++ b/components/shared/base/text.rs
@@ -4,6 +4,7 @@
 
 use std::fmt;
 use std::iter::Sum;
+use std::mem::size_of;
 use std::ops::{Add, AddAssign, Range, Sub, SubAssign};
 
 use malloc_size_of_derive::MallocSizeOf;
@@ -58,6 +59,9 @@ pub struct RangeAny<T> {
     /// `None` means the full available length
     pub end: Option<T>,
 }
+
+const _: () = assert!(size_of::<RangeAny<u32>>() == 16);
+const _: () = assert!(size_of::<Option<RangeAny<u32>>>() == 16);
 
 impl<T: fmt::Debug> fmt::Debug for RangeAny<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/components/shared/base/text.rs
+++ b/components/shared/base/text.rs
@@ -217,6 +217,13 @@ impl<T> From<Range<T>> for RangeAny<T> {
     }
 }
 
+/// A wrapper for `&str` whose length is not greater than 4 GiB, `u32::MAX` bytes
+///
+/// Using `Str32` with a string too long is not memory unsafe, but other APIs
+/// like `Utf8CodeUnits::length_of` may silently return an incorrect (wrapped) value.
+#[derive(Clone, Copy)]
+pub struct Str32<'a>(pub &'a str);
+
 #[expect(unexpected_cfgs)] // for `target_pointer_width = "128"`
 fn infalliable_u32_to_usize(value: u32) -> usize {
     cfg_if::cfg_if! {
@@ -340,11 +347,8 @@ unicode_length_type! {
 
 impl Utf8CodeUnits {
     /// Returns the length of `string` in UTF-8 code units (bytes)
-    ///
-    /// Note: this silently wraps and returns an incorrect value for strings larger than
-    /// `u32::MAX` bytes (4 GiB)
-    pub fn length_of(string: &str) -> Self {
-        Self(string.len() as u32)
+    pub fn length_of(string: Str32) -> Self {
+        Self(string.0.len() as u32)
     }
 
     pub fn length_of_char(char: char) -> Self {
@@ -355,11 +359,8 @@ impl Utf8CodeUnits {
 
 impl Utf16CodeUnits {
     /// Returns the length of `string` in UTF-16 code units
-    ///
-    /// Note: this silently wraps and returns an incorrect value for strings larger than
-    /// `u32::MAX` (~4 billion) code units
-    pub fn length_of(string: &str) -> Self {
-        Self(string.bytes().map(len_utf16_for_utf8_byte).sum())
+    pub fn length_of(string: Str32) -> Self {
+        Self(string.0.bytes().map(len_utf16_for_utf8_byte).sum())
 
         // TODO: after upgrading to a Rust version (1.99?) that includes that PR,
         // replace the above with:
@@ -374,25 +375,22 @@ impl Utf16CodeUnits {
     }
 
     /// Convert this UTF-16 offset in `string` to an UTF-8 (byte) offset
-    ///
-    /// Note: this silently wraps and returns an incorrect value for offsets larger than
-    /// `u32::MAX` bytes (4 GiB)
-    pub fn to_utf8_code_units_in(self, string: &str) -> Utf8CodeUnits {
+    pub fn to_utf8_code_units_in(self, string: Str32) -> Utf8CodeUnits {
         self.to_utf8_code_units_in_iter(Some(string))
     }
 
     /// Convert this UTF-16 offset in an iterator of strings, to an UTF-8 (byte) offset
     ///
-    /// Note: this silently wraps and returns an incorrect value for offsets larger than
-    /// `u32::MAX` bytes (4 GiB)
-    pub fn to_utf8_code_units_in_iter<S: AsRef<str>>(
+    /// Note: this silently wraps and returns an incorrect value for results larger than
+    /// `u32::MAX` bytes (4 GiB), even if individual iterator items fits `Str32`.
+    pub fn to_utf8_code_units_in_iter<'a>(
         self,
-        iter: impl IntoIterator<Item = S>,
+        iter: impl IntoIterator<Item = Str32<'a>>,
     ) -> Utf8CodeUnits {
         let mut current_utf16_offset = Utf16CodeUnits(0);
         let mut current_utf8_offset = Utf8CodeUnits(0);
         for string in iter {
-            for utf8_byte in string.as_ref().bytes() {
+            for utf8_byte in string.0.bytes() {
                 if current_utf16_offset >= self {
                     break;
                 }
@@ -477,22 +475,16 @@ fn increment_offsets_for_utf8_byte(
 
 impl Utf32CodeUnits {
     /// Returns the length of `string` in UTF-32 code units (`char` count)
-    ///
-    /// Note: this silently wraps and returns an incorrect value for strings larger than
-    /// `u32::MAX` (~4 billion) code units / `char`s
-    pub fn length_of(string: &str) -> Self {
+    pub fn length_of(string: Str32) -> Self {
         // `std::str::Chars::count` is optimized in:
         // https://github.com/rust-lang/rust/blob/main/library/core/src/str/count.rs
-        Self(string.chars().count() as u32)
+        Self(string.0.chars().count() as u32)
     }
 
     /// Convert this UTF-32 (`char`) offset in `string` to an UTF-8 (byte) offset
-    ///
-    /// Note: this silently wraps and returns an incorrect value for offsets larger than
-    /// `u32::MAX` bytes (4 GiB)
-    pub fn to_utf8_code_units_in(self, string: &str) -> Utf8CodeUnits {
+    pub fn to_utf8_code_units_in(self, string: Str32) -> Utf8CodeUnits {
         let mut current_utf32_offset = Utf32CodeUnits(0);
-        for (current_utf8_offset, utf8_byte) in string.bytes().enumerate() {
+        for (current_utf8_offset, utf8_byte) in string.0.bytes().enumerate() {
             if (utf8_byte & 0b1100_0000) == 0b1000_0000 {
                 // UTF-8 continuation byte
                 continue;
@@ -502,17 +494,14 @@ impl Utf32CodeUnits {
             }
             current_utf32_offset.0 += 1;
         }
-        Utf8CodeUnits(string.len() as u32)
+        Utf8CodeUnits(string.0.len() as u32)
     }
 
     /// Convert this UTF-32 (`char`) offset in `string` to an UTF-16 offset
-    ///
-    /// Note: this silently wraps and returns an incorrect value for offsets larger than
-    /// `u32::MAX` (~4 billion) code units
-    pub fn to_utf16_code_units_in(self, string: &str) -> Utf16CodeUnits {
+    pub fn to_utf16_code_units_in(self, string: Str32) -> Utf16CodeUnits {
         let mut current_utf32_offset = Utf32CodeUnits(0);
         let mut current_utf16_offset = Utf16CodeUnits(0);
-        for utf8_byte in string.bytes() {
+        for utf8_byte in string.0.bytes() {
             if current_utf32_offset >= self {
                 break;
             }
@@ -531,7 +520,7 @@ impl Utf32CodeUnitsOrNodeOffset {
     ///
     /// Note: this silently wraps and returns an incorrect value for offsets larger than
     /// `u32::MAX` (~4 billion) code units
-    pub fn to_utf16_code_units_in(self, string: &str) -> Utf16CodeUnits {
+    pub fn to_utf16_code_units_in(self, string: Str32) -> Utf16CodeUnits {
         Utf32CodeUnits(self.0).to_utf16_code_units_in(string)
     }
 }
@@ -561,13 +550,16 @@ mod test {
 
     #[test]
     fn test_utf16_length() {
-        assert_eq!(Utf16CodeUnits::length_of(""), Utf16CodeUnits(0));
-        assert_eq!(Utf16CodeUnits::length_of("a"), Utf16CodeUnits(1));
-        assert_eq!(Utf16CodeUnits::length_of("é"), Utf16CodeUnits(1));
-        assert_eq!(Utf16CodeUnits::length_of("字"), Utf16CodeUnits(1));
-        assert_eq!(Utf16CodeUnits::length_of("\u{1F4A9}"), Utf16CodeUnits(2));
+        assert_eq!(Utf16CodeUnits::length_of(Str32("")), Utf16CodeUnits(0));
+        assert_eq!(Utf16CodeUnits::length_of(Str32("a")), Utf16CodeUnits(1));
+        assert_eq!(Utf16CodeUnits::length_of(Str32("é")), Utf16CodeUnits(1));
+        assert_eq!(Utf16CodeUnits::length_of(Str32("字")), Utf16CodeUnits(1));
         assert_eq!(
-            Utf16CodeUnits::length_of("\u{1F4A9}字éa"),
+            Utf16CodeUnits::length_of(Str32("\u{1F4A9}")),
+            Utf16CodeUnits(2)
+        );
+        assert_eq!(
+            Utf16CodeUnits::length_of(Str32("\u{1F4A9}字éa")),
             Utf16CodeUnits(5)
         );
     }
@@ -618,7 +610,7 @@ mod test {
 
     #[test]
     fn test_utf32_to_utf16() {
-        let string = "aé字\u{1F4A9}";
+        let string = Str32("aé字\u{1F4A9}");
         assert_eq!(
             Utf32CodeUnits(0).to_utf16_code_units_in(string),
             Utf16CodeUnits(0),

--- a/components/shared/base/text.rs
+++ b/components/shared/base/text.rs
@@ -4,7 +4,7 @@
 
 use std::fmt;
 use std::iter::Sum;
-use std::mem::size_of;
+use std::mem::{MaybeUninit, size_of};
 use std::ops::{Add, AddAssign, Range, Sub, SubAssign};
 
 use malloc_size_of_derive::MallocSizeOf;
@@ -53,60 +53,147 @@ pub fn is_cjk(codepoint: char) -> bool {
 
 /// Equivalent to either `Range`, `RangeTo`, `RangeFrom`, or `RangeFull`
 #[derive(Clone, Copy, Eq, PartialEq, MallocSizeOf)]
-pub struct RangeAny<T> {
-    /// `None` means zero
-    pub start: Option<T>,
-    /// `None` means the full available length
-    pub end: Option<T>,
+pub struct RangeAny<T>(RangeAnyInner<T>);
+
+#[derive(Copy, MallocSizeOf)]
+pub enum RangeAnyInner<T> {
+    Range {
+        start: T,
+        end: T,
+    },
+    RangeFrom {
+        start: T,
+    },
+    RangeTo {
+        // Nudges rustc towards placing `end` at the same offset as in the `Range` variant,
+        // for slightly better codegen in the `fn end()` getter
+        #[ignore_malloc_size_of = "always uninitialized"]
+        _layout_hint: MaybeUninit<T>,
+        end: T,
+    },
+    RangeFull,
 }
 
-const _: () = assert!(size_of::<RangeAny<u32>>() == 16);
-const _: () = assert!(size_of::<Option<RangeAny<u32>>>() == 16);
+const _: () = assert!(size_of::<RangeAny<u32>>() == 12);
+const _: () = assert!(size_of::<Option<RangeAny<u32>>>() == 12);
 
 impl<T: fmt::Debug> fmt::Debug for RangeAny<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match (&self.start, &self.end) {
-            (Some(start), Some(end)) => write!(f, "{start:?}..{end:?}"),
-            (Some(start), None) => write!(f, "{start:?}.."),
-            (None, Some(end)) => write!(f, "..{end:?}"),
-            (None, None) => write!(f, ".."),
+        match &self.0 {
+            RangeAnyInner::Range { start, end } => write!(f, "{start:?}..{end:?}"),
+            RangeAnyInner::RangeFrom { start } => write!(f, "{start:?}.."),
+            RangeAnyInner::RangeTo { end, .. } => write!(f, "..{end:?}"),
+            RangeAnyInner::RangeFull => write!(f, ".."),
+        }
+    }
+}
+impl<T: Eq> Eq for RangeAnyInner<T> {}
+
+impl<T: PartialEq> PartialEq for RangeAnyInner<T> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                Self::Range {
+                    start: l_start,
+                    end: l_end,
+                },
+                Self::Range {
+                    start: r_start,
+                    end: r_end,
+                },
+            ) => l_start == r_start && l_end == r_end,
+            (Self::RangeFrom { start: l_start }, Self::RangeFrom { start: r_start }) => {
+                l_start == r_start
+            },
+            (Self::RangeTo { end: l_end, .. }, Self::RangeTo { end: r_end, .. }) => l_end == r_end,
+            _ => core::mem::discriminant(self) == core::mem::discriminant(other),
+        }
+    }
+}
+
+impl<T: Clone> Clone for RangeAnyInner<T> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Range { start, end } => Self::Range {
+                start: start.clone(),
+                end: end.clone(),
+            },
+            Self::RangeFrom { start } => Self::RangeFrom {
+                start: start.clone(),
+            },
+            Self::RangeTo { end, .. } => Self::RangeTo {
+                _layout_hint: MaybeUninit::uninit(),
+                end: end.clone(),
+            },
+            Self::RangeFull => Self::RangeFull,
         }
     }
 }
 
 impl<T> RangeAny<T> {
+    pub fn new(start: Option<T>, end: Option<T>) -> Self {
+        Self(match (start, end) {
+            (Some(start), Some(end)) => RangeAnyInner::Range { start, end },
+            (Some(start), None) => RangeAnyInner::RangeFrom { start },
+            (None, Some(end)) => RangeAnyInner::RangeTo {
+                _layout_hint: MaybeUninit::uninit(),
+                end,
+            },
+            (None, None) => RangeAnyInner::RangeFull,
+        })
+    }
+
     /// Returns a `RangeAny` that represents the full range: both bounds unset
     pub fn full() -> Self {
-        Self {
-            start: None,
-            end: None,
+        Self(RangeAnyInner::RangeFull)
+    }
+
+    // Note: for a fully-generic general puprose container we’d return `Option<&T>`
+    // and remove the `Copy` bound, but Servo only uses `RangeAny` with `Utf*CodeUnits` types
+    // that implement `Copy`, so relying on `Copy` makes callers less verbose.
+    pub fn start(&self) -> Option<T>
+    where
+        T: Copy,
+    {
+        match self.0 {
+            RangeAnyInner::Range { start, .. } | RangeAnyInner::RangeFrom { start } => Some(start),
+            RangeAnyInner::RangeTo { .. } | RangeAnyInner::RangeFull => None,
+        }
+    }
+
+    pub fn end(&self) -> Option<T>
+    where
+        T: Copy,
+    {
+        match self.0 {
+            RangeAnyInner::Range { end, .. } | RangeAnyInner::RangeTo { end, .. } => Some(end),
+            RangeAnyInner::RangeFrom { .. } | RangeAnyInner::RangeFull => None,
         }
     }
 
     /// Apply `Option::map` to each bound of this range
-    pub fn map<U>(self, f: impl Fn(T) -> U + Copy) -> RangeAny<U> {
-        let Self { start, end } = self;
-        RangeAny {
-            start: start.map(f),
-            end: end.map(f),
-        }
+    pub fn map<U>(&self, f: impl Fn(T) -> U + Copy) -> RangeAny<U>
+    where
+        T: Copy,
+    {
+        RangeAny::new(self.start().map(f), self.end().map(f))
     }
 
     /// Returns the intersection of two ranges, if it is non-empty
-    pub fn intersect(self, other: Self) -> Option<Self>
+    pub fn intersect(&self, other: Self) -> Option<Self>
     where
-        T: Ord,
+        T: Copy + Ord,
     {
         // TODO: https://github.com/rust-lang/rust/issues/144273
         // let start = a.start.reduce(b.start, std::cmp::max);
         // let end = a.end.reduce(b.end, std::cmp::min);
-        let start = match (self.start, other.start) {
+        let start = match (self.start(), other.start()) {
             (None, None) => None,
             (None, Some(b)) => Some(b),
             (Some(a), None) => Some(a),
             (Some(a), Some(b)) => Some(a.max(b)),
         };
-        let end = match (self.end, other.end) {
+        let end = match (self.end(), other.end()) {
             (None, None) => None,
             (None, Some(b)) => Some(b),
             (Some(a), None) => Some(a),
@@ -116,7 +203,7 @@ impl<T> RangeAny<T> {
             .as_ref()
             .is_none_or(|start| end.as_ref().is_none_or(|end| start < end))
         {
-            Some(RangeAny { start, end })
+            Some(Self::new(start, end))
         } else {
             // `max()..min()` producing a "backwards" range means the intersection is empty
             None
@@ -126,10 +213,7 @@ impl<T> RangeAny<T> {
 
 impl<T> From<Range<T>> for RangeAny<T> {
     fn from(value: Range<T>) -> Self {
-        Self {
-            start: Some(value.start),
-            end: Some(value.end),
-        }
+        Self::new(Some(value.start), Some(value.end))
     }
 }
 

--- a/components/shared/base/text.rs
+++ b/components/shared/base/text.rs
@@ -4,7 +4,6 @@
 
 use std::fmt;
 use std::iter::Sum;
-use std::mem::MaybeUninit;
 use std::ops::{Add, AddAssign, Range, Sub, SubAssign};
 
 use malloc_size_of_derive::MallocSizeOf;
@@ -55,22 +54,11 @@ pub fn is_cjk(codepoint: char) -> bool {
 #[derive(Clone, Copy, Eq, PartialEq, MallocSizeOf)]
 pub struct RangeAny<T>(RangeAnyInner<T>);
 
-#[derive(Copy, MallocSizeOf)]
+#[derive(Clone, Copy, Eq, PartialEq, MallocSizeOf)]
 enum RangeAnyInner<T> {
-    Range {
-        start: T,
-        end: T,
-    },
-    RangeFrom {
-        start: T,
-    },
-    RangeTo {
-        // Nudges rustc towards placing `end` at the same offset as in the `Range` variant,
-        // for slightly better codegen in the `fn end()` getter
-        #[ignore_malloc_size_of = "always uninitialized"]
-        _layout_hint: MaybeUninit<T>,
-        end: T,
-    },
+    Range { start: T, end: T },
+    RangeFrom { start: T },
+    RangeTo { end: T },
     RangeFull,
 }
 
@@ -87,60 +75,20 @@ impl<T: fmt::Debug> fmt::Debug for RangeAny<T> {
         }
     }
 }
-impl<T: Eq> Eq for RangeAnyInner<T> {}
-
-impl<T: PartialEq> PartialEq for RangeAnyInner<T> {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (
-                Self::Range {
-                    start: l_start,
-                    end: l_end,
-                },
-                Self::Range {
-                    start: r_start,
-                    end: r_end,
-                },
-            ) => l_start == r_start && l_end == r_end,
-            (Self::RangeFrom { start: l_start }, Self::RangeFrom { start: r_start }) => {
-                l_start == r_start
-            },
-            (Self::RangeTo { end: l_end, .. }, Self::RangeTo { end: r_end, .. }) => l_end == r_end,
-            _ => core::mem::discriminant(self) == core::mem::discriminant(other),
-        }
-    }
-}
-
-impl<T: Clone> Clone for RangeAnyInner<T> {
-    fn clone(&self) -> Self {
-        match self {
-            Self::Range { start, end } => Self::Range {
-                start: start.clone(),
-                end: end.clone(),
-            },
-            Self::RangeFrom { start } => Self::RangeFrom {
-                start: start.clone(),
-            },
-            Self::RangeTo { end, .. } => Self::RangeTo {
-                _layout_hint: MaybeUninit::uninit(),
-                end: end.clone(),
-            },
-            Self::RangeFull => Self::RangeFull,
-        }
-    }
-}
 
 impl<T> RangeAny<T> {
     pub fn new(start: Option<T>, end: Option<T>) -> Self {
         Self(match (start, end) {
             (Some(start), Some(end)) => RangeAnyInner::Range { start, end },
             (Some(start), None) => RangeAnyInner::RangeFrom { start },
-            (None, Some(end)) => RangeAnyInner::RangeTo {
-                _layout_hint: MaybeUninit::uninit(),
-                end,
-            },
+            (None, Some(end)) => RangeAnyInner::RangeTo { end },
             (None, None) => RangeAnyInner::RangeFull,
         })
+    }
+
+    /// Returns a `RangeAny` that represents the range from the start to the given end.
+    pub fn from_start_to(end: T) -> Self {
+        Self(RangeAnyInner::RangeTo { end })
     }
 
     /// Returns a `RangeAny` that represents the full range: both bounds unset
@@ -148,7 +96,7 @@ impl<T> RangeAny<T> {
         Self(RangeAnyInner::RangeFull)
     }
 
-    // Note: for a fully-generic general puprose container we’d return `Option<&T>`
+    // Note: for a fully-generic general purpose container we’d return `Option<&T>`
     // and remove the `Copy` bound, but Servo only uses `RangeAny` with `Utf*CodeUnits` types
     // that implement `Copy`, so relying on `Copy` makes callers less verbose.
     pub fn start(&self) -> Option<T>
@@ -241,6 +189,11 @@ macro_rules! unicode_length_type {
             #[inline]
             pub fn saturating_sub(self, value: Self) -> Self {
                 Self(self.0.saturating_sub(value.0))
+            }
+
+            #[inline]
+            pub fn to_usize_range(range: &Range<Self>) -> Range<usize> {
+                usize::from(range.start)..usize::from(range.end)
             }
         }
 
@@ -362,13 +315,13 @@ impl Utf16CodeUnits {
 
     /// Convert this UTF-16 offset in `string` to an UTF-8 (byte) offset
     pub fn to_utf8_code_units_in(self, _: AssumeUnder4GB, string: &str) -> Utf8CodeUnits {
-        self.to_utf8_code_units_in_iter(AssumeUnder4GB, Some(string))
+        self.to_utf8_code_units_in_iter(AssumeUnder4GB, std::iter::once(string))
     }
 
     /// Convert this UTF-16 offset in an iterator of strings, to an UTF-8 (byte) offset
     ///
     /// Note: this silently wraps and returns an incorrect value for results larger than
-    /// `u32::MAX` bytes (4 GiB), even if individual iterator items fits `Str32`.
+    /// `u32::MAX` bytes (4 GiB).
     pub fn to_utf8_code_units_in_iter<S>(
         self,
         _: AssumeUnder4GB,
@@ -393,8 +346,8 @@ impl Utf16CodeUnits {
 
     /// Convert this UTF-16 offset in `string` to an UTF-32 offset
     ///
-    /// Note: this never overflows since the return value is always less or equal
-    /// since one UTF-32 code unit corresponds to one or two UTF-16 code units.
+    /// Note: this never overflows since the return value is always less than or equal to self as
+    /// one UTF-32 code unit corresponds to one or two UTF-16 code units.
     pub fn to_utf32_code_units_in(self, string: &str) -> Utf32CodeUnits {
         let mut current_utf16_offset = Utf16CodeUnits(0);
         let mut current_utf32_offset = Utf32CodeUnits(0);
@@ -501,9 +454,6 @@ impl Utf32CodeUnits {
 
 impl Utf32CodeUnitsOrNodeOffset {
     /// Convert this UTF-32 (`char`) offset in `string` to an UTF-16 offset
-    ///
-    /// Note: this silently wraps and returns an incorrect value for offsets larger than
-    /// `u32::MAX` (~4 billion) code units
     pub fn to_utf16_code_units_in(self, _: AssumeUnder4GB, string: &str) -> Utf16CodeUnits {
         Utf32CodeUnits(self.0).to_utf16_code_units_in(AssumeUnder4GB, string)
     }

--- a/components/shared/base/text.rs
+++ b/components/shared/base/text.rs
@@ -4,7 +4,7 @@
 
 use std::fmt;
 use std::iter::Sum;
-use std::mem::{MaybeUninit, size_of};
+use std::mem::MaybeUninit;
 use std::ops::{Add, AddAssign, Range, Sub, SubAssign};
 
 use malloc_size_of_derive::MallocSizeOf;
@@ -56,7 +56,7 @@ pub fn is_cjk(codepoint: char) -> bool {
 pub struct RangeAny<T>(RangeAnyInner<T>);
 
 #[derive(Copy, MallocSizeOf)]
-pub enum RangeAnyInner<T> {
+enum RangeAnyInner<T> {
     Range {
         start: T,
         end: T,
@@ -74,8 +74,8 @@ pub enum RangeAnyInner<T> {
     RangeFull,
 }
 
-const _: () = assert!(size_of::<RangeAny<u32>>() == 12);
-const _: () = assert!(size_of::<Option<RangeAny<u32>>>() == 12);
+size_of_test!(RangeAny<u32>, 12);
+size_of_test!(Option<RangeAny<u32>>, 12);
 
 impl<T: fmt::Debug> fmt::Debug for RangeAny<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -224,23 +224,9 @@ impl<T> From<Range<T>> for RangeAny<T> {
 #[derive(Clone, Copy)]
 pub struct Str32<'a>(pub &'a str);
 
-#[expect(unexpected_cfgs)] // for `target_pointer_width = "128"`
-fn infalliable_u32_to_usize(value: u32) -> usize {
-    cfg_if::cfg_if! {
-        if #[cfg(any(
-            target_pointer_width = "32",
-            target_pointer_width = "64",
-            // Rust 1.98 supports no 128-bit target but maybe some future version will
-            // Some folks bother to write down RV128I after all
-            target_pointer_width = "128",
-        ))] {
-            value as usize
-        } else if #[cfg(target_pointer_width = "16")] {
-            const _: () = panic!("16-bit targets are not supported");
-        } else {
-            const _: () = panic!("This target exceeds the author’s wildest expectations");
-        }
-    }
+fn infallible_u32_to_usize(value: u32) -> usize {
+    const _: () = assert!(usize::BITS >= u32::BITS, "16-bit targets are not supported");
+    value as usize
 }
 
 macro_rules! unicode_length_type {
@@ -268,7 +254,7 @@ macro_rules! unicode_length_type {
         impl From<$type_name> for usize {
             #[inline]
             fn from(value: $type_name) -> usize {
-                infalliable_u32_to_usize(value.0)
+                infallible_u32_to_usize(value.0)
             }
         }
 
@@ -393,7 +379,7 @@ impl Utf16CodeUnits {
             for utf8_byte in string.0.bytes() {
                 current_utf16_offset.0 += len_utf16_for_utf8_byte(utf8_byte);
                 if current_utf16_offset > self {
-                    break;
+                    return current_utf8_offset;
                 }
                 current_utf8_offset.0 += len_utf8_for_utf8_byte(utf8_byte);
             }

--- a/components/shared/base/text.rs
+++ b/components/shared/base/text.rs
@@ -319,9 +319,6 @@ impl Utf16CodeUnits {
     }
 
     /// Convert this UTF-16 offset in an iterator of strings, to an UTF-8 (byte) offset
-    ///
-    /// Note: this silently wraps and returns an incorrect value for results larger than
-    /// `u32::MAX` bytes (4 GiB).
     pub fn to_utf8_code_units_in_iter<S>(
         self,
         _: AssumeUnder4GB,

--- a/components/shared/base/text.rs
+++ b/components/shared/base/text.rs
@@ -217,12 +217,12 @@ impl<T> From<Range<T>> for RangeAny<T> {
     }
 }
 
-/// A wrapper for `&str` whose length is not greater than 4 GiB, `u32::MAX` bytes
+/// A marker to make callers acknowledge that a method computes 32-bit offsets or lengths,
+/// and trying to compute past `u32::MAX` code units may result in integer overflow.
 ///
-/// Using `Str32` with a string too long is not memory unsafe, but other APIs
-/// like `Utf8CodeUnits::length_of` may silently return an incorrect (wrapped) value.
-#[derive(Clone, Copy)]
-pub struct Str32<'a>(pub &'a str);
+/// The default Rust behavior for integer overflow is panic on debug mode,
+/// and silent wrapping (which for offsets or lengths returns a wrong value) in release mode.
+pub struct AssumeUnder4GB;
 
 fn infallible_u32_to_usize(value: u32) -> usize {
     const _: () = assert!(usize::BITS >= u32::BITS, "16-bit targets are not supported");
@@ -333,8 +333,8 @@ unicode_length_type! {
 
 impl Utf8CodeUnits {
     /// Returns the length of `string` in UTF-8 code units (bytes)
-    pub fn length_of(string: Str32) -> Self {
-        Self(string.0.len() as u32)
+    pub fn length_of(_: AssumeUnder4GB, string: &str) -> Self {
+        Self(string.len() as u32)
     }
 
     pub fn length_of_char(char: char) -> Self {
@@ -345,8 +345,8 @@ impl Utf8CodeUnits {
 
 impl Utf16CodeUnits {
     /// Returns the length of `string` in UTF-16 code units
-    pub fn length_of(string: Str32) -> Self {
-        Self(string.0.bytes().map(len_utf16_for_utf8_byte).sum())
+    pub fn length_of(_: AssumeUnder4GB, string: &str) -> Self {
+        Self(string.bytes().map(len_utf16_for_utf8_byte).sum())
 
         // TODO: after upgrading to a Rust version (1.99?) that includes that PR,
         // replace the above with:
@@ -361,22 +361,26 @@ impl Utf16CodeUnits {
     }
 
     /// Convert this UTF-16 offset in `string` to an UTF-8 (byte) offset
-    pub fn to_utf8_code_units_in(self, string: Str32) -> Utf8CodeUnits {
-        self.to_utf8_code_units_in_iter(Some(string))
+    pub fn to_utf8_code_units_in(self, _: AssumeUnder4GB, string: &str) -> Utf8CodeUnits {
+        self.to_utf8_code_units_in_iter(AssumeUnder4GB, Some(string))
     }
 
     /// Convert this UTF-16 offset in an iterator of strings, to an UTF-8 (byte) offset
     ///
     /// Note: this silently wraps and returns an incorrect value for results larger than
     /// `u32::MAX` bytes (4 GiB), even if individual iterator items fits `Str32`.
-    pub fn to_utf8_code_units_in_iter<'a>(
+    pub fn to_utf8_code_units_in_iter<S>(
         self,
-        iter: impl IntoIterator<Item = Str32<'a>>,
-    ) -> Utf8CodeUnits {
+        _: AssumeUnder4GB,
+        iter: impl IntoIterator<Item = S>,
+    ) -> Utf8CodeUnits
+    where
+        S: AsRef<str>,
+    {
         let mut current_utf16_offset = Utf16CodeUnits(0);
         let mut current_utf8_offset = Utf8CodeUnits(0);
         for string in iter {
-            for utf8_byte in string.0.bytes() {
+            for utf8_byte in string.as_ref().bytes() {
                 current_utf16_offset.0 += len_utf16_for_utf8_byte(utf8_byte);
                 if current_utf16_offset > self {
                     return current_utf8_offset;
@@ -457,16 +461,16 @@ fn len_utf16_to_len_utf32_for_utf8_byte(len_utf16: u32) -> u32 {
 
 impl Utf32CodeUnits {
     /// Returns the length of `string` in UTF-32 code units (`char` count)
-    pub fn length_of(string: Str32) -> Self {
+    pub fn length_of(_: AssumeUnder4GB, string: &str) -> Self {
         // `std::str::Chars::count` is optimized in:
         // https://github.com/rust-lang/rust/blob/main/library/core/src/str/count.rs
-        Self(string.0.chars().count() as u32)
+        Self(string.chars().count() as u32)
     }
 
     /// Convert this UTF-32 (`char`) offset in `string` to an UTF-8 (byte) offset
-    pub fn to_utf8_code_units_in(self, string: Str32) -> Utf8CodeUnits {
+    pub fn to_utf8_code_units_in(self, _: AssumeUnder4GB, string: &str) -> Utf8CodeUnits {
         let mut current_utf32_offset = Utf32CodeUnits(0);
-        for (current_utf8_offset, utf8_byte) in string.0.bytes().enumerate() {
+        for (current_utf8_offset, utf8_byte) in string.bytes().enumerate() {
             if (utf8_byte & 0b1100_0000) == 0b1000_0000 {
                 // UTF-8 continuation byte
                 continue;
@@ -476,14 +480,14 @@ impl Utf32CodeUnits {
             }
             current_utf32_offset.0 += 1;
         }
-        Utf8CodeUnits(string.0.len() as u32)
+        Utf8CodeUnits(string.len() as u32)
     }
 
     /// Convert this UTF-32 (`char`) offset in `string` to an UTF-16 offset
-    pub fn to_utf16_code_units_in(self, string: Str32) -> Utf16CodeUnits {
+    pub fn to_utf16_code_units_in(self, _: AssumeUnder4GB, string: &str) -> Utf16CodeUnits {
         let mut current_utf32_offset = Utf32CodeUnits(0);
         let mut current_utf16_offset = Utf16CodeUnits(0);
-        for utf8_byte in string.0.bytes() {
+        for utf8_byte in string.bytes() {
             if current_utf32_offset >= self {
                 break;
             }
@@ -500,8 +504,8 @@ impl Utf32CodeUnitsOrNodeOffset {
     ///
     /// Note: this silently wraps and returns an incorrect value for offsets larger than
     /// `u32::MAX` (~4 billion) code units
-    pub fn to_utf16_code_units_in(self, string: Str32) -> Utf16CodeUnits {
-        Utf32CodeUnits(self.0).to_utf16_code_units_in(string)
+    pub fn to_utf16_code_units_in(self, _: AssumeUnder4GB, string: &str) -> Utf16CodeUnits {
+        Utf32CodeUnits(self.0).to_utf16_code_units_in(AssumeUnder4GB, string)
     }
 }
 
@@ -530,16 +534,28 @@ mod test {
 
     #[test]
     fn test_utf16_length() {
-        assert_eq!(Utf16CodeUnits::length_of(Str32("")), Utf16CodeUnits(0));
-        assert_eq!(Utf16CodeUnits::length_of(Str32("a")), Utf16CodeUnits(1));
-        assert_eq!(Utf16CodeUnits::length_of(Str32("é")), Utf16CodeUnits(1));
-        assert_eq!(Utf16CodeUnits::length_of(Str32("字")), Utf16CodeUnits(1));
         assert_eq!(
-            Utf16CodeUnits::length_of(Str32("\u{1F4A9}")),
+            Utf16CodeUnits::length_of(AssumeUnder4GB, ""),
+            Utf16CodeUnits(0)
+        );
+        assert_eq!(
+            Utf16CodeUnits::length_of(AssumeUnder4GB, "a"),
+            Utf16CodeUnits(1)
+        );
+        assert_eq!(
+            Utf16CodeUnits::length_of(AssumeUnder4GB, "é"),
+            Utf16CodeUnits(1)
+        );
+        assert_eq!(
+            Utf16CodeUnits::length_of(AssumeUnder4GB, "字"),
+            Utf16CodeUnits(1)
+        );
+        assert_eq!(
+            Utf16CodeUnits::length_of(AssumeUnder4GB, "\u{1F4A9}"),
             Utf16CodeUnits(2)
         );
         assert_eq!(
-            Utf16CodeUnits::length_of(Str32("\u{1F4A9}字éa")),
+            Utf16CodeUnits::length_of(AssumeUnder4GB, "\u{1F4A9}字éa"),
             Utf16CodeUnits(5)
         );
     }
@@ -590,37 +606,37 @@ mod test {
 
     #[test]
     fn test_utf32_to_utf16() {
-        let string = Str32("aé字\u{1F4A9}");
+        let string = "aé字\u{1F4A9}";
         assert_eq!(
-            Utf32CodeUnits(0).to_utf16_code_units_in(string),
+            Utf32CodeUnits(0).to_utf16_code_units_in(AssumeUnder4GB, string),
             Utf16CodeUnits(0),
         );
         assert_eq!(
-            Utf32CodeUnits(1).to_utf16_code_units_in(string),
+            Utf32CodeUnits(1).to_utf16_code_units_in(AssumeUnder4GB, string),
             Utf16CodeUnits(1),
         );
         assert_eq!(
-            Utf32CodeUnits(2).to_utf16_code_units_in(string),
+            Utf32CodeUnits(2).to_utf16_code_units_in(AssumeUnder4GB, string),
             Utf16CodeUnits(2),
         );
         assert_eq!(
-            Utf32CodeUnits(3).to_utf16_code_units_in(string),
+            Utf32CodeUnits(3).to_utf16_code_units_in(AssumeUnder4GB, string),
             Utf16CodeUnits(3),
         );
 
         assert_eq!(
-            Utf32CodeUnits(4).to_utf16_code_units_in(string),
+            Utf32CodeUnits(4).to_utf16_code_units_in(AssumeUnder4GB, string),
             Utf16CodeUnits(5),
         );
 
         // This 32-bit offset is out of bounds. We clamp to the nearest valid 16-bit offset,
         // a.k.a the UTF-16 length. Should this be an error instead?
         assert_eq!(
-            Utf32CodeUnits(6).to_utf16_code_units_in(string),
+            Utf32CodeUnits(6).to_utf16_code_units_in(AssumeUnder4GB, string),
             Utf16CodeUnits(5),
         );
         assert_eq!(
-            Utf32CodeUnits(1000).to_utf16_code_units_in(string),
+            Utf32CodeUnits(1000).to_utf16_code_units_in(AssumeUnder4GB, string),
             Utf16CodeUnits(5),
         );
     }

--- a/tests/unit/script/textinput.rs
+++ b/tests/unit/script/textinput.rs
@@ -48,7 +48,7 @@ fn test_set_content_ignores_max_length() {
         DummyClipboardContext::new(""),
     );
 
-    textinput.set_max_length(Some(Utf16CodeUnits::one()));
+    textinput.set_max_length(Some(Utf16CodeUnits(1)));
     textinput.set_content(DOMString::from("mozilla rocks"));
     assert_eq!(textinput.get_content(), DOMString::from("mozilla rocks"));
 }
@@ -97,7 +97,7 @@ fn test_textinput_when_content_is_already_longer_than_max_length_and_theres_no_s
         DummyClipboardContext::new(""),
     );
 
-    textinput.set_max_length(Some(Utf16CodeUnits::one()));
+    textinput.set_max_length(Some(Utf16CodeUnits(1)));
     textinput.insert('a');
     assert_eq!(textinput.get_content(), "abc");
 }
@@ -201,7 +201,7 @@ fn test_single_line_textinput_with_max_length_inside_char() {
         DummyClipboardContext::new(""),
     );
 
-    textinput.set_max_length(Some(Utf16CodeUnits::one()));
+    textinput.set_max_length(Some(Utf16CodeUnits(1)));
     textinput.insert('x');
     assert_eq!(textinput.get_content(), "\u{10437}");
 }
@@ -215,7 +215,7 @@ fn test_single_line_textinput_with_max_length_doesnt_allow_appending_characters_
         DummyClipboardContext::new(""),
     );
 
-    textinput.set_max_length(Some(Utf16CodeUnits::one()));
+    textinput.set_max_length(Some(Utf16CodeUnits(1)));
     textinput.insert('b');
     assert_eq!(textinput.get_content(), "a");
 }


### PR DESCRIPTION
Fixes https://github.com/servo/servo/issues/47696, attempt number 2
Closes https://github.com/servo/servo/pull/47714, the previous attempt
Testing: existing WPT and unit tests

In that previous attempt I used `NonMaxU32` in order to optimize the size of `Option<Utf8CodeUnits>`. This made `u32::MAX` memory-unsafe to use, so as a precaution I made every operation checked, returning `Result`s. Unsurprisingly, this was a huge pain to deal with. I gave up before getting the `script` crate to compile.

## Smaller `RangeAny`

Instead of the `Option` size optimization, per https://github.com/servo/servo/issues/47696#issuecomment-5499688316 I’ve changed `RangeAny` from storing two options (each with a 64-bit or 32-bit tag because of alignment) to a single 4-variant enum (with a single tag). So `RangeAny<u32>` occupies 12 bytes instead of 16. This change is internal, the public API is still based on two options (though no longer bare public fields)

## `u32` overflow

In this PR I’ve still reduced the width of `Utf*CodeUnits` from `usize` to `u32` but left the full `u32` range available. `impl Add for Utf8CodeUnits` is still there (not replaced with `checked_add`) and still defers to plain integer addition: checked with panic on overflow when compiled in debug mode, or wrapping in release mode.

In either compilation mode, trying to deal with offsets greater than `u32::MAX` would be a bug (though not memory-unsafe). To help surface this issue to callers, I’ve changed some APIs from taking `&str` arguments to taking a new `struct Str32(&str)` marker type that says: “this string is expected to not be bigger than 4 GiB (`u32::MAX` bytes)”

In practice the strings come from a few places:

* `DOMString` in many places in the script crate: multi-representation, UTF-8 or Latin-1
* `Rope` for the text value of `<input>` or `<textarea>` elements: UTF-8 `Vec<String>` (currently does not cache its total length)
* Text value of `CharacterData` DOM nodes: UTF-8  `String`
* Rendered text in layout: mostly from DOM text (`CharacterData`) nodes, but for `InlineFormattingContext` also computes offsets spanning multiple DOM nodes

Maybe we could systematically enforce limits on their sizes (with e.g. JS exceptions instead of Rust panics or silently incorrect behavior), but I haven’t done so in this PR. The script crate was already using `u32` is some places, so I suspect there were already bugs and/or limitations with very large strings including [a limitation from SpiderMonkey](https://stackoverflow.com/a/65570725).

## Splitting surrogate pairs

As a drive-by improvement, `Utf*CodeUnits` is used in more places instead of `usize`, and their methods instead of ad-hoc offset or length computations. The latter points out a subtle aspect of converting a UTF-16 offset to UTF-8 or UTF-32: if the UTF-16 offset would split a surrogate pair (for a non-BMP code point), `Utf16CodeUnits` methods used to arbitrarily snap to the code point boundary *after* the whole pair. When using this method to implement the `maxlength` HTML attribute of `<input>` or `<textarea>` however, the snap must be to *before* the surrogate pair. So I’ve changed the behavior of the `Utf16CodeUnits` methods, which also affects the result of changing the selection range through DOM APIs.