### PR TITLE
script: switch Rc<Promise> cases to RootedPromise instances for bluetooth components and permissions

### DIFF
--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -43,7 +43,6 @@ use js::conversions::ConversionResult;
 use profile_traits::{generic_channel};
 use std::collections::HashMap;
 use std::ffi::CStr;
-use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
 const KEY_CONVERSION_ERROR: &str =
@@ -171,7 +170,7 @@ impl Bluetooth {
     fn request_bluetooth_devices(
         &self,
         cx: &mut JSContext,
-        p: &Rc<Promise>,
+        p: &RootedPromise,
         filters: &Option<Vec<BluetoothLEScanFilterInit>>,
         optional_services: &[BluetoothServiceUUID],
         sender: GenericCallback<BluetoothResponseResult>,
@@ -246,7 +245,7 @@ impl Bluetooth {
 }
 
 pub(crate) fn response_async<T: AsyncBluetoothListener + DomObject + 'static>(
-    promise: &Rc<Promise>,
+    promise: &RootedPromise,
     receiver: &T,
 ) -> GenericCallback<BluetoothResponseResult> {
     let task_source = receiver
@@ -255,7 +254,7 @@ pub(crate) fn response_async<T: AsyncBluetoothListener + DomObject + 'static>(
         .networking_task_source()
         .to_sendable();
     let context = Arc::new(Mutex::new(BluetoothContext {
-        promise: Some(TrustedPromise::new(promise.clone())),
+        promise: Some(TrustedPromise::from(promise)),
         receiver: Trusted::new(receiver),
     }));
     GenericCallback::new(move |message| {
@@ -295,12 +294,12 @@ pub(crate) fn get_gatt_children<T, F>(
     instance_id: String,
     connected: bool,
     child_type: GATTType,
-) -> Rc<Promise>
+) -> RootedPromise
 where
     T: AsyncBluetoothListener + DomObject + 'static,
     F: FnOnce(StringOrUnsignedLong) -> Fallible<UUID>,
 {
-    let p = Promise::new_in_realm(cx);
+    let p = Promise::new_in_realm_rooted(cx);
 
     let result_uuid = if let Some(u) = uuid {
         // Step 1.
@@ -537,8 +536,8 @@ impl Convert<Error> for BluetoothError {
 
 impl BluetoothMethods<crate::DomTypeHolder> for Bluetooth {
     /// <https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-requestdevice>
-    fn RequestDevice(&self, cx: &mut CurrentRealm, option: &RequestDeviceOptions) -> Rc<Promise> {
-        let p = Promise::new_in_realm(cx);
+    fn RequestDevice(&self, cx: &mut CurrentRealm, option: &RequestDeviceOptions) -> RootedPromise {
+        let p = Promise::new_in_realm_rooted(cx);
         // Step 1.
         if (option.filters.is_some() && option.acceptAllDevices) ||
             (option.filters.is_none() && !option.acceptAllDevices)
@@ -555,8 +554,8 @@ impl BluetoothMethods<crate::DomTypeHolder> for Bluetooth {
     }
 
     /// <https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-getavailability>
-    fn GetAvailability(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
-        let p = Promise::new_in_realm(cx);
+    fn GetAvailability(&self, cx: &mut CurrentRealm) -> RootedPromise {
+        let p = Promise::new_in_realm_rooted(cx);
         // Step 1. We did not override the method
         // Step 2 - 3. in handle_response
         let sender = response_async(&p, self);
@@ -641,7 +640,7 @@ impl PermissionAlgorithm for Bluetooth {
     /// <https://webbluetoothcg.github.io/web-bluetooth/#query-the-bluetooth-permission>
     fn permission_query(
         cx: &mut JSContext,
-        promise: &Rc<Promise>,
+        promise: &RootedPromise,
         descriptor: &BluetoothPermissionDescriptor,
         status: &BluetoothPermissionResult,
     ) {
@@ -731,7 +730,7 @@ impl PermissionAlgorithm for Bluetooth {
     /// <https://webbluetoothcg.github.io/web-bluetooth/#request-the-bluetooth-permission>
     fn permission_request(
         cx: &mut JSContext,
-        promise: &Rc<Promise>,
+        promise: &RootedPromise,
         descriptor: &BluetoothPermissionDescriptor,
         status: &BluetoothPermissionResult,
     ) {

--- a/components/script/dom/bluetooth/bluetoothdevice.rs
+++ b/components/script/dom/bluetooth/bluetoothdevice.rs
@@ -4,7 +4,6 @@
 
 use std::cell::Cell;
 use std::collections::HashMap;
-use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
@@ -317,8 +316,8 @@ impl BluetoothDeviceMethods<crate::DomTypeHolder> for BluetoothDevice {
     }
 
     /// <https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-watchadvertisements>
-    fn WatchAdvertisements(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
-        let p = Promise::new_in_realm(cx);
+    fn WatchAdvertisements(&self, cx: &mut CurrentRealm) -> RootedPromise {
+        let p = Promise::new_in_realm_rooted(cx);
         let sender = response_async(&p, self);
         // TODO: Step 1.
         // Note: Steps 2 - 3 are implemented in components/bluetooth/lib.rs in watch_advertisements function

--- a/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::rc::Rc;
-
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::realm::CurrentRealm;
@@ -118,7 +116,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
         &self,
         cx: &mut CurrentRealm,
         descriptor: BluetoothDescriptorUUID,
-    ) -> Rc<Promise> {
+    ) -> RootedPromise {
         let is_connected = self.Service().Device().get_gatt(cx).Connected();
         get_gatt_children(
             cx,
@@ -137,7 +135,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
         &self,
         cx: &mut CurrentRealm,
         descriptor: Option<BluetoothDescriptorUUID>,
-    ) -> Rc<Promise> {
+    ) -> RootedPromise {
         let is_connected = self.Service().Device().get_gatt(cx).Connected();
         get_gatt_children(
             cx,
@@ -157,8 +155,8 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
     }
 
     /// <https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-readvalue>
-    fn ReadValue(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
-        let p = Promise::new_in_realm(cx);
+    fn ReadValue(&self, cx: &mut CurrentRealm) -> RootedPromise {
+        let p = Promise::new_in_realm_rooted(cx);
 
         // Step 1.
         if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Reads) {
@@ -194,8 +192,8 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
         &self,
         cx: &mut CurrentRealm,
         value: ArrayBufferViewOrArrayBuffer,
-    ) -> Rc<Promise> {
-        let p = Promise::new_in_realm(cx);
+    ) -> RootedPromise {
+        let p = Promise::new_in_realm_rooted(cx);
 
         // Step 1.
         if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Writes) {
@@ -242,8 +240,8 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
     }
 
     /// <https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-startnotifications>
-    fn StartNotifications(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
-        let p = Promise::new_in_realm(cx);
+    fn StartNotifications(&self, cx: &mut CurrentRealm) -> RootedPromise {
+        let p = Promise::new_in_realm_rooted(cx);
 
         // Step 1.
         if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Reads) {
@@ -279,8 +277,8 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
     }
 
     /// <https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-stopnotifications>
-    fn StopNotifications(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
-        let p = Promise::new_in_realm(cx);
+    fn StopNotifications(&self, cx: &mut CurrentRealm) -> RootedPromise {
+        let p = Promise::new_in_realm_rooted(cx);
         let sender = response_async(&p, self);
 
         // TODO: Step 3 - 4: Implement `active notification context set` for BluetoothRemoteGATTCharacteristic,

--- a/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::rc::Rc;
-
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::realm::CurrentRealm;
@@ -99,8 +97,8 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
     }
 
     /// <https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattdescriptor-readvalue>
-    fn ReadValue(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
-        let p = Promise::new_in_realm(cx);
+    fn ReadValue(&self, cx: &mut CurrentRealm) -> RootedPromise {
+        let p = Promise::new_in_realm_rooted(cx);
 
         // Step 1.
         if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Reads) {
@@ -135,8 +133,8 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
         &self,
         cx: &mut CurrentRealm,
         value: ArrayBufferViewOrArrayBuffer,
-    ) -> Rc<Promise> {
-        let p = Promise::new_in_realm(cx);
+    ) -> RootedPromise {
+        let p = Promise::new_in_realm_rooted(cx);
 
         // Step 1.
         if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Writes) {

--- a/components/script/dom/bluetooth/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattserver.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::Cell;
-use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
@@ -73,9 +72,9 @@ impl BluetoothRemoteGATTServerMethods<crate::DomTypeHolder> for BluetoothRemoteG
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattserver-connect
-    fn Connect(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
+    fn Connect(&self, cx: &mut CurrentRealm) -> RootedPromise {
         // Step 1.
-        let p = Promise::new_in_realm(cx);
+        let p = Promise::new_in_realm_rooted(cx);
         let sender = response_async(&p, self);
 
         // TODO: Step 3: Check if the UA is currently using the Bluetooth system.
@@ -117,7 +116,7 @@ impl BluetoothRemoteGATTServerMethods<crate::DomTypeHolder> for BluetoothRemoteG
         &self,
         cx: &mut CurrentRealm,
         service: BluetoothServiceUUID,
-    ) -> Rc<Promise> {
+    ) -> RootedPromise {
         let is_connected = self.Device().get_gatt(cx).Connected();
         // Step 1 - 2.
         get_gatt_children(
@@ -137,7 +136,7 @@ impl BluetoothRemoteGATTServerMethods<crate::DomTypeHolder> for BluetoothRemoteG
         &self,
         cx: &mut CurrentRealm,
         service: Option<BluetoothServiceUUID>,
-    ) -> Rc<Promise> {
+    ) -> RootedPromise {
         // Step 1 - 2.
         get_gatt_children(
             cx,

--- a/components/script/dom/bluetooth/bluetoothremotegattservice.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattservice.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::rc::Rc;
-
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::realm::CurrentRealm;
@@ -20,7 +18,7 @@ use crate::dom::bluetoothdevice::BluetoothDevice;
 use crate::dom::bluetoothuuid::{BluetoothCharacteristicUUID, BluetoothServiceUUID, BluetoothUUID};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::{Promise, RootedPromise};
+use crate::dom::promise::RootedPromise;
 
 // https://webbluetoothcg.github.io/web-bluetooth/#bluetoothremotegattservice
 #[dom_struct]
@@ -92,7 +90,7 @@ impl BluetoothRemoteGATTServiceMethods<crate::DomTypeHolder> for BluetoothRemote
         &self,
         cx: &mut CurrentRealm,
         characteristic: BluetoothCharacteristicUUID,
-    ) -> Rc<Promise> {
+    ) -> RootedPromise {
         let is_connected = self.Device().get_gatt(cx).Connected();
         get_gatt_children(
             cx,
@@ -111,7 +109,7 @@ impl BluetoothRemoteGATTServiceMethods<crate::DomTypeHolder> for BluetoothRemote
         &self,
         cx: &mut CurrentRealm,
         characteristic: Option<BluetoothCharacteristicUUID>,
-    ) -> Rc<Promise> {
+    ) -> RootedPromise {
         let is_connected = self.Device().get_gatt(cx).Connected();
         get_gatt_children(
             cx,
@@ -130,7 +128,7 @@ impl BluetoothRemoteGATTServiceMethods<crate::DomTypeHolder> for BluetoothRemote
         &self,
         cx: &mut CurrentRealm,
         service: BluetoothServiceUUID,
-    ) -> Rc<Promise> {
+    ) -> RootedPromise {
         let is_connected = self.Device().get_gatt(cx).Connected();
         get_gatt_children(
             cx,
@@ -149,7 +147,7 @@ impl BluetoothRemoteGATTServiceMethods<crate::DomTypeHolder> for BluetoothRemote
         &self,
         cx: &mut CurrentRealm,
         service: Option<BluetoothServiceUUID>,
-    ) -> Rc<Promise> {
+    ) -> RootedPromise {
         let is_connected = self.Device().get_gatt(cx).Connected();
         get_gatt_children(
             cx,

--- a/components/script/dom/permission/permissions.rs
+++ b/components/script/dom/permission/permissions.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::rc::Rc;
-
 use dom_struct::dom_struct;
 use embedder_traits::{self, AllowOrDeny, EmbedderMsg, PermissionFeature, WakeLockType};
 use js::context::JSContext;
@@ -17,6 +15,7 @@ use servo_base::generic_channel;
 use servo_config::pref;
 
 use crate::conversions::Convert;
+use crate::dom::RootedPromise;
 use crate::dom::bindings::codegen::Bindings::PermissionStatusBinding::{
     PermissionDescriptor, PermissionName, PermissionState, PermissionStatusMethods,
 };
@@ -44,13 +43,13 @@ pub(crate) trait PermissionAlgorithm {
     ) -> Result<Self::Descriptor, Error>;
     fn permission_query(
         cx: &mut JSContext,
-        promise: &Rc<Promise>,
+        promise: &RootedPromise,
         descriptor: &Self::Descriptor,
         status: &Self::Status,
     );
     fn permission_request(
         cx: &mut JSContext,
-        promise: &Rc<Promise>,
+        promise: &RootedPromise,
         descriptor: &Self::Descriptor,
         status: &Self::Status,
     );
@@ -88,8 +87,8 @@ impl Permissions {
         cx: &mut CurrentRealm,
         op: Operation,
         permission_desc: *mut JSObject,
-        promise: Option<Rc<Promise>>,
-    ) -> Rc<Promise> {
+        promise: Option<RootedPromise>,
+    ) -> RootedPromise {
         rooted!(&in(cx) let mut permission_desc_value = UndefinedValue());
         permission_desc_value
             .handle_mut()
@@ -98,7 +97,7 @@ impl Permissions {
         // (Query, Request) Step 3.
         let p = match promise {
             Some(promise) => promise,
-            None => Promise::new_in_realm(cx),
+            None => Promise::new_in_realm_rooted(cx),
         };
 
         // (Query, Request, Revoke) Step 1.
@@ -199,17 +198,17 @@ impl Permissions {
 // Currently these methods use Raw *mut JSObject which is potentially dangerous. We root this object immediately in `self.manipulate`.
 impl PermissionsMethods<crate::DomTypeHolder> for Permissions {
     /// <https://w3c.github.io/permissions/#dom-permissions-query>
-    fn Query(&self, cx: &mut CurrentRealm, permission_desc: *mut JSObject) -> Rc<Promise> {
+    fn Query(&self, cx: &mut CurrentRealm, permission_desc: *mut JSObject) -> RootedPromise {
         self.manipulate(cx, Operation::Query, permission_desc, None)
     }
 
     /// <https://w3c.github.io/permissions/#dom-permissions-request>
-    fn Request(&self, cx: &mut CurrentRealm, permission_desc: *mut JSObject) -> Rc<Promise> {
+    fn Request(&self, cx: &mut CurrentRealm, permission_desc: *mut JSObject) -> RootedPromise {
         self.manipulate(cx, Operation::Request, permission_desc, None)
     }
 
     /// <https://w3c.github.io/permissions/#dom-permissions-revoke>
-    fn Revoke(&self, cx: &mut CurrentRealm, permission_desc: *mut JSObject) -> Rc<Promise> {
+    fn Revoke(&self, cx: &mut CurrentRealm, permission_desc: *mut JSObject) -> RootedPromise {
         self.manipulate(cx, Operation::Revoke, permission_desc, None)
     }
 }
@@ -242,7 +241,7 @@ impl PermissionAlgorithm for Permissions {
     /// > permission_desc and a PermissionStatus status, runs the following steps:
     fn permission_query(
         _cx: &mut JSContext,
-        _promise: &Rc<Promise>,
+        _promise: &RootedPromise,
         _descriptor: &PermissionDescriptor,
         status: &PermissionStatus,
     ) {
@@ -253,7 +252,7 @@ impl PermissionAlgorithm for Permissions {
     /// <https://w3c.github.io/permissions/#boolean-permission-request-algorithm>
     fn permission_request(
         cx: &mut JSContext,
-        promise: &Rc<Promise>,
+        promise: &RootedPromise,
         descriptor: &PermissionDescriptor,
         status: &PermissionStatus,
     ) {

--- a/components/script/dom/serviceworker/notification.rs
+++ b/components/script/dom/serviceworker/notification.rs
@@ -704,7 +704,7 @@ fn request_notification_permission(
     cx: &mut JSContext,
     global: &GlobalScope,
 ) -> NotificationPermission {
-    let promise = &Promise::new(cx, global);
+    let promise = &Promise::new_rooted(cx, global);
     let descriptor = PermissionDescriptor {
         name: PermissionName::Notifications,
     };

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -66,34 +66,28 @@ DOMInterfaces = {
 
 'Bluetooth': {
     'realm': ['GetAvailability', 'RequestDevice'],
-    'useRcPromise': True,
 },
 
 'BluetoothDevice': {
     'realm': ['WatchAdvertisements'],
     'cx': ['GetGatt'],
-    'useRcPromise': True,
 },
 
 'BluetoothRemoteGATTCharacteristic': {
     'realm': ['ReadValue', 'StartNotifications', 'StopNotifications', 'WriteValue', 'GetDescriptor', 'GetDescriptors'],
-    'useRcPromise': True,
 },
 
 'BluetoothRemoteGATTDescriptor': {
     'realm': ['ReadValue', 'WriteValue'],
-    'useRcPromise': True,
 },
 
 'BluetoothRemoteGATTServer': {
     'realm': ['Connect', 'GetPrimaryService', 'GetPrimaryServices'],
     'cx': ['Disconnect'],
-    'useRcPromise': True,
 },
 
 'BluetoothRemoteGATTService': {
     'realm': ['GetCharacteristic', 'GetCharacteristics', 'GetIncludedService', 'GetIncludedServices'],
-    'useRcPromise': True,
 },
 
 'BroadcastChannel': {
@@ -1052,7 +1046,6 @@ DOMInterfaces = {
 
 'Permissions': {
     'realm': ['Query', 'Request', 'Revoke'],
-    'useRcPromise': True,
 },
 
 'Promise': {


### PR DESCRIPTION
This changes `Rc<Promise>` instances to `RootedPromise` for various bluetooth componets and permissions.
A notification function has been touched too due to changes in a PermissionAlgorithm method signature.

Testing: Used already existing tests
Fixes: Part of #47747