### PR TITLE
script: Implement full text track list sorting

### DIFF
--- a/components/script/dom/html/embedded_content/htmlmediaelement.rs
+++ b/components/script/dom/html/embedded_content/htmlmediaelement.rs
@@ -622,11 +622,6 @@ pub(crate) struct HTMLMediaElement {
     /// <https://html.spec.whatwg.org/multipage/#time-marches-on>
     /// was last invoked (if any)
     position_when_time_marches_on_ran: Cell<Option<f64>>,
-    /// Used to track whether the only reason
-    /// <https://html.spec.whatwg.org/multipage/#time-marches-on>
-    /// was called, because it was called as a normal monotic increase.
-    #[no_trace]
-    playback_was_moved: Cell<PlaybackPositionWasMoved>,
     /// <https://html.spec.whatwg.org/multipage/#list-of-newly-introduced-cues>
     newly_introduced_cues: DomRefCell<Vec<Dom<TextTrackCue>>>,
 }
@@ -724,7 +719,6 @@ impl HTMLMediaElement {
             media_controls_id: DomRefCell::new(None),
             did_perform_automatic_track_selection: Default::default(),
             position_when_time_marches_on_ran: Default::default(),
-            playback_was_moved: Default::default(),
             newly_introduced_cues: Default::default(),
         }
     }
@@ -797,8 +791,7 @@ impl HTMLMediaElement {
     /// <https://html.spec.whatwg.org/multipage/#time-marches-on>
     fn time_marches_on(&self, cx: &mut JSContext, playback_was_moved: PlaybackPositionWasMoved) {
         let playback_was_moved_monotonic_increase =
-            self.playback_was_moved.get() == PlaybackPositionWasMoved::NormalPlayback;
-        self.playback_was_moved.set(playback_was_moved);
+            playback_was_moved == PlaybackPositionWasMoved::NormalPlayback;
         // Step 1. Let current cues be a list of cues,
         // initialized to contain all the cues of all the hidden or
         // showing text tracks of the media element (not the disabled ones)
@@ -916,9 +909,7 @@ impl HTMLMediaElement {
         let mut prepare_an_event =
             |time: f64, event: Atom, text_track_cue: DomRoot<TextTrackCue>| {
                 // Step 1. Let track be the text track with which the text track cue target is associated.
-                let track = text_track_cue
-                    .get_track()
-                    .expect("Must always have a corresponding track element");
+                let track = text_track_cue.get_track();
                 // Step 2. Create a task to fire an event named event at target.
                 //
                 // We create the task in the for-loops below
@@ -927,7 +918,9 @@ impl HTMLMediaElement {
                 // the text track track, and the text track cue target.
                 events.push((time, (event, text_track_cue)));
                 // Step 4. Add track to affected tracks.
-                affected_tracks.push(track);
+                if let Some(track) = track {
+                    affected_tracks.push(track);
+                }
             };
 
         // Step 10. For each text track cue in missed cues,
@@ -1059,7 +1052,7 @@ impl HTMLMediaElement {
             // false and run the time marches on steps.
             if self.show_poster.get() {
                 self.show_poster.set(false);
-                self.time_marches_on(cx, PlaybackPositionWasMoved::ExplicitMove);
+                self.time_marches_on(cx, PlaybackPositionWasMoved::NormalPlayback);
             }
 
             // Step 3.3. Queue a media element task given the media element to fire an event named
@@ -1293,7 +1286,7 @@ impl HTMLMediaElement {
                 // time marches on steps.
                 if self.show_poster.get() {
                     self.show_poster.set(false);
-                    self.time_marches_on(cx, PlaybackPositionWasMoved::ExplicitMove);
+                    self.time_marches_on(cx, PlaybackPositionWasMoved::NormalPlayback);
                 }
 
                 // Step 3. Queue a media element task given the element to fire an event named play
@@ -3340,7 +3333,11 @@ impl HTMLMediaElement {
         let Some(text_tracks_list) = self.text_tracks_list.get() else {
             return;
         };
-        let candidates = text_tracks_list.tracks_for_kinds(text_track_kinds);
+        let candidates: Vec<DomRoot<TextTrack>> = text_tracks_list
+            .iter()
+            .filter(|track| text_track_kinds.contains(&track.Kind()))
+            .map(|track| DomRoot::from_ref(&*track))
+            .collect();
         // Step 2. If candidates is empty, then return.
         if candidates.is_empty() {
             return;

--- a/components/script/dom/webvtt/texttracklist.rs
+++ b/components/script/dom/webvtt/texttracklist.rs
@@ -7,7 +7,6 @@ use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::reflect_dom_object_with_cx;
 
-use crate::dom::bindings::codegen::Bindings::TextTrackBinding::{TextTrackKind, TextTrackMethods};
 use crate::dom::bindings::codegen::Bindings::TextTrackListBinding::TextTrackListMethods;
 use crate::dom::bindings::codegen::UnionTypes::VideoTrackOrAudioTrackOrTextTrack;
 use crate::dom::bindings::inheritance::Castable;
@@ -58,34 +57,6 @@ impl TextTrackList {
         )
     }
 
-    pub(crate) fn item(&self, idx: usize) -> Option<DomRoot<TextTrack>> {
-        self.dom_tracks
-            .borrow()
-            .get(idx)
-            .map(|t| DomRoot::from_ref(&**t))
-    }
-
-    pub(crate) fn find(&self, track: &TextTrack) -> Option<usize> {
-        self.dom_tracks
-            .borrow()
-            .iter()
-            .enumerate()
-            .find(|(_, t)| **t == track)
-            .map(|(i, _)| i)
-    }
-
-    pub(crate) fn tracks_for_kinds(
-        &self,
-        text_track_kinds: Vec<TextTrackKind>,
-    ) -> Vec<DomRoot<TextTrack>> {
-        self.dom_tracks
-            .borrow()
-            .iter()
-            .filter(|track| text_track_kinds.contains(&track.Kind()))
-            .map(|track| DomRoot::from_ref(&**track))
-            .collect()
-    }
-
     pub(crate) fn notify_media_element_for_added_cue(
         &self,
         cx: &mut JSContext,
@@ -95,11 +66,13 @@ impl TextTrackList {
     }
 
     pub(crate) fn add(&self, cx: &mut JSContext, track: &TextTrack) {
-        // Only add a track if it does not exist in the list
-        if self.find(track).is_some() {
-            return;
+        // We should only store the tracks created by `addTextTrack`
+        // since the iterator already traverses children of a media
+        // element for <track> elements. Otherwise, we would be double
+        // counting.
+        if track.associated_track().is_none() {
+            self.dom_tracks.borrow_mut().push(Dom::from_ref(track));
         }
-        self.dom_tracks.borrow_mut().push(Dom::from_ref(track));
 
         track.add_track_list(self);
         self.media_element
@@ -130,10 +103,14 @@ impl TextTrackList {
     }
 
     pub(crate) fn remove(&self, track: &TextTrack) {
-        let Some(idx) = self.find(track) else {
-            return;
+        if let Some(idx) = self
+            .dom_tracks
+            .borrow()
+            .iter()
+            .position(|dom_track| &**dom_track == track)
+        {
+            self.dom_tracks.borrow_mut().remove(idx);
         };
-        self.dom_tracks.borrow_mut().remove(idx);
         track.remove_track_list();
 
         let this = Trusted::new(self);
@@ -160,15 +137,21 @@ impl TextTrackList {
             }));
     }
 
-    pub(crate) fn iter(&self) -> TextTrackListIterator {
+    pub(crate) fn iter<'a>(&'a self) -> TextTrackListIterator<'a> {
         TextTrackListIterator {
-            track_elements: self
-                .media_element
-                .upcast::<Node>()
-                .children()
-                .filter_map(DomRoot::downcast::<HTMLTrackElement>)
-                .collect(),
-            current_track_element_index: 0,
+            track_elements: Box::new(
+                self.media_element
+                    .upcast::<Node>()
+                    .children()
+                    .filter_map(DomRoot::downcast::<HTMLTrackElement>),
+            ),
+            dom_tracks: Box::new(
+                self.dom_tracks
+                    .borrow()
+                    .clone()
+                    .into_iter()
+                    .map(|track| track.as_rooted()),
+            ),
         }
     }
 }
@@ -176,22 +159,27 @@ impl TextTrackList {
 impl TextTrackListMethods<crate::DomTypeHolder> for TextTrackList {
     /// <https://html.spec.whatwg.org/multipage/#dom-texttracklist-length>
     fn Length(&self) -> u32 {
-        self.dom_tracks.borrow().len() as u32
+        // > The length attribute of a TextTrackList object must return
+        // > the number of text tracks in the list represented by the TextTrackList object.
+        self.iter().count() as u32
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-texttracklist-item>
     fn IndexedGetter(&self, idx: u32) -> Option<DomRoot<TextTrack>> {
-        self.item(idx as usize)
+        // > To determine the value of an indexed property of a TextTrackList object
+        // > for a given index index, the user agent must return the indexth
+        // > text track in the list represented by the TextTrackList object.
+        self.iter().nth(idx as usize)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-texttracklist-gettrackbyid>
     fn GetTrackById(&self, id: DOMString) -> Option<DomRoot<TextTrack>> {
+        // > The getTrackById(id) method must return the first TextTrack in
+        // > the TextTrackList object whose id IDL attribute would return
+        // > a value equal to the value of the id argument.
+        // > When no tracks match the given argument, the method must return null.
         let id_str = String::from(id);
-        self.dom_tracks
-            .borrow()
-            .iter()
-            .find(|track| track.id() == id_str)
-            .map(|t| DomRoot::from_ref(&**t))
+        self.iter().find(|track| track.id() == id_str)
     }
 
     // https://html.spec.whatwg.org/multipage/#handler-texttracklist-onchange
@@ -205,24 +193,25 @@ impl TextTrackListMethods<crate::DomTypeHolder> for TextTrackList {
 }
 
 /// <https://html.spec.whatwg.org/multipage/#list-of-text-tracks>
-pub(crate) struct TextTrackListIterator {
-    track_elements: Vec<DomRoot<HTMLTrackElement>>,
-    current_track_element_index: usize,
+pub(crate) struct TextTrackListIterator<'a> {
+    track_elements: Box<dyn Iterator<Item = DomRoot<HTMLTrackElement>> + 'a>,
+    dom_tracks: Box<dyn Iterator<Item = DomRoot<TextTrack>> + 'a>,
 }
 
-impl Iterator for TextTrackListIterator {
+impl<'a> Iterator for TextTrackListIterator<'a> {
     type Item = DomRoot<TextTrack>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // > The text tracks are sorted as follows:
         // Step 1. The text tracks corresponding to track element children of the media element, in tree order.
-        if let Some(track_element) = self.track_elements.get(self.current_track_element_index) {
-            self.current_track_element_index += 1;
+        if let Some(track_element) = self.track_elements.next() {
             return Some(track_element.track());
         }
         // Step 2. Any text tracks added using the addTextTrack() method,
         // in the order they were added, oldest first.
-        // TODO
+        if let Some(dom_track) = self.dom_tracks.next() {
+            return Some(dom_track);
+        }
         // Step 3. Any media-resource-specific text tracks
         // (text tracks corresponding to data in the media resource),
         // in the order defined by the media resource's format specification.

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cue-negative-duration.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cue-negative-duration.html.ini
@@ -1,4 +1,0 @@
-[track-cue-negative-duration.html]
-  expected: TIMEOUT
-  [Enter, Exit events for a cue with negative duration]
-    expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cue-negative-timestamp-events.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cue-negative-timestamp-events.html.ini
@@ -1,4 +1,0 @@
-[track-cue-negative-timestamp-events.html]
-  expected: TIMEOUT
-  [Enter, Exit events for cues with negative timestamps]
-    expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-pause-on-exit.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-pause-on-exit.html.ini
@@ -1,3 +1,0 @@
-[track-cues-pause-on-exit.html]
-  [Video is paused after cues having pause-on-exit flag are processed]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-sorted-before-dispatch.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cues-sorted-before-dispatch.html.ini
@@ -1,3 +1,0 @@
-[track-cues-sorted-before-dispatch.html]
-  [All events are triggered in chronological order]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-mode.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-mode.html.ini
@@ -1,4 +1,0 @@
-[track-mode.html]
-  expected: TIMEOUT
-  [TextTrack mode attribute]
-    expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-remove-active-cue.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-remove-active-cue.html.ini
@@ -1,4 +1,3 @@
 [track-remove-active-cue.html]
-  expected: TIMEOUT
   [Removing an active cue]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-two-cue-layout-after-first-end.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-two-cue-layout-after-first-end.html.ini
@@ -1,2 +1,0 @@
-[track-webvtt-two-cue-layout-after-first-end.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/webvtt/api/VTTRegion/non-visible-cue-with-region.html.ini
+++ b/tests/wpt/meta/webvtt/api/VTTRegion/non-visible-cue-with-region.html.ini
@@ -1,3 +1,0 @@
-[non-visible-cue-with-region.html]
-  [Box-less VTTCue attached to VTTRegion]
-    expected: FAIL


### PR DESCRIPTION
The list should contain both tracks from `<track>`
elements as well as those added by `addTextTrack`, but
in the order as specified.

In a follow-up PR I plan to add `NoGC` to these, but that
requires a bit too much plumbing for this PR.

Part of #46288

Testing: new WPT tests pass