### PR TITLE
net: Clear image cache more thouroughly

### DIFF
--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -170,6 +170,13 @@ impl AllPendingLoads {
         }
     }
 
+    fn clear(&mut self) {
+        self.loads.clear();
+        self.loads.shrink_to_fit();
+        self.url_to_load_key.clear();
+        self.url_to_load_key.shrink_to_fit();
+    }
+
     // get a PendingLoad from its LoadKey.
     fn get_by_key_mut(&mut self, key: &LoadKey) -> Option<&mut PendingLoad> {
         self.loads.get_mut(key)
@@ -451,6 +458,14 @@ impl KeyCache {
             evicted_images: HashSet::new(),
         }
     }
+
+    fn clear(&mut self) {
+        self.cache = KeyCacheState::Ready(vec![]);
+        self.images_pending_keys.clear();
+        self.images_pending_keys.shrink_to_fit();
+        self.evicted_images.clear();
+        self.evicted_images.shrink_to_fit();
+    }
 }
 
 #[derive(Debug, Default, MallocSizeOf)]
@@ -458,6 +473,11 @@ impl KeyCache {
 struct SvgRasterizationTaskStore(FxHashSet<(PendingImageId, DeviceIntSize)>);
 
 impl SvgRasterizationTaskStore {
+    fn clear(&mut self) {
+        self.0.clear();
+        self.0.shrink_to_fit();
+    }
+
     /// Returns true if it is already being rasterized, otherwise false and sets it.
     fn is_or_set_being_rasterized(
         &mut self,
@@ -1347,6 +1367,8 @@ impl ImageCache for ImageCacheImpl {
 
     fn clear(&self) {
         self.store.lock().clear();
+        self.svg_id_image_id_map.lock().clear();
+        self.svg_id_image_id_map.lock().shrink_to_fit();
     }
 
     fn get_broken_image_icon(&self) -> Option<Arc<RasterImage>> {
@@ -1400,7 +1422,12 @@ impl ImageCacheStore {
         // explicitly on pipeline close, and again on Drop (as a safeguard,
         // since we could forget to explicitly clear).
         self.completed_loads.clear();
+        self.completed_loads.shrink_to_fit();
         self.rasterized_vector_images.clear();
+        self.rasterized_vector_images.shrink_to_fit();
+        self.svg_rasterization_task_store.clear();
+        self.pending_loads.clear();
+        self.key_cache.clear();
         let _ = self.broken_image_icon_image.take();
     }
 }

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -37,6 +37,8 @@ use uuid::Uuid;
 use webrender_api::ImageKey as WebRenderImageKey;
 use webrender_api::units::DeviceIntSize;
 
+use crate::image_cache::KeyCacheState::PipelineClosed;
+
 thread_local! {
     pub static SUPPRESS_ABORT_IN_PANIC_HOOK: Cell<bool> = const { Cell::new(false) };
 }
@@ -426,7 +428,7 @@ enum KeyCacheState {
     /// Currently filling images from the KeyCache. No new keys will be requested.
     Processing,
     /// A special state to demark that we will not process any images anymore because the pipeline is shut down.
-    StopProcessing,
+    PipelineClosed,
 }
 
 impl KeyCacheState {
@@ -434,7 +436,7 @@ impl KeyCacheState {
         match self {
             KeyCacheState::PendingBatch |
             KeyCacheState::Processing |
-            KeyCacheState::StopProcessing => 0,
+            KeyCacheState::PipelineClosed => 0,
             KeyCacheState::Ready(items) => items.len(),
         }
     }
@@ -463,8 +465,10 @@ impl KeyCache {
         }
     }
 
+    /// Clears all the keys.
     fn clear(&mut self) {
-        self.cache = KeyCacheState::StopProcessing;
+        // Webrender currently does not care about image keys that are requested but never used, so we do not need to delete them.
+        self.cache = KeyCacheState::PipelineClosed;
         self.images_pending_keys.clear();
         self.images_pending_keys.shrink_to_fit();
         self.evicted_images.clear();
@@ -601,7 +605,7 @@ impl ImageCacheStore {
                     self.fetch_more_image_keys();
                 },
             },
-            KeyCacheState::StopProcessing => {},
+            KeyCacheState::PipelineClosed(_) => {},
         }
     }
 
@@ -622,30 +626,34 @@ impl ImageCacheStore {
     }
 
     /// Insert received keys into the cache and complete the loading of images.
-    fn insert_keys_and_load_images(&mut self, image_keys: Vec<WebRenderImageKey>) {
-        if let KeyCacheState::Processing = self.key_cache.cache {
-            // We can set this now to ready as we have the exclusive write access.
-            self.key_cache.cache = KeyCacheState::Ready(image_keys);
-            let len = min(
-                self.key_cache.cache.size(),
-                self.key_cache.images_pending_keys.len(),
-            );
-            let images = self
-                .key_cache
-                .images_pending_keys
-                .drain(0..len)
-                .collect::<Vec<PendingKey>>();
-            for key in images {
-                self.load_image_with_keycache(key);
-            }
-            // It is important to fetch new image keys as we might have missed previous returns.
-            if !self.key_cache.images_pending_keys.is_empty() {
-                self.paint_api
-                    .generate_image_key_async(self.webview_id, self.pipeline_id);
-                self.key_cache.cache = KeyCacheState::PendingBatch
-            }
-        } else if KeyCacheState::StopProcessing != self.key_cache.cache {
-            unreachable!("A batch was received while we didn't request one")
+    fn insert_keys_and_load_images(&mut self, mut image_keys: Vec<WebRenderImageKey>) {
+        match &mut self.key_cache.cache {
+            KeyCacheState::Processing => {
+                // We can set this now to ready as we have the exclusive write access.
+                self.key_cache.cache = KeyCacheState::Ready(image_keys);
+                let len = min(
+                    self.key_cache.cache.size(),
+                    self.key_cache.images_pending_keys.len(),
+                );
+                let images = self
+                    .key_cache
+                    .images_pending_keys
+                    .drain(0..len)
+                    .collect::<Vec<PendingKey>>();
+                for key in images {
+                    self.load_image_with_keycache(key);
+                }
+                // It is important to fetch new image keys as we might have missed previous returns.
+                if !self.key_cache.images_pending_keys.is_empty() {
+                    self.paint_api
+                        .generate_image_key_async(self.webview_id, self.pipeline_id);
+                    self.key_cache.cache = KeyCacheState::PendingBatch
+                }
+            },
+            KeyCacheState::PendingBatch | KeyCacheState::Ready(_) => {
+                unreachable!("A batch was received while we didn't request one")
+            },
+            PipelineClosed(items) => items.append(&mut image_keys),
         }
     }
 
@@ -1419,6 +1427,7 @@ impl ImageCacheStore {
                     .and_then(|icon| icon.id)
                     .map(ImageUpdate::DeleteImage),
             )
+            .chain(key_cache.drain(..).map(ImageUpdate::DeleteImage))
             .collect();
         if !deletions.is_empty() {
             self.paint_api
@@ -1436,6 +1445,7 @@ impl ImageCacheStore {
         self.svg_rasterization_task_store.clear();
         self.pending_loads.clear();
         self.key_cache.clear();
+
         let _ = self.broken_image_icon_image.take();
     }
 }

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -149,7 +149,7 @@ type ImageKey = (ServoUrl, ImmutableOrigin, Option<CorsSettings>);
 
 // Represents all the currently pending loads/decodings. For
 // performance reasons, loads are indexed by a dedicated load key.
-#[derive(MallocSizeOf)]
+#[derive(Default, MallocSizeOf)]
 struct AllPendingLoads {
     // The loads, indexed by a load key. Used during most operations,
     // for performance reasons.
@@ -170,13 +170,6 @@ impl AllPendingLoads {
             url_to_load_key: HashMap::default(),
             keygen: LoadKeyGenerator::new(),
         }
-    }
-
-    fn clear(&mut self) {
-        self.loads.clear();
-        self.loads.shrink_to_fit();
-        self.url_to_load_key.clear();
-        self.url_to_load_key.shrink_to_fit();
     }
 
     // get a PendingLoad from its LoadKey.
@@ -320,7 +313,7 @@ impl ImageBytes {
 // A key used to communicate during loading.
 type LoadKey = PendingImageId;
 
-#[derive(MallocSizeOf)]
+#[derive(Default, MallocSizeOf)]
 struct LoadKeyGenerator {
     counter: u64,
 }
@@ -419,7 +412,7 @@ enum PendingKey {
 }
 
 /// The state of the `WebRenderImageKey`` cache
-#[derive(Debug, MallocSizeOf)]
+#[derive(Debug, Default, MallocSizeOf)]
 enum KeyCacheState {
     /// We already requested a batch of keys.
     PendingBatch,
@@ -428,6 +421,7 @@ enum KeyCacheState {
     /// Currently filling images from the KeyCache. No new keys will be requested.
     Processing,
     /// A special state to demark that we will not process any images anymore because the pipeline is shut down.
+    #[default]
     PipelineClosed,
 }
 
@@ -445,7 +439,7 @@ impl KeyCacheState {
 /// As getting new keys takes a round trip over the constellation, we keep a small cache of them.
 /// Additionally, this cache will store image resources that do not have a key yet because those
 /// are needed to complete the load.
-#[derive(MallocSizeOf)]
+#[derive(Default, MallocSizeOf)]
 struct KeyCache {
     /// A cache of `WebRenderImageKey`.
     cache: KeyCacheState,
@@ -464,16 +458,6 @@ impl KeyCache {
             evicted_images: HashSet::new(),
         }
     }
-
-    /// Clears all the keys.
-    fn clear(&mut self) {
-        // Webrender currently does not care about image keys that are requested but never used, so we do not need to delete them.
-        self.cache = KeyCacheState::PipelineClosed;
-        self.images_pending_keys.clear();
-        self.images_pending_keys.shrink_to_fit();
-        self.evicted_images.clear();
-        self.evicted_images.shrink_to_fit();
-    }
 }
 
 #[derive(Debug, Default, MallocSizeOf)]
@@ -481,11 +465,6 @@ impl KeyCache {
 struct SvgRasterizationTaskStore(FxHashSet<(PendingImageId, DeviceIntSize)>);
 
 impl SvgRasterizationTaskStore {
-    fn clear(&mut self) {
-        self.0.clear();
-        self.0.shrink_to_fit();
-    }
-
     /// Returns true if it is already being rasterized, otherwise false and sets it.
     fn is_or_set_being_rasterized(
         &mut self,
@@ -1380,9 +1359,7 @@ impl ImageCache for ImageCacheImpl {
 
     fn clear(&self) {
         self.store.lock().clear();
-        let mut svg_id_map = self.svg_id_image_id_map.lock();
-        svg_id_map.clear();
-        svg_id_map.shrink_to_fit();
+        *self.svg_id_image_id_map.lock() = Default::default();
     }
 
     fn get_broken_image_icon(&self) -> Option<Arc<RasterImage>> {
@@ -1405,6 +1382,7 @@ impl ImageCache for ImageCacheImpl {
 
 impl ImageCacheStore {
     /// Clear the image cache.
+    // Webrender currently does not care about keys that are loaded but do not have an image attached to it.
     fn clear(&mut self) {
         let deletions: smallvec::SmallVec<_> = self
             .completed_loads
@@ -1435,15 +1413,12 @@ impl ImageCacheStore {
         // Clear these fields, since `clear()` will be called multiple times,
         // explicitly on pipeline close, and again on Drop (as a safeguard,
         // since we could forget to explicitly clear).
-        self.completed_loads.clear();
-        self.completed_loads.shrink_to_fit();
-        self.vector_images.clear();
-        self.vector_images.shrink_to_fit();
-        self.rasterized_vector_images.clear();
-        self.rasterized_vector_images.shrink_to_fit();
-        self.svg_rasterization_task_store.clear();
-        self.pending_loads.clear();
-        self.key_cache.clear();
+        self.completed_loads = Default::default();
+        self.vector_images = Default::default();
+        self.rasterized_vector_images = Default::default();
+        self.svg_rasterization_task_store = Default::default();
+        self.pending_loads = Default::default();
+        self.key_cache = Default::default();
 
         let _ = self.broken_image_icon_image.take();
     }

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -425,12 +425,16 @@ enum KeyCacheState {
     Ready(Vec<WebRenderImageKey>),
     /// Currently filling images from the KeyCache. No new keys will be requested.
     Processing,
+    /// A special state to demark that we will not process any images anymore because the pipeline is shut down.
+    StopProcessing,
 }
 
 impl KeyCacheState {
     fn size(&self) -> usize {
         match self {
-            KeyCacheState::PendingBatch | KeyCacheState::Processing => 0,
+            KeyCacheState::PendingBatch |
+            KeyCacheState::Processing |
+            KeyCacheState::StopProcessing => 0,
             KeyCacheState::Ready(items) => items.len(),
         }
     }
@@ -460,7 +464,7 @@ impl KeyCache {
     }
 
     fn clear(&mut self) {
-        self.cache = KeyCacheState::Ready(vec![]);
+        self.cache = KeyCacheState::StopProcessing;
         self.images_pending_keys.clear();
         self.images_pending_keys.shrink_to_fit();
         self.evicted_images.clear();
@@ -597,6 +601,7 @@ impl ImageCacheStore {
                     self.fetch_more_image_keys();
                 },
             },
+            KeyCacheState::StopProcessing => {},
         }
     }
 
@@ -639,7 +644,7 @@ impl ImageCacheStore {
                     .generate_image_key_async(self.webview_id, self.pipeline_id);
                 self.key_cache.cache = KeyCacheState::PendingBatch
             }
-        } else {
+        } else if KeyCacheState::StopProcessing != self.key_cache.cache {
             unreachable!("A batch was received while we didn't request one")
         }
     }
@@ -1367,8 +1372,9 @@ impl ImageCache for ImageCacheImpl {
 
     fn clear(&self) {
         self.store.lock().clear();
-        self.svg_id_image_id_map.lock().clear();
-        self.svg_id_image_id_map.lock().shrink_to_fit();
+        let mut svg_id_map = self.svg_id_image_id_map.lock();
+        svg_id_map.clear();
+        svg_id_map.shrink_to_fit();
     }
 
     fn get_broken_image_icon(&self) -> Option<Arc<RasterImage>> {
@@ -1423,6 +1429,8 @@ impl ImageCacheStore {
         // since we could forget to explicitly clear).
         self.completed_loads.clear();
         self.completed_loads.shrink_to_fit();
+        self.vector_images.clear();
+        self.vector_images.shrink_to_fit();
         self.rasterized_vector_images.clear();
         self.rasterized_vector_images.shrink_to_fit();
         self.svg_rasterization_task_store.clear();

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -605,7 +605,7 @@ impl ImageCacheStore {
                     self.fetch_more_image_keys();
                 },
             },
-            KeyCacheState::PipelineClosed(_) => {},
+            KeyCacheState::PipelineClosed => {},
         }
     }
 
@@ -626,7 +626,7 @@ impl ImageCacheStore {
     }
 
     /// Insert received keys into the cache and complete the loading of images.
-    fn insert_keys_and_load_images(&mut self, mut image_keys: Vec<WebRenderImageKey>) {
+    fn insert_keys_and_load_images(&mut self, image_keys: Vec<WebRenderImageKey>) {
         match &mut self.key_cache.cache {
             KeyCacheState::Processing => {
                 // We can set this now to ready as we have the exclusive write access.
@@ -653,7 +653,7 @@ impl ImageCacheStore {
             KeyCacheState::PendingBatch | KeyCacheState::Ready(_) => {
                 unreachable!("A batch was received while we didn't request one")
             },
-            PipelineClosed(items) => items.append(&mut image_keys),
+            PipelineClosed => {},
         }
     }
 
@@ -1427,7 +1427,6 @@ impl ImageCacheStore {
                     .and_then(|icon| icon.id)
                     .map(ImageUpdate::DeleteImage),
             )
-            .chain(key_cache.drain(..).map(ImageUpdate::DeleteImage))
             .collect();
         if !deletions.is_empty() {
             self.paint_api

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -420,7 +420,7 @@ enum KeyCacheState {
     Ready(Vec<WebRenderImageKey>),
     /// Currently filling images from the KeyCache. No new keys will be requested.
     Processing,
-    /// A special state to demark that we will not process any images anymore because the pipeline is shut down.
+    /// We will not process any images anymore because the pipeline is shut down.
     #[default]
     PipelineClosed,
 }


### PR DESCRIPTION
Vec::clear() or HashMap::clear() do not return the memory they allocated.  This adds some shrink to fit calls (and some components that were not cleared) to be more thourough.

Testing: There are no automated tests for this as this is just  about resource allocation. WPT can be used for general testing of navigation which will use this code path.
