### PR TITLE
script: Convert streams interfaces to use rooted/traced promise types

### DIFF
--- a/components/script/dom/promise/promise.rs
+++ b/components/script/dom/promise/promise.rs
@@ -123,6 +123,12 @@ impl ToJSValConvertible for RootedPromise {
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct TracedPromise(#[conditional_malloc_size_of] Rc<Promise>);
 
+impl std::cmp::PartialEq for TracedPromise {
+    fn eq(&self, other: &Self) -> bool {
+        *self.0 == **other
+    }
+}
+
 impl HeapTracedPromiseHelpers<crate::DomTypeHolder> for TracedPromise {
     type StackRoot = RootedPromise;
     fn root(&self) -> RootedPromise {
@@ -306,7 +312,6 @@ impl Promise {
         Promise::new_with_js_promise(cx, p.handle())
     }
 
-    #[expect(dead_code)]
     pub(crate) fn new_rejected_rooted(
         cx: &mut JSContext,
         global: &GlobalScope,

--- a/components/script/dom/stream/byteteereadintorequest.rs
+++ b/components/script/dom/stream/byteteereadintorequest.rs
@@ -19,7 +19,7 @@ use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{RootedPromise, TracedPromise};
 use crate::dom::stream::byteteeunderlyingsource::ByteTeeUnderlyingSource;
 use crate::dom::stream::readablestream::ReadableStream;
 use crate::runtime::job_queue::MicrotaskRunnable;
@@ -57,8 +57,7 @@ pub(crate) struct ByteTeeReadIntoRequest {
     canceled_1: Rc<Cell<bool>>,
     #[conditional_malloc_size_of]
     canceled_2: Rc<Cell<bool>>,
-    #[conditional_malloc_size_of]
-    cancel_promise: Rc<Promise>,
+    cancel_promise: TracedPromise,
     tee_underlying_source: Dom<ByteTeeUnderlyingSource>,
 }
 impl ByteTeeReadIntoRequest {
@@ -74,7 +73,7 @@ impl ByteTeeReadIntoRequest {
         reading: Rc<Cell<bool>>,
         canceled_1: Rc<Cell<bool>>,
         canceled_2: Rc<Cell<bool>>,
-        cancel_promise: Rc<Promise>,
+        cancel_promise: &RootedPromise,
         tee_underlying_source: &ByteTeeUnderlyingSource,
         global: &GlobalScope,
     ) -> DomRoot<Self> {
@@ -91,7 +90,7 @@ impl ByteTeeReadIntoRequest {
                 reading,
                 canceled_1,
                 canceled_2,
-                cancel_promise,
+                cancel_promise: cancel_promise.to_traced(),
                 tee_underlying_source: Dom::from_ref(tee_underlying_source),
             }),
             global,

--- a/components/script/dom/stream/byteteereadrequest.rs
+++ b/components/script/dom/stream/byteteereadrequest.rs
@@ -20,7 +20,7 @@ use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{RootedPromise, TracedPromise};
 use crate::dom::stream::byteteeunderlyingsource::ByteTeeUnderlyingSource;
 use crate::dom::stream::readablestream::ReadableStream;
 use crate::runtime::job_queue::MicrotaskRunnable;
@@ -58,8 +58,7 @@ pub(crate) struct ByteTeeReadRequest {
     canceled_1: Rc<Cell<bool>>,
     #[conditional_malloc_size_of]
     canceled_2: Rc<Cell<bool>>,
-    #[conditional_malloc_size_of]
-    cancel_promise: Rc<Promise>,
+    cancel_promise: TracedPromise,
     tee_underlying_source: Dom<ByteTeeUnderlyingSource>,
 }
 impl ByteTeeReadRequest {
@@ -74,7 +73,7 @@ impl ByteTeeReadRequest {
         reading: Rc<Cell<bool>>,
         canceled_1: Rc<Cell<bool>>,
         canceled_2: Rc<Cell<bool>>,
-        cancel_promise: Rc<Promise>,
+        cancel_promise: &RootedPromise,
         tee_underlying_source: &ByteTeeUnderlyingSource,
         global: &GlobalScope,
     ) -> DomRoot<Self> {
@@ -90,7 +89,7 @@ impl ByteTeeReadRequest {
                 reading,
                 canceled_1,
                 canceled_2,
-                cancel_promise,
+                cancel_promise: cancel_promise.to_traced(),
                 tee_underlying_source: Dom::from_ref(tee_underlying_source),
             }),
             global,

--- a/components/script/dom/stream/byteteeunderlyingsource.rs
+++ b/components/script/dom/stream/byteteeunderlyingsource.rs
@@ -21,7 +21,7 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise, TracedPromise};
 use crate::dom::stream::byteteereadrequest::ByteTeeReadRequest;
 use crate::dom::stream::readablestreamdefaultreader::ReadRequest;
 use crate::dom::types::ReadableStream;
@@ -61,8 +61,7 @@ pub(crate) struct ByteTeeUnderlyingSource {
     reason_1: Rc<Heap<Value>>,
     #[ignore_malloc_size_of = "Mozjs"]
     reason_2: Rc<Heap<Value>>,
-    #[conditional_malloc_size_of]
-    cancel_promise: Rc<Promise>,
+    cancel_promise: TracedPromise,
     #[conditional_malloc_size_of]
     reader_version: Rc<Cell<u64>>,
     tee_cancel_algorithm: ByteTeeCancelAlgorithm,
@@ -83,7 +82,7 @@ impl ByteTeeUnderlyingSource {
         canceled_2: Rc<Cell<bool>>,
         reason_1: Rc<Heap<Value>>,
         reason_2: Rc<Heap<Value>>,
-        cancel_promise: Rc<Promise>,
+        cancel_promise: &RootedPromise,
         reader_version: Rc<Cell<u64>>,
         tee_cancel_algorithm: ByteTeeCancelAlgorithm,
         byte_tee_pull_algorithm: ByteTeePullAlgorithm,
@@ -103,7 +102,7 @@ impl ByteTeeUnderlyingSource {
                 canceled_2,
                 reason_1,
                 reason_2,
-                cancel_promise,
+                cancel_promise: cancel_promise.to_traced(),
                 reader_version,
                 tee_cancel_algorithm,
                 byte_tee_pull_algorithm,
@@ -140,7 +139,7 @@ impl ByteTeeUnderlyingSource {
                         &self.branch_2.get().expect("Branch 2 should be set."),
                         self.canceled_1.clone(),
                         self.canceled_2.clone(),
-                        self.cancel_promise.clone(),
+                        &self.cancel_promise.root(),
                         self.reader_version.clone(),
                         expected_version,
                     );
@@ -157,7 +156,7 @@ impl ByteTeeUnderlyingSource {
                         &self.branch_2.get().expect("Branch 2 should be set."),
                         self.canceled_1.clone(),
                         self.canceled_2.clone(),
-                        self.cancel_promise.clone(),
+                        &self.cancel_promise.root(),
                         self.reader_version.clone(),
                         expected_version,
                     );
@@ -208,7 +207,7 @@ impl ByteTeeUnderlyingSource {
                         self.reading.clone(),
                         self.canceled_1.clone(),
                         self.canceled_2.clone(),
-                        self.cancel_promise.clone(),
+                        &self.cancel_promise.root(),
                         self,
                         global,
                     );
@@ -278,14 +277,14 @@ impl ByteTeeUnderlyingSource {
                         self.reading.clone(),
                         self.canceled_1.clone(),
                         self.canceled_2.clone(),
-                        self.cancel_promise.clone(),
+                        &self.cancel_promise.root(),
                         self,
                         global,
                     );
 
-                    let read_into_request = ReadIntoRequest::ByteTee {
+                    rooted!(&in(cx) let read_into_request = ReadIntoRequest::ByteTee {
                         byte_tee_read_into_request: Dom::from_ref(&byte_tee_read_into_request),
-                    };
+                    });
 
                     // Perform ! ReadableStreamBYOBReaderRead(reader, view, 1, readIntoRequest).
                     reader.get().expect("Reader should be set.").read(
@@ -345,7 +344,7 @@ impl ByteTeeUnderlyingSource {
         &self,
         cx: &mut JSContext,
         byte_tee_pull_algorithm: Option<ByteTeePullAlgorithm>,
-    ) -> Rc<Promise> {
+    ) -> RootedPromise {
         let pull_algorithm =
             byte_tee_pull_algorithm.unwrap_or(self.byte_tee_pull_algorithm.clone());
 
@@ -356,7 +355,7 @@ impl ByteTeeUnderlyingSource {
                     // Set readAgainForBranch1 to true.
                     self.read_again_for_branch_1.set(true);
                     // Return a promise resolved with undefined.
-                    return Promise::new_resolved(cx, &self.stream.global(), ());
+                    return Promise::new_resolved_rooted(cx, &self.stream.global(), ());
                 }
 
                 // Set reading to true.
@@ -387,7 +386,7 @@ impl ByteTeeUnderlyingSource {
                 }
 
                 // Return a promise resolved with undefined.
-                Promise::new_resolved(cx, &self.stream.global(), ())
+                Promise::new_resolved_rooted(cx, &self.stream.global(), ())
             },
             ByteTeePullAlgorithm::Pull2Algorithm => {
                 // If reading is true,
@@ -396,7 +395,7 @@ impl ByteTeeUnderlyingSource {
                     self.read_again_for_branch_2.set(true);
 
                     // Return a promise resolved with undefined.
-                    return Promise::new_resolved(cx, &self.stream.global(), ());
+                    return Promise::new_resolved_rooted(cx, &self.stream.global(), ());
                 }
 
                 // Set reading to true.
@@ -426,7 +425,7 @@ impl ByteTeeUnderlyingSource {
                 }
 
                 // Return a promise resolved with undefined.
-                Promise::new_resolved(cx, &self.stream.global(), ())
+                Promise::new_resolved_rooted(cx, &self.stream.global(), ())
             },
         }
     }
@@ -439,7 +438,7 @@ impl ByteTeeUnderlyingSource {
         &self,
         cx: &mut JSContext,
         reason: SafeHandleValue,
-    ) -> Option<Result<Rc<Promise>, Error>> {
+    ) -> Option<Result<RootedPromise, Error>> {
         match self.tee_cancel_algorithm {
             ByteTeeCancelAlgorithm::Cancel1Algorithm => {
                 // Set canceled1 to true.
@@ -454,7 +453,7 @@ impl ByteTeeUnderlyingSource {
                 }
 
                 // Return cancelPromise.
-                Some(Ok(self.cancel_promise.clone()))
+                Some(Ok(self.cancel_promise.root()))
             },
             ByteTeeCancelAlgorithm::Cancel2Algorithm => {
                 // Set canceled_2 to true.
@@ -468,7 +467,7 @@ impl ByteTeeUnderlyingSource {
                     self.resolve_cancel_promise(cx);
                 }
                 // Return cancelPromise.
-                Some(Ok(self.cancel_promise.clone()))
+                Some(Ok(self.cancel_promise.root()))
             },
         }
     }

--- a/components/script/dom/stream/defaultteereadrequest.rs
+++ b/components/script/dom/stream/defaultteereadrequest.rs
@@ -18,7 +18,7 @@ use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::structuredclone;
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{RootedPromise, TracedPromise};
 use crate::dom::stream::defaultteeunderlyingsource::DefaultTeeUnderlyingSource;
 use crate::dom::stream::readablestream::ReadableStream;
 use crate::realms::enter_auto_realm;
@@ -56,8 +56,7 @@ pub(crate) struct DefaultTeeReadRequest {
     canceled_2: Rc<Cell<bool>>,
     #[conditional_malloc_size_of]
     clone_for_branch_2: Rc<Cell<bool>>,
-    #[conditional_malloc_size_of]
-    cancel_promise: Rc<Promise>,
+    cancel_promise: TracedPromise,
     tee_underlying_source: Dom<DefaultTeeUnderlyingSource>,
 }
 impl DefaultTeeReadRequest {
@@ -72,7 +71,7 @@ impl DefaultTeeReadRequest {
         canceled_1: Rc<Cell<bool>>,
         canceled_2: Rc<Cell<bool>>,
         clone_for_branch_2: Rc<Cell<bool>>,
-        cancel_promise: Rc<Promise>,
+        cancel_promise: &RootedPromise,
         tee_underlying_source: &DefaultTeeUnderlyingSource,
     ) -> DomRoot<Self> {
         reflect_dom_object(
@@ -87,7 +86,7 @@ impl DefaultTeeReadRequest {
                 canceled_1,
                 canceled_2,
                 clone_for_branch_2,
-                cancel_promise,
+                cancel_promise: cancel_promise.to_traced(),
                 tee_underlying_source: Dom::from_ref(tee_underlying_source),
             }),
             &*stream.global(),

--- a/components/script/dom/stream/defaultteeunderlyingsource.rs
+++ b/components/script/dom/stream/defaultteeunderlyingsource.rs
@@ -16,7 +16,7 @@ use crate::dom::bindings::error::Error;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise, TracedPromise};
 use crate::dom::stream::defaultteereadrequest::DefaultTeeReadRequest;
 use crate::dom::stream::readablestreamdefaultreader::ReadRequest;
 use crate::dom::types::{ReadableStream, ReadableStreamDefaultReader};
@@ -49,8 +49,7 @@ pub(crate) struct DefaultTeeUnderlyingSource {
     reason_1: Rc<Heap<Value>>,
     #[ignore_malloc_size_of = "mozjs"]
     reason_2: Rc<Heap<Value>>,
-    #[conditional_malloc_size_of]
-    cancel_promise: Rc<Promise>,
+    cancel_promise: TracedPromise,
     tee_cancel_algorithm: DefaultTeeCancelAlgorithm,
 }
 
@@ -68,7 +67,7 @@ impl DefaultTeeUnderlyingSource {
         clone_for_branch_2: Rc<Cell<bool>>,
         reason_1: Rc<Heap<Value>>,
         reason_2: Rc<Heap<Value>>,
-        cancel_promise: Rc<Promise>,
+        cancel_promise: &RootedPromise,
         tee_cancel_algorithm: DefaultTeeCancelAlgorithm,
     ) -> DomRoot<DefaultTeeUnderlyingSource> {
         reflect_dom_object(
@@ -86,7 +85,7 @@ impl DefaultTeeUnderlyingSource {
                 clone_for_branch_2,
                 reason_1,
                 reason_2,
-                cancel_promise,
+                cancel_promise: cancel_promise.to_traced(),
                 tee_cancel_algorithm,
             }),
             &*stream.global(),
@@ -103,13 +102,13 @@ impl DefaultTeeUnderlyingSource {
 
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaulttee>
     /// Let pullAlgorithm be the following steps:
-    pub(crate) fn pull_algorithm(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
+    pub(crate) fn pull_algorithm(&self, cx: &mut js::context::JSContext) -> RootedPromise {
         // If reading is true,
         if self.reading.get() {
             // Set readAgain to true.
             self.read_again.set(true);
             // Return a promise resolved with undefined.
-            return Promise::new_resolved(cx, &self.stream.global(), ());
+            return Promise::new_resolved_rooted(cx, &self.stream.global(), ());
         }
 
         // Set reading to true.
@@ -126,7 +125,7 @@ impl DefaultTeeUnderlyingSource {
             self.canceled_1.clone(),
             self.canceled_2.clone(),
             self.clone_for_branch_2.clone(),
-            self.cancel_promise.clone(),
+            &self.cancel_promise.root(),
             self,
         );
 
@@ -139,7 +138,7 @@ impl DefaultTeeUnderlyingSource {
         self.reader.read(cx, &read_request);
 
         // Return a promise resolved with undefined.
-        Promise::new_resolved(cx, &self.stream.global(), ())
+        Promise::new_resolved_rooted(cx, &self.stream.global(), ())
     }
 
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaulttee>
@@ -151,7 +150,7 @@ impl DefaultTeeUnderlyingSource {
         cx: &mut js::context::JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
-    ) -> Option<Result<Rc<Promise>, Error>> {
+    ) -> Option<Result<RootedPromise, Error>> {
         match self.tee_cancel_algorithm {
             DefaultTeeCancelAlgorithm::Cancel1Algorithm => {
                 // Set canceled_1 to true.
@@ -165,7 +164,7 @@ impl DefaultTeeUnderlyingSource {
                     self.resolve_cancel_promise(cx, global);
                 }
                 // Return cancelPromise.
-                Some(Ok(self.cancel_promise.clone()))
+                Some(Ok(self.cancel_promise.root()))
             },
             DefaultTeeCancelAlgorithm::Cancel2Algorithm => {
                 // Set canceled_2 to true.
@@ -179,7 +178,7 @@ impl DefaultTeeUnderlyingSource {
                     self.resolve_cancel_promise(cx, global);
                 }
                 // Return cancelPromise.
-                Some(Ok(self.cancel_promise.clone()))
+                Some(Ok(self.cancel_promise.root()))
             },
         }
     }

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -5,7 +5,6 @@
 use std::cell::Cell;
 use std::cmp::min;
 use std::collections::VecDeque;
-use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
@@ -31,7 +30,7 @@ use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise};
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::stream::readablestream::ReadableStream;
 use crate::dom::stream::readablestreambyobrequest::ReadableStreamBYOBRequest;
@@ -1662,14 +1661,14 @@ impl ReadableByteStreamController {
             let result = underlying_source
                 .call_pull_algorithm(cx, controller)
                 .unwrap_or_else(|| {
-                    let promise = Promise::new_resolved(cx, &global, ());
+                    let promise = Promise::new_resolved_rooted(cx, &global, ());
                     Ok(promise)
                 });
             let promise = result.unwrap_or_else(|error| {
                 rooted!(&in(cx) let mut rval = UndefinedValue());
                 // TODO: check if `self.global()` is the right globalscope.
                 error.to_jsval(cx, &global, rval.handle_mut());
-                Promise::new_rejected(cx, &global, rval.handle())
+                Promise::new_rejected_rooted(cx, &global, rval.handle())
             });
             promise.append_native_handler(cx, &handler);
         }
@@ -1774,7 +1773,7 @@ impl ReadableByteStreamController {
                     cx,
                     Controller::ReadableByteStreamController(rooted_byte_controller.clone()),
                 )
-                .unwrap_or_else(|| Ok(Promise::new_resolved(cx, global, ())));
+                .unwrap_or_else(|| Ok(Promise::new_resolved_rooted(cx, global, ())));
 
             // Let startPromise be a promise resolved with startResult.
             let start_promise = start_result?;
@@ -1822,7 +1821,7 @@ impl ReadableByteStreamController {
         cx: &mut JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
-    ) -> Rc<Promise> {
+    ) -> RootedPromise {
         // Perform ! ReadableByteStreamControllerClearPendingPullIntos(this).
         self.clear_pending_pull_intos();
 
@@ -1838,7 +1837,7 @@ impl ReadableByteStreamController {
         let result = underlying_source
             .call_cancel_algorithm(cx, global, reason)
             .unwrap_or_else(|| {
-                let promise = Promise::new(cx, global);
+                let promise = Promise::new_rooted(cx, global);
                 promise.resolve_native(cx, &());
                 Ok(promise)
             });
@@ -1846,7 +1845,7 @@ impl ReadableByteStreamController {
         let promise = result.unwrap_or_else(|error| {
             rooted!(&in(cx) let mut rval = UndefinedValue());
             error.to_jsval(cx, global, rval.handle_mut());
-            let promise = Promise::new(cx, global);
+            let promise = Promise::new_rooted(cx, global);
             promise.reject_native(cx, &rval.handle());
             promise
         });

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -1364,7 +1364,7 @@ impl ReadableStream {
     /// and before `stop_reading`.
     /// Native call to
     /// <https://streams.spec.whatwg.org/#readable-stream-default-reader-read>
-    pub(crate) fn read_a_chunk(&self, cx: &mut JSContext) -> Rc<Promise> {
+    pub(crate) fn read_a_chunk(&self, cx: &mut JSContext) -> RootedPromise {
         match self.reader.borrow().as_ref() {
             Some(ReaderType::Default(reader)) => {
                 let Some(reader) = reader.get() else {
@@ -1552,7 +1552,7 @@ impl ReadableStream {
 
                 // Let readIntoRequest be reader.[[readIntoRequests]][0].
                 // Remove readIntoRequest from reader.[[readIntoRequests]].
-                let read_into_request = reader.remove_read_into_request();
+                rooted!(&in(cx) let read_into_request = reader.remove_read_into_request());
 
                 // If done is true, perform readIntoRequest’s close steps, given chunk.
                 let result = RootedTraceableBox::new(Heap::default());
@@ -1734,7 +1734,7 @@ impl ReadableStream {
         let reason_2 = Rc::new(Heap::default());
 
         // Let cancelPromise be a new promise.
-        let cancel_promise = Promise::new(cx, &self.global());
+        let cancel_promise = Promise::new_rooted(cx, &self.global());
         let reader_version = Rc::new(Cell::new(0));
 
         let byte_tee_source_1 = ByteTeeUnderlyingSource::new(
@@ -1748,7 +1748,7 @@ impl ReadableStream {
             canceled_2.clone(),
             reason_1.clone(),
             reason_2.clone(),
-            cancel_promise.clone(),
+            &cancel_promise,
             reader_version.clone(),
             ByteTeeCancelAlgorithm::Cancel1Algorithm,
             ByteTeePullAlgorithm::Pull1Algorithm,
@@ -1765,7 +1765,7 @@ impl ReadableStream {
             canceled_2,
             reason_1,
             reason_2,
-            cancel_promise,
+            &cancel_promise,
             reader_version,
             ByteTeeCancelAlgorithm::Cancel2Algorithm,
             ByteTeePullAlgorithm::Pull2Algorithm,
@@ -1826,7 +1826,7 @@ impl ReadableStream {
         // Let reason2 be undefined.
         let reason_2 = Rc::new(Heap::default());
         // Let cancelPromise be a new promise.
-        let cancel_promise = Promise::new(cx, &self.global());
+        let cancel_promise = Promise::new_rooted(cx, &self.global());
 
         let tee_source_1 = DefaultTeeUnderlyingSource::new(
             cx,
@@ -1839,7 +1839,7 @@ impl ReadableStream {
             clone_for_branch_2.clone(),
             reason_1.clone(),
             reason_2.clone(),
-            cancel_promise.clone(),
+            &cancel_promise,
             DefaultTeeCancelAlgorithm::Cancel1Algorithm,
         );
 
@@ -1856,7 +1856,7 @@ impl ReadableStream {
             clone_for_branch_2,
             reason_1,
             reason_2,
-            cancel_promise.clone(),
+            &cancel_promise,
             DefaultTeeCancelAlgorithm::Cancel2Algorithm,
         );
 
@@ -1891,7 +1891,7 @@ impl ReadableStream {
             &branch_2,
             canceled_1,
             canceled_2,
-            cancel_promise,
+            &cancel_promise,
         );
 
         // Return « branch_1, branch_2 ».
@@ -2196,17 +2196,17 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
     }
 
     /// <https://streams.spec.whatwg.org/#rs-cancel>
-    fn Cancel(&self, cx: &mut JSContext, reason: SafeHandleValue) -> Rc<Promise> {
+    fn Cancel(&self, cx: &mut JSContext, reason: SafeHandleValue) -> RootedPromise {
         let global = self.global();
         if self.is_locked() {
             // If ! IsReadableStreamLocked(this) is true,
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new(cx, &global);
+            let promise = Promise::new_rooted(cx, &global);
             promise.reject_error(cx, Error::Type(c"stream is locked".to_owned()));
             promise
         } else {
             // Return ! ReadableStreamCancel(this, reason).
-            self.cancel(cx, &global, reason).into()
+            self.cancel(cx, &global, reason)
         }
     }
 
@@ -2243,13 +2243,13 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
         cx: &mut CurrentRealm,
         destination: &WritableStream,
         options: &StreamPipeOptions,
-    ) -> Rc<Promise> {
+    ) -> RootedPromise {
         let global = self.global();
 
         // If ! IsReadableStreamLocked(this) is true,
         if self.is_locked() {
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new(cx, &global);
+            let promise = Promise::new_rooted(cx, &global);
             promise.reject_error(cx, Error::Type(c"Source stream is locked".to_owned()));
             return promise;
         }
@@ -2257,7 +2257,7 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
         // If ! IsWritableStreamLocked(destination) is true,
         if destination.is_locked() {
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new(cx, &global);
+            let promise = Promise::new_rooted(cx, &global);
             promise.reject_error(cx, Error::Type(c"Destination stream is locked".to_owned()));
             return promise;
         }
@@ -2275,7 +2275,6 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
             options.preventCancel,
             signal,
         )
-        .into()
     }
 
     /// <https://streams.spec.whatwg.org/#rs-pipe-through>

--- a/components/script/dom/stream/readablestreambyobreader.rs
+++ b/components/script/dom/stream/readablestreambyobreader.rs
@@ -34,20 +34,23 @@ use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise, TracedPromise};
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::stream::readablestream::ReadableStream;
 use crate::realms::enter_auto_realm;
 
 /// <https://streams.spec.whatwg.org/#read-into-request>
 #[derive(Clone, JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub enum ReadIntoRequest {
     /// <https://streams.spec.whatwg.org/#byob-reader-read>
-    Read(#[conditional_malloc_size_of] Rc<Promise>),
+    Read(TracedPromise),
     ByteTee {
         byte_tee_read_into_request: Dom<ByteTeeReadIntoRequest>,
     },
 }
+
+impl js::gc::Rootable for ReadIntoRequest {}
 
 impl ReadIntoRequest {
     /// <https://streams.spec.whatwg.org/#ref-for-read-into-request-chunk-steps%E2%91%A0>
@@ -152,8 +155,7 @@ struct ByteTeeClosedPromiseRejectionHandler {
     canceled_1: Rc<Cell<bool>>,
     #[conditional_malloc_size_of]
     canceled_2: Rc<Cell<bool>>,
-    #[conditional_malloc_size_of]
-    cancel_promise: Rc<Promise>,
+    cancel_promise: TracedPromise,
     #[conditional_malloc_size_of]
     reader_version: Rc<Cell<u64>>,
     expected_version: u64,
@@ -192,8 +194,7 @@ pub(crate) struct ReadableStreamBYOBReader {
     read_into_requests: DomRefCell<VecDeque<ReadIntoRequest>>,
 
     /// <https://streams.spec.whatwg.org/#readablestreamgenericreader-closedpromise>
-    #[conditional_malloc_size_of]
-    closed_promise: DomRefCell<Rc<Promise>>,
+    closed_promise: DomRefCell<TracedPromise>,
 }
 
 impl ReadableStreamBYOBReader {
@@ -202,21 +203,21 @@ impl ReadableStreamBYOBReader {
         global: &GlobalScope,
         proto: Option<SafeHandleObject>,
     ) -> DomRoot<ReadableStreamBYOBReader> {
-        let closed_promise = Promise::new(cx, global);
+        let closed_promise = Promise::new_rooted(cx, global);
         reflect_dom_object_with_proto(
             cx,
-            Box::new(ReadableStreamBYOBReader::new_inherited(closed_promise)),
+            Box::new(ReadableStreamBYOBReader::new_inherited(&closed_promise)),
             global,
             proto,
         )
     }
 
-    fn new_inherited(promise: Rc<Promise>) -> ReadableStreamBYOBReader {
+    fn new_inherited(promise: &RootedPromise) -> ReadableStreamBYOBReader {
         ReadableStreamBYOBReader {
             reflector_: Reflector::new(),
             stream: MutNullableDom::new(None),
             read_into_requests: DomRefCell::new(Default::default()),
-            closed_promise: DomRefCell::new(promise),
+            closed_promise: DomRefCell::new(promise.to_traced()),
         }
     }
 
@@ -224,8 +225,8 @@ impl ReadableStreamBYOBReader {
         cx: &mut JSContext,
         global: &GlobalScope,
     ) -> DomRoot<ReadableStreamBYOBReader> {
-        let closed_promise = Promise::new(cx, global);
-        reflect_dom_object_with_cx(Box::new(Self::new_inherited(closed_promise)), global, cx)
+        let closed_promise = Promise::new_rooted(cx, global);
+        reflect_dom_object_with_cx(Box::new(Self::new_inherited(&closed_promise)), global, cx)
     }
 
     /// <https://streams.spec.whatwg.org/#set-up-readable-stream-byob-reader>
@@ -282,10 +283,10 @@ impl ReadableStreamBYOBReader {
         self.closed_promise.borrow().set_promise_is_handled(cx);
 
         // Let readRequests be reader.[[readRequests]].
-        let mut read_into_requests = self.take_read_into_requests();
+        rooted!(&in(cx) let read_into_requests = self.take_read_into_requests());
 
         // Set reader.[[readIntoRequests]] to a new empty list.
-        for request in read_into_requests.drain(0..) {
+        for request in read_into_requests.iter() {
             // Perform readIntoRequest’s error steps, given e.
             request.error_steps(cx, e);
         }
@@ -306,10 +307,10 @@ impl ReadableStreamBYOBReader {
     pub(crate) fn cancel(&self, cx: &mut JSContext) {
         // If reader is not undefined and reader implements ReadableStreamBYOBReader,
         // Let readIntoRequests be reader.[[readIntoRequests]].
-        let mut read_into_requests = self.take_read_into_requests();
+        rooted!(&in(cx) let read_into_requests = self.take_read_into_requests());
         // Set reader.[[readIntoRequests]] to an empty list.
         // Perform readIntoRequest’s close steps, given undefined.
-        for request in read_into_requests.drain(0..) {
+        for request in read_into_requests.iter() {
             // Perform readIntoRequest’s close steps, given undefined.
             request.close_steps(cx, None);
         }
@@ -369,7 +370,7 @@ impl ReadableStreamBYOBReader {
         branch_2: &ReadableStream,
         canceled_1: Rc<Cell<bool>>,
         canceled_2: Rc<Cell<bool>>,
-        cancel_promise: Rc<Promise>,
+        cancel_promise: &RootedPromise,
         reader_version: Rc<Cell<u64>>,
         expected_version: u64,
     ) {
@@ -387,7 +388,7 @@ impl ReadableStreamBYOBReader {
                 branch_2_controller: Dom::from_ref(&branch_2_controller),
                 canceled_1,
                 canceled_2,
-                cancel_promise,
+                cancel_promise: cancel_promise.to_traced(),
                 reader_version,
                 expected_version,
             })),
@@ -424,11 +425,11 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
         cx: &mut JSContext,
         view: CustomAutoRooterGuard<ArrayBufferView>,
         options: &ReadableStreamBYOBReaderReadOptions,
-    ) -> Rc<Promise> {
+    ) -> RootedPromise {
         let view = HeapBufferSource::<ArrayBufferViewU8>::from_view(cx, view);
         let min = options.min;
         // Let promise be a new promise.
-        let promise = Promise::new(cx, &self.global());
+        let promise = Promise::new_rooted(cx, &self.global());
 
         // If view.[[ByteLength]] is 0, return a promise rejected with a TypeError exception.
         if view.byte_length() == 0 {
@@ -499,7 +500,7 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
         //
         // error steps, given e
         // Reject promise with e
-        let read_into_request = ReadIntoRequest::Read(promise.clone());
+        rooted!(&in(cx) let read_into_request = ReadIntoRequest::Read(promise.to_traced()));
 
         // Perform ! ReadableStreamBYOBReaderRead(this, view, options["min"], readIntoRequest).
         self.read(cx, &view, min, &read_into_request);
@@ -520,23 +521,23 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
     }
 
     /// <https://streams.spec.whatwg.org/#generic-reader-closed>
-    fn Closed(&self) -> Rc<Promise> {
+    fn Closed(&self) -> RootedPromise {
         self.closed()
     }
 
     /// <https://streams.spec.whatwg.org/#generic-reader-cancel>
-    fn Cancel(&self, cx: &mut JSContext, reason: SafeHandleValue) -> Rc<Promise> {
+    fn Cancel(&self, cx: &mut JSContext, reason: SafeHandleValue) -> RootedPromise {
         self.generic_cancel(cx, &self.global(), reason)
     }
 }
 
 impl ReadableStreamGenericReader for ReadableStreamBYOBReader {
-    fn get_closed_promise(&self) -> Rc<Promise> {
-        self.closed_promise.borrow().clone()
+    fn get_closed_promise(&self) -> RootedPromise {
+        self.closed_promise.borrow().root()
     }
 
-    fn set_closed_promise(&self, promise: Rc<Promise>) {
-        *self.closed_promise.borrow_mut() = promise;
+    fn set_closed_promise(&self, promise: &RootedPromise) {
+        *self.closed_promise.borrow_mut() = promise.to_traced();
     }
 
     fn set_stream(&self, stream: Option<&ReadableStream>) {

--- a/components/script/dom/stream/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/readablestreamdefaultcontroller.rs
@@ -28,7 +28,7 @@ use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise};
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::stream::readablestream::ReadableStream;
 use crate::dom::stream::readablestreamdefaultreader::ReadRequest;
@@ -401,7 +401,7 @@ impl ReadableStreamDefaultController {
                     Controller::ReadableStreamDefaultController(rooted_default_controller.clone()),
                 )
                 .unwrap_or_else(|| {
-                    let promise = Promise::new_resolved(cx, global, ());
+                    let promise = Promise::new_resolved_rooted(cx, global, ());
                     Ok(promise)
                 });
 
@@ -522,14 +522,14 @@ impl ReadableStreamDefaultController {
         let result = underlying_source
             .call_pull_algorithm(cx, controller)
             .unwrap_or_else(|| {
-                let promise = Promise::new_resolved(cx, &global, ());
+                let promise = Promise::new_resolved_rooted(cx, &global, ());
                 Ok(promise)
             });
         let promise = result.unwrap_or_else(|error| {
             rooted!(&in(cx) let mut rval = UndefinedValue());
             // TODO: check if `self.global()` is the right globalscope.
             error.to_jsval(cx, &global, rval.handle_mut());
-            Promise::new_rejected(cx, &global, rval.handle())
+            Promise::new_rejected_rooted(cx, &global, rval.handle())
         });
         promise.append_native_handler(cx, &handler);
     }
@@ -540,7 +540,7 @@ impl ReadableStreamDefaultController {
         cx: &mut JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
-    ) -> Rc<Promise> {
+    ) -> RootedPromise {
         // Perform ! ResetQueue(this).
         self.queue.reset();
 
@@ -552,7 +552,7 @@ impl ReadableStreamDefaultController {
         let result = underlying_source
             .call_cancel_algorithm(cx, global, reason)
             .unwrap_or_else(|| {
-                let promise = Promise::new(cx, global);
+                let promise = Promise::new_rooted(cx, global);
                 promise.resolve_native(cx, &());
                 Ok(promise)
             });
@@ -560,7 +560,7 @@ impl ReadableStreamDefaultController {
             rooted!(&in(cx) let mut rval = UndefinedValue());
 
             error.to_jsval(cx, global, rval.handle_mut());
-            let promise = Promise::new(cx, global);
+            let promise = Promise::new_rooted(cx, global);
             promise.reject_native(cx, &rval.handle());
             promise
         });

--- a/components/script/dom/stream/readablestreamdefaultreader.rs
+++ b/components/script/dom/stream/readablestreamdefaultreader.rs
@@ -28,7 +28,7 @@ use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::{Promise, TracedPromise};
+use crate::dom::promise::{Promise, RootedPromise, TracedPromise};
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::readablestream::{ReadableStream, bytes_from_chunk_jsval};
 use crate::dom::stream::defaultteereadrequest::DefaultTeeReadRequest;
@@ -270,8 +270,7 @@ struct ByteTeeClosedPromiseRejectionHandler {
     canceled_1: Rc<Cell<bool>>,
     #[conditional_malloc_size_of]
     canceled_2: Rc<Cell<bool>>,
-    #[conditional_malloc_size_of]
-    cancel_promise: Rc<Promise>,
+    cancel_promise: TracedPromise,
     #[conditional_malloc_size_of]
     reader_version: Rc<Cell<u64>>,
     expected_version: u64,
@@ -310,8 +309,7 @@ struct DefaultTeeClosedPromiseRejectionHandler {
     canceled_1: Rc<Cell<bool>>,
     #[conditional_malloc_size_of]
     canceled_2: Rc<Cell<bool>>,
-    #[conditional_malloc_size_of]
-    cancel_promise: Rc<Promise>,
+    cancel_promise: TracedPromise,
 }
 
 impl Callback for DefaultTeeClosedPromiseRejectionHandler {
@@ -341,8 +339,7 @@ pub(crate) struct ReadableStreamDefaultReader {
     read_requests: DomRefCell<VecDeque<ReadRequest>>,
 
     /// <https://streams.spec.whatwg.org/#readablestreamgenericreader-closedpromise>
-    #[conditional_malloc_size_of]
-    closed_promise: DomRefCell<Rc<Promise>>,
+    closed_promise: DomRefCell<TracedPromise>,
 }
 
 impl ReadableStreamDefaultReader {
@@ -351,21 +348,21 @@ impl ReadableStreamDefaultReader {
         global: &GlobalScope,
         proto: Option<SafeHandleObject>,
     ) -> DomRoot<ReadableStreamDefaultReader> {
-        let closed_promise = Promise::new(cx, global);
+        let closed_promise = Promise::new_rooted(cx, global);
         reflect_dom_object_with_proto(
             cx,
-            Box::new(ReadableStreamDefaultReader::new_inherited(closed_promise)),
+            Box::new(ReadableStreamDefaultReader::new_inherited(&closed_promise)),
             global,
             proto,
         )
     }
 
-    fn new_inherited(promise: Rc<Promise>) -> ReadableStreamDefaultReader {
+    fn new_inherited(promise: &RootedPromise) -> ReadableStreamDefaultReader {
         ReadableStreamDefaultReader {
             reflector_: Reflector::new(),
             stream: MutNullableDom::new(None),
             read_requests: DomRefCell::new(Default::default()),
-            closed_promise: DomRefCell::new(promise),
+            closed_promise: DomRefCell::new(promise.to_traced()),
         }
     }
 
@@ -373,8 +370,8 @@ impl ReadableStreamDefaultReader {
         cx: &mut JSContext,
         global: &GlobalScope,
     ) -> DomRoot<ReadableStreamDefaultReader> {
-        let closed_promise = Promise::new(cx, global);
-        reflect_dom_object_with_cx(Box::new(Self::new_inherited(closed_promise)), global, cx)
+        let closed_promise = Promise::new_rooted(cx, global);
+        reflect_dom_object_with_cx(Box::new(Self::new_inherited(&closed_promise)), global, cx)
     }
 
     /// <https://streams.spec.whatwg.org/#set-up-readable-stream-default-reader>
@@ -516,7 +513,7 @@ impl ReadableStreamDefaultReader {
         branch_2: &ReadableStream,
         canceled_1: Rc<Cell<bool>>,
         canceled_2: Rc<Cell<bool>>,
-        cancel_promise: Rc<Promise>,
+        cancel_promise: &RootedPromise,
         reader_version: Rc<Cell<u64>>,
         expected_version: u64,
     ) {
@@ -534,7 +531,7 @@ impl ReadableStreamDefaultReader {
                 branch_2_controller: Dom::from_ref(&branch_2_controller),
                 canceled_1,
                 canceled_2,
-                cancel_promise,
+                cancel_promise: cancel_promise.to_traced(),
                 reader_version,
                 expected_version,
             })),
@@ -556,7 +553,7 @@ impl ReadableStreamDefaultReader {
         branch_2: &ReadableStream,
         canceled_1: Rc<Cell<bool>>,
         canceled_2: Rc<Cell<bool>>,
-        cancel_promise: Rc<Promise>,
+        cancel_promise: &RootedPromise,
     ) {
         let branch_1_controller = branch_1.get_default_controller();
 
@@ -572,7 +569,7 @@ impl ReadableStreamDefaultReader {
                 branch_2_controller: Dom::from_ref(&branch_2_controller),
                 canceled_1,
                 canceled_2,
-                cancel_promise,
+                cancel_promise: cancel_promise.to_traced(),
             })),
         );
 
@@ -641,7 +638,7 @@ impl ReadableStreamDefaultReaderMethods<crate::DomTypeHolder> for ReadableStream
     }
 
     /// <https://streams.spec.whatwg.org/#default-reader-read>
-    fn Read(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
+    fn Read(&self, cx: &mut js::context::JSContext) -> RootedPromise {
         // If this.[[stream]] is undefined, return a promise rejected with a TypeError exception.
         if self.stream.get().is_none() {
             rooted!(&in(cx) let mut error = UndefinedValue());
@@ -650,7 +647,7 @@ impl ReadableStreamDefaultReaderMethods<crate::DomTypeHolder> for ReadableStream
                 &self.global(),
                 error.handle_mut(),
             );
-            return Promise::new_rejected(cx, &self.global(), error.handle());
+            return Promise::new_rejected_rooted(cx, &self.global(), error.handle());
         }
         // Let promise be a new promise.
         let promise = Promise::new_rooted(cx, &self.global());
@@ -671,7 +668,7 @@ impl ReadableStreamDefaultReaderMethods<crate::DomTypeHolder> for ReadableStream
         self.read(cx, &read_request);
 
         // Return promise.
-        promise.into()
+        promise
     }
 
     /// <https://streams.spec.whatwg.org/#default-reader-release-lock>
@@ -686,23 +683,23 @@ impl ReadableStreamDefaultReaderMethods<crate::DomTypeHolder> for ReadableStream
     }
 
     /// <https://streams.spec.whatwg.org/#generic-reader-closed>
-    fn Closed(&self) -> Rc<Promise> {
+    fn Closed(&self) -> RootedPromise {
         self.closed()
     }
 
     /// <https://streams.spec.whatwg.org/#generic-reader-cancel>
-    fn Cancel(&self, cx: &mut js::context::JSContext, reason: SafeHandleValue) -> Rc<Promise> {
+    fn Cancel(&self, cx: &mut js::context::JSContext, reason: SafeHandleValue) -> RootedPromise {
         self.generic_cancel(cx, &self.global(), reason)
     }
 }
 
 impl ReadableStreamGenericReader for ReadableStreamDefaultReader {
-    fn get_closed_promise(&self) -> Rc<Promise> {
-        self.closed_promise.borrow().clone()
+    fn get_closed_promise(&self) -> RootedPromise {
+        self.closed_promise.borrow().root()
     }
 
-    fn set_closed_promise(&self, promise: Rc<Promise>) {
-        *self.closed_promise.borrow_mut() = promise;
+    fn set_closed_promise(&self, promise: &RootedPromise) {
+        *self.closed_promise.borrow_mut() = promise.to_traced();
     }
 
     fn set_stream(&self, stream: Option<&ReadableStream>) {

--- a/components/script/dom/stream/readablestreamgenericreader.rs
+++ b/components/script/dom/stream/readablestreamgenericreader.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::rc::Rc;
-
 use js::context::JSContext;
 use js::jsval::UndefinedValue;
 use js::rust::HandleValue as SafeHandleValue;
@@ -13,7 +11,7 @@ use crate::dom::bindings::error::{Error, ErrorToJsval, Fallible};
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise};
 use crate::dom::stream::readablestreambyobreader::ReadableStreamBYOBReader;
 use crate::dom::stream::readablestreamdefaultreader::ReadableStreamDefaultReader;
 use crate::dom::types::ReadableStream;
@@ -44,11 +42,11 @@ pub(crate) trait ReadableStreamGenericReader {
         if stream.is_readable() {
             // If stream.[[state]] is "readable
             // Set reader.[[closedPromise]] to a new promise.
-            self.set_closed_promise(Promise::new(cx, global));
+            self.set_closed_promise(&Promise::new_rooted(cx, global));
         } else if stream.is_closed() {
             // Otherwise, if stream.[[state]] is "closed",
             // Set reader.[[closedPromise]] to a promise resolved with undefined.
-            self.set_closed_promise(Promise::new_resolved(cx, global, ()));
+            self.set_closed_promise(&Promise::new_resolved_rooted(cx, global, ()));
         } else {
             // Assert: stream.[[state]] is "errored"
             assert!(stream.is_errored());
@@ -56,7 +54,7 @@ pub(crate) trait ReadableStreamGenericReader {
             // Set reader.[[closedPromise]] to a promise rejected with stream.[[storedError]].
             rooted!(&in(cx) let mut error = UndefinedValue());
             stream.get_stored_error(error.handle_mut());
-            self.set_closed_promise(Promise::new_rejected(cx, global, error.handle()));
+            self.set_closed_promise(&Promise::new_rejected_rooted(cx, global, error.handle()));
 
             // Set reader.[[closedPromise]].[[PromiseIsHandled]] to true
             self.get_closed_promise().set_promise_is_handled(cx);
@@ -69,7 +67,7 @@ pub(crate) trait ReadableStreamGenericReader {
         cx: &mut JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
-    ) -> Rc<Promise> {
+    ) -> RootedPromise {
         // Let stream be reader.[[stream]].
         let stream = self.get_stream();
 
@@ -78,7 +76,7 @@ pub(crate) trait ReadableStreamGenericReader {
             stream.expect("Reader should have a stream when generic cancel is called into.");
 
         // Return ! ReadableStreamCancel(stream, reason).
-        stream.cancel(cx, global, reason).into()
+        stream.cancel(cx, global, reason)
     }
 
     /// <https://streams.spec.whatwg.org/#readable-stream-reader-generic-release>
@@ -109,7 +107,7 @@ pub(crate) trait ReadableStreamGenericReader {
                     error.handle_mut(),
                 );
 
-                self.set_closed_promise(Promise::new_rejected(
+                self.set_closed_promise(&Promise::new_rejected_rooted(
                     cx,
                     &stream.global(),
                     error.handle(),
@@ -132,7 +130,7 @@ pub(crate) trait ReadableStreamGenericReader {
     }
 
     /// <https://streams.spec.whatwg.org/#generic-reader-closed>
-    fn closed(&self) -> Rc<Promise> {
+    fn closed(&self) -> RootedPromise {
         self.get_closed_promise()
     }
 
@@ -142,11 +140,11 @@ pub(crate) trait ReadableStreamGenericReader {
         cx: &mut JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
-    ) -> Rc<Promise> {
+    ) -> RootedPromise {
         if self.get_stream().is_none() {
             // If this.[[stream]] is undefined,
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new(cx, global);
+            let promise = Promise::new_rooted(cx, global);
             promise.reject_error(cx, Error::Type(c"stream is undefined".to_owned()));
             promise
         } else {
@@ -159,9 +157,9 @@ pub(crate) trait ReadableStreamGenericReader {
 
     fn get_stream(&self) -> Option<DomRoot<ReadableStream>>;
 
-    fn set_closed_promise(&self, promise: Rc<Promise>);
+    fn set_closed_promise(&self, promise: &RootedPromise);
 
-    fn get_closed_promise(&self) -> Rc<Promise>;
+    fn get_closed_promise(&self) -> RootedPromise;
 
     fn as_default_reader(&self) -> Option<&ReadableStreamDefaultReader> {
         None

--- a/components/script/dom/stream/transformstream.rs
+++ b/components/script/dom/stream/transformstream.rs
@@ -543,7 +543,7 @@ impl TransformStream {
         let readable = create_readable_stream(
             cx,
             global,
-            UnderlyingSourceType::Transform(self, &start_promise),
+            UnderlyingSourceType::Transform(self, start_promise),
             Some(readable_size_algorithm),
             Some(readable_high_water_mark),
         );

--- a/components/script/dom/stream/transformstream.rs
+++ b/components/script/dom/stream/transformstream.rs
@@ -34,7 +34,7 @@ use crate::dom::bindings::structuredclone::StructuredData;
 use crate::dom::bindings::transferable::Transferable;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::messageport::MessagePort;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise, TracedPromise};
 use crate::dom::promisenativehandler::Callback;
 use crate::dom::readablestream::{ReadableStream, create_readable_stream};
 use crate::dom::stream::countqueuingstrategy::{extract_high_water_mark, extract_size_algorithm};
@@ -53,8 +53,7 @@ impl js::gc::Rootable for TransformBackPressureChangePromiseFulfillment {}
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 struct TransformBackPressureChangePromiseFulfillment {
     /// The result of reacting to backpressureChangePromise.
-    #[conditional_malloc_size_of]
-    result_promise: Rc<Promise>,
+    result_promise: TracedPromise,
 
     #[ignore_malloc_size_of = "mozjs"]
     chunk: Box<Heap<JSVal>>,
@@ -117,8 +116,7 @@ impl Callback for TransformBackPressureChangePromiseFulfillment {
 /// Reacting to fulfillment of performTransform as part of
 /// <https://streams.spec.whatwg.org/#transform-stream-default-sink-write-algorithm>
 struct PerformTransformFulfillment {
-    #[conditional_malloc_size_of]
-    result_promise: Rc<Promise>,
+    result_promise: TracedPromise,
 }
 
 impl Callback for PerformTransformFulfillment {
@@ -133,8 +131,7 @@ impl Callback for PerformTransformFulfillment {
 /// Reacting to rejection of performTransform as part of
 /// <https://streams.spec.whatwg.org/#transform-stream-default-sink-write-algorithm>
 struct PerformTransformRejection {
-    #[conditional_malloc_size_of]
-    result_promise: Rc<Promise>,
+    result_promise: TracedPromise,
 }
 
 impl Callback for PerformTransformRejection {
@@ -149,8 +146,7 @@ impl Callback for PerformTransformRejection {
 /// Reacting to rejection of backpressureChangePromise as part of
 /// <https://streams.spec.whatwg.org/#transform-stream-default-sink-write-algorithm>
 struct BackpressureChangeRejection {
-    #[conditional_malloc_size_of]
-    result_promise: Rc<Promise>,
+    result_promise: TracedPromise,
 }
 
 impl Callback for BackpressureChangeRejection {
@@ -390,8 +386,7 @@ pub struct TransformStream {
     backpressure: Cell<bool>,
 
     /// <https://streams.spec.whatwg.org/#transformstream-backpressurechangepromise>
-    #[conditional_malloc_size_of]
-    backpressure_change_promise: DomRefCell<Option<Rc<Promise>>>,
+    backpressure_change_promise: DomRefCell<Option<TracedPromise>>,
 
     /// <https://streams.spec.whatwg.org/#transformstream-controller>
     controller: MutNullableDom<TransformStreamDefaultController>,
@@ -460,7 +455,7 @@ impl TransformStream {
         // NOTE: These steps are implemented in `TransformStreamDefaultController::new`
 
         // Step 8. Let startPromise be a promise resolved with undefined.
-        let start_promise = Promise::new_resolved(cx, global, ());
+        let start_promise = Promise::new_resolved_rooted(cx, global, ());
 
         // Step 9. Perform ! InitializeTransformStream(stream, startPromise,
         // writableHighWaterMark, writableSizeAlgorithm, readableHighWaterMark,
@@ -468,7 +463,7 @@ impl TransformStream {
         self.initialize(
             cx,
             global,
-            start_promise,
+            &start_promise,
             writable_high_water_mark,
             writable_size_algorithm,
             readable_high_water_mark,
@@ -508,7 +503,7 @@ impl TransformStream {
         &self,
         cx: &mut JSContext,
         global: &GlobalScope,
-        start_promise: Rc<Promise>,
+        start_promise: &RootedPromise,
         writable_high_water_mark: f64,
         writable_size_algorithm: Rc<QueuingStrategySize>,
         readable_high_water_mark: f64,
@@ -530,7 +525,7 @@ impl TransformStream {
             global,
             writable_high_water_mark,
             writable_size_algorithm,
-            UnderlyingSinkType::Transform(Dom::from_ref(self), start_promise.clone()),
+            UnderlyingSinkType::Transform(Dom::from_ref(self), start_promise.to_traced()),
         )?;
         self.writable.set(Some(&writable));
 
@@ -548,7 +543,7 @@ impl TransformStream {
         let readable = create_readable_stream(
             cx,
             global,
-            UnderlyingSourceType::Transform(self, start_promise),
+            UnderlyingSourceType::Transform(self, &start_promise),
             Some(readable_size_algorithm),
             Some(readable_high_water_mark),
         );
@@ -578,12 +573,14 @@ impl TransformStream {
 
         // If stream.[[backpressureChangePromise]] is not undefined, resolve
         // stream.[[backpressureChangePromise]] with undefined.
-        if let Some(promise) = self.backpressure_change_promise.borrow_mut().take() {
+        rooted!(&in(cx) let promise = self.backpressure_change_promise.borrow_mut().take());
+        if let Some(ref promise) = *promise {
             promise.resolve_native(cx, &());
         }
 
         // Set stream.[[backpressureChangePromise]] to a new promise.;
-        *self.backpressure_change_promise.borrow_mut() = Some(Promise::new(cx, global));
+        *self.backpressure_change_promise.borrow_mut() =
+            Some(Promise::new_rooted(cx, global).to_traced());
 
         // Set stream.[[backpressure]] to backpressure.
         self.backpressure.set(backpressure);
@@ -662,7 +659,7 @@ impl TransformStream {
         cx: &mut JSContext,
         global: &GlobalScope,
         chunk: SafeHandleValue,
-    ) -> Fallible<Rc<Promise>> {
+    ) -> Fallible<RootedPromise> {
         // Assert: stream.[[writable]].[[state]] is "writable".
         assert!(self.writable.get().is_some());
 
@@ -678,12 +675,12 @@ impl TransformStream {
             assert!(backpressure_change_promise.is_some());
 
             // Return the result of reacting to backpressureChangePromise with the following fulfillment steps:
-            let result_promise = Promise::new(cx, global);
+            let result_promise = Promise::new_rooted(cx, global);
             rooted!(&in(cx) let mut fulfillment_handler = Some(TransformBackPressureChangePromiseFulfillment {
                 controller: Dom::from_ref(&controller),
                 writable: Dom::from_ref(&self.writable.get().expect("writable stream")),
                 chunk: Heap::boxed(chunk.get()),
-                result_promise: result_promise.clone(),
+                result_promise: result_promise.to_traced(),
             }));
 
             let handler = PromiseNativeHandler::new(
@@ -691,7 +688,7 @@ impl TransformStream {
                 global,
                 fulfillment_handler.take().map(|h| Box::new(h) as Box<_>),
                 Some(Box::new(BackpressureChangeRejection {
-                    result_promise: result_promise.clone(),
+                    result_promise: result_promise.to_traced(),
                 })),
             );
             let mut realm = enter_auto_realm(cx, global);
@@ -714,7 +711,7 @@ impl TransformStream {
         cx: &mut JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
-    ) -> Fallible<Rc<Promise>> {
+    ) -> Fallible<RootedPromise> {
         // Let controller be stream.[[controller]].
         let controller = self.controller.get().expect("controller is not set");
 
@@ -727,7 +724,7 @@ impl TransformStream {
         let readable = self.readable.get().expect("readable stream is not set");
 
         // Let controller.[[finishPromise]] be a new promise.
-        controller.set_finish_promise(Promise::new(cx, global));
+        controller.set_finish_promise(&Promise::new_rooted(cx, global));
 
         // Let cancelPromise be the result of performing controller.[[cancelAlgorithm]], passing reason.
         let cancel_promise = controller.perform_cancel(cx, global, reason)?;
@@ -765,7 +762,7 @@ impl TransformStream {
         &self,
         cx: &mut JSContext,
         global: &GlobalScope,
-    ) -> Fallible<Rc<Promise>> {
+    ) -> Fallible<RootedPromise> {
         // Let controller be stream.[[controller]].
         let controller = self
             .controller
@@ -784,7 +781,7 @@ impl TransformStream {
             .ok_or(Error::Type(c"readable stream is not set".to_owned()))?;
 
         // Let controller.[[finishPromise]] be a new promise.
-        controller.set_finish_promise(Promise::new(cx, global));
+        controller.set_finish_promise(&Promise::new_rooted(cx, global));
 
         // Let flushPromise be the result of performing controller.[[flushAlgorithm]].
         let flush_promise = controller.perform_flush(cx, global)?;
@@ -822,7 +819,7 @@ impl TransformStream {
         cx: &mut JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
-    ) -> Fallible<Rc<Promise>> {
+    ) -> Fallible<RootedPromise> {
         // Let controller be stream.[[controller]].
         let controller = self
             .controller
@@ -841,7 +838,7 @@ impl TransformStream {
             .ok_or(Error::Type(c"writable stream is not set".to_owned()))?;
 
         // Let controller.[[finishPromise]] be a new promise.
-        controller.set_finish_promise(Promise::new(cx, global));
+        controller.set_finish_promise(&Promise::new_rooted(cx, global));
 
         // Let cancelPromise be the result of performing controller.[[cancelAlgorithm]], passing reason.
         let cancel_promise = controller.perform_cancel(cx, global, reason)?;
@@ -881,7 +878,7 @@ impl TransformStream {
         &self,
         cx: &mut JSContext,
         global: &GlobalScope,
-    ) -> Fallible<Rc<Promise>> {
+    ) -> Fallible<RootedPromise> {
         // Assert: stream.[[backpressure]] is true.
         assert!(self.backpressure.get());
 
@@ -895,8 +892,9 @@ impl TransformStream {
         Ok(self
             .backpressure_change_promise
             .borrow()
-            .clone()
-            .expect("Promise must be some by now."))
+            .as_ref()
+            .expect("Promise must be some by now.")
+            .root())
     }
 
     /// <https://streams.spec.whatwg.org/#transform-stream-error-writable-and-unblock-write>
@@ -992,7 +990,7 @@ impl TransformStreamMethods<crate::DomTypeHolder> for TransformStream {
         let writable_size_algorithm = extract_size_algorithm(cx, writable_strategy);
 
         // Let startPromise be a new promise.
-        let start_promise = Promise::new(cx, global);
+        let start_promise = Promise::new_rooted(cx, global);
 
         // Perform ! InitializeTransformStream(this, startPromise, writableHighWaterMark,
         // writableSizeAlgorithm, readableHighWaterMark, readableSizeAlgorithm).
@@ -1000,7 +998,7 @@ impl TransformStreamMethods<crate::DomTypeHolder> for TransformStream {
         stream.initialize(
             cx,
             global,
-            start_promise.clone(),
+            &start_promise,
             writable_high_water_mark,
             writable_size_algorithm,
             readable_high_water_mark,

--- a/components/script/dom/stream/transformstreamdefaultcontroller.rs
+++ b/components/script/dom/stream/transformstreamdefaultcontroller.rs
@@ -36,7 +36,7 @@ use crate::dom::encoding::textencoderstream::{
     Encoder, encode_and_enqueue_a_chunk, encode_and_flush,
 };
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise, TracedPromise};
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::types::{DecompressionStream, TransformStream};
 use crate::realms::enter_auto_realm;
@@ -126,8 +126,7 @@ pub struct TransformStreamDefaultController {
     stream: MutNullableDom<TransformStream>,
 
     /// <https://streams.spec.whatwg.org/#transformstreamdefaultcontroller-finishpromise>
-    #[conditional_malloc_size_of]
-    finish_promise: DomRefCell<Option<Rc<Promise>>>,
+    finish_promise: DomRefCell<Option<TracedPromise>>,
 }
 
 impl TransformStreamDefaultController {
@@ -171,12 +170,15 @@ impl TransformStreamDefaultController {
         self.stream.set(Some(stream));
     }
 
-    pub(crate) fn get_finish_promise(&self) -> Option<Rc<Promise>> {
-        self.finish_promise.borrow().clone()
+    pub(crate) fn get_finish_promise(&self) -> Option<RootedPromise> {
+        self.finish_promise
+            .borrow()
+            .as_ref()
+            .map(|promise| promise.root())
     }
 
-    pub(crate) fn set_finish_promise(&self, promise: Rc<Promise>) {
-        *self.finish_promise.borrow_mut() = Some(promise);
+    pub(crate) fn set_finish_promise(&self, promise: &RootedPromise) {
+        *self.finish_promise.borrow_mut() = Some(promise.to_traced());
     }
 
     /// <https://streams.spec.whatwg.org/#transform-stream-default-controller-perform-transform>
@@ -185,7 +187,7 @@ impl TransformStreamDefaultController {
         cx: &mut JSContext,
         global: &GlobalScope,
         chunk: SafeHandleValue,
-    ) -> Fallible<Rc<Promise>> {
+    ) -> Fallible<RootedPromise> {
         // Let transformPromise be the result of performing controller.[[transformAlgorithm]], passing chunk.
         let transform_promise = self.perform_transform(cx, global, chunk)?;
 
@@ -212,7 +214,7 @@ impl TransformStreamDefaultController {
         cx: &mut JSContext,
         global: &GlobalScope,
         chunk: SafeHandleValue,
-    ) -> Fallible<Rc<Promise>> {
+    ) -> Fallible<RootedPromise> {
         let result = match &self.transformer_type {
             // <https://streams.spec.whatwg.org/#set-up-transform-stream-default-controller-from-transformer>
             TransformerType::Js {
@@ -237,7 +239,7 @@ impl TransformStreamDefaultController {
                             ExceptionHandling::Rethrow,
                         )
                         .unwrap_or_else(|e| {
-                            let p = Promise::new(cx, global);
+                            let p = Promise::new_rooted(cx, global);
                             p.reject_error(cx, e);
                             p
                         })
@@ -248,10 +250,10 @@ impl TransformStreamDefaultController {
                     if let Err(error) = self.enqueue(cx, global, chunk) {
                         rooted!(&in(cx) let mut error_val = UndefinedValue());
                         error.to_jsval(cx, global, error_val.handle_mut());
-                        Promise::new_rejected(cx, global, error_val.handle())
+                        Promise::new_rejected_rooted(cx, global, error_val.handle())
                     } else {
                         // Otherwise, return a promise resolved with undefined.
-                        Promise::new_resolved(cx, global, ())
+                        Promise::new_resolved_rooted(cx, global, ())
                     }
                 }
             },
@@ -267,13 +269,13 @@ impl TransformStreamDefaultController {
                     // Step 5.2 If result is a Promise, then return result.
                     // Note: not applicable, the spec does NOT require deode_and_enqueue_a_chunk() to return a Promise
                     // Step 5.3 Return a promise resolved with undefined.
-                    .map(|_| Promise::new_resolved(cx, global, ()))
+                    .map(|_| Promise::new_resolved_rooted(cx, global, ()))
                     .unwrap_or_else(|e| {
                         // <https://streams.spec.whatwg.org/#transformstream-set-up>
                         // Step 5.1 If this throws an exception e,
                         let mut realm = enter_auto_realm(cx, self);
                         let realm = &mut realm.current_realm();
-                        let p = Promise::new_in_realm(realm);
+                        let p = Promise::new_in_realm_rooted(realm);
                         // return a promise rejected with e.
                         p.reject_error(realm, e);
                         p
@@ -290,13 +292,13 @@ impl TransformStreamDefaultController {
                     // Step 5.2 If result is a Promise, then return result.
                     // Note: not applicable, the spec does NOT require encode_and_enqueue_a_chunk() to return a Promise
                     // Step 5.3 Return a promise resolved with undefined.
-                    .map(|_| Promise::new_resolved(cx, global, ()))
+                    .map(|_| Promise::new_resolved_rooted(cx, global, ()))
                     .unwrap_or_else(|e| {
                         // <https://streams.spec.whatwg.org/#transformstream-set-up>
                         // Step 5.1 If this throws an exception e,
                         let mut realm = enter_auto_realm(cx, self);
                         let realm = &mut realm.current_realm();
-                        let p = Promise::new_in_realm(realm);
+                        let p = Promise::new_in_realm_rooted(realm);
                         // return a promise rejected with e.
                         p.reject_error(realm, e);
                         p
@@ -314,13 +316,13 @@ impl TransformStreamDefaultController {
                     // Note: not applicable, the spec does NOT require
                     // compress_and_enqueue_a_chunk() to return a Promise.
                     // Step 5.3 Return a promise resolved with undefined.
-                    .map(|_| Promise::new_resolved(cx, global, ()))
+                    .map(|_| Promise::new_resolved_rooted(cx, global, ()))
                     .unwrap_or_else(|e| {
                         // <https://streams.spec.whatwg.org/#transformstream-set-up>
                         // Step 5.1 If this throws an exception e,
                         let mut realm = enter_auto_realm(cx, self);
                         let realm = &mut realm.current_realm();
-                        let p = Promise::new_in_realm(realm);
+                        let p = Promise::new_in_realm_rooted(realm);
                         // return a promise rejected with e.
                         p.reject_error(realm, e);
                         p
@@ -338,13 +340,13 @@ impl TransformStreamDefaultController {
                     // Note: not applicable, the spec does NOT require
                     // decompress_and_enqueue_a_chunk() to return a Promise
                     // Step 5.3 Return a promise resolved with undefined.
-                    .map(|_| Promise::new_resolved(cx, global, ()))
+                    .map(|_| Promise::new_resolved_rooted(cx, global, ()))
                     .unwrap_or_else(|e| {
                         // <https://streams.spec.whatwg.org/#transformstream-set-up>
                         // Step 5.1 If this throws an exception e,
                         let mut realm = enter_auto_realm(cx, self);
                         let realm = &mut realm.current_realm();
-                        let p = Promise::new_in_realm(realm);
+                        let p = Promise::new_in_realm_rooted(realm);
                         // return a promise rejected with e.
                         p.reject_error(realm, e);
                         p
@@ -360,7 +362,7 @@ impl TransformStreamDefaultController {
         cx: &mut JSContext,
         global: &GlobalScope,
         chunk: SafeHandleValue,
-    ) -> Fallible<Rc<Promise>> {
+    ) -> Fallible<RootedPromise> {
         let result = match &self.transformer_type {
             // <https://streams.spec.whatwg.org/#set-up-transform-stream-default-controller-from-transformer>
             TransformerType::Js {
@@ -379,13 +381,13 @@ impl TransformStreamDefaultController {
                     cancel
                         .Call_(cx, &this_object.handle(), chunk, ExceptionHandling::Rethrow)
                         .unwrap_or_else(|e| {
-                            let p = Promise::new(cx, global);
+                            let p = Promise::new_rooted(cx, global);
                             p.reject_error(cx, e);
                             p
                         })
                 } else {
                     // Step 4. Let cancelAlgorithm be an algorithm which returns a promise resolved with undefined.
-                    Promise::new_resolved(cx, global, ())
+                    Promise::new_resolved_rooted(cx, global, ())
                 }
             },
             TransformerType::Decoder(_) => {
@@ -397,7 +399,7 @@ impl TransformStreamDefaultController {
                 // Step 7.2 If result is a Promise, then return result.
                 // Note: Not applicable.
                 // Step 7.3 Return a promise resolved with undefined.
-                Promise::new_resolved(cx, global, ())
+                Promise::new_resolved_rooted(cx, global, ())
             },
             TransformerType::Encoder(_) => {
                 // <https://streams.spec.whatwg.org/#transformstream-set-up>
@@ -408,7 +410,7 @@ impl TransformStreamDefaultController {
                 // Step 7.2 If result is a Promise, then return result.
                 // Note: Not applicable.
                 // Step 7.3 Return a promise resolved with undefined.
-                Promise::new_resolved(cx, global, ())
+                Promise::new_resolved_rooted(cx, global, ())
             },
             TransformerType::Compressor(_) => {
                 // <https://streams.spec.whatwg.org/#transformstream-set-up>
@@ -419,7 +421,7 @@ impl TransformStreamDefaultController {
                 // Step 7.2 If result is a Promise, then return result.
                 // Note: Not applicable.
                 // Step 7.3 Return a promise resolved with undefined.
-                Promise::new_resolved(cx, global, ())
+                Promise::new_resolved_rooted(cx, global, ())
             },
             TransformerType::Decompressor(_) => {
                 // <https://streams.spec.whatwg.org/#transformstream-set-up>
@@ -430,7 +432,7 @@ impl TransformStreamDefaultController {
                 // Step 7.2 If result is a Promise, then return result.
                 // Note: Not applicable.
                 // Step 7.3 Return a promise resolved with undefined.
-                Promise::new_resolved(cx, global, ())
+                Promise::new_resolved_rooted(cx, global, ())
             },
         };
 
@@ -441,7 +443,7 @@ impl TransformStreamDefaultController {
         &self,
         cx: &mut JSContext,
         global: &GlobalScope,
-    ) -> Fallible<Rc<Promise>> {
+    ) -> Fallible<RootedPromise> {
         let result = match &self.transformer_type {
             // <https://streams.spec.whatwg.org/#set-up-transform-stream-default-controller-from-transformer>
             TransformerType::Js {
@@ -459,13 +461,13 @@ impl TransformStreamDefaultController {
                     flush
                         .Call_(cx, &this_object.handle(), self, ExceptionHandling::Rethrow)
                         .unwrap_or_else(|e| {
-                            let p = Promise::new(cx, global);
+                            let p = Promise::new_rooted(cx, global);
                             p.reject_error(cx, e);
                             p
                         })
                 } else {
                     // Step 3. Let flushAlgorithm be an algorithm which returns a promise resolved with undefined.
-                    Promise::new_resolved(cx, global, ())
+                    Promise::new_resolved_rooted(cx, global, ())
                 }
             },
             TransformerType::Decoder(decoder) => {
@@ -480,13 +482,13 @@ impl TransformStreamDefaultController {
                     // Step 6.2 If result is a Promise, then return result.
                     // Note: Not applicable. The spec does NOT require flush_and_enqueue algo to return a Promise
                     // Step 6.3 Return a promise resolved with undefined.
-                    .map(|_| Promise::new_resolved(cx, global, ()))
+                    .map(|_| Promise::new_resolved_rooted(cx, global, ()))
                     .unwrap_or_else(|e| {
                         // <https://streams.spec.whatwg.org/#transformstream-set-up>
                         // Step 6.1 If this throws an exception e,
                         let mut realm = enter_auto_realm(cx, self);
                         let realm = &mut realm.current_realm();
-                        let p = Promise::new_in_realm(realm);
+                        let p = Promise::new_in_realm_rooted(realm);
                         // return a promise rejected with e.
                         p.reject_error(realm, e);
                         p
@@ -503,13 +505,13 @@ impl TransformStreamDefaultController {
                     // Step 6.2 If result is a Promise, then return result.
                     // Note: Not applicable. The spec does NOT require encode_and_flush algo to return a Promise
                     // Step 6.3 Return a promise resolved with undefined.
-                    .map(|_| Promise::new_resolved(cx, global, ()))
+                    .map(|_| Promise::new_resolved_rooted(cx, global, ()))
                     .unwrap_or_else(|e| {
                         // <https://streams.spec.whatwg.org/#transformstream-set-up>
                         // Step 6.1 If this throws an exception e,
                         let mut realm = enter_auto_realm(cx, self);
                         let realm = &mut realm.current_realm();
-                        let p = Promise::new_in_realm(realm);
+                        let p = Promise::new_in_realm_rooted(realm);
                         // return a promise rejected with e.
                         p.reject_error(realm, e);
                         p
@@ -528,13 +530,13 @@ impl TransformStreamDefaultController {
                     // Note: Not applicable. The spec does NOT require compress_flush_and_enqueue
                     // algo to return a Promise.
                     // Step 6.3 Return a promise resolved with undefined.
-                    .map(|_| Promise::new_resolved(cx, global, ()))
+                    .map(|_| Promise::new_resolved_rooted(cx, global, ()))
                     .unwrap_or_else(|e| {
                         // <https://streams.spec.whatwg.org/#transformstream-set-up>
                         // Step 6.1 If this throws an exception e,
                         let mut realm = enter_auto_realm(cx, self);
                         let realm = &mut realm.current_realm();
-                        let p = Promise::new_in_realm(realm);
+                        let p = Promise::new_in_realm_rooted(realm);
                         // return a promise rejected with e.
                         p.reject_error(realm, e);
                         p
@@ -553,13 +555,13 @@ impl TransformStreamDefaultController {
                     // Note: Not applicable. The spec does NOT require decompress_flush_and_enqueue
                     // algo to return a Promise.
                     // Step 6.3 Return a promise resolved with undefined.
-                    .map(|_| Promise::new_resolved(cx, global, ()))
+                    .map(|_| Promise::new_resolved_rooted(cx, global, ()))
                     .unwrap_or_else(|e| {
                         // <https://streams.spec.whatwg.org/#transformstream-set-up>
                         // Step 6.1 If this throws an exception e,
                         let mut realm = enter_auto_realm(cx, self);
                         let realm = &mut realm.current_realm();
-                        let p = Promise::new_in_realm(realm);
+                        let p = Promise::new_in_realm_rooted(realm);
                         // return a promise rejected with e.
                         p.reject_error(realm, e);
                         p

--- a/components/script/dom/stream/underlyingsourcecontainer.rs
+++ b/components/script/dom/stream/underlyingsourcecontainer.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::ptr;
-use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
@@ -21,7 +20,7 @@ use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::messageport::MessagePort;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise, TracedPromise};
 use crate::dom::stream::defaultteeunderlyingsource::DefaultTeeUnderlyingSource;
 use crate::dom::stream::transformstream::TransformStream;
 
@@ -36,7 +35,7 @@ enum UnderlyingSource {
     Js(JsUnderlyingSource, Heap<*mut JSObject>),
     Tee(Dom<DefaultTeeUnderlyingSource>),
     Transfer(Dom<MessagePort>),
-    Transform(Dom<TransformStream>, Rc<Promise>),
+    Transform(Dom<TransformStream>, TracedPromise),
     TeeByte(Dom<ByteTeeUnderlyingSource>),
 }
 
@@ -57,7 +56,7 @@ impl From<UnderlyingSourceType<'_>> for UnderlyingSource {
             UnderlyingSourceType::Tee(source) => UnderlyingSource::Tee(Dom::from_ref(source)),
             UnderlyingSourceType::Transfer(port) => UnderlyingSource::Transfer(Dom::from_ref(port)),
             UnderlyingSourceType::Transform(stream, promise) => {
-                UnderlyingSource::Transform(Dom::from_ref(stream), promise)
+                UnderlyingSource::Transform(Dom::from_ref(stream), promise.to_traced())
             },
             UnderlyingSourceType::TeeByte(source) => {
                 UnderlyingSource::TeeByte(Dom::from_ref(source))
@@ -88,7 +87,7 @@ pub(crate) enum UnderlyingSourceType<'a> {
     /// A struct representing a JS object as underlying source,
     /// and the actual JS object for use as `thisArg` in callbacks.
     /// This is used for the `TransformStream` API.
-    Transform(&'a TransformStream, Rc<Promise>),
+    Transform(&'a TransformStream, &'a RootedPromise),
     /// Tee Byte
     TeeByte(&'a ByteTeeUnderlyingSource),
 }
@@ -153,7 +152,7 @@ impl UnderlyingSourceContainer {
         cx: &mut JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
-    ) -> Option<Result<Rc<Promise>, Error>> {
+    ) -> Option<Result<RootedPromise, Error>> {
         match &self.underlying_source_type {
             UnderlyingSource::Js(source, this_obj) => {
                 if let Some(algo) = &source.cancel {
@@ -187,7 +186,7 @@ impl UnderlyingSourceContainer {
                 // Disentangle port.
                 self.global().disentangle_port(cx, port);
 
-                let promise = Promise::new(cx, &self.global());
+                let promise = Promise::new_rooted(cx, &self.global());
 
                 // If result is an abrupt completion,
                 if let Err(error) = result {
@@ -213,7 +212,7 @@ impl UnderlyingSourceContainer {
         &self,
         cx: &mut JSContext,
         controller: Controller,
-    ) -> Option<Result<Rc<Promise>, Error>> {
+    ) -> Option<Result<RootedPromise, Error>> {
         match &self.underlying_source_type {
             UnderlyingSource::Js(source, this_obj) => {
                 if let Some(algo) = &source.pull {
@@ -243,7 +242,7 @@ impl UnderlyingSourceContainer {
                     .expect("Sending pull should not fail.");
 
                 // Return a promise resolved with undefined.
-                let promise = Promise::new_resolved(cx, &self.global(), ());
+                let promise = Promise::new_resolved_rooted(cx, &self.global(), ());
                 Some(Ok(promise))
             },
             UnderlyingSource::TeeByte(tee_underlyin_source) => {
@@ -271,7 +270,7 @@ impl UnderlyingSourceContainer {
         &self,
         cx: &mut JSContext,
         controller: Controller,
-    ) -> Option<Result<Rc<Promise>, Error>> {
+    ) -> Option<Result<RootedPromise, Error>> {
         match &self.underlying_source_type {
             UnderlyingSource::Js(source, this_obj) => {
                 if let Some(start) = &source.start {
@@ -297,9 +296,9 @@ impl UnderlyingSourceContainer {
                         }
                     };
                     let promise = if is_promise {
-                        Promise::new_with_js_promise(cx, result_object.handle())
+                        Promise::new_with_js_promise_rooted(cx, result_object.handle())
                     } else {
-                        Promise::new_resolved(cx, &self.global(), result.get())
+                        Promise::new_resolved_rooted(cx, &self.global(), result.get())
                     };
                     return Some(Ok(promise));
                 }
@@ -316,7 +315,7 @@ impl UnderlyingSourceContainer {
             },
             UnderlyingSource::Transform(_, start_promise) => {
                 // Let startAlgorithm be an algorithm that returns startPromise.
-                Some(Ok(start_promise.clone()))
+                Some(Ok(start_promise.root()))
             },
             _ => None,
         }

--- a/components/script/dom/stream/writablestream.rs
+++ b/components/script/dom/stream/writablestream.rs
@@ -830,8 +830,8 @@ impl WritableStream {
                 // and backpressure is not stream.[[backpressure]],
                 if backpressure {
                     // If backpressure is true, set writer.[[readyPromise]] to a new promise.
-                    let promise = Promise::new(cx, global);
-                    writer.set_ready_promise(promise);
+                    let promise = Promise::new_rooted(cx, global);
+                    writer.set_ready_promise(&promise);
                 } else {
                     // Otherwise,
                     // Assert: backpressure is false.
@@ -865,14 +865,15 @@ impl WritableStream {
         // Note: other algorithms defined in the controller at call site.
 
         // Let backpressurePromise be a new promise.
-        let backpressure_promise = Rc::new(RefCell::new(Some(Promise::new(cx, &global))));
+        let backpressure_promise = Promise::new_rooted(cx, &global);
+        rooted!(&in(cx) let backpressure_promise = RcHolder(Rc::new(RefCell::new(Some(backpressure_promise.to_traced())))));
 
         // Let controller be a new WritableStreamDefaultController.
         let controller = WritableStreamDefaultController::new(
             cx,
             &global,
             UnderlyingSinkType::Transfer {
-                backpressure_promise: backpressure_promise.clone(),
+                backpressure_promise: backpressure_promise.0.clone(),
                 port: Dom::from_ref(port),
             },
             1.0,
@@ -883,7 +884,7 @@ impl WritableStream {
         // Add a handler for port’s messageerror event with the following steps:
         rooted!(&in(cx) let cross_realm_transform_writable = CrossRealmTransformWritable {
             controller: Dom::from_ref(&controller),
-            backpressure_promise,
+            backpressure_promise: backpressure_promise.0.clone(),
         });
         global.note_cross_realm_transform_writable(&cross_realm_transform_writable, port_id);
 
@@ -1052,29 +1053,29 @@ impl WritableStreamMethods<crate::DomTypeHolder> for WritableStream {
     }
 
     /// <https://streams.spec.whatwg.org/#ws-abort>
-    fn Abort(&self, cx: &mut CurrentRealm, reason: SafeHandleValue) -> Rc<Promise> {
+    fn Abort(&self, cx: &mut CurrentRealm, reason: SafeHandleValue) -> RootedPromise {
         let global = GlobalScope::from_current_realm(cx);
 
         // If ! IsWritableStreamLocked(this) is true,
         if self.is_locked() {
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new(cx, &global);
+            let promise = Promise::new_rooted(cx, &global);
             promise.reject_error(cx, Error::Type(c"Stream is locked.".to_owned()));
             return promise;
         }
 
         // Return ! WritableStreamAbort(this, reason).
-        self.abort(cx, &global, reason).into()
+        self.abort(cx, &global, reason)
     }
 
     /// <https://streams.spec.whatwg.org/#ws-close>
-    fn Close(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
+    fn Close(&self, cx: &mut CurrentRealm) -> RootedPromise {
         let global = GlobalScope::from_current_realm(cx);
 
         // If ! IsWritableStreamLocked(this) is true,
         if self.is_locked() {
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new(cx, &global);
+            let promise = Promise::new_rooted(cx, &global);
             promise.reject_error(cx, Error::Type(c"Stream is locked.".to_owned()));
             return promise;
         }
@@ -1082,7 +1083,7 @@ impl WritableStreamMethods<crate::DomTypeHolder> for WritableStream {
         // If ! WritableStreamCloseQueuedOrInFlight(this) is true
         if self.close_queued_or_in_flight() {
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new(cx, &global);
+            let promise = Promise::new_rooted(cx, &global);
             promise.reject_error(
                 cx,
                 Error::Type(c"Stream has closed queued or in-flight".to_owned()),
@@ -1091,7 +1092,7 @@ impl WritableStreamMethods<crate::DomTypeHolder> for WritableStream {
         }
 
         // Return ! WritableStreamClose(this).
-        self.close(cx, &global).into()
+        self.close(cx, &global)
     }
 
     /// <https://streams.spec.whatwg.org/#ws-get-writer>
@@ -1118,8 +1119,8 @@ pub(crate) struct CrossRealmTransformWritable {
     controller: Dom<WritableStreamDefaultController>,
 
     /// The `backpressurePromise` used in the algorithm.
-    #[ignore_malloc_size_of = "nested Rc"]
-    backpressure_promise: Rc<RefCell<Option<Rc<Promise>>>>,
+    #[conditional_malloc_size_of]
+    backpressure_promise: Rc<RefCell<Option<TracedPromise>>>,
 }
 
 impl CrossRealmTransformWritable {
@@ -1143,11 +1144,11 @@ impl CrossRealmTransformWritable {
             self.controller.error_if_needed(cx, value.handle(), global);
         }
 
-        let backpressure_promise = self.backpressure_promise.borrow_mut().take();
+        rooted!(&in(cx) let backpressure_promise = self.backpressure_promise.borrow_mut().take());
 
         // Note: the below steps are for both "pull" and "error" types.
         // If backpressurePromise is not undefined,
-        if let Some(promise) = backpressure_promise {
+        if let Some(ref promise) = *backpressure_promise {
             // Resolve backpressurePromise with undefined.
             promise.resolve_native(cx, &());
 
@@ -1260,3 +1261,8 @@ impl Transferable for WritableStream {
         }
     }
 }
+
+#[derive(JSTraceable)]
+struct RcHolder<T>(Rc<T>);
+
+impl<T: js::rust::Traceable> js::gc::Rootable for RcHolder<T> {}

--- a/components/script/dom/stream/writablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/writablestreamdefaultcontroller.rs
@@ -26,7 +26,7 @@ use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::messageport::MessagePort;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise, TracedPromise};
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::readablestreamdefaultcontroller::{EnqueuedValue, QueueWithSizes, ValueWithSize};
 use crate::dom::stream::writablestream::WritableStream;
@@ -147,12 +147,11 @@ impl js::gc::Rootable for TransferBackPressurePromiseReaction {}
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 struct TransferBackPressurePromiseReaction {
     /// The result of reacting to backpressurePromise.
-    #[conditional_malloc_size_of]
-    result_promise: Rc<Promise>,
+    result_promise: TracedPromise,
 
     /// The backpressurePromise.
     #[ignore_malloc_size_of = "nested Rc"]
-    backpressure_promise: Rc<RefCell<Option<Rc<Promise>>>>,
+    backpressure_promise: Rc<RefCell<Option<TracedPromise>>>,
 
     /// The chunk received by the `writeAlgorithm`.
     #[ignore_malloc_size_of = "mozjs"]
@@ -167,8 +166,8 @@ impl Callback for TransferBackPressurePromiseReaction {
     fn callback(&self, cx: &mut CurrentRealm, _v: SafeHandleValue) {
         let global = self.result_promise.global();
         // Set backpressurePromise to a new promise.
-        let promise = Promise::new(cx, &global);
-        *self.backpressure_promise.borrow_mut() = Some(promise);
+        let promise = Promise::new_rooted(cx, &global);
+        *self.backpressure_promise.borrow_mut() = Some(promise.to_traced());
 
         // Let result be PackAndPostMessageHandlingError(port, "chunk", chunk).
         rooted!(&in(cx) let mut chunk = UndefinedValue());
@@ -287,11 +286,11 @@ pub enum UnderlyingSinkType {
     /// Algorithms supporting streams transfer are implemented in Rust.
     /// The promise and port used in those algorithms are stored here.
     Transfer {
-        backpressure_promise: Rc<RefCell<Option<Rc<Promise>>>>,
+        backpressure_promise: Rc<RefCell<Option<TracedPromise>>>,
         port: Dom<MessagePort>,
     },
     /// Algorithms supporting transform streams are implemented in Rust.
-    Transform(Dom<TransformStream>, Rc<Promise>),
+    Transform(Dom<TransformStream>, TracedPromise),
 }
 
 impl UnderlyingSinkType {
@@ -518,7 +517,7 @@ impl WritableStreamDefaultController {
     }
 
     #[expect(unsafe_code)]
-    fn start_algorithm(&self, cx: &mut JSContext, global: &GlobalScope) -> Fallible<Rc<Promise>> {
+    fn start_algorithm(&self, cx: &mut JSContext, global: &GlobalScope) -> Fallible<RootedPromise> {
         match &self.underlying_sink_type {
             UnderlyingSinkType::Js {
                 start,
@@ -547,24 +546,24 @@ impl WritableStreamDefaultController {
                         }
                     };
                     if is_promise {
-                        Promise::new_with_js_promise(cx, result_object.handle())
+                        Promise::new_with_js_promise_rooted(cx, result_object.handle())
                     } else {
-                        Promise::new_resolved(cx, global, result.get())
+                        Promise::new_resolved_rooted(cx, global, result.get())
                     }
                 } else {
                     // Let startAlgorithm be an algorithm that returns undefined.
-                    Promise::new_resolved(cx, global, ())
+                    Promise::new_resolved_rooted(cx, global, ())
                 };
 
                 Ok(start_promise)
             },
             UnderlyingSinkType::Transfer { .. } => {
                 // Let startAlgorithm be an algorithm that returns undefined.
-                Ok(Promise::new_resolved(cx, global, ()))
+                Ok(Promise::new_resolved_rooted(cx, global, ()))
             },
             UnderlyingSinkType::Transform(_, start_promise) => {
                 // Let startAlgorithm be an algorithm that returns startPromise.
-                Ok(start_promise.clone())
+                Ok(start_promise.root())
             },
         }
     }
@@ -575,7 +574,7 @@ impl WritableStreamDefaultController {
         cx: &mut JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
-    ) -> Rc<Promise> {
+    ) -> RootedPromise {
         let result = match &self.underlying_sink_type {
             UnderlyingSinkType::Js {
                 abort,
@@ -594,10 +593,10 @@ impl WritableStreamDefaultController {
                         ExceptionHandling::Rethrow,
                     )
                 } else {
-                    Ok(Promise::new_resolved(cx, global, ()))
+                    Ok(Promise::new_resolved_rooted(cx, global, ()))
                 };
                 result.unwrap_or_else(|e| {
-                    let promise = Promise::new(cx, global);
+                    let promise = Promise::new_rooted(cx, global);
                     promise.reject_error(cx, e);
                     promise
                 })
@@ -612,7 +611,7 @@ impl WritableStreamDefaultController {
                 // Disentangle port.
                 global.disentangle_port(cx, port);
 
-                let promise = Promise::new(cx, global);
+                let promise = Promise::new_rooted(cx, global);
 
                 // If result is an abrupt completion, return a promise rejected with result.[[Value]]
                 if let Err(error) = result {
@@ -643,7 +642,7 @@ impl WritableStreamDefaultController {
         cx: &mut JSContext,
         chunk: SafeHandleValue,
         global: &GlobalScope,
-    ) -> Rc<Promise> {
+    ) -> RootedPromise {
         match &self.underlying_sink_type {
             UnderlyingSinkType::Js {
                 abort: _,
@@ -662,10 +661,10 @@ impl WritableStreamDefaultController {
                         ExceptionHandling::Rethrow,
                     )
                 } else {
-                    Ok(Promise::new_resolved(cx, global, ()))
+                    Ok(Promise::new_resolved_rooted(cx, global, ()))
                 };
                 result.unwrap_or_else(|e| {
-                    let promise = Promise::new(cx, global);
+                    let promise = Promise::new_rooted(cx, global);
                     promise.reject_error(cx, e);
                     promise
                 })
@@ -680,17 +679,17 @@ impl WritableStreamDefaultController {
                 // If backpressurePromise is undefined,
                 // set backpressurePromise to a promise resolved with undefined.
                 if backpressure_promise.borrow().is_none() {
-                    let promise = Promise::new_resolved(cx, global, ());
-                    *backpressure_promise.borrow_mut() = Some(promise);
+                    let promise = Promise::new_resolved_rooted(cx, global, ());
+                    *backpressure_promise.borrow_mut() = Some(promise.to_traced());
                 }
 
                 // Return the result of reacting to backpressurePromise with the following fulfillment steps:
-                let result_promise = Promise::new(cx, global);
+                let result_promise = Promise::new_rooted(cx, global);
                 rooted!(&in(cx) let mut fulfillment_handler = Some(TransferBackPressurePromiseReaction {
                     port: port.clone(),
                     backpressure_promise: backpressure_promise.clone(),
                     chunk: Heap::boxed(chunk.get()),
-                    result_promise: result_promise.clone(),
+                    result_promise: result_promise.to_traced(),
                 }));
                 let handler = PromiseNativeHandler::new(
                     cx,
@@ -717,7 +716,7 @@ impl WritableStreamDefaultController {
     }
 
     /// <https://streams.spec.whatwg.org/#writablestreamdefaultcontroller-closealgorithm>
-    fn call_close_algorithm(&self, cx: &mut JSContext, global: &GlobalScope) -> Rc<Promise> {
+    fn call_close_algorithm(&self, cx: &mut JSContext, global: &GlobalScope) -> RootedPromise {
         match &self.underlying_sink_type {
             UnderlyingSinkType::Js {
                 abort: _,
@@ -731,10 +730,10 @@ impl WritableStreamDefaultController {
                 let result = if let Some(algo) = algo {
                     algo.Call_(cx, &this_object.handle(), ExceptionHandling::Rethrow)
                 } else {
-                    Ok(Promise::new_resolved(cx, global, ()))
+                    Ok(Promise::new_resolved_rooted(cx, global, ()))
                 };
                 result.unwrap_or_else(|e| {
-                    let promise = Promise::new(cx, global);
+                    let promise = Promise::new_rooted(cx, global);
                     promise.reject_error(cx, e);
                     promise
                 })
@@ -752,7 +751,7 @@ impl WritableStreamDefaultController {
                 global.disentangle_port(cx, port);
 
                 // Return a promise resolved with undefined.
-                Promise::new_resolved(cx, global, ())
+                Promise::new_resolved_rooted(cx, global, ())
             },
             UnderlyingSinkType::Transform(stream, _) => {
                 // Return ! TransformStreamDefaultSinkCloseAlgorithm(stream).

--- a/components/script/dom/stream/writablestreamdefaultwriter.rs
+++ b/components/script/dom/stream/writablestreamdefaultwriter.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::RefCell;
-use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
@@ -17,7 +16,7 @@ use crate::dom::bindings::error::{Error, ErrorToJsval};
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::{Promise, RootedPromise};
+use crate::dom::promise::{Promise, RootedPromise, TracedPromise};
 use crate::dom::stream::writablestream::WritableStream;
 
 /// <https://streams.spec.whatwg.org/#writablestreamdefaultwriter>
@@ -25,12 +24,10 @@ use crate::dom::stream::writablestream::WritableStream;
 pub struct WritableStreamDefaultWriter {
     reflector_: Reflector,
 
-    #[conditional_malloc_size_of]
-    ready_promise: RefCell<Rc<Promise>>,
+    ready_promise: RefCell<TracedPromise>,
 
     /// <https://streams.spec.whatwg.org/#writablestreamdefaultwriter-closedpromise>
-    #[conditional_malloc_size_of]
-    closed_promise: RefCell<Rc<Promise>>,
+    closed_promise: RefCell<TracedPromise>,
 
     /// <https://streams.spec.whatwg.org/#writablestreamdefaultwriter-stream>
     stream: MutNullableDom<WritableStream>,
@@ -40,14 +37,14 @@ impl WritableStreamDefaultWriter {
     /// <https://streams.spec.whatwg.org/#set-up-writable-stream-default-writer>
     /// The parts that create a new promise.
     fn new_inherited(
-        closed_promise: Rc<Promise>,
-        ready_promise: Rc<Promise>,
+        closed_promise: &RootedPromise,
+        ready_promise: &RootedPromise,
     ) -> WritableStreamDefaultWriter {
         WritableStreamDefaultWriter {
             reflector_: Reflector::new(),
             stream: Default::default(),
-            closed_promise: RefCell::new(closed_promise),
-            ready_promise: RefCell::new(ready_promise),
+            closed_promise: RefCell::new(closed_promise.to_traced()),
+            ready_promise: RefCell::new(ready_promise.to_traced()),
         }
     }
 
@@ -56,13 +53,13 @@ impl WritableStreamDefaultWriter {
         global: &GlobalScope,
         proto: Option<SafeHandleObject>,
     ) -> DomRoot<WritableStreamDefaultWriter> {
-        let closed_promise = Promise::new_in_realm(cx);
-        let ready_promise = Promise::new_in_realm(cx);
+        let closed_promise = Promise::new_in_realm_rooted(cx);
+        let ready_promise = Promise::new_in_realm_rooted(cx);
         reflect_dom_object_with_proto(
             cx,
             Box::new(WritableStreamDefaultWriter::new_inherited(
-                closed_promise,
-                ready_promise,
+                &closed_promise,
+                &ready_promise,
             )),
             global,
             proto,
@@ -169,8 +166,8 @@ impl WritableStreamDefaultWriter {
         self.closed_promise.borrow().set_promise_is_handled(cx);
     }
 
-    pub(crate) fn set_ready_promise(&self, promise: Rc<Promise>) {
-        *self.ready_promise.borrow_mut() = promise;
+    pub(crate) fn set_ready_promise(&self, promise: &RootedPromise) {
+        *self.ready_promise.borrow_mut() = promise.to_traced();
     }
 
     pub(crate) fn resolve_ready_promise_with_undefined(&self, cx: &mut JSContext) {
@@ -188,10 +185,12 @@ impl WritableStreamDefaultWriter {
         global: &GlobalScope,
         error: SafeHandleValue,
     ) {
-        let ready_promise = self.ready_promise.borrow().clone();
+        let is_pending = self.ready_promise.borrow().is_pending();
 
         // If writer.[[readyPromise]].[[PromiseState]] is "pending",
-        if ready_promise.is_pending() {
+        if is_pending {
+            let ready_promise = self.ready_promise.borrow();
+
             // reject writer.[[readyPromise]] with error.
             ready_promise.reject_native(cx, &error);
 
@@ -199,11 +198,11 @@ impl WritableStreamDefaultWriter {
             ready_promise.set_promise_is_handled(cx);
         } else {
             // Otherwise, set writer.[[readyPromise]] to a promise rejected with error.
-            let promise = Promise::new_rejected(cx, global, error);
+            let promise = Promise::new_rejected_rooted(cx, global, error);
 
             // Set writer.[[readyPromise]].[[PromiseIsHandled]] to true.
             promise.set_promise_is_handled(cx);
-            *self.ready_promise.borrow_mut() = promise;
+            *self.ready_promise.borrow_mut() = promise.to_traced();
         }
     }
 
@@ -214,22 +213,23 @@ impl WritableStreamDefaultWriter {
         global: &GlobalScope,
         error: SafeHandleValue,
     ) {
-        let closed_promise = self.closed_promise.borrow().clone();
+        let is_pending = self.closed_promise.borrow().is_pending();
 
         // If writer.[[closedPromise]].[[PromiseState]] is "pending",
-        if closed_promise.is_pending() {
-            // reject writer.[[closedPromise]] with error.
+        if is_pending {
+            let closed_promise = self.closed_promise.borrow();
+
             closed_promise.reject_native(cx, &error);
 
             // Set writer.[[closedPromise]].[[PromiseIsHandled]] to true.
             closed_promise.set_promise_is_handled(cx);
         } else {
             // Otherwise, set writer.[[closedPromise]] to a promise rejected with error.
-            let promise = Promise::new_rejected(cx, global, error);
+            let promise = Promise::new_rejected_rooted(cx, global, error);
 
             // Set writer.[[closedPromise]].[[PromiseIsHandled]] to true.
             promise.set_promise_is_handled(cx);
-            *self.closed_promise.borrow_mut() = promise;
+            *self.closed_promise.borrow_mut() = promise.to_traced();
         }
     }
 
@@ -425,9 +425,9 @@ impl WritableStreamDefaultWriter {
 
 impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStreamDefaultWriter {
     /// <https://streams.spec.whatwg.org/#default-writer-closed>
-    fn Closed(&self) -> Rc<Promise> {
+    fn Closed(&self) -> RootedPromise {
         // Return this.[[closedPromise]].
-        return self.closed_promise.borrow().clone();
+        return self.closed_promise.borrow().root();
     }
 
     /// <https://streams.spec.whatwg.org/#default-writer-desired-size>
@@ -442,31 +442,31 @@ impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStream
     }
 
     /// <https://streams.spec.whatwg.org/#default-writer-ready>
-    fn Ready(&self) -> Rc<Promise> {
+    fn Ready(&self) -> RootedPromise {
         // Return this.[[readyPromise]].
-        return self.ready_promise.borrow().clone();
+        return self.ready_promise.borrow().root();
     }
 
     /// <https://streams.spec.whatwg.org/#default-writer-abort>
-    fn Abort(&self, cx: &mut CurrentRealm, reason: SafeHandleValue) -> Rc<Promise> {
+    fn Abort(&self, cx: &mut CurrentRealm, reason: SafeHandleValue) -> RootedPromise {
         let global = GlobalScope::from_current_realm(cx);
 
         // If this.[[stream]] is undefined,
         if self.stream.get().is_none() {
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new(cx, &global);
+            let promise = Promise::new_rooted(cx, &global);
             promise.reject_error(cx, Error::Type(c"Stream is undefined".to_owned()));
             return promise;
         }
 
         // Return ! WritableStreamDefaultWriterAbort(this, reason).
-        self.abort(cx, &global, reason).into()
+        self.abort(cx, &global, reason)
     }
 
     /// <https://streams.spec.whatwg.org/#default-writer-close>
-    fn Close(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
+    fn Close(&self, cx: &mut CurrentRealm) -> RootedPromise {
         let global = GlobalScope::from_current_realm(cx);
-        let promise = Promise::new(cx, &global);
+        let promise = Promise::new_rooted(cx, &global);
 
         // Let stream be this.[[stream]].
         let Some(stream) = self.stream.get() else {
@@ -486,7 +486,7 @@ impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStream
             return promise;
         }
 
-        self.close(cx, &global).into()
+        self.close(cx, &global)
     }
 
     /// <https://streams.spec.whatwg.org/#default-writer-release-lock>
@@ -507,19 +507,19 @@ impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStream
     }
 
     /// <https://streams.spec.whatwg.org/#default-writer-write>
-    fn Write(&self, cx: &mut CurrentRealm, chunk: SafeHandleValue) -> Rc<Promise> {
+    fn Write(&self, cx: &mut CurrentRealm, chunk: SafeHandleValue) -> RootedPromise {
         let global = GlobalScope::from_current_realm(cx);
 
         // If this.[[stream]] is undefined,
         if self.stream.get().is_none() {
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new(cx, &global);
+            let promise = Promise::new_rooted(cx, &global);
             promise.reject_error(cx, Error::Type(c"Stream is undefined".to_owned()));
             return promise;
         }
 
         // Return ! WritableStreamDefaultWriterWrite(this, chunk).
-        self.write(cx, &global, chunk).into()
+        self.write(cx, &global, chunk)
     }
 
     /// <https://streams.spec.whatwg.org/#default-writer-constructor>

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1623,7 +1623,6 @@ DOMInterfaces = {
 'ReadableStream': {
     'realm': ['PipeTo', 'PipeThrough'],
     'cx': ['Cancel', 'GetReader', 'Tee'],
-    'useRcPromise': True,
 },
 
 "ReadableStreamDefaultController": {
@@ -1640,12 +1639,10 @@ DOMInterfaces = {
 
 "ReadableStreamBYOBReader": {
     "cx": ["Cancel", "Read", "ReleaseLock"],
-    'useRcPromise': True,
 },
 
 "ReadableStreamDefaultReader": {
     "cx": ["Cancel", "Read", "ReleaseLock"],
-    'useRcPromise': True,
 },
 
 'ResizeObserver': {
@@ -1678,7 +1675,6 @@ DOMInterfaces = {
 
 'WritableStream': {
     'realm': ['Abort', 'Close', 'GetWriter'],
-    'useRcPromise': True,
 },
 
 'WritableStreamDefaultController': {
@@ -1688,7 +1684,6 @@ DOMInterfaces = {
 'WritableStreamDefaultWriter': {
     'cx': ['ReleaseLock'],
     'realm': ['Abort', 'Close', 'Constructor', 'Write'],
-    'useRcPromise': True,
 },
 
 'TransformStreamDefaultController': {
@@ -1890,7 +1885,6 @@ Callbacks = {
     },
     'callbackWithOnlyOneOptionalArg': {
         'rc': True,
-        'useRcPromise': True,
     },
     'CreateHTMLCallback': {
         'rc': True,
@@ -1984,47 +1978,36 @@ Callbacks = {
     },
     'TransformerCancelCallback': {
         'rc': True,
-        'useRcPromise': True,
     },
     'TransformerFlushCallback': {
         'rc': True,
-        'useRcPromise': True,
     },
     'TransformerStartCallback': {
         'rc': True,
-        'useRcPromise': True,
     },
     'TransformerTransformCallback': {
         'rc': True,
-        'useRcPromise': True,
     },
     'UnderlyingSinkAbortCallback': {
         'rc': True,
-        'useRcPromise': True,
     },
     'UnderlyingSinkCloseCallback': {
         'rc': True,
-        'useRcPromise': True,
     },
     'UnderlyingSinkStartCallback': {
         'rc': True,
-        'useRcPromise': True,
     },
     'UnderlyingSinkWriteCallback': {
         'rc': True,
-        'useRcPromise': True,
     },
     'UnderlyingSourceCancelCallback': {
         'rc': True,
-        'useRcPromise': True,
     },
     'UnderlyingSourcePullCallback': {
         'rc': True,
-        'useRcPromise': True,
     },
     'UnderlyingSourceStartCallback': {
         'rc': True,
-        'useRcPromise': True,
     },
     'VoidFunction': {
         'rc': True,

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1890,6 +1890,7 @@ Callbacks = {
     },
     'callbackWithOnlyOneOptionalArg': {
         'rc': True,
+        'useRcPromise': True,
     },
     'CreateHTMLCallback': {
         'rc': True,
@@ -1983,36 +1984,47 @@ Callbacks = {
     },
     'TransformerCancelCallback': {
         'rc': True,
+        'useRcPromise': True,
     },
     'TransformerFlushCallback': {
         'rc': True,
+        'useRcPromise': True,
     },
     'TransformerStartCallback': {
         'rc': True,
+        'useRcPromise': True,
     },
     'TransformerTransformCallback': {
         'rc': True,
+        'useRcPromise': True,
     },
     'UnderlyingSinkAbortCallback': {
         'rc': True,
+        'useRcPromise': True,
     },
     'UnderlyingSinkCloseCallback': {
         'rc': True,
+        'useRcPromise': True,
     },
     'UnderlyingSinkStartCallback': {
         'rc': True,
+        'useRcPromise': True,
     },
     'UnderlyingSinkWriteCallback': {
         'rc': True,
+        'useRcPromise': True,
     },
     'UnderlyingSourceCancelCallback': {
         'rc': True,
+        'useRcPromise': True,
     },
     'UnderlyingSourcePullCallback': {
         'rc': True,
+        'useRcPromise': True,
     },
     'UnderlyingSourceStartCallback': {
         'rc': True,
+        'useRcPromise': True,
     },
     'VoidFunction': {
         'rc': True,

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -8647,7 +8647,7 @@ class CGCallbackFunction(CGCallback):
     def __init__(self, callback: IDLCallback, descriptorProvider: DescriptorProvider) -> None:
         CGCallback.__init__(self, callback, descriptorProvider,
                             "CallbackFunction<D>",
-                            methods=[CallCallback(callback, descriptorProvider, useRcPromise=True)])
+                            methods=[CallCallback(callback, descriptorProvider, useRcPromise=descriptorProvider.callbackUsesRcPromise(callback.identifier.name))])
 
     def getConstructors(self) -> list[ClassConstructor]:
         return CGCallback.getConstructors(self)
@@ -8738,7 +8738,8 @@ class CallbackMember(CGNativeMember):
                                 extendedAttrs={},
                                 passJSBitsAsNeeded=False,
                                 unsafe=needThisHandling,
-                                visibility=visibility)
+                                visibility=visibility,
+                                useRcPromise=useRcPromise)
         # We have to do all the generation of our body now, because
         # the caller relies on us throwing if we can't manage it.
         self.exceptionCode = "return Err(JSFailed);\n"
@@ -8781,7 +8782,8 @@ class CallbackMember(CGNativeMember):
             self.descriptorProvider,
             exceptionCode=self.exceptionCode,
             # XXXbz we should try to do better here
-            sourceDescription="return value")
+            sourceDescription="return value",
+            useRcPromise=self.useRcPromise)
         template = info.template
         declType = info.declType
 

--- a/components/script_bindings/codegen/configuration.py
+++ b/components/script_bindings/codegen/configuration.py
@@ -225,6 +225,9 @@ class DescriptorProvider:
     def callbackUsesRc(self, callbackIdentifier: str) -> bool:
         return self.config.getCallbackConfig(callbackIdentifier).get('rc', False)
 
+    def callbackUsesRcPromise(self, callbackIdentifier: str) -> bool:
+        return self.config.getCallbackConfig(callbackIdentifier).get('useRcPromise', False)
+
 def MemberIsLegacyUnforgeable(member: IDLAttribute | IDLMethod, descriptor: Descriptor) -> bool:
     return ((member.isAttr() or member.isMethod())
             and not member.isStatic()


### PR DESCRIPTION
These are pretty much all mechanical changes to make the type checker and crown happy.

Testing: Existing tests suffice.
Part of #47747 and blocking #47749
