### PR TITLE
css: Determine effective `touch-action` from the touched element chain; Only apply to spec-allowed elements

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1616,9 +1616,11 @@ impl<'a> BuilderForBoxFragment<'a> {
             // restricts which gestures may scroll an ancestor on its behalf. Push a
             // hit test item that carries the restriction, so that the compositor
             // can determine the effective touch behavior of touches starting here.
-            let touch_action = state.touch_action.intersect(TouchAction::from(
-                self.fragment.style().get_box().touch_action,
-            ));
+            let touch_action = state.touch_action.intersect(
+                self.fragment
+                    .style()
+                    .used_touch_action(self.fragment.base.flags),
+            );
             if touch_action != TouchAction::Auto {
                 self.build_touch_action_hit_test(builder, state, touch_action);
             }

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -12,8 +12,6 @@ use euclid::{Box2D, Point2D, Rect, Scale, SideOffsets2D, Size2D, UnknownUnit, Ve
 use fonts::ShapedTextSlice;
 use gradient::WebRenderGradient;
 use layout_api::ReflowStatistics;
-use paint_api::display_list::{PaintDisplayListInfo, SpatialTreeNodeInfo};
-use net_traits::image_cache::Image as CachedImage;
 use paint_api::display_list::{PaintDisplayListInfo, SpatialTreeNodeInfo, TouchAction};
 use servo_arc::Arc as ServoArc;
 use servo_base::id::{PipelineId, ScrollTreeNodeId};

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -13,6 +13,8 @@ use fonts::ShapedTextSlice;
 use gradient::WebRenderGradient;
 use layout_api::ReflowStatistics;
 use paint_api::display_list::{PaintDisplayListInfo, SpatialTreeNodeInfo};
+use net_traits::image_cache::Image as CachedImage;
+use paint_api::display_list::{PaintDisplayListInfo, SpatialTreeNodeInfo, TouchAction};
 use servo_arc::Arc as ServoArc;
 use servo_base::id::{PipelineId, ScrollTreeNodeId};
 use servo_base::text::Utf32CodeUnits;
@@ -1588,10 +1590,11 @@ impl<'a> BuilderForBoxFragment<'a> {
             .effective_overflow(self.fragment.base.flags);
         let scrolls_via_user_input =
             |overflow| matches!(overflow, ComputedOverflow::Scroll | ComputedOverflow::Auto);
-        if (scrolls_via_user_input(overflow.x) || scrolls_via_user_input(overflow.y)) &&
-            self.fragment.style().get_inherited_ui().pointer_events !=
-                style::computed_values::pointer_events::T::None
-        {
+        let can_be_touch_scrolled =
+            scrolls_via_user_input(overflow.x) || scrolls_via_user_input(overflow.y);
+        let accepts_pointer_input = self.fragment.style().get_inherited_ui().pointer_events !=
+            style::computed_values::pointer_events::T::None;
+        if can_be_touch_scrolled && accepts_pointer_input {
             let mut inner_state = state.clone();
             inner_state.spatial_id = self
                 .fragment
@@ -1607,7 +1610,47 @@ impl<'a> BuilderForBoxFragment<'a> {
                     .translate(self.containing_block_origin.to_vector())
                     .to_webrender(),
             );
+        } else if !can_be_touch_scrolled && accepts_pointer_input {
+            // This box cannot be panned by touch itself, so the `touch-action` of
+            // itself and its ancestors (up to the nearest box that can be panned)
+            // restricts which gestures may scroll an ancestor on its behalf. Push a
+            // hit test item that carries the restriction, so that the compositor
+            // can determine the effective touch behavior of touches starting here.
+            let touch_action = state.touch_action.intersect(TouchAction::from(
+                self.fragment.style().get_box().touch_action,
+            ));
+            if touch_action != TouchAction::Auto {
+                self.build_touch_action_hit_test(builder, state, touch_action);
+            }
         }
+    }
+
+    /// Push a hit test item that carries the `touch-action` restriction of this
+    /// fragment, for fragments that cannot be panned by touch themselves. The
+    /// first component of the tag is the external scroll id of the enclosing
+    /// scroll tree node (used to find the node to scroll), while the second
+    /// component is the encoded [`TouchAction`] restriction.
+    fn build_touch_action_hit_test(
+        &self,
+        builder: &mut DisplayListBuilder,
+        state: &TraversalState,
+        touch_action: TouchAction,
+    ) {
+        let external_scroll_node_id = builder
+            .paint_info
+            .external_scroll_id_for_scroll_tree_node(state.spatial_id);
+
+        let mut common = builder.common_properties(state, self.border_rect, self.fragment.style());
+        if let Some(clip_chain_id) = self.border_edge_clip(builder, state, false) {
+            common.clip_chain_id = clip_chain_id;
+        }
+        builder.wr().push_hit_test(
+            common.clip_rect,
+            common.clip_chain_id,
+            common.spatial_id,
+            common.flags,
+            (external_scroll_node_id.0, touch_action.encode()),
+        );
     }
 
     fn build_hit_test(

--- a/components/layout/display_list/paint_traversal.rs
+++ b/components/layout/display_list/paint_traversal.rs
@@ -599,7 +599,7 @@ impl TraversalState {
                 TouchAction::Auto
             } else {
                 self.touch_action
-                    .intersect(TouchAction::from(style.get_box().touch_action))
+                    .intersect(style.used_touch_action(box_fragment.base.flags))
             }
         };
 

--- a/components/layout/display_list/paint_traversal.rs
+++ b/components/layout/display_list/paint_traversal.rs
@@ -6,7 +6,9 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use app_units::Au;
+use paint_api::display_list::TouchAction;
 use servo_base::id::ScrollTreeNodeId;
+use style::computed_values::overflow_x::T as ComputedOverflow;
 use style::values::computed::TextDecorationLine;
 
 use crate::display_list::{
@@ -17,6 +19,7 @@ use crate::fragment_tree::{
     PositioningFragment, Tag, TextFragment,
 };
 use crate::geom::{PhysicalPoint, PhysicalRect};
+use crate::style_ext::ComputedValuesExt;
 
 pub(crate) struct PaintTraversal<'a, Handler: PaintTraversalHandler> {
     handler: &'a mut Handler,
@@ -539,6 +542,13 @@ pub(crate) struct TraversalState {
     /// Used for text LCP candidate grouping — all text fragments within
     /// a single element are unioned before computing effective visual size.
     pub containing_element_tag: Option<Tag>,
+    /// The `touch-action` restriction that applies to touches starting on this
+    /// fragment or its descendants: the intersection of the `touch-action`
+    /// values of the fragment chain between them and the nearest ancestor that
+    /// can be panned by touch (exclusive). That ancestor's own `touch-action`
+    /// is stored on its scroll node and applied by the compositor instead.
+    /// <https://w3c.github.io/pointerevents/#determining-supported-direct-manipulation-behavior>
+    pub touch_action: TouchAction,
 }
 
 impl TraversalState {
@@ -579,6 +589,20 @@ impl TraversalState {
             },
         };
 
+        let touch_action = {
+            let overflow = style.effective_overflow(box_fragment.base.flags);
+            let scrolls_via_user_input =
+                |overflow| matches!(overflow, ComputedOverflow::Scroll | ComputedOverflow::Auto);
+            if scrolls_via_user_input(overflow.x) || scrolls_via_user_input(overflow.y) {
+                // This box can be panned by touch, so the restriction starts
+                // fresh for its descendants.
+                TouchAction::Auto
+            } else {
+                self.touch_action
+                    .intersect(TouchAction::from(style.get_box().touch_action))
+            }
+        };
+
         Self {
             origin: self.origin + box_fragment.content_rect().origin.to_vector(),
             spatial_id: box_fragment
@@ -587,6 +611,7 @@ impl TraversalState {
             clip_id: box_fragment.generated_clip_id().unwrap_or(self.clip_id),
             text_decorations,
             containing_element_tag: box_fragment.base.tag.or(self.containing_element_tag),
+            touch_action,
         }
     }
 
@@ -607,6 +632,7 @@ impl TraversalState {
             clip_id: self.clip_id,
             text_decorations: self.text_decorations.clone(),
             containing_element_tag: self.containing_element_tag,
+            touch_action: self.touch_action,
         }
     }
 
@@ -617,6 +643,11 @@ impl TraversalState {
             clip_id: stacking_context.clip_id,
             text_decorations: stacking_context.text_decorations.clone(),
             containing_element_tag: self.containing_element_tag,
+            // The `touch-action` restriction captured on the stacking context when
+            // the stacking context tree was built, which follows the box tree
+            // (unlike the traversal state, which does not descend through hoisted
+            // stacking contexts).
+            touch_action: stacking_context.touch_action,
         }
     }
 }

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -948,7 +948,7 @@ impl BoxFragmentWithStyle<'_> {
             if scrolls_via_user_input(overflow.x) || scrolls_via_user_input(overflow.y) {
                 TouchAction::Auto
             } else {
-                touch_action.intersect(TouchAction::from(style.get_box().touch_action))
+                touch_action.intersect(style.used_touch_action(self.base.flags))
             }
         };
 

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -201,6 +201,7 @@ impl StackingContextTree {
                 // to process it, if it is.
                 StackingContextBuildMode::IncludeHoisted,
                 &text_decorations,
+                TouchAction::Auto,
             );
         }
 
@@ -385,6 +386,10 @@ pub struct StackingContext {
     #[conditional_malloc_size_of]
     pub(crate) text_decorations: Rc<Vec<FragmentTextDecoration>>,
 
+    /// The `touch-action` restriction of the box tree at this stacking context's
+    /// establishing fragment (exclusive), captured while the tree was built.
+    pub(crate) touch_action: TouchAction,
+
     /// If this [`StackingContext`] also created a WebRender reference frame, this field
     /// holds information about that reference frame.
     pub(crate) reference_frame_info: Option<StackingContextReferenceFrameInfo>,
@@ -401,6 +406,7 @@ impl StackingContext {
             clip_id: ClipId::INVALID,
             z_index: 0,
             text_decorations: Default::default(),
+            touch_action: TouchAction::Auto,
             reference_frame_info: None,
         }
     }
@@ -414,6 +420,7 @@ impl StackingContext {
         clip_id: ClipId,
         initializing_fragment: Arc<BoxFragment>,
         text_decorations: Rc<Vec<FragmentTextDecoration>>,
+        touch_action: TouchAction,
         reference_frame_info: Option<StackingContextReferenceFrameInfo>,
     ) -> Self {
         let z_index = initializing_fragment
@@ -428,6 +435,7 @@ impl StackingContext {
             clip_id,
             z_index,
             text_decorations,
+            touch_action,
             reference_frame_info,
         }
     }
@@ -480,6 +488,7 @@ impl Fragment {
         stacking_context: &mut StackingContext,
         mode: StackingContextBuildMode,
         text_decorations: &Rc<Vec<FragmentTextDecoration>>,
+        touch_action: TouchAction,
     ) {
         let containing_block = containing_block_info.get_containing_block_for_fragment(self);
         let cumulative_containing_block = containing_block
@@ -515,6 +524,7 @@ impl Fragment {
                     containing_block_info,
                     stacking_context,
                     text_decorations,
+                    touch_action,
                 );
             },
             Fragment::LayoutRoot(..) => {
@@ -534,6 +544,7 @@ impl Fragment {
                     stacking_context,
                     StackingContextBuildMode::IncludeHoisted,
                     &Default::default(),
+                    touch_action,
                 );
             },
             Fragment::Positioning(fragment) => {
@@ -543,6 +554,7 @@ impl Fragment {
                     containing_block_info,
                     stacking_context,
                     text_decorations,
+                    touch_action,
                 );
             },
             Fragment::Text(_) | Fragment::Image(_) | Fragment::IFrame(_) => {},
@@ -589,6 +601,7 @@ impl BoxFragment {
         containing_block_info: &ContainingBlockInfo,
         parent_stacking_context: &mut StackingContext,
         text_decorations: &Rc<Vec<FragmentTextDecoration>>,
+        touch_action: TouchAction,
     ) {
         self.clear_stacking_context_tree_traversal_data();
         self.build_stacking_context_tree_maybe_creating_reference_frame(
@@ -598,6 +611,7 @@ impl BoxFragment {
             containing_block_info,
             parent_stacking_context,
             text_decorations,
+            touch_action,
         );
     }
 
@@ -609,6 +623,7 @@ impl BoxFragment {
         containing_block_info: &ContainingBlockInfo,
         parent_stacking_context: &mut StackingContext,
         text_decorations: &Rc<Vec<FragmentTextDecoration>>,
+        touch_action: TouchAction,
     ) {
         let reference_frame_data =
             match self.reference_frame_data_if_necessary(&containing_block.rect) {
@@ -621,6 +636,7 @@ impl BoxFragment {
                         containing_block_info,
                         parent_stacking_context,
                         text_decorations,
+                        touch_action,
                         None, /* reference_frame_info */
                     );
                 },
@@ -684,6 +700,7 @@ impl BoxFragment {
             &new_containing_block_info,
             parent_stacking_context,
             text_decorations,
+            touch_action,
             Some(reference_frame_info),
         );
     }
@@ -697,6 +714,7 @@ impl BoxFragment {
         containing_block_info: &ContainingBlockInfo,
         parent_stacking_context: &mut StackingContext,
         text_decorations: &Rc<Vec<FragmentTextDecoration>>,
+        touch_action: TouchAction,
         reference_frame_info: Option<StackingContextReferenceFrameInfo>,
     ) {
         let with_style = &self.with_style();
@@ -708,6 +726,7 @@ impl BoxFragment {
                 containing_block_info,
                 parent_stacking_context,
                 text_decorations,
+                touch_action,
             );
             return;
         };
@@ -768,6 +787,7 @@ impl BoxFragment {
             containing_block.clip_id,
             box_fragment,
             text_decorations.clone(),
+            touch_action,
             reference_frame_info,
         );
         with_style.build_stacking_context_tree_for_children(
@@ -776,6 +796,7 @@ impl BoxFragment {
             containing_block_info,
             &mut child_stacking_context,
             text_decorations,
+            touch_action,
         );
 
         let mut stolen_children = vec![];
@@ -803,6 +824,7 @@ impl BoxFragmentWithStyle<'_> {
         containing_block_info: &ContainingBlockInfo,
         stacking_context: &mut StackingContext,
         text_decorations: &Rc<Vec<FragmentTextDecoration>>,
+        touch_action: TouchAction,
     ) {
         let style = self.style();
         let establishes_containing_block_for_all_descendants =
@@ -917,6 +939,19 @@ impl BoxFragmentWithStyle<'_> {
             },
         };
 
+        // The `touch-action` restriction for descendants of this box, reset when this
+        // box can be panned by touch itself.
+        let children_touch_action = {
+            let overflow = style.effective_overflow(self.base.flags);
+            let scrolls_via_user_input =
+                |overflow| matches!(overflow, ComputedOverflow::Scroll | ComputedOverflow::Auto);
+            if scrolls_via_user_input(overflow.x) || scrolls_via_user_input(overflow.y) {
+                TouchAction::Auto
+            } else {
+                touch_action.intersect(TouchAction::from(style.get_box().touch_action))
+            }
+        };
+
         for child in &self.children {
             child.build_stacking_context_tree(
                 stacking_context_tree,
@@ -924,6 +959,7 @@ impl BoxFragmentWithStyle<'_> {
                 stacking_context,
                 StackingContextBuildMode::SkipHoisted,
                 text_decorations,
+                children_touch_action,
             );
         }
     }
@@ -1426,6 +1462,7 @@ impl PositioningFragment {
         containing_block_info: &ContainingBlockInfo,
         stacking_context: &mut StackingContext,
         text_decorations: &Rc<Vec<FragmentTextDecoration>>,
+        touch_action: TouchAction,
     ) {
         let rect = self
             .base
@@ -1442,6 +1479,7 @@ impl PositioningFragment {
                 stacking_context,
                 StackingContextBuildMode::SkipHoisted,
                 text_decorations,
+                touch_action,
             );
         }
     }

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -593,6 +593,7 @@ impl BoxFragment {
         None
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn build_stacking_context_tree(
         self: &Arc<Self>,
         fragment: Fragment,
@@ -615,6 +616,7 @@ impl BoxFragment {
         );
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn build_stacking_context_tree_maybe_creating_reference_frame(
         self: &Arc<Self>,
         fragment: Fragment,

--- a/components/layout/style_ext.rs
+++ b/components/layout/style_ext.rs
@@ -5,6 +5,7 @@
 use app_units::Au;
 use layout_api::{AxesOverflow, LayoutElementType, LayoutNode, LayoutNodeType};
 use malloc_size_of_derive::MallocSizeOf;
+use paint_api::display_list::TouchAction;
 use style::Zero;
 use style::color::AbsoluteColor;
 use style::computed_values::direction::T as Direction;
@@ -348,6 +349,7 @@ pub(crate) trait ComputedValuesExt {
     fn z_index_applies(&self, fragment_flags: FragmentFlags) -> bool;
     fn effective_z_index(&self, fragment_flags: FragmentFlags) -> i32;
     fn effective_overflow(&self, fragment_flags: FragmentFlags) -> AxesOverflow;
+    fn used_touch_action(&self, fragment_flags: FragmentFlags) -> TouchAction;
     fn used_transform_style(&self, fragment_flags: FragmentFlags) -> ComputedTransformStyle;
     fn establishes_block_formatting_context(&self, fragment_flags: FragmentFlags) -> bool;
     fn establishes_stacking_context(&self, fragment_flags: FragmentFlags) -> bool;
@@ -671,6 +673,28 @@ impl ComputedValuesExt for ComputedValues {
         }
 
         overflow
+    }
+
+    /// Get the `touch-action` value that applies to this element. The property
+    /// does not apply to non-replaced inline elements, table rows, table row
+    /// groups, table column groups, and table columns; those elements contribute
+    /// `auto` (no restriction) instead of their computed value.
+    /// <https://w3c.github.io/pointerevents/#the-touch-action-css-property>
+    fn used_touch_action(&self, fragment_flags: FragmentFlags) -> TouchAction {
+        let property_does_not_apply = self.is_inline_box(fragment_flags) ||
+            matches!(
+                self.get_box().display.inside(),
+                stylo::DisplayInside::TableColumn |
+                    stylo::DisplayInside::TableColumnGroup |
+                    stylo::DisplayInside::TableRow |
+                    stylo::DisplayInside::TableRowGroup |
+                    stylo::DisplayInside::TableHeaderGroup |
+                    stylo::DisplayInside::TableFooterGroup
+            );
+        if property_does_not_apply {
+            return TouchAction::Auto;
+        }
+        TouchAction::from(self.get_box().touch_action)
     }
 
     /// Get the used `transform-style` value according to the the rules in

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -11,7 +11,7 @@ use crossbeam_channel::Sender;
 use dpi::PhysicalSize;
 use embedder_traits::{
     InputEvent, InputEventAndId, InputEventId, InputEventResult, PaintHitTestResult,
-    ScreenshotCaptureError, Scroll, ViewportDetails, WebViewPoint, WebViewRect,
+    ScreenshotCaptureError, Scroll, TouchAction, ViewportDetails, WebViewPoint, WebViewRect,
 };
 use euclid::{Point2D, Rect, Scale, Size2D};
 use gleam::gl::RENDERER;
@@ -584,6 +584,11 @@ impl Painter {
                     pipeline_id,
                     point_in_viewport: Point2D::from_untyped(item.point_in_viewport.to_untyped()),
                     external_scroll_id,
+                    // The second component of the tag carries the `touch-action`
+                    // restriction of the hit item, encoded by the display list
+                    // constructor. Items that do not carry a restriction decode
+                    // to `Auto`.
+                    touch_action: TouchAction::decode(item.tag.1),
                 }
             })
             .collect()

--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -15,7 +15,7 @@ use embedder_traits::{
 use euclid::{Scale, Size2D, Vector2D};
 use log::{debug, warn};
 use malloc_size_of::MallocSizeOf;
-use paint_api::display_list::ScrollType;
+use paint_api::display_list::{ScrollType, TouchAction};
 use paint_api::viewport_description::{
     DEFAULT_PAGE_ZOOM, MAX_PAGE_ZOOM, MIN_PAGE_ZOOM, ViewportDescription,
 };
@@ -427,9 +427,9 @@ impl WebViewRenderer {
             None => None,
         };
 
-        // For touch-down, capture the hit node's `touch-action` and scrollable
-        // axes from the scroll tree so the pan axis-lock policy can be decided
-        // at pan-start.
+        // For touch-down, capture the hit node's `touch-action` and scrollable axes
+        // from the scroll tree, intersected with the hit test item's restriction, so
+        // the pan axis-lock policy can be decided at pan-start.
         if is_touch_down && let Some(hit) = &hit_test_result {
             let policy_input = self
                 .pipelines
@@ -441,7 +441,7 @@ impl WebViewRenderer {
                 })
                 .map(
                     |(touch_action, scrollable_x, scrollable_y)| PanPolicyInput {
-                        touch_action,
+                        touch_action: touch_action.intersect(hit.touch_action),
                         scrollable_x,
                         scrollable_y,
                     },
@@ -1016,6 +1016,9 @@ impl WebViewRenderer {
             // all the way through script and back here.
             point_in_viewport: Default::default(),
             external_scroll_id,
+            // This result does not correspond to a display list hit test item, so
+            // it does not carry any `touch-action` restriction of a touched element.
+            touch_action: TouchAction::Auto,
         };
 
         self.send_scroll_positions_to_layout_for_pipeline(root_pipeline_id, external_scroll_id);

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -928,6 +928,83 @@ impl UntrustedNodeAddress {
     }
 }
 
+/// A simplified representation of the CSS `touch-action` property, used by the
+/// compositor to decide how a touch gesture may scroll a given node.
+///
+/// NOTE: Directional variants (`pan-left`/`pan-right`/...) are not supported in Stylo at all.
+/// Firefox also fails the parsing.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, MallocSizeOf, PartialEq, Serialize)]
+pub enum TouchAction {
+    /// `touch-action: auto` (and `manipulation`, `pan-x pan-y`). The compositor
+    /// applies the scroll-chaining axis lock: lock to the dominant axis only
+    /// when the hit node cannot scroll that axis.
+    #[default]
+    Auto,
+    /// `touch-action: pan-x`. The vertical axis is excluded from input-event
+    /// scrolling (chains to ancestor); the gesture locks to its dominant axis.
+    PanX,
+    /// `touch-action: pan-y`. The horizontal axis is excluded from input-event
+    /// scrolling (chains to ancestor); the gesture locks to its dominant axis.
+    PanY,
+    /// `touch-action: none` (and `pinch-zoom` alone). No single-finger direct
+    /// manipulation: do not scroll.
+    None,
+}
+
+impl TouchAction {
+    /// Intersect two values to determine the effective touch behavior of a gesture.
+    /// <https://w3c.github.io/pointerevents/#determining-supported-direct-manipulation-behavior>
+    pub fn intersect(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Auto, other) | (other, Self::Auto) => other,
+            (Self::None, _) | (_, Self::None) => Self::None,
+            (Self::PanX, Self::PanX) => Self::PanX,
+            (Self::PanY, Self::PanY) => Self::PanY,
+            (Self::PanX, Self::PanY) | (Self::PanY, Self::PanX) => Self::None,
+        }
+    }
+
+    /// Encode this value into the second component of a WebRender hit test
+    /// tag, so that it can be transported through WebRender hit testing.
+    pub fn encode(self) -> u16 {
+        match self {
+            Self::Auto => 0,
+            Self::PanX => 1,
+            Self::PanY => 2,
+            Self::None => 3,
+        }
+    }
+
+    /// Decode a value encoded with [`Self::encode`]. Unknown values decode to `Auto`,
+    /// same as the encoding of items that do not carry any `touch-action` restriction.
+    pub fn decode(value: u16) -> Self {
+        match value {
+            1 => Self::PanX,
+            2 => Self::PanY,
+            3 => Self::None,
+            _ => Self::Auto,
+        }
+    }
+}
+
+impl From<style::values::specified::TouchAction> for TouchAction {
+    fn from(stylo: style::values::specified::TouchAction) -> Self {
+        use style::values::specified::TouchAction as T;
+        if stylo.contains(T::NONE) {
+            return TouchAction::None;
+        }
+        if stylo.contains(T::AUTO) || stylo.contains(T::MANIPULATION) {
+            return TouchAction::Auto;
+        }
+        match (stylo.contains(T::PAN_X), stylo.contains(T::PAN_Y)) {
+            (true, true) => TouchAction::Auto,
+            (true, false) => TouchAction::PanX,
+            (false, true) => TouchAction::PanY,
+            (false, false) => TouchAction::None,
+        }
+    }
+}
+
 /// The result of a hit test in `Paint`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PaintHitTestResult {
@@ -939,6 +1016,14 @@ pub struct PaintHitTestResult {
 
     /// The [`ExternalScrollId`] of the scroll tree node associated with this hit test item.
     pub external_scroll_id: ExternalScrollId,
+
+    /// The `touch-action` restriction of the hit test item: the intersection of the
+    /// `touch-action` values of the touched element and its ancestors up to (but
+    /// excluding) the nearest ancestor scroll container that can be panned by touch.
+    /// That scroll container's own `touch-action` is stored on its scroll node, so
+    /// the effective behavior of a gesture is this value intersected with the
+    /// `touch-action` of the scroll node in [`Self::external_scroll_id`].
+    pub touch_action: TouchAction,
 }
 
 /// For a given pipeline, whether any animations are currently running

--- a/components/shared/paint/display_list.rs
+++ b/components/shared/paint/display_list.rs
@@ -64,45 +64,7 @@ pub struct AxesScrollSensitivity {
     pub y: ScrollType,
 }
 
-/// A simplified representation of the CSS `touch-action` property, used by the
-/// compositor to decide how a touch gesture may scroll a given node.
-///
-/// NOTE: Directional variants (`pan-left`/`pan-right`/...) are not supported in Stylo at all.
-/// Firefox also fails the parsing.
-#[derive(Clone, Copy, Debug, Deserialize, Eq, MallocSizeOf, PartialEq, Serialize)]
-pub enum TouchAction {
-    /// `touch-action: auto` (and `manipulation`, `pan-x pan-y`). The compositor
-    /// applies the scroll-chaining axis lock: lock to the dominant axis only
-    /// when the hit node cannot scroll that axis.
-    Auto,
-    /// `touch-action: pan-x`. The vertical axis is excluded from input-event
-    /// scrolling (chains to ancestor); the gesture locks to its dominant axis.
-    PanX,
-    /// `touch-action: pan-y`. The horizontal axis is excluded from input-event
-    /// scrolling (chains to ancestor); the gesture locks to its dominant axis.
-    PanY,
-    /// `touch-action: none` (and `pinch-zoom` alone). No single-finger direct
-    /// manipulation: do not scroll.
-    None,
-}
-
-impl From<style::values::specified::TouchAction> for TouchAction {
-    fn from(stylo: style::values::specified::TouchAction) -> Self {
-        use style::values::specified::TouchAction as T;
-        if stylo.contains(T::NONE) {
-            return TouchAction::None;
-        }
-        if stylo.contains(T::AUTO) || stylo.contains(T::MANIPULATION) {
-            return TouchAction::Auto;
-        }
-        match (stylo.contains(T::PAN_X), stylo.contains(T::PAN_Y)) {
-            (true, true) => TouchAction::Auto,
-            (true, false) => TouchAction::PanX,
-            (false, true) => TouchAction::PanY,
-            (false, false) => TouchAction::None,
-        }
-    }
-}
+pub use embedder_traits::TouchAction;
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub enum SpatialTreeNodeInfo {

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-button-none-test_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-button-none-test_touch.html.ini
@@ -1,3 +1,0 @@
-[pointerevent_touch-action-button-none-test_touch.html]
-  [touch-action attribute test in element]
-    expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-auto-child-none_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-auto-child-none_touch.html.ini
@@ -1,3 +1,4 @@
 [pointerevent_touch-action-inherit_child-auto-child-none_touch.html]
+  expected: ERROR
   [touch-action attribute test]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-auto-child-none_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-auto-child-none_touch.html.ini
@@ -1,4 +1,0 @@
-[pointerevent_touch-action-inherit_child-auto-child-none_touch.html]
-  expected: ERROR
-  [touch-action attribute test]
-    expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-none_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-none_touch.html.ini
@@ -1,3 +1,4 @@
 [pointerevent_touch-action-inherit_child-none_touch.html]
+  expected: ERROR
   [touch-action attribute test]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-none_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-none_touch.html.ini
@@ -1,4 +1,0 @@
-[pointerevent_touch-action-inherit_child-none_touch.html]
-  expected: ERROR
-  [touch-action attribute test]
-    expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch.html.ini
@@ -1,3 +1,4 @@
 [pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch.html]
+  expected: ERROR
   [touch-action attribute test]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch.html.ini
@@ -1,4 +1,0 @@
-[pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch.html]
-  expected: ERROR
-  [touch-action attribute test]
-    expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-none-on-body-when-style-propagates-to-viewport_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-none-on-body-when-style-propagates-to-viewport_touch.html.ini
@@ -1,3 +1,0 @@
-[pointerevent_touch-action-none-on-body-when-style-propagates-to-viewport_touch.html]
-  [touch-action none on body when style propagates to viewport]
-    expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-svg-none-test_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-svg-none-test_touch.html.ini
@@ -1,3 +1,4 @@
 [pointerevent_touch-action-svg-none-test_touch.html]
+  expected: ERROR
   [touch-action attribute test in SVG]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-svg-none-test_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-svg-none-test_touch.html.ini
@@ -1,4 +1,0 @@
-[pointerevent_touch-action-svg-none-test_touch.html]
-  expected: ERROR
-  [touch-action attribute test in SVG]
-    expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-table-none-test_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-table-none-test_touch.html.ini
@@ -1,3 +1,0 @@
-[pointerevent_touch-action-table-none-test_touch.html]
-  [touch-action attribute test on the cell]
-    expected: FAIL

--- a/tests/wpt/tests/pointerevents/pointerevent_touch-action-none-on-body-when-style-propagates-to-viewport_touch.html
+++ b/tests/wpt/tests/pointerevents/pointerevent_touch-action-none-on-body-when-style-propagates-to-viewport_touch.html
@@ -12,7 +12,7 @@
   </style>
   <link rel="help" href="crbug.com/1031745">
   <link rel="help" href="https://drafts.csswg.org/css-overflow-3/#overflow-propagation">
-  <link rel="help" href="https://w3c.github.io/pointerevents/#determining-supported-touch-behavior">
+  <link rel="help" href="w3c.github.io/pointerevents/#determining-supported-direct-manipulation-behavior">
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/testdriver.js"></script>


### PR DESCRIPTION
1. Compute the effective value by intersecting the touched element's touch-action with its ancestors up to the first scroll container, by inject accumulated restriction into hit-test tag, then combine it with the scroll node's own value in the compositor.
2. Make sure `touch-action` does not apply to non-replaced inline elements, table rows, row groups, column groups, and columns

Testing: 
1. Only new passing, no new failure.
2. Updated outdated spec url for a test.

Fixes: #47737
Fixes: #47801