### PR TITLE
layout: Move largest_contentful_paint pref check to DisplayListBuilder instead of inline

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -129,6 +129,9 @@ pub(crate) struct DisplayListBuilder<'a> {
 
     /// Statistics collected about the reflow, in order to write tests for incremental layout.
     reflow_statistics: &'a mut ReflowStatistics,
+
+    /// Is LargestContentFulPaint enabled in the options,
+    largest_contentful_paint: bool,
 }
 
 struct InspectorHighlight {
@@ -209,6 +212,7 @@ impl DisplayListBuilder<'_> {
             device_pixel_ratio,
             paint_timing_handler,
             reflow_statistics,
+            largest_contentful_paint: pref!(largest_contentful_paint_enabled),
         };
 
         // Clear any caret color from previous display list constructions.
@@ -659,7 +663,7 @@ impl DisplayListBuilder<'_> {
         natural_width: Option<Au>,
         natural_height: Option<Au>,
     ) {
-        if !pref!(largest_contentful_paint_enabled) {
+        if !self.largest_contentful_paint {
             return;
         }
 

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1180,7 +1180,7 @@ impl Fragment {
 
         // Accumulate this text fragment for LCP by the containing element's tag
         if let Some(tag) = state.containing_element_tag &&
-            pref!(largest_contentful_paint_enabled)
+            builder.largest_contentful_paint_enabled
         {
             let transform = builder
                 .paint_info

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -130,8 +130,8 @@ pub(crate) struct DisplayListBuilder<'a> {
     /// Statistics collected about the reflow, in order to write tests for incremental layout.
     reflow_statistics: &'a mut ReflowStatistics,
 
-    /// Is LargestContentFulPaint enabled in the options,
-    largest_contentful_paint: bool,
+    /// Whether the `largest_contentul_paint_enabled` preference is enabled.
+    largest_contentful_paint_enabled: bool,
 }
 
 struct InspectorHighlight {
@@ -212,7 +212,7 @@ impl DisplayListBuilder<'_> {
             device_pixel_ratio,
             paint_timing_handler,
             reflow_statistics,
-            largest_contentful_paint: pref!(largest_contentful_paint_enabled),
+            largest_contentful_paint_enabled: pref!(largest_contentful_paint_enabled),
         };
 
         // Clear any caret color from previous display list constructions.
@@ -663,7 +663,7 @@ impl DisplayListBuilder<'_> {
         natural_width: Option<Au>,
         natural_height: Option<Au>,
     ) {
-        if !self.largest_contentful_paint {
+        if !self.largest_contentful_paint_enabled {
             return;
         }
 


### PR DESCRIPTION
This moves the pref!(largest_contentful_paint_enabled) check into DisplayListBuilder creation instead of `collect_image_record`. The RwLock was having 1% in a 200ms slice on script thread. This should be majorly reduced if a lot of images got replaced and are traversed by `traverse_replaced_content`.

Testing: This just moves things around and should not have any effect on functionality.
