### PR TITLE
script: Convert promise callback router to use rooted promise types

### DIFF
--- a/components/script/dom/audio/audiocontext.rs
+++ b/components/script/dom/audio/audiocontext.rs
@@ -156,7 +156,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
         }
 
         // Steps 4 and 5.
-        let trusted_promise = TrustedPromise::from(promise.clone());
+        let trusted_promise = TrustedPromise::from(&promise);
         match self.context.audio_context_impl().lock().unwrap().suspend() {
             Some(_) => {
                 let base_context = Trusted::new(&self.context);
@@ -212,7 +212,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
         }
 
         // Steps 4 and 5.
-        let trusted_promise = TrustedPromise::from(promise.clone());
+        let trusted_promise = TrustedPromise::from(&promise);
         match self.context.audio_context_impl().lock().unwrap().close() {
             Some(_) => {
                 let base_context = Trusted::new(&self.context);

--- a/components/script/dom/clipboard/clipboard.rs
+++ b/components/script/dom/clipboard/clipboard.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::rc::Rc;
 use std::str::FromStr;
 
 use data_url::mime::Mime;
@@ -26,7 +25,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::blob::Blob;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise, TracedPromise};
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::window::Window;
 use crate::realms::enter_auto_realm;
@@ -35,10 +34,12 @@ use crate::routed_promise::{RoutedPromiseListener, callback_promise};
 /// The fulfillment handler for the reacting to representationDataPromise part of
 /// <https://w3c.github.io/clipboard-apis/#dom-clipboard-readtext>.
 #[derive(Clone, JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 struct RepresentationDataPromiseFulfillmentHandler {
-    #[conditional_malloc_size_of]
-    promise: Rc<Promise>,
+    promise: TracedPromise,
 }
+
+impl js::gc::Rootable for RepresentationDataPromiseFulfillmentHandler {}
 
 impl Callback for RepresentationDataPromiseFulfillmentHandler {
     /// The fulfillment case of Step 3.4.1.1.4.3 of
@@ -60,10 +61,12 @@ impl Callback for RepresentationDataPromiseFulfillmentHandler {
 /// The rejection handler for the reacting to representationDataPromise part of
 /// <https://w3c.github.io/clipboard-apis/#dom-clipboard-readtext>.
 #[derive(Clone, JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 struct RepresentationDataPromiseRejectionHandler {
-    #[conditional_malloc_size_of]
-    promise: Rc<Promise>,
+    promise: TracedPromise,
 }
+
+impl js::gc::Rootable for RepresentationDataPromiseRejectionHandler {}
 
 impl Callback for RepresentationDataPromiseRejectionHandler {
     /// The rejection case of Step 3.4.1.1.4.3 of
@@ -94,12 +97,12 @@ impl Clipboard {
 
 impl ClipboardMethods<crate::DomTypeHolder> for Clipboard {
     /// <https://w3c.github.io/clipboard-apis/#dom-clipboard-readtext>
-    fn ReadText(&self, realm: &mut CurrentRealm) -> Rc<Promise> {
+    fn ReadText(&self, realm: &mut CurrentRealm) -> RootedPromise {
         // Step 1 Let realm be this's relevant realm.
         let global = self.global();
 
         // Step 2 Let p be a new promise in realm.
-        let p = Promise::new_in_realm(realm);
+        let p = Promise::new_in_realm_rooted(realm);
 
         // Step 3 Run the following steps in parallel:
 
@@ -122,11 +125,11 @@ impl ClipboardMethods<crate::DomTypeHolder> for Clipboard {
     }
 
     /// <https://w3c.github.io/clipboard-apis/#dom-clipboard-writetext>
-    fn WriteText(&self, realm: &mut CurrentRealm, data: DOMString) -> Rc<Promise> {
+    fn WriteText(&self, realm: &mut CurrentRealm, data: DOMString) -> RootedPromise {
         // Step 1 Let realm be this's relevant realm.
         let global = self.global();
         // Step 2 Let p be a new promise in realm.
-        let p = Promise::new_in_realm(realm);
+        let p = Promise::new_in_realm_rooted(realm);
 
         // Step 3 Run the following steps in parallel:
 
@@ -137,7 +140,7 @@ impl ClipboardMethods<crate::DomTypeHolder> for Clipboard {
         // to reject p with "NotAllowedError" DOMException in realm.
         // Step 3.2.2 Abort these steps.
 
-        let trusted_promise = TrustedPromise::new(p.clone());
+        let trusted_promise = TrustedPromise::from(&p);
         let bytes = Vec::from(data);
 
         // Step 3.3 Queue a global task on the clipboard task source,
@@ -182,7 +185,7 @@ impl RoutedPromiseListener<Result<String, String>> for Clipboard {
         &self,
         cx: &mut js::context::JSContext,
         response: Result<String, String>,
-        promise: &Rc<Promise>,
+        promise: &RootedPromise,
     ) {
         let global = self.global();
         let text = response.unwrap_or_default();
@@ -213,17 +216,21 @@ impl RoutedPromiseListener<Result<String, String>> for Clipboard {
 
         // Step 3.4.1.1.4.2 Let representationDataPromise be the representation’s data.
         // Step 3.4.1.1.4.3 React to representationDataPromise:
-        let fulfillment_handler = Box::new(RepresentationDataPromiseFulfillmentHandler {
-            promise: promise.clone(),
-        });
-        let rejection_handler = Box::new(RepresentationDataPromiseRejectionHandler {
-            promise: promise.clone(),
-        });
+        rooted!(&in(cx) let mut fulfillment_handler = Some(RepresentationDataPromiseFulfillmentHandler {
+            promise: promise.to_traced(),
+        }));
+        rooted!(&in(cx) let mut rejection_handler = Some(RepresentationDataPromiseRejectionHandler {
+            promise: promise.to_traced(),
+        }));
         let handler = PromiseNativeHandler::new(
             cx,
             &global,
-            Some(fulfillment_handler),
-            Some(rejection_handler),
+            fulfillment_handler
+                .take()
+                .map(|handler| Box::new(handler) as Box<dyn Callback>),
+            rejection_handler
+                .take()
+                .map(|handler| Box::new(handler) as Box<dyn Callback>),
         );
         let mut realm = enter_auto_realm(cx, &*global);
         let cx = &mut realm.current_realm();

--- a/components/script/dom/promise/promise.rs
+++ b/components/script/dom/promise/promise.rs
@@ -34,7 +34,9 @@ use js::rust::wrappers2::{
     SetAnyPromiseIsHandled, SetPromiseUserInputEventHandlingState,
 };
 use js::rust::{HandleObject, HandleValue, MutableHandleObject, Runtime};
-use script_bindings::interfaces::PromiseHelpers;
+use script_bindings::interfaces::{
+    HeapTracedPromiseHelpers, PromiseHelpers, StackRootPromiseHelpers,
+};
 use script_bindings::reflector::{DomObject, MutDomObject, Reflector};
 use script_bindings::settings_stack::run_a_script;
 
@@ -53,10 +55,23 @@ use crate::runtime::microtask::MicrotaskRunnable;
 #[derive(Clone)]
 pub(crate) struct RootedPromise(Rc<Promise>);
 
+impl StackRootPromiseHelpers<crate::DomTypeHolder> for RootedPromise {
+    type HeapTraced = TracedPromise;
+    fn to_traced(&self) -> TracedPromise {
+        RootedPromise::to_traced(self)
+    }
+}
+
 impl Deref for RootedPromise {
     type Target = Promise;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl From<Rc<Promise>> for RootedPromise {
+    fn from(promise: Rc<Promise>) -> Self {
+        RootedPromise(promise)
     }
 }
 
@@ -72,9 +87,9 @@ impl RootedPromise {
     }
 }
 
-impl From<RootedPromise> for TrustedPromise {
-    fn from(promise: RootedPromise) -> Self {
-        TrustedPromise::new(promise.0)
+impl From<&'_ RootedPromise> for TrustedPromise {
+    fn from(promise: &'_ RootedPromise) -> Self {
+        TrustedPromise::new(promise.0.clone())
     }
 }
 
@@ -108,6 +123,13 @@ impl ToJSValConvertible for RootedPromise {
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct TracedPromise(#[conditional_malloc_size_of] Rc<Promise>);
 
+impl HeapTracedPromiseHelpers<crate::DomTypeHolder> for TracedPromise {
+    type StackRoot = RootedPromise;
+    fn root(&self) -> RootedPromise {
+        TracedPromise::root(self)
+    }
+}
+
 impl js::rust::Rootable for TracedPromise {}
 
 impl TracedPromise {
@@ -116,8 +138,8 @@ impl TracedPromise {
     }
 }
 
-impl std::ops::Deref for TracedPromise {
-    type Target = Rc<Promise>;
+impl Deref for TracedPromise {
+    type Target = Promise;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -729,11 +751,16 @@ pub(crate) fn wait_for_all_promise(
 
 impl PromiseHelpers<crate::DomTypeHolder> for Promise {
     type StackRoot = RootedPromise;
+    type HeapTraced = TracedPromise;
 
     fn new_in_realm(
         cx: &mut CurrentRealm,
     ) -> Rc<<crate::DomTypeHolder as script_bindings::DomTypes>::Promise> {
         Promise::new_in_realm(cx)
+    }
+
+    fn new_in_realm_rooted(cx: &mut CurrentRealm) -> RootedPromise {
+        Promise::new_in_realm_rooted(cx)
     }
 
     fn reject_error(&self, cx: &mut js::context::JSContext, error: script_bindings::error::Error) {

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::rc::Rc;
-
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::conversions::ToJSValConvertible;
@@ -24,7 +22,7 @@ use crate::dom::bindings::codegen::Bindings::ServoInternalsBinding::ServoInterna
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise};
 use crate::event_loop::script_thread::ScriptThread;
 use crate::routed_promise::{RoutedPromiseListener, callback_promise};
 
@@ -66,8 +64,8 @@ impl ServoInternals {
 
 impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
     /// <https://servo.org/internal-no-spec>
-    fn ReportMemory(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
-        let promise = Promise::new_in_realm(cx);
+    fn ReportMemory(&self, cx: &mut CurrentRealm) -> RootedPromise {
+        let promise = Promise::new_in_realm_rooted(cx);
         let global = self.global();
         let task_manager = global.task_manager();
         let task_source = task_manager.dom_manipulation_task_source();
@@ -199,7 +197,7 @@ impl RoutedPromiseListener<MemoryReportResult> for ServoInternals {
         &self,
         cx: &mut JSContext,
         response: MemoryReportResult,
-        promise: &Rc<Promise>,
+        promise: &RootedPromise,
     ) {
         let stringified = serde_json::to_string(&response.results)
             .unwrap_or_else(|_| "{ error: \"failed to create memory report\"}".to_owned());

--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -1041,7 +1041,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     fn ResolvePromiseDelayed(&self, cx: &mut JSContext, p: &Promise, value: DOMString, delay: u64) {
         let promise = p.duplicate(cx);
         let cb = TestBindingCallback {
-            promise: TrustedPromise::from(promise),
+            promise: TrustedPromise::from(&promise),
             value,
         };
         let _ = self.global().schedule_callback(

--- a/components/script/dom/wakelock/wakelock.rs
+++ b/components/script/dom/wakelock/wakelock.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::Cell;
-use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use embedder_traits::{AllowOrDeny, EmbedderMsg};
@@ -22,7 +21,7 @@ use crate::dom::bindings::error::Error;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise};
 use crate::dom::wakelock::wakelocksentinel::WakeLockSentinel;
 use crate::routed_promise::{RoutedPromiseListener, callback_promise};
 
@@ -48,9 +47,9 @@ impl WakeLock {
 
 impl WakeLockMethods<crate::DomTypeHolder> for WakeLock {
     /// <https://w3c.github.io/screen-wake-lock/#the-request-method>
-    fn Request(&self, cx: &mut CurrentRealm, type_: WakeLockType) -> Rc<Promise> {
+    fn Request(&self, cx: &mut CurrentRealm, type_: WakeLockType) -> RootedPromise {
         let global = GlobalScope::from_current_realm(cx);
-        let promise = Promise::new_in_realm(cx);
+        let promise = Promise::new_in_realm_rooted(cx);
 
         // Step 1. Let document be this's relevant global object's associated Document.
         let document = global.as_window().Document();
@@ -98,7 +97,7 @@ impl WakeLockMethods<crate::DomTypeHolder> for WakeLock {
 
 impl RoutedPromiseListener<AllowOrDeny> for WakeLock {
     /// <https://w3c.github.io/screen-wake-lock/#the-request-method>
-    fn handle_response(&self, cx: &mut JSContext, response: AllowOrDeny, promise: &Rc<Promise>) {
+    fn handle_response(&self, cx: &mut JSContext, response: AllowOrDeny, promise: &RootedPromise) {
         match response {
             // Step 7a. If permission is denied, reject with NotAllowedError.
             AllowOrDeny::Deny => {

--- a/components/script/dom/webgpu/gpu_promise_listener.rs
+++ b/components/script/dom/webgpu/gpu_promise_listener.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::rc::Rc;
-
 use js::jsapi::HandleObject;
 use script_bindings::str::DOMString;
 use webgpu_traits::WebGPUAdapterResponse;
@@ -11,7 +9,7 @@ use webgpu_traits::WebGPUAdapterResponse;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::gpu::GPU;
 use crate::dom::gpuadapter::GPUAdapter;
-use crate::dom::promise::Promise;
+use crate::dom::promise::RootedPromise;
 use crate::routed_promise::RoutedPromiseListener;
 
 impl RoutedPromiseListener<WebGPUAdapterResponse> for GPU {
@@ -19,7 +17,7 @@ impl RoutedPromiseListener<WebGPUAdapterResponse> for GPU {
         &self,
         cx: &mut js::context::JSContext,
         response: WebGPUAdapterResponse,
-        promise: &Rc<Promise>,
+        promise: &RootedPromise,
     ) {
         match response {
             Some(Ok(adapter)) => {

--- a/components/script/dom/webgpu/gpuadapter_promise_listener.rs
+++ b/components/script/dom/webgpu/gpuadapter_promise_listener.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::rc::Rc;
-
 use js::jsapi::HandleObject;
 use script_bindings::cformat;
 use script_bindings::codegen::GenericBindings::WebGPUBinding::GPUDeviceLostReason;
@@ -12,7 +10,7 @@ use webgpu_traits::{RequestDeviceError, WebGPUDeviceResponse};
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::gpuadapter::GPUAdapter;
-use crate::dom::promise::Promise;
+use crate::dom::promise::RootedPromise;
 use crate::dom::types::GPUDevice;
 use crate::routed_promise::RoutedPromiseListener;
 
@@ -22,7 +20,7 @@ impl RoutedPromiseListener<WebGPUDeviceResponse> for GPUAdapter {
         &self,
         cx: &mut js::context::JSContext,
         response: WebGPUDeviceResponse,
-        promise: &Rc<Promise>,
+        promise: &RootedPromise,
     ) {
         match response {
             // 3.1 Let device be a new device with the capabilities described by descriptor.

--- a/components/script/dom/webgpu/gpubuffer_promise_listener.rs
+++ b/components/script/dom/webgpu/gpubuffer_promise_listener.rs
@@ -2,12 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::rc::Rc;
-
 use webgpu_traits::Mapping;
 use wgpu_core::resource::BufferAccessError;
 
-use crate::dom::promise::Promise;
+use crate::dom::promise::RootedPromise;
 use crate::dom::types::GPUBuffer;
 use crate::routed_promise::RoutedPromiseListener;
 
@@ -16,7 +14,7 @@ impl RoutedPromiseListener<Result<Mapping, BufferAccessError>> for GPUBuffer {
         &self,
         cx: &mut js::context::JSContext,
         response: Result<Mapping, BufferAccessError>,
-        promise: &Rc<Promise>,
+        promise: &RootedPromise,
     ) {
         match response {
             Ok(mapping) => self.map_success(cx, promise, mapping),

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -50,7 +50,7 @@ use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise, TracedPromise};
 use crate::dom::types::{GPUError, GPUQuerySet};
 use crate::dom::webgpu::gpuadapter::GPUAdapter;
 use crate::dom::webgpu::gpuadapterinfo::GPUAdapterInfo;
@@ -103,8 +103,7 @@ pub(crate) struct GPUDevice {
     label: DomRefCell<USVString>,
     default_queue: Dom<GPUQueue>,
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-lost>
-    #[conditional_malloc_size_of]
-    lost_promise: DomRefCell<Rc<Promise>>,
+    lost_promise: DomRefCell<TracedPromise>,
     valid: Cell<bool>,
     droppable: DroppableGPUDevice,
 }
@@ -120,7 +119,7 @@ impl GPUDevice {
         device: WebGPUDevice,
         queue: &GPUQueue,
         label: String,
-        lost_promise: Rc<Promise>,
+        lost_promise: &RootedPromise,
     ) -> Self {
         Self {
             eventtarget: EventTarget::new_inherited(),
@@ -131,7 +130,7 @@ impl GPUDevice {
             adapter_info: Dom::from_ref(adapter_info),
             label: DomRefCell::new(USVString::from(label)),
             default_queue: Dom::from_ref(queue),
-            lost_promise: DomRefCell::new(lost_promise),
+            lost_promise: DomRefCell::new(lost_promise.to_traced()),
             valid: Cell::new(true),
             droppable: DroppableGPUDevice { channel, device },
         }
@@ -154,7 +153,7 @@ impl GPUDevice {
         let limits = GPUSupportedLimits::new(cx, global, limits);
         let features = GPUSupportedFeatures::Constructor(cx, global, None, features).unwrap();
         let adapter_info = GPUAdapterInfo::clone_from(cx, global, &adapter.Info());
-        let lost_promise = Promise::new(cx, global);
+        let lost_promise = Promise::new_rooted(cx, global);
         let device = reflect_weak_referenceable_dom_object(
             cx,
             Rc::new(GPUDevice::new_inherited(
@@ -166,7 +165,7 @@ impl GPUDevice {
                 device,
                 &queue,
                 label,
-                lost_promise,
+                &lost_promise,
             )),
             global,
         );
@@ -432,8 +431,8 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-lost>
-    fn Lost(&self) -> Rc<Promise> {
-        self.lost_promise.borrow().clone()
+    fn Lost(&self) -> RootedPromise {
+        self.lost_promise.borrow().root()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbuffer>
@@ -502,8 +501,8 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
         &self,
         cx: &mut CurrentRealm<'_>,
         descriptor: &GPUComputePipelineDescriptor,
-    ) -> Rc<Promise> {
-        let promise = Promise::new_in_realm(cx);
+    ) -> RootedPromise {
+        let promise = Promise::new_in_realm_rooted(cx);
         let callback = callback_promise(
             &promise,
             self,
@@ -562,9 +561,9 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
         &self,
         cx: &mut CurrentRealm<'_>,
         descriptor: &GPURenderPipelineDescriptor,
-    ) -> Fallible<Rc<Promise>> {
+    ) -> Fallible<RootedPromise> {
         let desc = self.parse_render_pipeline(descriptor)?;
-        let promise = Promise::new_in_realm(cx);
+        let promise = Promise::new_in_realm_rooted(cx);
         let callback = callback_promise(
             &promise,
             self,
@@ -618,8 +617,8 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-poperrorscope>
-    fn PopErrorScope(&self, cx: &mut CurrentRealm<'_>) -> Rc<Promise> {
-        let promise = Promise::new_in_realm(cx);
+    fn PopErrorScope(&self, cx: &mut CurrentRealm<'_>) -> RootedPromise {
+        let promise = Promise::new_in_realm_rooted(cx);
         let callback = callback_promise(
             &promise,
             self,
@@ -665,7 +664,7 @@ impl RoutedPromiseListener<WebGPUPoppedErrorScopeResponse> for GPUDevice {
         &self,
         cx: &mut js::context::JSContext,
         response: WebGPUPoppedErrorScopeResponse,
-        promise: &Rc<Promise>,
+        promise: &RootedPromise,
     ) {
         match response {
             Ok(None) | Err(PopError::Lost) => promise.resolve_native(cx, &None::<Option<GPUError>>),
@@ -686,7 +685,7 @@ impl RoutedPromiseListener<WebGPUComputePipelineResponse> for GPUDevice {
         &self,
         cx: &mut js::context::JSContext,
         response: WebGPUComputePipelineResponse,
-        promise: &Rc<Promise>,
+        promise: &RootedPromise,
     ) {
         match response {
             Ok(pipeline) => {
@@ -726,7 +725,7 @@ impl RoutedPromiseListener<WebGPURenderPipelineResponse> for GPUDevice {
         &self,
         cx: &mut js::context::JSContext,
         response: WebGPURenderPipelineResponse,
-        promise: &Rc<Promise>,
+        promise: &RootedPromise,
     ) {
         match response {
             Ok(pipeline) => {

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::rc::Rc;
-
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
 use pixels::{SnapshotAlphaMode, SnapshotPixelFormat};
@@ -33,7 +31,7 @@ use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise};
 use crate::dom::webgpu::gpubuffer::GPUBuffer;
 use crate::dom::webgpu::gpucommandbuffer::GPUCommandBuffer;
 use crate::dom::webgpu::gpudevice::GPUDevice;
@@ -391,9 +389,9 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueue-onsubmittedworkdone>
-    fn OnSubmittedWorkDone(&self, cx: &mut JSContext) -> Rc<Promise> {
+    fn OnSubmittedWorkDone(&self, cx: &mut JSContext) -> RootedPromise {
         let global = self.global();
-        let promise = Promise::new(cx, &global);
+        let promise = Promise::new_rooted(cx, &global);
         let task_manager = global.task_manager();
         let task_source = task_manager.dom_manipulation_task_source();
         let callback = callback_promise(&promise, self, task_source);
@@ -417,7 +415,7 @@ impl RoutedPromiseListener<()> for GPUQueue {
         &self,
         cx: &mut js::context::JSContext,
         _response: (),
-        promise: &Rc<Promise>,
+        promise: &RootedPromise,
     ) {
         promise.resolve_native(cx, &());
     }

--- a/components/script/dom/webgpu/gpushadermodule_promise_listener.rs
+++ b/components/script/dom/webgpu/gpushadermodule_promise_listener.rs
@@ -2,12 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::rc::Rc;
-
 use webgpu_traits::ShaderCompilationInfo;
 
 use crate::dom::bindings::reflector::DomGlobal;
-use crate::dom::promise::Promise;
+use crate::dom::promise::RootedPromise;
 use crate::dom::types::{GPUCompilationInfo, GPUShaderModule};
 use crate::routed_promise::RoutedPromiseListener;
 
@@ -16,7 +14,7 @@ impl RoutedPromiseListener<Option<ShaderCompilationInfo>> for GPUShaderModule {
         &self,
         cx: &mut js::context::JSContext,
         response: Option<ShaderCompilationInfo>,
-        promise: &Rc<Promise>,
+        promise: &RootedPromise,
     ) {
         let info = GPUCompilationInfo::from(cx, &self.global(), response);
         promise.resolve_native(cx, &info);

--- a/components/script/dom/webgpu/mod.rs
+++ b/components/script/dom/webgpu/mod.rs
@@ -2,17 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::rc::Rc;
 use std::sync::Arc;
 
 use script_webgpu::traits::{WebGPUGlobalTrait, WebGPUPromiseTrait};
 use webgpu_traits::Mapping;
 use wgpu_core::resource::BufferAccessError;
 
+use crate::dom::GlobalScope;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::gpu::GPU;
+use crate::dom::promise::RootedPromise;
 use crate::dom::types::{GPUAdapter, GPUBuffer, GPUShaderModule};
-use crate::dom::{GlobalScope, Promise};
 use crate::routed_promise::callback_promise;
 
 pub(crate) mod gpu_promise_listener;
@@ -150,9 +150,9 @@ pub(crate) mod wgsllanguagefeatures {
         script_webgpu::wgsllanguagefeatures::WGSLLanguageFeatures<crate::DomTypeHolder>;
 }
 
-impl WebGPUPromiseTrait<crate::DomTypeHolder> for Promise {
+impl WebGPUPromiseTrait<crate::DomTypeHolder> for RootedPromise {
     fn callback_promise_adapter(
-        self: &Rc<Self>,
+        &self,
         d: &GPUAdapter,
     ) -> servo_base::generic_channel::GenericCallback<webgpu_traits::WebGPUDeviceResponse> {
         let task_manager = <GPUAdapter as DomGlobal>::global(d).task_manager();
@@ -160,7 +160,7 @@ impl WebGPUPromiseTrait<crate::DomTypeHolder> for Promise {
     }
 
     fn callback_promise_gpubuffer(
-        self: &Rc<Self>,
+        &self,
         d: &GPUBuffer,
     ) -> servo_base::generic_channel::GenericCallback<Result<Mapping, BufferAccessError>> {
         let task_manager = <GPUBuffer as DomGlobal>::global(d).task_manager();
@@ -168,7 +168,7 @@ impl WebGPUPromiseTrait<crate::DomTypeHolder> for Promise {
     }
 
     fn callback_promise_gpu(
-        self: &Rc<Self>,
+        &self,
         d: &GPU,
     ) -> servo_base::generic_channel::GenericCallback<webgpu_traits::WebGPUAdapterResponse> {
         let task_manager = <GPU as DomGlobal>::global(d).task_manager();
@@ -176,7 +176,7 @@ impl WebGPUPromiseTrait<crate::DomTypeHolder> for Promise {
     }
 
     fn callback_promise_gpushadermodule(
-        self: &Rc<Self>,
+        &self,
         d: &script_webgpu::gpushadermodule::GPUShaderModule<crate::DomTypeHolder>,
     ) -> servo_base::generic_channel::GenericCallback<Option<webgpu_traits::ShaderCompilationInfo>>
     {

--- a/components/script/routed_promise.rs
+++ b/components/script/routed_promise.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::rc::Rc;
-
 use js::context::JSContext;
 use script_bindings::reflector::DomObject;
 use serde::Serialize;
@@ -11,11 +9,11 @@ use serde::de::DeserializeOwned;
 use servo_base::generic_channel::GenericCallback;
 
 use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
-use crate::dom::promise::Promise;
+use crate::dom::promise::RootedPromise;
 use crate::tasks::task_source::TaskSource;
 
 pub(crate) trait RoutedPromiseListener<R: Serialize + DeserializeOwned + Send> {
-    fn handle_response(&self, cx: &mut JSContext, response: R, promise: &Rc<Promise>);
+    fn handle_response(&self, cx: &mut JSContext, response: R, promise: &RootedPromise);
 }
 
 pub(crate) struct RoutedPromiseContext<
@@ -31,7 +29,7 @@ impl<R: Serialize + DeserializeOwned + Send, T: RoutedPromiseListener<R> + DomOb
     RoutedPromiseContext<R, T>
 {
     fn response(self, cx: &mut JSContext, response: R) {
-        let promise = self.trusted.root();
+        let promise = RootedPromise::from(self.trusted.root());
         self.receiver.root().handle_response(cx, response, &promise);
     }
 }
@@ -40,12 +38,12 @@ pub(crate) fn callback_promise<
     R: Serialize + DeserializeOwned + Send + 'static,
     T: RoutedPromiseListener<R> + DomObject + 'static,
 >(
-    promise: &Rc<Promise>,
+    promise: &RootedPromise,
     receiver: &T,
     task_source: TaskSource,
 ) -> GenericCallback<R> {
     let task_source = task_source.to_sendable();
-    let mut trusted: Option<TrustedPromise> = Some(TrustedPromise::new(promise.clone()));
+    let mut trusted: Option<TrustedPromise> = Some(TrustedPromise::from(promise));
     let trusted_receiver = Trusted::new(receiver);
     GenericCallback::new(move |message| {
         let trusted = if let Some(trusted) = trusted.take() {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -130,7 +130,6 @@ DOMInterfaces = {
 
 'Clipboard': {
     'realm': ['ReadText', 'WriteText'],
-    'useRcPromise': True,
 },
 
 'ClipboardItem': {
@@ -539,12 +538,10 @@ DOMInterfaces = {
 'GPU': {
     'realm': ['RequestAdapter'],
     'cx': ['WgslLanguageFeatures'],
-    'useRcPromise': True,
 },
 
 'GPUAdapter': {
     'realm': ['RequestDevice'],
-    'useRcPromise': True,
 },
 
 'GPUBindGroup': {
@@ -559,7 +556,6 @@ DOMInterfaces = {
     'realm': ['MapAsync'],
     'cx': ['Destroy', 'GetMappedRange',  'Unmap', 'PopErrorScope'],
     'no_gc': ['SetLabel'],
-    'useRcPromise': True,
 },
 
 'GPUCanvasContext': {
@@ -590,7 +586,6 @@ DOMInterfaces = {
 },
 
 'GPUDevice': {
-    'useRcPromise': True,
     'realm': ['CreateComputePipelineAsync', 'CreateRenderPipelineAsync',
         'CreateShaderModule', # create promise for compilation info
         'PopErrorScope',
@@ -610,7 +605,6 @@ DOMInterfaces = {
 },
 
 'GPUQueue': {
-    'useRcPromise': True,
     'cx': ['CopyExternalImageToTexture', 'OnSubmittedWorkDone', 'WriteBuffer', 'WriteTexture'],
     'no_gc': ['SetLabel'],
 },
@@ -648,7 +642,6 @@ DOMInterfaces = {
 },
 
 'GPUShaderModule': {
-    'useRcPromise': True,
     'no_gc': ['SetLabel'],
 },
 
@@ -982,7 +975,6 @@ DOMInterfaces = {
 
 'WakeLock': {
     'realm': ['Request'],
-    'useRcPromise': True,
 },
 
 'Node': {
@@ -1162,7 +1154,6 @@ DOMInterfaces = {
     'cx': ['DefaultPreferenceValue', 'GetPreference'],
     'realm': ['ReportMemory'],
     'additionalTraits': ['crate::interfaces::ServoInternalsHelpers'],
-    'useRcPromise': True,
 },
 
 'ServoTestUtils': {

--- a/components/script_bindings/interfaces.rs
+++ b/components/script_bindings/interfaces.rs
@@ -3,15 +3,18 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::RefCell;
+use std::ops::Deref;
 use std::rc::Rc;
 use std::thread::LocalKey;
 
 use js::context::JSContext;
-use js::conversions::ToJSValConvertible;
+use js::conversions::{FromJSValConvertible, ToJSValConvertible};
+use js::gc::Traceable;
 use js::glue::JSPrincipalsCallbacks;
 use js::jsapi::{CallArgs, JSObject};
 use js::realm::CurrentRealm;
 use js::rust::{HandleObject, MutableHandleObject};
+use malloc_size_of::MallocSizeOf;
 use servo_base::id::PipelineId;
 use servo_constellation_traits::ScriptToConstellationChan;
 use servo_url::{MutableOrigin, ServoUrl};
@@ -90,11 +93,27 @@ pub trait GlobalScopeHelpers<D: DomTypes> {
     fn script_to_constellation_chan(&self) -> ScriptToConstellationChan;
 }
 
+pub trait HeapTracedPromiseHelpers<D: DomTypes> {
+    type StackRoot;
+    fn root(&self) -> Self::StackRoot;
+}
+
+pub trait StackRootPromiseHelpers<D: DomTypes> {
+    type HeapTraced;
+    fn to_traced(&self) -> Self::HeapTraced;
+}
+
 pub trait PromiseHelpers<D: DomTypes> {
-    type StackRoot: js::conversions::FromJSValConvertible<Config = ()>
-        + js::conversions::ToJSValConvertible
-        + std::ops::Deref<Target = D::Promise>;
+    type StackRoot: FromJSValConvertible<Config = ()>
+        + ToJSValConvertible
+        + Deref<Target = D::Promise>
+        + StackRootPromiseHelpers<D, HeapTraced = Self::HeapTraced>;
+    type HeapTraced: Traceable
+        + MallocSizeOf
+        + Deref<Target = D::Promise>
+        + HeapTracedPromiseHelpers<D, StackRoot = Self::StackRoot>;
     fn new_in_realm(cx: &mut CurrentRealm) -> Rc<D::Promise>;
+    fn new_in_realm_rooted(cx: &mut CurrentRealm) -> Self::StackRoot;
     fn reject_error(&self, cx: &mut JSContext, error: Error);
     fn is_rejected(&self) -> bool;
     fn is_pending(&self) -> bool;

--- a/components/script_webgpu/gpu.rs
+++ b/components/script_webgpu/gpu.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::marker::PhantomData;
-use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
@@ -57,7 +56,8 @@ impl<D: Equivalence> GPU<D> {
 impl<D> GPUMethods<D> for GPU<D>
 where
     D: Equivalence,
-    D::Promise: PromiseHelpers<D> + WebGPUPromiseTrait<D>,
+    D::Promise: PromiseHelpers<D>,
+    <D::Promise as PromiseHelpers<D>>::StackRoot: WebGPUPromiseTrait<D>,
     D::GPU: DomGlobalGeneric<D>,
     D::GlobalScope: WebGPUGlobalTrait,
     Self: DomGlobalGeneric<D>,
@@ -67,11 +67,11 @@ where
         &self,
         cx: &mut CurrentRealm,
         options: &GPURequestAdapterOptions,
-    ) -> Rc<D::Promise> {
+    ) -> <D::Promise as PromiseHelpers<D>>::StackRoot {
         let global = self.global_from_reflector();
         // 1. Let promise be a new promise.
-        let promise = D::Promise::new_in_realm(cx);
-        let callback = D::Promise::callback_promise_gpu(&promise, self);
+        let promise = D::Promise::new_in_realm_rooted(cx);
+        let callback = promise.callback_promise_gpu(self);
 
         let power_preference = match options.powerPreference {
             Some(GPUPowerPreference::Low_power) => PowerPreference::LowPower,

--- a/components/script_webgpu/gpuadapter.rs
+++ b/components/script_webgpu/gpuadapter.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::rc::Rc;
-
 use dom_struct::dom_struct;
 use js::jsapi::{HandleObject, Heap, JSObject};
 use js::realm::CurrentRealm;
@@ -190,7 +188,8 @@ where
 impl<D> GPUAdapterMethods<D> for GPUAdapter<D>
 where
     D: Equivalence,
-    D::Promise: WebGPUPromiseTrait<D> + PromiseHelpers<D>,
+    D::Promise: PromiseHelpers<D>,
+    <D::Promise as PromiseHelpers<D>>::StackRoot: WebGPUPromiseTrait<D>,
     D::GlobalScope: WebGPUGlobalTrait,
     Self: DomGlobalGeneric<D>,
 {
@@ -199,11 +198,11 @@ where
         &self,
         cx: &mut CurrentRealm<'_>,
         descriptor: &GPUDeviceDescriptor,
-    ) -> Rc<D::Promise> {
+    ) -> <D::Promise as PromiseHelpers<D>>::StackRoot {
         // Step 2
-        let promise = D::Promise::new_in_realm(cx);
+        let promise = D::Promise::new_in_realm_rooted(cx);
 
-        let callback = WebGPUPromiseTrait::<D>::callback_promise_adapter(&promise, self);
+        let callback = promise.callback_promise_adapter(self);
         let mut required_features = wgpu_types::Features::empty();
         for &ext in descriptor.requiredFeatures.iter() {
             if let Some(feature) = gpu_to_wgt_feature(ext) {

--- a/components/script_webgpu/gpubuffer.rs
+++ b/components/script_webgpu/gpubuffer.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::ops::Range;
-use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
@@ -19,7 +18,7 @@ use script_bindings::codegen::GenericBindings::WebGPUBinding::{
     GPUMapModeConstants, GPUMapModeFlags, GPUSize64,
 };
 use script_bindings::error::{Error, Fallible};
-use script_bindings::interfaces::PromiseHelpers;
+use script_bindings::interfaces::{PromiseHelpers, StackRootPromiseHelpers};
 use script_bindings::reflector::{DomGlobalGeneric, Reflector, reflect_dom_object_with_wrap};
 use script_bindings::trace::RootedTraceableBox;
 use servo_base::generic_channel::GenericSharedMemory;
@@ -102,8 +101,7 @@ pub struct GPUBuffer<D: DomTypes> {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-usage>
     usage: GPUFlagsConstant,
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-pending_map-slot>
-    #[conditional_malloc_size_of]
-    pending_map: DomRefCell<Option<Rc<D::Promise>>>,
+    pending_map: DomRefCell<Option<<D::Promise as PromiseHelpers<D>>::HeapTraced>>,
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-mapping-slot>
     mapping: DomRefCell<Option<ActiveBufferMapping>>,
 }
@@ -222,7 +220,8 @@ where
 impl<D> GPUBufferMethods<D> for GPUBuffer<D>
 where
     D: Equivalence,
-    D::Promise: PromiseHelpers<D> + WebGPUPromiseTrait<D> + PartialEq,
+    D::Promise: PromiseHelpers<D> + PartialEq,
+    <D::Promise as PromiseHelpers<D>>::StackRoot: WebGPUPromiseTrait<D>,
     D::GPUDevice: GPUDeviceTrait<D>,
     D::GPUDevice: DomGlobalGeneric<D> + GPUDeviceTrait<D>,
     D::GlobalScope: WebGPUGlobalTrait,
@@ -290,8 +289,8 @@ where
         mode: u32,
         offset: GPUSize64,
         size: Option<GPUSize64>,
-    ) -> Rc<D::Promise> {
-        let promise = D::Promise::new_in_realm(cx);
+    ) -> <D::Promise as PromiseHelpers<D>>::StackRoot {
+        let promise = D::Promise::new_in_realm_rooted(cx);
         // Step 2
         if self.pending_map.borrow().is_some() {
             promise.reject_error(
@@ -301,7 +300,7 @@ where
             return promise;
         }
         // Step 4
-        *self.pending_map.safe_borrow_mut(cx) = Some(promise.clone());
+        *self.pending_map.safe_borrow_mut(cx) = Some(promise.to_traced());
         // Step 5
         let host_map = match mode {
             GPUMapModeConstants::READ => HostMap::Read,
@@ -316,7 +315,7 @@ where
             },
         };
 
-        let callback = D::Promise::callback_promise_gpubuffer(&promise, self);
+        let callback = promise.callback_promise_gpubuffer(self);
         if let Err(e) = self
             .droppable
             .channel
@@ -460,9 +459,13 @@ where
     D::Promise: PromiseHelpers<D> + PartialEq,
     D::GPUDevice: GPUDeviceTrait<D>,
 {
-    pub fn map_failure(&self, cx: &mut JSContext, p: &Rc<D::Promise>) {
+    pub fn map_failure(
+        &self,
+        cx: &mut JSContext,
+        p: &<D::Promise as PromiseHelpers<D>>::StackRoot,
+    ) {
         // Step 1
-        if self.pending_map.borrow().as_ref() != Some(p) {
+        if self.pending_map.borrow().as_deref() != Some(&*p) {
             assert!(p.is_rejected());
             return;
         }
@@ -482,11 +485,11 @@ where
     pub fn map_success(
         &self,
         cx: &mut js::context::JSContext,
-        p: &Rc<D::Promise>,
+        p: &<D::Promise as PromiseHelpers<D>>::StackRoot,
         wgpu_mapping: Mapping,
     ) {
         // Step 1
-        if self.pending_map.borrow().as_ref() != Some(p) {
+        if self.pending_map.borrow().as_deref() != Some(&*p) {
             assert!(p.is_rejected());
             return;
         }

--- a/components/script_webgpu/gpubuffer.rs
+++ b/components/script_webgpu/gpubuffer.rs
@@ -465,7 +465,7 @@ where
         p: &<D::Promise as PromiseHelpers<D>>::StackRoot,
     ) {
         // Step 1
-        if self.pending_map.borrow().as_deref() != Some(&*p) {
+        if self.pending_map.borrow().as_deref() != Some(p) {
             assert!(p.is_rejected());
             return;
         }
@@ -489,7 +489,7 @@ where
         wgpu_mapping: Mapping,
     ) {
         // Step 1
-        if self.pending_map.borrow().as_deref() != Some(&*p) {
+        if self.pending_map.borrow().as_deref() != Some(p) {
             assert!(p.is_rejected());
             return;
         }

--- a/components/script_webgpu/gpucomputepassencoder.rs
+++ b/components/script_webgpu/gpucomputepassencoder.rs
@@ -103,7 +103,8 @@ where
     D::GlobalScope: WebGPUGlobalTrait,
     D::GPUDevice: GPUDeviceTrait<D>,
     D::GPUExternalTexture: GPUExternalTextureTrait<D>,
-    D::Promise: WebGPUPromiseTrait<D> + PromiseHelpers<D>,
+    D::Promise: PromiseHelpers<D>,
+    <D::Promise as PromiseHelpers<D>>::StackRoot: WebGPUPromiseTrait<D>,
 {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {

--- a/components/script_webgpu/gpucomputepipeline.rs
+++ b/components/script_webgpu/gpucomputepipeline.rs
@@ -103,7 +103,8 @@ where
 impl<D> GPUComputePipeline<D>
 where
     D: Equivalence,
-    D::Promise: WebGPUPromiseTrait<D> + PromiseHelpers<D>,
+    D::Promise: PromiseHelpers<D>,
+    <D::Promise as PromiseHelpers<D>>::StackRoot: WebGPUPromiseTrait<D>,
     D::GlobalScope: WebGPUGlobalTrait + GlobalScopeHelpers<D>,
     D::GPUDevice: GPUDeviceTrait<D>,
 {
@@ -152,7 +153,8 @@ where
     D::GlobalScope: WebGPUGlobalTrait,
     D::GPUDevice: GPUDeviceTrait<D>,
     Self: DomGlobalGeneric<D>,
-    D::Promise: PromiseHelpers<D> + WebGPUPromiseTrait<D>,
+    D::Promise: PromiseHelpers<D>,
+    <D::Promise as PromiseHelpers<D>>::StackRoot: WebGPUPromiseTrait<D>,
 {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {

--- a/components/script_webgpu/gpuconvert.rs
+++ b/components/script_webgpu/gpuconvert.rs
@@ -760,7 +760,8 @@ where
     D: Equivalence,
     D::GlobalScope: WebGPUGlobalTrait + GlobalScopeHelpers<D>,
     D::GPUDevice: GPUDeviceTrait<D>,
-    D::Promise: PromiseHelpers<D> + WebGPUPromiseTrait<D>,
+    D::Promise: PromiseHelpers<D>,
+    <D::Promise as PromiseHelpers<D>>::StackRoot: WebGPUPromiseTrait<D>,
 {
     fn convert(self) -> ProgrammableStageDescriptor<'a> {
         ProgrammableStageDescriptor {

--- a/components/script_webgpu/gpushadermodule.rs
+++ b/components/script_webgpu/gpushadermodule.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::rc::Rc;
-
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
 use js::realm::CurrentRealm;
@@ -14,7 +12,9 @@ use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::WebGPUBinding::{
     GPUShaderModuleDescriptor, GPUShaderModuleMethods, GPUShaderModuleWrap,
 };
-use script_bindings::interfaces::PromiseHelpers;
+use script_bindings::interfaces::{
+    HeapTracedPromiseHelpers, PromiseHelpers, StackRootPromiseHelpers,
+};
 use script_bindings::reflector::{DomGlobalGeneric, Reflector, reflect_dom_object_with_wrap};
 use webgpu_traits::{WebGPU, WebGPURequest, WebGPUShaderModule};
 
@@ -51,8 +51,7 @@ impl Drop for DroppableGPUShaderModule {
 pub struct GPUShaderModule<D: DomTypes> {
     reflector_: Reflector,
     label: DomRefCell<USVString>,
-    #[ignore_malloc_size_of = "promise"]
-    compilation_info_promise: Rc<D::Promise>,
+    compilation_info_promise: <D::Promise as PromiseHelpers<D>>::HeapTraced,
     droppable: DroppableGPUShaderModule,
 }
 
@@ -61,12 +60,12 @@ impl<D: Equivalence> GPUShaderModule<D> {
         channel: WebGPU,
         shader_module: WebGPUShaderModule,
         label: USVString,
-        promise: Rc<D::Promise>,
+        promise: &<D::Promise as PromiseHelpers<D>>::StackRoot,
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
             label: DomRefCell::new(label),
-            compilation_info_promise: promise,
+            compilation_info_promise: promise.to_traced(),
             droppable: DroppableGPUShaderModule {
                 channel,
                 shader_module,
@@ -80,7 +79,7 @@ impl<D: Equivalence> GPUShaderModule<D> {
         channel: WebGPU,
         shader_module: WebGPUShaderModule,
         label: USVString,
-        promise: Rc<D::Promise>,
+        promise: &<D::Promise as PromiseHelpers<D>>::StackRoot,
     ) -> DomRoot<Self> {
         reflect_dom_object_with_wrap::<D, _, _>(
             Box::new(GPUShaderModule::new_inherited(
@@ -99,7 +98,8 @@ impl<D: Equivalence> GPUShaderModule<D> {
 impl<D> GPUShaderModule<D>
 where
     D: Equivalence,
-    D::Promise: WebGPUPromiseTrait<D> + PromiseHelpers<D>,
+    D::Promise: PromiseHelpers<D>,
+    <D::Promise as PromiseHelpers<D>>::StackRoot: WebGPUPromiseTrait<D>,
     D::GlobalScope: WebGPUGlobalTrait,
     D::GPUDevice: GPUDeviceTrait<D>,
 {
@@ -117,17 +117,16 @@ where
             .global_from_reflector()
             .global_wgpu_id_hub()
             .create_shader_module_id();
-        let promise = D::Promise::new_in_realm(cx);
+        let promise = D::Promise::new_in_realm_rooted(cx);
         let shader_module = GPUShaderModule::new(
             cx,
             &*device.global_from_reflector(),
             device.channel(),
             WebGPUShaderModule(program_id),
             descriptor.parent.label.clone(),
-            promise.clone(),
+            &promise,
         );
-        let callback =
-            WebGPUPromiseTrait::<D>::callback_promise_gpushadermodule(&promise, &*shader_module);
+        let callback = promise.callback_promise_gpushadermodule(&*shader_module);
         device
             .channel()
             .0
@@ -155,7 +154,7 @@ impl<D: DomTypes> GPUShaderModuleMethods<D> for GPUShaderModule<D> {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpushadermodule-getcompilationinfo>
-    fn GetCompilationInfo(&self) -> Rc<D::Promise> {
-        self.compilation_info_promise.clone()
+    fn GetCompilationInfo(&self) -> <D::Promise as PromiseHelpers<D>>::StackRoot {
+        self.compilation_info_promise.root()
     }
 }

--- a/components/script_webgpu/traits.rs
+++ b/components/script_webgpu/traits.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::rc::Rc;
 use std::sync::Arc;
 
 use script_bindings::DomTypes;
@@ -90,20 +89,17 @@ pub trait Equivalence =  DomTypes<
 
 /// The main trait for creating and using promises in script_webgpu.
 pub trait WebGPUPromiseTrait<D: DomTypes> {
-    fn callback_promise_adapter(
-        self: &Rc<Self>,
-        d: &GPUAdapter<D>,
-    ) -> GenericCallback<WebGPUDeviceResponse>;
+    fn callback_promise_adapter(&self, d: &GPUAdapter<D>) -> GenericCallback<WebGPUDeviceResponse>;
 
     fn callback_promise_gpubuffer(
-        self: &Rc<Self>,
+        &self,
         d: &GPUBuffer<D>,
     ) -> GenericCallback<Result<Mapping, BufferAccessError>>;
 
-    fn callback_promise_gpu(self: &Rc<Self>, d: &GPU<D>) -> GenericCallback<WebGPUAdapterResponse>;
+    fn callback_promise_gpu(&self, d: &GPU<D>) -> GenericCallback<WebGPUAdapterResponse>;
 
     fn callback_promise_gpushadermodule(
-        self: &Rc<Self>,
+        &self,
         d: &GPUShaderModule<D>,
     ) -> GenericCallback<Option<ShaderCompilationInfo>>;
 }


### PR DESCRIPTION
These changes build on #47735 and #47682 to convert some tricky promise infrastructure pieces and the code that calls them.

Testing: Existing tests suffice.
Part of #47747
