### PR TITLE
net: Pinned check in HttpCache previously errored

### DIFF
--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -259,6 +259,12 @@ pub struct HttpCache {
     disk_cache: Option<std::sync::Arc<DiskCache>>,
 }
 
+impl std::fmt::Debug for HttpCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list().entries(self.entries.iter()).finish()
+    }
+}
+
 impl MallocSizeOf for HttpCache {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         self.entries
@@ -291,6 +297,12 @@ impl HttpCache {
             entries: memory_cache,
             disk_cache,
         }
+    }
+
+    #[allow(unused, clippy::len_without_is_empty)]
+    /// The number of entries in the memory cache. This does not say anything about the disk cache.
+    pub fn len(&self) -> usize {
+        self.entries.len()
     }
 }
 

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -298,7 +298,7 @@ impl HttpCache {
 /// The lifecycle hooks of the HttpCache.
 /// Responsible for moving data to the disk.
 pub struct MemoryCacheLifecycle {
-    pub(crate) disk_cache: Option<std::sync::Arc<DiskCache>>,
+    pub(crate) disk_cache: Option<StdArc<DiskCache>>,
 }
 
 impl MemoryCacheLifecycle {
@@ -313,9 +313,11 @@ impl Lifecycle<CacheKey, CacheEntry> for MemoryCacheLifecycle {
     // Cached Resources that are not complete could get evicted which means they cannot fill their body.
     // We allow unfinished resources to stay in the cache.
     fn is_pinned(&self, _: &CacheKey, val: &CacheEntry) -> bool {
-        val.blocking_read()
-            .iter()
-            .any(|resource| !resource.is_done())
+        tokio::task::block_in_place(|| {
+            val.blocking_read()
+                .iter()
+                .any(|resource| !resource.is_done())
+        })
     }
 
     fn on_evict(&self, _state: &mut Self::RequestState, key: CacheKey, value: CacheEntry) {

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -16,7 +16,7 @@ use headers::{
     CacheControl, ContentRange, Expires, HeaderMapExt, LastModified, Pragma, Range, Vary,
 };
 use http::{HeaderMap, Method, StatusCode, header};
-use log::{debug, error};
+use log::{debug, error, info};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use malloc_size_of_derive::MallocSizeOf;
 use net_traits::http_status::HttpStatus;
@@ -312,15 +312,17 @@ impl Lifecycle<CacheKey, CacheEntry> for MemoryCacheLifecycle {
 
     // Cached Resources that are not complete could get evicted which means they cannot fill their body.
     // We allow unfinished resources to stay in the cache.
-    fn is_pinned(&self, _: &CacheKey, val: &CacheEntry) -> bool {
-        tokio::task::block_in_place(|| {
-            val.blocking_read()
-                .iter()
-                .any(|resource| !resource.is_done())
-        })
+    fn is_pinned(&self, key: &CacheKey, val: &CacheEntry) -> bool {
+        let pinned = val
+            .try_read()
+            .map(|cached_resources| cached_resources.iter().any(|resource| !resource.is_done()))
+            .unwrap_or(true);
+        info!("Key {key:?} is pinned",);
+        pinned
     }
 
     fn on_evict(&self, _state: &mut Self::RequestState, key: CacheKey, value: CacheEntry) {
+        info!("Evicting {key:?} from memory cache");
         if let Some(disk_cache_data) = &self.disk_cache {
             let disk_cache_data = disk_cache_data.clone();
             tokio::spawn(async move { disk_cache_data.store(key, value).await });

--- a/components/net/tests/http_cache.rs
+++ b/components/net/tests/http_cache.rs
@@ -10,6 +10,7 @@ use net_traits::request::{Referrer, RequestBuilder};
 use net_traits::response::{Response, ResponseBody};
 use net_traits::{ResourceFetchTiming, ResourceTimingType};
 use servo_base::id::TEST_PIPELINE_ID;
+use servo_config::prefs::Preferences;
 use servo_url::ServoUrl;
 use tokio::sync::mpsc::unbounded_channel as unbounded;
 
@@ -224,4 +225,127 @@ async fn test_stale_while_revalidate_not_used_when_request_demands_revalidation(
         },
         "a no-cache request must trigger synchronous validation, not background revalidation"
     );
+}
+
+#[tokio::test]
+async fn http_cache_get_items() {
+    servo_config::prefs::set(Preferences {
+        network_http_cache_size: 4,
+        ..Default::default()
+    });
+    let cache = HttpCache::new(HttpCacheAssignment::Public);
+    let url = ServoUrl::parse(&format!("https://www.servo.org/really_long_request")).unwrap();
+    let request = RequestBuilder::new(
+        None,
+        UrlWithBlobClaim::new(url.clone(), None),
+        Referrer::NoReferrer,
+    )
+    .pipeline_id(Some(TEST_PIPELINE_ID))
+    .origin(url.origin())
+    .build();
+    let timing = ResourceFetchTiming::new(ResourceTimingType::Navigation);
+    let mut response = Response::new(url, timing);
+    response
+        .headers
+        .insert(CACHE_CONTROL, HeaderValue::from_static("max-age=36000"));
+    *response.body.lock() = ResponseBody::Done(vec![1, 2, 3]);
+    cache.store(&request, &response).await;
+
+    let cache_result = cache.construct_response(&request, &mut None).await;
+
+    assert!(cache_result.is_some());
+    let cache_result = cache_result.unwrap();
+    assert_eq!(
+        &*cache_result.body.lock(),
+        &ResponseBody::Done(vec![1, 2, 3])
+    );
+}
+
+#[tokio::test]
+async fn http_cache_size() {
+    servo_config::prefs::set(Preferences {
+        network_http_cache_size: 4,
+        ..Default::default()
+    });
+    let cache = HttpCache::new(HttpCacheAssignment::Public);
+
+    // Fill requests that are not done
+    for i in 0..4 {
+        let url = ServoUrl::parse(&format!("https://www.servo.org/{i}")).unwrap();
+        let request = RequestBuilder::new(
+            None,
+            UrlWithBlobClaim::new(url.clone(), None),
+            Referrer::NoReferrer,
+        )
+        .pipeline_id(Some(TEST_PIPELINE_ID))
+        .origin(url.origin())
+        .build();
+        let timing = ResourceFetchTiming::new(ResourceTimingType::Navigation);
+        let mut response = Response::new(url, timing);
+        response
+            .headers
+            .insert(CACHE_CONTROL, HeaderValue::from_static("max-age=36000"));
+        *response.body.lock() = ResponseBody::Done(vec![1, 2, 3]);
+
+        cache.store(&request, &response).await;
+    }
+
+    assert_eq!(cache.len(), 4);
+}
+
+#[tokio::test]
+async fn http_cache_do_not_evict_unfinished_requests() {
+    servo_config::prefs::set(Preferences {
+        network_http_cache_size: 4,
+        ..Default::default()
+    });
+    let cache = HttpCache::new(HttpCacheAssignment::Public);
+
+    // Store a not yet finished request
+    let not_finished_request = {
+        let url = ServoUrl::parse(&format!("https://www.servo.org/really_long_request")).unwrap();
+        let request = RequestBuilder::new(
+            None,
+            UrlWithBlobClaim::new(url.clone(), None),
+            Referrer::NoReferrer,
+        )
+        .pipeline_id(Some(TEST_PIPELINE_ID))
+        .origin(url.origin())
+        .build();
+        let timing = ResourceFetchTiming::new(ResourceTimingType::Navigation);
+        let mut response = Response::new(url, timing);
+        response
+            .headers
+            .insert(CACHE_CONTROL, HeaderValue::from_static("max-age=36000"));
+        *response.body.lock() = ResponseBody::Receiving(vec![1, 2, 3]);
+        cache.store(&request, &response).await;
+        request
+    };
+
+    // Fill requests that are not done
+    for i in 0..12 {
+        let url = ServoUrl::parse(&format!("https://www.servo.org/{i}")).unwrap();
+        let request = RequestBuilder::new(
+            None,
+            UrlWithBlobClaim::new(url.clone(), None),
+            Referrer::NoReferrer,
+        )
+        .pipeline_id(Some(TEST_PIPELINE_ID))
+        .origin(url.origin())
+        .build();
+        let timing = ResourceFetchTiming::new(ResourceTimingType::Navigation);
+        let mut response = Response::new(url, timing);
+        response
+            .headers
+            .insert(CACHE_CONTROL, HeaderValue::from_static("max-age=36000"));
+        *response.body.lock() = ResponseBody::Done(vec![1, 2, 3]);
+
+        cache.store(&request, &response).await;
+    }
+
+    let result = cache
+        .construct_response(&not_finished_request, &mut None)
+        .await;
+    println!("cache {:?}", cache);
+    assert!(result.is_some());
 }


### PR DESCRIPTION
This fixes the pinned check mechanism in HttpCache to not error by using the correct tokio method.

Testing: Manual test with small cache size shows that the previous crash does not exist anymore. No automatic tests exist.
