### PR TITLE
script: Improve ML-DSA steps for the `supports()` method

### DIFF
--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -2584,7 +2584,11 @@ pub(crate) fn check_support_for_algorithm(
                 SignAlgorithm::Ed448(normalized_algorithm) => normalized_algorithm
                     .context
                     .is_none_or(|context| context.len() <= 255),
-                SignAlgorithm::Hmac(_) | SignAlgorithm::MlDsa(_) | SignAlgorithm::Kmac(_) => true,
+                SignAlgorithm::Hmac(_) => true,
+                SignAlgorithm::MlDsa(normalized_algorithm) => normalized_algorithm
+                    .context
+                    .is_none_or(|context| context.len() <= 255),
+                SignAlgorithm::Kmac(_) => true,
             }
         },
         "verify" => {
@@ -2601,9 +2605,11 @@ pub(crate) fn check_support_for_algorithm(
                 VerifyAlgorithm::Ed448(normalized_algorithm) => normalized_algorithm
                     .context
                     .is_none_or(|context| context.len() <= 255),
-                VerifyAlgorithm::Hmac(_) | VerifyAlgorithm::MlDsa(_) | VerifyAlgorithm::Kmac(_) => {
-                    true
-                },
+                VerifyAlgorithm::Hmac(_) => true,
+                VerifyAlgorithm::MlDsa(normalized_algorithm) => normalized_algorithm
+                    .context
+                    .is_none_or(|context| context.len() <= 255),
+                VerifyAlgorithm::Kmac(_) => true,
             }
         },
         "digest" => {

--- a/components/script/dom/webcrypto/subtlecrypto/ml_dsa_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ml_dsa_operation.rs
@@ -30,7 +30,19 @@ pub(crate) fn sign(
     key: &CryptoKey,
     message: &[u8],
 ) -> Result<Vec<u8>, Error> {
-    // Step 1. If the [[type]] internal slot of key is not "private", then throw an
+    // Step 1. If the context member of normalizedAlgorithm is present and has a length greater than
+    // 255 bytes, then throw an OperationError.
+    if normalized_algorithm
+        .context
+        .as_ref()
+        .is_some_and(|context| context.len() > 255)
+    {
+        return Err(Error::Operation(Some(
+            "The context is present and has a length greater than 255 bytes".into(),
+        )));
+    }
+
+    // Step 2. If the [[type]] internal slot of key is not "private", then throw an
     // InvalidAccessError.
     if key.Type() != KeyType::Private {
         return Err(Error::InvalidAccess(Some(
@@ -38,15 +50,15 @@ pub(crate) fn sign(
         )));
     }
 
-    // Step 2. Let context be the context member of normalizedAlgorithm or the empty octet string
+    // Step 3. Let context be the context member of normalizedAlgorithm or the empty octet string
     // if the context member of normalizedAlgorithm is not present.
     let context = normalized_algorithm.context.as_deref().unwrap_or_default();
 
-    // Step 3. Let result be the result of performing the ML-DSA.Sign signing algorithm, as
+    // Step 4. Let result be the result of performing the ML-DSA.Sign signing algorithm, as
     // specified in Section 5.2 of [FIPS-204], with the parameter set indicated by the name member
     // of normalizedAlgorithm, using the ML-DSA private key associated with key as sk, message as M
     // and context as ctx.
-    // Step 4. If the ML-DSA.Sign algorithm returned an error, return an OperationError.
+    // Step 5. If the ML-DSA.Sign algorithm returned an error, return an OperationError.
     let result = match normalized_algorithm.name {
         CryptoAlgorithm::MlDsa44 => {
             let Handle::MlDsa44PrivateKey(private_key) = key.handle() else {
@@ -92,7 +104,7 @@ pub(crate) fn sign(
         },
     };
 
-    // Step 5. Return result.
+    // Step 6. Return result.
     Ok(result)
 }
 
@@ -103,7 +115,19 @@ pub(crate) fn verify(
     message: &[u8],
     signature: &[u8],
 ) -> Result<bool, Error> {
-    // Step 1. If the [[type]] internal slot of key is not "public", then throw an
+    // Step 1. If the context member of normalizedAlgorithm is present and has a length greater than
+    // 255 bytes, then throw an OperationError.
+    if normalized_algorithm
+        .context
+        .as_ref()
+        .is_some_and(|context| context.len() > 255)
+    {
+        return Err(Error::Operation(Some(
+            "The context is present and has a length greater than 255 bytes".into(),
+        )));
+    }
+
+    // Step 2. If the [[type]] internal slot of key is not "public", then throw an
     // InvalidAccessError.
     if key.Type() != KeyType::Public {
         return Err(Error::InvalidAccess(Some(
@@ -111,15 +135,15 @@ pub(crate) fn verify(
         )));
     }
 
-    // Step 2. Let context be the context member of normalizedAlgorithm or the empty octet string
+    // Step 3. Let context be the context member of normalizedAlgorithm or the empty octet string
     // if the context member of normalizedAlgorithm is not present.
     let context = normalized_algorithm.context.as_deref().unwrap_or_default();
 
-    // Step 3. Let result be the result of performing the ML-DSA.Verify verification algorithm, as
+    // Step 4. Let result be the result of performing the ML-DSA.Verify verification algorithm, as
     // specified in Section 5.3 of [FIPS-204], with the parameter set indicated by the name member
     // of normalizedAlgorithm, using the ML-DSA public key associated with key as pk, message as M,
     // signature as σ and context as ctx.
-    // Step 4. If the ML-DSA.Verify algorithm returned an error, return an OperationError.
+    // Step 5. If the ML-DSA.Verify algorithm returned an error, return an OperationError.
     let result = match normalized_algorithm.name {
         CryptoAlgorithm::MlDsa44 => {
             let Handle::MlDsa44PublicKey(public_key) = key.handle() else {
@@ -162,7 +186,7 @@ pub(crate) fn verify(
         },
     };
 
-    // Step 5. Return result.
+    // Step 6. Return result.
     Ok(result)
 }
 

--- a/tests/wpt/meta/WebCryptoAPI/supports-modern.tentative.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/supports-modern.tentative.https.any.js.ini
@@ -1,22 +1,4 @@
 [supports-modern.tentative.https.any.html]
-  [supports validates ML-DSA-44 sign context length]
-    expected: FAIL
-
-  [supports validates ML-DSA-44 verify context length]
-    expected: FAIL
-
-  [supports validates ML-DSA-65 sign context length]
-    expected: FAIL
-
-  [supports validates ML-DSA-65 verify context length]
-    expected: FAIL
-
-  [supports validates ML-DSA-87 sign context length]
-    expected: FAIL
-
-  [supports validates ML-DSA-87 verify context length]
-    expected: FAIL
-
   [supports encapsulateKey with an algorithm without raw-secret import]
     expected: FAIL
 
@@ -37,24 +19,6 @@
 
 
 [supports-modern.tentative.https.any.worker.html]
-  [supports validates ML-DSA-44 sign context length]
-    expected: FAIL
-
-  [supports validates ML-DSA-44 verify context length]
-    expected: FAIL
-
-  [supports validates ML-DSA-65 sign context length]
-    expected: FAIL
-
-  [supports validates ML-DSA-65 verify context length]
-    expected: FAIL
-
-  [supports validates ML-DSA-87 sign context length]
-    expected: FAIL
-
-  [supports validates ML-DSA-87 verify context length]
-    expected: FAIL
-
   [supports encapsulateKey with an algorithm without raw-secret import]
     expected: FAIL
 


### PR DESCRIPTION
Modern Algorithm in WebCrypto API specification has updated the sign and verify operations of ML-DSA, in order to improve `supports()` method validation coverage.

We follow the update to add a step to check the context length at the beginning of the sign and verify operations of ML-DSA.

The implementation of Step 8 of the **check support for an algorithm** algorithm also follows these changes.

Spec Update: https://github.com/WICG/webcrypto-modern-algos/pull/76
WPT Update: https://github.com/web-platform-tests/wpt/pull/62115

Testing: Pass more WPT tests.
