### PR TITLE
fix(layout): add position:relative handling for grid items

### DIFF
--- a/components/layout/taffy/layout.rs
+++ b/components/layout/taffy/layout.rs
@@ -4,6 +4,7 @@
 
 use app_units::Au;
 use atomic_refcell::{AtomicRef, AtomicRefCell};
+use style::computed_values::position::T as Position;
 use style::properties::ComputedValues;
 use style::values::computed::CSSPixelLength;
 use style::values::computed::length_percentage::CalcLengthPercentage;
@@ -25,7 +26,7 @@ use crate::fragment_tree::{
 };
 use crate::geom::{LogicalVec2, PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalSize};
 use crate::layout_box_base::IndependentFormattingContextLayoutResult;
-use crate::positioned::{AbsolutelyPositionedBox, PositioningContext, PositioningContextLength};
+use crate::positioned::{AbsolutelyPositionedBox, PositioningContext, PositioningContextLength,     relative_adjustement ,};
 use crate::sizing::{
     ComputeInlineContentSizes, ContentSizes, InlineContentSizesResult, LazySize, SizeConstraint,
 };
@@ -537,12 +538,21 @@ impl TaffyContainer {
                                 Au::from_f32_px(baseline) - padding.top - border.top
                             }),
                         });
+             
+                        let flags =box_fragment.base.flags;
+                        let style =box_fragment.style();
+                        if style.establishes_containing_block_for_absolute_descendants(flags){
 
                         child.positioning_context.layout_collected_children(
                             container_ctx.layout_context,
                             &mut box_fragment,
                         );
-
+                    }
+          
+                    if style.clone_position()==Position::Relative {box_fragment.base.translate_rect (
+                 relative_adjustement(style,containing_block)
+                 .to_physical_size(containing_block.style.writing_mode),
+                 ); }
                         child
                             .positioning_context
                             .adjust_static_position_of_hoisted_fragments_with_offset(


### PR DESCRIPTION
This fixes CSS Grid issue #34535 where absolutely-positioned elements inside grid items with 'position: relative' were not positioned correctly.

The grid layout code was missing two key behaviors that flexbox already has:

1. **Containing block check**: layout_collected_children() was called unconditionally for all in-flow grid items. Now it's gated behind establishes_containing_block_for_absolute_descendants() check, matching flexbox behavior. This ensures absolutely-positioned children are only laid out as children of items that actually establish a containing block.

2. **position:relative translation**: Grid items with 'position: relative' now get their fragments translated by relative_adjustement(), applying top/right/bottom/left offsets. This was completely missing before.

Both changes align grid item handling with the flexbox implementation in flexbox/layout.rs (FlexLineItem::collect_fragment).

