### PR TITLE
script: Convert AsyncBluetoothListener trait to rooted promise types.

### DIFF
--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -36,7 +36,7 @@ use crate::dom::bluetoothuuid::{BluetoothServiceUUID, BluetoothUUID, UUID};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::permissions::{descriptor_permission_state, PermissionAlgorithm};
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise};
 use crate::tasks::task::TaskOnce;
 use dom_struct::dom_struct;
 use js::conversions::ConversionResult;
@@ -113,7 +113,12 @@ struct BluetoothContext<T: AsyncBluetoothListener + DomObject> {
 }
 
 pub(crate) trait AsyncBluetoothListener {
-    fn handle_response(&self, cx: &mut JSContext, result: BluetoothResponse, promise: &Rc<Promise>);
+    fn handle_response(
+        &self,
+        cx: &mut JSContext,
+        result: BluetoothResponse,
+        promise: &RootedPromise,
+    );
 }
 
 impl<T> BluetoothContext<T>
@@ -121,7 +126,8 @@ where
     T: AsyncBluetoothListener + DomObject,
 {
     fn response(&mut self, cx: &mut JSContext, response: BluetoothResponseResult) {
-        let promise = self.promise.take().expect("bt promise is missing").root();
+        let promise =
+            RootedPromise::from(self.promise.take().expect("bt promise is missing").root());
 
         // JSAutoRealm needs to be manually made.
         // Otherwise, Servo will crash.
@@ -573,7 +579,7 @@ impl AsyncBluetoothListener for Bluetooth {
         &self,
         cx: &mut JSContext,
         response: BluetoothResponse,
-        promise: &Rc<Promise>,
+        promise: &RootedPromise,
     ) {
         match response {
             // https://webbluetoothcg.github.io/web-bluetooth/#request-bluetooth-devices

--- a/components/script/dom/bluetooth/bluetoothdevice.rs
+++ b/components/script/dom/bluetooth/bluetoothdevice.rs
@@ -34,7 +34,7 @@ use crate::dom::bluetoothremotegattserver::BluetoothRemoteGATTServer;
 use crate::dom::bluetoothremotegattservice::BluetoothRemoteGATTService;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise};
 
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 #[derive(JSTraceable, MallocSizeOf)]
@@ -357,7 +357,7 @@ impl AsyncBluetoothListener for BluetoothDevice {
         &self,
         cx: &mut JSContext,
         response: BluetoothResponse,
-        promise: &Rc<Promise>,
+        promise: &RootedPromise,
     ) {
         match response {
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-unwatchadvertisements

--- a/components/script/dom/bluetooth/bluetoothpermissionresult.rs
+++ b/components/script/dom/bluetooth/bluetoothpermissionresult.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::rc::Rc;
-
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
@@ -26,7 +24,7 @@ use crate::dom::bluetooth::{AllowedBluetoothDevice, AsyncBluetoothListener, Blue
 use crate::dom::bluetoothdevice::BluetoothDevice;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::permissionstatus::PermissionStatus;
-use crate::dom::promise::Promise;
+use crate::dom::promise::RootedPromise;
 
 // https://webbluetoothcg.github.io/web-bluetooth/#bluetoothpermissionresult
 #[dom_struct]
@@ -102,7 +100,7 @@ impl AsyncBluetoothListener for BluetoothPermissionResult {
         &self,
         cx: &mut JSContext,
         response: BluetoothResponse,
-        promise: &Rc<Promise>,
+        promise: &RootedPromise,
     ) {
         match response {
             // https://webbluetoothcg.github.io/web-bluetooth/#request-bluetooth-devices

--- a/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
@@ -32,7 +32,7 @@ use crate::dom::bluetoothremotegattservice::BluetoothRemoteGATTService;
 use crate::dom::bluetoothuuid::{BluetoothDescriptorUUID, BluetoothUUID};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise};
 
 // Maximum length of an attribute value.
 // https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=286439 (Vol. 3, page 2169)
@@ -310,7 +310,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTCharacteristic {
         &self,
         cx: &mut JSContext,
         response: BluetoothResponse,
-        promise: &Rc<Promise>,
+        promise: &RootedPromise,
     ) {
         let device = self.Service().Device();
         match response {

--- a/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
@@ -28,7 +28,7 @@ use crate::dom::bluetoothremotegattcharacteristic::{
     BluetoothRemoteGATTCharacteristic, MAXIMUM_ATTRIBUTE_LENGTH,
 };
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise};
 
 // http://webbluetoothcg.github.io/web-bluetooth/#bluetoothremotegattdescriptor
 #[dom_struct]
@@ -183,7 +183,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTDescriptor {
         &self,
         cx: &mut JSContext,
         response: BluetoothResponse,
-        promise: &Rc<Promise>,
+        promise: &RootedPromise,
     ) {
         match response {
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattdescriptor-readvalue

--- a/components/script/dom/bluetooth/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattserver.rs
@@ -21,7 +21,7 @@ use crate::dom::bluetooth::{AsyncBluetoothListener, get_gatt_children, response_
 use crate::dom::bluetoothdevice::BluetoothDevice;
 use crate::dom::bluetoothuuid::{BluetoothServiceUUID, BluetoothUUID};
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise};
 
 // https://webbluetoothcg.github.io/web-bluetooth/#bluetoothremotegattserver
 #[dom_struct]
@@ -157,7 +157,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTServer {
         &self,
         cx: &mut JSContext,
         response: BluetoothResponse,
-        promise: &Rc<Promise>,
+        promise: &RootedPromise,
     ) {
         match response {
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattserver-connect

--- a/components/script/dom/bluetooth/bluetoothremotegattservice.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattservice.rs
@@ -20,7 +20,7 @@ use crate::dom::bluetoothdevice::BluetoothDevice;
 use crate::dom::bluetoothuuid::{BluetoothCharacteristicUUID, BluetoothServiceUUID, BluetoothUUID};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise};
 
 // https://webbluetoothcg.github.io/web-bluetooth/#bluetoothremotegattservice
 #[dom_struct]
@@ -178,7 +178,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTService {
         &self,
         cx: &mut JSContext,
         response: BluetoothResponse,
-        promise: &Rc<Promise>,
+        promise: &RootedPromise,
     ) {
         let device = self.Device();
         match response {


### PR DESCRIPTION
These changes just update the trait without changing any of the interfaces that make use of it. Follow up to #47816.

Testing: Existing tests suffice.
Part of #47747
