### PR TITLE
Add scaling factor when shaping glyphs and use `linearHoriAdvance` to obtain advance of scalable glyph

### DIFF
--- a/components/fonts/lib.rs
+++ b/components/fonts/lib.rs
@@ -95,6 +95,12 @@ impl FallbackFontSelectionOptions {
     }
 }
 
+// According to https://harfbuzz.github.io/harfbuzz-hb-font.html#hb-font-set-scale,
+// Harfbuzz's `hb_position_t` is an integer type, so we need to multiply it by a scale factor to avoid losing precision.
+// For now, the scale factor is set to 32.0, which is a reasonable value that provides enough precision for most cases.
+// However, if the needs of the application change, this value may need to be adjusted accordingly.
+pub(crate) static GLYPH_SCALE_FACTOR: f64 = 32.0;
+
 pub(crate) fn float_to_fixed(before: usize, f: f64) -> i32 {
     ((1i32 << before) as f64 * f) as i32
 }

--- a/components/fonts/platform/freetype/font.rs
+++ b/components/fonts/platform/freetype/font.rs
@@ -8,9 +8,9 @@ use app_units::Au;
 use euclid::default::{Point2D, Rect, Size2D};
 use fonts_traits::{FontIdentifier, FontTemplateDescriptor, LocalFontIdentifier};
 use freetype_sys::{
-    FT_F26Dot6, FT_Get_Char_Index, FT_Get_Kerning, FT_GlyphSlot, FT_KERNING_DEFAULT,
-    FT_LOAD_DEFAULT, FT_LOAD_NO_HINTING, FT_Load_Glyph, FT_Size_Metrics, FT_SizeRec, FT_UInt,
-    FT_ULong, FT_Vector,
+    FT_F26Dot6, FT_Fixed, FT_Get_Char_Index, FT_Get_Kerning, FT_GlyphSlot, FT_IS_SCALABLE,
+    FT_KERNING_DEFAULT, FT_LOAD_DEFAULT, FT_LOAD_NO_HINTING, FT_Load_Glyph, FT_Size_Metrics,
+    FT_SizeRec, FT_UInt, FT_ULong, FT_Vector,
 };
 use log::debug;
 use memmap2::Mmap;
@@ -33,6 +33,11 @@ const SEMI_BOLD_U16: u16 = Weight::SEMI_BOLD.value() as u16;
 /// Convert FreeType-style 26.6 fixed point to an [`f64`].
 fn fixed_26_dot_6_to_float(fixed: FT_F26Dot6) -> f64 {
     fixed as f64 / 64.0
+}
+
+/// Convert FreeType-style 16.16 fixed point to an [`f64`].
+fn fixed_16_dot_16_to_float(fixed: FT_Fixed) -> f64 {
+    fixed as f64 / 65536.0
 }
 
 #[derive(Debug)]
@@ -210,8 +215,13 @@ impl PlatformFontMethods for PlatformFont {
             mozilla_glyphslot_embolden_less(slot);
         }
 
-        let advance = unsafe { (*slot).metrics.horiAdvance };
-        Some(fixed_26_dot_6_to_float(advance) * self.unscalable_font_metrics_scale())
+        let advance = if unsafe { FT_IS_SCALABLE(face.as_ptr()) } {
+            fixed_16_dot_16_to_float(unsafe { (*slot).linearHoriAdvance })
+        } else {
+            fixed_26_dot_6_to_float(unsafe { (*slot).metrics.horiAdvance })
+        };
+
+        Some(advance * self.unscalable_font_metrics_scale())
     }
 
     fn metrics(&self) -> FontMetrics {

--- a/components/fonts/platform/freetype/freetype_face.rs
+++ b/components/fonts/platform/freetype/freetype_face.rs
@@ -11,7 +11,7 @@ use fonts_traits::FontData;
 use freetype_sys::{
     FT_Done_Face, FT_Done_MM_Var, FT_F26Dot6, FT_FACE_FLAG_COLOR, FT_FACE_FLAG_FIXED_SIZES,
     FT_FACE_FLAG_SCALABLE, FT_Face, FT_FaceRec, FT_Fixed, FT_Get_MM_Var, FT_HAS_MULTIPLE_MASTERS,
-    FT_Int32, FT_LOAD_COLOR, FT_LOAD_DEFAULT, FT_LOAD_TARGET_LIGHT, FT_Long, FT_MM_Var,
+    FT_Int32, FT_LOAD_COLOR, FT_LOAD_DEFAULT, FT_LOAD_NO_HINTING, FT_Long, FT_MM_Var,
     FT_New_Memory_Face, FT_Pos, FT_Select_Size, FT_Set_Char_Size, FT_Set_Var_Design_Coordinates,
     FTErrorMethods,
 };
@@ -166,11 +166,11 @@ impl FreeTypeFace {
     pub(crate) fn glyph_load_flags(&self) -> FT_Int32 {
         let mut load_flags = FT_LOAD_DEFAULT;
 
-        // Default to slight hinting, which is what most
-        // Linux distros use by default, and is a better
-        // default than no hinting.
-        // TODO(gw): Make this configurable.
-        load_flags |= FT_LOAD_TARGET_LIGHT;
+        // Default to no hinting. Although most Linux distros use slight hinting by default, no hinting is needed as default,
+        // else freetype can only return glyph advances in whole numbers, which in turn makes rendering glyphs with non-whole number advances,
+        // such as 3.544px impossible as it will be rounded off to 4px.
+        // TODO: Make this configurable.
+        load_flags |= FT_LOAD_NO_HINTING;
 
         let face_flags = self.as_ref().face_flags;
         if (face_flags & (FT_FACE_FLAG_FIXED_SIZES as FT_Long)) != 0 {

--- a/components/fonts/platform/freetype/freetype_face.rs
+++ b/components/fonts/platform/freetype/freetype_face.rs
@@ -11,7 +11,7 @@ use fonts_traits::FontData;
 use freetype_sys::{
     FT_Done_Face, FT_Done_MM_Var, FT_F26Dot6, FT_FACE_FLAG_COLOR, FT_FACE_FLAG_FIXED_SIZES,
     FT_FACE_FLAG_SCALABLE, FT_Face, FT_FaceRec, FT_Fixed, FT_Get_MM_Var, FT_HAS_MULTIPLE_MASTERS,
-    FT_Int32, FT_LOAD_COLOR, FT_LOAD_DEFAULT, FT_LOAD_NO_HINTING, FT_Long, FT_MM_Var,
+    FT_Int32, FT_LOAD_COLOR, FT_LOAD_DEFAULT, FT_LOAD_TARGET_LIGHT, FT_Long, FT_MM_Var,
     FT_New_Memory_Face, FT_Pos, FT_Select_Size, FT_Set_Char_Size, FT_Set_Var_Design_Coordinates,
     FTErrorMethods,
 };
@@ -166,11 +166,11 @@ impl FreeTypeFace {
     pub(crate) fn glyph_load_flags(&self) -> FT_Int32 {
         let mut load_flags = FT_LOAD_DEFAULT;
 
-        // Default to no hinting. Although most Linux distros use slight hinting by default, no hinting is needed as default,
-        // else freetype can only return glyph advances in whole numbers, which in turn makes rendering glyphs with non-whole number advances,
-        // such as 3.544px impossible as it will be rounded off to 4px.
-        // TODO: Make this configurable.
-        load_flags |= FT_LOAD_NO_HINTING;
+        // Default to slight hinting, which is what most
+        // Linux distros use by default, and is a better
+        // default than no hinting.
+        // TODO(gw): Make this configurable.
+        load_flags |= FT_LOAD_TARGET_LIGHT;
 
         let face_flags = self.as_ref().face_flags;
         if (face_flags & (FT_FACE_FLAG_FIXED_SIZES as FT_Long)) != 0 {

--- a/components/fonts/shapers/harfbuzz.rs
+++ b/components/fonts/shapers/harfbuzz.rs
@@ -32,8 +32,8 @@ use read_fonts::types::Tag;
 use super::{GlyphShapingResult, ShapedGlyph, unicode_script_to_iso15924_tag};
 use crate::platform::font::FontTable;
 use crate::{
-    BASE, Font, FontBaseline, FontTableMethods, GlyphId, ShapedText, ShapingFlags, ShapingOptions,
-    fixed_to_float, float_to_fixed,
+    BASE, Font, FontBaseline, FontTableMethods, GLYPH_SCALE_FACTOR, GlyphId, ShapedText,
+    ShapingFlags, ShapingOptions, fixed_to_float, float_to_fixed,
 };
 
 const HB_OT_TAG_DEFAULT_SCRIPT: hb_tag_t = u32::from_be_bytes(Tag::new(b"DFLT").to_be_bytes());
@@ -101,10 +101,10 @@ impl<'a> Iterator for ShapedGlyphIterator<'a> {
                 .shaped_glyph_data
                 .pos_infos
                 .add(self.current_glyph_offset);
-            let x_offset = Shaper::fixed_to_float((*pos_info_i).x_offset);
-            let y_offset = Shaper::fixed_to_float((*pos_info_i).y_offset);
-            let x_advance = Shaper::fixed_to_float((*pos_info_i).x_advance);
-            let y_advance = Shaper::fixed_to_float((*pos_info_i).y_advance);
+            let x_offset = Shaper::fixed_to_float((*pos_info_i).x_offset) / GLYPH_SCALE_FACTOR;
+            let y_offset = Shaper::fixed_to_float((*pos_info_i).y_offset) / GLYPH_SCALE_FACTOR;
+            let x_advance = Shaper::fixed_to_float((*pos_info_i).x_advance) / GLYPH_SCALE_FACTOR;
+            let y_advance = Shaper::fixed_to_float((*pos_info_i).y_advance) / GLYPH_SCALE_FACTOR;
 
             let x_offset = Au::from_f64_px(x_offset);
             let y_offset = Au::from_f64_px(y_offset);
@@ -204,8 +204,8 @@ impl Shaper {
             // Set scaling. Note that this takes 16.16 fixed point.
             hb_font_set_scale(
                 hb_font,
-                Shaper::float_to_fixed(pt_size) as c_int,
-                Shaper::float_to_fixed(pt_size) as c_int,
+                Shaper::float_to_fixed(pt_size * GLYPH_SCALE_FACTOR) as c_int,
+                Shaper::float_to_fixed(pt_size * GLYPH_SCALE_FACTOR) as c_int,
             );
 
             if servo_config::pref!(layout_variable_fonts_enabled) {
@@ -419,7 +419,7 @@ extern "C" fn glyph_h_advance_func(
     assert!(!font.is_null());
 
     let advance = unsafe { (*font).glyph_h_advance(glyph as GlyphId) };
-    Shaper::float_to_fixed(advance)
+    Shaper::float_to_fixed(advance * GLYPH_SCALE_FACTOR)
 }
 
 /// Callback to get a font table out of a font.


### PR DESCRIPTION
Currently, Servo would often round glyph advance to the nearest integer (see relevant issue). To fix this, this PR does two things: 

- Add `GLYPH_SHAPING_FACTOR`, a multiplier that `pt_size` will be multiplied with when calling `hb_set_scale()`. The reason is according to [HarfBuzz manual](https://harfbuzz.github.io/harfbuzz-hb-font.html#hb-font-set-scale), `hb_position_t` is an integer type, therefore we need to shift the bits left by a few units (and shift back later) to obtain decimal point results.
-  On Freetype-based platforms, use `linearHoriAdvance` to obtain horizontal advance if glyph is scalable. Currently, we always use `HoriAdvance`, however field is often rounded off to nearest integer according to the [docs](https://freetype.org/freetype2/docs/tutorial/step2.html):

> Indeed, the value of metrics.horiAdvance that is returned in the glyph slot is normally rounded to integer pixel coordinates (i.e., being a multiple of 64) by the font driver that actually loads the glyph image. 

After some manual testing, the character width computed by servo is now accurate to within 0.1 pixels with Chromium. One reason for the inaccuracy is because of `px` (`fp64`) to `Au` conversion.

Testing: Manual testing.
Fixes: [#47739](https://github.com/servo/servo/issues/47739)
