### PR TITLE
script: Add error messages for `document`

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -3608,13 +3608,18 @@ impl Document {
         }
         // Step 6: If document is an XML document, then throw an "InvalidStateError" DOMException.
         if !self.is_html_document() {
-            return Err(Error::InvalidState(None));
+            return Err(Error::InvalidState(Some(
+                "Document must be a HTML document".into(),
+            )));
         }
 
         // Step 7: If document's throw-on-dynamic-markup-insertion counter is greater than 0,
         // then throw an "InvalidStateError" DOMException.
         if self.throw_on_dynamic_markup_insertion_counter.get() > 0 {
-            return Err(Error::InvalidState(None));
+            return Err(Error::InvalidState(Some(
+                "A custom element constructor attempted to open, close or write to this document"
+                    .into(),
+            )));
         }
 
         // Step 8: If document's active parser was aborted is true, then return.
@@ -5459,7 +5464,9 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     fn SetDomain(&self, value: DOMString) -> ErrorResult {
         // Step 1. If this's browsing context is null, then throw a "SecurityError" DOMException.
         if !self.has_browsing_context {
-            return Err(Error::Security(None));
+            return Err(Error::Security(Some(
+                "Document's browsing context has not been set".into(),
+            )));
         }
 
         // Step 2. If this Document object's active sandboxing flag set has its sandboxed
@@ -5467,20 +5474,22 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         if self.has_active_sandboxing_flag(
             SandboxingFlagSet::SANDBOXED_DOCUMENT_DOMAIN_BROWSING_CONTEXT_FLAG,
         ) {
-            return Err(Error::Security(None));
+            return Err(Error::Security(Some(
+                "Sandboxed document cannot set its domain".into(),
+            )));
         }
 
         // Step 3. Let effectiveDomain be this's origin's effective domain.
         let effective_domain = match self.origin().effective_domain() {
             Some(effective_domain) => effective_domain,
             // Step 4. If effectiveDomain is null, then throw a "SecurityError" DOMException.
-            None => return Err(Error::Security(None)),
+            None => return Err(Error::Security(Some("Document's origin is opaque".into()))),
         };
 
         // Step 5. If the given value is not a registrable domain suffix of and is not equal to effectiveDomain, then throw a "SecurityError" DOMException.
         let host =
             match get_registrable_domain_suffix_of_or_is_equal_to(&value.str(), effective_domain) {
-                None => return Err(Error::Security(None)),
+                None => return Err(Error::Security(Some("Provided domain is not a registrable domain suffix and is not equal to document's effectiveDomain".into()))),
                 Some(host) => host,
             };
 
@@ -5627,24 +5636,26 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         mut local_name: DOMString,
         options: StringOrElementCreationOptions,
     ) -> Fallible<DomRoot<Element>> {
-        // Step 1. If localName is not a valid element local name,
-        //      then throw an "InvalidCharacterError" DOMException.
+        // Step 1. If localName is not a valid element local name, then throw an "InvalidCharacterError" DOMException.
         if !is_valid_element_local_name(&local_name.str()) {
-            debug!("Not a valid element name");
-            return Err(Error::InvalidCharacter(None));
+            return Err(Error::InvalidCharacter(Some(
+                "Provided element local name is invalid".into(),
+            )));
         }
 
+        // Step 2. If this is an HTML document, then set localName to localName in ASCII lowercase.
         if self.is_html_document {
             local_name.make_ascii_lowercase();
         }
 
+        // Step 4. Let namespace be the HTML namespace, if this is an HTML document or this’s content type is "application/xhtml+xml"; otherwise null.
         let ns = if self.is_html_document || self.is_xhtml_document() {
             ns!(html)
         } else {
             ns!()
         };
-
         let name = QualName::new(None, ns, LocalName::from(local_name));
+
         let is = match options {
             StringOrElementCreationOptions::String(_) => None,
             StringOrElementCreationOptions::ElementCreationOptions(options) => {
@@ -5704,12 +5715,14 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         cx: &mut JSContext,
         mut local_name: DOMString,
     ) -> Fallible<DomRoot<Attr>> {
-        // Step 1. If localName is not a valid attribute local name,
-        //      then throw an "InvalidCharacterError" DOMException
+        // Step 1. If localName is not a valid attribute local name, then throw an "InvalidCharacterError" DOMException
         if !is_valid_attribute_local_name(&local_name.str()) {
-            debug!("Not a valid attribute name");
-            return Err(Error::InvalidCharacter(None));
+            return Err(Error::InvalidCharacter(Some(
+                "Provided local name is invalid".into(),
+            )));
         }
+
+        // Step 2. If this is an HTML document, then set localName to localName in ASCII lowercase.
         if self.is_html_document {
             local_name.make_ascii_lowercase();
         }
@@ -5772,12 +5785,14 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     ) -> Fallible<DomRoot<CDATASection>> {
         // Step 1
         if self.is_html_document {
-            return Err(Error::NotSupported(None));
+            return Err(Error::NotSupported(Some(
+                "Document must be an XML document".into(),
+            )));
         }
 
         // Step 2
         if data.contains("]]>") {
-            return Err(Error::InvalidCharacter(None));
+            return Err(Error::InvalidCharacter(Some("CDATA section cannot include `]]>', as this is the closing seqeuence of the CDATA section itself".into())));
         }
 
         // Step 3
@@ -5798,12 +5813,16 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     ) -> Fallible<DomRoot<ProcessingInstruction>> {
         // Step 1. If target does not match the Name production, then throw an "InvalidCharacterError" DOMException.
         if !matches_name_production(&target.str()) {
-            return Err(Error::InvalidCharacter(None));
+            return Err(Error::InvalidCharacter(Some(
+                "Target name provided is invalid".into(),
+            )));
         }
 
-        // Step 2.
+        // Step 2. If data contains the string "?>", then throw an "InvalidCharacterError" DOMException.
         if data.contains("?>") {
-            return Err(Error::InvalidCharacter(None));
+            return Err(Error::InvalidCharacter(Some(
+                "Processing instruction's data cannot contain `>?`".into(),
+            )));
         }
 
         // Step 3.
@@ -5819,7 +5838,9 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     ) -> Fallible<DomRoot<Node>> {
         // Step 1. If node is a document or shadow root, then throw a "NotSupportedError" DOMException.
         if node.is::<Document>() || node.is::<ShadowRoot>() {
-            return Err(Error::NotSupported(None));
+            return Err(Error::NotSupported(Some(
+                "Node cannot be a document or shadow root".into(),
+            )));
         }
         // Step 2. Let subtree be false.
         let (subtree, registry) = match options {
@@ -5863,12 +5884,16 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     fn AdoptNode(&self, cx: &mut JSContext, node: &Node) -> Fallible<DomRoot<Node>> {
         // Step 1.
         if node.is::<Document>() {
-            return Err(Error::NotSupported(None));
+            return Err(Error::NotSupported(Some(
+                "Node cannot be a document".into(),
+            )));
         }
 
         // Step 2.
         if node.is::<ShadowRoot>() {
-            return Err(Error::HierarchyRequest(None));
+            return Err(Error::HierarchyRequest(Some(
+                "Node cannot be a shadow root".into(),
+            )));
         }
 
         // Step 3.
@@ -5949,7 +5974,9 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                 cx,
                 &self.window,
             ))),
-            _ => Err(Error::NotSupported(None)),
+            _ => Err(Error::NotSupported(Some(
+                "Interface is not supported".into(),
+            ))),
         }
     }
 
@@ -6126,7 +6153,11 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         // Step 1. If the new value is not a body or frameset element, then throw a "HierarchyRequestError" DOMException.
         let new_body = match new_body {
             Some(new_body) => new_body,
-            None => return Err(Error::HierarchyRequest(None)),
+            None => {
+                return Err(Error::HierarchyRequest(Some(
+                    "HTML element provided is neither a body nor a frameset element".into(),
+                )));
+            },
         };
 
         let node = new_body.upcast::<Node>();
@@ -6135,7 +6166,11 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLFrameSetElement,
             )) => {},
-            _ => return Err(Error::HierarchyRequest(None)),
+            _ => {
+                return Err(Error::HierarchyRequest(Some(
+                    "HTML element provided is neither a body nor a frameset element".into(),
+                )));
+            },
         }
 
         // Step 2. Otherwise, if the new value is the same as the body element, return.
@@ -6154,7 +6189,9 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             },
 
             // Step 4. Otherwise, if there is no document element, throw a "HierarchyRequestError" DOMException.
-            (None, _) => Err(Error::HierarchyRequest(None)),
+            (None, _) => Err(Error::HierarchyRequest(Some(
+                "Document element is missing".into(),
+            ))),
 
             // Step 5. Otherwise, the body element is null, but there's a document element.
             // Append the new value to the document element.
@@ -6326,7 +6363,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         }
 
         if !self.origin().is_tuple() {
-            return Err(Error::Security(None));
+            return Err(Error::Security(Some("Document's origin is opaque".into())));
         }
 
         let url = self.url();
@@ -6348,7 +6385,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         }
 
         if !self.origin().is_tuple() {
-            return Err(Error::Security(None));
+            return Err(Error::Security(Some("Document's origin is opaque".into())));
         }
 
         if !cookie.is_valid_for_cookie() {
@@ -6602,13 +6639,18 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     ) -> Fallible<DomRoot<Document>> {
         // Step 1. If document is an XML document, then throw an "InvalidStateError" DOMException.
         if !self.is_html_document() {
-            return Err(Error::InvalidState(None));
+            return Err(Error::InvalidState(Some(
+                "Document must be a HTML document".into(),
+            )));
         }
 
         // Step 2. If document's throw-on-dynamic-markup-insertion counter is greater than 0,
         // then throw an "InvalidStateError" DOMException.
         if self.throw_on_dynamic_markup_insertion_counter.get() > 0 {
-            return Err(Error::InvalidState(None));
+            return Err(Error::InvalidState(Some(
+                "A custom element constructor attempted to open, close or write to this document"
+                    .into(),
+            )));
         }
 
         // Step 3. Let entryDocument be the entry global object's associated Document.
@@ -6620,7 +6662,9 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             .origin()
             .same_origin(&entry_responsible_document.origin())
         {
-            return Err(Error::Security(None));
+            return Err(Error::Security(Some(
+                "Document's origin is not the same as entryDocument's origin".into(),
+            )));
         }
 
         // Step 5. If document has an active parser whose script nesting level is greater than 0,
@@ -6736,7 +6780,9 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         features: DOMString,
     ) -> Fallible<Option<DomRoot<WindowProxy>>> {
         self.browsing_context()
-            .ok_or(Error::InvalidAccess(None))?
+            .ok_or(Error::InvalidAccess(Some(
+                "Document is not fully active".into(),
+            )))?
             .open(cx, url, target, features)
     }
 
@@ -6758,13 +6804,18 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     fn Close(&self, cx: &mut JSContext) -> ErrorResult {
         if !self.is_html_document() {
             // Step 1. If this is an XML document, then throw an "InvalidStateError" DOMException.
-            return Err(Error::InvalidState(None));
+            return Err(Error::InvalidState(Some(
+                "Document must be a HTML document".into(),
+            )));
         }
 
         // Step 2. If this's throw-on-dynamic-markup-insertion counter is greater than zero,
         // then throw an "InvalidStateError" DOMException.
         if self.throw_on_dynamic_markup_insertion_counter.get() > 0 {
-            return Err(Error::InvalidState(None));
+            return Err(Error::InvalidState(Some(
+                "A custom element constructor attempted to open, close or write to this document"
+                    .into(),
+            )));
         }
 
         // Step 3. If there is no script-created parser associated with this, then return.
@@ -6871,7 +6922,9 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     fn ServoGetMediaControls(&self, id: DOMString) -> Fallible<DomRoot<ShadowRoot>> {
         match self.media_controls.borrow().get(&*id.str()) {
             Some(m) => Ok(DomRoot::from_ref(m)),
-            None => Err(Error::InvalidAccess(None)),
+            None => Err(Error::InvalidAccess(Some(
+                "No registered media controls exist with provided id".into(),
+            ))),
         }
     }
 

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -5465,7 +5465,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         // Step 1. If this's browsing context is null, then throw a "SecurityError" DOMException.
         if !self.has_browsing_context {
             return Err(Error::Security(Some(
-                "Document's browsing context has not been set".into(),
+                "Document has no browsing context".into(),
             )));
         }
 
@@ -5489,7 +5489,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         // Step 5. If the given value is not a registrable domain suffix of and is not equal to effectiveDomain, then throw a "SecurityError" DOMException.
         let host =
             match get_registrable_domain_suffix_of_or_is_equal_to(&value.str(), effective_domain) {
-                None => return Err(Error::Security(Some("Provided domain is not a registrable domain suffix and is not equal to document's effectiveDomain".into()))),
+                None => return Err(Error::Security(Some("Provided domain is not a registrable domain suffix and is not equal to document's effective domain".into()))),
                 Some(host) => host,
             };
 
@@ -5792,7 +5792,9 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
 
         // Step 2
         if data.contains("]]>") {
-            return Err(Error::InvalidCharacter(Some("CDATA section cannot include `]]>', as this is the closing seqeuence of the CDATA section itself".into())));
+            return Err(Error::InvalidCharacter(Some(
+                "CDATA section cannot include `]]>`".into(),
+            )));
         }
 
         // Step 3
@@ -6663,7 +6665,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             .same_origin(&entry_responsible_document.origin())
         {
             return Err(Error::Security(Some(
-                "Document's origin is not the same as entryDocument's origin".into(),
+                "Document's origin is not the same as entry global's document origin".into(),
             )));
         }
 

--- a/components/script/dom/document/documentorshadowroot.rs
+++ b/components/script/dom/document/documentorshadowroot.rs
@@ -394,7 +394,7 @@ impl DocumentOrShadowRoot {
             // > If value’s constructed flag is not set, or its constructor document is not equal
             // > to this DocumentOrShadowRoot’s node document, throw a "NotAllowedError" DOMException.
             if !sheet.constructor_document_matches(owner_doc) {
-                return Err(Error::NotAllowed(None));
+                return Err(Error::NotAllowed(Some("CSS style sheet constructor flag is not set or its constructor document is not equal to this DocumentOrShadowRoot's node document".into())));
             }
         }
 

--- a/components/script/dom/document/documentorshadowroot.rs
+++ b/components/script/dom/document/documentorshadowroot.rs
@@ -394,7 +394,10 @@ impl DocumentOrShadowRoot {
             // > If value’s constructed flag is not set, or its constructor document is not equal
             // > to this DocumentOrShadowRoot’s node document, throw a "NotAllowedError" DOMException.
             if !sheet.constructor_document_matches(owner_doc) {
-                return Err(Error::NotAllowed(Some("CSS style sheet constructor flag is not set or its constructor document is not equal to this DocumentOrShadowRoot's node document".into())));
+                return Err(Error::NotAllowed(Some(
+                    "Stylesheet is not constructed or its constructor document does not match"
+                        .into(),
+                )));
             }
         }
 

--- a/components/script/dom/document/domimplementation.rs
+++ b/components/script/dom/document/domimplementation.rs
@@ -67,8 +67,9 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
         // Step 1. If name is not a valid doctype name, then throw an
         //      "InvalidCharacterError" DOMException.
         if !is_valid_doctype_name(&qualified_name) {
-            debug!("Not a valid doctype name");
-            return Err(Error::InvalidCharacter(None));
+            return Err(Error::InvalidCharacter(Some(
+                "Name is not a valid doctype name, as it contains ASCII whitespace".into(),
+            )));
         }
 
         Ok(DocumentType::new(

--- a/components/script/dom/document/domimplementation.rs
+++ b/components/script/dom/document/domimplementation.rs
@@ -68,7 +68,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
         //      "InvalidCharacterError" DOMException.
         if !is_valid_doctype_name(&qualified_name) {
             return Err(Error::InvalidCharacter(Some(
-                "Name is not a valid doctype name, as it contains ASCII whitespace".into(),
+                "Doctype name contains ASCII whitespace".into(),
             )));
         }
 

--- a/components/script/dom/document/websocket.rs
+++ b/components/script/dom/document/websocket.rs
@@ -149,11 +149,13 @@ impl WebSocket {
         websocket
     }
 
-    /// <https://html.spec.whatwg.org/multipage/#dom-websocket-send>
+    /// <https://websockets.spec.whatwg.org/#dom-websocket-send>
     fn send_impl(&self, data_byte_len: u64) -> Fallible<bool> {
         let return_after_buffer = match self.ready_state.get() {
             WebSocketRequestState::Connecting => {
-                return Err(Error::InvalidState(None));
+                return Err(Error::InvalidState(Some(
+                    "Web Socket has not connected yet".into(),
+                )));
             },
             WebSocketRequestState::Open => false,
             WebSocketRequestState::Closing | WebSocketRequestState::Closed => true,
@@ -197,7 +199,7 @@ impl WebSocket {
 }
 
 impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
-    /// <https://html.spec.whatwg.org/multipage/#dom-websocket>
+    /// <https://websockets.spec.whatwg.org/#dom-websocket-websocket>
     fn Constructor(
         cx: &mut JSContext,
         global: &GlobalScope,
@@ -209,8 +211,9 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
         let base_url = global.api_base_url();
         // Step 2. Let urlRecord be the result of applying the URL parser to url with baseURL.
         // Step 3. If urlRecord is failure, then throw a "SyntaxError" DOMException.
-        let mut url_record =
-            ServoUrl::parse_with_base(Some(&base_url), &url.str()).or(Err(Error::Syntax(None)))?;
+        let mut url_record = ServoUrl::parse_with_base(Some(&base_url), &url.str()).or(Err(
+            Error::Syntax(Some("Failed to parse url with baseURL".into())),
+        ))?;
 
         // Step 4. If urlRecord’s scheme is "http", then set urlRecord’s scheme to "ws".
         // Step 5. Otherwise, if urlRecord’s scheme is "https", set urlRecord’s scheme to "wss".
@@ -229,12 +232,18 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
                     .expect("Can't set scheme from https to wss");
             },
             "ws" | "wss" => {},
-            _ => return Err(Error::Syntax(None)),
+            _ => {
+                return Err(Error::Syntax(Some(
+                    "urlRecord's scheme is not http nor https".into(),
+                )));
+            },
         }
 
         // Step 7. If urlRecord’s fragment is non-null, then throw a "SyntaxError" DOMException.
         if url_record.fragment().is_some() {
-            return Err(Error::Syntax(None));
+            return Err(Error::Syntax(Some(
+                "urlRecord's fragment is non-null".into(),
+            )));
         }
 
         // Step 8. If protocols is a string, set protocols to a sequence consisting of just that string.
@@ -256,12 +265,16 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
                 .iter()
                 .any(|p| p.eq_ignore_ascii_case(protocol))
             {
-                return Err(Error::Syntax(None));
+                return Err(Error::Syntax(Some(
+                    "Protocol header field occurs more than once".into(),
+                )));
             }
 
             // https://tools.ietf.org/html/rfc6455#section-4.1
             if !is_token(protocol.as_bytes()) {
-                return Err(Error::Syntax(None));
+                return Err(Error::Syntax(Some(
+                    "Protocol header field is not a valid token".into(),
+                )));
             }
         }
 
@@ -442,27 +455,29 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
         Ok(())
     }
 
-    /// <https://html.spec.whatwg.org/multipage/#dom-websocket-close>
+    /// <https://websockets.spec.whatwg.org/#dom-websocket-close>
     fn Close(&self, code: Option<u16>, reason: Option<USVString>) -> ErrorResult {
+        // Step 1. If code is present, but is neither an integer equal to 1000 nor an integer in the range 3000 to 4999, inclusive, throw an "InvalidAccessError" DOMException.
         if let Some(code) = code {
-            // Fail if the supplied code isn't normal and isn't reserved for libraries, frameworks, and applications
             if code != close_code::NORMAL && !(3000..=4999).contains(&code) {
-                return Err(Error::InvalidAccess(None));
+                return Err(Error::InvalidAccess(Some(
+                    "Invalid WebSocket connection close code".into(),
+                )));
             }
         }
+
+        // Step 2.2. If reasonBytes is longer than 123 bytes, then throw a "SyntaxError" DOMException.
         if let Some(ref reason) = reason &&
             reason.0.len() > 123
         {
-            // reason cannot be larger than 123 bytes
             return Err(Error::Syntax(Some("Reason too long".to_string())));
         }
 
+        // Step 3. Run the first matching steps from the following list:
         match self.ready_state.get() {
             WebSocketRequestState::Closing | WebSocketRequestState::Closed => {}, // Do nothing
             WebSocketRequestState::Connecting => {
-                // Connection is not yet established
-                /*By setting the state to closing, the open function
-                will abort connecting the websocket*/
+                // If the WebSocket connection is not yet established [WSP] Fail the WebSocket connection and set this’s ready state to CLOSING (2).
                 self.ready_state.set(WebSocketRequestState::Closing);
 
                 fail_the_websocket_connection(
@@ -475,6 +490,7 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
                 );
             },
             WebSocketRequestState::Open => {
+                // If the WebSocket closing handshake has not yet been started [WSP] Start the WebSocket closing handshake and set this’s ready state to CLOSING (2). [WSP]
                 self.ready_state.set(WebSocketRequestState::Closing);
 
                 // Kick off _Start the WebSocket Closing Handshake_

--- a/components/script/dom/document/websocket.rs
+++ b/components/script/dom/document/websocket.rs
@@ -458,12 +458,13 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
     /// <https://websockets.spec.whatwg.org/#dom-websocket-close>
     fn Close(&self, code: Option<u16>, reason: Option<USVString>) -> ErrorResult {
         // Step 1. If code is present, but is neither an integer equal to 1000 nor an integer in the range 3000 to 4999, inclusive, throw an "InvalidAccessError" DOMException.
-        if let Some(code) = code {
-            if code != close_code::NORMAL && !(3000..=4999).contains(&code) {
-                return Err(Error::InvalidAccess(Some(
-                    "Invalid WebSocket connection close code".into(),
-                )));
-            }
+        if let Some(code) = code &&
+            code != close_code::NORMAL &&
+            !(3000..=4999).contains(&code)
+        {
+            return Err(Error::InvalidAccess(Some(
+                "Invalid WebSocket connection close code".into(),
+            )));
         }
 
         // Step 2.2. If reasonBytes is longer than 123 bytes, then throw a "SyntaxError" DOMException.

--- a/components/script/dom/document/websocket.rs
+++ b/components/script/dom/document/websocket.rs
@@ -154,7 +154,7 @@ impl WebSocket {
         let return_after_buffer = match self.ready_state.get() {
             WebSocketRequestState::Connecting => {
                 return Err(Error::InvalidState(Some(
-                    "Web Socket has not connected yet".into(),
+                    "Cannot send while socket is connecting".into(),
                 )));
             },
             WebSocketRequestState::Open => false,
@@ -211,9 +211,8 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
         let base_url = global.api_base_url();
         // Step 2. Let urlRecord be the result of applying the URL parser to url with baseURL.
         // Step 3. If urlRecord is failure, then throw a "SyntaxError" DOMException.
-        let mut url_record = ServoUrl::parse_with_base(Some(&base_url), &url.str()).or(Err(
-            Error::Syntax(Some("Failed to parse url with baseURL".into())),
-        ))?;
+        let mut url_record = ServoUrl::parse_with_base(Some(&base_url), &url.str())
+            .or(Err(Error::Syntax(Some("Failed to parse url".into()))))?;
 
         // Step 4. If urlRecord’s scheme is "http", then set urlRecord’s scheme to "ws".
         // Step 5. Otherwise, if urlRecord’s scheme is "https", set urlRecord’s scheme to "wss".
@@ -233,17 +232,13 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
             },
             "ws" | "wss" => {},
             _ => {
-                return Err(Error::Syntax(Some(
-                    "urlRecord's scheme is not http nor https".into(),
-                )));
+                return Err(Error::Syntax(Some("Forbidden URL scheme".into())));
             },
         }
 
         // Step 7. If urlRecord’s fragment is non-null, then throw a "SyntaxError" DOMException.
         if url_record.fragment().is_some() {
-            return Err(Error::Syntax(Some(
-                "urlRecord's fragment is non-null".into(),
-            )));
+            return Err(Error::Syntax(Some("Forbidden URL fragment".into())));
         }
 
         // Step 8. If protocols is a string, set protocols to a sequence consisting of just that string.
@@ -265,9 +260,7 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
                 .iter()
                 .any(|p| p.eq_ignore_ascii_case(protocol))
             {
-                return Err(Error::Syntax(Some(
-                    "Protocol header field occurs more than once".into(),
-                )));
+                return Err(Error::Syntax(Some("Duplicate protocol header".into())));
             }
 
             // https://tools.ietf.org/html/rfc6455#section-4.1

--- a/python/tidy/error_message_exceptions.txt
+++ b/python/tidy/error_message_exceptions.txt
@@ -39,10 +39,6 @@
 ./components/script/dom/credentialmanagement/credentialscontainer.rs 8
 ./components/script/dom/credentialmanagement/passwordcredential.rs 1
 ./components/script/dom/datatransfer/datatransferitemlist.rs 1
-./components/script/dom/document/document.rs 28
-./components/script/dom/document/documentorshadowroot.rs 1
-./components/script/dom/document/domimplementation.rs 1
-./components/script/dom/document/websocket.rs 7
 ./components/script/dom/element/element.rs 11
 ./components/script/dom/element/namednodemap.rs 2
 ./components/script/dom/event/eventtarget.rs 1


### PR DESCRIPTION
This adds error messages for `document` while also adding missing spec doc comments. This clears up all the remaining `None`'s in error messages for this crate.

Testing: Not necessary
Fixes: Part of #40756 