### PR TITLE
fonts: Allow to take FontData if it is already a vec

### DIFF
--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -1349,7 +1349,7 @@ impl RemoteWebFontDownloader {
         );
 
         let font_data = match fontsan::process(&font_data) {
-            Ok(bytes) => FontData::from_bytes(&bytes),
+            Ok(bytes) => FontData::from_vec(bytes),
             Err(error) => {
                 debug!(
                     "Sanitiser rejected web font url={:?} with {error:?}",

--- a/components/shared/fonts/lib.rs
+++ b/components/shared/fonts/lib.rs
@@ -43,6 +43,11 @@ impl FontData {
         Self(Arc::new(GenericSharedMemory::from_bytes(bytes)))
     }
 
+    /// This is in single process mode more efficient because we do not have to copy the vector.
+    pub fn from_vec(bytes: Vec<u8>) -> Self {
+        Self(Arc::new(GenericSharedMemory::from_vec(bytes)))
+    }
+
     pub fn as_ipc_shared_memory(&self) -> Arc<GenericSharedMemory> {
         self.0.clone()
     }


### PR DESCRIPTION
Similarly to GenericSharedMemory::from_vec we expose a similar method on FontData and use it in `process_download_font_and_signal_completion` to be slightly more efficient, saving us an allocation of ~600Kb in a run of thomann.de

Testing: GenericSharedMemory::from_vec is already tested and the method just forwards the data, so no extra tests are needed.
