### PR TITLE
paint: Do not panic when a rendering context has no surfman connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7955,6 +7955,8 @@ dependencies = [
  "env_logger",
  "euclid",
  "gaol",
+ "gleam",
+ "glow",
  "gstreamer",
  "http",
  "http-body-util",

--- a/components/paint/paint.rs
+++ b/components/paint/paint.rs
@@ -20,9 +20,7 @@ use embedder_traits::{
 };
 use euclid::{Scale, Size2D};
 use image::RgbaImage;
-use log::debug;
-#[cfg(feature = "webgl")]
-use log::warn;
+use log::{debug, warn};
 use paint_api::rendering_context::RenderingContext;
 use paint_api::{
     PaintMessage, PaintProxy, PainterSurfmanDetails, PainterSurfmanDetailsMap,
@@ -272,22 +270,29 @@ impl Paint {
         }
 
         let painter = Painter::new(rendering_context.clone(), self);
-        let connection = rendering_context
-            .connection()
-            .expect("Failed to get connection");
-        let adapter = connection
-            .create_adapter()
-            .expect("Failed to create adapter");
-
-        let painter_surfman_details = PainterSurfmanDetails {
-            connection,
-            adapter,
-        };
-        self.painter_surfman_details_map
-            .insert(painter.painter_id, painter_surfman_details);
-
         let painter_id = painter.painter_id;
         self.painters.push(Rc::new(RefCell::new(painter)));
+
+        // These are only used to serve WebGL external images, which handles their
+        // absence from the map
+        let Some(connection) = rendering_context.connection() else {
+            warn!("The rendering context has no surfman connection, WebGL will be unavailable");
+            return painter_id;
+        };
+        let Ok(adapter) = connection.create_adapter().inspect_err(|error| {
+            warn!("Could not create a surfman adapter, WebGL will be unavailable: {error:?}")
+        }) else {
+            return painter_id;
+        };
+
+        self.painter_surfman_details_map.insert(
+            painter_id,
+            PainterSurfmanDetails {
+                connection,
+                adapter,
+            },
+        );
+
         painter_id
     }
 

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -195,6 +195,8 @@ ohos-pasteboard = { workspace = true, optional = true }
 [dev-dependencies]
 accesskit_consumer = { workspace = true }
 content-security-policy = { workspace = true }
+gleam = { workspace = true }
+glow = { workspace = true }
 http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -18,6 +18,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use http_body_util::combinators::BoxBody;
 use hyper::body::{Bytes, Incoming};
 use hyper::{Request as HyperRequest, Response as HyperResponse};
+use image::RgbaImage;
 use itertools::Itertools;
 use net::test_util::{make_body, make_server, replace_host_table};
 use servo::{
@@ -29,8 +30,9 @@ use servo::{
 };
 use servo_config::prefs::Preferences;
 use servo_url::ServoUrl;
+use surfman::Error;
 use url::Url;
-use webrender_api::units::{DeviceIntSize, DevicePoint, DeviceVector2D};
+use webrender_api::units::{DeviceIntRect, DeviceIntSize, DevicePoint, DeviceVector2D};
 
 use crate::common::{
     ServoTest, WebViewDelegateImpl, click_at_point, evaluate_javascript,
@@ -70,6 +72,58 @@ fn test_create_webview() {
     let servo_test = ServoTest::new();
     let delegate = Rc::new(WebViewDelegateImpl::default());
     let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .build();
+
+    servo_test.spin(move || !delegate.url_changed.get());
+
+    let url = webview.url();
+    assert!(url.is_some());
+    assert_eq!(url.unwrap().to_string(), "about:blank");
+}
+
+/// A [`RenderingContext`] that provides no surfman connection, which the trait
+/// permits: `connection()` returns `None`.
+struct ConnectionlessRenderingContext(Rc<dyn RenderingContext>);
+
+impl RenderingContext for ConnectionlessRenderingContext {
+    fn read_to_image(&self, source_rectangle: DeviceIntRect) -> Option<RgbaImage> {
+        self.0.read_to_image(source_rectangle)
+    }
+
+    fn size(&self) -> PhysicalSize<u32> {
+        self.0.size()
+    }
+
+    fn resize(&self, size: PhysicalSize<u32>) {
+        self.0.resize(size);
+    }
+
+    fn present(&self) {
+        self.0.present();
+    }
+
+    fn make_current(&self) -> Result<(), Error> {
+        self.0.make_current()
+    }
+
+    fn gleam_gl_api(&self) -> Rc<dyn gleam::gl::Gl> {
+        self.0.gleam_gl_api()
+    }
+
+    fn glow_gl_api(&self) -> Arc<glow::Context> {
+        self.0.glow_gl_api()
+    }
+}
+
+#[test]
+fn test_create_webview_without_surfman_connection() {
+    let servo_test = ServoTest::new();
+    let rendering_context = Rc::new(ConnectionlessRenderingContext(
+        servo_test.rendering_context.clone(),
+    ));
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo(), rendering_context)
         .delegate(delegate.clone())
         .build();
 

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -12,7 +12,8 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 
 use dpi::PhysicalSize;
-use embedder_traits::UrlRequest;
+use embedder_traits::{RefreshDriver, UrlRequest};
+use euclid::default::Size2D as UntypedSize2D;
 use euclid::{Point2D, Size2D};
 use http::{HeaderMap, HeaderName, HeaderValue};
 use http_body_util::combinators::BoxBody;
@@ -30,7 +31,7 @@ use servo::{
 };
 use servo_config::prefs::Preferences;
 use servo_url::ServoUrl;
-use surfman::Error;
+use surfman::{Error, Surface, SurfaceTexture};
 use url::Url;
 use webrender_api::units::{DeviceIntRect, DeviceIntSize, DevicePoint, DeviceVector2D};
 
@@ -83,10 +84,15 @@ fn test_create_webview() {
 }
 
 /// A [`RenderingContext`] that provides no surfman connection, which the trait
-/// permits: `connection()` returns `None`.
+/// permits: `connection()` returns `None`. Every other method must forward to the
+/// inner context; a defaulted `prepare_for_rendering` would bind no framebuffer.
 struct ConnectionlessRenderingContext(Rc<dyn RenderingContext>);
 
 impl RenderingContext for ConnectionlessRenderingContext {
+    fn prepare_for_rendering(&self) {
+        self.0.prepare_for_rendering();
+    }
+
     fn read_to_image(&self, source_rectangle: DeviceIntRect) -> Option<RgbaImage> {
         self.0.read_to_image(source_rectangle)
     }
@@ -113,6 +119,21 @@ impl RenderingContext for ConnectionlessRenderingContext {
 
     fn glow_gl_api(&self) -> Arc<glow::Context> {
         self.0.glow_gl_api()
+    }
+
+    fn create_texture(
+        &self,
+        surface: Surface,
+    ) -> Option<(SurfaceTexture, u32, UntypedSize2D<i32>)> {
+        self.0.create_texture(surface)
+    }
+
+    fn destroy_texture(&self, surface_texture: SurfaceTexture) -> Option<Surface> {
+        self.0.destroy_texture(surface_texture)
+    }
+
+    fn refresh_driver(&self) -> Option<Rc<dyn RefreshDriver>> {
+        self.0.refresh_driver()
     }
 }
 

--- a/components/shared/paint/lib.rs
+++ b/components/shared/paint/lib.rs
@@ -559,8 +559,7 @@ impl PainterSurfmanDetailsMap {
 
     pub fn remove(&self, painter_id: PainterId) {
         let mut map = self.0.lock().expect("poisoned");
-        let details = map.remove(&painter_id);
-        assert!(details.is_some());
+        map.remove(&painter_id);
     }
 }
 


### PR DESCRIPTION
`Paint::register_rendering_context` calls `expect()` on `RenderingContext::connection()` and `Connection::create_adapter()`, so a `WebView` built on a rendering context without a surfman connection panics
 with "Failed to get connection". `connection()` is a defaulted trait method that returns `None` - an embedder that implements `RenderingContext` over its own GL context reaches that path; on devices whose drivers are EGL 1.4, surfman cannot create a `Connection`.

The connection and the adapter are only used by the WebGL, which  already treats a missing `PainterSurfmanDetails` as a recoverable error.  Neither the map nor this function is gated on the `webgl` feature, so a build  without WebGL panics as well. Both failures now log a warning and `PainterSurfmanDetailsMap::remove` no longer asserts that one existed.

Testing: New `test_create_webview_without_surfman_connection`. It panics  without  this change.