### PR TITLE
script: Optimize some struct layout

### DIFF
--- a/components/script/dom/css/cssstylesheet.rs
+++ b/components/script/dom/css/cssstylesheet.rs
@@ -65,9 +65,6 @@ pub(crate) struct CSSStyleSheet {
     #[no_trace]
     style_shared_lock: SharedRwLock,
 
-    /// <https://drafts.csswg.org/cssom/#concept-css-style-sheet-origin-clean-flag>
-    origin_clean: Cell<bool>,
-
     /// In which [Document] that this stylesheet was constructed.
     ///
     /// <https://drafts.csswg.org/cssom/#concept-css-style-sheet-constructor-document>
@@ -75,6 +72,9 @@ pub(crate) struct CSSStyleSheet {
 
     /// <https://drafts.csswg.org/cssom/#concept-css-style-sheet-disallow-modification-flag>
     disallow_modification: Cell<bool>,
+
+    /// <https://drafts.csswg.org/cssom/#concept-css-style-sheet-origin-clean-flag>
+    origin_clean: Cell<bool>,
 
     /// <https://drafts.csswg.org/cssom/#concept-css-style-sheet-stylesheet-base-url>
     #[no_trace]

--- a/components/script/dom/html/document_metadata/htmllinkelement.rs
+++ b/components/script/dom/html/document_metadata/htmllinkelement.rs
@@ -101,17 +101,18 @@ pub(crate) struct HTMLLinkElement {
 
     /// <https://html.spec.whatwg.org/multipage/#a-style-sheet-that-is-blocking-scripts>
     parser_inserted: Cell<bool>,
-    /// The number of loads that this link element has triggered (could be more
-    /// than one because of imports) and have not yet finished.
-    pending_loads: Cell<u32>,
     /// Whether any of the loads have failed.
     any_failed_load: Cell<bool>,
-    /// A monotonically increasing counter that keeps track of which stylesheet to apply.
-    request_generation_id: Cell<RequestGenerationId>,
     /// <https://html.spec.whatwg.org/multipage/#explicitly-enabled>
     is_explicitly_enabled: Cell<bool>,
     /// Whether the previous type matched with the destination
     previous_type_matched: Cell<bool>,
+    /// The number of loads that this link element has triggered (could be more
+    /// than one because of imports) and have not yet finished.
+    pending_loads: Cell<u32>,
+    /// A monotonically increasing counter that keeps track of which stylesheet to apply.
+    request_generation_id: Cell<RequestGenerationId>,
+
     /// Whether the previous media environment matched with the media query
     previous_media_environment_matched: Cell<bool>,
     /// Line number this element was created on

--- a/components/script/dom/html/embedded_content/htmlimageelement.rs
+++ b/components/script/dom/html/embedded_content/htmlimageelement.rs
@@ -109,11 +109,9 @@ struct ImageRequest {
 #[dom_struct]
 pub(crate) struct HTMLImageElement {
     htmlelement: HTMLElement,
-    image_request: Cell<ImageRequestPhase>,
     current_request: DomRefCell<ImageRequest>,
     pending_request: DomRefCell<ImageRequest>,
     form_owner: MutNullableDom<HTMLFormElement>,
-    generation: Cell<u32>,
     source_set: DomRefCell<SourceSet>,
     /// <https://html.spec.whatwg.org/multipage/#concept-img-dimension-attribute-source>
     /// Always non-null after construction.
@@ -124,6 +122,8 @@ pub(crate) struct HTMLImageElement {
     image_decode_promises: DomRefCell<Vec<Rc<Promise>>>,
     /// Line number this element was created on
     line_number: u64,
+    image_request: Cell<ImageRequestPhase>,
+    generation: Cell<u32>,
 }
 
 impl HTMLImageElement {

--- a/components/script/dom/html/form_controls/htmlinputelement.rs
+++ b/components/script/dom/html/form_controls/htmlinputelement.rs
@@ -109,21 +109,21 @@ pub(crate) struct HTMLInputElement {
     /// textual input. This is cached so that it can be read during layout.
     is_textual_or_password: Cell<bool>,
 
-    /// <https://html.spec.whatwg.org/multipage/#concept-input-checked-dirty-flag>
-    checked_changed: Cell<bool>,
     placeholder: DomRefCell<DOMString>,
     size: Cell<u32>,
     maxlength: Cell<i32>,
     minlength: Cell<i32>,
+    /// <https://html.spec.whatwg.org/multipage/#concept-input-checked-dirty-flag>
+    checked_changed: Cell<bool>,
     #[no_trace]
     textinput: DomRefCell<TextInput<EmbedderClipboardProvider>>,
-    /// <https://html.spec.whatwg.org/multipage/#concept-input-value-dirty-flag>
-    value_dirty: Cell<bool>,
     form_owner: MutNullableDom<HTMLFormElement>,
     labels_node_list: MutNullableDom<NodeList>,
     validity_state: MutNullableDom<ValidityState>,
     #[no_trace]
     pending_webdriver_response: RefCell<Option<PendingWebDriverResponse>>,
+    /// <https://html.spec.whatwg.org/multipage/#concept-input-value-dirty-flag>
+    value_dirty: Cell<bool>,
 
     /// <https://w3c.github.io/selection-api/#dfn-has-scheduled-selectionchange-event>
     has_scheduled_selectionchange_event: Cell<bool>,


### PR DESCRIPTION
As all our DomStructs are repr(C) the rust compiler can not efficiently pack them. This means that we are leaving bytes on the table. This reorders some fields of structs that are most highly used.
For example in HTMLImageElement we save 8 bytes which could amount to a kilobyte on a particular busy site.

padlock-cli helped with finding these structs.

Testing: This just reorders struct fields.
