### PR TITLE
android: Require `initialUri` in constructor

### DIFF
--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
@@ -82,6 +82,7 @@ class MainActivity : ComponentActivity(), Servo.Client {
             servoArgs = intent.getStringExtra("servoargs"),
             servoLog = intent.getStringExtra("servolog"),
             experimentalMode = settings.experimental,
+            initialUri = if (Intent.ACTION_VIEW == intent.action) intent.data.toString() else null,
             navigator = navigator,
         )
 
@@ -214,10 +215,6 @@ class MainActivity : ComponentActivity(), Servo.Client {
             Os.setenv("HOST_FILE", host, false)
         } catch (e: ErrnoException) {
             e.printStackTrace()
-        }
-
-        if (Intent.ACTION_VIEW == intent.action) {
-            servoView.loadUri(intent.data.toString())
         }
     }
 

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.kt
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.kt
@@ -24,11 +24,11 @@ class ServoView(
     servoArgs: String?,
     servoLog: String?,
     private val experimentalMode: Boolean,
+    private val initialUri: String?,
     navigator: ServoNavigator,
 ) : SurfaceView(context), Servo.RunCallback, Choreographer.FrameCallback {
     private val glThread: GLThread
     private var servo: Servo? = null
-    private var initialUri: String? = null
 
     init {
         isFocusable = true
@@ -120,12 +120,7 @@ class ServoView(
     }
 
     fun loadUri(uri: String) {
-        val servo = servo
-        if (servo != null) {
-            servo.loadUri(uri)
-        } else {
-            initialUri = uri
-        }
+        servo!!.loadUri(uri)
     }
 
     fun mediaSessionAction(action: Int) {


### PR DESCRIPTION
Makes it self-evident that passing `initialUri` during construction is part of the initialisation phase of the JNI.

`loadUri` now contains a non-null assertion, but that will be removed as `servo` becomes non-null in a future PR.

Testing: There are no automated tests for Android.