### PR TITLE
fetch: Detect forbidden request/response headers more efficiently

### DIFF
--- a/components/script/dom/fetch/headers.rs
+++ b/components/script/dom/fetch/headers.rs
@@ -432,9 +432,10 @@ pub(crate) fn is_forbidden_request_header(name: &str, value: &[u8]) -> bool {
 
     // Step 1: If name is a byte-case-insensitive match for one of (forbidden_header_names), return
     // true
-    let lowercase_name = name.to_lowercase();
-
-    if forbidden_header_names.contains(&lowercase_name.as_str()) {
+    if forbidden_header_names
+        .into_iter()
+        .any(|header| name.eq_ignore_ascii_case(header))
+    {
         return true;
     }
 
@@ -442,8 +443,11 @@ pub(crate) fn is_forbidden_request_header(name: &str, value: &[u8]) -> bool {
 
     // Step 2: If name when byte-lowercased starts with `proxy-` or `sec-`, then return true.
     if forbidden_header_prefixes
-        .iter()
-        .any(|prefix| lowercase_name.starts_with(prefix))
+        .into_iter()
+        .any(|forbidden_prefix| {
+            name.get(..forbidden_prefix.len())
+                .is_some_and(|name_prefix| name_prefix.eq_ignore_ascii_case(forbidden_prefix))
+        })
     {
         return true;
     }
@@ -456,8 +460,8 @@ pub(crate) fn is_forbidden_request_header(name: &str, value: &[u8]) -> bool {
 
     // Step 3: If name is a byte-case-insensitive match for one of (potentially_forbidden_header_names)
     if potentially_forbidden_header_names
-        .iter()
-        .any(|header| *header == lowercase_name)
+        .into_iter()
+        .any(|header| name.eq_ignore_ascii_case(header))
     {
         // Step 3.1: Let parsedValues be the result of getting, decoding, and splitting value.
         let parsed_values = get_decode_and_split_header_value(value.to_vec());
@@ -476,8 +480,7 @@ pub(crate) fn is_forbidden_request_header(name: &str, value: &[u8]) -> bool {
 /// <https://fetch.spec.whatwg.org/#forbidden-response-header-name>
 fn is_forbidden_response_header(name: &str) -> bool {
     // A forbidden response-header name is a header name that is a byte-case-insensitive match for one of
-    let name = name.to_ascii_lowercase();
-    matches!(name.as_str(), "set-cookie" | "set-cookie2")
+    name.eq_ignore_ascii_case("set-cookie") || name.eq_ignore_ascii_case("set-cookie2")
 }
 
 fn validate_name(name: ByteString) -> Fallible<String> {


### PR DESCRIPTION
These are run for each header name for every new request/rsponse header construction.

Testing: No behaviour change.
Similar to #47285.