### PR TITLE
layout: Mark `display: none` nodes as hidden for accessibility

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -289,11 +289,6 @@ impl AccessibilityTree {
             update.insert_damage(root_id, AccessibilityDamage::Rebuild);
             update.insert_dom_node(root_id, *root_dom_node);
             self.populate_pending_scroll_updates_from_scroll_tree(context);
-        } else {
-            // TODO(#47161) This hack is necessary because we don't collect accessibility damage
-            // from layout.
-            update.insert_damage(root_id, AccessibilityDamage::Subtree);
-            update.insert_dom_node(root_id, *root_dom_node);
         }
 
         self.root_node = Some(root_node);
@@ -431,7 +426,14 @@ impl AccessibilityTree {
             }
         }
 
-        common_ancestors.pop()
+        let lowest_common_ancestor = common_ancestors.pop();
+
+        for ancestor_id in common_ancestors {
+            let ancestor = self.assert_node_for_id(&ancestor_id);
+            ancestor.borrow_mut().dirty_state -= DirtyState::DescendantHasDamage;
+        }
+
+        lowest_common_ancestor
     }
 
     /// Get the [`AccessibilityNode`] corresponding to the given DOM node.
@@ -755,36 +757,44 @@ impl AccessibilityNode {
     ) -> LocalAccessibilityDamage {
         let mut local_damage = LocalAccessibilityDamage::empty();
 
-        let damage = self.compute_damage(update);
+        let dom_node = update.take_dom_node(&self.id);
+        let damage = self.compute_damage(dom_node, update);
+        let mut children_changed = false;
 
-        if let Some(dom_node) = update.take_dom_node(&self.id) {
+        if let Some(dom_node) = dom_node {
             // TODO(#47162, #47161): Once we handle scrolling properly and have a way of tracking
             // damage from layout, we won't need to update every node.
             local_damage.insert(self.update_properties_and_children_from_dom_node(
                 ref_self, &dom_node, damage, tree, update,
             ));
-            self.update_bounds_from_dom_node(&dom_node, context, update);
+            self.update_node_from_layout(&dom_node, damage, context, update);
 
-            if local_damage.contains(LocalAccessibilityDamage::SubtreeChanged) &&
-                let Some(scroll_offset) = self.scroll_offset
-            {
-                // If children have changed, re-set the scroll transforms on all children.
-                self.set_scroll_offset(scroll_offset, update);
+            if local_damage.contains(LocalAccessibilityDamage::SubtreeChanged) {
+                children_changed = true;
             }
 
             self.dirty_state -= DirtyState::HasDamage;
         }
 
-        for child_node in self.children() {
-            let child_node_ref = child_node.clone();
-            let mut child_node = child_node.borrow_mut();
-            let child_local_damage =
-                child_node.update_subtree(child_node_ref, context, tree, update);
-            if !child_local_damage.is_empty() {
-                local_damage.insert(LocalAccessibilityDamage::SubtreeChanged);
+        if self.dirty_state.descendant_has_damage() ||
+            damage.contains(AccessibilityDamage::DescendantHasDamage)
+        {
+            for child_node in self.children() {
+                let child_node_ref = child_node.clone();
+                let mut child_node = child_node.borrow_mut();
+                let child_local_damage =
+                    child_node.update_subtree(child_node_ref, context, tree, update);
+                if !child_local_damage.is_empty() {
+                    local_damage.insert(LocalAccessibilityDamage::SubtreeChanged);
+                }
             }
         }
         self.dirty_state -= DirtyState::DescendantHasDamage;
+
+        if children_changed && let Some(scroll_offset) = self.scroll_offset {
+            // If this node may have new children, update their scroll offsets.
+            self.set_scroll_offset(scroll_offset, update);
+        }
 
         local_damage.insert(self.update_node_local(local_damage, update));
 
@@ -829,9 +839,13 @@ impl AccessibilityNode {
     ) -> LocalAccessibilityDamage {
         let mut local_damage = LocalAccessibilityDamage::empty();
 
-        // TODO(#47162): We currently need to walk the children each time so that we always find the
-        // DOM node for each accessibility node, since we update bounds on every node.
-        // Once this is no longer true, we can check dom_damage and potentially early return here.
+        if !dom_damage.intersects(
+            AccessibilityDamage::Node |
+                AccessibilityDamage::Children |
+                AccessibilityDamage::DescendantHasDamage,
+        ) {
+            return local_damage;
+        }
 
         update.counters.nodes_updated_from_dom += 1;
 
@@ -849,13 +863,15 @@ impl AccessibilityNode {
         &mut self,
         ref_self: ArcRefCell<AccessibilityNode>,
         dom_node: &ServoLayoutNode<'update>,
-        _dom_damage: AccessibilityDamage,
+        dom_damage: AccessibilityDamage,
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate<'update>,
     ) -> LocalAccessibilityDamage {
-        // TODO(#47162): We currently need to walk the children each time so that we always find the
-        // DOM node for each accessibility node, since we update bounds on every node.
-        // Once this is no longer true, we can check _dom_damage and potentially early return here.
+        if !dom_damage
+            .intersects(AccessibilityDamage::Children | AccessibilityDamage::DescendantHasDamage)
+        {
+            return LocalAccessibilityDamage::empty();
+        }
 
         let mut remaining_dom_children = dom_node.flat_tree_children().peekable();
         let mut old_child_ids = self.child_ids().iter().peekable();
@@ -947,12 +963,17 @@ impl AccessibilityNode {
     }
 
     /// Update this node's bounds from the current layout geometry.
-    fn update_bounds_from_dom_node(
+    fn update_node_from_layout(
         &mut self,
-        dom_node: &ServoLayoutNode,
+        dom_node: &ServoLayoutNode<'_>,
+        dom_damage: AccessibilityDamage,
         context: &AccessibilityContext,
         update: &mut AccessibilityUpdate,
     ) {
+        if !dom_damage.contains(AccessibilityDamage::Layout) {
+            return;
+        }
+
         update.counters.nodes_updated_bounds += 1;
 
         // Border box without transforms. Bounds are in CSS pixels, relative to the document origin;
@@ -984,8 +1005,8 @@ impl AccessibilityNode {
         // its rendered descendants.
         match bounds {
             Some(bounds) => self.set_bounds(bounds),
-            None => self.clear_bounds(),
-        }
+            None => self.clear_bounds(), // display: contents case
+        };
     }
 
     /// Update this node's properties based on changes already made to the accessibility tree.
@@ -1216,13 +1237,26 @@ impl AccessibilityNode {
         );
     }
 
-    fn compute_damage(&self, update: &mut AccessibilityUpdate) -> AccessibilityDamage {
+    fn compute_damage(
+        &self,
+        dom_node: Option<ServoLayoutNode<'_>>,
+        update: &mut AccessibilityUpdate,
+    ) -> AccessibilityDamage {
         let mut damage = AccessibilityDamage::empty();
 
         if self.dirty_state.has_damage() {
             damage |= update.take_damage(&self.id);
         }
 
+        if let Some(dom_node) = dom_node &&
+            let Some(element) = dom_node.as_element() &&
+            let Some(style_data) = element.style_data()
+        {
+            let mut element_data = style_data.element_data.borrow_mut();
+            let restyle_damage = std::mem::take(&mut element_data.damage);
+            let damage_from_layout = AccessibilityDamage::from_bits_retain(restyle_damage.bits());
+            damage |= damage_from_layout;
+        }
         damage
     }
 }

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -50,6 +50,8 @@ bitflags! {
         const RoleChanged = 0b0010;
         /// This node's computed label or text value (for a text node) changed.
         const TextChanged = 0b0100;
+        /// This node's visibility changed.
+        const VisibilityChanged = 0b1000;
     }
 }
 
@@ -306,10 +308,14 @@ impl AccessibilityTree {
             return;
         };
         let damage_root = self.assert_node_for_id(&damage_root_id);
-        let local_damage =
-            damage_root
-                .borrow_mut()
-                .update_subtree(damage_root.clone(), context, self, update);
+        let hidden = false;
+        let local_damage = damage_root.borrow_mut().update_subtree(
+            damage_root.clone(),
+            hidden,
+            context,
+            self,
+            update,
+        );
 
         damage_root.borrow().update_ancestors(local_damage, update);
     }
@@ -751,6 +757,7 @@ impl AccessibilityNode {
     fn update_subtree<'update>(
         &mut self,
         ref_self: ArcRefCell<Self>,
+        mut hidden: bool,
         context: &AccessibilityContext,
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate<'update>,
@@ -767,7 +774,8 @@ impl AccessibilityNode {
             local_damage.insert(self.update_properties_and_children_from_dom_node(
                 ref_self, &dom_node, damage, tree, update,
             ));
-            self.update_node_from_layout(&dom_node, damage, context, update);
+            local_damage
+                .insert(self.update_node_from_layout(&dom_node, damage, hidden, context, update));
 
             if local_damage.contains(LocalAccessibilityDamage::SubtreeChanged) {
                 children_changed = true;
@@ -776,6 +784,8 @@ impl AccessibilityNode {
             self.dirty_state -= DirtyState::HasDamage;
         }
 
+        hidden |= self.is_hidden();
+
         if self.dirty_state.descendant_has_damage() ||
             damage.contains(AccessibilityDamage::DescendantHasDamage)
         {
@@ -783,16 +793,21 @@ impl AccessibilityNode {
                 let child_node_ref = child_node.clone();
                 let mut child_node = child_node.borrow_mut();
                 let child_local_damage =
-                    child_node.update_subtree(child_node_ref, context, tree, update);
+                    child_node.update_subtree(child_node_ref, hidden, context, tree, update);
                 if !child_local_damage.is_empty() {
                     local_damage.insert(LocalAccessibilityDamage::SubtreeChanged);
+                    if child_local_damage.contains(LocalAccessibilityDamage::VisibilityChanged) &&
+                        !child_node.is_hidden()
+                    {
+                        children_changed = true;
+                    }
                 }
             }
         }
         self.dirty_state -= DirtyState::DescendantHasDamage;
 
         if children_changed && let Some(scroll_offset) = self.scroll_offset {
-            // If this node may have new children, update their scroll offsets.
+            // If this node may have new, or newly-visible, children, update their scroll offsets.
             self.set_scroll_offset(scroll_offset, update);
         }
 
@@ -962,16 +977,40 @@ impl AccessibilityNode {
         local_damage
     }
 
-    /// Update this node's bounds from the current layout geometry.
+    /// Update this node's bounds from layout, given a query function and the bounds inherited from
+    /// an ancestor (used as a fallback for nodes without their own box). Returns the damage caused by
+    /// the update, and the bounds descendants without their own box should inherit.
     fn update_node_from_layout(
         &mut self,
         dom_node: &ServoLayoutNode<'_>,
-        dom_damage: AccessibilityDamage,
+        mut dom_damage: AccessibilityDamage,
+        hidden: bool,
         context: &AccessibilityContext,
         update: &mut AccessibilityUpdate,
-    ) {
-        if !dom_damage.contains(AccessibilityDamage::Layout) {
-            return;
+    ) -> LocalAccessibilityDamage {
+        let mut local_damage = LocalAccessibilityDamage::empty();
+
+        if !dom_damage.intersects(AccessibilityDamage::Style | AccessibilityDamage::Layout) {
+            return local_damage;
+        }
+
+        if dom_damage.contains(AccessibilityDamage::Style) &&
+            let Some(dom_element) = dom_node.as_element() &&
+            dom_element.style_data().is_some()
+        {
+            let data = dom_element.element_data();
+            let style = data.styles.primary();
+            if style.clone_display().is_none() {
+                self.clear_bounds();
+                local_damage.insert(self.set_hidden());
+            } else {
+                dom_damage |= AccessibilityDamage::Layout;
+                local_damage.insert(self.clear_hidden());
+            }
+        }
+
+        if hidden || self.is_hidden() || !dom_damage.contains(AccessibilityDamage::Layout) {
+            return local_damage;
         }
 
         update.counters.nodes_updated_bounds += 1;
@@ -1007,6 +1046,7 @@ impl AccessibilityNode {
             Some(bounds) => self.set_bounds(bounds),
             None => self.clear_bounds(), // display: contents case
         };
+        local_damage
     }
 
     /// Update this node's properties based on changes already made to the accessibility tree.
@@ -1045,6 +1085,9 @@ impl AccessibilityNode {
         let mut text = String::new();
         while let Some(child) = children.pop_front() {
             let child = child.borrow();
+            if child.is_hidden() {
+                continue;
+            }
             match child.role() {
                 Role::TextRun => {
                     if let Some(child_text) = child.value() {
@@ -1096,6 +1139,9 @@ impl AccessibilityNode {
         let transform = scroll_offset_to_affine(offset);
         for child in self.children() {
             let mut child = child.borrow_mut();
+            if child.is_hidden() {
+                continue;
+            }
             child.set_transform(transform);
             if child.dirty_state.updated() {
                 update.add(&mut child);
@@ -1163,6 +1209,29 @@ impl AccessibilityNode {
         self.accesskit_node.set_value(value);
         self.dirty_state |= DirtyState::Updated;
         LocalAccessibilityDamage::TextChanged
+    }
+
+    fn is_hidden(&self) -> bool {
+        self.accesskit_node.is_hidden()
+    }
+
+    fn set_hidden(&mut self) -> LocalAccessibilityDamage {
+        if self.is_hidden() {
+            return LocalAccessibilityDamage::empty();
+        }
+        self.accesskit_node.set_hidden();
+        self.dirty_state |= DirtyState::Updated;
+        LocalAccessibilityDamage::VisibilityChanged
+    }
+
+    fn clear_hidden(&mut self) -> LocalAccessibilityDamage {
+        if !self.is_hidden() {
+            return LocalAccessibilityDamage::empty();
+        }
+
+        self.accesskit_node.clear_hidden();
+        self.dirty_state |= DirtyState::Updated;
+        LocalAccessibilityDamage::VisibilityChanged
     }
 
     fn bounds(&self) -> Option<accesskit::Rect> {
@@ -1263,6 +1332,9 @@ impl AccessibilityNode {
 
 impl Debug for AccessibilityNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.is_hidden() {
+            write!(f, "[hidden] ")?;
+        }
         write!(f, "{:?}: {:?}", self.id, self.role())?;
         if let Some(html_tag) = self.html_tag() {
             write!(f, " (html_tag: {html_tag:?})")?;

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -61,6 +61,9 @@ pub(crate) struct LayoutContext<'a> {
 
     /// The device dimensions on which this layout is running, in device pixels.
     pub device_size: Size2D<f32, DevicePixel>,
+
+    /// Whether accessibility is active.
+    pub accessibility_active: bool,
 }
 
 impl LayoutContext<'_> {

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -21,11 +21,12 @@ use fonts::{FontContext, FontContextWebFontMethods};
 use fonts_traits::{StylesheetWebFontLoadFinishedCallback, WebFontSetDifference};
 use icu_locid::subtags::Language;
 use layout_api::{
-    AxesOverflow, BoxAreaType, CSSPixelRectVec, DangerousStyleNode, HitTestFlags, HitTestResult,
-    IFrameSizes, Layout, LayoutConfig, LayoutDamage, LayoutElement, LayoutFactory, LayoutNode,
-    NodeRenderingType, OffsetParentResponse, PhysicalSides, QueryMsg, ReflowGoal, ReflowPhasesRun,
-    ReflowRequest, ReflowRequestRestyle, ReflowResult, ReflowStatistics, ScrollContainerQueryFlags,
-    ScrollContainerResponse, TrustedNodeAddress, with_layout_state,
+    AccessibilityDamage, AxesOverflow, BoxAreaType, CSSPixelRectVec, DangerousStyleNode,
+    HitTestFlags, HitTestResult, IFrameSizes, Layout, LayoutConfig, LayoutDamage, LayoutElement,
+    LayoutFactory, LayoutNode, NodeRenderingType, OffsetParentResponse, PhysicalSides, QueryMsg,
+    ReflowGoal, ReflowPhasesRun, ReflowRequest, ReflowRequestRestyle, ReflowResult,
+    ReflowStatistics, ScrollContainerQueryFlags, ScrollContainerResponse, TrustedNodeAddress,
+    with_layout_state,
 };
 use log::{debug, warn};
 use malloc_size_of::{MallocConditionalSizeOf, MallocSizeOf, MallocSizeOfOps};
@@ -38,7 +39,7 @@ use profile_traits::time::{
     self as profile_time, TimerMetadata, TimerMetadataFrameType, TimerMetadataReflowType,
 };
 use profile_traits::{path, time_profile};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use script::layout_dom::{
     ServoDangerousStyleDocument, ServoDangerousStyleElement, ServoLayoutElement, ServoLayoutNode,
 };
@@ -943,14 +944,14 @@ impl LayoutThread {
     fn handle_accessibility_tree_update(
         &self,
         root_element: &ServoLayoutNode,
-        reflow_request: &mut ReflowRequest,
+        accessibility_damage: Option<AccessibilityDamageMap>,
+        rooted_nodes: Option<FxHashSet<OpaqueNode>>,
         reflow_statistics: &mut ReflowStatistics,
     ) -> bool {
-        let Some(accessibility_damage) = std::mem::take(&mut reflow_request.accessibility_damage)
-        else {
+        let Some(damage) = accessibility_damage else {
             return false;
         };
-        if !self.force_accessibility_update() && accessibility_damage.is_empty() {
+        if !self.force_accessibility_update() && damage.is_empty() {
             return false;
         }
 
@@ -969,17 +970,6 @@ impl LayoutThread {
             return false;
         };
         debug_assert!(!self.need_new_stacking_context_tree.get());
-
-        let rooted_nodes =
-            std::mem::take(&mut reflow_request.rooted_nodes_for_accessibility_integrity_check);
-
-        let damage: AccessibilityDamageMap = accessibility_damage
-            .into_iter()
-            .map(|(address, damage)| {
-                let node = unsafe { ServoLayoutNode::new(&address) };
-                (node.opaque(), (node, damage))
-            })
-            .collect();
 
         let accessibility_context = AccessibilityContext {
             layout_thread: self,
@@ -1056,8 +1046,25 @@ impl LayoutThread {
         });
         let mut reflow_statistics = Default::default();
 
+        let mut accessibility_damage: Option<FxHashMap<_, _>> =
+            std::mem::take(&mut reflow_request.accessibility_damage).map(|vec| {
+                vec.into_iter()
+                    .map(|(address, damage)| {
+                        let node = unsafe { ServoLayoutNode::new(&address) };
+                        (node.opaque(), (node, damage))
+                    })
+                    .collect()
+            });
+
         let (mut reflow_phases_run, iframe_sizes, changed_web_fonts) = self
-            .restyle_and_build_trees(&mut reflow_request, document, root_element, &image_resolver);
+            .restyle_and_build_trees(
+                &mut reflow_request,
+                document,
+                root_element,
+                &image_resolver,
+                accessibility_damage.as_mut(),
+            );
+
         if self.build_stacking_context_tree_for_reflow(&reflow_request) {
             reflow_phases_run.insert(ReflowPhasesRun::BuiltStackingContextTree);
         }
@@ -1069,7 +1076,8 @@ impl LayoutThread {
         }
         if self.handle_accessibility_tree_update(
             &root_element.as_node(),
-            &mut reflow_request,
+            accessibility_damage,
+            reflow_request.rooted_nodes_for_accessibility_integrity_check,
             &mut reflow_statistics,
         ) {
             reflow_phases_run.insert(ReflowPhasesRun::UpdatedAccessibilityTree);
@@ -1183,12 +1191,13 @@ impl LayoutThread {
     }
 
     #[servo_tracing::instrument(skip_all)]
-    fn restyle_and_build_trees(
+    fn restyle_and_build_trees<'dom>(
         &mut self,
         reflow_request: &mut ReflowRequest,
         document: ServoDangerousStyleDocument<'_>,
-        root_element: ServoLayoutElement<'_>,
+        root_element: ServoLayoutElement<'dom>,
         image_resolver: &Arc<ImageResolver>,
+        mut accessibility_damage: Option<&mut AccessibilityDamageMap<'dom>>,
     ) -> (ReflowPhasesRun, IFrameSizes, WebFontSetDifference) {
         let mut snapshot_map = SnapshotMap::new();
         let _snapshot_setter = match reflow_request.restyle.as_mut() {
@@ -1256,6 +1265,7 @@ impl LayoutThread {
             parallelism_job_count_minimum: pref!(layout_parallelism_job_count_minimum) as usize,
             parallelism_job_size_minimum: pref!(layout_parallelism_job_size_minimum) as usize,
             device_size: reflow_request.viewport_details.device_size.cast_unit(),
+            accessibility_active: self.accessibility_active(),
         };
 
         let restyle = reflow_request
@@ -1348,15 +1358,24 @@ impl LayoutThread {
             }
 
             debug_assert!(!layout_roots.is_empty());
+            if let Some(map) = accessibility_damage.as_mut() {
+                for layout_root in layout_roots.iter() {
+                    let node = layout_root.node;
+                    if let Some(element) = node.as_element() {
+                        let accessibility_damage = AccessibilityDamage::from_bits_retain(
+                            element.element_data().damage.bits(),
+                        );
+                        map.insert(
+                            layout_root.node.opaque(),
+                            (layout_root.node, accessibility_damage),
+                        );
+                    }
+                }
+            }
             if layout_roots
                 .iter()
                 .all(|layout_root| layout_root.try_layout(&layout_context))
             {
-                if self.accessibility_active() {
-                    // TODO(#47162) Compute accessibility damage rather than forcing a full update.
-                    self.set_force_accessibility_update();
-                }
-
                 return (
                     ReflowPhasesRun::RanLayout,
                     std::mem::take(&mut *layout_context.iframe_sizes.lock()),
@@ -1404,9 +1423,10 @@ impl LayoutThread {
                 .dump_stdout(&layout_context.style_context.guards);
         }
 
-        if self.accessibility_active() {
-            // TODO(#47162) Compute accessibility damage rather than forcing a full upate.
-            self.set_force_accessibility_update();
+        if let Some(map) = accessibility_damage.as_mut() {
+            let accessibility_damage =
+                AccessibilityDamage::from_bits_retain(root_element.element_data().damage.bits());
+            map.insert(root_node.opaque(), (root_node, accessibility_damage));
         }
 
         // GC the rule tree if some heuristics are met.

--- a/components/layout/layout_root.rs
+++ b/components/layout/layout_root.rs
@@ -34,7 +34,7 @@ use crate::fragment_tree::Fragment;
 /// has started to escape from the layout root. In that case, a full fragment tree layout
 /// becomes necessary to rebuild the fragment properly.
 pub(crate) struct LayoutRoot<'dom> {
-    node: ServoLayoutNode<'dom>,
+    pub(crate) node: ServoLayoutNode<'dom>,
 }
 
 impl<'dom> TryFrom<ServoLayoutNode<'dom>> for LayoutRoot<'dom> {

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -5,7 +5,8 @@
 use std::sync::Arc;
 
 use layout_api::{
-    DangerousStyleElement, DangerousStyleNode, LayoutDamage, LayoutElement, LayoutNode,
+    AccessibilityDamage, DangerousStyleElement, DangerousStyleNode, LayoutDamage, LayoutElement,
+    LayoutNode,
 };
 use script::layout_dom::ServoLayoutNode;
 use style::context::{SharedStyleContext, StyleContext};
@@ -155,6 +156,15 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_above_dirty_root<'dom>(
     let mut damage_for_parent = layout_damage;
     let mut maybe_parent_node = unsafe { dirty_root.dangerous_flat_tree_parent() };
     while let Some(parent_node) = maybe_parent_node {
+        if layout_context.accessibility_active &&
+            damage_for_parent.contains(LayoutDamage::DescendantHasAccessibilityDamage) &&
+            let Some(parent_element) = parent_node.as_element()
+        {
+            let mut element_data = parent_element.element_data_mut();
+            element_data.damage.insert(RestyleDamage::from_bits_retain(
+                AccessibilityDamage::DescendantHasDamage.bits(),
+            ));
+        }
         let damage_set = ElementDamageSet {
             node: parent_node,
             from_parent: LayoutDamage::empty(),
@@ -225,6 +235,17 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_below_dirty_root<'dom>(
         damage_for_children,
         layout_roots,
     );
+
+    if layout_context.accessibility_active &&
+        damage_set
+            .from_children
+            .intersects(LayoutDamage::DescendantHasAccessibilityDamage)
+    {
+        let mut element_data = element.element_data_mut();
+        element_data.damage.insert(RestyleDamage::from_bits_retain(
+            AccessibilityDamage::DescendantHasDamage.bits(),
+        ));
+    }
 
     // Apply the calculated damage to this element (perhaps triggering box tree layout),
     // and propagate resulting damage to ancestors.
@@ -327,9 +348,24 @@ impl<'a> ElementDamageSet<'a> {
         let only_layout_mode_damage =
             (self.from_parent | self.on_element | self.from_children).only_layout_modes();
 
+        let record_accessibility_layout_damage = || {
+            if layout_context.accessibility_active &&
+                let Some(element) = self.node.as_element()
+            {
+                let mut element_data = element.element_data_mut();
+                element_data.damage.insert(RestyleDamage::from_bits_retain(
+                    AccessibilityDamage::Layout.bits(),
+                ));
+                return LayoutDamage::DescendantHasAccessibilityDamage;
+            }
+            LayoutDamage::empty()
+        };
+
         let invalidate_for_rebuild = || {
             self.node.unset_all_boxes();
-            LayoutDamage::DescendantHasBoxDamage | LayoutDamage::Relayout
+            record_accessibility_layout_damage() |
+                LayoutDamage::DescendantHasBoxDamage |
+                LayoutDamage::Relayout
         };
 
         // This removes any dirty layout roots from descendants.
@@ -349,7 +385,9 @@ impl<'a> ElementDamageSet<'a> {
                 {
                     // In this case, we have rebuilt the box tree from this point and we do not
                     // have to propagate rebuild box tree damage up the tree any further.
-                    LayoutDamage::Relayout | LayoutDamage::RecomputeInlineContentSizes
+                    record_accessibility_layout_damage() |
+                        LayoutDamage::Relayout |
+                        LayoutDamage::RecomputeInlineContentSizes
                 } else {
                     // A descendant needs to be rebuilt, but couldn't be rebuilt here,
                     // because this node was an not a rebuild-compatible independent
@@ -416,7 +454,9 @@ impl<'a> ElementDamageSet<'a> {
                     base.invalidate_caches(&self);
                     base.mark_fragments_as_descendants_changed();
                 });
-                LayoutDamage::RecalculateOverflow |
+
+                record_accessibility_layout_damage() |
+                    LayoutDamage::RecalculateOverflow |
                     LayoutDamage::DescendantCollectedAsLayoutRoot |
                     LayoutDamage::RecomputeInlineContentSizes
             },

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -203,6 +203,18 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_below_dirty_root<'dom>(
         )
     };
 
+    let mut damage_for_parent = element_damage | damage_from_parent;
+
+    if layout_context.accessibility_active &&
+        element_damage.contains(LayoutDamage::AccessibilityStyleDamage)
+    {
+        let mut element_data = element.element_data_mut();
+        element_data.damage.insert(RestyleDamage::from_bits_retain(
+            AccessibilityDamage::Style.bits(),
+        ));
+        damage_for_parent.insert(LayoutDamage::DescendantHasAccessibilityDamage)
+    }
+
     let has_dirty_descendants;
     #[expect(unsafe_code)]
     unsafe {
@@ -213,7 +225,7 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_below_dirty_root<'dom>(
 
     if is_display_none {
         node.unset_all_boxes();
-        return element_damage | damage_from_parent;
+        return damage_for_parent;
     }
 
     let mut damage_set = ElementDamageSet {

--- a/components/script/layout_dom/servo_dangerous_style_element.rs
+++ b/components/script/layout_dom/servo_dangerous_style_element.rs
@@ -509,7 +509,7 @@ impl<'dom> style::dom::TElement for ServoDangerousStyleElement<'dom> {
     }
 
     fn compute_layout_damage(old: &ComputedValues, new: &ComputedValues) -> RestyleDamage {
-        let box_tree_needs_rebuild = || {
+        let box_tree_needs_rebuild = |accessibility_style_damaged: &mut bool| {
             let old_box = old.get_box();
             let new_box = new.get_box();
 
@@ -517,6 +517,9 @@ impl<'dom> style::dom::TElement for ServoDangerousStyleElement<'dom> {
                 old_box.float != new_box.float ||
                 old_box.position != new_box.position
             {
+                if old_box.display.is_none() != new_box.display.is_none() {
+                    *accessibility_style_damaged = true;
+                }
                 return true;
             }
 
@@ -633,8 +636,13 @@ impl<'dom> style::dom::TElement for ServoDangerousStyleElement<'dom> {
             false
         };
 
-        if box_tree_needs_rebuild() {
-            RestyleDamage::from_bits_retain(LayoutDamage::BoxDamage.bits())
+        let mut accessibility_style_damaged = false;
+        if box_tree_needs_rebuild(&mut accessibility_style_damaged) {
+            let mut layout_damage = LayoutDamage::BoxDamage;
+            if accessibility_style_damaged {
+                layout_damage |= LayoutDamage::AccessibilityStyleDamage;
+            }
+            RestyleDamage::from_bits_retain(layout_damage.bits())
         } else if text_shaping_needs_recollect() {
             RestyleDamage::from_bits_retain(LayoutDamage::DescendantHasBoxDamage.bits())
         } else {

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -963,6 +963,87 @@ fn test_accessibility_unchanged_bounds_are_not_resent() {
     );
 }
 
+#[test]
+fn test_accessibility_display_none_change() {
+    let url = "data:text/html,<!DOCTYPE html>\
+               <style>section.subdued em { display: none }</style>
+               <section class='subdued'><h1>We <em>really</em> love the web</h1></section>";
+    let (servo_test, delegate, webview, mut tree) = build_webview_and_tree(url);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let heading = find_first_matching_node(root, |node| node.role() == Role::Heading)
+        .expect("Should have a heading");
+    let heading_children: Vec<_> = heading.children().collect();
+    assert_eq!(heading_children.len(), 3);
+    let em = heading_children[1];
+    assert_eq!(em.is_hidden(), true);
+    assert_eq!(heading.label(), Some("We  love the web".to_owned()));
+
+    let _ = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "document.querySelector('section').removeAttribute('class');",
+    );
+
+    let mut updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
+    assert_eq!(updates.len(), 1);
+    let update = updates.pop().expect("Guaranteed by assert above");
+    tree.update_and_process_changes(update, &mut NoOpChangeHandler);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let heading = find_first_matching_node(root, |node| node.role() == Role::Heading)
+        .expect("Heading should still be in the tree");
+    assert_eq!(heading.label(), Some("We really love the web".to_owned()));
+    let heading_children: Vec<_> = heading.children().collect();
+    assert_eq!(heading_children.len(), 3);
+    let em = heading_children[1];
+    assert_eq!(em.is_hidden(), false);
+
+    let _ = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "document.querySelector('section').className = 'subdued';\
+         document.querySelector('em').firstChild.appendData(', really');",
+    );
+
+    let mut updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
+    assert_eq!(updates.len(), 1);
+    let update = updates.pop().expect("Guaranteed by assert above");
+    tree.update_and_process_changes(update, &mut NoOpChangeHandler);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let heading = find_first_matching_node(root, |node| node.role() == Role::Heading)
+        .expect("Heading should still be in the tree");
+    assert_eq!(heading.label(), Some("We  love the web".to_owned()));
+    let heading_children: Vec<_> = heading.children().collect();
+    assert_eq!(heading_children.len(), 3);
+    let em = heading_children[1];
+    assert_eq!(em.is_hidden(), true);
+
+    let _ = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "document.querySelector('section').removeAttribute('class');",
+    );
+
+    let mut updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
+    assert_eq!(updates.len(), 1);
+    let update = updates.pop().expect("Guaranteed by assert above");
+    tree.update_and_process_changes(update, &mut NoOpChangeHandler);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let heading = find_first_matching_node(root, |node| node.role() == Role::Heading)
+        .expect("Heading should still be in the tree");
+    assert_eq!(
+        heading.label(),
+        Some("We really, really love the web".to_owned())
+    );
+    let heading_children: Vec<_> = heading.children().collect();
+    assert_eq!(heading_children.len(), 3);
+    let em = heading_children[1];
+    assert_eq!(em.is_hidden(), false);
+}
+
 // ************************************************************************************************
 // If you're adding a new test here, consider adding a matching test in
 // tests/wpt/mozilla/tests/accessibility-tree/

--- a/components/shared/layout/layout_damage.rs
+++ b/components/shared/layout/layout_damage.rs
@@ -31,10 +31,16 @@ bitflags! {
         /// Rebuild this box and all of its ancestors. Do not rebuild any children. This
         /// is used when a box's content (such as text content) changes or a descendant
         /// has box damage ([`Self::BOX_DAMAGE`]).
-        const DescendantHasBoxDamage = 0b0011_1111_1111_0000;
+        const DescendantHasBoxDamage = 0b0011_0000_0000_0000;
+
         /// Rebuild this box, all of its ancestors and all of its descendants. This is the
         /// most a box can be damaged.
-        const BoxDamage = 0b1111_1111_1111_0000;
+        const BoxDamage = 0b1111_1111_0000_0000;
+
+        // Accessibility-specific damage
+        /// A descendant of this node has accessibility damage. This node should be marked as having
+        /// `AccessibilityDamage::DescendantHasDamage`.
+        const DescendantHasAccessibilityDamage = 0b0000_0000_1000_0000;
     }
 }
 
@@ -61,8 +67,10 @@ bitflags! {
     pub struct AccessibilityDamage: u16 {
         const Node = 0b0001;
         const Children = 0b0010;
-        const Subtree = 0b0100;
+        const Layout = 0b1000;
         const Rebuild = 0b1111;
+
+        const DescendantHasDamage = 0b1000_0000;
     }
 }
 malloc_size_of::malloc_size_of_is_0!(AccessibilityDamage);

--- a/components/shared/layout/layout_damage.rs
+++ b/components/shared/layout/layout_damage.rs
@@ -41,6 +41,9 @@ bitflags! {
         /// A descendant of this node has accessibility damage. This node should be marked as having
         /// `AccessibilityDamage::DescendantHasDamage`.
         const DescendantHasAccessibilityDamage = 0b0000_0000_1000_0000;
+        /// This node has accessibility damage caused by a new style property being applied. This
+        /// node should be marked as having `AccessibilityDamage::Style`.
+        const AccessibilityStyleDamage = 0b0000_0000_0100_0000;
     }
 }
 
@@ -67,6 +70,7 @@ bitflags! {
     pub struct AccessibilityDamage: u16 {
         const Node = 0b0001;
         const Children = 0b0010;
+        const Style = 0b0100;
         const Layout = 0b1000;
         const Rebuild = 0b1111;
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -11388,42 +11388,42 @@
   "testharness": {
    "accessibility-tree": {
     "accessibility-update-basic-mutation.html": [
-     "abf3f9fe8d658356ed2a863cb945330faa82c639",
+     "b355be6cbfcfdc07d2fef93e04477c81b09dcf36",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-children-of-heading-change.html": [
-     "362d24c4aa572ef951fa60d61e9378f7df00c501",
+     "ccbb12516e759ab24c78a925e804d75f30bb4ffb",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-descendants-of-heading-change.html": [
-     "0cafef06b23e2a478cd55918e2bd481ad4649b10",
+     "2703ff591c53562d33bafcdef3d8cd445b74a884",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-mutation-move-nodes.html": [
-     "27bd37752fcebe51c429bd676a3ed1f98c4de138",
+     "4a425c715838f69ea8f4f397bad1656f65ae24b0",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-partial-subtree-move-and-delete.html": [
-     "0e2d375bbd4efba12cd7e12072925daa4c793313",
+     "12660f98bc3d3c488cd0a93d3a82baa9bf8908a2",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-text-change.html": [
-     "1a0071fbbbfa22f0b310044419f589ed7ec94a7c",
+     "aaa6acae93024a97eb37ddad3301084d889e1cd6",
      [
       null,
       {}

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -11388,42 +11388,42 @@
   "testharness": {
    "accessibility-tree": {
     "accessibility-update-basic-mutation.html": [
-     "29f6c8d5c9c46e1134b9a0bb5ad1636554e1cf44",
+     "abf3f9fe8d658356ed2a863cb945330faa82c639",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-children-of-heading-change.html": [
-     "a5147a6a8f6745f6e30e18afdf5da3bc9ce8f7c2",
+     "362d24c4aa572ef951fa60d61e9378f7df00c501",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-descendants-of-heading-change.html": [
-     "bd8c0e35509d8d32038e1b5df7e06fa19c0c7ff9",
+     "0cafef06b23e2a478cd55918e2bd481ad4649b10",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-mutation-move-nodes.html": [
-     "71e749f898ce0e731986dbdef48bc7f76ce20932",
+     "27bd37752fcebe51c429bd676a3ed1f98c4de138",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-partial-subtree-move-and-delete.html": [
-     "8e61b0b1f2484d387efe2aebbaf81331fae4faf4",
+     "0e2d375bbd4efba12cd7e12072925daa4c793313",
      [
       null,
       {}
      ]
     ],
     "accessibility-update-text-change.html": [
-     "c39136e64d3ced27ef7d04c0e722bc90f3af469a",
+     "1a0071fbbbfa22f0b310044419f589ed7ec94a7c",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-basic-mutation.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-basic-mutation.html
@@ -16,8 +16,8 @@
 
       assert_equals(initial.nodesUpdatedFromDom, 19, "nodesUpdatedFromDom");
       assert_equals(initial.nodesUpdatedFromTree, 19, "nodesUpdatedFromTree");
-      // Bounds are refreshed for every node in the tree
-      assert_equals(initial.nodesUpdatedBounds, 19, "nodesUpdatedBounds");
+      // Bounds are refreshed for every visible node in the tree
+      assert_equals(initial.nodesUpdatedBounds, 12, "nodesUpdatedBounds");
       assert_equals(initial.nodesInTreeUpdate, 19, "nodesInTreeUpdate");
 
       document.getElementById("h2").remove();

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-basic-mutation.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-basic-mutation.html
@@ -24,15 +24,17 @@
       let update = ServoTestUtils.forceAccessibilityUpdate();
 
       // Only the <section> is updated from the DOM
-      // But we need to walk all the nodes to make sure we can update bounds.
-      assert_equals(update.nodesUpdatedFromDom, 17, "nodesUpdatedFromDom");
+      // Nodes visited because of subtree layout damage:
+      // - <html>
+      // - <body>
+      assert_equals(update.nodesUpdatedFromDom, 3, "nodesUpdatedFromDom");
 
       // The <section>, its parent <body> and the document are checked for changes as their subtrees
       // changed
       assert_equals(update.nodesUpdatedFromTree, 3, "nodesUpdatedFromTree");
 
-      // Bounds are refreshed for every node still in the tree (the <h2> and its text are gone)
-      assert_equals(update.nodesUpdatedBounds, 17, "nodesUpdatedBounds");
+      // Bounds are updated for the <section> and its ancestors.
+      assert_equals(update.nodesUpdatedBounds, 3, "nodesUpdatedFromLayout");
 
       // The tree update holds the parent <section> of the removed <h2>, plus the <body> and the
       // document, whose heights shrank when the <h2> was removed

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-children-of-heading-change.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-children-of-heading-change.html
@@ -13,8 +13,8 @@
 
       assert_equals(initial.nodesUpdatedFromDom, 15, "nodesUpdatedFromDom");
       assert_equals(initial.nodesUpdatedFromTree, 15, "nodesUpdatedFromTree");
-      // Bounds are refreshed for every node in the tree
-      assert_equals(initial.nodesUpdatedBounds, 15, "nodesUpdatedBounds");
+      // Bounds are refreshed for every visible node in the tree
+      assert_equals(initial.nodesUpdatedBounds, 8, "nodesUpdatedBounds");
       assert_equals(initial.nodesInTreeUpdate, 15, "nodesInTreeUpdate");
 
       document.querySelector("code").remove();

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-children-of-heading-change.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-children-of-heading-change.html
@@ -23,14 +23,16 @@
 
       // Updated nodes:
       // - h2 (<code> removed)
-      // But we need to walk all the nodes to make sure we can update bounds.
-      assert_equals(update.nodesUpdatedFromDom, 13, "nodesUpdatedFromDom");
+      // Nodes visited because of subtree layout damage:
+      // - <html>
+      // - <body>
+      assert_equals(update.nodesUpdatedFromDom, 3, "nodesUpdatedFromDom");
 
       // <html>, <body>, <h2>
       assert_equals(update.nodesUpdatedFromTree, 3, "nodesUpdatedFromTree");
 
-      // Bounds are refreshed for every node still in the tree (the <code> and its text are gone)
-      assert_equals(update.nodesUpdatedBounds, 13, "nodesUpdatedBounds");
+      // Bounds are updated for the <h2> and its ancestors.
+      assert_equals(update.nodesUpdatedBounds, 3, "nodesUpdatedBounds");
 
       // Changed nodes:
       // - <h2>, children and label changed (its geometry did not: the text still fits one line)

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-descendants-of-heading-change.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-descendants-of-heading-change.html
@@ -25,14 +25,17 @@
 
       // Updated nodes:
       // - em (<strong> removed)
-      // But we need to walk all the nodes to make sure we can update bounds.
-      assert_equals(update.nodesUpdatedFromDom, 16, "nodesUpdatedFromDom");
+      // Nodes visited because of subtree layout damage:
+      // - <html>
+      // - <body>
+      // - <h2>
+      assert_equals(update.nodesUpdatedFromDom, 4, "nodesUpdatedFromDom");
 
       // <html>, <body>, <h2>, <em>
       assert_equals(update.nodesUpdatedFromTree, 4, "nodesUpdatedFromTree");
 
-      // Bounds are refreshed for every node still in the tree (the <strong> and its text are gone)
-      assert_equals(update.nodesUpdatedBounds, 16, "nodesUpdatedBounds");
+      // Bounds are updated for the <em> and its ancestors.
+      assert_equals(update.nodesUpdatedBounds, 4, "nodesUpdatedBounds");
 
       // Changed nodes:
       // - <h2>, label changed

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-descendants-of-heading-change.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-descendants-of-heading-change.html
@@ -15,8 +15,8 @@
 
       assert_equals(initial.nodesUpdatedFromDom, 18, "nodesUpdatedFromDom");
       assert_equals(initial.nodesUpdatedFromTree, 18, "nodesUpdatedFromTree");
-      // Bounds are refreshed for every node in the tree
-      assert_equals(initial.nodesUpdatedBounds, 18, "nodesUpdatedBounds");
+      // Bounds are refreshed for every visible node in the tree
+      assert_equals(initial.nodesUpdatedBounds, 11, "nodesUpdatedBounds");
       assert_equals(initial.nodesInTreeUpdate, 18, "nodesInTreeUpdate");
 
       document.querySelector("strong").remove();

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-mutation-move-nodes.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-mutation-move-nodes.html
@@ -30,8 +30,10 @@
       // - div1 (child added)
       // - div2 (child added)
       // - <section> (children removed)
-      // But we need to walk all the nodes to make sure we can update bounds.
-      assert_equals(update.nodesUpdatedFromDom, 23, "nodesUpdatedFromDom");
+      // Nodes visited because of subtree layout damage:
+      // - <html>
+      // - <body>
+      assert_equals(update.nodesUpdatedFromDom, 5, "nodesUpdatedFromDom");
 
       // Nodes checked for changes based on the tree:
       // - the document
@@ -41,8 +43,7 @@
       // - div2
       assert_equals(update.nodesUpdatedFromTree, 5, "nodesUpdatedFromTree");
 
-      // Bounds are refreshed for every node in the tree; moving nodes removes none
-      assert_equals(update.nodesUpdatedBounds, 23, "nodesUpdatedBounds");
+      assert_equals(update.nodesUpdatedBounds, 7, "nodesUpdatedBounds");
 
       //  updated nodes:
       // - <section>, which had 2 children removed

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-mutation-move-nodes.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-mutation-move-nodes.html
@@ -18,8 +18,8 @@
 
       assert_equals(initial.nodesUpdatedFromDom, 23, "nodesUpdatedFromDom");
       assert_equals(initial.nodesUpdatedFromTree, 23, "nodesUpdatedFromTree");
-      // Bounds are refreshed for every node in the tree
-      assert_equals(initial.nodesUpdatedBounds, 23, "nodesUpdatedBounds");
+      // Bounds are refreshed for every visible node in the tree
+      assert_equals(initial.nodesUpdatedBounds, 16, "nodesUpdatedBounds");
       assert_equals(initial.nodesInTreeUpdate, 23, "nodesInTreeUpdate");
 
       div1.moveBefore(h1, null);

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-partial-subtree-move-and-delete.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-partial-subtree-move-and-delete.html
@@ -36,17 +36,16 @@
       // - <section> (div1 removed)
       // - div2 (<p> and <h1> removed)
       // - div3 (new children)
-      // But we need to walk all the nodes to make sure we can update bounds.
-      assert_equals(update.nodesUpdatedFromDom, 24, "nodesUpdatedFromDom");
+      // Nodes visited because of subtree layout damage:
+      // - <html>
+      // - <body>
+      assert_equals(update.nodesUpdatedFromDom, 5, "nodesUpdatedFromDom");
 
       // <html>, <body>, <section>, div3, div2
       assert_equals(update.nodesUpdatedFromTree, 5, "nodesUpdatedFromTree");
 
-      // Bounds are refreshed for every node still in the tree. Gone are div1, the <p> and its
-      // text, plus the two whitespace-only text nodes that were direct children of div1: one
-      // between div1's start tag and div2 (div2 itself moved out, but not its whitespace
-      // siblings), and one between div2 and div1's end tag.
-      assert_equals(update.nodesUpdatedBounds, 24, "nodesUpdatedBounds");
+      // <html>, <body>, <section>, div3, <h1>, div2
+      assert_equals(update.nodesUpdatedBounds, 6, "nodesUpdatedBounds");
 
       // Changed nodes:
       // - <section>, children changed (and it shrank, changing its bounds)
@@ -54,7 +53,8 @@
       // - div3, children changed (and it now wraps more content, changing its bounds)
       // - <h2>, which moved up when the <p> was removed, changing its bounds
       // - <body> and the document, whose heights shrank, changing their bounds
-      assert_equals(update.nodesInTreeUpdate, 6, "nodesInTreeUpdate");
+      // The <h1>'s bounds do NOT change.
+      assert_equals(update.nodesInTreeUpdate, 5, "nodesInTreeUpdate");
     }, "");
 
     done();

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-partial-subtree-move-and-delete.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-partial-subtree-move-and-delete.html
@@ -21,8 +21,8 @@
 
       assert_equals(initial.nodesUpdatedFromDom, 29, "nodesUpdatedFromDom");
       assert_equals(initial.nodesUpdatedFromTree, 29, "nodesUpdatedFromTree");
-      // Bounds are refreshed for every node in the tree
-      assert_equals(initial.nodesUpdatedBounds, 29, "nodesUpdatedBounds");
+      // Bounds are refreshed for every visible node in the tree
+      assert_equals(initial.nodesUpdatedBounds, 22, "nodesUpdatedBounds");
       assert_equals(initial.nodesInTreeUpdate, 29, "nodesInTreeUpdate");
 
       div3.moveBefore(div2, h2);

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-text-change.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-text-change.html
@@ -15,8 +15,8 @@
 
       assert_equals(initial.nodesUpdatedFromDom, 16, "nodesUpdatedFromDom");
       assert_equals(initial.nodesUpdatedFromTree, 16, "nodesUpdatedFromTree");
-      // Bounds are refreshed for every node in the tree
-      assert_equals(initial.nodesUpdatedBounds, 16, "nodesUpdatedBounds");
+      // Bounds are refreshed for every visible node in the tree
+      assert_equals(initial.nodesUpdatedBounds, 9, "nodesUpdatedBounds");
       assert_equals(initial.nodesInTreeUpdate, 16, "nodesInTreeUpdate");
 
       h1.firstChild.appendData(", now with more text");

--- a/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-text-change.html
+++ b/tests/wpt/mozilla/tests/accessibility-tree/accessibility-update-text-change.html
@@ -23,14 +23,18 @@
       let update = window.ServoTestUtils.forceAccessibilityUpdate();
 
       // Just the text node has changed
-      // But we need to walk all the nodes to make sure we can update bounds.
-      assert_equals(update.nodesUpdatedFromDom, 16, "nodesUpdatedFromDom");
+      // Nodes visited because of subtree layout damage:
+      // - <html>
+      // - <body>
+      // - <section>
+      // - <h1>
+      assert_equals(update.nodesUpdatedFromDom, 4, "nodesUpdatedFromDom");
 
       // The document, <body>, <section>, <h1> and the text node.
       assert_equals(update.nodesUpdatedFromTree, 5, "nodesUpdatedFromTree");
 
-      // Bounds are refreshed for every node in the tree; no nodes were added or removed
-      assert_equals(update.nodesUpdatedBounds, 16, "nodesUpdatedBounds");
+      // Bounds are checked for the <h1> and its ancestors.
+      assert_equals(update.nodesUpdatedBounds, 4, "nodesUpdatedBounds");
 
       //  updated nodes:
       // - <h1>, computed label changed


### PR DESCRIPTION
Note: includes the changes from #47690.

This change adds a mechanism for tracking accessibility damage during style computation, and a new type of accessibility damage: `AccessibilityDamage::Style`.

Unlike other types of accessibility damage computation, accessibility damage from style is computed regardless of whether accessibility is active, because we have no way check whether accessibility is active when computing layout damage from style in `ServoDangerousStyleElement::compute_layout_damage()`.

In the accessibility tree update, we now track whether we're in a hidden subtree throughout the update. If we are in a hidden subtree, we don't update any node bounds during `update_node_from_layout`. If a node becomes visible, the bounds of all of its non-hidden descendents will be recomputed, since they will all be marked as having damage from layout. 

We also don't set translations from scrolling on any hidden children of scroll containers, but set those translations if those children become visible.

Additionally, when performing text computation, we now ignore hidden descendants.

Testing: Adds a new test for `display: none` behaviour, other existing tests modified as necessary.
Fixes: #46809
