### PR TITLE
script: Pass `&NoGC` to `TextTrackList::iter()`

### DIFF
--- a/components/script/dom/html/embedded_content/htmlmediaelement.rs
+++ b/components/script/dom/html/embedded_content/htmlmediaelement.rs
@@ -806,13 +806,9 @@ impl HTMLMediaElement {
         };
         type CueVec = Vec<DomRoot<TextTrackCue>>;
         let (current_cues, other_cues): (CueVec, CueVec) = text_tracks_list
-            .iter()
-            .filter_map(|text_track| {
-                // Implicitly `GetCues` already filters for Disabled and returns
-                // None in that case
-                text_track.GetCues(cx)
-            })
-            .flat_map(|text_track| text_track.cues())
+            .iter(cx.no_gc())
+            .filter(|text_track| text_track.Mode() != TextTrackMode::Disabled)
+            .flat_map(|text_track| text_track.get_cues())
             .partition(|cue| {
                 cue.start_time() <= current_playback_position &&
                     cue.end_time() > current_playback_position
@@ -3334,9 +3330,9 @@ impl HTMLMediaElement {
             return;
         };
         let candidates: Vec<DomRoot<TextTrack>> = text_tracks_list
-            .iter()
+            .iter(cx.no_gc())
             .filter(|track| text_track_kinds.contains(&track.Kind()))
-            .map(|track| DomRoot::from_ref(&*track))
+            .map(|track| track.as_rooted())
             .collect();
         // Step 2. If candidates is empty, then return.
         if candidates.is_empty() {

--- a/components/script/dom/html/embedded_content/htmltrackelement.rs
+++ b/components/script/dom/html/embedded_content/htmltrackelement.rs
@@ -8,7 +8,7 @@ use bytes::Bytes;
 use content_security_policy::Destination;
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name};
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::rust::HandleObject;
 use net_traits::request::RequestId;
 use net_traits::{FetchMetadata, NetworkError, ResourceFetchTiming};
@@ -25,7 +25,7 @@ use crate::dom::bindings::codegen::Bindings::TextTrackBinding::{TextTrackMethods
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
-use crate::dom::bindings::root::{Dom, DomRoot};
+use crate::dom::bindings::root::{Dom, DomRoot, UnrootedDom};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::csp::Violation;
 use crate::dom::document::Document;
@@ -183,8 +183,8 @@ impl HTMLTrackElement {
         }
     }
 
-    pub(crate) fn track(&self) -> DomRoot<TextTrack> {
-        self.track.as_rooted()
+    pub(crate) fn track<'a>(&self, no_gc: &'a NoGC) -> UnrootedDom<'a, TextTrack> {
+        UnrootedDom::from_dom(self.track.clone(), no_gc)
     }
 }
 

--- a/components/script/dom/webvtt/texttracklist.rs
+++ b/components/script/dom/webvtt/texttracklist.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::reflect_dom_object_with_cx;
 
@@ -12,7 +12,7 @@ use crate::dom::bindings::codegen::UnionTypes::VideoTrackOrAudioTrackOrTextTrack
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
-use crate::dom::bindings::root::{Dom, DomRoot};
+use crate::dom::bindings::root::{Dom, DomRoot, UnrootedDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
@@ -137,20 +137,21 @@ impl TextTrackList {
             }));
     }
 
-    pub(crate) fn iter<'a>(&'a self) -> TextTrackListIterator<'a> {
+    pub(crate) fn iter<'a>(&'a self, no_gc: &'a NoGC) -> TextTrackListIterator<'a> {
         TextTrackListIterator {
+            no_gc,
             track_elements: Box::new(
                 self.media_element
                     .upcast::<Node>()
-                    .children()
-                    .filter_map(DomRoot::downcast::<HTMLTrackElement>),
+                    .children_unrooted(no_gc)
+                    .filter_map(UnrootedDom::downcast::<HTMLTrackElement>),
             ),
             dom_tracks: Box::new(
                 self.dom_tracks
                     .borrow()
                     .clone()
                     .into_iter()
-                    .map(|track| track.as_rooted()),
+                    .map(|track| UnrootedDom::from_dom(track, no_gc)),
             ),
         }
     }
@@ -158,28 +159,32 @@ impl TextTrackList {
 
 impl TextTrackListMethods<crate::DomTypeHolder> for TextTrackList {
     /// <https://html.spec.whatwg.org/multipage/#dom-texttracklist-length>
-    fn Length(&self) -> u32 {
+    fn Length(&self, no_gc: &NoGC) -> u32 {
         // > The length attribute of a TextTrackList object must return
         // > the number of text tracks in the list represented by the TextTrackList object.
-        self.iter().count() as u32
+        self.iter(no_gc).count() as u32
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-texttracklist-item>
-    fn IndexedGetter(&self, idx: u32) -> Option<DomRoot<TextTrack>> {
+    fn IndexedGetter(&self, no_gc: &NoGC, idx: u32) -> Option<DomRoot<TextTrack>> {
         // > To determine the value of an indexed property of a TextTrackList object
         // > for a given index index, the user agent must return the indexth
         // > text track in the list represented by the TextTrackList object.
-        self.iter().nth(idx as usize)
+        self.iter(no_gc)
+            .nth(idx as usize)
+            .map(|track| track.as_rooted())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-texttracklist-gettrackbyid>
-    fn GetTrackById(&self, id: DOMString) -> Option<DomRoot<TextTrack>> {
+    fn GetTrackById(&self, no_gc: &NoGC, id: DOMString) -> Option<DomRoot<TextTrack>> {
         // > The getTrackById(id) method must return the first TextTrack in
         // > the TextTrackList object whose id IDL attribute would return
         // > a value equal to the value of the id argument.
         // > When no tracks match the given argument, the method must return null.
         let id_str = String::from(id);
-        self.iter().find(|track| track.id() == id_str)
+        self.iter(no_gc)
+            .find(|track| track.id() == id_str)
+            .map(|track| track.as_rooted())
     }
 
     // https://html.spec.whatwg.org/multipage/#handler-texttracklist-onchange
@@ -194,18 +199,19 @@ impl TextTrackListMethods<crate::DomTypeHolder> for TextTrackList {
 
 /// <https://html.spec.whatwg.org/multipage/#list-of-text-tracks>
 pub(crate) struct TextTrackListIterator<'a> {
-    track_elements: Box<dyn Iterator<Item = DomRoot<HTMLTrackElement>> + 'a>,
-    dom_tracks: Box<dyn Iterator<Item = DomRoot<TextTrack>> + 'a>,
+    no_gc: &'a NoGC,
+    track_elements: Box<dyn Iterator<Item = UnrootedDom<'a, HTMLTrackElement>> + 'a>,
+    dom_tracks: Box<dyn Iterator<Item = UnrootedDom<'a, TextTrack>> + 'a>,
 }
 
 impl<'a> Iterator for TextTrackListIterator<'a> {
-    type Item = DomRoot<TextTrack>;
+    type Item = UnrootedDom<'a, TextTrack>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // > The text tracks are sorted as follows:
         // Step 1. The text tracks corresponding to track element children of the media element, in tree order.
         if let Some(track_element) = self.track_elements.next() {
-            return Some(track_element.track());
+            return Some(track_element.track(self.no_gc));
         }
         // Step 2. Any text tracks added using the addTextTrack() method,
         // in the order they were added, oldest first.

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1279,6 +1279,10 @@ DOMInterfaces = {
     'cx': ['GetCues', 'GetActiveCues', 'AddCue', 'RemoveCue', 'SetMode']
 },
 
+'TextTrackList': {
+    'no_gc': ['Length', 'IndexedGetter', 'GetTrackById'],
+},
+
 'TreeWalker': {
     'cx': ['ParentNode', 'PreviousNode', 'NextNode', 'FirstChild', 'LastChild', 'PreviousSibling', 'NextSibling']
 },

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -6629,10 +6629,16 @@ class CGDOMJSProxyHandler_ownPropertyKeys(CGAbstractExternMethod):
         else:
             cross_origin = "None"
         if self.descriptor.operations['IndexedGetter']:
+            cx_argument = "_cx"
+            length_argument = ""
             if "Length" in self.descriptor.cxMethods or "Length" in self.descriptor.cx_no_gcMethods:
-                length = f"Some(|unwrapped_proxy: &{self.descriptor.concreteType}, cx| unwrapped_proxy.Length(cx))"
-            else:
-                length = f"Some(|unwrapped_proxy: &{self.descriptor.concreteType}, _cx| unwrapped_proxy.Length())"
+                cx_argument = "cx"
+                length_argument = "cx"
+            elif "Length" in self.descriptor.no_gcMethods:
+                cx_argument = "cx"
+                length_argument = "cx.no_gc()"
+
+            length = f"Some(|unwrapped_proxy: &{self.descriptor.concreteType}, {cx_argument}| unwrapped_proxy.Length({length_argument}))"
         else:
             length = "None"
 


### PR DESCRIPTION
Speeds up DOM traversal and ensures we don't perform any
GC in between.

Part of #46288

Testing: it compiles