### PR TITLE
xpath: Fix `name`, `local-name` and `namespace-uri` to correctly process attributes

### DIFF
--- a/components/xpath/src/eval.rs
+++ b/components/xpath/src/eval.rs
@@ -224,7 +224,7 @@ fn apply_node_test<D: Dom>(test: &NodeTest, node: &D::Node) -> Result<bool, Erro
                 false
             }
         },
-        NodeTest::Wildcard => node.as_element().is_some(),
+        NodeTest::Wildcard => node.as_element().is_some() || node.as_attribute().is_some(),
         NodeTest::Kind(kind) => match kind {
             KindTest::PI(target) => {
                 if let Some(processing_instruction) = node.as_processing_instruction() {

--- a/components/xpath/src/functions.rs
+++ b/components/xpath/src/functions.rs
@@ -17,13 +17,13 @@ struct NodeNameParts {
 
 fn name_parts<N: Node>(node: &N) -> Option<NodeNameParts> {
     match (node.as_element(), node.as_attribute()) {
-        (Some(e), _) => Some(NodeNameParts {
-            prefix: e.prefix(),
-            local_name: e.local_name(),
+        (Some(element), _) => Some(NodeNameParts {
+            prefix: element.prefix(),
+            local_name: element.local_name(),
         }),
-        (_, Some(a)) => Some(NodeNameParts {
-            prefix: a.prefix(),
-            local_name: a.local_name(),
+        (_, Some(attribute)) => Some(NodeNameParts {
+            prefix: attribute.prefix(),
+            local_name: attribute.local_name(),
         }),
         _ => None,
     }

--- a/components/xpath/src/functions.rs
+++ b/components/xpath/src/functions.rs
@@ -2,33 +2,56 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use markup5ever::{LocalName, Prefix};
+
 use crate::ast::CoreFunction;
 use crate::context::EvaluationCtx;
 use crate::eval::try_extract_nodeset;
 use crate::value::{NodeSet, parse_number_from_string};
-use crate::{Document, Dom, Element, Error, Node, Value};
+use crate::{Attribute, Document, Dom, Element, Error, Node, Value};
+
+struct NodeNameParts {
+    prefix: Option<Prefix>,
+    local_name: LocalName,
+}
+
+fn name_parts<N: Node>(node: &N) -> Option<NodeNameParts> {
+    match (node.as_element(), node.as_attribute()) {
+        (Some(e), _) => Some(NodeNameParts {
+            prefix: e.prefix(),
+            local_name: e.local_name(),
+        }),
+        (_, Some(a)) => Some(NodeNameParts {
+            prefix: a.prefix(),
+            local_name: a.local_name(),
+        }),
+        _ => None,
+    }
+}
 
 /// Returns e.g. "rect" for `<svg:rect>`
 fn local_name<N: Node>(node: &N) -> Option<String> {
-    node.as_element()
-        .map(|element| element.local_name().to_string())
+    name_parts(node).map(|node_name_parts| node_name_parts.local_name.to_string())
 }
 
 /// Returns e.g. "svg:rect" for `<svg:rect>`
 fn name<N: Node>(node: &N) -> Option<String> {
-    node.as_element().map(|element| {
-        if let Some(prefix) = element.prefix().as_ref() {
-            format!("{}:{}", prefix, element.local_name())
-        } else {
-            element.local_name().to_string()
-        }
-    })
+    let NodeNameParts { prefix, local_name } = name_parts(node)?;
+
+    if let Some(prefix) = prefix {
+        Some(format!("{}:{}", prefix, local_name))
+    } else {
+        Some(local_name.to_string())
+    }
 }
 
 /// Returns e.g. the SVG namespace URI for `<svg:rect>`
 fn namespace_uri<N: Node>(node: &N) -> Option<String> {
-    node.as_element()
-        .map(|element| element.namespace().to_string())
+    match (node.as_element(), node.as_attribute()) {
+        (Some(e), _) => Some(e.namespace().to_string()),
+        (_, Some(a)) => Some(a.namespace().to_string()),
+        _ => None,
+    }
 }
 
 /// If s2 is found inside s1, return everything *before* s2. Return all of s1 otherwise.

--- a/components/xpath/src/functions.rs
+++ b/components/xpath/src/functions.rs
@@ -48,8 +48,8 @@ fn name<N: Node>(node: &N) -> Option<String> {
 /// Returns e.g. the SVG namespace URI for `<svg:rect>`
 fn namespace_uri<N: Node>(node: &N) -> Option<String> {
     match (node.as_element(), node.as_attribute()) {
-        (Some(e), _) => Some(e.namespace().to_string()),
-        (_, Some(a)) => Some(a.namespace().to_string()),
+        (Some(element), _) => Some(element.namespace().to_string()),
+        (_, Some(attribute)) => Some(attribute.namespace().to_string()),
         _ => None,
     }
 }

--- a/tests/wpt/tests/domxpath/fns-name-related.html
+++ b/tests/wpt/tests/domxpath/fns-name-related.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<link rel="help-name" href="https://www.w3.org/TR/1999/REC-xpath-19991116/#function-name">
+<link rel="help-local-name" href="https://www.w3.org/TR/1999/REC-xpath-19991116/#function-local-name">
+<link rel="help-namespace-uri" href="https://www.w3.org/TR/1999/REC-xpath-19991116/#function-namespace-uri">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+// Test the functions with various scenarios
+function testFunction(expression, xmlString, expected) {
+  const doc = (new DOMParser()).parseFromString(xmlString, 'text/xml');
+  test(() => {
+    const result = doc.evaluate(expression, doc.documentElement, null, XPathResult.STRING_TYPE, null);
+    assert_equals(result.resultType, XPathResult.STRING_TYPE);
+    assert_equals(result.stringValue, expected);
+  })
+}
+
+const context = '<root xmlns:alpha="http://example.com/alpha" xmlns:gamma="http://example.com/gamma"><alpha:beta gamma:delta="epsilon"></alpha:beta></root>';
+
+testFunction("name(./*[1])", context, "alpha:beta");
+testFunction("local-name(./*[1])", context, "beta");
+testFunction("namespace-uri(./*[1])", context, "http://example.com/alpha");
+testFunction("name(./*[1]/@*)", context, "gamma:delta");
+testFunction("local-name(./*[1]/@*)", context, "delta");
+testFunction("namespace-uri(./*[1]/@*)", context, "http://example.com/gamma");
+</script>
+</body>


### PR DESCRIPTION
Changed the implementation of each relevant function to include attributes as well as elements. Wasn't sure whether to introduce a new struct or just use tuples in `name_parts`. Advice from reviewers much appreciated. 

Advice also appreciated on use of shadowing in `if let Some(prefix) = prefix`.

Testing: Added a WPT in `domxpath` to cover these name-related functions. I don't know anything about the WPT upstreaming process but I assume this could be upstreamed?
Fixes: #47798 

Behaviour before code change:
```
  ▶ OK /domxpath/fns-name-related.html
  │   ▶ FAIL [expected PASS] fns-name-related 3
  │   │   → assert_equals: expected "gamma:delta" but got ""
  │   │ 
  │   │ testFunction/<@http://web-platform.test:8000/domxpath/fns-name-related.html:15:18
  │   │ Test.prototype.step@http://web-platform.test:8000/resources/testharness.js:2869:25
  │   │ test@http://web-platform.test:8000/resources/testharness.js:633:30
  │   │ testFunction@http://web-platform.test:8000/domxpath/fns-name-related.html:12:7
  │   └ @http://web-platform.test:8000/domxpath/fns-name-related.html:24:13
  │   ▶ FAIL [expected PASS] fns-name-related 4
  │   │   → assert_equals: expected "delta" but got ""
  │   │ 
  │   │ testFunction/<@http://web-platform.test:8000/domxpath/fns-name-related.html:15:18
  │   │ Test.prototype.step@http://web-platform.test:8000/resources/testharness.js:2869:25
  │   │ test@http://web-platform.test:8000/resources/testharness.js:633:30
  │   │ testFunction@http://web-platform.test:8000/domxpath/fns-name-related.html:12:7
  │   └ @http://web-platform.test:8000/domxpath/fns-name-related.html:25:13
  │   ▶ FAIL [expected PASS] fns-name-related 5
  │   │   → assert_equals: expected "http://example.com/gamma" but got ""
  │   │ 
  │   │ testFunction/<@http://web-platform.test:8000/domxpath/fns-name-related.html:15:18
  │   │ Test.prototype.step@http://web-platform.test:8000/resources/testharness.js:2869:25
  │   │ test@http://web-platform.test:8000/resources/testharness.js:633:30
  │   │ testFunction@http://web-platform.test:8000/domxpath/fns-name-related.html:12:7
  └   └ @http://web-platform.test:8000/domxpath/fns-name-related.html:26:13
```
