### PR TITLE
script: Focus text controls when `select()` is called

### DIFF
--- a/components/script/dom/html/form_controls/htmlinputelement.rs
+++ b/components/script/dom/html/form_controls/htmlinputelement.rs
@@ -1464,8 +1464,8 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-select>
-    fn Select(&self) {
-        self.selection().dom_select();
+    fn Select(&self, cx: &mut JSContext) {
+        self.selection().dom_select(cx);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionstart>

--- a/components/script/dom/html/form_controls/htmltextareaelement.rs
+++ b/components/script/dom/html/form_controls/htmltextareaelement.rs
@@ -449,8 +449,8 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
     make_labels_getter!(Labels, labels_node_list);
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-select>
-    fn Select(&self) {
-        self.selection().dom_select();
+    fn Select(&self, cx: &mut JSContext) {
+        self.selection().dom_select(cx);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionstart>

--- a/components/script/dom/html/form_controls/text_control.rs
+++ b/components/script/dom/html/form_controls/text_control.rs
@@ -9,6 +9,7 @@
 
 use std::cell::Ref;
 
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
 use servo_base::text::Utf16CodeUnits;
 
@@ -21,6 +22,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::html::form_controls::text_input::{
     EmbedderClipboardProvider, SelectionDirection, SelectionState, TextInput,
 };
+use crate::dom::node::focus::FocusTrigger;
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::types::Element;
 
@@ -54,12 +56,21 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-select>
-    pub(crate) fn dom_select(&self) {
+    pub(crate) fn dom_select(&self, cx: &mut JSContext) {
         // Step 1: If this element is an input element, and either select() does not apply
         // to this element or the corresponding control has no selectable text, return.
         if !self.element.has_selectable_text() {
             return;
         }
+
+        // Not in the specification, but Gecko, Blink and WebKit all move focus to the text
+        // control when `select()` is called on it. Servo only renders a text control's
+        // selection while that control is focused, so without this a programmatic
+        // `select()` would never be visible to the user.
+        // See <https://www.w3.org/Bugs/Public/show_bug.cgi?id=7581>.
+        self.element
+            .upcast::<Node>()
+            .run_the_focusing_steps(cx, None, FocusTrigger::Other);
 
         // Step 2 : Set the selection range with 0 and infinity.
         self.set_range(

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -743,6 +743,7 @@ DOMInterfaces = {
         'GetLabels',
         'GetValueAsDate',
         'ReportValidity',
+        'Select',
         'SetCustomValidity',
         'StepDown',
         'StepUp',
@@ -838,7 +839,7 @@ DOMInterfaces = {
 },
 
 'HTMLTextAreaElement': {
-    'cx': ['CheckValidity', 'ReportValidity', 'SetCustomValidity', 'Validity', 'ValidationMessage', 'Labels'],
+    'cx': ['CheckValidity', 'ReportValidity', 'Select', 'SetCustomValidity', 'Validity', 'ValidationMessage', 'Labels'],
 },
 
 'HTMLVideoElement': {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -6930,6 +6930,19 @@
       {}
      ]
     ],
+    "textarea-select-selection.html": [
+     "8f26be86f98eb5249c897095091199d910fea4f5",
+     [
+      null,
+      [
+       [
+        "/_mozilla/css/textarea-select-selection-ref.html",
+        "=="
+       ]
+      ],
+      {}
+     ]
+    ],
     "textarea-space-calculation.html": [
      "ef6cb45f70d8e7148322bb35375eba1bea0e4d2d",
      [
@@ -10561,6 +10574,10 @@
     ],
     "text-transform-uppercase-ref.html": [
      "97d2f366ea32246c55b7a8c01a89c1df86c3378c",
+     []
+    ],
+    "textarea-select-selection-ref.html": [
+     "070de600f9433b549733ac7da3dac73e287f2eb4",
      []
     ],
     "textarea-space-calculation-ref.html": [
@@ -15112,6 +15129,13 @@
     ],
     "textcontent.html": [
      "c89bb1b640fba0d36c5e931091b8e9e358afee57",
+     [
+      null,
+      {}
+     ]
+    ],
+    "textcontrol-select-focus.html": [
+     "64b444d228bb48636ce321f87b0a1e0767ef826e",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/css/textarea-select-selection-ref.html
+++ b/tests/wpt/mozilla/tests/css/textarea-select-selection-ref.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CSS Reftest Reference</title>
+    <style>
+      textarea {
+        font: 16px sans-serif;
+        border: 0 none;
+        margin: 0;
+        padding: 0;
+        color: white;
+        outline: none;
+      }
+      ::selection {
+        color: white;
+        background: rgba(176, 214, 255, 1.0);
+      }
+    </style>
+    <script>
+      function startReference() {
+        var textarea = document.querySelector("textarea");
+        textarea.focus();
+        textarea.setSelectionRange(0, textarea.value.length);
+      }
+    </script>
+  </head>
+  <body onload="startReference();">
+    <textarea rows="1" cols="10">Hello</textarea>
+  </body>
+</html>

--- a/tests/wpt/mozilla/tests/css/textarea-select-selection.html
+++ b/tests/wpt/mozilla/tests/css/textarea-select-selection.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>textarea select() paints a selection when the element was not focused</title>
+    <link rel="match" href="textarea-select-selection-ref.html">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-textarea/input-select">
+    <style>
+      textarea {
+        font: 16px sans-serif;
+        border: 0 none;
+        margin: 0;
+        padding: 0;
+        color: white;
+        outline: none;
+      }
+      ::selection {
+        color: white;
+        background: rgba(176, 214, 255, 1.0);
+      }
+    </style>
+    <script>
+      function startTest() {
+        // The textarea is not focused, but select() should still make the
+        // selection visible.
+        document.querySelector("textarea").select();
+      }
+    </script>
+  </head>
+  <body onload="startTest();">
+    <textarea rows="1" cols="10">Hello</textarea>
+  </body>
+</html>

--- a/tests/wpt/mozilla/tests/mozilla/textcontrol-select-focus.html
+++ b/tests/wpt/mozilla/tests/mozilla/textcontrol-select-focus.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>select() moves focus to the text control</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-textarea/input-select">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<textarea id="textarea">Gesundheit</textarea>
+<input type="text" id="input" value="Gesundheit">
+
+<script>
+test(() => {
+  const textarea = document.getElementById("textarea");
+  assert_not_equals(document.activeElement, textarea, "the textarea starts out unfocused");
+
+  textarea.select();
+
+  assert_equals(document.activeElement, textarea, "select() focuses the textarea");
+  assert_equals(textarea.selectionStart, 0);
+  assert_equals(textarea.selectionEnd, textarea.value.length);
+}, "textarea.select() moves focus to the textarea");
+
+test(() => {
+  const input = document.getElementById("input");
+  assert_not_equals(document.activeElement, input, "the input starts out unfocused");
+
+  input.select();
+
+  assert_equals(document.activeElement, input, "select() focuses the input");
+  assert_equals(input.selectionStart, 0);
+  assert_equals(input.selectionEnd, input.value.length);
+}, "input.select() moves focus to the input");
+</script>


### PR DESCRIPTION
## Description

Gecko, Blink, and WebKit all move focus to a text control when `select()` is called on it.

Servo only creates a selection for layout to paint while the control is focused. `maybe_update_shared_selection()` gates the shared selection on `focus_state()`, so calling `select()` on an `<input>` or `<textarea>` that was not already focused updated `selectionStart` / `selectionEnd`, but never showed a selection to the user.

This change runs the focusing steps for the element in `select()` before setting the selection range.

This matches what [[Gecko does](https://searchfox.org/mozilla-central/source/dom/html/HTMLTextAreaElement.cpp)](https://searchfox.org/mozilla-central/source/dom/html/HTMLTextAreaElement.cpp): `HTMLTextAreaElement::Select()` calls `nsFocusManager::SetFocus` with `FLAG_NOSCROLL` first.

This behavior is not currently defined by the specification; see [[W3C bug 7581](https://www.w3.org/Bugs/Public/show_bug.cgi?id=7581)](https://www.w3.org/Bugs/Public/show_bug.cgi?id=7581). However, all major browser engines implement it, and the WPT references for:

* `css/css-pseudo/selection-input-011.html`
* `css/css-pseudo/selection-textarea-011.html`

explicitly call `focus()` on the control to match this behavior.

`Select` is also added to the `cx` list for both interfaces in `Bindings.conf`, allowing the generated bindings to pass a `JSContext` down to the focusing steps.

## Testing

Adds the following tests:

* `_mozilla/mozilla/textcontrol-select-focus.html`

  * A testharness test verifying that `select()` moves focus to an unfocused `<input>` and `<textarea>`.
  * Also verifies that all text in the control is selected.

* `_mozilla/css/textarea-select-selection.html`

  * A reftest verifying that the resulting selection is actually painted.

## Fixes

Fixes #47753