### PR TITLE
ci: Pass profile as input to clippy in lint.yml

### DIFF
--- a/.github/workflows/dispatch-workflow.yml
+++ b/.github/workflows/dispatch-workflow.yml
@@ -128,7 +128,9 @@ jobs:
     name: Lint
     # Note: The lint workflow does not need access to any secrets.
     uses: ./.github/workflows/lint.yml
-
+    with:
+      profile: ${{ inputs.profile }}
+      
   android:
     if: ${{ inputs.workflow == 'android' }}
     name: Android

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,17 @@
 name: Lint
 on:
   workflow_call:
+    inputs:
+      profile:
+        required: false
+        default: "checked-release"
+        type: string
   workflow_dispatch:
+    inputs:
+      profile:
+        required: false
+        default: "checked-release"
+        type: string      
 
 env:
   RUST_BACKTRACE: 1
@@ -80,7 +90,7 @@ jobs:
           ./mach bootstrap --yes --skip-nextest
       - name: Clippy
         run: |
-          ./mach clippy --locked --github-annotations -- -- --deny warnings
+          ./mach clippy --profile ${{ inputs.profile }} --locked --github-annotations -- -- --deny warnings
       - name: Tidy
         env:
           CI_PULL_REQUEST_BODY: ${{ github.event.pull_request.body }}

--- a/components/webgl/webgl_thread.rs
+++ b/components/webgl/webgl_thread.rs
@@ -2034,7 +2034,7 @@ impl WebGLImpl {
                 gl.tex_parameter_f32(target, param, value)
             },
             WebGLCommand::LinkProgram(program_id, ref sender) => {
-                return sender.send(Self::link_program(gl, program_id)).unwrap();
+                sender.send(Self::link_program(gl, program_id)).unwrap()
             },
             WebGLCommand::UseProgram(program_id) => unsafe {
                 gl.use_program(program_id.map(|p| p.glow()))


### PR DESCRIPTION
Pass profile as input to clippy in lint.yml

- Defaulting to `checked-release` as other jobs 
- And a nit

> I guess we all believe release build should be free from any warnings.

Testing: Success ci run.
Fixes: #47771

