### PR TITLE
layout: Compute accessibility bounds for inline elements.

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -966,7 +966,8 @@ impl AccessibilityNode {
             context.stacking_context_tree,
             *dom_node,
             BoxAreaType::Border,
-            true, /* exclude_transform_and_inline */
+            true,  /* include_inline */
+            false, /* include_transform */
         )
         .map(au_rect_to_accesskit_rect);
 

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -36,7 +36,7 @@ use crate::ArcRefCell;
 use crate::cell::WeakRefCell;
 use crate::display_list::StackingContextTree;
 use crate::layout_impl::LayoutThread;
-use crate::query::process_box_area_request;
+use crate::query::{BoxAreaInclusion, process_box_area_request};
 
 bitflags! {
     /// Damage which was caused by changes to the accessibility tree. These changes can cause other
@@ -966,8 +966,7 @@ impl AccessibilityNode {
             context.stacking_context_tree,
             *dom_node,
             BoxAreaType::Border,
-            true,  /* include_inline */
-            false, /* include_transform */
+            BoxAreaInclusion::Inlines,
         )
         .map(au_rect_to_accesskit_rect);
 

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -408,12 +408,16 @@ impl Layout for LayoutThread {
             let node = unsafe { ServoLayoutNode::new(&node) };
             let stacking_context_tree = self.stacking_context_tree.borrow();
             let stacking_context_tree = stacking_context_tree.as_ref()?;
+            let include_inline = !exclude_transform_and_inline;
+            let include_transform = !exclude_transform_and_inline;
+
             process_box_area_request(
                 self,
                 stacking_context_tree,
                 node,
                 area,
-                exclude_transform_and_inline,
+                include_inline,
+                include_transform,
             )
         })
     }

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -86,8 +86,8 @@ use crate::context::{CachedImageOrError, ImageResolver, LayoutContext};
 use crate::display_list::{DisplayListBuilder, HitTest, PaintTimingHandler, StackingContextTree};
 use crate::dom::NodeExt;
 use crate::query::{
-    find_character_offset_in_fragment_descendants, get_the_text_steps, process_box_area_request,
-    process_box_areas_request, process_client_rect_request,
+    BoxAreaInclusion, find_character_offset_in_fragment_descendants, get_the_text_steps,
+    process_box_area_request, process_box_areas_request, process_client_rect_request,
     process_containing_block_descendant_query, process_containing_block_query,
     process_current_css_zoom_query, process_effective_overflow_query,
     process_node_scroll_area_request, process_offset_parent_query, process_padding_request,
@@ -408,17 +408,13 @@ impl Layout for LayoutThread {
             let node = unsafe { ServoLayoutNode::new(&node) };
             let stacking_context_tree = self.stacking_context_tree.borrow();
             let stacking_context_tree = stacking_context_tree.as_ref()?;
-            let include_inline = !exclude_transform_and_inline;
-            let include_transform = !exclude_transform_and_inline;
+            let inclusion = if exclude_transform_and_inline {
+                BoxAreaInclusion::empty()
+            } else {
+                BoxAreaInclusion::Transforms | BoxAreaInclusion::Inlines
+            };
 
-            process_box_area_request(
-                self,
-                stacking_context_tree,
-                node,
-                area,
-                include_inline,
-                include_transform,
-            )
+            process_box_area_request(self, stacking_context_tree, node, area, inclusion)
         })
     }
 

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -113,7 +113,7 @@ pub(crate) fn process_box_area_request(
             .iter()
             .filter(|fragment| {
                 inclusion.contains(BoxAreaInclusion::Inlines) ||
-                    !fragment
+                    fragment
                         .retrieve_box_fragment()
                         .is_none_or(|fragment| !fragment.with_style().is_inline_box())
             })

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -95,7 +95,8 @@ pub(crate) fn process_box_area_request(
     stacking_context_tree: &StackingContextTree,
     node: ServoLayoutNode<'_>,
     area: BoxAreaType,
-    exclude_transform_and_inline: bool,
+    include_inline: bool,
+    include_transform: bool,
 ) -> Option<Rect<Au, CSSPixel>> {
     // Borrow fragments to avoid cloning on this hot path for accessibility and
     // `getBoundingClientRect()`.
@@ -103,8 +104,8 @@ pub(crate) fn process_box_area_request(
         let mut rects = fragments
             .iter()
             .filter(|fragment| {
-                !exclude_transform_and_inline ||
-                    fragment
+                include_inline ||
+                    !fragment
                         .retrieve_box_fragment()
                         .is_none_or(|fragment| !fragment.with_style().is_inline_box())
             })
@@ -114,7 +115,7 @@ pub(crate) fn process_box_area_request(
         rects.peek()?;
         let rect_union = rects.fold(Rect::zero(), |unioned_rect, rect| rect.union(&unioned_rect));
 
-        if exclude_transform_and_inline {
+        if !include_transform {
             return Some(rect_union);
         }
 

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -10,6 +10,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use app_units::Au;
+use bitflags::bitflags;
 use embedder_traits::UntrustedNodeAddress;
 use euclid::{Point2D, Rect, Size2D};
 use layout_api::{
@@ -90,13 +91,20 @@ pub(crate) fn process_padding_request(node: ServoLayoutNode<'_>) -> Option<Physi
     )
 }
 
+bitflags! {
+    #[derive(Clone, Copy)]
+    pub(crate) struct BoxAreaInclusion: u8 {
+        const Transforms = 1 << 0;
+        const Inlines = 1 << 1;
+    }
+}
+
 pub(crate) fn process_box_area_request(
     layout_thread: &LayoutThread,
     stacking_context_tree: &StackingContextTree,
     node: ServoLayoutNode<'_>,
     area: BoxAreaType,
-    include_inline: bool,
-    include_transform: bool,
+    inclusion: BoxAreaInclusion,
 ) -> Option<Rect<Au, CSSPixel>> {
     // Borrow fragments to avoid cloning on this hot path for accessibility and
     // `getBoundingClientRect()`.
@@ -104,7 +112,7 @@ pub(crate) fn process_box_area_request(
         let mut rects = fragments
             .iter()
             .filter(|fragment| {
-                include_inline ||
+                inclusion.contains(BoxAreaInclusion::Inlines) ||
                     !fragment
                         .retrieve_box_fragment()
                         .is_none_or(|fragment| !fragment.with_style().is_inline_box())
@@ -115,7 +123,7 @@ pub(crate) fn process_box_area_request(
         rects.peek()?;
         let rect_union = rects.fold(Rect::zero(), |unioned_rect, rect| rect.union(&unioned_rect));
 
-        if !include_transform {
+        if !inclusion.contains(BoxAreaInclusion::Transforms) {
             return Some(rect_union);
         }
 

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -9,7 +9,8 @@ use std::cell::Cell;
 use std::collections::VecDeque;
 use std::rc::Rc;
 
-use accesskit::{NodeId, Rect, Role, TreeId, TreeUpdate};
+use accesskit::Role::{self, GenericContainer};
+use accesskit::{NodeId, Rect, TreeId, TreeUpdate};
 use accesskit_consumer::TreeChangeHandler;
 use euclid::Scale;
 use servo::{
@@ -961,6 +962,33 @@ fn test_accessibility_unchanged_bounds_are_not_resent() {
         !resent_ids.contains(&node_b_id),
         "A node whose bounds did not change should not be re-serialized, but got {resent_ids:?}"
     );
+}
+
+#[test]
+fn test_accessibility_bounds_are_computed_for_inline_elements() {
+    let url = "data:text/html,<!DOCTYPE html>\
+               <h1>We really <em>really <strong>really</strong></em> like owls</h1>";
+
+    let (servo_test, delegate, webview, mut tree) = build_webview_and_tree(url);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+
+    let heading = find_first_matching_node(root, |node| node.role() == Role::Heading)
+        .expect("Should be exactly one heading");
+    assert_eq!(
+        heading.label(),
+        Some("We really really really like owls".to_owned())
+    );
+    assert!(heading.has_bounds());
+
+    let heading_children: Vec<_> = heading.children().collect();
+    let em = find_first_matching_node(heading, |node| node.role() == GenericContainer)
+        .expect("Heading should have one GenericContainer child");
+    assert!(em.has_bounds());
+
+    let strong = find_first_matching_node(em, |node| node.role() == GenericContainer)
+        .expect("<em> should have one GenericContainer child");
+    assert!(strong.has_bounds());
 }
 
 // ************************************************************************************************


### PR DESCRIPTION
Modify `query::process_box_area_request()` to split the `exclude_inlines_and_transform` argument into two separate arguments.

Also remove the double negatives by switching them to `include` rather than `exclude`.

This doesn't change `Layout::query_box_area()`, which takes the same argument.

Testing: Added a new test asserting that accessibility bounds are computed for inline elements. 
Fixes: #47906 