### PR TITLE
script_bindings: Trace reflector objects.

### DIFF
--- a/components/script_bindings/reflector.rs
+++ b/components/script_bindings/reflector.rs
@@ -50,7 +50,11 @@ pub struct Reflector<T = ()> {
 }
 
 unsafe impl<T> js::gc::Traceable for Reflector<T> {
-    unsafe fn trace(&self, _: *mut js::jsapi::JSTracer) {}
+    unsafe fn trace(&self, tracer: *mut js::jsapi::JSTracer) {
+        unsafe {
+            self.object.trace(tracer);
+        }
+    }
 }
 
 impl<T> PartialEq for Reflector<T> {

--- a/components/script_bindings/root.rs
+++ b/components/script_bindings/root.rs
@@ -16,7 +16,7 @@ use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use crate::assert::assert_in_script;
 use crate::conversions::DerivedFrom;
 use crate::inheritance::Castable;
-use crate::reflector::{DomObject, MutDomObject, Reflector};
+use crate::reflector::{DomObject, MutDomObject};
 use crate::trace::trace_reflector;
 
 /// A rooted value.
@@ -72,20 +72,7 @@ where
     T: DomObject,
 {
     fn stable_trace_object(&self) -> *const dyn JSTraceable {
-        // The JSTraceable impl for Reflector doesn't actually do anything,
-        // so we need this shenanigan to actually trace the reflector of the
-        // T pointer in Dom<T>.
-        #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-        struct ReflectorStackRoot<T>(Reflector<T>);
-        unsafe impl<T> JSTraceable for ReflectorStackRoot<T> {
-            unsafe fn trace(&self, tracer: *mut JSTracer) {
-                unsafe { trace_reflector(tracer, "on stack", &self.0) };
-            }
-        }
-        unsafe {
-            &*(self.reflector() as *const Reflector<T::ReflectorType>
-                as *const ReflectorStackRoot<T::ReflectorType>)
-        }
+        self.reflector()
     }
 }
 
@@ -94,23 +81,7 @@ where
     T: DomObject,
 {
     fn stable_trace_object(&self) -> *const dyn JSTraceable {
-        // The JSTraceable impl for Reflector doesn't actually do anything,
-        // so we need this shenanigan to actually trace the reflector of the
-        // T pointer in Dom<T>.
-        struct MaybeUnreflectedStackRoot<T>(T);
-        unsafe impl<T> JSTraceable for MaybeUnreflectedStackRoot<T>
-        where
-            T: DomObject,
-        {
-            unsafe fn trace(&self, tracer: *mut JSTracer) {
-                if self.0.reflector().get_jsobject().is_null() {
-                    unsafe { self.0.trace(tracer) };
-                } else {
-                    unsafe { trace_reflector(tracer, "on stack", self.0.reflector()) };
-                }
-            }
-        }
-        unsafe { &*(self.ptr.as_ptr() as *const T as *const MaybeUnreflectedStackRoot<T>) }
+        unsafe { self.ptr.as_ref().reflector() }
     }
 }
 


### PR DESCRIPTION
Ever since some of the earliest GC integration work in Servo (https://github.com/servo/servo/pull/1591), we have explicitly never traced the contents of Reflector as part of tracing a struct that contains it. Instead, any `Dom<T>` that is traced would trace the reflector of the contained type T. I can't remember why I made that choice and the reasoning is not documented anywhere; it's possible that it was intended as a performance optimization since there was no way to encounter a reflector during tracing without tracing it via a `Dom<T>`.

With the changes coming from #47749, this model no longer works. Promises stored inside traceable structures no longer have their own permanent roots, and so the current implementation silently ignores their reflector objects when tracing the containing structure. This leads to crashes when the GC frees the promises while they are still reachable from our Rust objects.

This change moves us to a model that is internally consistent—any reflector is traced when it is present in a structure, and we continue to trace the reflector of any object stored in a `Dom<T>`.

Testing: Existing test coverage must suffice. We do not have the ability to run with zealous GC in CI, since it takes too long on most tests.
Part of #47749
