### PR TITLE
script: Rework DOM position comparison

### DIFF
--- a/components/script/css/stylesheet_loader.rs
+++ b/components/script/css/stylesheet_loader.rs
@@ -303,7 +303,7 @@ impl StylesheetContext {
                 //
                 // Note that even in the failure case, we should create an empty stylesheet.
                 // That's why `set_stylesheet` also removes the previous stylesheet
-                link.set_stylesheet(stylesheet);
+                link.set_stylesheet(cx.no_gc(), stylesheet);
             },
             StylesheetContextSource::Import(import_rule) => {
                 let mut guard = document.style_shared_author_lock().write();

--- a/components/script/dom/css/csskeyframesrule.rs
+++ b/components/script/dom/css/csskeyframesrule.rs
@@ -133,7 +133,7 @@ impl CSSKeyframesRuleMethods<crate::DomTypeHolder> for CSSKeyframesRule {
         };
 
         if let Ok(rule) = rule {
-            self.css_rule.parent_stylesheet().will_modify();
+            self.css_rule.parent_stylesheet().will_modify(no_gc);
             {
                 let mut guard = self.css_rule.shared_lock().write();
                 self.keyframes_rule
@@ -189,7 +189,7 @@ impl CSSKeyframesRuleMethods<crate::DomTypeHolder> for CSSKeyframesRule {
         // Spec deviation: https://github.com/w3c/csswg-drafts/issues/801
         // Setting this property to a CSS-wide keyword or `none` does not throw,
         // it stores a value that serializes as a quoted string.
-        self.css_rule.parent_stylesheet().will_modify();
+        self.css_rule.parent_stylesheet().will_modify(no_gc);
         let name = KeyframesName::from_ident(&value.str());
         let mut guard = self.css_rule.shared_lock().write();
         self.keyframes_rule.borrow().write_with(&mut guard).name = name;

--- a/components/script/dom/css/cssrulelist.rs
+++ b/components/script/dom/css/cssrulelist.rs
@@ -121,7 +121,7 @@ impl CSSRuleList {
         rule: &DOMString,
         idx: u32,
     ) -> Fallible<u32> {
-        self.parent_stylesheet.will_modify();
+        self.parent_stylesheet.will_modify(cx.no_gc());
         let css_rules = if let RulesSource::Rules(rules) = &*self.rules.borrow() {
             rules.clone()
         } else {
@@ -188,7 +188,7 @@ impl CSSRuleList {
         }
 
         let parent_stylesheet = &*self.parent_stylesheet;
-        parent_stylesheet.will_modify();
+        parent_stylesheet.will_modify(cx.no_gc());
 
         let dom_rule = CSSRule::new_specific(
             cx,
@@ -206,7 +206,7 @@ impl CSSRuleList {
 
     /// In case of a keyframe rule, index must be valid.
     pub(crate) fn remove_rule(&self, cx: &mut JSContext, index: u32) -> ErrorResult {
-        self.parent_stylesheet.will_modify();
+        self.parent_stylesheet.will_modify(cx.no_gc());
 
         let index = index as usize;
         let mut guard = self.parent_stylesheet.shared_lock().write();

--- a/components/script/dom/css/cssstyledeclaration.rs
+++ b/components/script/dom/css/cssstyledeclaration.rs
@@ -126,7 +126,7 @@ impl CSSStyleOwner {
                 result
             },
             CSSStyleOwner::CSSRule(ref rule, ref pdb) => {
-                rule.parent_stylesheet().will_modify();
+                rule.parent_stylesheet().will_modify(cx.no_gc());
                 let result = {
                     let mut guard = rule.shared_lock().write();
                     f(&mut *pdb.borrow().write_with(&mut guard), &mut changed)

--- a/components/script/dom/css/cssstylerule.rs
+++ b/components/script/dom/css/cssstylerule.rs
@@ -183,7 +183,9 @@ impl CSSStyleRuleMethods<crate::DomTypeHolder> for CSSStyleRule {
         }) else {
             return;
         };
-        self.css_grouping_rule.parent_stylesheet().will_modify();
+        self.css_grouping_rule
+            .parent_stylesheet()
+            .will_modify(no_gc);
         // This mirrors what we do in CSSStyleOwner::mutate_associated_block.
         let mut guard = self.css_grouping_rule.shared_lock().write();
         mem::swap(

--- a/components/script/dom/css/cssstylesheet.rs
+++ b/components/script/dom/css/cssstylesheet.rs
@@ -260,7 +260,7 @@ impl CSSStyleSheet {
         }
     }
 
-    pub(crate) fn will_modify(&self) {
+    pub(crate) fn will_modify(&self, no_gc: &NoGC) {
         let Some(node) = self.owner_node.get() else {
             return;
         };
@@ -269,7 +269,7 @@ impl CSSStyleSheet {
             return;
         };
 
-        node.will_modify_stylesheet();
+        node.will_modify_stylesheet(no_gc);
     }
 
     pub(crate) fn update_style_stylesheet(
@@ -311,7 +311,7 @@ impl CSSStyleSheet {
         let global = self.global();
         let window = global.as_window();
 
-        self.will_modify();
+        self.will_modify(no_gc);
 
         let _span = profile_traits::trace_span!("ParseStylesheet").entered();
         let sheet = self.style_stylesheet();

--- a/components/script/dom/css/stylesheetlist.rs
+++ b/components/script/dom/css/stylesheetlist.rs
@@ -46,11 +46,18 @@ impl StyleSheetListOwner {
         }
     }
 
-    pub(crate) fn add_owned_stylesheet(&self, owner_node: &Element, sheet: Arc<Stylesheet>) {
+    pub(crate) fn add_owned_stylesheet(
+        &self,
+        no_gc: &NoGC,
+        owner_node: &Element,
+        sheet: Arc<Stylesheet>,
+    ) {
         match *self {
-            StyleSheetListOwner::Document(ref doc) => doc.add_owned_stylesheet(owner_node, sheet),
+            StyleSheetListOwner::Document(ref doc) => {
+                doc.add_owned_stylesheet(no_gc, owner_node, sheet)
+            },
             StyleSheetListOwner::ShadowRoot(ref shadow_root) => {
-                shadow_root.add_owned_stylesheet(owner_node, sheet)
+                shadow_root.add_owned_stylesheet(no_gc, owner_node, sheet)
             },
         }
     }

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -4674,7 +4674,12 @@ impl Document {
     ///
     /// <https://drafts.csswg.org/cssom/#documentorshadowroot-final-css-style-sheets>
     #[cfg_attr(crown, expect(crown::unrooted_must_root))] // Owner needs to be rooted already necessarily.
-    pub(crate) fn add_owned_stylesheet(&self, owner_node: &Element, sheet: Arc<Stylesheet>) {
+    pub(crate) fn add_owned_stylesheet(
+        &self,
+        no_gc: &NoGC,
+        owner_node: &Element,
+        sheet: Arc<Stylesheet>,
+    ) {
         let insertion_point = {
             let stylesheets = &mut *self.stylesheets.borrow_mut();
 
@@ -4684,9 +4689,9 @@ impl Document {
                 .map(|(sheet, _origin)| sheet)
                 .find(|sheet_in_doc| {
                     match &sheet_in_doc.owner {
-                        StylesheetSource::Element(other_node) => {
-                            owner_node.upcast::<Node>().is_before(other_node.upcast())
-                        },
+                        StylesheetSource::Element(other_node) => owner_node
+                            .upcast::<Node>()
+                            .is_before(no_gc, other_node.upcast()),
                         // Non-constructed stylesheet should be ordered before the
                         // constructed ones.
                         StylesheetSource::Constructed(_) => true,
@@ -6486,7 +6491,10 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                 match names_with_first_named_element_map.entry(id.clone()) {
                     Vacant(entry) => drop(entry.insert(first.as_rooted())),
                     Occupied(mut entry) => {
-                        if first.upcast::<Node>().is_before(entry.get().upcast()) {
+                        if first
+                            .upcast::<Node>()
+                            .is_before(no_gc, entry.get().upcast())
+                        {
                             *entry.get_mut() = first.as_rooted();
                         }
                     },
@@ -6501,7 +6509,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                 // This can happen if an img has an id different from its name,
                 // spec does not say which string to put first.
                 a.0.cmp(&b.0)
-            } else if a.1.upcast::<Node>().is_before(b.1.upcast::<Node>()) {
+            } else if a.1.upcast::<Node>().is_before(no_gc, b.1.upcast::<Node>()) {
                 Ordering::Less
             } else {
                 Ordering::Greater

--- a/components/script/dom/execcommand/basecommand.rs
+++ b/components/script/dom/execcommand/basecommand.rs
@@ -378,7 +378,7 @@ impl CommandName {
         };
         let mut at_least_two_different_effective_values = false;
         let mut previous_effective_value: Option<DOMString> = None;
-        active_range.for_each_effectively_contained_child(|node| {
+        active_range.for_each_effectively_contained_child(cx, |cx, node| {
             if at_least_two_different_effective_values || !node.is_formattable(cx.no_gc()) {
                 return;
             }
@@ -427,7 +427,7 @@ impl CommandName {
                 let active_range = selection.active_range(cx)?;
                 let mut at_least_one_child_is_formattable = false;
                 let mut all_children_have_matching_command_values = true;
-                active_range.for_each_effectively_contained_child(|node| {
+                active_range.for_each_effectively_contained_child(cx, |cx, node| {
                     if !node.is_formattable(cx.no_gc()) {
                         return;
                     }

--- a/components/script/dom/execcommand/commands/createlink.rs
+++ b/components/script/dom/execcommand/commands/createlink.rs
@@ -32,7 +32,7 @@ pub(crate) fn execute_createlink_command(
     let active_range = selection
         .active_range(cx)
         .expect("Must always have an active range");
-    active_range.for_each_effectively_contained_child(|node| {
+    active_range.for_each_effectively_contained_child(cx, |cx, node| {
         for ancestor in node.inclusive_ancestors(ShadowIncluding::No) {
             if !ancestor.is_editable() {
                 return;

--- a/components/script/dom/execcommand/commands/insertparagraph.rs
+++ b/components/script/dom/execcommand/commands/insertparagraph.rs
@@ -118,7 +118,7 @@ pub(crate) fn execute_insert_paragraph_command(
         let new_range = selection.expect_active_range(cx).block_extend(cx, document);
         // Step 11.4. Append to node list the first node in tree order that is contained in new range and is an allowed child of "p", if any.
         let mut node_list = if let Some(eligible_node) = new_range
-            .contained_children()
+            .contained_children(cx.no_gc())
             .ok()
             .and_then(|contained_children| {
                 contained_children
@@ -273,8 +273,8 @@ pub(crate) fn execute_insert_paragraph_command(
     // and whose end is (container, length of container).
     let new_line_range = document.CreateRange(cx);
     let (start_container, start_offset) = selection.start_boundary(cx);
-    let _ = new_line_range.SetStart(&start_container, start_offset);
-    let _ = new_line_range.SetEnd(&container, container.len());
+    let _ = new_line_range.SetStart(cx.no_gc(), &start_container, start_offset);
+    let _ = new_line_range.SetEnd(cx.no_gc(), &container, container.len());
     // Step 15. While new line range's start offset is zero and its start node
     // is not a prohibited paragraph child,
     // set its start to (parent of start node, index of start node).
@@ -285,6 +285,7 @@ pub(crate) fn execute_insert_paragraph_command(
     {
         let start = new_line_range.start_container();
         let _ = new_line_range.SetStart(
+            cx.no_gc(),
             &start.GetParentNode().expect("Must always have a parent"),
             start.index(),
         );
@@ -299,18 +300,21 @@ pub(crate) fn execute_insert_paragraph_command(
     {
         let start = new_line_range.start_container();
         let _ = new_line_range.SetStart(
+            cx.no_gc(),
             &start.GetParentNode().expect("Must always have a parent"),
             1 + start.index(),
         );
     }
     // Step 17. Let end of line be true if new line range contains either nothing or a single br, and false otherwise.
-    let end_of_line = new_line_range
-        .contained_children()
-        .is_ok_and(|contained_children| {
-            let contained_children = contained_children.contained_children;
-            contained_children.is_empty() ||
-                (contained_children.len() == 1 && contained_children[0].is::<HTMLBRElement>())
-        });
+    let end_of_line =
+        new_line_range
+            .contained_children(cx.no_gc())
+            .is_ok_and(|contained_children| {
+                let contained_children = contained_children.contained_children;
+                contained_children.is_empty() ||
+                    (contained_children.len() == 1 &&
+                        contained_children[0].is::<HTMLBRElement>())
+            });
     // Step 18. If the local name of container is "h1", "h2", "h3", "h4", "h5", or "h6",
     // and end of line is true, let new container name be the default single-line container name.
     let container_as_element = container

--- a/components/script/dom/execcommand/commands/removeformat.rs
+++ b/components/script/dom/execcommand/commands/removeformat.rs
@@ -69,7 +69,7 @@ pub(crate) fn execute_removeformat_command(
         .active_range(cx)
         .expect("Must always have an active range");
     let mut elements = vec![];
-    active_range.for_each_effectively_contained_child(|node| {
+    active_range.for_each_effectively_contained_child(cx, |_cx, node| {
         if let Some(html_element) = node.downcast::<HTMLElement>() &&
             is_remove_format_candidate(html_element.upcast())
         {
@@ -104,7 +104,7 @@ pub(crate) fn execute_removeformat_command(
         let Ok(start_text) = start_text.SplitText(cx, start_offset) else {
             unreachable!("Must always be able to split");
         };
-        let _ = active_range.SetStart(start_text.upcast(), 0);
+        let _ = active_range.SetStart(cx.no_gc(), start_text.upcast(), 0);
     }
     // Step 4. If the active range's end node is an editable Text node,
     // and its end offset is neither zero nor its end node's length,
@@ -122,7 +122,7 @@ pub(crate) fn execute_removeformat_command(
     };
     // Step 5. Let node list consist of all editable nodes effectively contained in the active range.
     let mut node_list = vec![];
-    active_range.for_each_effectively_contained_child(|node| {
+    active_range.for_each_effectively_contained_child(cx, |_cx, node| {
         if node.is_editable() {
             node_list.push(DomRoot::from_ref(node));
         }

--- a/components/script/dom/execcommand/commands/unlink.rs
+++ b/components/script/dom/execcommand/commands/unlink.rs
@@ -21,7 +21,7 @@ pub(crate) fn execute_unlink_command(cx: &mut JSContext, selection: &Selection) 
         .active_range(cx)
         .expect("Must always have an active range");
     let mut hyperlinks = vec![];
-    active_range.for_each_effectively_contained_child(|node| {
+    active_range.for_each_effectively_contained_child(cx, |_cx, node| {
         if let Some(anchor) = node.downcast::<HTMLAnchorElement>() &&
             anchor
                 .upcast::<Element>()

--- a/components/script/dom/execcommand/contenteditable/htmlelement.rs
+++ b/components/script/dom/execcommand/contenteditable/htmlelement.rs
@@ -262,8 +262,8 @@ impl HTMLElement {
             }
             previous_node = child;
         }
-        let _ = range.SetStart(&selected_node, selected_offset);
-        let _ = range.SetEnd(&selected_node, selected_offset);
-        selection.AddRange(&range);
+        let _ = range.SetStart(cx.no_gc(), &selected_node, selected_offset);
+        let _ = range.SetEnd(cx.no_gc(), &selected_node, selected_offset);
+        selection.AddRange(cx.no_gc(), &range);
     }
 }

--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -232,8 +232,8 @@ where
     let (new_end_container, new_end_offset) =
         adjust_boundary_point(end_container, end_offset, should_adjust_end);
 
-    let _ = active_range.SetStart(&new_start_container, new_start_offset);
-    let _ = active_range.SetEnd(&new_end_container, new_end_offset);
+    let _ = active_range.SetStart(cx.no_gc(), &new_start_container, new_start_offset);
+    let _ = active_range.SetEnd(cx.no_gc(), &new_end_container, new_end_offset);
 }
 
 /// <https://w3c.github.io/editing/docs/execCommand/#allowed-child>
@@ -674,19 +674,19 @@ where
             let start_offset = range.start_offset();
 
             if start_container == parent_of_new_parent && start_offset == new_parent.index() {
-                let _ = range.SetStart(&start_container, start_offset + 1);
+                let _ = range.SetStart(cx.no_gc(), &start_container, start_offset + 1);
             }
 
             let end_container = range.end_container();
             let end_offset = range.end_offset();
 
             if end_container == parent_of_new_parent && end_offset == new_parent.index() {
-                let _ = range.SetEnd(&end_container, end_offset + 1);
+                let _ = range.SetEnd(cx.no_gc(), &end_container, end_offset + 1);
             }
         }
     }
     // Step 12. If new parent is before the first member of node list in tree order:
-    if new_parent.is_before(first_in_node_list) {
+    if new_parent.is_before(cx.no_gc(), first_in_node_list) {
         // Step 12.1. If new parent is not an inline node, but the last visible child of new parent
         // and the first visible member of node list are both inline nodes,
         // and the last child of new parent is not a br,
@@ -2023,7 +2023,9 @@ impl Node {
         // Step 8. If fix collapsed space is true, then while (start node, start offset)
         // is before (end node, end offset):
         if fix_collapsed_space {
-            while bp_position(&start_node, start_offset, &end_node, end_offset) == Ordering::Less {
+            while bp_position(cx.no_gc(), &start_node, start_offset, &end_node, end_offset) ==
+                Ordering::Less
+            {
                 // Step 8.1. If end node has a child in the same editing host with index end offset − 1,
                 // set end node to that child, then set end offset to end node's length.
                 if end_offset > 0 &&
@@ -2083,7 +2085,9 @@ impl Node {
         );
         let mut replacement_whitespace_chars = replacement_whitespace.chars();
         // Step 10. While (start node, start offset) is before (end node, end offset):
-        while bp_position(&start_node, start_offset, &end_node, end_offset) == Ordering::Less {
+        while bp_position(cx.no_gc(), &start_node, start_offset, &end_node, end_offset) ==
+            Ordering::Less
+        {
             // Step 10.1. If start node has a child with index start offset, set start node to that child, then set start offset to zero.
             if let Some(child) = start_node.children().nth(start_offset as usize) {
                 start_node = child;

--- a/components/script/dom/execcommand/contenteditable/range.rs
+++ b/components/script/dom/execcommand/contenteditable/range.rs
@@ -23,7 +23,7 @@ use crate::dom::text::Text;
 
 impl Range {
     /// <https://w3c.github.io/editing/docs/execCommand/#effectively-contained>
-    fn is_effectively_contained_node(&self, node: &Node) -> bool {
+    fn is_effectively_contained_node(&self, no_gc: &NoGC, node: &Node) -> bool {
         // > A node node is effectively contained in a range range if range is not collapsed,
         if self.collapsed() {
             return false;
@@ -40,11 +40,11 @@ impl Range {
             return true;
         }
         // > node is contained in range.
-        if self.contains(node) {
+        if self.contains(no_gc, node) {
             return true;
         }
         // > node has at least one child; and all its children are effectively contained in range;
-        node.children_count() > 0 && node.children().all(|child| self.is_effectively_contained_node(&child))
+        node.children_count() > 0 && node.children().all(|child| self.is_effectively_contained_node(no_gc, &child))
         // > and either range's start node is not a descendant of node or is not a Text node or range's start offset is zero;
         && (!node.is_ancestor_of(&start_container) || !start_container.is::<Text>() || self.start_offset() == 0)
         // > and either range's end node is not a descendant of node or is not a Text node or range's end offset is its end node's length.
@@ -75,12 +75,15 @@ impl Range {
 
         self.ancestor_for_effectively_contained()
             .traverse_preorder_non_rooting(no_gc, ShadowIncluding::No)
-            .find(|child| child.is_formattable(no_gc) && self.is_effectively_contained_node(child))
+            .find(|child| {
+                child.is_formattable(no_gc) && self.is_effectively_contained_node(no_gc, child)
+            })
             .map(|node| node.as_rooted())
     }
 
-    pub(crate) fn for_each_effectively_contained_child<Callback: FnMut(&Node)>(
+    pub(crate) fn for_each_effectively_contained_child<Callback: FnMut(&mut JSContext, &Node)>(
         &self,
+        cx: &mut JSContext,
         mut callback: Callback,
     ) {
         if self.collapsed() {
@@ -95,8 +98,8 @@ impl Range {
             .collect::<Vec<DomRoot<Node>>>();
 
         for child in children {
-            if self.is_effectively_contained_node(&child) {
-                callback(&child);
+            if self.is_effectively_contained_node(cx.no_gc(), &child) {
+                callback(cx, &child);
             }
         }
     }
@@ -107,7 +110,7 @@ impl Range {
     ) -> impl Iterator<Item = UnrootedDom<'a, Node>> {
         self.CommonAncestorContainer()
             .traverse_preorder_non_rooting(no_gc, ShadowIncluding::No)
-            .filter(|node| self.contains(node))
+            .filter(|node| self.contains(no_gc, node))
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#block-extend>
@@ -196,8 +199,8 @@ impl Range {
         // Step 8. Let new range be a new range whose start and end nodes and offsets are start node,
         // start offset, end node, and end offset.
         let new_range = document.CreateRange(cx);
-        let _ = new_range.SetStart(&start_node, start_offset);
-        let _ = new_range.SetEnd(&end_node, end_offset);
+        let _ = new_range.SetStart(cx.no_gc(), &start_node, start_offset);
+        let _ = new_range.SetEnd(cx.no_gc(), &end_node, end_offset);
         // Step 9. Return new range.
         new_range
     }

--- a/components/script/dom/execcommand/contenteditable/selection.rs
+++ b/components/script/dom/execcommand/contenteditable/selection.rs
@@ -193,7 +193,9 @@ impl Selection {
         let (mut end_node, mut end_offset) = self.end_boundary(cx).first_equivalent_point();
 
         // Step 6. If (end node, end offset) is not after (start node, start offset):
-        if bp_position(&end_node, end_offset, &start_node, start_offset) != Ordering::Greater {
+        if bp_position(cx.no_gc(), &end_node, end_offset, &start_node, start_offset) !=
+            Ordering::Greater
+        {
             // Step 6.1. If direction is "forward", call collapseToStart() on the context object's selection.
             if direction == SelectionDeleteDirection::Forward {
                 let _ = self.CollapseToStart(cx);
@@ -823,7 +825,7 @@ impl Selection {
             };
             let _ = self
                 .expect_active_range(cx)
-                .SetStart(start_text.upcast(), 0);
+                .SetStart(cx.no_gc(), start_text.upcast(), 0);
         }
         // Step 4. If the active range's end node is an editable Text node,
         // and its end offset is neither zero nor its end node's length,
@@ -841,7 +843,7 @@ impl Selection {
         // Step 5. Let element list be all editable Elements effectively contained in the active range.
         // Step 6. For each element in element list, clear the value of element.
         self.expect_active_range(cx)
-            .for_each_effectively_contained_child(|child| {
+            .for_each_effectively_contained_child(cx, |cx, child| {
                 if child.is_editable() &&
                     let Some(element_child) = child.downcast::<HTMLElement>()
                 {
@@ -851,7 +853,7 @@ impl Selection {
         // Step 7. Let node list be all editable nodes effectively contained in the active range.
         // Step 8. For each node in node list:
         self.expect_active_range(cx)
-            .for_each_effectively_contained_child(|child| {
+            .for_each_effectively_contained_child(cx, |cx, child| {
                 if child.is_editable() {
                     // Step 8.1. Push down values on node.
                     child.push_down_values(cx, &command, new_value.clone());

--- a/components/script/dom/execcommand/execcommands.rs
+++ b/components/script/dom/execcommand/execcommands.rs
@@ -51,7 +51,7 @@ fn bump_selection_out_of_invalid_node(cx: &mut JSContext, selection: &Selection)
         let Some(parent) = start_container.GetParentNode() else {
             return Err(());
         };
-        let _ = active_range.SetStart(&parent, start_container.index());
+        let _ = active_range.SetStart(cx.no_gc(), &parent, start_container.index());
     }
     if let end_container = active_range.end_container() &&
         (end_container.is::<Comment>() || end_container.is::<ProcessingInstruction>())
@@ -59,7 +59,7 @@ fn bump_selection_out_of_invalid_node(cx: &mut JSContext, selection: &Selection)
         let Some(parent) = end_container.GetParentNode() else {
             return Err(());
         };
-        let _ = active_range.SetEnd(&parent, end_container.index());
+        let _ = active_range.SetEnd(cx.no_gc(), &parent, end_container.index());
     }
     Ok(())
 }

--- a/components/script/dom/html/document_metadata/htmllinkelement.rs
+++ b/components/script/dom/html/document_metadata/htmllinkelement.rs
@@ -186,7 +186,7 @@ impl HTMLLinkElement {
     // FIXME(emilio): These methods are duplicated with
     // HTMLStyleElement::set_stylesheet.
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-    pub(crate) fn set_stylesheet(&self, new_stylesheet: Arc<Stylesheet>) {
+    pub(crate) fn set_stylesheet(&self, no_gc: &NoGC, new_stylesheet: Arc<Stylesheet>) {
         let owner = self.stylesheet_list_owner();
         if let Some(old_stylesheet) = self.stylesheet.borrow_mut().replace(new_stylesheet.clone()) {
             owner.remove_stylesheet(
@@ -194,7 +194,7 @@ impl HTMLLinkElement {
                 &old_stylesheet,
             );
         }
-        owner.add_owned_stylesheet(self.upcast(), new_stylesheet);
+        owner.add_owned_stylesheet(no_gc, self.upcast(), new_stylesheet);
     }
 
     pub(crate) fn get_stylesheet(&self) -> Option<Arc<Stylesheet>> {

--- a/components/script/dom/html/document_metadata/htmlstyleelement.rs
+++ b/components/script/dom/html/document_metadata/htmlstyleelement.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name};
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::rust::HandleObject;
 use net_traits::ReferrerPolicy;
 use script_bindings::cell::DomRefCell;
@@ -210,7 +210,7 @@ impl HTMLStyleElement {
 
         // Finally, update our stylesheet, regardless of which scenario we ran into
         self.clean_stylesheet_ownership();
-        self.set_stylesheet(sheet, cache_key);
+        self.set_stylesheet(cx.no_gc(), sheet, cache_key);
     }
 
     // FIXME(emilio): This is duplicated with HTMLLinkElement::set_stylesheet.
@@ -219,23 +219,24 @@ impl HTMLStyleElement {
     // this function has a bit difference with `HTMLLinkElement::set_stylesheet` now.
     pub(crate) fn set_stylesheet(
         &self,
-        s: Arc<Stylesheet>,
+        no_gc: &NoGC,
+        stylesheet: Arc<Stylesheet>,
         cache_key: Option<StylesheetContentsCacheKey>,
     ) {
-        *self.stylesheet.borrow_mut() = Some(s.clone());
+        *self.stylesheet.borrow_mut() = Some(stylesheet.clone());
         *self.stylesheetcontents_cache_key.borrow_mut() = cache_key;
         self.stylesheet_list_owner()
-            .add_owned_stylesheet(self.upcast(), s);
+            .add_owned_stylesheet(no_gc, self.upcast(), stylesheet);
     }
 
-    pub(crate) fn will_modify_stylesheet(&self) {
+    pub(crate) fn will_modify_stylesheet(&self, no_gc: &NoGC) {
         if let Some(stylesheet_with_owned_contents) = self.create_owned_contents_stylesheet() {
             self.remove_stylesheet();
             if let Some(cssom_stylesheet) = self.cssom_stylesheet.get() {
                 let guard = stylesheet_with_owned_contents.shared_lock.read();
                 cssom_stylesheet.update_style_stylesheet(&stylesheet_with_owned_contents, &guard);
             }
-            self.set_stylesheet(stylesheet_with_owned_contents, None);
+            self.set_stylesheet(no_gc, stylesheet_with_owned_contents, None);
         }
     }
 

--- a/components/script/dom/html/form_controls/htmlformelement.rs
+++ b/components/script/dom/html/form_controls/htmlformelement.rs
@@ -528,7 +528,7 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#the-form-element:supported-property-names
-    fn SupportedPropertyNames(&self, _: &NoGC) -> Vec<DOMString> {
+    fn SupportedPropertyNames(&self, no_gc: &NoGC) -> Vec<DOMString> {
         // Step 1
         #[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
         enum SourcedNameSource {
@@ -623,7 +623,7 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
         sourced_names_vec.sort_by(|a, b| {
             if a.element
                 .upcast::<Node>()
-                .CompareDocumentPosition(b.element.upcast::<Node>()) ==
+                .CompareDocumentPosition(no_gc, b.element.upcast::<Node>()) ==
                 0
             {
                 if a.source.is_past() && b.source.is_past() {
@@ -634,7 +634,7 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
             } else if a
                 .element
                 .upcast::<Node>()
-                .CompareDocumentPosition(b.element.upcast::<Node>()) &
+                .CompareDocumentPosition(no_gc, b.element.upcast::<Node>()) &
                 NodeConstants::DOCUMENT_POSITION_FOLLOWING ==
                 NodeConstants::DOCUMENT_POSITION_FOLLOWING
             {

--- a/components/script/dom/media/medialist.rs
+++ b/components/script/dom/media/medialist.rs
@@ -157,7 +157,7 @@ impl MediaListMethods<crate::DomTypeHolder> for MediaList {
 
     /// <https://drafts.csswg.org/cssom/#dom-medialist-mediatext>
     fn SetMediaText(&self, no_gc: &NoGC, value: DOMString) {
-        self.parent_stylesheet.will_modify();
+        self.parent_stylesheet.will_modify(no_gc);
         let global = self.global();
         let mut guard = self.shared_lock().write();
         let media_queries_borrowed = self.media_queries.borrow();
@@ -218,7 +218,7 @@ impl MediaListMethods<crate::DomTypeHolder> for MediaList {
             }
         }
         // Step 4
-        self.parent_stylesheet.will_modify();
+        self.parent_stylesheet.will_modify(no_gc);
         let mut guard = self.shared_lock().write();
         self.media_queries
             .borrow()
@@ -239,7 +239,7 @@ impl MediaListMethods<crate::DomTypeHolder> for MediaList {
             return;
         }
         // Step 3
-        self.parent_stylesheet.will_modify();
+        self.parent_stylesheet.will_modify(no_gc);
         let m_serialized = m.unwrap().to_css_string();
         let mut guard = self.shared_lock().write();
         let media_queries_borrowed = self.media_queries.borrow();

--- a/components/script/dom/node/comparator.rs
+++ b/components/script/dom/node/comparator.rs
@@ -1,0 +1,201 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::cmp::Ordering;
+
+use bitflags::bitflags;
+use js::context::NoGC;
+use script_bindings::dom::UnrootedDom;
+
+use crate::dom::Node;
+use crate::dom::traversal::NoGcTraversal;
+
+#[derive(Clone, Copy)]
+pub(crate) struct DomPositionContainment(u8);
+
+bitflags! {
+    impl DomPositionContainment: u8 {
+        const AContainsB = 1 << 0;
+        const BContainsA = 1 << 1;
+    }
+}
+
+pub(crate) fn compare_dom_positions<Traversal: NoGcTraversal>(
+    no_gc: &NoGC,
+    container_a: &Node,
+    offset_a: u32,
+    container_b: &Node,
+    offset_b: u32,
+) -> (Option<Ordering>, DomPositionContainment) {
+    if container_a == container_b {
+        return (
+            Some(offset_a.cmp(&offset_b)),
+            DomPositionContainment::empty(),
+        );
+    }
+
+    if let Some(child_of_a) = find_child_in_ancestors::<Traversal>(no_gc, container_b, container_a)
+    {
+        let ordering =
+            match compare_offset_and_node_in_same_parent::<Traversal>(no_gc, offset_a, &child_of_a)
+            {
+                Ordering::Equal => Ordering::Less,
+                ordering => ordering,
+            };
+        return (Some(ordering), DomPositionContainment::AContainsB);
+    }
+
+    if let Some(child_of_b) = find_child_in_ancestors::<Traversal>(no_gc, container_a, container_b)
+    {
+        let ordering =
+            match compare_offset_and_node_in_same_parent::<Traversal>(no_gc, offset_b, &child_of_b)
+            {
+                Ordering::Equal => Ordering::Greater,
+                ordering => ordering.reverse(),
+            };
+        return (Some(ordering), DomPositionContainment::BContainsA);
+    }
+
+    let Some((least_common_ancestor_child_of_a, least_common_ancestor_child_of_b)) =
+        least_common_ancestor_children::<Traversal>(no_gc, container_a, container_b)
+    else {
+        return (None, DomPositionContainment::empty());
+    };
+
+    let ordering = compare_nodes_in_same_parent::<Traversal>(
+        no_gc,
+        &least_common_ancestor_child_of_a,
+        &least_common_ancestor_child_of_b,
+    );
+    (Some(ordering), DomPositionContainment::empty())
+}
+
+/// If `possible_ancestor` is an ancestor of `possible_descendant` return the
+/// child of `possible_ancestor` that is an ancestor of `possible_descendant` or
+/// is `possible_descendant` itself.
+fn find_child_in_ancestors<'a, Traversal: NoGcTraversal>(
+    no_gc: &'a NoGC,
+    possible_descendant: &Node,
+    possible_ancestor: &Node,
+) -> Option<UnrootedDom<'a, Node>> {
+    let mut child = UnrootedDom::from_ref(possible_descendant, no_gc);
+    let mut maybe_ancestor = Traversal::parent(no_gc, possible_descendant);
+    while let Some(ancestor) = maybe_ancestor {
+        if **ancestor == *possible_ancestor {
+            return Some(child);
+        }
+
+        maybe_ancestor = Traversal::parent(no_gc, &ancestor);
+        child = ancestor;
+    }
+    None
+}
+
+/// Compare an offset in a parent node with a child node in that same parent node.
+fn compare_offset_and_node_in_same_parent<Traversal: NoGcTraversal>(
+    no_gc: &NoGC,
+    offset_a: u32,
+    node_b: &Node,
+) -> Ordering {
+    let parent = Traversal::parent(no_gc, node_b).expect("Node should always have a parent");
+    for (current_offset, child) in Traversal::children(no_gc, &parent).enumerate() {
+        if current_offset == offset_a as usize && **child == *node_b {
+            return Ordering::Equal;
+        }
+        if current_offset == offset_a as usize {
+            return Ordering::Less;
+        }
+        if **child == *node_b {
+            return Ordering::Greater;
+        }
+    }
+    unreachable!("A node should always be a child of its parent.");
+}
+
+/// Compare two nodes that are both children of the same parent node.
+fn compare_nodes_in_same_parent<Traversal: NoGcTraversal>(
+    no_gc: &NoGC,
+    node_a: &Node,
+    node_b: &Node,
+) -> Ordering {
+    if node_a == node_b {
+        return Ordering::Equal;
+    }
+
+    let parent = Traversal::parent(no_gc, node_a).expect("Node should always have a parent");
+    for child in Traversal::children(no_gc, &parent) {
+        if **child == *node_a {
+            return Ordering::Less;
+        }
+        if **child == *node_b {
+            return Ordering::Greater;
+        }
+    }
+    unreachable!("A node should always be a child of its parent.");
+}
+
+/// When `node_a` and `node_b` share a least common ancestor, this function returns a
+/// tuple containing the child of the least common ancestor that is an inclusive ancestor
+/// of `node_a` and the child of the least common ancestor that is an inclusive ancestor
+/// of `node_b`. If `node_a` and `node_b` do not have a least common ancestor, this
+/// returns `None`.
+///
+/// Note: This function assumes that the least common inclusive ancestor is neither of the
+/// nodes passed as arguments.
+fn least_common_ancestor_children<'a, Traversal: NoGcTraversal>(
+    no_gc: &'a NoGC,
+    node_a: &Node,
+    node_b: &Node,
+) -> Option<(UnrootedDom<'a, Node>, UnrootedDom<'a, Node>)> {
+    let mut depth_a = 0;
+    let mut inclusive_ancestor = Some(UnrootedDom::from_ref(node_a, no_gc));
+    while let Some(ancestor) = inclusive_ancestor {
+        debug_assert!(**ancestor != *node_b);
+        inclusive_ancestor = Traversal::parent(no_gc, &ancestor);
+        depth_a += 1;
+    }
+
+    let mut depth_b = 0;
+    let mut inclusive_ancestor = Some(UnrootedDom::from_ref(node_b, no_gc));
+    while let Some(ancestor) = inclusive_ancestor {
+        debug_assert!(**ancestor != *node_a);
+        inclusive_ancestor = Traversal::parent(no_gc, &ancestor);
+        depth_b += 1;
+    }
+
+    let mut inclusive_ancestor_of_a = Some(UnrootedDom::from_ref(node_a, no_gc));
+    let mut inclusive_ancestor_of_b = Some(UnrootedDom::from_ref(node_b, no_gc));
+
+    while depth_a > depth_b {
+        let ancestor = inclusive_ancestor_of_a.expect("Guaranteed by depth");
+        inclusive_ancestor_of_a = Traversal::parent(no_gc, &ancestor);
+        depth_a -= 1;
+    }
+
+    while depth_b > depth_a {
+        let ancestor = inclusive_ancestor_of_b.expect("Guaranteed by depth");
+        inclusive_ancestor_of_b = Traversal::parent(no_gc, &ancestor);
+        depth_b -= 1;
+    }
+
+    let mut candidate_child_a = inclusive_ancestor_of_a.expect("Should always have a candidate");
+    let mut candidate_child_b = inclusive_ancestor_of_b.expect("Should always have a candidate");
+    let mut inclusive_ancestor_of_a = Traversal::parent(no_gc, &candidate_child_a);
+    let mut inclusive_ancestor_of_b = Traversal::parent(no_gc, &candidate_child_b);
+
+    while let Some(ancestor_of_a) = inclusive_ancestor_of_a &&
+        let Some(ancestor_of_b) = inclusive_ancestor_of_b
+    {
+        if ancestor_of_a == ancestor_of_b {
+            return Some((candidate_child_a, candidate_child_b));
+        }
+
+        inclusive_ancestor_of_a = Traversal::parent(no_gc, &ancestor_of_a);
+        inclusive_ancestor_of_b = Traversal::parent(no_gc, &ancestor_of_b);
+        candidate_child_a = ancestor_of_a;
+        candidate_child_b = ancestor_of_b;
+    }
+
+    None
+}

--- a/components/script/dom/node/mod.rs
+++ b/components/script/dom/node/mod.rs
@@ -4,6 +4,7 @@
 
 pub(crate) use self::node::*;
 pub(crate) mod children_mutation;
+pub(crate) mod comparator;
 pub(crate) mod context;
 pub(crate) mod customelementregistry;
 pub(crate) mod focus;
@@ -13,6 +14,7 @@ pub(crate) mod layout_dom;
 pub(crate) mod node;
 pub(crate) mod nodeiterator;
 pub(crate) mod nodelist;
+pub(crate) mod traversal;
 pub(crate) mod treewalker;
 pub(crate) mod virtualmethods;
 

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -85,6 +85,7 @@ use crate::dom::bindings::root::{
 };
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::characterdata::CharacterData;
+use crate::dom::comparator::{DomPositionContainment, compare_dom_positions};
 use crate::dom::context::{BindContext, IsShadowTree, MoveContext, UnbindContext};
 use crate::dom::css::cssstylesheet::CSSStyleSheet;
 use crate::dom::css::stylesheetlist::StyleSheetListOwner;
@@ -122,6 +123,7 @@ use crate::dom::servoparser::html::HtmlSerialize;
 use crate::dom::servoparser::serialize_html_fragment;
 use crate::dom::shadowroot::{IsUserAgentWidget, ShadowRoot};
 use crate::dom::text::Text;
+use crate::dom::traversal::LightDomNoGcTraversal;
 use crate::dom::types::{CDATASection, KeyboardEvent, MouseEvent, ProcessingInstruction};
 use crate::dom::window::Window;
 use crate::dom::{
@@ -717,8 +719,8 @@ impl Node {
 
     /// Returns true if this node is before `other` in the same connected DOM
     /// tree.
-    pub(crate) fn is_before(&self, other: &Node) -> bool {
-        let cmp = other.CompareDocumentPosition(self);
+    pub(crate) fn is_before(&self, no_gc: &NoGC, other: &Node) -> bool {
+        let cmp = other.CompareDocumentPosition(no_gc, self);
         if cmp & NodeConstants::DOCUMENT_POSITION_DISCONNECTED != 0 {
             return false;
         }
@@ -4261,7 +4263,7 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-node-comparedocumentposition>
-    fn CompareDocumentPosition(&self, other: &Node) -> u16 {
+    fn CompareDocumentPosition(&self, no_gc: &NoGC, other: &Node) -> u16 {
         // Step 1. If this is other, then return zero.
         if self == other {
             return 0;
@@ -4334,86 +4336,65 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
             unreachable!();
         }
 
-        // Step 6
-        match (node1, node2) {
-            (None, _) => {
-                // node1 is null
-                NodeConstants::DOCUMENT_POSITION_FOLLOWING +
-                    NodeConstants::DOCUMENT_POSITION_DISCONNECTED +
-                    NodeConstants::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC
-            },
-            (_, None) => {
-                // node2 is null
-                NodeConstants::DOCUMENT_POSITION_PRECEDING +
-                    NodeConstants::DOCUMENT_POSITION_DISCONNECTED +
-                    NodeConstants::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC
-            },
-            (Some(node1), Some(node2)) => {
-                // still step 6, testing if node1 and 2 share a root
-                let mut self_and_ancestors = node2
-                    .inclusive_ancestors(ShadowIncluding::No)
-                    .collect::<SmallVec<[_; 20]>>();
-                let mut other_and_ancestors = node1
-                    .inclusive_ancestors(ShadowIncluding::No)
-                    .collect::<SmallVec<[_; 20]>>();
+        // Step 6. If node1 or node2 is null, or node1’s root is not node2’s root, then
+        // return the result of adding DOCUMENT_POSITION_DISCONNECTED,
+        // DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC, and either
+        // DOCUMENT_POSITION_PRECEDING or DOCUMENT_POSITION_FOLLOWING, with the constraint
+        // that this is to be consistent, together.
+        let options = GetRootNodeOptions { composed: false };
+        let node1_root = node1.map(|node| node.GetRootNode(&options));
+        let node2_root = node2.map(|node| node.GetRootNode(&options));
+        if node1_root.is_none() || node2_root.is_none() || node1_root != node2_root {
+            // Auto-deref and compare the addresses of GC-owned `&Node`s,
+            // more stable than addresses of SmallVec-owned `&Root<Dom<Node>>`
+            let pointer1 = node1.map(as_uintptr::<Node>).unwrap_or_default();
+            let pointer2 = node2.map(as_uintptr::<Node>).unwrap_or_default();
+            let arbitrary_order = if pointer1 < pointer2 {
+                NodeConstants::DOCUMENT_POSITION_PRECEDING
+            } else {
+                NodeConstants::DOCUMENT_POSITION_FOLLOWING
+            };
 
-                if self_and_ancestors.last() != other_and_ancestors.last() {
-                    // Auto-deref and compare the addresses of GC-owned `&Node`s,
-                    // more stable than addresses of SmallVec-owned `&Root<Dom<Node>>`
-                    let arbitrary = as_uintptr::<Node>(self_and_ancestors.last().unwrap()) <
-                        as_uintptr::<Node>(other_and_ancestors.last().unwrap());
-                    let arbitrary = if arbitrary {
-                        NodeConstants::DOCUMENT_POSITION_FOLLOWING
-                    } else {
-                        NodeConstants::DOCUMENT_POSITION_PRECEDING
-                    };
-
-                    // Disconnected.
-                    return arbitrary +
-                        NodeConstants::DOCUMENT_POSITION_DISCONNECTED +
-                        NodeConstants::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC;
-                }
-                // steps 7-10
-                let mut parent = self_and_ancestors.pop().unwrap();
-                other_and_ancestors.pop().unwrap();
-
-                let mut current_position =
-                    cmp::min(self_and_ancestors.len(), other_and_ancestors.len());
-
-                while current_position > 0 {
-                    current_position -= 1;
-                    let child_1 = self_and_ancestors.pop().unwrap();
-                    let child_2 = other_and_ancestors.pop().unwrap();
-
-                    if child_1 != child_2 {
-                        for child in parent.children() {
-                            if child == child_1 {
-                                // `other` is following `self`.
-                                return NodeConstants::DOCUMENT_POSITION_FOLLOWING;
-                            }
-                            if child == child_2 {
-                                // `other` is preceding `self`.
-                                return NodeConstants::DOCUMENT_POSITION_PRECEDING;
-                            }
-                        }
-                    }
-
-                    parent = child_1;
-                }
-
-                // We hit the end of one of the parent chains, so one node needs to be
-                // contained in the other.
-                //
-                // If we're the container, return that `other` is contained by us.
-                if self_and_ancestors.len() < other_and_ancestors.len() {
-                    NodeConstants::DOCUMENT_POSITION_FOLLOWING +
-                        NodeConstants::DOCUMENT_POSITION_CONTAINED_BY
-                } else {
-                    NodeConstants::DOCUMENT_POSITION_PRECEDING +
-                        NodeConstants::DOCUMENT_POSITION_CONTAINS
-                }
-            },
+            return arbitrary_order +
+                NodeConstants::DOCUMENT_POSITION_DISCONNECTED +
+                NodeConstants::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC;
         }
+
+        // Comparison goes here:
+        let (ordering, containment_flags) = match (node1, node2) {
+            (Some(node1), Some(node2)) => {
+                compare_dom_positions::<LightDomNoGcTraversal>(no_gc, node1, 0, node2, 0)
+            },
+            _ => (None, DomPositionContainment::empty()),
+        };
+
+        // Step 7. If node1 is an ancestor of node2 and attr1 is null, or node1 is node2
+        // and attr2 is non-null, then return the result of adding
+        // DOCUMENT_POSITION_CONTAINS to DOCUMENT_POSITION_PRECEDING.
+        if (containment_flags.contains(DomPositionContainment::AContainsB) && attr1.is_none()) ||
+            (node1 == node2 && attr2.is_some())
+        {
+            return NodeConstants::DOCUMENT_POSITION_CONTAINS +
+                NodeConstants::DOCUMENT_POSITION_PRECEDING;
+        }
+
+        // Step 8. If node1 is a descendant of node2 and attr2 is null, or node1 is node2
+        // and attr1 is non-null, then return the result of adding
+        // DOCUMENT_POSITION_CONTAINED_BY to DOCUMENT_POSITION_FOLLOWING.
+        if (containment_flags.contains(DomPositionContainment::BContainsA) && attr2.is_none()) ||
+            (node1 == node2 && attr1.is_some())
+        {
+            return NodeConstants::DOCUMENT_POSITION_CONTAINED_BY +
+                NodeConstants::DOCUMENT_POSITION_FOLLOWING;
+        }
+
+        // Step 9. If node1 is preceding node2, then return DOCUMENT_POSITION_PRECEDING.
+        if ordering == Some(Ordering::Less) {
+            return NodeConstants::DOCUMENT_POSITION_PRECEDING;
+        }
+
+        // Step 10. Return DOCUMENT_POSITION_FOLLOWING.
+        NodeConstants::DOCUMENT_POSITION_FOLLOWING
     }
 
     /// <https://dom.spec.whatwg.org/#dom-node-contains>

--- a/components/script/dom/node/traversal.rs
+++ b/components/script/dom/node/traversal.rs
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use js::context::NoGC;
+use script_bindings::dom::UnrootedDom;
+
+use crate::dom::Node;
+
+pub(crate) trait NoGcTraversal {
+    fn parent<'a>(no_gc: &'a NoGC, node: &Node) -> Option<UnrootedDom<'a, Node>>;
+    fn children<'a>(no_gc: &'a NoGC, node: &Node) -> impl Iterator<Item = UnrootedDom<'a, Node>>;
+}
+
+pub(crate) struct LightDomNoGcTraversal;
+
+impl NoGcTraversal for LightDomNoGcTraversal {
+    fn parent<'a>(no_gc: &'a NoGC, node: &Node) -> Option<UnrootedDom<'a, Node>> {
+        node.get_parent_node_unrooted(no_gc)
+    }
+    fn children<'a>(no_gc: &'a NoGC, node: &Node) -> impl Iterator<Item = UnrootedDom<'a, Node>> {
+        node.children_unrooted(no_gc)
+    }
+}

--- a/components/script/dom/range/abstractrange.rs
+++ b/components/script/dom/range/abstractrange.rs
@@ -3,10 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::Cell;
-use std::cmp::{Ord, Ordering, PartialEq, PartialOrd};
+use std::cmp::{Ord, Ordering, PartialEq};
 
 use deny_public_fields::DenyPublicFields;
 use dom_struct::dom_struct;
+use js::context::NoGC;
 use script_bindings::reflector::Reflector;
 use servo_base::text::Utf16CodeUnits;
 
@@ -109,11 +110,10 @@ impl BoundaryPoint {
     pub(crate) fn node(&self) -> &MutDom<Node> {
         &self.node
     }
-}
 
-impl PartialOrd for BoundaryPoint {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    pub(crate) fn partial_cmp(&self, no_gc: &NoGC, other: &Self) -> Option<Ordering> {
         Some(bp_position(
+            no_gc,
             &self.node.get(),
             self.offset.get(),
             &other.node.get(),
@@ -131,7 +131,13 @@ impl PartialEq for BoundaryPoint {
 }
 
 /// <https://dom.spec.whatwg.org/#concept-range-bp-position>
-pub(crate) fn bp_position(a_node: &Node, a_offset: u32, b_node: &Node, b_offset: u32) -> Ordering {
+pub(crate) fn bp_position(
+    no_gc: &NoGC,
+    a_node: &Node,
+    a_offset: u32,
+    b_node: &Node,
+    b_offset: u32,
+) -> Ordering {
     // Step 1: Assert: nodeA and nodeB have the same root.
     debug_assert!(
         a_node.GetRootNode(&Default::default()) == b_node.GetRootNode(&Default::default())
@@ -143,7 +149,7 @@ pub(crate) fn bp_position(a_node: &Node, a_offset: u32, b_node: &Node, b_offset:
         return a_offset.cmp(&b_offset);
     }
 
-    let position = b_node.CompareDocumentPosition(a_node);
+    let position = b_node.CompareDocumentPosition(no_gc, a_node);
     assert!(
         position & NodeConstants::DOCUMENT_POSITION_DISCONNECTED == 0,
         "Nodes should be in the same tree"
@@ -152,7 +158,7 @@ pub(crate) fn bp_position(a_node: &Node, a_offset: u32, b_node: &Node, b_offset:
         // Step 3: If nodeA is following nodeB, then if the position of (nodeB, offsetB)
         // relative to (nodeA, offsetA) is before, return after, and if it is after,
         // return before.
-        return match bp_position(b_node, b_offset, a_node, a_offset) {
+        return match bp_position(no_gc, b_node, b_offset, a_node, a_offset) {
             Ordering::Less => Ordering::Greater,
             Ordering::Greater => Ordering::Less,
             Ordering::Equal => unreachable!("Should be impossible due to Step 2."),

--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::{LazyCell, RefCell};
-use std::cmp::{Ordering, PartialOrd};
+use std::cmp::Ordering;
 use std::iter;
 use std::rc::Rc;
 
@@ -156,14 +156,20 @@ impl Range {
     }
 
     /// <https://dom.spec.whatwg.org/#contained>
-    pub(crate) fn contains(&self, node: &Node) -> bool {
+    pub(crate) fn contains(&self, no_gc: &NoGC, node: &Node) -> bool {
         // > A node node is contained in a live range range if node’s root is range’s root,
         // > and (node, 0) is after range’s start, and (node, node’s length) is before range’s end.
         node.GetRootNode(&Default::default()) == self.root() &&
             matches!(
                 (
-                    bp_position(node, 0, &self.start_container(), self.start_offset()),
-                    bp_position(node, node.len(), &self.end_container(), self.end_offset()),
+                    bp_position(no_gc, node, 0, &self.start_container(), self.start_offset()),
+                    bp_position(
+                        no_gc,
+                        node,
+                        node.len(),
+                        &self.end_container(),
+                        self.end_offset()
+                    ),
                 ),
                 (Ordering::Greater, Ordering::Less)
             )
@@ -182,7 +188,7 @@ impl Range {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-range-clone>
-    pub(crate) fn contained_children(&self) -> Fallible<ContainedChildren> {
+    pub(crate) fn contained_children(&self, no_gc: &NoGC) -> Fallible<ContainedChildren> {
         let start_node = self.start_container();
         let end_node = self.end_container();
         // Steps 5-6.
@@ -211,7 +217,7 @@ impl Range {
         // Step 11.
         let contained_children: Vec<DomRoot<Node>> = common_ancestor
             .children()
-            .filter(|n| self.contains(n))
+            .filter(|n| self.contains(no_gc, n))
             .collect();
 
         // Step 12.
@@ -280,7 +286,7 @@ impl Range {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-comparepointnode-offset>
-    fn compare_point(&self, node: &Node, offset: u32) -> Fallible<Ordering> {
+    fn compare_point(&self, no_gc: &NoGC, node: &Node, offset: u32) -> Fallible<Ordering> {
         // Step 1. If node’s root is not this’s root, then throw a "WrongDocumentError"
         // DOMException.
         if node.GetRootNode(&Default::default()) != self.root() {
@@ -298,13 +304,17 @@ impl Range {
         }
         // Step 4. If (node, offset) is before start, then return −1.
         let start_node = self.start_container();
-        if let Ordering::Less = bp_position(node, offset, &start_node, self.start_offset()) {
+        if let Ordering::Less = bp_position(no_gc, node, offset, &start_node, self.start_offset()) {
             return Ok(Ordering::Less);
         }
         // Step 5. If (node, offset) is after end, then return 1.
-        if let Ordering::Greater =
-            bp_position(node, offset, &self.end_container(), self.end_offset())
-        {
+        if let Ordering::Greater = bp_position(
+            no_gc,
+            node,
+            offset,
+            &self.end_container(),
+            self.end_offset(),
+        ) {
             return Ok(Ordering::Greater);
         }
         // Step 6. Return 0.
@@ -404,6 +414,7 @@ impl Range {
     /// <https://dom.spec.whatwg.org/#concept-range-bp-set>
     fn set_the_start_or_end(
         &self,
+        no_gc: &NoGC,
         node: &Node,
         offset: u32,
         start_or_end: StartOrEnd,
@@ -429,8 +440,13 @@ impl Range {
                 // Step 4.1. If range’s root is not equal to node’s root, or if bp is after
                 // the range’s end, set range’s end to bp.
                 if self.root() != node.GetRootNode(&Default::default()) ||
-                    bp_position(node, offset, &self.end_container(), self.end_offset()) ==
-                        Ordering::Greater
+                    bp_position(
+                        no_gc,
+                        node,
+                        offset,
+                        &self.end_container(),
+                        self.end_offset(),
+                    ) == Ordering::Greater
                 {
                     notification.set(
                         SelectionLiveRangeNotification::End,
@@ -449,8 +465,13 @@ impl Range {
                 // Step 4.1. If range’s root is not equal to node’s root, or if bp is
                 // before the range’s start, set range’s start to bp.
                 if self.root() != node.GetRootNode(&Default::default()) ||
-                    bp_position(node, offset, &self.start_container(), self.start_offset()) ==
-                        Ordering::Less
+                    bp_position(
+                        no_gc,
+                        node,
+                        offset,
+                        &self.start_container(),
+                        self.start_offset(),
+                    ) == Ordering::Less
                 {
                     notification.set(
                         SelectionLiveRangeNotification::Start,
@@ -509,37 +530,37 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-setstart>
-    fn SetStart(&self, node: &Node, offset: u32) -> ErrorResult {
-        self.set_the_start_or_end(node, offset, StartOrEnd::Start)
+    fn SetStart(&self, no_gc: &NoGC, node: &Node, offset: u32) -> ErrorResult {
+        self.set_the_start_or_end(no_gc, node, offset, StartOrEnd::Start)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-setend>
-    fn SetEnd(&self, node: &Node, offset: u32) -> ErrorResult {
-        self.set_the_start_or_end(node, offset, StartOrEnd::End)
+    fn SetEnd(&self, no_gc: &NoGC, node: &Node, offset: u32) -> ErrorResult {
+        self.set_the_start_or_end(no_gc, node, offset, StartOrEnd::End)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-setstartbefore>
-    fn SetStartBefore(&self, node: &Node) -> ErrorResult {
+    fn SetStartBefore(&self, no_gc: &NoGC, node: &Node) -> ErrorResult {
         let parent = node.GetParentNode().ok_or(Error::InvalidNodeType(None))?;
-        self.SetStart(&parent, node.index())
+        self.SetStart(no_gc, &parent, node.index())
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-setstartafter>
-    fn SetStartAfter(&self, node: &Node) -> ErrorResult {
+    fn SetStartAfter(&self, no_gc: &NoGC, node: &Node) -> ErrorResult {
         let parent = node.GetParentNode().ok_or(Error::InvalidNodeType(None))?;
-        self.SetStart(&parent, node.index() + 1)
+        self.SetStart(no_gc, &parent, node.index() + 1)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-setendbefore>
-    fn SetEndBefore(&self, node: &Node) -> ErrorResult {
+    fn SetEndBefore(&self, no_gc: &NoGC, node: &Node) -> ErrorResult {
         let parent = node.GetParentNode().ok_or(Error::InvalidNodeType(None))?;
-        self.SetEnd(&parent, node.index())
+        self.SetEnd(no_gc, &parent, node.index())
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-setendafter>
-    fn SetEndAfter(&self, node: &Node) -> ErrorResult {
+    fn SetEndAfter(&self, no_gc: &NoGC, node: &Node) -> ErrorResult {
         let parent = node.GetParentNode().ok_or(Error::InvalidNodeType(None))?;
-        self.SetEnd(&parent, node.index() + 1)
+        self.SetEnd(no_gc, &parent, node.index() + 1)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-collapse>
@@ -580,7 +601,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-compareboundarypoints>
-    fn CompareBoundaryPoints(&self, how: u16, source_range: &Range) -> Fallible<i16> {
+    fn CompareBoundaryPoints(&self, no_gc: &NoGC, how: u16, source_range: &Range) -> Fallible<i16> {
         // Step 1. If how is not one of
         //    * START_TO_START,
         //    * START_TO_END,
@@ -619,7 +640,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         //      Return 0.
         //  ↪ after
         //      Return 1.
-        match this_point.partial_cmp(source_point).unwrap() {
+        match this_point.partial_cmp(no_gc, source_point).unwrap() {
             Ordering::Less => Ok(-1),
             Ordering::Equal => Ok(0),
             Ordering::Greater => Ok(1),
@@ -641,8 +662,8 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-ispointinrange>
-    fn IsPointInRange(&self, node: &Node, offset: u32) -> Fallible<bool> {
-        match self.compare_point(node, offset) {
+    fn IsPointInRange(&self, no_gc: &NoGC, node: &Node, offset: u32) -> Fallible<bool> {
+        match self.compare_point(no_gc, node, offset) {
             Ok(Ordering::Less) => Ok(false),
             Ok(Ordering::Equal) => Ok(true),
             Ok(Ordering::Greater) => Ok(false),
@@ -656,16 +677,17 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-comparepoint>
-    fn ComparePoint(&self, node: &Node, offset: u32) -> Fallible<i16> {
-        self.compare_point(node, offset).map(|order| match order {
-            Ordering::Less => -1,
-            Ordering::Equal => 0,
-            Ordering::Greater => 1,
-        })
+    fn ComparePoint(&self, no_gc: &NoGC, node: &Node, offset: u32) -> Fallible<i16> {
+        self.compare_point(no_gc, node, offset)
+            .map(|order| match order {
+                Ordering::Less => -1,
+                Ordering::Equal => 0,
+                Ordering::Greater => 1,
+            })
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-intersectsnode>
-    fn IntersectsNode(&self, node: &Node) -> bool {
+    fn IntersectsNode(&self, no_gc: &NoGC, node: &Node) -> bool {
         // Step 1. If node’s root is not this’s root, then return false.
         if self.root() != node.GetRootNode(&Default::default()) {
             return false;
@@ -681,9 +703,16 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         // start, then return true.
         // Step 6. Return false.
         let start_node = self.start_container();
-        Ordering::Greater == bp_position(&parent, offset + 1, &start_node, self.start_offset()) &&
+        Ordering::Greater ==
+            bp_position(no_gc, &parent, offset + 1, &start_node, self.start_offset()) &&
             Ordering::Less ==
-                bp_position(&parent, offset, &self.end_container(), self.end_offset())
+                bp_position(
+                    no_gc,
+                    &parent,
+                    offset,
+                    &self.end_container(),
+                    self.end_offset(),
+                )
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-clonecontents>
@@ -722,7 +751,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             first_partially_contained_child,
             last_partially_contained_child,
             contained_children,
-        } = self.contained_children()?;
+        } = self.contained_children(cx.no_gc())?;
 
         if let Some(child) = first_partially_contained_child {
             // Step 13.
@@ -837,7 +866,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             first_partially_contained_child,
             last_partially_contained_child,
             contained_children,
-        } = self.contained_children()?;
+        } = self.contained_children(cx.no_gc())?;
 
         let (new_node, new_offset) = if start_node.is_inclusive_ancestor_of(&end_node) {
             // Step 13.
@@ -932,8 +961,8 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         }
 
         // Step 20.
-        self.SetStart(&new_node, new_offset)?;
-        self.SetEnd(&new_node, new_offset)?;
+        self.SetStart(cx.no_gc(), &new_node, new_offset)?;
+        self.SetEnd(cx.no_gc(), &new_node, new_offset)?;
 
         // Step 21.
         Ok(fragment)
@@ -1067,7 +1096,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
 
         let mut next = iter.next();
         while let Some(child) = next {
-            if self.contains(&child) {
+            if self.contains(cx.no_gc(), &child) {
                 contained_children.push(Dom::from_ref(&*child));
                 next = iter.next_skipping_children();
             } else {
@@ -1101,8 +1130,8 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         };
 
         // Step 8. Set this’s start and end to (newNode, newOffset).
-        self.SetStart(&new_node, new_offset).unwrap();
-        self.SetEnd(&new_node, new_offset).unwrap();
+        self.SetStart(cx.no_gc(), &new_node, new_offset).unwrap();
+        self.SetEnd(cx.no_gc(), &new_node, new_offset).unwrap();
 
         // Step 9. If originalStartNode is a CharacterData node,
         // then replace data of originalStartNode with originalStartOffset,
@@ -1214,7 +1243,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             .filter_map(UnrootedDom::downcast::<Text>);
 
         for child in iter {
-            if self.contains(child.upcast()) {
+            if self.contains(no_gc, child.upcast()) {
                 s.push_str(&child.upcast::<CharacterData>().Data().str());
             }
         }

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -126,7 +126,7 @@ impl Selection {
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-    fn set_range(&self, new_range: Option<SelectionRange>) -> bool {
+    fn set_range(&self, no_gc: &NoGC, new_range: Option<SelectionRange>) -> bool {
         let changed;
         {
             let mut range = self.range.borrow_mut();
@@ -139,18 +139,18 @@ impl Selection {
 
         if changed {
             self.selection_boundaries_changed();
-            self.assert_valid_selection();
+            self.assert_valid_selection(no_gc);
         }
 
         changed
     }
 
-    pub(crate) fn set_live_range(&self, new_range: Option<&Range>) {
+    pub(crate) fn set_live_range(&self, no_gc: &NoGC, new_range: Option<&Range>) {
         if new_range == self.live_range.get().as_deref() {
             return;
         }
 
-        let boundaries_changed = self.set_range(new_range.map(|new_range| new_range.into()));
+        let boundaries_changed = self.set_range(no_gc, new_range.map(|new_range| new_range.into()));
 
         // It's possible that `set_range` was a no-op, but still in that case we need to
         // replace the live range per-specification.
@@ -418,7 +418,7 @@ impl Selection {
         (range.end_container(), range.end_offset())
     }
 
-    fn assert_valid_selection(&self) {
+    fn assert_valid_selection(&self, no_gc: &NoGC) {
         #[cfg(not(debug_assertions))]
         return;
 
@@ -432,6 +432,7 @@ impl Selection {
         );
         debug_assert!(
             bp_position(
+                no_gc,
                 &range.start.container,
                 range.start.offset,
                 &range.end.container,
@@ -440,11 +441,11 @@ impl Selection {
         );
     }
 
-    fn assert_valid_selection_and_live_range(&self) {
+    fn assert_valid_selection_and_live_range(&self, no_gc: &NoGC) {
         #[cfg(not(debug_assertions))]
         return;
 
-        self.assert_valid_selection();
+        self.assert_valid_selection(no_gc);
 
         let Some(active_range) = self.live_range.get() else {
             return;
@@ -462,6 +463,7 @@ impl Selection {
         debug_assert_eq!(range.end.offset, active_range.end_offset());
         debug_assert!(
             bp_position(
+                no_gc,
                 &active_range.start_container(),
                 active_range.start_offset(),
                 &active_range.end_container(),
@@ -475,7 +477,7 @@ impl Selection {
     /// > The active range is the range of the selection given by calling
     /// > getSelection() on the context object. (Thus the active range may be null.)
     pub(crate) fn active_range(&self, cx: &mut JSContext) -> Option<DomRoot<Range>> {
-        self.assert_valid_selection_and_live_range();
+        self.assert_valid_selection_and_live_range(cx.no_gc());
 
         if let Some(active_range) = self.live_range.get() {
             return Some(active_range);
@@ -938,7 +940,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-addrange>
-    fn AddRange(&self, range: &Range) {
+    fn AddRange(&self, no_gc: &NoGC, range: &Range) {
         // Step 1. If the root of the range's boundary points are not the document
         // associated with this, abort these steps.
         if !self.is_in_document_of_range(&range.start_container()) {
@@ -951,44 +953,44 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         }
 
         // Step 3. Set this's range to range by a strong reference (not by making a copy).
-        self.set_live_range(Some(range));
+        self.set_live_range(no_gc, Some(range));
 
         // Are we supposed to set Direction here? w3c/selection-api#116
         self.direction.set(Direction::Forwards);
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-removerange>
-    fn RemoveRange(&self, range: &Range) -> ErrorResult {
+    fn RemoveRange(&self, no_gc: &NoGC, range: &Range) -> ErrorResult {
         // > The method must make this empty by disassociating its range if this's range
         // > is range. Otherwise, it must throw a NotFoundError.
         if let Some(own_range) = self.live_range.get() &&
             &*own_range == range
         {
-            self.set_range(None);
+            self.set_range(no_gc, None);
             return Ok(());
         }
         Err(Error::NotFound(None))
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-removeallranges>
-    fn RemoveAllRanges(&self) {
+    fn RemoveAllRanges(&self, no_gc: &NoGC) {
         // > The method must make this empty by disassociating its range if this has an
         // > associated range.
-        self.set_range(None);
+        self.set_range(no_gc, None);
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-empty>
-    fn Empty(&self) {
+    fn Empty(&self, no_gc: &NoGC) {
         // > The method must be an alias, and behave identically, to removeAllRanges().
-        self.RemoveAllRanges();
+        self.RemoveAllRanges(no_gc);
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-collapse>
-    fn Collapse(&self, _cx: &mut JSContext, node: Option<&Node>, offset: u32) -> ErrorResult {
+    fn Collapse(&self, cx: &mut JSContext, node: Option<&Node>, offset: u32) -> ErrorResult {
         // Step 1. If node is null, this method must behave identically as
         // removeAllRanges() and abort these steps.
         let Some(node) = node else {
-            self.set_range(None);
+            self.set_range(cx.no_gc(), None);
             return Ok(());
         };
 
@@ -1019,9 +1021,12 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // Step 5. Otherwise, let newRange be a new range.
         // Step 6. Set the start the start and the end of newRange to (node, offset).
         // Step 7. Set this's range to newRange.
-        self.set_range(Some(SelectionRange::collapsed_at(SelectionBoundary::new(
-            node, offset,
-        ))));
+        self.set_range(
+            cx.no_gc(),
+            Some(SelectionRange::collapsed_at(SelectionBoundary::new(
+                node, offset,
+            ))),
+        );
 
         // Are we supposed to set Direction here? w3c/selection-api#116
         self.direction.set(Direction::Forwards);
@@ -1069,7 +1074,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-extend>
-    fn Extend(&self, _cx: &mut JSContext, node: &Node, offset: u32) -> ErrorResult {
+    fn Extend(&self, cx: &mut JSContext, node: &Node, offset: u32) -> ErrorResult {
         // Step 1. If the document associated with this is not a shadow-including
         // inclusive ancestor of node, abort these steps.
         //
@@ -1118,30 +1123,45 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         drop(range_borrow);
 
         if !is_in_document_of_range {
-            self.set_range(Some(SelectionRange::collapsed_at(SelectionBoundary::new(
-                node, offset,
-            ))));
+            self.set_range(
+                cx.no_gc(),
+                Some(SelectionRange::collapsed_at(SelectionBoundary::new(
+                    node, offset,
+                ))),
+            );
             direction = Direction::Forwards;
         } else {
             let is_old_anchor_before_or_equal = matches!(
-                bp_position(&old_anchor_node, old_anchor_offset, node, offset),
+                bp_position(
+                    cx.no_gc(),
+                    &old_anchor_node,
+                    old_anchor_offset,
+                    node,
+                    offset
+                ),
                 Ordering::Less | Ordering::Equal
             );
             if is_old_anchor_before_or_equal {
                 // Step 6. Otherwise, if oldAnchor is before or equal to newFocus, set the start
                 // newRange's start to oldAnchor, then set its end to newFocus.
-                self.set_range(Some(SelectionRange::new(
-                    SelectionBoundary::new(&old_anchor_node, old_anchor_offset),
-                    SelectionBoundary::new(node, offset),
-                )));
+                self.set_range(
+                    cx.no_gc(),
+                    Some(SelectionRange::new(
+                        SelectionBoundary::new(&old_anchor_node, old_anchor_offset),
+                        SelectionBoundary::new(node, offset),
+                    )),
+                );
                 direction = Direction::Forwards;
             } else {
                 // Step 7. Otherwise, set the start newRange's start to newFocus, then set
                 // its end to oldAnchor.
-                self.set_range(Some(SelectionRange::new(
-                    SelectionBoundary::new(node, offset),
-                    SelectionBoundary::new(&old_anchor_node, old_anchor_offset),
-                )));
+                self.set_range(
+                    cx.no_gc(),
+                    Some(SelectionRange::new(
+                        SelectionBoundary::new(node, offset),
+                        SelectionBoundary::new(&old_anchor_node, old_anchor_offset),
+                    )),
+                );
                 direction = Direction::Backwards;
             }
         }
@@ -1159,7 +1179,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     /// <https://w3c.github.io/selection-api/#dom-selection-setbaseandextent>
     fn SetBaseAndExtent(
         &self,
-        _cx: &mut JSContext,
+        cx: &mut JSContext,
         anchor_node: &Node,
         anchor_offset: u32,
         focus_node: &Node,
@@ -1206,19 +1226,30 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // Step 5. If anchor is before focus, set the start the newRange's start to anchor
         // and its end to focus. Otherwise, set the start them to focus and anchor
         // respectively.
-        let is_anchor_before_focus =
-            bp_position(anchor_node, anchor_offset, focus_node, focus_offset) == Ordering::Less;
+        let is_anchor_before_focus = bp_position(
+            cx.no_gc(),
+            anchor_node,
+            anchor_offset,
+            focus_node,
+            focus_offset,
+        ) == Ordering::Less;
         let direction = if is_anchor_before_focus {
-            self.set_range(Some(SelectionRange::new(
-                SelectionBoundary::new(anchor_node, anchor_offset),
-                SelectionBoundary::new(focus_node, focus_offset),
-            )));
+            self.set_range(
+                cx.no_gc(),
+                Some(SelectionRange::new(
+                    SelectionBoundary::new(anchor_node, anchor_offset),
+                    SelectionBoundary::new(focus_node, focus_offset),
+                )),
+            );
             Direction::Forwards
         } else {
-            self.set_range(Some(SelectionRange::new(
-                SelectionBoundary::new(focus_node, focus_offset),
-                SelectionBoundary::new(anchor_node, anchor_offset),
-            )));
+            self.set_range(
+                cx.no_gc(),
+                Some(SelectionRange::new(
+                    SelectionBoundary::new(focus_node, focus_offset),
+                    SelectionBoundary::new(anchor_node, anchor_offset),
+                )),
+            );
             Direction::Backwards
         };
 
@@ -1233,7 +1264,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-selectallchildren>
-    fn SelectAllChildren(&self, _cx: &mut JSContext, node: &Node) -> ErrorResult {
+    fn SelectAllChildren(&self, cx: &mut JSContext, node: &Node) -> ErrorResult {
         // Step 1. If node is a DocumentType, throw an InvalidNodeTypeError exception and
         // abort these steps.
         if node.is_doctype() {
@@ -1252,10 +1283,13 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // Step 4. Set newRange's start to (node, 0).
         // Step 5. Set newRange's end to (node, childCount).
         // Step 6. Set this's range to newRange.
-        self.set_range(Some(SelectionRange::new(
-            SelectionBoundary::new(node, 0),
-            SelectionBoundary::new(node, child_count),
-        )));
+        self.set_range(
+            cx.no_gc(),
+            Some(SelectionRange::new(
+                SelectionBoundary::new(node, 0),
+                SelectionBoundary::new(node, child_count),
+            )),
+        );
 
         // Step 7. Set this's direction to forwards.
         self.direction.set(Direction::Forwards);
@@ -1282,7 +1316,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-containsnode>
-    fn ContainsNode(&self, node: &Node, allow_partial_containment: bool) -> bool {
+    fn ContainsNode(&self, no_gc: &NoGC, node: &Node, allow_partial_containment: bool) -> bool {
         // > The method must return false if this is empty or if node's root is not the document
         // > associated with this.
         // >
@@ -1320,10 +1354,16 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // https://github.com/w3c/selection-api/issues/6
         // For now it is simplified to "position is equal".
         matches!(
-            bp_position(start_node, range.start.offset, node, compare_start_to),
+            bp_position(
+                no_gc,
+                start_node,
+                range.start.offset,
+                node,
+                compare_start_to
+            ),
             Ordering::Less | Ordering::Equal
         ) && matches!(
-            bp_position(end_node, range.end.offset, node, compare_end_to),
+            bp_position(no_gc, end_node, range.end.offset, node, compare_end_to),
             Ordering::Greater | Ordering::Equal
         )
     }

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -214,7 +214,12 @@ impl ShadowRoot {
     ///
     /// <https://drafts.csswg.org/cssom/#documentorshadowroot-final-css-style-sheets>
     #[cfg_attr(crown, expect(crown::unrooted_must_root))] // Owner needs to be rooted already necessarily.
-    pub(crate) fn add_owned_stylesheet(&self, owner_node: &Element, sheet: Arc<Stylesheet>) {
+    pub(crate) fn add_owned_stylesheet(
+        &self,
+        no_gc: &NoGC,
+        owner_node: &Element,
+        sheet: Arc<Stylesheet>,
+    ) {
         let stylesheets = &mut self.author_styles.borrow_mut().stylesheets;
 
         // FIXME(stevennovaryo): This is almost identical with the one in Document::add_stylesheet.
@@ -222,9 +227,9 @@ impl ShadowRoot {
             .iter()
             .find(|sheet_in_shadow| {
                 match &sheet_in_shadow.owner {
-                    StylesheetSource::Element(other_node) => {
-                        owner_node.upcast::<Node>().is_before(other_node.upcast())
-                    },
+                    StylesheetSource::Element(other_node) => owner_node
+                        .upcast::<Node>()
+                        .is_before(no_gc, other_node.upcast()),
                     // Non-constructed stylesheet should be ordered before the
                     // constructed ones.
                     StylesheetSource::Constructed(_) => true,

--- a/components/script/dom/xpath/xpathexpression.rs
+++ b/components/script/dom/xpath/xpathexpression.rs
@@ -87,8 +87,8 @@ impl XPathExpression {
         // Cast the result to the type we wanted
         let result_value: Value = match result_type {
             XPathResultType::Boolean => result_value.convert_to_boolean().into(),
-            XPathResultType::Number => result_value.convert_to_number().into(),
-            XPathResultType::String => result_value.convert_to_string().into(),
+            XPathResultType::Number => result_value.convert_to_number(cx).into(),
+            XPathResultType::String => result_value.convert_to_string(cx).into(),
             _ => result_value,
         };
 

--- a/components/script/xpath.rs
+++ b/components/script/xpath.rs
@@ -90,10 +90,10 @@ impl xpath::Node for XPathWrapper<DomRoot<Node>> {
         self.0.children().map(XPathWrapper)
     }
 
-    fn compare_tree_order(&self, other: &Self) -> Ordering {
+    fn compare_tree_order(&self, cx: &mut JSContext, other: &Self) -> Ordering {
         if self == other {
             Ordering::Equal
-        } else if self.0.is_before(&other.0) {
+        } else if self.0.is_before(cx.no_gc(), &other.0) {
             Ordering::Less
         } else {
             Ordering::Greater

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -946,7 +946,8 @@ DOMInterfaces = {
 },
 
 'Node': {
-    'cx': ['AppendChild', 'ChildNodes', 'CloneNode', 'InsertBefore', 'Normalize', 'RemoveChild', 'ReplaceChild', 'SetNodeValue', 'SetTextContent']
+    'cx': ['AppendChild', 'ChildNodes', 'CloneNode', 'InsertBefore', 'Normalize', 'RemoveChild', 'ReplaceChild', 'SetNodeValue', 'SetTextContent'],
+    'no_gc': ['CompareDocumentPosition'],
 },
 
 'NodeIterator': {
@@ -1026,7 +1027,19 @@ DOMInterfaces = {
 'Range': {
     'weakReferenceable': True,
     'cx': ['CloneContents', 'CloneRange', 'CreateContextualFragment', 'DeleteContents', 'ExtractContents', 'GetBoundingClientRect', 'GetClientRects', 'InsertNode', 'SurroundContents'],
-    'no_gc': ['Stringifier'],
+    'no_gc': [
+         'CompareBoundaryPoints',
+        'ComparePoint',
+        'IntersectsNode',
+        'IsPointInRange',
+        'SetEnd',
+        'SetEndAfter',
+        'SetEndBefore',
+        'SetStart',
+        'SetStartAfter',
+        'SetStartBefore',
+        'Stringifier'
+    ],
 },
 
 'Request': {
@@ -1068,6 +1081,13 @@ DOMInterfaces = {
         'SetBaseAndExtent',
         'SetPosition',
         'Stringifier'
+    ],
+    'no_gc': [
+        'AddRange',
+        'ContainsNode',
+        'Empty',
+        'RemoveAllRanges',
+        'RemoveRange'
     ],
 },
 

--- a/components/script_bindings/dom.rs
+++ b/components/script_bindings/dom.rs
@@ -129,6 +129,17 @@ impl<'a, T: DomObject> UnrootedDom<'a, T> {
             _phantom: PhantomData,
         }
     }
+
+    /// Construct an [`UnrootedDom`] with the lifetime of the given [`NoGC`] token. It is
+    /// safe to keep the returned value on the stack as it cannot outlive the lifetime of
+    /// the token and the token should ensure that no garbage collection will take place
+    /// as long as it is alive.
+    pub fn from_ref(object: &T, _no_gc: &'a NoGC) -> UnrootedDom<'a, T> {
+        UnrootedDom {
+            inner: Dom::from_ref(object),
+            _phantom: PhantomData,
+        }
+    }
 }
 
 impl<'a, T: DomObject> Deref for UnrootedDom<'a, T> {

--- a/components/xpath/src/eval.rs
+++ b/components/xpath/src/eval.rs
@@ -46,35 +46,35 @@ impl Expression {
                 let right_value = right.evaluate(cx, context)?;
 
                 let value = match binary_operator {
-                    BinaryOperator::Equal => (left_value == right_value).into(),
-                    BinaryOperator::NotEqual => (left_value != right_value).into(),
-                    BinaryOperator::LessThan => {
-                        (left_value.convert_to_number() < right_value.convert_to_number()).into()
-                    },
-                    BinaryOperator::GreaterThan => {
-                        (left_value.convert_to_number() > right_value.convert_to_number()).into()
-                    },
-                    BinaryOperator::LessThanOrEqual => {
-                        (left_value.convert_to_number() <= right_value.convert_to_number()).into()
-                    },
-                    BinaryOperator::GreaterThanOrEqual => {
-                        (left_value.convert_to_number() >= right_value.convert_to_number()).into()
-                    },
-                    BinaryOperator::Add => {
-                        (left_value.convert_to_number() + right_value.convert_to_number()).into()
-                    },
-                    BinaryOperator::Subtract => {
-                        (left_value.convert_to_number() - right_value.convert_to_number()).into()
-                    },
-                    BinaryOperator::Multiply => {
-                        (left_value.convert_to_number() * right_value.convert_to_number()).into()
-                    },
-                    BinaryOperator::Divide => {
-                        (left_value.convert_to_number() / right_value.convert_to_number()).into()
-                    },
-                    BinaryOperator::Modulo => {
-                        (left_value.convert_to_number() % right_value.convert_to_number()).into()
-                    },
+                    BinaryOperator::Equal => (left_value.partial_eq(cx, &right_value)).into(),
+                    BinaryOperator::NotEqual => (!left_value.partial_eq(cx, &right_value)).into(),
+                    BinaryOperator::LessThan => (left_value.convert_to_number(cx) <
+                        right_value.convert_to_number(cx))
+                    .into(),
+                    BinaryOperator::GreaterThan => (left_value.convert_to_number(cx) >
+                        right_value.convert_to_number(cx))
+                    .into(),
+                    BinaryOperator::LessThanOrEqual => (left_value.convert_to_number(cx) <=
+                        right_value.convert_to_number(cx))
+                    .into(),
+                    BinaryOperator::GreaterThanOrEqual => (left_value.convert_to_number(cx) >=
+                        right_value.convert_to_number(cx))
+                    .into(),
+                    BinaryOperator::Add => (left_value.convert_to_number(cx) +
+                        right_value.convert_to_number(cx))
+                    .into(),
+                    BinaryOperator::Subtract => (left_value.convert_to_number(cx) -
+                        right_value.convert_to_number(cx))
+                    .into(),
+                    BinaryOperator::Multiply => (left_value.convert_to_number(cx) *
+                        right_value.convert_to_number(cx))
+                    .into(),
+                    BinaryOperator::Divide => (left_value.convert_to_number(cx) /
+                        right_value.convert_to_number(cx))
+                    .into(),
+                    BinaryOperator::Modulo => (left_value.convert_to_number(cx) %
+                        right_value.convert_to_number(cx))
+                    .into(),
                     BinaryOperator::Union => {
                         let as_nodes = |cx: &mut D::Context, e: &Expression| {
                             e.evaluate(cx, context).and_then(try_extract_nodeset)
@@ -83,7 +83,7 @@ impl Expression {
                         let right_nodes = as_nodes(cx, right)?;
 
                         left_nodes.extend(right_nodes);
-                        left_nodes.sort();
+                        left_nodes.sort(cx);
                         Value::NodeSet(left_nodes)
                     },
                     _ => unreachable!("And/Or were handled above"),
@@ -92,7 +92,7 @@ impl Expression {
                 Ok(value)
             },
             Expression::Negate(expr) => {
-                let value = -expr.evaluate(cx, context)?.convert_to_number();
+                let value = -expr.evaluate(cx, context)?.convert_to_number(cx);
                 Ok(value.into())
             },
             Expression::Path(path_expr) => path_expr.evaluate(cx, context),
@@ -134,7 +134,7 @@ impl PathExpression {
         } else {
             current_nodes.push(starting_node);
         }
-        current_nodes.assume_sorted();
+        current_nodes.assume_sorted(cx);
 
         let have_multiple_steps = self.steps.len() > 1;
 
@@ -315,11 +315,11 @@ impl LocationStepExpression {
                 Axis::DescendantOrSelf
         ) {
             // The elements on these axis values are already in tree order
-            filtered_nodes.assume_sorted();
+            filtered_nodes.assume_sorted(cx);
         } else {
             // The elements on these axis values are in inverse tree order
             filtered_nodes.reverse();
-            filtered_nodes.assume_sorted();
+            filtered_nodes.assume_sorted(cx);
         };
 
         Ok(Value::NodeSet(filtered_nodes))

--- a/components/xpath/src/functions.rs
+++ b/components/xpath/src/functions.rs
@@ -149,14 +149,14 @@ impl CoreFunction {
             },
             CoreFunction::String(expr_opt) => match expr_opt {
                 Some(expr) => Ok(Value::String(
-                    expr.evaluate(cx, context)?.convert_to_string(),
+                    expr.evaluate(cx, context)?.convert_to_string(cx),
                 )),
                 None => Ok(Value::String(context.context_node.text_content())),
             },
             CoreFunction::Concat(exprs) => {
                 let strings: Result<Vec<_>, _> = exprs
                     .iter()
-                    .map(|e| Ok(e.evaluate(cx, context)?.convert_to_string()))
+                    .map(|e| Ok(e.evaluate(cx, context)?.convert_to_string(cx)))
                     .collect();
                 Ok(Value::String(strings?.join("")))
             },
@@ -183,10 +183,11 @@ impl CoreFunction {
                         extend_result_with_matching_nodes(cx, &node.text_content())
                     }
                 } else {
-                    extend_result_with_matching_nodes(cx, &argument.convert_to_string())
+                    let conversion_to_string = argument.convert_to_string(cx);
+                    extend_result_with_matching_nodes(cx, &conversion_to_string)
                 }
 
-                result.sort();
+                result.sort(cx);
                 Ok(Value::NodeSet(result))
             },
             CoreFunction::LocalName(expr_opt) => {
@@ -194,7 +195,7 @@ impl CoreFunction {
                     Some(expr) => expr
                         .evaluate(cx, context)
                         .and_then(try_extract_nodeset)?
-                        .first(),
+                        .first(cx),
                     None => Some(context.context_node.clone()),
                 };
                 let name = node.and_then(|n| local_name(&n)).unwrap_or_default();
@@ -205,7 +206,7 @@ impl CoreFunction {
                     Some(expr) => expr
                         .evaluate(cx, context)
                         .and_then(try_extract_nodeset)?
-                        .first(),
+                        .first(cx),
                     None => Some(context.context_node.clone()),
                 };
                 let ns = node.and_then(|n| namespace_uri(&n)).unwrap_or_default();
@@ -216,40 +217,42 @@ impl CoreFunction {
                     Some(expr) => expr
                         .evaluate(cx, context)
                         .and_then(try_extract_nodeset)?
-                        .first(),
+                        .first(cx),
                     None => Some(context.context_node.clone()),
                 };
                 let name = node.and_then(|n| name(&n)).unwrap_or_default();
                 Ok(Value::String(name))
             },
             CoreFunction::StartsWith(str1, str2) => {
-                let s1 = str1.evaluate(cx, context)?.convert_to_string();
-                let s2 = str2.evaluate(cx, context)?.convert_to_string();
+                let s1 = str1.evaluate(cx, context)?.convert_to_string(cx);
+                let s2 = str2.evaluate(cx, context)?.convert_to_string(cx);
                 Ok(Value::Boolean(s1.starts_with(&s2)))
             },
             CoreFunction::Contains(str1, str2) => {
-                let s1 = str1.evaluate(cx, context)?.convert_to_string();
-                let s2 = str2.evaluate(cx, context)?.convert_to_string();
+                let s1 = str1.evaluate(cx, context)?.convert_to_string(cx);
+                let s2 = str2.evaluate(cx, context)?.convert_to_string(cx);
                 Ok(Value::Boolean(s1.contains(&s2)))
             },
             CoreFunction::SubstringBefore(str1, str2) => {
-                let s1 = str1.evaluate(cx, context)?.convert_to_string();
-                let s2 = str2.evaluate(cx, context)?.convert_to_string();
+                let s1 = str1.evaluate(cx, context)?.convert_to_string(cx);
+                let s2 = str2.evaluate(cx, context)?.convert_to_string(cx);
                 Ok(Value::String(substring_before(&s1, &s2)))
             },
             CoreFunction::SubstringAfter(str1, str2) => {
-                let s1 = str1.evaluate(cx, context)?.convert_to_string();
-                let s2 = str2.evaluate(cx, context)?.convert_to_string();
+                let s1 = str1.evaluate(cx, context)?.convert_to_string(cx);
+                let s2 = str2.evaluate(cx, context)?.convert_to_string(cx);
                 Ok(Value::String(substring_after(&s1, &s2)))
             },
             CoreFunction::Substring(source_expression, start, length) => {
-                let source = source_expression.evaluate(cx, context)?.convert_to_string();
+                let source = source_expression
+                    .evaluate(cx, context)?
+                    .convert_to_string(cx);
                 let start_idx =
-                    start.evaluate(cx, context)?.convert_to_number().round() as isize - 1;
+                    start.evaluate(cx, context)?.convert_to_number(cx).round() as isize - 1;
                 let result = if let Some(length_expression) = length {
                     let length = length_expression
                         .evaluate(cx, context)?
-                        .convert_to_number()
+                        .convert_to_number(cx)
                         .round() as isize;
                     substring(&source, start_idx, Some(length))
                 } else {
@@ -259,23 +262,23 @@ impl CoreFunction {
             },
             CoreFunction::StringLength(expr_opt) => {
                 let string = match expr_opt {
-                    Some(expr) => expr.evaluate(cx, context)?.convert_to_string(),
+                    Some(expr) => expr.evaluate(cx, context)?.convert_to_string(cx),
                     None => context.context_node.text_content(),
                 };
                 Ok(Value::Number(string.chars().count() as f64))
             },
             CoreFunction::NormalizeSpace(expr_opt) => {
                 let string = match expr_opt {
-                    Some(expr) => expr.evaluate(cx, context)?.convert_to_string(),
+                    Some(expr) => expr.evaluate(cx, context)?.convert_to_string(cx),
                     None => context.context_node.text_content(),
                 };
 
                 Ok(Value::String(normalize_space(&string)))
             },
             CoreFunction::Translate(str1, str2, str3) => {
-                let string = str1.evaluate(cx, context)?.convert_to_string();
-                let from = str2.evaluate(cx, context)?.convert_to_string();
-                let to = str3.evaluate(cx, context)?.convert_to_string();
+                let string = str1.evaluate(cx, context)?.convert_to_string(cx);
+                let from = str2.evaluate(cx, context)?.convert_to_string(cx);
+                let to = str3.evaluate(cx, context)?.convert_to_string(cx);
                 Ok(Value::String(translate(&string, &from, &to)))
             },
             CoreFunction::Number(expr_opt) => {
@@ -283,7 +286,7 @@ impl CoreFunction {
                     Some(expr) => expr.evaluate(cx, context)?,
                     None => Value::String(context.context_node.text_content()),
                 };
-                Ok(Value::Number(val.convert_to_number()))
+                Ok(Value::Number(val.convert_to_number(cx)))
             },
             CoreFunction::Sum(expr) => {
                 let nodes = expr.evaluate(cx, context).and_then(try_extract_nodeset)?;
@@ -294,15 +297,15 @@ impl CoreFunction {
                 Ok(Value::Number(sum))
             },
             CoreFunction::Floor(expr) => {
-                let num = expr.evaluate(cx, context)?.convert_to_number();
+                let num = expr.evaluate(cx, context)?.convert_to_number(cx);
                 Ok(Value::Number(num.floor()))
             },
             CoreFunction::Ceiling(expr) => {
-                let num = expr.evaluate(cx, context)?.convert_to_number();
+                let num = expr.evaluate(cx, context)?.convert_to_number(cx);
                 Ok(Value::Number(num.ceil()))
             },
             CoreFunction::Round(expr) => {
-                let num = expr.evaluate(cx, context)?.convert_to_number();
+                let num = expr.evaluate(cx, context)?.convert_to_number(cx);
                 Ok(Value::Number(num.round()))
             },
             CoreFunction::Boolean(expr) => Ok(Value::Boolean(
@@ -315,7 +318,7 @@ impl CoreFunction {
             CoreFunction::False => Ok(Value::Boolean(false)),
             CoreFunction::Lang(expr) => {
                 let context_lang = context.context_node.language();
-                let lang = expr.evaluate(cx, context)?.convert_to_string();
+                let lang = expr.evaluate(cx, context)?.convert_to_string(cx);
                 Ok(Value::Boolean(lang_matches(context_lang.as_deref(), &lang)))
             },
         }

--- a/components/xpath/src/lib.rs
+++ b/components/xpath/src/lib.rs
@@ -28,7 +28,7 @@ pub trait Dom {
 }
 
 /// A handle to a DOM node exposing all functionality needed by xpath.
-pub trait Node: Eq + Clone + fmt::Debug {
+pub trait Node: Clone + fmt::Debug {
     type Context;
 
     type ProcessingInstruction: ProcessingInstruction;
@@ -46,7 +46,7 @@ pub trait Node: Eq + Clone + fmt::Debug {
     fn parent(&self) -> Option<Self>;
     fn children(&self) -> impl Iterator<Item = Self>;
     /// <https://dom.spec.whatwg.org/#concept-tree-order>
-    fn compare_tree_order(&self, other: &Self) -> std::cmp::Ordering;
+    fn compare_tree_order(&self, cx: &mut Self::Context, other: &Self) -> std::cmp::Ordering;
     /// A non-shadow-including preorder traversal.
     fn traverse_preorder(&self) -> impl Iterator<Item = Self>;
     fn inclusive_ancestors(&self) -> impl Iterator<Item = Self>;
@@ -127,7 +127,7 @@ pub fn evaluate_parsed_xpath<D: Dom>(
         Ok(mut value) => {
             if let Value::NodeSet(node_set) = &mut value {
                 node_set.deduplicate();
-                node_set.sort();
+                node_set.sort(cx);
             }
 
             log::debug!("Evaluated XPath: {value:?}");
@@ -232,7 +232,7 @@ mod dummy_implementation {
         fn children(&self) -> impl Iterator<Item = Self> {
             iter::empty()
         }
-        fn compare_tree_order(&self, _: &Self) -> cmp::Ordering {
+        fn compare_tree_order(&self, _: &mut Self::Context, _: &Self) -> cmp::Ordering {
             cmp::Ordering::Greater
         }
         fn traverse_preorder(&self) -> impl Iterator<Item = Self> {

--- a/components/xpath/src/value.rs
+++ b/components/xpath/src/value.rs
@@ -63,22 +63,23 @@ impl<N: Node> NodeSet<N> {
     }
 
     /// Assume that this set is sorted, without actually sorting it.
-    pub(crate) fn assume_sorted(&mut self) {
+    pub(crate) fn assume_sorted(&mut self, cx: &mut N::Context) {
         debug_assert!(
             self.nodes
-                .is_sorted_by(|a, b| a.compare_tree_order(b).is_le())
+                .is_sorted_by(|a, b| a.compare_tree_order(cx, b).is_le())
         );
         self.is_sorted = true;
     }
 
-    pub(crate) fn sort(&mut self) {
+    pub(crate) fn sort(&mut self, cx: &mut N::Context) {
         if self.is_sorted() {
             return;
         }
 
         // Using sort_unstable_by here is fine because duplicates won't appear in the final
         // result anyways.
-        self.nodes.sort_unstable_by(|a, b| a.compare_tree_order(b));
+        self.nodes
+            .sort_unstable_by(|a, b| a.compare_tree_order(cx, b));
     }
 
     pub(crate) fn iter(&self) -> impl Iterator<Item = &N> {
@@ -88,12 +89,14 @@ impl<N: Node> NodeSet<N> {
     /// Return the first node in tree order that appears within this set.
     ///
     /// This method will not sort the set itself.
-    pub(crate) fn first(&self) -> Option<N> {
+    pub(crate) fn first(&self, cx: &mut N::Context) -> Option<N> {
         if self.is_sorted() {
             return self.nodes.first().cloned();
         }
 
-        self.iter().min_by(|a, b| a.compare_tree_order(b)).cloned()
+        self.iter()
+            .min_by(|a, b| a.compare_tree_order(cx, b))
+            .cloned()
     }
 
     pub(crate) fn deduplicate(&mut self) {
@@ -162,8 +165,8 @@ fn num_vals<N: Node>(nodes: &NodeSet<N>) -> Vec<f64> {
         .collect()
 }
 
-impl<N: Node> PartialEq<Value<N>> for Value<N> {
-    fn eq(&self, other: &Value<N>) -> bool {
+impl<N: Node> Value<N> {
+    pub(crate) fn partial_eq(&self, cx: &mut N::Context, other: &Self) -> bool {
         match (self, other) {
             (Value::NodeSet(left_nodes), Value::NodeSet(right_nodes)) => {
                 let left_strings: HashSet<String> =
@@ -186,14 +189,12 @@ impl<N: Node> PartialEq<Value<N>> for Value<N> {
                 self.convert_to_boolean() == other.convert_to_boolean()
             },
             (&Value::Number(_), _) | (_, &Value::Number(_)) => {
-                self.convert_to_number() == other.convert_to_number()
+                self.convert_to_number(cx) == other.convert_to_number(cx)
             },
-            _ => self.convert_to_string() == other.convert_to_string(),
+            _ => self.convert_to_string(cx) == other.convert_to_string(cx),
         }
     }
-}
 
-impl<N: Node> Value<N> {
     /// <https://www.w3.org/TR/1999/REC-xpath-19991116/#function-boolean>
     pub fn convert_to_boolean(&self) -> bool {
         match self {
@@ -205,7 +206,7 @@ impl<N: Node> Value<N> {
     }
 
     /// <https://www.w3.org/TR/1999/REC-xpath-19991116/#function-number>
-    pub fn convert_to_number(&self) -> f64 {
+    pub fn convert_to_number(&self, cx: &mut N::Context) -> f64 {
         match self {
             Value::Boolean(boolean) => {
                 if *boolean {
@@ -216,12 +217,12 @@ impl<N: Node> Value<N> {
             },
             Value::Number(number) => *number,
             Value::String(string) => parse_number_from_string(string),
-            Value::NodeSet(_) => parse_number_from_string(&self.convert_to_string()),
+            Value::NodeSet(_) => parse_number_from_string(&self.convert_to_string(cx)),
         }
     }
 
     /// <https://www.w3.org/TR/1999/REC-xpath-19991116/#function-string>
-    pub fn convert_to_string(&self) -> String {
+    pub fn convert_to_string(&self, cx: &mut N::Context) -> String {
         match self {
             Value::Boolean(value) => value.to_string(),
             Value::Number(number) => {
@@ -240,7 +241,7 @@ impl<N: Node> Value<N> {
             },
             Value::String(string) => string.to_owned(),
             Value::NodeSet(nodes) => nodes
-                .first()
+                .first(cx)
                 .as_ref()
                 .map(Node::text_content)
                 .unwrap_or_default(),
@@ -304,41 +305,47 @@ mod tests {
 
     #[test]
     fn string_value_to_number() {
-        assert_eq!(Value::String("42.123".into()).convert_to_number(), 42.123);
-        assert_eq!(Value::String(" 42\n".into()).convert_to_number(), 42.);
+        let cx = &mut ();
+        assert_eq!(Value::String("42.123".into()).convert_to_number(cx), 42.123);
+        assert_eq!(Value::String(" 42\n".into()).convert_to_number(cx), 42.);
         assert!(
             Value::String("totally-invalid".into())
-                .convert_to_number()
+                .convert_to_number(cx)
                 .is_nan()
         );
 
         // U+2004 is non-ascii whitespace, which should be rejected
         assert!(
             Value::String("\u{2004}42".into())
-                .convert_to_number()
+                .convert_to_number(cx)
                 .is_nan()
         );
     }
 
     #[test]
     fn number_value_to_string() {
-        assert_eq!(Value::Number(f64::NAN).convert_to_string(), "NaN");
-        assert_eq!(Value::Number(0.).convert_to_string(), "0");
-        assert_eq!(Value::Number(-0.).convert_to_string(), "0");
-        assert_eq!(Value::Number(f64::INFINITY).convert_to_string(), "Infinity");
+        let cx = &mut ();
+        assert_eq!(Value::Number(f64::NAN).convert_to_string(cx), "NaN");
+        assert_eq!(Value::Number(0.).convert_to_string(cx), "0");
+        assert_eq!(Value::Number(-0.).convert_to_string(cx), "0");
         assert_eq!(
-            Value::Number(f64::NEG_INFINITY).convert_to_string(),
+            Value::Number(f64::INFINITY).convert_to_string(cx),
+            "Infinity"
+        );
+        assert_eq!(
+            Value::Number(f64::NEG_INFINITY).convert_to_string(cx),
             "-Infinity"
         );
-        assert_eq!(Value::Number(42.0).convert_to_string(), "42");
-        assert_eq!(Value::Number(-42.0).convert_to_string(), "-42");
-        assert_eq!(Value::Number(0.75).convert_to_string(), "0.75");
-        assert_eq!(Value::Number(-0.75).convert_to_string(), "-0.75");
+        assert_eq!(Value::Number(42.0).convert_to_string(cx), "42");
+        assert_eq!(Value::Number(-42.0).convert_to_string(cx), "-42");
+        assert_eq!(Value::Number(0.75).convert_to_string(cx), "0.75");
+        assert_eq!(Value::Number(-0.75).convert_to_string(cx), "-0.75");
     }
 
     #[test]
     fn boolean_value_to_string() {
-        assert_eq!(Value::Boolean(false).convert_to_string(), "false");
-        assert_eq!(Value::Boolean(true).convert_to_string(), "true");
+        let cx = &mut ();
+        assert_eq!(Value::Boolean(false).convert_to_string(cx), "false");
+        assert_eq!(Value::Boolean(true).convert_to_string(cx), "true");
     }
 }


### PR DESCRIPTION
This change reworks the DOM position comparison function to be generic
over a `NoGcTraversal` trait. The ultimate goal here is to allow this
function to work in both the light dom and the flat tree (for
selections). In addition, to allowing a flat tree implementation, this
switches to `NoGC` approach which should dramatically decrease the
amount of rooting that happens during these comparisons.

The downside is that this required threading `NoGC` and `JSContext`
through a large number of methods and functions.

One small behavior change from this PR is that null nodes now have a
different abitrary order than non-null nodes (they now sort first).

Testing: This should not change observable behavior so should be covered by existing tests.
