### PR TITLE
script: Add error messages for `css`

### DIFF
--- a/components/script/dom/css/css.rs
+++ b/components/script/dom/css/css.rs
@@ -95,8 +95,12 @@ impl CSSMethods<crate::DomTypeHolder> for CSS {
             InvalidSyntax |
             InvalidInitialValue |
             NoInitialValue |
-            InitialValueNotComputationallyIndependent => Error::Syntax(None),
-            AlreadyRegistered => Error::InvalidModification(None),
+            InitialValueNotComputationallyIndependent => Error::Syntax(Some(
+                "CSS property value is not computationally independent".into(),
+            )),
+            AlreadyRegistered => {
+                Error::InvalidModification(Some("CSS property is already registered".into()))
+            },
         })
     }
 }

--- a/components/script/dom/css/cssrulelist.rs
+++ b/components/script/dom/css/cssrulelist.rs
@@ -36,10 +36,14 @@ unsafe_no_jsmanaged_fields!(RulesSource);
 impl Convert<Error> for RulesMutateError {
     fn convert(self) -> Error {
         match self {
-            RulesMutateError::Syntax => Error::Syntax(None),
-            RulesMutateError::IndexSize => Error::IndexSize(None),
-            RulesMutateError::HierarchyRequest => Error::HierarchyRequest(None),
-            RulesMutateError::InvalidState => Error::InvalidState(None),
+            RulesMutateError::Syntax => Error::Syntax(Some("Invalid CSS syntax".into())),
+            RulesMutateError::IndexSize => Error::IndexSize(Some("Index is out of bounds".into())),
+            RulesMutateError::HierarchyRequest => Error::HierarchyRequest(Some(
+                "This request would result in an incorrect node tree".into(),
+            )),
+            RulesMutateError::InvalidState => {
+                Error::InvalidState(Some("CSS rule is invalid".into()))
+            },
         }
     }
 }

--- a/components/script/dom/css/cssstyledeclaration.rs
+++ b/components/script/dom/css/cssstyledeclaration.rs
@@ -344,7 +344,9 @@ impl CSSStyleDeclaration {
     ) -> ErrorResult {
         // Step 1. If the readonly flag is set, then throw a NoModificationAllowedError exception.
         if self.readonly {
-            return Err(Error::NoModificationAllowed(None));
+            return Err(Error::NoModificationAllowed(Some(
+                "This CSS style declaration is read-only".into(),
+            )));
         }
 
         let id = match id {
@@ -535,7 +537,9 @@ impl CSSStyleDeclarationMethods<crate::DomTypeHolder> for CSSStyleDeclaration {
     fn RemoveProperty(&self, cx: &mut JSContext, property: DOMString) -> Fallible<DOMString> {
         // Step 1
         if self.readonly {
-            return Err(Error::NoModificationAllowed(None));
+            return Err(Error::NoModificationAllowed(Some(
+                "This CSS style declaration is read-only".into(),
+            )));
         }
 
         let id = match PropertyId::parse_enabled_for_all_content(&property.str()) {
@@ -602,7 +606,9 @@ impl CSSStyleDeclarationMethods<crate::DomTypeHolder> for CSSStyleDeclaration {
     fn SetCssText(&self, cx: &mut JSContext, value: DOMString) -> ErrorResult {
         // Step 1. If the readonly flag is set, then throw a NoModificationAllowedError exception.
         if self.readonly {
-            return Err(Error::NoModificationAllowed(None));
+            return Err(Error::NoModificationAllowed(Some(
+                "This CSS style declaration is read-only".into(),
+            )));
         }
 
         let window = self.owner.window();

--- a/components/script/dom/css/fontface.rs
+++ b/components/script/dom/css/fontface.rs
@@ -159,7 +159,9 @@ fn parse_font_face_descriptors(
     if error_reporter.not_encountered_error.get() {
         Ok(parsed_font_face_rule)
     } else {
-        Err(Error::Syntax(None))
+        Err(Error::Syntax(Some(
+            "Failed to parse `@font-face` descriptors".into(),
+        )))
     }
 }
 
@@ -206,7 +208,8 @@ impl FontFace {
         let font_status_promise = Promise::new(cx, global);
         // If any of them fail to parse correctly, reject font face’s [[FontStatusPromise]] with a
         // DOMException named "SyntaxError"
-        font_status_promise.reject_error(cx, Error::Syntax(None));
+        font_status_promise
+            .reject_error(cx, Error::Syntax(Some("Failed to parse font face".into())));
 
         // set font face’s corresponding attributes to the empty string, and set font face’s status
         // attribute to "error"
@@ -416,7 +419,7 @@ impl FontFace {
             // Step 2. Otherwise, reject font face’s [[FontStatusPromise]] with a DOMException named "SyntaxError"
             // and set font face’s status attribute to "error".
             self.font_status_promise
-                .reject_error(cx, Error::Syntax(None));
+                .reject_error(cx, Error::Syntax(Some("Failed to parse font data".into())));
             self.status.set(FontFaceLoadStatus::Error);
 
             // For each FontFaceSet font face is in:
@@ -647,7 +650,7 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
                             // [[FontStatusPromise]] with a DOMException whose name is "NetworkError"
                             // and set font face’s status attribute to "error".
                             font_face.status.set(FontFaceLoadStatus::Error);
-                            font_face.font_status_promise.reject_error(cx, Error::Network(None));
+                            font_face.font_status_promise.reject_error(cx, Error::Network(Some("Failed to load font data".into())));
                         }
                         Some(template) => {
                             // Step 5.2. Otherwise, font face now represents the loaded font;

--- a/python/tidy/error_message_exceptions.txt
+++ b/python/tidy/error_message_exceptions.txt
@@ -38,10 +38,6 @@
 ./components/script/dom/cookiestore/cookiestore.rs 8
 ./components/script/dom/credentialmanagement/credentialscontainer.rs 8
 ./components/script/dom/credentialmanagement/passwordcredential.rs 1
-./components/script/dom/css/css.rs 2
-./components/script/dom/css/cssrulelist.rs 4
-./components/script/dom/css/cssstyledeclaration.rs 3
-./components/script/dom/css/fontface.rs 4
 ./components/script/dom/datatransfer/datatransferitemlist.rs 1
 ./components/script/dom/document/document.rs 28
 ./components/script/dom/document/documentorshadowroot.rs 1


### PR DESCRIPTION
This clears up the remaining `None`s in the `css` crate.

Testing: Not necessary
Fixes: Part of #40756
