### PR TITLE
script: Make `HTMLMediaElement::change_ready_state` match the spec

### DIFF
--- a/components/script/dom/html/embedded_content/htmlmediaelement.rs
+++ b/components/script/dom/html/embedded_content/htmlmediaelement.rs
@@ -1189,12 +1189,14 @@ impl HTMLMediaElement {
     /// <https://html.spec.whatwg.org/multipage/#ready-states>
     fn change_ready_state(&self, cx: &mut JSContext, ready_state: ReadyState) {
         let old_ready_state = self.ready_state.get();
+        let was_potentially_playing = self.is_potentially_playing();
         self.ready_state.set(ready_state);
 
+        // > When the ready state of a media element whose networkState is not NETWORK_EMPTY changes,
+        // > the user agent must follow the steps given below:
         if self.network_state.get() == NetworkState::Empty {
             return;
         }
-
         if old_ready_state == ready_state {
             return;
         }
@@ -1204,18 +1206,17 @@ impl HTMLMediaElement {
             // => "If the previous ready state was HAVE_NOTHING, and the new ready state is
             // HAVE_METADATA"
             (ReadyState::HaveNothing, ReadyState::HaveMetadata) => {
-                // Queue a media element task given the media element to fire an event named
-                // loadedmetadata at the element.
+                // > Queue a media element task given the media element to fire an event named
+                // > loadedmetadata at the element.
                 self.queue_media_element_task_to_fire_event(atom!("loadedmetadata"));
-                // No other steps are applicable in this case.
                 return;
             },
             // => "If the previous ready state was HAVE_METADATA and the new ready state is
             // HAVE_CURRENT_DATA or greater"
             (ReadyState::HaveMetadata, new) if new >= ReadyState::HaveCurrentData => {
-                // If this is the first time this occurs for this media element since the load()
-                // algorithm was last invoked, the user agent must queue a media element task given
-                // the media element to fire an event named loadeddata at the element.
+                // > If this is the first time this occurs for this media element since the load()
+                // > algorithm was last invoked, the user agent must queue a media element task given
+                // > the media element to fire an event named loadeddata at the element.
                 if !self.fired_loadeddata_event.get() {
                     self.fired_loadeddata_event.set(true);
 
@@ -1239,63 +1240,109 @@ impl HTMLMediaElement {
                         }));
                 }
 
-                // Steps for the transition from HaveMetadata to HaveCurrentData
-                // or HaveFutureData also apply here, as per the next match
-                // expression.
+                // > If the new ready state is HAVE_FUTURE_DATA or HAVE_ENOUGH_DATA,
+                // > then the relevant steps below must then be run also.
+                if new != ReadyState::HaveFutureData && new != ReadyState::HaveEnoughData {
+                    return;
+                }
             },
-            (ReadyState::HaveFutureData, new) if new <= ReadyState::HaveCurrentData => {
-                // FIXME(nox): Queue a task to fire timeupdate and waiting
-                // events if the conditions call from the spec are met.
+            _ => {},
+        }
+        match (old_ready_state, ready_state) {
+            // => "If the previous ready state was HAVE_FUTURE_DATA or more,
+            // and the new ready state is HAVE_CURRENT_DATA or less"
+            (old, new)
+                if old >= ReadyState::HaveFutureData && new <= ReadyState::HaveCurrentData =>
+            {
+                // > If the media element was potentially playing before its readyState
+                // > attribute changed to a value lower than HAVE_FUTURE_DATA,
+                // > and the element has not ended playback,
+                // > and playback has not stopped due to errors,
+                // > paused for user interaction, or paused for in-band content,
+                // > the user agent must queue a media element task given the media element
+                // > to fire an event named timeupdate at the element,
+                // > and queue a media element task given the media element
+                // > to fire an event named waiting at the element.
+                if was_potentially_playing &&
+                    !self.ended_playback(LoopCondition::Included) &&
+                    !self.error.get().is_none() &&
+                    !self.is_paused_for_user_interaction() &&
+                    !self.is_paused_for_in_band_content()
+                {
+                    self.queue_media_element_task_to_fire_event(atom!("timeupdate"));
+                    self.queue_media_element_task_to_fire_event(atom!("waiting"));
+                }
+            },
 
-                // No other steps are applicable in this case.
-                return;
+            // => "If the previous ready state was HAVE_CURRENT_DATA or less,
+            // and the new ready state is HAVE_FUTURE_DATA"
+            (old, ReadyState::HaveFutureData) if old <= ReadyState::HaveCurrentData => {
+                // > The user agent must queue a media element task given the media element to fire an
+                // > event named canplay at the element.
+                self.queue_media_element_task_to_fire_event(atom!("canplay"));
+
+                // > If the element's paused attribute is false, the user agent must notify about playing
+                // > for the element.
+                if !self.Paused() {
+                    self.notify_about_playing();
+                }
+            },
+
+            // >= "If the new ready state is HAVE_ENOUGH_DATA"
+            (_, ReadyState::HaveEnoughData) => {
+                // > If the previous ready state was HAVE_CURRENT_DATA or less,
+                // > the user agent must queue a media element task given the media element
+                // > to fire an event named canplay at the element, and,
+                // > if the element's paused attribute is false, notify about playing for the element.
+                if old_ready_state <= ReadyState::HaveCurrentData {
+                    self.queue_media_element_task_to_fire_event(atom!("canplay"));
+                    if !self.Paused() {
+                        self.notify_about_playing();
+                    }
+                }
+
+                // > The user agent must queue a media element task given the media element to fire an
+                // > event named canplaythrough at the element.
+                self.queue_media_element_task_to_fire_event(atom!("canplaythrough"));
+
+                // > If the element is not eligible for autoplay,
+                // > then the user agent must abort these substeps.
+                if !self.eligible_for_autoplay() {
+                    self.update_media_state();
+                    return;
+                }
+
+                // > The user agent may run the following substeps:
+                if self.eligible_for_autoplay() {
+                    // Step 1. Set the paused attribute to false.
+                    self.paused.set(false);
+
+                    // Step 2. If the element's show poster flag is true, set it to false and run the
+                    // time marches on steps.
+                    if self.show_poster.get() {
+                        self.show_poster.set(false);
+                        self.time_marches_on(cx, PlaybackPositionWasMoved::NormalPlayback);
+                    }
+
+                    // Step 3. Queue a media element task given the element to fire an event named play
+                    // at the element.
+                    self.queue_media_element_task_to_fire_event(atom!("play"));
+
+                    // Step 4. Notify about playing for the element.
+                    self.notify_about_playing();
+                }
+
+                // > Alternatively, if the element is a video element,
+                // > the user agent may start observing whether the element intersects the viewport.
+                // > When the element starts intersecting the viewport,
+                // > if the element is still eligible for autoplay, run the substeps above.
+                // > Optionally, when the element stops intersecting the viewport,
+                // > if the can autoplay flag is still true and the autoplay attribute
+                // > is still specified, run the following substeps:
+                // TODO
             },
 
             _ => (),
-        }
-
-        // => "If the previous ready state was HAVE_CURRENT_DATA or less, and the new ready state is
-        // HAVE_FUTURE_DATA or more"
-        if old_ready_state <= ReadyState::HaveCurrentData &&
-            ready_state >= ReadyState::HaveFutureData
-        {
-            // The user agent must queue a media element task given the media element to fire an
-            // event named canplay at the element.
-            self.queue_media_element_task_to_fire_event(atom!("canplay"));
-
-            // If the element's paused attribute is false, the user agent must notify about playing
-            // for the element.
-            if !self.Paused() {
-                self.notify_about_playing();
-            }
-        }
-
-        // => "If the new ready state is HAVE_ENOUGH_DATA"
-        if ready_state == ReadyState::HaveEnoughData {
-            // The user agent must queue a media element task given the media element to fire an
-            // event named canplaythrough at the element.
-            self.queue_media_element_task_to_fire_event(atom!("canplaythrough"));
-
-            // If the element is eligible for autoplay, then the user agent may run the following
-            // substeps:
-            if self.eligible_for_autoplay() {
-                // Step 1. Set the paused attribute to false.
-                self.paused.set(false);
-
-                // Step 2. If the element's show poster flag is true, set it to false and run the
-                // time marches on steps.
-                if self.show_poster.get() {
-                    self.show_poster.set(false);
-                    self.time_marches_on(cx, PlaybackPositionWasMoved::NormalPlayback);
-                }
-
-                // Step 3. Queue a media element task given the element to fire an event named play
-                // at the element.
-                self.queue_media_element_task_to_fire_event(atom!("play"));
-
-                // Step 4. Notify about playing for the element.
-                self.notify_about_playing();
-            }
         }
 
         self.update_media_state();
@@ -1913,6 +1960,10 @@ impl HTMLMediaElement {
 
     /// <https://html.spec.whatwg.org/multipage/#potentially-playing>
     fn is_potentially_playing(&self) -> bool {
+        // > A media element is said to be potentially playing when
+        // > its paused attribute is false, the element has not ended playback,
+        // > playback has not stopped due to errors,
+        // > and the element is not a blocked media element.
         !self.paused.get() &&
             !self.ended_playback(LoopCondition::Included) &&
             self.error.get().is_none() &&


### PR DESCRIPTION
In attempt to figure out why there is flakiness in `<track>` tests, update the `change_ready_state` to fully match the spec. The missing case for HaveFutureData and HaveCurrentData has been implemented.

Part of #46288

Testing: no behaviour changes, but should help with
upcoming changes to track events