### PR TITLE
dom_struct: Infer `DomObject::ReflectorType` from type of first field of dom_struct

### DIFF
--- a/components/dom_struct/domobject.rs
+++ b/components/dom_struct/domobject.rs
@@ -6,21 +6,14 @@ use quote::{TokenStreamExt, quote};
 
 /// First field of DomObject must be either reflector or another dom_struct,
 /// all other fields must not implement DomObject
-pub(crate) fn expand_dom_object(
-    input: syn::ItemStruct,
-    associated_memory: bool,
-) -> proc_macro2::TokenStream {
+pub(crate) fn expand_dom_object(input: syn::ItemStruct) -> proc_macro2::TokenStream {
     let fields = input.fields.iter().collect::<Vec<&syn::Field>>();
     let (first_field, fields) = fields
         .split_first()
         .expect("#[dom_struct] should not be applied on empty structs");
 
     let first_field_name = first_field.ident.as_ref().unwrap();
-    let reflector_type = if associated_memory {
-        quote! { crate::AssociatedMemory }
-    } else {
-        quote! { () }
-    };
+    let first_field_ty = &first_field.ty;
     let mut field_types_and_cfgs = vec![];
     for field in fields {
         if field_types_and_cfgs.contains(&(&field.ty, vec![])) {
@@ -45,7 +38,7 @@ pub(crate) fn expand_dom_object(
         }
 
         impl #impl_generics crate::DomObject for #name #ty_generics #where_clause {
-            type ReflectorType = #reflector_type;
+            type ReflectorType = <#first_field_ty as crate::DomObject>::ReflectorType;
 
             #[inline]
             fn reflector(&self) -> &crate::Reflector<Self::ReflectorType> {

--- a/components/dom_struct/lib.rs
+++ b/components/dom_struct/lib.rs
@@ -22,10 +22,9 @@ fn dom_struct_impl(
     args: proc_macro2::TokenStream,
     input: proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
-    let associated_memory = args.to_string().contains("associated_memory");
     let no_has_parent = args.to_string().contains("no_has_parent");
-    if !associated_memory && !no_has_parent && !args.is_empty() {
-        panic!("#[dom_struct] only takes 'associated_memory' or 'no_has_parent' as an argument");
+    if !no_has_parent && !args.is_empty() {
+        panic!("#[dom_struct] only takes 'no_has_parent' as an argument");
     }
     let attributes = quote! {
         #[derive(deny_public_fields::DenyPublicFields, JSTraceable, MallocSizeOf)]
@@ -41,7 +40,7 @@ fn dom_struct_impl(
     let item: Item = syn::parse2(output).unwrap();
 
     if let Item::Struct(s) = item {
-        let expanded_dom_object = expand_dom_object(s.clone(), associated_memory);
+        let expanded_dom_object = expand_dom_object(s.clone());
         let s2 = quote! { #s #expanded_dom_object };
         if no_has_parent {
             return s2;
@@ -88,7 +87,7 @@ fn dom_struct_impl(
 
 #[test]
 fn test_valid_dom_struct_generation() {
-    let args = quote! { associated_memory };
+    let args = quote! {};
     let reflector_type: syn::Type = parse_quote!(Reflector);
     let input = quote! {
         struct DomElement {
@@ -132,7 +131,7 @@ fn test_valid_dom_struct_generation() {
             }
         }
         impl crate::DomObject for DomElement {
-            type ReflectorType = crate::AssociatedMemory;
+            type ReflectorType = <Reflector as crate::DomObject>::ReflectorType;
             #[inline]
             fn reflector(&self) -> &crate::Reflector<Self::ReflectorType> {
                 self.reflector.reflector()
@@ -175,7 +174,7 @@ fn test_valid_dom_struct_generation() {
 }
 
 #[test]
-#[should_panic(expected = "#[dom_struct] only takes 'associated_memory'")]
+#[should_panic(expected = "#[dom_struct] only takes 'no_has_parent' as an argument")]
 fn test_invalid_arguments_panic() {
     let args = quote! { invalid_flag_here };
     let input = quote! { struct MockStruct { first_field: i32 } };

--- a/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
@@ -38,7 +38,7 @@ use crate::dom::path2d::Path2D;
 use crate::dom::textmetrics::TextMetrics;
 
 // https://html.spec.whatwg.org/multipage/#canvasrenderingcontext2d
-#[dom_struct(associated_memory)]
+#[dom_struct]
 pub(crate) struct CanvasRenderingContext2D {
     reflector_: Reflector<AssociatedMemory>,
     canvas: HTMLCanvasElementOrOffscreenCanvas,

--- a/components/script/dom/canvas/2d/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/offscreencanvasrenderingcontext2d.rs
@@ -35,7 +35,7 @@ use crate::dom::offscreencanvas::OffscreenCanvas;
 use crate::dom::path2d::Path2D;
 use crate::dom::textmetrics::TextMetrics;
 
-#[dom_struct(associated_memory)]
+#[dom_struct]
 pub(crate) struct OffscreenCanvasRenderingContext2D {
     context: CanvasRenderingContext2D,
 }

--- a/components/script/dom/webgl/webglbuffer.rs
+++ b/components/script/dom/webgl/webglbuffer.rs
@@ -109,7 +109,7 @@ impl Drop for DroppableWebGLBuffer {
     }
 }
 
-#[dom_struct(associated_memory)]
+#[dom_struct]
 pub(crate) struct WebGLBuffer {
     webgl_object: WebGLObject,
     /// The target to which this buffer was bound the first time

--- a/components/script/dom/webgl/webglframebuffer.rs
+++ b/components/script/dom/webgl/webglframebuffer.rs
@@ -144,7 +144,7 @@ impl Drop for DroppableWebGLFramebuffer {
     }
 }
 
-#[dom_struct(associated_memory)] // actual memory usage is reported in WebGLFramebufferAttachment
+#[dom_struct] // actual memory usage is reported in WebGLFramebufferAttachment
 pub(crate) struct WebGLFramebuffer {
     webgl_object: WebGLObject,
     #[no_trace]

--- a/components/script/dom/webgl/webglframebuffer.rs
+++ b/components/script/dom/webgl/webglframebuffer.rs
@@ -144,7 +144,7 @@ impl Drop for DroppableWebGLFramebuffer {
     }
 }
 
-#[dom_struct] // actual memory usage is reported in WebGLFramebufferAttachment
+#[dom_struct]
 pub(crate) struct WebGLFramebuffer {
     webgl_object: WebGLObject,
     #[no_trace]

--- a/components/script/dom/webgl/webglobject.rs
+++ b/components/script/dom/webgl/webglobject.rs
@@ -15,7 +15,7 @@ use crate::dom::bindings::str::USVString;
 use crate::dom::webgl::webglrenderingcontext::WebGLRenderingContext;
 use crate::dom::webglrenderingcontext::{Operation, capture_webgl_backtrace};
 
-#[dom_struct(associated_memory)]
+#[dom_struct]
 pub(crate) struct WebGLObject {
     reflector_: Reflector<AssociatedMemory>,
     #[no_trace]

--- a/components/script/dom/webgl/webglprogram.rs
+++ b/components/script/dom/webgl/webglprogram.rs
@@ -172,7 +172,7 @@ impl Drop for DroppableWebGLProgram {
     }
 }
 
-#[dom_struct(associated_memory)]
+#[dom_struct]
 pub(crate) struct WebGLProgram {
     webgl_object: WebGLObject,
     link_called: Cell<bool>,

--- a/components/script/dom/webgl/webglquery.rs
+++ b/components/script/dom/webgl/webglquery.rs
@@ -54,7 +54,7 @@ impl Drop for DroppableWebGLQuery {
     }
 }
 
-#[dom_struct(associated_memory)]
+#[dom_struct]
 pub(crate) struct WebGLQuery {
     webgl_object: WebGLObject,
     gl_target: Cell<Option<u32>>,

--- a/components/script/dom/webgl/webglrenderbuffer.rs
+++ b/components/script/dom/webgl/webglrenderbuffer.rs
@@ -79,7 +79,7 @@ impl Drop for DroppableWebGLRenderbuffer {
     }
 }
 
-#[dom_struct(associated_memory)]
+#[dom_struct]
 pub(crate) struct WebGLRenderbuffer {
     webgl_object: WebGLObject,
     ever_bound: Cell<bool>,

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -164,7 +164,7 @@ impl Drop for DroppableWebGLRenderingContext {
     }
 }
 
-#[dom_struct(associated_memory)]
+#[dom_struct]
 pub(crate) struct WebGLRenderingContext {
     reflector_: Reflector<AssociatedMemory>,
     #[no_trace]

--- a/components/script/dom/webgl/webglsampler.rs
+++ b/components/script/dom/webgl/webglsampler.rs
@@ -53,7 +53,7 @@ impl Drop for DroppableWebGLSampler {
     }
 }
 
-#[dom_struct(associated_memory)]
+#[dom_struct]
 pub(crate) struct WebGLSampler {
     webgl_object: WebGLObject,
     droppable: DroppableWebGLSampler,

--- a/components/script/dom/webgl/webglshader.rs
+++ b/components/script/dom/webgl/webglshader.rs
@@ -73,7 +73,7 @@ impl Drop for DroppableWebGLShader {
     }
 }
 
-#[dom_struct(associated_memory)]
+#[dom_struct]
 pub(crate) struct WebGLShader {
     webgl_object: WebGLObject,
     gl_type: u32,

--- a/components/script/dom/webgl/webglsync.rs
+++ b/components/script/dom/webgl/webglsync.rs
@@ -57,7 +57,7 @@ impl Drop for DroppableWebGLSync {
     }
 }
 
-#[dom_struct(associated_memory)]
+#[dom_struct]
 pub(crate) struct WebGLSync {
     webgl_object: WebGLObject,
     client_wait_status: Cell<Option<u32>>,

--- a/components/script/dom/webgl/webgltexture.rs
+++ b/components/script/dom/webgl/webgltexture.rs
@@ -107,7 +107,7 @@ impl Drop for DroppableWebGLTexture {
     }
 }
 
-#[dom_struct(associated_memory)]
+#[dom_struct]
 pub(crate) struct WebGLTexture {
     webgl_object: WebGLObject,
     /// The target to which this texture was bound the first time

--- a/components/script/dom/webgl/webgltransformfeedback.rs
+++ b/components/script/dom/webgl/webgltransformfeedback.rs
@@ -58,7 +58,7 @@ impl Drop for DroppableWebGLTransformFeedback {
     }
 }
 
-#[dom_struct(associated_memory)]
+#[dom_struct]
 pub(crate) struct WebGLTransformFeedback {
     webgl_object: WebGLObject,
     has_been_bound: Cell<bool>,

--- a/components/script/dom/webgl/webglvertexarrayobject.rs
+++ b/components/script/dom/webgl/webglvertexarrayobject.rs
@@ -15,7 +15,7 @@ use crate::dom::webgl::webglbuffer::WebGLBuffer;
 use crate::dom::webgl::webglobject::WebGLObject;
 use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
 
-#[dom_struct(associated_memory)]
+#[dom_struct]
 pub(crate) struct WebGLVertexArrayObject {
     webgl_object_: WebGLObject,
     array_object: VertexArrayObject,

--- a/components/script/dom/webgl/webglvertexarrayobjectoes.rs
+++ b/components/script/dom/webgl/webglvertexarrayobjectoes.rs
@@ -15,7 +15,7 @@ use crate::dom::webgl::webglbuffer::WebGLBuffer;
 use crate::dom::webgl::webglobject::WebGLObject;
 use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
 
-#[dom_struct(associated_memory)]
+#[dom_struct]
 pub(crate) struct WebGLVertexArrayObjectOES {
     webgl_object_: WebGLObject,
     array_object: VertexArrayObject,

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -49,7 +49,7 @@ mod xpath;
 
 pub use event_loop::script_thread::ScriptThread;
 pub(crate) use script_bindings::DomTypes;
-pub(crate) use script_bindings::reflector::{AssociatedMemory, DomObject, MutDomObject, Reflector};
+pub(crate) use script_bindings::reflector::{DomObject, MutDomObject, Reflector};
 
 pub(crate) use crate::dom::bindings::codegen::DomTypeHolder::DomTypeHolder;
 // These trait exports are public, because they are used in the DOM bindings.


### PR DESCRIPTION
Before user had to manually provide `#[dom_struct(associated_memory)]` in addition to first field already having proper ReflectorType (even reflector has it!). But after looking at https://github.com/servo/servo/pull/47907 I noticed that we could simply use ReflectorType of first field for DomObject::ReflectorType. This will also works for inherited and generic cases as everything has DomObject trait.

Testing: It compiles and there are tests for proc macro.