### PR TITLE
wpt: Make a few `touch-action` pointerevents tests work under 800x600

### DIFF
--- a/tests/wpt/tests/pointerevents/pointerevent_touch-action-inherit_child-auto-child-none_touch.html
+++ b/tests/wpt/tests/pointerevents/pointerevent_touch-action-inherit_child-auto-child-none_touch.html
@@ -13,6 +13,9 @@
         <script src="/resources/testdriver-vendor.js"></script>
         <script src="pointerevent_support.js"></script>
         <style>
+            .scroller {
+            height: 200px;
+            }
             .scroller > div {
             touch-action: auto;
             }

--- a/tests/wpt/tests/pointerevents/pointerevent_touch-action-inherit_child-none_touch.html
+++ b/tests/wpt/tests/pointerevents/pointerevent_touch-action-inherit_child-none_touch.html
@@ -12,6 +12,9 @@
         <script src="/resources/testdriver-vendor.js"></script>
         <script src="pointerevent_support.js"></script>
         <style>
+            .scroller {
+            height: 200px;
+            }
             .scroller > div {
             touch-action: none;
             }

--- a/tests/wpt/tests/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch.html
+++ b/tests/wpt/tests/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch.html
@@ -12,6 +12,9 @@
         <script src="/resources/testdriver-vendor.js"></script>
         <script src="pointerevent_support.js"></script>
         <style>
+            .scroller {
+            height: 200px;
+            }
             .scroller > div {
             touch-action: pan-x;
             }

--- a/tests/wpt/tests/pointerevents/pointerevent_touch-action-svg-none-test_touch.html
+++ b/tests/wpt/tests/pointerevents/pointerevent_touch-action-svg-none-test_touch.html
@@ -13,11 +13,11 @@
         <script src="pointerevent_support.js"></script>
         <style>
             #target0 {
-            height: 350px;
+            height: 200px;
             width: 300px;
             overflow-y: auto;
             background: black;
-            padding: 100px;
+            padding: 20px;
             position: relative;
             }
         </style>


### PR DESCRIPTION
This should fix the WebDriver Out of Bound Error for Safari ([run](https://staging.wpt.fyi/results/pointerevents?diff&filter=ADC&run_id=5422356349583360&run_id=4684953817186304)), and prevent it from happening for Servo after https://github.com/servo/servo/pull/47821. Right now Servo only FAIL but not ERROR as it ignores `touch-action: none` under certain circumstances (https://github.com/servo/servo/issues/47737) and scrolls the viewport.

Firefox/Chromium passed without the change as they don't always use 800x600 except for reftests. The approach we take is similar to https://github.com/web-platform-tests/wpt/pull/48994.

The reason I open this in Servo is that it impacts https://github.com/servo/servo/pull/47821.

Testing: Screenshot verified with Firefox/Edge.
| Before | After |
| -------- | -------- |
| <img width="1249" height="943" alt="image" src="https://github.com/user-attachments/assets/6cd472a4-236e-40ea-961e-1bf298eec1dc" /> | <img width="1244" height="938" alt="image" src="https://github.com/user-attachments/assets/60687f38-2c42-4a31-b60c-0c442b6a0f3e" /> |

Fixes: https://github.com/web-platform-tests/wpt/issues/62481