### PR TITLE
script: Fully support `Content-Language`

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -736,6 +736,9 @@ pub(crate) struct Document {
     #[no_trace]
     theme: Cell<Option<Theme>>,
 
+    /// Language specific for this document, set by a meta element
+    default_language: DomRefCell<Option<String>>,
+
     /// True if this document is no longer the active document of its associated
     /// window.
     window_detached: Cell<bool>,
@@ -3833,6 +3836,11 @@ impl<'dom> LayoutDom<'dom, Document> {
     pub(crate) fn selection_for_layout(&self) -> Option<LayoutDom<'dom, Selection>> {
         unsafe { self.unsafe_get().selection.to_layout() }
     }
+
+    #[expect(unsafe_code)]
+    pub(crate) fn default_language_for_layout(&self) -> Option<&'dom str> {
+        unsafe { self.unsafe_get().default_language.borrow_for_layout() }.as_deref()
+    }
 }
 
 // https://html.spec.whatwg.org/multipage/#is-a-registrable-domain-suffix-of-or-is-equal-to
@@ -4100,6 +4108,7 @@ impl Document {
             image_cache,
             history: Default::default(),
             theme: Default::default(),
+            default_language: Default::default(),
             window_detached: Default::default(),
             live_ranges: Default::default(),
         }
@@ -5255,6 +5264,14 @@ impl Document {
     pub(crate) fn set_theme(&self, new_theme: Option<Theme>) {
         self.theme.set(new_theme);
         self.window.refresh_theme();
+    }
+
+    pub(crate) fn default_language(&self) -> Option<String> {
+        self.default_language.borrow().clone()
+    }
+
+    pub(crate) fn set_default_language(&self, new_language: Option<String>) {
+        *self.default_language.borrow_mut() = new_language;
     }
 }
 

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -1621,19 +1621,32 @@ impl<'dom> LayoutDom<'dom, Element> {
         &(self.unsafe_get()).namespace
     }
 
+    /// <https://html.spec.whatwg.org/multipage/#language>
     pub(crate) fn get_lang_attr_val_for_layout(self) -> Option<&'dom str> {
+        // > If the node is an element that has a lang attribute in the XML namespace set
+        // >     Use the value of that attribute.
         if let Some(attr) = self.get_attr_val_for_layout(&ns!(xml), &local_name!("lang")) {
             return Some(attr);
         }
-        if let Some(attr) = self.get_attr_val_for_layout(&ns!(), &local_name!("lang")) {
-            return Some(attr);
+        // > If the node is an HTML element or an element in the SVG namespace,
+        // > and it has a lang in no namespace attribute set
+        // >     Use the value of that attribute.
+        if self.is_html_element() || self.namespace() == &ns!(svg) {
+            return self.get_attr_val_for_layout(&ns!(), &local_name!("lang"));
         }
         None
     }
 
+    /// <https://html.spec.whatwg.org/multipage/#language>
     pub(crate) fn get_lang_for_layout(self) -> AtomString {
+        // > To determine the language of a node,
+        // > user agents must use the first appropriate step in the following list:
         let mut current_node = Some(self.upcast::<Node>());
         while let Some(node) = current_node {
+            // > If the node's parent element is not null
+            // >     Use the language of that parent element.
+            // > If the node's parent is a shadow root
+            // >     Use the language of that shadow root's host.
             current_node = node.composed_parent_node_ref();
             match node.downcast::<Element>() {
                 Some(elem) => {
@@ -1644,8 +1657,24 @@ impl<'dom> LayoutDom<'dom, Element> {
                 None => continue,
             }
         }
-        // TODO: Check meta tags for a pragma-set default language
-        // TODO: Check HTTP Content-Language header
+        // > If there is a pragma-set default language set,
+        // > then that is the language of the node.
+        // > If there is no pragma-set default language set,
+        // > then language information from a higher-level protocol (such as HTTP),
+        // > if any, must be used as the final fallback language instead.
+        // > In the absence of any such language information,
+        // > and in cases where the higher-level protocol reports multiple languages,
+        // > the language of the node is unknown,
+        // > and the corresponding language tag is the empty string.
+        //
+        // We store the default_language when retrieving from HTTP
+        // and then later overwrite if it we process a <meta> element
+        // that sets content-language. Hence, we only need to call
+        // default_language here to cover both cases.
+        let document = self.upcast::<Node>().owner_doc_for_layout();
+        if let Some(document_language) = document.default_language_for_layout() {
+            return AtomString::from(document_language);
+        }
         AtomString::default()
     }
 

--- a/components/script/dom/html/document_metadata/htmlmetaelement.rs
+++ b/components/script/dom/html/document_metadata/htmlmetaelement.rs
@@ -71,8 +71,9 @@ impl HTMLMetaElement {
             if name.eq_ignore_ascii_case("viewport") {
                 self.parse_and_send_viewport_if_necessary(cx);
             }
+        }
         // https://html.spec.whatwg.org/multipage/#attr-meta-http-equiv
-        } else if !self.HttpEquiv().is_empty() {
+        if !self.HttpEquiv().is_empty() {
             // TODO: Implement additional http-equiv candidates
             if self.HttpEquiv().eq_ignore_ascii_case("refresh") {
                 self.declarative_refresh();
@@ -81,6 +82,8 @@ impl HTMLMetaElement {
                 .eq_ignore_ascii_case("content-security-policy")
             {
                 self.apply_csp_list();
+            } else if self.HttpEquiv().eq_ignore_ascii_case("content-language") {
+                self.pragma_set_default_language();
             }
         }
     }
@@ -252,6 +255,35 @@ impl HTMLMetaElement {
                 /* from_meta_element */ true,
             );
         }
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#pragma-set-default-language>
+    fn pragma_set_default_language(&self) {
+        // Step 3. Let input be the value of the element's content attribute.
+        let input = self.Content();
+        let input = input.str();
+        // Step 2. If the element's content attribute contains
+        // a U+002C COMMA character (,), then return.
+        let candidate = if input.contains('\u{002C}') {
+            None
+        } else {
+            // Step 1. If the meta element has no content attribute, then return.
+            // Step 4. Let position point at the first character of input.
+            // Step 5. Skip ASCII whitespace within input given position.
+            // Step 6. Collect a sequence of code points that are
+            // not ASCII whitespace from input given position.
+            // Step 7. Let candidate be the string that resulted from the previous step.
+            // Step 8. If candidate is the empty string, return.
+            input
+                .trim_start()
+                .split_ascii_whitespace()
+                .next()
+                .filter(|candidate| !candidate.is_empty())
+                .map(|candidate| candidate.to_owned())
+        };
+
+        // Step 9. Set the pragma-set default language to candidate.
+        self.owner_document().set_default_language(candidate);
     }
 }
 

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -1994,15 +1994,47 @@ impl Node {
 
     /// <https://html.spec.whatwg.org/multipage/#language>
     pub(crate) fn get_lang(&self) -> Option<String> {
+        // > To determine the language of a node,
+        // > user agents must use the first appropriate step in the following list:
+
+        // > If the node's parent is a shadow root
+        // >     Use the language of that shadow root's host.
+        // > If the node's parent element is not null
+        // >     Use the language of that parent element.
         self.inclusive_ancestors(ShadowIncluding::Yes)
             .find_map(|node| {
-                node.downcast::<Element>().and_then(|el| {
-                    el.get_attribute_string_value_with_namespace(&ns!(xml), &local_name!("lang"))
-                        .or_else(|| el.get_attribute_string_value(&local_name!("lang")))
+                node.downcast::<Element>().and_then(|element| {
+                    // > If the node is an element that has a lang attribute in the XML namespace set
+                    // >     Use the value of that attribute.
+                    element
+                        .get_attribute_string_value_with_namespace(&ns!(xml), &local_name!("lang"))
+                        // > If the node is an HTML element or an element in the SVG namespace,
+                        // > and it has a lang in no namespace attribute set
+                        // >     Use the value of that attribute.
+                        .or_else(|| {
+                            if element.namespace() == &ns!() || element.namespace() == &ns!(svg) {
+                                element.get_attribute_string_value(&local_name!("lang"))
+                            } else {
+                                None
+                            }
+                        })
                 })
-                // TODO: Check meta tags for a pragma-set default language
-                // TODO: Check HTTP Content-Language header
             })
+            // > If there is a pragma-set default language set,
+            // > then that is the language of the node.
+            // > If there is no pragma-set default language set,
+            // > then language information from a higher-level protocol (such as HTTP),
+            // > if any, must be used as the final fallback language instead.
+            // > In the absence of any such language information,
+            // > and in cases where the higher-level protocol reports multiple languages,
+            // > the language of the node is unknown,
+            // > and the corresponding language tag is the empty string.
+            //
+            // We store the default_language when retrieving from HTTP
+            // and then later overwrite if it we process a <meta> element
+            // that sets content-language. Hence, we only need to call
+            // default_language here to cover both cases.
+            .or_else(|| self.owner_document().default_language())
     }
 
     /// <https://dom.spec.whatwg.org/#assign-slotables-for-a-tree>

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1374,17 +1374,25 @@ impl ParserContext {
         // Step 21.9. Set responsePolicyContainer to the result of creating a
         // policy container from a fetch response given response and request's
         // reserved client.
-        let (policy_container, endpoints_list, link_headers) = match metadata.as_ref() {
-            None => (PolicyContainer::default(), None, vec![]),
-            Some(metadata) => (
-                Self::create_policy_container_from_fetch_response(metadata),
-                ReportingEndpoint::parse_reporting_endpoints_header(
-                    &self.url.clone(),
-                    &metadata.headers,
-                ),
-                extract_links_from_headers(&metadata.headers),
-            ),
-        };
+        let (policy_container, endpoints_list, link_headers, content_language) = metadata
+            .as_ref()
+            .map(|metadata| {
+                (
+                    Self::create_policy_container_from_fetch_response(metadata),
+                    ReportingEndpoint::parse_reporting_endpoints_header(
+                        &self.url.clone(),
+                        &metadata.headers,
+                    ),
+                    extract_links_from_headers(&metadata.headers),
+                    metadata
+                        .headers
+                        .as_ref()
+                        .and_then(|headers| headers.get("Content-Language"))
+                        .and_then(|header| header.to_str().ok())
+                        .map(|string| string.to_owned()),
+                )
+            })
+            .unwrap_or_default();
 
         // Step 21.10. Set finalSandboxFlags to the union of targetSnapshotParams's
         // sandboxing flags and responsePolicyContainer's CSP list's CSP-derived
@@ -1473,6 +1481,10 @@ impl ParserContext {
         if let Some(endpoints) = endpoints_list {
             window.set_endpoints_list(endpoints);
         }
+        // https://html.spec.whatwg.org/multipage/#language
+        // > then language information from a higher-level protocol (such as HTTP),
+        // > if any, must be used as the final fallback language instead
+        document.set_default_language(content_language);
         if let Some(parser) = document.get_current_parser() {
             self.parser = Some(Trusted::new(&*parser));
         }

--- a/tests/wpt/meta/css/CSS2/selectors/lang-selector-005.xht.ini
+++ b/tests/wpt/meta/css/CSS2/selectors/lang-selector-005.xht.ini
@@ -1,2 +1,0 @@
-[lang-selector-005.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/selectors/lang-selector-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/selectors/lang-selector-006.xht.ini
@@ -1,2 +1,0 @@
-[lang-selector-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/html/dom/elements/global-attributes/lang-attribute.window.js.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/lang-attribute.window.js.ini
@@ -1,3 +1,0 @@
-[lang-attribute.window.html]
-  [unnamespaced lang attribute only works on elements in the HTML namespace]
-    expected: FAIL

--- a/tests/wpt/meta/html/dom/elements/global-attributes/the-lang-attribute-003.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/the-lang-attribute-003.html.ini
@@ -1,3 +1,0 @@
-[the-lang-attribute-003.html]
-  [The browser will recognize a language declared in the HTTP header, when there is no internal language declaration.]
-    expected: FAIL

--- a/tests/wpt/meta/html/dom/elements/global-attributes/the-lang-attribute-004.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/the-lang-attribute-004.html.ini
@@ -1,3 +1,0 @@
-[the-lang-attribute-004.html]
-  [The browser will recognize a language declared in a meta element in the head using http-equiv='Content-Language' content='..' (with a single language tag value), when there is no other language declaration inside the document.]
-    expected: FAIL

--- a/tests/wpt/meta/html/dom/elements/global-attributes/the-lang-attribute-006.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/the-lang-attribute-006.html.ini
@@ -1,3 +1,0 @@
-[the-lang-attribute-006.html]
-  [If there is a conflict between the language declarations in the HTTP header and the Content-Language meta element, the UA will recognize the language declared in the meta element.]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/document-metadata/the-meta-element/http-equiv-and-name-2.html.ini
+++ b/tests/wpt/meta/html/semantics/document-metadata/the-meta-element/http-equiv-and-name-2.html.ini
@@ -1,3 +1,0 @@
-[http-equiv-and-name-2.html]
-  [<meta> set the content-language to de-DE]
-    expected: FAIL

--- a/tests/wpt/tests/html/dom/elements/global-attributes/the-lang-attribute-011.html
+++ b/tests/wpt/tests/html/dom/elements/global-attributes/the-lang-attribute-011.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>Multiple Content-Language HTTP headers</title>
+<link rel='help' href='https://html.spec.whatwg.org/multipage/#the-lang-and-xml:lang-attributes'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta name='flags' content='dom'>
+<style type='text/css'>
+    #colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+    #colonlangcontroltest:lang(xx) { display:none; }
+.test div { width: 50px; }
+#box:lang(ko) { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.</p>
+
+
+<!--Notes:
+
+This test uses :lang to detect whether the language has been set. If :lang is not supported, a message will appear and the test will fail.
+
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, "If there are multiple Content-Language HTTP headers, the UA will recognize the language declared in the first header.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/tests/wpt/tests/html/dom/elements/global-attributes/the-lang-attribute-011.html.headers
+++ b/tests/wpt/tests/html/dom/elements/global-attributes/the-lang-attribute-011.html.headers
@@ -1,1 +1,2 @@
-Content-Language: ko,zh,ja
+Content-Language: ko
+Content-Language: ja

--- a/tests/wpt/tests/html/semantics/document-metadata/the-meta-element/pragma-directives/http-equiv-lang-removal.html
+++ b/tests/wpt/tests/html/semantics/document-metadata/the-meta-element/pragma-directives/http-equiv-lang-removal.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<title>Removal of meta element with content-language should not reset pragma directive</title>
+<meta http-equiv=content-language content=de-DE>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  test(() => {
+    document.querySelector('meta').remove();
+    assert_equals(document.querySelector(":root:lang(de-DE)"), document.documentElement);
+  }, "Removal of <meta> with content-language should not reset pragma directive");
+</script>

--- a/tests/wpt/tests/html/semantics/document-metadata/the-meta-element/pragma-directives/http-equiv-lang-whitespace-after-comma.html
+++ b/tests/wpt/tests/html/semantics/document-metadata/the-meta-element/pragma-directives/http-equiv-lang-whitespace-after-comma.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<title>Comma should always make content-language invalid, even if it has whitespace before</title>
+<meta http-equiv=content-language content="de-DE ,nl-NL">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  test(() => {
+    assert_equals(document.querySelector(":root:lang(de-DE)"), null);
+  }, "Comma should always make content-language invalid, even if it has whitespace before");
+</script>

--- a/tests/wpt/tests/html/semantics/document-metadata/the-meta-element/pragma-directives/http-equiv-lang-whitespace-end.html
+++ b/tests/wpt/tests/html/semantics/document-metadata/the-meta-element/pragma-directives/http-equiv-lang-whitespace-end.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<title>Whitespace at end of content attribute should be ignored for content-language</title>
+<meta http-equiv=content-language content="de-DE ">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  test(() => {
+    assert_equals(document.querySelector(":root:lang(de-DE)"), document.documentElement);
+  }, "Whitespace at end of content attribute should be ignored for content-language");
+</script>

--- a/tests/wpt/tests/html/semantics/document-metadata/the-meta-element/pragma-directives/http-equiv-lang-whitespace-start.html
+++ b/tests/wpt/tests/html/semantics/document-metadata/the-meta-element/pragma-directives/http-equiv-lang-whitespace-start.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<title>Whitespace at start of content attribute should be ignored for content-language</title>
+<meta http-equiv=content-language content=" de-DE">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  test(() => {
+    assert_equals(document.querySelector(":root:lang(de-DE)"), document.documentElement);
+  }, "Whitespace at start of content attribute should be ignored for content-language");
+</script>


### PR DESCRIPTION
This is supported both for `<meta>` as well as the HTTP header. It adds several new tests that weren't covered. Notably the tests regarding whitespace (which is what the spec states) pass in Firefox but fail in Chrome. We follow Firefox' behavior as specced.

This fixes the last test we were failing in
`html/semantics/document-metadata/the-meta-element/` :tada:

Testing: new WPT tests added and passing