### PR TITLE
webgl: Add webgl to default_web_features

### DIFF
--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -23,7 +23,7 @@ default = ["bundled", "clipboard", "js_jit"]
 #  configuration with `--no-default-features` build
 #
 # A convenience feature to enable all default web features servo has.
-default_web_features = ["brotli-compression-stream", "clipboard", "webcrypto", "webgpu", "webxr"]
+default_web_features = ["brotli-compression-stream", "clipboard", "webcrypto", "webgpu", "webgl", "webxr"]
 # Bundle required resources in the binary.
 bundled = ["baked-in-resources", "bundled_freetype"]
 

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -48,7 +48,7 @@ default = ["default_without_allocator", "servo-allocator/use-jemalloc"]
 default_without_allocator = ["bundled", "default_web_features", "max_log_level", "js_jit"]
 # Default web features should be kept in sync with the list in servo/Cargo.toml.
 # We also need to enable our own features, since we also have `cfg` gated code here.
-default_web_features = ["servo/default_web_features", "gamepad", "webgpu", "webxr"]
+default_web_features = ["servo/default_web_features", "gamepad", "webgpu", "webgl", "webxr"]
 # Bundle required resources in the binary.
 bundled = ["servo/bundled"]
 


### PR DESCRIPTION
webgl:  Add webgl to the default_web_features 

Testing: `./mach chech` and `./mach check --no-default-features  --features bundled,gamepad,webgpu,max_log_level,js_jit`.
Fixes: [#47858](https://github.com/servo/servo/issues/47858)
And is mentioned by https://github.com/servo/servo/issues/47184 

As far as I understand, I should have added `webgl` to the `default_web_features` back in the 47184, but did not, because at the time I thought that having just `webxr` is enough, as it depends on `webgl` and auto-imports it. 

I do agree that `webgl` should have been put more explicitly.

Does this PR need anything more? or is this generally enough?
The `./mach check` passes both for with and without `webgl` 