### PR TITLE
script: Set no-quirks mode for text documents and media

### DIFF
--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1212,6 +1212,7 @@ impl ParserContext {
         let page = "<html><body></body></html>".into();
         parser.push_string_input_chunk(page);
         parser.parse_sync(cx);
+        // Step 2. Set document's mode to "no-quirks".
         parser.document.set_quirks_mode(ServoQuirksMode::NoQuirks);
 
         let doc = &parser.document;

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1212,6 +1212,7 @@ impl ParserContext {
         let page = "<html><body></body></html>".into();
         parser.push_string_input_chunk(page);
         parser.parse_sync(cx);
+        parser.document.set_quirks_mode(ServoQuirksMode::NoQuirks);
 
         let doc = &parser.document;
         // Step 5. Set the appropriate attribute of the element host element, as described below,

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1186,6 +1186,8 @@ impl ParserContext {
         parser.push_string_input_chunk(page);
         parser.parse_sync(cx);
         parser.tokenizer.set_plaintext_state();
+        // Step 3. Set document's mode to "no-quirks".
+        parser.document.set_quirks_mode(ServoQuirksMode::NoQuirks);
         // The first task that the networking task source places on the task queue while fetching
         // runs must process link headers given document, navigationParams's response, and "media",
         // after the task has been processed by the HTML parser.

--- a/tests/wpt/meta/html/browsers/browsing-the-web/read-media/pageload-image.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/read-media/pageload-image.html.ini
@@ -1,3 +1,0 @@
-[pageload-image.html]
-  [The document for a standalone media file should have one child in the body.]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/read-media/pageload-video.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/read-media/pageload-video.html.ini
@@ -1,3 +1,0 @@
-[pageload-video.html]
-  [The document for a standalone media file should have one child in the body.]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/read-text/load-text-plain.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/read-text/load-text-plain.html.ini
@@ -1,3 +1,0 @@
-[load-text-plain.html]
-  [Checking document metadata for text file]
-    expected: FAIL


### PR DESCRIPTION
This sets no-quirks mode for texts documents and media.
The step 3 is performed after the `parse_sync`, to avoid `html5ever` overriding back to quirks mode.
I would say this is related to the absence of [step 2](https://html.spec.whatwg.org/multipage/document-lifecycle.html#navigate-text) in the implementation.

Testing: Covered by the WPT tests (pageload-image.html, pageload-video.html). Test expectations have been updated. 
Additionally I made a quick manual check using the snippets provided as a reproduction step in the related issue.

Fixes: #47809 
