### PR TITLE
mime_classifier: fix typo in `is_font`

### DIFF
--- a/components/shared/net/mime_classifier.rs
+++ b/components/shared/net/mime_classifier.rs
@@ -319,7 +319,7 @@ impl MimeClassifier {
             (mt.type_() == mime::APPLICATION &&
                 ([
                     "font-cff",
-                    "font-off",
+                    "font-otf",
                     "font-sfnt",
                     "font-ttf",
                     "font-woff",


### PR DESCRIPTION
fix #47903
