### PR TITLE
script: reduce the lifetime of mutable borrows in maybe_update_shared_selection()

### DIFF
--- a/components/script/dom/html/form_controls/htmlinputelement.rs
+++ b/components/script/dom/html/form_controls/htmlinputelement.rs
@@ -987,26 +987,29 @@ impl TextControlElement for HTMLInputElement {
     }
 
     fn maybe_update_shared_selection(&self) {
-        let mut text_input = self.textinput.borrow_mut();
-        let selection_range = text_input.selection_start()..text_input.selection_end();
-        let enabled = self.is_textual_or_password() && self.upcast::<Element>().focus_state();
+        let selection = {
+            let mut text_input = self.textinput.borrow_mut();
+            let selection_range = text_input.selection_start()..text_input.selection_end();
+            let enabled = self.is_textual_or_password() && self.upcast::<Element>().focus_state();
 
-        let range_remained_equal = selection_range == text_input.previous_selection_range;
-        if range_remained_equal && enabled == text_input.selection_for_layout.is_some() {
-            return;
-        }
+            let range_remained_equal = selection_range == text_input.previous_selection_range;
+            if range_remained_equal && enabled == text_input.selection_for_layout.is_some() {
+                return;
+            }
 
-        if !range_remained_equal {
-            // https://w3c.github.io/selection-api/#selectionchange-event
-            // > When an input or textarea element provide a text selection and its selection changes
-            // > (in either extent or direction),
-            // > the user agent must schedule a selectionchange event on the element.
-            self.schedule_a_selection_change_event();
-        }
+            if !range_remained_equal {
+                // https://w3c.github.io/selection-api/#selectionchange-event
+                // > When an input or textarea element provide a text selection and its selection changes
+                // > (in either extent or direction),
+                // > the user agent must schedule a selectionchange event on the element.
+                self.schedule_a_selection_change_event();
+            }
 
-        let selection = enabled.then(|| text_input.sorted_selection_character_offsets_range());
-        text_input.previous_selection_range = selection_range;
-        text_input.selection_for_layout = selection;
+            let selection = enabled.then(|| text_input.sorted_selection_character_offsets_range());
+            text_input.previous_selection_range = selection_range;
+            text_input.selection_for_layout = selection;
+            selection
+        };
 
         if let Some(text_input_widget) = self.input_type.borrow().as_specific().text_input_widget()
         {

--- a/components/script/dom/html/form_controls/htmltextareaelement.rs
+++ b/components/script/dom/html/form_controls/htmltextareaelement.rs
@@ -272,26 +272,29 @@ impl TextControlElement for HTMLTextAreaElement {
     }
 
     fn maybe_update_shared_selection(&self) {
-        let mut text_input = self.textinput.borrow_mut();
-        let selection_range = text_input.selection_start()..text_input.selection_end();
-        let enabled = self.upcast::<Element>().focus_state();
+        let selection = {
+            let mut text_input = self.textinput.borrow_mut();
+            let selection_range = text_input.selection_start()..text_input.selection_end();
+            let enabled = self.upcast::<Element>().focus_state();
 
-        let range_remained_equal = selection_range == text_input.previous_selection_range;
-        if range_remained_equal && enabled == text_input.selection_for_layout.is_some() {
-            return;
-        }
+            let range_remained_equal = selection_range == text_input.previous_selection_range;
+            if range_remained_equal && enabled == text_input.selection_for_layout.is_some() {
+                return;
+            }
 
-        if !range_remained_equal {
-            // https://w3c.github.io/selection-api/#selectionchange-event
-            // > When an input or textarea element provide a text selection and its selection changes
-            // > (in either extent or direction),
-            // > the user agent must schedule a selectionchange event on the element.
-            self.schedule_a_selection_change_event();
-        }
+            if !range_remained_equal {
+                // https://w3c.github.io/selection-api/#selectionchange-event
+                // > When an input or textarea element provide a text selection and its selection changes
+                // > (in either extent or direction),
+                // > the user agent must schedule a selectionchange event on the element.
+                self.schedule_a_selection_change_event();
+            }
 
-        let selection = enabled.then(|| text_input.sorted_selection_character_offsets_range());
-        text_input.previous_selection_range = selection_range;
-        text_input.selection_for_layout = selection;
+            let selection = enabled.then(|| text_input.sorted_selection_character_offsets_range());
+            text_input.previous_selection_range = selection_range;
+            text_input.selection_for_layout = selection;
+            selection
+        };
 
         if self
             .text_input_widget


### PR DESCRIPTION
This doesn't crash in servoshell but causes issues in my fork because it needs to borrow the input again to update the state of the virtual keyboard implementation.

Testing: This fixes an issue with a fork and not Servo itself, so isn't really possible to test easily.
