### PR TITLE
indexeddb: Allow duplicate index names in different tables

### DIFF
--- a/components/storage/indexeddb/engines/sqlite/create.rs
+++ b/components/storage/indexeddb/engines/sqlite/create.rs
@@ -43,11 +43,11 @@ create table object_store_index (
     primary key autoincrement,
     object_store_id   integer        not null
     references object_store,
-    name              varchar        not null
-    unique,
+    name              varchar        not null,
     key_path          varbinary_blob not null,
     unique_index      boolean        not null,
-    multi_entry_index boolean        not null
+    multi_entry_index boolean        not null,
+    unique(object_store_id, name)
 );"#;
     conn.execute(OBJECT_STORE_INDEX, [])?;
 

--- a/tests/wpt/tests/IndexedDB/idbobjectstore_createIndex.any.js
+++ b/tests/wpt/tests/IndexedDB/idbobjectstore_createIndex.any.js
@@ -55,6 +55,33 @@ async_test(t => {
 }, "Attempt to create an index that requires unique values on an object store already contains duplicates");
 
 async_test(t => {
+    let db;
+
+    let open_rq = createdb(t);
+    open_rq.onupgradeneeded = function (e) {
+        db = e.target.result;
+        let txn = e.target.transaction,
+            objStore1 = db.createObjectStore("store1"),
+            objStore2 = db.createObjectStore("store2");
+
+        let index1 = objStore1.createIndex("index", "indexedProperty1");
+        let index2 = objStore2.createIndex("index", "indexedProperty2");
+
+        assert_true(index1 instanceof IDBIndex, "IDBIndex");
+        assert_true(index2 instanceof IDBIndex, "IDBIndex");
+        assert_equals(index1.name, "index", "index1.name");
+        assert_equals(index1.objectStore, objStore1, "index1.objectStore");
+        assert_equals(index1.keyPath, "indexedProperty1", "index1.keyPath");
+        assert_equals(index2.name, "index", "index2.name");
+        assert_equals(index2.objectStore, objStore2, "index2.objectStore");
+        assert_equals(index2.keyPath, "indexedProperty2", "index2.keyPath");
+    };
+    open_rq.onsuccess = function () {
+        t.done();
+    }
+}, "Create two object stores each with index of the same name");
+
+async_test(t => {
     let db, aborted;
 
     let open_rq = createdb(t);


### PR DESCRIPTION
Change the indexes SQLite table to only require the combination of object store id and index name to be unique. See [the spec](https://www.w3.org/TR/IndexedDB/#dom-idbobjectstore-createindex):

> If an [index](https://www.w3.org/TR/IndexedDB/#index-concept) [named](https://www.w3.org/TR/IndexedDB/#index-name) name already exists in store, [throw](https://webidl.spec.whatwg.org/#dfn-throw) a "[ConstraintError](https://webidl.spec.whatwg.org/#constrainterror)" [DOMException](https://webidl.spec.whatwg.org/#idl-DOMException).

Testing: Added WPT. Test for negative case with duplicate names in same table already exists and is still passing so no regression there.
Fixes: #47927 
