### PR TITLE
layout: Give caret and text selection rectangles a consistent height / position

### DIFF
--- a/components/layout/display_list/hit_test.rs
+++ b/components/layout/display_list/hit_test.rs
@@ -211,7 +211,7 @@ impl PaintTraversalHandler for HitTest<'_> {
     fn visit_text(
         &mut self,
         state: &TraversalState,
-        _: PhysicalRect<Au>,
+        _line_box_rect: PhysicalRect<Au>,
         fragment: &Arc<TextFragment>,
     ) {
         Fragment::Text(fragment.clone()).hit_test(state, self);

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -890,7 +890,7 @@ impl PaintTraversalHandler for DisplayListBuilder<'_> {
     fn visit_text(
         &mut self,
         state: &TraversalState,
-        containing_block: PhysicalRect<Au>,
+        line_box_rect: PhysicalRect<Au>,
         fragment: &Arc<TextFragment>,
     ) {
         fragment.base.visit_fragment(self);
@@ -899,7 +899,7 @@ impl PaintTraversalHandler for DisplayListBuilder<'_> {
         if style.get_inherited_box().visibility != Visibility::Visible {
             return;
         }
-        Fragment::build_display_list_for_text_fragment(fragment, self, state, &containing_block);
+        Fragment::build_display_list_for_text_fragment(fragment, self, state, &line_box_rect);
     }
 
     fn visit_positioning(&mut self, _state: &TraversalState, fragment: &Arc<PositioningFragment>) {
@@ -1045,14 +1045,11 @@ impl Fragment {
         fragment: &TextFragment,
         builder: &mut DisplayListBuilder,
         state: &TraversalState,
-        containing_block: &PhysicalRect<Au>,
+        line_box_rect: &PhysicalRect<Au>,
     ) {
         // NB: The order of painting text components (CSS Text Decoration Module Level 3) is:
         // shadows, underline, overline, text, text-emphasis, and then line-through.
-        let rect = fragment
-            .base
-            .rect()
-            .translate(containing_block.origin.to_vector());
+        let rect = fragment.base.rect().translate(state.origin.to_vector());
         let mut baseline_origin = rect.origin;
         baseline_origin.y += fragment.font_metrics.ascent;
 
@@ -1128,14 +1125,7 @@ impl Fragment {
             );
         }
 
-        Self::build_display_list_for_text_selection(
-            fragment,
-            builder,
-            state,
-            containing_block,
-            fragment.base.rect().min_x(),
-            fragment.justification_adjustment,
-        );
+        Self::build_display_list_for_text_selection(fragment, builder, state, line_box_rect);
 
         for text_decoration in state.text_decorations.iter() {
             if text_decoration.line.contains(TextDecorationLine::UNDERLINE) {
@@ -1316,9 +1306,7 @@ impl Fragment {
         fragment: &TextFragment,
         builder: &mut DisplayListBuilder<'_>,
         state: &TraversalState,
-        containing_block_rect: &PhysicalRect<Au>,
-        fragment_x_offset: Au,
-        justification_adjustment: Au,
+        line_box_rect: &PhysicalRect<Au>,
     ) {
         let run_data = &fragment.run_data;
         let Some(selection) = *run_data.selection.borrow() else {
@@ -1358,7 +1346,8 @@ impl Fragment {
                 selection_character_range.start
             {
                 current_advance += glyph_store.total_advance() +
-                    (justification_adjustment * glyph_store.total_word_separators() as i32);
+                    (fragment.justification_adjustment *
+                        glyph_store.total_word_separators() as i32);
                 current_character_index += glyph_store_character_count;
                 continue;
             }
@@ -1375,7 +1364,7 @@ impl Fragment {
                 current_character_index += Utf32CodeUnits(glyph.character_count());
                 current_advance += glyph.advance();
                 if glyph.char_is_word_separator() {
-                    current_advance += justification_adjustment;
+                    current_advance += fragment.justification_adjustment;
                 }
 
                 if current_character_index <= selection_character_range.end {
@@ -1387,12 +1376,15 @@ impl Fragment {
         let start_x = start_advance.unwrap_or(current_advance);
         let end_x = end_advance.unwrap_or(current_advance);
 
+        let fragment_rect = fragment.base.rect();
+        let fragment_origin =
+            (state.origin + fragment_rect.origin.to_vector()) + Vector2D::new(start_x, Au::zero());
+
         let parent_style = fragment.style();
         if !selection_character_range.is_empty() {
             let selection_rect = Rect::new(
-                containing_block_rect.origin +
-                    Vector2D::new(fragment_x_offset + start_x, Au::zero()),
-                Size2D::new(end_x - start_x, containing_block_rect.height()),
+                Point2D::new(fragment_origin.x, line_box_rect.min_y()),
+                Size2D::new(end_x - start_x, line_box_rect.height()),
             )
             .to_webrender();
 
@@ -1415,10 +1407,10 @@ impl Fragment {
         }
 
         let insertion_point_rect = Rect::new(
-            containing_block_rect.origin + Vector2D::new(start_x + fragment_x_offset, Au::zero()),
+            fragment_origin,
             Size2D::new(
                 INSERTION_POINT_LOGICAL_WIDTH,
-                containing_block_rect.height(),
+                fragment.font_metrics.line_gap,
             ),
         )
         .to_webrender();

--- a/components/layout/display_list/paint_traversal.rs
+++ b/components/layout/display_list/paint_traversal.rs
@@ -150,7 +150,19 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
             // >  ↪ If root is an inline-level box
             // >     For each line box root is in, paint a box in a line box given root, the
             // >     line box, and canvas.
-            self.traverse_box_in_a_line_box(state, root, true /* at_stacking_context_root */);
+
+            // TODO(mrobinson): This is not actually the real line box, but the content rectangle
+            // of the inline box. The real line box is hard to access when an inline box starts
+            // a stacking container, so we fall back gracefully to this (perhaps smaller) rectangle.
+            // To fix this, we'd need to put the containing line box rectangle on the `StackingContext`
+            // data structure or onto the `TextFragment` itself somehow.
+            let line_box_rect = PhysicalRect::new(inner_state.origin, root.content_rect().size);
+            self.traverse_box_in_a_line_box(
+                state,
+                root,
+                line_box_rect,
+                true, /* at_stacking_context_root */
+            );
         } else if saw_inline_level_or_replaced {
             // >  ↪ Otherwise
             // >    First for root, then for all its in-flow, non-positioned, block-level
@@ -339,8 +351,10 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
             },
             Fragment::Positioning(positioning_fragment) if positioning_fragment.is_line_box() => {
                 let state = state.push_positioning_fragment(positioning_fragment);
+                let line_box_rect =
+                    PhysicalRect::new(state.origin, positioning_fragment.base.rect().size);
                 for child in &positioning_fragment.children {
-                    self.traverse_fragment_in_a_line_box(&state, child);
+                    self.traverse_fragment_in_a_line_box(&state, child, line_box_rect);
                 }
             },
             Fragment::Positioning(positioning_fragment) => {
@@ -361,23 +375,26 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
         }
     }
 
-    fn traverse_fragment_in_a_line_box(&mut self, state: &TraversalState, fragment: &Fragment) {
+    fn traverse_fragment_in_a_line_box(
+        &mut self,
+        state: &TraversalState,
+        fragment: &Fragment,
+        line_box_rect: PhysicalRect<Au>,
+    ) {
         match fragment {
-            Fragment::LayoutRoot(layout_root_fragment) => {
-                self.traverse_fragment_in_a_line_box(state, &layout_root_fragment.inner())
-            },
+            Fragment::LayoutRoot(layout_root_fragment) => self.traverse_fragment_in_a_line_box(
+                state,
+                &layout_root_fragment.inner(),
+                line_box_rect,
+            ),
             Fragment::Box(box_fragment) => self.traverse_box_in_a_line_box(
                 state,
                 &box_fragment.with_style(),
+                line_box_rect,
                 false, /* at_stacking_context_root */
             ),
             Fragment::Text(text_fragment) => {
-                // This containing block is wrong and should use the size from the parent
-                // positioning context.
-                let containing_block =
-                    PhysicalRect::new(state.origin, text_fragment.base.rect().size);
-                self.handler
-                    .visit_text(state, containing_block, text_fragment);
+                self.handler.visit_text(state, line_box_rect, text_fragment);
             },
             Fragment::AbsoluteOrFixedPositionedPlaceholder(..) | Fragment::Float(..) => {},
             Fragment::Positioning(..) => {
@@ -394,6 +411,7 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
         &mut self,
         state: &TraversalState,
         box_fragment: &BoxFragmentWithStyle<'_>,
+        line_box_rect: PhysicalRect<Au>,
         at_stacking_context_root: bool,
     ) {
         // If this box establishes a stacking context or stacking container, do not paint
@@ -439,7 +457,7 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
         } else {
             let state = state.push_box_fragment(box_fragment);
             for child in &box_fragment.children {
-                self.traverse_fragment_in_a_line_box(&state, child);
+                self.traverse_fragment_in_a_line_box(&state, child, line_box_rect);
             }
         }
     }
@@ -513,7 +531,7 @@ pub(crate) trait PaintTraversalHandler {
     fn visit_text(
         &mut self,
         state: &TraversalState,
-        containing_block: PhysicalRect<Au>,
+        line_box_rect: PhysicalRect<Au>,
         fragment: &Arc<TextFragment>,
     );
     fn visit_positioning(&mut self, _state: &TraversalState, _fragment: &Arc<PositioningFragment>) {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -212,6 +212,19 @@
   },
   "reftest": {
    "appearance": {
+    "document-selection-visible-height.html": [
+     "4320002c1416ee7e957f92bd24c0ca4a62e61e54",
+     [
+      null,
+      [
+       [
+        "/_mozilla/appearance/document-selection-visible-height-ref.html",
+        "=="
+       ]
+      ],
+      {}
+     ]
+    ],
     "input-range.html": [
      "ed42641aa50cb89647ac3671da73d40b30f55f0d",
      [
@@ -8430,6 +8443,10 @@
     []
    ],
    "appearance": {
+    "document-selection-visible-height-ref.html": [
+     "d24a8715c8b453906323e89a1d605ba3e77351f0",
+     []
+    ],
     "input-range-ref.html": [
      "a805e58f2bf0f48b597a3fef54ac7fa7c50db3b5",
      []

--- a/tests/wpt/mozilla/tests/appearance/document-selection-visible-height-ref.html
+++ b/tests/wpt/mozilla/tests/appearance/document-selection-visible-height-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Document selection visible height should be consistent regardless of font size</title>
+</head>
+
+<style>
+    .test {
+        color: transparent;
+    }
+</style>
+
+<div class="test" style="width: 300px; overflow: clip;">
+<span style="font-size: 100px">AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA</span>
+</div>
+
+<script>
+    document.getSelection().selectAllChildren(document.querySelector(".test"));
+</script>

--- a/tests/wpt/mozilla/tests/appearance/document-selection-visible-height.html
+++ b/tests/wpt/mozilla/tests/appearance/document-selection-visible-height.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Document selection visible height should be consistent regardless of font size</title>
+    <link rel="match" href="document-selection-visible-height-ref.html">
+</head>
+
+<style>
+    .test {
+        color: transparent;
+    }
+</style>
+
+<div class="test" style="width: 300px; overflow: clip;">
+<span style="font-size: 30px">A</span><span style="font-size: 100px">A</span><span style="font-size: 30px">A</span><span style="font-size: 30px">A</span><span style="font-size: 100px">A</span><span style="font-size: 30px">A</span><span style="font-size: 30px">A</span><span style="font-size: 100px">a</span><span style="font-size: 30px">A</span><span style="font-size: 30px">A</span><span style="font-size: 100px">A</span><span style="font-size: 30px">A</span><span style="font-size: 30px">A</span><span style="font-size: 100px">A</span><span style="font-size: 30px">A</span><span style="font-size: 30px">A</span><span style="font-size: 100px">A</span><span style="font-size: 30px">A</span>
+</div>
+
+<script>
+    document.getSelection().selectAllChildren(document.querySelector(".test"));
+</script>


### PR DESCRIPTION
This change ensures that visible selection rectangles and carets have a
consistent height:

 - Selection rectangles paint the entire height of the line box so the
   rectangle height should be consistent across the entire selected
   contents of the line.
 - Carets now paint the line gap height of the font metrics of the
   text fragment they are attached to.

From a high level, this behavior matches Chromium.

Testing: This change adds a Servo-specific WPT-style text.
Fixes: #36924.
Fixes: #47553.
