### PR TITLE
script: Convert CSS font interfaces to traced/rooted promises.

### DIFF
--- a/components/script/dom/css/fontface.rs
+++ b/components/script/dom/css/fontface.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::{Cell, Ref, RefCell};
-use std::rc::Rc;
 
 use cssparser::{Parser, ParserInput};
 use dom_struct::dom_struct;
@@ -37,7 +36,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::css::fontfaceset::FontFaceSet;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::node::NodeTraits;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise, TracedPromise};
 use crate::dom::window::Window;
 
 /// <https://drafts.csswg.org/css-font-loading/#fontface-interface>
@@ -67,8 +66,7 @@ pub struct FontFace {
     urls: DomRefCell<Option<SourceList>>,
 
     /// <https://drafts.csswg.org/css-font-loading/#dom-fontface-fontstatuspromise-slot>
-    #[conditional_malloc_size_of]
-    font_status_promise: Rc<Promise>,
+    font_status_promise: TracedPromise,
 
     /// The `@font-face` rule that this `FontFace` object is [css-connected] to, if any.
     ///
@@ -205,7 +203,7 @@ impl FontFace {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<Self> {
-        let font_status_promise = Promise::new(cx, global);
+        let font_status_promise = Promise::new_rooted(cx, global);
         // If any of them fail to parse correctly, reject font face’s [[FontStatusPromise]] with a
         // DOMException named "SyntaxError"
         font_status_promise
@@ -218,7 +216,7 @@ impl FontFace {
             Box::new(Self {
                 reflector: Reflector::new(),
                 font_face_set: MutNullableDom::default(),
-                font_status_promise,
+                font_status_promise: font_status_promise.to_traced(),
                 family_name: DomRefCell::default(),
                 urls: Default::default(),
                 descriptors: DomRefCell::new(FontFaceDescriptors {
@@ -247,7 +245,7 @@ impl FontFace {
         family_name: DOMString,
         urls: Option<SourceList>,
         descriptors: &Descriptors,
-        font_status_promise: Rc<Promise>,
+        font_status_promise: &RootedPromise,
     ) -> Self {
         Self {
             reflector: Reflector::new(),
@@ -262,7 +260,7 @@ impl FontFace {
             family_name: DomRefCell::new(family_name),
             urls: DomRefCell::new(urls),
             template: RefCell::default(),
-            font_status_promise,
+            font_status_promise: font_status_promise.to_traced(),
             css_font_face_rule: Default::default(),
         }
     }
@@ -275,7 +273,7 @@ impl FontFace {
         font_family: DOMString,
         urls: Option<SourceList>,
         descriptors: &Descriptors,
-        font_status_promise: Rc<Promise>,
+        font_status_promise: &RootedPromise,
     ) -> DomRoot<Self> {
         reflect_dom_object_with_proto(
             cx,
@@ -295,7 +293,7 @@ impl FontFace {
         family_name: DOMString,
         descriptors: FontFaceDescriptors,
         src: Option<SourceList>,
-        font_status_promise: Rc<Promise>,
+        font_status_promise: &RootedPromise,
         font_face_rule: ServoArc<FontFaceRuleInfo>,
     ) -> Self {
         Self {
@@ -306,7 +304,7 @@ impl FontFace {
             family_name: DomRefCell::new(family_name),
             urls: DomRefCell::new(src),
             template: RefCell::default(),
-            font_status_promise,
+            font_status_promise: font_status_promise.to_traced(),
             css_font_face_rule: DomRefCell::new(Some(font_face_rule)),
         }
     }
@@ -333,14 +331,14 @@ impl FontFace {
         // > descriptors in the @font-face rule.
         let descriptors = serialize_parsed_descriptors(&font_face_rule.descriptors);
 
-        let font_status_promise = Promise::new(cx, global);
+        let font_status_promise = Promise::new_rooted(cx, global);
         Some(reflect_dom_object_with_proto(
             cx,
             Box::new(Self::new_inherited_for_web_font(
                 family_name,
                 descriptors,
                 font_face_rule.descriptors.src.clone(),
-                font_status_promise,
+                &font_status_promise,
                 font_face_rule,
             )),
             global,
@@ -617,15 +615,15 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
     /// load. For fonts constructed from a buffer source, or fonts that are already loading or
     /// loaded, it does nothing.
     /// <https://drafts.csswg.org/css-font-loading/#font-face-load>
-    fn Load(&self, cx: &mut JSContext) -> Rc<Promise> {
+    fn Load(&self, cx: &mut JSContext) -> RootedPromise {
         // Step 2. If font face’s [[Urls]] slot is null, or its status attribute is anything
         // other than "unloaded", return font face’s [[FontStatusPromise]] and abort these
         // steps.
         let Some(sources) = self.urls.borrow_mut().take() else {
-            return self.font_status_promise.clone();
+            return self.font_status_promise.root();
         };
         if self.status.get() != FontFaceLoadStatus::Unloaded {
-            return self.font_status_promise.clone();
+            return self.font_status_promise.root();
         }
 
         let global = self.global();
@@ -707,12 +705,12 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
             font_face_set.handle_font_face_status_changed(cx, self);
         }
 
-        self.font_status_promise.clone()
+        self.font_status_promise.root()
     }
 
     /// <https://drafts.csswg.org/css-font-loading/#dom-fontface-loaded>
-    fn Loaded(&self) -> Rc<Promise> {
-        self.font_status_promise.clone()
+    fn Loaded(&self) -> RootedPromise {
+        self.font_status_promise.root()
     }
 
     /// <https://drafts.csswg.org/css-font-loading/#font-face-constructor>
@@ -748,7 +746,7 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
         };
 
         // Set its internal [[FontStatusPromise]] slot to a fresh pending Promise object.
-        let font_status_promise = Promise::new(cx, global);
+        let font_status_promise = Promise::new_rooted(cx, global);
 
         let sources = parsed_font_face_rule.descriptors.src.clone();
         // Let font face be a fresh FontFace object.
@@ -759,7 +757,7 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
             family,
             sources,
             &parsed_font_face_rule.descriptors,
-            font_status_promise,
+            &font_status_promise,
         );
 
         // If font face’s status is "error", terminate this algorithm;

--- a/components/script/dom/css/fontfaceset.rs
+++ b/components/script/dom/css/fontfaceset.rs
@@ -2,9 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::RefCell;
-use std::rc::Rc;
-
 use cssparser::{Parser, ParserInput, UnicodeRange};
 use dom_struct::dom_struct;
 use fonts::FontFaceRuleInfo;
@@ -40,7 +37,7 @@ use crate::dom::document::Document;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::fontface::FontFace;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise, TracedPromise};
 use crate::dom::promisenativehandler::Callback;
 use crate::dom::types::PromiseNativeHandler;
 use crate::dom::window::Window;
@@ -52,17 +49,16 @@ pub(crate) struct FontFaceSet {
     target: EventTarget,
 
     /// <https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-readypromise-slot>
-    #[conditional_malloc_size_of]
-    promise: RefCell<Rc<Promise>>,
+    promise: DomRefCell<TracedPromise>,
 
     set_entries: DomRefCell<Vec<Dom<FontFace>>>,
 }
 
 impl FontFaceSet {
-    fn new_inherited(promise: Rc<Promise>) -> Self {
+    fn new_inherited(promise: &RootedPromise) -> Self {
         FontFaceSet {
             target: EventTarget::new_inherited(),
-            promise: promise.into(),
+            promise: DomRefCell::new(promise.to_traced()),
             set_entries: Default::default(),
         }
     }
@@ -72,10 +68,10 @@ impl FontFaceSet {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<Self> {
-        let promise = Promise::new(cx, global);
+        let promise = Promise::new_rooted(cx, global);
         reflect_dom_object_with_proto(
             cx,
-            Box::new(FontFaceSet::new_inherited(promise)),
+            Box::new(FontFaceSet::new_inherited(&promise)),
             global,
             proto,
         )
@@ -105,7 +101,7 @@ impl FontFaceSet {
 
     /// Fulfill the font ready promise, returning true if it was not already fulfilled beforehand.
     pub(crate) fn fulfill_ready_promise_if_needed(&self, cx: &mut JSContext) -> bool {
-        let promise = self.promise.borrow().clone();
+        let promise = self.promise.borrow();
         if promise.is_fulfilled() {
             return false;
         }
@@ -145,7 +141,8 @@ impl FontFaceSet {
         // Step 3. If font face set’s [[ReadyPromise]] slot currently holds a fulfilled
         // promise, replace it with a fresh pending promise.
         if self.promise.borrow().is_fulfilled() {
-            *self.promise.borrow_mut() = Promise::new(cx, &self.global());
+            let promise = Promise::new_rooted(cx, &self.global());
+            *self.promise.borrow_mut() = promise.to_traced()
         }
 
         // Step 4. Queue a task to fire a font load event named loading at font face set.
@@ -278,13 +275,13 @@ impl FontFaceSet {
 
 impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
     /// <https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-ready>
-    fn Ready(&self, cx: &mut JSContext) -> Rc<Promise> {
+    fn Ready(&self, cx: &mut JSContext) -> RootedPromise {
         if self.promise.borrow().is_fulfilled() {
             // There may be pending style changes that cause new web fonts to start loading,
             // re-initializing document.fonts.ready.
             self.flush_author_font_set(cx);
         }
-        self.promise.borrow().clone()
+        self.promise.borrow().root()
     }
 
     /// <https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-add>
@@ -344,10 +341,10 @@ impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
     }
 
     /// <https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-load>
-    fn Load(&self, cx: &mut JSContext, font: DOMString, text: DOMString) -> Rc<Promise> {
+    fn Load(&self, cx: &mut JSContext, font: DOMString, text: DOMString) -> RootedPromise {
         // Step 1. Let font face set be the FontFaceSet object this method was called on. Let
         // promise be a newly-created promise object.
-        let load_promise = Promise::new(cx, &self.global());
+        let load_promise = Promise::new_rooted(cx, &self.global());
 
         // Step 2. Return promise. Complete the rest of these steps asynchronously.
         #[derive(MallocSizeOf, JSTraceable)]
@@ -358,8 +355,7 @@ impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
             /// (Our current implementation waits for `document.fonts.ready` instead)
             font_face_objects: Vec<Dom<FontFace>>,
 
-            #[conditional_malloc_size_of]
-            load_promise: Rc<Promise>,
+            load_promise: TracedPromise,
         }
         impl Callback for LoadPromiseFulfillmentHandler {
             fn callback(&self, cx: &mut CurrentRealm, _: Handle<Value>) {
@@ -374,14 +370,14 @@ impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
 
         // Step 4. Queue a task to run the following steps synchronously:
         let trusted_this = Trusted::new(self);
-        let trusted_load_promise = TrustedPromise::new(load_promise.clone());
+        let trusted_load_promise = TrustedPromise::from(&load_promise);
         let font = font.to_string();
         let text = text.to_string();
         self.global()
             .task_manager()
             .font_loading_task_source()
             .queue(task!(resolve_font_face_set_load_task: move |cx| {
-                let load_promise = trusted_load_promise.root();
+                let load_promise = trusted_load_promise.root().duplicate(cx);
                 let this = trusted_this.root();
 
                 // This will need adjustments once FontFaceSet is exposed to workers.
@@ -417,7 +413,7 @@ impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
                     &global,
                     Some(Box::new(LoadPromiseFulfillmentHandler {
                         font_face_objects: font_face_objects.into_iter().map(|font_face| font_face.as_traced()).collect(),
-                        load_promise,
+                        load_promise: load_promise.to_traced(),
                     })),
                     None,
                 );

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -508,12 +508,10 @@ DOMInterfaces = {
 
 'FontFace': {
     'cx': ['Load'],
-    'useRcPromise': True,
 },
 
 'FontFaceSet': {
     'cx': ['Add', 'Load', 'Ready', 'Clear', 'Size'],
-    'useRcPromise': True,
 },
 
 'FormData': {


### PR DESCRIPTION
Testing: Existing tests suffice.
Part of #47747
Closes #47637
