### PR TITLE
threadboost: display some information about the CPU cores configuration

### DIFF
--- a/components/shared/base/threadboost.rs
+++ b/components/shared/base/threadboost.rs
@@ -24,6 +24,8 @@ mod linux_sysfs {
     use std::fs;
     use std::sync::LazyLock;
 
+    use log::info;
+
     // The current maximum supported by CPU_SET is 1024, so u16 is sufficiently large.
     // <https://man7.org/linux/man-pages/man3/CPU_SET.3.html>
     type CoreId = u16;
@@ -84,6 +86,7 @@ mod linux_sysfs {
         classes.sort_unstable();
         classes.dedup();
         if classes.len() < 2 {
+            info!("No little/big cores configuration");
             return Ok(None);
         }
         let little = classes[0];
@@ -93,8 +96,14 @@ mod linux_sysfs {
             .map(|&(cpu, _)| cpu)
             .collect();
         if chosen.len() < 2 {
+            info!("Not enough big cores available ({})", chosen.len());
             return Ok(None);
         }
+        info!(
+            "CPU cores configuration: {} big cores out of {}",
+            chosen.len(),
+            cpus.len()
+        );
         Ok(Some(chosen))
     }
 


### PR DESCRIPTION
This just emits some basic information about the CPU cores to verify that we detect the correct big/little arrangement.

Testing: Checked on devices with different CPUs that this works as expected: Pixel 3a (2 big, 6 little), Framework with intel i7 (no big/little), Apple M1 running Fedora (4 big, 4 little).

cc @jschwe 