### PR TITLE
net: Remove unneded type parameter from async_runtime::spawn_blocking_task

### DIFF
--- a/components/net/async_runtime.rs
+++ b/components/net/async_runtime.rs
@@ -82,7 +82,7 @@ where
 }
 
 /// Spawn a blocking task using the handle to the runtime.
-pub fn spawn_blocking_task<F, R>(task: F) -> F::Output
+pub fn spawn_blocking_task<F>(task: F) -> F::Output
 where
     F: Future,
 {

--- a/components/net/test_util.rs
+++ b/components/net/test_util.rs
@@ -94,10 +94,7 @@ where
 
     let listener = StdTcpListener::bind("0.0.0.0:0").unwrap();
     listener.set_nonblocking(true).unwrap();
-    let listener =
-        spawn_blocking_task::<_, TcpListener>(
-            async move { TcpListener::from_std(listener).unwrap() },
-        );
+    let listener = spawn_blocking_task(async move { TcpListener::from_std(listener).unwrap() });
 
     let url_string = format!("http://localhost:{}", listener.local_addr().unwrap().port());
     let url = UrlWithBlobClaim::new(ServoUrl::parse(&url_string).unwrap(), None);
@@ -189,10 +186,7 @@ where
     let handler = Arc::new(handler);
     let listener = StdTcpListener::bind("[::0]:0").unwrap();
     listener.set_nonblocking(true).unwrap();
-    let listener =
-        spawn_blocking_task::<_, TcpListener>(
-            async move { TcpListener::from_std(listener).unwrap() },
-        );
+    let listener = spawn_blocking_task(async move { TcpListener::from_std(listener).unwrap() });
 
     let url_string = format!("http://localhost:{}", listener.local_addr().unwrap().port());
     let url = UrlWithBlobClaim::new(ServoUrl::parse(&url_string).unwrap(), None);

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -213,7 +213,7 @@ fn test_fetch_blob() {
         expected: bytes.to_vec(),
     };
 
-    spawn_blocking_task::<_, Response>(methods::fetch(request, &mut target, &context));
+    spawn_blocking_task(methods::fetch(request, &mut target, &context));
 
     let fetch_response = receiver.recv().unwrap();
     assert!(!fetch_response.is_network_error());

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -1623,7 +1623,7 @@ fn test_fetch_compressed_response_update_count() {
         sender: Some(sender),
         update_count: 0,
     };
-    let response_update_count = spawn_blocking_task::<_, Response>(async move {
+    let response_update_count = spawn_blocking_task(async move {
         methods::fetch(request, &mut target, &mut new_fetch_context(None, None)).await;
         receiver.await.unwrap()
     });

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -167,7 +167,7 @@ fn fetch_with_context(request: Request, mut context: &mut FetchContext) -> Respo
     let mut target = FetchResponseCollector {
         sender: Some(sender),
     };
-    spawn_blocking_task::<_, Response>(async move {
+    spawn_blocking_task(async move {
         methods::fetch(request, &mut target, &mut context).await;
         receiver.await.unwrap()
     })
@@ -179,7 +179,7 @@ fn fetch_with_cors_cache(request: Request, cache: &mut CorsCache) -> Response {
         sender: Some(sender),
     };
     let mut fetch_context = new_fetch_context(None, None);
-    spawn_blocking_task::<_, Response>(async move {
+    spawn_blocking_task(async move {
         methods::fetch_with_cors_cache(request, cache, &mut target, &mut fetch_context).await;
         receiver.await.unwrap()
     })


### PR DESCRIPTION
This type parameter is not needed so we can just remove it.

Testing: This is a refactor so compilation is the test.
