### PR TITLE
ci: Give `try-label.yml` `checks: write` and `pull-requests: write` permissions

### DIFF
--- a/.github/workflows/try-label.yml
+++ b/.github/workflows/try-label.yml
@@ -125,6 +125,10 @@ jobs:
       # We should find a nother way to handle that to avoid needing to hand-out this
       # permission.
       actions: write
+      # The following two are used by the code that uploads a comment and check run
+      # when processing WPT results.
+      checks: write
+      pull-requests: write
     strategy:
       fail-fast: ${{ fromJson(needs.parse-comment.outputs.configuration).fail_fast }}
       matrix:


### PR DESCRIPTION
`etc/ci/report_aggregated_expected_results.py` script needs these
permissions to upload comments and check runs after running WPT tests.
These permissions were originally tightened in #47680. This is a speculative
fix for #47900.

Testing: There is no testing for GitHub Actions unfortunately, which
is one reason this regression slipped through.
Fixes: #47900.
