### PR TITLE
layout: Wrap `FP` and `FCP` in `PaintTimingReport`

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -251,11 +251,11 @@ impl DisplayListBuilder<'_> {
     }
 
     fn mark_is_paintable(&mut self) {
-        self.paint_info.is_paintable = true;
+        self.paint_timing_handler.mark_document_is_paintable();
     }
 
     fn mark_is_contentful(&mut self) {
-        self.paint_info.is_contentful = true;
+        self.paint_timing_handler.mark_document_is_contentful();
     }
 
     fn spatial_id(&self, id: ScrollTreeNodeId) -> SpatialId {
@@ -635,7 +635,7 @@ impl DisplayListBuilder<'_> {
         // An element el is paintable when all of the following apply:
         // > el is being rendered.
         // > el’s used visibility is visible.
-        // Above conditions are met, as we selectively call this API.
+        // Note: Above conditions are met, as we selectively call this API.
 
         // > el and all of its ancestors' used opacity is greater than zero.
         if opacity <= 0.0 {

--- a/components/layout/display_list/paint_timing_handler.rs
+++ b/components/layout/display_list/paint_timing_handler.rs
@@ -7,6 +7,7 @@ use std::collections::{HashMap, HashSet};
 use app_units::Au;
 use euclid::Rect;
 use layout_api::LCPCandidate;
+use paint_api::display_list::PaintTimingReport;
 use servo_base::id::LCPCandidateID;
 use servo_geometry::FastLayoutTransform;
 use servo_url::ServoUrl;
@@ -60,6 +61,12 @@ pub(crate) struct PaintTimingHandler {
     viewport_rect: LayoutRect,
     /// The document’s largest contentful paint size
     lcp_size: f32,
+    /// Whether the current display list contains paintable items.
+    is_document_paintable: bool,
+    /// Whether the current display list contains contentful items.
+    is_document_contentful: bool,
+    /// <https://www.w3.org/TR/paint-timing/#set-of-previously-reported-paints>
+    previously_reported_paints: PaintTimingReport,
     /// Counter for generating unique LCP candidate UUIDs.
     lcp_next_uuid: u64,
     /// The LCP candidate, it may be a image or text.
@@ -81,6 +88,9 @@ impl PaintTimingHandler {
     pub(crate) fn new(viewport_size: LayoutSize) -> Self {
         Self {
             lcp_size: 0.0,
+            is_document_paintable: false,
+            is_document_contentful: false,
+            previously_reported_paints: PaintTimingReport::default(),
             lcp_next_uuid: 0,
             lcp_candidate: None,
             lcp_candidate_updated: false,
@@ -90,6 +100,16 @@ impl PaintTimingHandler {
             reported_text_nodes: HashSet::new(),
             painted_text_nodes: HashMap::new(),
         }
+    }
+
+    /// Marks the current display list as containing a paintable item.
+    pub(crate) fn mark_document_is_paintable(&mut self) {
+        self.is_document_paintable = true;
+    }
+
+    /// Marks the current display list as containing a contentful item.
+    pub(crate) fn mark_document_is_contentful(&mut self) {
+        self.is_document_contentful = true;
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -385,28 +405,112 @@ impl PaintTimingHandler {
         // Note: Step 6-7 are handled in script.
     }
 
+    /// <https://www.w3.org/TR/paint-timing/#first-paint>
+    fn should_report_first_paint(&self) -> bool {
+        // Step 1. If document's set of previously reported paints contains
+        // "first-paint", then return false.
+        if self
+            .previously_reported_paints
+            .contains(PaintTimingReport::FirstPaint)
+        {
+            return false;
+        }
+        // Step 2. If document contains at least one element that is
+        // paintable, then return true.
+        // Step 3. Otherwise, return false.
+        self.is_document_paintable
+    }
+
+    /// <https://www.w3.org/TR/paint-timing/#first-contentful-paint>
+    fn should_report_first_contentful_paint(&self) -> bool {
+        // Step 1. If document's set of previously reported paints contains
+        // "first-contentful-paint", then return false.
+        if self
+            .previously_reported_paints
+            .contains(PaintTimingReport::FirstContentfulPaint)
+        {
+            return false;
+        }
+        // Step 2. If document contains at least one element that is both
+        // paintable and contentful, then return true.
+        // Step 3. Otherwise, return false.
+        self.is_document_paintable && self.is_document_contentful
+    }
+
     /// <https://www.w3.org/TR/paint-timing/#mark-paint-timing>
+    ///
+    /// Note: Step 10 is not in the current version of the specifications.
+    /// Refer <https://github.com/w3c/paint-timing/issues/122> for details on
+    /// the issue and for the modified steps yet to be merged.
     #[servo_tracing::instrument(name = "Mark Paint Timing", skip_all, fields(halt_lcp = halt_lcp))]
-    pub(crate) fn mark_paint_timing(&mut self, halt_lcp: bool) {
-        // > From: <https://www.w3.org/TR/largest-contentful-paint/#sec-report-largest-contentful-paint>
-        // > Note: Each pending image record in paintedImages and text
-        // > element in paintedTextNodes will only be reported exactly
-        // > once, from mark paint timing, for the first paint where the
-        // > element is considered paintable (i.e. has opacity and
-        // > visibility) and contentful (i.e. image resource or blocking
-        // > fonts are sufficiently loaded).
+    pub(crate) fn mark_paint_timing(&mut self, halt_lcp: bool) -> PaintTimingReport {
+        // TODO Step 1. If the document's browsing context is not paint-timing
+        // eligible, return.
+
+        // TODO Step 2. Let paintTimingInfo be a new paint timing info, whose
+        // rendering update end time is the current high resolution time given
+        // document's relevant global object.
+
+        // Step 3. Let paintedImages be a new ordered set.
+        // Step 4. Let paintedTextNodes be a new ordered set.
+
+        // Step 5. For each record in doc's images pending rendering list:
+        // Step 5.1. If record's request is available and ready to be painted,
+        // then run the following steps:
+        // Note: Only available images are accumulated, hence it is fulfilled.
+        // Step 5.1.1. Append record to paintedImages.
+        // Step 5.1.2. Remove record from doc's images pending rendering list.
         self.painted_images.retain(|record| {
             record
                 .tag
                 .is_none_or(|tag| self.reported_image_nodes.insert(tag.node))
         });
+
+        // Step 6. For each Element element in doc's descendants:
+        // Step 6.1. If element is contained in doc's set of elements with
+        // rendered text, continue.
+        // Step 6.2. If element's set of owned text nodes is empty, continue.
+        // Step 6.3. Append element to doc's set of elements with rendered text.
+        // Step 6.4. Append element to paintedTextNodes.
         self.painted_text_nodes
             .retain(|node, _record| self.reported_text_nodes.insert(*node));
 
+        // Step 7. Let reportedPaints be the document’s set of previously
+        // reported paints. (Directly accessing)
+
+        // TODO Step 8. Let frameTimingInfo be document’s current frame timing info.
+        // TODO Step 9. Set document’s current frame timing info to null.
+
         // Step 10. Let flushPaintTimings be the following steps:
+
+        // Note: A new PaintTimingReport to accumulate the paints.
+        let mut paint_timing_report = PaintTimingReport::default();
+
+        // Step 10.1. If document should report first paint, then:
+        // Note: This step is not in the current version of the specifications,
+        // are waiting to be merged at w3c/paint-timing#123.
+        if self.should_report_first_paint() {
+            // Step 10.1.1. Report paint timing given document, "first-paint",
+            // and paintTimingInfo.
+            paint_timing_report.insert(PaintTimingReport::FirstPaint);
+        }
+
+        // Step 10.2. If document should report first contentful paint, then:
+        if self.should_report_first_contentful_paint() {
+            // Step 10.2.1. Report paint timing given document,
+            // "first-contentful-paint", and paintTimingInfo.
+            paint_timing_report.insert(PaintTimingReport::FirstContentfulPaint);
+        }
+
         // Step 10.3. Report largest contentful paint given document,
         // paintTimingInfo, paintedImages and paintedTextNodes.
         self.report_largest_contentful_paint(halt_lcp);
+
+        // Note: Append the newly reported paints aka [`PaintTimingReport`] to
+        // the document's set of previously reported paints.
+        self.previously_reported_paints |= paint_timing_report;
+
+        paint_timing_report
     }
 
     pub(crate) fn did_lcp_candidate_update(&self) -> bool {

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1533,7 +1533,8 @@ impl LayoutThread {
             paint_timing_handler,
             reflow_statistics,
         );
-        paint_timing_handler.mark_paint_timing(reflow_request.halt_lcp);
+        stacking_context_tree.paint_info.paint_timing_report =
+            paint_timing_handler.mark_paint_timing(reflow_request.halt_lcp);
         self.paint_api.send_display_list(
             self.webview_id,
             &stacking_context_tree.paint_info,

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -18,7 +18,7 @@ use gleam::gl::RENDERER;
 use image::RgbaImage;
 use log::{debug, error, info, warn};
 use media::WindowGLContext;
-use paint_api::display_list::{PaintDisplayListInfo, ScrollType};
+use paint_api::display_list::{PaintDisplayListInfo, PaintTimingReport, ScrollType};
 use paint_api::rendering_context::RenderingContext;
 use paint_api::viewport_description::ViewportDescription;
 use paint_api::{
@@ -986,14 +986,18 @@ impl Painter {
 
         let epoch = display_list_info.epoch.into();
         let first_reflow = display_list_info.first_reflow;
-        if details.first_paint_metric == PaintMetricState::Waiting && display_list_info.is_paintable
+        if details.first_paint_metric == PaintMetricState::Waiting &&
+            display_list_info
+                .paint_timing_report
+                .contains(PaintTimingReport::FirstPaint)
         {
             details.first_paint_metric = PaintMetricState::Seen(epoch, first_reflow);
         }
 
         if details.first_contentful_paint_metric == PaintMetricState::Waiting &&
-            display_list_info.is_paintable &&
-            display_list_info.is_contentful
+            display_list_info
+                .paint_timing_report
+                .contains(PaintTimingReport::FirstContentfulPaint)
         {
             details.first_contentful_paint_metric = PaintMetricState::Seen(epoch, first_reflow);
         }

--- a/components/shared/paint/display_list.rs
+++ b/components/shared/paint/display_list.rs
@@ -896,6 +896,25 @@ impl ScrollTree {
     }
 }
 
+/// A bitflags set that represents the paint timing report for a display list.
+///
+/// <https://www.w3.org/TR/paint-timing/#set-of-previously-reported-paints>
+/// Note: Analogous to the document's "set of previously reported paints". It
+/// is produced by layout's `mark paint timing` as the report for the current
+/// display list. In the specification this is an ordered set of paint-type
+/// strings (`"first-paint"`,`"first-contentful-paint"`).
+#[derive(Clone, Copy, Debug, Default, Deserialize, MallocSizeOf, PartialEq, Serialize)]
+pub struct PaintTimingReport(u8);
+
+bitflags! {
+    impl PaintTimingReport: u8 {
+        /// Report first paint (the spec's `"first-paint"`).
+        const FirstPaint = 1 << 0;
+        /// Report first contentful paint (the spec's `"first-contentful-paint"`).
+        const FirstContentfulPaint = 1 << 1;
+    }
+}
+
 /// A data structure which stores `Paint`-side information about
 /// display lists sent to `Paint`.
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
@@ -925,18 +944,12 @@ pub struct PaintDisplayListInfo {
     /// tree.
     pub root_scroll_node_id: ScrollTreeNodeId,
 
-    /// From <https://www.w3.org/TR/paint-timing/#paintable>:
-    /// Whether the display list contains paintable items.
-    pub is_paintable: bool,
-
-    /// From <https://www.w3.org/TR/paint-timing/#contentful>:
-    /// Contentful paint i.e. whether the display list contains items of type
-    /// text, image, non-white canvas or SVG). Used by metrics.
-    pub is_contentful: bool,
-
     /// Whether the first layout or a subsequent (incremental) layout triggered this
     /// display list creation.
     pub first_reflow: bool,
+
+    /// The paint-timing report for this display list.
+    pub paint_timing_report: PaintTimingReport,
 
     /// If this display list contains a blinking caret, this value will be filled with its animation
     /// key and original color value so that the painter can animate the caret.
@@ -989,9 +1002,8 @@ impl PaintDisplayListInfo {
             scroll_tree,
             root_reference_frame_id,
             root_scroll_node_id,
-            is_paintable: false,
-            is_contentful: false,
             first_reflow,
+            paint_timing_report: PaintTimingReport::default(),
             caret_property_binding: Default::default(),
         }
     }


### PR DESCRIPTION
Define `PaintTimingReport` as per specifications for FP and FCP

Testing: This change doesn't modify observable behavior so is covered by existing tests.
Fixes: Part of https://github.com/servo/servo/issues/42623
