### PR TITLE
crown: Add linter pass for manual DOMString creation

### DIFF
--- a/components/script/dom/navigator/navigatorinfo.rs
+++ b/components/script/dom/navigator/navigatorinfo.rs
@@ -42,7 +42,7 @@ pub(crate) fn AppCodeName() -> DOMString {
 #[expect(non_snake_case)]
 #[cfg(target_os = "windows")]
 pub(crate) fn Platform() -> DOMString {
-    DOMString::from("Win32")
+    DOMString::from_static("Win32")
 }
 
 #[expect(non_snake_case)]
@@ -54,13 +54,13 @@ pub(crate) fn Platform() -> DOMString {
 #[expect(non_snake_case)]
 #[cfg(target_os = "macos")]
 pub(crate) fn Platform() -> DOMString {
-    DOMString::from("Mac")
+    DOMString::from_static("Mac")
 }
 
 #[expect(non_snake_case)]
 #[cfg(target_os = "ios")]
 pub(crate) fn Platform() -> DOMString {
-    DOMString::from("iOS")
+    DOMString::from_static("iOS")
 }
 
 #[expect(non_snake_case)]

--- a/support/crown/Cargo.toml
+++ b/support/crown/Cargo.toml
@@ -12,7 +12,8 @@ publish = false
 compiletest_rs = { version = "0.11", features = ["tmp"] }
 
 [features]
-default = ["unrooted_must_root_lint", "trace_in_no_trace_lint"]
+default = ["manual_domstring_new", "unrooted_must_root_lint", "trace_in_no_trace_lint"]
+manual_domstring_new = []
 unrooted_must_root_lint = []
 trace_in_no_trace_lint = []
 

--- a/support/crown/src/common.rs
+++ b/support/crown/src/common.rs
@@ -2,8 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use rustc_ast::ast::LitKind;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{CrateNum, DefId};
+use rustc_hir::ExprKind;
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_infer::traits::{EvaluationResult, Obligation, ObligationCause};
 use rustc_lint::LateContext;
@@ -82,6 +84,17 @@ pub fn trait_in_crate<'tcx>(
         .iter()
         .find(|id| tcx.opt_item_name(**id) == Some(trait_sym))
         .copied()
+}
+
+pub fn value_if_expr_is_str(expr_kind: &ExprKind<'_>) -> Option<String> {
+    // It's a directly instantiated string
+    if let ExprKind::Lit(lit) = expr_kind {
+        if let LitKind::Str(value, _) = lit.node {
+            return Some(value.to_string());
+        };
+    };
+
+    None
 }
 
 /*
@@ -163,4 +176,16 @@ pub fn implements_trait_with_env_from_iter<'tcx>(
     infcx
         .evaluate_obligation(&obligation)
         .is_ok_and(EvaluationResult::must_apply_modulo_regions)
+}
+
+/// <https://github.com/rust-lang/rust-clippy/blob/4e521d16cec7b404db646f7a5b285e80df85b73e/clippy_lints/src/manual_string_new.rs#L68-L77>
+pub fn is_expr_kind_empty_str(expr_kind: &ExprKind<'_>) -> bool {
+    let ExprKind::Lit(lit) = expr_kind else {
+        return false;
+    };
+    let LitKind::Str(value, _) = lit.node else {
+        return false;
+    };
+
+    value == rustc_span::sym::empty
 }

--- a/support/crown/src/main.rs
+++ b/support/crown/src/main.rs
@@ -30,6 +30,9 @@ use rustc_interface::interface::Config;
 
 mod common;
 
+#[cfg(feature = "manual_domstring_new")]
+mod manual_domstring_new;
+
 #[cfg(feature = "unrooted_must_root_lint")]
 mod unrooted_must_root;
 
@@ -50,6 +53,8 @@ impl Callbacks for MyCallbacks {
                 return;
             }
 
+            #[cfg(feature = "manual_domstring_new")]
+            manual_domstring_new::register(lint_store);
             #[cfg(feature = "unrooted_must_root_lint")]
             unrooted_must_root::register(lint_store);
             #[cfg(feature = "trace_in_no_trace_lint")]

--- a/support/crown/src/manual_domstring_new.rs
+++ b/support/crown/src/manual_domstring_new.rs
@@ -1,0 +1,179 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use rustc_hir::{self as hir};
+use rustc_lint::{LateContext, LateLintPass, Lint, LintContext, LintPass, LintStore};
+use rustc_macros::Diagnostic;
+use rustc_middle::ty;
+use rustc_session::declare_tool_lint;
+use rustc_span::symbol::Symbol;
+use rustc_span::Span;
+
+use crate::common::{is_expr_kind_empty_str, match_def_path, value_if_expr_is_str};
+use crate::symbols;
+
+declare_tool_lint! {
+    pub crown::MANUAL_DOMSTRING_NEW,
+    Warn,
+    "Warn and report creation of manual domstrings"
+}
+
+pub fn register(lint_store: &mut LintStore) {
+    let symbols = Symbols::new();
+    lint_store.register_lints(&[MANUAL_DOMSTRING_NEW]);
+    lint_store.register_late_pass(move |_| Box::new(ManualDOMStringPass::new(symbols.clone())));
+}
+
+#[derive(Diagnostic)]
+#[diag("use DOMString::new() instead")]
+struct EmptyDOMStringDiagnostic {
+    #[suggestion(
+        "use constructor instead",
+        applicability = "machine-applicable",
+        code = "DOMString::new()"
+    )]
+    span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag("use DOMString::from_static(\"{$value}\") instead")]
+struct StaticDOMStringDiagnostic {
+    value: String,
+    #[suggestion(
+        "use from_static instead",
+        applicability = "machine-applicable",
+        code = "DOMString::from_static(\"{value}\")"
+    )]
+    span: Span,
+}
+
+/// Lint for checking if manual dom strings are using appropriate APIs
+///
+/// This lint (disable with `-A crown::manual_domstring_new`/`#[allow(crown::manual_domstring_new)]`) ensures that
+/// static domstrings are created appropriately.
+///
+/// "Incorrect" usage includes:
+///
+///  - DomString::from("Static string")
+///  - "Static string".into()
+///  - DomString::from("")
+///  - "".into()
+///
+/// "Correct" usage for these:
+///
+///  - DomString::from_static("Static string")
+///  - DomString::from_static("Static string")
+///  - DomString::new()
+///  - DomString::new()
+///
+pub(crate) struct ManualDOMStringPass {
+    symbols: Symbols,
+}
+
+impl ManualDOMStringPass {
+    pub(crate) fn new(symbols: Symbols) -> ManualDOMStringPass {
+        ManualDOMStringPass { symbols }
+    }
+}
+
+impl LintPass for ManualDOMStringPass {
+    fn name(&self) -> &'static str {
+        "ServoManualDOMStringPass"
+    }
+
+    fn get_lints(&self) -> Vec<&'static Lint> {
+        vec![MANUAL_DOMSTRING_NEW]
+    }
+}
+
+impl<'tcx> ManualDOMStringPass {
+    fn is_dom_string_path(&self, def_path: hir::definitions::DefPath) -> bool {
+        def_path
+            .data
+            .iter()
+            .any(|def| def.data.get_opt_name() == Some(self.symbols.DOMString))
+    }
+
+    fn is_domstring_type(&self, cx: &LateContext<'tcx>, ty: ty::Ty) -> bool {
+        match ty.kind() {
+            ty::Adt(did, _) => {
+                let def_path = cx.tcx.def_path(did.did());
+                self.is_dom_string_path(def_path)
+            },
+            _ => false,
+        }
+    }
+
+    fn maybe_report_for_string_value(
+        cx: &LateContext<'tcx>,
+        span: Span,
+        expr_kind: &hir::ExprKind<'_>,
+    ) {
+        if is_expr_kind_empty_str(expr_kind) {
+            cx.emit_span_lint(
+                MANUAL_DOMSTRING_NEW,
+                span,
+                EmptyDOMStringDiagnostic { span },
+            );
+        } else if let Some(value) = value_if_expr_is_str(expr_kind) {
+            cx.emit_span_lint(
+                MANUAL_DOMSTRING_NEW,
+                span,
+                StaticDOMStringDiagnostic { value, span },
+            );
+        }
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for ManualDOMStringPass {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr) {
+        let sym = &self.symbols;
+        match expr.kind {
+            // Any static function call like `DOMString::from`
+            hir::ExprKind::Call(callee, args) => {
+                let ty = cx.typeck_results().expr_ty(callee);
+                let ty::FnDef(fn_, def_id) = ty.kind() else {
+                    return;
+                };
+                let Some(inner) = def_id.first().and_then(|arg| arg.as_type()) else {
+                    return;
+                };
+                // The type we struct we call a function on is the DOMString
+                // and the function we call is `From::from`
+                if !self.is_domstring_type(cx, inner) {
+                    return;
+                }
+                if !match_def_path(cx, *fn_, &[sym.core, sym.convert, sym.From, sym.from]) {
+                    return;
+                }
+                if args.len() != 1 {
+                    return;
+                }
+                Self::maybe_report_for_string_value(cx, expr.span, &args[0].kind);
+            },
+            hir::ExprKind::MethodCall(path, callee, _, _) => {
+                let ty = cx.typeck_results().expr_ty(expr);
+                // The type the object we call a function on is the DOMString
+                if !self.is_domstring_type(cx, ty) {
+                    return;
+                }
+                // The function we call is `Into::into`
+                if path.ident.name != sym.into {
+                    return;
+                }
+                Self::maybe_report_for_string_value(cx, expr.span, &callee.kind);
+            },
+            _ => {},
+        }
+    }
+}
+
+symbols! {
+    DOMString
+    core
+    convert
+    From
+    from
+    into
+}

--- a/support/crown/tests/compile-fail/manual_domstring_empty.rs
+++ b/support/crown/tests/compile-fail/manual_domstring_empty.rs
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+//@rustc-env:RUSTC_BOOTSTRAP=1
+
+#![expect(dead_code)]
+#![deny(crown::manual_domstring_new)]
+
+struct DOMString {
+}
+
+impl DOMString {
+    fn new() -> Self {
+        Self {}
+    }
+}
+
+impl From<&str> for DOMString {
+    fn from(string: &str) -> Self {
+        Self {}
+    }
+}
+
+fn func(str_: DOMString) {}
+
+fn main() {
+    DOMString::from("");
+    //~^ ERROR: 27:5: 27:24: use DOMString::new() instead [crown::manual_domstring_new]
+    let dom_string: DOMString = "".into();
+    //~^ ERROR: 29:33: 29:42: use DOMString::new() instead [crown::manual_domstring_new]
+    func("".into());
+    //~^ ERROR: 31:10: 31:19: use DOMString::new() instead [crown::manual_domstring_new]
+    let t = "";
+    DOMString::from(t);
+}

--- a/support/crown/tests/compile-fail/manual_domstring_static.rs
+++ b/support/crown/tests/compile-fail/manual_domstring_static.rs
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+//@rustc-env:RUSTC_BOOTSTRAP=1
+
+#![expect(dead_code)]
+#![deny(crown::manual_domstring_new)]
+
+struct DOMString {
+}
+
+impl DOMString {
+    fn new() -> Self {
+        Self {}
+    }
+}
+
+impl From<&str> for DOMString {
+    fn from(string: &str) -> Self {
+        Self {}
+    }
+}
+
+fn func(str_: DOMString) {}
+
+fn main() {
+    DOMString::from("Static string");
+    //~^ ERROR: 27:5: 27:37: use DOMString::from_static("Static string") instead [crown::manual_domstring_new]
+    let dom_string: DOMString = "Static string".into();
+    //~^ ERROR: 29:33: 29:55: use DOMString::from_static("Static string") instead [crown::manual_domstring_new]
+    func("Static string".into());
+    //~^ ERROR: 31:10: 31:32: use DOMString::from_static("Static string") instead [crown::manual_domstring_new]
+}

--- a/support/crown/tests/run-pass/manual_domstring_empty.rs
+++ b/support/crown/tests/run-pass/manual_domstring_empty.rs
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+//@rustc-env:RUSTC_BOOTSTRAP=1
+
+#![expect(dead_code)]
+
+struct DOMString {
+}
+
+impl DOMString {
+    fn new() -> Self {
+        Self {}
+    }
+}
+
+impl From<&str> for DOMString {
+    fn from(string: &str) -> Self {
+        Self {}
+    }
+}
+
+fn func(str_: DOMString) {}
+
+fn func_with_str(str_: &str) {
+    DOMString::from(str_);
+    let dom_string: DOMString = str_.into();
+    String::from("");
+    func(str_.into());
+}
+
+fn main() {
+    func_with_str("");
+}

--- a/support/crown/tests/run-pass/manual_domstring_static.rs
+++ b/support/crown/tests/run-pass/manual_domstring_static.rs
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+//@rustc-env:RUSTC_BOOTSTRAP=1
+
+#![expect(dead_code)]
+
+struct DOMString {
+}
+
+impl DOMString {
+    fn from_static(str_: &str) {}
+}
+
+fn main() {
+    DOMString::from_static("Static string");
+}


### PR DESCRIPTION
This implements a linter pass that can check for patterns such as `DOMString::from("")` and instead suggests the appropriate alternatives. This is especially valuable for cases where `DOMString::from_static` can be used, since that's more performant

Part of #47512

Testing: script crate compiles and crown tests added