### PR TITLE
script_bindings: Introduce separate types for traced and rooted WebIDL callbacks

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -55,7 +55,7 @@ use profile_traits::time::TimerMetadataFrameType;
 use profile_traits::{generic_channel as profile_generic_channel, path};
 use regex::bytes::Regex;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
-use script_bindings::callback::ThisReflector;
+use script_bindings::callback::{RootedCallback, ThisReflector};
 use script_bindings::cell::{DomRefCell, Ref, RefMut};
 use script_bindings::interfaces::DocumentHelpers;
 use script_bindings::reflector::reflect_dom_object_with_proto;
@@ -6904,7 +6904,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         &self,
         cx: &mut JSContext,
         expression: DOMString,
-        resolver: Option<Rc<XPathNSResolver>>,
+        resolver: Option<RootedCallback<XPathNSResolver>>,
     ) -> Fallible<DomRoot<crate::dom::types::XPathExpression>> {
         let parsed_expression =
             parse_expression(cx, &expression.str(), resolver, self.is_html_document())?;
@@ -6928,7 +6928,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         cx: &mut JSContext,
         expression: DOMString,
         context_node: &Node,
-        resolver: Option<Rc<XPathNSResolver>>,
+        resolver: Option<RootedCallback<XPathNSResolver>>,
         result_type: u16,
         result: Option<&crate::dom::types::XPathResult>,
     ) -> Fallible<DomRoot<crate::dom::types::XPathResult>> {

--- a/components/script/dom/webxr/xrsession.rs
+++ b/components/script/dom/webxr/xrsession.rs
@@ -20,6 +20,7 @@ use js::rust::MutableHandleValue;
 use js::typedarray::HeapFloat32Array;
 use profile_traits::generic_callback::GenericCallback as ProfileGenericCallback;
 use rustc_hash::FxBuildHasher;
+use script_bindings::callback::{RootedCallback, TracedCallback};
 use script_bindings::trace::RootedTraceableBox;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use stylo_atoms::Atom;
@@ -91,9 +92,10 @@ pub(crate) struct XRSession {
 
     next_raf_id: Cell<i32>,
     #[ignore_malloc_size_of = "closures are hard"]
-    raf_callback_list: DomRefCell<Vec<(i32, Option<Rc<XRFrameRequestCallback>>)>>,
+    raf_callback_list: DomRefCell<Vec<(i32, Option<TracedCallback<XRFrameRequestCallback>>)>>,
     #[ignore_malloc_size_of = "closures are hard"]
-    current_raf_callback_list: DomRefCell<Vec<(i32, Option<Rc<XRFrameRequestCallback>>)>>,
+    current_raf_callback_list:
+        DomRefCell<Vec<(i32, Option<TracedCallback<XRFrameRequestCallback>>)>>,
     input_sources: Dom<XRInputSourceArray>,
     // Any promises from calling end()
     #[conditional_malloc_size_of]
@@ -490,8 +492,8 @@ impl XRSession {
         self.outside_raf.set(false);
         let len = self.current_raf_callback_list.borrow().len();
         for i in 0..len {
-            let callback = self.current_raf_callback_list.borrow()[i].1.clone();
-            if let Some(callback) = callback {
+            rooted!(&in(cx) let callback = self.current_raf_callback_list.borrow()[i].1.clone());
+            if let Some(ref callback) = *callback {
                 let _ = callback.Call__(cx, time, &frame, ExceptionHandling::Report);
             }
         }
@@ -796,13 +798,13 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
     }
 
     /// <https://immersive-web.github.io/webxr/#dom-xrsession-requestanimationframe>
-    fn RequestAnimationFrame(&self, callback: Rc<XRFrameRequestCallback>) -> i32 {
+    fn RequestAnimationFrame(&self, callback: RootedCallback<XRFrameRequestCallback>) -> i32 {
         // queue up RAF callback, obtain ID
         let raf_id = self.next_raf_id.get();
         self.next_raf_id.set(raf_id + 1);
         self.raf_callback_list
             .borrow_mut()
-            .push((raf_id, Some(callback)));
+            .push((raf_id, Some(callback.to_traced())));
 
         raf_id
     }

--- a/components/script/dom/xpath/xpathevaluator.rs
+++ b/components/script/dom/xpath/xpathevaluator.rs
@@ -2,11 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::rc::Rc;
-
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
+use script_bindings::callback::RootedCallback;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 
@@ -64,7 +63,7 @@ impl XPathEvaluatorMethods<crate::DomTypeHolder> for XPathEvaluator {
         &self,
         cx: &mut JSContext,
         expression: DOMString,
-        resolver: Option<Rc<XPathNSResolver>>,
+        resolver: Option<RootedCallback<XPathNSResolver>>,
     ) -> Fallible<DomRoot<XPathExpression>> {
         let parsed_expression = parse_expression(
             cx,
@@ -92,7 +91,7 @@ impl XPathEvaluatorMethods<crate::DomTypeHolder> for XPathEvaluator {
         cx: &mut JSContext,
         expression: DOMString,
         context_node: &Node,
-        resolver: Option<Rc<XPathNSResolver>>,
+        resolver: Option<RootedCallback<XPathNSResolver>>,
         result_type: u16,
         result: Option<&XPathResult>,
     ) -> Fallible<DomRoot<XPathResult>> {

--- a/components/script/xpath.rs
+++ b/components/script/xpath.rs
@@ -7,11 +7,10 @@
 use std::cell::Ref;
 use std::cmp::Ordering;
 use std::fmt::Debug;
-use std::rc::Rc;
 
 use html5ever::{LocalName, Namespace, Prefix};
 use js::context::JSContext;
-use script_bindings::callback::ExceptionHandling;
+use script_bindings::callback::{ExceptionHandling, RootedCallback};
 use script_bindings::codegen::GenericBindings::AttrBinding::AttrMethods;
 use script_bindings::codegen::GenericBindings::NodeBinding::{GetRootNodeOptions, NodeMethods};
 use script_bindings::root::Dom;
@@ -45,7 +44,7 @@ pub(crate) struct XPathImplementation;
 impl xpath::Dom for XPathImplementation {
     type Context = JSContext;
     type Node = XPathWrapper<DomRoot<Node>>;
-    type NamespaceResolver = XPathWrapper<Rc<XPathNSResolver>>;
+    type NamespaceResolver = XPathWrapper<RootedCallback<XPathNSResolver>>;
 }
 
 impl xpath::Node for XPathWrapper<DomRoot<Node>> {
@@ -280,7 +279,7 @@ impl xpath::Attribute for XPathWrapper<DomRoot<Attr>> {
     }
 }
 
-impl xpath::NamespaceResolver for XPathWrapper<Rc<XPathNSResolver>> {
+impl xpath::NamespaceResolver for XPathWrapper<RootedCallback<XPathNSResolver>> {
     type Context = JSContext;
 
     fn resolve_namespace_prefix(&self, cx: &mut JSContext, prefix: &str) -> Option<String> {
@@ -307,7 +306,7 @@ impl<T> From<T> for XPathWrapper<T> {
 pub(crate) fn parse_expression(
     cx: &mut JSContext,
     expression: &str,
-    resolver: Option<Rc<XPathNSResolver>>,
+    resolver: Option<RootedCallback<XPathNSResolver>>,
     is_in_html_document: bool,
 ) -> Fallible<xpath::Expression> {
     xpath::parse(

--- a/components/script_bindings/callback.rs
+++ b/components/script_bindings/callback.rs
@@ -61,6 +61,61 @@ pub enum ExceptionHandling {
     Rethrow,
 }
 
+#[derive(JSTraceable)]
+pub struct RootedCallback<T>(Rc<T>);
+
+impl<T> RootedCallback<T> {
+    pub fn to_traced(&self) -> TracedCallback<T> {
+        TracedCallback(self.0.clone())
+    }
+}
+
+impl<T> Clone for RootedCallback<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T> std::ops::Deref for RootedCallback<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> From<Rc<T>> for RootedCallback<T> {
+    fn from(callback: Rc<T>) -> Self {
+        Self(callback)
+    }
+}
+
+impl<T: js::conversions::ToJSValConvertible> js::conversions::ToJSValConvertible
+    for RootedCallback<T>
+{
+    fn to_jsval(&self, cx: &mut JSContext, rval: MutableHandleValue<'_>) {
+        self.0.to_jsval(cx, rval)
+    }
+}
+
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
+#[derive(JSTraceable, MallocSizeOf)]
+pub struct TracedCallback<T>(#[conditional_malloc_size_of] Rc<T>);
+
+impl<T: crate::JSTraceable> js::gc::Rootable for TracedCallback<T> {}
+
+impl<T> Clone for TracedCallback<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T> std::ops::Deref for TracedCallback<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 /// A common base class for representing IDL callback function and
 /// callback interface types.
 #[derive(JSTraceable, MallocSizeOf)]

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -470,6 +470,10 @@ DOMInterfaces = {
     'cx': ['TimeStamp'],
 },
 
+'EventListener': {
+    'useRcCallback': True,
+},
+
 'EventSource': {
     'weakReferenceable': True,
 },
@@ -988,6 +992,10 @@ DOMInterfaces = {
 'Node': {
     'cx': ['AppendChild', 'ChildNodes', 'CloneNode', 'InsertBefore', 'Normalize', 'RemoveChild', 'ReplaceChild', 'SetNodeValue', 'SetTextContent'],
     'no_gc': ['CompareDocumentPosition'],
+},
+
+'NodeFilter': {
+    'useRcCallback': True,
 },
 
 'NodeIterator': {
@@ -1554,6 +1562,10 @@ DOMInterfaces = {
     'cx': ['Evaluate'],
 },
 
+'XPathNSResolver': {
+    'useRcCallback': True,
+},
+
 'Origin': {
     'cx': ['From'],
 },
@@ -1871,4 +1883,151 @@ SubCrates = {
     'GPUBuffer', 'GPUBufferUsage', 'GPUCommandBuffer', 'GPUColorWrite',
     'GPUCompilationInfo', 'GPUCompilationMessage', 'GPUDeviceLostInfo', 'GPUMapMode', 'GPURenderBundle', 'GPUShaderStage',
     'GPUSupportedLimits', 'GPUSupportedFeatures', 'GPUTextureUsage', 'WGSLLanguageFeatures'],
+}
+
+Callbacks = {
+    'AnimationFrameProvider': {
+        'rc': True,
+    },
+    'AnyCallback': {
+        'rc': True,
+    },
+    'BlobCallback': {
+        'rc': True,
+    },
+    'callbackWithOnlyOneOptionalArg': {
+        'rc': True,
+    },
+    'CreateHTMLCallback': {
+        'rc': True,
+    },
+    'CreateScriptCallback': {
+        'rc': True,
+    },
+    'CreateScriptURLCallback': {
+        'rc': True,
+    },
+    'CustomElementConstructor': {
+        'rc': True,
+    },
+    'DecodeSuccessCallback': {
+        'rc': True,
+    },
+    'DecodeErrorCallback': {
+        'rc': True,
+    },
+    'ErrorCallback': {
+        'rc': True,
+    },
+    'EventHandlerNonNull': {
+        'rc': True,
+    },
+    'EventListener': {
+        'rc': True,
+    },
+    'FileCallback': {
+        'rc': True,
+    },
+    'FileSystemEntriesCallback': {
+        'rc': True,
+    },
+    'FileSystemEntryCallback': {
+        'rc': True,
+    },
+    'FrameRequestCallback': {
+        'rc': True,
+    },
+    'Function': {
+        'rc': True,
+    },
+    'FunctionStringCallback': {
+        'rc': True,
+    },
+    'IntersectionObserverCallback': {
+        'rc': True,
+    },
+    'MediaSessionActionHandler': {
+        'rc': True,
+    },
+    'MutationCallback': {
+        'rc': True,
+    },
+    'NodeFilter': {
+        'rc': True,
+    },
+    'NotificationPermissionCallback': {
+        'rc': True,
+    },
+    'OnBeforeUnloadEventHandlerNonNull': {
+        'rc': True,
+    },
+    'OnErrorEventHandlerNonNull': {
+        'rc': True,
+    },
+    'PerformanceObserverCallback': {
+        'rc': True,
+    },
+    'PositionCallback': {
+        'rc': True,
+    },
+    'PositionErrorCallback': {
+        'rc': True,
+    },
+    'PromiseJobCallback': {
+        'rc': True,
+    },
+    'QueuingStrategySize': {
+        'rc': True,
+    },
+    'ReportingObserverCallback': {
+        'rc': True,
+    },
+    'ResizeObserverCallback': {
+        'rc': True,
+    },
+    'SimpleCallback': {
+        'rc': True,
+    },
+    'TransformerCancelCallback': {
+        'rc': True,
+    },
+    'TransformerFlushCallback': {
+        'rc': True,
+    },
+    'TransformerStartCallback': {
+        'rc': True,
+    },
+    'TransformerTransformCallback': {
+        'rc': True,
+    },
+    'UnderlyingSinkAbortCallback': {
+        'rc': True,
+    },
+    'UnderlyingSinkCloseCallback': {
+        'rc': True,
+    },
+    'UnderlyingSinkStartCallback': {
+        'rc': True,
+    },
+    'UnderlyingSinkWriteCallback': {
+        'rc': True,
+    },
+    'UnderlyingSourceCancelCallback': {
+        'rc': True,
+    },
+    'UnderlyingSourcePullCallback': {
+        'rc': True,
+    },
+    'UnderlyingSourceStartCallback': {
+        'rc': True,
+    },
+    'VoidFunction': {
+        'rc': True,
+    },
+    'XPathNSResolver': {
+        'rc': True,
+    },
+    'XRFrameRequestCallback': {
+        'rc': True,
+    },
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1562,10 +1562,6 @@ DOMInterfaces = {
     'cx': ['Evaluate'],
 },
 
-'XPathNSResolver': {
-    'useRcCallback': True,
-},
-
 'Origin': {
     'cx': ['From'],
 },
@@ -2022,9 +2018,6 @@ Callbacks = {
         'rc': True,
     },
     'VoidFunction': {
-        'rc': True,
-    },
-    'XPathNSResolver': {
         'rc': True,
     },
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -2027,7 +2027,4 @@ Callbacks = {
     'XPathNSResolver': {
         'rc': True,
     },
-    'XRFrameRequestCallback': {
-        'rc': True,
-    },
 }

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -1002,8 +1002,11 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
 
         if descriptor.interface.isCallback():
             name = descriptor.nativeType
-            declType = CGWrapper(CGGeneric(f"{name}<D>"), pre="Rc<", post=">")
+            pre = "Rc" if descriptor.useRcCallback else "RootedCallback"
+            declType = CGWrapper(CGGeneric(f"{name}<D>"), pre=f"{pre}<", post=">")
             template = f"{name}::new(cx, ${{val}}.get().to_object())"
+            if not descriptor.useRcCallback:
+                template = f"RootedCallback::from({template})"
             if type.nullable():
                 declType = CGWrapper(declType, pre="Option<", post=">")
                 template = wrapObjectTemplate(f"Some({template})", "None",
@@ -1209,9 +1212,11 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
         # pyrefly: ignore  # missing-attribute
         callback = type.unroll().callback
         declType = CGGeneric(f"{callback.identifier.name}<D>")
-        finalDeclType = CGTemplatedType("Rc", declType)
+        useRc = descriptorProvider.callbackUsesRc(callback.identifier.name)
+        typeName = "Rc" if useRc else "RootedCallback"
+        finalDeclType = CGTemplatedType(typeName, declType)
 
-        conversion = CGCallbackTempRoot(declType.define())
+        conversion = CGCallbackTempRoot(declType.define(), useRc)
 
         if type.nullable():
             declType = CGTemplatedType("Option", declType)
@@ -1664,7 +1669,8 @@ def getRetvalDeclarationForType(returnType: IDLType | None, descriptorProvider: 
     if returnType.isCallback():
         # pyrefly: ignore  # missing-attribute
         callback = returnType.unroll().callback
-        result = CGGeneric(f'Rc<{getModuleFromObject(callback)}::{callback.identifier.name}<D>>')
+        typeName = "Rc" if descriptorProvider.callbackUsesRc(callback.identifier.name) else "RootedCallback"
+        result = CGGeneric(f'{typeName}<{getModuleFromObject(callback)}::{callback.identifier.name}<D>>')
         if returnType.nullable():
             result = CGWrapper(result, pre="Option<", post=">")
         return result
@@ -2866,8 +2872,11 @@ class CGGeneric(CGThing):
 
 
 class CGCallbackTempRoot(CGGeneric):
-    def __init__(self, name: str) -> None:
-        CGGeneric.__init__(self, f"unsafe {{ {name.replace('<D>', '::<D>')}::new(cx, ${{val}}.get().to_object()) }}")
+    def __init__(self, name: str, useRc: bool) -> None:
+        inner = CGGeneric(f"unsafe {{ {name.replace('<D>', '::<D>')}::new(cx, ${{val}}.get().to_object()) }}")
+        pre = "RootedCallback::from(" if not useRc else ""
+        post = ")" if not useRc else ""
+        CGGeneric.__init__(self, CGWrapper(inner, pre, post).define())
 
 
 def getAllTypes(
@@ -5619,7 +5628,7 @@ impl{self.generic} Clone for {self.type}{self.genericSuffix} {{
             if type_needs_tracing(t):
                 return "RootedTraceableBox"
             if t.isCallback():
-                return "Rc"
+                return "Rc" if self.descriptorProvider.callbackUsesRc(t.name) else "RootedCallback"
             return ""
 
         assert self.type.flatMemberTypes is not None
@@ -5839,7 +5848,8 @@ class CGUnionConversionStruct(CGThing):
         if type_needs_tracing(t):
             actualType = f"RootedTraceableBox<{actualType}>"
         if t.isCallback():
-            actualType = f"Rc<{actualType}>"
+            typeName = "Rc" if self.descriptorProvider.callbackUsesRc(t.name) else "RootedCallback"
+            actualType = f"{typeName}<{actualType}>"
         returnType = f"Result<Option<{actualType}>, ()>"
         jsConversion = templateVars["jsConversion"]
 
@@ -5992,7 +6002,7 @@ class ClassConstructor(ClassItem):
 
     body contains a string with the code for the constructor, defaults to empty.
     """
-    def __init__(self, args: list[Argument], inline: bool = False, bodyInHeader: bool = False,
+    def __init__(self, args: list[Argument], useRc: bool, inline: bool = False, bodyInHeader: bool = False,
                  visibility: str = "priv", explicit: bool = False, baseConstructors: list[str] | None = None,
                  body: str = "") -> None:
         self.args = args
@@ -6001,6 +6011,7 @@ class ClassConstructor(ClassItem):
         self.explicit = explicit
         self.baseConstructors = baseConstructors or []
         self.body = body
+        self.useRc = useRc
         ClassItem.__init__(self, None, visibility)
 
     def getDecorators(self, declaring: bool) -> str:
@@ -8522,6 +8533,7 @@ class CGCallback(CGClass):
         self.baseName = baseName
         self._deps = idlObject.getDeps()
         name = idlObject.identifier.name
+        self.useRc = descriptorProvider.callbackUsesRc(name)
         # For our public methods that needThisHandling we want most of the
         # same args and the same return type as what CallbackMember
         # generates.  So we want to take advantage of all its
@@ -8546,6 +8558,7 @@ class CGCallback(CGClass):
     def getConstructors(self) -> list[ClassConstructor]:
         return [ClassConstructor(
             [Argument("&JSContext", "cx"), Argument("*mut JSObject", "aCallback")],
+            useRc=self.useRc,
             bodyInHeader=True,
             visibility="pub",
             explicit=False,

--- a/components/script_bindings/codegen/configuration.py
+++ b/components/script_bindings/codegen/configuration.py
@@ -59,6 +59,7 @@ class Configuration:
         self.enumConfig = glbl['Enums']
         self.dictConfig = glbl['Dictionaries']
         self.unionConfig = glbl['Unions']
+        self.callbackConfig = glbl['Callbacks']
         self.sub_crates = glbl['SubCrates']
 
         # Build descriptors for all the interfaces we have in the parse data.
@@ -179,6 +180,9 @@ class Configuration:
     def getCallbacks(self, webIDLFile: str = "") -> list[IDLCallback]:
         return self._filterForFile(self.callbacks, webIDLFile=webIDLFile)
 
+    def getCallbackConfig(self, name: str) -> dict[str, Any]:
+        return self.callbackConfig.get(name, {})
+
     def getDescriptor(self, interfaceName: str) -> Descriptor:
         """
         Gets the appropriate descriptor for the given interface name.
@@ -218,6 +222,8 @@ class DescriptorProvider:
         """
         return self.config.getDescriptor(interfaceName)
 
+    def callbackUsesRc(self, callbackIdentifier: str) -> bool:
+        return self.config.getCallbackConfig(callbackIdentifier).get('rc', False)
 
 def MemberIsLegacyUnforgeable(member: IDLAttribute | IDLMethod, descriptor: Descriptor) -> bool:
     return ((member.isAttr() or member.isMethod())
@@ -316,6 +322,7 @@ class Descriptor(DescriptorProvider):
         self.useSystemCompartment = desc.get('useSystemCompartment', False)
         self.allowDropImpl = desc.get('allowDropImpl', False)
         self.useRcPromise = desc.get('useRcPromise', False)
+        self.useRcCallback = self.interface.isCallback() and desc.get('useRcCallback', False)
 
         # If we're concrete, we need to crawl our ancestor interfaces and mark
         # them as having a concrete descendant.

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -32,7 +32,7 @@ pub(crate) mod base {
 
     pub(crate) use crate::callback::{
         CallbackContainer, CallbackFunction, CallbackInterface, CallbackObject, ExceptionHandling,
-        OwnerWindow, ThisReflector, call_setup, wrap_call_this_value,
+        OwnerWindow, RootedCallback, ThisReflector, call_setup, wrap_call_this_value,
     };
     pub(crate) use crate::codegen::DomTypes::DomTypes;
     pub(crate) use crate::codegen::GenericUnionTypes;


### PR DESCRIPTION
Like https://github.com/servo/servo/pull/47735, these changes introduce two new types for storing WebIDL callbacks in locations where either tracing or rooting is required. To avoid boiling the callback ocean all at once, this adds a new codegen flag for each callback type to allow incrementally migrating uses to the new types.

Testing: no behaviour change; existing tests suffice.
Fixes #47748
Part of #45262
