### PR TITLE
script: Mechanically migrate to `reflect_dom_object`

### DIFF
--- a/components/script/dom/animations/documenttimeline.rs
+++ b/components/script/dom/animations/documenttimeline.rs
@@ -7,7 +7,7 @@ use js::context::JSContext;
 use js::gc::HandleObject;
 use num_traits::ToPrimitive;
 use script_bindings::codegen::GenericBindings::DocumentTimelineBinding::DocumentTimelineOptions;
-use script_bindings::reflector::{reflect_dom_object_with_cx, reflect_dom_object_with_proto};
+use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_proto};
 use script_bindings::root::DomRoot;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_config::pref;
@@ -57,13 +57,13 @@ impl DocumentTimeline {
         } else {
             CrossProcessInstant::now() - window.navigation_start()
         };
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(Self {
                 animation_timeline: AnimationTimeline::new_inherited(duration),
                 origin_offset: Duration::ZERO,
             }),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/attributes/domstringmap.rs
+++ b/components/script/dom/attributes/domstringmap.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use html5ever::{LocalName, ns};
 use js::context::{JSContext, NoGC};
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::codegen::Bindings::DOMStringMapBinding::DOMStringMapMethods;
 use crate::dom::bindings::error::{Error, ErrorResult};
@@ -123,10 +123,10 @@ impl DOMStringMap {
     }
 
     pub(crate) fn new(cx: &mut JSContext, element: &HTMLElement) -> DomRoot<DOMStringMap> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(DOMStringMap::new_inherited(element)),
             &*element.owner_window(),
-            cx,
         )
     }
 

--- a/components/script/dom/attributes/domtokenlist.rs
+++ b/components/script/dom/attributes/domtokenlist.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use html5ever::LocalName;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use style::str::HTML_SPACE_CHARACTERS;
 use stylo_atoms::Atom;
 
@@ -46,14 +46,14 @@ impl DOMTokenList {
         local_name: &LocalName,
         supported_tokens: Option<Vec<Atom>>,
     ) -> DomRoot<DOMTokenList> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(DOMTokenList::new_inherited(
                 element,
                 local_name.clone(),
                 supported_tokens,
             )),
             &*element.owner_window(),
-            cx,
         )
     }
 

--- a/components/script/dom/audio/audiotrack.rs
+++ b/components/script/dom/audio/audiotrack.rs
@@ -7,7 +7,7 @@ use std::cell::Cell;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::audio::audiotracklist::AudioTrackList;
 use crate::dom::bindings::codegen::Bindings::AudioTrackBinding::AudioTrackMethods;
@@ -54,12 +54,12 @@ impl AudioTrack {
         language: DOMString,
         track_list: Option<&AudioTrackList>,
     ) -> DomRoot<AudioTrack> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(AudioTrack::new_inherited(
                 id, kind, label, language, track_list,
             )),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/audio/audiotracklist.rs
+++ b/components/script/dom/audio/audiotracklist.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 
 use crate::dom::audio::audiotrack::AudioTrack;
 use crate::dom::bindings::codegen::Bindings::AudioTrackListBinding::AudioTrackListMethods;
@@ -43,10 +43,10 @@ impl AudioTrackList {
         tracks: &[&AudioTrack],
         media_element: Option<&HTMLMediaElement>,
     ) -> DomRoot<AudioTrackList> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(AudioTrackList::new_inherited(tracks, media_element)),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/bluetooth/bluetoothcharacteristicproperties.rs
+++ b/components/script/dom/bluetooth/bluetoothcharacteristicproperties.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::codegen::Bindings::BluetoothCharacteristicPropertiesBinding::BluetoothCharacteristicPropertiesMethods;
 use crate::dom::bindings::root::DomRoot;
@@ -67,7 +67,8 @@ impl BluetoothCharacteristicProperties {
         reliableWrite: bool,
         writableAuxiliaries: bool,
     ) -> DomRoot<BluetoothCharacteristicProperties> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(BluetoothCharacteristicProperties::new_inherited(
                 broadcast,
                 read,
@@ -80,7 +81,6 @@ impl BluetoothCharacteristicProperties {
                 writableAuxiliaries,
             )),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/bluetooth/bluetoothdevice.rs
+++ b/components/script/dom/bluetooth/bluetoothdevice.rs
@@ -11,7 +11,7 @@ use js::context::JSContext;
 use js::realm::CurrentRealm;
 use profile_traits::generic_channel;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_base::generic_channel::GenericSender;
 use servo_bluetooth_traits::{
     BluetoothCharacteristicMsg, BluetoothDescriptorMsg, BluetoothRequest, BluetoothResponse,
@@ -84,10 +84,10 @@ impl BluetoothDevice {
         name: Option<DOMString>,
         context: &Bluetooth,
     ) -> DomRoot<BluetoothDevice> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(BluetoothDevice::new_inherited(id, name, context)),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/bluetooth/bluetoothpermissionresult.rs
+++ b/components/script/dom/bluetooth/bluetoothpermissionresult.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_base::generic_channel::GenericSender;
 use servo_bluetooth_traits::{BluetoothRequest, BluetoothResponse};
 
@@ -51,10 +51,10 @@ impl BluetoothPermissionResult {
         global: &GlobalScope,
         status: &PermissionStatus,
     ) -> DomRoot<BluetoothPermissionResult> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(BluetoothPermissionResult::new_inherited(status)),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
@@ -8,7 +8,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::realm::CurrentRealm;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_base::generic_channel::GenericSender;
 use servo_bluetooth_traits::blocklist::{Blocklist, uuid_is_blocklisted};
 use servo_bluetooth_traits::{BluetoothRequest, BluetoothResponse, GATTType};
@@ -74,7 +74,8 @@ impl BluetoothRemoteGATTCharacteristic {
         properties: &BluetoothCharacteristicProperties,
         instance_id: String,
     ) -> DomRoot<BluetoothRemoteGATTCharacteristic> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(BluetoothRemoteGATTCharacteristic::new_inherited(
                 service,
                 uuid,
@@ -82,7 +83,6 @@ impl BluetoothRemoteGATTCharacteristic {
                 instance_id,
             )),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
@@ -8,7 +8,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::realm::CurrentRealm;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_base::generic_channel::GenericSender;
 use servo_bluetooth_traits::blocklist::{Blocklist, uuid_is_blocklisted};
 use servo_bluetooth_traits::{BluetoothRequest, BluetoothResponse};
@@ -62,14 +62,14 @@ impl BluetoothRemoteGATTDescriptor {
         uuid: DOMString,
         instance_id: String,
     ) -> DomRoot<BluetoothRemoteGATTDescriptor> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(BluetoothRemoteGATTDescriptor::new_inherited(
                 characteristic,
                 uuid,
                 instance_id,
             )),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/bluetooth/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattserver.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::realm::CurrentRealm;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_base::generic_channel::GenericSender;
 use servo_bluetooth_traits::{BluetoothRequest, BluetoothResponse, GATTType};
 
@@ -45,10 +45,10 @@ impl BluetoothRemoteGATTServer {
         global: &GlobalScope,
         device: &BluetoothDevice,
     ) -> DomRoot<BluetoothRemoteGATTServer> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(BluetoothRemoteGATTServer::new_inherited(device)),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/bluetooth/bluetoothremotegattservice.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattservice.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::realm::CurrentRealm;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_bluetooth_traits::{BluetoothResponse, GATTType};
 
 use crate::dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding::BluetoothRemoteGATTServerMethods;
@@ -57,12 +57,12 @@ impl BluetoothRemoteGATTService {
         isPrimary: bool,
         instanceID: String,
     ) -> DomRoot<BluetoothRemoteGATTService> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(BluetoothRemoteGATTService::new_inherited(
                 device, uuid, isPrimary, instanceID,
             )),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/canvas/2d/canvaspattern.rs
+++ b/components/script/dom/canvas/2d/canvaspattern.rs
@@ -7,7 +7,7 @@ use euclid::default::{Size2D, Transform2D};
 use js::context::JSContext;
 use pixels::{SharedSnapshot, Snapshot};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_canvas_traits::canvas::{FillOrStrokeStyle, RepetitionStyle, SurfaceStyle};
 
 use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::CanvasPatternMethods;
@@ -65,7 +65,8 @@ impl CanvasPattern {
         repeat: RepetitionStyle,
         origin_clean: bool,
     ) -> DomRoot<CanvasPattern> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(CanvasPattern::new_inherited(
                 surface_data,
                 surface_size,
@@ -73,7 +74,6 @@ impl CanvasPattern {
                 origin_clean,
             )),
             global,
-            cx,
         )
     }
     pub(crate) fn origin_is_clean(&self) -> bool {

--- a/components/script/dom/canvas/2d/textmetrics.rs
+++ b/components/script/dom/canvas/2d/textmetrics.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::codegen::Bindings::TextMetricsBinding::TextMetricsMethods;
 use crate::dom::bindings::num::Finite;
@@ -80,7 +80,8 @@ impl TextMetrics {
         alphabeticBaseline: f64,
         ideographicBaseline: f64,
     ) -> DomRoot<TextMetrics> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(TextMetrics::new_inherited(
                 width,
                 actualBoundingBoxLeft,
@@ -96,7 +97,6 @@ impl TextMetrics {
                 ideographicBaseline,
             )),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/canvas/imagebitmap.rs
+++ b/components/script/dom/canvas/imagebitmap.rs
@@ -13,7 +13,7 @@ use pixels::{CorsStatus, Snapshot, SnapshotAlphaMode, SnapshotPixelFormat};
 use rustc_hash::FxHashMap;
 use script_bindings::cell::DomRefCell;
 use script_bindings::error::{Error, Fallible};
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_base::id::{ImageBitmapId, ImageBitmapIndex};
 use servo_constellation_traits::SerializableImageBitmap;
 
@@ -55,10 +55,10 @@ impl ImageBitmap {
         global: &GlobalScope,
         bitmap_data: Snapshot,
     ) -> DomRoot<ImageBitmap> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(ImageBitmap::new_inherited(bitmap_data)),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/canvas/imagebitmaprenderingcontext.rs
+++ b/components/script/dom/canvas/imagebitmaprenderingcontext.rs
@@ -10,7 +10,7 @@ use js::context::JSContext;
 use paint_api::SerializableImageData;
 use pixels::Snapshot;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_base::Epoch;
 use webrender_api::units::DeviceIntSize;
 use webrender_api::{ImageDescriptor, ImageFormat, ImageKey};
@@ -64,12 +64,12 @@ impl ImageBitmapRenderingContext {
         global: &GlobalScope,
         canvas: &RootedHTMLCanvasElementOrOffscreenCanvas,
     ) -> DomRoot<ImageBitmapRenderingContext> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(ImageBitmapRenderingContext::new_inherited(
                 HTMLCanvasElementOrOffscreenCanvas::from(canvas),
             )),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/credentialmanagement/credential.rs
+++ b/components/script/dom/credentialmanagement/credential.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::realm::CurrentRealm;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use script_bindings::str::{DOMString, USVString};
 
 use crate::dom::bindings::codegen::Bindings::CredentialBinding::CredentialMethods;
@@ -39,10 +39,10 @@ impl Credential {
         id: USVString,
         credential_type: DOMString,
     ) -> DomRoot<Credential> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(Credential::new_inherited(id, credential_type)),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/css/cssfontfacedescriptors.rs
+++ b/components/script/dom/css/cssfontfacedescriptors.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use style::font_face::DescriptorId;
 
 use crate::dom::GlobalScope;
@@ -39,10 +39,10 @@ impl CSSFontFaceDescriptors {
         global: &GlobalScope,
         font_face_rule: &CSSFontFaceRule,
     ) -> DomRoot<CSSFontFaceDescriptors> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(CSSFontFaceDescriptors::new_inherited(font_face_rule)),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/css/cssfontfacerule.rs
+++ b/components/script/dom/css/cssfontfacerule.rs
@@ -7,7 +7,7 @@ use std::cell::RefCell;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::dom::MutNullableDom;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_arc::Arc;
 use style::font_face::DescriptorId;
 use style::shared_lock::{Locked, ToCssWithGuard};
@@ -52,14 +52,14 @@ impl CSSFontFaceRule {
         parent_stylesheet: &CSSStyleSheet,
         fontfacerule: Arc<Locked<FontFaceRule>>,
     ) -> DomRoot<CSSFontFaceRule> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(CSSFontFaceRule::new_inherited(
                 parent_rule,
                 parent_stylesheet,
                 fontfacerule,
             )),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/css/cssfontfeaturevaluesmap.rs
+++ b/components/script/dom/css/cssfontfeaturevaluesmap.rs
@@ -7,7 +7,7 @@ use indexmap::IndexMap;
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
 use script_bindings::like::Maplike;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use style::stylesheets::font_feature_values_rule::{
     FFVDeclaration, PairValues, SingleValue, VectorValues,
 };
@@ -42,10 +42,10 @@ impl CSSFontFeatureValuesMap {
         global: &GlobalScope,
         map: IndexMap<DOMString, Vec<u32>>,
     ) -> DomRoot<CSSFontFeatureValuesMap> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(CSSFontFeatureValuesMap::new_inherited(map)),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/css/cssfontfeaturevaluesrule.rs
+++ b/components/script/dom/css/cssfontfeaturevaluesrule.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::dom::MutNullableDom;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_arc::Arc;
 use style::shared_lock::ToCssWithGuard;
 use style::stylesheets::{CssRuleType, FontFeatureValuesRule};
@@ -74,14 +74,14 @@ impl CSSFontFeatureValuesRule {
         parent_stylesheet: &CSSStyleSheet,
         font_feature_values_rule: Arc<FontFeatureValuesRule>,
     ) -> DomRoot<CSSFontFeatureValuesRule> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(CSSFontFeatureValuesRule::new_inherited(
                 parent_rule,
                 parent_stylesheet,
                 font_feature_values_rule,
             )),
             window,
-            cx,
         )
     }
 }

--- a/components/script/dom/css/cssimportrule.rs
+++ b/components/script/dom/css/cssimportrule.rs
@@ -6,7 +6,7 @@ use std::cell::RefCell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_arc::Arc;
 use style::shared_lock::{Locked, ToCssWithGuard};
 use style::stylesheets::import_rule::ImportLayer;
@@ -48,14 +48,14 @@ impl CSSImportRule {
         parent_stylesheet: &CSSStyleSheet,
         import_rule: Arc<Locked<ImportRule>>,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(Self::new_inherited(
                 parent_rule,
                 parent_stylesheet,
                 import_rule,
             )),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/css/csskeyframerule.rs
+++ b/components/script/dom/css/csskeyframerule.rs
@@ -6,7 +6,7 @@ use std::cell::RefCell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_arc::Arc;
 use style::shared_lock::{Locked, SharedRwLockReadGuard, ToCssWithGuard};
 use style::stylesheets::CssRuleType;
@@ -52,14 +52,14 @@ impl CSSKeyframeRule {
         parent_stylesheet: &CSSStyleSheet,
         keyframerule: Arc<Locked<Keyframe>>,
     ) -> DomRoot<CSSKeyframeRule> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(CSSKeyframeRule::new_inherited(
                 parent_rule,
                 parent_stylesheet,
                 keyframerule,
             )),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/css/csskeyframesrule.rs
+++ b/components/script/dom/css/csskeyframesrule.rs
@@ -7,7 +7,7 @@ use std::cell::RefCell;
 use cssparser::{Parser, ParserInput};
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_arc::Arc;
 use style::shared_lock::{Locked, SharedRwLockReadGuard, ToCssWithGuard};
 use style::stylesheets::keyframes_rule::{Keyframe, KeyframeSelectors, KeyframesRule};
@@ -56,14 +56,14 @@ impl CSSKeyframesRule {
         parent_stylesheet: &CSSStyleSheet,
         keyframesrule: Arc<Locked<KeyframesRule>>,
     ) -> DomRoot<CSSKeyframesRule> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(CSSKeyframesRule::new_inherited(
                 parent_rule,
                 parent_stylesheet,
                 keyframesrule,
             )),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/css/csslayerblockrule.rs
+++ b/components/script/dom/css/csslayerblockrule.rs
@@ -6,7 +6,7 @@ use std::cell::RefCell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_arc::Arc;
 use style::shared_lock::{Locked, SharedRwLockReadGuard, ToCssWithGuard};
 use style::stylesheets::{CssRuleType, CssRules, LayerBlockRule};
@@ -47,14 +47,14 @@ impl CSSLayerBlockRule {
         parent_stylesheet: &CSSStyleSheet,
         layerblockrule: Arc<LayerBlockRule>,
     ) -> DomRoot<CSSLayerBlockRule> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(CSSLayerBlockRule::new_inherited(
                 parent_rule,
                 parent_stylesheet,
                 layerblockrule,
             )),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/css/csslayerstatementrule.rs
+++ b/components/script/dom/css/csslayerstatementrule.rs
@@ -7,7 +7,7 @@ use std::cell::RefCell;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::MutableHandleValue;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_arc::Arc;
 use style::shared_lock::ToCssWithGuard;
 use style::stylesheets::{CssRuleType, LayerStatementRule};
@@ -49,14 +49,14 @@ impl CSSLayerStatementRule {
         parent_stylesheet: &CSSStyleSheet,
         layerstatementrule: Arc<LayerStatementRule>,
     ) -> DomRoot<CSSLayerStatementRule> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(CSSLayerStatementRule::new_inherited(
                 parent_rule,
                 parent_stylesheet,
                 layerstatementrule,
             )),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/css/cssmediarule.rs
+++ b/components/script/dom/css/cssmediarule.rs
@@ -6,7 +6,7 @@ use std::cell::RefCell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_arc::Arc;
 use style::shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
 use style::stylesheets::{CssRuleType, MediaRule};
@@ -57,14 +57,14 @@ impl CSSMediaRule {
         parent_stylesheet: &CSSStyleSheet,
         mediarule: Arc<MediaRule>,
     ) -> DomRoot<CSSMediaRule> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(CSSMediaRule::new_inherited(
                 parent_rule,
                 parent_stylesheet,
                 mediarule,
             )),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/css/cssnamespacerule.rs
+++ b/components/script/dom/css/cssnamespacerule.rs
@@ -6,7 +6,7 @@ use std::cell::RefCell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_arc::Arc;
 use style::shared_lock::ToCssWithGuard;
 use style::stylesheets::{CssRuleType, NamespaceRule};
@@ -46,14 +46,14 @@ impl CSSNamespaceRule {
         parent_stylesheet: &CSSStyleSheet,
         namespacerule: Arc<NamespaceRule>,
     ) -> DomRoot<CSSNamespaceRule> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(CSSNamespaceRule::new_inherited(
                 parent_rule,
                 parent_stylesheet,
                 namespacerule,
             )),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/css/cssnesteddeclarations.rs
+++ b/components/script/dom/css/cssnesteddeclarations.rs
@@ -6,7 +6,7 @@ use std::cell::RefCell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_arc::Arc;
 use style::shared_lock::{Locked, SharedRwLockReadGuard, ToCssWithGuard};
 use style::stylesheets::{CssRuleType, NestedDeclarationsRule};
@@ -51,14 +51,14 @@ impl CSSNestedDeclarations {
         parent_stylesheet: &CSSStyleSheet,
         nesteddeclarationsrule: Arc<Locked<NestedDeclarationsRule>>,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(Self::new_inherited(
                 parent_rule,
                 parent_stylesheet,
                 nesteddeclarationsrule,
             )),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/css/csspropertyrule.rs
+++ b/components/script/dom/css/csspropertyrule.rs
@@ -6,7 +6,7 @@ use std::cell::RefCell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_arc::Arc;
 use style::shared_lock::ToCssWithGuard;
 use style::stylesheets::{CssRuleType, PropertyRule};
@@ -47,14 +47,14 @@ impl CSSPropertyRule {
         parent_stylesheet: &CSSStyleSheet,
         property_rule: Arc<PropertyRule>,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(Self::new_inherited(
                 parent_rule,
                 parent_stylesheet,
                 property_rule,
             )),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/css/cssrulelist.rs
+++ b/components/script/dom/css/cssrulelist.rs
@@ -9,7 +9,7 @@ use itertools::izip;
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
 use script_bindings::inheritance::Castable;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use script_bindings::str::DOMString;
 use servo_arc::Arc;
 use style::shared_lock::{Locked, SharedRwLockReadGuard};
@@ -98,14 +98,14 @@ impl CSSRuleList {
         parent_stylesheet: &CSSStyleSheet,
         rules: RulesSource,
     ) -> DomRoot<CSSRuleList> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(CSSRuleList::new_inherited(
                 created_by_rule,
                 parent_stylesheet,
                 rules,
             )),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/css/cssstyledeclaration.rs
+++ b/components/script/dom/css/cssstyledeclaration.rs
@@ -9,7 +9,7 @@ use std::sync::LazyLock;
 use dom_struct::dom_struct;
 use html5ever::local_name;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_arc::Arc;
 use servo_url::ServoUrl;
 use style::attr::AttrValue;
@@ -261,14 +261,14 @@ impl CSSStyleDeclaration {
         pseudo: Option<PseudoElement>,
         modification_access: CSSModificationAccess,
     ) -> DomRoot<CSSStyleDeclaration> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(CSSStyleDeclaration::new_inherited(
                 owner,
                 pseudo,
                 modification_access,
             )),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/css/cssstylerule.rs
+++ b/components/script/dom/css/cssstylerule.rs
@@ -8,7 +8,7 @@ use std::mem;
 use cssparser::{Parser as CssParser, ParserInput as CssParserInput, ToCss};
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use selectors::parser::{ParseRelative, SelectorList};
 use servo_arc::Arc;
 use style::selector_parser::SelectorParser;
@@ -56,14 +56,14 @@ impl CSSStyleRule {
         parent_stylesheet: &CSSStyleSheet,
         stylerule: Arc<Locked<StyleRule>>,
     ) -> DomRoot<CSSStyleRule> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(CSSStyleRule::new_inherited(
                 parent_rule,
                 parent_stylesheet,
                 stylerule,
             )),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/css/cssstylesheet.rs
+++ b/components/script/dom/css/cssstylesheet.rs
@@ -12,7 +12,7 @@ use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::StyleSheetBinding::StyleSheetMethods;
 use script_bindings::inheritance::Castable;
-use script_bindings::reflector::{reflect_dom_object_with_cx, reflect_dom_object_with_proto};
+use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_proto};
 use script_bindings::root::Dom;
 use servo_arc::Arc;
 use style::media_queries::MediaList as StyleMediaList;
@@ -114,7 +114,8 @@ impl CSSStyleSheet {
         stylesheet: Arc<StyleStyleSheet>,
         constructor_document: Option<&Document>,
     ) -> DomRoot<CSSStyleSheet> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(CSSStyleSheet::new_inherited(
                 owner,
                 type_,
@@ -124,7 +125,6 @@ impl CSSStyleSheet {
                 constructor_document,
             )),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/css/csssupportsrule.rs
+++ b/components/script/dom/css/csssupportsrule.rs
@@ -6,7 +6,7 @@ use std::cell::RefCell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_arc::Arc;
 use style::shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
 use style::stylesheets::{CssRuleType, SupportsRule};
@@ -52,14 +52,14 @@ impl CSSSupportsRule {
         parent_stylesheet: &CSSStyleSheet,
         supportsrule: Arc<SupportsRule>,
     ) -> DomRoot<CSSSupportsRule> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(CSSSupportsRule::new_inherited(
                 parent_rule,
                 parent_stylesheet,
                 supportsrule,
             )),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/css/stylepropertymapreadonly.rs
+++ b/components/script/dom/css/stylepropertymapreadonly.rs
@@ -7,7 +7,7 @@ use std::iter::Iterator;
 
 use dom_struct::dom_struct;
 use rustc_hash::FxBuildHasher;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use style::custom_properties;
 use stylo_atoms::Atom;
 
@@ -55,10 +55,10 @@ impl StylePropertyMapReadOnly {
             values.push(Dom::from_ref(&*value));
         }
         let iter = keys.into_iter().zip(values.iter().cloned());
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(StylePropertyMapReadOnly::new_inherited(iter)),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/css/stylesheetlist.rs
+++ b/components/script/dom/css/stylesheetlist.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_arc::Arc;
 use style::stylesheets::Stylesheet;
 
@@ -107,10 +107,10 @@ impl StyleSheetList {
         window: &Window,
         doc_or_sr: StyleSheetListOwner,
     ) -> DomRoot<StyleSheetList> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(StyleSheetList::new_inherited(doc_or_sr)),
             window,
-            cx,
         )
     }
 }

--- a/components/script/dom/datatransfer/datatransferitem.rs
+++ b/components/script/dom/datatransfer/datatransferitem.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::callback::ExceptionHandling;
 use crate::dom::bindings::codegen::Bindings::DataTransferItemBinding::{
@@ -63,10 +63,10 @@ impl DataTransferItem {
         data_store: Rc<RefCell<Option<DragDataStore>>>,
         id: u16,
     ) -> DomRoot<DataTransferItem> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(DataTransferItem::new_inherited(data_store, id)),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/datatransfer/datatransferitemlist.rs
+++ b/components/script/dom/datatransfer/datatransferitemlist.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::MutableHandleValue;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::codegen::Bindings::DataTransferItemListBinding::DataTransferItemListMethods;
 use crate::dom::bindings::error::{Error, Fallible};
@@ -45,10 +45,10 @@ impl DataTransferItemList {
         window: &Window,
         data_store: Rc<RefCell<Option<DragDataStore>>>,
     ) -> DomRoot<DataTransferItemList> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(DataTransferItemList::new_inherited(data_store)),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/debugger/pipelineid.rs
+++ b/components/script/dom/debugger/pipelineid.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::codegen::Bindings::DebuggerAddDebuggeeEventBinding::PipelineIdMethods;
 use crate::dom::bindings::root::DomRoot;
@@ -23,13 +23,13 @@ impl PipelineId {
         global: &GlobalScope,
         pipeline_id: servo_base::id::PipelineId,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(Self {
                 reflector_: Reflector::new(),
                 inner: pipeline_id,
             }),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/document/domimplementation.rs
+++ b/components/script/dom/document/domimplementation.rs
@@ -6,7 +6,7 @@ use dom_struct::dom_struct;
 use html5ever::{QualName, local_name, ns};
 use js::context::JSContext;
 use script_bindings::error::Error;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use script_traits::DocumentActivity;
 
 use crate::dom::bindings::codegen::Bindings::DOMImplementationBinding::DOMImplementationMethods;
@@ -46,10 +46,10 @@ impl DOMImplementation {
 
     pub(crate) fn new(cx: &mut JSContext, document: &Document) -> DomRoot<DOMImplementation> {
         let window = document.window();
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(DOMImplementation::new_inherited(document)),
             window,
-            cx,
         )
     }
 }

--- a/components/script/dom/document/visibilitystateentry.rs
+++ b/components/script/dom/document/visibilitystateentry.rs
@@ -6,7 +6,7 @@ use std::ops::Deref;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use time::Duration;
 
@@ -49,10 +49,10 @@ impl VisibilityStateEntry {
         state: DocumentVisibilityState,
         timestamp: CrossProcessInstant,
     ) -> DomRoot<VisibilityStateEntry> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(VisibilityStateEntry::new_inherited(state, timestamp)),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -7,9 +7,7 @@ use js::context::{JSContext, NoGC};
 use js::rust::HandleObject;
 use rustc_hash::FxHashMap;
 use script_bindings::match_domstring_ascii;
-use script_bindings::reflector::{
-    Reflector, reflect_dom_object_with_cx, reflect_dom_object_with_proto,
-};
+use script_bindings::reflector::{Reflector, reflect_dom_object, reflect_dom_object_with_proto};
 use servo_base::id::{DomExceptionId, DomExceptionIndex};
 use servo_constellation_traits::DomException;
 
@@ -184,10 +182,10 @@ impl DOMException {
     ) -> DomRoot<DOMException> {
         let (message, name) = DOMException::get_error_data_by_code(code);
 
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(DOMException::new_inherited(message, name)),
             global,
-            cx,
         )
     }
 
@@ -199,10 +197,10 @@ impl DOMException {
     ) -> DomRoot<DOMException> {
         let (_, name) = DOMException::get_error_data_by_code(code);
 
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(DOMException::new_inherited(DOMString::from(message), name)),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/event/touchevent.rs
+++ b/components/script/dom/event/touchevent.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use style::Atom;
 
 use crate::dom::bindings::codegen::Bindings::TouchEventBinding::TouchEventMethods;
@@ -70,14 +70,14 @@ impl TouchEvent {
         changed_touches: &TouchList,
         target_touches: &TouchList,
     ) -> DomRoot<TouchEvent> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(TouchEvent::new_inherited(
                 touches,
                 changed_touches,
                 target_touches,
             )),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/fetch/fetchlaterresult.rs
+++ b/components/script/dom/fetch/fetchlaterresult.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::codegen::Bindings::FetchLaterResultBinding::FetchLaterResultMethods;
 use crate::dom::bindings::reflector::DomGlobal;
@@ -35,10 +35,10 @@ impl FetchLaterResult {
         window: &Window,
         deferred_record_id: DeferredFetchRecordId,
     ) -> DomRoot<FetchLaterResult> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(FetchLaterResult::new_inherited(deferred_record_id)),
             window,
-            cx,
         )
     }
 }

--- a/components/script/dom/file/filelist.rs
+++ b/components/script/dom/file/filelist.rs
@@ -6,7 +6,7 @@ use std::slice::Iter;
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_base::id::{FileListId, FileListIndex};
 use servo_constellation_traits::SerializableFileList;
 
@@ -39,12 +39,12 @@ impl FileList {
         window: &Window,
         files: Vec<DomRoot<File>>,
     ) -> DomRoot<FileList> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(FileList::new_inherited(
                 files.iter().map(|r| Dom::from_ref(&**r)).collect(),
             )),
             window,
-            cx,
         )
     }
 
@@ -53,12 +53,12 @@ impl FileList {
         global: &GlobalScope,
         files: Vec<DomRoot<File>>,
     ) -> DomRoot<FileList> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(FileList::new_inherited(
                 files.iter().map(|r| Dom::from_ref(&**r)).collect(),
             )),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/filesystem/filesystemdirectoryentry.rs
+++ b/components/script/dom/filesystem/filesystemdirectoryentry.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 
 use crate::dom::bindings::codegen::Bindings::FileSystemDirectoryEntryBinding::{
     FileSystemDirectoryEntryMethods, FileSystemFlags,
@@ -43,10 +43,10 @@ impl FileSystemDirectoryEntry {
         name: USVString,
         full_path: USVString,
     ) -> DomRoot<FileSystemDirectoryEntry> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(FileSystemDirectoryEntry::new_inherited(name, full_path)),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/filesystem/filesystemdirectoryreader.rs
+++ b/components/script/dom/filesystem/filesystemdirectoryreader.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::callback::ExceptionHandling;
 use crate::dom::bindings::codegen::Bindings::FileSystemDirectoryReaderBinding::{
@@ -57,10 +57,10 @@ impl FileSystemDirectoryReader {
         global: &GlobalScope,
         dir: &FileSystemDirectoryEntry,
     ) -> DomRoot<FileSystemDirectoryReader> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(FileSystemDirectoryReader::new_inherited(dir)),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/filesystem/filesystemfileentry.rs
+++ b/components/script/dom/filesystem/filesystemfileentry.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 
 use crate::dom::bindings::callback::ExceptionHandling;
 use crate::dom::bindings::codegen::Bindings::FileSystemEntryBinding::ErrorCallback;
@@ -56,10 +56,10 @@ impl FileSystemFileEntry {
         full_path: USVString,
         file: &File,
     ) -> DomRoot<FileSystemFileEntry> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(FileSystemFileEntry::new_inherited(name, full_path, file)),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/form/radionodelist.rs
+++ b/components/script/dom/form/radionodelist.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use script_bindings::root::DomRoot;
 use stylo_atoms::Atom;
 
@@ -39,10 +39,10 @@ impl RadioNodeList {
         window: &Window,
         list_type: NodeListType,
     ) -> DomRoot<RadioNodeList> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(RadioNodeList::new_inherited(list_type)),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/gamepad/gamepadbutton.rs
+++ b/components/script/dom/gamepad/gamepadbutton.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::codegen::Bindings::GamepadButtonBinding::GamepadButtonMethods;
 use crate::dom::bindings::num::Finite;
@@ -37,10 +37,10 @@ impl GamepadButton {
         pressed: bool,
         touched: bool,
     ) -> DomRoot<GamepadButton> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(GamepadButton::new_inherited(pressed, touched)),
             window,
-            cx,
         )
     }
 }

--- a/components/script/dom/gamepad/gamepadhapticactuator.rs
+++ b/components/script/dom/gamepad/gamepadhapticactuator.rs
@@ -11,7 +11,7 @@ use js::context::JSContext;
 use js::realm::CurrentRealm;
 use js::rust::MutableHandleValue;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_base::generic_channel::GenericCallback;
 
 use crate::dom::bindings::codegen::Bindings::GamepadHapticActuatorBinding::{
@@ -103,13 +103,13 @@ impl GamepadHapticActuator {
         gamepad_index: u32,
         supported_haptic_effects: GamepadSupportedHapticEffects,
     ) -> DomRoot<GamepadHapticActuator> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(GamepadHapticActuator::new_inherited(
                 gamepad_index,
                 supported_haptic_effects,
             )),
             window,
-            cx,
         )
     }
 }

--- a/components/script/dom/geolocation/geolocationcoordinates.rs
+++ b/components/script/dom/geolocation/geolocationcoordinates.rs
@@ -6,7 +6,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::codegen::GenericBindings::GeolocationCoordinatesBinding::GeolocationCoordinatesMethods;
 use script_bindings::num::Finite;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use script_bindings::root::DomRoot;
 
 use crate::dom::globalscope::GlobalScope;
@@ -57,7 +57,8 @@ impl GeolocationCoordinates {
         heading: Option<Finite<f64>>,
         speed: Option<Finite<f64>>,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(Self::new_inherited(
                 accuracy,
                 latitude,
@@ -68,7 +69,6 @@ impl GeolocationCoordinates {
                 speed,
             )),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/html/form_controls/htmlformcontrolscollection.rs
+++ b/components/script/dom/html/form_controls/htmlformcontrolscollection.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::HTMLCollectionBinding::HTMLCollectionMethods;
@@ -48,10 +48,10 @@ impl HTMLFormControlsCollection {
         form: &HTMLFormElement,
         filter: Box<dyn CollectionFilter + 'static>,
     ) -> DomRoot<HTMLFormControlsCollection> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(HTMLFormControlsCollection::new_inherited(form, filter)),
             window,
-            cx,
         )
     }
 }

--- a/components/script/dom/html/form_controls/htmloptionscollection.rs
+++ b/components/script/dom/html/form_controls/htmloptionscollection.rs
@@ -7,7 +7,7 @@ use std::cmp::Ordering;
 use dom_struct::dom_struct;
 use html5ever::{QualName, local_name, ns};
 use js::context::{JSContext, NoGC};
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 
 use crate::dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLCollectionBinding::HTMLCollectionMethods;
@@ -49,10 +49,10 @@ impl HTMLOptionsCollection {
         select: &HTMLSelectElement,
         filter: Box<dyn CollectionFilter + 'static>,
     ) -> DomRoot<HTMLOptionsCollection> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(HTMLOptionsCollection::new_inherited(select, filter)),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/html/htmlcollection.rs
+++ b/components/script/dom/html/htmlcollection.rs
@@ -8,7 +8,7 @@ use dom_struct::dom_struct;
 use html5ever::{LocalName, QualName, local_name, namespace_url, ns};
 use js::context::{JSContext, NoGC};
 use script_bindings::dom::UnrootedDom;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use style::str::split_html_space_chars;
 use stylo_atoms::Atom;
 
@@ -141,7 +141,7 @@ impl HTMLCollection {
         root: &Node,
         filter: Box<dyn CollectionFilter + 'static>,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(Box::new(Self::new_inherited(root, filter)), window, cx)
+        reflect_dom_object(cx, Box::new(Self::new_inherited(root, filter)), window)
     }
 
     /// Create a new  [`HTMLCollection`] that just filters element using a static function.
@@ -188,10 +188,10 @@ impl HTMLCollection {
         root: &Node,
         source: Box<dyn CollectionSource + 'static>,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(Self::new_inherited_with_source(root, source)),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/html/internals/elementinternals.rs
+++ b/components/script/dom/html/internals/elementinternals.rs
@@ -8,7 +8,7 @@ use dom_struct::dom_struct;
 use html5ever::local_name;
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::codegen::Bindings::ElementInternalsBinding::{
     ElementInternalsMethods, ValidityStateFlags,
@@ -102,10 +102,10 @@ impl ElementInternals {
 
     pub(crate) fn new(cx: &mut JSContext, element: &HTMLElement) -> DomRoot<ElementInternals> {
         let global = element.owner_window();
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(ElementInternals::new_inherited(element)),
             &*global,
-            cx,
         )
     }
 

--- a/components/script/dom/indexeddb/idbcursor.rs
+++ b/components/script/dom/indexeddb/idbcursor.rs
@@ -10,7 +10,7 @@ use js::jsapi::Heap;
 use js::jsval::{JSVal, UndefinedValue};
 use js::rust::MutableHandleValue;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use storage_traits::indexeddb::{IndexedDBKeyRange, IndexedDBKeyType, IndexedDBRecord};
 
 use crate::dom::bindings::codegen::Bindings::IDBCursorBinding::{
@@ -114,7 +114,8 @@ impl IDBCursor {
         range: IndexedDBKeyRange,
         key_only: bool,
     ) -> DomRoot<IDBCursor> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(IDBCursor::new_inherited(
                 transaction,
                 direction,
@@ -124,7 +125,6 @@ impl IDBCursor {
                 key_only,
             )),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/indexeddb/idbcursorwithvalue.rs
+++ b/components/script/dom/indexeddb/idbcursorwithvalue.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::MutableHandleValue;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use storage_traits::indexeddb::IndexedDBKeyRange;
 
 use crate::dom::bindings::codegen::Bindings::IDBCursorBinding::IDBCursorDirection;
@@ -54,7 +54,8 @@ impl IDBCursorWithValue {
         range: IndexedDBKeyRange,
         key_only: bool,
     ) -> DomRoot<IDBCursorWithValue> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(IDBCursorWithValue::new_inherited(
                 transaction,
                 direction,
@@ -64,7 +65,6 @@ impl IDBCursorWithValue {
                 key_only,
             )),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/indexeddb/idbdatabase.rs
+++ b/components/script/dom/indexeddb/idbdatabase.rs
@@ -7,7 +7,7 @@ use std::cell::Cell;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_base::generic_channel::{GenericSend, GenericSender};
 use storage_traits::indexeddb::{AsyncSchemaOperation, IndexedDBThreadMsg, KeyPath, SyncOperation};
 use stylo_atoms::Atom;
@@ -79,7 +79,8 @@ impl IDBDatabase {
         version: u64,
         object_store_names: Vec<String>,
     ) -> DomRoot<IDBDatabase> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(IDBDatabase::new_inherited(
                 name,
                 id,
@@ -87,7 +88,6 @@ impl IDBDatabase {
                 object_store_names,
             )),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/indexeddb/idbindex.rs
+++ b/components/script/dom/indexeddb/idbindex.rs
@@ -9,7 +9,7 @@ use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::IDBIndexBinding::IDBIndexMethods;
 use script_bindings::codegen::GenericBindings::IDBTransactionBinding::IDBTransactionMode;
 use script_bindings::error::{Error, ErrorResult};
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use script_bindings::str::DOMString;
 
 use crate::dom::bindings::root::{Dom, DomRoot};
@@ -54,7 +54,8 @@ impl IDBIndex {
         unique: bool,
         key_path: KeyPath,
     ) -> DomRoot<IDBIndex> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(IDBIndex::new_inherited(
                 object_store,
                 name,
@@ -63,7 +64,6 @@ impl IDBIndex {
                 key_path,
             )),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/indexeddb/idbobjectstore.rs
+++ b/components/script/dom/indexeddb/idbobjectstore.rs
@@ -14,7 +14,7 @@ use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::IDBObjectStoreBinding::IDBIndexParameters;
 use script_bindings::codegen::GenericUnionTypes::StringOrStringSequence;
 use script_bindings::error::ErrorResult;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_base::generic_channel::{GenericSend, GenericSender};
 use storage_traits::indexeddb::{
     self, AsyncOperation, AsyncReadOnlyOperation, AsyncReadWriteOperation, AsyncSchemaOperation,
@@ -171,7 +171,8 @@ impl IDBObjectStore {
         abort_state: IDBObjectStoreAbortState,
         transaction: &IDBTransaction,
     ) -> DomRoot<IDBObjectStore> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(IDBObjectStore::new_inherited(
                 db_name,
                 name,
@@ -180,7 +181,6 @@ impl IDBObjectStore {
                 transaction,
             )),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/indexeddb/idbtransaction.rs
+++ b/components/script/dom/indexeddb/idbtransaction.rs
@@ -11,7 +11,7 @@ use profile_traits::generic_callback::GenericCallback;
 use profile_traits::generic_channel::channel;
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericUnionTypes::StringOrStringSequence;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_base::generic_channel::{GenericSend, GenericSender};
 use servo_base::id::ScriptEventLoopId;
 use storage_traits::indexeddb::{
@@ -158,7 +158,8 @@ impl IDBTransaction {
         scope: &DOMStringList,
         serial_number: u64,
     ) -> DomRoot<IDBTransaction> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(IDBTransaction::new_inherited(
                 connection,
                 mode,
@@ -167,7 +168,6 @@ impl IDBTransaction {
                 serial_number,
             )),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/media/mediadeviceinfo.rs
+++ b/components/script/dom/media/mediadeviceinfo.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_media::streams::device_monitor::MediaDeviceKind as ServoMediaDeviceKind;
 
 use crate::conversions::Convert;
@@ -48,12 +48,12 @@ impl MediaDeviceInfo {
         label: &str,
         group_id: &str,
     ) -> DomRoot<MediaDeviceInfo> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(MediaDeviceInfo::new_inherited(
                 device_id, kind, label, group_id,
             )),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/media/medialist.rs
+++ b/components/script/dom/media/medialist.rs
@@ -7,7 +7,7 @@ use std::cell::RefCell;
 use cssparser::{Parser, ParserInput};
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_arc::Arc;
 use style::media_queries::{MediaList as StyleMediaList, MediaQuery};
 use style::parser::ParserContext;
@@ -53,10 +53,10 @@ impl MediaList {
         parent_stylesheet: &CSSStyleSheet,
         media_queries: Arc<Locked<StyleMediaList>>,
     ) -> DomRoot<MediaList> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(MediaList::new_inherited(parent_stylesheet, media_queries)),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/media/mediastreamtrack.rs
+++ b/components/script/dom/media/mediastreamtrack.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_media::streams::MediaStreamType;
 use servo_media::streams::registry::MediaStreamId;
 
@@ -40,10 +40,10 @@ impl MediaStreamTrack {
         id: MediaStreamId,
         ty: MediaStreamType,
     ) -> DomRoot<MediaStreamTrack> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(MediaStreamTrack::new_inherited(id, ty)),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/media/videotrack.rs
+++ b/components/script/dom/media/videotrack.rs
@@ -7,7 +7,7 @@ use std::cell::Cell;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::codegen::Bindings::VideoTrackBinding::VideoTrackMethods;
 use crate::dom::bindings::root::{Dom, DomRoot};
@@ -54,12 +54,12 @@ impl VideoTrack {
         language: DOMString,
         track_list: Option<&VideoTrackList>,
     ) -> DomRoot<VideoTrack> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(VideoTrack::new_inherited(
                 id, kind, label, language, track_list,
             )),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/media/videotracklist.rs
+++ b/components/script/dom/media/videotracklist.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 
 use crate::dom::bindings::codegen::Bindings::VideoTrackListBinding::VideoTrackListMethods;
 use crate::dom::bindings::inheritance::Castable;
@@ -43,10 +43,10 @@ impl VideoTrackList {
         tracks: &[&VideoTrack],
         media_element: Option<&HTMLMediaElement>,
     ) -> DomRoot<VideoTrackList> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(VideoTrackList::new_inherited(tracks, media_element)),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/mutationobserver/mutationrecord.rs
+++ b/components/script/dom/mutationobserver/mutationrecord.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Namespace};
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::codegen::Bindings::MutationRecordBinding::MutationRecord_Binding::MutationRecordMethods;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
@@ -47,7 +47,7 @@ impl MutationRecord {
             None,
             None,
         ));
-        reflect_dom_object_with_cx(record, &*target.owner_window(), cx)
+        reflect_dom_object(cx, record, &*target.owner_window())
     }
 
     pub(crate) fn character_data_mutated(
@@ -55,7 +55,8 @@ impl MutationRecord {
         target: &Node,
         old_value: Option<DOMString>,
     ) -> DomRoot<MutationRecord> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(MutationRecord::new_inherited(
                 "characterData",
                 target,
@@ -68,7 +69,6 @@ impl MutationRecord {
                 None,
             )),
             &*target.owner_window(),
-            cx,
         )
     }
 
@@ -86,7 +86,8 @@ impl MutationRecord {
         let removed_nodes =
             removed_nodes.map(|list| NodeList::new_simple_list_slice(cx, &window, list));
 
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(MutationRecord::new_inherited(
                 "childList",
                 target,
@@ -99,7 +100,6 @@ impl MutationRecord {
                 prev_sibling,
             )),
             &*window,
-            cx,
         )
     }
 

--- a/components/script/dom/node/nodeiterator.rs
+++ b/components/script/dom/node/nodeiterator.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::callback::OwnerWindow;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::callback::ExceptionHandling::Rethrow;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
@@ -52,10 +52,10 @@ impl NodeIterator {
         what_to_show: u32,
         filter: Filter,
     ) -> DomRoot<NodeIterator> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(NodeIterator::new_inherited(root_node, what_to_show, filter)),
             document.window(),
-            cx,
         )
     }
 

--- a/components/script/dom/node/treewalker.rs
+++ b/components/script/dom/node/treewalker.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::callback::OwnerWindow;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use script_bindings::script_runtime::temp_cx;
 
 use crate::dom::bindings::callback::ExceptionHandling::Rethrow;
@@ -51,10 +51,10 @@ impl TreeWalker {
         what_to_show: u32,
         filter: Filter,
     ) -> DomRoot<TreeWalker> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(TreeWalker::new_inherited(root_node, what_to_show, filter)),
             document.window(),
-            cx,
         )
     }
 

--- a/components/script/dom/performance/largestcontentfulpaint.rs
+++ b/components/script/dom/performance/largestcontentfulpaint.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_url::ServoUrl;
 use time::Duration;
@@ -65,7 +65,8 @@ impl LargestContentfulPaint {
         url: Option<ServoUrl>,
         element: Option<&Element>,
     ) -> DomRoot<LargestContentfulPaint> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(LargestContentfulPaint::new_inherited(
                 render_time,
                 size,
@@ -73,7 +74,6 @@ impl LargestContentfulPaint {
                 element,
             )),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -15,7 +15,7 @@ use script_bindings::codegen::GenericBindings::PerformanceBinding::PerformanceMa
 use script_bindings::codegen::GenericBindings::PerformanceMarkBinding::PerformanceMarkMethods;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::codegen::GenericUnionTypes::StringOrPerformanceMeasureOptions;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use time::Duration;
 
@@ -170,14 +170,14 @@ impl Performance {
     ) -> DomRoot<Performance> {
         let timing = PerformanceTiming::new(cx, global);
         let navigation = PerformanceNavigation::new(cx, global);
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(Performance::new_inherited(
                 navigation_start,
                 &timing,
                 &navigation,
             )),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/performance/performancemeasure.rs
+++ b/components/script/dom/performance/performancemeasure.rs
@@ -8,7 +8,7 @@ use js::gc::HandleValue;
 use js::jsapi::Heap;
 use js::jsval::JSVal;
 use js::rust::MutableHandleValue;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use time::Duration;
 
@@ -49,12 +49,12 @@ impl PerformanceMeasure {
         start_time: CrossProcessInstant,
         duration: Duration,
     ) -> DomRoot<PerformanceMeasure> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(PerformanceMeasure::new_inherited(
                 name, start_time, duration,
             )),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/performance/performancenavigationtiming.rs
+++ b/components/script/dom/performance/performancenavigationtiming.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use net_traits::{ResourceFetchTiming, ResourceTimingType};
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 
 use super::performanceresourcetiming::{InitiatorType, PerformanceResourceTiming};
 use crate::dom::bindings::codegen::Bindings::PerformanceBinding::DOMHighResTimeStamp;
@@ -49,10 +49,10 @@ impl PerformanceNavigationTiming {
         global: &GlobalScope,
         document: &Document,
     ) -> DomRoot<PerformanceNavigationTiming> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(PerformanceNavigationTiming::new_inherited(document)),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/performance/performanceobserverentrylist.rs
+++ b/components/script/dom/performance/performanceobserverentrylist.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use super::performance::PerformanceEntryList;
 use super::performanceentry::{EntryType, PerformanceEntry};
@@ -33,10 +33,10 @@ impl PerformanceObserverEntryList {
         global: &GlobalScope,
         entries: Vec<DomRoot<PerformanceEntry>>,
     ) -> DomRoot<PerformanceObserverEntryList> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(PerformanceObserverEntryList::new_inherited(entries)),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/performance/performanceresourcetiming.rs
+++ b/components/script/dom/performance/performanceresourcetiming.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use net_traits::ResourceFetchTiming;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_url::ServoUrl;
 use time::Duration;
@@ -123,14 +123,14 @@ impl PerformanceResourceTiming {
         initiator_type: InitiatorType,
         resource_timing: &ResourceFetchTiming,
     ) -> DomRoot<PerformanceResourceTiming> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(PerformanceResourceTiming::new_inherited(
                 url,
                 initiator_type,
                 resource_timing,
             )),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/permission/permissionstatus.rs
+++ b/components/script/dom/permission/permissionstatus.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 
 use crate::dom::bindings::codegen::Bindings::PermissionStatusBinding::{
     PermissionDescriptor, PermissionName, PermissionState, PermissionStatusMethods,
@@ -37,10 +37,10 @@ impl PermissionStatus {
         global: &GlobalScope,
         query: &PermissionDescriptor,
     ) -> DomRoot<PermissionStatus> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(PermissionStatus::new_inherited(query.name)),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/promise/promisenativehandler.rs
+++ b/components/script/dom/promise/promisenativehandler.rs
@@ -7,7 +7,7 @@ use js::context::JSContext;
 use js::realm::CurrentRealm;
 use js::rust::HandleValue;
 use malloc_size_of::MallocSizeOf;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::trace::JSTraceable;
@@ -35,14 +35,14 @@ impl PromiseNativeHandler {
         resolve: Option<Box<dyn Callback>>,
         reject: Option<Box<dyn Callback>>,
     ) -> DomRoot<PromiseNativeHandler> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(PromiseNativeHandler {
                 reflector: Reflector::new(),
                 resolve,
                 reject,
             }),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/quotaexceedederror.rs
+++ b/components/script/dom/quotaexceedederror.rs
@@ -10,7 +10,7 @@ use script_bindings::codegen::GenericBindings::QuotaExceededErrorBinding::{
     QuotaExceededErrorMethods, QuotaExceededErrorOptions,
 };
 use script_bindings::num::Finite;
-use script_bindings::reflector::{reflect_dom_object_with_cx, reflect_dom_object_with_proto};
+use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_proto};
 use script_bindings::root::DomRoot;
 use script_bindings::str::DOMString;
 use servo_base::id::{QuotaExceededErrorId, QuotaExceededErrorIndex};
@@ -52,10 +52,10 @@ impl QuotaExceededError {
         quota: Option<Finite<f64>>,
         requested: Option<Finite<f64>>,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(Self::new_inherited(message, quota, requested)),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -12,7 +12,7 @@ use rustc_hash::FxHashSet;
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::ShadowRootBinding::ShadowRootMethods;
 use script_bindings::dom::UnrootedDom;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_base::text::{RangeAny, Utf16CodeUnits, Utf32CodeUnits, Utf32CodeUnitsOrNodeOffset};
 
 use crate::dom::abstractrange::bp_position;
@@ -75,10 +75,10 @@ impl Selection {
     }
 
     pub(crate) fn new(cx: &mut JSContext, document: &Document) -> DomRoot<Selection> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(Selection::new_inherited(document)),
             &*document.global(),
-            cx,
         )
     }
 

--- a/components/script/dom/serviceworker/client.rs
+++ b/components/script/dom/serviceworker/client.rs
@@ -7,7 +7,7 @@ use js::context::JSContext;
 use js::jsapi::{Heap, JSObject};
 use js::rust::{CustomAutoRooter, CustomAutoRooterGuard, HandleValue};
 use script_bindings::error::ErrorResult;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use script_bindings::root::DomRoot;
 use servo_base::generic_channel::GenericSender;
 use servo_base::id::ServiceWorkerId;
@@ -66,7 +66,8 @@ impl Client {
         frame_type: FrameType,
         worker_id: ServiceWorkerId,
     ) -> DomRoot<Client> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(Client::new_inherited(
                 swmanager_sender,
                 url,
@@ -74,7 +75,6 @@ impl Client {
                 worker_id,
             )),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/serviceworker/serviceworker.rs
+++ b/components/script/dom/serviceworker/serviceworker.rs
@@ -9,7 +9,7 @@ use js::context::JSContext;
 use js::jsapi::{Heap, JSObject};
 use js::rust::{CustomAutoRooter, CustomAutoRooterGuard, HandleValue};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_base::id::ServiceWorkerId;
 use servo_constellation_traits::{DOMMessage, ScriptToConstellationMessage};
 use servo_url::ServoUrl;
@@ -66,14 +66,14 @@ impl ServiceWorker {
         scope_url: ServoUrl,
         worker_id: ServiceWorkerId,
     ) -> DomRoot<ServiceWorker> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(ServiceWorker::new_inherited(
                 script_url.as_str(),
                 scope_url,
                 worker_id,
             )),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/serviceworker/serviceworkercontainer.rs
+++ b/components/script/dom/serviceworker/serviceworkercontainer.rs
@@ -12,7 +12,7 @@ use js::jsval::UndefinedValue;
 use js::realm::CurrentRealm;
 use script_bindings::cell::DomRefCell;
 use script_bindings::inheritance::Castable;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_base::generic_channel::GenericCallback;
 use servo_constellation_traits::{
     Job, JobError, JobResult, JobResultValue, JobType, ScriptToConstellationMessage,
@@ -62,10 +62,10 @@ impl ServiceWorkerContainer {
     }
 
     pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<ServiceWorkerContainer> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(ServiceWorkerContainer::new_inherited()),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/serviceworker/serviceworkerregistration.rs
+++ b/components/script/dom/serviceworker/serviceworkerregistration.rs
@@ -12,7 +12,7 @@ use net_traits::request::Referrer;
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::NavigatorBinding::NavigatorMethods;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_base::id::ServiceWorkerRegistrationId;
 use servo_constellation_traits::{ScopeThings, WorkerScriptLoadOrigin};
 use servo_url::ServoUrl;
@@ -82,13 +82,13 @@ impl ServiceWorkerRegistration {
         scope: ServoUrl,
         registration_id: ServiceWorkerRegistrationId,
     ) -> DomRoot<ServiceWorkerRegistration> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(ServiceWorkerRegistration::new_inherited(
                 scope,
                 registration_id,
             )),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -34,7 +34,7 @@ use profile_traits::time::{
 };
 use profile_traits::time_profile;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use script_bindings::script_runtime::temp_cx;
 use script_traits::DocumentActivity;
 use servo_base::id::{PipelineId, WebViewId};
@@ -553,7 +553,8 @@ impl ServoParser {
         encoding_hint_from_content_type: Option<&'static Encoding>,
         encoding_of_container_document: Option<&'static Encoding>,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(ServoParser::new_inherited(
                 document,
                 tokenizer,
@@ -562,7 +563,6 @@ impl ServoParser {
                 encoding_of_container_document,
             )),
             document.window(),
-            cx,
         )
     }
 

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -13,7 +13,7 @@ use js::rust::{HandleValue, MutableHandleValue};
 use script_bindings::cell::{DomRefCell, RefMut};
 use script_bindings::dom::UnrootedDom;
 use script_bindings::error::{ErrorResult, Fallible};
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_arc::Arc;
 use style::author_styles::AuthorStyles;
 use style::invalidation::element::restyle_hints::RestyleHint;
@@ -168,7 +168,8 @@ impl ShadowRoot {
         clonable: bool,
         is_user_agent_widget: IsUserAgentWidget,
     ) -> DomRoot<ShadowRoot> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(ShadowRoot::new_inherited(
                 host,
                 document,
@@ -178,7 +179,6 @@ impl ShadowRoot {
                 is_user_agent_widget,
             )),
             document.window(),
-            cx,
         )
     }
 

--- a/components/script/dom/stream/byteteereadintorequest.rs
+++ b/components/script/dom/stream/byteteereadintorequest.rs
@@ -9,7 +9,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::jsval::UndefinedValue;
 use js::typedarray::ArrayBufferViewU8;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use script_bindings::trace::RootedTraceableBox;
 
 use super::byteteeunderlyingsource::ByteTeePullAlgorithm;
@@ -78,7 +78,8 @@ impl ByteTeeReadIntoRequest {
         tee_underlying_source: &ByteTeeUnderlyingSource,
         global: &GlobalScope,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(ByteTeeReadIntoRequest {
                 reflector_: Reflector::new(),
                 for_branch2,
@@ -94,7 +95,6 @@ impl ByteTeeReadIntoRequest {
                 tee_underlying_source: Dom::from_ref(tee_underlying_source),
             }),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/stream/byteteereadrequest.rs
+++ b/components/script/dom/stream/byteteereadrequest.rs
@@ -11,7 +11,7 @@ use js::jsapi::Heap;
 use js::jsval::{JSVal, UndefinedValue};
 use js::typedarray::ArrayBufferViewU8;
 use script_bindings::error::Fallible;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use super::byteteeunderlyingsource::ByteTeePullAlgorithm;
 use crate::dom::bindings::buffer_source::HeapBufferSource;
@@ -78,7 +78,8 @@ impl ByteTeeReadRequest {
         tee_underlying_source: &ByteTeeUnderlyingSource,
         global: &GlobalScope,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(ByteTeeReadRequest {
                 reflector_: Reflector::new(),
                 branch_1: Dom::from_ref(branch_1),
@@ -93,7 +94,6 @@ impl ByteTeeReadRequest {
                 tee_underlying_source: Dom::from_ref(tee_underlying_source),
             }),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/stream/byteteeunderlyingsource.rs
+++ b/components/script/dom/stream/byteteeunderlyingsource.rs
@@ -11,7 +11,7 @@ use js::jsapi::{HandleValueArray, Heap, NewArrayObject, Value};
 use js::jsval::ObjectValue;
 use js::rust::HandleValue as SafeHandleValue;
 use js::typedarray::ArrayBufferViewU8;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use super::byteteereadintorequest::ByteTeeReadIntoRequest;
 use super::readablestream::ReaderType;
@@ -88,7 +88,8 @@ impl ByteTeeUnderlyingSource {
         tee_cancel_algorithm: ByteTeeCancelAlgorithm,
         byte_tee_pull_algorithm: ByteTeePullAlgorithm,
     ) -> DomRoot<ByteTeeUnderlyingSource> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(ByteTeeUnderlyingSource {
                 reflector_: Reflector::new(),
                 reader,
@@ -108,7 +109,6 @@ impl ByteTeeUnderlyingSource {
                 byte_tee_pull_algorithm,
             }),
             &*stream.global(),
-            cx,
         )
     }
 

--- a/components/script/dom/stream/defaultteereadrequest.rs
+++ b/components/script/dom/stream/defaultteereadrequest.rs
@@ -10,7 +10,7 @@ use js::context::JSContext;
 use js::jsapi::Heap;
 use js::jsval::{JSVal, UndefinedValue};
 use js::rust::HandleValue as SafeHandleValue;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::error::ErrorToJsval;
 use crate::dom::bindings::reflector::DomGlobal;
@@ -75,7 +75,8 @@ impl DefaultTeeReadRequest {
         cancel_promise: Rc<Promise>,
         tee_underlying_source: &DefaultTeeUnderlyingSource,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(DefaultTeeReadRequest {
                 reflector_: Reflector::new(),
                 stream: Dom::from_ref(stream),
@@ -90,7 +91,6 @@ impl DefaultTeeReadRequest {
                 tee_underlying_source: Dom::from_ref(tee_underlying_source),
             }),
             &*stream.global(),
-            cx,
         )
     }
     /// Call into cancel of the stream,

--- a/components/script/dom/stream/defaultteeunderlyingsource.rs
+++ b/components/script/dom/stream/defaultteeunderlyingsource.rs
@@ -10,7 +10,7 @@ use js::context::JSContext;
 use js::jsapi::{HandleValueArray, Heap, NewArrayObject, Value};
 use js::jsval::ObjectValue;
 use js::rust::HandleValue as SafeHandleValue;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::reflector::DomGlobal;
@@ -71,7 +71,8 @@ impl DefaultTeeUnderlyingSource {
         cancel_promise: Rc<Promise>,
         tee_cancel_algorithm: DefaultTeeCancelAlgorithm,
     ) -> DomRoot<DefaultTeeUnderlyingSource> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(DefaultTeeUnderlyingSource {
                 reflector_: Reflector::new(),
                 reader: Dom::from_ref(reader),
@@ -89,7 +90,6 @@ impl DefaultTeeUnderlyingSource {
                 tee_cancel_algorithm,
             }),
             &*stream.global(),
-            cx,
         )
     }
 

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -15,7 +15,7 @@ use js::realm::CurrentRealm;
 use js::rust::{HandleObject, HandleValue as SafeHandleValue, HandleValue};
 use js::typedarray::{ArrayBufferU8, ArrayBufferViewU8};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use super::readablestreambyobreader::ReadIntoRequest;
 use super::readablestreamdefaultreader::ReadRequest;
@@ -252,13 +252,13 @@ impl ReadableByteStreamController {
     ) -> DomRoot<ReadableByteStreamController> {
         let underlying_source_container =
             UnderlyingSourceContainer::new(cx, global, underlying_source_type);
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(ReadableByteStreamController::new_inherited(
                 &underlying_source_container,
                 strategy_hwm,
             )),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/stream/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/readablestreamdefaultcontroller.rs
@@ -16,7 +16,7 @@ use js::realm::CurrentRealm;
 use js::rust::wrappers2::JS_GetPendingException;
 use js::rust::{HandleObject, HandleValue as SafeHandleValue, HandleValue, MutableHandleValue};
 use js::typedarray::Uint8;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::buffer_source::create_buffer_source;
 use crate::dom::bindings::callback::ExceptionHandling;
@@ -357,14 +357,14 @@ impl ReadableStreamDefaultController {
         strategy_size: Rc<QueuingStrategySize>,
     ) -> DomRoot<ReadableStreamDefaultController> {
         let underlying_source = UnderlyingSourceContainer::new(cx, global, underlying_source);
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(ReadableStreamDefaultController::new_inherited(
                 strategy_hwm,
                 strategy_size,
                 &underlying_source,
             )),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/stream/transformstreamdefaultcontroller.rs
+++ b/components/script/dom/stream/transformstreamdefaultcontroller.rs
@@ -14,7 +14,7 @@ use js::jsval::UndefinedValue;
 use js::realm::CurrentRealm;
 use js::rust::{HandleObject as SafeHandleObject, HandleValue as SafeHandleValue};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::callback::ExceptionHandling;
 use crate::dom::bindings::codegen::Bindings::TransformStreamDefaultControllerBinding::TransformStreamDefaultControllerMethods;
@@ -147,12 +147,12 @@ impl TransformStreamDefaultController {
         global: &GlobalScope,
         transformer_type: TransformerType,
     ) -> DomRoot<TransformStreamDefaultController> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(TransformStreamDefaultController::new_inherited(
                 transformer_type,
             )),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/stream/underlyingsourcecontainer.rs
+++ b/components/script/dom/stream/underlyingsourcecontainer.rs
@@ -10,7 +10,7 @@ use js::context::JSContext;
 use js::jsapi::{Heap, IsPromiseObject, JSObject};
 use js::jsval::{JSVal, UndefinedValue};
 use js::rust::{Handle as SafeHandle, HandleObject, HandleValue as SafeHandleValue, IntoHandle};
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use super::byteteeunderlyingsource::ByteTeeUnderlyingSource;
 use crate::dom::bindings::callback::ExceptionHandling;
@@ -130,12 +130,12 @@ impl UnderlyingSourceContainer {
         // TODO: setting the underlying source dict as the prototype of the
         // `UnderlyingSourceContainer`, as it is later used as the "this" in Call_.
         // Is this a good idea?
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(UnderlyingSourceContainer::new_inherited(
                 underlying_source_type,
             )),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/testing/accessibilityupdateresult.rs
+++ b/components/script/dom/testing/accessibilityupdateresult.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::codegen::Bindings::ServoTestUtilsBinding::AccessibilityUpdateResultMethods;
 use crate::dom::bindings::root::DomRoot;
@@ -42,7 +42,8 @@ impl AccessibilityUpdateResult {
         nodes_updated_bounds: u32,
         nodes_in_tree_update: u32,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(Self::new_inherited(
                 nodes_updated_from_dom,
                 nodes_updated_from_tree,
@@ -50,7 +51,6 @@ impl AccessibilityUpdateResult {
                 nodes_in_tree_update,
             )),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/testing/layoutresult.rs
+++ b/components/script/dom/testing/layoutresult.rs
@@ -5,7 +5,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::gc::MutableHandleValue;
 use script_bindings::domstring::DOMString;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::codegen::Bindings::ServoTestUtilsBinding::LayoutResultMethods;
 use crate::dom::bindings::root::DomRoot;
@@ -45,7 +45,8 @@ impl LayoutResult {
         restyle_fragment_count: u32,
         only_descendants_changed_count: u32,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(Self::new_inherited(
                 phases,
                 rebuilt_fragment_count,
@@ -53,7 +54,6 @@ impl LayoutResult {
                 only_descendants_changed_count,
             )),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/touch/touch.rs
+++ b/components/script/dom/touch/touch.rs
@@ -10,9 +10,7 @@ use euclid::Point2D;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::inheritance::Castable;
-use script_bindings::reflector::{
-    Reflector, reflect_dom_object_with_cx, reflect_dom_object_with_proto,
-};
+use script_bindings::reflector::{Reflector, reflect_dom_object, reflect_dom_object_with_proto};
 use script_traits::MouseButtons;
 
 use crate::dom::bindings::codegen::Bindings::TouchBinding::{TouchInit, TouchMethods};
@@ -74,12 +72,12 @@ impl Touch {
         page_x: Finite<f64>,
         page_y: Finite<f64>,
     ) -> DomRoot<Touch> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(Touch::new_inherited(
                 identifier, target, screen_x, screen_y, client_x, client_y, page_x, page_y,
             )),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/visualviewport.rs
+++ b/components/script/dom/visualviewport.rs
@@ -13,7 +13,7 @@ use script_bindings::codegen::GenericBindings::VisualViewportBinding::VisualView
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::inheritance::Castable;
 use script_bindings::num::Finite;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use script_bindings::root::{Dom, DomRoot};
 use style_traits::CSSPixel;
 use webrender_api::units::DevicePixel;
@@ -71,14 +71,14 @@ impl VisualViewport {
         window: &Window,
         viewport_size: Size2D<f32, CSSPixel>,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(Self::new_inherited(
                 window,
                 Rect::from_size(viewport_size),
                 Scale::identity(),
             )),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/webgl/extensions/ext/angleinstancedarrays.rs
+++ b/components/script/dom/webgl/extensions/ext/angleinstancedarrays.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_canvas_traits::webgl::WebGLVersion;
 
 use super::{WebGLExtension, WebGLExtensionSpec, WebGLExtensions};
@@ -34,10 +34,10 @@ impl WebGLExtension for ANGLEInstancedArrays {
     type Extension = Self;
 
     fn new(cx: &mut JSContext, ctx: &WebGLRenderingContext) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(ANGLEInstancedArrays::new_inherited(ctx)),
             &*ctx.global(),
-            cx,
         )
     }
 

--- a/components/script/dom/webgl/extensions/ext/oesvertexarrayobject.rs
+++ b/components/script/dom/webgl/extensions/ext/oesvertexarrayobject.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_canvas_traits::webgl::WebGLVersion;
 
 use super::{WebGLExtension, WebGLExtensionSpec, WebGLExtensions};
@@ -59,10 +59,10 @@ impl OESVertexArrayObjectMethods<crate::DomTypeHolder> for OESVertexArrayObject 
 impl WebGLExtension for OESVertexArrayObject {
     type Extension = OESVertexArrayObject;
     fn new(cx: &mut JSContext, ctx: &WebGLRenderingContext) -> DomRoot<OESVertexArrayObject> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(OESVertexArrayObject::new_inherited(ctx)),
             &*ctx.global(),
-            cx,
         )
     }
 

--- a/components/script/dom/webgl/webglactiveinfo.rs
+++ b/components/script/dom/webgl/webglactiveinfo.rs
@@ -5,7 +5,7 @@
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/webgl.idl
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::codegen::Bindings::WebGLActiveInfoBinding::WebGLActiveInfoMethods;
 use crate::dom::bindings::root::DomRoot;
@@ -38,10 +38,10 @@ impl WebGLActiveInfo {
         ty: u32,
         name: DOMString,
     ) -> DomRoot<WebGLActiveInfo> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(WebGLActiveInfo::new_inherited(size, ty, name)),
             window,
-            cx,
         )
     }
 }

--- a/components/script/dom/webgl/webglbuffer.rs
+++ b/components/script/dom/webgl/webglbuffer.rs
@@ -7,7 +7,7 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{DomObject, reflect_dom_object_with_cx};
+use script_bindings::reflector::{DomObject, reflect_dom_object};
 use script_bindings::weakref::WeakRef;
 use servo_base::generic_channel;
 use servo_canvas_traits::webgl::{
@@ -153,10 +153,10 @@ impl WebGLBuffer {
         context: &WebGLRenderingContext,
         id: WebGLBufferId,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(WebGLBuffer::new_inherited(context, id)),
             &*context.global(),
-            cx,
         )
     }
 }

--- a/components/script/dom/webgl/webglframebuffer.rs
+++ b/components/script/dom/webgl/webglframebuffer.rs
@@ -10,7 +10,7 @@ use dom_struct::dom_struct;
 use euclid::Size2D;
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::{
     WebGLCommand, WebGLError, WebGLFramebufferBindingRequest, WebGLFramebufferId,
@@ -221,10 +221,10 @@ impl WebGLFramebuffer {
         context: &WebGLRenderingContext,
         id: WebGLFramebufferId,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(WebGLFramebuffer::new_inherited(context, id)),
             &*context.global(),
-            cx,
         )
     }
 }

--- a/components/script/dom/webgl/webglprogram.rs
+++ b/components/script/dom/webgl/webglprogram.rs
@@ -9,7 +9,7 @@ use std::collections::HashSet;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::{DomRefCell, Ref};
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::{
     ActiveAttribInfo, ActiveUniformBlockInfo, ActiveUniformInfo, WebGLCommand, WebGLError,
@@ -226,10 +226,10 @@ impl WebGLProgram {
         context: &WebGLRenderingContext,
         id: WebGLProgramId,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(WebGLProgram::new_inherited(context, id)),
             &*context.global(),
-            cx,
         )
     }
 }

--- a/components/script/dom/webgl/webglquery.rs
+++ b/components/script/dom/webgl/webglquery.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::WebGLError::*;
 use servo_canvas_traits::webgl::{WebGLCommand, WebGLQueryId, webgl_channel};
@@ -83,10 +83,10 @@ impl WebGLQuery {
         context.send_command(WebGLCommand::GenerateQuery(sender));
         let id = receiver.recv().unwrap();
 
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(Self::new_inherited(context, id)),
             &*context.global(),
-            cx,
         )
     }
 

--- a/components/script/dom/webgl/webglrenderbuffer.rs
+++ b/components/script/dom/webgl/webglrenderbuffer.rs
@@ -7,7 +7,7 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::{
     GlType, InternalFormatIntVec, WebGLCommand, WebGLError, WebGLRenderbufferId, WebGLResult,
@@ -124,10 +124,10 @@ impl WebGLRenderbuffer {
         context: &WebGLRenderingContext,
         id: WebGLRenderbufferId,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(WebGLRenderbuffer::new_inherited(context, id)),
             &*context.global(),
-            cx,
         )
     }
 }

--- a/components/script/dom/webgl/webglsampler.rs
+++ b/components/script/dom/webgl/webglsampler.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::WebGLError::*;
 use servo_canvas_traits::webgl::{WebGLCommand, WebGLSamplerId, webgl_channel};
@@ -126,10 +126,10 @@ impl WebGLSampler {
         context.send_command(WebGLCommand::GenerateSampler(sender));
         let id = receiver.recv().unwrap();
 
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(Self::new_inherited(context, id)),
             &*context.global(),
-            cx,
         )
     }
 

--- a/components/script/dom/webgl/webglshaderprecisionformat.rs
+++ b/components/script/dom/webgl/webglshaderprecisionformat.rs
@@ -5,7 +5,7 @@
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/webgl.idl
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::codegen::Bindings::WebGLShaderPrecisionFormatBinding::WebGLShaderPrecisionFormatMethods;
 use crate::dom::bindings::root::DomRoot;
@@ -36,12 +36,12 @@ impl WebGLShaderPrecisionFormat {
         range_max: i32,
         precision: i32,
     ) -> DomRoot<WebGLShaderPrecisionFormat> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(WebGLShaderPrecisionFormat::new_inherited(
                 range_min, range_max, precision,
             )),
             window,
-            cx,
         )
     }
 }

--- a/components/script/dom/webgl/webglsync.rs
+++ b/components/script/dom/webgl/webglsync.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::{WebGLCommand, WebGLSyncId, webgl_channel};
 
@@ -84,10 +84,10 @@ impl WebGLSync {
         context.send_command(WebGLCommand::FenceSync(sender));
         let sync_id = receiver.recv().unwrap();
 
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(WebGLSync::new_inherited(context, sync_id)),
             &*context.global(),
-            cx,
         )
     }
 }

--- a/components/script/dom/webgl/webgltexture.rs
+++ b/components/script/dom/webgl/webgltexture.rs
@@ -10,7 +10,7 @@ use std::cmp;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{DomObject as _, reflect_dom_object_with_cx};
+use script_bindings::reflector::{DomObject as _, reflect_dom_object};
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::{
     TexDataType, TexFormat, TexParameter, TexParameterBool, TexParameterInt, WebGLCommand,
@@ -175,7 +175,8 @@ impl WebGLTexture {
         context: &WebGLRenderingContext,
         id: WebGLTextureId,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(WebGLTexture::new_inherited(
                 context,
                 id,
@@ -183,7 +184,6 @@ impl WebGLTexture {
                 None,
             )),
             &*context.global(),
-            cx,
         )
     }
 
@@ -194,10 +194,10 @@ impl WebGLTexture {
         id: WebGLTextureId,
         session: &XRSession,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(WebGLTexture::new_inherited(context, id, Some(session))),
             &*context.global(),
-            cx,
         )
     }
 }

--- a/components/script/dom/webgl/webgltransformfeedback.rs
+++ b/components/script/dom/webgl/webgltransformfeedback.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::{WebGLCommand, webgl_channel};
 
@@ -87,10 +87,10 @@ impl WebGLTransformFeedback {
         context.send_command(WebGLCommand::CreateTransformFeedback(sender));
         let id = receiver.recv().unwrap();
 
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(WebGLTransformFeedback::new_inherited(context, id)),
             &*context.global(),
-            cx,
         )
     }
 }

--- a/components/script/dom/webgl/webgluniformlocation.rs
+++ b/components/script/dom/webgl/webgluniformlocation.rs
@@ -5,7 +5,7 @@
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/webgl.idl
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_canvas_traits::webgl::{WebGLContextId, WebGLProgramId};
 
 use crate::dom::bindings::root::DomRoot;
@@ -55,7 +55,8 @@ impl WebGLUniformLocation {
         size: Option<i32>,
         type_: u32,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(Self::new_inherited(
                 id,
                 context_id,
@@ -65,7 +66,6 @@ impl WebGLUniformLocation {
                 type_,
             )),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/webgl/webglvertexarrayobject.rs
+++ b/components/script/dom/webgl/webglvertexarrayobject.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::Ref;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_canvas_traits::webgl::{ActiveAttribInfo, WebGLResult, WebGLVertexArrayId};
 
 use crate::dom::bindings::reflector::DomGlobal;
@@ -34,10 +34,10 @@ impl WebGLVertexArrayObject {
         context: &WebGLRenderingContext,
         id: Option<WebGLVertexArrayId>,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(WebGLVertexArrayObject::new_inherited(context, id)),
             &*context.global(),
-            cx,
         )
     }
 

--- a/components/script/dom/webgl/webglvertexarrayobjectoes.rs
+++ b/components/script/dom/webgl/webglvertexarrayobjectoes.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::Ref;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_canvas_traits::webgl::{ActiveAttribInfo, WebGLResult, WebGLVertexArrayId};
 
 use crate::dom::bindings::reflector::DomGlobal;
@@ -34,10 +34,10 @@ impl WebGLVertexArrayObjectOES {
         context: &WebGLRenderingContext,
         id: Option<WebGLVertexArrayId>,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(WebGLVertexArrayObjectOES::new_inherited(context, id)),
             &*context.global(),
-            cx,
         )
     }
 

--- a/components/script/dom/webgpu/gpucommandencoder.rs
+++ b/components/script/dom/webgpu/gpucommandencoder.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use script_webgpu::gpuconvert::{
     WebGPUConvert, WebGPUTryConvert, convert_load_op, convert_texture_for_wgpu_with_cx,
 };
@@ -82,12 +82,12 @@ impl GPUCommandEncoder {
         encoder: WebGPUCommandEncoder,
         label: USVString,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(GPUCommandEncoder::new_inherited(
                 channel, device, encoder, label,
             )),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/webgpu/gpucomputepassencoder.rs
+++ b/components/script/dom/webgpu/gpucomputepassencoder.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use webgpu_traits::{WebGPU, WebGPUComputePass, WebGPURequest};
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUComputePassEncoderMethods;
@@ -71,7 +71,8 @@ impl GPUComputePassEncoder {
         compute_pass: WebGPUComputePass,
         label: USVString,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(GPUComputePassEncoder::new_inherited(
                 channel,
                 parent,
@@ -79,7 +80,6 @@ impl GPUComputePassEncoder {
                 label,
             )),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/webgpu/gpucomputepipeline.rs
+++ b/components/script/dom/webgpu/gpucomputepipeline.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use script_webgpu::gpuconvert::WebGPUConvert;
 use servo_base::generic_channel::GenericCallback;
 use webgpu_traits::{
@@ -80,14 +80,14 @@ impl GPUComputePipeline {
         label: USVString,
         device: &GPUDevice,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(GPUComputePipeline::new_inherited(
                 compute_pipeline,
                 label,
                 device,
             )),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/webgpu/gpuexternaltexture.rs
+++ b/components/script/dom/webgpu/gpuexternaltexture.rs
@@ -12,7 +12,7 @@ use pixels::Snapshot;
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::WebGPUBinding::GPUDeviceMethods as _;
 use script_bindings::error::Fallible;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use script_webgpu::traits::GPUExternalTextureTrait;
 use webgpu_traits::{
     WebGPU, WebGPUDevice, WebGPUExternalTexture, WebGPUQueue, WebGPURequest, WebGPUTexture,
@@ -178,7 +178,8 @@ impl GPUExternalTexture {
         label: USVString,
         planar_texture: Option<Rc<PlanarTexture>>,
     ) -> DomRoot<GPUExternalTexture> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(GPUExternalTexture::new_inherited(
                 channel,
                 external_texture,
@@ -186,7 +187,6 @@ impl GPUExternalTexture {
                 planar_texture,
             )),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/webgpu/gpupipelinelayout.rs
+++ b/components/script/dom/webgpu/gpupipelinelayout.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use script_webgpu::gpuconvert::WebGPUConvert;
 use webgpu_traits::{WebGPU, WebGPUBindGroupLayout, WebGPUPipelineLayout, WebGPURequest};
 use wgpu_core::binding_model::PipelineLayoutDescriptor;
@@ -79,7 +79,8 @@ impl GPUPipelineLayout {
         label: USVString,
         bgls: Vec<WebGPUBindGroupLayout>,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(GPUPipelineLayout::new_inherited(
                 channel,
                 pipeline_layout,
@@ -87,7 +88,6 @@ impl GPUPipelineLayout {
                 bgls,
             )),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/webgpu/gpuqueryset.rs
+++ b/components/script/dom/webgpu/gpuqueryset.rs
@@ -7,7 +7,7 @@ use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::WebGPUBinding::{GPUDeviceMethods, GPUQueryType};
 use script_bindings::error::{Error, Fallible};
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use script_bindings::root::DomRoot;
 use script_webgpu::gpuconvert::WebGPUConvert;
 use script_webgpu::traits::GPUQuerySetTrait;
@@ -78,12 +78,12 @@ impl GPUQuerySet {
         r#type: GPUQueryType,
         count: u32,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(GPUQuerySet::new_inherited(
                 label, channel, query_set, r#type, count,
             )),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -14,7 +14,7 @@ use script_bindings::codegen::GenericBindings::HTMLImageElementBinding::HTMLImag
 use script_bindings::codegen::GenericBindings::HTMLVideoElementBinding::HTMLVideoElementMethods;
 use script_bindings::codegen::GenericBindings::ImageBitmapBinding::ImageBitmapMethods;
 use script_bindings::codegen::GenericBindings::OffscreenCanvasBinding::OffscreenCanvasMethods;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use script_webgpu::gpuconvert::{WebGPUConvert, WebGPUTryConvert};
 use servo_base::generic_channel::GenericSharedMemory;
 use webgpu_traits::{WebGPU, WebGPUQueue, WebGPURequest};
@@ -68,10 +68,10 @@ impl GPUQueue {
         channel: WebGPU,
         queue: WebGPUQueue,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(GPUQueue::new_inherited(channel, queue)),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/webgpu/gpurenderbundleencoder.rs
+++ b/components/script/dom/webgpu/gpurenderbundleencoder.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use script_webgpu::gpuconvert::WebGPUConvert;
 use webgpu_traits::{
     RenderBundleCommand, WebGPU, WebGPURenderBundle, WebGPURenderBundleEncoder, WebGPURequest,
@@ -84,7 +84,8 @@ impl GPURenderBundleEncoder {
         channel: WebGPU,
         label: USVString,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(GPURenderBundleEncoder::new_inherited(
                 device,
                 channel,
@@ -92,7 +93,6 @@ impl GPURenderBundleEncoder {
                 render_bundle_encoder,
             )),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/webgpu/gpurenderpassencoder.rs
+++ b/components/script/dom/webgpu/gpurenderpassencoder.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use script_webgpu::gpuconvert::WebGPUTryConvert;
 use webgpu_traits::{RenderCommand, WebGPU, WebGPURenderPass, WebGPURequest};
 
@@ -76,7 +76,8 @@ impl GPURenderPassEncoder {
         parent: &GPUCommandEncoder,
         label: USVString,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(GPURenderPassEncoder::new_inherited(
                 channel,
                 render_pass,
@@ -84,7 +85,6 @@ impl GPURenderPassEncoder {
                 label,
             )),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/webgpu/gpurenderpipeline.rs
+++ b/components/script/dom/webgpu/gpurenderpipeline.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_base::generic_channel::GenericCallback;
 use webgpu_traits::{
     WebGPU, WebGPUBindGroupLayout, WebGPURenderPipeline, WebGPURenderPipelineResponse,
@@ -77,14 +77,14 @@ impl GPURenderPipeline {
         label: USVString,
         device: &GPUDevice,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(GPURenderPipeline::new_inherited(
                 render_pipeline,
                 label,
                 device,
             )),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/webgpu/gpusampler.rs
+++ b/components/script/dom/webgpu/gpusampler.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use script_webgpu::gpuconvert::WebGPUConvert;
 use script_webgpu::traits::GPUSamplerTrait;
 use webgpu_traits::{WebGPU, WebGPUDevice, WebGPURequest, WebGPUSampler};
@@ -76,7 +76,8 @@ impl GPUSampler {
         sampler: WebGPUSampler,
         label: USVString,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(GPUSampler::new_inherited(
                 channel,
                 device,
@@ -85,7 +86,6 @@ impl GPUSampler {
                 label,
             )),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/webgpu/gpushadermodule.rs
+++ b/components/script/dom/webgpu/gpushadermodule.rs
@@ -8,7 +8,7 @@ use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
 use js::realm::CurrentRealm;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use script_webgpu::traits::GPUShaderModuleTrait;
 use webgpu_traits::{ShaderCompilationInfo, WebGPU, WebGPURequest, WebGPUShaderModule};
 
@@ -83,7 +83,8 @@ impl GPUShaderModule {
         label: USVString,
         promise: Rc<Promise>,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(GPUShaderModule::new_inherited(
                 channel,
                 shader_module,
@@ -91,7 +92,6 @@ impl GPUShaderModule {
                 promise,
             )),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/webgpu/gputexture.rs
+++ b/components/script/dom/webgpu/gputexture.rs
@@ -7,7 +7,7 @@ use std::string::String;
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use script_webgpu::gpuconvert::{WebGPUConvert, convert_texture_descriptor};
 use script_webgpu::traits::GPUTextureTrait;
 use webgpu_traits::{WebGPU, WebGPURequest, WebGPUTexture, WebGPUTextureView};
@@ -109,7 +109,8 @@ impl GPUTexture {
         texture_usage: u32,
         label: USVString,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(GPUTexture::new_inherited(
                 texture,
                 device,
@@ -123,7 +124,6 @@ impl GPUTexture {
                 label,
             )),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/webgpu/gputextureview.rs
+++ b/components/script/dom/webgpu/gputextureview.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use script_webgpu::traits::GPUTextureViewTrait;
 use webgpu_traits::{WebGPU, WebGPURequest, WebGPUTextureView};
 
@@ -73,7 +73,8 @@ impl GPUTextureView {
         texture: &GPUTexture,
         label: USVString,
     ) -> DomRoot<GPUTextureView> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(GPUTextureView::new_inherited(
                 channel,
                 texture_view,
@@ -81,7 +82,6 @@ impl GPUTextureView {
                 label,
             )),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/webvtt/texttrack.rs
+++ b/components/script/dom/webvtt/texttrack.rs
@@ -7,7 +7,7 @@ use std::cell::Cell;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 
 use crate::dom::bindings::codegen::Bindings::TextTrackBinding::{
     TextTrackKind, TextTrackMethods, TextTrackMode,
@@ -74,12 +74,12 @@ impl TextTrack {
         mode: TextTrackMode,
         track_list: Option<&TextTrackList>,
     ) -> DomRoot<TextTrack> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(TextTrack::new_inherited(
                 id, kind, label, language, mode, track_list,
             )),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/webxr/fakexrinputcontroller.rs
+++ b/components/script/dom/webxr/fakexrinputcontroller.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_base::generic_channel::GenericSender;
 use webxr_api::{
     Handedness, InputId, MockButton, MockButtonType, MockDeviceMsg, MockInputMsg, SelectEvent,
@@ -52,10 +52,10 @@ impl FakeXRInputController {
         sender: GenericSender<MockDeviceMsg>,
         id: InputId,
     ) -> DomRoot<FakeXRInputController> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(FakeXRInputController::new_inherited(sender, id)),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/webxr/xrboundedreferencespace.rs
+++ b/components/script/dom/webxr/xrboundedreferencespace.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::MutableHandleValue;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 
 use crate::dom::bindings::codegen::Bindings::XRBoundedReferenceSpaceBinding::XRBoundedReferenceSpaceMethods;
 use crate::dom::bindings::codegen::Bindings::XRReferenceSpaceBinding::XRReferenceSpaceType;
@@ -56,10 +56,10 @@ impl XRBoundedReferenceSpace {
         session: &XRSession,
         offset: &XRRigidTransform,
     ) -> DomRoot<XRBoundedReferenceSpace> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(XRBoundedReferenceSpace::new_inherited(session, offset)),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/webxr/xrhittestresult.rs
+++ b/components/script/dom/webxr/xrhittestresult.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use webxr_api::HitTestResult;
 
 use crate::dom::bindings::codegen::Bindings::XRHitTestResultBinding::XRHitTestResultMethods;
@@ -38,10 +38,10 @@ impl XRHitTestResult {
         result: HitTestResult,
         frame: &XRFrame,
     ) -> DomRoot<XRHitTestResult> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(XRHitTestResult::new_inherited(result, frame)),
             window,
-            cx,
         )
     }
 }

--- a/components/script/dom/webxr/xrhittestsource.rs
+++ b/components/script/dom/webxr/xrhittestsource.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use webxr_api::HitTestId;
 
 use crate::dom::bindings::codegen::Bindings::XRHitTestSourceBinding::XRHitTestSourceMethods;
@@ -35,10 +35,10 @@ impl XRHitTestSource {
         id: HitTestId,
         session: &XRSession,
     ) -> DomRoot<XRHitTestSource> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(XRHitTestSource::new_inherited(id, session)),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/webxr/xrjointpose.rs
+++ b/components/script/dom/webxr/xrjointpose.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 
 use crate::dom::bindings::codegen::Bindings::XRJointPoseBinding::XRJointPoseMethods;
 use crate::dom::bindings::num::Finite;
@@ -35,10 +35,10 @@ impl XRJointPose {
         radius: Option<f32>,
     ) -> DomRoot<XRJointPose> {
         let transform = XRRigidTransform::new(cx, window, pose);
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(XRJointPose::new_inherited(&transform, radius)),
             window,
-            cx,
         )
     }
 }

--- a/components/script/dom/webxr/xrjointspace.rs
+++ b/components/script/dom/webxr/xrjointspace.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use euclid::RigidTransform3D;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use webxr_api::{BaseSpace, Frame, InputId, Joint, JointFrame, Space};
 
 use crate::dom::bindings::codegen::Bindings::XRHandBinding::XRHandJoint;
@@ -49,10 +49,10 @@ impl XRJointSpace {
         joint: Joint,
         hand_joint: XRHandJoint,
     ) -> DomRoot<XRJointSpace> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(Self::new_inherited(session, input, joint, hand_joint)),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/webxr/xrreferencespace.rs
+++ b/components/script/dom/webxr/xrreferencespace.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use euclid::{Point2D, RigidTransform3D};
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use webxr_api::{self, Floor, Frame, Space};
 
 use crate::dom::bindings::codegen::Bindings::XRReferenceSpaceBinding::{
@@ -57,10 +57,10 @@ impl XRReferenceSpace {
         ty: XRReferenceSpaceType,
         offset: &XRRigidTransform,
     ) -> DomRoot<XRReferenceSpace> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(XRReferenceSpace::new_inherited(session, offset, ty)),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/webxr/xrrenderstate.rs
+++ b/components/script/dom/webxr/xrrenderstate.rs
@@ -8,7 +8,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::MutableHandleValue;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use webxr_api::SubImages;
 
 use crate::dom::bindings::codegen::Bindings::XRRenderStateBinding::XRRenderStateMethods;
@@ -58,7 +58,8 @@ impl XRRenderState {
         layer: Option<&XRWebGLLayer>,
         layers: Vec<&XRLayer>,
     ) -> DomRoot<XRRenderState> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(XRRenderState::new_inherited(
                 depth_near,
                 depth_far,
@@ -67,7 +68,6 @@ impl XRRenderState {
                 layers,
             )),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/webxr/xrspace.rs
+++ b/components/script/dom/webxr/xrspace.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use euclid::RigidTransform3D;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use webxr_api::{BaseSpace, Frame, Space};
 
 use crate::dom::bindings::inheritance::Castable;
@@ -56,10 +56,10 @@ impl XRSpace {
         input: &XRInputSource,
         is_grip_space: bool,
     ) -> DomRoot<XRSpace> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(XRSpace::new_inputspace_inner(session, input, is_grip_space)),
             global,
-            cx,
         )
     }
 

--- a/components/script/dom/webxr/xrsystem.rs
+++ b/components/script/dom/webxr/xrsystem.rs
@@ -13,7 +13,7 @@ use js::realm::CurrentRealm;
 use profile_traits::generic_callback::GenericCallback as ProfileGenericCallback;
 use profile_traits::ipc;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_dom_object;
 use servo_base::id::PipelineId;
 use servo_config::pref;
 use webxr_api::{Error as XRError, Frame, Session, SessionInit, SessionMode};
@@ -63,10 +63,10 @@ impl XRSystem {
     }
 
     pub(crate) fn new(cx: &mut JSContext, window: &Window) -> DomRoot<XRSystem> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(XRSystem::new_inherited(window.pipeline_id())),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/webxr/xrview.rs
+++ b/components/script/dom/webxr/xrview.rs
@@ -8,7 +8,7 @@ use dom_struct::dom_struct;
 use euclid::RigidTransform3D;
 use js::context::JSContext;
 use js::typedarray::{Float32, HeapFloat32Array};
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use script_bindings::trace::RootedTraceableBox;
 use webxr_api::{ApiSpace, View};
 
@@ -66,7 +66,8 @@ impl XRView {
         let transform: RigidTransform3D<f32, V, BaseSpace> = view.transform.then(to_base);
         let transform = XRRigidTransform::new(cx, window, cast_transform(transform));
 
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(XRView::new_inherited(
                 session,
                 &transform,
@@ -75,7 +76,6 @@ impl XRView {
                 view.cast_unit(),
             )),
             window,
-            cx,
         )
     }
 

--- a/components/script/dom/window/dissimilaroriginlocation.rs
+++ b/components/script/dom/window/dissimilaroriginlocation.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::codegen::Bindings::DissimilarOriginLocationBinding::DissimilarOriginLocationMethods;
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
@@ -40,10 +40,10 @@ impl DissimilarOriginLocation {
         cx: &mut JSContext,
         window: &DissimilarOriginWindow,
     ) -> DomRoot<DissimilarOriginLocation> {
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(DissimilarOriginLocation::new_inherited(window)),
             window,
-            cx,
         )
     }
 }

--- a/components/script/dom/worklet/worklet.rs
+++ b/components/script/dom/worklet/worklet.rs
@@ -28,7 +28,7 @@ use malloc_size_of::malloc_size_of_is_0;
 use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{Destination, Origin, PreloadedResources, RequestClient};
 use rustc_hash::FxHashMap;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_base::id::PipelineId;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use style::thread_state::{self, ThreadState};
@@ -124,14 +124,14 @@ impl Worklet {
         thread_pool_constructor: Box<dyn FnOnce() -> Rc<dyn WorkletThreadPool>>,
     ) -> DomRoot<Worklet> {
         debug!("Creating worklet {:?}.", global_type);
-        reflect_dom_object_with_cx(
+        reflect_dom_object(
+            cx,
             Box::new(Worklet::new_inherited(
                 window,
                 global_type,
                 thread_pool_constructor,
             )),
             window,
-            cx,
         )
     }
 


### PR DESCRIPTION
As a cleanup follow-up to the migration to pass `&mut JSContext`, this PR is the result of applying the following regex replacement to the codebase:

Before:

```
reflect_dom_object_with_cx\((([^<]|\n)+),\n\s+?cx,\n\s+?\)\n
```

After:

```
reflect_dom_object(cx, $1)\n
```

This did not catch all usages, but is a good start.

Part of #40600

Testing: it compiles
