### PR TITLE
script: Remove incorrect `Element::is_editing_host` method

### DIFF
--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -82,7 +82,6 @@ use crate::dom::bindings::codegen::Bindings::ElementBinding::{
 };
 use crate::dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
 use crate::dom::bindings::codegen::Bindings::FunctionBinding::Function;
-use crate::dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLTemplateElementBinding::HTMLTemplateElementMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use crate::dom::bindings::codegen::Bindings::SanitizerBinding::{
@@ -1965,11 +1964,6 @@ impl Element {
         } else {
             false
         }
-    }
-
-    pub(crate) fn is_editing_host(&self) -> bool {
-        self.downcast::<HTMLElement>()
-            .is_some_and(|element| element.IsContentEditable())
     }
 
     pub(crate) fn is_actually_disabled(&self) -> bool {

--- a/components/script/dom/element/focus.rs
+++ b/components/script/dom/element/focus.rs
@@ -107,10 +107,10 @@ impl Element {
                 // >  - Editing hosts
                 // > -  Elements with a draggable attribute set, if that would enable the user agent to allow
                 // >    the user to begin drag operations for those elements without the use of a pointing device
-                self.downcast::<HTMLElement>()
-                    .is_some_and(|html_element| html_element.is_a_summary_for_its_parent_details()) ||
-                    self.is_editing_host() ||
-                    self.get_string_attribute(&local_name!("draggable")) == "true"
+                self.downcast::<HTMLElement>().is_some_and(|html_element| {
+                    html_element.is_a_summary_for_its_parent_details() ||
+                        html_element.is_editing_host()
+                }) || self.get_string_attribute(&local_name!("draggable")) == "true"
             },
         };
 

--- a/tests/wpt/meta/dom/events/no-focus-events-at-clicking-editable-content-in-link.html.ini
+++ b/tests/wpt/meta/dom/events/no-focus-events-at-clicking-editable-content-in-link.html.ini
@@ -1,3 +1,0 @@
-[no-focus-events-at-clicking-editable-content-in-link.html]
-  [Click editable link]
-    expected: FAIL

--- a/tests/wpt/meta/selection/contenteditable/modifying-selection-with-non-primary-mouse-button.tentative.html.ini
+++ b/tests/wpt/meta/selection/contenteditable/modifying-selection-with-non-primary-mouse-button.tentative.html.ini
@@ -1,8 +1,5 @@
 [modifying-selection-with-non-primary-mouse-button.tentative.html?secondary]
   expected: ERROR
-  [secondary click should set focus to clicked editable element and collapse selection around the clicked point]
-    expected: FAIL
-
   [secondary click should move caret in an editable element]
     expected: FAIL
 
@@ -18,9 +15,6 @@
 
 [modifying-selection-with-non-primary-mouse-button.tentative.html?middle]
   expected: ERROR
-  [middle click should set focus to clicked editable element and collapse selection around the clicked point]
-    expected: FAIL
-
   [middle click should move caret in an editable element]
     expected: FAIL
 

--- a/tests/wpt/meta/selection/contenteditable/modifying-selection-with-primary-mouse-button.tentative.html.ini
+++ b/tests/wpt/meta/selection/contenteditable/modifying-selection-with-primary-mouse-button.tentative.html.ini
@@ -1,10 +1,4 @@
 [modifying-selection-with-primary-mouse-button.tentative.html]
-  [Primary click should set focus to clicked editable element and collapse selection around the clicked point]
-    expected: FAIL
-
-  [Primary click should move caret in an editable element]
-    expected: FAIL
-
   [Shift + Primary click should extend the selection]
     expected: FAIL
 

--- a/tests/wpt/meta/shadow-dom/focus/click-focus-slot-ancestor.html.ini
+++ b/tests/wpt/meta/shadow-dom/focus/click-focus-slot-ancestor.html.ini
@@ -4,6 +4,3 @@
 
   [Select on non-focusable slot inside focusable div will select text]
     expected: FAIL
-
-  [Select on non-focusable non-editable slot in a contenteditable shadow DOM and inside focusable div will select text]
-    expected: FAIL


### PR DESCRIPTION
Its only caller whas in a context where the spec linked "Editing hosts" to https://html.spec.whatwg.org/multipage/interaction.html#editing-host but the incorrect implementation called `HTMLElement::IsContentEditable` https://html.spec.whatwg.org/multipage/interaction.html#dom-iscontenteditable where editing hosts are only one of the two cases.

Instead, the caller is changed to call `HTMLElement::is_editing_host` which already existed and was correct.

Testing: WPT