### PR TITLE
script/script_bindings: Cleanup LiveDomReferences and LivePromiseReferences

### DIFF
--- a/components/script/dom/bindings/refcounted.rs
+++ b/components/script/dom/bindings/refcounted.rs
@@ -21,12 +21,11 @@ use script_bindings::trace::trace_reflector;
 use crate::dom::promise::Promise;
 use crate::tasks::task::TaskOnce;
 
-thread_local!(pub(super) static LIVE_REFERENCES: Rc<RefCell<LivePromiseReferences>> =
-    Rc::new(RefCell::new(
+thread_local!(pub(super) static LIVE_PROMISE_REFERENCES: LivePromiseReferences =
     LivePromiseReferences {
         promise_table: RefCell::new(FxHashMap::default()),
     }
-)));
+);
 
 /// The set of live, pinned DOM objects that are currently prevented
 /// from being garbage collected due to outstanding references.
@@ -37,8 +36,7 @@ pub(crate) struct LivePromiseReferences {
 
 impl LivePromiseReferences {
     pub(crate) fn destruct() {
-        LIVE_REFERENCES.with(|r| {
-            let live_references = r.borrow_mut();
+        LIVE_PROMISE_REFERENCES.with(|live_references| {
             let _ = live_references.promise_table.take();
         });
     }
@@ -65,8 +63,7 @@ impl TrustedPromise {
     /// be prevented from being GCed for the duration of the resulting `TrustedPromise` object's
     /// lifetime.
     pub(crate) fn new(promise: Rc<Promise>) -> TrustedPromise {
-        LIVE_REFERENCES.with(|r| {
-            let live_references = &*r.borrow();
+        LIVE_PROMISE_REFERENCES.with(|live_references| {
             let ptr = &raw const *promise;
             live_references.addref_promise(promise);
             TrustedPromise {
@@ -80,8 +77,7 @@ impl TrustedPromise {
     /// a different thread than the original value from which this `TrustedPromise` was
     /// obtained.
     pub(crate) fn root(self) -> Rc<Promise> {
-        LIVE_REFERENCES.with(|r| {
-            let live_references = &*r.borrow();
+        LIVE_PROMISE_REFERENCES.with(|live_references| {
             assert_eq!(
                 self.owner_thread,
                 live_references as *const _ as *const libc::c_void
@@ -132,18 +128,16 @@ impl TrustedPromise {
 
 /// A JSTraceDataOp for tracing reflectors held in LIVE_REFERENCES
 pub(crate) unsafe fn trace_refcounted_objects(tracer: *mut JSTracer) {
-    trace!("tracing live refcounted references");
-    LIVE_REFERENCES.with(|r| {
-        let live_references = &*r.borrow();
-        {
-            let table = live_references.promise_table.borrow_mut();
-            for promise in table.keys() {
-                unsafe {
-                    trace_reflector(tracer, "refcounted", (**promise).reflector());
-                }
+    trace!("tracing live refcounted promises");
+    LIVE_PROMISE_REFERENCES.with(|live_references| {
+        let table = live_references.promise_table.borrow_mut();
+        for promise in table.keys() {
+            unsafe {
+                trace_reflector(tracer, "refcounted", (**promise).reflector());
             }
         }
     });
+    trace!("tracing live refcounted references");
     unsafe {
         script_bindings::refcounted::trace_live_domreferences(tracer);
     }

--- a/components/script/dom/bindings/refcounted.rs
+++ b/components/script/dom/bindings/refcounted.rs
@@ -128,7 +128,7 @@ impl TrustedPromise {
 
 /// A JSTraceDataOp for tracing reflectors held in LIVE_REFERENCES
 pub(crate) unsafe fn trace_refcounted_objects(tracer: *mut JSTracer) {
-    trace!("tracing live refcounted promises");
+    trace!("tracing live refcounted promise references");
     LIVE_PROMISE_REFERENCES.with(|live_references| {
         let table = live_references.promise_table.borrow_mut();
         for promise in table.keys() {

--- a/components/script_bindings/refcounted.rs
+++ b/components/script_bindings/refcounted.rs
@@ -26,18 +26,16 @@ use std::cell::RefCell;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::hash::Hash;
 use std::marker::PhantomData;
-use std::rc::Rc;
 use std::sync::{Arc, Weak};
 
 use js::jsapi::JSTracer;
 use rustc_hash::FxHashMap;
 
-thread_local!(pub(super) static LIVE_REFERENCES: Rc<RefCell<LiveDOMReferences>> =
-    Rc::new(RefCell::new(
+thread_local!(pub(super) static LIVE_DOM_REFERENCES: LiveDOMReferences =
     LiveDOMReferences {
         reflectable_table: RefCell::new(FxHashMap::default()),
     }
-)));
+);
 
 use crate::root::DomRoot;
 use crate::trace::trace_reflector;
@@ -91,8 +89,7 @@ impl<T: DomObject> Trusted<T> {
         fn add_live_reference(
             ptr: *const libc::c_void,
         ) -> (Arc<TrustedReference>, *const LiveDOMReferences) {
-            LIVE_REFERENCES.with(|r| {
-                let live_references = &*r.borrow();
+            LIVE_DOM_REFERENCES.with(|live_references| {
                 let refcount = unsafe { live_references.addref(ptr) };
                 (refcount, live_references as *const _)
             })
@@ -111,11 +108,9 @@ impl<T: DomObject> Trusted<T> {
     /// obtained.
     pub fn root(&self) -> DomRoot<T> {
         fn validate(owner_thread: *const LiveDOMReferences) {
-            assert!(LIVE_REFERENCES.with(|r| {
-                let r = r.borrow();
-                let live_references = &*r;
-                owner_thread == live_references
-            }));
+            assert!(
+                LIVE_DOM_REFERENCES.with(|live_references| { owner_thread == live_references })
+            );
         }
         validate(self.owner_thread);
         unsafe { DomRoot::from_ref(&*(self.refcount.0 as *const T)) }
@@ -143,8 +138,7 @@ pub struct LiveDOMReferences {
 /// # Safety
 /// tracer must point to a valid, non-null JS tracer.
 pub unsafe fn trace_live_domreferences(tracer: *mut JSTracer) {
-    LIVE_REFERENCES.with(|r| {
-        let live_references = r.borrow();
+    LIVE_DOM_REFERENCES.with(|live_references| {
         let mut table = live_references.reflectable_table.borrow_mut();
         remove_nulls(&mut table);
         for obj in table.keys() {
@@ -157,8 +151,7 @@ pub unsafe fn trace_live_domreferences(tracer: *mut JSTracer) {
 
 impl LiveDOMReferences {
     pub fn destruct() {
-        LIVE_REFERENCES.with(|r| {
-            let live_references = r.borrow_mut();
+        LIVE_DOM_REFERENCES.with(|live_references| {
             let _ = live_references.reflectable_table.take();
         });
     }


### PR DESCRIPTION
As discussed in https://github.com/servo/servo/pull/47608, the `Rc<RefCell<>>` does not seem to be necessary for the thread_local type. We remove them and do some general variable renaming.

Testing: WPT test run here https://github.com/Narfinger/servo/actions/runs/33849816744
