### PR TITLE
script: Return actual placeholder container element if it exists.

### DIFF
--- a/components/script/dom/html/form_controls/input_type/text_input_widget.rs
+++ b/components/script/dom/html/form_controls/input_type/text_input_widget.rs
@@ -151,7 +151,7 @@ impl TextInputWidgetShadowTree {
         element: &impl TextControlElement,
     ) -> Option<DomRoot<Element>> {
         if let Some(placeholder_container) = &*self.placeholder_container.borrow() {
-            return Some(placeholder_container.root_element());
+            return Some(placeholder_container.as_rooted());
         }
         // If there is no placeholder text and we haven't already created one then it is
         // not necessary to initialize a new placeholder container.

--- a/tests/wpt/tests/html/semantics/forms/the-input-element/placeholder-update-no-value-ref.html
+++ b/tests/wpt/tests/html/semantics/forms/the-input-element/placeholder-update-no-value-ref.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<input type=text placeholder=pass>

--- a/tests/wpt/tests/html/semantics/forms/the-input-element/placeholder-update-no-value.html
+++ b/tests/wpt/tests/html/semantics/forms/the-input-element/placeholder-update-no-value.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<link rel="help" href="https://github.com/servo/servo/issues/47616">
+<link rel="match" href="placeholder-update-no-value-ref.html">
+<body>
+<input id=input type=text placeholder=fail>
+<script>
+input.placeholder = "pass";
+</script>
+</body>
+</html>


### PR DESCRIPTION
init_placeholder_container_if_necessary is supposed to return the placeholder container if it exists. Instead, we returned the root element of the container if it exists, probably because of confusion around the word `root` when attempting to return a rooted element.

Testing: New reftest added.
Fixes: #47616
