### PR TITLE
script: Update placeholder on ClipboardEvent

### DIFF
--- a/components/script/dom/html/form_controls/htmlinputelement.rs
+++ b/components/script/dom/html/form_controls/htmlinputelement.rs
@@ -2353,6 +2353,7 @@ impl VirtualMethods for HTMLInputElement {
             }
             if !flags.is_empty() {
                 event.mark_as_handled();
+                self.update_placeholder_shown_state();
                 self.upcast::<Node>()
                     .dirty(cx.no_gc(), NodeDamage::ContentOrHeritage);
             }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -7929,6 +7929,23 @@
      ]
     ]
    },
+   "input-events": {
+    "input-events-text-input-copy-paste.html": [
+     "76dce0e7133c1fb049d75a1109bdcfd2f138a51b",
+     [
+      null,
+      [
+       [
+        "/_mozilla/input-events/input-events-text-input-copy-paste-ref.html",
+        "=="
+       ]
+      ],
+      {
+       "testdriver": true
+      }
+     ]
+    ]
+   },
    "mozilla": {
     "FileAPI": {
      "blob-url-upload.html": [
@@ -10867,6 +10884,10 @@
     ]
    },
    "input-events": {
+    "input-events-text-input-copy-paste-ref.html": [
+     "9c1b5dfe19738c0c54a41d49f2729dd07aa018cd",
+     []
+    ],
     "input-events.js": [
      "d5c471f80064d5d848283d833c49cfe36f2475e2",
      []

--- a/tests/wpt/mozilla/tests/input-events/input-events-text-input-copy-paste-ref.html
+++ b/tests/wpt/mozilla/tests/input-events/input-events-text-input-copy-paste-ref.html
@@ -1,0 +1,6 @@
+<style>
+input {
+  box-sizing: border-box;
+</style>
+<input type="text" id="copy_target" value="copy_me"></input>
+<input type="text" id="text_input" value="copy_me" placeholder="placeholder"></input>

--- a/tests/wpt/mozilla/tests/input-events/input-events-text-input-copy-paste.html
+++ b/tests/wpt/mozilla/tests/input-events/input-events-text-input-copy-paste.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+    <head>
+        <meta charset="utf-8">
+        <title>Copy and Paste should stop placeholder displaying</title>
+        <link rel=match href=input-events-text-input-copy-paste-ref.html>
+        <script src="/common/reftest-wait.js"></script>
+        <script src="/resources/testdriver.js"></script>
+        <script src="/resources/testdriver-actions.js"></script>
+        <script src="/resources/testdriver-vendor.js"></script>
+        <style>
+        input {
+            box-sizing: border-box;
+        }
+        </style>
+    </head>
+    <body>
+        <input type="text" id="copy_target" value="copy_me"></input>
+        <input type="text" id="text_input" placeholder="placeholder"></input>
+        <script>
+        let modifier_key = "\uE009";
+        if(navigator.platform.includes('Mac'))
+            modifier_key = "\uE03D";
+        const commands = {
+            COPY: 'copy',
+            CUT: 'cut',
+            PASTE: 'paste',
+        }
+        function selectTextCommand(target, command) {
+          let command_key = "";
+          if(command == "copy")
+            command_key = "c";
+          else if (command == "cut")
+            command_key = "x";
+          else if (command == "paste")
+            command_key = "v";
+          target.focus();
+          return new test_driver.Actions()
+              .keyDown(modifier_key)
+              .keyDown("a")
+              .keyUp("a")
+              .keyDown(command_key)
+              .keyUp(command_key)
+              .keyUp(modifier_key)
+              .send();
+        }
+
+        const copy_target = document.getElementById("copy_target")
+        const text_input = document.getElementById("text_input");
+
+        async function copyPasteTargetsAndTakeScreenshot(){
+          await selectTextCommand(copy_target, commands.COPY);
+          await selectTextCommand(text_input, commands.PASTE);
+          text_input.blur();
+          takeScreenshot();
+        }
+
+        copyPasteTargetsAndTakeScreenshot()
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
Update the state of the placeholder on clipboard events so that pasting correctly hides the placeholder. Precedent in `handle_key_reaction`:
https://github.com/servo/servo/blob/7f4b0ab19486364d7d5505a71f43c5ac2383d294/components/script/dom/html/form_controls/htmlinputelement.rs#L854

Testing: Added a WPT reftest. The only quirk here is that the calculated widths of the inputs were different in the ref and the test which was causing it to fail. So I added a `box-sizing: border-box;` style which fixed it.

Fixes: #47766
