### PR TITLE
script: Fix manual DOMString violations

### DIFF
--- a/components/script/dom/animations/animationeffect.rs
+++ b/components/script/dom/animations/animationeffect.rs
@@ -14,6 +14,7 @@ use script_bindings::error::{Error, Fallible};
 use script_bindings::num::Finite;
 use script_bindings::reflector::Reflector;
 use script_bindings::root::Dom;
+use script_bindings::str::DOMString;
 use style::parser::Parse;
 use style::stylesheets::CssRuleType;
 use style::values::generics::easing::TimingKeyword;
@@ -309,7 +310,9 @@ impl IterationDurationOrAuto {
 impl From<IterationDurationOrAuto> for UnrestrictedDoubleOrString {
     fn from(value: IterationDurationOrAuto) -> Self {
         match value {
-            IterationDurationOrAuto::Auto => UnrestrictedDoubleOrString::String("auto".into()),
+            IterationDurationOrAuto::Auto => {
+                UnrestrictedDoubleOrString::String(DOMString::from_static("auto"))
+            },
             IterationDurationOrAuto::Duration(double) => {
                 UnrestrictedDoubleOrString::UnrestrictedDouble(double)
             },

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -165,7 +165,7 @@ impl Console {
 fn handle_value_to_string(cx: &mut JSContext, value: HandleValue) -> DOMString {
     match std::ptr::NonNull::new(unsafe { JS_ValueToSource(cx, value) }) {
         Some(js_str) => unsafe { jsstr_to_string(cx, js_str) }.into(),
-        None => "<error converting value to string>".into(),
+        None => DOMString::from_static("<error converting value to string>"),
     }
 }
 
@@ -612,7 +612,9 @@ fn maybe_stringify_dom_object(cx: &mut JSContext, value: HandleValue) -> Option<
     }
     rooted!(&in(cx) let class_name = unsafe { ToString(cx, value) });
     let Some(class_name) = NonNull::new(class_name.get()) else {
-        return Some("<error converting DOM object to string>".into());
+        return Some(DOMString::from_static(
+            "<error converting DOM object to string>",
+        ));
     };
     let class_name = unsafe { jsstr_to_string(cx, class_name) }
         .replace("[object ", "")
@@ -644,7 +646,9 @@ fn maybe_stringify_dom_object(cx: &mut JSContext, value: HandleValue) -> Option<
         )
     };
     if !stringify_result {
-        return Some("<error converting DOM object to string>".into());
+        return Some(DOMString::from_static(
+            "<error converting DOM object to string>",
+        ));
     }
     Some(repr.into())
 }

--- a/components/script/dom/credentialmanagement/passwordcredential.rs
+++ b/components/script/dom/credentialmanagement/passwordcredential.rs
@@ -8,7 +8,7 @@ use js::gc::HandleObject;
 use script_bindings::codegen::GenericBindings::PasswordCredentialBinding::PasswordCredentialData;
 use script_bindings::error::{Error, Fallible};
 use script_bindings::reflector::reflect_dom_object_with_proto;
-use script_bindings::str::USVString;
+use script_bindings::str::{DOMString, USVString};
 
 use crate::dom::bindings::codegen::Bindings::PasswordCredentialBinding::PasswordCredentialMethods;
 use crate::dom::bindings::codegen::DomTypeHolder::DomTypeHolder;
@@ -28,7 +28,7 @@ pub(crate) struct PasswordCredential {
 impl PasswordCredential {
     fn new_inherited(id: USVString, origin: USVString, password: USVString) -> PasswordCredential {
         PasswordCredential {
-            credential: Credential::new_inherited(id, "password".into()),
+            credential: Credential::new_inherited(id, DOMString::from_static("password")),
             origin,
             password,
         }

--- a/components/script/dom/css/cssstylesheet.rs
+++ b/components/script/dom/css/cssstylesheet.rs
@@ -390,7 +390,7 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
             window,
             proto,
             None, // owner
-            "text/css".into(),
+            DOMString::from_static("text/css"),
             None, // href
             None, // title
             stylesheet,

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -5926,7 +5926,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             "storageevent" => Ok(DomRoot::upcast(StorageEvent::new_uninitialized(
                 cx,
                 &self.window,
-                "".into(),
+                DOMString::new(),
             ))),
             "textevent" => Ok(DomRoot::upcast(TextEvent::new_uninitialized(
                 cx,

--- a/components/script/dom/document/document_embedder_controls.rs
+++ b/components/script/dom/document/document_embedder_controls.rs
@@ -21,6 +21,7 @@ use script_bindings::codegen::GenericBindings::HistoryBinding::HistoryMethods;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::inheritance::Castable;
 use script_bindings::root::{Dom, DomRoot};
+use script_bindings::str::DOMString;
 use servo_base::Epoch;
 use servo_base::generic_channel::GenericSend;
 use servo_constellation_traits::{LoadData, NavigationHistoryBehavior};
@@ -438,8 +439,11 @@ impl ContextMenuNodes {
             let Some(browsing_context) = document.browsing_context() else {
                 return;
             };
-            let (browsing_context, new) =
-                browsing_context.choose_a_navigable(cx, "_blank".into(), true /* noopener */);
+            let (browsing_context, new) = browsing_context.choose_a_navigable(
+                cx,
+                DOMString::from_static("_blank"),
+                true, /* noopener */
+            );
             let Some(browsing_context) = browsing_context else {
                 return;
             };

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -2573,7 +2573,7 @@ impl Element {
         // Step 2.1: Let nonce be element's [[CryptographicNonce]].
         let nonce = self.nonce_value();
         // Step 2.2: Set an attribute value for element using "nonce" and the empty string.
-        self.set_string_attribute(cx, &local_name!("nonce"), "".into());
+        self.set_string_attribute(cx, &local_name!("nonce"), DOMString::new());
         // Step 2.3: Set element's [[CryptographicNonce]] to nonce.
         self.update_nonce_internal_slot(nonce, cx.no_gc());
     }

--- a/components/script/dom/execcommand/basecommand.rs
+++ b/components/script/dom/execcommand/basecommand.rs
@@ -308,7 +308,7 @@ impl CssPropertyName {
     ) {
         let style = element.Style(cx);
 
-        let _ = style.SetProperty(cx, self.property_name(), new_value, "".into());
+        let _ = style.SetProperty(cx, self.property_name(), new_value, DOMString::new());
     }
 
     pub(crate) fn remove_from_element(&self, cx: &mut JSContext, element: &HTMLElement) {

--- a/components/script/dom/execcommand/commands/bold.rs
+++ b/components/script/dom/execcommand/commands/bold.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use js::context::JSContext;
+use script_bindings::str::DOMString;
 
 use crate::dom::document::Document;
 use crate::dom::execcommand::basecommand::CommandName;
@@ -17,10 +18,10 @@ pub(crate) fn execute_bold_command(
 ) -> bool {
     // > If queryCommandState("bold") returns true, set the selection's value to "normal".
     // > Otherwise set the selection's value to "bold". Either way, return true.
-    let value = if document.command_state_for_command(cx, "bold".into()) {
-        Some("normal".into())
+    let value = if document.command_state_for_command(cx, DOMString::from_static("bold")) {
+        Some(DOMString::from_static("normal"))
     } else {
-        Some("bold".into())
+        Some(DOMString::from_static("bold"))
     };
     selection.set_the_selection_value(cx, value, CommandName::Bold, document);
 

--- a/components/script/dom/execcommand/commands/italic.rs
+++ b/components/script/dom/execcommand/commands/italic.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use js::context::JSContext;
+use script_bindings::str::DOMString;
 
 use crate::dom::document::Document;
 use crate::dom::execcommand::basecommand::CommandName;
@@ -17,10 +18,10 @@ pub(crate) fn execute_italic_command(
 ) -> bool {
     // > If queryCommandState("italic") returns true, set the selection's value to "normal".
     // > Otherwise set the selection's value to "italic". Either way, return true.
-    let value = if document.command_state_for_command(cx, "italic".into()) {
-        Some("normal".into())
+    let value = if document.command_state_for_command(cx, DOMString::from_static("italic")) {
+        Some(DOMString::from_static("normal"))
     } else {
-        Some("italic".into())
+        Some(DOMString::from_static("italic"))
     };
     selection.set_the_selection_value(cx, value, CommandName::Italic, document);
 

--- a/components/script/dom/execcommand/commands/strikethrough.rs
+++ b/components/script/dom/execcommand/commands/strikethrough.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use js::context::JSContext;
+use script_bindings::str::DOMString;
 
 use crate::dom::document::Document;
 use crate::dom::execcommand::basecommand::CommandName;
@@ -17,8 +18,8 @@ pub(crate) fn execute_strikethrough_command(
 ) -> bool {
     // > If queryCommandState("strikethrough") returns true, set the selection's value to null.
     // > Otherwise set the selection's value to "line-through". Either way, return true.
-    let value = (!document.command_state_for_command(cx, "strikethrough".into()))
-        .then_some("line-through".into());
+    let value = (!document.command_state_for_command(cx, DOMString::from_static("strikethrough")))
+        .then_some(DOMString::from_static("line-through"));
     selection.set_the_selection_value(cx, value, CommandName::Strikethrough, document);
 
     true

--- a/components/script/dom/execcommand/commands/subscript.rs
+++ b/components/script/dom/execcommand/commands/subscript.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use js::context::JSContext;
+use script_bindings::str::DOMString;
 
 use crate::dom::document::Document;
 use crate::dom::execcommand::basecommand::CommandName;
@@ -22,7 +23,7 @@ pub(crate) fn execute_subscript_command(
     if state.is_none_or(|state| !state) {
         selection.set_the_selection_value(
             cx,
-            Some("subscript".into()),
+            Some(DOMString::from_static("subscript")),
             CommandName::Subscript,
             document,
         );

--- a/components/script/dom/execcommand/commands/superscript.rs
+++ b/components/script/dom/execcommand/commands/superscript.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use js::context::JSContext;
+use script_bindings::str::DOMString;
 
 use crate::dom::document::Document;
 use crate::dom::execcommand::basecommand::CommandName;
@@ -22,7 +23,7 @@ pub(crate) fn execute_superscript_command(
     if state.is_none_or(|state| !state) {
         selection.set_the_selection_value(
             cx,
-            Some("superscript".into()),
+            Some(DOMString::from_static("superscript")),
             CommandName::Superscript,
             document,
         );

--- a/components/script/dom/execcommand/commands/underline.rs
+++ b/components/script/dom/execcommand/commands/underline.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use js::context::JSContext;
+use script_bindings::str::DOMString;
 
 use crate::dom::document::Document;
 use crate::dom::execcommand::basecommand::CommandName;
@@ -17,8 +18,8 @@ pub(crate) fn execute_underline_command(
 ) -> bool {
     // > If queryCommandState("underline") returns true, set the selection's value to null.
     // > Otherwise set the selection's value to "underline". Either way, return true.
-    let value =
-        (!document.command_state_for_command(cx, "underline".into())).then_some("underline".into());
+    let value = (!document.command_state_for_command(cx, DOMString::from_static("underline")))
+        .then_some(DOMString::from_static("underline"));
     selection.set_the_selection_value(cx, value, CommandName::Underline, document);
 
     true

--- a/components/script/dom/execcommand/contenteditable/element.rs
+++ b/components/script/dom/execcommand/contenteditable/element.rs
@@ -56,11 +56,11 @@ impl Element {
             CommandName::Subscript | CommandName::Superscript => {
                 // Step 3.1. If element is a sup, return "superscript".
                 if matches!(*self.local_name(), local_name!("sup")) {
-                    return Some("superscript".into());
+                    return Some(DOMString::from_static("superscript"));
                 }
                 // Step 3.2. If element is a sub, return "subscript".
                 if matches!(*self.local_name(), local_name!("sub")) {
-                    return Some("subscript".into());
+                    return Some(DOMString::from_static("subscript"));
                 }
                 // Step 3.3. Return null.
                 return None;
@@ -72,11 +72,11 @@ impl Element {
                     // Step 4.2. Return null.
                     return value
                         .contains("line-through")
-                        .then_some("line-through".into());
+                        .then_some(DOMString::from_static("line-through"));
                 }
                 // Step 5. If command is "strikethrough" and element is an s or strike element, return "line-through".
                 if matches!(*self.local_name(), local_name!("s") | local_name!("strike")) {
-                    return Some("line-through".into());
+                    return Some(DOMString::from_static("line-through"));
                 }
             },
             CommandName::Underline => {
@@ -84,11 +84,13 @@ impl Element {
                 if let Some(value) = CssPropertyName::TextDecorationLine.value_set_for_style(self) {
                     // Step 6.1. If element's style attribute sets "text-decoration" to a value containing "underline", return "underline".
                     // Step 6.2. Return null.
-                    return value.contains("underline").then_some("underline".into());
+                    return value
+                        .contains("underline")
+                        .then_some(DOMString::from_static("underline"));
                 }
                 // Step 7. If command is "underline" and element is a u element, return "underline".
                 if *self.local_name() == local_name!("u") {
-                    return Some("underline".into());
+                    return Some(DOMString::from_static("underline"));
                 }
             },
             _ => {},
@@ -124,12 +126,12 @@ impl Element {
             CssPropertyName::FontWeight
                 if element_name == &local_name!("b") || element_name == &local_name!("strong") =>
             {
-                Some("bold".into())
+                Some(DOMString::from_static("bold"))
             },
             CssPropertyName::FontStyle
                 if element_name == &local_name!("i") || element_name == &local_name!("em") =>
             {
-                Some("italic".into())
+                Some(DOMString::from_static("italic"))
             },
             // Step 13. Return null.
             _ => None,

--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -2282,7 +2282,7 @@ impl Node {
                     }
                     current_element = element.upcast::<Node>().GetParentElement();
                 }
-                Some("rgba(0, 0, 0, 0)".into())
+                Some(DOMString::from_static("rgba(0, 0, 0, 0)"))
             },
             // Step 5. If command is "subscript" or "superscript":
             CommandName::Subscript | CommandName::Superscript => {
@@ -2311,11 +2311,11 @@ impl Node {
                 Some(match (affected_by_subscript, affected_by_superscript) {
                     // Step 5.3. If affected by subscript and affected by superscript are both true,
                     // return the string "mixed".
-                    (true, true) => "mixed".into(),
+                    (true, true) => DOMString::from_static("mixed"),
                     // Step 5.4. If affected by subscript is true, return "subscript".
-                    (true, false) => "subscript".into(),
+                    (true, false) => DOMString::from_static("subscript"),
                     // Step 5.5. If affected by superscript is true, return "superscript".
-                    (false, true) => "superscript".into(),
+                    (false, true) => DOMString::from_static("superscript"),
                     // Step 5.6. Return null.
                     (false, false) => return None,
                 })
@@ -2332,7 +2332,7 @@ impl Node {
                         })
                         .is_some_and(|property| property.contains("line-through"))
                 })
-                .then_some("line-through".into()),
+                .then_some(DOMString::from_static("line-through")),
             // Step 7. If command is "underline",
             // and the "text-decoration" property of node or any of its ancestors has resolved value containing "underline",
             // return "underline". Otherwise, return null.
@@ -2345,7 +2345,7 @@ impl Node {
                         })
                         .is_some_and(|property| property.contains("underline"))
                 })
-                .then_some("underline".into()),
+                .then_some(DOMString::from_static("underline")),
             // Step 8. Return the resolved value for node of the relevant CSS property for command.
             _ => command.resolved_value_for_node(element),
         }

--- a/components/script/dom/execcommand/contenteditable/range.rs
+++ b/components/script/dom/execcommand/contenteditable/range.rs
@@ -4,6 +4,7 @@
 
 use js::context::{JSContext, NoGC};
 use script_bindings::inheritance::Castable;
+use script_bindings::str::DOMString;
 
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
@@ -300,9 +301,12 @@ impl Range {
                             .current_state(cx, context_object)
                             .is_some_and(|value| value != bool_) =>
                     {
-                        override_state
-                            .command
-                            .execute(cx, context_object, selection, "".into());
+                        override_state.command.execute(
+                            cx,
+                            context_object,
+                            selection,
+                            DOMString::new(),
+                        );
                     },
                     BoolOrOptionalString::OptionalString(optional_string) => {
                         match override_state.command {
@@ -344,7 +348,7 @@ impl Range {
                                         .map(|value| {
                                             legacy_font_size_for(value as f32, context_object)
                                         })
-                                        .unwrap_or("7".into());
+                                        .unwrap_or(DOMString::from_static("7"));
                                     // Step 2.6. Take the action for "fontSize", with value equal to override.
                                     CommandName::FontSize.execute(
                                         cx,

--- a/components/script/dom/execcommand/execcommands.rs
+++ b/components/script/dom/execcommand/execcommands.rs
@@ -302,7 +302,7 @@ impl DocumentExecCommandSupport for Document {
                 0,
                 None,
                 false,
-                "".into(),
+                DOMString::new(),
             );
             let event = event.upcast::<Event>();
             // Step 4.3. If the value returned by the previous step is false, return false.

--- a/components/script/dom/fetch/response.rs
+++ b/components/script/dom/fetch/response.rs
@@ -15,6 +15,7 @@ use net_traits::http_status::HttpStatus;
 use script_bindings::cell::DomRefCell;
 use script_bindings::cformat;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::str::DOMString;
 use servo_url::ServoUrl;
 use url::Position;
 
@@ -265,7 +266,7 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
         response.Headers(cx).set_guard(Guard::Response);
 
         // 4. Perform initialize a response given responseObject, init, and (body, "application/json").
-        body.content_type = Some("application/json".into());
+        body.content_type = Some(DOMString::from_static("application/json"));
         initialize_response(cx, Some(body), init, response)
     }
 

--- a/components/script/dom/form/radionodelist.rs
+++ b/components/script/dom/form/radionodelist.rs
@@ -105,7 +105,7 @@ impl RadioNodeListMethods<crate::DomTypeHolder> for RadioNodeList {
                 })
             })
             // Step 2
-            .unwrap_or(DOMString::from(""))
+            .unwrap_or(DOMString::new())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-radionodelist-value>

--- a/components/script/dom/html/document_metadata/htmllinkelement.rs
+++ b/components/script/dom/html/document_metadata/htmllinkelement.rs
@@ -211,7 +211,7 @@ impl HTMLLinkElement {
                     cx,
                     &self.owner_window(),
                     Some(self.upcast::<Element>()),
-                    "text/css".into(),
+                    DOMString::from_static("text/css"),
                     Some(self.Href().into()),
                     None, // todo handle title
                     sheet,
@@ -1112,11 +1112,14 @@ impl StylesheetOwner for HTMLLinkElement {
         self.parser_inserted() ||
             self.blocking
                 .get()
-                .is_some_and(|list| list.Contains("render".into()))
+                .is_some_and(|list| list.Contains(DOMString::from_static("render")))
     }
 
     fn referrer_policy(&self, cx: &mut js::context::JSContext) -> ReferrerPolicy {
-        if self.RelList(cx).Contains("noreferrer".into()) {
+        if self
+            .RelList(cx)
+            .Contains(DOMString::from_static("noreferrer"))
+        {
             return ReferrerPolicy::NoReferrer;
         }
 

--- a/components/script/dom/html/document_metadata/htmlstyleelement.rs
+++ b/components/script/dom/html/document_metadata/htmlstyleelement.rs
@@ -254,7 +254,7 @@ impl HTMLStyleElement {
                     cx,
                     &self.owner_window(),
                     Some(self.upcast::<Element>()),
-                    "text/css".into(),
+                    DOMString::from_static("text/css"),
                     None, // todo handle location
                     None, // todo handle title
                     sheet,
@@ -439,7 +439,7 @@ impl StylesheetOwner for HTMLStyleElement {
         self.parser_inserted() ||
             self.blocking
                 .get()
-                .is_some_and(|list| list.Contains("render".into()))
+                .is_some_and(|list| list.Contains(DOMString::from_static("render")))
     }
 
     fn referrer_policy(&self, _cx: &mut JSContext) -> ReferrerPolicy {

--- a/components/script/dom/html/embedded_content/htmlmediaelement.rs
+++ b/components/script/dom/html/embedded_content/htmlmediaelement.rs
@@ -3733,7 +3733,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
         let track = TextTrack::new(
             cx,
             &window,
-            "".into(),
+            DOMString::new(),
             kind,
             label,
             language,

--- a/components/script/dom/html/form_controls/htmlfieldsetelement.rs
+++ b/components/script/dom/html/form_controls/htmlfieldsetelement.rs
@@ -144,7 +144,7 @@ impl HTMLFieldSetElementMethods<crate::DomTypeHolder> for HTMLFieldSetElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-fieldset-type>
     fn Type(&self) -> DOMString {
-        "fieldset".into()
+        DOMString::from_static("fieldset")
     }
 }
 

--- a/components/script/dom/html/form_controls/htmlinputelement.rs
+++ b/components/script/dom/html/form_controls/htmlinputelement.rs
@@ -1153,7 +1153,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
                 .upcast::<Element>()
                 .get_attribute_string_value(&local_name!("value"))
                 .map(|value| value.into())
-                .unwrap_or(DOMString::from("on")),
+                .unwrap_or(DOMString::from_static("on")),
             ValueMode::Filename => {
                 let mut path = DOMString::new();
                 match self.input_type().as_specific().get_files() {
@@ -1654,7 +1654,7 @@ impl HTMLInputElement {
                             // but this is _type_ of element rather than content right?
                             ty,
                             name,
-                            value: FormDatumValue::String(DOMString::from("")),
+                            value: FormDatumValue::String(DOMString::new()),
                         })
                     },
                     // Step 5.8.2: Otherwise, for each file in selected files, create an entry with name and a File object representing the file, and append it to entry list.

--- a/components/script/dom/html/form_controls/htmlprogresselement.rs
+++ b/components/script/dom/html/form_controls/htmlprogresselement.rs
@@ -84,7 +84,7 @@ impl HTMLProgressElement {
         );
 
         // FIXME: This should use ::-moz-progress-bar
-        progress_bar.SetId(cx, "-servo-progress-bar".into());
+        progress_bar.SetId(cx, DOMString::from_static("-servo-progress-bar"));
         root.upcast::<Node>()
             .AppendChild(cx, progress_bar.upcast::<Node>())
             .unwrap();

--- a/components/script/dom/html/form_controls/input_type/mod.rs
+++ b/components/script/dom/html/form_controls/input_type/mod.rs
@@ -406,7 +406,7 @@ pub(crate) trait SpecificInputType {
     }
 
     fn value_for_shadow_dom(&self, _input: &HTMLInputElement) -> DOMString {
-        "".into()
+        DOMString::new()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#signal-a-type-change>

--- a/components/script/dom/html/form_controls/input_type/text_input_widget.rs
+++ b/components/script/dom/html/form_controls/input_type/text_input_widget.rs
@@ -12,6 +12,7 @@ use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
 use script_bindings::codegen::GenericBindings::NodeBinding::NodeMethods;
 use script_bindings::inheritance::Castable;
 use script_bindings::root::{Dom, DomRoot};
+use script_bindings::str::DOMString;
 use servo_base::text::{RangeAny, Utf32CodeUnits};
 use style::selector_parser::PseudoElement;
 
@@ -222,7 +223,7 @@ impl TextInputWidgetShadowTree {
                 .collect::<String>()
                 .into(),
             (false, _) => value,
-            (true, _) => "\u{200B}".into(),
+            (true, _) => DOMString::from_static("\u{200B}"),
         };
 
         if let Some(character_data) = self.value_character_data() &&
@@ -258,7 +259,7 @@ fn create_ua_widget_div_with_text_node(
         .unwrap();
     el.upcast::<Node>()
         .set_implemented_pseudo_element(implemented_pseudo);
-    let text_node = document.CreateTextNode(cx, "".into());
+    let text_node = document.CreateTextNode(cx, DOMString::new());
 
     if !as_first_child {
         el.upcast::<Node>()

--- a/components/script/dom/html/links/relations.rs
+++ b/components/script/dom/html/links/relations.rs
@@ -378,7 +378,7 @@ pub(crate) fn get_element_target(
         target.contains_tab_or_newline() &&
         target.contains("\u{003C}")
     {
-        return Some("_blank".into());
+        return Some(DOMString::from_static("_blank"));
     }
     // Step 3. Return target.
     target
@@ -411,7 +411,7 @@ pub(crate) fn follow_hyperlink(
                 .event_handler()
                 .alternate_action_keyboard_modifier_active()
             {
-                Some("_blank".into())
+                Some(DOMString::from_static("_blank"))
             } else {
                 get_element_target(subject, None)
             }

--- a/components/script/dom/html/scripting/htmlscriptelement.rs
+++ b/components/script/dom/html/scripting/htmlscriptelement.rs
@@ -572,7 +572,7 @@ impl HTMLScriptElement {
     fn has_render_blocking_attribute(&self) -> bool {
         self.blocking
             .get()
-            .is_some_and(|list| list.Contains("render".into()))
+            .is_some_and(|list| list.Contains(DOMString::from_static("render")))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#potentially-render-blocking>

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -173,7 +173,7 @@ macro_rules! make_enumerated_getter(
                     // Step 1.1. If the attribute has a missing value default state defined, then return that
                     // missing value default state.
                     // Step 1.2 Otherwise, return no state.
-                    return DOMString::from($missing);
+                    return DOMString::from_static($missing);
                 },
                 Some(value) => {
                     // Step 2. If the attribute's value is an ASCII case-insensitive match for one of the keywords
@@ -189,13 +189,13 @@ macro_rules! make_enumerated_getter(
                     // Step 3. If the attribute has an empty value default state defined and the attribute's value
                     // is the empty string, then return that empty value default state.
                     if value.is_empty() {
-                        return DOMString::from($empty)
+                        return DOMString::from_static($empty)
                     }
 
                     // Step 4. If the attribute has an invalid value default state defined, then return that invalid
                     // value default state.
                     // Step 5. Return no state.
-                    return DOMString::from($invalid);
+                    return DOMString::from_static($invalid);
                 }
             }
         }

--- a/components/script/dom/media/mediaquerylist.rs
+++ b/components/script/dom/media/mediaquerylist.rs
@@ -105,7 +105,7 @@ impl MediaQueryListMethods<crate::DomTypeHolder> for MediaQueryList {
     /// <https://drafts.csswg.org/cssom-view/#dom-mediaquerylist-addlistener>
     fn AddListener(&self, listener: Option<Rc<EventListener>>) {
         self.upcast::<EventTarget>().add_event_listener(
-            "change".into(),
+            DOMString::from_static("change"),
             listener,
             AddEventListenerOptions {
                 parent: EventListenerOptions { capture: false },
@@ -119,7 +119,7 @@ impl MediaQueryListMethods<crate::DomTypeHolder> for MediaQueryList {
     /// <https://drafts.csswg.org/cssom-view/#dom-mediaquerylist-removelistener>
     fn RemoveListener(&self, listener: Option<Rc<EventListener>>) {
         self.upcast::<EventTarget>().remove_event_listener(
-            "change".into(),
+            DOMString::from_static("change"),
             &listener,
             &EventListenerOptions { capture: false },
         );

--- a/components/script/dom/media/mediastreamtrack.rs
+++ b/components/script/dom/media/mediastreamtrack.rs
@@ -60,8 +60,8 @@ impl MediaStreamTrackMethods<crate::DomTypeHolder> for MediaStreamTrack {
     /// <https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-kind>
     fn Kind(&self) -> DOMString {
         match self.ty {
-            MediaStreamType::Video => "video".into(),
-            MediaStreamType::Audio => "audio".into(),
+            MediaStreamType::Video => DOMString::from_static("video"),
+            MediaStreamType::Audio => DOMString::from_static("audio"),
         }
     }
 

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -633,7 +633,7 @@ impl Node {
             0,                                  // twist
             PI / 2.0,                           // altitude_angle
             0.0,                                // azimuth_angle
-            DOMString::from(""),                // pointer_type
+            DOMString::new(),                   // pointer_type
             false,                              // is_primary
             vec![],                             // coalesced_events
             vec![],                             // predicted_events

--- a/components/script/dom/performance/performancepainttiming.rs
+++ b/components/script/dom/performance/performancepainttiming.rs
@@ -30,7 +30,7 @@ impl PerformancePaintTiming {
             ProgressiveWebMetricType::FirstContentfulPaint => {
                 DOMString::from_static("first-contentful-paint")
             },
-            _ => DOMString::from(""),
+            _ => DOMString::new(),
         };
         PerformancePaintTiming {
             entry: PerformanceEntry::new_inherited(

--- a/components/script/dom/quotaexceedederror.rs
+++ b/components/script/dom/quotaexceedederror.rs
@@ -39,7 +39,10 @@ impl QuotaExceededError {
         requested: Option<Finite<f64>>,
     ) -> Self {
         Self {
-            dom_exception: DOMException::new_inherited(message, "QuotaExceededError".into()),
+            dom_exception: DOMException::new_inherited(
+                message,
+                DOMString::from_static("QuotaExceededError"),
+            ),
             quota,
             requested,
         }

--- a/components/script/dom/security/cspviolationreporttask.rs
+++ b/components/script/dom/security/cspviolationreporttask.rs
@@ -10,6 +10,7 @@ use net_traits::request::{
     CredentialsMode, Destination, RequestBody, RequestId, create_request_body_with_content,
 };
 use net_traits::{FetchMetadata, NetworkError, ResourceFetchTiming};
+use script_bindings::str::DOMString;
 use servo_url::ServoUrl;
 use stylo_atoms::Atom;
 
@@ -166,7 +167,7 @@ impl TaskOnce for CSPViolationReportTask {
             // Step 3.5.3. Generate and queue a report with the following arguments:
             ReportingObserver::generate_and_queue_a_report(
                 &self.global.root(),
-                "csp-violation".into(),
+                DOMString::from_static("csp-violation"),
                 Some(body),
                 report_to_directive.value.join(" ").into(),
             )

--- a/components/script/dom/security/sanitizer.rs
+++ b/components/script/dom/security/sanitizer.rs
@@ -436,7 +436,7 @@ fn sanitize_core(
 
                 // Step 1.6.7. Let elementWithLocalAttributes be « [] ».
                 let mut element_with_local_attributes =
-                    SanitizerElementWithAttributes::String("".into());
+                    SanitizerElementWithAttributes::String(DOMString::new());
 
                 // Step 1.6.8. If configuration["elements"] exists and configuration["elements"]
                 // contains elementName:

--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -705,7 +705,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     fn PassOverloaded_(&self, _: DOMString) {}
 
     fn PassOverloadedDict(&self, _: &Node) -> DOMString {
-        "node".into()
+        DOMString::from_static("node")
     }
 
     fn PassOverloadedDict_(&self, u: &TestURLLike) -> DOMString {
@@ -713,40 +713,40 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     }
 
     fn PassOverloadedUnionOfObjectAndString(&self, _: ObjectOrString) -> DOMString {
-        "union".into()
+        DOMString::from_static("union")
     }
     fn PassOverloadedUnionOfObjectAndString_(&self, _: bool) -> DOMString {
-        "boolean".into()
+        DOMString::from_static("boolean")
     }
     fn PassOverloadedUnionOfObjectAndNumber(&self, _: ObjectOrLong) -> DOMString {
-        "union".into()
+        DOMString::from_static("union")
     }
     fn PassOverloadedUnionOfObjectAndNumber_(&self, _: bool) -> DOMString {
-        "boolean".into()
+        DOMString::from_static("boolean")
     }
     fn PassOverloadedUnionOfObjectAndBoolean(&self, _: ObjectOrBoolean) -> DOMString {
-        "union".into()
+        DOMString::from_static("union")
     }
     fn PassOverloadedUnionOfObjectAndBoolean_(&self, _: i32) -> DOMString {
-        "number".into()
+        DOMString::from_static("number")
     }
     fn PassOverloadedUnionOfStringAndNumber(&self, _: StringOrLong) -> DOMString {
-        "union".into()
+        DOMString::from_static("union")
     }
     fn PassOverloadedUnionOfStringAndNumber_(&self, _: bool) -> DOMString {
-        "boolean".into()
+        DOMString::from_static("boolean")
     }
     fn PassOverloadedUnionOfStringAndBoolean(&self, _: StringOrBoolean) -> DOMString {
-        "union".into()
+        DOMString::from_static("union")
     }
     fn PassOverloadedUnionOfStringAndBoolean_(&self, _: i32) -> DOMString {
-        "number".into()
+        DOMString::from_static("number")
     }
     fn PassOverloadedUnionOfNumberAndBoolean(&self, _: LongOrBoolean) -> DOMString {
-        "union".into()
+        DOMString::from_static("union")
     }
     fn PassOverloadedUnionOfNumberAndBoolean_(&self, _: DOMString) -> DOMString {
-        "string".into()
+        DOMString::from_static("string")
     }
 
     fn PassNullableBoolean(&self, _: Option<bool>) {}

--- a/components/script/dom/webgpu/gpupipelineerror.rs
+++ b/components/script/dom/webgpu/gpupipelineerror.rs
@@ -25,7 +25,10 @@ pub(crate) struct GPUPipelineError {
 impl GPUPipelineError {
     fn new_inherited(message: DOMString, reason: GPUPipelineErrorReason) -> Self {
         Self {
-            exception: DOMException::new_inherited(message, "GPUPipelineError".into()),
+            exception: DOMException::new_inherited(
+                message,
+                DOMString::from_static("GPUPipelineError"),
+            ),
             reason,
         }
     }

--- a/components/script/dom/webrtc/rtcerror.rs
+++ b/components/script/dom/webrtc/rtcerror.rs
@@ -29,7 +29,10 @@ pub(crate) struct RTCError {
 impl RTCError {
     fn new_inherited(init: &RTCErrorInit, message: DOMString) -> RTCError {
         RTCError {
-            exception: DOMException::new_inherited(message, "OperationError".into()),
+            exception: DOMException::new_inherited(
+                message,
+                DOMString::from_static("OperationError"),
+            ),
             error_detail: init.errorDetail,
             sdp_line_number: init.sdpLineNumber,
             http_request_status_code: init.httpRequestStatusCode,

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -2272,7 +2272,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     fn Name(&self) -> DOMString {
         match self.undiscarded_window_proxy() {
             Some(proxy) => proxy.get_name(),
-            None => "".into(),
+            None => DOMString::new(),
         }
     }
 

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -942,7 +942,7 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
             elif tag is IDLType.Tags.usvstring:
                 default = f'{union_native_type(type)}::USVString(USVString("{defaultValue.value}".to_owned()))'
             elif tag is IDLType.Tags.domstring:
-                default = f'{union_native_type(type)}::String(DOMString::from("{defaultValue.value}"))'
+                default = f'{union_native_type(type)}::String(DOMString::from_static("{defaultValue.value}"))'
             elif defaultValue.type.isEnum():
                 enum = defaultValue.type.inner.identifier.name
                 default = f"{union_native_type(type)}::{enum}({enum}::{getEnumValueName(defaultValue.value)})"
@@ -1126,7 +1126,7 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
             default = "None"
         else:
             assert defaultValue.type.tag() == IDLType.Tags.domstring
-            default = f'DOMString::from("{defaultValue.value}")'
+            default = f'DOMString::from_static("{defaultValue.value}")'
             if type.nullable():
                 default = f"Some({default})"
 

--- a/components/script_webgpu/gpuadapter.rs
+++ b/components/script_webgpu/gpuadapter.rs
@@ -157,11 +157,12 @@ where
         // subgroup size. Otherwise, set this value to 4.
         // Step 7. If "subgroups" is supported, set subgroupMaxSize to the largest supported
         // subgroup size. Otherwise, set this value to 128.
-        let (subgroup_min_size, subgroup_max_size) = if features.has(cx, "subgroups".into()) {
-            (info.subgroup_min_size, info.subgroup_max_size)
-        } else {
-            (4, 128)
-        };
+        let (subgroup_min_size, subgroup_max_size) =
+            if features.has(cx, DOMString::from_static("subgroups")) {
+                (info.subgroup_min_size, info.subgroup_max_size)
+            } else {
+                (4, 128)
+            };
 
         // Step 8. Set adapterInfo.isFallbackAdapter to adapter.[[fallback]].
         let is_fallback_adapter = info.device_type == wgpu_types::DeviceType::Cpu;


### PR DESCRIPTION
All of these are reported by the new Crown linter. This fixes all pre-existing issues, so that we can land the Crown linter.

Part of #47512

Testing: it compiles

