### PR TITLE
script: Avoid messaging when possible in `WindowProxy` subframe getter

### DIFF
--- a/components/script/dom/document/iframe_collection.rs
+++ b/components/script/dom/document/iframe_collection.rs
@@ -84,6 +84,10 @@ impl IFrameCollection {
             .and_then(|index| self.iframes.remove(index).size)
     }
 
+    pub(crate) fn at_index(&self, index: usize) -> Option<&IFrame> {
+        self.iframes.get(index)
+    }
+
     pub(crate) fn get(&self, browsing_context_id: BrowsingContextId) -> Option<&IFrame> {
         self.iframes
             .iter()

--- a/components/script/dom/window/windowproxy.rs
+++ b/components/script/dom/window/windowproxy.rs
@@ -1867,20 +1867,26 @@ impl WindowOrDissimilarOriginWindow {
         &self,
         index: u32,
     ) -> Option<DomRoot<WindowProxy>> {
-        let browsing_context_id = self.window_proxy().browsing_context_id();
-        let (result_sender, result_receiver) = generic_channel::channel().unwrap();
-        let _ = self.global_scope().script_to_constellation_chan().send(
-            ScriptToConstellationMessage::GetChildBrowsingContextId(
-                browsing_context_id,
-                index as usize,
-                result_sender,
-            ),
-        );
-        result_receiver
-            .recv()
-            .ok()
-            .flatten()
-            .and_then(|id| ScriptThread::window_proxies().find_window_proxy(id))
+        let window_proxy = self.window_proxy();
+        let browsing_context_id = if let Some(document) = window_proxy.document() {
+            document
+                .iframes()
+                .at_index(index as usize)?
+                .element
+                .browsing_context_id()?
+        } else {
+            let parent_browsing_context_id = window_proxy.browsing_context_id();
+            let (result_sender, result_receiver) = generic_channel::channel().unwrap();
+            let _ = self.global_scope().script_to_constellation_chan().send(
+                ScriptToConstellationMessage::GetChildBrowsingContextId(
+                    parent_browsing_context_id,
+                    index as usize,
+                    result_sender,
+                ),
+            );
+            result_receiver.recv().ok().flatten()?
+        };
+        ScriptThread::window_proxies().find_window_proxy(browsing_context_id)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#document-tree-child-navigable-target-name-property-set>


### PR DESCRIPTION
When getting subframes, the `WindowProxy` was using IPC to resolve
subframe indices to their browsing context id. This can be done
synchronously when the target `Window` is lives in the same
ScriptThread. Doing this should improve the performance of this
 operation.

Testing: This shouldn't change observable behavior and there is otherwise
no good way to test these kind of obvious performance improvements.
Fixes: This is part of #47773.